### PR TITLE
feat: event-sourced task transition store

### DIFF
--- a/src/bernstein/core/task_event_store.py
+++ b/src/bernstein/core/task_event_store.py
@@ -1,0 +1,212 @@
+"""Append-only event-sourced task transition store.
+
+Each task gets a separate JSONL file under ``.sdd/events/{task_id}.jsonl``.
+Events are immutable, append-only records of every lifecycle transition.
+
+Usage::
+
+    from pathlib import Path
+    from bernstein.core.task_event_store import (
+        TaskEventKind, TaskEventStore, record_transition,
+    )
+
+    store = TaskEventStore(Path(".sdd/events"))
+    evt = record_transition(store, "task-1", TaskEventKind.CREATED, "orchestrator")
+    print(store.current_state("task-1"))  # "CREATED"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class TaskEventKind(StrEnum):
+    """Canonical lifecycle events for a task."""
+
+    CREATED = "CREATED"
+    CLAIMED = "CLAIMED"
+    STARTED = "STARTED"
+    COMPLETED = "COMPLETED"
+    VERIFIED = "VERIFIED"
+    MERGED = "MERGED"
+    CLOSED = "CLOSED"
+    FAILED = "FAILED"
+    BLOCKED = "BLOCKED"
+    UNBLOCKED = "UNBLOCKED"
+    CANCELLED = "CANCELLED"
+
+
+@dataclass(frozen=True)
+class TaskEvent:
+    """An immutable record of a single task lifecycle transition.
+
+    Attributes:
+        task_id: Identifier of the task this event belongs to.
+        kind: The type of lifecycle event.
+        timestamp: ISO 8601 timestamp of when the event occurred.
+        actor: Who caused this event (agent id or ``"orchestrator"``).
+        metadata: Optional extra context for the event.
+    """
+
+    task_id: str
+    kind: TaskEventKind
+    timestamp: str
+    actor: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this event to a plain dictionary."""
+        return {
+            "task_id": self.task_id,
+            "kind": str(self.kind),
+            "timestamp": self.timestamp,
+            "actor": self.actor,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TaskEvent:
+        """Deserialize a dictionary back into a ``TaskEvent``.
+
+        Args:
+            data: Dictionary with ``task_id``, ``kind``, ``timestamp``,
+                ``actor``, and optional ``metadata`` keys.
+
+        Returns:
+            A new frozen ``TaskEvent`` instance.
+        """
+        return cls(
+            task_id=data["task_id"],
+            kind=TaskEventKind(data["kind"]),
+            timestamp=data["timestamp"],
+            actor=data["actor"],
+            metadata=data.get("metadata", {}),
+        )
+
+
+class TaskEventStore:
+    """File-backed, append-only event store for task transitions.
+
+    Each task's events live in a separate JSONL file so that reads/writes
+    for one task never contend with another.
+
+    Args:
+        store_path: Directory where ``{task_id}.jsonl`` files are stored.
+    """
+
+    def __init__(self, store_path: Path) -> None:
+        self._path = store_path
+        self._path.mkdir(parents=True, exist_ok=True)
+
+    def _task_file(self, task_id: str) -> Path:
+        """Return the JSONL path for a given task."""
+        return self._path / f"{task_id}.jsonl"
+
+    def append(self, event: TaskEvent) -> None:
+        """Append an event to the task's JSONL file.
+
+        Args:
+            event: The event to persist.
+        """
+        path = self._task_file(event.task_id)
+        line = json.dumps(event.to_dict(), separators=(",", ":"))
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+    def events_for(self, task_id: str) -> list[TaskEvent]:
+        """Read all events for a task in chronological order.
+
+        Args:
+            task_id: The task to look up.
+
+        Returns:
+            List of events ordered oldest-first.  Empty list if the task
+            has no recorded events.
+        """
+        path = self._task_file(task_id)
+        if not path.exists():
+            return []
+        events: list[TaskEvent] = []
+        with path.open(encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    data = json.loads(stripped)
+                    events.append(TaskEvent.from_dict(data))
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    logger.warning(
+                        "Skipping corrupt event line %d in %s",
+                        lineno,
+                        path,
+                    )
+        return events
+
+    def current_state(self, task_id: str) -> str | None:
+        """Derive the current status of a task from its latest event.
+
+        Args:
+            task_id: The task to query.
+
+        Returns:
+            The ``TaskEventKind`` value of the most recent event, or
+            ``None`` if no events exist.
+        """
+        events = self.events_for(task_id)
+        if not events:
+            return None
+        return str(events[-1].kind)
+
+    def all_task_ids(self) -> list[str]:
+        """List every task that has at least one recorded event.
+
+        Returns:
+            Sorted list of task ID strings.
+        """
+        ids: list[str] = []
+        for p in self._path.iterdir():
+            if p.suffix == ".jsonl" and p.is_file():
+                ids.append(p.stem)
+        ids.sort()
+        return ids
+
+
+def record_transition(
+    store: TaskEventStore,
+    task_id: str,
+    kind: TaskEventKind,
+    actor: str,
+    **metadata: Any,
+) -> TaskEvent:
+    """Create and persist a task event in one call.
+
+    Args:
+        store: The event store to write to.
+        task_id: Task this event belongs to.
+        kind: The lifecycle transition.
+        actor: Who triggered the transition.
+        **metadata: Arbitrary key-value pairs stored alongside the event.
+
+    Returns:
+        The newly created (and already persisted) ``TaskEvent``.
+    """
+    event = TaskEvent(
+        task_id=task_id,
+        kind=kind,
+        timestamp=datetime.now(UTC).isoformat(),
+        actor=actor,
+        metadata=metadata if metadata else {},
+    )
+    store.append(event)
+    return event

--- a/src/bernstein/core/task_event_store.py
+++ b/src/bernstein/core/task_event_store.py
@@ -62,7 +62,7 @@ class TaskEvent:
     kind: TaskEventKind
     timestamp: str
     actor: str
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize this event to a plain dictionary."""

--- a/tests/unit/test_task_event_store.py
+++ b/tests/unit/test_task_event_store.py
@@ -1,0 +1,232 @@
+"""Tests for the append-only task event store."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.task_event_store import (
+    TaskEvent,
+    TaskEventKind,
+    TaskEventStore,
+    record_transition,
+)
+
+
+class TestTaskEventKind:
+    def test_all_values_are_strings(self) -> None:
+        for member in TaskEventKind:
+            assert isinstance(member.value, str)
+            assert member.value == member.name
+
+    def test_expected_members(self) -> None:
+        names = {m.name for m in TaskEventKind}
+        assert names == {
+            "CREATED",
+            "CLAIMED",
+            "STARTED",
+            "COMPLETED",
+            "VERIFIED",
+            "MERGED",
+            "CLOSED",
+            "FAILED",
+            "BLOCKED",
+            "UNBLOCKED",
+            "CANCELLED",
+        }
+
+
+class TestTaskEvent:
+    def test_frozen(self) -> None:
+        evt = TaskEvent(
+            task_id="t1",
+            kind=TaskEventKind.CREATED,
+            timestamp="2026-01-01T00:00:00+00:00",
+            actor="orchestrator",
+        )
+        with pytest.raises(AttributeError):
+            evt.task_id = "t2"  # type: ignore[misc]
+
+    def test_to_dict(self) -> None:
+        evt = TaskEvent(
+            task_id="t1",
+            kind=TaskEventKind.STARTED,
+            timestamp="2026-01-01T00:00:00+00:00",
+            actor="agent-42",
+            metadata={"branch": "feat-x"},
+        )
+        d = evt.to_dict()
+        assert d == {
+            "task_id": "t1",
+            "kind": "STARTED",
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "actor": "agent-42",
+            "metadata": {"branch": "feat-x"},
+        }
+
+    def test_from_dict_round_trip(self) -> None:
+        original = TaskEvent(
+            task_id="t1",
+            kind=TaskEventKind.COMPLETED,
+            timestamp="2026-06-15T12:30:00+00:00",
+            actor="agent-7",
+            metadata={"files_changed": 3},
+        )
+        restored = TaskEvent.from_dict(original.to_dict())
+        assert restored == original
+
+    def test_from_dict_missing_metadata_defaults_empty(self) -> None:
+        data = {
+            "task_id": "t1",
+            "kind": "FAILED",
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "actor": "orchestrator",
+        }
+        evt = TaskEvent.from_dict(data)
+        assert evt.metadata == {}
+
+    def test_default_metadata_is_empty_dict(self) -> None:
+        evt = TaskEvent(
+            task_id="t1",
+            kind=TaskEventKind.CREATED,
+            timestamp="2026-01-01T00:00:00+00:00",
+            actor="orchestrator",
+        )
+        assert evt.metadata == {}
+
+
+class TestTaskEventStore:
+    def test_append_and_read_back(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        evt = TaskEvent(
+            task_id="t1",
+            kind=TaskEventKind.CREATED,
+            timestamp="2026-01-01T00:00:00+00:00",
+            actor="orchestrator",
+        )
+        store.append(evt)
+        events = store.events_for("t1")
+        assert len(events) == 1
+        assert events[0] == evt
+
+    def test_current_state_returns_latest(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        store.append(TaskEvent("t1", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        store.append(TaskEvent("t1", TaskEventKind.CLAIMED, "2026-01-01T00:01:00+00:00", "agent-1"))
+        store.append(TaskEvent("t1", TaskEventKind.STARTED, "2026-01-01T00:02:00+00:00", "agent-1"))
+        assert store.current_state("t1") == "STARTED"
+
+    def test_events_for_chronological_order(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        kinds = [TaskEventKind.CREATED, TaskEventKind.CLAIMED, TaskEventKind.COMPLETED]
+        for i, kind in enumerate(kinds):
+            store.append(TaskEvent("t1", kind, f"2026-01-01T00:0{i}:00+00:00", "orch"))
+        events = store.events_for("t1")
+        assert [e.kind for e in events] == kinds
+
+    def test_empty_task_returns_empty_list(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        assert store.events_for("nonexistent") == []
+
+    def test_current_state_empty_returns_none(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        assert store.current_state("nonexistent") is None
+
+    def test_multiple_tasks_do_not_interfere(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        store.append(TaskEvent("t1", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        store.append(TaskEvent("t2", TaskEventKind.FAILED, "2026-01-01T00:00:00+00:00", "orch"))
+        assert store.current_state("t1") == "CREATED"
+        assert store.current_state("t2") == "FAILED"
+        assert len(store.events_for("t1")) == 1
+        assert len(store.events_for("t2")) == 1
+
+    def test_all_task_ids(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        store.append(TaskEvent("beta", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        store.append(TaskEvent("alpha", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        assert store.all_task_ids() == ["alpha", "beta"]
+
+    def test_all_task_ids_empty_store(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        assert store.all_task_ids() == []
+
+    def test_creates_directory_if_missing(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b" / "events"
+        store = TaskEventStore(nested)
+        store.append(TaskEvent("t1", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        assert nested.is_dir()
+        assert len(store.events_for("t1")) == 1
+
+    def test_corrupt_line_skipped(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        store.append(TaskEvent("t1", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        # Inject a corrupt line
+        task_file = tmp_path / "events" / "t1.jsonl"
+        with task_file.open("a", encoding="utf-8") as fh:
+            fh.write("NOT VALID JSON\n")
+        store.append(TaskEvent("t1", TaskEventKind.STARTED, "2026-01-01T00:01:00+00:00", "agent-1"))
+        events = store.events_for("t1")
+        assert len(events) == 2
+        assert events[0].kind == TaskEventKind.CREATED
+        assert events[1].kind == TaskEventKind.STARTED
+
+    def test_jsonl_file_format(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        store.append(TaskEvent("t1", TaskEventKind.CREATED, "2026-01-01T00:00:00+00:00", "orch"))
+        raw = (tmp_path / "events" / "t1.jsonl").read_text(encoding="utf-8")
+        lines = [ln for ln in raw.splitlines() if ln.strip()]
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["kind"] == "CREATED"
+        assert parsed["task_id"] == "t1"
+
+
+class TestRecordTransition:
+    def test_creates_and_persists_event(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        evt = record_transition(store, "t1", TaskEventKind.CREATED, "orchestrator")
+        assert evt.task_id == "t1"
+        assert evt.kind == TaskEventKind.CREATED
+        assert evt.actor == "orchestrator"
+        assert evt.timestamp  # non-empty ISO string
+        # Event was persisted
+        events = store.events_for("t1")
+        assert len(events) == 1
+        assert events[0] == evt
+
+    def test_metadata_kwargs_passed_through(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        evt = record_transition(
+            store,
+            "t1",
+            TaskEventKind.COMPLETED,
+            "agent-5",
+            files_changed=2,
+            tests_passing=True,
+        )
+        assert evt.metadata == {"files_changed": 2, "tests_passing": True}
+
+    def test_no_metadata_yields_empty_dict(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        evt = record_transition(store, "t1", TaskEventKind.BLOCKED, "orch")
+        assert evt.metadata == {}
+
+    def test_round_trip_via_record_transition(self, tmp_path: Path) -> None:
+        store = TaskEventStore(tmp_path / "events")
+        record_transition(store, "t1", TaskEventKind.CREATED, "orch")
+        record_transition(store, "t1", TaskEventKind.CLAIMED, "agent-1")
+        record_transition(store, "t1", TaskEventKind.STARTED, "agent-1")
+        record_transition(store, "t1", TaskEventKind.COMPLETED, "agent-1", pr_url="https://gh/1")
+        events = store.events_for("t1")
+        assert len(events) == 4
+        assert [e.kind for e in events] == [
+            TaskEventKind.CREATED,
+            TaskEventKind.CLAIMED,
+            TaskEventKind.STARTED,
+            TaskEventKind.COMPLETED,
+        ]
+        assert events[-1].metadata == {"pr_url": "https://gh/1"}
+        assert store.current_state("t1") == "COMPLETED"


### PR DESCRIPTION
## Summary
- Adds `TaskEventStore`, an append-only JSONL-backed event store for task lifecycle transitions
- Each task gets its own file at `.sdd/events/{task_id}.jsonl` with immutable `TaskEvent` records
- Includes `TaskEventKind` enum (11 lifecycle states), frozen `TaskEvent` dataclass with serialization round-trip, and `record_transition()` convenience function

This is a new parallel subsystem -- the existing `TaskStatus` enum and task lifecycle in `models.py` are untouched.

## Test plan
- [x] 22 unit tests covering append/read, current state derivation, chronological ordering, multi-task isolation, corrupt line handling, JSONL format, and convenience function
- [x] Ruff lint and format pass
- [x] Pyright strict typecheck passes (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)