### PR TITLE
fix: Windows compatibility and activity log improvements

### DIFF
--- a/src/bernstein/cli/commands/stop_cmd.py
+++ b/src/bernstein/cli/commands/stop_cmd.py
@@ -406,6 +406,50 @@ class _ProcessSnapshot:
 
 def _list_process_snapshots() -> list[_ProcessSnapshot]:
     """Return a best-effort snapshot of all local processes."""
+    if sys.platform == "win32":
+        return _list_process_snapshots_windows()
+    return _list_process_snapshots_unix()
+
+
+def _list_process_snapshots_windows() -> list[_ProcessSnapshot]:
+    """Windows: use WMIC or PowerShell to list processes."""
+    snapshots: list[_ProcessSnapshot] = []
+    try:
+        # Use PowerShell for better reliability
+        result = subprocess.run(
+            [
+                "powershell", "-NoProfile", "-Command",
+                "Get-Process | Select-Object Id, @{N='ParentId';E={(Get-CimInstance Win32_Process -Filter \"ProcessId=$($_.Id)\").ParentProcessId}}, Path | ConvertTo-Csv -NoTypeInformation"
+            ],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            return []
+        lines = result.stdout.strip().splitlines()
+        if len(lines) < 2:
+            return []
+        # Skip header: "Id","ParentId","Path"
+        for line in lines[1:]:
+            # Parse CSV: "1234","5678","C:\path\to\exe"
+            parts = line.strip().strip('"').split('","')
+            if len(parts) >= 3:
+                try:
+                    pid = int(parts[0])
+                    ppid = int(parts[1]) if parts[1] else 0
+                    command = parts[2] if parts[2] else ""
+                    snapshots.append(_ProcessSnapshot(pid=pid, ppid=ppid, pgid=0, command=command))
+                except (ValueError, IndexError):
+                    continue
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return snapshots
+
+
+def _list_process_snapshots_unix() -> list[_ProcessSnapshot]:
+    """Unix: use ps to list processes."""
     try:
         result = subprocess.run(
             ["ps", "-ax", "-o", "pid=,ppid=,pgid=,command="],
@@ -473,18 +517,41 @@ def _collect_repo_processes(killed: set[int]) -> None:
 def _kill_port_holder(port: int, killed: set[int]) -> None:
     """Kill whatever process is holding a port (last resort)."""
     try:
-        result = subprocess.run(
-            ["lsof", "-ti", f":{port}"],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=5,
-        )
-        for line in result.stdout.strip().splitlines():
-            pid = int(line.strip())
-            if pid not in killed:
-                _kill_named_pid(pid, f"Port {port} holder", killed)
+        if sys.platform == "win32":
+            # Windows: use netstat to find the PID
+            result = subprocess.run(
+                ["netstat", "-ano"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            for line in result.stdout.splitlines():
+                # Match lines like: TCP    127.0.0.1:8052    0.0.0.0:0    LISTENING    12345
+                if f":{port}" in line and "LISTENING" in line:
+                    parts = line.split()
+                    if parts:
+                        try:
+                            pid = int(parts[-1])
+                            if pid not in killed:
+                                _kill_named_pid(pid, f"Port {port} holder", killed)
+                        except ValueError:
+                            continue
+        else:
+            # Unix: use lsof
+            result = subprocess.run(
+                ["lsof", "-ti", f":{port}"],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+            )
+            for line in result.stdout.strip().splitlines():
+                pid = int(line.strip())
+                if pid not in killed:
+                    _kill_named_pid(pid, f"Port {port} holder", killed)
     except (OSError, ValueError, subprocess.TimeoutExpired):
         pass
 

--- a/src/bernstein/cli/dashboard_app.py
+++ b/src/bernstein/cli/dashboard_app.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
+import re
 import time
 from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import IO, TYPE_CHECKING, Any, ClassVar
 
 if TYPE_CHECKING:
     from textual import events
@@ -255,6 +257,31 @@ class BernsteinApp(App[None]):
         self._last_activity: list[str] = []
         self._compare_mark: str | None = None  # first task ID for compare
         self._resize_timer: object | None = None  # debounce timer handle (TUI-001)
+        # Activity log file (--activity-log flag)
+        self._activity_log_file: IO[str] | None = None
+        activity_log_path = os.environ.get("BERNSTEIN_ACTIVITY_LOG")
+        if activity_log_path:
+            try:
+                log_path = Path(activity_log_path)
+                log_path.parent.mkdir(parents=True, exist_ok=True)
+                self._activity_log_file = open(log_path, "a", encoding="utf-8")  # noqa: SIM115
+            except OSError as exc:
+                logging.getLogger(__name__).warning("Failed to open activity log file: %s", exc)
+
+    def _write_activity(self, role: str, line: str) -> None:
+        """Write an activity line to the RichLog and optionally to a file."""
+        formatted = _format_activity_line(role, line)
+        try:
+            log = self.query_one("#activity-log", RichLog)
+            log.write(formatted)
+        except Exception:
+            pass  # Widget may not exist yet during startup
+        # Write to activity log file if configured
+        if self._activity_log_file:
+            # Strip Rich markup for plain text file
+            plain = re.sub(r"\[/?[^\]]+\]", "", formatted)
+            self._activity_log_file.write(plain + "\n")
+            self._activity_log_file.flush()
 
     def compose(self) -> ComposeResult:
         yield DashboardHeader(id="header-bar")
@@ -315,6 +342,11 @@ class BernsteinApp(App[None]):
             logger.debug("Layout calculation error during resize (ignored)", exc_info=True)
 
     def on_mount(self) -> None:
+        # Skip historical spawner.log entries - start from current position
+        sp = Path(".sdd/runtime/spawner.log")
+        if sp.exists():
+            self._spawner_size = sp.stat().st_size
+
         t: DataTable[Any] = self.query_one("#tasks-table", DataTable)  # pyright: ignore[reportUnknownVariableType]
         t.add_columns("", "P", "ROLE", "TASK")
         t.cursor_type = "row"
@@ -330,25 +362,24 @@ class BernsteinApp(App[None]):
                 logger.warning("Failed to read evolve.json: %s", exc)
 
         # Write startup messages to activity log
-        log = self.query_one("#activity-log", RichLog)
-        log.write(_format_activity_line("system", "Bernstein starting..."))
-        log.write(_format_activity_line("system", "Connecting to task server on :8052"))
+        self._write_activity("system", "Bernstein starting...")
+        self._write_activity("system", "Connecting to task server on :8052")
 
         # Immediate agent display from local file (no HTTP wait)
         agents = _load_agents()
         if agents:
             alive = sum(1 for a in agents if a.get("status") != "dead")
-            log.write(_format_activity_line("system", f"{alive} agent(s) active"))
+            self._write_activity("system", f"{alive} agent(s) active")
             costs: dict[str, Any] = {}
             self._update_agents(agents, costs)
         else:
-            log.write(_format_activity_line("system", "Spawning agents..."))
+            self._write_activity("system", "Spawning agents...")
             # Show worktree count as early signal of activity
             wt_dir = Path(".sdd/worktrees")
             if wt_dir.exists():
                 wt_count = sum(1 for _ in wt_dir.iterdir() if _.is_dir())
                 if wt_count > 0:
-                    log.write(_format_activity_line("system", f"{wt_count} worktree(s) detected"))
+                    self._write_activity("system", f"{wt_count} worktree(s) detected")
 
         # File watcher for agents.json (500ms — instant agent visibility)
         self.set_interval(0.5, self._check_agents_file)
@@ -395,20 +426,19 @@ class BernsteinApp(App[None]):
                         f.seek(self._spawner_size)
                         new_lines = f.read()
                     self._spawner_size = size
-                    log = self.query_one("#activity-log", RichLog)
                     for line in new_lines.strip().split("\n"):
                         if not line:
                             continue
                         message = line.split("] ")[-1] if "] " in line else line
                         # Filter to important events
                         if "agent_spawned" in line or "Spawning" in line or "spawned" in line.lower():
-                            log.write(_format_activity_line("system", f"spawned: {message}"))
+                            self._write_activity("system", f"spawned: {message}")
                         elif "ERROR" in line or "error" in line:
-                            log.write(_format_activity_line("system", message))
+                            self._write_activity("system", message)
                         elif "WARNING" in line:
-                            log.write(_format_activity_line("system", f"warning: {message}"))
+                            self._write_activity("system", f"warning: {message}")
                         elif "completed" in line.lower() or "reaped" in line.lower() or "merged" in line.lower():
-                            log.write(_format_activity_line("system", message))
+                            self._write_activity("system", message)
             except Exception:
                 pass
 
@@ -882,7 +912,7 @@ class BernsteinApp(App[None]):
                 message = f"config - {path} (was {before})"
             else:
                 message = f"config ~ {path}: {before} -> {after}"
-            log.write(_format_activity_line("system", message))
+            self._write_activity("system", message)
 
     ROLE_COLORS: ClassVar[dict[str, str]] = ROLE_COLORS
 
@@ -901,6 +931,7 @@ class BernsteinApp(App[None]):
         "no tasks",
         "idle",
         "waiting for",
+        "agent working",
     )
 
     def _update_activity(self, agents: list[dict[str, Any]]) -> None:
@@ -923,6 +954,11 @@ class BernsteinApp(App[None]):
         for line in new_lines:
             if line not in self._last_activity:
                 log.write(line)
+                # Write to activity log file if configured
+                if self._activity_log_file:
+                    plain = re.sub(r"\[/?[^\]]+\]", "", line)
+                    self._activity_log_file.write(plain + "\n")
+                    self._activity_log_file.flush()
         self._last_activity = new_lines
 
     # -- Actions --

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -483,6 +483,14 @@ class _RichGroup(click.Group):
     default=False,
     help="Automatically create a GitHub PR when all tasks complete.",
 )
+@click.option(
+    "--activity-log",
+    "activity_log_path",
+    is_flag=False,
+    flag_value=".sdd/logs/activity.log",
+    default=None,
+    help="Write activity to log file. Default: .sdd/logs/activity.log",
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -510,6 +518,7 @@ def cli(
     quiet: bool,
     task_filter: str | None,
     auto_pr: bool,
+    activity_log_path: str | None,
 ) -> None:
     """Declarative agent orchestration for engineering teams."""
     setup_json_logging()
@@ -679,6 +688,7 @@ def cli(
         profile=False,
         task_filter=task_filter,
         auto_pr=auto_pr,
+        activity_log_path=activity_log_path,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -615,6 +615,14 @@ def exec_restart() -> None:
     default=False,
     help="Automatically create a GitHub PR when all tasks complete.",
 )
+@click.option(
+    "--activity-log",
+    "activity_log_path",
+    is_flag=False,
+    flag_value=".sdd/logs/activity.log",
+    default=None,
+    help="Write activity to log file. Use --activity-log for default (.sdd/logs/activity.log) or --activity-log PATH for custom.",
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -643,6 +651,7 @@ def run(
     profile: bool = False,
     task_filter: str | None = None,
     auto_pr: bool = False,
+    activity_log_path: str | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -717,9 +726,14 @@ def run(
     # Propagate task filter so the orchestrator only ingests matching backlog tasks
     if task_filter:
         os.environ["BERNSTEIN_TASK_FILTER"] = task_filter
+
     # Propagate auto-PR flag so the orchestrator creates a PR when all tasks complete
     if auto_pr:
         os.environ["BERNSTEIN_AUTO_PR"] = "1"
+
+    # Propagate activity log path so the dashboard writes activity to a file
+    if activity_log_path:
+        os.environ["BERNSTEIN_ACTIVITY_LOG"] = activity_log_path
 
     _configure_quality_gate_bypass(
         goal=goal,

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -376,6 +376,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "prompt_injection": "bernstein.core.tokens.prompt_injection",
     "prompt_precheck": "bernstein.core.tokens.prompt_precheck",
     "prompt_token_analysis": "bernstein.core.tokens.prompt_token_analysis",
+    "prompt_optimizer": "bernstein.core.prompt_optimizer",
     "prompt_versioning": "bernstein.core.tokens.prompt_versioning",
     "provider_circuit_breaker": "bernstein.core.observability.provider_circuit_breaker",
     "provider_latency": "bernstein.core.observability.provider_latency",

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -537,6 +537,7 @@ def _render_prompt(
     task_graph: TaskGraph | None = None,
     meta_messages: list[str] | None = None,
     file_ownership: dict[str, str] | None = None,
+    prompt_optimizer: Any | None = None,
 ) -> str:
     """Build the full agent prompt from role template + tasks + context.
 
@@ -547,6 +548,10 @@ def _render_prompt(
 
     If *catalog_system_prompt* is provided it replaces the built-in role
     template entirely, so the spawner can inject catalog-defined personas.
+
+    If *prompt_optimizer* is provided and has an active A/B test for the
+    role, the variant selected by the optimizer overrides the template-based
+    role prompt, enabling continuous prompt improvement.
 
     Args:
         tasks: Batch of 1-3 tasks (all same role).
@@ -562,6 +567,8 @@ def _render_prompt(
         meta_messages: Optional list of operational nudges/hints (T423).
         file_ownership: Optional mapping of filepath -> agent_id for files
             currently being edited by other agents.
+        prompt_optimizer: Optional PromptOptimizer instance.  When provided,
+            assigns tasks to prompt variants and records outcomes for A/B tests.
 
     Returns:
         Complete prompt string ready for the CLI adapter.
@@ -639,14 +646,39 @@ def _render_prompt(
 
     # Use catalog system prompt when available (Agency specialist prompt),
     # otherwise fall back to role template or built-in default.
+    # When a PromptOptimizer is active, it may override the role prompt with
+    # a variant assigned via A/B testing.
+    _optimizer_assignment: Any = None
     if catalog_system_prompt:
         role_prompt = catalog_system_prompt
     else:
-        try:
-            role_prompt = render_role_prompt(role, context, templates_dir=templates_dir)
-        except (FileNotFoundError, TemplateError) as exc:
-            logger.debug("Template render failed for role %s, using fallback: %s", role, exc)
-            role_prompt = _render_fallback(role, templates_dir, agency_catalog)
+        # Check prompt optimizer for an active variant before loading template
+        optimizer_override: str | None = None
+        if prompt_optimizer is not None:
+            try:
+                task_id = tasks[0].id if tasks else ""
+                _optimizer_assignment = prompt_optimizer.assign_variant(
+                    role=role, task_id=task_id
+                )
+                optimizer_override = _optimizer_assignment.content_override
+                if optimizer_override:
+                    logger.debug(
+                        "PromptOptimizer: using variant v%s for role %r task %r",
+                        _optimizer_assignment.variant_version,
+                        role,
+                        task_id,
+                    )
+            except Exception as _opt_exc:
+                logger.debug("PromptOptimizer variant selection failed: %s", _opt_exc)
+
+        if optimizer_override:
+            role_prompt = optimizer_override
+        else:
+            try:
+                role_prompt = render_role_prompt(role, context, templates_dir=templates_dir)
+            except (FileNotFoundError, TemplateError) as exc:
+                logger.debug("Template render failed for role %s, using fallback: %s", role, exc)
+                role_prompt = _render_fallback(role, templates_dir, agency_catalog)
 
     # Inject prior agent lessons based on task tags (cached per role)
     sdd_dir = workdir / ".sdd"
@@ -934,6 +966,7 @@ def render_prompt(
     task_graph: TaskGraph | None = None,
     meta_messages: list[str] | None = None,
     file_ownership: dict[str, str] | None = None,
+    prompt_optimizer: Any | None = None,
 ) -> str:
     """Public wrapper for compatibility-safe prompt rendering."""
     return _render_prompt(
@@ -948,6 +981,7 @@ def render_prompt(
         task_graph=task_graph,
         meta_messages=meta_messages,
         file_ownership=file_ownership,
+        prompt_optimizer=prompt_optimizer,
     )
 
 

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -383,7 +383,7 @@ def path_separator() -> str:
 
 
 def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
-    """Kill a process on Windows via ``taskkill``.
+    """Kill a process on Windows via ``taskkill`` with PowerShell fallback.
 
     Args:
         pid: Process ID.
@@ -391,8 +391,9 @@ def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
         tree: If True, adds ``/T`` (kill child processes).
 
     Returns:
-        True if taskkill exited successfully.
+        True if the process was killed successfully.
     """
+    # Try taskkill first (faster when it works)
     cmd: list[str] = ["taskkill"]
     if force:
         cmd.append("/F")
@@ -406,11 +407,26 @@ def _win_taskkill(pid: int, *, force: bool = False, tree: bool = False) -> bool:
             text=True,
             encoding="utf-8",
             errors="replace",
-            timeout=10,
+            timeout=5,
         )
-        return result.returncode == 0
+        if result.returncode == 0:
+            return True
     except (subprocess.TimeoutExpired, OSError) as exc:
         logger.debug("taskkill failed for PID %d: %s", pid, exc)
+
+    # Fallback: PowerShell Stop-Process (more reliable for stubborn processes)
+    try:
+        ps_cmd = f"Stop-Process -Id {pid} -Force -ErrorAction SilentlyContinue"
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", ps_cmd],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=5,
+        )
+        # PowerShell returns 0 even if process doesn't exist, so verify
+        return not _win_process_alive(pid)
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("PowerShell Stop-Process failed for PID %d: %s", pid, exc)
         return False
 
 

--- a/src/bernstein/core/git/git_pr.py
+++ b/src/bernstein/core/git/git_pr.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import logging
+import os
 import py_compile
+import shutil
+import stat
 import subprocess
+import sys
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -353,17 +357,22 @@ def create_github_pr(
 ) -> PullRequestResult:
     """Create a GitHub pull request via the ``gh`` CLI.
 
+    Labels are added as a best-effort post-creation step. If labels don't
+    exist on the repo, the PR is still created successfully and a warning
+    is logged.
+
     Args:
         cwd: Repository root (used as working directory for ``gh``).
         title: PR title.
         body: PR body / description.
         head: Source branch name.
         base: Target branch (default ``"main"``).
-        labels: Optional list of label names to attach.
+        labels: Optional list of label names to attach (best-effort).
 
     Returns:
         PullRequestResult with ``pr_url`` set on success.
     """
+    # Create PR without labels first to avoid failure if labels don't exist
     cmd = [
         "gh",
         "pr",
@@ -377,8 +386,6 @@ def create_github_pr(
         "--base",
         base,
     ]
-    if labels:
-        cmd.extend(["--label", ",".join(labels)])
     try:
         result = subprocess.run(
             cmd,
@@ -389,10 +396,33 @@ def create_github_pr(
             errors="replace",
             timeout=30,
         )
-        if result.returncode == 0:
-            pr_url = result.stdout.strip()
-            return PullRequestResult(success=True, pr_url=pr_url)
-        return PullRequestResult(success=False, error=result.stderr.strip())
+        if result.returncode != 0:
+            return PullRequestResult(success=False, error=result.stderr.strip())
+
+        pr_url = result.stdout.strip()
+
+        # Add labels separately (best-effort) - don't fail if labels don't exist
+        if labels and pr_url:
+            try:
+                label_result = subprocess.run(
+                    ["gh", "pr", "edit", pr_url, "--add-label", ",".join(labels)],
+                    cwd=cwd,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=15,
+                )
+                if label_result.returncode != 0:
+                    logger.warning(
+                        "PR created but failed to add labels %s: %s",
+                        labels,
+                        label_result.stderr.strip(),
+                    )
+            except (subprocess.TimeoutExpired, OSError) as exc:
+                logger.warning("PR created but failed to add labels %s: %s", labels, exc)
+
+        return PullRequestResult(success=True, pr_url=pr_url)
     except (subprocess.TimeoutExpired, OSError) as exc:
         return PullRequestResult(success=False, error=str(exc))
 
@@ -447,12 +477,57 @@ def worktree_add(cwd: Path, path: Path, branch: str) -> GitResult:
 
 
 def worktree_remove(cwd: Path, path: Path) -> GitResult:
-    """Remove a worktree (force)."""
-    return run_git(
-        ["worktree", "remove", "--force", str(path)],
-        cwd,
-        timeout=30,
-    )
+    """Remove a worktree (force), with Windows retry logic.
+
+    On Windows, file locks from recently-terminated processes or antivirus
+    can prevent immediate deletion. This function retries up to 3 times with
+    delays, then falls back to manual directory deletion if git fails.
+    """
+    max_attempts = 3 if sys.platform == "win32" else 1
+
+    for attempt in range(max_attempts):
+        result = run_git(
+            ["worktree", "remove", "--force", str(path)],
+            cwd,
+            timeout=30,
+        )
+        if result.ok:
+            return result
+
+        # On Windows, retry after a short delay (file locks may release)
+        if sys.platform == "win32" and attempt < max_attempts - 1:
+            time.sleep(1.0)
+            continue
+
+        # Final fallback on Windows: manual deletion with permission override
+        if sys.platform == "win32" and path.exists():
+            # Extra delay for stubborn file locks (processes fully exiting)
+            time.sleep(2.0)
+
+            def _onerror(func, fpath, _exc_info):  # type: ignore[no-untyped-def]
+                """Clear read-only flag and retry; ignore if still locked."""
+                try:
+                    os.chmod(fpath, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+                    func(fpath)
+                except OSError:
+                    pass  # File still locked, skip it
+
+            try:
+                shutil.rmtree(path, onerror=_onerror)
+                # Prune to clean up git's worktree list after manual deletion
+                run_git(["worktree", "prune"], cwd, timeout=10)
+                logger.debug("Worktree %s removed via manual deletion fallback", path)
+                return GitResult(returncode=0, stdout="", stderr="")
+            except Exception as exc:
+                logger.debug("Manual worktree deletion failed for %s: %s", path, exc)
+                # Check if directory is mostly gone (some locked files may remain)
+                if not path.exists() or not any(path.iterdir()):
+                    run_git(["worktree", "prune"], cwd, timeout=10)
+                    return GitResult(returncode=0, stdout="", stderr="")
+
+        return result
+
+    return result
 
 
 def worktree_list(cwd: Path) -> str:

--- a/src/bernstein/core/git/github.py
+++ b/src/bernstein/core/git/github.py
@@ -908,7 +908,6 @@ def sync_github_issues_to_backlog(workdir: Path) -> int:
                 logger.debug("Skipping issue #%d - does not match filter '%s'", number, task_filter)
                 continue
 
-        title: str = issue.get("title", "Untitled issue")
         body: str = (issue.get("body") or "")[:500]
         labels_raw: list[dict[str, Any]] = issue.get("labels", [])
         labels: list[str] = [str(lbl.get("name", "")).lower() for lbl in labels_raw if lbl.get("name")]

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -16,17 +16,67 @@ Usage::
 from __future__ import annotations
 
 import logging
+import sys
 from typing import Any, cast
 
-from prometheus_client import (
-    CollectorRegistry,
-    Counter,
-    Gauge,
-    Histogram,
-    generate_latest,
-)
-
 logger = logging.getLogger(__name__)
+
+# prometheus_client can hang on Windows during import due to multiprocessing issues.
+# Make it optional with stub fallbacks for Windows compatibility.
+_PROMETHEUS_AVAILABLE = False
+try:
+    # Set a short import timeout using threading on Windows
+    if sys.platform == "win32":
+        import threading
+        _import_done = threading.Event()
+        _import_error: Exception | None = None
+        def _try_import() -> None:
+            global _PROMETHEUS_AVAILABLE, _import_error
+            try:
+                global CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+                from prometheus_client import (
+                    CollectorRegistry,
+                    Counter,
+                    Gauge,
+                    Histogram,
+                    generate_latest,
+                )
+                _PROMETHEUS_AVAILABLE = True
+            except Exception as e:
+                _import_error = e
+            finally:
+                _import_done.set()
+        t = threading.Thread(target=_try_import, daemon=True)
+        t.start()
+        if not _import_done.wait(timeout=3.0):
+            logger.warning("prometheus_client import timed out on Windows - metrics disabled")
+        elif _import_error:
+            logger.warning("prometheus_client import failed: %s - metrics disabled", _import_error)
+    else:
+        from prometheus_client import (
+            CollectorRegistry,
+            Counter,
+            Gauge,
+            Histogram,
+            generate_latest,
+        )
+        _PROMETHEUS_AVAILABLE = True
+except ImportError as e:
+    logger.warning("prometheus_client not available: %s - metrics disabled", e)
+
+# Stub classes for when prometheus is unavailable
+if not _PROMETHEUS_AVAILABLE:
+    class CollectorRegistry:  # type: ignore[no-redef]
+        def __init__(self, *args: Any, **kwargs: Any) -> None: pass
+    class _StubMetric:
+        def __init__(self, *args: Any, **kwargs: Any) -> None: pass
+        def labels(self, *args: Any, **kwargs: Any) -> "_StubMetric": return self
+        def inc(self, *args: Any, **kwargs: Any) -> None: pass
+        def dec(self, *args: Any, **kwargs: Any) -> None: pass
+        def set(self, *args: Any, **kwargs: Any) -> None: pass
+        def observe(self, *args: Any, **kwargs: Any) -> None: pass
+    Counter = Gauge = Histogram = _StubMetric  # type: ignore[misc,assignment]
+    def generate_latest(*args: Any, **kwargs: Any) -> bytes: return b""
 
 __all__ = [
     "agent_spawn_duration",

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -21,7 +21,9 @@ import logging
 import os
 import shutil
 import signal
+import stat
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -171,6 +173,48 @@ def _run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
         errors="replace",
         check=False,
     )
+
+
+def _rmtree_windows_safe(path: Path, max_attempts: int = 3) -> bool:
+    """Remove a directory tree with Windows file-lock handling.
+
+    On Windows, files may be locked by processes that haven't fully exited,
+    antivirus scanning, or editor file watchers. This function retries with
+    delays and uses a permission-override handler as a last resort.
+
+    Args:
+        path: Directory to remove.
+        max_attempts: Number of retry attempts on Windows (default 3).
+
+    Returns:
+        True if the directory was removed, False otherwise.
+    """
+    if not path.exists():
+        return True
+
+    def _onerror(func: object, fpath: str, exc_info: object) -> None:
+        """Handle permission errors by making file writable and retrying."""
+        try:
+            os.chmod(fpath, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            if callable(func):
+                func(fpath)
+        except OSError:
+            pass  # Give up on this file
+
+    attempts = max_attempts if sys.platform == "win32" else 1
+    for attempt in range(attempts):
+        try:
+            shutil.rmtree(path, onerror=_onerror)
+            return True
+        except OSError as exc:
+            if attempt < attempts - 1:
+                # Wait for file locks to release (antivirus, processes exiting)
+                time.sleep(1.0)
+                logger.debug("Retry %d/%d removing %s: %s", attempt + 1, attempts, path, exc)
+            else:
+                logger.warning("Failed to remove %s after %d attempts: %s", path, attempts, exc)
+                return False
+    return False
 
 
 def _is_process_alive(pid: int) -> bool:
@@ -664,19 +708,25 @@ class DrainCoordinator:
             for entry in sorted(wt_dir.iterdir()):
                 if not entry.is_dir():
                     continue
-                result = _run_git(
-                    ["worktree", "remove", "--force", str(entry)],
-                    cwd=self._workdir,
-                )
-                if result.returncode == 0:
-                    worktrees_removed += 1
-                else:
-                    # Fallback: rm -rf then prune.
-                    try:
-                        shutil.rmtree(entry)
+                # On Windows, retry git worktree remove with delays for file locks
+                max_git_attempts = 3 if sys.platform == "win32" else 1
+                removed = False
+                for attempt in range(max_git_attempts):
+                    result = _run_git(
+                        ["worktree", "remove", "--force", str(entry)],
+                        cwd=self._workdir,
+                    )
+                    if result.returncode == 0:
                         worktrees_removed += 1
-                    except OSError as exc:
-                        logger.warning("Failed to remove worktree %s: %s", entry, exc)
+                        removed = True
+                        break
+                    if attempt < max_git_attempts - 1:
+                        time.sleep(1.0)  # Wait for file locks to release
+
+                if not removed:
+                    # Fallback: rm -rf with Windows file-lock handling
+                    if _rmtree_windows_safe(entry):
+                        worktrees_removed += 1
 
         # Prune worktree registry BEFORE deleting branches — this
         # unregisters removed worktrees so branch -D succeeds.

--- a/src/bernstein/core/orchestration/preflight.py
+++ b/src/bernstein/core/orchestration/preflight.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 from pathlib import Path
 
 from rich.console import Console
@@ -18,6 +19,19 @@ from rich.console import Console
 logger = logging.getLogger(__name__)
 
 console = Console()
+
+# Use ASCII-safe symbols on Windows with legacy encoding
+def _safe_symbol(unicode_char: str, ascii_fallback: str) -> str:
+    """Return unicode_char if encodable, else ascii_fallback."""
+    if sys.platform == "win32":
+        try:
+            unicode_char.encode(sys.stdout.encoding or "utf-8")
+        except (UnicodeEncodeError, LookupError):
+            return ascii_fallback
+    return unicode_char
+
+_CHECK = _safe_symbol("✓", "+")
+_ARROW = _safe_symbol("↳", "->")
 
 # Binary install hints for each supported CLI adapter.
 _CLI_INSTALL_HINT: dict[str, str] = {
@@ -375,7 +389,7 @@ def preflight_checks(cli: str, port: int) -> None:
     """
     if cli == "mock":
         # Mock adapter: no binary or API key needed (built-in simulation)
-        console.print("[green]✓[/green] Mock adapter ready (no API key needed)")
+        console.print(f"[green]{_CHECK}[/green] Mock adapter ready (no API key needed)")
     elif cli == "auto":
         # Auto mode: use agent_discovery for rich detection with auth + model info
         from bernstein.core.agent_discovery import discover_agents_cached, short_model
@@ -394,11 +408,11 @@ def preflight_checks(cli: str, port: int) -> None:
             auth_note = "" if agent.logged_in else " [dim](not authenticated)[/dim]"
             agent_parts.append(f"{agent.name.capitalize()} ({'/'.join(short_models)}){auth_note}")
         routing_note = "Using auto-routing." if len(discovery.agents) > 1 else "Using as primary."
-        console.print(f"[green]✓[/green] Found: {', '.join(agent_parts)}. {routing_note}")
+        console.print(f"[green]{_CHECK}[/green] Found: {', '.join(agent_parts)}. {routing_note}")
 
         # Surface any auth warnings as hints
         for w in discovery.warnings:
-            console.print(f"  [yellow]↳[/yellow] {w}")
+            console.print(f"  [yellow]{_ARROW}[/yellow] {w}")
     else:
         _check_binary(cli)
         _check_api_key(cli)

--- a/src/bernstein/core/prompt_optimizer.py
+++ b/src/bernstein/core/prompt_optimizer.py
@@ -1,0 +1,724 @@
+"""Automatic prompt optimization using A/B testing with sequential testing.
+
+Maintains multiple prompt variants per role, assigns variants to tasks, tracks
+quality gate pass rate per variant, and uses Sequential Probability Ratio Test
+(SPRT) to determine winners with minimal sample size.  After a winner is
+promoted, a new challenger is automatically introduced to continue improvement
+without human intervention.
+
+Usage::
+
+    optimizer = PromptOptimizer(sdd_dir, templates_dir)
+
+    # At spawn time — get variant assignment for a task
+    assignment = optimizer.assign_variant(role="backend", task_id="abc123")
+    if assignment.content_override:
+        role_prompt_content = assignment.content_override
+
+    # After task completes — record quality gate outcome
+    optimizer.record_outcome(
+        role="backend",
+        task_id="abc123",
+        passed=True,
+        quality_score=0.85,
+        cost_usd=0.04,
+        latency_s=42.0,
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: False positive rate (Type I error) — probability of promoting a worse variant.
+_DEFAULT_ALPHA: float = 0.05
+#: False negative rate (Type II error) — probability of missing a real improvement.
+_DEFAULT_BETA: float = 0.20
+#: Minimum detectable improvement in success rate before promotion.
+_DEFAULT_MIN_EFFECT: float = 0.08
+#: Hard cap on observations per variant to bound experiment duration.
+_DEFAULT_MAX_SAMPLE: int = 200
+#: Minimum observations before SPRT can make a decision.
+_DEFAULT_MIN_SAMPLE: int = 10
+
+
+# ---------------------------------------------------------------------------
+# SPRT implementation
+# ---------------------------------------------------------------------------
+
+
+class SprtDecision(Enum):
+    """Outcome of a Sequential Probability Ratio Test."""
+
+    CONTINUE = "continue"       # Insufficient evidence — keep collecting
+    PROMOTE_CHALLENGER = "promote_challenger"  # Challenger is significantly better
+    KEEP_CONTROL = "keep_control"   # Challenger is not better — revert to control
+    MAX_SAMPLE_REACHED = "max_sample_reached"  # Forced decision from sample cap
+
+
+@dataclass(frozen=True)
+class SprtConfig:
+    """Configuration for the Sequential Probability Ratio Test.
+
+    Attributes:
+        alpha: False positive rate (Type I error).  Lower = fewer bad promotions.
+        beta: False negative rate (Type II error).  Lower = fewer missed improvements.
+        min_effect_size: Minimum difference in success rate deemed worth detecting.
+        max_sample: Hard cap on observations per variant before forced decision.
+        min_sample: Minimum observations on each side before any decision.
+    """
+
+    alpha: float = _DEFAULT_ALPHA
+    beta: float = _DEFAULT_BETA
+    min_effect_size: float = _DEFAULT_MIN_EFFECT
+    max_sample: int = _DEFAULT_MAX_SAMPLE
+    min_sample: int = _DEFAULT_MIN_SAMPLE
+
+
+def _sprt_decide(
+    control_successes: int,
+    control_obs: int,
+    challenger_successes: int,
+    challenger_obs: int,
+    *,
+    cfg: SprtConfig,
+) -> SprtDecision:
+    """Apply Wald's SPRT to decide the A/B test outcome.
+
+    Tests H0 (no difference) vs H1 (challenger is better by min_effect_size).
+    Uses log-likelihood ratio for numerical stability.
+
+    Args:
+        control_successes: Number of successes for control variant.
+        control_obs: Total observations for control variant.
+        challenger_successes: Number of successes for challenger variant.
+        challenger_obs: Total observations for challenger variant.
+        cfg: SPRT configuration.
+
+    Returns:
+        Decision based on current evidence.
+    """
+    if control_obs < cfg.min_sample or challenger_obs < cfg.min_sample:
+        return SprtDecision.CONTINUE
+
+    # Force a decision when the max sample cap is hit on either arm.
+    if control_obs >= cfg.max_sample or challenger_obs >= cfg.max_sample:
+        if challenger_successes / max(challenger_obs, 1) > control_successes / max(control_obs, 1):
+            return SprtDecision.MAX_SAMPLE_REACHED
+        return SprtDecision.KEEP_CONTROL
+
+    # Estimated success rates with Laplace smoothing to avoid log(0).
+    p0 = (control_successes + 1) / (control_obs + 2)      # control rate
+    p1_hyp = min(p0 + cfg.min_effect_size, 1.0 - 1e-9)    # H1: challenger beats by delta
+
+    # SPRT decision boundaries (log scale).
+    log_A = math.log((1.0 - cfg.beta) / cfg.alpha)    # upper boundary → promote challenger
+    log_B = math.log(cfg.beta / (1.0 - cfg.alpha))    # lower boundary → keep control
+
+    # Compute log-likelihood ratio for the challenger arm.
+    llr = 0.0
+    ch_rate = (challenger_successes + 1) / (challenger_obs + 2)
+
+    # We approximate LLR using aggregate sufficient statistics.
+    # successes contribute log(p1/p0), failures contribute log((1-p1)/(1-p0)).
+    s = challenger_successes
+    f = challenger_obs - challenger_successes
+    if p0 > 0 and p1_hyp > 0 and (1.0 - p0) > 0 and (1.0 - p1_hyp) > 0:
+        llr = s * math.log(p1_hyp / p0) + f * math.log((1.0 - p1_hyp) / (1.0 - p0))
+    else:
+        # Degenerate case — fall back to raw comparison.
+        if ch_rate > p0 + cfg.min_effect_size:
+            return SprtDecision.PROMOTE_CHALLENGER
+        return SprtDecision.CONTINUE
+
+    if llr >= log_A:
+        return SprtDecision.PROMOTE_CHALLENGER
+    if llr <= log_B:
+        return SprtDecision.KEEP_CONTROL
+    return SprtDecision.CONTINUE
+
+
+# ---------------------------------------------------------------------------
+# Challenger generation
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChallengerTemplate:
+    """A named strategy for generating challenger prompt content.
+
+    Attributes:
+        name: Short identifier for the strategy.
+        suffix: Text appended to the base prompt to create the challenger.
+    """
+
+    name: str
+    suffix: str
+
+
+#: Ordered list of challenger strategies cycled through per role.
+_CHALLENGER_TEMPLATES: list[ChallengerTemplate] = [
+    ChallengerTemplate(
+        name="step_by_step",
+        suffix=(
+            "\n\n## Reasoning approach\n"
+            "Before writing any code, briefly outline the steps you'll take. "
+            "This helps catch edge cases early and produce more correct solutions."
+        ),
+    ),
+    ChallengerTemplate(
+        name="examples_first",
+        suffix=(
+            "\n\n## Existing patterns\n"
+            "Always search for existing code that solves a similar problem before "
+            "writing new code. Prefer consistency with existing patterns over novelty."
+        ),
+    ),
+    ChallengerTemplate(
+        name="test_driven",
+        suffix=(
+            "\n\n## Test-first mindset\n"
+            "When implementing a feature, write or verify the test first. "
+            "Let the failing test guide the implementation."
+        ),
+    ),
+    ChallengerTemplate(
+        name="minimal_diff",
+        suffix=(
+            "\n\n## Minimal changes\n"
+            "Make the smallest diff that satisfies the requirement. "
+            "Avoid touching code unrelated to the task."
+        ),
+    ),
+    ChallengerTemplate(
+        name="verify_before_commit",
+        suffix=(
+            "\n\n## Verify before committing\n"
+            "Run linting and tests locally before every commit. "
+            "A passing CI pipeline is part of a complete task."
+        ),
+    ),
+    ChallengerTemplate(
+        name="explicit_contracts",
+        suffix=(
+            "\n\n## Document contracts\n"
+            "For every public function or class you add, write a one-line docstring "
+            "that states what it does, its main parameter, and its return value."
+        ),
+    ),
+    ChallengerTemplate(
+        name="defensive_review",
+        suffix=(
+            "\n\n## Self-review\n"
+            "After finishing the implementation, re-read the diff once as a code "
+            "reviewer would. Fix any issue you spot before marking the task done."
+        ),
+    ),
+    ChallengerTemplate(
+        name="context_scan",
+        suffix=(
+            "\n\n## Context awareness\n"
+            "Before starting, scan relevant files to understand data structures, "
+            "naming conventions, and API contracts used by neighboring code."
+        ),
+    ),
+]
+
+
+def _next_challenger_template(current_index: int) -> tuple[ChallengerTemplate, int]:
+    """Return the next challenger template and its index.
+
+    Args:
+        current_index: Index of the last-used template (or -1 for first run).
+
+    Returns:
+        Tuple of (template, new_index).
+    """
+    next_idx = (current_index + 1) % len(_CHALLENGER_TEMPLATES)
+    return _CHALLENGER_TEMPLATES[next_idx], next_idx
+
+
+def generate_challenger_content(base_content: str, template: ChallengerTemplate) -> str:
+    """Generate challenger prompt content from a base and a strategy template.
+
+    Args:
+        base_content: The current winning prompt content.
+        template: The challenger strategy to apply.
+
+    Returns:
+        Modified prompt content for the challenger variant.
+    """
+    return base_content + template.suffix
+
+
+# ---------------------------------------------------------------------------
+# Variant assignment
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VariantAssignment:
+    """Records which prompt variant was assigned to a task.
+
+    Attributes:
+        role: Agent role (e.g. "backend").
+        task_id: Task being assigned.
+        variant_version: Version number from PromptRegistry, or None if default.
+        content_override: Non-None when the variant differs from the template file.
+            Callers should use this string as the role system prompt.
+        assigned_at: Unix timestamp of assignment.
+    """
+
+    role: str
+    task_id: str
+    variant_version: int | None = None
+    content_override: str | None = None
+    assigned_at: float = field(default_factory=time.time)
+
+    def is_challenger(self, control_version: int | None) -> bool:
+        """Return True if this assignment is the challenger (not control).
+
+        Args:
+            control_version: The control (active) version number.
+
+        Returns:
+            True when this task was assigned the non-control variant.
+        """
+        return self.variant_version is not None and self.variant_version != control_version
+
+
+# ---------------------------------------------------------------------------
+# PromptOptimizer
+# ---------------------------------------------------------------------------
+
+
+class PromptOptimizer:
+    """Continuous prompt optimizer — manages A/B tests per role with SPRT.
+
+    For each role:
+    - Maintains an active version (control) and optionally a challenger.
+    - Randomly assigns tasks to control or challenger.
+    - Records quality gate outcomes per variant.
+    - Uses SPRT to determine when to promote the challenger.
+    - After promotion, automatically introduces a new challenger.
+
+    State is persisted in ``.sdd/prompt_optimizer/`` so it survives restarts.
+
+    Args:
+        sdd_dir: Path to ``.sdd/`` directory.
+        templates_dir: Path to ``templates/roles/`` directory (for seeding prompts).
+        cfg: SPRT configuration (defaults used if not provided).
+    """
+
+    _STATE_FILE = "state.json"
+
+    def __init__(
+        self,
+        sdd_dir: "Path",
+        templates_dir: "Path | None" = None,
+        cfg: SprtConfig | None = None,
+    ) -> None:
+        from pathlib import Path as _Path
+
+        self._sdd_dir = _Path(sdd_dir)
+        self._templates_dir = _Path(templates_dir) if templates_dir else None
+        self._cfg = cfg or SprtConfig()
+        self._state_dir = self._sdd_dir / "prompt_optimizer"
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+        self._state: dict[str, Any] = self._load_state()
+
+        # In-memory index: task_id → VariantAssignment (cleared on reload)
+        self._assignments: dict[str, VariantAssignment] = {}
+
+    # ------------------------------------------------------------------
+    # State persistence
+    # ------------------------------------------------------------------
+
+    def _load_state(self) -> dict[str, Any]:
+        """Load optimizer state from disk."""
+        path = self._state_dir / self._STATE_FILE
+        if path.exists():
+            try:
+                return json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Could not load prompt_optimizer state: %s", exc)
+        return {}
+
+    def _save_state(self) -> None:
+        """Persist optimizer state to disk."""
+        path = self._state_dir / self._STATE_FILE
+        try:
+            path.write_text(json.dumps(self._state, indent=2), encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Could not save prompt_optimizer state: %s", exc)
+
+    def _role_state(self, role: str) -> dict[str, Any]:
+        """Return mutable state dict for a role, initialising if absent."""
+        if role not in self._state:
+            self._state[role] = {
+                "active_version": None,
+                "challenger_version": None,
+                "challenger_template_idx": -1,
+                "control_metrics": {"observations": 0, "successes": 0},
+                "challenger_metrics": {"observations": 0, "successes": 0},
+                "tests_run": 0,
+                "promotions": [],
+            }
+        return self._state[role]
+
+    # ------------------------------------------------------------------
+    # Registry access
+    # ------------------------------------------------------------------
+
+    def _get_registry(self) -> "PromptRegistry":
+        """Return a PromptRegistry for sdd_dir."""
+        from bernstein.core.tokens.prompt_versioning import PromptRegistry
+
+        return PromptRegistry(self._sdd_dir)
+
+    def _ensure_role_seeded(self, role: str) -> bool:
+        """Seed v1 for a role from templates if not yet tracked.
+
+        Args:
+            role: Agent role name.
+
+        Returns:
+            True if seeding succeeded or prompt already existed.
+        """
+        registry = self._get_registry()
+        if registry.get_meta(role) is not None:
+            return True
+        if self._templates_dir is None:
+            return False
+        template_path = self._templates_dir / "roles" / role / "system_prompt.md"
+        if not template_path.exists():
+            return False
+        content = template_path.read_text(encoding="utf-8")
+        pv = registry.add_version(
+            role,
+            content,
+            author="system",
+            description="Initial version seeded from templates",
+            set_active=True,
+        )
+        logger.info("Seeded prompt for role %r as v%d", role, pv.version)
+        return True
+
+    # ------------------------------------------------------------------
+    # Variant assignment
+    # ------------------------------------------------------------------
+
+    def assign_variant(self, role: str, task_id: str) -> VariantAssignment:
+        """Select and record a prompt variant for a task.
+
+        If no challenger exists yet, returns the active (control) version.
+        During an active A/B test, deterministically assigns based on task_id.
+
+        Args:
+            role: Agent role (e.g. "backend").
+            task_id: Unique task identifier for deterministic assignment.
+
+        Returns:
+            VariantAssignment with optional content_override.
+        """
+        self._ensure_role_seeded(role)
+        registry = self._get_registry()
+        rs = self._role_state(role)
+
+        meta = registry.get_meta(role)
+        if meta is None:
+            # No prompt registered — return default (no override)
+            return VariantAssignment(role=role, task_id=task_id)
+
+        # Sync active version from registry if not yet tracked locally
+        if rs["active_version"] is None:
+            rs["active_version"] = meta.active_version
+            self._save_state()
+
+        control_version: int = rs["active_version"]
+        challenger_version: int | None = rs["challenger_version"]
+
+        # Ensure challenger exists; introduce one if missing
+        if challenger_version is None:
+            challenger_version = self._introduce_challenger(role, registry, rs)
+
+        # Assign using the registry's deterministic split
+        if challenger_version is not None and meta.ab_enabled:
+            selected = registry.select_version(role, task_id)
+        else:
+            selected = control_version
+
+        # Resolve content
+        content_override: str | None = None
+        if selected != control_version or meta.active_version != control_version:
+            # Use the versioned content from registry when it differs from v1
+            pv = registry.get_version(role, selected)
+            if pv and pv.content:
+                content_override = pv.content
+
+        assignment = VariantAssignment(
+            role=role,
+            task_id=task_id,
+            variant_version=selected,
+            content_override=content_override,
+        )
+        self._assignments[task_id] = assignment
+        return assignment
+
+    def _introduce_challenger(
+        self,
+        role: str,
+        registry: "PromptRegistry",
+        rs: dict[str, Any],
+    ) -> int | None:
+        """Add a new challenger version and start an A/B test.
+
+        Args:
+            role: Agent role.
+            registry: Prompt registry.
+            rs: Role state dict (mutated in place).
+
+        Returns:
+            Version number of the new challenger, or None on failure.
+        """
+        control_version: int = rs["active_version"]
+        control_pv = registry.get_version(role, control_version)
+        if control_pv is None or not control_pv.content:
+            logger.debug("Cannot introduce challenger for %r — control has no content", role)
+            return None
+
+        # Pick the next challenger template
+        tmpl, next_idx = _next_challenger_template(rs["challenger_template_idx"])
+        challenger_content = generate_challenger_content(control_pv.content, tmpl)
+
+        # Add new version to registry
+        new_pv = registry.add_version(
+            role,
+            challenger_content,
+            author="prompt_optimizer",
+            description=f"Challenger: {tmpl.name}",
+        )
+        challenger_version = new_pv.version
+
+        # Start A/B test
+        registry.start_ab_test(role, control_version, challenger_version)
+
+        rs["challenger_version"] = challenger_version
+        rs["challenger_template_idx"] = next_idx
+        rs["control_metrics"] = {"observations": 0, "successes": 0}
+        rs["challenger_metrics"] = {"observations": 0, "successes": 0}
+        self._save_state()
+
+        logger.info(
+            "Introduced challenger v%d for role %r using template %r",
+            challenger_version,
+            role,
+            tmpl.name,
+        )
+        return challenger_version
+
+    # ------------------------------------------------------------------
+    # Outcome recording
+    # ------------------------------------------------------------------
+
+    def record_outcome(
+        self,
+        role: str,
+        task_id: str,
+        *,
+        passed: bool,
+        quality_score: float = 0.0,
+        cost_usd: float = 0.0,
+        latency_s: float = 0.0,
+    ) -> SprtDecision | None:
+        """Record a task's quality gate outcome and run SPRT check.
+
+        Args:
+            role: Agent role.
+            task_id: Task identifier (must match a previous assign_variant call,
+                but falls back to recording for the active version if not found).
+            passed: Whether the task passed quality gates.
+            quality_score: Quality score from review (0–1).
+            cost_usd: Cost incurred by this task.
+            latency_s: Task duration in seconds.
+
+        Returns:
+            SprtDecision if a decision was reached this call, else None.
+        """
+        rs = self._role_state(role)
+        registry = self._get_registry()
+
+        # Look up which variant this task was assigned
+        assignment = self._assignments.get(task_id)
+        control_version: int | None = rs.get("active_version")
+        challenger_version: int | None = rs.get("challenger_version")
+
+        if assignment is not None:
+            used_version = assignment.variant_version
+        else:
+            used_version = control_version
+
+        # Record in registry
+        if used_version is not None:
+            registry.record_outcome(
+                role,
+                used_version,
+                success=passed,
+                quality_score=quality_score,
+                cost_usd=cost_usd,
+                latency_s=latency_s,
+            )
+
+        # Update local metrics (for SPRT without reloading all registry data)
+        if used_version == challenger_version:
+            m = rs["challenger_metrics"]
+        else:
+            m = rs["control_metrics"]
+        m["observations"] += 1
+        if passed:
+            m["successes"] += 1
+
+        self._save_state()
+        self._assignments.pop(task_id, None)  # clean up
+
+        # Run SPRT only when both arms have enough data
+        if challenger_version is None:
+            return None
+
+        decision = _sprt_decide(
+            control_successes=rs["control_metrics"]["successes"],
+            control_obs=rs["control_metrics"]["observations"],
+            challenger_successes=rs["challenger_metrics"]["successes"],
+            challenger_obs=rs["challenger_metrics"]["observations"],
+            cfg=self._cfg,
+        )
+
+        if decision != SprtDecision.CONTINUE:
+            self._conclude_test(role, decision, registry, rs)
+
+        return decision if decision != SprtDecision.CONTINUE else None
+
+    def _conclude_test(
+        self,
+        role: str,
+        decision: SprtDecision,
+        registry: "PromptRegistry",
+        rs: dict[str, Any],
+    ) -> None:
+        """Finalize an A/B test: promote winner and introduce new challenger.
+
+        Args:
+            role: Agent role.
+            decision: SPRT decision that triggered conclusion.
+            registry: Prompt registry.
+            rs: Role state dict (mutated in place).
+        """
+        control_version: int = rs["active_version"]
+        challenger_version: int = rs["challenger_version"]
+
+        if decision in (SprtDecision.PROMOTE_CHALLENGER, SprtDecision.MAX_SAMPLE_REACHED):
+            # Check raw rates when max sample is reached
+            if decision == SprtDecision.MAX_SAMPLE_REACHED:
+                c_rate = rs["challenger_metrics"]["successes"] / max(rs["challenger_metrics"]["observations"], 1)
+                ctrl_rate = rs["control_metrics"]["successes"] / max(rs["control_metrics"]["observations"], 1)
+                if c_rate <= ctrl_rate:
+                    decision = SprtDecision.KEEP_CONTROL
+
+        if decision in (SprtDecision.PROMOTE_CHALLENGER, SprtDecision.MAX_SAMPLE_REACHED):
+            winner = challenger_version
+            registry.promote_version(role, challenger_version)
+            rs["active_version"] = challenger_version
+            outcome_label = "promoted"
+            logger.info(
+                "PromptOptimizer: promoted challenger v%d for role %r "
+                "(control obs=%d sr=%.2f, challenger obs=%d sr=%.2f)",
+                challenger_version,
+                role,
+                rs["control_metrics"]["observations"],
+                rs["control_metrics"]["successes"] / max(rs["control_metrics"]["observations"], 1),
+                rs["challenger_metrics"]["observations"],
+                rs["challenger_metrics"]["successes"] / max(rs["challenger_metrics"]["observations"], 1),
+            )
+        else:
+            winner = control_version
+            registry.stop_ab_test(role)
+            outcome_label = "retained"
+            logger.info(
+                "PromptOptimizer: control v%d retained for role %r "
+                "(challenger v%d not better: obs=%d sr=%.2f vs control sr=%.2f)",
+                control_version,
+                role,
+                challenger_version,
+                rs["challenger_metrics"]["observations"],
+                rs["challenger_metrics"]["successes"] / max(rs["challenger_metrics"]["observations"], 1),
+                rs["control_metrics"]["successes"] / max(rs["control_metrics"]["observations"], 1),
+            )
+
+        rs["tests_run"] = rs.get("tests_run", 0) + 1
+        rs["promotions"].append(
+            {
+                "concluded_at": time.time(),
+                "decision": decision.value,
+                "outcome": outcome_label,
+                "winner": winner,
+                "control_version": control_version,
+                "challenger_version": challenger_version,
+                "control_obs": rs["control_metrics"]["observations"],
+                "control_sr": round(rs["control_metrics"]["successes"] / max(rs["control_metrics"]["observations"], 1), 4),
+                "challenger_obs": rs["challenger_metrics"]["observations"],
+                "challenger_sr": round(rs["challenger_metrics"]["successes"] / max(rs["challenger_metrics"]["observations"], 1), 4),
+            }
+        )
+
+        # Reset challenger to trigger new introduction on next spawn
+        rs["challenger_version"] = None
+        rs["control_metrics"] = {"observations": 0, "successes": 0}
+        rs["challenger_metrics"] = {"observations": 0, "successes": 0}
+        self._save_state()
+
+    # ------------------------------------------------------------------
+    # Reporting
+    # ------------------------------------------------------------------
+
+    def get_status(self, role: str) -> dict[str, Any]:
+        """Return current optimizer status for a role.
+
+        Args:
+            role: Agent role to query.
+
+        Returns:
+            Dict with active version, challenger version, metrics, and test history.
+        """
+        rs = self._role_state(role)
+        return {
+            "role": role,
+            "active_version": rs.get("active_version"),
+            "challenger_version": rs.get("challenger_version"),
+            "tests_run": rs.get("tests_run", 0),
+            "control_metrics": rs.get("control_metrics", {}),
+            "challenger_metrics": rs.get("challenger_metrics", {}),
+            "recent_promotions": rs.get("promotions", [])[-5:],
+        }
+
+    def list_active_roles(self) -> list[str]:
+        """Return list of roles that have optimizer state.
+
+        Returns:
+            Sorted list of role names.
+        """
+        return sorted(self._state.keys())

--- a/tests/unit/test_prompt_optimizer.py
+++ b/tests/unit/test_prompt_optimizer.py
@@ -1,0 +1,394 @@
+"""Tests for bernstein.core.prompt_optimizer — SPRT, assignments, challenger generation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.prompt_optimizer import (
+    SprtConfig,
+    SprtDecision,
+    VariantAssignment,
+    _CHALLENGER_TEMPLATES,
+    _next_challenger_template,
+    _sprt_decide,
+    generate_challenger_content,
+    PromptOptimizer,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sdd_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".sdd"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture()
+def templates_dir(tmp_path: Path) -> Path:
+    roles_dir = tmp_path / "templates" / "roles"
+    for role in ("backend", "qa", "frontend"):
+        role_dir = roles_dir / role
+        role_dir.mkdir(parents=True)
+        (role_dir / "system_prompt.md").write_text(f"You are a {role} expert.", encoding="utf-8")
+    return tmp_path / "templates"
+
+
+@pytest.fixture()
+def optimizer(sdd_dir: Path, templates_dir: Path) -> PromptOptimizer:
+    cfg = SprtConfig(
+        alpha=0.05,
+        beta=0.20,
+        min_effect_size=0.10,
+        max_sample=50,
+        min_sample=5,
+    )
+    return PromptOptimizer(sdd_dir, templates_dir, cfg=cfg)
+
+
+# ---------------------------------------------------------------------------
+# SprtDecision — _sprt_decide
+# ---------------------------------------------------------------------------
+
+
+class TestSprtDecide:
+    def test_sprt_continue_when_below_min_sample(self) -> None:
+        # Arrange
+        cfg = SprtConfig(min_sample=10)
+
+        # Act
+        result = _sprt_decide(
+            control_successes=4,
+            control_obs=8,
+            challenger_successes=6,
+            challenger_obs=8,
+            cfg=cfg,
+        )
+
+        # Assert
+        assert result == SprtDecision.CONTINUE
+
+    def test_sprt_promote_challenger_when_clearly_better(self) -> None:
+        # Arrange: challenger has 90% success, control has 40% (large delta)
+        cfg = SprtConfig(alpha=0.05, beta=0.20, min_effect_size=0.10, min_sample=10, max_sample=500)
+
+        # Act: simulate many successes for challenger
+        result = _sprt_decide(
+            control_successes=20,
+            control_obs=50,   # 40% success rate
+            challenger_successes=45,
+            challenger_obs=50,  # 90% success rate — clearly better
+            cfg=cfg,
+        )
+
+        # Assert
+        assert result == SprtDecision.PROMOTE_CHALLENGER
+
+    def test_sprt_keep_control_when_challenger_is_worse(self) -> None:
+        # Arrange: challenger clearly worse (10% vs 70% success)
+        cfg = SprtConfig(alpha=0.05, beta=0.20, min_effect_size=0.10, min_sample=10, max_sample=500)
+
+        # Act
+        result = _sprt_decide(
+            control_successes=35,
+            control_obs=50,   # 70% success
+            challenger_successes=5,
+            challenger_obs=50,  # 10% success
+            cfg=cfg,
+        )
+
+        # Assert
+        assert result == SprtDecision.KEEP_CONTROL
+
+    def test_sprt_max_sample_reached_promotes_better_challenger(self) -> None:
+        # Arrange
+        cfg = SprtConfig(min_sample=5, max_sample=10)
+
+        # Act: both at max sample, challenger slightly better
+        result = _sprt_decide(
+            control_successes=6,
+            control_obs=10,
+            challenger_successes=8,
+            challenger_obs=10,
+            cfg=cfg,
+        )
+
+        # Assert
+        assert result == SprtDecision.MAX_SAMPLE_REACHED
+
+    def test_sprt_max_sample_reached_keeps_control_when_challenger_not_better(self) -> None:
+        # Arrange
+        cfg = SprtConfig(min_sample=5, max_sample=10)
+
+        # Act: both at max sample, control better
+        result = _sprt_decide(
+            control_successes=8,
+            control_obs=10,
+            challenger_successes=6,
+            challenger_obs=10,
+            cfg=cfg,
+        )
+
+        # Assert
+        assert result == SprtDecision.KEEP_CONTROL
+
+    def test_sprt_continue_when_insufficient_evidence(self) -> None:
+        # Arrange: small difference, needs more data
+        cfg = SprtConfig(alpha=0.05, beta=0.20, min_effect_size=0.10, min_sample=5, max_sample=500)
+
+        # Act: 55% vs 50% — tiny difference, insufficient evidence
+        result = _sprt_decide(
+            control_successes=5,
+            control_obs=10,
+            challenger_successes=6,
+            challenger_obs=10,
+            cfg=cfg,
+        )
+
+        # Assert
+        assert result == SprtDecision.CONTINUE
+
+
+# ---------------------------------------------------------------------------
+# Challenger generation
+# ---------------------------------------------------------------------------
+
+
+class TestChallengerGeneration:
+    def test_generate_challenger_content_appends_suffix(self) -> None:
+        # Arrange
+        base = "You are a backend engineer."
+        template = _CHALLENGER_TEMPLATES[0]
+
+        # Act
+        result = generate_challenger_content(base, template)
+
+        # Assert
+        assert result.startswith(base)
+        assert template.suffix in result
+        assert len(result) > len(base)
+
+    def test_next_challenger_template_cycles(self) -> None:
+        # Arrange: cycle through all templates
+        idx = -1
+        seen: set[str] = set()
+
+        # Act
+        for _ in range(len(_CHALLENGER_TEMPLATES) + 1):
+            tmpl, idx = _next_challenger_template(idx)
+            seen.add(tmpl.name)
+
+        # Assert: all templates covered
+        assert seen == {t.name for t in _CHALLENGER_TEMPLATES}
+
+    def test_next_challenger_template_wraps_around(self) -> None:
+        # Arrange: start at last index
+        last_idx = len(_CHALLENGER_TEMPLATES) - 1
+
+        # Act
+        tmpl, new_idx = _next_challenger_template(last_idx)
+
+        # Assert: wraps back to 0
+        assert new_idx == 0
+        assert tmpl.name == _CHALLENGER_TEMPLATES[0].name
+
+
+# ---------------------------------------------------------------------------
+# VariantAssignment
+# ---------------------------------------------------------------------------
+
+
+class TestVariantAssignment:
+    def test_is_challenger_returns_true_for_non_control(self) -> None:
+        # Arrange
+        assignment = VariantAssignment(role="backend", task_id="t1", variant_version=2)
+
+        # Act / Assert
+        assert assignment.is_challenger(control_version=1) is True
+
+    def test_is_challenger_returns_false_for_control(self) -> None:
+        # Arrange
+        assignment = VariantAssignment(role="backend", task_id="t1", variant_version=1)
+
+        # Act / Assert
+        assert assignment.is_challenger(control_version=1) is False
+
+    def test_is_challenger_returns_false_when_no_version(self) -> None:
+        # Arrange
+        assignment = VariantAssignment(role="backend", task_id="t1", variant_version=None)
+
+        # Act / Assert
+        assert assignment.is_challenger(control_version=1) is False
+
+
+# ---------------------------------------------------------------------------
+# PromptOptimizer integration
+# ---------------------------------------------------------------------------
+
+
+class TestPromptOptimizer:
+    def test_assign_variant_seeds_role_and_returns_assignment(
+        self, optimizer: PromptOptimizer
+    ) -> None:
+        # Arrange / Act
+        assignment = optimizer.assign_variant(role="backend", task_id="task-001")
+
+        # Assert
+        assert assignment.role == "backend"
+        assert assignment.task_id == "task-001"
+
+    def test_assign_variant_introduces_challenger_on_first_call(
+        self, optimizer: PromptOptimizer
+    ) -> None:
+        # Arrange / Act
+        optimizer.assign_variant(role="backend", task_id="task-001")
+        status = optimizer.get_status("backend")
+
+        # Assert: challenger introduced
+        assert status["challenger_version"] is not None
+        assert status["challenger_version"] != status["active_version"]
+
+    def test_record_outcome_accumulates_metrics(
+        self, optimizer: PromptOptimizer
+    ) -> None:
+        # Arrange
+        optimizer.assign_variant(role="backend", task_id="task-001")
+
+        # Act
+        optimizer.record_outcome(role="backend", task_id="task-001", passed=True)
+        status = optimizer.get_status("backend")
+
+        # Assert: at least one side has one observation
+        total_obs = (
+            status["control_metrics"]["observations"]
+            + status["challenger_metrics"]["observations"]
+        )
+        assert total_obs == 1
+
+    def test_optimizer_state_persists_across_instances(
+        self, sdd_dir: Path, templates_dir: Path
+    ) -> None:
+        # Arrange: create optimizer, assign, record
+        cfg = SprtConfig(min_sample=5, max_sample=50)
+        opt1 = PromptOptimizer(sdd_dir, templates_dir, cfg=cfg)
+        opt1.assign_variant(role="qa", task_id="t1")
+        opt1.record_outcome(role="qa", task_id="t1", passed=True)
+
+        # Act: reload from disk
+        opt2 = PromptOptimizer(sdd_dir, templates_dir, cfg=cfg)
+        status = opt2.get_status("qa")
+
+        # Assert: observations survived reload
+        total_obs = (
+            status["control_metrics"]["observations"]
+            + status["challenger_metrics"]["observations"]
+        )
+        assert total_obs >= 1
+
+    def test_optimizer_promotes_challenger_after_clear_winner(
+        self, sdd_dir: Path, templates_dir: Path
+    ) -> None:
+        # Arrange: tight cfg so promotion happens quickly
+        cfg = SprtConfig(
+            alpha=0.05,
+            beta=0.20,
+            min_effect_size=0.10,
+            min_sample=5,
+            max_sample=100,
+        )
+        opt = PromptOptimizer(sdd_dir, templates_dir, cfg=cfg)
+
+        # Act: assign 50 tasks all to the challenger (by seeding the state)
+        # We force challenger assignment by manipulating the registry
+        opt.assign_variant(role="backend", task_id="seed")
+        status = opt.get_status("backend")
+        challenger_ver = status["challenger_version"]
+        control_ver = status["active_version"]
+
+        # Simulate recording many outcomes: challenger almost always passes,
+        # control fails often.  We bypass assignment tracking by directly
+        # manipulating internal state to record known versions.
+        rs = opt._role_state("backend")
+
+        # Record control outcomes: 3/10 pass (30%)
+        for _ in range(3):
+            rs["control_metrics"]["successes"] += 1
+        rs["control_metrics"]["observations"] = 10
+
+        # Record challenger outcomes: 9/10 pass (90%)
+        for _ in range(9):
+            rs["challenger_metrics"]["successes"] += 1
+        rs["challenger_metrics"]["observations"] = 10
+        opt._save_state()
+
+        # Now record one more challenger success — should trigger SPRT
+        # Assign a new task forced to challenger
+        from bernstein.core.tokens.prompt_versioning import PromptRegistry
+        registry = PromptRegistry(sdd_dir)
+        registry.record_outcome(
+            "backend", challenger_ver, success=True, quality_score=0.9
+        )
+        rs["challenger_metrics"]["successes"] += 1
+        rs["challenger_metrics"]["observations"] += 1
+        opt._save_state()
+
+        decision = _sprt_decide(
+            control_successes=rs["control_metrics"]["successes"],
+            control_obs=rs["control_metrics"]["observations"],
+            challenger_successes=rs["challenger_metrics"]["successes"],
+            challenger_obs=rs["challenger_metrics"]["observations"],
+            cfg=cfg,
+        )
+
+        # Assert: SPRT should detect promotion
+        assert decision == SprtDecision.PROMOTE_CHALLENGER
+
+    def test_list_active_roles_returns_tracked_roles(
+        self, optimizer: PromptOptimizer
+    ) -> None:
+        # Arrange
+        optimizer.assign_variant(role="backend", task_id="t1")
+        optimizer.assign_variant(role="qa", task_id="t2")
+
+        # Act
+        roles = optimizer.list_active_roles()
+
+        # Assert
+        assert "backend" in roles
+        assert "qa" in roles
+
+    def test_get_status_returns_expected_keys(
+        self, optimizer: PromptOptimizer
+    ) -> None:
+        # Arrange
+        optimizer.assign_variant(role="frontend", task_id="t1")
+
+        # Act
+        status = optimizer.get_status("frontend")
+
+        # Assert
+        assert "role" in status
+        assert "active_version" in status
+        assert "challenger_version" in status
+        assert "tests_run" in status
+        assert "control_metrics" in status
+        assert "challenger_metrics" in status
+        assert "recent_promotions" in status
+
+    def test_record_outcome_for_unknown_task_id_does_not_raise(
+        self, optimizer: PromptOptimizer
+    ) -> None:
+        # Arrange: record without prior assign
+        optimizer.assign_variant(role="backend", task_id="t1")
+
+        # Act / Assert: should not raise
+        optimizer.record_outcome(role="backend", task_id="unknown-task", passed=True)


### PR DESCRIPTION
## Summary
- Fix Windows stop command with taskkill/PowerShell fallback
- Fix Windows process detection using kernel32 APIs  
- Add Windows retry logic for worktree cleanup with file-lock handling
- Make PR labels best-effort (don't fail if label doesn't exist)
- Add `--activity-log` flag to write activity to file
- Skip historical spawner.log entries on dashboard startup
- Filter "agent working" from activity noise patterns
- Add prompt optimizer with SPRT-based A/B testing

## Test plan
- [x] Tested `bernstein stop` on Windows
- [x] Verified worktree cleanup with locked files
- [x] Verified `--activity-log` flag writes to file
- [x] Verified activity log no longer repeats messages