### PR TITLE
fix: Windows compatibility for agent spawn

### DIFF
--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -88,7 +88,7 @@ def build_worker_cmd(
     return [
         sys.executable,
         "-m",
-        "bernstein.core.worker",
+        "bernstein.core.orchestration.worker",
         "--role",
         role,
         "--session",

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -35,6 +35,22 @@ _BASE_ALLOWLIST: frozenset[str] = frozenset(
         # --- User home directory ---
         # Claude Code, aider, gemini CLI etc. read ~/.config, ~/.claude, ~/.cache
         "HOME",
+        # --- Windows system variables ---
+        # Without SYSTEMROOT/WINDIR, Windows processes fail to locate system DLLs
+        # and exit with code -1 (0xFFFFFFFF) before even starting
+        "SYSTEMROOT",
+        "WINDIR",
+        "COMSPEC",  # Path to cmd.exe, needed for shell operations
+        "APPDATA",
+        "LOCALAPPDATA",
+        "USERPROFILE",  # Windows equivalent of HOME
+        "SystemDrive",
+        "ProgramFiles",
+        "ProgramFiles(x86)",
+        "ProgramData",
+        "CommonProgramFiles",
+        "CommonProgramFiles(x86)",
+        "USERNAME",  # Windows equivalent of USER
         # --- Locale / text encoding ---
         # Many CLIs break on non-UTF-8 terminals without these
         "LANG",

--- a/src/bernstein/adapters/manager.py
+++ b/src/bernstein/adapters/manager.py
@@ -45,7 +45,7 @@ class ManagerAdapter(CLIAdapter):
         cmd = [
             sys.executable,
             "-m",
-            "bernstein.core.manager",
+            "bernstein.core.orchestration.manager",
             "--port",
             "8052",
             "--task-id",

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -158,6 +158,10 @@ class _CLIRedirectLoader:
         module.__file__ = getattr(real, "__file__", None)
         sys.modules[fullname] = real
 
+    def get_code(self, fullname: str) -> None:
+        """Return None — redirect loaders don't provide code objects."""
+        return None
+
 
 if not any(isinstance(f, _CLIRedirectFinder) for f in sys.meta_path):
     sys.meta_path.append(_CLIRedirectFinder())

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -598,6 +598,10 @@ class _CoreRedirectLoader:
         # Also register real module under old name for subsequent imports
         sys.modules[fullname] = real
 
+    def get_code(self, fullname: str) -> None:
+        """Return None — redirect loaders don't provide code objects."""
+        return None
+
 
 # Register the finder once at import time
 if not any(isinstance(f, _CoreRedirectFinder) for f in sys.meta_path):

--- a/src/bernstein/core/orchestration/adaptive_parallelism.py
+++ b/src/bernstein/core/orchestration/adaptive_parallelism.py
@@ -96,9 +96,18 @@ class AdaptiveParallelism:
             CPU usage percentage (0-100+).
         """
         try:
-            _, load5, _ = os.getloadavg()
-            cpu_count = os.cpu_count() or 1
-            return (load5 / cpu_count) * 100.0
+            if hasattr(os, "getloadavg"):
+                # Unix: use 5-minute load average
+                _, load5, _ = os.getloadavg()
+                cpu_count = os.cpu_count() or 1
+                return (load5 / cpu_count) * 100.0
+            else:
+                # Windows: use psutil if available, otherwise return 0
+                try:
+                    import psutil
+                    return psutil.cpu_percent(interval=None)
+                except ImportError:
+                    return 0.0
         except OSError:
             return 0.0
 

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -405,7 +405,7 @@ def _start_spawner(
         [
             sys.executable,
             "-m",
-            "bernstein.core.orchestrator",
+            "bernstein.core.orchestration.orchestrator",
             "--port",
             str(port),
             "--cells",


### PR DESCRIPTION
## Summary

- Add Windows system environment variables to `_BASE_ALLOWLIST` in `env_isolation.py` (`SYSTEMROOT`, `WINDIR`, `COMSPEC`, `APPDATA`, `LOCALAPPDATA`, `USERPROFILE`, etc.) - without these, spawned processes fail with exit code -1 (0xFFFFFFFF) because Windows cannot locate system DLLs
- Add Windows fallback for `os.getloadavg()` in `adaptive_parallelism.py` using `psutil.cpu_percent()` since `getloadavg` is Unix-only
- Fix redirect module paths to use real module paths instead of redirect aliases (redirect modules cannot be run with `python -m` as they have no code object)
- Add `get_code()` method to redirect loaders to satisfy Python import system requirements

## Test plan

- [ ] Run `bernstein run` on Windows and verify agents spawn successfully (no exit code 4294967295)
- [ ] Verify orchestrator tick loop runs without `os.getloadavg` errors
- [ ] Verify `python -m bernstein.core.orchestration.worker` imports correctly