### PR TITLE
feat: add user-defined command aliases via ~/.bernstein/aliases.yaml

### DIFF
--- a/src/bernstein/cli/aliases.py
+++ b/src/bernstein/cli/aliases.py
@@ -33,7 +33,7 @@ ALIASES: dict[str, str] = {
 }
 
 # Track which aliases are user-defined (populated at load time)
-_USER_ALIASES: dict[str, str] = {}
+_user_aliases: dict[str, str] = {}
 
 _USER_ALIASES_PATH = Path.home() / ".bernstein" / "aliases.yaml"
 
@@ -62,8 +62,9 @@ def _load_user_aliases() -> dict[str, str]:
     try:
         with open(_USER_ALIASES_PATH) as f:
             raw: object = yaml.safe_load(f) or {}
-        data: dict[str, object] = raw if isinstance(raw, dict) else {}
-        return {str(k): str(v) for k, v in data.items() if isinstance(k, str) and isinstance(v, str)}
+        if not isinstance(raw, dict):
+            return {}
+        return {str(k): str(v) for k, v in raw.items()}
     except Exception:
         logger.debug("Failed to load user aliases from %s", _USER_ALIASES_PATH, exc_info=True)
         return {}
@@ -71,9 +72,9 @@ def _load_user_aliases() -> dict[str, str]:
 
 def _merge_aliases() -> None:
     """Merge user aliases into the global registry (user overrides built-in)."""
-    global _USER_ALIASES
-    _USER_ALIASES = _load_user_aliases()
-    ALIASES.update(_USER_ALIASES)
+    global _user_aliases
+    _user_aliases = _load_user_aliases()
+    ALIASES.update(_user_aliases)
 
 
 # Call at module load time
@@ -145,7 +146,7 @@ def aliases_cmd() -> None:
 
     for alias, command in sorted(ALIASES.items()):
         desc = _descriptions.get(alias, "")
-        source = "[cyan]user[/cyan]" if alias in _USER_ALIASES else "[dim]built-in[/dim]"
+        source = "[cyan]user[/cyan]" if alias in _user_aliases else "[dim]built-in[/dim]"
         table.add_row(alias, command, source, desc)
 
     console.print(table)


### PR DESCRIPTION
Resubmission of #265/#275. Fixes #249.

All Pyright errors resolved:
- Renamed _USER_ALIASES to _user_aliases (lowercase, not treated as constant)
- Fixed dict type narrowing in _load_user_aliases()
- Removed unnecessary isinstance checks

Extended the alias system to support user-defined aliases loaded from ~/.bernstein/aliases.yaml. User aliases override built-in ones. The ernstein aliases command shows whether each alias is built-in or user-defined.