### PR TITLE
Permission mode hierarchy

### DIFF
--- a/src/bernstein/core/janitor.py
+++ b/src/bernstein/core/janitor.py
@@ -126,6 +126,7 @@ async def run_janitor(
     *,
     server_url: str | None = None,
     guardrails_config: GuardrailsConfig | None = None,
+    permission_mode: str | None = None,
 ) -> list[JanitorResult]:
     """Evaluate tasks and return structured results.
 
@@ -143,11 +144,14 @@ async def run_janitor(
         server_url: Optional task server URL for auto-creating fix tasks.
         guardrails_config: Guardrail configuration. Defaults to GuardrailsConfig()
             (all checks enabled). Pass None to disable all guardrails.
+        permission_mode: Permission mode string (bypass/plan/auto/default).
+            When ``"bypass"``, non-immune guardrail checks are relaxed.
 
     Returns:
         List of JanitorResult for each evaluated task.
     """
     _guardrails = guardrails_config if guardrails_config is not None else GuardrailsConfig()
+    _bypass_guardrails = permission_mode == "bypass"
     results: list[JanitorResult] = []
     for task in tasks:
         if not task.completion_signals:
@@ -193,7 +197,9 @@ async def run_janitor(
 
         # Run pre-merge guardrails on the agent's diff
         diff = _get_git_diff(task, workdir)
-        guardrail_results: list[GuardrailResult] = run_guardrails(diff, task, _guardrails, workdir)
+        guardrail_results: list[GuardrailResult] = run_guardrails(
+            diff, task, _guardrails, workdir, bypass_enabled=_bypass_guardrails,
+        )
 
         # Hard-blocked guardrails (e.g. secrets detected) prevent merge
         blocked_guards = [r for r in guardrail_results if r.blocked and not r.passed]

--- a/src/bernstein/core/task_completion.py
+++ b/src/bernstein/core/task_completion.py
@@ -662,11 +662,18 @@ def process_completed_tasks(
                             risk_level=risk,
                         )
 
+                # Wire permission mode into approval bypass: BYPASS mode
+                # auto-approves so headless/CI runs are not blocked.
+                from bernstein.core.permission_mode import PermissionMode
+
+                _bypass = orch.permission_mode == PermissionMode.BYPASS
+
                 _approval_result = _approval_gate.evaluate(
                     task,
                     session_id=session.id,
                     override_mode=_override_mode,
                     timeout_s=_timeout_s,
+                    bypass_enabled=_bypass,
                 )
                 if _approval_result.rejected:
                     _skip_merge = True


### PR DESCRIPTION
## Permission mode hierarchy

## Summary

Implement a documented permission mode hierarchy (for example bypass → plan → auto → default) where each mode defines which rule severities apply, which can be relaxed, and how hooks interact, so behavior is predictable across CLI, TUI, and headless runs.

## Objective & Definition of Done

- [ ] Modes are enumerated with a single source of truth and migration path from legacy flags.
- [ ] Approval, guardrails, and orchestrator read the effective mode consistently per tick or per spawn.
- [ ] Compatibility matrix documented (mode × rule type × hook outcome).
- [ ] Tests added proving the feature works
- [ ] Documentation updated if applicable

## Verification

- Table-driven tests for each mode against representative tool calls
- Short integration-style test with orchestrator config wiring

## Audit note (2026-04-03)
PARTIAL: permission_rules.py (343 lines) implements rule-based deny/ask/allow engine.
permission_matrix.py (228 lines) implements hook-permission resolution with precedence.
Missing: documented mode hierarchy (bypass/plan/auto/default), mode-based rule severity,
single source of truth enum, and compatibility matrix documentation.

<!-- source: p0_c3_020426_feat_permission-mode-hierarchy.yaml -->

**Role**: architect
**Model**: opus

---
*Generated by Bernstein — task `4e9eccdc76ac`*