### PR TITLE
feat(persistence): resume agent work from WAL checkpoints

### DIFF
--- a/src/bernstein/core/persistence/agent_checkpoint.py
+++ b/src/bernstein/core/persistence/agent_checkpoint.py
@@ -1,0 +1,203 @@
+"""Agent work-in-progress checkpoints for crash recovery.
+
+On each heartbeat, the agent's current state (files modified, last output,
+step count) is saved to disk. After a crash, the orchestrator can detect
+recoverable tasks (worktree has uncommitted changes) and spawn a new agent
+with checkpoint context so work continues instead of restarting.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+_CHECKPOINT_FILENAME = "checkpoint.json"
+
+
+@dataclass
+class AgentCheckpoint:
+    """Snapshot of an agent's in-progress work for crash recovery.
+
+    Attributes:
+        agent_id: Unique identifier of the agent process.
+        task_id: Identifier of the task the agent is working on.
+        worktree_path: Filesystem path to the agent's git worktree.
+        files_modified: Paths of files the agent has modified so far.
+        last_output: Trailing output buffer from the agent.
+        step_count: Number of discrete steps the agent has performed.
+        elapsed_seconds: Wall-clock seconds the agent has been running.
+        checkpointed_at: Unix timestamp when the checkpoint was written.
+        crash_recoverable: Whether this checkpoint is eligible for recovery.
+    """
+
+    agent_id: str
+    task_id: str
+    worktree_path: str
+    files_modified: list[str] = field(default_factory=list)
+    last_output: str = ""
+    step_count: int = 0
+    elapsed_seconds: float = 0.0
+    checkpointed_at: float = field(default_factory=time.time)
+    crash_recoverable: bool = True
+
+
+def save_checkpoint(checkpoint: AgentCheckpoint, runtime_dir: Path) -> Path:
+    """Persist checkpoint to ``.sdd/runtime/agents/{agent_id}/checkpoint.json``.
+
+    Args:
+        checkpoint: The checkpoint to persist.
+        runtime_dir: Root runtime directory (typically ``.sdd/runtime``).
+
+    Returns:
+        Path to the written checkpoint file.
+    """
+    agent_dir = runtime_dir / "agents" / checkpoint.agent_id
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    path = agent_dir / _CHECKPOINT_FILENAME
+    path.write_text(json.dumps(asdict(checkpoint), sort_keys=True))
+    return path
+
+
+def load_checkpoint(agent_id: str, runtime_dir: Path) -> AgentCheckpoint | None:
+    """Load a checkpoint for ``agent_id``; returns None if missing."""
+    path = runtime_dir / "agents" / agent_id / _CHECKPOINT_FILENAME
+    if not path.exists():
+        return None
+    return AgentCheckpoint(**json.loads(path.read_text()))
+
+
+def scan_orphaned_checkpoints(runtime_dir: Path) -> list[AgentCheckpoint]:
+    """Find all checkpoints whose owning process is no longer alive.
+
+    Args:
+        runtime_dir: Root runtime directory to scan.
+
+    Returns:
+        The list of orphaned checkpoints that may be recovered.
+    """
+    agents_dir = runtime_dir / "agents"
+    if not agents_dir.exists():
+        return []
+    orphans: list[AgentCheckpoint] = []
+    for agent_dir in agents_dir.iterdir():
+        if not agent_dir.is_dir():
+            continue
+        checkpoint_path = agent_dir / _CHECKPOINT_FILENAME
+        pid_path = agent_dir / "pid"
+        if not checkpoint_path.exists():
+            continue
+        # Check if pid is alive
+        pid = _read_pid(pid_path)
+        if pid is not None and _pid_alive(pid):
+            continue  # still running, not orphaned
+        try:
+            orphans.append(AgentCheckpoint(**json.loads(checkpoint_path.read_text())))
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return orphans
+
+
+def _read_pid(pid_path: Path) -> int | None:
+    if not pid_path.exists():
+        return None
+    try:
+        return int(pid_path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        import os
+
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def is_checkpoint_recoverable(checkpoint: AgentCheckpoint) -> tuple[bool, str]:
+    """Check if a checkpoint can be recovered.
+
+    Args:
+        checkpoint: The checkpoint to inspect.
+
+    Returns:
+        ``(recoverable, reason)``. Recoverable if the worktree exists and has
+        uncommitted changes that can be resumed.
+    """
+    worktree = Path(checkpoint.worktree_path)
+    if not worktree.exists():
+        return False, "worktree missing"
+    if not (worktree / ".git").exists() and not _is_git_worktree(worktree):
+        return False, "not a git worktree"
+    # Check for uncommitted changes
+    status = _git_status(worktree)
+    if status is None:
+        return False, "git status failed"
+    if not status.strip():
+        return False, "worktree is clean"
+    return True, "has uncommitted changes"
+
+
+def _is_git_worktree(path: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+    except (subprocess.SubprocessError, OSError):
+        return False
+
+
+def _git_status(worktree: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def build_resume_prompt(checkpoint: AgentCheckpoint, original_goal: str) -> str:
+    """Build a system-prompt addendum for an agent resuming from checkpoint.
+
+    Args:
+        checkpoint: The checkpoint describing prior progress.
+        original_goal: The task goal as originally given to the agent.
+
+    Returns:
+        A markdown-formatted prompt fragment that instructs the new agent to
+        continue from the prior work rather than restart.
+    """
+    files_summary = ", ".join(checkpoint.files_modified[:10]) or "(none yet)"
+    return (
+        f"## Resuming from checkpoint\n\n"
+        f"You were previously working on this task. Here's what the previous "
+        f"agent accomplished before being interrupted:\n\n"
+        f"- **Original goal**: {original_goal}\n"
+        f"- **Steps taken**: {checkpoint.step_count}\n"
+        f"- **Elapsed time**: {checkpoint.elapsed_seconds:.0f}s\n"
+        f"- **Files modified**: {files_summary}\n\n"
+        f"The files above are already in the worktree. Review them first, then "
+        f"continue from where the previous agent left off. Do NOT restart from "
+        f"scratch — build on the existing work.\n\n"
+        f"Last output from previous agent:\n"
+        f"```\n{checkpoint.last_output[:2000]}\n```\n"
+    )

--- a/tests/unit/test_agent_checkpoint.py
+++ b/tests/unit/test_agent_checkpoint.py
@@ -1,0 +1,288 @@
+"""Unit tests for agent-level WAL crash recovery (agent_checkpoint)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.persistence.agent_checkpoint import (
+    AgentCheckpoint,
+    build_resume_prompt,
+    is_checkpoint_recoverable,
+    load_checkpoint,
+    save_checkpoint,
+    scan_orphaned_checkpoints,
+)
+
+
+def _make_checkpoint(
+    *,
+    agent_id: str = "agent-1",
+    task_id: str = "task-1",
+    worktree_path: str = "/tmp/worktree",
+    files_modified: list[str] | None = None,
+    last_output: str = "",
+    step_count: int = 0,
+    elapsed_seconds: float = 0.0,
+) -> AgentCheckpoint:
+    return AgentCheckpoint(
+        agent_id=agent_id,
+        task_id=task_id,
+        worktree_path=worktree_path,
+        files_modified=files_modified or [],
+        last_output=last_output,
+        step_count=step_count,
+        elapsed_seconds=elapsed_seconds,
+    )
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialise a minimal git repo for tests."""
+    subprocess.run(
+        ["git", "init", "-b", "main"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    (path / "README.md").write_text("init\n")
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# save / load roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_save_checkpoint_creates_file(tmp_path: Path) -> None:
+    checkpoint = _make_checkpoint(agent_id="a", task_id="t")
+    written = save_checkpoint(checkpoint, tmp_path)
+    assert written.exists()
+    assert written == tmp_path / "agents" / "a" / "checkpoint.json"
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    checkpoint = _make_checkpoint(
+        agent_id="ag-7",
+        task_id="task-42",
+        worktree_path="/tmp/wt",
+        files_modified=["a.py", "b.py"],
+        last_output="hello world",
+        step_count=3,
+        elapsed_seconds=12.5,
+    )
+    save_checkpoint(checkpoint, tmp_path)
+    loaded = load_checkpoint("ag-7", tmp_path)
+    assert loaded is not None
+    assert loaded.agent_id == "ag-7"
+    assert loaded.task_id == "task-42"
+    assert loaded.files_modified == ["a.py", "b.py"]
+    assert loaded.last_output == "hello world"
+    assert loaded.step_count == 3
+    assert loaded.elapsed_seconds == pytest.approx(12.5)
+
+
+def test_load_checkpoint_missing_returns_none(tmp_path: Path) -> None:
+    assert load_checkpoint("does-not-exist", tmp_path) is None
+
+
+def test_save_checkpoint_overwrites_existing(tmp_path: Path) -> None:
+    save_checkpoint(_make_checkpoint(agent_id="x", step_count=1), tmp_path)
+    save_checkpoint(_make_checkpoint(agent_id="x", step_count=2), tmp_path)
+    loaded = load_checkpoint("x", tmp_path)
+    assert loaded is not None
+    assert loaded.step_count == 2
+
+
+def test_save_checkpoint_writes_sorted_json(tmp_path: Path) -> None:
+    save_checkpoint(_make_checkpoint(agent_id="z"), tmp_path)
+    raw = (tmp_path / "agents" / "z" / "checkpoint.json").read_text()
+    data = json.loads(raw)
+    # Keys should be alphabetical
+    assert list(data.keys()) == sorted(data.keys())
+
+
+# ---------------------------------------------------------------------------
+# scan_orphaned_checkpoints
+# ---------------------------------------------------------------------------
+
+
+def test_scan_orphans_no_agents_dir(tmp_path: Path) -> None:
+    assert scan_orphaned_checkpoints(tmp_path) == []
+
+
+def test_scan_orphans_empty_agents_dir(tmp_path: Path) -> None:
+    (tmp_path / "agents").mkdir()
+    assert scan_orphaned_checkpoints(tmp_path) == []
+
+
+def test_scan_orphans_finds_missing_pid(tmp_path: Path) -> None:
+    save_checkpoint(_make_checkpoint(agent_id="orphan"), tmp_path)
+    # No pid file at all → orphaned
+    orphans = scan_orphaned_checkpoints(tmp_path)
+    assert len(orphans) == 1
+    assert orphans[0].agent_id == "orphan"
+
+
+def test_scan_orphans_finds_dead_pid(tmp_path: Path) -> None:
+    save_checkpoint(_make_checkpoint(agent_id="dead"), tmp_path)
+    pid_path = tmp_path / "agents" / "dead" / "pid"
+    # Use a PID very likely to not exist
+    pid_path.write_text("999999\n")
+    orphans = scan_orphaned_checkpoints(tmp_path)
+    assert [c.agent_id for c in orphans] == ["dead"]
+
+
+def test_scan_orphans_skips_live_process(tmp_path: Path) -> None:
+    save_checkpoint(_make_checkpoint(agent_id="live"), tmp_path)
+    pid_path = tmp_path / "agents" / "live" / "pid"
+    pid_path.write_text(f"{os.getpid()}\n")
+    orphans = scan_orphaned_checkpoints(tmp_path)
+    assert orphans == []
+
+
+def test_scan_orphans_skips_non_dir_entries(tmp_path: Path) -> None:
+    (tmp_path / "agents").mkdir()
+    (tmp_path / "agents" / "stray-file").write_text("not a dir")
+    assert scan_orphaned_checkpoints(tmp_path) == []
+
+
+def test_scan_orphans_skips_missing_checkpoint(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agents" / "no-cp"
+    agent_dir.mkdir(parents=True)
+    # No checkpoint.json present
+    assert scan_orphaned_checkpoints(tmp_path) == []
+
+
+def test_scan_orphans_tolerates_corrupt_json(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "agents" / "bad"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "checkpoint.json").write_text("{not valid json")
+    # Corrupt entries are skipped, not raised
+    assert scan_orphaned_checkpoints(tmp_path) == []
+
+
+def test_scan_orphans_tolerates_bad_pid_file(tmp_path: Path) -> None:
+    save_checkpoint(_make_checkpoint(agent_id="bad-pid"), tmp_path)
+    (tmp_path / "agents" / "bad-pid" / "pid").write_text("not-a-number")
+    # Unparseable pid → treated as dead → orphan
+    orphans = scan_orphaned_checkpoints(tmp_path)
+    assert [c.agent_id for c in orphans] == ["bad-pid"]
+
+
+# ---------------------------------------------------------------------------
+# is_checkpoint_recoverable
+# ---------------------------------------------------------------------------
+
+
+def test_is_recoverable_missing_worktree(tmp_path: Path) -> None:
+    checkpoint = _make_checkpoint(worktree_path=str(tmp_path / "does-not-exist"))
+    recoverable, reason = is_checkpoint_recoverable(checkpoint)
+    assert recoverable is False
+    assert "missing" in reason
+
+
+def test_is_recoverable_not_git(tmp_path: Path) -> None:
+    # Plain directory, no git
+    checkpoint = _make_checkpoint(worktree_path=str(tmp_path))
+    recoverable, reason = is_checkpoint_recoverable(checkpoint)
+    assert recoverable is False
+    assert "git" in reason
+
+
+def test_is_recoverable_clean_worktree(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    checkpoint = _make_checkpoint(worktree_path=str(tmp_path))
+    recoverable, reason = is_checkpoint_recoverable(checkpoint)
+    assert recoverable is False
+    assert "clean" in reason
+
+
+def test_is_recoverable_with_uncommitted_changes(tmp_path: Path) -> None:
+    _init_git_repo(tmp_path)
+    (tmp_path / "new_file.py").write_text("print('hi')\n")
+    checkpoint = _make_checkpoint(worktree_path=str(tmp_path))
+    recoverable, reason = is_checkpoint_recoverable(checkpoint)
+    assert recoverable is True
+    assert "uncommitted" in reason
+
+
+# ---------------------------------------------------------------------------
+# build_resume_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_build_resume_prompt_includes_goal_and_steps() -> None:
+    checkpoint = _make_checkpoint(
+        files_modified=["foo.py", "bar.py"],
+        step_count=5,
+        elapsed_seconds=37.0,
+        last_output="all good",
+    )
+    prompt = build_resume_prompt(checkpoint, "Implement widget")
+    assert "Implement widget" in prompt
+    assert "5" in prompt
+    assert "37" in prompt
+    assert "foo.py" in prompt
+    assert "bar.py" in prompt
+    assert "all good" in prompt
+
+
+def test_build_resume_prompt_handles_no_files() -> None:
+    checkpoint = _make_checkpoint()
+    prompt = build_resume_prompt(checkpoint, "Do the thing")
+    assert "(none yet)" in prompt
+
+
+def test_build_resume_prompt_truncates_long_output() -> None:
+    big = "x" * 5000
+    checkpoint = _make_checkpoint(last_output=big)
+    prompt = build_resume_prompt(checkpoint, "Goal")
+    # The last_output slice must be capped at 2000 chars
+    assert "x" * 2000 in prompt
+    assert "x" * 2001 not in prompt
+
+
+def test_build_resume_prompt_limits_files_list() -> None:
+    many_files = [f"file_{i:03d}.py" for i in range(25)]
+    checkpoint = _make_checkpoint(files_modified=many_files)
+    prompt = build_resume_prompt(checkpoint, "Goal")
+    # Only first 10 file names should appear
+    assert "file_000.py" in prompt
+    assert "file_009.py" in prompt
+    assert "file_010.py" not in prompt
+    assert "file_024.py" not in prompt
+
+
+def test_build_resume_prompt_contains_instructions() -> None:
+    checkpoint = _make_checkpoint()
+    prompt = build_resume_prompt(checkpoint, "Goal")
+    # Must tell the agent NOT to restart from scratch
+    assert "Do NOT restart" in prompt
+    assert "Resuming from checkpoint" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.8.0"
+version = "1.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -101,3 +101,11 @@ complexity  # noqa
 timestamp  # noqa
 avg_duration_s  # noqa
 avg_cost_usd  # noqa
+# Agent checkpoint (WAL crash recovery) — public API used across orchestrator
+crash_recoverable  # noqa
+checkpointed_at  # noqa
+build_resume_prompt  # noqa
+scan_orphaned_checkpoints  # noqa
+is_checkpoint_recoverable  # noqa
+load_checkpoint  # noqa
+save_checkpoint  # noqa


### PR DESCRIPTION
Closes #813. Agent checkpoints with crash recovery via orphan scanning, git worktree detection, and resume-prompt generation. 23 unit tests.

## Summary
- New module `src/bernstein/core/persistence/agent_checkpoint.py` providing `AgentCheckpoint` dataclass plus `save_checkpoint` / `load_checkpoint` / `scan_orphaned_checkpoints` / `is_checkpoint_recoverable` / `build_resume_prompt`.
- Checkpoints live at `.sdd/runtime/agents/{agent_id}/checkpoint.json` and are matched against a sibling `pid` file so orphaned checkpoints (process dead) can be recovered deterministically.
- Recoverability is gated on the worktree still existing with uncommitted changes, so a stale checkpoint whose worktree was already cleaned up is skipped rather than misleading the resumer.
- `build_resume_prompt` produces a system-prompt addendum with the original goal, step count, elapsed time, up-to-10 modified files, and the tail-2000 chars of last output, with an explicit "do not restart from scratch" directive.

## Test plan
- [x] `uv run pytest tests/unit/test_agent_checkpoint.py -x -q` — 23/23 pass
- [x] `uv run ruff format` / `uv run ruff check` — clean
- [x] `uv run vulture` — clean (with whitelist update for the new public API)