### PR TITLE
Add 30s periodic activity summaries for background agents

### DIFF
--- a/src/bernstein/core/activity_summary_poller.py
+++ b/src/bernstein/core/activity_summary_poller.py
@@ -1,0 +1,125 @@
+"""Periodic activity summary broadcaster for background agents.
+
+Runs a daemon thread that every *interval* seconds reads the current
+activity state from an :class:`~bernstein.activity_tracker.ActivitySession`
+and posts an :class:`~bernstein.core.bulletin.AgentActivitySummary` to a
+:class:`~bernstein.core.bulletin.BulletinBoard`.
+
+This gives the dashboard and other agents a continuously-fresh 3-5 word
+description of what each background agent is currently doing.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.activity_tracker import ActivitySession
+    from bernstein.core.bulletin import BulletinBoard
+
+from bernstein.core.bulletin import AgentActivitySummary
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_INTERVAL = 30.0
+
+
+@dataclass
+class ActivitySummaryPoller:
+    """Publish 3-5 word activity summaries to the bulletin board every *interval* seconds.
+
+    Spawns a single daemon thread on :meth:`start`.  The thread calls
+    :meth:`poll_once` on each wake-up, then sleeps for *interval* seconds.
+    Calling :meth:`stop` signals the thread to exit gracefully.
+
+    Attributes:
+        agent_id: Identifier of the agent whose activity is tracked.
+        session: The :class:`~bernstein.activity_tracker.ActivitySession` to
+            query for the current summary text.
+        board: The :class:`~bernstein.core.bulletin.BulletinBoard` to post
+            summaries to.
+        interval: Seconds between successive polls (default: 30.0).
+    """
+
+    agent_id: str
+    session: ActivitySession
+    board: BulletinBoard
+    interval: float = _DEFAULT_INTERVAL
+
+    _stop_event: threading.Event = field(default_factory=threading.Event, init=False, repr=False)
+    _thread: threading.Thread | None = field(default=None, init=False, repr=False)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the background polling thread.
+
+        No-op if the thread is already running.
+        """
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"activity-summary-poller-{self.agent_id}",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.debug("ActivitySummaryPoller started for agent %s (interval=%.1fs)", self.agent_id, self.interval)
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Signal the polling thread to stop and wait for it to exit.
+
+        Args:
+            timeout: Maximum seconds to wait for the thread to finish.
+        """
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        logger.debug("ActivitySummaryPoller stopped for agent %s", self.agent_id)
+
+    def poll_once(self) -> AgentActivitySummary:
+        """Generate and post one activity summary now.
+
+        Reads the current summary text from the session, wraps it in an
+        :class:`~bernstein.core.bulletin.AgentActivitySummary`, posts it to
+        the board, and returns the posted object.
+
+        Returns:
+            The :class:`~bernstein.core.bulletin.AgentActivitySummary` that
+            was posted.
+        """
+        summary_text = self.session.get_summary()
+        activity_summary = AgentActivitySummary(
+            agent_id=self.agent_id,
+            summary=summary_text,
+        )
+        self.board.post_activity_summary(activity_summary)
+        logger.debug("ActivitySummaryPoller posted '%s' for agent %s", summary_text, self.agent_id)
+        return activity_summary
+
+    @property
+    def is_running(self) -> bool:
+        """Return True if the background thread is alive."""
+        return self._thread is not None and self._thread.is_alive()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _run(self) -> None:
+        """Thread entry point: poll immediately, then on each interval."""
+        while not self._stop_event.is_set():
+            try:
+                self.poll_once()
+            except Exception:
+                logger.warning("ActivitySummaryPoller poll_once failed for agent %s", self.agent_id, exc_info=True)
+            # Sleep in small increments so stop() can interrupt promptly.
+            self._stop_event.wait(timeout=self.interval)

--- a/tests/unit/test_activity_summary_poller.py
+++ b/tests/unit/test_activity_summary_poller.py
@@ -1,0 +1,137 @@
+"""Tests for ActivitySummaryPoller — periodic bulletin-board broadcasts."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from bernstein.activity_tracker import ActivitySession
+from bernstein.core.activity_summary_poller import ActivitySummaryPoller
+from bernstein.core.bulletin import BulletinBoard
+
+
+@pytest.fixture()
+def activity_dir(tmp_path: Path) -> Path:
+    return tmp_path / "metrics"
+
+
+@pytest.fixture()
+def session(activity_dir: Path) -> ActivitySession:
+    return ActivitySession(activity_dir)
+
+
+@pytest.fixture()
+def board() -> BulletinBoard:
+    return BulletinBoard()
+
+
+class TestPollOnce:
+    def test_posts_idle_summary_when_no_activity(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="agent-1", session=session, board=board)
+        poller.poll_once()
+        result = board.get_latest_activity_summary("agent-1")
+        assert result is not None
+        assert result.summary == "idle no recent activity"
+
+    def test_posts_in_progress_when_active(self, session: ActivitySession, board: BulletinBoard) -> None:
+        session.start_activity("coding", "Implement feature")
+        poller = ActivitySummaryPoller(agent_id="agent-2", session=session, board=board)
+        poller.poll_once()
+        result = board.get_latest_activity_summary("agent-2")
+        assert result is not None
+        assert result.summary == "coding in progress"
+
+    def test_posts_completed_after_stop(self, session: ActivitySession, board: BulletinBoard) -> None:
+        session.start_activity("testing", "Run tests")
+        time.sleep(0.02)
+        session.stop_activity()
+        poller = ActivitySummaryPoller(agent_id="agent-3", session=session, board=board)
+        poller.poll_once()
+        result = board.get_latest_activity_summary("agent-3")
+        assert result is not None
+        assert result.summary == "testing task completed"
+
+    def test_latest_summary_overwrites_previous(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="agent-4", session=session, board=board)
+        poller.poll_once()  # idle
+        session.start_activity("coding", "Write code")
+        poller.poll_once()  # coding in progress
+        result = board.get_latest_activity_summary("agent-4")
+        assert result is not None
+        assert result.summary == "coding in progress"
+
+    def test_returns_posted_summary(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="agent-5", session=session, board=board)
+        returned = poller.poll_once()
+        assert returned.agent_id == "agent-5"
+        assert returned.summary == "idle no recent activity"
+
+    def test_summary_has_fresh_timestamp(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="agent-6", session=session, board=board)
+        before = time.time()
+        poller.poll_once()
+        after = time.time()
+        result = board.get_latest_activity_summary("agent-6")
+        assert result is not None
+        assert before <= result.timestamp <= after
+
+
+class TestPollerThread:
+    def test_start_spawns_running_thread(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="bg-1", session=session, board=board, interval=60.0)
+        assert not poller.is_running
+        poller.start()
+        try:
+            assert poller.is_running
+        finally:
+            poller.stop()
+
+    def test_stop_terminates_thread(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="bg-2", session=session, board=board, interval=60.0)
+        poller.start()
+        poller.stop(timeout=2.0)
+        assert not poller.is_running
+
+    def test_start_is_idempotent(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="bg-3", session=session, board=board, interval=60.0)
+        poller.start()
+        poller.start()  # second call should not raise or spawn a second thread
+        try:
+            assert poller.is_running
+        finally:
+            poller.stop()
+
+    def test_periodic_poll_updates_board(self, activity_dir: Path, board: BulletinBoard) -> None:
+        """Summary reflects activity changes across polling cycles."""
+        session = ActivitySession(activity_dir)
+        poller = ActivitySummaryPoller(agent_id="bg-4", session=session, board=board, interval=0.05)
+        poller.start()
+        try:
+            # Wait for first poll (idle)
+            time.sleep(0.12)
+            result = board.get_latest_activity_summary("bg-4")
+            assert result is not None
+            assert result.summary == "idle no recent activity"
+
+            # Start an activity and wait for next poll cycle
+            session.start_activity("coding", "Some task")
+            time.sleep(0.12)
+            result = board.get_latest_activity_summary("bg-4")
+            assert result is not None
+            assert result.summary == "coding in progress"
+        finally:
+            poller.stop()
+
+    def test_summary_is_3_to_5_words_from_thread(self, session: ActivitySession, board: BulletinBoard) -> None:
+        poller = ActivitySummaryPoller(agent_id="bg-5", session=session, board=board, interval=0.05)
+        poller.start()
+        try:
+            time.sleep(0.12)
+            result = board.get_latest_activity_summary("bg-5")
+            assert result is not None
+            words = result.summary.split()
+            assert 3 <= len(words) <= 5
+        finally:
+            poller.stop()


### PR DESCRIPTION
## Add 30s periodic activity summaries for background agents

## Summary
Generate short activity descriptions for dashboard display.

## Objective & Definition of Done
- [ ] Fork agent to produce 3-5 word activity summary
- [ ] Update every 30s via periodic polling
- [ ] Test: summary updates reflect current agent activity

## Claude Code Reference
- Source: `cloned/claude-code/services/AgentSummary/agentSummary.ts`

## Verification
- All acceptance criteria met and verified via automated tests or manual inspection

<!-- source: p2_c4_030426_feat_agent-summary-periodic.yaml -->

**Role**: frontend
**Model**: sonnet

---
*Generated by Bernstein — task `379eff3bd107`*