### PR TITLE
docs: add glossary of Bernstein-specific terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 [![MCP Compatible](https://img.shields.io/badge/MCP-1.0%2C%201.1-blue)](docs/compatibility.md)
 [![A2A Compatible](https://img.shields.io/badge/A2A-0.2%2C%200.3-blue)](docs/compatibility.md)
 
-[Documentation](https://chernistry.github.io/bernstein/) &middot; [Getting Started](docs/GETTING_STARTED.md) &middot; [Limitations](docs/KNOWN_LIMITATIONS.md)
+[Documentation](https://chernistry.github.io/bernstein/) &middot; [Getting Started](docs/GETTING_STARTED.md) &middot; [Glossary](docs/GLOSSARY.md) &middot; [Limitations](docs/KNOWN_LIMITATIONS.md)
 
 #### Wall of fame
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,53 @@
+# Glossary
+
+Bernstein-specific terms used throughout the codebase and documentation.
+
+---
+
+### Bulletin Board
+
+An append-only communication channel where agents post findings, blockers, and status updates visible to all other agents in the same run. Implemented in `src/bernstein/core/bulletin.py`.
+
+### Circuit Breaker
+
+A state machine (CLOSED → OPEN → HALF_OPEN) that prevents infinite retry loops when an agent or provider repeatedly fails. After N consecutive failures, the breaker "opens" and blocks further attempts until a recovery probe succeeds. Implemented in `src/bernstein/core/circuit_breaker.py`.
+
+### Drain
+
+Stop accepting new work and wait for active agents to finish their current tasks. Used during graceful shutdown or rolling upgrades. Implemented in `src/bernstein/core/drain.py`.
+
+### Fast Path
+
+An optimization that skips full planning for simple, single-file tasks. Instead of decomposing into subtasks, the agent handles the work directly. Implemented in `src/bernstein/core/fast_path.py`.
+
+### Janitor
+
+The verification system that checks whether an agent's work is correct — runs lint, type-checks, tests, and other quality gates before accepting work. Implemented in `src/bernstein/core/janitor.py`.
+
+### Nudge
+
+A message sent to a stalled agent to prompt it to continue working. Part of the heartbeat and idle detection system. Implemented in `src/bernstein/core/nudge_manager.py`.
+
+### Quality Gate
+
+Automated checks (lint, type-check, tests, coverage) that must pass before work is accepted or merged. Gates run in sequence and any failure blocks the pipeline. Implemented in `src/bernstein/core/quality_gates.py`.
+
+### Reap
+
+Killing or collecting agents that have exceeded their timeout or become unresponsive. Part of the agent lifecycle management. Implemented in `src/bernstein/core/agent_lifecycle.py`.
+
+### SDD
+
+Software-Defined Development — the `.sdd/` directory where all runtime state lives: worktrees, sessions, task logs, and agent data. Initialized in `src/bernstein/core/bootstrap.py`.
+
+### Spawn
+
+Creating a short-lived agent process for a task batch. The spawner handles prompt construction, worktree setup, and process management. Implemented in `src/bernstein/core/spawner.py`.
+
+### Tick
+
+The orchestrator's polling cycle (approximately 3 seconds). Each tick fetches pending tasks, spawns agents, checks heartbeats, and evaluates quality gates. Implemented in `src/bernstein/core/orchestrator.py`.
+
+### Worktree
+
+An isolated git worktree per agent, located at `.sdd/worktrees/{session_id}`. Each agent works in its own branch without interfering with others. Implemented in `src/bernstein/core/worktree.py`.


### PR DESCRIPTION
Fixes #245

Added docs/GLOSSARY.md with 12 Bernstein-specific terms defined in alphabetical order. Each definition references the source file where the term is used. Also linked the glossary from the README documentation section.

Terms covered: Bulletin Board, Circuit Breaker, Drain, Fast Path, Janitor, Nudge, Quality Gate, Reap, SDD, Spawn, Tick, Worktree.