### PR TITLE
feat(security): agent identity cards with capability enforcement

### DIFF
--- a/src/bernstein/core/security/agent_identity.py
+++ b/src/bernstein/core/security/agent_identity.py
@@ -1,0 +1,122 @@
+"""Agent identity cards with capabilities and scope enforcement.
+
+Implements OWASP Top 10 for Agentic Applications (2026) requirement for
+verifiable agent identity. Each spawned agent gets an identity card
+declaring its capabilities, denied capabilities, scope, and budget.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DEFAULT_CAPABILITIES: dict[str, list[str]] = {
+    "backend": ["read_files", "write_files", "run_tests", "network_access"],
+    "frontend": ["read_files", "write_files", "run_tests", "network_access"],
+    "qa": ["read_files", "run_tests"],
+    "reviewer": ["read_files"],
+    "security": ["read_files", "run_tests", "network_access"],
+    "docs": ["read_files", "write_files"],
+    "devops": ["read_files", "write_files", "run_tests", "network_access"],
+}
+
+DEFAULT_DENIED: dict[str, list[str]] = {
+    "reviewer": ["write_files", "delete_files", "push_git", "access_secrets"],
+    "qa": ["delete_files", "push_git", "access_secrets"],
+    "docs": ["delete_files", "push_git", "access_secrets"],
+}
+
+
+@dataclass
+class AgentIdentityCard:
+    agent_id: str
+    role: str
+    adapter: str
+    model: str
+    capabilities: list[str] = field(default_factory=list)
+    denied_capabilities: list[str] = field(default_factory=list)
+    scope: list[str] = field(default_factory=list)
+    max_budget_usd: float = 10.0
+    created_at: float = field(default_factory=time.time)
+    expires_at: float = 0.0
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), sort_keys=True)
+
+    @property
+    def card_hash(self) -> str:
+        return hashlib.sha256(self.to_json().encode()).hexdigest()[:16]
+
+    def has_capability(self, name: str) -> bool:
+        if name in self.denied_capabilities:
+            return False
+        return name in self.capabilities
+
+    def in_scope(self, path: str) -> bool:
+        if not self.scope:
+            return True  # empty scope = unrestricted
+        return any(path.startswith(prefix) for prefix in self.scope)
+
+    def is_expired(self) -> bool:
+        return self.expires_at > 0 and time.time() > self.expires_at
+
+
+def issue_identity_card(
+    agent_id: str,
+    role: str,
+    adapter: str,
+    model: str,
+    *,
+    scope: list[str] | None = None,
+    max_budget_usd: float = 10.0,
+    ttl_seconds: int = 3600,
+) -> AgentIdentityCard:
+    """Generate an identity card for a newly spawned agent."""
+    now = time.time()
+    return AgentIdentityCard(
+        agent_id=agent_id,
+        role=role,
+        adapter=adapter,
+        model=model,
+        capabilities=list(DEFAULT_CAPABILITIES.get(role, ["read_files"])),
+        denied_capabilities=list(DEFAULT_DENIED.get(role, [])),
+        scope=scope or [],
+        max_budget_usd=max_budget_usd,
+        created_at=now,
+        expires_at=now + ttl_seconds if ttl_seconds > 0 else 0.0,
+    )
+
+
+def save_identity_card(card: AgentIdentityCard, runtime_dir: Path) -> Path:
+    """Persist card to .sdd/runtime/agents/{agent_id}/identity.json."""
+    agent_dir = runtime_dir / "agents" / card.agent_id
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / "identity.json"
+    path.write_text(card.to_json())
+    return path
+
+
+def load_identity_card(agent_id: str, runtime_dir: Path) -> AgentIdentityCard | None:
+    """Load a previously issued identity card, or None if not found."""
+    path = runtime_dir / "agents" / agent_id / "identity.json"
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text())
+    return AgentIdentityCard(**data)
+
+
+def check_capability(card: AgentIdentityCard, capability: str) -> tuple[bool, str]:
+    """Returns (allowed, reason). Used by enforcement middleware."""
+    if card.is_expired():
+        return False, "identity card expired"
+    if capability in card.denied_capabilities:
+        return False, f"capability '{capability}' explicitly denied for role '{card.role}'"
+    if capability not in card.capabilities:
+        return False, f"capability '{capability}' not granted to role '{card.role}'"
+    return True, "allowed"

--- a/tests/unit/test_agent_identity_card.py
+++ b/tests/unit/test_agent_identity_card.py
@@ -1,0 +1,98 @@
+"""Tests for agent identity cards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.security.agent_identity import (
+    AgentIdentityCard,
+    check_capability,
+    issue_identity_card,
+    load_identity_card,
+    save_identity_card,
+)
+
+
+class TestIssueIdentityCard:
+    def test_backend_role_gets_full_capabilities(self) -> None:
+        card = issue_identity_card("agent-1", "backend", "claude", "sonnet")
+        assert "write_files" in card.capabilities
+        assert "run_tests" in card.capabilities
+        assert card.role == "backend"
+
+    def test_reviewer_role_cannot_write(self) -> None:
+        card = issue_identity_card("agent-2", "reviewer", "claude", "opus")
+        assert "write_files" not in card.capabilities
+        assert "write_files" in card.denied_capabilities
+
+    def test_unknown_role_gets_minimal_capabilities(self) -> None:
+        card = issue_identity_card("agent-3", "unknown", "claude", "haiku")
+        assert card.capabilities == ["read_files"]
+
+    def test_card_has_stable_hash(self) -> None:
+        card = issue_identity_card("agent-4", "qa", "claude", "haiku")
+        h1 = card.card_hash
+        h2 = card.card_hash
+        assert h1 == h2
+        assert len(h1) == 16
+
+    def test_ttl_sets_expiry(self) -> None:
+        card = issue_identity_card("agent-5", "qa", "claude", "haiku", ttl_seconds=60)
+        assert card.expires_at > card.created_at
+        assert not card.is_expired()
+
+
+class TestSaveLoadIdentityCard:
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        card = issue_identity_card("agent-6", "backend", "claude", "sonnet")
+        save_identity_card(card, tmp_path)
+        loaded = load_identity_card("agent-6", tmp_path)
+        assert loaded is not None
+        assert loaded.agent_id == card.agent_id
+        assert loaded.capabilities == card.capabilities
+
+    def test_missing_returns_none(self, tmp_path: Path) -> None:
+        assert load_identity_card("nonexistent", tmp_path) is None
+
+
+class TestCheckCapability:
+    def test_allowed_capability(self) -> None:
+        card = issue_identity_card("a", "backend", "claude", "sonnet")
+        ok, _ = check_capability(card, "write_files")
+        assert ok
+
+    def test_denied_capability(self) -> None:
+        card = issue_identity_card("a", "reviewer", "claude", "opus")
+        ok, reason = check_capability(card, "write_files")
+        assert not ok
+        assert "denied" in reason
+
+    def test_ungranted_capability(self) -> None:
+        card = issue_identity_card("a", "qa", "claude", "haiku")
+        ok, reason = check_capability(card, "network_access")
+        assert not ok
+        assert "not granted" in reason
+
+    def test_expired_card(self) -> None:
+        card = AgentIdentityCard(
+            agent_id="a",
+            role="backend",
+            adapter="claude",
+            model="sonnet",
+            capabilities=["write_files"],
+            expires_at=1.0,  # long ago
+        )
+        ok, reason = check_capability(card, "write_files")
+        assert not ok
+        assert "expired" in reason
+
+
+class TestInScope:
+    def test_empty_scope_allows_all(self) -> None:
+        card = issue_identity_card("a", "backend", "claude", "sonnet")
+        assert card.in_scope("/any/path")
+
+    def test_scope_restricts(self) -> None:
+        card = issue_identity_card("a", "backend", "claude", "sonnet", scope=["/src/api/"])
+        assert card.in_scope("/src/api/users.py")
+        assert not card.in_scope("/src/auth/")

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -45,3 +45,16 @@ record_fire  # noqa
 extract_github_context  # noqa
 list_scenarios  # noqa
 get_scenario_detail  # noqa
+# Agent identity card — public API
+AgentIdentityCard  # noqa
+issue_identity_card  # noqa
+save_identity_card  # noqa
+load_identity_card  # noqa
+check_capability  # noqa
+DEFAULT_CAPABILITIES  # noqa
+DEFAULT_DENIED  # noqa
+# Agent identity card — dataclass fields and methods consumed by middleware
+created_at  # noqa
+card_hash  # noqa
+has_capability  # noqa
+in_scope  # noqa


### PR DESCRIPTION
Closes #809. Implements `AgentIdentityCard` with per-role capabilities, denied capabilities, scope restrictions, budget, and TTL expiry. Includes save/load/enforcement helpers and 13 unit tests.

## Summary
- New module `src/bernstein/core/security/agent_identity.py` with `AgentIdentityCard` dataclass and helpers `issue_identity_card`, `save_identity_card`, `load_identity_card`, `check_capability`.
- Default capability/deny matrices keyed by role (backend, frontend, qa, reviewer, security, docs, devops).
- Stable SHA-256 `card_hash` for auditing; scope-prefix enforcement; TTL-based expiry.
- Implements OWASP Top 10 for Agentic Applications (2026) requirement for verifiable agent identity.

## Test plan
- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — all checks passed
- [x] `uv run pytest tests/unit/test_agent_identity_card.py -x -q` — 13 passed
- [x] `uv run vulture` — clean (whitelist updated)