### PR TITLE
refactor(orchestration): extract evolve/cleanup bodies from Orchestrator

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -73,12 +73,11 @@ from bernstein.core.models import (
     OrchestratorConfig,
     ProgressSnapshot,
     Task,
-    TaskType,
     TestAgentConfig,
 )
 from bernstein.core.notifications import NotificationManager, NotificationPayload, NotificationTarget
 from bernstein.core.orchestration.adaptive_parallelism import AdaptiveParallelism
-from bernstein.core.orchestration.evolution import EvolutionCoordinator, UpgradeStatus
+from bernstein.core.orchestration.evolution import EvolutionCoordinator
 from bernstein.core.orchestration.tick_pipeline import (
     CompletionData,
     RuffViolation,
@@ -96,7 +95,6 @@ from bernstein.core.orchestration.tick_pipeline import (
 from bernstein.core.orchestration.tick_pipeline import (
     total_spent_cache as total_spent_cache,
 )
-from bernstein.core.platform_compat import kill_process_group
 from bernstein.core.quality_gate_coalescer import QualityGateCoalescer
 from bernstein.core.quarantine import QuarantineStore
 from bernstein.core.quota_poller import QuotaPoller
@@ -131,7 +129,7 @@ from bernstein.core.token_monitor import check_token_growth
 from bernstein.core.wal import WALRecovery, WALWriter
 from bernstein.core.watchdog import WatchdogManager, collect_watchdog_findings
 from bernstein.core.workflow import WorkflowExecutor, load_workflow
-from bernstein.evolution.governance import AdaptiveGovernor, GovernanceEntry, ProjectContext
+from bernstein.evolution.governance import AdaptiveGovernor
 from bernstein.evolution.risk import RiskScorer
 
 _BERNSTEIN_YAML = "bernstein.yaml"
@@ -1666,71 +1664,22 @@ class Orchestrator:
         return uncommitted
 
     def stop(self) -> None:
-        """Signal the run loop to exit after the current tick.
+        """Delegate to orchestrator_cleanup.stop."""
+        from bernstein.core.orchestration import orchestrator_cleanup
 
-        Also writes SHUTDOWN signal files to all active agents so they can
-        save WIP and exit cleanly before the orchestrator terminates.
-        """
-        self._shutting_down.set()
-        self._running = False
-        with contextlib.suppress(Exception):
-            send_shutdown_signals(self, reason="orchestrator_stopped")
+        orchestrator_cleanup.stop(self)
 
     def is_shutting_down(self) -> bool:
-        """Return True when the orchestrator is draining for shutdown."""
-        return self._shutting_down.is_set()
+        """Delegate to orchestrator_cleanup.is_shutting_down."""
+        from bernstein.core.orchestration import orchestrator_cleanup
+
+        return orchestrator_cleanup.is_shutting_down(self)
 
     def _drain_before_cleanup(self, timeout_s: float | None = None) -> None:
-        """Stop new work, send SHUTDOWN signals, reap completed agents, then drain executor.
+        """Delegate to orchestrator_cleanup.drain_before_cleanup."""
+        from bernstein.core.orchestration import orchestrator_cleanup
 
-        Sends SHUTDOWN signals to all active agents at the start of drain so
-        they can save WIP and exit cleanly.  During the wait loop, continues
-        reaping dead agents and processing completed tasks so that work
-        finished during drain is not lost.
-
-        Args:
-            timeout_s: Maximum seconds to wait for agents to finish.  Defaults
-                to ``self._config.drain_timeout_s`` (60 s).
-        """
-        if self._executor_drained:
-            return
-
-        if timeout_s is None:
-            timeout_s = self._config.drain_timeout_s
-
-        # BUG-06: Send SHUTDOWN signals so agents save WIP and exit cleanly
-        with contextlib.suppress(Exception):
-            send_shutdown_signals(self, reason="drain_before_cleanup")
-
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            active_sessions = [
-                session
-                for session in self._agents.values()
-                if session.status != "dead" and self._spawner.check_alive(session)
-            ]
-            if not active_sessions:
-                break
-
-            # BUG-20: Reap dead agents and process completed tasks each
-            # iteration so work that finishes during drain is merged.
-            try:
-                tasks_by_status = fetch_all_tasks(self._client, self._config.server_url)
-                done_tasks = tasks_by_status.get("done", [])
-                if done_tasks:
-                    process_completed_tasks(self, done_tasks, TickResult())
-                reap_dead_agents(self, TickResult(), tasks_by_status)
-            except Exception:
-                logger.debug("Drain poll: task fetch/reap failed (non-critical)", exc_info=True)
-
-            time.sleep(1.0)
-
-        try:
-            self._executor.shutdown(wait=True, cancel_futures=True)
-        except TypeError:
-            self._executor.shutdown(wait=True)
-        self._executor_drained = True
-        logger.info("Executor drained before cleanup")
+        orchestrator_cleanup.drain_before_cleanup(self, timeout_s=timeout_s)
 
     # -- Delegating methods (keep as methods for backward compat) -----------
 
@@ -2303,103 +2252,22 @@ class Orchestrator:
     # -- Session and cleanup ------------------------------------------------
 
     def _save_session_state(self) -> None:
-        """Persist session state for fast resume on next start.
+        """Delegate to orchestrator_cleanup.save_session_state."""
+        from bernstein.core.orchestration import orchestrator_cleanup
 
-        Queries the task server for current task statuses and writes a
-        session snapshot to ``.sdd/runtime/session.json``.  Errors are
-        silently caught -- session saving is best-effort.
-        """
-        try:
-            from bernstein.core.session import SessionState, save_session
-
-            resp = self._client.get(f"{self._config.server_url}/tasks")
-            resp.raise_for_status()
-            from typing import cast as _cast_session
-
-            tasks_data: Any = resp.json()
-            task_list: list[dict[str, Any]] = []
-            if isinstance(tasks_data, list):
-                task_list = _cast_session("list[dict[str, Any]]", tasks_data)
-            elif isinstance(tasks_data, dict):
-                raw_dict = _cast_session("dict[str, Any]", tasks_data)
-                task_list = _cast_session("list[dict[str, Any]]", raw_dict.get("tasks", []))
-
-            done_ids: list[str] = [str(t["id"]) for t in task_list if t.get("status") == "done"]
-            pending_ids: list[str] = [str(t["id"]) for t in task_list if t.get("status") in ("claimed", "in_progress")]
-
-            state = SessionState(
-                saved_at=time.time(),
-                goal="",
-                completed_task_ids=done_ids,
-                pending_task_ids=pending_ids,
-                cost_spent=self._cost_tracker.spent_usd,
-            )
-            save_session(self._workdir, state)
-            logger.info("Session state saved (%d done, %d pending)", len(done_ids), len(pending_ids))
-        except Exception:
-            logger.debug("Failed to save session state (best-effort)", exc_info=True)
+        orchestrator_cleanup.save_session_state(self)
 
     def _cleanup(self) -> None:
-        """Release resources held by the orchestrator."""
-        # Save session state before releasing resources
-        self._save_session_state()
+        """Delegate to orchestrator_cleanup.cleanup."""
+        from bernstein.core.orchestration import orchestrator_cleanup
 
-        # SOC 2: generate Merkle seal on shutdown when audit mode is active
-        if self._audit_mode and self._audit_log is not None:
-            try:
-                from bernstein.core.merkle import compute_seal, save_seal
-
-                audit_dir = self._workdir / ".sdd" / "audit"
-                merkle_dir = audit_dir / "merkle"
-                _tree, seal = compute_seal(audit_dir)
-                seal_path = save_seal(seal, merkle_dir)
-                logger.info("Merkle audit seal written: %s (root=%s)", seal_path, seal["root_hash"])
-            except Exception:
-                logger.warning("Merkle seal generation on shutdown failed", exc_info=True)
-
-        # Full git hygiene on shutdown
-        try:
-            from bernstein.core.git_hygiene import run_hygiene
-
-            run_hygiene(self._workdir, full=True)
-        except Exception:
-            logger.debug("Git hygiene on shutdown failed (non-critical)", exc_info=True)
-
-        # Stop cluster heartbeat client (unregisters from central server)
-        if self._heartbeat_client is not None:
-            self._heartbeat_client.stop()
-            logger.info("Cluster heartbeat client stopped")
-
-        # Cancel pending futures first
-        for future in (self._pending_ruff_future, self._pending_test_future):
-            if future is not None and not future.done():
-                future.cancel()
-        self._pending_ruff_future = None
-        self._pending_test_future = None
-
-        # Shut down the thread pool
-        if not self._executor_drained:
-            try:
-                self._executor.shutdown(wait=False, cancel_futures=True)
-            except TypeError:
-                # Python <3.9 doesn't have cancel_futures
-                self._executor.shutdown(wait=False)
-        logger.info("Executor shut down, background test/ruff processes released")
+        orchestrator_cleanup.cleanup(self)
 
     def _restart(self) -> None:
-        """Replace the current process with a fresh orchestrator.
+        """Delegate to orchestrator_cleanup.restart."""
+        from bernstein.core.orchestration import orchestrator_cleanup
 
-        BUG-22 fix: sends SHUTDOWN signals and drains active agents before
-        calling ``os.execv`` so that running agents are not orphaned.
-        """
-        import sys
-
-        logger.info("Stopping active agents before restart")
-        self.stop()
-        self._drain_before_cleanup()
-        self._cleanup()
-        logger.info("Exec'ing fresh orchestrator process")
-        os.execv(sys.executable, [sys.executable, *sys.argv])
+        orchestrator_cleanup.restart(self)
 
     # -- Evolve mode ---------------------------------------------------------
 
@@ -2414,403 +2282,56 @@ class Orchestrator:
     ]
 
     def _check_evolve(self, result: TickResult, tasks_by_status: dict[str, list[Task]]) -> None:
-        """If evolve mode is on and all tasks are done, trigger a new cycle.
+        """Delegate to orchestrator_evolve.check_evolve."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        Args:
-            result: Current tick result (mutated in place).
-            tasks_by_status: Pre-fetched task snapshot keyed by status string.
-        """
-        evolve_path = self._workdir / ".sdd" / "runtime" / "evolve.json"
-        if not evolve_path.exists():
-            return
-
-        try:
-            evolve_cfg = json.loads(evolve_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return
-
-        if not evolve_cfg.get("enabled"):
-            return
-
-        # Only trigger when idle: no open/claimed tasks, no alive agents
-        open_tasks = tasks_by_status.get("open", [])
-        claimed_tasks = tasks_by_status.get("claimed", [])
-        alive = sum(1 for a in self._agents.values() if a.status != "dead")
-        if open_tasks or claimed_tasks or alive > 0:
-            return  # Still working
-
-        # Check cycle limits
-        cycle_count = evolve_cfg.get("_cycle_count", 0)
-        max_cycles = evolve_cfg.get("max_cycles", 0)
-        if max_cycles > 0 and cycle_count >= max_cycles:
-            logger.info("Evolve: max cycles (%d) reached, stopping", max_cycles)
-            return
-
-        # Check budget cap
-        budget_usd = evolve_cfg.get("budget_usd", 0)
-        spent_usd = evolve_cfg.get("_spent_usd", 0.0)
-        if budget_usd > 0 and spent_usd >= budget_usd:
-            logger.info("Evolve: budget cap ($%.2f) reached, stopping", budget_usd)
-            return
-
-        # Diminishing returns backoff
-        consecutive_empty = evolve_cfg.get("_consecutive_empty", 0)
-        backoff_factor = min(2**consecutive_empty, 8) if consecutive_empty >= 3 else 1
-
-        last_cycle_ts = evolve_cfg.get("_last_cycle_ts", 0)
-        base_interval = evolve_cfg.get("interval_s", 300)
-        effective_interval = base_interval * backoff_factor
-        if time.time() - last_cycle_ts < effective_interval:
-            return
-
-        cycle_number = cycle_count + 1
-        cycle_start = time.time()
-        logger.info(
-            "Evolve: triggering cycle %d (backoff=%dx, interval=%ds)",
-            cycle_number,
-            backoff_factor,
-            effective_interval,
-        )
-
-        # Step 1: ANALYZE
-        tasks_completed = len(tasks_by_status.get("done", []))
-        tasks_failed = len(tasks_by_status.get("failed", []))
-
-        # Step 2: VERIFY
-        test_info = self._evolve_run_tests()
-
-        # Step 3: COMMIT
-        committed = self._evolve_auto_commit()
-
-        # Step 3b: GOVERN
-        # _governor is always non-None here because _check_evolve only runs
-        # when evolve_mode is enabled, and we initialize the governor in that case.
-        assert self._governor is not None, "AdaptiveGovernor must be initialized in evolve mode"
-        weights_before = self._governor.get_current_weights()
-        test_pass_rate = test_info.get("passed", 0) / max(test_info.get("passed", 0) + test_info.get("failed", 0), 1)
-        gov_context = ProjectContext(
-            cycle_number=cycle_number,
-            test_pass_rate=test_pass_rate,
-            lint_violations=evolve_cfg.get("_lint_violations", 0),
-            security_issues_last_5_cycles=evolve_cfg.get("_security_issues", 0),
-            codebase_size_files=evolve_cfg.get("_codebase_files", 0),
-            consecutive_empty_cycles=consecutive_empty,
-        )
-        weights_after, weight_reason = self._governor.adjust_weights(weights_before, gov_context)
-        self._governor.persist_weights(weights_after, reason=weight_reason)
-        self._governor.log_decision(
-            GovernanceEntry(
-                cycle=cycle_number,
-                timestamp=datetime.now(UTC).isoformat(),
-                weights_before=weights_before.to_dict(),
-                weights_after=weights_after.to_dict(),
-                weight_change_reason=weight_reason,
-                proposals_evaluated=tasks_completed + tasks_failed,
-                proposals_applied=tasks_completed,
-                risk_scores=self._last_cycle_risk_scores,
-                outcome_metrics={
-                    "test_pass_rate": test_pass_rate,
-                    "committed": 1.0 if committed else 0.0,
-                },
-            )
-        )
-        logger.info(
-            "Evolve: governance cycle %d -- weights adjusted (%s)",
-            cycle_number,
-            weight_reason,
-        )
-
-        # Step 4: PLAN
-        focus_areas: list[str] = self._EVOLVE_FOCUS_AREAS
-        focus_idx: int = cycle_count % len(focus_areas)
-        focus: str = str(focus_areas[focus_idx])
-        self._evolve_spawn_manager(
-            cycle_number=cycle_number,
-            focus_area=focus,
-            test_summary=test_info.get("summary", ""),
-        )
-
-        # Track diminishing returns
-        produced_changes = committed or tasks_completed > 0
-        if produced_changes:
-            evolve_cfg["_consecutive_empty"] = 0
-        else:
-            evolve_cfg["_consecutive_empty"] = consecutive_empty + 1
-
-        # Update state
-        now = time.time()
-        evolve_cfg["_cycle_count"] = cycle_number
-        evolve_cfg["_last_cycle_ts"] = now
-        with contextlib.suppress(OSError):
-            evolve_path.write_text(json.dumps(evolve_cfg))
-
-        # Log cycle metrics
-        self._log_evolve_cycle(
-            cycle_number,
-            now,
-            {
-                "focus_area": focus,
-                "tasks_completed": tasks_completed,
-                "tasks_failed": tasks_failed,
-                "tests_passed": test_info.get("passed", 0),
-                "tests_failed": test_info.get("failed", 0),
-                "commits_made": 1 if committed else 0,
-                "backoff_factor": backoff_factor,
-                "consecutive_empty": evolve_cfg.get("_consecutive_empty", 0),
-                "duration_s": round(now - cycle_start, 2),
-            },
-        )
-
-        self._post_bulletin(
-            "status",
-            f"evolve cycle {cycle_number} complete: focus={focus}, completed={tasks_completed}, committed={committed}",
-        )
+        orchestrator_evolve.check_evolve(self, result, tasks_by_status)
 
     _REPLENISH_COOLDOWN_S: float = 60.0
     _REPLENISH_MAX_TASKS: int = 5
 
     def _run_ruff_check(self) -> list[RuffViolation]:
-        """Run ruff check and return parsed violations (runs in a background thread)."""
-        import subprocess
+        """Delegate to orchestrator_evolve.run_ruff_check."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        proc = subprocess.Popen(
-            ["uv", "run", "ruff", "check", ".", "--output-format", "json"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            cwd=self._workdir,
-            start_new_session=True,
-        )
-        try:
-            stdout, _ = proc.communicate(timeout=60)
-        except subprocess.TimeoutExpired:
-            kill_process_group(proc.pid, sig=9)
-            proc.wait()
-            return []
-        return json.loads(stdout) if stdout.strip() else []
+        return orchestrator_evolve.run_ruff_check(self)
 
     def _create_ruff_tasks(self, violations: list[RuffViolation]) -> None:
-        """Create backlog tasks from ruff violations."""
-        if not violations:
-            logger.debug("Replenish: no ruff violations found, backlog is clean")
-            return
+        """Delegate to orchestrator_evolve.create_ruff_tasks."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        by_rule: dict[str, RuffViolation] = {}
-        for v in violations:
-            code = (v.get("code") or "unknown").strip()
-            if code not in by_rule:
-                by_rule[code] = v
-
-        base = self._config.server_url
-        created = 0
-        for code, v in by_rule.items():
-            if created >= self._REPLENISH_MAX_TASKS:
-                break
-            filename = v.get("filename", "")
-            message = v.get("message", "")
-            row = v.get("location", {}).get("row", "?")
-            task_payload = {
-                "title": f"Fix ruff violation {code}",
-                "description": (
-                    f"Fix all occurrences of ruff rule {code}.\n"
-                    f"Example: {filename}:{row} -- {message}\n"
-                    f"Run `uv run ruff check . --select {code}` to find all instances."
-                ),
-                "role": "backend",
-                "priority": 3,
-                "model": "sonnet",
-                "effort": "low",
-            }
-            try:
-                resp = self._client.post(f"{base}/tasks", json=task_payload)
-                resp.raise_for_status()
-                created += 1
-                logger.info("Replenish: created task for ruff rule %s", code)
-            except httpx.HTTPError as exc:
-                logger.warning("Replenish: failed to create task for %s: %s", code, exc)
-
-        if created:
-            logger.info("Replenish: created %d lint-fix task(s)", created)
+        orchestrator_evolve.create_ruff_tasks(self, violations)
 
     def _replenish_backlog(self, result: TickResult) -> None:
-        """Create fix tasks from ruff lint violations when evolve mode is idle."""
-        if not self._config.evolve_mode:
-            return
-        if result.open_tasks > 0:
-            return
+        """Delegate to orchestrator_evolve.replenish_backlog."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        # Harvest a completed ruff future
-        if self._pending_ruff_future is not None:
-            if not self._pending_ruff_future.done():
-                return  # still running; skip this tick
-            try:
-                violations: list[RuffViolation] = self._pending_ruff_future.result()
-            except (concurrent.futures.CancelledError, RuntimeError) as exc:
-                logger.warning("Replenish: ruff check failed: %s", exc)
-                self._pending_ruff_future = None
-                return
-            self._pending_ruff_future = None
-            self._create_ruff_tasks(violations)
-            return
-
-        # Check cooldown before submitting a new run
-        now = time.time()
-        if now - self._last_replenish_ts < self._REPLENISH_COOLDOWN_S:
-            return
-
-        self._last_replenish_ts = now
-        self._pending_ruff_future = self._executor.submit(self._run_ruff_check)
-        logger.debug("Replenish: ruff check submitted to background thread")
+        orchestrator_evolve.replenish_backlog(self, result)
 
     def _run_pytest(self) -> TestResults:
-        """Run pytest and return parsed results (runs in a background thread)."""
-        import subprocess
+        """Delegate to orchestrator_evolve.run_pytest."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        info: TestResults = {"passed": 0, "failed": 0, "summary": ""}
-        proc = subprocess.Popen(
-            ["uv", "run", "pytest", _TESTS_DIR, "-x", "-q", "--tb=line"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            cwd=self._workdir,
-            start_new_session=True,
-        )
-        try:
-            stdout, stderr = proc.communicate(timeout=120)
-        except subprocess.TimeoutExpired:
-            if not kill_process_group(proc.pid, sig=9):
-                proc.kill()
-            proc.wait()
-            info["summary"] = "pytest timed out after 120s"
-            logger.warning("Background pytest timed out, killed process group")
-            return info
-
-        output = stdout + stderr
-        info["summary"] = output.strip().splitlines()[-1] if output.strip() else ""
-        match = re.search(r"(\d+)[ \t]{1,10}passed\b", output)
-        if match:
-            info["passed"] = int(match.group(1))
-        match = re.search(r"(\d+)[ \t]{1,10}failed\b", output)
-        if match:
-            info["failed"] = int(match.group(1))
-        return info
+        return orchestrator_evolve.run_pytest(self)
 
     def _evolve_run_tests(self) -> TestResults:
-        """Return test results from a background pytest run."""
-        info: TestResults = {"passed": 0, "failed": 0, "summary": ""}
+        """Delegate to orchestrator_evolve.evolve_run_tests."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        if self._pending_test_future is not None:
-            if not self._pending_test_future.done():
-                return info
-            try:
-                info = self._pending_test_future.result()
-            except (concurrent.futures.CancelledError, RuntimeError) as exc:
-                logger.warning("Evolve: test run failed: %s", exc)
-                info["summary"] = f"test run error: {exc}"
-            self._pending_test_future = None
-            return info
-
-        self._pending_test_future = self._executor.submit(self._run_pytest)
-        return info
+        return orchestrator_evolve.evolve_run_tests(self)
 
     @staticmethod
     def _generate_evolve_commit_msg(staged_files: list[str]) -> str:
-        """Build a short, descriptive commit message from the list of staged files."""
-        if not staged_files:
-            return "Evolve: housekeeping"
+        """Delegate to orchestrator_evolve.generate_evolve_commit_msg."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        LABEL_RULES: list[tuple[str, str]] = [
-            ("src/bernstein/cli/dashboard", "improve dashboard"),
-            ("src/bernstein/cli/main", "update CLI"),
-            ("src/bernstein/cli/cost", "add cost tracking"),
-            ("src/bernstein/cli/", "update CLI"),
-            ("src/bernstein/core/orchestrator", "fix orchestrator"),
-            ("src/bernstein/core/server", "fix server"),
-            ("src/bernstein/core/models", "extend models"),
-            ("src/bernstein/core/spawner", "fix spawner"),
-            ("src/bernstein/core/", "update core"),
-            ("src/bernstein/adapters/", "refactor adapters"),
-            ("src/bernstein/evolution/", "tune evolution"),
-            ("src/bernstein/agents/", "update agents"),
-            (_TESTS_DIR, "update tests"),
-            ("docs/", "update docs"),
-            ("README", "update README"),
-            ("CONTRIBUTING", "update CONTRIBUTING"),
-            (".sdd/backlog/", "add backlog tasks"),
-        ]
-
-        seen: set[str] = set()
-        labels: list[str] = []
-        for path in staged_files:
-            for prefix, label in LABEL_RULES:
-                if prefix in path and label not in seen:
-                    seen.add(label)
-                    labels.append(label)
-                    break
-
-        if not labels:
-            first = staged_files[0].split("/")[-1]
-            labels = [f"update {first}"]
-
-        summary = "; ".join(labels[:3])
-        return f"Evolve: {summary}"
+        return orchestrator_evolve.generate_evolve_commit_msg(staged_files)
 
     def _evolve_auto_commit(self) -> bool:
-        """Auto-commit and push any uncommitted changes from the last cycle."""
-        import subprocess
+        """Delegate to orchestrator_evolve.evolve_auto_commit."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        from bernstein.core.git_ops import (
-            checkout_discard,
-            conventional_commit,
-            safe_push,
-            stage_all_except,
-            status_porcelain,
-        )
-
-        try:
-            changed = status_porcelain(self._workdir)
-            if not changed:
-                return False
-
-            stage_all_except(self._workdir, exclude=[".sdd/runtime/", ".sdd/metrics/"])
-
-            test_result = subprocess.run(
-                ["uv", "run", "pytest", _TESTS_DIR, "-x", "-q", "--tb=line"],
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                cwd=self._workdir,
-                timeout=300,
-            )
-            if test_result.returncode != 0:
-                logger.warning("Evolve: tests failed, rolling back changes")
-                checkout_discard(self._workdir)
-                return False
-
-            result = conventional_commit(self._workdir, evolve=True)
-            if not result.ok:
-                logger.warning("Evolve: commit failed: %s", result.stderr)
-                return False
-
-            safe_push(self._workdir, "main")
-            logger.info("Evolve: auto-committed and pushed changes")
-
-            if "src/bernstein/" in changed:
-                logger.info("Evolve: own source code changed, signaling restart")
-                restart_flag = self._workdir / ".sdd" / "runtime" / "restart_requested"
-                restart_flag.parent.mkdir(parents=True, exist_ok=True)
-                restart_flag.write_text(str(time.time()))
-
-            return True
-
-        except (subprocess.TimeoutExpired, OSError) as exc:
-            logger.warning("Evolve: auto-commit failed: %s", exc)
-            return False
+        return orchestrator_evolve.evolve_auto_commit(self)
 
     def _evolve_spawn_manager(
         self,
@@ -2818,106 +2339,15 @@ class Orchestrator:
         focus_area: str = "new_features",
         test_summary: str = "",
     ) -> None:
-        """Spawn a manager agent to analyze the codebase and create new tasks."""
-        base = self._config.server_url
+        """Delegate to orchestrator_evolve.evolve_spawn_manager."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        research_context = ""
-        try:
-            from bernstein.core.researcher import format_research_context, run_research_sync
-
-            report = run_research_sync(self._workdir)
-            research_context = format_research_context(report)
-            if research_context:
-                logger.info("Evolve: research produced %d bytes of context", len(research_context))
-        except Exception as exc:
-            logger.debug("Evolve: research unavailable: %s", exc)
-
-        focus_instructions = {
-            "new_features": "Focus on missing features that block real usage.",
-            "user_interface": (
-                "Focus on the CLI dashboard and user-facing experience. "
-                "Improve the Textual dashboard (src/bernstein/cli/dashboard.py): "
-                "better live metrics display, clearer task status, more useful panels. "
-                "Also improve CLI output quality and error messages."
-            ),
-            "test_coverage": "Focus on test gaps and missing edge-case coverage.",
-            "code_quality": "Focus on code smells, type safety, and refactoring.",
-            "performance": "Focus on performance bottlenecks and efficiency.",
-            "documentation": "Focus on missing docs that block contributors.",
-        }
-        focus_text = focus_instructions.get(focus_area, "Focus on high-impact improvements.")
-
-        description = (
-            f"You are a PRODUCT DIRECTOR in EVOLVE mode (cycle {cycle_number}). "
-            "Think strategically: what would make this project genuinely useful "
-            "to developers? What do competitors lack? What's the shortest path "
-            "to a feature that gets people excited?\n\n"
-            "Create tasks for specialist agents to implement. "
-            "You plan, they code.\n\n"
-            f"## This cycle's focus: {focus_area.replace('_', ' ')}\n"
-            f"{focus_text}\n\n"
-            + (f"## Current test state\n```\n{test_summary}\n```\n\n" if test_summary else "")
-            + "## Rules (from self-evolving systems research)\n"
-            "- NEVER create tasks that are cosmetic, trivial, or busy-work\n"
-            "- Each task must have a measurable outcome (test passes, "
-            "benchmark improves, bug is fixed)\n"
-            "- Prefer config/prompt changes over code changes (cheaper, safer)\n"
-            "- If tests already pass at 100%, focus on functionality, not more tests\n"
-            "- If architecture is clean, focus on features users actually need\n"
-            "- Create 3-5 tasks MAX. Quality over quantity.\n\n"
-            "## Prioritization\n"
-            "1. Bugs and broken functionality (P1)\n"
-            "2. Missing features that block real usage (P1)\n"
-            "3. Performance and reliability (P2)\n"
-            "4. Code quality and test gaps (P2)\n"
-            "5. Documentation (P3 -- only if truly missing)\n\n"
-            "## Process\n"
-            "1. Run `uv run python scripts/run_tests.py -x` to see current test state\n"
-            "2. Read key files to understand architecture\n"
-            "3. Identify 3-5 high-impact improvements\n"
-            "4. Create tasks via HTTP. YOU decide model and effort per task:\n"
-            f"   curl -X POST {base}/tasks -H 'Content-Type: application/json' \\\n"
-            '   -d \'{"title": "...", "description": "...", '
-            '"role": "backend", "priority": 2, '
-            '"model": "sonnet", "effort": "high"}\'\n\n'
-            "## Model/effort selection (you decide per task)\n"
-            '- model: "opus" (deep reasoning, slow) or "sonnet" (fast, default)\n'
-            '- effort: "max" (100 turns), "high" (50), "medium" (30), "low" (15)\n'
-            "- Use sonnet/high for most implementation tasks (fast)\n"
-            "- Use opus/max ONLY for complex architecture or security reviews\n"
-            "- Use sonnet/low for simple fixes, typos, config changes\n\n"
-            "## Task size -- KEEP THEM SMALL\n"
-            "Each task MUST be completable in ONE file change, under 10 minutes.\n"
-            "BAD: 'Implement entire web research module'\n"
-            "GOOD: 'Add Tavily search function to researcher.py'\n"
-            "GOOD: 'Add --evolve flag handling to cli/main.py'\n"
-            "Break big features into 3-5 atomic file-level tasks.\n\n"
-            "## README\n"
-            "Every 3rd cycle, create a task to update README.md with:\n"
-            "- Current feature state, correct CLI usage, accurate test count.\n\n"
-            "5. Then exit.\n\n"
-            "IMPORTANT: Do NOT implement changes yourself. Only create tasks."
+        orchestrator_evolve.evolve_spawn_manager(
+            self,
+            cycle_number=cycle_number,
+            focus_area=focus_area,
+            test_summary=test_summary,
         )
-
-        if research_context:
-            description += research_context
-
-        task_body = {
-            "title": f"Evolve cycle {cycle_number}: {focus_area.replace('_', ' ')}",
-            "description": description,
-            "role": "manager",
-            "priority": 1,
-            "scope": "medium",
-            "complexity": "medium",
-        }
-
-        try:
-            resp = self._client.post(f"{base}/tasks", json=task_body)
-            resp.raise_for_status()
-            task_id = resp.json().get("id", "?")
-            logger.info("Evolve: created manager task %s (focus=%s)", task_id, focus_area)
-        except httpx.HTTPError as exc:
-            logger.error("Evolve: failed to create manager task: %s", exc)
 
     def _log_evolve_cycle(
         self,
@@ -2925,160 +2355,34 @@ class Orchestrator:
         timestamp: float,
         metrics: dict[str, Any] | None = None,
     ) -> None:
-        """Append an entry to the evolve_cycles.jsonl log."""
-        metrics_dir = self._workdir / ".sdd" / "metrics"
-        metrics_dir.mkdir(parents=True, exist_ok=True)
-        log_path = metrics_dir / "evolve_cycles.jsonl"
-        entry: dict[str, Any] = {
-            "cycle": cycle_number,
-            "timestamp": timestamp,
-            "iso_time": datetime.fromtimestamp(timestamp, tz=UTC).isoformat(),
-            "tick": self._tick_count,
-        }
-        if metrics:
-            entry.update(metrics)
-        try:
-            with log_path.open("a") as f:
-                f.write(json.dumps(entry) + "\n")
-        except OSError as exc:
-            logger.warning("Evolve: failed to write cycle log: %s", exc)
+        """Delegate to orchestrator_evolve.log_evolve_cycle."""
+        from bernstein.core.orchestration import orchestrator_evolve
+
+        orchestrator_evolve.log_evolve_cycle(self, cycle_number, timestamp, metrics)
 
     # -- Evolution integration -----------------------------------------------
 
     def make_evolution_loop(self, **kwargs: Any) -> EvolutionLoop:
-        """Create an EvolutionLoop wired to this orchestrator's AdaptiveGovernor.
-
-        Passes the orchestrator's governor so the evolution loop shares the
-        same weight history and governance log as the orchestrator's evolve
-        cycles.  Any extra keyword arguments are forwarded to ``EvolutionLoop``.
+        """Delegate to orchestrator_evolve.make_evolution_loop.
 
         Returns:
             A fully-wired ``EvolutionLoop`` instance.
         """
-        from bernstein.evolution.loop import EvolutionLoop
+        from bernstein.core.orchestration import orchestrator_evolve
 
-        return EvolutionLoop(
-            state_dir=self._workdir / ".sdd",
-            repo_root=self._workdir,
-            governor=self._governor,
-            **kwargs,
-        )
+        return orchestrator_evolve.make_evolution_loop(self, **kwargs)
 
     def _run_evolution_cycle(self, result: TickResult) -> None:
-        """Run an evolution analysis cycle and create upgrade tasks from proposals."""
-        assert self._evolution is not None
-        try:
-            proposals = self._evolution.run_analysis_cycle()
+        """Delegate to orchestrator_evolve.run_evolution_cycle."""
+        from bernstein.core.orchestration import orchestrator_evolve
 
-            # Score each proposal with Strategic Risk Score before routing
-            cycle_risk_scores: list[float] = []
-            for proposal in proposals:
-                target_files = proposal.risk_assessment.affected_components
-                # Estimate diff size from description length (heuristic)
-                diff_estimate = max(len(proposal.proposed_change) // 10, 10)
-                risk_score = self._risk_scorer.score_proposal(
-                    target_files=target_files,
-                    diff_size=diff_estimate,
-                    test_coverage_delta=0.0,  # unknown pre-execution
-                )
-                cycle_risk_scores.append(risk_score.composite_risk)
-                if self._risk_scorer.is_high_risk(risk_score):
-                    logger.info(
-                        "Proposal %s (%s) flagged high-risk (%.2f) — routing to sandbox",
-                        proposal.id,
-                        proposal.title,
-                        risk_score.composite_risk,
-                    )
-                else:
-                    logger.info(
-                        "Proposal %s (%s) low-risk (%.2f) — fast-tracking",
-                        proposal.id,
-                        proposal.title,
-                        risk_score.composite_risk,
-                    )
-            self._last_cycle_risk_scores = cycle_risk_scores
-
-            # Persist pending proposals
-            self._persist_pending_proposals()
-
-            # Execute approved proposals; rollback on failure
-            executed = self._evolution.execute_pending_upgrades()
-            for proposal in executed:
-                logger.info(
-                    "Applied upgrade %s: %s (status=%s)",
-                    proposal.id,
-                    proposal.title,
-                    proposal.status.value,
-                )
-
-            if not proposals:
-                return
-
-            _task_eligible_statuses = {UpgradeStatus.PENDING, UpgradeStatus.APPROVED}
-            base = self._config.server_url
-            for proposal in proposals:
-                if proposal.status not in _task_eligible_statuses:
-                    continue
-                try:
-                    # Score for task priority routing
-                    target_files = proposal.risk_assessment.affected_components
-                    diff_estimate = max(len(proposal.proposed_change) // 10, 10)
-                    risk_score = self._risk_scorer.score_proposal(
-                        target_files=target_files,
-                        diff_size=diff_estimate,
-                        test_coverage_delta=0.0,
-                    )
-                    is_high = self._risk_scorer.is_high_risk(risk_score)
-                    task_body = {
-                        "title": f"Upgrade: {proposal.title}",
-                        "description": proposal.description,
-                        "role": "backend",
-                        "priority": 1 if is_high else 2,
-                        "scope": "large" if is_high else "medium",
-                        "complexity": "high" if is_high else "medium",
-                        "estimated_minutes": 60 if is_high else 30,
-                        "task_type": TaskType.UPGRADE_PROPOSAL.value,
-                    }
-                    resp = self._client.post(f"{base}/tasks", json=task_body)
-                    resp.raise_for_status()
-                    logger.info(
-                        "Created upgrade task for proposal %s: %s (risk=%.2f)",
-                        proposal.id,
-                        proposal.title,
-                        risk_score.composite_risk,
-                    )
-                except httpx.HTTPError as exc:
-                    logger.warning(
-                        "Failed to create upgrade task for proposal %s: %s",
-                        proposal.id,
-                        exc,
-                    )
-                    result.errors.append(f"evolution_task: {exc}")
-        except (OSError, ValueError, RuntimeError) as exc:
-            logger.error("Evolution analysis cycle failed: %s", exc)
-            result.errors.append(f"evolution: {exc}")
+        orchestrator_evolve.run_evolution_cycle(self, result)
 
     def _persist_pending_proposals(self) -> None:
-        """Write pending upgrade proposals to .sdd/upgrades/pending.json."""
-        if self._evolution is None:
-            return
-        upgrades_dir = self._workdir / ".sdd" / "upgrades"
-        upgrades_dir.mkdir(parents=True, exist_ok=True)
-        pending_path = upgrades_dir / "pending.json"
-        pending = self._evolution.get_pending_upgrades()
-        data = [
-            {
-                "id": p.id,
-                "title": p.title,
-                "category": p.category.value,
-                "description": p.description,
-                "status": p.status.value,
-                "confidence": p.confidence,
-                "created_at": p.created_at,
-            }
-            for p in pending
-        ]
-        pending_path.write_text(json.dumps(data, indent=2))
+        """Delegate to orchestrator_evolve.persist_pending_proposals."""
+        from bernstein.core.orchestration import orchestrator_evolve
+
+        orchestrator_evolve.persist_pending_proposals(self)
 
     # -- Backlog -------------------------------------------------------------
 

--- a/tests/unit/test_orchestrator_god_class_delegation.py
+++ b/tests/unit/test_orchestrator_god_class_delegation.py
@@ -99,7 +99,7 @@ def test_evolve_focus_areas_still_on_class() -> None:
 
 def test_replenish_constants_preserved() -> None:
     """Cooldown / max-task class constants stay on the class for back-compat."""
-    assert Orchestrator._REPLENISH_COOLDOWN_S == 60.0
+    assert Orchestrator._REPLENISH_COOLDOWN_S == pytest.approx(60.0)
     assert Orchestrator._REPLENISH_MAX_TASKS == 5
 
 

--- a/tests/unit/test_orchestrator_god_class_delegation.py
+++ b/tests/unit/test_orchestrator_god_class_delegation.py
@@ -1,0 +1,231 @@
+"""Tests for audit-009: Orchestrator God-class delegation.
+
+After the audit-009 refactor, the Orchestrator class methods for
+evolve/cleanup/summary subsystems are thin delegators to free functions
+in orchestrator_evolve.py and orchestrator_cleanup.py.
+
+These tests verify:
+1. The public method surface on Orchestrator is preserved (backward compat).
+2. Each method body actually forwards to the module-level function
+   so we don't accidentally carry a divergent copy.
+3. Static / non-orch helpers still produce the same outputs.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from bernstein.core.orchestration import (
+    orchestrator_cleanup,
+    orchestrator_evolve,
+)
+from bernstein.core.orchestration.orchestrator import Orchestrator
+
+
+# Each tuple is (method_name_on_class, module_level_function, module).
+#
+# These delegations were extracted from Orchestrator in audit-009 so the
+# Orchestrator class can shrink below its 4496-line God-class footprint.
+_EVOLVE_DELEGATIONS: list[tuple[str, str]] = [
+    ("_check_evolve", "check_evolve"),
+    ("_run_ruff_check", "run_ruff_check"),
+    ("_create_ruff_tasks", "create_ruff_tasks"),
+    ("_replenish_backlog", "replenish_backlog"),
+    ("_run_pytest", "run_pytest"),
+    ("_evolve_run_tests", "evolve_run_tests"),
+    ("_evolve_auto_commit", "evolve_auto_commit"),
+    ("_evolve_spawn_manager", "evolve_spawn_manager"),
+    ("_log_evolve_cycle", "log_evolve_cycle"),
+    ("make_evolution_loop", "make_evolution_loop"),
+    ("_run_evolution_cycle", "run_evolution_cycle"),
+    ("_persist_pending_proposals", "persist_pending_proposals"),
+]
+
+
+_CLEANUP_DELEGATIONS: list[tuple[str, str]] = [
+    ("stop", "stop"),
+    ("is_shutting_down", "is_shutting_down"),
+    ("_drain_before_cleanup", "drain_before_cleanup"),
+    ("_save_session_state", "save_session_state"),
+    ("_cleanup", "cleanup"),
+    ("_restart", "restart"),
+]
+
+
+@pytest.mark.parametrize(("method_name", "target"), _EVOLVE_DELEGATIONS)
+def test_evolve_method_delegates_to_module(method_name: str, target: str) -> None:
+    """Every evolve method on Orchestrator must forward to orchestrator_evolve.
+
+    Verified by reading the source of the method and checking it references
+    the module-level function name.  This guards against someone adding an
+    inline copy of the body again.
+    """
+    method = getattr(Orchestrator, method_name)
+    src = inspect.getsource(method)
+    assert f"orchestrator_evolve.{target}" in src, (
+        f"Orchestrator.{method_name} body does not delegate to "
+        f"orchestrator_evolve.{target}: {src!r}"
+    )
+    assert hasattr(orchestrator_evolve, target), (
+        f"orchestrator_evolve.{target} does not exist"
+    )
+
+
+@pytest.mark.parametrize(("method_name", "target"), _CLEANUP_DELEGATIONS)
+def test_cleanup_method_delegates_to_module(method_name: str, target: str) -> None:
+    """Every cleanup method on Orchestrator must forward to orchestrator_cleanup."""
+    method = getattr(Orchestrator, method_name)
+    src = inspect.getsource(method)
+    assert f"orchestrator_cleanup.{target}" in src, (
+        f"Orchestrator.{method_name} body does not delegate to "
+        f"orchestrator_cleanup.{target}: {src!r}"
+    )
+    assert hasattr(orchestrator_cleanup, target), (
+        f"orchestrator_cleanup.{target} does not exist"
+    )
+
+
+def test_evolve_focus_areas_still_on_class() -> None:
+    """Tests access ``Orchestrator._EVOLVE_FOCUS_AREAS``; keep the ClassVar."""
+    assert hasattr(Orchestrator, "_EVOLVE_FOCUS_AREAS")
+    assert isinstance(Orchestrator._EVOLVE_FOCUS_AREAS, list)
+    assert "new_features" in Orchestrator._EVOLVE_FOCUS_AREAS
+    assert "code_quality" in Orchestrator._EVOLVE_FOCUS_AREAS
+
+
+def test_replenish_constants_preserved() -> None:
+    """Cooldown / max-task class constants stay on the class for back-compat."""
+    assert Orchestrator._REPLENISH_COOLDOWN_S == 60.0
+    assert Orchestrator._REPLENISH_MAX_TASKS == 5
+
+
+def test_generate_evolve_commit_msg_passes_through_staticmethod() -> None:
+    """Static delegator must return the same string the module function does."""
+    files = ["src/bernstein/cli/main.py", "docs/readme.md"]
+    from_class = Orchestrator._generate_evolve_commit_msg(files)
+    from_module = orchestrator_evolve.generate_evolve_commit_msg(files)
+    assert from_class == from_module
+    assert from_class.startswith("Evolve: ")
+
+
+def test_generate_evolve_commit_msg_empty_files_housekeeping() -> None:
+    """Empty input short-circuits to the fixed housekeeping label."""
+    assert Orchestrator._generate_evolve_commit_msg([]) == "Evolve: housekeeping"
+
+
+def test_stop_delegation_calls_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Orchestrator.stop must invoke orchestrator_cleanup.stop with self."""
+    captured: dict[str, Any] = {}
+
+    def fake_stop(orch: Any) -> None:
+        captured["orch"] = orch
+
+    monkeypatch.setattr(orchestrator_cleanup, "stop", fake_stop)
+
+    fake_self = MagicMock()
+    Orchestrator.stop(fake_self)
+
+    assert captured.get("orch") is fake_self
+
+
+def test_is_shutting_down_returns_module_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return value must flow through unmodified."""
+    monkeypatch.setattr(
+        orchestrator_cleanup,
+        "is_shutting_down",
+        lambda _orch: True,
+    )
+    assert Orchestrator.is_shutting_down(MagicMock()) is True
+
+    monkeypatch.setattr(
+        orchestrator_cleanup,
+        "is_shutting_down",
+        lambda _orch: False,
+    )
+    assert Orchestrator.is_shutting_down(MagicMock()) is False
+
+
+def test_drain_before_cleanup_forwards_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """timeout_s keyword must reach the module function unchanged."""
+    received: dict[str, Any] = {}
+
+    def fake_drain(orch: Any, *, timeout_s: float | None = None) -> None:
+        received["orch"] = orch
+        received["timeout"] = timeout_s
+
+    monkeypatch.setattr(orchestrator_cleanup, "drain_before_cleanup", fake_drain)
+
+    fake_self = MagicMock()
+    Orchestrator._drain_before_cleanup(fake_self, timeout_s=5.5)
+    assert received == {"orch": fake_self, "timeout": 5.5}
+
+
+def test_check_evolve_forwards_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Positional args for check_evolve must reach the module function."""
+    received: dict[str, Any] = {}
+
+    def fake_check_evolve(
+        orch: Any,
+        result: Any,
+        tasks_by_status: dict[str, list[Any]],
+    ) -> None:
+        received["orch"] = orch
+        received["result"] = result
+        received["tasks_by_status"] = tasks_by_status
+
+    monkeypatch.setattr(orchestrator_evolve, "check_evolve", fake_check_evolve)
+
+    fake_self = MagicMock()
+    fake_result = object()
+    tasks = {"open": []}
+    Orchestrator._check_evolve(fake_self, fake_result, tasks)
+
+    assert received["orch"] is fake_self
+    assert received["result"] is fake_result
+    assert received["tasks_by_status"] is tasks
+
+
+def test_make_evolution_loop_forwards_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """make_evolution_loop must pass through extra kwargs to the module."""
+    captured: dict[str, Any] = {}
+
+    def fake_make(orch: Any, **kwargs: Any) -> str:
+        captured["orch"] = orch
+        captured["kwargs"] = kwargs
+        return "sentinel-loop"
+
+    monkeypatch.setattr(orchestrator_evolve, "make_evolution_loop", fake_make)
+
+    fake_self = MagicMock()
+    result = Orchestrator.make_evolution_loop(fake_self, interval_s=123)
+    assert result == "sentinel-loop"
+    assert captured["orch"] is fake_self
+    assert captured["kwargs"] == {"interval_s": 123}
+
+
+def test_evolve_run_tests_returns_module_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return value of evolve_run_tests must propagate back through the method."""
+    sentinel = {"passed": 1, "failed": 0, "summary": "ok"}
+    monkeypatch.setattr(orchestrator_evolve, "evolve_run_tests", lambda _o: sentinel)
+    assert Orchestrator._evolve_run_tests(MagicMock()) is sentinel
+
+
+def test_run_ruff_check_returns_module_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ruff check output must be returned unchanged."""
+    sentinel: list[dict[str, Any]] = [{"code": "E501"}]
+    monkeypatch.setattr(orchestrator_evolve, "run_ruff_check", lambda _o: sentinel)
+    assert Orchestrator._run_ruff_check(MagicMock()) is sentinel

--- a/tests/unit/test_orchestrator_god_class_delegation.py
+++ b/tests/unit/test_orchestrator_god_class_delegation.py
@@ -25,7 +25,6 @@ from bernstein.core.orchestration import (
 )
 from bernstein.core.orchestration.orchestrator import Orchestrator
 
-
 # Each tuple is (method_name_on_class, module_level_function, module).
 #
 # These delegations were extracted from Orchestrator in audit-009 so the
@@ -99,7 +98,7 @@ def test_evolve_focus_areas_still_on_class() -> None:
 
 def test_replenish_constants_preserved() -> None:
     """Cooldown / max-task class constants stay on the class for back-compat."""
-    assert Orchestrator._REPLENISH_COOLDOWN_S == pytest.approx(60.0)
+    assert pytest.approx(60.0) == Orchestrator._REPLENISH_COOLDOWN_S
     assert Orchestrator._REPLENISH_MAX_TASKS == 5
 
 


### PR DESCRIPTION
Orchestrator had 4496 LOC of inline method bodies that were already
duplicated in orchestrator_evolve.py and orchestrator_cleanup.py as
free functions. Replace the inline bodies with thin delegators so the
module-level functions are the single source of truth.

Scope (narrow, per ticket warning about zombies from /003/008):
- Evolve subsystem: _check_evolve, _run_ruff_check, _create_ruff_tasks,
 _replenish_backlog, _run_pytest, _evolve_run_tests,
 _generate_evolve_commit_msg, _evolve_auto_commit, _evolve_spawn_manager,
 _log_evolve_cycle, make_evolution_loop, _run_evolution_cycle,
 _persist_pending_proposals.
- Cleanup subsystem: stop, is_shutting_down, _drain_before_cleanup,
 _save_session_state, _cleanup, _restart.

Out of scope (explicitly deferred by ticket risks section):
- __init__ decomposition.
- _generate_run_summary / _emit_summary_card (AUTO_PR branch still diverges
 from orchestrator_summary.py -- follow-up PR).

Preserved:
- All public method signatures on Orchestrator -- tests that call
 orch._check_evolve / orch._replenish_backlog / orch._save_session_state
 continue to work.
- Orchestrator._EVOLVE_FOCUS_AREAS ClassVar (tests read it).
- Orchestrator._REPLENISH_COOLDOWN_S / _REPLENISH_MAX_TASKS constants.

Result: orchestrator.py shrinks from 4496 → 3793 LOC (-703).

Part of batch-1 audit cleanup (12 parallel fixes). Some branches in this batch touch overlapping files (`orchestrator.py`, `src/bernstein/core/__init__.py`). Rebase conflicts expected; merging sequentially.