### PR TITLE
MCP fake lab for unit tests

### DIFF
--- a/tests/fixtures/mcp_fake_lab.py
+++ b/tests/fixtures/mcp_fake_lab.py
@@ -1,0 +1,327 @@
+"""MCP fake lab: in-memory Bernstein task server for unit tests (T602).
+
+Wires ``create_mcp_server`` to a fake ``httpx`` transport so every MCP tool
+can be exercised without a running Bernstein server or real network calls.
+
+Usage::
+
+    from tests.fixtures.mcp_fake_lab import McpFakeLab
+
+    async def test_run_creates_task():
+        lab = McpFakeLab()
+        text = await lab.call_tool("bernstein_run", {"goal": "Do X", "role": "qa"})
+        assert "fake-" in text
+        lab.assert_called("POST", "/tasks")
+
+    async def test_tasks_returns_seeded_task():
+        lab = McpFakeLab()
+        lab.seed_task("T-001", title="Fix bug", role="backend")
+        text = await lab.call_tool("bernstein_tasks", {})
+        assert "T-001" in text
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+
+# ---------------------------------------------------------------------------
+# Default data helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_status() -> dict[str, Any]:
+    return {
+        "total": 0,
+        "open": 0,
+        "claimed": 0,
+        "done": 0,
+        "failed": 0,
+        "per_role": [],
+        "total_cost_usd": 0.0,
+    }
+
+
+def _make_task_dict(
+    task_id: str,
+    title: str = "Fake task",
+    status: str = "open",
+    role: str = "backend",
+    description: str = "",
+    priority: int = 2,
+    scope: str = "medium",
+    complexity: str = "medium",
+    estimated_minutes: int = 30,
+    result_summary: str | None = None,
+    **_extra: Any,
+) -> dict[str, Any]:
+    """Build a minimal task dict matching the Bernstein task server schema."""
+    return {
+        "id": task_id,
+        "title": title,
+        "description": description or title,
+        "role": role,
+        "priority": priority,
+        "scope": scope,
+        "complexity": complexity,
+        "estimated_minutes": estimated_minutes,
+        "status": status,
+        "depends_on": [],
+        "owned_files": [],
+        "assigned_agent": None,
+        "result_summary": result_summary,
+        "cell_id": None,
+        "task_type": "standard",
+        "upgrade_details": None,
+        "model": None,
+        "effort": None,
+        "completion_signals": [],
+        "created_at": 1711574400.0,
+        "progress_log": [],
+        "version": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fake httpx transport — routes to in-memory state
+# ---------------------------------------------------------------------------
+
+_COMPLETE_RE = re.compile(r"^/tasks/(.+)/complete$")
+_FAIL_RE = re.compile(r"^/tasks/(.+)/fail$")
+
+
+class _BernsteinFakeTransport(httpx.AsyncBaseTransport):
+    """httpx async transport that simulates the Bernstein task server in memory.
+
+    Operates on the data structures passed at construction time so it does not
+    need to access private attributes of :class:`McpFakeLab`.
+
+    Args:
+        requests: List to append each incoming request to.
+        tasks: Shared task store (mutated on POST /tasks and complete/fail).
+        status_data: Fixed payload returned for GET /status.
+    """
+
+    def __init__(
+        self,
+        requests: list[httpx.Request],
+        tasks: dict[str, dict[str, Any]],
+        status_data: dict[str, Any],
+    ) -> None:
+        self._requests = requests
+        self._tasks = tasks
+        self._status_data = status_data
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self._requests.append(request)
+        method = request.method
+        path = request.url.path
+
+        # GET /status
+        if method == "GET" and path == "/status":
+            return httpx.Response(200, json=self._status_data)
+
+        # GET /tasks[?status=...]
+        if method == "GET" and path == "/tasks":
+            status_filter = request.url.params.get("status")
+            tasks = list(self._tasks.values())
+            if status_filter:
+                tasks = [t for t in tasks if t["status"] == status_filter]
+            return httpx.Response(200, json=tasks)
+
+        # POST /tasks — create new task
+        if method == "POST" and path == "/tasks":
+            body: dict[str, Any] = json.loads(request.content) if request.content else {}
+            task_id = f"fake-{len(self._tasks) + 1:04d}"
+            task = _make_task_dict(task_id=task_id, **body)
+            self._tasks[task_id] = task
+            return httpx.Response(201, json=task)
+
+        # POST /tasks/{id}/complete
+        m_complete = _COMPLETE_RE.match(path)
+        if method == "POST" and m_complete:
+            task_id = m_complete.group(1)
+            if task_id not in self._tasks:
+                return httpx.Response(404, json={"error": f"task {task_id!r} not found"})
+            body = json.loads(request.content) if request.content else {}
+            self._tasks[task_id]["status"] = "done"
+            self._tasks[task_id]["result_summary"] = body.get("result_summary")
+            return httpx.Response(200, json=self._tasks[task_id])
+
+        # POST /tasks/{id}/fail
+        m_fail = _FAIL_RE.match(path)
+        if method == "POST" and m_fail:
+            task_id = m_fail.group(1)
+            if task_id not in self._tasks:
+                return httpx.Response(404, json={"error": f"task {task_id!r} not found"})
+            body = json.loads(request.content) if request.content else {}
+            self._tasks[task_id]["status"] = "failed"
+            self._tasks[task_id]["result_summary"] = body.get("result_summary")
+            return httpx.Response(200, json=self._tasks[task_id])
+
+        return httpx.Response(404, json={"error": f"fake lab: unhandled {method} {path}"})
+
+
+# ---------------------------------------------------------------------------
+# McpFakeLab
+# ---------------------------------------------------------------------------
+
+_FAKE_SERVER_URL = "http://bernstein-fake"
+
+
+class McpFakeLab:
+    """Test harness for exercising Bernstein MCP tools in isolation.
+
+    Seeds an in-memory task store, injects it into ``create_mcp_server`` via
+    a fake ``httpx`` transport, and exposes ``call_tool`` so tests can drive
+    every tool without a real Bernstein server or real network calls.
+
+    All HTTP requests made during ``call_tool`` are recorded in
+    :attr:`requests` for post-call verification.
+
+    Example::
+
+        async def test_status_reflects_seeded_tasks():
+            lab = McpFakeLab()
+            lab.seed_task("T-001", status="open")
+            lab.seed_task("T-002", status="done")
+            lab.seed_status(total=2, open=1, done=1)
+            text = await lab.call_tool("bernstein_status", {})
+            assert "open" in text
+
+    Args:
+        server_url: URL passed to ``create_mcp_server``.  Defaults to a
+            placeholder that is never actually contacted.
+    """
+
+    def __init__(self, server_url: str = _FAKE_SERVER_URL) -> None:
+        self._server_url = server_url
+        self._tasks: dict[str, dict[str, Any]] = {}
+        self._status_data: dict[str, Any] = _default_status()
+        self._requests: list[httpx.Request] = []
+
+    # ------------------------------------------------------------------
+    # State seeding
+    # ------------------------------------------------------------------
+
+    def seed_task(
+        self,
+        task_id: str,
+        status: str = "open",
+        title: str = "Fake task",
+        role: str = "backend",
+        **kwargs: Any,
+    ) -> None:
+        """Pre-load a task into the fake server.
+
+        Args:
+            task_id: Task identifier (e.g. ``"T-001"``).
+            status: Initial task status.
+            title: Task title.
+            role: Assignee role.
+            **kwargs: Additional fields merged into the task dict.
+        """
+        self._tasks[task_id] = _make_task_dict(
+            task_id=task_id,
+            status=status,
+            title=title,
+            role=role,
+            **kwargs,
+        )
+
+    def seed_status(self, **kwargs: Any) -> None:
+        """Override fields in the ``/status`` response.
+
+        Args:
+            **kwargs: Fields to update (e.g. ``total=5, open=2, done=3``).
+        """
+        self._status_data.update(kwargs)
+
+    # ------------------------------------------------------------------
+    # Tool invocation
+    # ------------------------------------------------------------------
+
+    async def call_tool(self, tool_name: str, args: dict[str, Any]) -> str:
+        """Invoke *tool_name* via the real FastMCP server with the fake transport.
+
+        Patches ``httpx.AsyncClient`` in ``bernstein.mcp.server`` so every
+        HTTP call hits the in-memory transport instead of the network.
+
+        Args:
+            tool_name: MCP tool name (e.g. ``"bernstein_run"``).
+            args: Tool arguments dict.
+
+        Returns:
+            The first text content item from the tool's response.
+
+        Raises:
+            httpx.HTTPStatusError: If the fake transport returns a non-2xx
+                response and the tool calls ``raise_for_status()``.
+        """
+        from bernstein.mcp.server import create_mcp_server
+
+        transport = _BernsteinFakeTransport(
+            requests=self._requests,
+            tasks=self._tasks,
+            status_data=self._status_data,
+        )
+        # Capture the real class before patching so _make_client doesn't recurse.
+        _RealAsyncClient = httpx.AsyncClient
+
+        def _make_client(*_args: Any, **_kwargs: Any) -> httpx.AsyncClient:
+            return _RealAsyncClient(transport=transport)
+
+        mcp = create_mcp_server(server_url=self._server_url)
+        with patch("bernstein.mcp.server.httpx.AsyncClient", side_effect=_make_client):
+            result = await mcp.call_tool(tool_name, args)
+
+        # FastMCP returns a list of lists of content objects
+        return result[0][0].text  # type: ignore[index]
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def requests(self) -> list[httpx.Request]:
+        """All HTTP requests captured during this lab session, in order."""
+        return list(self._requests)
+
+    def assert_called(self, method: str, path: str) -> None:
+        """Assert that at least one request with *method* and *path* was made.
+
+        Args:
+            method: HTTP method (``"GET"``, ``"POST"``, …).
+            path: URL path (e.g. ``"/tasks"``).
+
+        Raises:
+            AssertionError: If no matching request was found.
+        """
+        matches = [
+            r for r in self._requests if r.method == method and r.url.path == path
+        ]
+        if not matches:
+            made = [(r.method, r.url.path) for r in self._requests]
+            msg = f"Expected {method} {path} but requests were: {made}"
+            raise AssertionError(msg)
+
+    def assert_not_called(self, method: str, path: str) -> None:
+        """Assert that no request with *method* and *path* was made.
+
+        Args:
+            method: HTTP method.
+            path: URL path.
+
+        Raises:
+            AssertionError: If a matching request was found.
+        """
+        matches = [
+            r for r in self._requests if r.method == method and r.url.path == path
+        ]
+        if matches:
+            msg = f"Expected no {method} {path} but found {len(matches)} request(s)"
+            raise AssertionError(msg)

--- a/tests/unit/test_mcp_fake_lab.py
+++ b/tests/unit/test_mcp_fake_lab.py
@@ -1,0 +1,269 @@
+"""Tests for the McpFakeLab harness (T602).
+
+Validates that the lab correctly drives every Bernstein MCP tool via the
+in-memory transport, and that it catches representative protocol regressions.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.fixtures.mcp_fake_lab import McpFakeLab
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def lab() -> McpFakeLab:
+    """Fresh McpFakeLab for each test."""
+    return McpFakeLab()
+
+
+# ---------------------------------------------------------------------------
+# bernstein_run
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinRun:
+    """McpFakeLab correctly exercises bernstein_run."""
+
+    @pytest.mark.asyncio
+    async def test_run_returns_task_id(self, lab: McpFakeLab) -> None:
+        """bernstein_run returns a JSON string containing a task_id."""
+        text = await lab.call_tool("bernstein_run", {"goal": "Build auth"})
+        data = json.loads(text)
+        assert "task_id" in data
+        assert data["task_id"].startswith("fake-")
+
+    @pytest.mark.asyncio
+    async def test_run_posts_to_tasks_endpoint(self, lab: McpFakeLab) -> None:
+        """bernstein_run must POST to /tasks — catches regressions in the HTTP call."""
+        await lab.call_tool("bernstein_run", {"goal": "Build auth"})
+        lab.assert_called("POST", "/tasks")
+
+    @pytest.mark.asyncio
+    async def test_run_sends_goal_as_title(self, lab: McpFakeLab) -> None:
+        """The goal is sent as the task title in the request body."""
+        await lab.call_tool("bernstein_run", {"goal": "Refactor login flow"})
+        post_req = next(r for r in lab.requests if r.method == "POST" and r.url.path == "/tasks")
+        body = json.loads(post_req.content)
+        assert body["title"] == "Refactor login flow"
+
+    @pytest.mark.asyncio
+    async def test_run_uses_provided_role(self, lab: McpFakeLab) -> None:
+        """bernstein_run forwards the role arg to the task server."""
+        await lab.call_tool("bernstein_run", {"goal": "Write tests", "role": "qa"})
+        post_req = next(r for r in lab.requests if r.method == "POST")
+        body = json.loads(post_req.content)
+        assert body["role"] == "qa"
+
+    @pytest.mark.asyncio
+    async def test_run_persists_task_in_lab(self, lab: McpFakeLab) -> None:
+        """After bernstein_run, the fake lab holds the created task."""
+        await lab.call_tool("bernstein_run", {"goal": "Deploy pipeline"})
+        assert len(lab._tasks) == 1
+        task = next(iter(lab._tasks.values()))
+        assert task["status"] == "open"
+
+
+# ---------------------------------------------------------------------------
+# bernstein_status
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinStatus:
+    """McpFakeLab correctly exercises bernstein_status."""
+
+    @pytest.mark.asyncio
+    async def test_status_reflects_seeded_data(self, lab: McpFakeLab) -> None:
+        """bernstein_status returns the seeded status payload."""
+        lab.seed_status(total=7, open=3, done=4)
+        text = await lab.call_tool("bernstein_status", {})
+        data = json.loads(text)
+        assert data["total"] == 7
+        assert data["open"] == 3
+
+    @pytest.mark.asyncio
+    async def test_status_queries_status_endpoint(self, lab: McpFakeLab) -> None:
+        """bernstein_status must GET /status — catches endpoint regressions."""
+        await lab.call_tool("bernstein_status", {})
+        lab.assert_called("GET", "/status")
+
+    @pytest.mark.asyncio
+    async def test_status_default_all_zeros(self, lab: McpFakeLab) -> None:
+        """Without seeding, status has all-zero counts."""
+        text = await lab.call_tool("bernstein_status", {})
+        data = json.loads(text)
+        assert data["total"] == 0
+        assert data["total_cost_usd"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# bernstein_tasks
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinTasks:
+    """McpFakeLab correctly exercises bernstein_tasks."""
+
+    @pytest.mark.asyncio
+    async def test_tasks_lists_seeded_tasks(self, lab: McpFakeLab) -> None:
+        """bernstein_tasks returns all seeded tasks when no filter is given."""
+        lab.seed_task("T-001", title="Alpha")
+        lab.seed_task("T-002", title="Beta")
+        text = await lab.call_tool("bernstein_tasks", {})
+        data = json.loads(text)
+        ids = {t["id"] for t in data}
+        assert ids == {"T-001", "T-002"}
+
+    @pytest.mark.asyncio
+    async def test_tasks_filters_by_status(self, lab: McpFakeLab) -> None:
+        """bernstein_tasks passes status=open to /tasks and returns only matching tasks."""
+        lab.seed_task("T-001", status="open")
+        lab.seed_task("T-002", status="done")
+        text = await lab.call_tool("bernstein_tasks", {"status": "open"})
+        data = json.loads(text)
+        assert all(t["status"] == "open" for t in data)
+        # Verify the query param was actually sent
+        get_req = next(r for r in lab.requests if r.method == "GET" and r.url.path == "/tasks")
+        assert get_req.url.params.get("status") == "open"
+
+    @pytest.mark.asyncio
+    async def test_tasks_empty_by_default(self, lab: McpFakeLab) -> None:
+        """Without seeding, bernstein_tasks returns an empty list."""
+        text = await lab.call_tool("bernstein_tasks", {})
+        data = json.loads(text)
+        assert data == []
+
+
+# ---------------------------------------------------------------------------
+# bernstein_cost
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinCost:
+    """McpFakeLab correctly exercises bernstein_cost."""
+
+    @pytest.mark.asyncio
+    async def test_cost_returns_total_cost(self, lab: McpFakeLab) -> None:
+        """bernstein_cost reads total_cost_usd from /status."""
+        lab.seed_status(total_cost_usd=1.23, per_role=[{"role": "qa", "cost_usd": 0.50}])
+        text = await lab.call_tool("bernstein_cost", {})
+        data = json.loads(text)
+        assert data["total_cost_usd"] == pytest.approx(1.23)
+
+    @pytest.mark.asyncio
+    async def test_cost_includes_per_role_breakdown(self, lab: McpFakeLab) -> None:
+        """bernstein_cost exposes per-role cost data."""
+        lab.seed_status(
+            total_cost_usd=0.75,
+            per_role=[{"role": "backend", "cost_usd": 0.50}, {"role": "qa", "cost_usd": 0.25}],
+        )
+        text = await lab.call_tool("bernstein_cost", {})
+        data = json.loads(text)
+        roles = {r["role"] for r in data["per_role"]}
+        assert "backend" in roles
+        assert "qa" in roles
+
+
+# ---------------------------------------------------------------------------
+# bernstein_approve
+# ---------------------------------------------------------------------------
+
+
+class TestBernsteinApprove:
+    """McpFakeLab correctly exercises bernstein_approve."""
+
+    @pytest.mark.asyncio
+    async def test_approve_marks_task_done(self, lab: McpFakeLab) -> None:
+        """bernstein_approve calls /tasks/{id}/complete and returns done status."""
+        lab.seed_task("T-100", status="open")
+        text = await lab.call_tool("bernstein_approve", {"task_id": "T-100"})
+        data = json.loads(text)
+        assert data["status"] == "done"
+        assert lab._tasks["T-100"]["status"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_approve_records_note(self, lab: McpFakeLab) -> None:
+        """bernstein_approve stores the approval note as result_summary."""
+        lab.seed_task("T-101", status="open")
+        await lab.call_tool("bernstein_approve", {"task_id": "T-101", "note": "LGTM"})
+        assert lab._tasks["T-101"]["result_summary"] == "LGTM"
+
+    @pytest.mark.asyncio
+    async def test_approve_posts_to_complete_endpoint(self, lab: McpFakeLab) -> None:
+        """bernstein_approve must POST to /tasks/{id}/complete — regression guard."""
+        lab.seed_task("T-102", status="open")
+        await lab.call_tool("bernstein_approve", {"task_id": "T-102"})
+        lab.assert_called("POST", "/tasks/T-102/complete")
+
+    @pytest.mark.asyncio
+    async def test_approve_missing_task_raises(self, lab: McpFakeLab) -> None:
+        """bernstein_approve raises when the task does not exist in the fake server.
+
+        FastMCP wraps underlying exceptions in ToolError; the 404 message is
+        present in the error string.
+        """
+        from mcp.server.fastmcp.exceptions import ToolError
+
+        with pytest.raises(ToolError, match="404"):
+            await lab.call_tool("bernstein_approve", {"task_id": "no-such-task"})
+
+
+# ---------------------------------------------------------------------------
+# Regression guards — harness catches protocol drift
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionGuards:
+    """The harness detects representative regressions in the MCP tool protocol."""
+
+    @pytest.mark.asyncio
+    async def test_regression_run_must_not_skip_post(self, lab: McpFakeLab) -> None:
+        """Regression: if bernstein_run stops POSTing to /tasks, assert_called catches it.
+
+        This test documents the regression pattern: a future change that
+        removes the HTTP call (e.g. returns a hard-coded response) would
+        fail assert_called() because no POST request would be recorded.
+        """
+        await lab.call_tool("bernstein_run", {"goal": "Regression test task"})
+        # Would raise AssertionError if the tool skips the POST
+        lab.assert_called("POST", "/tasks")
+
+    @pytest.mark.asyncio
+    async def test_regression_tasks_filter_must_reach_server(self, lab: McpFakeLab) -> None:
+        """Regression: status filter must be sent as a query param to /tasks.
+
+        If bernstein_tasks filters client-side instead of passing ?status=X to
+        the server, the query param assertion below catches the regression.
+        """
+        lab.seed_task("T-open", status="open")
+        lab.seed_task("T-done", status="done")
+        await lab.call_tool("bernstein_tasks", {"status": "open"})
+
+        get_req = next(r for r in lab.requests if r.method == "GET" and r.url.path == "/tasks")
+        assert get_req.url.params.get("status") == "open", (
+            "Regression: bernstein_tasks must pass status as a server-side query param"
+        )
+
+    @pytest.mark.asyncio
+    async def test_harness_assert_called_raises_on_missing_request(
+        self, lab: McpFakeLab
+    ) -> None:
+        """The harness itself raises AssertionError when an expected call never happens."""
+        # Don't make any calls — assert_called should detect the absence
+        with pytest.raises(AssertionError, match="Expected POST /tasks"):
+            lab.assert_called("POST", "/tasks")
+
+    @pytest.mark.asyncio
+    async def test_harness_assert_not_called_raises_on_unexpected_request(
+        self, lab: McpFakeLab
+    ) -> None:
+        """The harness raises AssertionError when a forbidden call was made."""
+        await lab.call_tool("bernstein_status", {})
+        with pytest.raises(AssertionError, match="Expected no GET /status"):
+            lab.assert_not_called("GET", "/status")


### PR DESCRIPTION
## MCP fake lab for unit tests

---
id: "T602"
title: "MCP fake lab for unit tests"
status: open
type: feature
priority: 1
scope: small
complexity: minimal
role: qa
model: auto
effort: normal
estimated_minutes: 15
depends_on: []
blocks: []
tags: ["testing", "extensibility"]
janitor_signals: []
context_files: ["/Users/sasha/IdeaProjects/cloned/claude-code/entrypoints/sdk/coreSchemas.ts", "/Users/sasha/IdeaProjects/cloned/claude-code/cli/structuredIO.ts"]
affected_paths: ["tests/unit", "src/bernstein/plugins/manager.py", "src/bernstein/adapters/base.py", "scripts/run_tests.py"]
max_tokens: null
require_review: true
require_human_approval: false
---

## Summary

This ticket lowers the cost of extending Bernstein without letting protocols drift. The deeper audit points to contract-first development: golden transcripts, adapter conformance, replay packs, and scaffolds for new plugins and hooks.

## Objective & Definition of Done

- [ ] Build the mCP fake lab for unit tests harness, generator, or scaffold inside Bernstein's testing and extension tooling.
- [ ] Make the resulting protocol or extension seam easy to validate in isolation.
- [ ] Add self-tests proving the harness catches at least one representative regression.
- [ ] Tests added proving it works

## Verification

- Run targeted unit tests for the new harness or contract surface and keep the isolated test runner green
- Run `uv run ruff check src/` and `uv run pyright src/` on touched modules

<!-- source: p1_c0_020426_feat_mcp-fake-lab-for-unit-tests.yaml -->

**Role**: qa
**Model**: sonnet

---
*Generated by Bernstein — task `4aa9a38c4271`*