### PR TITLE
feat: Jira sync, stack detector, opt-in usage telemetry

### DIFF
--- a/src/bernstein/core/jira_sync.py
+++ b/src/bernstein/core/jira_sync.py
@@ -1,0 +1,137 @@
+"""Jira issue-to-backlog synchronisation.
+
+Fetches open issues from a Jira project and writes them as YAML backlog files,
+mirroring the GitHub sync in :mod:`bernstein.core.github`.  Uses only stdlib
+``urllib`` so there are no extra dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — used at runtime
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class JiraSyncConfig:
+    """Configuration for Jira backlog synchronisation.
+
+    Attributes:
+        base_url: Jira instance base URL (e.g. ``https://myorg.atlassian.net``).
+        project_key: Jira project key used in JQL queries (e.g. ``"BERN"``).
+        auth_token_env: Name of the environment variable holding the
+            Base64-encoded ``email:api-token`` string for Basic auth.
+    """
+
+    base_url: str
+    project_key: str
+    auth_token_env: str = "JIRA_TOKEN"
+
+
+def fetch_jira_issues(config: JiraSyncConfig) -> list[dict[str, Any]]:
+    """Fetch open issues from Jira via the REST API.
+
+    Uses ``/rest/api/2/search`` with JQL ``project={key} AND status != Done``.
+
+    Args:
+        config: Jira connection configuration.
+
+    Returns:
+        List of raw issue dicts from the Jira response, or an empty list on
+        any network/auth error.
+    """
+    token = os.environ.get(config.auth_token_env, "")
+    if not token:
+        logger.warning("Jira auth token env var %s is not set", config.auth_token_env)
+        return []
+
+    jql = f"project={config.project_key} AND status != Done"
+    url = (
+        f"{config.base_url.rstrip('/')}/rest/api/2/search"
+        f"?jql={jql}&maxResults=100&fields=summary,description,status,labels"
+    )
+
+    req = Request(url)
+    req.add_header("Authorization", f"Basic {token}")
+    req.add_header("Accept", "application/json")
+
+    try:
+        with urlopen(req, timeout=30) as resp:
+            data: dict[str, Any] = json.loads(resp.read().decode("utf-8"))
+            issues: list[dict[str, Any]] = data.get("issues", [])
+            return issues
+    except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to fetch Jira issues: %s", exc)
+        return []
+
+
+def sync_jira_to_backlog(config: JiraSyncConfig, backlog_dir: Path) -> int:
+    """Sync Jira issues into the backlog directory as YAML files.
+
+    For each issue that does not already have a corresponding
+    ``jira-{key}.yaml`` file, writes a YAML-frontmatter backlog file.
+
+    Args:
+        config: Jira connection configuration.
+        backlog_dir: Directory to write backlog YAML files into
+            (typically ``.sdd/backlog/open``).
+
+    Returns:
+        Number of new backlog files created.
+    """
+    backlog_dir.mkdir(parents=True, exist_ok=True)
+
+    issues = fetch_jira_issues(config)
+    if not issues:
+        return 0
+
+    # Build set of existing Jira keys already synced.
+    existing_keys: set[str] = set()
+    for path in backlog_dir.glob("jira-*.yaml"):
+        m = re.match(r"jira-([A-Z]+-\d+)", path.name)
+        if m:
+            existing_keys.add(m.group(1))
+
+    created = 0
+    for issue in issues:
+        key: str = issue.get("key", "")
+        if not key or key in existing_keys:
+            continue
+
+        fields: dict[str, Any] = issue.get("fields", {})
+        summary: str = fields.get("summary", "Untitled")
+        description: str = (fields.get("description") or "")[:500]
+
+        slug = re.sub(r"[^a-z0-9]+", "-", summary.lower()).strip("-")[:60]
+        filename = f"jira-{key}-{slug}.yaml"
+
+        content = (
+            f"---\n"
+            f"id: jira-{key}\n"
+            f'title: "[JIRA:{key}] {summary}"\n'
+            f"role: backend\n"
+            f"priority: 4\n"
+            f"scope: medium\n"
+            f"complexity: medium\n"
+            f"type: feature\n"
+            f"metadata:\n"
+            f"  jira_key: {key}\n"
+            f"---\n\n"
+            f"# [JIRA:{key}] {summary}\n\n"
+            f"{description}\n"
+        )
+
+        file_path = backlog_dir / filename
+        file_path.write_text(content, encoding="utf-8")
+        created += 1
+        logger.info("Synced Jira issue %s to backlog: %s", key, filename)
+
+    return created

--- a/src/bernstein/core/stack_detector.py
+++ b/src/bernstein/core/stack_detector.py
@@ -105,10 +105,10 @@ class StackInfo:
         ci_systems: CI/CD systems detected by config files.
     """
 
-    languages: list[str] = field(default_factory=list)
-    frameworks: list[str] = field(default_factory=list)
-    package_managers: list[str] = field(default_factory=list)
-    ci_systems: list[str] = field(default_factory=list)
+    languages: list[str] = field(default_factory=list[str])
+    frameworks: list[str] = field(default_factory=list[str])
+    package_managers: list[str] = field(default_factory=list[str])
+    ci_systems: list[str] = field(default_factory=list[str])
 
 
 def detect_stack(project_dir: Path) -> StackInfo:

--- a/src/bernstein/core/stack_detector.py
+++ b/src/bernstein/core/stack_detector.py
@@ -1,0 +1,267 @@
+"""Project stack auto-detection.
+
+Scans a project directory for marker files (``pyproject.toml``,
+``package.json``, ``go.mod``, etc.) and reports detected languages,
+frameworks, package managers, and CI systems.  The compatibility report
+maps detected stack elements to Bernstein adapter recommendations.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path  # noqa: TC003 — used at runtime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Marker-file → language mapping ──────────────────────────────────────────
+
+_LANGUAGE_MARKERS: dict[str, str] = {
+    "pyproject.toml": "Python",
+    "setup.py": "Python",
+    "requirements.txt": "Python",
+    "package.json": "JavaScript",
+    "go.mod": "Go",
+    "Cargo.toml": "Rust",
+    "pom.xml": "Java",
+    "build.gradle": "Java",
+}
+
+# ── Package-manager lock files ──────────────────────────────────────────────
+
+_PACKAGE_MANAGER_MARKERS: dict[str, str] = {
+    "uv.lock": "uv",
+    "poetry.lock": "poetry",
+    "Pipfile.lock": "pipenv",
+    "yarn.lock": "yarn",
+    "pnpm-lock.yaml": "pnpm",
+    "package-lock.json": "npm",
+    "Cargo.lock": "cargo",
+    "go.sum": "go modules",
+}
+
+# ── CI system markers ──────────────────────────────────────────────────────
+
+_CI_DIR_MARKERS: dict[str, str] = {
+    ".github/workflows": "GitHub Actions",
+}
+
+_CI_FILE_MARKERS: dict[str, str] = {
+    ".gitlab-ci.yml": "GitLab CI",
+    "Jenkinsfile": "Jenkins",
+    ".circleci/config.yml": "CircleCI",
+    ".travis.yml": "Travis CI",
+}
+
+# ── Framework detection in dependency files ────────────────────────────────
+
+_PYTHON_FRAMEWORKS: dict[str, str] = {
+    "django": "Django",
+    "flask": "Flask",
+    "fastapi": "FastAPI",
+    "starlette": "Starlette",
+}
+
+_JS_FRAMEWORKS: dict[str, str] = {
+    "react": "React",
+    "next": "Next.js",
+    "express": "Express",
+    "vue": "Vue",
+    "angular": "Angular",
+}
+
+_GO_FRAMEWORKS: dict[str, str] = {
+    "gin-gonic/gin": "Gin",
+    "gorilla/mux": "Gorilla",
+}
+
+_RUST_FRAMEWORKS: dict[str, str] = {
+    "actix-web": "Actix",
+    "rocket": "Rocket",
+    "axum": "Axum",
+}
+
+# ── Adapter recommendations ────────────────────────────────────────────────
+
+_LANGUAGE_ADAPTERS: dict[str, list[str]] = {
+    "Python": ["claude", "codex", "aider", "gemini"],
+    "JavaScript": ["claude", "codex", "gemini", "cursor"],
+    "Go": ["claude", "codex", "gemini"],
+    "Rust": ["claude", "codex", "gemini"],
+    "Java": ["claude", "codex", "gemini"],
+}
+
+
+@dataclass
+class StackInfo:
+    """Detected project stack information.
+
+    Attributes:
+        languages: Programming languages found in the project.
+        frameworks: Frameworks detected from dependency manifests.
+        package_managers: Package managers identified by lock files.
+        ci_systems: CI/CD systems detected by config files.
+    """
+
+    languages: list[str] = field(default_factory=list)
+    frameworks: list[str] = field(default_factory=list)
+    package_managers: list[str] = field(default_factory=list)
+    ci_systems: list[str] = field(default_factory=list)
+
+
+def detect_stack(project_dir: Path) -> StackInfo:
+    """Detect the technology stack of a project directory.
+
+    Checks for language marker files, dependency manifests, lock files,
+    and CI configuration to build a comprehensive stack profile.
+
+    Args:
+        project_dir: Root directory of the project to scan.
+
+    Returns:
+        Populated :class:`StackInfo` with deduplicated, sorted lists.
+    """
+    languages: set[str] = set()
+    frameworks: set[str] = set()
+    package_managers: set[str] = set()
+    ci_systems: set[str] = set()
+
+    # Languages
+    for marker, lang in _LANGUAGE_MARKERS.items():
+        if (project_dir / marker).exists():
+            languages.add(lang)
+
+    # Check for TypeScript (tsconfig.json or .ts files referenced in package.json)
+    if (project_dir / "tsconfig.json").exists():
+        languages.add("TypeScript")
+        languages.discard("JavaScript")
+
+    # Package managers
+    for marker, pm in _PACKAGE_MANAGER_MARKERS.items():
+        if (project_dir / marker).exists():
+            package_managers.add(pm)
+
+    # CI systems
+    for marker, ci in _CI_DIR_MARKERS.items():
+        if (project_dir / marker).is_dir():
+            ci_systems.add(ci)
+    for marker, ci in _CI_FILE_MARKERS.items():
+        if (project_dir / marker).exists():
+            ci_systems.add(ci)
+
+    # Framework detection from dependency files
+    _detect_python_frameworks(project_dir, frameworks)
+    _detect_js_frameworks(project_dir, frameworks)
+    _detect_go_frameworks(project_dir, frameworks)
+    _detect_rust_frameworks(project_dir, frameworks)
+
+    return StackInfo(
+        languages=sorted(languages),
+        frameworks=sorted(frameworks),
+        package_managers=sorted(package_managers),
+        ci_systems=sorted(ci_systems),
+    )
+
+
+def compatibility_report(stack: StackInfo) -> dict[str, Any]:
+    """Generate a Bernstein adapter compatibility report for a detected stack.
+
+    Args:
+        stack: Stack information from :func:`detect_stack`.
+
+    Returns:
+        Dict with ``"recommended_adapters"`` (list of adapter names),
+        ``"language_coverage"`` (mapping of language to adapter list),
+        and ``"stack_summary"`` (human-readable summary string).
+    """
+    recommended: set[str] = set()
+    coverage: dict[str, list[str]] = {}
+
+    for lang in stack.languages:
+        adapters = _LANGUAGE_ADAPTERS.get(lang, ["claude", "generic"])
+        coverage[lang] = adapters
+        recommended.update(adapters)
+
+    if not recommended:
+        recommended = {"claude", "generic"}
+
+    summary_parts: list[str] = []
+    if stack.languages:
+        summary_parts.append(f"Languages: {', '.join(stack.languages)}")
+    if stack.frameworks:
+        summary_parts.append(f"Frameworks: {', '.join(stack.frameworks)}")
+    if stack.package_managers:
+        summary_parts.append(f"Package managers: {', '.join(stack.package_managers)}")
+    if stack.ci_systems:
+        summary_parts.append(f"CI: {', '.join(stack.ci_systems)}")
+
+    return {
+        "recommended_adapters": sorted(recommended),
+        "language_coverage": coverage,
+        "stack_summary": "; ".join(summary_parts) if summary_parts else "No stack detected",
+    }
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+
+
+def _detect_python_frameworks(project_dir: Path, frameworks: set[str]) -> None:
+    """Check pyproject.toml for Python framework dependencies."""
+    pyproject = project_dir / "pyproject.toml"
+    if not pyproject.exists():
+        return
+    try:
+        text = pyproject.read_text(encoding="utf-8").lower()
+        for dep, name in _PYTHON_FRAMEWORKS.items():
+            if dep in text:
+                frameworks.add(name)
+    except OSError:
+        pass
+
+
+def _detect_js_frameworks(project_dir: Path, frameworks: set[str]) -> None:
+    """Check package.json for JavaScript/TypeScript framework dependencies."""
+    pkg = project_dir / "package.json"
+    if not pkg.exists():
+        return
+    try:
+        data: dict[str, Any] = json.loads(pkg.read_text(encoding="utf-8"))
+        all_deps: dict[str, str] = {
+            **data.get("dependencies", {}),
+            **data.get("devDependencies", {}),
+        }
+        for dep, name in _JS_FRAMEWORKS.items():
+            if dep in all_deps:
+                frameworks.add(name)
+    except (OSError, json.JSONDecodeError):
+        pass
+
+
+def _detect_go_frameworks(project_dir: Path, frameworks: set[str]) -> None:
+    """Check go.mod for Go framework dependencies."""
+    gomod = project_dir / "go.mod"
+    if not gomod.exists():
+        return
+    try:
+        text = gomod.read_text(encoding="utf-8")
+        for dep, name in _GO_FRAMEWORKS.items():
+            if dep in text:
+                frameworks.add(name)
+    except OSError:
+        pass
+
+
+def _detect_rust_frameworks(project_dir: Path, frameworks: set[str]) -> None:
+    """Check Cargo.toml for Rust framework dependencies."""
+    cargo = project_dir / "Cargo.toml"
+    if not cargo.exists():
+        return
+    try:
+        text = cargo.read_text(encoding="utf-8")
+        for dep, name in _RUST_FRAMEWORKS.items():
+            if dep in text:
+                frameworks.add(name)
+    except OSError:
+        pass

--- a/src/bernstein/core/usage_telemetry.py
+++ b/src/bernstein/core/usage_telemetry.py
@@ -1,0 +1,135 @@
+"""Opt-in usage telemetry with local consent management.
+
+Provides a consent layer on top of the existing OpenTelemetry integration
+in :mod:`bernstein.core.telemetry`.  Events are only recorded when the user
+has explicitly opted in; otherwise all recording functions are no-ops.
+
+Consent state is persisted in ``<config_dir>/telemetry.json`` (typically
+``~/.bernstein/telemetry.json``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CONSENT_FILENAME = "telemetry.json"
+
+
+class TelemetryConsent(Enum):
+    """User consent state for usage telemetry.
+
+    Attributes:
+        OPT_IN: User has explicitly opted in to telemetry.
+        OPT_OUT: User has explicitly opted out.
+        UNDECIDED: User has not yet made a choice (treated as opt-out).
+    """
+
+    OPT_IN = "opt_in"
+    OPT_OUT = "opt_out"
+    UNDECIDED = "undecided"
+
+
+@dataclass
+class TelemetryConfig:
+    """Runtime telemetry configuration.
+
+    Attributes:
+        consent: Current consent state.
+        anonymous_id: Stable anonymous identifier for this installation.
+        events_endpoint: Optional remote endpoint URL (unused when logging
+            locally; reserved for future use).
+    """
+
+    consent: TelemetryConsent
+    anonymous_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    events_endpoint: str = ""
+
+
+def load_consent(config_dir: Path) -> TelemetryConsent:
+    """Load the telemetry consent state from disk.
+
+    Args:
+        config_dir: Directory containing ``telemetry.json``
+            (e.g. ``~/.bernstein``).
+
+    Returns:
+        The persisted consent value, or :attr:`TelemetryConsent.UNDECIDED`
+        if the file is missing or unreadable.
+    """
+    path = config_dir / _CONSENT_FILENAME
+    if not path.exists():
+        return TelemetryConsent.UNDECIDED
+
+    try:
+        data: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        raw = data.get("consent", "undecided")
+        return TelemetryConsent(raw)
+    except (OSError, json.JSONDecodeError, ValueError):
+        logger.debug("Could not read telemetry consent from %s", path)
+        return TelemetryConsent.UNDECIDED
+
+
+def save_consent(config_dir: Path, consent: TelemetryConsent) -> None:
+    """Persist the telemetry consent state to disk.
+
+    Creates the config directory if it does not exist.
+
+    Args:
+        config_dir: Directory to write ``telemetry.json`` into.
+        consent: Consent state to persist.
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    path = config_dir / _CONSENT_FILENAME
+    data = {"consent": consent.value}
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    logger.info("Telemetry consent saved: %s", consent.value)
+
+
+def record_usage_event(
+    config: TelemetryConfig,
+    event: str,
+    properties: dict[str, Any],
+    *,
+    log_dir: Path | None = None,
+) -> None:
+    """Record a usage event if the user has opted in.
+
+    When consent is not :attr:`TelemetryConsent.OPT_IN`, this function is a
+    complete no-op and returns immediately.  Otherwise the event is appended
+    as a JSON line to ``<log_dir>/usage_events.jsonl``.
+
+    Args:
+        config: Telemetry configuration (checked for consent).
+        event: Event name (e.g. ``"run.start"``, ``"task.complete"``).
+        properties: Arbitrary key-value properties attached to the event.
+        log_dir: Directory for the event log file.  Defaults to the current
+            working directory if not specified.
+    """
+    if config.consent is not TelemetryConsent.OPT_IN:
+        return
+
+    record: dict[str, Any] = {
+        "event": event,
+        "anonymous_id": config.anonymous_id,
+        "timestamp": time.time(),
+        "properties": properties,
+    }
+
+    target_dir = log_dir or Path.cwd()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    log_path = target_dir / "usage_events.jsonl"
+
+    try:
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except OSError as exc:
+        logger.warning("Failed to write usage event: %s", exc)

--- a/tests/unit/test_jira_sync.py
+++ b/tests/unit/test_jira_sync.py
@@ -1,0 +1,167 @@
+"""Tests for Jira issue-to-backlog synchronisation."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.core.jira_sync import JiraSyncConfig, fetch_jira_issues, sync_jira_to_backlog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_JIRA_RESPONSE: dict[str, Any] = {
+    "issues": [
+        {
+            "key": "BERN-1",
+            "fields": {
+                "summary": "Add rate limiting",
+                "description": "We need rate limiting on the API.",
+                "status": {"name": "To Do"},
+                "labels": ["backend"],
+            },
+        },
+        {
+            "key": "BERN-2",
+            "fields": {
+                "summary": "Fix login page",
+                "description": None,
+                "status": {"name": "In Progress"},
+                "labels": [],
+            },
+        },
+    ],
+}
+
+
+@pytest.fixture()
+def jira_config() -> JiraSyncConfig:
+    return JiraSyncConfig(
+        base_url="https://myorg.atlassian.net",
+        project_key="BERN",
+        auth_token_env="JIRA_TOKEN",
+    )
+
+
+def _mock_urlopen(response_data: dict[str, Any]) -> MagicMock:
+    """Build a mock for urllib.request.urlopen that returns *response_data*."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(response_data).encode("utf-8")
+    mock_resp.__enter__ = lambda self: self
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+# ---------------------------------------------------------------------------
+# fetch_jira_issues
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_jira_issues_returns_issues(
+    jira_config: JiraSyncConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JIRA_TOKEN", "dXNlcjp0b2tlbg==")
+
+    mock_resp = _mock_urlopen(SAMPLE_JIRA_RESPONSE)
+    with patch("bernstein.core.jira_sync.urlopen", return_value=mock_resp):
+        issues = fetch_jira_issues(jira_config)
+
+    assert len(issues) == 2
+    assert issues[0]["key"] == "BERN-1"
+    assert issues[1]["key"] == "BERN-2"
+
+
+def test_fetch_jira_issues_no_token(
+    jira_config: JiraSyncConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("JIRA_TOKEN", raising=False)
+    issues = fetch_jira_issues(jira_config)
+    assert issues == []
+
+
+def test_fetch_jira_issues_network_error(
+    jira_config: JiraSyncConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JIRA_TOKEN", "dXNlcjp0b2tlbg==")
+
+    from urllib.error import URLError
+
+    with patch("bernstein.core.jira_sync.urlopen", side_effect=URLError("timeout")):
+        issues = fetch_jira_issues(jira_config)
+
+    assert issues == []
+
+
+# ---------------------------------------------------------------------------
+# sync_jira_to_backlog
+# ---------------------------------------------------------------------------
+
+
+def test_sync_creates_yaml_files(
+    jira_config: JiraSyncConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JIRA_TOKEN", "dXNlcjp0b2tlbg==")
+    backlog_dir = tmp_path / "backlog" / "open"
+
+    mock_resp = _mock_urlopen(SAMPLE_JIRA_RESPONSE)
+    with patch("bernstein.core.jira_sync.urlopen", return_value=mock_resp):
+        count = sync_jira_to_backlog(jira_config, backlog_dir)
+
+    assert count == 2
+    files = list(backlog_dir.glob("jira-BERN-*.yaml"))
+    assert len(files) == 2
+
+    # Verify YAML content of first file
+    content = (backlog_dir / files[0].name).read_text(encoding="utf-8")
+    assert "jira-BERN-" in content
+    assert "title:" in content
+    assert "role: backend" in content
+
+
+def test_sync_deduplicates(
+    jira_config: JiraSyncConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing jira-BERN-1-*.yaml files should not be re-created."""
+    monkeypatch.setenv("JIRA_TOKEN", "dXNlcjp0b2tlbg==")
+    backlog_dir = tmp_path / "backlog" / "open"
+    backlog_dir.mkdir(parents=True)
+
+    # Pre-create a file for BERN-1
+    (backlog_dir / "jira-BERN-1-add-rate-limiting.yaml").write_text("existing", encoding="utf-8")
+
+    mock_resp = _mock_urlopen(SAMPLE_JIRA_RESPONSE)
+    with patch("bernstein.core.jira_sync.urlopen", return_value=mock_resp):
+        count = sync_jira_to_backlog(jira_config, backlog_dir)
+
+    # Only BERN-2 should be created
+    assert count == 1
+
+
+def test_sync_empty_response(
+    jira_config: JiraSyncConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JIRA_TOKEN", "dXNlcjp0b2tlbg==")
+    backlog_dir = tmp_path / "backlog" / "open"
+
+    mock_resp = _mock_urlopen({"issues": []})
+    with patch("bernstein.core.jira_sync.urlopen", return_value=mock_resp):
+        count = sync_jira_to_backlog(jira_config, backlog_dir)
+
+    assert count == 0

--- a/tests/unit/test_stack_detector.py
+++ b/tests/unit/test_stack_detector.py
@@ -1,0 +1,200 @@
+"""Tests for project stack auto-detection."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from bernstein.core.stack_detector import StackInfo, compatibility_report, detect_stack
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# detect_stack — language detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_python(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[build-system]\n", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "Python" in stack.languages
+
+
+def test_detect_javascript(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "JavaScript" in stack.languages
+
+
+def test_detect_typescript_replaces_js(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "tsconfig.json").write_text("{}", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "TypeScript" in stack.languages
+    assert "JavaScript" not in stack.languages
+
+
+def test_detect_go(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/foo\n", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "Go" in stack.languages
+
+
+def test_detect_rust(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "Rust" in stack.languages
+
+
+def test_detect_java(tmp_path: Path) -> None:
+    (tmp_path / "pom.xml").write_text("<project/>", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "Java" in stack.languages
+
+
+# ---------------------------------------------------------------------------
+# detect_stack — package managers
+# ---------------------------------------------------------------------------
+
+
+def test_detect_uv_lock(tmp_path: Path) -> None:
+    (tmp_path / "uv.lock").write_text("", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "uv" in stack.package_managers
+
+
+def test_detect_yarn_lock(tmp_path: Path) -> None:
+    (tmp_path / "yarn.lock").write_text("", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "yarn" in stack.package_managers
+
+
+def test_detect_cargo_lock(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.lock").write_text("", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "cargo" in stack.package_managers
+
+
+# ---------------------------------------------------------------------------
+# detect_stack — CI systems
+# ---------------------------------------------------------------------------
+
+
+def test_detect_github_actions(tmp_path: Path) -> None:
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    stack = detect_stack(tmp_path)
+    assert "GitHub Actions" in stack.ci_systems
+
+
+def test_detect_gitlab_ci(tmp_path: Path) -> None:
+    (tmp_path / ".gitlab-ci.yml").write_text("stages:\n", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "GitLab CI" in stack.ci_systems
+
+
+def test_detect_jenkins(tmp_path: Path) -> None:
+    (tmp_path / "Jenkinsfile").write_text("pipeline {}\n", encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "Jenkins" in stack.ci_systems
+
+
+# ---------------------------------------------------------------------------
+# detect_stack — framework detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_python_framework_fastapi(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\ndependencies = ["fastapi>=0.100"]\n',
+        encoding="utf-8",
+    )
+    stack = detect_stack(tmp_path)
+    assert "FastAPI" in stack.frameworks
+
+
+def test_detect_js_framework_react(tmp_path: Path) -> None:
+    pkg = {"dependencies": {"react": "^18.0.0"}}
+    (tmp_path / "package.json").write_text(json.dumps(pkg), encoding="utf-8")
+    stack = detect_stack(tmp_path)
+    assert "React" in stack.frameworks
+
+
+def test_detect_go_framework_gin(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text(
+        "module example.com/foo\nrequire github.com/gin-gonic/gin v1.9.0\n",
+        encoding="utf-8",
+    )
+    stack = detect_stack(tmp_path)
+    assert "Gin" in stack.frameworks
+
+
+def test_detect_rust_framework_actix(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text(
+        '[dependencies]\nactix-web = "4"\n',
+        encoding="utf-8",
+    )
+    stack = detect_stack(tmp_path)
+    assert "Actix" in stack.frameworks
+
+
+# ---------------------------------------------------------------------------
+# detect_stack — empty project
+# ---------------------------------------------------------------------------
+
+
+def test_detect_empty_project(tmp_path: Path) -> None:
+    stack = detect_stack(tmp_path)
+    assert stack.languages == []
+    assert stack.frameworks == []
+    assert stack.package_managers == []
+    assert stack.ci_systems == []
+
+
+# ---------------------------------------------------------------------------
+# detect_stack — multi-language
+# ---------------------------------------------------------------------------
+
+
+def test_detect_multi_language(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[build]\n", encoding="utf-8")
+    (tmp_path / "go.mod").write_text("module m\n", encoding="utf-8")
+    (tmp_path / "uv.lock").write_text("", encoding="utf-8")
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    stack = detect_stack(tmp_path)
+    assert "Python" in stack.languages
+    assert "Go" in stack.languages
+    assert "uv" in stack.package_managers
+    assert "GitHub Actions" in stack.ci_systems
+
+
+# ---------------------------------------------------------------------------
+# compatibility_report
+# ---------------------------------------------------------------------------
+
+
+def test_compatibility_report_python() -> None:
+    stack = StackInfo(languages=["Python"], frameworks=["FastAPI"], package_managers=["uv"])
+    report = compatibility_report(stack)
+    assert "claude" in report["recommended_adapters"]
+    assert "Python" in report["language_coverage"]
+    assert "Python" in report["stack_summary"]
+    assert "FastAPI" in report["stack_summary"]
+
+
+def test_compatibility_report_empty_stack() -> None:
+    stack = StackInfo()
+    report = compatibility_report(stack)
+    assert "claude" in report["recommended_adapters"]
+    assert "generic" in report["recommended_adapters"]
+    assert report["stack_summary"] == "No stack detected"
+
+
+def test_compatibility_report_multi_lang() -> None:
+    stack = StackInfo(languages=["Python", "Rust"])
+    report = compatibility_report(stack)
+    assert "Python" in report["language_coverage"]
+    assert "Rust" in report["language_coverage"]
+    # Adapters from both languages should be merged
+    assert "claude" in report["recommended_adapters"]

--- a/tests/unit/test_usage_telemetry.py
+++ b/tests/unit/test_usage_telemetry.py
@@ -1,0 +1,119 @@
+"""Tests for opt-in usage telemetry consent and event recording."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from bernstein.core.usage_telemetry import (
+    TelemetryConfig,
+    TelemetryConsent,
+    load_consent,
+    record_usage_event,
+    save_consent,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Consent persistence
+# ---------------------------------------------------------------------------
+
+
+def test_load_consent_missing_file(tmp_path: Path) -> None:
+    """Missing telemetry.json should return UNDECIDED."""
+    assert load_consent(tmp_path) is TelemetryConsent.UNDECIDED
+
+
+def test_save_and_load_opt_in(tmp_path: Path) -> None:
+    save_consent(tmp_path, TelemetryConsent.OPT_IN)
+    assert load_consent(tmp_path) is TelemetryConsent.OPT_IN
+
+
+def test_save_and_load_opt_out(tmp_path: Path) -> None:
+    save_consent(tmp_path, TelemetryConsent.OPT_OUT)
+    assert load_consent(tmp_path) is TelemetryConsent.OPT_OUT
+
+
+def test_save_creates_directory(tmp_path: Path) -> None:
+    nested = tmp_path / "deep" / "config"
+    save_consent(nested, TelemetryConsent.OPT_IN)
+    assert (nested / "telemetry.json").exists()
+    assert load_consent(nested) is TelemetryConsent.OPT_IN
+
+
+def test_load_consent_corrupt_file(tmp_path: Path) -> None:
+    (tmp_path / "telemetry.json").write_text("not json!!!", encoding="utf-8")
+    assert load_consent(tmp_path) is TelemetryConsent.UNDECIDED
+
+
+def test_load_consent_invalid_value(tmp_path: Path) -> None:
+    (tmp_path / "telemetry.json").write_text(
+        json.dumps({"consent": "banana"}),
+        encoding="utf-8",
+    )
+    assert load_consent(tmp_path) is TelemetryConsent.UNDECIDED
+
+
+# ---------------------------------------------------------------------------
+# Event recording
+# ---------------------------------------------------------------------------
+
+
+def test_record_event_opt_in(tmp_path: Path) -> None:
+    config = TelemetryConfig(consent=TelemetryConsent.OPT_IN, anonymous_id="test-id-123")
+    record_usage_event(config, "run.start", {"plan": "my-plan.yaml"}, log_dir=tmp_path)
+
+    log_path = tmp_path / "usage_events.jsonl"
+    assert log_path.exists()
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+
+    record = json.loads(lines[0])
+    assert record["event"] == "run.start"
+    assert record["anonymous_id"] == "test-id-123"
+    assert record["properties"]["plan"] == "my-plan.yaml"
+    assert "timestamp" in record
+
+
+def test_record_event_opt_out_is_noop(tmp_path: Path) -> None:
+    config = TelemetryConfig(consent=TelemetryConsent.OPT_OUT)
+    record_usage_event(config, "run.start", {"x": 1}, log_dir=tmp_path)
+
+    log_path = tmp_path / "usage_events.jsonl"
+    assert not log_path.exists()
+
+
+def test_record_event_undecided_is_noop(tmp_path: Path) -> None:
+    config = TelemetryConfig(consent=TelemetryConsent.UNDECIDED)
+    record_usage_event(config, "run.start", {"x": 1}, log_dir=tmp_path)
+
+    log_path = tmp_path / "usage_events.jsonl"
+    assert not log_path.exists()
+
+
+def test_record_multiple_events(tmp_path: Path) -> None:
+    config = TelemetryConfig(consent=TelemetryConsent.OPT_IN, anonymous_id="multi")
+    record_usage_event(config, "run.start", {}, log_dir=tmp_path)
+    record_usage_event(config, "task.complete", {"task_id": "t1"}, log_dir=tmp_path)
+
+    log_path = tmp_path / "usage_events.jsonl"
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+
+    events = [json.loads(line)["event"] for line in lines]
+    assert events == ["run.start", "task.complete"]
+
+
+# ---------------------------------------------------------------------------
+# TelemetryConfig defaults
+# ---------------------------------------------------------------------------
+
+
+def test_config_generates_anonymous_id() -> None:
+    config = TelemetryConfig(consent=TelemetryConsent.OPT_IN)
+    assert len(config.anonymous_id) == 32  # uuid4 hex
+    assert config.events_endpoint == ""


### PR DESCRIPTION
## Summary
- **road-010**: `jira_sync.py` — `JiraSyncConfig`, `fetch_jira_issues`, `sync_jira_to_backlog` for syncing Jira issues into `.sdd/backlog/open/` as YAML files (stdlib urllib, no new deps)
- **road-011**: `stack_detector.py` — `StackInfo`, `detect_stack`, `compatibility_report` for auto-detecting project languages/frameworks/package-managers/CI and mapping them to Bernstein adapters
- **road-012**: `usage_telemetry.py` — `TelemetryConsent` enum, `load_consent`/`save_consent` persistence, `record_usage_event` with opt-in guard (complete no-op when not OPT_IN)

All three features include full unit test suites (38 tests total, all passing).

## Test plan
- [x] `uv run pytest tests/unit/test_jira_sync.py -x -q` — 6 passed
- [x] `uv run pytest tests/unit/test_stack_detector.py -x -q` — 21 passed
- [x] `uv run pytest tests/unit/test_usage_telemetry.py -x -q` — 11 passed
- [x] `uv run ruff check` — all checks passed
- [x] `uv run pyright` — 0 errors (strict mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)