### PR TITLE
docs: create monthly Community Spotlight blog post template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,13 @@ bernstein stop
 pkill -f bernstein   # kills everything including your own shell session
 ```
 
+## Recognition
+
+All contributors are listed in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+Outstanding contributions are featured in our
+[monthly Community Spotlight](https://alexchernysh.com/blog)
+blog posts, which are shared on Twitter/X, LinkedIn, and dev.to.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).

--- a/docs/community-spotlight-april-2026.md
+++ b/docs/community-spotlight-april-2026.md
@@ -1,0 +1,22 @@
+# Community Spotlight — April 2026
+
+## Featured Contributors
+
+### @oldschoola — [Contribution title]
+[2-3 sentences about their contribution and impact]
+PR: #NNN
+
+### @alexanderxfgl-bit — [Contribution title]
+[2-3 sentences about their contribution and impact]
+PR: #NNN
+
+## This Month in Numbers
+- PRs merged: X
+- New contributors: X
+- Tests added: X
+- Issues closed: X
+
+## Get Featured
+Want to be in next month's spotlight? Check out our
+[good first issues](https://github.com/chernistry/bernstein/labels/good%20first%20issue)
+and start contributing!

--- a/docs/community-spotlight-template.md
+++ b/docs/community-spotlight-template.md
@@ -1,0 +1,22 @@
+# Community Spotlight — [Month] 2026
+
+## Featured Contributors
+
+### @username — [What they built]
+[2-3 sentences about their contribution and impact]
+PR: #NNN
+
+### @username — [What they built]
+[2-3 sentences about their contribution and impact]
+PR: #NNN
+
+## This Month in Numbers
+- PRs merged: X
+- New contributors: X
+- Tests added: X
+- Issues closed: X
+
+## Get Featured
+Want to be in next month's spotlight? Check out our
+[good first issues](https://github.com/chernistry/bernstein/labels/good%20first%20issue)
+and start contributing!


### PR DESCRIPTION
## Summary

- Create `docs/community-spotlight-template.md` with the monthly Community Spotlight template (featured contributors, monthly stats, call-to-action)
- Create `docs/community-spotlight-april-2026.md` as the first spotlight draft featuring @oldschoola and @alexanderxfgl-bit
- Update `CONTRIBUTING.md` with a Recognition section linking to CONTRIBUTORS.md and the community spotlight blog

Closes #774