### PR TITLE
Implement Activity Summary Generator

### DIFF
--- a/src/bernstein/activity_tracker.py
+++ b/src/bernstein/activity_tracker.py
@@ -148,6 +148,21 @@ class ActivitySession:
     # Query
     # ------------------------------------------------------------------
 
+    def get_summary(self) -> str:
+        """Return a 3-5 word summary of the current activity state.
+
+        Returns:
+            A concise string: "coding in progress", "testing task completed",
+            or "idle no recent activity".
+        """
+        with self._lock:
+            if self._active_category is not None:
+                return f"{self._active_category} in progress"
+            if self._completed:
+                last = max(self._completed, key=lambda m: m.timestamp)
+                return f"{last.category} task completed"
+        return "idle no recent activity"
+
     def get_activity_summary(self, since: float = 0) -> list[ActivityMetric]:
         """Return all completed metrics since the given timestamp.
 

--- a/src/bernstein/core/bulletin.py
+++ b/src/bernstein/core/bulletin.py
@@ -392,6 +392,38 @@ class BulletinMessage:
 
 
 @dataclass
+class AgentActivitySummary:
+    """Activity summary broadcast by an agent for cross-agent visibility.
+
+    Attributes:
+        agent_id: Unique agent session identifier.
+        summary: 3-5 word description of current activity state.
+        timestamp: Unix seconds when the summary was posted.
+    """
+
+    agent_id: str
+    summary: str
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "agent_id": self.agent_id,
+            "summary": self.summary,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, object]) -> AgentActivitySummary:
+        """Deserialise from a dict."""
+        return cls(
+            agent_id=str(d.get("agent_id", "")),
+            summary=str(d.get("summary", "")),
+            timestamp=float(d.get("timestamp", 0.0) or 0.0),
+        )
+
+
+@dataclass
 class BulletinBoard:
     """Append-only message log for cross-agent communication.
 
@@ -402,6 +434,7 @@ class BulletinBoard:
     _messages: list[BulletinMessage] = field(default_factory=list)  # type: ignore[reportUnknownVariableType]
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _status_notifications: list[AgentStatusNotification] = field(default_factory=list)
+    _activity_summaries: dict[str, AgentActivitySummary] = field(default_factory=dict)
 
     def post(self, msg: BulletinMessage) -> BulletinMessage:
         """Append a message to the board.
@@ -617,3 +650,37 @@ class BulletinBoard:
             result = list(self._status_notifications)
             self._status_notifications.clear()
         return result
+
+    # -- Agent activity summaries ---------------------------------------------
+
+    def post_activity_summary(self, activity_summary: AgentActivitySummary) -> None:
+        """Record the latest activity summary for an agent.
+
+        Only the most-recent summary per agent_id is retained.
+
+        Args:
+            activity_summary: The summary to record.
+        """
+        with self._lock:
+            self._activity_summaries[activity_summary.agent_id] = activity_summary
+
+    def get_latest_activity_summary(self, agent_id: str) -> AgentActivitySummary | None:
+        """Return the latest activity summary for a specific agent.
+
+        Args:
+            agent_id: The agent whose summary to retrieve.
+
+        Returns:
+            The most recent AgentActivitySummary, or None if not found.
+        """
+        with self._lock:
+            return self._activity_summaries.get(agent_id)
+
+    def get_all_activity_summaries(self) -> dict[str, AgentActivitySummary]:
+        """Return the latest activity summary for every agent that has posted one.
+
+        Returns:
+            Mapping of agent_id -> AgentActivitySummary.
+        """
+        with self._lock:
+            return dict(self._activity_summaries)

--- a/tests/unit/test_activity_summary.py
+++ b/tests/unit/test_activity_summary.py
@@ -1,0 +1,75 @@
+"""Tests for ActivitySession.get_summary() — 3-5 word activity summaries."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from bernstein.activity_tracker import ActivitySession
+
+
+@pytest.fixture()
+def activity_dir(tmp_path: Path) -> Path:
+    return tmp_path / "metrics"
+
+
+class TestGetSummary:
+    def test_idle_with_no_metrics_returns_idle_phrase(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        summary = session.get_summary()
+        assert summary == "idle no recent activity"
+
+    def test_active_session_returns_category_in_progress(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        session.start_activity("coding", "Implement feature")
+        summary = session.get_summary()
+        assert summary == "coding in progress"
+
+    def test_active_category_reflected_correctly(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        session.start_activity("testing", "Run unit tests")
+        assert session.get_summary() == "testing in progress"
+
+    def test_completed_activity_returns_last_category_completed(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        session.start_activity("reviewing", "Code review")
+        time.sleep(0.02)
+        session.stop_activity()
+        summary = session.get_summary()
+        assert summary == "reviewing task completed"
+
+    def test_summary_reflects_most_recent_completed(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        session.start_activity("planning", "Plan sprint")
+        time.sleep(0.02)
+        session.start_activity("coding", "Write code")  # stops planning, starts coding
+        time.sleep(0.02)
+        session.stop_activity()
+        # coding was most recent completion
+        assert session.get_summary() == "coding task completed"
+
+    def test_summary_is_3_to_5_words(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        for category in ("coding", "planning", "testing", "reviewing", "waiting", "other"):
+            session.start_activity(category, "Some task")
+            time.sleep(0.02)
+            session.stop_activity()
+            words = session.get_summary().split()
+            assert 3 <= len(words) <= 5, f"Summary '{session.get_summary()}' is not 3-5 words"
+
+    def test_summary_idle_after_reset(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        session.start_activity("coding", "Some work")
+        time.sleep(0.02)
+        session.stop_activity()
+        session.reset()
+        assert session.get_summary() == "idle no recent activity"
+
+    def test_in_progress_summary_updates_on_category_change(self, activity_dir: Path) -> None:
+        session = ActivitySession(activity_dir)
+        session.start_activity("planning", "Task A")
+        assert session.get_summary() == "planning in progress"
+        session.start_activity("coding", "Task B")
+        assert session.get_summary() == "coding in progress"

--- a/tests/unit/test_bulletin_activity_summary.py
+++ b/tests/unit/test_bulletin_activity_summary.py
@@ -1,0 +1,77 @@
+"""Tests for AgentActivitySummary and BulletinBoard activity summary methods."""
+
+from __future__ import annotations
+
+import time
+
+from bernstein.core.bulletin import AgentActivitySummary, BulletinBoard
+
+
+class TestAgentActivitySummary:
+    def test_to_dict_roundtrip(self) -> None:
+        s = AgentActivitySummary(agent_id="agent-1", summary="coding in progress", timestamp=1700000000.0)
+        d = s.to_dict()
+        assert d == {"agent_id": "agent-1", "summary": "coding in progress", "timestamp": 1700000000.0}
+        restored = AgentActivitySummary.from_dict(d)
+        assert restored.agent_id == s.agent_id
+        assert restored.summary == s.summary
+        assert restored.timestamp == s.timestamp
+
+    def test_default_timestamp_is_recent(self) -> None:
+        before = time.time()
+        s = AgentActivitySummary(agent_id="a", summary="idle no recent activity")
+        after = time.time()
+        assert before <= s.timestamp <= after
+
+
+class TestBulletinBoardActivitySummaries:
+    def test_post_and_retrieve_summary(self) -> None:
+        board = BulletinBoard()
+        s = AgentActivitySummary(agent_id="agent-1", summary="coding in progress")
+        board.post_activity_summary(s)
+        result = board.get_latest_activity_summary("agent-1")
+        assert result is not None
+        assert result.agent_id == "agent-1"
+        assert result.summary == "coding in progress"
+
+    def test_returns_none_for_unknown_agent(self) -> None:
+        board = BulletinBoard()
+        assert board.get_latest_activity_summary("nonexistent") is None
+
+    def test_latest_summary_overwrites_previous(self) -> None:
+        board = BulletinBoard()
+        board.post_activity_summary(AgentActivitySummary(agent_id="a1", summary="planning in progress"))
+        board.post_activity_summary(AgentActivitySummary(agent_id="a1", summary="coding in progress"))
+        result = board.get_latest_activity_summary("a1")
+        assert result is not None
+        assert result.summary == "coding in progress"
+
+    def test_get_all_summaries_multiple_agents(self) -> None:
+        board = BulletinBoard()
+        board.post_activity_summary(AgentActivitySummary(agent_id="a1", summary="coding in progress"))
+        board.post_activity_summary(AgentActivitySummary(agent_id="a2", summary="testing task completed"))
+        all_summaries = board.get_all_activity_summaries()
+        assert set(all_summaries.keys()) == {"a1", "a2"}
+        assert all_summaries["a1"].summary == "coding in progress"
+        assert all_summaries["a2"].summary == "testing task completed"
+
+    def test_get_all_summaries_returns_copy(self) -> None:
+        board = BulletinBoard()
+        board.post_activity_summary(AgentActivitySummary(agent_id="a1", summary="coding in progress"))
+        summaries = board.get_all_activity_summaries()
+        summaries["a1"] = AgentActivitySummary(agent_id="a1", summary="mutated")
+        # Original board should be unaffected
+        assert board.get_latest_activity_summary("a1").summary == "coding in progress"  # type: ignore[union-attr]
+
+    def test_summary_includes_timestamp(self) -> None:
+        board = BulletinBoard()
+        before = time.time()
+        board.post_activity_summary(AgentActivitySummary(agent_id="a1", summary="idle no recent activity"))
+        after = time.time()
+        result = board.get_latest_activity_summary("a1")
+        assert result is not None
+        assert before <= result.timestamp <= after
+
+    def test_empty_board_returns_empty_dict(self) -> None:
+        board = BulletinBoard()
+        assert board.get_all_activity_summaries() == {}


### PR DESCRIPTION
## Implement Activity Summary Generator

Add 3-5 word activity summary generation to ActivitySession. [subtask of b50bebb97c11]

## Objective
Extend activity_tracker.py to generate concise summaries from current activity state.

## Definition of Done
- [ ] Add `get_summary()` method to ActivitySession returning 3-5 word string
- [ ] Summary accurately reflects current activity state (idle, task in progress, completed)
- [ ] Unit tests verify summary generation for different activity scenarios
- [ ] Summary format testable via `test_activity_summary.py`

**Role**: frontend
**Model**: sonnet

---
*Generated by Bernstein — task `80751167e1a2`*