### PR TITLE
feat(core): implement test data generators for realistic task payloads

### DIFF
--- a/src/bernstein/core/test_data_gen.py
+++ b/src/bernstein/core/test_data_gen.py
@@ -1,0 +1,415 @@
+﻿"""Realistic test data generators for Bernstein task payloads.
+
+This module provides configurable generators for test tasks, plans,
+and completion signals that mirror the structure of real agent
+work in the Bernstein orchestrator.
+
+Used by the test suite to generate realistic task graphs without
+hand-coding dozens of fixture objects.
+"""
+
+from __future__ import annotations
+
+import random
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+__all__ = [
+    "TaskTemplate",
+    "GeneratedTask",
+    "generate_task",
+    "generate_task_batch",
+    "generate_plan",
+    "generate_completion_signal",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+_ROLES = ["coder", "reviewer", "tester", "devops", "architect"]
+
+_COMPLEXITY_FILE_COUNTS: dict[str, tuple[int, int]] = {
+    "low": (1, 3),
+    "medium": (2, 6),
+    "high": (5, 15),
+}
+
+_COMPLEXITY_DEPENDENCY_COUNTS: dict[str, tuple[int, int]] = {
+    "low": (0, 0),
+    "medium": (0, 2),
+    "high": (2, 4),
+}
+
+_COMPLEXITY_GATE_COUNTS: dict[str, tuple[int, int]] = {
+    "low": (1, 2),
+    "medium": (2, 3),
+    "high": (3, 5),
+}
+
+_COMPLEXITY_PRIORITIES: dict[str, tuple[int, int]] = {
+    "low": (7, 10),
+    "medium": (4, 6),
+    "high": (1, 3),
+}
+
+_QUALITY_GATES_ALL = [
+    "tests_pass",
+    "lint_clean",
+    "type_check",
+    "coverage_above_80",
+    "security_scan",
+    "doc_updated",
+]
+
+_TASK_PREFIXES = [
+    "Fix",
+    "Add",
+    "Refactor",
+    "Optimize",
+    "Implement",
+    "Remove",
+    "Update",
+    "Migrate",
+    "Split",
+    "Merge",
+]
+
+_TASK_NOUNS = [
+    "auth",
+    "cache",
+    "api",
+    "ui",
+    "database",
+    "logger",
+    "config",
+    "tests",
+    "docs",
+    "migration",
+    "errors",
+    "metrics",
+    "pagination",
+    "rate_limiting",
+    "health_checks",
+]
+
+_TASK_MODIFIERS = [
+    "middleware",
+    "handler",
+    "service",
+    "client",
+    "integration",
+    "endpoint",
+    "pipeline",
+    "store",
+    "gateway",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class TaskTemplate:
+    """Template for generating realistic test tasks.
+
+    Attributes:
+        role: The primary agent role responsible for this task
+            (e.g., "coder", "reviewer", "tester").
+        complexity: One of "low", "medium", or "high". Controls file
+            counts, dependency depth, and priority ranges.
+        file_count_range: Inclusive range of files this task touches.
+        has_dependencies: Whether this task depends on sibling tasks.
+        quality_gates: Collection of quality gates the task must pass.
+    """
+
+    role: str
+    complexity: str  # "low" | "medium" | "high"
+    file_count_range: tuple[int, int]
+    has_dependencies: bool
+    quality_gates: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GeneratedTask:
+    """A generated realistic test task.
+
+    Attributes:
+        task_id: Unique identifier for this task (8-char hex).
+        title: Human-readable task title (e.g., "Fix auth middleware").
+        goal: Detailed description of what the task accomplishes.
+        role: The agent role responsible for execution.
+        scope: List of file paths the task touches.
+        dependencies: Task IDs this task depends on.
+        quality_gates: Quality gates that must pass for completion.
+        priority: Integer priority (1 = highest).
+        complexity: Complexity tier ("low", "medium", "high").
+    """
+
+    task_id: str
+    title: str
+    goal: str
+    role: str
+    scope: list[str]
+    dependencies: list[str]
+    quality_gates: list[str]
+    priority: int
+    complexity: str
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers
+# --------------------------------------------------------------------------- #
+
+def _generate_scope(template: TaskTemplate) -> list[str]:
+    """Generate a realistic file-scope list for a task."""
+    count = random.randint(*template.file_count_range)
+    modules = random.sample(_TASK_NOUNS, k=min(count, len(_TASK_NOUNS)))
+    scope = []
+    for mod in modules:
+        scope.append(f"src/bernstein/core/{mod}.py")
+        if random.random() > 0.5:
+            scope.append(f"tests/unit/test_{mod}.py")
+    return scope
+
+
+def _generate_title() -> str:
+    """Generate a plausible task title."""
+    prefix = random.choice(_TASK_PREFIXES)
+    noun = random.choice(_TASK_NOUNS)
+    modifier = random.choice(_TASK_MODIFIERS)
+    # Avoid awkward repetitions
+    if noun in modifier:
+        modifier = random.choice(_TASK_MODIFIERS)
+    return f"{prefix} {noun} {modifier}"
+
+
+def _generate_goal(title: str, scope: list[str]) -> str:
+    """Generate a task goal from a title and scope."""
+    primary_file = scope[0] if scope else "the relevant module"
+    return (
+        f"Complete the following task: {title}. "
+        f"Modify {primary_file} and related files. "
+        f"Ensure all quality gates pass before marking complete."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+def generate_task(template: TaskTemplate | None = None) -> GeneratedTask:
+    """Generate a single realistic test task.
+
+    Args:
+        template: Optional template controlling complexity, role, and
+            gate configuration. If omitted, a random template is used.
+
+    Returns:
+        A fully-populated GeneratedTask instance.
+    """
+    if template is None:
+        complexity = random.choice(["low", "medium", "high"])
+        role = random.choice(_ROLES)
+        file_counts = _COMPLEXITY_FILE_COUNTS[complexity]
+        dep_counts = _COMPLEXITY_DEPENDENCY_COUNTS[complexity]
+        gate_counts = _COMPLEXITY_GATE_COUNTS[complexity]
+        priority_range = _COMPLEXITY_PRIORITIES[complexity]
+
+        num_gates = random.randint(*gate_counts)
+        gates = sorted(random.sample(_QUALITY_GATES_ALL, k=num_gates))
+
+        template = TaskTemplate(
+            role=role,
+            complexity=complexity,
+            file_count_range=file_counts,
+            has_dependencies=random.choice([True, False]),
+            quality_gates=tuple(gates),
+        )
+
+    title = _generate_title()
+    scope = _generate_scope(template)
+    goal = _generate_goal(title, scope)
+
+    num_deps = random.randint(*_COMPLEXITY_DEPENDENCY_COUNTS[template.complexity])
+
+    return GeneratedTask(
+        task_id=uuid.uuid4().hex[:8],
+        title=title,
+        goal=goal,
+        role=template.role,
+        scope=scope,
+        dependencies=[],  # populated by caller or generate_plan
+        quality_gates=list(template.quality_gates),
+        priority=random.randint(*_COMPLEXITY_PRIORITIES[template.complexity]),
+        complexity=template.complexity,
+    )
+
+
+def generate_task_batch(
+    count: int,
+    roles: list[str] | None = None,
+    complexity: str | None = None,
+) -> list[GeneratedTask]:
+    """Generate a batch of realistic test tasks.
+
+    Args:
+        count: Number of tasks to generate.
+        roles: Optional list of roles to restrict task generation to.
+            If None, roles are chosen randomly.
+        complexity: Optional fixed complexity for all tasks.
+            If None, complexity is chosen randomly per task.
+
+    Returns:
+        A list of `count` unique GeneratedTask instances.
+    """
+    tasks: list[GeneratedTask] = []
+    seen_ids: set[str] = set()
+
+    for _ in range(count):
+        role = random.choice(roles) if roles else random.choice(_ROLES)
+        cmp = complexity or random.choice(["low", "medium", "high"])
+        file_counts = _COMPLEXITY_FILE_COUNTS[cmp]
+        gate_counts = _COMPLEXITY_GATE_COUNTS[cmp]
+        priority_range = _COMPLEXITY_PRIORITIES[cmp]
+
+        num_gates = random.randint(*gate_counts)
+        gates = sorted(random.sample(_QUALITY_GATES_ALL, k=num_gates))
+
+        template = TaskTemplate(
+            role=role,
+            complexity=cmp,
+            file_count_range=file_counts,
+            has_dependencies=random.random() > 0.4,
+            quality_gates=tuple(gates),
+        )
+
+        task = generate_task(template)
+        # Ensure uniqueness
+        while task.task_id in seen_ids:
+            task = generate_task(template)
+        seen_ids.add(task.task_id)
+        tasks.append(task)
+
+    return tasks
+
+
+def generate_plan(
+    stages: int = 3,
+    tasks_per_stage: int = 3,
+) -> dict[str, Any]:
+    """Generate a realistic multi-stage test plan with inter-stage dependencies.
+
+    Each stage's tasks depend on tasks from the previous stage, forming
+    a realistic dependency chain that mirrors staged refactoring or
+    feature development.
+
+    Args:
+        stages: Number of plan stages to generate (default 3).
+        tasks_per_stage: Number of tasks per stage (default 3).
+
+    Returns:
+        A dict with keys `"stages"` (list of stage dicts) and
+        `"tasks"` (flat list of all GeneratedTask instances).
+        Each stage dict contains `stage_id`, `tasks`, and
+        `depends_on` (task IDs from the previous stage).
+    """
+    all_tasks: list[GeneratedTask] = []
+    stage_outputs: list[list[str]] = []  # task_ids per stage
+
+    for stage_idx in range(stages):
+        stage_tasks = generate_task_batch(tasks_per_stage)
+        prev_ids = stage_outputs[-1] if stage_outputs else []
+
+        # Wire inter-stage dependencies
+        wired_tasks: list[GeneratedTask] = []
+        for task in stage_tasks:
+            num_deps = min(len(prev_ids), random.randint(0, 2)) if prev_ids else 0
+            deps = random.sample(prev_ids, k=num_deps) if num_deps else []
+            wired_tasks.append(
+                GeneratedTask(
+                    task_id=task.task_id,
+                    title=task.title,
+                    goal=task.goal,
+                    role=task.role,
+                    scope=task.scope,
+                    dependencies=deps,
+                    quality_gates=task.quality_gates,
+                    priority=task.priority,
+                    complexity=task.complexity,
+                )
+            )
+
+        all_tasks.extend(wired_tasks)
+        stage_outputs.append([t.task_id for t in wired_tasks])
+
+    # Build stage structure
+    stage_objs: list[dict[str, Any]] = []
+    for i, task_group in enumerate(stage_outputs):
+        stage_objs.append({
+            "stage_id": i + 1,
+            "task_ids": task_group,
+            "depends_on": stage_outputs[i - 1] if i > 0 else [],
+        })
+
+    return {
+        "stages": stage_objs,
+        "tasks": [
+            {
+                "task_id": t.task_id,
+                "title": t.title,
+                "role": t.role,
+                "complexity": t.complexity,
+                "priority": t.priority,
+                "dependencies": t.dependencies,
+                "scope": t.scope,
+                "quality_gates": t.quality_gates,
+                "goal": t.goal,
+            }
+            for t in all_tasks
+        ],
+    }
+
+
+def generate_completion_signal(task: GeneratedTask) -> dict[str, Any]:
+    """Generate a realistic task completion signal.
+
+    Simulates the payload that the Bernstein agent runtime emits when
+    a task is marked complete.
+
+    Args:
+        task: The GeneratedTask that was completed.
+
+    Returns:
+        A dict containing `task_id`, `files_changed`,
+        `tests_pass`, `quality_gates_pass`, `duration_seconds`,
+        and `completed_at`.
+    """
+    from datetime import datetime, timezone
+
+    gate_results = {
+        gate: random.random() > 0.1  # ~90% pass rate per gate
+        for gate in task.quality_gates
+    }
+
+    # Bias tests_pass based on overall gate health
+    all_pass = all(gate_results.values())
+    tests_pass = all_pass or random.random() > 0.3
+
+    # Derive files_changed from scope length
+    files_changed = len(task.scope)
+
+    return {
+        "task_id": task.task_id,
+        "files_changed": files_changed,
+        "tests_pass": tests_pass,
+        "quality_gates_pass": gate_results,
+        "duration_seconds": random.randint(60, 7200),
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+    }

--- a/tests/unit/test_data_gen.py
+++ b/tests/unit/test_data_gen.py
@@ -1,0 +1,191 @@
+﻿"""Tests for bernstein.core.test_data_gen."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from bernstein.core.test_data_gen import (
+    GeneratedTask,
+    TaskTemplate,
+    generate_completion_signal,
+    generate_plan,
+    generate_task,
+    generate_task_batch,
+)
+
+
+class TestGenerateTask:
+    def test_returns_generated_task(self) -> None:
+        task = generate_task()
+        assert isinstance(task, GeneratedTask)
+        assert len(task.task_id) == 8
+        assert task.title
+        assert task.goal
+        assert task.role in {"coder", "reviewer", "tester", "devops", "architect"}
+        assert task.complexity in {"low", "medium", "high"}
+
+    def test_with_template_low_complexity(self) -> None:
+        template = TaskTemplate(
+            role="coder",
+            complexity="low",
+            file_count_range=(1, 3),
+            has_dependencies=False,
+            quality_gates=("tests_pass",),
+        )
+        task = generate_task(template)
+        assert task.complexity == "low"
+        assert task.priority >= 7
+        assert len(task.scope) <= 3
+
+    def test_with_template_high_complexity(self) -> None:
+        template = TaskTemplate(
+            role="architect",
+            complexity="high",
+            file_count_range=(5, 15),
+            has_dependencies=True,
+            quality_gates=("tests_pass", "lint_clean", "type_check", "security_scan"),
+        )
+        task = generate_task(template)
+        assert task.complexity == "high"
+        assert task.priority <= 3
+        assert len(task.scope) >= 5
+
+    def test_title_format(self) -> None:
+        for _ in range(20):
+            task = generate_task()
+            parts = task.title.split(" ")
+            assert len(parts) >= 2
+            assert parts[0] in {
+                "Fix",
+                "Add",
+                "Refactor",
+                "Optimize",
+                "Implement",
+                "Remove",
+                "Update",
+                "Migrate",
+                "Split",
+                "Merge",
+            }
+
+    def test_scope_paths_format(self) -> None:
+        task = generate_task()
+        for path in task.scope:
+            assert path.startswith("src/bernstein/") or path.startswith("tests/unit/")
+
+
+class TestGenerateTaskBatch:
+    def test_returns_correct_count(self) -> None:
+        tasks = generate_task_batch(10)
+        assert len(tasks) == 10
+
+    def test_no_duplicate_ids(self) -> None:
+        tasks = generate_task_batch(100)
+        ids = [t.task_id for t in tasks]
+        assert len(ids) == len(set(ids))
+
+    def test_role_filter(self) -> None:
+        tasks = generate_task_batch(20, roles=["tester"])
+        for task in tasks:
+            assert task.role == "tester"
+
+    def test_complexity_filter(self) -> None:
+        tasks = generate_task_batch(20, complexity="high")
+        for task in tasks:
+            assert task.complexity == "high"
+            assert task.priority <= 3
+
+    def test_batch_unique_ids_across_calls(self) -> None:
+        batch1 = generate_task_batch(50)
+        batch2 = generate_task_batch(50)
+        ids1 = {t.task_id for t in batch1}
+        ids2 = {t.task_id for t in batch2}
+        assert ids1.isdisjoint(ids2)
+
+
+class TestGeneratePlan:
+    def test_returns_stages_and_tasks(self) -> None:
+        plan = generate_plan(stages=3, tasks_per_stage=4)
+        assert "stages" in plan
+        assert "tasks" in plan
+        assert len(plan["stages"]) == 3
+        assert len(plan["tasks"]) == 12  # 3 * 4
+
+    def test_inter_stage_dependencies(self) -> None:
+        plan = generate_plan(stages=3, tasks_per_stage=2)
+        tasks_by_id = {t["task_id"]: t for t in plan["tasks"]}
+
+        # Stage 1 tasks should have no dependencies
+        stage1_ids = plan["stages"][0]["task_ids"]
+        for tid in stage1_ids:
+            assert tasks_by_id[tid]["dependencies"] == []
+
+        # Stage 2+ tasks may have dependencies on previous stage
+        for stage in plan["stages"][1:]:
+            for tid in stage["task_ids"]:
+                for dep in tasks_by_id[tid]["dependencies"]:
+                    # Dependencies must be from an earlier stage
+                    assert dep in sum((s["task_ids"] for s in plan["stages"][: stage["stage_id"] - 1]), [])
+
+    def test_all_task_ids_from_stages(self) -> None:
+        plan = generate_plan(stages=4, tasks_per_stage=3)
+        stage_ids = set()
+        for s in plan["stages"]:
+            stage_ids.update(s["task_ids"])
+        task_ids = {t["task_id"] for t in plan["tasks"]}
+        assert stage_ids == task_ids
+
+
+class TestGenerateCompletionSignal:
+    def test_required_keys_present(self) -> None:
+        task = generate_task()
+        signal = generate_completion_signal(task)
+        assert "task_id" in signal
+        assert "files_changed" in signal
+        assert "tests_pass" in signal
+        assert "quality_gates_pass" in signal
+        assert "duration_seconds" in signal
+        assert "completed_at" in signal
+
+    def test_task_id_matches(self) -> None:
+        task = generate_task()
+        signal = generate_completion_signal(task)
+        assert signal["task_id"] == task.task_id
+
+    def test_files_changed_matches_scope(self) -> None:
+        task = generate_task()
+        signal = generate_completion_signal(task)
+        assert signal["files_changed"] == len(task.scope)
+
+    def test_quality_gates_contain_all_task_gates(self) -> None:
+        task = generate_task()
+        signal = generate_completion_signal(task)
+        for gate in task.quality_gates:
+            assert gate in signal["quality_gates_pass"]
+
+    def test_completed_at_is_iso_format(self) -> None:
+        import re
+        task = generate_task()
+        signal = generate_completion_signal(task)
+        # ISO 8601 with timezone
+        assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", signal["completed_at"])
+
+
+class TestFrozenDataclasses:
+    def test_task_template_immutable(self) -> None:
+        template = TaskTemplate(
+            role="coder",
+            complexity="low",
+            file_count_range=(1, 3),
+            has_dependencies=False,
+            quality_gates=("tests_pass",),
+        )
+        with pytest.raises(Exception):  # frozen dataclass
+            template.role = "reviewer"  # type: ignore[assignment]
+
+    def test_generated_task_immutable(self) -> None:
+        task = generate_task()
+        with pytest.raises(Exception):  # frozen dataclass
+            task.title = "Hacked"  # type: ignore[assignment]


### PR DESCRIPTION
## Implementation Plan for `src/bernstein/core/test_data_gen.py`

Great issue — the data model design is solid. Here's a concrete implementation plan based on the acceptance criteria:

### Imports and structure

```python
from __future__ import annotations

import random
import uuid
from dataclasses import dataclass, field
from typing import Any

_ROLES = ["coder", "reviewer", "tester", "devops", "architect"]
_COMPLEXITIES = ["low", "medium", "high"]
_QUALITY_GATES = ["tests_pass", "lint_clean", "type_check", "coverage_above_80", "security_scan", "doc_updated"]
_TASK_PREFIXES = ["Fix", "Add", "Refactor", "Optimize", "Implement", "Remove", "Update"]
_TASK_NOUNS = ["auth", "cache", "api", "ui", "database", "logger", "config", "tests", "docs", "migration"]
```

### Data model (as specified)

```python
@dataclass(frozen=True)
class TaskTemplate:
    role: str
    complexity: str  # "low" | "medium" | "high"
    file_count_range: tuple[int, int]
    has_dependencies: bool
    quality_gates: tuple[str, ...]

@dataclass(frozen=True)
class GeneratedTask:
    task_id: str
    title: str
    goal: str
    role: str
    scope: list[str]
    dependencies: list[str]
    quality_gates: list[str]
    priority: int
    complexity: str
```

### Core generation logic

**`generate_task`** — build a single realistic task:
- For "low" complexity: `file_count_range=(1, 3)`, no dependencies, 1-2 quality gates
- For "medium": `file_count_range=(2, 6)`, optionally 1-2 dependencies, 2-3 gates
- For "high": `file_count_range=(5, 15)`, 2-4 dependencies, 3-5 gates
- Title format: `"{prefix} {noun} {modifier}"` (e.g., "Add cache invalidation", "Refactor auth middleware")
- `scope` should be a list of realistic file paths like `["src/bernstein/core/cache.py", "tests/unit/test_cache.py"]`

**`generate_task_batch`** — generate N tasks, optionally filtered by role:
- Ensure task_ids are unique (use `uuid.uuid4().hex[:8]`)
- Set priority 1-3 for high, 4-6 for medium, 7-10 for low complexity

**`generate_plan`** — multi-stage plan with inter-stage dependencies:
- Each stage's tasks depend on the previous stage's outputs
- Stage 1 tasks have no dependencies
- Stage N tasks depend on Stage N-1 task_ids

**`generate_completion_signal`** — realistic completion payload:
```python
{
    "task_id": task.task_id,
    "files_changed": random.randint(*task.scope_file_count_range),
    "tests_pass": random.choice([True, True, True, False]),  # weighted True
    "quality_gates_pass": {g: random.random() > 0.1 for g in task.quality_gates},
    "duration_seconds": random.randint(60, 3600),
}
```

### Key implementation notes

1. **Frozen dataclasses** — all dataclasses use `frozen=True` for immutability
2. **File count estimation** — derive `scope_file_count_range` from the template's `file_count_range`
3. **Deterministic-ish generation** — use `random.seed()` in tests for reproducibility
4. **Docstrings** — all public functions get Google-style docstrings per acceptance criteria
5. **Type hints** — full type annotations, no `Any` in public signatures

### Test file structure (`tests/unit/test_data_gen.py`)

Test cases to cover:
- `test_generate_task_low_complexity` — low complexity task has correct ranges
- `test_generate_task_batch_no_duplicates` — no duplicate task_ids in batch
- `test_generate_plan_stages_have_dependencies` — later stages depend on earlier ones
- `test_generate_completion_signal_has_required_fields` — all expected keys present
- `test_generate_task_respects_role_filter` — batch filtered by role returns correct roles
- `test_frozen_dataclasses_are_immutable` — attempt to mutate raises FrozenInstanceError

### One question for maintainers

Should `scope` file paths be absolute (e.g., `src/bernstein/...`) or relative to a configurable root? Happy to add a `root_path: str = "src/bernstein"` parameter to `generate_task` if relative paths make more sense for the test harness.
