### PR TITLE
fix(tasks): claim_by_id rejects double-claim

### DIFF
--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -946,8 +946,9 @@ class TaskStore:
 
         Raises:
             KeyError: If task_id does not exist.
-            ValueError: If expected_version doesn't match (CAS conflict) or
-                if agent_role doesn't match task role.
+            ValueError: If expected_version doesn't match (CAS conflict),
+                if agent_role doesn't match task role, or if the task is
+                not in an OPEN state (already claimed / in progress / terminal).
         """
         async with self._lock:
             task = self._tasks.get(task_id)
@@ -961,20 +962,28 @@ class TaskStore:
                 raise ValueError(
                     f"role mismatch: task {task_id} requires role '{task.role}', agent has role '{agent_role}'"
                 )
-            if task.status == TaskStatus.OPEN:
-                if not self._dependencies_satisfied(task):
-                    raise ValueError(f"task {task_id} has unresolved dependencies")
-                # TASK-003: file ownership overlap check
-                overlap_msg = self._check_file_ownership_overlap(task)
-                if overlap_msg is not None:
-                    raise ValueError(overlap_msg)
-                self._index_remove(task)
-                transition_task(task, TaskStatus.CLAIMED, actor="task_store", reason="claim_by_id")
-                task.claimed_at = time.time()
-                task.claimed_by_session = claimed_by_session
-                task.version += 1
-                self._index_add(task)
-                await self._append_jsonl(self._task_to_record(task))
+            if task.status != TaskStatus.OPEN:
+                # audit-014: never silently re-return an already-claimed or
+                # terminal task — that enables double-claim. Raise so the
+                # HTTP layer can map it to 409 Conflict.
+                raise ValueError(
+                    f"task {task_id} is not open (status={task.status.value}); "
+                    f"cannot claim (already claimed by session "
+                    f"{task.claimed_by_session!r})"
+                )
+            if not self._dependencies_satisfied(task):
+                raise ValueError(f"task {task_id} has unresolved dependencies")
+            # TASK-003: file ownership overlap check
+            overlap_msg = self._check_file_ownership_overlap(task)
+            if overlap_msg is not None:
+                raise ValueError(overlap_msg)
+            self._index_remove(task)
+            transition_task(task, TaskStatus.CLAIMED, actor="task_store", reason="claim_by_id")
+            task.claimed_at = time.time()
+            task.claimed_by_session = claimed_by_session
+            task.version += 1
+            self._index_add(task)
+            await self._append_jsonl(self._task_to_record(task))
             return task
 
     async def claim_batch(

--- a/tests/unit/test_claim_by_id_double_claim.py
+++ b/tests/unit/test_claim_by_id_double_claim.py
@@ -1,0 +1,112 @@
+"""Regression tests for audit-014: claim_by_id must reject double-claim.
+
+Before the fix, ``TaskStore.claim_by_id`` silently returned the unchanged
+Task when it was already CLAIMED (or in any non-OPEN state), which let two
+agents each receive a "successful" claim for the same task and run in
+parallel on the same files.  The fix makes ``claim_by_id`` raise
+``ValueError`` (matching the CAS / role-mismatch contract) so the HTTP
+layer can return 409 Conflict to the second caller.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from bernstein.core.models import TaskStatus
+from bernstein.core.task_store import TaskStore
+
+
+def _task_request(
+    *,
+    title: str = "Implement parser",
+    description: str = "Write the parser module.",
+    role: str = "backend",
+    priority: int = 1,
+    scope: str = "medium",
+    complexity: str = "medium",
+    depends_on: list[str] | None = None,
+) -> Any:
+    """Build a TaskCreate-shaped request object for TaskStore.create."""
+    return SimpleNamespace(
+        title=title,
+        description=description,
+        role=role,
+        priority=priority,
+        scope=scope,
+        complexity=complexity,
+        estimated_minutes=30,
+        depends_on=depends_on or [],
+        owned_files=[],
+        cell_id=None,
+        task_type="standard",
+        upgrade_details=None,
+        model=None,
+        effort=None,
+        batch_eligible=False,
+        completion_signals=[],
+        slack_context=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_rejects_second_claim_when_already_claimed(
+    tmp_path: Path,
+) -> None:
+    """audit-014: the second claim on an already-claimed task must raise.
+
+    Previously claim_by_id silently returned the unchanged Task, enabling
+    two agents to believe they both owned the same work.
+    """
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+    task = await store.create(_task_request())
+
+    first = await store.claim_by_id(task.id, claimed_by_session="agent-alpha")
+    assert first.status == TaskStatus.CLAIMED
+    assert first.claimed_by_session == "agent-alpha"
+    first_version = first.version
+
+    # A second agent must not be able to silently "claim" the same task.
+    with pytest.raises(ValueError, match="not open"):
+        await store.claim_by_id(task.id, claimed_by_session="agent-beta")
+
+    # Task must remain owned by the original claimant and untouched.
+    stored = store.get_task(task.id)
+    assert stored is not None
+    assert stored.status == TaskStatus.CLAIMED
+    assert stored.claimed_by_session == "agent-alpha"
+    assert stored.version == first_version
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_rejects_claim_on_terminal_task(tmp_path: Path) -> None:
+    """A completed task must not be re-claimable through claim_by_id."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+    task = await store.create(_task_request())
+
+    await store.claim_by_id(task.id, claimed_by_session="agent-alpha")
+    await store.complete(task.id, "done")
+
+    with pytest.raises(ValueError, match="not open"):
+        await store.claim_by_id(task.id, claimed_by_session="agent-beta")
+
+    stored = store.get_task(task.id)
+    assert stored is not None
+    assert stored.status == TaskStatus.DONE
+
+
+@pytest.mark.anyio
+async def test_claim_by_id_double_claim_error_names_status(tmp_path: Path) -> None:
+    """The raised error should surface the current task status for diagnostics."""
+    store = TaskStore(tmp_path / "runtime" / "tasks.jsonl")
+    task = await store.create(_task_request())
+    await store.claim_by_id(task.id, claimed_by_session="agent-alpha")
+
+    with pytest.raises(ValueError) as exc_info:
+        await store.claim_by_id(task.id, claimed_by_session="agent-beta")
+
+    message = str(exc_info.value)
+    assert task.id in message
+    assert "claimed" in message

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1524,16 +1524,22 @@ async def test_claim_by_id_unknown_task(client: AsyncClient) -> None:
 
 @pytest.mark.anyio
 async def test_claim_by_id_already_claimed(client: AsyncClient) -> None:
-    """Claiming an already-claimed task still returns the task."""
+    """Claiming an already-claimed task returns 409 Conflict (audit-014).
+
+    Previously the server silently re-returned the unchanged task,
+    enabling double-claim — two agents both believed they owned the
+    same task. The second claim must now fail with 409.
+    """
     create_resp = await client.post("/tasks", json=TASK_PAYLOAD)
     task_id = create_resp.json()["id"]
 
-    await client.post(f"/tasks/{task_id}/claim")
+    first = await client.post(f"/tasks/{task_id}/claim")
+    assert first.status_code == 200
+    assert first.json()["status"] == "claimed"
+
     resp = await client.post(f"/tasks/{task_id}/claim")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["id"] == task_id
-    assert data["status"] == "claimed"
+    assert resp.status_code == 409
+    assert "not open" in resp.json()["detail"]
 
 
 # -- POST /tasks/claim-batch ------------------------------------------------


### PR DESCRIPTION
## Summary

`TaskStore.claim_by_id` silently returned the unchanged `Task` whenever the task was not in `OPEN` state. Two agents posting `POST /tasks/{id}/claim` concurrently both received `200 OK` with `status=claimed`, each believing they owned the task, and ran in parallel against the same files.

The fix makes `claim_by_id` raise `ValueError` when the task is not `OPEN`, matching the existing contract for CAS/role-mismatch. The HTTP route already maps `ValueError` to `409 Conflict`, so the second caller now gets a proper conflict response.

## What changed

- `src/bernstein/core/tasks/task_store_core.py` — flip the `if status == OPEN` guard into an early `raise ValueError` on non-OPEN; error message names the current status and the prior claimant's session.
- `tests/unit/test_server.py::test_claim_by_id_already_claimed` — updated to assert `409 Conflict` and `"not open"` in detail (was asserting silent 200).
- `tests/unit/test_claim_by_id_double_claim.py` — new regression suite:
 - second claim on an already-claimed task raises and leaves the first claimant's ownership intact
 - claim on a terminal (done) task raises
 - error message exposes task id and current status for diagnostics

The auto-claim sites in `/complete` and `/fail` (task_crud.py lines 705, 766) are gated on `status == "open"`, so they are unaffected by the behavior change.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` on the three files
- [x] `uv run pytest tests/unit/test_claim_by_id_double_claim.py tests/unit/test_server.py -x -q` — 123 passed in 22.6s
- [ ] CI green on PR