### PR TITLE
Automatic code formatting enforcement before merge (not just linting)

### DIFF
--- a/src/bernstein/core/gate_runner.py
+++ b/src/bernstein/core/gate_runner.py
@@ -34,6 +34,7 @@ GateStatus = Literal["pass", "fail", "warn", "timeout", "skipped", "bypassed"]
 
 VALID_GATE_NAMES = frozenset(
     {
+        "auto_format",
         "lint",
         "type_check",
         "tests",
@@ -194,6 +195,8 @@ def _migration_downgrade_is_pass(source: str) -> bool:
 def build_default_pipeline(config: QualityGatesConfig) -> list[GatePipelineStep]:
     """Build the implicit pipeline used when the seed file omits one."""
     pipeline: list[GatePipelineStep] = []
+    if config.auto_format:
+        pipeline.append(GatePipelineStep(name="auto_format", required=False, condition="any_changed"))
     if config.lint:
         pipeline.append(GatePipelineStep(name="lint", required=True, condition="always"))
     if config.type_check:
@@ -374,6 +377,9 @@ class GateRunner:
         changed_files: list[str],
     ) -> GateResult:
         from bernstein.core import quality_gates as qg
+
+        if step.name == "auto_format":
+            return await asyncio.to_thread(self._run_auto_format_gate_sync, step, run_dir, changed_files)
 
         if step.name == "lint":
             command = self._lint_command(step, changed_files)
@@ -1018,6 +1024,149 @@ class GateRunner:
             details=detail,
             metadata={"threshold": threshold, "oversized_files": len(oversized)},
         )
+
+    def _run_auto_format_gate_sync(
+        self,
+        step: GatePipelineStep,
+        run_dir: Path,
+        changed_files: list[str],
+    ) -> GateResult:
+        """Auto-format changed files in place before lint runs.
+
+        Runs language-appropriate formatters on changed files only (not the
+        whole repo).  The gate always passes — it fixes rather than blocks.
+        Any files reformatted are reported in the gate details so that the
+        commit/push step can stage the changes.
+
+        Supported languages:
+        - Python: ``ruff format`` (configured via ``auto_format_python_command``)
+        - JS/TS:  ``prettier --write`` (configured via ``auto_format_js_command``,
+          only when ``prettier`` is on PATH)
+        - Rust:   ``rustfmt`` (configured via ``auto_format_rust_command``,
+          only when ``rustfmt`` is on PATH)
+        """
+        import shutil
+
+        if not changed_files:
+            return self._skipped(step, "No changed files to format.")
+
+        formatted: list[str] = []
+        skipped_langs: list[str] = []
+
+        # --- Python: ruff format ---
+        py_files = [f for f in changed_files if f.endswith(".py")]
+        if py_files:
+            py_cmd_base = self._config.auto_format_python_command
+            py_exe = shlex.split(py_cmd_base)[0] if py_cmd_base else "ruff"
+            # ruff is invoked via "uv run ruff" in this project, but we honour
+            # whatever command is configured.  Resolve the first token via PATH;
+            # if it's "uv" we always try (uv is present in the project env).
+            if py_exe == "uv" or shutil.which(py_exe) is not None:
+                py_result = self._run_formatter_sync(
+                    py_cmd_base, py_files, run_dir, lang="Python"
+                )
+                if py_result:
+                    formatted.append(py_result)
+            else:
+                skipped_langs.append(f"Python ({py_exe!r} not found)")
+
+        # --- JS/TS: prettier ---
+        js_exts = {".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs"}
+        js_files = [f for f in changed_files if Path(f).suffix in js_exts]
+        if js_files:
+            js_cmd_base = self._config.auto_format_js_command
+            js_exe = shlex.split(js_cmd_base)[0] if js_cmd_base else "prettier"
+            if shutil.which(js_exe) is not None:
+                js_result = self._run_formatter_sync(
+                    js_cmd_base, js_files, run_dir, lang="JS/TS"
+                )
+                if js_result:
+                    formatted.append(js_result)
+            else:
+                skipped_langs.append(f"JS/TS ({js_exe!r} not found)")
+
+        # --- Rust: rustfmt ---
+        rs_files = [f for f in changed_files if f.endswith(".rs")]
+        if rs_files:
+            rs_cmd_base = self._config.auto_format_rust_command
+            rs_exe = shlex.split(rs_cmd_base)[0] if rs_cmd_base else "rustfmt"
+            if shutil.which(rs_exe) is not None:
+                rs_result = self._run_formatter_sync(
+                    rs_cmd_base, rs_files, run_dir, lang="Rust"
+                )
+                if rs_result:
+                    formatted.append(rs_result)
+            else:
+                skipped_langs.append(f"Rust ({rs_exe!r} not found)")
+
+        if not py_files and not js_files and not rs_files:
+            return self._skipped(step, "No formattable files changed (Python/JS/TS/Rust).")
+
+        parts: list[str] = []
+        if formatted:
+            parts.append("; ".join(formatted))
+        else:
+            parts.append("all changed files already well-formatted")
+        if skipped_langs:
+            parts.append(f"skipped: {', '.join(skipped_langs)}")
+
+        return GateResult(
+            name=step.name,
+            status="pass",
+            required=step.required,
+            blocked=False,
+            cached=False,
+            duration_ms=0,
+            details=". ".join(parts),
+            metadata={"formatted_langs": [r.split(":")[0] for r in formatted]},
+        )
+
+    def _run_formatter_sync(
+        self,
+        base_command: str,
+        files: list[str],
+        run_dir: Path,
+        lang: str,
+    ) -> str | None:
+        """Run a formatter on the specified files; return a summary string or None."""
+        cmd = shlex.split(base_command) + files
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=run_dir,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+            logger.warning("auto_format: %s formatter error: %s", lang, exc)
+            return None
+
+        if proc.returncode not in (0, 1):
+            # exit code 1 from ruff means "files were changed", which is fine;
+            # anything else is unexpected but we still don't block.
+            logger.warning(
+                "auto_format: %s formatter exited %d: %s",
+                lang,
+                proc.returncode,
+                (proc.stderr or proc.stdout)[:200],
+            )
+            return None
+
+        # Count reformatted files by inspecting stdout (ruff reports "N file(s) reformatted")
+        output = (proc.stdout or "").strip()
+        reformatted = 0
+        if "reformatted" in output:
+            for token in output.split():
+                try:
+                    reformatted = int(token)
+                    break
+                except ValueError:
+                    continue
+
+        if reformatted:
+            return f"{lang}: {reformatted} file(s) reformatted"
+        return None
 
     async def _run_integration_test_gen_gate(
         self,

--- a/src/bernstein/core/quality_gates.py
+++ b/src/bernstein/core/quality_gates.py
@@ -152,6 +152,14 @@ class QualityGatesConfig:
         mutation_timeout_s: Timeout for mutation testing (longer than other gates).
         intent_verification: Config for the LLM-based intent verification gate.
         benchmark: Config for the performance benchmark regression gate.
+        auto_format: Run automatic code formatting before lint. Auto-fixes
+            formatting issues on changed files rather than blocking merge.
+        auto_format_python_command: Shell command for Python formatting
+            (applied to changed .py files; default: ``ruff format``).
+        auto_format_js_command: Shell command for JS/TS formatting
+            (applied to changed .js/.ts/.jsx/.tsx files; default: ``prettier --write``).
+        auto_format_rust_command: Shell command for Rust formatting
+            (applied to changed .rs files; default: ``rustfmt``).
     """
 
     enabled: bool = True
@@ -215,6 +223,10 @@ class QualityGatesConfig:
     large_file_threshold: int = 500
     integration_test_gen: bool = False
     review_rubric: bool = False
+    auto_format: bool = False
+    auto_format_python_command: str = "ruff format"
+    auto_format_js_command: str = "prettier --write"
+    auto_format_rust_command: str = "rustfmt"
 
 
 @dataclass

--- a/tests/unit/test_gate_runner.py
+++ b/tests/unit/test_gate_runner.py
@@ -215,3 +215,102 @@ def test_bypass_denied_when_disabled(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="bypass is disabled"):
         asyncio.run(runner.run_all(_make_task(), tmp_path, skip_gates=["lint"]))
+
+
+# ---------------------------------------------------------------------------
+# Auto-format gate
+# ---------------------------------------------------------------------------
+
+
+def _make_auto_format_runner(tmp_path: Path, *, python_cmd: str = "ruff format") -> GateRunner:
+    config = QualityGatesConfig(
+        auto_format=True,
+        auto_format_python_command=python_cmd,
+        pipeline=[GatePipelineStep(name="auto_format", required=False, condition="any_changed")],
+        cache_enabled=False,
+    )
+    return GateRunner(config, tmp_path)
+
+
+def test_auto_format_passes_and_reports_reformatted_files(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """auto_format gate always passes and reports how many files were reformatted."""
+    import subprocess
+
+    (tmp_path / "a.py").write_text("x=1\n", encoding="utf-8")
+    runner = _make_auto_format_runner(tmp_path)
+    task = _make_task(owned_files=["a.py"])
+
+    fake_proc = subprocess.CompletedProcess(
+        args=["ruff", "format", "a.py"],
+        returncode=0,
+        stdout="1 file reformatted",
+        stderr="",
+    )
+
+    with patch("subprocess.run", return_value=fake_proc):
+        report = asyncio.run(runner.run_all(task, tmp_path))
+
+    result = report.results[0]
+    assert result.name == "auto_format"
+    assert result.status == "pass"
+    assert result.blocked is False
+    assert "Python" in result.details
+    assert "reformatted" in result.details
+
+
+def test_auto_format_skips_when_formatter_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """auto_format skips a language when its formatter binary is not on PATH."""
+    import shutil
+
+    (tmp_path / "a.py").write_text("x=1\n", encoding="utf-8")
+    runner = _make_auto_format_runner(tmp_path, python_cmd="nonexistent-fmt")
+    task = _make_task(owned_files=["a.py"])
+
+    original_which = shutil.which
+
+    def fake_which(name: str) -> str | None:
+        if name == "nonexistent-fmt":
+            return None
+        return original_which(name)
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+
+    report = asyncio.run(runner.run_all(task, tmp_path))
+
+    result = report.results[0]
+    assert result.status == "pass"
+    assert result.blocked is False
+    assert "not found" in result.details
+
+
+def test_auto_format_skips_when_no_changed_files(tmp_path: Path) -> None:
+    """auto_format gate skips cleanly when no changed files are present."""
+    config = QualityGatesConfig(
+        auto_format=True,
+        pipeline=[GatePipelineStep(name="auto_format", required=False, condition="any_changed")],
+        cache_enabled=False,
+    )
+    runner = GateRunner(config, tmp_path)
+    task = _make_task(owned_files=[])
+
+    report = asyncio.run(runner.run_all(task, tmp_path))
+
+    result = report.results[0]
+    assert result.status == "skipped"
+    assert result.blocked is False
+
+
+def test_auto_format_appears_before_lint_in_default_pipeline(tmp_path: Path) -> None:
+    """auto_format is inserted before lint in the default pipeline."""
+    from bernstein.core.gate_runner import build_default_pipeline
+
+    config = QualityGatesConfig(auto_format=True, lint=True)
+    pipeline = build_default_pipeline(config)
+    names = [step.name for step in pipeline]
+    assert "auto_format" in names
+    assert "lint" in names
+    assert names.index("auto_format") < names.index("lint")


### PR DESCRIPTION
## Automatic code formatting enforcement before merge (not just linting)

# Automatic code formatting enforcement before merge (not just linting)

## Description

Automatically run formatters (black/ruff format for Python, prettier for JS/TS, rustfmt for Rust) on agent output before merge. If the agent produced correctly-functioning but poorly-formatted code, fix it automatically rather than failing the quality gate. Different from the existing lint gate (which reports errors) -- this auto-fixes formatting.

## Review status (2026-04-08)

This is partially implemented:

- `src/bernstein/core/fast_path.py` already auto-runs `ruff format` for deterministic low-level tasks.
- `scripts/safe-push-main.sh` enforces formatting in the manual main-branch push flow.
- CI and remediation helpers already recognize format failures and point to the formatter.

What is still missing:

- A universal pre-merge formatting stage in the normal quality-gate/janitor path.
- Language-aware formatter selection beyond Python.
- Guardrails so auto-format only touches task-owned or changed files before merge.

Recommended implementation:

1. Add an optional auto-fix formatting step before lint inside `src/bernstein/core/gate_runner.py`.
2. Start with Python (`ruff format`) on changed/owned files only.
3. Extend the same mechanism to Prettier/rustfmt once file ownership and command availability checks are wired in.

<!-- source: road-169-automatic-code-formatting-enforcement-before-merge-not-just.yaml -->

**Role**: qa
**Model**: sonnet

---
*Generated by Bernstein — task `b6be5dacaac9`*