### PR TITLE
fix: Windows Unicode compatibility for subprocess and terminal display

### DIFF
--- a/src/bernstein/adapters/ci/github_actions.py
+++ b/src/bernstein/adapters/ci/github_actions.py
@@ -181,7 +181,7 @@ def download_github_actions_log(
     result = subprocess.run(
         ["gh", "run", "view", run_id, "--log-failed"],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=timeout,
     )
     if result.returncode != 0:
@@ -231,7 +231,7 @@ def download_github_actions_log_api(
             '.jobs[] | select(.conclusion == "failure") | .id',
         ],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=timeout,
     )
     if result.returncode != 0:
@@ -248,7 +248,7 @@ def download_github_actions_log_api(
         log_result = subprocess.run(
             ["gh", "api", f"repos/{repo}/actions/jobs/{job_id}/logs"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
         )
         if log_result.returncode == 0:

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -156,7 +156,7 @@ class ClaudeCodeAdapter(CLIAdapter):
             result = subprocess.run(
                 ["claude", "--print", "--max-turns", "1", "--output-format", "text", "-p", "say ok"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=COST.rate_limit_probe_timeout_s,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -499,7 +499,7 @@ class {class_name}(CLIAdapter):
             cwd=workdir,
             stdout=open(log_path, "w"),
             stderr=subprocess.STDOUT,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
         )
         return SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
 '''

--- a/src/bernstein/adapters/goose.py
+++ b/src/bernstein/adapters/goose.py
@@ -116,7 +116,7 @@ class GooseAdapter(CLIAdapter):
             result = subprocess.run(
                 ["goose", "--version"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
                 check=False,
             )

--- a/src/bernstein/agents/agency_provider.py
+++ b/src/bernstein/agents/agency_provider.py
@@ -446,7 +446,7 @@ class AgencyProvider:
             result = subprocess.run(
                 ["git", "-C", str(target), "pull", "--ff-only", "--quiet"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=60,
             )
             if result.returncode != 0:
@@ -462,7 +462,7 @@ class AgencyProvider:
             result = subprocess.run(
                 ["git", "clone", "--depth=1", "--quiet", url, str(target)],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=120,
             )
             if result.returncode != 0:

--- a/src/bernstein/benchmark/comparative.py
+++ b/src/bernstein/benchmark/comparative.py
@@ -375,7 +375,7 @@ class ComparativeBenchmark:
                 ["bernstein", "--goal", goal, "--headless", "--budget", budget],
                 cwd=self._workdir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=600,
             )
             success = proc.returncode == 0

--- a/src/bernstein/benchmark/swe_bench.py
+++ b/src/bernstein/benchmark/swe_bench.py
@@ -520,7 +520,7 @@ class SWEBenchRunner:
             ["bernstein", "--goal", goal, "--headless", "--budget", "2.00"],
             cwd=self.workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=600,
         )
 

--- a/src/bernstein/cli/commands/changelog_cmd.py
+++ b/src/bernstein/cli/commands/changelog_cmd.py
@@ -70,7 +70,7 @@ def _run_git(args: list[str], cwd: Path) -> str:
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         return result.stdout.strip()

--- a/src/bernstein/cli/commands/checkpoint_cmd.py
+++ b/src/bernstein/cli/commands/checkpoint_cmd.py
@@ -20,7 +20,7 @@ def _get_git_sha() -> str:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
         )
         return result.stdout.strip()

--- a/src/bernstein/cli/commands/diff_cmd.py
+++ b/src/bernstein/cli/commands/diff_cmd.py
@@ -114,7 +114,7 @@ def _run_git(args: list[str], cwd: Path) -> str:
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         return result.stdout.strip()

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -159,7 +159,7 @@ def check_git_installed() -> dict[str, Any]:
         result = subprocess.run(
             ["git", "--version"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
         )
         version = result.stdout.strip()

--- a/src/bernstein/cli/commands/playground.py
+++ b/src/bernstein/cli/commands/playground.py
@@ -149,7 +149,7 @@ def _run_git(args: list[str], cwd: Path | None = None) -> subprocess.CompletedPr
     return subprocess.run(
         ["git", *args],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         cwd=cwd,
         timeout=30,
     )
@@ -285,7 +285,7 @@ def apply_sandbox(session: PlaygroundSession) -> bool:
         ["git", "apply", "--3way", "-"],
         input=diff,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         cwd=original,
         timeout=30,
     )

--- a/src/bernstein/cli/commands/self_update_cmd.py
+++ b/src/bernstein/cli/commands/self_update_cmd.py
@@ -171,7 +171,7 @@ def _pip_install(spec: str) -> bool:
     result = subprocess.run(
         [sys.executable, "-m", "pip", "install", spec, "--quiet"],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
     )
     if result.returncode != 0:
         console.print(f"[red]pip error:[/red]\n{result.stderr.strip()}")

--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,7 @@ from typing import Any, cast
 
 import click
 
+from bernstein.cli.display.icons import get_icons
 from bernstein.cli.helpers import (
     SDD_PID_SERVER,
     SDD_PID_SPAWNER,
@@ -133,7 +135,7 @@ def return_claimed_to_open() -> int:
         num = f.name.split("-")[0]
         try:
             if num in closed_nums:
-                f.unlink()  # already completed — remove duplicate
+                f.unlink()  # already completed - remove duplicate
             else:
                 f.rename(open_dir / f.name)
                 count += 1
@@ -221,7 +223,7 @@ def sigint_handler(signum: int, frame: Any) -> None:
         signum: Signal number (always ``SIGINT``).
         frame: Current stack frame (unused).
     """
-    console.print("\n[yellow]Ctrl+C received — saving state…[/yellow]")
+    console.print("\n[yellow]Ctrl+C received - saving state...[/yellow]")
     with contextlib.suppress(OSError):
         save_session_on_stop(Path.cwd())
     moved = return_claimed_to_open()
@@ -258,21 +260,28 @@ def soft_stop(timeout: int) -> None:
     _last_phase: dict[str, int] = {"number": 0}
 
     def on_update(phase: object, agents: object) -> None:
+        _icons = get_icons()
         number = getattr(phase, "number", 0)
         name = getattr(phase, "name", "")
         detail = getattr(phase, "detail", "")
         status = getattr(phase, "status", "")
+
+        # ASCII-safe icons for Windows
+        _running = "..." if sys.platform == "win32" else "\u23f3"  # hourglass
+        _done = _icons.check
+        _failed = _icons.cross
+        _commit = "[w]" if sys.platform == "win32" else "\U0001f4dd"  # memo emoji
 
         # Print phase header on transition
         if number != _last_phase["number"]:
             if _last_phase["number"] > 0:
                 print()  # newline after previous phase
             if status == "running":
-                icon = "⏳"
+                icon = _running
             elif status == "done":
-                icon = "✓"
+                icon = _done
             else:
-                icon = "✗"
+                icon = _failed
             print(f"  {icon} Phase {number}/6: {name}", flush=True)
             _last_phase["number"] = number
 
@@ -286,7 +295,7 @@ def soft_stop(timeout: int) -> None:
             for a_obj in cast("list[object]", agents):
                 sid: str = getattr(a_obj, "session_id", "?")
                 st: str = getattr(a_obj, "status", "?")
-                sym = {"running": "⏳", "exited": "✓", "killed": "✗", "committing": "📝"}.get(st, "?")
+                sym = {"running": _running, "exited": _done, "killed": _failed, "committing": _commit}.get(st, "?")
                 agent_lines.append(f"{sym} {sid}")
             if agent_lines:
                 print(f"\r    {' | '.join(agent_lines)}    ", end="", flush=True)
@@ -326,7 +335,7 @@ def _kill_named_pid(pid: int, label: str, killed: set[int]) -> None:
     if dead:
         console.print(f"[red]Killed {label} (PID {pid}).[/red]")
     else:
-        console.print(f"[yellow]{label} (PID {pid}) resisted SIGKILL — may need manual cleanup.[/yellow]")
+        console.print(f"[yellow]{label} (PID {pid}) resisted SIGKILL - may need manual cleanup.[/yellow]")
 
 
 def _kill_pid_file(path: str, label: str, killed: set[int]) -> None:
@@ -401,7 +410,7 @@ def _list_process_snapshots() -> list[_ProcessSnapshot]:
         result = subprocess.run(
             ["ps", "-ax", "-o", "pid=,ppid=,pgid=,command="],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
             check=False,
         )
@@ -465,7 +474,7 @@ def _kill_port_holder(port: int, killed: set[int]) -> None:
         result = subprocess.run(
             ["lsof", "-ti", f":{port}"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
         )
         for line in result.stdout.strip().splitlines():
@@ -520,11 +529,11 @@ def hard_stop() -> None:
     _collect_pids_from_metadata(killed_pids)
     _collect_repo_processes(killed_pids)
 
-    # 4. Verification sweep — re-scan and retry anything still alive
+    # 4. Verification sweep - re-scan and retry anything still alive
     time.sleep(0.1)
     survivors: list[int] = [p for p in killed_pids if is_alive(p)]
     if survivors:
-        console.print(f"[yellow]Retrying {len(survivors)} survivor(s)…[/yellow]")
+        console.print(f"[yellow]Retrying {len(survivors)} survivor(s)...[/yellow]")
         for pid in survivors:
             _kill_named_pid(pid, f"survivor-{pid}", killed_pids)
     _collect_repo_processes(killed_pids)
@@ -545,9 +554,9 @@ def hard_stop() -> None:
 
     total = len(killed_pids)
     if total:
-        console.print(f"\n[red]Bernstein stopped (hard) — killed {total} process(es).[/red]")
+        console.print(f"\n[red]Bernstein stopped (hard) - killed {total} process(es).[/red]")
     else:
-        console.print("\n[red]Bernstein stopped (hard) — no processes were running.[/red]")
+        console.print("\n[red]Bernstein stopped (hard) - no processes were running.[/red]")
 
 
 # ---------------------------------------------------------------------------
@@ -584,9 +593,9 @@ def stop(timeout: int, force: bool) -> None:
     print_banner()
 
     if force:
-        console.print("[bold red]Hard stop — killing everything immediately…[/bold red]\n")
+        console.print("[bold red]Hard stop - killing everything immediately...[/bold red]\n")
         hard_stop()
     else:
-        console.print("[bold]Soft stop — giving agents time to save…[/bold]\n")
+        console.print("[bold]Soft stop - giving agents time to save...[/bold]\n")
         soft_stop(timeout)
         _unregister_mcp_discovery(Path.cwd())

--- a/src/bernstein/cli/commands/undo_cmd.py
+++ b/src/bernstein/cli/commands/undo_cmd.py
@@ -36,7 +36,7 @@ def undo_cmd(task_id: str | None, revert_all: bool, yes: bool) -> None:
         res = subprocess.run(
             ["git", "log", "-n", "50", "--pretty=format:%H %s"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=".",
         )
         for line in res.stdout.splitlines():

--- a/src/bernstein/cli/commands/wrap_up_cmd.py
+++ b/src/bernstein/cli/commands/wrap_up_cmd.py
@@ -23,7 +23,7 @@ def _get_git_diff_stat(start_sha: str) -> str:
             result = subprocess.run(
                 ["git", "diff", "--stat", f"{start_sha}..HEAD"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 check=False,
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -35,7 +35,7 @@ def _get_git_diff_stat(start_sha: str) -> str:
         result = subprocess.run(
             ["git", "diff", "--stat", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=False,
         )
         if result.returncode == 0:
@@ -59,7 +59,7 @@ def _find_session_start_sha(saved_at: float) -> str:
         result = subprocess.run(
             ["git", "log", "--format=%H", "--reverse", f"--after={iso}"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=False,
         )
         if result.returncode != 0:
@@ -72,7 +72,7 @@ def _find_session_start_sha(saved_at: float) -> str:
         parent_result = subprocess.run(
             ["git", "rev-parse", f"{first_commit}^"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=False,
         )
         if parent_result.returncode == 0:

--- a/src/bernstein/cli/commit_stats.py
+++ b/src/bernstein/cli/commit_stats.py
@@ -118,7 +118,7 @@ def _run_git_log(
     if until:
         cmd.extend(["--until", until])
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, cmd, result.stdout, result.stderr)
 
@@ -199,14 +199,14 @@ def collect_commit_stats(
         commit_cmd.extend(["--until", until])
 
     try:
-        commit_result = subprocess.run(commit_cmd, capture_output=True, text=True)
+        commit_result = subprocess.run(commit_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
         if commit_result.returncode == 0:
             author_cmd: list[str] = ["git", "-C", repo_dir, "log", "--format=%an <%ae>"]
             if since:
                 author_cmd.extend(["--since", since])
             if until:
                 author_cmd.extend(["--until", until])
-            author_result = subprocess.run(author_cmd, capture_output=True, text=True)
+            author_result = subprocess.run(author_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
             if author_result.returncode == 0:
                 author_lines = [line.strip() for line in author_result.stdout.splitlines() if line.strip()]
                 for author_line in author_lines:

--- a/src/bernstein/cli/dashboard_app.py
+++ b/src/bernstein/cli/dashboard_app.py
@@ -1254,7 +1254,7 @@ class BernsteinApp(App[None]):
             result = subprocess.run(
                 ["git", "status", "--porcelain"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 cwd=".",
             )
             if result.stdout.strip():

--- a/src/bernstein/cli/display/compare_screen.py
+++ b/src/bernstein/cli/display/compare_screen.py
@@ -32,7 +32,7 @@ def _run_git(args: list[str], cwd: Path) -> str:
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         return result.stdout.strip()

--- a/src/bernstein/cli/display/icons.py
+++ b/src/bernstein/cli/display/icons.py
@@ -2,6 +2,7 @@
 
 Detection: set NERD_FONT=1 or BERNSTEIN_NERD_FONT=1 to enable Nerd Font glyphs.
 Falls back to standard Unicode characters otherwise.
+On Windows with cp1252 encoding, falls back to ASCII-safe characters.
 
 Usage::
 
@@ -15,6 +16,7 @@ Usage::
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass
 
 
@@ -43,6 +45,18 @@ class NerdFontIcons:
     gate_test: str = "\uf0c3"  # nf-md-flask
     gate_security: str = "\uf9be"  # nf-md-shield_check
 
+    # Common symbols
+    arrow_right: str = "\uf061"  # nf-fa-arrow_right
+    arrow_left: str = "\uf060"  # nf-fa-arrow_left
+    arrow_up: str = "\uf062"  # nf-fa-arrow_up
+    arrow_down: str = "\uf063"  # nf-fa-arrow_down
+    check: str = "\uf058"  # nf-fa-check_circle
+    cross: str = "\uf057"  # nf-fa-times_circle
+    warning: str = "\uf071"  # nf-fa-exclamation_triangle
+    bullet: str = "\uf111"  # nf-fa-circle
+    em_dash: str = "\u2014"  # —
+    plus_minus: str = "\u00b1"  # ±
+
 
 @dataclass(frozen=True)
 class UnicodeFallbackIcons:
@@ -65,23 +79,96 @@ class UnicodeFallbackIcons:
     gate_test: str = "\u2697"  # ⚗  (alembic / flask)
     gate_security: str = "\u25c8"  # ◈  (diamond with dot)
 
+    # Common symbols
+    arrow_right: str = "\u2192"  # →
+    arrow_left: str = "\u2190"  # ←
+    arrow_up: str = "\u2191"  # ↑
+    arrow_down: str = "\u2193"  # ↓
+    check: str = "\u2713"  # ✓
+    cross: str = "\u2717"  # ✗
+    warning: str = "\u26a0"  # ⚠
+    bullet: str = "\u2022"  # •
+    em_dash: str = "\u2014"  # —
+    plus_minus: str = "\u00b1"  # ±
+
+
+@dataclass(frozen=True)
+class AsciiSafeIcons:
+    """Icon set using ASCII-safe characters for Windows cp1252 compatibility."""
+
+    # Agent icons
+    agent_claude: str = "*"
+    agent_codex: str = "o"
+    agent_gemini: str = "+"
+    agent_cursor: str = ">"
+
+    # Status icons
+    status_running: str = "*"
+    status_done: str = "+"
+    status_failed: str = "x"
+    status_blocked: str = "#"
+
+    # Quality gate icons
+    gate_lint: str = "~"
+    gate_test: str = "T"
+    gate_security: str = "S"
+
+    # Common symbols
+    arrow_right: str = "->"
+    arrow_left: str = "<-"
+    arrow_up: str = "^"
+    arrow_down: str = "v"
+    check: str = "+"
+    cross: str = "x"
+    warning: str = "!"
+    bullet: str = "*"
+    em_dash: str = "-"
+    plus_minus: str = "+/-"
+
 
 def _is_truthy(value: str) -> bool:
     """Return True for opt-in values like '1', 'true', 'yes'."""
     return value.lower() in ("1", "true", "yes", "on")
 
 
-def get_icons() -> NerdFontIcons | UnicodeFallbackIcons:
+def _needs_ascii_fallback() -> bool:
+    """Check if we need ASCII-safe characters (Windows with legacy encoding)."""
+    if sys.platform != "win32":
+        return False
+
+    # Check if UTF-8 mode is enabled
+    if os.environ.get("PYTHONUTF8", "") == "1":
+        return False
+
+    # Check stdout encoding
+    try:
+        encoding = sys.stdout.encoding
+        if encoding and encoding.lower() in ("utf-8", "utf8"):
+            return False
+    except Exception:
+        pass
+
+    # Default to ASCII on Windows to be safe
+    return True
+
+
+def get_icons() -> NerdFontIcons | UnicodeFallbackIcons | AsciiSafeIcons:
     """Return the appropriate icon set based on environment detection.
 
-    Checks NERD_FONT and BERNSTEIN_NERD_FONT env vars.
-    Any value treated as truthy (1, true, yes, on) activates Nerd Font mode.
+    Priority:
+    1. NERD_FONT=1 or BERNSTEIN_NERD_FONT=1 -> NerdFontIcons
+    2. Windows with cp1252/legacy encoding -> AsciiSafeIcons
+    3. Otherwise -> UnicodeFallbackIcons
     """
     nerd_font_env = os.environ.get("NERD_FONT", "")
     bernstein_nf_env = os.environ.get("BERNSTEIN_NERD_FONT", "")
 
     if _is_truthy(nerd_font_env) or _is_truthy(bernstein_nf_env):
         return NerdFontIcons()
+
+    if _needs_ascii_fallback():
+        return AsciiSafeIcons()
+
     return UnicodeFallbackIcons()
 
 

--- a/src/bernstein/cli/display/splash.py
+++ b/src/bernstein/cli/display/splash.py
@@ -6,6 +6,7 @@ a computer booting up — no wasted lines, no empty gaps.
 
 from __future__ import annotations
 
+import sys
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -14,6 +15,9 @@ if TYPE_CHECKING:
 
 # ── Compact one-line logo ──────────────────────────────────────
 LOGO_INLINE = "[bold]BERNSTEIN[/bold] [dim]v{version}[/dim]"
+
+# Use ASCII-safe separator on Windows to avoid cp1252 encoding issues
+_SEP_CHAR = "-" if sys.platform == "win32" else "─"
 
 
 def _detect_terminal_width(console: Console) -> int:
@@ -40,7 +44,7 @@ def splash(
     is_animated = not skip_animation and console.is_terminal
 
     # ── Header line ──
-    sep = "[dim]─[/dim]" * min(56, width - 2)
+    sep = f"[dim]{_SEP_CHAR}[/dim]" * min(56, width - 2)
     console.print(sep)
     ver = f" v{version}" if version else ""
     console.print(f"  [bold blue]BERNSTEIN[/bold blue][dim]{ver}  declarative agent orchestration[/dim]")

--- a/src/bernstein/cli/display/splash_screen.py
+++ b/src/bernstein/cli/display/splash_screen.py
@@ -14,13 +14,20 @@ from __future__ import annotations
 import os
 import platform
 import re
-import select
 import subprocess
 import sys
-import termios
 import time
-import tty
 from contextlib import contextmanager
+
+# Platform-specific imports for terminal input handling
+if sys.platform == "win32":
+    import msvcrt
+    _HAS_TERMIOS = False
+else:
+    import select
+    import termios
+    import tty
+    _HAS_TERMIOS = True
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -77,6 +84,11 @@ def _raw_mode() -> Iterator[None]:
         yield
         return
 
+    if sys.platform == "win32":
+        # Windows doesn't need raw mode for msvcrt.kbhit()
+        yield
+        return
+
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     try:
@@ -93,6 +105,13 @@ def _key_pressed() -> bool:
     """
     if not sys.stdin.isatty():
         return False
+
+    if sys.platform == "win32":
+        try:
+            return msvcrt.kbhit()
+        except (OSError, ValueError):
+            return False
+
     try:
         return bool(select.select([sys.stdin], [], [], 0.0)[0])
     except (OSError, ValueError):
@@ -103,6 +122,15 @@ def _drain_input() -> None:
     """Consume any buffered input so it doesn't leak to the next prompt."""
     if not sys.stdin.isatty():
         return
+
+    if sys.platform == "win32":
+        try:
+            while msvcrt.kbhit():
+                msvcrt.getch()
+        except (OSError, ValueError):
+            pass
+        return
+
     try:
         while select.select([sys.stdin], [], [], 0.0)[0]:
             sys.stdin.read(1)
@@ -127,7 +155,7 @@ def _memory_gb() -> int:
             result = subprocess.run(
                 ["sysctl", "-n", "hw.memsize"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=2,
             )
             if result.returncode == 0:

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import signal
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -36,10 +37,17 @@ SDD_PID_SERVER = ".sdd/runtime/server.pid"
 SDD_PID_SPAWNER = ".sdd/runtime/spawner.pid"
 SDD_PID_WATCHDOG = ".sdd/runtime/watchdog.pid"
 
-BANNER = """\
-╔══════════════════════════════════╗
-║  🎼 Bernstein — Agent Orchestra  ║
-╚══════════════════════════════════╝"""
+# Use ASCII-safe banner on Windows to avoid cp1252 encoding issues
+if sys.platform == "win32":
+    BANNER = """\
++----------------------------------+
+|  Bernstein - Agent Orchestra     |
++----------------------------------+"""
+else:
+    BANNER = """\
+\u2554\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2557
+\u2551  \U0001F3BC Bernstein \u2014 Agent Orchestra  \u2551
+\u255a\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u2550\u255d"""
 
 # Task status -> Rich color
 STATUS_COLORS: dict[str, str] = {

--- a/src/bernstein/cli/plan/plan_display.py
+++ b/src/bernstein/cli/plan/plan_display.py
@@ -50,25 +50,63 @@ C_BRIGHT = "#ffffff"
 # Risk display helpers
 # ---------------------------------------------------------------------------
 
-_RISK_ICON: dict[str, str] = {
-    "low": "\u2713",
-    "medium": "\u26a0",
-    "high": "\u26a1",
-    "critical": "\u2b24",
-}
+# Use ASCII-safe characters on Windows to avoid cp1252 encoding issues
+if _IS_WINDOWS:
+    _RISK_ICON: dict[str, str] = {
+        "low": "+",
+        "medium": "!",
+        "high": "!!",
+        "critical": "X",
+    }
+    _STATUS_LABEL: dict[str, str] = {
+        PlanStatus.PENDING.value: "pending - awaiting approval",
+        PlanStatus.APPROVED.value: "approved",
+        PlanStatus.REJECTED.value: "rejected",
+        PlanStatus.EXPIRED.value: "expired",
+    }
+    # Box-drawing characters for Windows (ASCII)
+    _BOX_H = "-"
+    _BOX_TL = "+"
+    _BOX_TR = "+"
+    _BOX_BL = "+"
+    _BOX_BR = "+"
+    _BOX_V = "|"
+    _ICON_PLAY = ">"
+    _ICON_X = "x"
+    _ICON_CHECK = "+"
+    _ICON_WARN = "!"
+    _ICON_DASH = "-"
+else:
+    _RISK_ICON: dict[str, str] = {
+        "low": "\u2713",
+        "medium": "\u26a0",
+        "high": "\u26a1",
+        "critical": "\u2b24",
+    }
+    _STATUS_LABEL: dict[str, str] = {
+        PlanStatus.PENDING.value: "pending \u2014 awaiting approval",
+        PlanStatus.APPROVED.value: "approved",
+        PlanStatus.REJECTED.value: "rejected",
+        PlanStatus.EXPIRED.value: "expired",
+    }
+    # Box-drawing characters for Unix (Unicode)
+    _BOX_H = "\u2500"  # ─
+    _BOX_TL = "\u250c"  # ┌
+    _BOX_TR = "\u2510"  # ┐
+    _BOX_BL = "\u2514"  # └
+    _BOX_BR = "\u2518"  # ┘
+    _BOX_V = "\u2502"  # │
+    _ICON_PLAY = "\u25b6"  # ▶
+    _ICON_X = "\u2715"  # ✕
+    _ICON_CHECK = "\u2713"  # ✓
+    _ICON_WARN = "\u26a0"  # ⚠
+    _ICON_DASH = "\u2014"  # —
 
 _RISK_COLOR: dict[str, str] = {
     "low": C_GREEN,
     "medium": C_WARN,
     "high": C_ERR,
     "critical": C_ERR,
-}
-
-_STATUS_LABEL: dict[str, str] = {
-    PlanStatus.PENDING.value: "pending \u2014 awaiting approval",
-    PlanStatus.APPROVED.value: "approved",
-    PlanStatus.REJECTED.value: "rejected",
-    PlanStatus.EXPIRED.value: "expired",
 }
 
 # ---------------------------------------------------------------------------
@@ -100,7 +138,8 @@ def _truncate(text: str, max_len: int) -> str:
     """Truncate text with ellipsis if it exceeds max_len."""
     if len(text) <= max_len:
         return text
-    return text[: max_len - 1] + "\u2026"
+    ellipsis = "..." if _IS_WINDOWS else "\u2026"
+    return text[: max_len - len(ellipsis)] + ellipsis
 
 
 # ---------------------------------------------------------------------------
@@ -193,44 +232,44 @@ def _drain_input() -> None:
 
 def _hline(width: int) -> str:
     """Horizontal rule inside the outer box."""
-    return f"[{C_DIM}]{'─' * width}[/{C_DIM}]"
+    return f"[{C_DIM}]{_BOX_H * width}[/{C_DIM}]"
 
 
 def _box_top(width: int) -> str:
-    """Top border: ┌──...──┐"""
-    inner = "─" * (width - 2)
-    return f"[{C_DIM}]┌{inner}┐[/{C_DIM}]"
+    """Top border: +--...--+"""
+    inner = _BOX_H * (width - 2)
+    return f"[{C_DIM}]{_BOX_TL}{inner}{_BOX_TR}[/{C_DIM}]"
 
 
 def _box_bottom(width: int) -> str:
-    """Bottom border: └──...──┘"""
-    inner = "─" * (width - 2)
-    return f"[{C_DIM}]└{inner}┘[/{C_DIM}]"
+    """Bottom border: +--...--+"""
+    inner = _BOX_H * (width - 2)
+    return f"[{C_DIM}]{_BOX_BL}{inner}{_BOX_BR}[/{C_DIM}]"
 
 
 def _box_row(content: str, width: int) -> str:
-    """Row inside the outer box: │  content  │  (content is Rich markup)."""
+    """Row inside the outer box: |  content  |  (content is Rich markup)."""
     # We can't measure Rich markup width exactly, so we pad the raw line
     # and let the outer borders frame it visually.
-    return f"[{C_DIM}]│[/{C_DIM}]  {content}"
+    return f"[{C_DIM}]{_BOX_V}[/{C_DIM}]  {content}"
 
 
 def _inner_box_top(label: str, width: int) -> str:
-    """Inner box top: ┌─ Label ─────...─┐"""
-    prefix = f"─ {label} "
-    fill = "─" * max(0, width - len(prefix) - 2)
-    return f"  [{C_DIM}]┌{prefix}{fill}┐[/{C_DIM}]"
+    """Inner box top: +- Label -----...--+"""
+    prefix = f"{_BOX_H} {label} "
+    fill = _BOX_H * max(0, width - len(prefix) - 2)
+    return f"  [{C_DIM}]{_BOX_TL}{prefix}{fill}{_BOX_TR}[/{C_DIM}]"
 
 
 def _inner_box_row(content: str) -> str:
-    """Inner box row: │  content  │"""
-    return f"  [{C_DIM}]│[/{C_DIM}]  {content}"
+    """Inner box row: |  content  |"""
+    return f"  [{C_DIM}]{_BOX_V}[/{C_DIM}]  {content}"
 
 
 def _inner_box_bottom(width: int) -> str:
-    """Inner box bottom: └─────...─┘"""
-    inner = "─" * (width - 2)
-    return f"  [{C_DIM}]└{inner}┘[/{C_DIM}]"
+    """Inner box bottom: +-----...--+"""
+    inner = _BOX_H * (width - 2)
+    return f"  [{C_DIM}]{_BOX_BL}{inner}{_BOX_BR}[/{C_DIM}]"
 
 
 # ---------------------------------------------------------------------------
@@ -335,9 +374,12 @@ class _PlanRenderer:
         high_risk = len(plan.high_risk_tasks)
         risk_color = C_ERR if high_risk > 0 else C_GREEN
 
+        # Use ASCII-safe plus-minus for Windows
+        pm = "+/-" if _IS_WINDOWS else "\u00b1"
+
         rows: list[tuple[str, str, str]] = [
             ("Tasks", str(len(plan.task_estimates)), C_BRIGHT),
-            ("Est. cost", f"{_fmt_cost(plan.total_estimated_cost_usd)} (±20%)", C_CYAN),
+            ("Est. cost", f"{_fmt_cost(plan.total_estimated_cost_usd)} ({pm}20%)", C_CYAN),
             ("Est. time", _fmt_minutes(plan.total_estimated_minutes), C_WHITE),
             ("High-risk", str(high_risk), risk_color),
         ]
@@ -348,7 +390,7 @@ class _PlanRenderer:
             warning = (
                 f"Estimated cost (${plan.total_estimated_cost_usd:.2f}) exceeds configured budget (${budget_usd:.2f})."
             )
-            self._add(_box_row(f"[bold {C_ERR}]⚠ BUDGET WARNING[/{C_ERR}]", self.width))
+            self._add(_box_row(f"[bold {C_ERR}]{_ICON_WARN} BUDGET WARNING[/{C_ERR}]", self.width))
             self._add(_box_row(f"[{C_ERR}]{_truncate(warning, self.width - 6)}[/{C_ERR}]", self.width))
             self._blank()
 
@@ -449,8 +491,8 @@ class _PlanRenderer:
         self._blank()
 
         # Buttons
-        approve_btn = f"[bold {C_GREEN}][ \u25b6 APPROVE ][/bold {C_GREEN}]"
-        cancel_btn = f"[bold {C_ERR}][ \u2715 CANCEL ][/bold {C_ERR}]"
+        approve_btn = f"[bold {C_GREEN}][ {_ICON_PLAY} APPROVE ][/bold {C_GREEN}]"
+        cancel_btn = f"[bold {C_ERR}][ {_ICON_X} CANCEL ][/bold {C_ERR}]"
         # Center the buttons
         btn_text = f"{approve_btn}        {cancel_btn}"
         # Approximate centering (markup is invisible to width calc)
@@ -528,7 +570,7 @@ def display_plan_and_confirm(
 
     if not is_tty or is_ci:
         render_plan(plan, tasks, console=console)
-        console.print(f"\n  [{C_DIM}]Non-interactive mode \u2014 auto-approved[/{C_DIM}]")
+        console.print(f"\n  [{C_DIM}]Non-interactive mode {_ICON_DASH} auto-approved[/{C_DIM}]")
         return True
 
     # Interactive: render plan, then wait for keypress
@@ -562,9 +604,9 @@ def display_plan_and_confirm(
 
     approved = key in _approve_keys
     if approved:
-        console.print(f"\n  [bold {C_GREEN}]\u2713 Plan approved[/bold {C_GREEN}]")
+        console.print(f"\n  [bold {C_GREEN}]{_ICON_CHECK} Plan approved[/bold {C_GREEN}]")
     else:
-        console.print(f"\n  [{C_DIM}]\u2715 Cancelled[/{C_DIM}]")
+        console.print(f"\n  [{C_DIM}]{_ICON_X} Cancelled[/{C_DIM}]")
 
     return approved
 

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -1274,7 +1274,7 @@ def _has_git_commits_on_branch(worktree_path: Path) -> bool:
             ["git", "log", "--oneline", "main..HEAD"],
             cwd=str(worktree_path),
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
         )
         return len(result.stdout.strip()) > 0

--- a/src/bernstein/core/agents/container.py
+++ b/src/bernstein/core/agents/container.py
@@ -455,7 +455,7 @@ class ContainerManager:
             result = subprocess.run(
                 args,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=_CONTAINER_CMD_TIMEOUT_S,
             )
         except subprocess.TimeoutExpired as exc:
@@ -496,7 +496,7 @@ class ContainerManager:
             result = subprocess.run(
                 [self._runtime_cmd, "start", handle.container_id],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=_CONTAINER_CMD_TIMEOUT_S,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
@@ -557,7 +557,7 @@ class ContainerManager:
                 result = subprocess.run(
                     exec_args,
                     capture_output=True,
-                    text=True,
+                    text=True, encoding="utf-8", errors="replace",
                     timeout=timeout_s or _CONTAINER_CMD_TIMEOUT_S,
                 )
                 return result
@@ -633,7 +633,7 @@ class ContainerManager:
             result = subprocess.run(
                 run_args,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=_CONTAINER_CMD_TIMEOUT_S,
             )
         except (subprocess.TimeoutExpired, OSError) as exc:
@@ -676,7 +676,7 @@ class ContainerManager:
                     handle.container_id,
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             return result.stdout.strip().lower() == "true"
@@ -702,7 +702,7 @@ class ContainerManager:
                     handle.container_id,
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             if result.returncode == 0:
@@ -732,7 +732,7 @@ class ContainerManager:
                     handle.container_id,
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -801,7 +801,7 @@ class ContainerManager:
                     "{{.Names}}",
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=_CONTAINER_CMD_TIMEOUT_S,
             )
         except (subprocess.TimeoutExpired, OSError):
@@ -953,7 +953,7 @@ class ContainerManager:
             result = subprocess.run(
                 run_args,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=timeout_s,
             )
         except subprocess.TimeoutExpired:
@@ -996,7 +996,7 @@ class ContainerManager:
                     handle.container_id,
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             if result.returncode == 0:
@@ -1083,7 +1083,7 @@ def ensure_agent_image(
         result = subprocess.run(
             build_args,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=600,  # 10 minutes for image build
         )
         if result.returncode != 0:

--- a/src/bernstein/core/agents/idle_detection.py
+++ b/src/bernstein/core/agents/idle_detection.py
@@ -122,7 +122,7 @@ def _check_git_changes(workdir: Path, session_id: str) -> bool:
             ["git", "status", "--porcelain"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             check=False,
         )
@@ -134,7 +134,7 @@ def _check_git_changes(workdir: Path, session_id: str) -> bool:
             ["git", "log", "--since=5 minutes ago", "--oneline"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             check=False,
         )

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -1176,7 +1176,7 @@ def expand_shell_commands(template: str, *, timeout: int = 5, workdir: Path | No
             result = _subprocess.run(
                 _shlex.split(cmd),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=timeout,
                 cwd=workdir,
             )

--- a/src/bernstein/core/agents/spawner_worktree.py
+++ b/src/bernstein/core/agents/spawner_worktree.py
@@ -125,7 +125,7 @@ def prune_orphan_worktrees(
                 ["git", "worktree", "prune"],
                 cwd=mgr.repo_root,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
         except Exception as exc:

--- a/src/bernstein/core/communication/notifications.py
+++ b/src/bernstein/core/communication/notifications.py
@@ -452,7 +452,7 @@ class NotificationManager:
                 [notifier, "-title", payload.title, "-message", body or payload.event, "-group", "bernstein"],
                 check=False,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
             )
             logger.info("Desktop notification sent via terminal-notifier: event=%s", payload.event)
             return
@@ -465,6 +465,6 @@ class NotificationManager:
             [notifier, payload.title, body or payload.event],
             check=False,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
         )
         logger.info("Desktop notification sent via notify-send: event=%s", payload.event)

--- a/src/bernstein/core/config/manifest.py
+++ b/src/bernstein/core/config/manifest.py
@@ -34,7 +34,7 @@ def _git_head_sha() -> str:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
             timeout=5,
         )

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -403,7 +403,7 @@ def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
         result = subprocess.run(
             cmd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         return result.returncode == 0

--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -77,7 +77,7 @@ def run_git(
         ["git", *args],
         cwd=cwd,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=timeout,
         input=input_data,
     )

--- a/src/bernstein/core/git/git_context.py
+++ b/src/bernstein/core/git/git_context.py
@@ -31,7 +31,7 @@ def _run_git(args: list[str], cwd: Path, *, timeout: int = 10) -> str | None:
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
         )
         if result.returncode == 0 and result.stdout.strip():

--- a/src/bernstein/core/git/git_hooks.py
+++ b/src/bernstein/core/git/git_hooks.py
@@ -49,7 +49,7 @@ _PRE_COMMIT_TEMPLATE: Final[str] = textwrap.dedent("""\
     def main() -> int:
         result = subprocess.run(
             ["git", "diff", "--cached", "--name-only"],
-            capture_output=True, text=True, check=False,
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
         )
         if result.returncode != 0:
             print("bernstein pre-commit: failed to get staged files", file=sys.stderr)

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -384,7 +384,7 @@ def create_github_pr(
             cmd,
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         if result.returncode == 0:
@@ -410,7 +410,7 @@ def enable_pr_auto_merge(cwd: Path, pr_url_or_number: str) -> GitResult:
             ["gh", "pr", "merge", "--auto", "--squash", pr_url_or_number],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         return GitResult(
@@ -500,7 +500,7 @@ def bisect_regression(
             ["git", "bisect", "run", *test_cmd.split()],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=600,
         )
 

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -151,7 +151,7 @@ def _check_git_health(repo_root: Path) -> list[str]:
             ["git", "rev-parse", "--verify", "HEAD"],
             cwd=repo_root,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         if result.returncode != 0:
@@ -183,7 +183,7 @@ def _apply_sparse_checkout(worktree_path: Path, sparse_paths: Sequence[str]) -> 
             ["git", "sparse-checkout", "init", "--cone"],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         if result.returncode != 0:
@@ -194,7 +194,7 @@ def _apply_sparse_checkout(worktree_path: Path, sparse_paths: Sequence[str]) -> 
             ["git", "sparse-checkout", "set", *sparse_paths],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         if result.returncode != 0:
@@ -282,7 +282,7 @@ def setup_worktree_env(
                 shlex.split(config.setup_command),
                 cwd=worktree_path,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=_SETUP_COMMAND_TIMEOUT_S,
             )
             if result.returncode != 0:
@@ -461,7 +461,7 @@ class WorktreeManager:
                 ["git", "worktree", "prune"],
                 cwd=self.repo_root,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
         except Exception as exc:
@@ -674,7 +674,7 @@ def apply_sparse_checkout(
             ["git", "sparse-checkout", "init", "--cone"],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
         )
         if result.returncode != 0:
@@ -690,7 +690,7 @@ def apply_sparse_checkout(
             ["git", "sparse-checkout", "set", *sparse_paths],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
         )
         if result.returncode != 0:

--- a/src/bernstein/core/knowledge/graduated_memory_guard.py
+++ b/src/bernstein/core/knowledge/graduated_memory_guard.py
@@ -306,7 +306,7 @@ def _parse_vm_stat() -> MemoryStatus:
     result = subprocess.run(
         ["vm_stat"],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=5,
         check=True,
     )

--- a/src/bernstein/core/knowledge/knowledge_base.py
+++ b/src/bernstein/core/knowledge/knowledge_base.py
@@ -376,7 +376,7 @@ class TaskContextBuilder:
                         ["grep", "-n", f"import.*{filename}", fpath],
                         cwd=self.workdir,
                         capture_output=True,
-                        text=True,
+                        text=True, encoding="utf-8", errors="replace",
                         timeout=2,
                     )
                     if grep_result.returncode == 0:

--- a/src/bernstein/core/knowledge/memory_guard.py
+++ b/src/bernstein/core/knowledge/memory_guard.py
@@ -71,7 +71,7 @@ def get_rss_bytes(pid: int) -> int | None:
         result = subprocess.run(
             ["ps", "-o", "rss=", "-p", str(pid)],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
         )
         rss_kb = int(result.stdout.strip())

--- a/src/bernstein/core/knowledge/repo_index.py
+++ b/src/bernstein/core/knowledge/repo_index.py
@@ -246,7 +246,7 @@ def _git_file_owners(workdir: Path, files: list[str]) -> dict[str, str]:
                 ["git", "shortlog", "-sn", "--no-merges", "-1", "--", fpath],
                 cwd=workdir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=5,
             )
             if result.returncode == 0 and result.stdout.strip():

--- a/src/bernstein/core/knowledge/semantic_diff.py
+++ b/src/bernstein/core/knowledge/semantic_diff.py
@@ -440,7 +440,7 @@ def _get_file_at_revision(
             ["git", "show", f"{revision}:{file_rel}"],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         if result.returncode != 0:
@@ -458,7 +458,7 @@ def _get_all_python_files(worktree_path: Path) -> list[Path]:
             ["git", "ls-files", "--cached", "--others", "--exclude-standard", "*.py"],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         if result.returncode != 0:

--- a/src/bernstein/core/observability/circuit_breaker.py
+++ b/src/bernstein/core/observability/circuit_breaker.py
@@ -216,7 +216,7 @@ def _get_worktree_changed_files(worktree_path: Path) -> list[str] | None:
         result = subprocess.run(
             ["git", "-C", str(worktree_path), "diff", "--name-only", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         if result.returncode != 0:
@@ -227,7 +227,7 @@ def _get_worktree_changed_files(worktree_path: Path) -> list[str] | None:
         result2 = subprocess.run(
             ["git", "-C", str(worktree_path), "ls-files", "--others", "--exclude-standard"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         untracked = [f.strip() for f in result2.stdout.splitlines() if f.strip()]
@@ -263,7 +263,7 @@ def _get_worktree_diff(worktree_path: Path) -> str | None:
         result = subprocess.run(
             ["git", "-C", str(worktree_path), "diff", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=15,
         )
         if result.returncode != 0:
@@ -382,7 +382,7 @@ def _get_worktree_branch(worktree_path: Path) -> str | None:
         result = subprocess.run(
             ["git", "-C", str(worktree_path), "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
         )
         if result.returncode == 0:

--- a/src/bernstein/core/observability/startup_selftest.py
+++ b/src/bernstein/core/observability/startup_selftest.py
@@ -337,7 +337,7 @@ def _check_git(workdir: Path | None) -> CheckResult:
         result = subprocess.run(
             ["git", "rev-parse", "--is-inside-work-tree"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
             cwd=str(workdir),
         )

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -27,6 +27,8 @@ import httpx
 from rich.console import Console
 from rich.status import Status
 
+from bernstein.cli.display.icons import get_icons
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable as _Awaitable
 
@@ -684,7 +686,8 @@ def bootstrap_from_goal(
         console.print(f"[bold]First run detected[/bold] — auto-configuring for {type_note}")
         console.print(agents_note)
 
-    console.print(f"[green]→[/green] Goal: [bold]{goal[:80]}[/bold]")
+    _icons = get_icons()
+    console.print(f"[green]{_icons.arrow_right}[/green] Goal: [bold]{goal[:80]}[/bold]")
     try:
         from bernstein.core.complexity_advisor import ComplexityMode, suggest_goal_execution_mode
 
@@ -708,15 +711,15 @@ def bootstrap_from_goal(
             auto_write_bernstein_yaml(workdir)
         _clean_stale_runtime(workdir)
     if created:
-        console.print("[green]→[/green] Created .sdd/ workspace")
+        console.print(f"[green]{_icons.arrow_right}[/green] Created .sdd/ workspace")
     else:
-        console.print("[green]→[/green] Workspace ready")
+        console.print(f"[green]{_icons.arrow_right}[/green] Workspace ready")
 
     with Status("[bold]Loading agent catalog...[/bold]", console=console):
         _discover_catalog(workdir)
-    console.print("[green]→[/green] Agent catalog loaded")
+    console.print(f"[green]{_icons.arrow_right}[/green] Agent catalog loaded")
 
-    # Index codebase with a hard 10s deadline — don't block startup.
+    # Index codebase with a hard 10s deadline - don't block startup.
     # We must NOT use ThreadPoolExecutor as a context manager because its
     # __exit__ calls shutdown(wait=True), which blocks until the thread
     # finishes even after the timeout fires.
@@ -726,9 +729,9 @@ def bootstrap_from_goal(
         try:
             _index_future.result(timeout=10)
         except concurrent.futures.TimeoutError:
-            console.print("[yellow]→[/yellow] Indexing taking too long — continuing in background")
+            console.print(f"[yellow]{_icons.arrow_right}[/yellow] Indexing taking too long - continuing in background")
     _index_pool.shutdown(wait=False)
-    console.print("[green]→[/green] Codebase indexed")
+    console.print(f"[green]{_icons.arrow_right}[/green] Codebase indexed")
 
     with Status("[bold]Checking safety invariants...[/bold]", console=console):
         from bernstein.evolution.invariants import verify_invariants, write_lockfile
@@ -755,7 +758,7 @@ def bootstrap_from_goal(
                 fix="Check .sdd/runtime/server.log for details",
             ).print()
             raise SystemExit(1)
-    console.print(f"[green]→[/green] Task server ready (PID {server_pid}, {bind_host}:{port})")
+    console.print(f"[green]{_icons.arrow_right}[/green] Task server ready (PID {server_pid}, {bind_host}:{port})")
 
     # Register Bernstein as a discoverable MCP server for Claude Code sessions
     with contextlib.suppress(OSError):
@@ -772,7 +775,7 @@ def bootstrap_from_goal(
 
         gh_count = sync_github_issues_to_backlog(workdir)
         if gh_count > 0:
-            console.print(f"[green]\u2192[/green] Synced {gh_count} GitHub issue(s) to backlog")
+            console.print(f"[green]{_icons.arrow_right}[/green] Synced {gh_count} GitHub issue(s) to backlog")
     except Exception as exc:
         logger.debug("GitHub issue sync skipped: %s", exc)
 
@@ -790,7 +793,7 @@ def bootstrap_from_goal(
         with httpx.Client(timeout=10.0) as _wf_client:
             _wf_imported = import_workflow_tasks(workdir, _wf_client, server_url)
         if _wf_imported:
-            console.print(f"[green]→[/green] Imported {_wf_imported} task(s) from workflow file(s)")
+            console.print(f"[green]{_icons.arrow_right}[/green] Imported {_wf_imported} task(s) from workflow file(s)")
             backlog_count += _wf_imported
     except Exception as _wf_exc:
         logger.debug("Workflow import skipped: %s", _wf_exc)
@@ -824,11 +827,11 @@ def bootstrap_from_goal(
             import asyncio
 
             asyncio.run(with_init_timeout(_post_all(), context="posting tasks from plan file"))
-        console.print(f"[green]→[/green] Posted {len(tasks)} tasks from plan file")
+        console.print(f"[green]{_icons.arrow_right}[/green] Posted {len(tasks)} tasks from plan file")
         backlog_count = len(tasks)
     elif backlog_count > 0:
         console.print(
-            f"[green]→[/green] Planning tasks ({backlog_count} found in backlog"
+            f"[green]{_icons.arrow_right}[/green] Planning tasks ({backlog_count} found in backlog"
             + (f", {len(sync_result.skipped)} already synced" if sync_result.skipped else "")
             + ")"
         )
@@ -841,7 +844,7 @@ def bootstrap_from_goal(
                 server_url=server_url,
                 auth_token=auth_token,
             )
-        console.print("[green]→[/green] Planning tasks (manager agent will decompose goal)")
+        console.print(f"[green]{_icons.arrow_right}[/green] Planning tasks (manager agent will decompose goal)")
 
     # Cost estimation — show before spawning agents
     from bernstein.core.cost import estimate_run_cost
@@ -856,7 +859,7 @@ def bootstrap_from_goal(
     with Status(f"[bold]Spawning agents ({cell_label})...[/bold]", console=console):
         spawner_pid = _start_spawner(workdir, port, cells=cells, ab_test=ab_test)
         _start_watchdog(workdir, port)
-    console.print(f"[green]→[/green] Spawning agents (PID {spawner_pid})")
+    console.print(f"[green]{_icons.arrow_right}[/green] Spawning agents (PID {spawner_pid})")
 
     console.print("\n[bold green]Dashboard ready.[/bold green] Use [bold]bernstein stop[/bold] to stop.")
 

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -166,7 +166,7 @@ def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         ["git", *args],
         cwd=cwd,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         check=False,
     )
 

--- a/src/bernstein/core/orchestration/evolve_mode.py
+++ b/src/bernstein/core/orchestration/evolve_mode.py
@@ -244,7 +244,7 @@ class EvolveMixin:
             ["uv", "run", "ruff", "check", ".", "--output-format", "json"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=self._workdir,  # type: ignore[attr-defined]
             start_new_session=True,
         )
@@ -308,7 +308,7 @@ class EvolveMixin:
             ["uv", "run", "pytest", "tests/", "-x", "-q", "--tb=line"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=self._workdir,  # type: ignore[attr-defined]
             start_new_session=True,
         )
@@ -414,7 +414,7 @@ class EvolveMixin:
             test_result = subprocess.run(
                 ["uv", "run", "pytest", "tests/", "-x", "-q", "--tb=line"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 cwd=self._workdir,  # type: ignore[attr-defined]
                 timeout=300,
             )

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -2683,7 +2683,7 @@ class Orchestrator:
             ["uv", "run", "ruff", "check", ".", "--output-format", "json"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=self._workdir,
             start_new_session=True,
         )
@@ -2777,7 +2777,7 @@ class Orchestrator:
             ["uv", "run", "pytest", "tests/", "-x", "-q", "--tb=line"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=self._workdir,
             start_new_session=True,
         )
@@ -2883,7 +2883,7 @@ class Orchestrator:
             test_result = subprocess.run(
                 ["uv", "run", "pytest", "tests/", "-x", "-q", "--tb=line"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 cwd=self._workdir,
                 timeout=300,
             )

--- a/src/bernstein/core/orchestration/orchestrator_evolve.py
+++ b/src/bernstein/core/orchestration/orchestrator_evolve.py
@@ -216,7 +216,7 @@ def run_ruff_check(orch: Any) -> list[RuffViolation]:
         ["uv", "run", "ruff", "check", ".", "--output-format", "json"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         cwd=orch._workdir,
         start_new_session=True,
     )
@@ -330,7 +330,7 @@ def run_pytest(orch: Any) -> TestResults:
         ["uv", "run", "pytest", "tests/", "-x", "-q", "--tb=line"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         cwd=orch._workdir,
         start_new_session=True,
     )
@@ -459,7 +459,7 @@ def evolve_auto_commit(orch: Any) -> bool:
         test_result = subprocess.run(
             ["uv", "run", "pytest", "tests/", "-x", "-q", "--tb=line"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=orch._workdir,
             timeout=300,
         )

--- a/src/bernstein/core/orchestration/process_utils.py
+++ b/src/bernstein/core/orchestration/process_utils.py
@@ -23,7 +23,7 @@ def process_state(pid: int) -> str | None:
         result = subprocess.run(
             ["ps", "-o", "stat=", "-p", str(pid)],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=2,
             check=False,
         )
@@ -56,7 +56,7 @@ def process_cwd(pid: int) -> Path | None:
         result = subprocess.run(
             ["lsof", "-a", "-p", str(pid), "-d", "cwd", "-Fn"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=2,
             check=False,
         )

--- a/src/bernstein/core/orchestration/run_changelog.py
+++ b/src/bernstein/core/orchestration/run_changelog.py
@@ -91,7 +91,7 @@ def _run_git(args: list[str], cwd: Path, timeout: int = 30) -> str:
             ["git", *args],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
         )
         return result.stdout

--- a/src/bernstein/core/orchestration/run_session.py
+++ b/src/bernstein/core/orchestration/run_session.py
@@ -59,7 +59,7 @@ def _git_head_sha() -> str:
         result = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
             timeout=5,
         )

--- a/src/bernstein/core/persistence/file_health.py
+++ b/src/bernstein/core/persistence/file_health.py
@@ -214,7 +214,7 @@ def _compute_churn_score(file_path: Path, workdir: Path, days: int = 30) -> int:
             ["git", "log", f"--since={days}.days", "--oneline", "--", rel],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         if result.returncode != 0:

--- a/src/bernstein/core/persistence/merkle.py
+++ b/src/bernstein/core/persistence/merkle.py
@@ -179,7 +179,7 @@ def anchor_to_git(root_hash: str, workdir: Path) -> str | None:
             ["git", "tag", "-a", tag, "-m", f"Merkle audit seal: {root_hash}"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
         )
         return tag

--- a/src/bernstein/core/persistence/runtime_state.py
+++ b/src/bernstein/core/persistence/runtime_state.py
@@ -186,7 +186,7 @@ def current_git_branch(workdir: Path) -> str:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
             check=False,
         )
@@ -204,7 +204,7 @@ def current_git_sha(workdir: Path) -> str:
             ["git", "rev-parse", "HEAD"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=5,
             check=False,
         )

--- a/src/bernstein/core/persistence/workspace.py
+++ b/src/bernstein/core/persistence/workspace.py
@@ -162,7 +162,7 @@ class Workspace:
             cmd = ["git", "clone", "--branch", repo.branch, repo.url, str(abs_path)]
             logger.info("Cloning %s -> %s", repo.url, abs_path)
             try:
-                subprocess.run(cmd, capture_output=True, text=True, check=True)
+                subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=True)
                 cloned.append(repo.name)
             except subprocess.CalledProcessError as exc:
                 logger.warning("Failed to clone '%s': %s", repo.name, exc.stderr.strip())
@@ -267,7 +267,7 @@ class Workspace:
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 cwd=str(repo_path),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 check=True,
             )
             return result.stdout.strip()
@@ -282,7 +282,7 @@ class Workspace:
                 ["git", "status", "--porcelain"],
                 cwd=str(repo_path),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 check=True,
             )
             return result.stdout.strip() == ""
@@ -297,7 +297,7 @@ class Workspace:
                 ["git", "rev-list", "--left-right", "--count", "HEAD...@{upstream}"],
                 cwd=str(repo_path),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 check=True,
             )
             parts = result.stdout.strip().split()

--- a/src/bernstein/core/plugins_core/plugin_installer.py
+++ b/src/bernstein/core/plugins_core/plugin_installer.py
@@ -340,7 +340,7 @@ def _install_npm(source: NpmSource, install_dir: Path) -> PluginInstallResult:
         pack_cmd = ["npm", "pack", pkg_spec, "--pack-destination", str(tmp_path)]
         logger.info("plugin_installer: npm packing %s", pkg_spec)
         try:
-            result = subprocess.run(pack_cmd, check=True, capture_output=True, text=True, timeout=120)
+            result = subprocess.run(pack_cmd, check=True, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120)
         except subprocess.CalledProcessError as exc:
             return PluginInstallResult(
                 success=False,

--- a/src/bernstein/core/protocols/cluster_autoscaler.py
+++ b/src/bernstein/core/protocols/cluster_autoscaler.py
@@ -424,7 +424,7 @@ class KubernetesHPABackend(ScalingBackend):
             result = subprocess.run(
                 cmd,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             if result.returncode == 0 and result.stdout.strip():
@@ -465,7 +465,7 @@ class KubernetesHPABackend(ScalingBackend):
             result = subprocess.run(
                 cmd,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=15,
             )
             if result.returncode == 0:

--- a/src/bernstein/core/quality/auto_formatter.py
+++ b/src/bernstein/core/quality/auto_formatter.py
@@ -146,7 +146,7 @@ def _run_single_formatter(
             cmd,
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=effective_timeout,
         )
     except FileNotFoundError:

--- a/src/bernstein/core/quality/benchmark_gate.py
+++ b/src/bernstein/core/quality/benchmark_gate.py
@@ -187,7 +187,7 @@ class BenchmarkGate:
             shlex.split(self._benchmark_command),
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=600,
         )
         if result.returncode != 0:

--- a/src/bernstein/core/quality/ci_fix.py
+++ b/src/bernstein/core/quality/ci_fix.py
@@ -330,7 +330,7 @@ def check_test_dependencies() -> list[dict[str, str]]:
     result = subprocess.run(
         ["uv", "run", "ruff", "--version"],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=10,
     )
     ruff_ok = result.returncode == 0
@@ -347,7 +347,7 @@ def check_test_dependencies() -> list[dict[str, str]]:
     result = subprocess.run(
         ["uv", "run", "pytest", "--version"],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=10,
     )
     pytest_ok = result.returncode == 0
@@ -364,7 +364,7 @@ def check_test_dependencies() -> list[dict[str, str]]:
     result = subprocess.run(
         ["uv", "run", "pyright", "--version"],
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         timeout=10,
     )
     pyright_ok = result.returncode == 0

--- a/src/bernstein/core/quality/code_health.py
+++ b/src/bernstein/core/quality/code_health.py
@@ -209,7 +209,7 @@ def _score_churn(file_path: Path, project_root: Path) -> float:
         result = subprocess.run(
             ["git", "log", "--follow", "--oneline", "--", str(file_path)],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=str(project_root),
             timeout=10,
         )

--- a/src/bernstein/core/quality/coverage_gate.py
+++ b/src/bernstein/core/quality/coverage_gate.py
@@ -134,7 +134,7 @@ class CoverageGate:
             shlex.split(self._coverage_command),
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=600,
         )
         if result.returncode != 0:

--- a/src/bernstein/core/quality/cross_model_verifier.py
+++ b/src/bernstein/core/quality/cross_model_verifier.py
@@ -148,7 +148,7 @@ def _get_diff(worktree_path: Path, owned_files: list[str]) -> str:
         cmd = ["git", "diff", "HEAD~1", "--"]
         if owned_files:
             cmd.extend(owned_files)
-        result = subprocess.run(cmd, cwd=worktree_path, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(cmd, cwd=worktree_path, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30)
         diff = result.stdout.strip()
         if not diff:
             # Fallback: uncommitted staged changes
@@ -156,7 +156,7 @@ def _get_diff(worktree_path: Path, owned_files: list[str]) -> str:
                 ["git", "diff", "HEAD", "--"],
                 cwd=worktree_path,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
             diff = result.stdout.strip()

--- a/src/bernstein/core/quality/dead_code_detector.py
+++ b/src/bernstein/core/quality/dead_code_detector.py
@@ -122,7 +122,7 @@ def _get_diff(workdir: Path, changed_files: list[str]) -> str:
             cmd,
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         diff = result.stdout.strip()
@@ -132,7 +132,7 @@ def _get_diff(workdir: Path, changed_files: list[str]) -> str:
                 ["git", "diff", "--cached", "--"],
                 cwd=workdir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
             diff = result.stdout.strip()
@@ -192,7 +192,7 @@ def _find_callers_in_codebase(name: str, workdir: Path) -> list[str]:
             ],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=15,
         )
         if result.returncode not in (0, 1):
@@ -222,7 +222,7 @@ def _count_py_files(workdir: Path) -> int:
             ["git", "ls-files", "--cached", "--others", "--exclude-standard", "*.py"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         return len(result.stdout.strip().splitlines())

--- a/src/bernstein/core/quality/dependency_scan.py
+++ b/src/bernstein/core/quality/dependency_scan.py
@@ -340,7 +340,7 @@ def _run_dependency_command(command: DependencyScanCommand, *, cwd: Path, timeou
         list(command.argv),
         cwd=cwd,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         check=False,
         timeout=timeout_s,
     )

--- a/src/bernstein/core/quality/fast_path.py
+++ b/src/bernstein/core/quality/fast_path.py
@@ -205,7 +205,7 @@ def _run_ruff_format(workdir: Path, owned_files: list[str]) -> FastPathResult:
         proc = subprocess.run(
             ["uv", "run", "ruff", "format", *targets],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=workdir,
             timeout=30,
         )
@@ -245,7 +245,7 @@ def _run_ruff_fix(workdir: Path, owned_files: list[str]) -> FastPathResult:
         proc = subprocess.run(
             ["uv", "run", "ruff", "check", "--fix", *targets],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=workdir,
             timeout=30,
         )
@@ -278,7 +278,7 @@ def _run_sort_imports(workdir: Path, owned_files: list[str]) -> FastPathResult:
         proc = subprocess.run(
             ["uv", "run", "ruff", "check", "--select", "I", "--fix", *targets],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=workdir,
             timeout=30,
         )

--- a/src/bernstein/core/quality/formal_verification.py
+++ b/src/bernstein/core/quality/formal_verification.py
@@ -347,7 +347,7 @@ def _verify_lean4(
             result = subprocess.run(
                 ["lean", str(lean_file)],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=timeout_s,
                 cwd=tmpdir,
             )

--- a/src/bernstein/core/quality/gate_cache.py
+++ b/src/bernstein/core/quality/gate_cache.py
@@ -230,7 +230,7 @@ class GateRunnerCacheMixin:
                 ["git", "diff", "--name-only", f"{self._base_ref}..HEAD"],
                 cwd=run_dir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
         except (OSError, subprocess.TimeoutExpired):

--- a/src/bernstein/core/quality/gate_commands.py
+++ b/src/bernstein/core/quality/gate_commands.py
@@ -982,7 +982,7 @@ class GateRunnerCommandsMixin:
                 ["git", "worktree", "add", "--detach", str(temp_path), self._base_ref],
                 cwd=self._workdir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=60,
             )
             if add_proc.returncode != 0:
@@ -994,7 +994,7 @@ class GateRunnerCommandsMixin:
                     ["git", "worktree", "remove", "--force", str(temp_path)],
                     cwd=self._workdir,
                     capture_output=True,
-                    text=True,
+                    text=True, encoding="utf-8", errors="replace",
                     timeout=60,
                 )
 

--- a/src/bernstein/core/quality/gate_runner.py
+++ b/src/bernstein/core/quality/gate_runner.py
@@ -1254,7 +1254,7 @@ class GateRunner:
                 ["git", "worktree", "add", "--detach", str(temp_path), self._base_ref],
                 cwd=self._workdir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=60,
             )
             if add_proc.returncode != 0:
@@ -1266,7 +1266,7 @@ class GateRunner:
                     ["git", "worktree", "remove", "--force", str(temp_path)],
                     cwd=self._workdir,
                     capture_output=True,
-                    text=True,
+                    text=True, encoding="utf-8", errors="replace",
                     timeout=60,
                 )
 
@@ -1551,7 +1551,7 @@ class GateRunner:
                 ["git", "diff", "--name-only", f"{self._base_ref}..HEAD"],
                 cwd=run_dir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
         except (OSError, subprocess.TimeoutExpired):

--- a/src/bernstein/core/quality/integration_test_gen.py
+++ b/src/bernstein/core/quality/integration_test_gen.py
@@ -125,7 +125,7 @@ def _get_diff(run_dir: Path, base_ref: str = "HEAD~1") -> str:
         result = subprocess.run(
             ["git", "diff", base_ref, "--", "*.py"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             cwd=run_dir,
             timeout=30,
         )
@@ -134,7 +134,7 @@ def _get_diff(run_dir: Path, base_ref: str = "HEAD~1") -> str:
             result = subprocess.run(
                 ["git", "diff", "--cached", "--", "*.py"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 cwd=run_dir,
                 timeout=30,
             )

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -363,7 +363,7 @@ def _get_git_diff(task: Task, workdir: Path) -> str:
             cmd,
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         diff = result.stdout.strip()
@@ -669,7 +669,7 @@ def _check_llm_review(spec: str, workdir: Path) -> tuple[bool, str]:
             ["claude", "-p", prompt, "--model", "sonnet"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=60,
         )
         stdout = result.stdout.strip()

--- a/src/bernstein/core/quality/mutation_testing.py
+++ b/src/bernstein/core/quality/mutation_testing.py
@@ -324,7 +324,7 @@ def run_mutant(
             test_command,
             shell=True,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
             cwd=original_path.parent,
         )

--- a/src/bernstein/core/quality/perf_benchmark_gate.py
+++ b/src/bernstein/core/quality/perf_benchmark_gate.py
@@ -146,7 +146,7 @@ def run_benchmark(
         result = subprocess.run(
             shlex.split(command),
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
         )
         elapsed_ms = (time.monotonic() - start) * 1000.0
 

--- a/src/bernstein/core/quality/pr_status_widget.py
+++ b/src/bernstein/core/quality/pr_status_widget.py
@@ -225,7 +225,7 @@ def inject_widget_into_pr(pr_number: int, widget: StatusWidget) -> bool:
         result = subprocess.run(
             ["gh", "pr", "view", str(pr_number), "--json", "body", "--jq", ".body"],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
             timeout=30,
         )
@@ -240,7 +240,7 @@ def inject_widget_into_pr(pr_number: int, widget: StatusWidget) -> bool:
         subprocess.run(
             ["gh", "pr", "edit", str(pr_number), "--body", new_body],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             check=True,
             timeout=30,
         )

--- a/src/bernstein/core/quality/quality_gates.py
+++ b/src/bernstein/core/quality/quality_gates.py
@@ -323,14 +323,14 @@ def _get_intent_diff(worktree_path: Path, owned_files: list[str]) -> str:
         cmd = ["git", "diff", "HEAD~1", "--"]
         if owned_files:
             cmd.extend(owned_files)
-        result = subprocess.run(cmd, cwd=worktree_path, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(cmd, cwd=worktree_path, capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=30)
         diff = result.stdout.strip()
         if not diff:
             result = subprocess.run(
                 ["git", "diff", "HEAD", "--"],
                 cwd=worktree_path,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
             diff = result.stdout.strip()
@@ -498,7 +498,7 @@ def _run_command(command: str, cwd: Path, timeout_s: int) -> tuple[bool, str]:
             # that may use pipes or globs; not user input
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout_s,
         )
         output = (proc.stdout + proc.stderr).strip()

--- a/src/bernstein/core/quality/release_train.py
+++ b/src/bernstein/core/quality/release_train.py
@@ -158,7 +158,7 @@ def _gh_check_runs(repo: str, branch: str, timeout: int = 30) -> list[dict[str, 
         result = subprocess.run(
             cmd,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout,
         )
         if result.returncode != 0:

--- a/src/bernstein/core/routes/observability.py
+++ b/src/bernstein/core/routes/observability.py
@@ -290,7 +290,7 @@ def _get_git_diff_stats(workdir: Path, done_tasks: list[Any]) -> dict[str, Any]:
             ["git", "diff", "--stat", "--numstat"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             check=False,
         )

--- a/src/bernstein/core/security/external_policy_hook.py
+++ b/src/bernstein/core/security/external_policy_hook.py
@@ -173,7 +173,7 @@ class OPAHook(ExternalPolicyHook):
                     "json",
                 ],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
 

--- a/src/bernstein/core/security/policy_engine.py
+++ b/src/bernstein/core/security/policy_engine.py
@@ -494,7 +494,7 @@ def _run_opa_eval(policy_path: Path, payload: dict[str, Any]) -> object:
             ],
             check=False,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
     finally:
@@ -519,7 +519,7 @@ def _run_git(run_dir: Path, args: list[str]) -> str:
         cwd=run_dir,
         check=False,
         capture_output=True,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
     )
     if completed.returncode != 0:
         return ""

--- a/src/bernstein/core/security/rule_enforcer.py
+++ b/src/bernstein/core/security/rule_enforcer.py
@@ -214,7 +214,7 @@ def _get_git_diff(run_dir: Path) -> str:
                 diff_cmd,
                 cwd=run_dir,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
             if result.returncode == 0 and result.stdout:
@@ -366,7 +366,7 @@ def _check_command(rule: RuleSpec, run_dir: Path, timeout_s: int = 60) -> RuleVi
             # features; not user input
             cwd=run_dir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=timeout_s,
         )
         if proc.returncode == 0:

--- a/src/bernstein/core/security/sbom.py
+++ b/src/bernstein/core/security/sbom.py
@@ -417,7 +417,7 @@ class SBOMGenerator:
                 ["osv-scanner", "--format=json", "--sbom", str(sbom_path)],
                 cwd=str(self._workdir),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 check=False,
                 timeout=self._scan_timeout_s,
             )
@@ -449,7 +449,7 @@ class SBOMGenerator:
                 ["grype", f"sbom:{sbom_path}", "-o", "json"],
                 cwd=str(self._workdir),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 check=False,
                 timeout=self._scan_timeout_s,
             )

--- a/src/bernstein/core/security/secrets.py
+++ b/src/bernstein/core/security/secrets.py
@@ -280,7 +280,7 @@ class OnePasswordSecretsProvider(SecretsProvider):
             result = subprocess.run(
                 ["op", "item", "get", path, "--format=json"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=15,
             )
         except FileNotFoundError as exc:
@@ -314,7 +314,7 @@ class OnePasswordSecretsProvider(SecretsProvider):
             result = subprocess.run(
                 ["op", "whoami", "--format=json"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             if result.returncode != 0:

--- a/src/bernstein/core/security/security_incident_response.py
+++ b/src/bernstein/core/security/security_incident_response.py
@@ -429,7 +429,7 @@ class SecurityIncidentResponder:
             result = subprocess.run(
                 ["git", "rev-parse", branch],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=5,
                 cwd=str(self.workdir),
             )
@@ -539,7 +539,7 @@ class SecurityIncidentResponder:
             r = subprocess.run(
                 ["git", "log", "-1", "--format=%H %s"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=5,
                 cwd=str(self.workdir),
             )
@@ -550,7 +550,7 @@ class SecurityIncidentResponder:
             r2 = subprocess.run(
                 ["git", "status", "--short"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=5,
                 cwd=str(self.workdir),
             )

--- a/src/bernstein/core/security/vault_injector.py
+++ b/src/bernstein/core/security/vault_injector.py
@@ -286,7 +286,7 @@ class _OnePasswordInjector:
             result = subprocess.run(
                 ["op", "item", "get", config.path, "--format=json"],
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=20,
             )
         except FileNotFoundError as exc:

--- a/src/bernstein/core/server/api_compat_checker.py
+++ b/src/bernstein/core/server/api_compat_checker.py
@@ -432,7 +432,7 @@ def _git_diff_files(workdir: Path, base_ref: str, diff_filter: str) -> list[str]
             ["git", "diff", "--name-only", f"--diff-filter={diff_filter}", base_ref, "--", "*.py"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         return [f.strip() for f in result.stdout.splitlines() if f.strip().endswith(".py")]
@@ -520,7 +520,7 @@ def _git_show(workdir: Path, ref: str, rel_path: str) -> str:
             ["git", "show", f"{ref}:{rel_path}"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
         )
         if result.returncode == 0:

--- a/src/bernstein/core/tasks/task_diff_preview.py
+++ b/src/bernstein/core/tasks/task_diff_preview.py
@@ -8,7 +8,7 @@ Usage::
 
     diff_output = subprocess.check_output(
         ["git", "diff", "--stat", "--numstat", "main...HEAD"],
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
     )
     summary = build_diff_summary("task-042", diff_output, {"pytest": "passed"})
     print(format_diff_preview(summary))

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -2294,7 +2294,7 @@ def _get_changed_files_in_worktree(worktree_path: Path) -> list[str]:
             ["git", "diff", "--name-only", "HEAD"],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         if result.returncode == 0:
@@ -2321,7 +2321,7 @@ def _get_git_diff_line_count_in_worktree(worktree_path: Path) -> int:
             ["git", "diff", "--numstat", "HEAD"],
             cwd=worktree_path,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         if result.returncode != 0:

--- a/src/bernstein/eval/scenario_runner.py
+++ b/src/bernstein/eval/scenario_runner.py
@@ -323,7 +323,7 @@ class ScenarioRunner:
                 # commands are developer-authored YAML configs that may use
                 # shell features; not user input
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=self._command_timeout,
                 cwd=self._repo_root,
             )
@@ -652,7 +652,7 @@ class ScenarioRunner:
                 # validation commands are developer-authored shell strings
                 # from YAML configs; not user input
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=self._command_timeout,
                 cwd=self._repo_root,
             )

--- a/src/bernstein/evolution/sandbox.py
+++ b/src/bernstein/evolution/sandbox.py
@@ -331,7 +331,7 @@ class SandboxValidator:
                 # pipes or globs; not user input
                 cwd=worktree,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=SANDBOX_TIMEOUT,
             )
             output = result.stdout + "\n" + result.stderr

--- a/src/bernstein/github_app/app.py
+++ b/src/bernstein/github_app/app.py
@@ -204,7 +204,7 @@ def create_installation_token(config: GitHubAppConfig, installation_id: int) -> 
                 "POST",
             ],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
             check=False,
         )

--- a/src/bernstein/github_app/ci_router.py
+++ b/src/bernstein/github_app/ci_router.py
@@ -50,7 +50,7 @@ def get_commit_files(head_sha: str, cwd: Path | None = None) -> list[str]:
         result = subprocess.run(
             ["git", "diff-tree", "--no-commit-id", "-r", "--name-only", head_sha],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             cwd=cwd,
         )
@@ -78,7 +78,7 @@ def get_commit_diff(head_sha: str, cwd: Path | None = None) -> str:
         result = subprocess.run(
             ["git", "show", "--stat", "--patch", head_sha],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=15,
             cwd=cwd,
         )
@@ -103,7 +103,7 @@ def get_commit_message(head_sha: str, cwd: Path | None = None) -> str:
         result = subprocess.run(
             ["git", "log", "--format=%s", "-1", head_sha],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
             cwd=cwd,
         )

--- a/src/bernstein/github_app/cost_reporter.py
+++ b/src/bernstein/github_app/cost_reporter.py
@@ -106,7 +106,7 @@ def _find_existing_cost_comment(pr_number: int, repo: str) -> int | None:
         result = subprocess.run(
             args,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=15,
         )
         if result.returncode == 0:

--- a/src/bernstein/plugins/manager.py
+++ b/src/bernstein/plugins/manager.py
@@ -322,7 +322,7 @@ class CommandHook:
                 proc = subprocess.run(
                     [str(script)],
                     input=json.dumps(sub_kwargs),
-                    text=True,
+                    text=True, encoding="utf-8", errors="replace",
                     capture_output=True,
                     env=env,
                     check=False,

--- a/src/bernstein/templates/renderer.py
+++ b/src/bernstein/templates/renderer.py
@@ -79,7 +79,7 @@ def _execute_shell_commands(template: str) -> str:
             result = subprocess.run(
                 shlex.split(cmd),
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=10,
             )
             if result.returncode != 0:

--- a/src/bernstein/testing/patch_harness.py
+++ b/src/bernstein/testing/patch_harness.py
@@ -66,7 +66,7 @@ def apply_patch(patch: str, workdir: Path) -> bool:
     check = subprocess.run(
         ["git", "apply", "--check"],
         input=patch,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         capture_output=True,
         cwd=str(workdir),
     )
@@ -76,7 +76,7 @@ def apply_patch(patch: str, workdir: Path) -> bool:
     subprocess.run(
         ["git", "apply"],
         input=patch,
-        text=True,
+        text=True, encoding="utf-8", errors="replace",
         check=True,
         cwd=str(workdir),
     )

--- a/src/bernstein/tui/worktree_status.py
+++ b/src/bernstein/tui/worktree_status.py
@@ -44,7 +44,7 @@ def get_worktree_status(workdir: Path) -> WorktreeStatus | None:
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         if branch_result.returncode != 0:
@@ -55,7 +55,7 @@ def get_worktree_status(workdir: Path) -> WorktreeStatus | None:
             ["git", "status", "--porcelain"],
             cwd=workdir,
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=10,
         )
         is_dirty = bool(dirty_result.stdout.strip())


### PR DESCRIPTION
## Summary

- Add `encoding="utf-8", errors="replace"` to all `subprocess.run` calls with `text=True` to prevent `UnicodeDecodeError` on Windows where the default encoding may be cp1252 or other legacy codepages
- Add `AsciiSafeIcons` fallback class in `icons.py` for Windows terminals that cannot render Unicode characters
- Update splash, plan display, and helper modules to detect Windows terminal capabilities and use ASCII-safe fallbacks
- Fix terminal input handling in `plan_display.py`, `stop_cmd.py`, `bootstrap.py` for Windows compatibility

## Test plan

- [ ] Run `bernstein run` on Windows and verify no `UnicodeDecodeError` from subprocess output
- [ ] Verify terminal display renders correctly on Windows Command Prompt
- [ ] Verify terminal display renders correctly on Windows Terminal (with Unicode support)
- [ ] Verify Linux/macOS functionality is unchanged