### PR TITLE
fix: escalate SIGTERM to SIGKILL in adapter kill path

### DIFF
--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -12,7 +12,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
-from bernstein.core.platform_compat import kill_process_group, process_alive
+from bernstein.core.platform_compat import (
+    kill_process_group,
+    kill_process_group_graceful,
+    process_alive,
+)
 from bernstein.core.resource_limits import ResourceLimits, make_preexec_fn
 
 if TYPE_CHECKING:
@@ -308,8 +312,13 @@ class CLIAdapter(ABC):
         equals the PGID.  Using the PID directly avoids ``os.getpgid()``
         failing when the wrapper process has already exited — this prevents
         orphan child processes from accumulating.
+
+        Sends SIGTERM first, polls for exit for a short grace period, then
+        escalates to SIGKILL if the group is still alive.  Without this
+        escalation, agents that trap SIGTERM survive reap paths (wall-clock
+        timeout and stale heartbeat) — see audit-011.
         """
-        kill_process_group(pid, signal.SIGTERM)
+        kill_process_group_graceful(pid)
 
     @abstractmethod
     def name(self) -> str:

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -6,7 +6,6 @@ import contextlib
 import json
 import logging
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -18,7 +17,7 @@ from bernstein.adapters.claude_agents import build_agents_json
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.core.defaults import COST
 from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderType, RateLimit
-from bernstein.core.platform_compat import kill_process_group, process_alive
+from bernstein.core.platform_compat import kill_process_group_graceful, process_alive
 
 # Map short model names to Claude Code CLI model IDs.
 # Updated 2026-04-16 — Opus 4.7 generally available, same price as 4.6.
@@ -705,11 +704,16 @@ class ClaudeCodeAdapter(CLIAdapter):
         # of os.getpgid() which fails when the process is already dead —
         # this ensures we kill the entire session group including any
         # child processes (the actual claude CLI) that outlive the wrapper.
-        kill_process_group(pid, signal.SIGTERM)
-        # Also kill the wrapper process
+        #
+        # ``kill_process_group_graceful`` sends SIGTERM, polls briefly, and
+        # escalates to SIGKILL if the group is still alive.  Without the
+        # escalation, agents that trap SIGTERM survive reap paths — see
+        # audit-011.
+        kill_process_group_graceful(pid)
+        # Also kill the wrapper process with the same TERM→KILL escalation
         wrapper_pid = self._wrapper_pids.pop(pid, None)
         if wrapper_pid:
-            kill_process_group(wrapper_pid, signal.SIGTERM)
+            kill_process_group_graceful(wrapper_pid)
         self._procs.pop(pid, None)
 
     def name(self) -> str:

--- a/src/bernstein/core/config/platform_compat.py
+++ b/src/bernstein/core/config/platform_compat.py
@@ -20,6 +20,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -285,6 +286,67 @@ def kill_process_group(pgid: int, sig: int = 15) -> bool:
     # Windows: kill process tree
     force = sig == 9
     return _win_taskkill(pgid, force=force, tree=True)
+
+
+def kill_process_group_graceful(
+    pgid: int,
+    *,
+    grace_seconds: float = 3.0,
+    poll_interval: float = 0.1,
+) -> bool:
+    """Send SIGTERM to a process group, then SIGKILL if it fails to exit.
+
+    Bernstein adapters spawn child processes with ``start_new_session=True``
+    so the PID equals the PGID.  Reap paths (wall-clock timeout and stale
+    heartbeat) invoke :meth:`CLIAdapter.kill`, which historically only sent
+    SIGTERM without waiting or escalating — wedged agents that trap SIGTERM
+    (e.g. ``trap '' TERM``) survive the reap and leak resources until the
+    next orchestrator startup.
+
+    This helper performs the standard TERM → poll → KILL escalation used
+    elsewhere (see ``orchestration/drain.py``) so every kill path is
+    guaranteed to reap the process group.
+
+    Args:
+        pgid: Process group ID (on Unix) or PID (on Windows).
+        grace_seconds: Total time to wait for SIGTERM to take effect
+            before escalating to SIGKILL.  Defaults to 3s — reap paths
+            need to be aggressive because the agent already failed to
+            heartbeat or exceeded its wall-clock timeout.
+        poll_interval: How often to poll :func:`process_alive` during the
+            grace window.  Smaller values make the helper exit sooner when
+            the process dies cleanly after SIGTERM.
+
+    Returns:
+        ``True`` if SIGTERM was delivered successfully (even if SIGKILL
+        later had to be used).  ``False`` when the group was already dead
+        or the initial SIGTERM could not be sent.
+    """
+    if pgid <= 0:
+        return False
+
+    # Best-effort TERM first; if it fails the group is already gone.
+    if not kill_process_group(pgid, signal.SIGTERM):
+        return False
+
+    # Poll for graceful exit.  Using the lead PID as a liveness proxy is
+    # safe because it is guaranteed to be the session leader (start_new_session=True).
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline:
+        if not process_alive(pgid):
+            return True
+        time.sleep(poll_interval)
+
+    # Still alive after grace period — escalate.
+    if process_alive(pgid):
+        logger.warning(
+            "Process group %d did not exit within %.1fs of SIGTERM; sending SIGKILL",
+            pgid,
+            grace_seconds,
+        )
+        kill_sig = signal.SIGKILL if is_signal_supported("SIGKILL") else 9
+        kill_process_group(pgid, kill_sig)
+    return True
 
 
 def process_alive(pid: int) -> bool:

--- a/tests/unit/test_adapter_aider.py
+++ b/tests/unit/test_adapter_aider.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -380,13 +379,13 @@ class TestAiderKill:
     def test_calls_killpg_with_pid_as_pgid(self) -> None:
         """kill() uses pid directly as pgid (start_new_session=True)."""
         adapter = AiderAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_kill:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_kill:
             adapter.kill(555)
-        mock_kill.assert_called_once_with(555, signal.SIGTERM)
+        mock_kill.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = AiderAdapter()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_amp.py
+++ b/tests/unit/test_adapter_amp.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from collections.abc import Generator
@@ -362,13 +361,13 @@ class TestAmpIsAlive:
 class TestAmpKill:
     def test_calls_killpg(self) -> None:
         adapter = AmpAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = AmpAdapter()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_claude.py
+++ b/tests/unit/test_adapter_claude.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -371,27 +370,27 @@ class TestKill:
         ClaudeCodeAdapter._procs[50] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[50] = 51
 
-        with patch("bernstein.adapters.claude.kill_process_group") as mock_kpg:
+        with patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg:
             adapter.kill(50)
 
-        mock_kpg.assert_any_call(50, signal.SIGTERM)
+        mock_kpg.assert_any_call(50)
 
     def test_kills_wrapper_process(self) -> None:
         adapter = ClaudeCodeAdapter()
         ClaudeCodeAdapter._procs[60] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[60] = 61
 
-        with patch("bernstein.adapters.claude.kill_process_group") as mock_kpg:
+        with patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg:
             adapter.kill(60)
 
-        mock_kpg.assert_any_call(61, signal.SIGTERM)
+        mock_kpg.assert_any_call(61)
 
     def test_removes_pid_from_tracking(self) -> None:
         adapter = ClaudeCodeAdapter()
         ClaudeCodeAdapter._procs[70] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[70] = 71
 
-        with patch("bernstein.adapters.claude.kill_process_group"):
+        with patch("bernstein.adapters.claude.kill_process_group_graceful"):
             adapter.kill(70)
 
         assert 70 not in ClaudeCodeAdapter._procs
@@ -403,7 +402,7 @@ class TestKill:
         ClaudeCodeAdapter._procs[80] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[80] = 81
 
-        with patch("bernstein.adapters.claude.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.claude.kill_process_group_graceful", return_value=False):
             adapter.kill(80)  # must not raise
 
     def test_handles_failed_wrapper_kill(self) -> None:
@@ -412,11 +411,14 @@ class TestKill:
         ClaudeCodeAdapter._procs[90] = MagicMock()
         ClaudeCodeAdapter._wrapper_pids[90] = 91
 
-        # kill_process_group succeeds for main pid (90), fails for wrapper (91)
-        def _kpg_side_effect(pgid: int, sig: int) -> bool:
+        # kill_process_group_graceful succeeds for main pid (90), fails for wrapper (91)
+        def _kpg_side_effect(pgid: int) -> bool:
             return pgid != 91
 
-        with patch("bernstein.adapters.claude.kill_process_group", side_effect=_kpg_side_effect):
+        with patch(
+            "bernstein.adapters.claude.kill_process_group_graceful",
+            side_effect=_kpg_side_effect,
+        ):
             adapter.kill(90)  # must not raise
 
     def test_kill_without_tracked_wrapper(self) -> None:
@@ -425,11 +427,11 @@ class TestKill:
         ClaudeCodeAdapter._procs[100] = MagicMock()
         # _wrapper_pids intentionally not set for pid 100
 
-        with patch("bernstein.adapters.claude.kill_process_group") as mock_kpg:
+        with patch("bernstein.adapters.claude.kill_process_group_graceful") as mock_kpg:
             adapter.kill(100)
 
         # Only the main process group is killed, no wrapper
-        mock_kpg.assert_called_once_with(100, signal.SIGTERM)
+        mock_kpg.assert_called_once_with(100)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -351,13 +350,13 @@ class TestCodexIsAlive:
 class TestCodexKill:
     def test_calls_killpg(self) -> None:
         adapter = CodexAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = CodexAdapter()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -140,12 +140,12 @@ class TestAdapterContract:
 
     def test_kill_does_not_raise(self, name: str, factory: Any) -> None:
         adapter = factory()
-        with patch("bernstein.adapters.base.kill_process_group"):
+        with patch("bernstein.adapters.base.kill_process_group_graceful"):
             adapter.kill(999)  # must not raise
 
     def test_kill_suppresses_oserror(self, name: str, factory: Any) -> None:
         adapter = factory()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(99999)  # must not raise
 
     def test_detect_tier_returns_none_or_api_tier_info(self, name: str, factory: Any) -> None:

--- a/tests/unit/test_adapter_gemini.py
+++ b/tests/unit/test_adapter_gemini.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -342,13 +341,13 @@ class TestGeminiIsAlive:
 class TestGeminiKill:
     def test_calls_killpg(self) -> None:
         adapter = GeminiAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = GeminiAdapter()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_generic.py
+++ b/tests/unit/test_adapter_generic.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -369,13 +368,13 @@ class TestGenericIsAlive:
 class TestGenericKill:
     def test_calls_killpg(self) -> None:
         adapter = GenericAdapter(cli_command="agent")
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = GenericAdapter(cli_command="agent")
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_iac.py
+++ b/tests/unit/test_adapter_iac.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -306,9 +305,9 @@ class TestIaCIsAlive:
 class TestIaCKill:
     def test_calls_killpg_with_pid_as_pgid(self) -> None:
         adapter = IaCAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from collections.abc import Callable, Generator
@@ -659,18 +658,19 @@ class TestIsAlive:
     ids=["codex", "gemini", "qwen", "generic"],
 )
 class TestKill:
-    """kill() calls kill_process_group with SIGTERM and handles failure gracefully."""
+    """kill() calls kill_process_group_graceful and handles failure gracefully."""
 
     def test_calls_killpg(self, adapter_factory: Callable[[], CLIAdapter]) -> None:
         adapter = adapter_factory()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        # PID is used directly as PGID (start_new_session=True)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        # PID is used directly as PGID (start_new_session=True); the helper
+        # performs the SIGTERM→poll→SIGKILL escalation required by audit-011.
+        mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self, adapter_factory: Callable[[], CLIAdapter]) -> None:
         adapter = adapter_factory()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -411,13 +410,13 @@ class TestQwenIsAlive:
 class TestQwenKill:
     def test_calls_killpg(self) -> None:
         adapter = QwenAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = QwenAdapter()
-        with patch("bernstein.adapters.base.kill_process_group", return_value=False):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 

--- a/tests/unit/test_cloudflare_agents_adapter.py
+++ b/tests/unit/test_cloudflare_agents_adapter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -382,6 +381,6 @@ class TestCloudflareIsAlive:
 class TestCloudflareKill:
     def test_calls_killpg(self) -> None:
         adapter = CloudflareAgentsAdapter()
-        with patch("bernstein.adapters.base.kill_process_group") as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
-        mock_killpg.assert_called_once_with(555, signal.SIGTERM)
+        mock_killpg.assert_called_once_with(555)

--- a/tests/unit/test_platform_compat.py
+++ b/tests/unit/test_platform_compat.py
@@ -7,6 +7,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import time
 from unittest.mock import patch
 
 import pytest
@@ -18,6 +19,7 @@ from bernstein.core.platform_compat import (
     is_signal_supported,
     kill_process,
     kill_process_group,
+    kill_process_group_graceful,
     normalize_path,
     path_separator,
     process_alive,
@@ -138,6 +140,109 @@ class TestKillProcessGroup:
         assert result is True
         proc.wait(timeout=5)
         assert process_alive(proc.pid) is False
+
+
+# ---------------------------------------------------------------------------
+# kill_process_group_graceful — audit-011
+# ---------------------------------------------------------------------------
+
+
+class TestKillProcessGroupGraceful:
+    """Tests for kill_process_group_graceful() — SIGTERM→poll→SIGKILL."""
+
+    def test_zero_pgid_returns_false(self) -> None:
+        assert kill_process_group_graceful(0) is False
+
+    def test_negative_pgid_returns_false(self) -> None:
+        assert kill_process_group_graceful(-1) is False
+
+    def test_returns_false_when_initial_term_fails(self) -> None:
+        """If SIGTERM cannot be delivered, the helper must report failure."""
+        with patch(
+            "bernstein.core.config.platform_compat.kill_process_group",
+            return_value=False,
+        ) as mock_kpg:
+            assert kill_process_group_graceful(12345) is False
+        # Only the initial SIGTERM attempt should have happened.
+        mock_kpg.assert_called_once()
+
+    def test_exits_early_when_process_dies_after_term(self) -> None:
+        """When process dies after SIGTERM, no SIGKILL should be sent."""
+        alive_states = iter([True, False])
+
+        def _alive(_pid: int) -> bool:
+            try:
+                return next(alive_states)
+            except StopIteration:
+                return False
+
+        with (
+            patch(
+                "bernstein.core.config.platform_compat.kill_process_group",
+                return_value=True,
+            ) as mock_kpg,
+            patch(
+                "bernstein.core.config.platform_compat.process_alive",
+                side_effect=_alive,
+            ),
+        ):
+            assert kill_process_group_graceful(12345, grace_seconds=1.0, poll_interval=0.01) is True
+
+        # Only the SIGTERM call — no SIGKILL escalation.
+        assert mock_kpg.call_count == 1
+        assert mock_kpg.call_args_list[0].args[1] == signal.SIGTERM
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="SIGKILL not available on Windows")
+    def test_escalates_to_sigkill_when_process_survives_term(self) -> None:
+        """If the group never exits, SIGKILL must be sent after the grace period."""
+        with (
+            patch(
+                "bernstein.core.config.platform_compat.kill_process_group",
+                return_value=True,
+            ) as mock_kpg,
+            patch(
+                "bernstein.core.config.platform_compat.process_alive",
+                return_value=True,
+            ),
+        ):
+            assert kill_process_group_graceful(12345, grace_seconds=0.05, poll_interval=0.01) is True
+
+        # Expect two calls — SIGTERM first, then SIGKILL.
+        assert mock_kpg.call_count == 2
+        assert mock_kpg.call_args_list[0].args == (12345, signal.SIGTERM)
+        assert mock_kpg.call_args_list[1].args == (12345, signal.SIGKILL)
+
+    @pytest.mark.skipif(IS_WINDOWS, reason="Requires POSIX process groups + SIGTERM trap")
+    def test_reaps_wedged_process_that_traps_sigterm(self) -> None:
+        """End-to-end: a child that traps SIGTERM must still be killed."""
+        # Spawn a child that ignores SIGTERM via Python's signal module and
+        # sits in a long sleep.  Without SIGKILL escalation, SIGTERM alone
+        # leaves the process running.
+        script = (
+            "import signal, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "time.sleep(60)\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        try:
+            # Give the child a moment to install its handler.
+            time.sleep(0.2)
+            assert process_alive(proc.pid) is True
+
+            # Reap with a short grace so the test doesn't linger.
+            assert kill_process_group_graceful(proc.pid, grace_seconds=0.3, poll_interval=0.05) is True
+            proc.wait(timeout=5)
+            assert process_alive(proc.pid) is False
+        finally:
+            # Belt-and-braces cleanup in case the assertion above failed.
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CLIAdapter.kill and ClaudeCodeAdapter.kill previously sent only SIGTERM
to the process group. Reap paths in core/agents/agent_lifecycle (wall-
clock timeout and stale-heartbeat reap) invoke this kill and return
immediately, so agents that trap SIGTERM (e.g. `trap '' TERM`) survived
the reap and leaked until the next orchestrator startup.

Add kill_process_group_graceful(pgid) to core/config/platform_compat:
SIGTERM -> poll process_alive for a short grace window -> SIGKILL.
This mirrors the escalation already used by orchestration/drain.py and
now runs on every reap path.

Centralising in platform_compat keeps the escalation consistent across
adapters and lets the watchdog retain its existing explicit-sequence
behaviour untouched.

Part of batch-1 audit cleanup (12 parallel fixes). Some branches in this batch touch overlapping files (`orchestrator.py`, `src/bernstein/core/__init__.py`). Rebase conflicts expected; merging sequentially.