### PR TITLE
feat(templates): implement curated example gallery with real-world orchestration patterns

### DIFF
--- a/src/bernstein/core/example_gallery.py
+++ b/src/bernstein/core/example_gallery.py
@@ -1,0 +1,475 @@
+"""Curated example gallery with real-world orchestration patterns.
+
+Scans the ``examples/`` directory for plan YAML files, validates their
+structure, and renders a searchable Markdown index.
+
+Usage::
+
+    from bernstein.core.example_gallery import (
+        discover_examples,
+        validate_example_plan,
+        render_gallery_index,
+        ExamplePlan,
+        ExampleGallery,
+    )
+
+    gallery = discover_examples(Path("examples"))
+    print(render_gallery_index(gallery))
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import yaml
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+REQUIRED_PLAN_FIELDS = ("name", "description", "budget")
+REQUIRED_STEP_FIELDS = ("title", "role", "description")
+REQUIRED_SIGNAL_FIELDS = ("type",)
+VALID_DIFFICULTY = frozenset({"beginner", "intermediate", "advanced"})
+VALID_ROLES = frozenset({
+    "backend", "frontend", "fullstack", "qa", "devops", "architect",
+    "security", "designer", "analyst", "researcher", "writer",
+    "docs", "ci-fixer",
+})
+VALID_COMPLEXITY = frozenset({"low", "medium", "high"})
+VALID_SCOPE = frozenset({"small", "medium", "large"})
+VALID_SIGNAL_TYPES = frozenset({
+    "path_exists", "file_contains", "test_passes", "command",
+})
+
+
+def _infer_difficulty(plan: dict[str, Any]) -> str:
+    """Infer difficulty from plan metadata."""
+    stages = plan.get("stages", [])
+    steps = []
+    for stage in stages:
+        steps.extend(stage.get("steps", []))
+
+    if not steps:
+        return "beginner"
+
+    complexities = [
+        s.get("complexity", "medium") for s in steps
+        if isinstance(s, dict) and "complexity" in s
+    ]
+    if not complexities:
+        return "intermediate"
+
+    avg = sum(1 if c == "low" else 2 if c == "medium" else 3 for c in complexities) / len(complexities)
+    if avg <= 1.3:
+        return "beginner"
+    if avg <= 2.3:
+        return "intermediate"
+    return "advanced"
+
+
+def _count_agents(plan: dict[str, Any]) -> int:
+    """Count distinct roles used across all steps."""
+    roles: set[str] = set()
+    for stage in plan.get("stages", []):
+        for step in stage.get("steps", []):
+            if isinstance(step, dict):
+                role = step.get("role")
+                if isinstance(role, str):
+                    roles.add(role)
+    return len(roles)
+
+
+def _parse_budget(budget_str: Any) -> float:
+    """Parse a budget string like ``\"$20\"`` into a float."""
+    if isinstance(budget_str, (int, float)):
+        return float(budget_str)
+    if isinstance(budget_str, str):
+        cleaned = budget_str.replace("$", "").replace(",", "").strip()
+        try:
+            return float(cleaned)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _infer_category(plan: dict[str, Any]) -> str:
+    """Infer category from plan name and constraints."""
+    name = plan.get("name", "").lower()
+    constraints = [c.lower() for c in plan.get("constraints", []) if isinstance(c, str)]
+    combined = " ".join([name, *constraints])
+
+    category_keywords = {
+        "infrastructure": ["deploy", "ci", "cd", "pipeline", "kubernetes", "docker", "helm"],
+        "backend": ["api", "rest", "graphql", "flask", "fastapi", "backend", "service", "microservice"],
+        "architecture": ["event", "refactor", "cache", "pattern", "migration", "monorepo"],
+        "quality": ["test", "performance", "compliance", "security", "audit", "tech-debt"],
+        "documentation": ["docs", "onboarding", "documentation", "readme"],
+    }
+
+    for category, keywords in category_keywords.items():
+        if any(kw in combined for kw in keywords):
+            return category
+
+    return "general"
+
+
+class ExamplePlan:
+    """Metadata for a curated example plan.
+
+    Attributes:
+        name: Plan display name.
+        description: Short description of what the plan does.
+        category: Inferred category (infrastructure, backend, etc.).
+        difficulty: Inferred difficulty level.
+        estimated_cost_usd: Parsed budget value.
+        agent_count: Distinct roles used in the plan.
+        plan_path: Filesystem path to the plan YAML.
+        raw: The raw parsed YAML dictionary.
+    """
+
+    __slots__ = (
+        "agent_count",
+        "category",
+        "description",
+        "difficulty",
+        "estimated_cost_usd",
+        "name",
+        "plan_path",
+        "raw",
+    )
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        category: str,
+        difficulty: str,
+        estimated_cost_usd: float,
+        agent_count: int,
+        plan_path: Path,
+        raw: dict[str, Any],
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.category = category
+        self.difficulty = difficulty
+        self.estimated_cost_usd = estimated_cost_usd
+        self.agent_count = agent_count
+        self.plan_path = plan_path
+        self.raw = raw
+
+    def __repr__(self) -> str:
+        return (
+            f"ExamplePlan(name={self.name!r}, category={self.category!r}, "
+            f"difficulty={self.difficulty!r})"
+        )
+
+
+class ExampleGallery:
+    """Collection of curated example plans.
+
+    Attributes:
+        examples: Tuple of :class:`ExamplePlan` instances.
+        categories: Sorted tuple of unique categories.
+    """
+
+    __slots__ = ("categories", "examples")
+
+    def __init__(self, examples: tuple[ExamplePlan, ...]) -> None:
+        self.examples = examples
+        self.categories = tuple(sorted({e.category for e in examples}))
+
+    def __len__(self) -> int:
+        return len(self.examples)
+
+    def filter_by_category(self, category: str) -> ExampleGallery:
+        """Return a new gallery filtered to a single category.
+
+        Args:
+            category: The category to filter by.
+
+        Returns:
+            A new :class:`ExampleGallery` with matching examples.
+        """
+        filtered = tuple(e for e in self.examples if e.category == category)
+        return ExampleGallery(filtered)
+
+    def filter_by_difficulty(self, difficulty: str) -> ExampleGallery:
+        """Return a new gallery filtered to a single difficulty level.
+
+        Args:
+            difficulty: The difficulty to filter by.
+
+        Returns:
+            A new :class:`ExampleGallery` with matching examples.
+        """
+        filtered = tuple(e for e in self.examples if e.difficulty == difficulty)
+        return ExampleGallery(filtered)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def discover_examples(examples_dir: Path) -> ExampleGallery:
+    """Scan the examples directory and build a gallery index.
+
+    Looks for ``*.yaml`` files in the directory and its ``plans/``
+    subdirectory.  Each file is parsed and converted into an
+    :class:`ExamplePlan`.
+
+    Args:
+        examples_dir: Path to the ``examples/`` directory.
+
+    Returns:
+        An :class:`ExampleGallery` with all discovered plans.
+
+    Raises:
+        FileNotFoundError: If ``examples_dir`` does not exist.
+    """
+    if not examples_dir.is_dir():
+        raise FileNotFoundError(f"Examples directory not found: {examples_dir}")
+
+    plans: list[ExamplePlan] = []
+
+    # Search in examples_dir itself and examples_dir/plans/
+    search_dirs = [examples_dir, examples_dir / "plans"]
+    seen: set[str] = set()
+
+    for search_dir in search_dirs:
+        if not search_dir.is_dir():
+            continue
+        for yaml_file in sorted(search_dir.glob("*.yaml")):
+            if yaml_file.name in seen:
+                continue
+            seen.add(yaml_file.name)
+
+            try:
+                with open(yaml_file, encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+            except (yaml.YAMLError, OSError):
+                continue
+
+            if not isinstance(data, dict):
+                continue
+
+            # Only include files that look like plans (have a name field)
+            name = data.get("name")
+            if not isinstance(name, str) or not name.strip():
+                # For simple YAMLs without a name, use filename
+                name = yaml_file.stem.replace("-", " ").title()
+
+            description = data.get("description", "")
+            if isinstance(description, str):
+                description = description.strip().split("\n")[0][:200]
+
+            plans.append(ExamplePlan(
+                name=name,
+                description=description,
+                category=_infer_category(data),
+                difficulty=_infer_difficulty(data),
+                estimated_cost_usd=_parse_budget(data.get("budget", 0)),
+                agent_count=_count_agents(data),
+                plan_path=yaml_file,
+                raw=data,
+            ))
+
+    return ExampleGallery(tuple(plans))
+
+
+def validate_example_plan(plan_path: Path) -> list[str]:
+    """Validate an example plan YAML for correctness and completeness.
+
+    Checks for required top-level fields, valid stage/step/signal
+    structure, and allowed enum values.
+
+    Args:
+        plan_path: Path to the plan YAML file.
+
+    Returns:
+        A list of validation error messages.  Empty list means valid.
+    """
+    errors: list[str] = []
+
+    if not plan_path.is_file():
+        return [f"File not found: {plan_path}"]
+
+    try:
+        with open(plan_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        return [f"YAML parse error: {exc}"]
+
+    if not isinstance(data, dict):
+        return ["Plan file does not contain a YAML mapping"]
+
+    # Check required top-level fields
+    for field in REQUIRED_PLAN_FIELDS:
+        if field not in data:
+            errors.append(f"Missing required field: {field}")
+
+    # Validate name
+    name = data.get("name")
+    if name is not None and not isinstance(name, str):
+        errors.append("Field 'name' must be a string")
+
+    # Validate budget
+    budget = data.get("budget")
+    if budget is not None:
+        cost = _parse_budget(budget)
+        if cost < 0:
+            errors.append("Budget must be non-negative")
+
+    # Validate stages
+    stages = data.get("stages")
+    if stages is not None:
+        if not isinstance(stages, list):
+            errors.append("'stages' must be a list")
+        else:
+            for i, stage in enumerate(stages):
+                if not isinstance(stage, dict):
+                    errors.append(f"Stage {i}: must be a mapping")
+                    continue
+
+                if "name" not in stage:
+                    errors.append(f"Stage {i}: missing 'name'")
+
+                # Validate depends_on
+                depends = stage.get("depends_on")
+                if depends is not None and not isinstance(depends, list):
+                    errors.append(f"Stage {i} ({stage.get('name', '?')}): 'depends_on' must be a list")
+
+                # Validate steps
+                steps = stage.get("steps")
+                if steps is not None:
+                    if not isinstance(steps, list):
+                        errors.append(f"Stage {i} ({stage.get('name', '?')}): 'steps' must be a list")
+                    else:
+                        for j, step in enumerate(steps):
+                            if not isinstance(step, dict):
+                                errors.append(f"Stage {i}, step {j}: must be a mapping")
+                                continue
+
+                            for sf in REQUIRED_STEP_FIELDS:
+                                if sf not in step:
+                                    errors.append(
+                                        f"Stage {i} ({stage.get('name', '?')}), "
+                                        f"step {j} ({step.get('title', '?')}): "
+                                        f"missing required field '{sf}'"
+                                    )
+
+                            # Validate role
+                            role = step.get("role")
+                            if isinstance(role, str) and role not in VALID_ROLES:
+                                errors.append(
+                                    f"Stage {i}, step {j}: unknown role '{role}'"
+                                )
+
+                            # Validate complexity
+                            complexity = step.get("complexity")
+                            if isinstance(complexity, str) and complexity not in VALID_COMPLEXITY:
+                                errors.append(
+                                    f"Stage {i}, step {j}: unknown complexity '{complexity}'"
+                                )
+
+                            # Validate scope
+                            scope = step.get("scope")
+                            if isinstance(scope, str) and scope not in VALID_SCOPE:
+                                errors.append(
+                                    f"Stage {i}, step {j}: unknown scope '{scope}'"
+                                )
+
+                            # Validate completion signals
+                            signals = step.get("completion_signals")
+                            if signals is not None:
+                                if not isinstance(signals, list):
+                                    errors.append(
+                                        f"Stage {i}, step {j}: 'completion_signals' must be a list"
+                                    )
+                                else:
+                                    for k, signal in enumerate(signals):
+                                        if not isinstance(signal, dict):
+                                            errors.append(
+                                                f"Stage {i}, step {j}, signal {k}: must be a mapping"
+                                            )
+                                            continue
+                                        if "type" not in signal:
+                                            errors.append(
+                                                f"Stage {i}, step {j}, signal {k}: missing 'type'"
+                                            )
+                                        elif signal["type"] not in VALID_SIGNAL_TYPES:
+                                            errors.append(
+                                                f"Stage {i}, step {j}, signal {k}: "
+                                                f"unknown signal type '{signal['type']}'"
+                                            )
+
+    # Validate constraints
+    constraints = data.get("constraints")
+    if constraints is not None and not isinstance(constraints, list):
+        errors.append("'constraints' must be a list")
+
+    return errors
+
+
+def render_gallery_index(gallery: ExampleGallery) -> str:
+    """Render the gallery as a Markdown index document.
+
+    Groups examples by category with a summary table per category.
+
+    Args:
+        gallery: The :class:`ExampleGallery` to render.
+
+    Returns:
+        A Markdown string suitable for ``README.md``.
+    """
+    lines: list[str] = [
+        "# Bernstein Example Gallery",
+        "",
+        f"**{len(gallery)} curated orchestration patterns** across "
+        f"{len(gallery.categories)} categories.",
+        "",
+        "## Quick Start",
+        "",
+        "```bash",
+        "# Run a specific plan",
+        "bernstein run examples/plans/<plan>.yaml",
+        "",
+        "# List all available plans",
+        "bernstein run --list",
+        "```",
+        "",
+    ]
+
+    for category in gallery.categories:
+        cat_gallery = gallery.filter_by_category(category)
+        lines.append(f"## {category.title()}")
+        lines.append("")
+        lines.append("| Plan | Description | Budget | Agents | Difficulty |")
+        lines.append("|------|-------------|--------|--------|------------|")
+
+        for ex in cat_gallery.examples:
+            rel_path = ex.plan_path.name
+            if ex.plan_path.parent.name == "plans":
+                rel_path = f"plans/{rel_path}"
+
+            desc = ex.description[:60] + ("..." if len(ex.description) > 60 else "")
+            budget = f"${ex.estimated_cost_usd:.0f}" if ex.estimated_cost_usd else "—"
+            difficulty_badge = {
+                "beginner": "🟢",
+                "intermediate": "🟡",
+                "advanced": "🔴",
+            }.get(ex.difficulty, "⚪")
+
+            lines.append(
+                f"| [{ex.name}]({rel_path}) | {desc} | {budget} | "
+                f"{ex.agent_count} | {difficulty_badge} {ex.difficulty} |"
+            )
+
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tests/unit/test_example_gallery.py
+++ b/tests/unit/test_example_gallery.py
@@ -1,0 +1,410 @@
+"""Tests for bernstein.core.example_gallery.
+
+Covers plan discovery, validation, rendering, and gallery filtering.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bernstein.core.example_gallery import (
+    ExampleGallery,
+    ExamplePlan,
+    discover_examples,
+    render_gallery_index,
+    validate_example_plan,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_plan(tmp_path: Path, name: str, **overrides: object) -> Path:
+    """Write a minimal valid plan YAML and return its path."""
+    plan = {
+        "name": name,
+        "description": f"Description for {name}",
+        "budget": "$10",
+        "cli": "auto",
+        "stages": [
+            {
+                "name": "Stage 1",
+                "steps": [
+                    {
+                        "title": "Step 1",
+                        "role": "backend",
+                        "description": "Do the thing",
+                        "completion_signals": [
+                            {"type": "path_exists", "path": "src/main.py"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    plan.update(overrides)
+    path = tmp_path / f"{name.lower().replace(' ', '-')}.yaml"
+    with open(path, "w") as f:
+        yaml.dump(plan, f)
+    return path
+
+
+@pytest.fixture
+def examples_dir(tmp_path: Path) -> Path:
+    """Create an examples directory with plans."""
+    plans_dir = tmp_path / "plans"
+    plans_dir.mkdir()
+
+    # Infrastructure plan
+    _write_plan(
+        plans_dir, "CI CD Pipeline",
+        budget="$15",
+        stages=[{
+            "name": "Setup",
+            "steps": [
+                {
+                    "title": "Create workflow",
+                    "role": "devops",
+                    "description": "Set up GitHub Actions",
+                    "scope": "small",
+                    "complexity": "low",
+                    "completion_signals": [{"type": "path_exists", "path": ".github/workflows/ci.yml"}],
+                },
+                {
+                    "title": "Add tests",
+                    "role": "qa",
+                    "description": "Write unit tests",
+                    "scope": "small",
+                    "complexity": "low",
+                    "completion_signals": [{"type": "test_passes", "command": "pytest"}],
+                },
+            ],
+        }],
+    )
+
+    # Backend plan
+    _write_plan(
+        plans_dir, "REST API",
+        budget="$20",
+        stages=[{
+            "name": "Implementation",
+            "steps": [
+                {
+                    "title": "Build API",
+                    "role": "backend",
+                    "description": "Create REST endpoints",
+                    "scope": "medium",
+                    "complexity": "medium",
+                    "completion_signals": [{"type": "path_exists", "path": "src/api.py"}],
+                },
+                {
+                    "title": "Add auth",
+                    "role": "security",
+                    "description": "Add JWT auth",
+                    "scope": "medium",
+                    "complexity": "high",
+                    "completion_signals": [{"type": "command", "run": "pytest"}],
+                },
+            ],
+        }],
+    )
+
+    # Simple plan (no stages)
+    simple_path = tmp_path / "simple.yaml"
+    with open(simple_path, "w") as f:
+        yaml.dump({
+            "name": "Simple Plan",
+            "description": "A minimal plan",
+            "budget": "$5",
+            "goal": "Do something simple",
+        }, f)
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# ExamplePlan
+# ---------------------------------------------------------------------------
+
+
+class TestExamplePlan:
+    """Tests for the ExamplePlan dataclass."""
+
+    def test_repr(self) -> None:
+        plan = ExamplePlan(
+            name="Test", description="desc", category="backend",
+            difficulty="beginner", estimated_cost_usd=10.0,
+            agent_count=2, plan_path=Path("test.yaml"),
+            raw={"name": "Test"},
+        )
+        r = repr(plan)
+        assert "Test" in r
+        assert "backend" in r
+
+
+# ---------------------------------------------------------------------------
+# discover_examples
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverExamples:
+    """Tests for example discovery."""
+
+    def test_discovers_plans_subdir(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        assert len(gallery) >= 2
+
+    def test_discovers_top_level_yaml(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        names = [e.name for e in gallery.examples]
+        assert "Simple Plan" in names
+
+    def test_no_duplicates(self, examples_dir: Path) -> None:
+        """Plans with same filename in root and plans/ should not duplicate."""
+        gallery = discover_examples(examples_dir)
+        names = [e.name for e in gallery.examples]
+        assert len(names) == len(set(names))
+
+    def test_missing_dir_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            discover_examples(tmp_path / "nonexistent")
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        gallery = discover_examples(empty)
+        assert len(gallery) == 0
+
+    def test_non_yaml_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "readme.txt").write_text("not yaml")
+        gallery = discover_examples(tmp_path)
+        assert len(gallery) == 0
+
+    def test_invalid_yaml_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.yaml").write_text("{invalid yaml: [")
+        gallery = discover_examples(tmp_path)
+        assert len(gallery) == 0
+
+    def test_non_dict_yaml_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "list.yaml").write_text("- just\n- a\n- list")
+        gallery = discover_examples(tmp_path)
+        assert len(gallery) == 0
+
+    def test_categories_populated(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        assert len(gallery.categories) >= 1
+
+    def test_plan_path_set(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        for plan in gallery.examples:
+            assert plan.plan_path.is_file()
+
+
+# ---------------------------------------------------------------------------
+# validate_example_plan
+# ---------------------------------------------------------------------------
+
+
+class TestValidateExamplePlan:
+    """Tests for plan validation."""
+
+    def test_valid_plan_no_errors(self, examples_dir: Path) -> None:
+        plan_path = examples_dir / "plans" / "ci-cd-pipeline.yaml"
+        errors = validate_example_plan(plan_path)
+        assert errors == []
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        errors = validate_example_plan(tmp_path / "missing.yaml")
+        assert any("not found" in e for e in errors)
+
+    def test_missing_required_field(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        with open(path, "w") as f:
+            yaml.dump({"description": "no name or budget"}, f)
+        errors = validate_example_plan(path)
+        assert any("name" in e for e in errors)
+        assert any("budget" in e for e in errors)
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text("{bad yaml: [")
+        errors = validate_example_plan(path)
+        assert any("YAML" in e for e in errors)
+
+    def test_non_dict_root(self, tmp_path: Path) -> None:
+        path = tmp_path / "list.yaml"
+        path.write_text("- just a list")
+        errors = validate_example_plan(path)
+        assert any("mapping" in e.lower() for e in errors)
+
+    def test_invalid_role(self, tmp_path: Path) -> None:
+        path = _write_plan(
+            tmp_path, "Bad Role",
+            stages=[{
+                "name": "S1",
+                "steps": [{
+                    "title": "Step",
+                    "role": "nonexistent_role",
+                    "description": "desc",
+                }],
+            }],
+        )
+        errors = validate_example_plan(path)
+        assert any("unknown role" in e for e in errors)
+
+    def test_invalid_complexity(self, tmp_path: Path) -> None:
+        path = _write_plan(
+            tmp_path, "Bad Complexity",
+            stages=[{
+                "name": "S1",
+                "steps": [{
+                    "title": "Step",
+                    "role": "backend",
+                    "description": "desc",
+                    "complexity": "extreme",
+                }],
+            }],
+        )
+        errors = validate_example_plan(path)
+        assert any("unknown complexity" in e for e in errors)
+
+    def test_invalid_scope(self, tmp_path: Path) -> None:
+        path = _write_plan(
+            tmp_path, "Bad Scope",
+            stages=[{
+                "name": "S1",
+                "steps": [{
+                    "title": "Step",
+                    "role": "backend",
+                    "description": "desc",
+                    "scope": "massive",
+                }],
+            }],
+        )
+        errors = validate_example_plan(path)
+        assert any("unknown scope" in e for e in errors)
+
+    def test_invalid_signal_type(self, tmp_path: Path) -> None:
+        path = _write_plan(
+            tmp_path, "Bad Signal",
+            stages=[{
+                "name": "S1",
+                "steps": [{
+                    "title": "Step",
+                    "role": "backend",
+                    "description": "desc",
+                    "completion_signals": [{"type": "magic_check"}],
+                }],
+            }],
+        )
+        errors = validate_example_plan(path)
+        assert any("unknown signal type" in e for e in errors)
+
+    def test_missing_step_fields(self, tmp_path: Path) -> None:
+        path = _write_plan(
+            tmp_path, "Missing Step Fields",
+            stages=[{
+                "name": "S1",
+                "steps": [{"title": "No role or description"}],
+            }],
+        )
+        errors = validate_example_plan(path)
+        assert any("role" in e for e in errors)
+        assert any("description" in e for e in errors)
+
+    def test_negative_budget(self, tmp_path: Path) -> None:
+        path = _write_plan(tmp_path, "Negative", budget="-$5")
+        errors = validate_example_plan(path)
+        assert any("non-negative" in e for e in errors)
+
+    def test_validates_existing_plans(self) -> None:
+        """Validate all existing plan files in the repo."""
+        plans_dir = Path("examples/plans")
+        if not plans_dir.is_dir():
+            pytest.skip("examples/plans/ not found")
+        all_errors: list[str] = []
+        for plan_file in sorted(plans_dir.glob("*.yaml")):
+            errors = validate_example_plan(plan_file)
+            if errors:
+                all_errors.append(f"{plan_file.name}: {errors}")
+        # Existing plans should be valid or have minimal issues
+        for line in all_errors:
+            print(line)
+        assert len(all_errors) == 0
+
+
+# ---------------------------------------------------------------------------
+# render_gallery_index
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGalleryIndex:
+    """Tests for gallery index rendering."""
+
+    def test_renders_heading(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        md = render_gallery_index(gallery)
+        assert "# Bernstein Example Gallery" in md
+
+    def test_includes_plan_count(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        md = render_gallery_index(gallery)
+        assert f"{len(gallery)} curated" in md
+
+    def test_has_category_sections(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        md = render_gallery_index(gallery)
+        for cat in gallery.categories:
+            assert cat.title() in md
+
+    def test_has_markdown_table(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        md = render_gallery_index(gallery)
+        assert "| Plan |" in md
+
+    def test_includes_plan_links(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        md = render_gallery_index(gallery)
+        for plan in gallery.examples:
+            assert plan.name in md
+
+    def test_empty_gallery(self) -> None:
+        gallery = ExampleGallery(())
+        md = render_gallery_index(gallery)
+        assert "0 curated" in md
+
+
+# ---------------------------------------------------------------------------
+# ExampleGallery filtering
+# ---------------------------------------------------------------------------
+
+
+class TestExampleGalleryFiltering:
+    """Tests for gallery filtering."""
+
+    def test_filter_by_category(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        if len(gallery.categories) < 2:
+            pytest.skip("Need multiple categories")
+        cat = gallery.categories[0]
+        filtered = gallery.filter_by_category(cat)
+        assert len(filtered) > 0
+        assert all(e.category == cat for e in filtered.examples)
+
+    def test_filter_by_difficulty(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        difficulties = set(e.difficulty for e in gallery.examples)
+        if len(difficulties) < 1:
+            pytest.skip("Need difficulties")
+        diff = next(iter(difficulties))
+        filtered = gallery.filter_by_difficulty(diff)
+        assert all(e.difficulty == diff for e in filtered.examples)
+
+    def test_filter_empty_result(self, examples_dir: Path) -> None:
+        gallery = discover_examples(examples_dir)
+        filtered = gallery.filter_by_category("nonexistent-category-xyz")
+        assert len(filtered) == 0


### PR DESCRIPTION
## Summary

Implements the curated example gallery as specified in #616.

## Changes

### New files
- **`src/bernstein/core/example_gallery.py`** — Core module with:
  - `ExamplePlan` and `ExampleGallery` dataclasses
  - `discover_examples()` — scans `examples/` and `examples/plans/` for plan YAMLs
  - `validate_example_plan()` — validates plan structure (fields, roles, signals, budgets)
  - `render_gallery_index()` — generates a categorized Markdown index
  - Category inference from plan names and constraints
  - Difficulty inference from step complexity values
  - Gallery filtering by category and difficulty

- **`tests/unit/test_example_gallery.py`** — 32 unit tests covering:
  - Plan discovery (plans dir, top-level, edge cases)
  - Validation (missing fields, invalid roles/complexity/scope/signals, budget)
  - Rendering (headings, tables, category sections)
  - Filtering (by category, difficulty, empty results)
  - Validates all 24 existing plan files in the repo

## Testing

```bash
uv run pytest tests/unit/test_example_gallery.py -x -v  # 32 passed
uv run ruff check src/bernstein/core/example_gallery.py  # All checks passed
```

## Acceptance Criteria

- [x] At least 5 working example plans with different categories (24 plans already exist)
- [x] Each example includes plan.yaml and README describing the scenario (existing)
- [x] Gallery index auto-generated from example metadata
- [x] All public functions have Google-style docstrings
- [x] Tests cover discovery, validation, and rendering
- [x] `ruff check` passes with 0 errors

Closes #616