### PR TITLE
Create state machine diagrams for task and agent lifecycles

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -246,6 +246,48 @@ stateDiagram-v2
     dead --> [*]
 ```
 
+### Agent Turn FSM (10 states)
+
+Tracks the lifecycle of a single task-handling turn within an agent process.
+Source: `src/bernstein/core/agent_turn_state.py`.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> CLAIMING : task_claimed
+
+    CLAIMING --> SPAWNING : agent_spawned
+    CLAIMING --> FAILED : task_failed
+
+    SPAWNING --> RUNNING : agent_spawned
+    SPAWNING --> FAILED : task_failed
+
+    RUNNING --> TOOL_USE : tool_started
+    RUNNING --> COMPACTING : compact_needed
+    RUNNING --> VERIFYING : verify_requested
+    RUNNING --> FAILED : task_failed
+
+    TOOL_USE --> RUNNING : tool_completed
+    TOOL_USE --> FAILED : task_failed
+
+    COMPACTING --> RUNNING : verify_requested
+    COMPACTING --> FAILED : task_failed
+
+    VERIFYING --> COMPLETING : task_completed
+    VERIFYING --> RUNNING : compact_needed
+    VERIFYING --> FAILED : task_failed
+
+    COMPLETING --> REAPED : agent_reaped
+
+    FAILED --> REAPED : agent_reaped
+
+    REAPED --> [*]
+```
+
+See [LIFECYCLE.md](LIFECYCLE.md#agent-turn-states-10-states) for the full
+transition table and events reference.
+
 ---
 
 ## Non-goals for this document

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -216,6 +216,105 @@ These classify abnormal agent terminations:
 
 ---
 
+## Agent Turn States (10 states)
+
+The agent turn FSM operates at a finer granularity than the agent session FSM above.
+It tracks the lifecycle of a **single task handling turn** within an agent process —
+from the moment a task is claimed through to cleanup.
+
+Source of truth: `src/bernstein/core/agent_turn_state.py` (`AgentTurnState`,
+`AgentTurnEvent`, `AgentTurnStateMachine`).
+
+| State | Description |
+|-------|-------------|
+| `IDLE` | No active turn — agent is between tasks or not yet assigned. |
+| `CLAIMING` | A task has been claimed; worktree is being prepared. |
+| `SPAWNING` | Agent process has been launched but hasn't started executing yet. |
+| `RUNNING` | Agent process is actively working on the task. |
+| `TOOL_USE` | Agent is executing an external tool (file editor, shell, search, etc.). |
+| `COMPACTING` | Context window is near its limit; compaction/summarization is in progress. |
+| `VERIFYING` | Task work is done; janitor or LLM verification is pending. |
+| `COMPLETING` | Verification passed; task is being marked done and metrics emitted. |
+| `FAILED` | An error, crash, or verification failure occurred. |
+| `REAPED` | Cleanup is complete (worktree removed, metrics flushed). Terminal. |
+
+### Agent Turn State Diagram
+
+Events that drive transitions are shown on each arrow.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IDLE
+
+    IDLE --> CLAIMING : task_claimed
+
+    CLAIMING --> SPAWNING : agent_spawned
+    CLAIMING --> FAILED : task_failed
+
+    SPAWNING --> RUNNING : agent_spawned
+    SPAWNING --> FAILED : task_failed
+
+    RUNNING --> TOOL_USE : tool_started
+    RUNNING --> COMPACTING : compact_needed
+    RUNNING --> VERIFYING : verify_requested
+    RUNNING --> FAILED : task_failed
+
+    TOOL_USE --> RUNNING : tool_completed
+    TOOL_USE --> FAILED : task_failed
+
+    COMPACTING --> RUNNING : verify_requested
+    COMPACTING --> FAILED : task_failed
+
+    VERIFYING --> COMPLETING : task_completed
+    VERIFYING --> RUNNING : compact_needed
+    VERIFYING --> FAILED : task_failed
+
+    COMPLETING --> REAPED : agent_reaped
+
+    FAILED --> REAPED : agent_reaped
+
+    REAPED --> [*]
+```
+
+### Agent Turn Transition Table (exhaustive)
+
+| From | Event | To | Notes |
+|------|-------|----|-------|
+| `IDLE` | `task_claimed` | `CLAIMING` | Orchestrator picks up the next open task |
+| `CLAIMING` | `agent_spawned` | `SPAWNING` | Worktree ready; CLI process launched |
+| `CLAIMING` | `task_failed` | `FAILED` | Worktree setup failed (permission error, git conflict) |
+| `SPAWNING` | `agent_spawned` | `RUNNING` | Process confirmed alive and active |
+| `SPAWNING` | `task_failed` | `FAILED` | Spawn error or adapter rejected the task |
+| `RUNNING` | `tool_started` | `TOOL_USE` | Agent invoked a tool (Edit, Bash, Glob, etc.) |
+| `RUNNING` | `compact_needed` | `COMPACTING` | Context window approaching the model's limit |
+| `RUNNING` | `verify_requested` | `VERIFYING` | Agent signals it is done; verification begins |
+| `RUNNING` | `task_failed` | `FAILED` | Runtime error or abort during execution |
+| `TOOL_USE` | `tool_completed` | `RUNNING` | Tool call finished; agent resumes |
+| `TOOL_USE` | `task_failed` | `FAILED` | Fatal error inside the tool invocation |
+| `COMPACTING` | `verify_requested` | `RUNNING` | Compaction done; context summarized; agent continues |
+| `COMPACTING` | `task_failed` | `FAILED` | Compaction itself failed (`compact_failure` abort) |
+| `VERIFYING` | `task_completed` | `COMPLETING` | All completion signals satisfied |
+| `VERIFYING` | `compact_needed` | `RUNNING` | Context grew during verification; must compact first |
+| `VERIFYING` | `task_failed` | `FAILED` | Janitor rejected the result |
+| `COMPLETING` | `agent_reaped` | `REAPED` | Task marked done; worktree removed; metrics flushed |
+| `FAILED` | `agent_reaped` | `REAPED` | Error handled; resources cleaned up |
+
+### Events Reference
+
+| Event | Fired by | Meaning |
+|-------|----------|---------|
+| `task_claimed` | Spawner / orchestrator | A task was successfully reserved for this agent |
+| `agent_spawned` | Adapter / spawner | CLI process started (fires twice: at launch and at readiness confirmation) |
+| `tool_started` | Agent turn monitor | Agent began a tool call |
+| `tool_completed` | Agent turn monitor | Tool call returned |
+| `compact_needed` | Token monitor | Context window usage crossed the compaction threshold |
+| `verify_requested` | Agent / orchestrator | Agent declared the task finished |
+| `task_completed` | Janitor | All completion signals confirmed |
+| `task_failed` | Any layer | Unrecoverable error at the current phase |
+| `agent_reaped` | Janitor / spawner | Cleanup of process and worktree is complete |
+
+---
+
 ## Abort Chain Hierarchy
 
 Agent aborts follow a three-level containment hierarchy:

--- a/docs/concepts.html
+++ b/docs/concepts.html
@@ -77,6 +77,8 @@
     <ul>
       <li><a href="#architecture">Architecture</a></li>
       <li><a href="#task-lifecycle">Task lifecycle</a></li>
+      <li><a href="#agent-session-states">Agent session states</a></li>
+      <li><a href="#agent-turn-states">Agent turn states</a></li>
       <li><a href="#agent-roles">Agent roles</a></li>
       <li><a href="#model-routing">Model routing</a></li>
       <li><a href="#completion-signals">Completion signals</a></li>
@@ -132,16 +134,69 @@ Janitor (completion signal verification)</code></pre>
     </div>
 
     <h2 id="task-lifecycle">Task lifecycle</h2>
-    <p>Every task moves through a well-defined state machine:</p>
+    <p>Every task moves through a deterministic finite state machine (FSM) enforced by the Lifecycle Governance Kernel (<code>core/lifecycle.py</code>). Illegal transitions raise <code>IllegalTransitionError</code> and are recorded in the audit log.</p>
 
     <div class="code-block">
-      <pre><code class="language-text">open → claimed → in_progress → done → closed
-         ↑                    ↘ failed
-         │                    ↘ orphaned → open (retry)
-         │                               ↘ failed (max retries)
-         │
-    blocked (dependency not yet met)
-    open → cancelled (user cancellation)</code></pre>
+      <pre><code class="language-text">                    ┌─────────────────────────────────────────────┐
+                    │             TASK STATE MACHINE               │
+                    └─────────────────────────────────────────────┘
+
+  [plan mode] ──► PLANNED ──► OPEN ◄────────────────────────────────┐
+  [dynamic]  ──────────────► OPEN                                   │
+                              │                                      │
+              ┌───────────────┤                                      │
+              │               │                                      │
+              ▼               ▼                                      │
+          CANCELLED       CLAIMED ──────────────────────────────┐   │
+                              │                                  │   │
+              ┌───────────────┤                                  │   │
+              │               │                                  │   │
+              ▼               ▼                                  │   │
+          CANCELLED      IN_PROGRESS                             │   │
+                              │                                  │   │
+         ┌────────────────────┤                                  │   │
+         │         │          │          │           │           │   │
+         ▼         ▼          ▼          ▼           ▼           │   │
+       DONE      FAILED    BLOCKED  WAITING_FOR  ORPHANED        │   │
+         │         │          │     SUBTASKS        │            │   │
+         │         │          │         │           │            │   │
+         ▼         ▼          └────────►└───────────┘            │   │
+       CLOSED    OPEN ◄────────────────────────────────────────┘   │
+                              └────────────────────────────────────┘
+
+  Terminal states: CLOSED, CANCELLED</code></pre>
+    </div>
+
+    <table>
+      <thead>
+        <tr><th>State</th><th>Meaning</th><th>Terminal?</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>planned</code></td><td>Created from a plan file; awaiting human approval before execution.</td><td></td></tr>
+        <tr><td><code>open</code></td><td>Ready for an agent to claim. Default starting state for dynamically created tasks.</td><td></td></tr>
+        <tr><td><code>claimed</code></td><td>An agent has reserved the task but hasn't started executing yet.</td><td></td></tr>
+        <tr><td><code>in_progress</code></td><td>An agent is actively working. Heartbeat timeout triggers crash recovery if the agent goes silent.</td><td></td></tr>
+        <tr><td><code>done</code></td><td>Agent reported completion. Janitor verification and merge are pending.</td><td></td></tr>
+        <tr><td><code>closed</code></td><td>Janitor verified and branch merged. Fully complete.</td><td>Yes</td></tr>
+        <tr><td><code>failed</code></td><td>Agent reported failure or janitor rejected the result. Can be retried (up to <code>max_retries</code>).</td><td></td></tr>
+        <tr><td><code>blocked</code></td><td>Has unsatisfied dependencies. Transitions to <code>open</code> automatically when resolved.</td><td></td></tr>
+        <tr><td><code>waiting_for_subtasks</code></td><td>Parent task waiting for child subtasks to complete (agent decomposed work).</td><td></td></tr>
+        <tr><td><code>cancelled</code></td><td>Manually or programmatically cancelled.</td><td>Yes</td></tr>
+        <tr><td><code>orphaned</code></td><td>Agent crashed mid-task. The orchestrator attempts recovery: requeue to <code>open</code>, or <code>failed</code> after max retries.</td><td></td></tr>
+      </tbody>
+    </table>
+
+    <p>See <a href="https://github.com/chernistry/bernstein/blob/main/docs/LIFECYCLE.md" target="_blank" rel="noopener">LIFECYCLE.md</a> for the complete transition table and audit metadata reference.</p>
+
+    <h2 id="agent-session-states">Agent session states</h2>
+    <p>The agent session FSM tracks the lifecycle of a <strong>process</strong> — from spawn to termination. One agent session can handle multiple sequential tasks.</p>
+
+    <div class="code-block">
+      <pre><code class="language-text">spawn() ──► starting ──► working ──► idle ──► working (next task)
+                │            │         │
+                │            │         └──► dead (idle recycle)
+                │            └──────────── dead (crash / kill / timeout)
+                └────────────────────────► dead (spawn failure)</code></pre>
     </div>
 
     <table>
@@ -149,15 +204,51 @@ Janitor (completion signal verification)</code></pre>
         <tr><th>State</th><th>Meaning</th></tr>
       </thead>
       <tbody>
-        <tr><td><code>open</code></td><td>Waiting in the queue. No agent has picked it up yet.</td></tr>
-        <tr><td><code>blocked</code></td><td>Has unsatisfied <code>depends_on</code> entries. Will become <code>open</code> automatically when dependencies complete.</td></tr>
-        <tr><td><code>claimed</code></td><td>An agent has reserved the task but hasn't started yet.</td></tr>
-        <tr><td><code>in_progress</code></td><td>An agent is actively working. Heartbeat timeout triggers respawn if the agent goes silent.</td></tr>
-        <tr><td><code>done</code></td><td>Agent reported completion <em>and</em> janitor verified completion signals.</td></tr>
-        <tr><td><code>closed</code></td><td>Janitor verification passed after <code>done</code>. Terminal state — the task is fully complete.</td></tr>
-        <tr><td><code>failed</code></td><td>Agent reported failure, or janitor found completion signals unmet after max retries.</td></tr>
-        <tr><td><code>cancelled</code></td><td>User cancelled the task from <code>open</code> or <code>blocked</code> state.</td></tr>
-        <tr><td><code>orphaned</code></td><td>Agent crashed or went silent during <code>in_progress</code>. Retried back to <code>open</code>, or moved to <code>failed</code> after max retries.</td></tr>
+        <tr><td><code>starting</code></td><td>Process spawned; waiting for first heartbeat confirming it is alive.</td></tr>
+        <tr><td><code>working</code></td><td>Actively executing a task.</td></tr>
+        <tr><td><code>idle</code></td><td>Task complete; session is alive and can accept a new task.</td></tr>
+        <tr><td><code>dead</code></td><td>Process exited — crash, SIGKILL, timeout watchdog, or idle recycling. Terminal.</td></tr>
+      </tbody>
+    </table>
+
+    <h2 id="agent-turn-states">Agent turn states</h2>
+    <p>The agent turn FSM operates at a finer granularity than the session FSM. It tracks the lifecycle of a <strong>single task-handling turn</strong> within an agent process — from task claim through to cleanup.</p>
+
+    <div class="code-block">
+      <pre><code class="language-text">IDLE ──task_claimed──► CLAIMING ──agent_spawned──► SPAWNING ──agent_spawned──► RUNNING
+                           │                           │                           │
+                      task_failed                 task_failed              ┌───────┼──────────────┐
+                           │                           │                   │       │              │
+                           ▼                           ▼            tool_started   │         verify_requested
+                         FAILED ◄──────────────── FAILED            │       │              │
+                           │                                         │  compact_needed      │
+                           │                                         ▼       │              ▼
+                      agent_reaped                               TOOL_USE    │          VERIFYING
+                           │                                         │       ▼              │
+                           ▼                                    tool_completed  COMPACTING  │
+                         REAPED ◄── agent_reaped ◄── COMPLETING ◄──┘        │   │      task_completed
+                                                         │            verify_requested     │
+                                                    task_completed          │              ▼
+                                                         │                  └──► RUNNING  COMPLETING
+                                                         │                               │
+                                                         └──────────────────────────────►REAPED</code></pre>
+    </div>
+
+    <table>
+      <thead>
+        <tr><th>State</th><th>Meaning</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>IDLE</code></td><td>No active turn — between tasks or not yet assigned.</td></tr>
+        <tr><td><code>CLAIMING</code></td><td>Task claimed; worktree is being prepared.</td></tr>
+        <tr><td><code>SPAWNING</code></td><td>CLI process launched but not yet executing.</td></tr>
+        <tr><td><code>RUNNING</code></td><td>Agent is actively working on the task.</td></tr>
+        <tr><td><code>TOOL_USE</code></td><td>Agent is executing an external tool (file editor, shell, search).</td></tr>
+        <tr><td><code>COMPACTING</code></td><td>Context window near limit; compaction/summarization in progress.</td></tr>
+        <tr><td><code>VERIFYING</code></td><td>Work done; janitor or LLM verification pending.</td></tr>
+        <tr><td><code>COMPLETING</code></td><td>Verification passed; task being marked done, metrics emitted.</td></tr>
+        <tr><td><code>FAILED</code></td><td>Error, crash, or verification failure. Awaiting cleanup.</td></tr>
+        <tr><td><code>REAPED</code></td><td>Cleanup complete — worktree removed, metrics flushed. Terminal.</td></tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
## Create state machine diagrams for task and agent lifecycles

# Create state machine diagrams for task and agent lifecycles

## Description

The lifecycle FSM is defined in code (`lifecycle.py`) but never visualized. Generate Mermaid state diagrams showing: all task states, all agent states, allowed transitions, and transition triggers. Include in DESIGN.md and the web docs.

<!-- source: doc-002-create-state-machine-diagrams-for-task-and-agent-lifecycles.yaml -->

**Role**: docs
**Model**: sonnet

---
*Generated by Bernstein — task `06d162798b06`*