### PR TITLE
feat: add --task/-t flag to filter backlog tasks

### DIFF
--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -469,6 +469,14 @@ class _RichGroup(click.Group):
 )
 @click.option("--verbose", "-v", is_flag=True, default=False, help="Show debug-level output.")
 @click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress all non-error output.")
+@click.option(
+    "--task",
+    "-t",
+    "task_filter",
+    default=None,
+    metavar="PATTERN",
+    help="Run only backlog tasks matching PATTERN (e.g. 'gh-62' or 'mutant-fish').",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -494,6 +502,7 @@ def cli(
     auto_approve: bool,
     verbose: bool,
     quiet: bool,
+    task_filter: str | None,
 ) -> None:
     """Declarative agent orchestration for engineering teams."""
     setup_json_logging()
@@ -661,6 +670,7 @@ def cli(
         ab_test=False,
         dry_run=False,
         profile=False,
+        task_filter=task_filter,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -601,6 +601,14 @@ def exec_restart() -> None:
         "Profile orchestrator execution with cProfile. Writes .prof binary and .txt report to .sdd/runtime/profiles/."
     ),
 )
+@click.option(
+    "--task",
+    "-t",
+    "task_filter",
+    default=None,
+    metavar="PATTERN",
+    help="Run only backlog tasks matching PATTERN (e.g. 'gh-62' or 'mutant-fish').",
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -627,6 +635,7 @@ def run(
     ab_test: bool = False,
     dry_run: bool = False,
     profile: bool = False,
+    task_filter: str | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -697,6 +706,10 @@ def run(
     # Propagate quiet flag so the orchestrator suppresses the live summary card
     if quiet:
         os.environ["BERNSTEIN_QUIET"] = "1"
+
+    # Propagate task filter so the orchestrator only ingests matching backlog tasks
+    if task_filter:
+        os.environ["BERNSTEIN_TASK_FILTER"] = task_filter
 
     _configure_quality_gate_bypass(
         goal=goal,

--- a/src/bernstein/core/git/github.py
+++ b/src/bernstein/core/git/github.py
@@ -617,7 +617,7 @@ class GitHubClient:
             result = subprocess.run(
                 args,
                 capture_output=True,
-                text=True,
+                text=True, encoding="utf-8", errors="replace",
                 timeout=30,
             )
             if result.returncode != 0:
@@ -806,7 +806,7 @@ def sync_github_issues_to_backlog(workdir: Path) -> int:
                 "500",
             ],
             capture_output=True,
-            text=True,
+            text=True, encoding="utf-8", errors="replace",
             timeout=30,
             cwd=str(workdir),
         )
@@ -893,6 +893,15 @@ def sync_github_issues_to_backlog(workdir: Path) -> int:
         title: str = issue.get("title", "Untitled issue")
         if title.lower().strip() in existing_titles:
             continue  # Already covered by an existing backlog file
+
+        # Task filter: skip issues that don't match the pattern (e.g., "gh-62")
+        task_filter = os.environ.get("BERNSTEIN_TASK_FILTER")
+        if task_filter:
+            slug_preview = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:60]
+            filename_preview = f"gh-{number}-{slug_preview}"
+            if task_filter.lower() not in filename_preview.lower():
+                logger.debug("Skipping issue #%d - does not match filter '%s'", number, task_filter)
+                continue
 
         title: str = issue.get("title", "Untitled issue")
         body: str = (issue.get("body") or "")[:500]

--- a/src/bernstein/core/orchestration/orchestrator_backlog.py
+++ b/src/bernstein/core/orchestration/orchestrator_backlog.py
@@ -98,6 +98,14 @@ def ingest_backlog(orch: Any) -> int:
             backlog_files.extend(src_dir.glob("*.yml"))
     backlog_files.sort()
 
+    # Filter by task pattern if BERNSTEIN_TASK_FILTER is set (e.g. "gh-62" or "mutant-fish")
+    import os
+    task_filter = os.environ.get("BERNSTEIN_TASK_FILTER")
+    if task_filter:
+        task_filter_lower = task_filter.lower()
+        backlog_files = [f for f in backlog_files if task_filter_lower in f.name.lower()]
+        logger.info("Task filter '%s' matched %d backlog file(s)", task_filter, len(backlog_files))
+
     if not backlog_files:
         return 0
 


### PR DESCRIPTION
## Summary

Add ability to run only specific backlog tasks by pattern matching:

```bash
bernstein -t gh-62 -g "Work on github issue #62"
```

- Add `--task`/`-t` option to CLI
- Set `BERNSTEIN_TASK_FILTER` environment variable for orchestrator
- Filter GitHub issue sync to skip non-matching issues (prevents syncing all 700+ issues)
- Filter backlog ingestion to only process matching files

## Problem

When running `bernstein -t gh-62`, the system would:
1. Sync ALL open GitHub issues to `.sdd/backlog/open/`
2. Ingest them all into the task server
3. Only then apply the filter (too late)

This caused task spam with hundreds of tasks being created when only one was needed.

## Solution

Apply the filter at two points:
1. **GitHub sync** (`github.py`): Skip issues that don't match the pattern
2. **Backlog ingestion** (`orchestrator_backlog.py`): Filter files before posting to server

## Test plan

- [ ] Run `bernstein -t gh-62 -g "Work on issue #62"` and verify only gh-62 task is created
- [ ] Verify `.sdd/backlog/open/` only contains matching file
- [ ] Verify server only has one task (not hundreds)