### PR TITLE
feat: add user-defined command aliases via ~/.bernstein/aliases.yaml

### DIFF
--- a/src/bernstein/cli/aliases.py
+++ b/src/bernstein/cli/aliases.py
@@ -61,9 +61,8 @@ def _load_user_aliases() -> dict[str, str]:
         return {}
     try:
         with open(_USER_ALIASES_PATH) as f:
-            data = yaml.safe_load(f) or {}
-        if not isinstance(data, dict):
-            return {}
+            raw: object = yaml.safe_load(f) or {}
+        data: dict[str, object] = raw if isinstance(raw, dict) else {}
         return {str(k): str(v) for k, v in data.items() if isinstance(k, str) and isinstance(v, str)}
     except Exception:
         logger.debug("Failed to load user aliases from %s", _USER_ALIASES_PATH, exc_info=True)


### PR DESCRIPTION
Resubmission of #265 (closed before Pyright fixes landed).

Fixes #249

Extended the alias system to support user-defined aliases loaded from ~/.bernstein/aliases.yaml. User aliases override built-in ones. The ernstein aliases command now shows whether each alias is built-in or user-defined.

Changes:
- Added _load_user_aliases() to load aliases from YAML
- Added _merge_aliases() called at module load time
- Updated liases_cmd to show source column (built-in vs user)
- Graceful handling of missing/invalid YAML files
- Pyright strict-mode typing issues resolved