### PR TITLE
Create state machine diagrams for task and agent lifecycles

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -226,7 +226,12 @@ stateDiagram-v2
 
     CLOSED --> [*]
     CANCELLED --> [*]
+
+    %% PENDING_APPROVAL has no FSM-managed transitions — set directly by the approval subsystem.
+    PENDING_APPROVAL --> [*]
 ```
+
+> **Note — `PENDING_APPROVAL`:** Set directly by the approval subsystem; has no entry or exit in `TASK_TRANSITIONS`. See [LIFECYCLE.md](LIFECYCLE.md#terminal-states) for details.
 
 ### Agent FSM (4 states)
 

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -76,7 +76,13 @@ stateDiagram-v2
 
     CLOSED --> [*]
     CANCELLED --> [*]
+
+    %% PENDING_APPROVAL is a terminal state set directly by the approval
+    %% subsystem. It has no FSM-managed inbound or outbound transitions.
+    PENDING_APPROVAL --> [*]
 ```
+
+> **Note — `PENDING_APPROVAL`:** This state exists in the `TaskStatus` enum and is used by the approval subsystem (see `src/bernstein/core/approval.py`). It is set directly rather than through the `TASK_TRANSITIONS` table, so it has no FSM-managed entry or exit path. Tasks in this state await human review and cannot progress further without manual intervention.
 
 ### Task Transition Table (exhaustive)
 


### PR DESCRIPTION
## Create state machine diagrams for task and agent lifecycles

# Create state machine diagrams for task and agent lifecycles

## Description

The lifecycle FSM is defined in code (`lifecycle.py`) but never visualized. Generate Mermaid state diagrams showing: all task states, all agent states, allowed transitions, and transition triggers. Include in DESIGN.md and the web docs.

<!-- source: doc-002-create-state-machine-diagrams-for-task-and-agent-lifecycles.yaml -->

**Role**: docs
**Model**: sonnet

---
*Generated by Bernstein — task `1b7af5b011a5`*