### PR TITLE
feat: make backlog ingestion atomic with batch POST

### DIFF
--- a/src/bernstein/core/orchestrator.py
+++ b/src/bernstein/core/orchestrator.py
@@ -141,6 +141,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from bernstein.core.backlog_parser import ParsedBacklogTask
     from bernstein.core.container import ContainerConfig
     from bernstein.core.permission_mode import PermissionMode
     from bernstein.core.quality_gates import QualityGatesConfig
@@ -3151,44 +3152,93 @@ class Orchestrator:
         existing_titles = self._ingested_titles
 
         claimed_dir.mkdir(parents=True, exist_ok=True)
-        count = 0
+
+        from bernstein.core.backlog_parser import parse_backlog_text
+
+        # Phase 1: Collect — parse files, pre-filter known dupes, build batch
+        batch_files: list[tuple[Path, ParsedBacklogTask]] = []
         for backlog_file in backlog_files:
-            if count >= _MAX_INGEST_PER_TICK:
+            if len(batch_files) >= _MAX_INGEST_PER_TICK:
                 break
 
             if (claimed_dir / backlog_file.name).exists():
                 continue
 
             content = backlog_file.read_text(encoding="utf-8")
-            from bernstein.core.backlog_parser import parse_backlog_text
-
             parsed_task = parse_backlog_text(backlog_file.name, content)
             if parsed_task is None:
                 logger.warning("ingest_backlog: could not parse %s — skipping", backlog_file.name)
-                # Move unparseable files to claimed/ so we don't retry every tick
                 backlog_file.rename(claimed_dir / backlog_file.name)
                 continue
-            payload = parsed_task.to_task_payload()
 
-            # Dedup: skip if title already exists on server
-            title_key = str(payload.get("title", "")).lower().strip()
+            title_key = parsed_task.title.lower().strip()
             if title_key in existing_titles:
-                # Move to claimed/ without POSTing — task already exists
                 backlog_file.rename(claimed_dir / backlog_file.name)
                 continue
 
-            try:
-                resp = self._client.post(f"{self._config.server_url}/tasks", json=payload)
-                resp.raise_for_status()
-            except httpx.HTTPError as exc:
-                logger.warning("ingest_backlog: POST /tasks failed for %s: %s", backlog_file.name, exc)
-                continue
+            batch_files.append((backlog_file, parsed_task))
 
+        if not batch_files:
+            return 0
+
+        # Phase 2: POST batch — single HTTP call for all collected tasks
+        payloads = [parsed.to_task_payload() for _, parsed in batch_files]
+        try:
+            resp = self._client.post(
+                f"{self._config.server_url}/tasks/batch",
+                json={"tasks": payloads},
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                # Server doesn't support batch yet — fall back to one-by-one
+                return self._ingest_backlog_one_by_one(batch_files, claimed_dir)
+            logger.warning("ingest_backlog: batch POST failed: %s", exc)
+            return 0  # Move NONE on failure
+        except httpx.HTTPError as exc:
+            logger.warning("ingest_backlog: batch POST failed: %s", exc)
+            return 0
+
+        # Phase 3: Move ALL files — only on success
+        count = 0
+        for backlog_file, parsed in batch_files:
+            title_key = parsed.title.lower().strip()
             existing_titles.add(title_key)
-            backlog_file.rename(claimed_dir / backlog_file.name)
+            with contextlib.suppress(OSError):
+                backlog_file.rename(claimed_dir / backlog_file.name)
             count += 1
             logger.info("Ingested backlog file: %s", backlog_file.name)
 
+        return count
+
+    def _ingest_backlog_one_by_one(
+        self,
+        batch_files: list[tuple[Path, ParsedBacklogTask]],
+        claimed_dir: Path,
+    ) -> int:
+        """Fallback: ingest files one-by-one when server lacks batch endpoint."""
+        count = 0
+        for backlog_file, parsed in batch_files:
+            payload = parsed.to_task_payload()
+            try:
+                resp = self._client.post(
+                    f"{self._config.server_url}/tasks",
+                    json=payload,
+                )
+                resp.raise_for_status()
+            except httpx.HTTPError as exc:
+                logger.warning(
+                    "ingest_backlog: POST failed for %s: %s",
+                    backlog_file.name,
+                    exc,
+                )
+                continue  # Skip this file, try next
+
+            self._ingested_titles.add(parsed.title.lower().strip())
+            with contextlib.suppress(OSError):
+                backlog_file.rename(claimed_dir / backlog_file.name)
+            count += 1
+            logger.info("Ingested backlog file (one-by-one): %s", backlog_file.name)
         return count
 
     @staticmethod

--- a/tests/unit/test_orchestrator_batch_ingest.py
+++ b/tests/unit/test_orchestrator_batch_ingest.py
@@ -1,0 +1,273 @@
+"""Tests for atomic batch ingestion in Orchestrator.ingest_backlog().
+
+Covers the 3-phase batch pattern: collect, POST /tasks/batch, move files.
+All HTTP communication is mocked via httpx.MockTransport.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from bernstein.core.models import OrchestratorConfig
+from bernstein.core.orchestrator import Orchestrator
+from bernstein.core.spawner import AgentSpawner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_adapter() -> Any:
+    """Minimal mock adapter that satisfies AgentSpawner."""
+    from unittest.mock import MagicMock
+
+    from bernstein.adapters.base import CLIAdapter
+
+    adapter = MagicMock(spec=CLIAdapter)
+    adapter.name.return_value = "mock"
+    return adapter
+
+
+def _build_orchestrator(
+    tmp_path: Path,
+    transport: httpx.MockTransport,
+) -> Orchestrator:
+    """Build an Orchestrator with a mock HTTP transport."""
+    cfg = OrchestratorConfig(
+        max_agents=6,
+        poll_interval_s=1,
+        heartbeat_timeout_s=120,
+        max_tasks_per_agent=3,
+        server_url="http://testserver",
+    )
+    adapter = _mock_adapter()
+    templates_dir = tmp_path / "templates" / "roles"
+    templates_dir.mkdir(parents=True)
+    spawner = AgentSpawner(adapter, templates_dir, tmp_path)
+    client = httpx.Client(transport=transport, base_url="http://testserver")
+    return Orchestrator(cfg, spawner, tmp_path, client=client)
+
+
+def _write_backlog_files(
+    open_dir: Path,
+    count: int,
+    *,
+    prefix: str = "task",
+) -> list[Path]:
+    """Write N valid markdown backlog files into *open_dir*."""
+    files: list[Path] = []
+    for i in range(count):
+        p = open_dir / f"{prefix}-{i:03d}.md"
+        p.write_text(
+            f"# {prefix.title()} {i}\n\n"
+            f"**Role:** backend\n"
+            f"**Priority:** 2\n"
+            f"**Scope:** medium\n"
+            f"**Complexity:** low\n\n"
+            f"Description for {prefix} {i}.\n",
+            encoding="utf-8",
+        )
+        files.append(p)
+    return files
+
+
+def _setup_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    """Create .sdd/backlog/open and .sdd/backlog/claimed directories."""
+    open_dir = tmp_path / ".sdd" / "backlog" / "open"
+    open_dir.mkdir(parents=True)
+    claimed_dir = tmp_path / ".sdd" / "backlog" / "claimed"
+    claimed_dir.mkdir(parents=True)
+    return open_dir, claimed_dir
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBatchIngestPostsAllAtOnce:
+    """5 files should produce a single POST to /tasks/batch."""
+
+    def test_single_batch_post(self, tmp_path: Path) -> None:
+        open_dir, claimed_dir = _setup_dirs(tmp_path)
+        _write_backlog_files(open_dir, 5)
+
+        requests_log: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests_log.append(request)
+            if request.method == "GET" and request.url.path == "/tasks":
+                return httpx.Response(200, json=[])
+            if request.method == "POST" and request.url.path == "/tasks/batch":
+                body = json.loads(request.content)
+                assert len(body["tasks"]) == 5
+                return httpx.Response(200, json={"created": 5})
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        orch = _build_orchestrator(tmp_path, transport)
+        count = orch.ingest_backlog()
+
+        assert count == 5
+        batch_posts = [r for r in requests_log if r.url.path == "/tasks/batch"]
+        assert len(batch_posts) == 1
+
+
+class TestBatchIngestMovesAllOnSuccess:
+    """All files should move to claimed/ after a successful batch POST."""
+
+    def test_files_moved(self, tmp_path: Path) -> None:
+        open_dir, claimed_dir = _setup_dirs(tmp_path)
+        files = _write_backlog_files(open_dir, 3)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                return httpx.Response(200, json=[])
+            if request.method == "POST" and request.url.path == "/tasks/batch":
+                return httpx.Response(200, json={"created": 3})
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        orch = _build_orchestrator(tmp_path, transport)
+        count = orch.ingest_backlog()
+
+        assert count == 3
+        # All originals gone from open/
+        for f in files:
+            assert not f.exists(), f"{f.name} should have been moved"
+        # All present in claimed/
+        claimed_names = {p.name for p in claimed_dir.iterdir()}
+        for f in files:
+            assert f.name in claimed_names
+
+
+class TestBatchIngestMovesNoneOnFailure:
+    """If the batch POST returns 500, NO files should move."""
+
+    def test_no_files_moved_on_500(self, tmp_path: Path) -> None:
+        open_dir, claimed_dir = _setup_dirs(tmp_path)
+        files = _write_backlog_files(open_dir, 4)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                return httpx.Response(200, json=[])
+            if request.method == "POST" and request.url.path == "/tasks/batch":
+                return httpx.Response(500, json={"error": "internal"})
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        orch = _build_orchestrator(tmp_path, transport)
+        count = orch.ingest_backlog()
+
+        assert count == 0
+        # All files should still be in open/
+        for f in files:
+            assert f.exists(), f"{f.name} should NOT have been moved"
+        # Nothing in claimed/
+        assert list(claimed_dir.iterdir()) == []
+
+
+class TestBatchIngestFallbackOn404:
+    """If the batch endpoint returns 404, fall back to one-by-one POSTs."""
+
+    def test_fallback_to_individual_posts(self, tmp_path: Path) -> None:
+        open_dir, claimed_dir = _setup_dirs(tmp_path)
+        files = _write_backlog_files(open_dir, 3)
+
+        individual_posts: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                return httpx.Response(200, json=[])
+            if request.method == "POST" and request.url.path == "/tasks/batch":
+                return httpx.Response(404, json={"error": "not found"})
+            if request.method == "POST" and request.url.path == "/tasks":
+                individual_posts.append(request)
+                return httpx.Response(200, json={"id": "new", "status": "open"})
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        orch = _build_orchestrator(tmp_path, transport)
+        count = orch.ingest_backlog()
+
+        assert count == 3
+        assert len(individual_posts) == 3
+        # All files should be moved to claimed/
+        for f in files:
+            assert not f.exists()
+
+
+class TestBatchIngestSkipsUnparseable:
+    """Unparseable files should be moved to claimed/ individually."""
+
+    def test_bad_files_moved(self, tmp_path: Path) -> None:
+        open_dir, claimed_dir = _setup_dirs(tmp_path)
+
+        # Write 2 valid + 1 unparseable file
+        _write_backlog_files(open_dir, 2, prefix="good")
+        bad_file = open_dir / "garbage.md"
+        bad_file.write_text("", encoding="utf-8")  # empty = unparseable
+
+        batch_payloads: list[Any] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                return httpx.Response(200, json=[])
+            if request.method == "POST" and request.url.path == "/tasks/batch":
+                body = json.loads(request.content)
+                batch_payloads.append(body)
+                return httpx.Response(200, json={"created": len(body["tasks"])})
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        orch = _build_orchestrator(tmp_path, transport)
+        count = orch.ingest_backlog()
+
+        # Only 2 valid files should have been batch-posted
+        assert count == 2
+        assert len(batch_payloads) == 1
+        assert len(batch_payloads[0]["tasks"]) == 2
+
+        # Bad file should be in claimed/
+        assert not bad_file.exists()
+        assert (claimed_dir / "garbage.md").exists()
+
+
+class TestBatchIngestSkipsKnownTitles:
+    """Files with titles already in _ingested_titles should be skipped."""
+
+    def test_known_titles_skipped(self, tmp_path: Path) -> None:
+        open_dir, claimed_dir = _setup_dirs(tmp_path)
+
+        # Write 3 files; pre-populate _ingested_titles with title of first one
+        files = _write_backlog_files(open_dir, 3, prefix="task")
+
+        batch_payloads: list[Any] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.method == "GET" and request.url.path == "/tasks":
+                # Return one task whose title matches "Task 0"
+                return httpx.Response(200, json=[{"title": "Task 0"}])
+            if request.method == "POST" and request.url.path == "/tasks/batch":
+                body = json.loads(request.content)
+                batch_payloads.append(body)
+                return httpx.Response(200, json={"created": len(body["tasks"])})
+            return httpx.Response(200, json={})
+
+        transport = httpx.MockTransport(handler)
+        orch = _build_orchestrator(tmp_path, transport)
+        count = orch.ingest_backlog()
+
+        # Task 0 should be skipped (known title), only 2 posted
+        assert count == 2
+        assert len(batch_payloads) == 1
+        assert len(batch_payloads[0]["tasks"]) == 2
+
+        # The skipped file (task-000) should be in claimed/ (dedup move)
+        assert not files[0].exists()
+        assert (claimed_dir / files[0].name).exists()


### PR DESCRIPTION
## Summary
- Rewrites `ingest_backlog()` to use a 3-phase collect/POST/move pattern instead of one-by-one processing
- Phase 1 collects up to 10 parseable, non-duplicate files into a batch
- Phase 2 POSTs all tasks in a single call to `/tasks/batch`; if server returns 404, falls back to one-by-one via `_ingest_backlog_one_by_one()`
- Phase 3 moves ALL files to `claimed/` only after a successful POST -- if the POST fails (500, network error), no files move

## Test plan
- [x] `test_ingest_backlog_batch_posts_all_at_once` -- 5 files produce a single POST to /tasks/batch
- [x] `test_ingest_backlog_batch_moves_all_on_success` -- all files moved to claimed/ after success
- [x] `test_ingest_backlog_batch_moves_none_on_failure` -- POST returns 500, no files move
- [x] `test_ingest_backlog_batch_fallback_on_404` -- POST returns 404, falls back to individual POSTs
- [x] `test_ingest_backlog_batch_skips_unparseable` -- bad files moved individually during collect phase
- [x] `test_ingest_backlog_batch_skips_known_titles` -- pre-populated _ingested_titles cause dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)