### PR TITLE
fix: exclude gh-* files from title dedup to allow regeneration

### DIFF
--- a/src/bernstein/core/git/github.py
+++ b/src/bernstein/core/git/github.py
@@ -858,6 +858,9 @@ def _collect_existing_titles(workdir: Path, backlog_open: Path) -> set[str]:
         if not src_dir.is_dir():
             continue
         for path in [*src_dir.glob("*.yaml"), *src_dir.glob("*.md")]:
+            # Skip gh-* files - we always regenerate those from GitHub
+            if path.name.startswith("gh-"):
+                continue
             try:
                 raw_text = path.read_text(encoding="utf-8")
                 if not raw_text.startswith("---"):


### PR DESCRIPTION
## Summary
Fix GitHub issue backlog sync still skipping existing files due to title dedup.

## Problem
Even after PR #738 removed the skip-by-number check, backlog files were still not being regenerated because:
- `_collect_existing_titles()` included `gh-*.yaml` files in the title set
- The title check at line 907-908 saw the title existed and skipped the issue

## Solution
Exclude `gh-*` files from `_collect_existing_titles()` since we always want to regenerate those from GitHub.

## Test
Run `bernstein -t gh-59` and verify the backlog file gets regenerated with full issue content.