### PR TITLE
feat(security): implement agent credential scope minimization

### DIFF
--- a/src/bernstein/core/credential_scoping.py
+++ b/src/bernstein/core/credential_scoping.py
@@ -1,0 +1,393 @@
+"""Agent credential scope minimization for least-privilege API keys.
+
+Provides scoped API credentials that restrict each agent to only the
+operations, models, and token budgets it needs.  Instead of sharing a
+single API key with full access, each agent receives a credential
+whose scope is enforced locally — either via a proxy layer or via
+pre-flight validation before dispatching requests to upstream
+providers.
+
+Usage::
+
+    from bernstein.core.credential_scoping import (
+        CredentialScope,
+        ScopedCredential,
+        CredentialScopeManager,
+        create_scoped_credential,
+        validate_request_against_scope,
+        get_scope_for_role,
+    )
+
+    scope = get_scope_for_role("backend")
+    cred = create_scoped_credential("agent-42", scope)
+    is_valid = validate_request_against_scope(
+        {"operation": "code_gen", "model": "gpt-4", "tokens": 500},
+        cred.scope,
+    )
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CredentialScope:
+    """Scope definition for an agent credential.
+
+    Attributes:
+        allowed_operations: Operations this credential permits
+            (e.g. ``"code_gen"``, ``"web_search"``, ``"file_read"``).
+        allowed_models: If set, restrict which LLM models may be used.
+        max_tokens_per_request: Per-request token budget cap.
+        rate_limit_rpm: Maximum requests per minute.
+    """
+
+    allowed_operations: tuple[str, ...]
+    allowed_models: tuple[str, ...] | None = None
+    max_tokens_per_request: int | None = None
+    rate_limit_rpm: int | None = None
+
+
+@dataclass(frozen=True)
+class ScopedCredential:
+    """A scoped API credential for an agent.
+
+    Attributes:
+        key_id: Unique identifier for this credential.
+        agent_id: The agent this credential is issued to.
+        scope: The attached :class:`CredentialScope`.
+        created_at: When the credential was created.
+        expires_at: When the credential expires.
+    """
+
+    key_id: str
+    agent_id: str
+    scope: CredentialScope
+    created_at: datetime
+    expires_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Pre-defined role scopes
+# ---------------------------------------------------------------------------
+
+_ROLE_SCOPES: dict[str, CredentialScope] = {
+    "backend": CredentialScope(
+        allowed_operations=("code_gen", "file_read", "file_write"),
+        allowed_models=("gpt-4", "claude-sonnet-4-20250514"),
+        max_tokens_per_request=8192,
+        rate_limit_rpm=60,
+    ),
+    "frontend": CredentialScope(
+        allowed_operations=("code_gen", "file_read", "file_write"),
+        allowed_models=("gpt-4",),
+        max_tokens_per_request=4096,
+        rate_limit_rpm=30,
+    ),
+    "researcher": CredentialScope(
+        allowed_operations=("web_search", "file_read"),
+        allowed_models=("gpt-4",),
+        max_tokens_per_request=2048,
+        rate_limit_rpm=20,
+    ),
+    "analyst": CredentialScope(
+        allowed_operations=("file_read", "code_gen"),
+        allowed_models=("gpt-4",),
+        max_tokens_per_request=4096,
+        rate_limit_rpm=30,
+    ),
+    "admin": CredentialScope(
+        allowed_operations=(
+            "code_gen",
+            "web_search",
+            "file_read",
+            "file_write",
+            "system_admin",
+        ),
+        max_tokens_per_request=16384,
+        rate_limit_rpm=120,
+    ),
+}
+
+_DEFAULT_TTL_HOURS = 24
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def create_scoped_credential(
+    agent_id: str,
+    scope: CredentialScope,
+    *,
+    ttl_hours: int = _DEFAULT_TTL_HOURS,
+) -> ScopedCredential:
+    """Create a scoped API credential for an agent.
+
+    Generates a unique ``key_id`` and sets the expiration to
+    ``ttl_hours`` from now.
+
+    Args:
+        agent_id: Identifier of the agent receiving the credential.
+        scope: The :class:`CredentialScope` to attach.
+        ttl_hours: Time-to-live in hours before the credential expires.
+
+    Returns:
+        A new :class:`ScopedCredential`.
+    """
+    now = datetime.now(UTC)
+    return ScopedCredential(
+        key_id=f"sk-{uuid.uuid4().hex[:16]}",
+        agent_id=agent_id,
+        scope=scope,
+        created_at=now,
+        expires_at=now + timedelta(hours=ttl_hours),
+    )
+
+
+def validate_request_against_scope(
+    request: dict[str, Any],
+    scope: CredentialScope,
+) -> bool:
+    """Validate that a request falls within the given credential scope.
+
+    The ``request`` dict is expected to contain some subset of:
+
+    - ``operation`` (``str``): The operation being performed.
+    - ``model`` (``str``): The model being used.
+    - ``tokens`` (``int``): Token count for this request.
+
+    Args:
+        request: The incoming request to validate.
+        scope: The :class:`CredentialScope` to check against.
+
+    Returns:
+        ``True`` if the request is within scope, ``False`` otherwise.
+    """
+    # Check operation
+    operation = request.get("operation")
+    if operation is not None and operation not in scope.allowed_operations:
+        return False
+
+    # Check model
+    model = request.get("model")
+    if model is not None and scope.allowed_models is not None and model not in scope.allowed_models:
+        return False
+
+    # Check token budget
+    tokens = request.get("tokens")
+    tokens_within_budget = (
+        tokens is None
+        or scope.max_tokens_per_request is None
+        or tokens <= scope.max_tokens_per_request
+    )
+
+    return tokens_within_budget
+
+
+def revoke_credential(key_id: str) -> None:
+    """Revoke a scoped credential.
+
+    Delegates to the :class:`CredentialScopeManager` singleton.
+    This is a convenience wrapper; for batch revocation use the manager
+    directly.
+
+    Args:
+        key_id: The ``key_id`` of the credential to revoke.
+    """
+    _default_manager.revoke(key_id)
+
+
+def get_scope_for_role(role: str) -> CredentialScope:
+    """Return the default :class:`CredentialScope` for a role.
+
+    If the role is unknown, returns a minimal read-only scope.
+
+    Args:
+        role: Role name (e.g. ``"backend"``, ``"researcher"``).
+
+    Returns:
+        The matching :class:`CredentialScope`.
+    """
+    return _ROLE_SCOPES.get(
+        role,
+        CredentialScope(
+            allowed_operations=("file_read",),
+            max_tokens_per_request=1024,
+            rate_limit_rpm=10,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credential manager
+# ---------------------------------------------------------------------------
+
+
+class CredentialScopeManager:
+    """Manages scoped credentials lifecycle: creation, lookup, revocation.
+
+    Usage::
+
+        mgr = CredentialScopeManager()
+        cred = mgr.create("agent-1", get_scope_for_role("backend"))
+        assert mgr.is_valid(cred.key_id)
+        mgr.revoke(cred.key_id)
+        assert not mgr.is_valid(cred.key_id)
+    """
+
+    def __init__(self) -> None:
+        self._credentials: dict[str, ScopedCredential] = {}
+        self._revoked: set[str] = set()
+
+    # -- Create ---------------------------------------------------------------
+
+    def create(
+        self,
+        agent_id: str,
+        scope: CredentialScope,
+        *,
+        ttl_hours: int = _DEFAULT_TTL_HOURS,
+    ) -> ScopedCredential:
+        """Create and store a scoped credential.
+
+        Args:
+            agent_id: Identifier of the agent.
+            scope: The scope to attach.
+            ttl_hours: Credential time-to-live in hours.
+
+        Returns:
+            The new :class:`ScopedCredential`.
+        """
+        cred = create_scoped_credential(agent_id, scope, ttl_hours=ttl_hours)
+        self._credentials[cred.key_id] = cred
+        return cred
+
+    # -- Lookup ---------------------------------------------------------------
+
+    def get(self, key_id: str) -> ScopedCredential | None:
+        """Look up a credential by its ``key_id``.
+
+        Args:
+            key_id: The credential key identifier.
+
+        Returns:
+            The :class:`ScopedCredential`, or ``None`` if not found.
+        """
+        return self._credentials.get(key_id)
+
+    def list_for_agent(self, agent_id: str) -> list[ScopedCredential]:
+        """List all active credentials for an agent.
+
+        Args:
+            agent_id: The agent identifier.
+
+        Returns:
+            A list of matching :class:`ScopedCredential` instances.
+        """
+        return [
+            c
+            for c in self._credentials.values()
+            if c.agent_id == agent_id
+            and c.key_id not in self._revoked
+            and datetime.now(UTC) < c.expires_at
+        ]
+
+    # -- Validation -----------------------------------------------------------
+
+    def is_valid(self, key_id: str) -> bool:
+        """Check whether a credential is still valid.
+
+        A credential is valid if it exists, has not been revoked, and
+        has not expired.
+
+        Args:
+            key_id: The credential key identifier.
+
+        Returns:
+            ``True`` if the credential is currently valid.
+        """
+        cred = self._credentials.get(key_id)
+        if cred is None:
+            return False
+        if key_id in self._revoked:
+            return False
+        return datetime.now(UTC) < cred.expires_at
+
+    def validate_request(self, key_id: str, request: dict[str, Any]) -> bool:
+        """Validate a request against a credential's scope.
+
+        Combines credential validity and scope checks in one call.
+
+        Args:
+            key_id: The credential key identifier.
+            request: The incoming request dictionary.
+
+        Returns:
+            ``True`` if the credential is valid **and** the request is
+            within scope.
+        """
+        if not self.is_valid(key_id):
+            return False
+        cred = self._credentials[key_id]
+        return validate_request_against_scope(request, cred.scope)
+
+    # -- Revocation -----------------------------------------------------------
+
+    def revoke(self, key_id: str) -> None:
+        """Revoke a credential.
+
+        The credential remains in storage but is marked as revoked.
+
+        Args:
+            key_id: The credential key identifier.
+        """
+        self._revoked.add(key_id)
+
+    def revoke_all_for_agent(self, agent_id: str) -> int:
+        """Revoke all credentials for a given agent.
+
+        Args:
+            agent_id: The agent identifier.
+
+        Returns:
+            The number of credentials revoked.
+        """
+        count = 0
+        for cred in self._credentials.values():
+            if cred.agent_id == agent_id:
+                self._revoked.add(cred.key_id)
+                count += 1
+        return count
+
+    # -- Cleanup --------------------------------------------------------------
+
+    def cleanup_expired(self) -> int:
+        """Remove expired credentials from storage.
+
+        Returns:
+            The number of credentials removed.
+        """
+        now = datetime.now(UTC)
+        expired_keys = [
+            kid
+            for kid, cred in self._credentials.items()
+            if now >= cred.expires_at
+        ]
+        for kid in expired_keys:
+            del self._credentials[kid]
+            self._revoked.discard(kid)
+        return len(expired_keys)
+
+
+# Module-level default manager for convenience functions
+_default_manager = CredentialScopeManager()

--- a/tests/unit/test_credential_scoping.py
+++ b/tests/unit/test_credential_scoping.py
@@ -1,0 +1,289 @@
+"""Tests for bernstein.core.credential_scoping.
+
+Covers credential creation, scope validation, revocation, role defaults,
+and the CredentialScopeManager lifecycle.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from bernstein.core.credential_scoping import (
+    CredentialScope,
+    CredentialScopeManager,
+    ScopedCredential,
+    create_scoped_credential,
+    get_scope_for_role,
+    validate_request_against_scope,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def backend_scope() -> CredentialScope:
+    """Create a backend-style scope."""
+    return CredentialScope(
+        allowed_operations=("code_gen", "file_read", "file_write"),
+        allowed_models=("gpt-4",),
+        max_tokens_per_request=8192,
+        rate_limit_rpm=60,
+    )
+
+
+@pytest.fixture
+def manager() -> CredentialScopeManager:
+    """Create a fresh CredentialScopeManager."""
+    return CredentialScopeManager()
+
+
+# ---------------------------------------------------------------------------
+# CredentialScope
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialScope:
+    """Tests for the CredentialScope dataclass."""
+
+    def test_frozen(self) -> None:
+        scope = CredentialScope(allowed_operations=("code_gen",))
+        with pytest.raises(AttributeError):
+            scope.allowed_operations = ("web_search",)  # type: ignore[misc]
+
+    def test_defaults(self) -> None:
+        scope = CredentialScope(allowed_operations=("code_gen",))
+        assert scope.allowed_models is None
+        assert scope.max_tokens_per_request is None
+        assert scope.rate_limit_rpm is None
+
+    def test_all_fields(self) -> None:
+        scope = CredentialScope(
+            allowed_operations=("code_gen",),
+            allowed_models=("gpt-4", "claude-sonnet-4-20250514"),
+            max_tokens_per_request=4096,
+            rate_limit_rpm=30,
+        )
+        assert len(scope.allowed_operations) == 1
+        assert len(scope.allowed_models) == 2  # type: ignore[arg-type]
+        assert scope.max_tokens_per_request == 4096
+        assert scope.rate_limit_rpm == 30
+
+
+# ---------------------------------------------------------------------------
+# create_scoped_credential
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScopedCredential:
+    """Tests for the create_scoped_credential helper."""
+
+    def test_creates_credential(self, backend_scope: CredentialScope) -> None:
+        cred = create_scoped_credential("agent-1", backend_scope)
+        assert isinstance(cred, ScopedCredential)
+        assert cred.agent_id == "agent-1"
+        assert cred.scope is backend_scope
+
+    def test_key_id_format(self, backend_scope: CredentialScope) -> None:
+        cred = create_scoped_credential("agent-1", backend_scope)
+        assert cred.key_id.startswith("sk-")
+        assert len(cred.key_id) > 5
+
+    def test_unique_key_ids(self, backend_scope: CredentialScope) -> None:
+        cred_a = create_scoped_credential("agent-1", backend_scope)
+        cred_b = create_scoped_credential("agent-1", backend_scope)
+        assert cred_a.key_id != cred_b.key_id
+
+    def test_expiry_default_ttl(self, backend_scope: CredentialScope) -> None:
+        cred = create_scoped_credential("agent-1", backend_scope)
+        delta = cred.expires_at - cred.created_at
+        assert delta == timedelta(hours=24)
+
+    def test_expiry_custom_ttl(self, backend_scope: CredentialScope) -> None:
+        cred = create_scoped_credential("agent-1", backend_scope, ttl_hours=1)
+        delta = cred.expires_at - cred.created_at
+        assert delta == timedelta(hours=1)
+
+    def test_created_at_is_utc(self, backend_scope: CredentialScope) -> None:
+        cred = create_scoped_credential("agent-1", backend_scope)
+        assert cred.created_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# validate_request_against_scope
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRequestAgainstScope:
+    """Tests for request-scope validation."""
+
+    def test_valid_operation(self, backend_scope: CredentialScope) -> None:
+        assert validate_request_against_scope(
+            {"operation": "code_gen"}, backend_scope
+        )
+
+    def test_invalid_operation(self, backend_scope: CredentialScope) -> None:
+        assert not validate_request_against_scope(
+            {"operation": "web_search"}, backend_scope
+        )
+
+    def test_valid_model(self, backend_scope: CredentialScope) -> None:
+        assert validate_request_against_scope(
+            {"model": "gpt-4"}, backend_scope
+        )
+
+    def test_invalid_model(self, backend_scope: CredentialScope) -> None:
+        assert not validate_request_against_scope(
+            {"model": "llama-3"}, backend_scope
+        )
+
+    def test_no_model_restriction(self) -> None:
+        scope = CredentialScope(allowed_operations=("code_gen",))
+        assert validate_request_against_scope(
+            {"model": "anything"}, scope
+        )
+
+    def test_tokens_within_budget(self, backend_scope: CredentialScope) -> None:
+        assert validate_request_against_scope(
+            {"tokens": 100}, backend_scope
+        )
+
+    def test_tokens_exceeds_budget(self, backend_scope: CredentialScope) -> None:
+        assert not validate_request_against_scope(
+            {"tokens": 10000}, backend_scope
+        )
+
+    def test_empty_request(self, backend_scope: CredentialScope) -> None:
+        assert validate_request_against_scope({}, backend_scope)
+
+    def test_combined_fields(self, backend_scope: CredentialScope) -> None:
+        assert validate_request_against_scope(
+            {"operation": "code_gen", "model": "gpt-4", "tokens": 100},
+            backend_scope,
+        )
+
+    def test_combined_one_invalid(self, backend_scope: CredentialScope) -> None:
+        assert not validate_request_against_scope(
+            {"operation": "code_gen", "model": "llama-3", "tokens": 100},
+            backend_scope,
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_scope_for_role
+# ---------------------------------------------------------------------------
+
+
+class TestGetScopeForRole:
+    """Tests for role-to-scope mapping."""
+
+    def test_backend_role(self) -> None:
+        scope = get_scope_for_role("backend")
+        assert "code_gen" in scope.allowed_operations
+        assert scope.allowed_models is not None
+
+    def test_researcher_role(self) -> None:
+        scope = get_scope_for_role("researcher")
+        assert "web_search" in scope.allowed_operations
+        assert "code_gen" not in scope.allowed_operations
+
+    def test_admin_role(self) -> None:
+        scope = get_scope_for_role("admin")
+        assert "system_admin" in scope.allowed_operations
+
+    def test_unknown_role_gets_minimal(self) -> None:
+        scope = get_scope_for_role("nonexistent")
+        assert scope.allowed_operations == ("file_read",)
+        assert scope.max_tokens_per_request == 1024
+
+    def test_frontend_role(self) -> None:
+        scope = get_scope_for_role("frontend")
+        assert "code_gen" in scope.allowed_operations
+        assert "web_search" not in scope.allowed_operations
+
+
+# ---------------------------------------------------------------------------
+# CredentialScopeManager
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialScopeManager:
+    """Tests for the CredentialScopeManager."""
+
+    def test_create_and_get(self, manager: CredentialScopeManager) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        fetched = manager.get(cred.key_id)
+        assert fetched is cred
+
+    def test_is_valid_fresh(self, manager: CredentialScopeManager) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        assert manager.is_valid(cred.key_id)
+
+    def test_is_valid_unknown_key(self, manager: CredentialScopeManager) -> None:
+        assert not manager.is_valid("sk-nonexistent")
+
+    def test_revoke(self, manager: CredentialScopeManager) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        manager.revoke(cred.key_id)
+        assert not manager.is_valid(cred.key_id)
+
+    def test_revoke_all_for_agent(self, manager: CredentialScopeManager) -> None:
+        manager.create("agent-1", get_scope_for_role("backend"))
+        manager.create("agent-1", get_scope_for_role("frontend"))
+        manager.create("agent-2", get_scope_for_role("backend"))
+        count = manager.revoke_all_for_agent("agent-1")
+        assert count == 2
+
+    def test_list_for_agent(self, manager: CredentialScopeManager) -> None:
+        manager.create("agent-1", get_scope_for_role("backend"))
+        manager.create("agent-1", get_scope_for_role("frontend"))
+        manager.create("agent-2", get_scope_for_role("backend"))
+        creds = manager.list_for_agent("agent-1")
+        assert len(creds) == 2
+
+    def test_list_excludes_revoked(self, manager: CredentialScopeManager) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        manager.revoke(cred.key_id)
+        assert len(manager.list_for_agent("agent-1")) == 0
+
+    def test_validate_request(self, manager: CredentialScopeManager) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        assert manager.validate_request(
+            cred.key_id, {"operation": "code_gen", "model": "gpt-4"}
+        )
+
+    def test_validate_request_revoked(self, manager: CredentialScopeManager) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        manager.revoke(cred.key_id)
+        assert not manager.validate_request(
+            cred.key_id, {"operation": "code_gen"}
+        )
+
+    def test_validate_request_out_of_scope(
+        self, manager: CredentialScopeManager
+    ) -> None:
+        cred = manager.create("agent-1", get_scope_for_role("backend"))
+        assert not manager.validate_request(
+            cred.key_id, {"operation": "web_search"}
+        )
+
+    def test_cleanup_expired(self, manager: CredentialScopeManager) -> None:
+        # Create a credential that expires immediately
+        cred = manager.create(
+            "agent-1", get_scope_for_role("backend"), ttl_hours=0
+        )
+        # Manually set expiration in the past
+        expired_cred = ScopedCredential(
+            key_id=cred.key_id,
+            agent_id=cred.agent_id,
+            scope=cred.scope,
+            created_at=cred.created_at,
+            expires_at=datetime.now(UTC) - timedelta(seconds=1),
+        )
+        manager._credentials[cred.key_id] = expired_cred
+        removed = manager.cleanup_expired()
+        assert removed == 1
+        assert manager.get(cred.key_id) is None


### PR DESCRIPTION
## Summary

Implements the agent credential scope minimization as specified in #663.

## Changes

### New files
- **`src/bernstein/core/credential_scoping.py`** — Core module with:
  - `CredentialScope` and `ScopedCredential` dataclasses
  - `create_scoped_credential()`, `validate_request_against_scope()`, `revoke_credential()` helpers
  - Role-based scope defaults (backend, frontend, researcher, analyst, admin)
  - `CredentialScopeManager` with full lifecycle (create, lookup, validate, revoke, cleanup)

- **`tests/unit/test_credential_scoping.py`** — 35 unit tests covering:
  - Credential scope validation (operations, models, token budgets)
  - Role-based scope defaults
  - Credential lifecycle (create, revoke, expire)
  - Request validation against scopes

## Testing

```bash
uv run pytest tests/unit/test_credential_scoping.py -x -v  # 35 passed
uv run ruff check src/bernstein/core/credential_scoping.py  # All checks passed
uv run ruff check tests/unit/test_credential_scoping.py    # All checks passed
```

## Acceptance Criteria

- [x] Scoped credentials limit operations and models
- [x] Request validation blocks out-of-scope requests
- [x] Credentials have expiration and can be revoked
- [x] All public functions have Google-style docstrings
- [x] Tests cover creation, validation, revocation
- [x] `ruff check` and `pyright` pass with 0 errors

Closes #663