### PR TITLE
feat: batch backlog sync for atomic task creation

### DIFF
--- a/src/bernstein/core/sync.py
+++ b/src/bernstein/core/sync.py
@@ -189,6 +189,64 @@ def _build_existing_slugs(client: httpx.Client, server_url: str) -> set[str]:
 
 
 # ---------------------------------------------------------------------------
+# Payload & fallback helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_task_payload(task: BacklogTask) -> dict[str, Any]:
+    """Build the JSON payload for creating a single task on the server.
+
+    Embeds the source filename in the description for traceability.
+
+    Args:
+        task: Parsed backlog task.
+
+    Returns:
+        Dict suitable for ``POST /tasks`` or inclusion in a batch.
+    """
+    description = task.description
+    if f"source: {task.source_file}" not in description:
+        description = description + f"\n\n<!-- source: {task.source_file} -->"
+
+    return {
+        "title": task.title,
+        "description": description,
+        "role": task.role,
+        "priority": task.priority,
+        "scope": task.scope,
+        "complexity": task.complexity,
+        "approval_required": task.approval_required,
+    }
+
+
+def _sync_one_by_one(
+    payloads: list[dict[str, Any]],
+    files: list[Path],
+    client: httpx.Client,
+    server_url: str,
+    result: SyncResult,
+) -> None:
+    """Create tasks one-by-one (fallback when ``/tasks/batch`` is unavailable).
+
+    Args:
+        payloads: Pre-built task payloads.
+        files: Corresponding backlog file paths (same order as *payloads*).
+        client: httpx client.
+        server_url: Base URL of the task server.
+        result: SyncResult to populate with created IDs or errors.
+    """
+    for payload, md_file in zip(payloads, files, strict=True):
+        try:
+            resp = client.post(f"{server_url}/tasks", json=payload)
+            resp.raise_for_status()
+            task_id: str = resp.json().get("id", "unknown")
+            result.created.append(task_id)
+            logger.info("Created task %s from %s", task_id, md_file.name)
+        except httpx.HTTPError as exc:
+            result.errors.append(f"Failed to create task from {md_file.name}: {exc}")
+
+
+# ---------------------------------------------------------------------------
 # SyncResult
 # ---------------------------------------------------------------------------
 
@@ -261,7 +319,10 @@ def sync_backlog_to_server(
 
         md_files = sorted([*backlog_open.glob("*.yaml"), *backlog_open.glob("*.md")])
 
-        # --- Step 1: create new tasks ---
+        # --- Step 1: create new tasks (batched) ---
+        batch_payloads: list[dict[str, Any]] = []
+        batch_files: list[Path] = []
+
         for md_file in md_files:
             task = parse_backlog_file(md_file)
             if task is None:
@@ -273,30 +334,41 @@ def sync_backlog_to_server(
                 logger.debug("Skipping %s — task already on server", md_file.name)
                 continue
 
-            # Embed source filename in description so it can be traced back
-            description = task.description
-            if f"source: {task.source_file}" not in description:
-                description = description + f"\n\n<!-- source: {task.source_file} -->"
+            payload = _build_task_payload(task)
+            batch_payloads.append(payload)
+            batch_files.append(md_file)
+            # Track slug immediately so later files in the same batch
+            # with an identical title are deduplicated before sending.
+            existing_slugs.add(normalise_title(task.title))
 
-            payload: dict[str, Any] = {
-                "title": task.title,
-                "description": description,
-                "role": task.role,
-                "priority": task.priority,
-                "scope": task.scope,
-                "complexity": task.complexity,
-                "approval_required": task.approval_required,
-            }
+        if batch_payloads:
             try:
-                resp = _client.post(f"{server_url}/tasks", json=payload)
+                resp = _client.post(
+                    f"{server_url}/tasks/batch",
+                    json={"tasks": batch_payloads},
+                )
                 resp.raise_for_status()
-                task_id: str = resp.json().get("id", "unknown")
-                result.created.append(task_id)
-                # Add to slugs so subsequent files don't create duplicates
-                existing_slugs.add(normalise_title(task.title))
-                logger.info("Created task %s from %s", task_id, md_file.name)
+                data: dict[str, Any] = resp.json()
+                for created_task in data.get("created", []):
+                    task_id: str = created_task.get("id", "unknown")
+                    result.created.append(task_id)
+                    logger.info("Batch-created task %s", task_id)
+                for title in data.get("skipped_titles", []):
+                    result.skipped.append(title)
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    # Server doesn't support batch — fall back to one-by-one
+                    _sync_one_by_one(
+                        batch_payloads,
+                        batch_files,
+                        _client,
+                        server_url,
+                        result,
+                    )
+                else:
+                    result.errors.append(f"Batch create failed: {exc}")
             except httpx.HTTPError as exc:
-                result.errors.append(f"Failed to create task from {md_file.name}: {exc}")
+                result.errors.append(f"Batch create failed: {exc}")
 
         # --- Step 2: move files for completed tasks ---
         done_slugs: set[str] = {

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -448,6 +448,8 @@ class TestSyncBacklogToServer:
             key = f"{request.method} {url.path}"
             if url.query:
                 key += f"?{url.query.decode()}"
+            if request.method == "POST" and url.path == "/tasks/batch":
+                return httpx.Response(404, json={"detail": "not found"})
             if request.method == "POST" and url.path == "/tasks":
                 captured_payloads.append(json.loads(request.content))
                 return httpx.Response(201, json={"id": "T-001", "status": "open"})

--- a/tests/unit/test_sync_batch.py
+++ b/tests/unit/test_sync_batch.py
@@ -1,0 +1,241 @@
+"""Tests for batch sync in sync_backlog_to_server().
+
+Validates that Step 1 (task creation) uses the ``POST /tasks/batch``
+endpoint, falls back to one-by-one on 404, and handles errors correctly.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import httpx
+
+from bernstein.core.sync import SyncResult, sync_backlog_to_server
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_MD_A = """\
+# Task Alpha
+
+**Role:** backend
+**Priority:** 2 (normal)
+**Scope:** medium
+**Complexity:** medium
+
+Alpha description.
+"""
+
+SAMPLE_MD_B = """\
+# Task Beta
+
+**Role:** frontend
+**Priority:** 1 (critical)
+**Scope:** small
+**Complexity:** low
+
+Beta description.
+"""
+
+SAMPLE_MD_C = """\
+# Task Gamma
+
+**Role:** qa
+**Priority:** 3 (nice-to-have)
+**Scope:** large
+**Complexity:** high
+
+Gamma description.
+"""
+
+_Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _write_md(path: Path, content: str) -> None:
+    """Write content to *path*, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _status_responses() -> dict[str, httpx.Response]:
+    """Standard empty-server responses for all status queries."""
+    return {
+        "GET /tasks?status=open": httpx.Response(200, json=[]),
+        "GET /tasks?status=claimed": httpx.Response(200, json=[]),
+        "GET /tasks?status=in_progress": httpx.Response(200, json=[]),
+        "GET /tasks?status=done": httpx.Response(200, json=[]),
+        "GET /tasks?status=failed": httpx.Response(200, json=[]),
+        "GET /tasks?status=closed": httpx.Response(200, json=[]),
+    }
+
+
+def _make_handler(
+    post_hook: _Handler | None = None,
+    *,
+    extra_status: dict[str, httpx.Response] | None = None,
+) -> _Handler:
+    """Build a mock handler with standard status responses and optional POST hook.
+
+    Args:
+        post_hook: If set, called for every POST request. Return a response
+            to handle it, or ``None`` to fall through to the default 404.
+        extra_status: Additional or overridden status-query responses merged
+            on top of the empty-server defaults.
+    """
+    responses = _status_responses()
+    if extra_status:
+        responses.update(extra_status)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        url = request.url
+        key = f"{request.method} {url.path}"
+        if url.query:
+            key += f"?{url.query.decode()}"
+
+        if request.method == "POST" and post_hook is not None:
+            result = post_hook(request)
+            if result is not None:
+                return result
+
+        resp = responses.get(key)
+        if resp is not None:
+            return resp
+        return httpx.Response(404, json={"detail": f"No mock for {key}"})
+
+    return handler
+
+
+def _sync(tmp_path: Path, handler: _Handler) -> SyncResult:
+    """Run sync_backlog_to_server with the given mock handler."""
+    client = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+    return sync_backlog_to_server(tmp_path, "http://test", client=client)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_batch_creates_all_tasks(tmp_path: Path) -> None:
+    """Batch endpoint returns 3 created tasks; result.created has 3 IDs."""
+    backlog_open = tmp_path / ".sdd" / "backlog" / "open"
+    _write_md(backlog_open / "001-alpha.md", SAMPLE_MD_A)
+    _write_md(backlog_open / "002-beta.md", SAMPLE_MD_B)
+    _write_md(backlog_open / "003-gamma.md", SAMPLE_MD_C)
+
+    captured_batch: list[dict[str, object]] = []
+
+    def post_hook(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/tasks/batch":
+            body = json.loads(request.content)
+            captured_batch.append(body)
+            created = [{"id": f"T-{i + 1:03d}", "title": t["title"]} for i, t in enumerate(body["tasks"])]
+            return httpx.Response(201, json={"created": created, "skipped_titles": []})
+        return httpx.Response(404, json={"detail": "no mock"})
+
+    result = _sync(tmp_path, _make_handler(post_hook))
+
+    assert len(result.created) == 3
+    assert result.created == ["T-001", "T-002", "T-003"]
+    assert result.errors == []
+    assert len(captured_batch) == 1
+    assert len(captured_batch[0]["tasks"]) == 3
+
+
+def test_sync_batch_skips_duplicates(tmp_path: Path) -> None:
+    """Files whose titles already exist on the server are skipped pre-batch."""
+    backlog_open = tmp_path / ".sdd" / "backlog" / "open"
+    _write_md(backlog_open / "001-alpha.md", SAMPLE_MD_A)
+    _write_md(backlog_open / "002-beta.md", SAMPLE_MD_B)
+
+    existing_task = {"id": "T-existing", "title": "Task Alpha", "status": "open"}
+    captured_batch: list[dict[str, object]] = []
+
+    def post_hook(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/tasks/batch":
+            body = json.loads(request.content)
+            captured_batch.append(body)
+            created = [{"id": "T-new-1", "title": body["tasks"][0]["title"]}]
+            return httpx.Response(201, json={"created": created, "skipped_titles": []})
+        return httpx.Response(404, json={"detail": "no mock"})
+
+    result = _sync(
+        tmp_path,
+        _make_handler(
+            post_hook,
+            extra_status={
+                "GET /tasks?status=open": httpx.Response(200, json=[existing_task]),
+            },
+        ),
+    )
+
+    assert "001-alpha.md" in result.skipped
+    assert len(result.created) == 1
+    assert len(captured_batch) == 1
+    assert len(captured_batch[0]["tasks"]) == 1
+    assert captured_batch[0]["tasks"][0]["title"] == "Task Beta"
+
+
+def test_sync_batch_fallback_on_404(tmp_path: Path) -> None:
+    """When /tasks/batch returns 404, fallback creates tasks one-by-one."""
+    backlog_open = tmp_path / ".sdd" / "backlog" / "open"
+    _write_md(backlog_open / "001-alpha.md", SAMPLE_MD_A)
+    _write_md(backlog_open / "002-beta.md", SAMPLE_MD_B)
+
+    individual_posts: list[dict[str, object]] = []
+
+    def post_hook(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/tasks/batch":
+            return httpx.Response(404, json={"detail": "not found"})
+        if request.url.path == "/tasks":
+            body = json.loads(request.content)
+            individual_posts.append(body)
+            task_id = f"T-{len(individual_posts):03d}"
+            return httpx.Response(201, json={"id": task_id, "status": "open"})
+        return httpx.Response(404, json={"detail": "no mock"})
+
+    result = _sync(tmp_path, _make_handler(post_hook))
+
+    assert len(result.created) == 2
+    assert result.errors == []
+    assert len(individual_posts) == 2
+
+
+def test_sync_batch_records_errors_on_failure(tmp_path: Path) -> None:
+    """A 500 from /tasks/batch records an error without creating any tasks."""
+    backlog_open = tmp_path / ".sdd" / "backlog" / "open"
+    _write_md(backlog_open / "001-alpha.md", SAMPLE_MD_A)
+
+    def post_hook(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/tasks/batch":
+            return httpx.Response(500, json={"detail": "internal error"})
+        return httpx.Response(404, json={"detail": "no mock"})
+
+    result = _sync(tmp_path, _make_handler(post_hook))
+
+    assert result.created == []
+    assert len(result.errors) == 1
+    assert "Batch create failed" in result.errors[0]
+
+
+def test_sync_batch_handles_empty_backlog(tmp_path: Path) -> None:
+    """No files in open/ means no HTTP calls to /tasks or /tasks/batch."""
+    backlog_open = tmp_path / ".sdd" / "backlog" / "open"
+    backlog_open.mkdir(parents=True)
+
+    post_calls: list[str] = []
+
+    def post_hook(request: httpx.Request) -> httpx.Response:
+        post_calls.append(request.url.path)
+        return httpx.Response(404, json={"detail": "no mock"})
+
+    result = _sync(tmp_path, _make_handler(post_hook))
+
+    assert result == SyncResult()
+    assert post_calls == []


### PR DESCRIPTION
## Summary
- Rewrote `sync_backlog_to_server()` Step 1 to POST all new tasks as a single batch via `POST /tasks/batch` instead of one-by-one
- Falls back to individual `POST /tasks` calls when the batch endpoint returns 404 (backward compatible)
- On non-404 errors, no tasks are created (atomic -- can retry on next startup)
- Extracted `_build_task_payload()` and `_sync_one_by_one()` helpers

## Test plan
- [x] `test_sync_batch_creates_all_tasks` -- batch returns 3 created, result has 3 IDs
- [x] `test_sync_batch_skips_duplicates` -- pre-existing server tasks are skipped before batching
- [x] `test_sync_batch_fallback_on_404` -- 404 from batch triggers one-by-one fallback
- [x] `test_sync_batch_records_errors_on_failure` -- 500 populates result.errors
- [x] `test_sync_batch_handles_empty_backlog` -- no files means no HTTP POST calls
- [x] All 29 existing `test_sync.py` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)