### PR TITLE
fix: add port-based fallback to find task server PID

### DIFF
--- a/src/bernstein/core/git/git_hygiene.py
+++ b/src/bernstein/core/git/git_hygiene.py
@@ -25,7 +25,12 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import shutil
+import stat
+import subprocess
+import sys
+import time
 from typing import TYPE_CHECKING
 
 from bernstein.core.git.git_basic import run_git
@@ -34,6 +39,73 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _rmtree_windows_safe(path: Path, max_attempts: int = 3) -> bool:
+    """Remove a directory tree with Windows file-lock handling.
+
+    On Windows, files may be locked by processes that haven't fully exited,
+    antivirus scanning, or editor file watchers. This function:
+    1. Tries shutil.rmtree with permission override
+    2. Retries with delays for transient locks
+    3. Falls back to PowerShell Remove-Item -Force
+
+    Args:
+        path: Directory to remove.
+        max_attempts: Number of retry attempts (default 3).
+
+    Returns:
+        True if the directory was removed, False otherwise.
+    """
+    if not path.exists():
+        return True
+
+    def _onerror(func: object, fpath: str, exc_info: object) -> None:
+        """Handle permission errors by making file writable and retrying."""
+        try:
+            os.chmod(fpath, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+            if callable(func):
+                func(fpath)
+        except OSError:
+            pass  # Give up on this file
+
+    is_windows = sys.platform == "win32"
+    attempts = max_attempts if is_windows else 1
+
+    for attempt in range(attempts):
+        try:
+            shutil.rmtree(path, onerror=_onerror)
+            return True
+        except OSError as exc:
+            if attempt < attempts - 1:
+                # Wait for file locks to release (antivirus, processes exiting)
+                time.sleep(1.0)
+                logger.debug("Retry %d/%d removing %s: %s", attempt + 1, attempts, path, exc)
+            # Continue to PowerShell fallback
+
+    # Final fallback on Windows: PowerShell Remove-Item -Force
+    if is_windows and path.exists():
+        try:
+            result = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    f"Remove-Item -LiteralPath '{path}' -Recurse -Force -ErrorAction SilentlyContinue",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if not path.exists():
+                return True
+        except Exception as exc:
+            logger.debug("PowerShell Remove-Item failed for %s: %s", path, exc)
+
+    if path.exists():
+        logger.warning("Failed to remove %s after %d attempts", path, attempts)
+        return False
+    return True
 
 
 def run_hygiene(workdir: Path, *, full: bool = False) -> dict[str, int]:
@@ -101,12 +173,9 @@ def _clean_stale_worktrees(workdir: Path) -> int:
             continue
         if str(entry) not in tracked_paths:
             # Stale directory — not tracked by git
-            try:
-                shutil.rmtree(entry)
+            if _rmtree_windows_safe(entry):
                 cleaned += 1
                 logger.debug("Removed stale worktree dir: %s", entry.name)
-            except OSError as exc:
-                logger.warning("Failed to remove stale worktree %s: %s", entry.name, exc)
 
     return cleaned
 

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -417,7 +417,8 @@ def bootstrap_from_seed(
         stale_minutes=_stale_minutes,
     )
 
-    sync_result = sync_backlog_to_server(workdir, server_url=server_url)
+    task_filter = os.environ.get("BERNSTEIN_TASK_FILTER")
+    sync_result = sync_backlog_to_server(workdir, server_url=server_url, task_filter=task_filter)
     backlog_count = len(sync_result.created) + len(sync_result.skipped)
 
     # Import unchecked items from TODO.md / TASKS.md / .plan if present.
@@ -781,8 +782,9 @@ def bootstrap_from_goal(
 
     prior_session = check_resume_session(workdir, force_fresh=force_fresh)
 
+    task_filter = os.environ.get("BERNSTEIN_TASK_FILTER")
     with Status("[bold]Loading tasks...[/bold]", console=console):
-        sync_result = sync_backlog_to_server(workdir, server_url=server_url)
+        sync_result = sync_backlog_to_server(workdir, server_url=server_url, task_filter=task_filter)
     backlog_count = len(sync_result.created) + len(sync_result.skipped)
 
     # Import unchecked items from TODO.md / TASKS.md / .plan if present.

--- a/src/bernstein/core/orchestration/drain.py
+++ b/src/bernstein/core/orchestration/drain.py
@@ -828,7 +828,50 @@ class DrainCoordinator:
             snapshot = read_supervisor_state(self._workdir / ".sdd")
             if snapshot is not None and snapshot.current_pid > 0:
                 server_pid = snapshot.current_pid
+        # Fallback: find server by port if PID file missing
+        if server_pid is None:
+            server_pid = self._find_pid_by_port(8052)
+            if server_pid:
+                logger.debug("Found task server by port scan: PID %d", server_pid)
         await self._terminate_process(server_pid, "task server")
+
+    def _find_pid_by_port(self, port: int) -> int | None:
+        """Find PID of process listening on a port (Windows/Unix)."""
+        import subprocess
+        import sys
+
+        try:
+            if sys.platform == "win32":
+                # Windows: netstat -ano | findstr :port | findstr LISTENING
+                result = subprocess.run(
+                    ["netstat", "-ano"],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    timeout=5,
+                )
+                for line in result.stdout.splitlines():
+                    if f":{port}" in line and "LISTENING" in line:
+                        parts = line.split()
+                        if parts:
+                            try:
+                                return int(parts[-1])
+                            except ValueError:
+                                pass
+            else:
+                # Unix: lsof -ti :port
+                result = subprocess.run(
+                    ["lsof", "-ti", f":{port}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    return int(result.stdout.strip().split()[0])
+        except Exception as exc:
+            logger.debug("Port scan for %d failed: %s", port, exc)
+        return None
 
     def _read_runtime_pid(self, filename: str) -> int | None:
         """Read a runtime PID file, returning None for missing or invalid data."""

--- a/src/bernstein/core/persistence/sync.py
+++ b/src/bernstein/core/persistence/sync.py
@@ -281,6 +281,7 @@ def sync_backlog_to_server(
     server_url: str = "http://127.0.0.1:8052",
     *,
     client: httpx.Client | None = None,
+    task_filter: str | None = None,
 ) -> SyncResult:
     """Sync ``.sdd/backlog/open/`` and ``issues/`` files with the task server.
 
@@ -296,6 +297,7 @@ def sync_backlog_to_server(
         workdir: Project root directory (parent of ``.sdd/``).
         server_url: Base URL of the task server.
         client: Optional httpx client for testing (created if not given).
+        task_filter: Optional pattern to filter backlog files by name (case-insensitive substring match).
 
     Returns:
         SyncResult with counts and errors.
@@ -328,6 +330,11 @@ def sync_backlog_to_server(
                 md_files.extend(src_dir.glob("*.yaml"))
                 md_files.extend(src_dir.glob("*.md"))
         md_files.sort()
+
+        # Apply task filter if provided (case-insensitive substring match on filename)
+        if task_filter:
+            task_filter_lower = task_filter.lower()
+            md_files = [f for f in md_files if task_filter_lower in f.name.lower()]
 
         # --- Step 1: create new tasks (batched) ---
         batch_payloads: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- Add port-based fallback (netstat parsing) to find task server PID when file-based tracking fails
- Add Windows-safe stale worktree removal with retries and PowerShell fallback
- Apply task filter during backlog sync so `-t` flag correctly filters tasks
- Include full GitHub issue body in backlog files (was truncated to 500 chars)

## Changes
1. **drain.py**: `_find_pid_by_port()` parses `netstat -ano` output to find the process listening on the task server port
2. **drain.py**: `_rmtree_windows_safe()` handles Windows file locking with retries and PowerShell Remove-Item fallback
3. **git_hygiene.py**: Same `_rmtree_windows_safe()` function for stale worktree cleanup
4. **sync.py**: Added `task_filter` parameter to `sync_backlog_to_server()` - filters backlog files by filename before syncing
5. **bootstrap.py**: Pass `BERNSTEIN_TASK_FILTER` env var to `sync_backlog_to_server()`
6. **orchestrator.py**: Apply task filter in `ingest_backlog()` periodic sync
7. **github.py**: Remove 500-char truncation of GitHub issue body when syncing to backlog files

## Test plan
- [ ] Run `bernstein stop` after a crashed session - verify server is killed via port detection
- [ ] Verify stale worktrees are cleaned up on Windows without WinError 32
- [ ] Run `bernstein -t gh-62 --auto-pr` with 2 backlog files (gh-59 and gh-62) - verify only 1 task synced
- [ ] Delete gh-59 backlog file, re-run sync - verify full issue body is included