### PR TITLE
feat: add POST /tasks/batch endpoint for atomic batch creation

### DIFF
--- a/src/bernstein/core/routes/tasks.py
+++ b/src/bernstein/core/routes/tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import time
 from typing import TYPE_CHECKING
 
@@ -14,6 +15,7 @@ from starlette.responses import StreamingResponse
 from bernstein.core.bulletin import BulletinBoard, BulletinMessage
 from bernstein.core.difficulty_estimator import estimate_difficulty, minutes_for_level
 from bernstein.core.eu_ai_act import (
+    TaskRiskAssessment,
     append_assessment_log,
     assess_task,
     build_log_record,
@@ -37,6 +39,8 @@ from bernstein.core.server import (
     A2ATaskSendRequest,
     BatchClaimRequest,
     BatchClaimResponse,
+    BatchCreateRequest,
+    BatchCreateResponse,
     BulletinMessageResponse,
     BulletinPostRequest,
     ClusterStatusResponse,
@@ -72,6 +76,8 @@ from bernstein.core.task_store import ArchiveRecord, SnapshotEntry
 from bernstein.core.telemetry import start_span
 from bernstein.core.tenanting import request_tenant_id, resolve_tenant_scope
 from bernstein.plugins.manager import HookBlockingError, get_plugin_manager
+
+logger = logging.getLogger(__name__)
 
 _DRAINING_DETAIL = "Server is draining -- no new claims accepted"
 
@@ -199,6 +205,81 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
         sse_bus.publish("task_update", json.dumps({"id": task.id, "status": task.status.value}))
         get_plugin_manager().fire_task_created(task_id=task.id, role=task.role, title=task.title)
         return task_to_response(task)
+
+
+@router.post(
+    "/tasks/batch",
+    status_code=201,
+    response_model=BatchCreateResponse,
+    responses={503: {"description": "Server is draining"}},
+)
+async def create_tasks_batch(body: BatchCreateRequest, request: Request) -> BatchCreateResponse:
+    """Create multiple tasks atomically with title dedup."""
+    if request.app.state.draining:  # type: ignore[attr-defined]
+        raise HTTPException(
+            status_code=503,
+            detail=_DRAINING_DETAIL,
+        )
+    store = _get_store(request)
+    sse_bus = _get_sse_bus(request)
+
+    prepared: list[TaskCreate] = []
+    assessments: list[TaskRiskAssessment] = []
+    for task_body in body.tasks:
+        effective = task_body.model_copy(update={"tenant_id": request_tenant_id(request)})
+
+        # Auto-classify role if not specified
+        if effective.role == "auto":
+            effective.role = classify_role(effective.description)
+
+        # Auto-estimate difficulty if minutes not provided
+        if effective.estimated_minutes is None:
+            score = estimate_difficulty(effective.description)
+            effective.estimated_minutes = minutes_for_level(score.level)
+
+        assessment = assess_task(effective)
+        effective = effective.model_copy(
+            update={
+                "eu_ai_act_risk": merge_eu_ai_act_risk(effective.eu_ai_act_risk, assessment.risk_level).value,
+                "approval_required": bool(effective.approval_required or assessment.approval_required),
+                "risk_level": merge_bernstein_risk(effective.risk_level, assessment.bernstein_risk_level),
+            }
+        )
+
+        # Pre-create hook: skip individual task if blocked (don't fail entire batch)
+        try:
+            pm = get_plugin_manager()
+            pm.fire_pre_task_create(
+                task_id="",
+                role=effective.role,
+                title=effective.title,
+                description=effective.description,
+            )
+        except HookBlockingError:
+            logger.warning("Pre-create hook blocked task '%s' — skipping", effective.title)
+            continue
+
+        prepared.append(effective)
+        assessments.append(assessment)
+
+    created_tasks, skipped_titles = await store.create_batch(prepared, dedup_by_title=True)
+
+    # Build a title->assessment lookup for created tasks (dedup may have dropped some)
+    assessment_by_title = dict(zip([t.title for t in prepared], assessments, strict=False))
+    for task in created_tasks:
+        task_assessment = assessment_by_title.get(task.title)
+        if task_assessment is not None:
+            append_assessment_log(
+                request.app.state.sdd_dir,
+                build_log_record(task.id, task, task_assessment),
+            )
+        sse_bus.publish("task_update", json.dumps({"id": task.id, "status": task.status.value}))
+        get_plugin_manager().fire_task_created(task_id=task.id, role=task.role, title=task.title)
+
+    return BatchCreateResponse(
+        created=[task_to_response(t) for t in created_tasks],
+        skipped_titles=skipped_titles,
+    )
 
 
 @router.post(

--- a/src/bernstein/core/server.py
+++ b/src/bernstein/core/server.py
@@ -442,6 +442,19 @@ class BatchClaimResponse(BaseModel):
     failed: list[str]
 
 
+class BatchCreateRequest(BaseModel):
+    """Body for POST /tasks/batch."""
+
+    tasks: list[TaskCreate]
+
+
+class BatchCreateResponse(BaseModel):
+    """Response for POST /tasks/batch."""
+
+    created: list[TaskResponse]
+    skipped_titles: list[str]
+
+
 class RoleCounts(BaseModel):
     """Per-role open task counts."""
 

--- a/tests/unit/test_batch_create_route.py
+++ b/tests/unit/test_batch_create_route.py
@@ -1,0 +1,139 @@
+"""Tests for POST /tasks/batch — atomic batch task creation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from bernstein.core.server import create_app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def app(tmp_path: Path):  # type: ignore[no-untyped-def]
+    return create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+
+@pytest.fixture()
+async def client(app) -> AsyncClient:  # type: ignore[no-untyped-def]
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _task_payload(title: str, role: str = "backend") -> dict[str, str]:
+    return {"title": title, "description": f"Do {title}", "role": role}
+
+
+@pytest.mark.anyio
+async def test_batch_create_all_succeed(app, client: AsyncClient) -> None:  # type: ignore[no-untyped-def]
+    """POST /tasks/batch with 3 distinct tasks creates all of them."""
+    # Patch create_batch on the store since it may not exist yet
+    store = app.state.store
+
+    async def _fake_create_batch(
+        requests: list,  # type: ignore[type-arg]
+        *,
+        dedup_by_title: bool = True,
+    ) -> tuple[list, list[str]]:  # type: ignore[type-arg]
+        tasks = []
+        for req in requests:
+            task = await store.create(req)
+            tasks.append(task)
+        return tasks, []
+
+    with patch.object(store, "create_batch", side_effect=_fake_create_batch, create=True):
+        resp = await client.post(
+            "/tasks/batch",
+            json={
+                "tasks": [
+                    _task_payload("Task A"),
+                    _task_payload("Task B"),
+                    _task_payload("Task C"),
+                ]
+            },
+        )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data["created"]) == 3
+    assert data["skipped_titles"] == []
+    titles = {t["title"] for t in data["created"]}
+    assert titles == {"Task A", "Task B", "Task C"}
+
+
+@pytest.mark.anyio
+async def test_batch_create_dedup_within_batch(app, client: AsyncClient) -> None:  # type: ignore[no-untyped-def]
+    """POST /tasks/batch with duplicate titles: 1 created, 1 skipped."""
+    store = app.state.store
+
+    async def _fake_create_batch(
+        requests: list,  # type: ignore[type-arg]
+        *,
+        dedup_by_title: bool = True,
+    ) -> tuple[list, list[str]]:  # type: ignore[type-arg]
+        seen_titles: set[str] = set()
+        tasks = []
+        skipped: list[str] = []
+        for req in requests:
+            if dedup_by_title and req.title in seen_titles:
+                skipped.append(req.title)
+                continue
+            seen_titles.add(req.title)
+            task = await store.create(req)
+            tasks.append(task)
+        return tasks, skipped
+
+    with patch.object(store, "create_batch", side_effect=_fake_create_batch, create=True):
+        resp = await client.post(
+            "/tasks/batch",
+            json={
+                "tasks": [
+                    _task_payload("Duplicate Task"),
+                    _task_payload("Duplicate Task"),
+                ]
+            },
+        )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert len(data["created"]) == 1
+    assert data["created"][0]["title"] == "Duplicate Task"
+    assert data["skipped_titles"] == ["Duplicate Task"]
+
+
+@pytest.mark.anyio
+async def test_batch_create_empty_list(app, client: AsyncClient) -> None:  # type: ignore[no-untyped-def]
+    """POST /tasks/batch with empty tasks list returns empty response."""
+    store = app.state.store
+
+    async def _fake_create_batch(
+        requests: list,  # type: ignore[type-arg]
+        *,
+        dedup_by_title: bool = True,
+    ) -> tuple[list, list[str]]:  # type: ignore[type-arg]
+        return [], []
+
+    with patch.object(store, "create_batch", side_effect=_fake_create_batch, create=True):
+        resp = await client.post("/tasks/batch", json={"tasks": []})
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["created"] == []
+    assert data["skipped_titles"] == []
+
+
+@pytest.mark.anyio
+async def test_batch_create_while_draining(app, client: AsyncClient) -> None:  # type: ignore[no-untyped-def]
+    """POST /tasks/batch returns 503 when the server is draining."""
+    app.state.draining = True
+    resp = await client.post(
+        "/tasks/batch",
+        json={"tasks": [_task_payload("Should fail")]},
+    )
+    assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- Adds `BatchCreateRequest` and `BatchCreateResponse` Pydantic models to `server.py`
- Adds `POST /tasks/batch` route in `routes/tasks.py` with full task preparation pipeline (role classification, difficulty estimation, risk assessment, pre-create hooks)
- Hook-blocked tasks are skipped (logged as warning) rather than failing the entire batch
- Calls `store.create_batch(prepared, dedup_by_title=True)` for atomic creation with title dedup (method being implemented by another agent in parallel)
- Publishes SSE events and fires `fire_task_created` plugin hooks for each created task

## Test plan
- [x] `test_batch_create_all_succeed` -- 3 tasks, all created
- [x] `test_batch_create_dedup_within_batch` -- duplicate titles, 1 created + 1 skipped
- [x] `test_batch_create_empty_list` -- empty input returns empty response
- [x] `test_batch_create_while_draining` -- returns 503
- [x] Existing `test_server.py` (120 tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)