### PR TITLE
feat: add --auto-pr flag to create PR when tasks complete

### DIFF
--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -469,6 +469,12 @@ class _RichGroup(click.Group):
 )
 @click.option("--verbose", "-v", is_flag=True, default=False, help="Show debug-level output.")
 @click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress all non-error output.")
+@click.option(
+    "--auto-pr",
+    is_flag=True,
+    default=False,
+    help="Automatically create a GitHub PR when all tasks complete.",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -494,6 +500,7 @@ def cli(
     auto_approve: bool,
     verbose: bool,
     quiet: bool,
+    auto_pr: bool,
 ) -> None:
     """Declarative agent orchestration for engineering teams."""
     setup_json_logging()
@@ -661,6 +668,7 @@ def cli(
         ab_test=False,
         dry_run=False,
         profile=False,
+        auto_pr=auto_pr,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -601,6 +601,12 @@ def exec_restart() -> None:
         "Profile orchestrator execution with cProfile. Writes .prof binary and .txt report to .sdd/runtime/profiles/."
     ),
 )
+@click.option(
+    "--auto-pr",
+    is_flag=True,
+    default=False,
+    help="Automatically create a GitHub PR when all tasks complete.",
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -627,6 +633,7 @@ def run(
     ab_test: bool = False,
     dry_run: bool = False,
     profile: bool = False,
+    auto_pr: bool = False,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -697,6 +704,10 @@ def run(
     # Propagate quiet flag so the orchestrator suppresses the live summary card
     if quiet:
         os.environ["BERNSTEIN_QUIET"] = "1"
+
+    # Propagate auto-PR flag so the orchestrator creates a PR when all tasks complete
+    if auto_pr:
+        os.environ["BERNSTEIN_AUTO_PR"] = "1"
 
     _configure_quality_gate_bypass(
         goal=goal,

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3460,6 +3460,10 @@ class Orchestrator:
             run_start_ts=self._run_start_ts,
         )
 
+        # Auto-PR: create a GitHub PR if BERNSTEIN_AUTO_PR is set
+        if os.environ.get("BERNSTEIN_AUTO_PR") == "1":
+            self._create_auto_pr(done_tasks, total_cost, duration_str)
+
         self._emit_summary_card(
             done_tasks=done_tasks,
             failed_tasks=failed_tasks,
@@ -3467,6 +3471,109 @@ class Orchestrator:
             wall_clock_s=wall_clock_s,
             total_cost=total_cost,
         )
+
+    def _create_auto_pr(
+        self,
+        done_tasks: list[Task],
+        total_cost: float,
+        duration_str: str,
+    ) -> None:
+        """Create a GitHub PR with the completed work.
+
+        Called when BERNSTEIN_AUTO_PR=1 is set and all tasks complete.
+        """
+        import subprocess
+
+        from bernstein.core.git.git_pr import create_github_pr
+
+        # Get current branch name
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=self._workdir,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            )
+            current_branch = result.stdout.strip()
+        except Exception as exc:
+            logger.warning("Auto-PR: failed to get current branch: %s", exc)
+            return
+
+        if current_branch in ("main", "master"):
+            logger.info("Auto-PR: skipping - already on %s branch", current_branch)
+            return
+
+        # Check if there are commits to push
+        try:
+            result = subprocess.run(
+                ["git", "log", "origin/main..HEAD", "--oneline"],
+                cwd=self._workdir,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+            )
+            if not result.stdout.strip():
+                logger.info("Auto-PR: skipping - no commits ahead of main")
+                return
+        except Exception:
+            pass  # Continue anyway
+
+        # Push the branch
+        try:
+            subprocess.run(
+                ["git", "push", "-u", "origin", current_branch],
+                cwd=self._workdir,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
+            )
+        except Exception as exc:
+            logger.warning("Auto-PR: failed to push branch: %s", exc)
+            return
+
+        # Build PR title and body
+        if len(done_tasks) == 1:
+            pr_title = done_tasks[0].title
+        else:
+            pr_title = f"Bernstein: {len(done_tasks)} tasks completed"
+
+        body_lines = [
+            "## Summary",
+            "",
+            f"Completed {len(done_tasks)} task(s) in {duration_str} (${total_cost:.4f}).",
+            "",
+            "### Tasks",
+            "",
+        ]
+        for task in done_tasks:
+            body_lines.append(f"- [x] {task.title}")
+        body_lines.append("")
+
+        pr_result = create_github_pr(
+            cwd=self._workdir,
+            title=pr_title,
+            body="\n".join(body_lines),
+            head=current_branch,
+            base="main",
+        )
+
+        if pr_result.success:
+            logger.info("Auto-PR created: %s", pr_result.pr_url)
+            self._notify(
+                "pr.created",
+                "Pull request created",
+                f"PR for {len(done_tasks)} task(s): {pr_result.pr_url}",
+                pr_url=pr_result.pr_url,
+            )
+        else:
+            logger.warning("Auto-PR failed: %s", pr_result.error)
 
     def _emit_summary_card(
         self,


### PR DESCRIPTION
## Summary

Add ability to automatically create a GitHub PR when all tasks finish:

```bash
bernstein --auto-pr -g "Fix the bug"
```

When all tasks complete, the orchestrator will:
1. Get current branch name
2. Skip if already on main/master
3. Push the branch to origin
4. Create a PR via `gh` CLI with a summary of completed tasks
5. Send a notification with the PR URL

## Test plan

- [ ] Run `bernstein --auto-pr -g "test task"` on a feature branch
- [ ] Verify PR is created when all tasks complete
- [ ] Verify PR title matches single task title (or summary for multiple)
- [ ] Verify PR body contains task list
- [ ] Verify no PR is created when on main branch