### PR TITLE
feat: add create_batch() to TaskStore

### DIFF
--- a/src/bernstein/core/task_store.py
+++ b/src/bernstein/core/task_store.py
@@ -782,6 +782,146 @@ class TaskStore:
 
         return task
 
+    async def create_batch(
+        self,
+        requests: list[TaskCreateRequest],
+        *,
+        dedup_by_title: bool = True,
+    ) -> tuple[list[Task], list[str]]:
+        """Atomically create multiple tasks, deduplicating by title.
+
+        All insertions happen under a single lock acquisition so the batch
+        is visible atomically to other callers.  Dependency validation
+        errors skip the individual task rather than aborting the batch.
+
+        Args:
+            requests: Task creation requests to process.
+            dedup_by_title: When True, skip requests whose normalised title
+                (lowered + stripped) already exists in the store or earlier
+                in the same batch.
+
+        Returns:
+            A tuple of (created_tasks, skipped_titles).
+        """
+        from bernstein.core.lifecycle import _content_hash, get_audit_log
+        from bernstein.core.models import Complexity, Scope
+
+        created_tasks: list[Task] = []
+        skipped_titles: list[str] = []
+
+        async with self._lock:
+            existing_titles: set[str] = set()
+            if dedup_by_title:
+                existing_titles = {t.title.lower().strip() for t in self._tasks.values()}
+
+            for req in requests:
+                normalised = req.title.lower().strip()
+                if dedup_by_title and normalised in existing_titles:
+                    skipped_titles.append(req.title)
+                    continue
+
+                # -- build task (mirrors create() logic) --
+                batch_eligible: bool = getattr(req, "batch_eligible", False)
+                complexity_val = Complexity(req.complexity)
+                if not batch_eligible and req.priority != 1:
+                    from bernstein.core.fast_path import TaskLevel, classify_task
+
+                    _probe = Task(
+                        id="__probe__",
+                        title=req.title,
+                        description=req.description,
+                        role=req.role,
+                        priority=req.priority,
+                        scope=Scope(req.scope),
+                        complexity=complexity_val,
+                        model=req.model,
+                    )
+                    _cls = classify_task(_probe)
+                    batch_eligible = _cls.level in (TaskLevel.L0, TaskLevel.L1)
+
+                task = Task(
+                    id=uuid.uuid4().hex[:12],
+                    title=req.title,
+                    description=req.description,
+                    role=req.role,
+                    priority=req.priority,
+                    scope=Scope(req.scope),
+                    complexity=complexity_val,
+                    estimated_minutes=req.estimated_minutes,
+                    depends_on=req.depends_on,
+                    parent_task_id=getattr(req, "parent_task_id", None),
+                    owned_files=req.owned_files,
+                    tenant_id=normalize_tenant_id(getattr(req, "tenant_id", "default")),
+                    cell_id=req.cell_id,
+                    repo=getattr(req, "repo", None),
+                    depends_on_repo=getattr(req, "depends_on_repo", None),
+                    task_type=TaskType(req.task_type),
+                    upgrade_details=_parse_upgrade_dict(req.upgrade_details),
+                    model=req.model,
+                    effort=req.effort,
+                    batch_eligible=batch_eligible,
+                    eu_ai_act_risk=getattr(req, "eu_ai_act_risk", "minimal"),
+                    approval_required=bool(getattr(req, "approval_required", False)),
+                    risk_level=getattr(req, "risk_level", "low"),
+                    completion_signals=[CompletionSignal(type=s.type, value=s.value) for s in req.completion_signals],
+                    slack_context=req.slack_context,
+                    metadata=getattr(req, "metadata", None) or {},
+                    parent_session_id=getattr(req, "parent_session_id", None),
+                )
+
+                # -- dependency validation (skip on error, don't abort batch) --
+                if task.depends_on:
+                    missing = [dep for dep in task.depends_on if dep not in self._tasks]
+                    if missing:
+                        logger.warning(
+                            "create_batch: skipping %r — depends_on references non-existent task(s): %s",
+                            task.title,
+                            ", ".join(missing),
+                        )
+                        skipped_titles.append(req.title)
+                        continue
+                    cycle = self._detect_cycle(self._tasks, task)
+                    if cycle is not None:
+                        logger.warning(
+                            "create_batch: skipping %r — circular dependency: %s",
+                            task.title,
+                            " -> ".join(cycle),
+                        )
+                        skipped_titles.append(req.title)
+                        continue
+
+                self._tasks[task.id] = task
+                self._index_add(task)
+                await self._append_jsonl(self._task_to_record(task))
+
+                if dedup_by_title:
+                    existing_titles.add(normalised)
+
+                created_tasks.append(task)
+
+        # Fire audit log entries outside the lock (non-critical I/O)
+        audit = get_audit_log()
+        if audit is not None:
+            for task in created_tasks:
+                input_data = {"title": task.title, "role": task.role, "priority": task.priority}
+                output_data = {"task_id": task.id, "status": task.status.value}
+                audit.log(
+                    event_type="task.created",
+                    actor="task_store",
+                    resource_type="task",
+                    resource_id=task.id,
+                    details={
+                        "action": "create_batch",
+                        "title": task.title,
+                        "role": task.role,
+                        "priority": task.priority,
+                        "input_hash": _content_hash(input_data),
+                        "output_hash": _content_hash(output_data),
+                    },
+                )
+
+        return created_tasks, skipped_titles
+
     async def claim_next(
         self,
         role: str,

--- a/tests/unit/test_task_store_batch.py
+++ b/tests/unit/test_task_store_batch.py
@@ -1,0 +1,151 @@
+"""Tests for TaskStore.create_batch() atomic batch creation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from bernstein.core.models import TaskStatus
+from bernstein.core.task_store import TaskStore
+
+
+def _task_request(
+    *,
+    title: str = "Implement parser",
+    description: str = "Write the parser module.",
+    role: str = "backend",
+    priority: int = 2,
+    scope: str = "medium",
+    complexity: str = "medium",
+    depends_on: list[str] | None = None,
+) -> Any:
+    """Build a create-task request with attributes TaskStore expects."""
+    return SimpleNamespace(
+        title=title,
+        description=description,
+        role=role,
+        priority=priority,
+        scope=scope,
+        complexity=complexity,
+        estimated_minutes=30,
+        depends_on=depends_on or [],
+        parent_task_id=None,
+        depends_on_repo=None,
+        owned_files=[],
+        tenant_id="default",
+        cell_id=None,
+        repo=None,
+        task_type="standard",
+        upgrade_details=None,
+        model=None,
+        effort=None,
+        batch_eligible=False,
+        eu_ai_act_risk="minimal",
+        approval_required=False,
+        risk_level="low",
+        completion_signals=[],
+        slack_context=None,
+        parent_session_id=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_create_batch_creates_all_tasks(tmp_path: Path) -> None:
+    """All three requests should be created when titles are unique."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    reqs = [
+        _task_request(title="Task A"),
+        _task_request(title="Task B"),
+        _task_request(title="Task C"),
+    ]
+    created, skipped = await store.create_batch(reqs)
+
+    assert len(created) == 3
+    assert len(skipped) == 0
+    assert {t.title for t in created} == {"Task A", "Task B", "Task C"}
+    for task in created:
+        assert task.status == TaskStatus.OPEN
+        assert store.get_task(task.id) is not None
+
+
+@pytest.mark.anyio
+async def test_create_batch_skips_duplicate_titles(tmp_path: Path) -> None:
+    """When two requests share a title the second is skipped."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    reqs = [
+        _task_request(title="Same title"),
+        _task_request(title="Same title"),
+    ]
+    created, skipped = await store.create_batch(reqs)
+
+    assert len(created) == 1
+    assert created[0].title == "Same title"
+    assert skipped == ["Same title"]
+
+
+@pytest.mark.anyio
+async def test_create_batch_skips_titles_matching_existing(tmp_path: Path) -> None:
+    """A batch request whose title already exists in the store is skipped."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    await store.create(_task_request(title="Existing task"))
+
+    reqs = [
+        _task_request(title="Existing task"),
+        _task_request(title="New task"),
+    ]
+    created, skipped = await store.create_batch(reqs)
+
+    assert len(created) == 1
+    assert created[0].title == "New task"
+    assert skipped == ["Existing task"]
+
+
+@pytest.mark.anyio
+async def test_create_batch_atomicity_under_lock(tmp_path: Path) -> None:
+    """All tasks from the batch appear in the store after the call."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    reqs = [_task_request(title=f"Batch task {i}") for i in range(5)]
+    created, skipped = await store.create_batch(reqs)
+
+    assert len(created) == 5
+    assert len(skipped) == 0
+    all_tasks = store.list_tasks()
+    assert len(all_tasks) == 5
+    stored_ids = {t.id for t in all_tasks}
+    for task in created:
+        assert task.id in stored_ids
+
+
+@pytest.mark.anyio
+async def test_create_batch_empty_list(tmp_path: Path) -> None:
+    """An empty request list returns empty results."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    created, skipped = await store.create_batch([])
+
+    assert created == []
+    assert skipped == []
+
+
+@pytest.mark.anyio
+async def test_create_batch_dedup_within_batch(tmp_path: Path) -> None:
+    """Three tasks where two share a title: only the first duplicate is created."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+
+    reqs = [
+        _task_request(title="Unique task"),
+        _task_request(title="Duplicate title"),
+        _task_request(title="Duplicate title"),
+    ]
+    created, skipped = await store.create_batch(reqs)
+
+    assert len(created) == 2
+    assert {t.title for t in created} == {"Unique task", "Duplicate title"}
+    assert skipped == ["Duplicate title"]


### PR DESCRIPTION
## Summary
- Add `create_batch()` method to `TaskStore` for atomic multi-task creation under a single lock acquisition
- Supports title-based deduplication (both against existing tasks and within the batch itself)
- Gracefully skips tasks with dependency errors instead of aborting the entire batch
- Fires SOC 2 audit log entries for each created task

## Test plan
- [x] `test_create_batch_creates_all_tasks` -- 3 unique requests all succeed
- [x] `test_create_batch_skips_duplicate_titles` -- 2 same-title requests, second skipped
- [x] `test_create_batch_skips_titles_matching_existing` -- pre-existing title is skipped
- [x] `test_create_batch_atomicity_under_lock` -- all 5 tasks visible in store
- [x] `test_create_batch_empty_list` -- empty input returns empty results
- [x] `test_create_batch_dedup_within_batch` -- 3 tasks, 2 share title, only first created
- [x] All existing `test_task_store*` tests still pass (18 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)