### PR TITLE
security(pii): dedup on (rule, span) not rule alone

### DIFF
--- a/src/bernstein/core/security/pii_output_gate.py
+++ b/src/bernstein/core/security/pii_output_gate.py
@@ -246,6 +246,25 @@ def _is_allowlisted(line: str, allowlist_prefixes: list[str] | None = None) -> b
     return any(p.search(line) for p in _ALLOWLIST_PATTERNS) or _contains_allowlist_prefix(line, allowlist_prefixes)
 
 
+def _passes_rule_filters(
+    rule_label: str,
+    m: re.Match[str],
+) -> bool:
+    """Return True if a match survives rule-specific post-filters.
+
+    Some rules (credit cards, high-entropy assignments) have additional checks
+    beyond the regex itself. This is split from the matching step so callers can
+    iterate multiple matches per line and still apply the filters per-match.
+    """
+    if rule_label == "credit_card_number" and not _looks_like_credit_card(m.group(0)):
+        return False
+    if rule_label == "high_entropy_assignment":
+        value = m.group(1) if m.lastindex and m.lastindex >= 1 else m.group(0)
+        if not _has_mixed_case_and_digits(value):
+            return False
+    return True
+
+
 def _check_rule_match(
     rule_label: str,
     pattern: re.Pattern[str],
@@ -253,18 +272,12 @@ def _check_rule_match(
 ) -> re.Match[str] | None:
     """Check a single rule against a line, applying rule-specific filters.
 
-    Returns the match object if the rule fires, or None if it does not apply.
+    Returns the first match that passes rule-specific filters, or None.
     """
-    m = pattern.search(line)
-    if not m:
-        return None
-    if rule_label == "credit_card_number" and not _looks_like_credit_card(m.group(0)):
-        return None
-    if rule_label == "high_entropy_assignment":
-        value = m.group(1) if m.lastindex and m.lastindex >= 1 else m.group(0)
-        if not _has_mixed_case_and_digits(value):
-            return None
-    return m
+    for m in pattern.finditer(line):
+        if _passes_rule_filters(rule_label, m):
+            return m
+    return None
 
 
 def _build_redacted_excerpt(line: str, m: re.Match[str]) -> str:
@@ -283,30 +296,39 @@ def _build_redacted_excerpt(line: str, m: re.Match[str]) -> str:
 def _scan_line(
     line: str,
     line_num: int,
-    seen_rules: set[str],
+    seen_matches: set[tuple[str, int, int, int]],
     allowlist_prefixes: list[str] | None,
     findings: list[SecretFinding],
 ) -> None:
-    """Scan a single line against all secret rules, appending any findings."""
+    """Scan a single line against all secret rules, appending any findings.
+
+    Deduplication keys on ``(rule, line_num, match_start, match_end)`` so that
+    multiple distinct secrets of the same rule (e.g. two different AWS keys) are
+    each reported, while exact duplicates (same rule hitting the same span —
+    possible if scans ever overlap) are not counted twice. This prevents the
+    scanner-evasion bug where a single rule's dedup would silently drop the
+    second/third secret of the same type (audit-044).
+    """
     if _is_allowlisted(line, allowlist_prefixes):
         return
     for rule_label, pattern, severity, description in _SECRET_RULES:
-        if rule_label in seen_rules:
-            continue
-        m = _check_rule_match(rule_label, pattern, line)
-        if m is None:
-            continue
-        redacted = _build_redacted_excerpt(line, m)
-        findings.append(
-            SecretFinding(
-                rule=rule_label,
-                severity=severity,
-                line_number=line_num,
-                redacted_match=redacted,
-                description=description,
+        for m in pattern.finditer(line):
+            if not _passes_rule_filters(rule_label, m):
+                continue
+            match_key = (rule_label, line_num, m.start(), m.end())
+            if match_key in seen_matches:
+                continue
+            redacted = _build_redacted_excerpt(line, m)
+            findings.append(
+                SecretFinding(
+                    rule=rule_label,
+                    severity=severity,
+                    line_number=line_num,
+                    redacted_match=redacted,
+                    description=description,
+                )
             )
-        )
-        seen_rules.add(rule_label)
+            seen_matches.add(match_key)
 
 
 def scan_text(
@@ -331,10 +353,10 @@ def scan_text(
         return []
 
     findings: list[SecretFinding] = []
-    seen_rules: set[str] = set()
+    seen_matches: set[tuple[str, int, int, int]] = set()
 
     for line_num, line in enumerate(text.splitlines(), start=1):
-        _scan_line(line, line_num, seen_rules, allowlist_prefixes, findings)
+        _scan_line(line, line_num, seen_matches, allowlist_prefixes, findings)
 
     return findings
 
@@ -357,7 +379,7 @@ def scan_diff(
         List of SecretFinding objects found in added lines.
     """
     findings: list[SecretFinding] = []
-    seen_rules: set[str] = set()
+    seen_matches: set[tuple[str, int, int, int]] = set()
     diff_line_num = 0
 
     for raw_line in diff_text.splitlines():
@@ -368,7 +390,7 @@ def scan_diff(
             continue
 
         line = raw_line[1:]  # strip the leading "+"
-        _scan_line(line, diff_line_num, seen_rules, allowlist_prefixes, findings)
+        _scan_line(line, diff_line_num, seen_matches, allowlist_prefixes, findings)
 
     return findings
 

--- a/tests/unit/test_pii_output_gate.py
+++ b/tests/unit/test_pii_output_gate.py
@@ -233,11 +233,80 @@ class TestFindingProperties:
         assert "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ" not in gh.redacted_match
         assert "***" in gh.redacted_match
 
-    def test_each_rule_fires_at_most_once(self) -> None:
+    def test_same_rule_fires_for_each_distinct_match(self) -> None:
+        """Regression for audit-044: the scanner used to dedup per rule_id,
+        silently dropping the second secret of the same type. A rule must now
+        fire once per distinct (rule, line, span) match."""
         text = "key1@real.com\nkey2@real.com\n"
         findings = scan_text(text)
         email_findings = [f for f in findings if f.rule == "email_address"]
-        assert len(email_findings) <= 1
+        assert len(email_findings) == 2
+        assert {f.line_number for f in email_findings} == {1, 2}
+
+    def test_duplicate_identical_line_deduped(self) -> None:
+        """Exact same span on the same line must not be reported twice —
+        ``(rule, line_num, start, end)`` dedup still applies."""
+        text = "alert@real.com"
+        findings = scan_text(text)
+        email_findings = [f for f in findings if f.rule == "email_address"]
+        assert len(email_findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# audit-044 regression: per-rule dedup must not swallow distinct secrets
+# ---------------------------------------------------------------------------
+
+
+class TestAudit044PerRuleDedup:
+    """Regression tests for audit-044.
+
+    Prior to the fix, ``_scan_line`` skipped any rule after its first hit
+    (``if rule_label in seen_rules: continue``), so a file with two different
+    AWS keys or two different credit-card numbers would report only one —
+    scanner evasion. Dedup now keys on ``(rule, line_num, span)`` instead.
+    """
+
+    def test_two_distinct_aws_keys_both_reported(self) -> None:
+        text = 'honeypot = "AKIAIOSFODNN7EXAMPLE"\nreal = "AKIAI44QH8DHBEXAMPLE"\n'
+        findings = scan_text(text)
+        aws = [f for f in findings if f.rule == "aws_access_key"]
+        assert len(aws) == 2, f"expected 2 aws_access_key findings, got {len(aws)}: {aws}"
+        assert {f.line_number for f in aws} == {1, 2}
+
+    def test_two_distinct_credit_cards_both_reported(self) -> None:
+        # Two different Luhn-valid numbers on separate lines.
+        text = "card_a = '4111 1111 1111 1111'\ncard_b = '5500 0000 0000 0004'\n"
+        findings = scan_text(text)
+        cards = [f for f in findings if f.rule == "credit_card_number"]
+        assert len(cards) == 2, f"expected 2 credit_card_number findings, got {len(cards)}: {cards}"
+        assert {f.line_number for f in cards} == {1, 2}
+
+    def test_two_distinct_github_tokens_both_reported(self) -> None:
+        text = 'a = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"\nb = "ghp_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"\n'
+        findings = scan_text(text)
+        toks = [f for f in findings if f.rule == "github_token"]
+        assert len(toks) == 2
+        assert {f.line_number for f in toks} == {1, 2}
+
+    def test_two_distinct_aws_keys_on_same_line_both_reported(self) -> None:
+        """Even on the same line, two distinct matches (different spans) fire."""
+        text = 'pair = ("AKIAIOSFODNN7EXAMPLE", "AKIAI44QH8DHBEXAMPLE")'
+        findings = scan_text(text)
+        aws = [f for f in findings if f.rule == "aws_access_key"]
+        assert len(aws) == 2
+
+    def test_diff_with_two_distinct_aws_keys_both_reported(self) -> None:
+        diff = (
+            "--- a/config.py\n"
+            "+++ b/config.py\n"
+            "@@ -1,1 +1,3 @@\n"
+            ' previous = "AKIAI44QH8DHBEXAMPLE"\n'
+            '+honeypot = "AKIAIOSFODNN7EXAMPLE"\n'
+            '+real = "AKIAI44QH8DHBPREVIEW"\n'
+        )
+        findings = scan_diff(diff)
+        aws = [f for f in findings if f.rule == "aws_access_key"]
+        assert len(aws) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes scanner-evasion bug in `pii_output_gate`: dedup was keyed by `rule_id` alone, so files with two different AWS keys / GitHub tokens / credit cards only reported one finding, letting a real secret hide behind a decoy of the same type.
- Dedup key is now `(rule, line_number, match_start, match_end)`, preserving dedup of exact re-scans while surfacing each distinct span.
- Adds `TestAudit044PerRuleDedup` regression class covering two AWS keys (different lines), two credit cards, two GitHub tokens, two AWS keys on the same line, and diff input with two AWS keys.

## Test plan
- [x] `uv run ruff check src/bernstein/core/security/pii_output_gate.py tests/unit/test_pii_output_gate.py` — passes
- [x] `uv run ruff format --check ...` — both files already formatted
- [x] `uv run pytest tests/unit/test_pii_output_gate.py -x -q` — 58 passed