### PR TITLE
fix(persistence): close uncommitted WAL entries on recovery

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1710,6 +1710,32 @@ class Orchestrator:
         # so a fresh agent can resume them (audit-001 fix part b).
         preserved_paths = self._preserve_prior_worktrees_with_wip()
 
+        # Close every prior-run WAL we observed so future boots do not
+        # re-scan the same uncommitted entries forever (audit-072).
+        # We close the union of run_ids that held uncommitted entries and
+        # run_ids that held orphaned claims -- in practice these are the
+        # only WALs whose entries were returned by the scan helpers.
+        closed_run_ids = sorted({r for r, _ in uncommitted} | {r for r, _ in orphaned})
+        for closed_run_id in closed_run_ids:
+            run_uncommitted = sum(1 for r, _ in uncommitted if r == closed_run_id)
+            run_orphaned = sum(1 for r, _ in orphaned if r == closed_run_id)
+            try:
+                WALRecovery.close_wal(
+                    closed_run_id,
+                    sdd_dir,
+                    reason="recovered_by_orchestrator",
+                    uncommitted_count=run_uncommitted,
+                    orphaned_count=run_orphaned,
+                )
+            except OSError as exc:
+                # Never block orchestrator startup on marker write failure;
+                # next boot will simply re-run recovery for this WAL.
+                logger.warning(
+                    "WAL recovery: failed to write .closed marker for run=%s: %s",
+                    closed_run_id,
+                    exc,
+                )
+
         self._recorder.record(
             "wal_recovery",
             uncommitted_count=len(uncommitted),
@@ -1717,6 +1743,7 @@ class Orchestrator:
             retried_count=retried,
             preserved_worktrees=[str(p) for p in preserved_paths],
             run_ids=sorted({r for r, _ in uncommitted}),
+            closed_run_ids=closed_run_ids,
         )
         if retried:
             logger.warning(

--- a/src/bernstein/core/persistence/wal.py
+++ b/src/bernstein/core/persistence/wal.py
@@ -294,6 +294,12 @@ class WALRecovery:
         for entry in recovery.get_uncommitted_entries():
             # re-execute or quarantine
             ...
+        WALRecovery.close_wal(run_id, sdd_dir, reason="recovered")
+
+    Once ``close_wal`` has been called, subsequent scans (via
+    :meth:`scan_all_uncommitted` / :meth:`find_orphaned_claims`) skip the
+    WAL so the same uncommitted entries are not re-reported forever
+    (audit-072).
     """
 
     def __init__(self, run_id: str, sdd_dir: Path) -> None:
@@ -309,6 +315,74 @@ class WALRecovery:
         except FileNotFoundError:
             return []
 
+    # ------------------------------------------------------------------
+    # Closed-WAL sidecar marker (audit-072)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _closed_marker_path(run_id: str, sdd_dir: Path) -> Path:
+        """Return the ``.closed`` sidecar marker path for *run_id*."""
+        return sdd_dir / "runtime" / "wal" / f"{run_id}.wal.closed"
+
+    @staticmethod
+    def is_wal_closed(run_id: str, sdd_dir: Path) -> bool:
+        """Return True when a ``.closed`` marker exists for *run_id*.
+
+        A closed marker signals that a previous recovery cycle has
+        already observed and handled every uncommitted entry in the
+        corresponding WAL — future scans must skip it to prevent
+        unbounded re-scanning of the same entries (audit-072).
+        """
+        return WALRecovery._closed_marker_path(run_id, sdd_dir).exists()
+
+    @staticmethod
+    def close_wal(
+        run_id: str,
+        sdd_dir: Path,
+        *,
+        reason: str = "recovered",
+        uncommitted_count: int = 0,
+        orphaned_count: int = 0,
+    ) -> Path:
+        """Write a ``.closed`` sidecar marker next to ``{run_id}.wal.jsonl``.
+
+        After this call, :meth:`scan_all_uncommitted` and
+        :meth:`find_orphaned_claims` will skip ``run_id`` on every
+        subsequent invocation.  The marker is a small JSON document
+        recording when and why the WAL was closed so operators can audit
+        recovery history.
+
+        The write is ``fsync``'d to guarantee that a crash immediately
+        after recovery cannot undo the close (which would reintroduce
+        the unbounded re-scan bug).
+
+        Args:
+            run_id: Run ID whose WAL is being closed.
+            sdd_dir: The ``.sdd`` directory root.
+            reason: Free-form string recorded in the marker body.
+            uncommitted_count: Number of uncommitted entries that were
+                observed during recovery (for audit trail).
+            orphaned_count: Number of orphaned claims that were observed
+                during recovery (for audit trail).
+
+        Returns:
+            Path to the ``.closed`` marker.
+        """
+        marker = WALRecovery._closed_marker_path(run_id, sdd_dir)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "run_id": run_id,
+            "closed_at": time.time(),
+            "reason": reason,
+            "uncommitted_count": int(uncommitted_count),
+            "orphaned_count": int(orphaned_count),
+        }
+        with marker.open("w") as f:
+            f.write(json.dumps(payload, separators=(",", ":")))
+            f.flush()
+            os.fsync(f.fileno())
+        return marker
+
     @staticmethod
     def scan_all_uncommitted(
         sdd_dir: Path,
@@ -318,8 +392,11 @@ class WALRecovery:
         """Scan all WAL files for uncommitted entries from previous runs.
 
         Iterates over every ``*.wal.jsonl`` file in the WAL directory, skipping
-        *exclude_run_id* (typically the current run). Returns a flat list of
-        ``(run_id, WALEntry)`` pairs for every entry with ``committed=False``.
+        *exclude_run_id* (typically the current run) and any WAL whose
+        ``.closed`` sidecar marker is present (audit-072 — prevents
+        unbounded re-scanning of already-recovered WALs). Returns a flat
+        list of ``(run_id, WALEntry)`` pairs for every entry with
+        ``committed=False``.
 
         Returns an empty list when the WAL directory does not exist (fresh
         project with no prior runs).
@@ -339,6 +416,8 @@ class WALRecovery:
         for wal_file in sorted(wal_dir.glob("*.wal.jsonl")):
             run_id = wal_file.name.removesuffix(".wal.jsonl")
             if run_id == exclude_run_id:
+                continue
+            if WALRecovery.is_wal_closed(run_id, sdd_dir):
                 continue
             recovery = WALRecovery(run_id=run_id, sdd_dir=sdd_dir)
             for entry in recovery.get_uncommitted_entries():
@@ -361,6 +440,9 @@ class WALRecovery:
         task would otherwise sit in *claimed* forever (or be abandoned by
         ``_reconcile_claimed_tasks`` without a dedicated retry audit trail).
 
+        WALs with a ``.closed`` sidecar marker are skipped (audit-072) so
+        that orphans handled by a prior recovery are not retried forever.
+
         Args:
             sdd_dir: The ``.sdd`` directory root.
             exclude_run_id: Run ID to skip (the in-progress run).
@@ -376,6 +458,8 @@ class WALRecovery:
         for wal_file in sorted(wal_dir.glob("*.wal.jsonl")):
             run_id = wal_file.name.removesuffix(".wal.jsonl")
             if run_id == exclude_run_id:
+                continue
+            if WALRecovery.is_wal_closed(run_id, sdd_dir):
                 continue
             reader = WALReader(run_id=run_id, sdd_dir=sdd_dir)
             try:

--- a/tests/unit/test_wal.py
+++ b/tests/unit/test_wal.py
@@ -651,3 +651,142 @@ class TestWALRecoveryScanAll:
         task_ids = [e.inputs["task_id"] for _, e in result]
         assert "T-1" in task_ids
         assert "T-2" in task_ids
+
+
+# ---------------------------------------------------------------------------
+# TestWALRecoveryClosedMarker (audit-072)
+# ---------------------------------------------------------------------------
+
+
+class TestWALRecoveryClosedMarker:
+    """Tests for the ``.closed`` sidecar marker (audit-072).
+
+    Regression: without a close step, every previous run's uncommitted
+    entries are re-returned on every boot, growing unboundedly.  After
+    recovery the orchestrator MUST write a ``.closed`` marker so that
+    subsequent scans skip the WAL.
+    """
+
+    def test_is_wal_closed_false_without_marker(self, tmp_path: Path) -> None:
+        """Fresh WAL with no sidecar is not closed."""
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+        w = WALWriter(run_id="r-1", sdd_dir=sdd)
+        w.append("d", {}, {}, "a", committed=False)
+        assert WALRecovery.is_wal_closed("r-1", sdd) is False
+
+    def test_close_wal_writes_marker_file(self, tmp_path: Path) -> None:
+        """close_wal writes a JSON sidecar next to the WAL file."""
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+        WALWriter(run_id="r-1", sdd_dir=sdd).append("d", {}, {}, "a", committed=False)
+
+        marker = WALRecovery.close_wal(
+            "r-1",
+            sdd,
+            reason="unit_test",
+            uncommitted_count=1,
+            orphaned_count=0,
+        )
+        assert marker.exists()
+        assert marker.name == "r-1.wal.closed"
+        payload = json.loads(marker.read_text())
+        assert payload["run_id"] == "r-1"
+        assert payload["reason"] == "unit_test"
+        assert payload["uncommitted_count"] == 1
+        assert payload["orphaned_count"] == 0
+        assert "closed_at" in payload
+        assert WALRecovery.is_wal_closed("r-1", sdd) is True
+
+    def test_scan_skips_closed_wals(self, tmp_path: Path) -> None:
+        """scan_all_uncommitted returns nothing for a closed WAL."""
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+        w = WALWriter(run_id="old", sdd_dir=sdd)
+        w.append("task_claimed", {"task_id": "T-1"}, {}, "lifecycle", committed=False)
+        w.append("task_claimed", {"task_id": "T-2"}, {}, "lifecycle", committed=False)
+
+        # Before closing: uncommitted entries are visible.
+        assert len(WALRecovery.scan_all_uncommitted(sdd)) == 2
+
+        WALRecovery.close_wal("old", sdd)
+
+        # After closing: the WAL is skipped entirely.
+        assert WALRecovery.scan_all_uncommitted(sdd) == []
+
+    def test_find_orphaned_claims_skips_closed_wals(self, tmp_path: Path) -> None:
+        """find_orphaned_claims also respects the .closed marker."""
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+        w = WALWriter(run_id="old", sdd_dir=sdd)
+        # Orphan: claim with no matching spawn_confirmed.
+        w.append("task_claimed", {"task_id": "T-orphan"}, {}, "lifecycle", committed=False)
+
+        assert len(WALRecovery.find_orphaned_claims(sdd)) == 1
+        WALRecovery.close_wal("old", sdd)
+        assert WALRecovery.find_orphaned_claims(sdd) == []
+
+    def test_recovery_then_close_is_noop_on_next_scan(self, tmp_path: Path) -> None:
+        """Fresh WAL (2 committed + 3 uncommitted): recover, close, re-scan is empty.
+
+        This is the core audit-072 regression test: after a recovery
+        cycle the next scan on the same WAL must return zero entries,
+        so the orchestrator does not re-process the same uncommitted
+        entries on every boot.
+        """
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+
+        run_id = "audit-072-run"
+        w = WALWriter(run_id=run_id, sdd_dir=sdd)
+        # 2 committed entries
+        w.append("tick_started", {"tick": 0}, {}, "orchestrator", committed=True)
+        w.append("task_spawn_confirmed", {"task_id": "T-ok"}, {}, "lifecycle", committed=True)
+        # 3 uncommitted entries (simulated crashes between claim and spawn)
+        w.append("task_claimed", {"task_id": "T-1"}, {}, "lifecycle", committed=False)
+        w.append("task_claimed", {"task_id": "T-2"}, {}, "lifecycle", committed=False)
+        w.append("task_claimed", {"task_id": "T-3"}, {}, "lifecycle", committed=False)
+
+        # First recovery pass: scan sees all 3 uncommitted entries.
+        first_pass = WALRecovery.scan_all_uncommitted(sdd)
+        assert len(first_pass) == 3
+        task_ids = sorted(e.inputs["task_id"] for _, e in first_pass)
+        assert task_ids == ["T-1", "T-2", "T-3"]
+
+        # Orchestrator finishes recovery by closing the WAL.
+        marker = WALRecovery.close_wal(
+            run_id,
+            sdd,
+            reason="recovered_by_orchestrator",
+            uncommitted_count=len(first_pass),
+            orphaned_count=len(first_pass),
+        )
+        assert marker.exists()
+        assert WALRecovery.is_wal_closed(run_id, sdd) is True
+
+        # Second recovery pass on the SAME state: the WAL is skipped,
+        # so no entries are returned -- the unbounded re-scan is fixed.
+        second_pass = WALRecovery.scan_all_uncommitted(sdd)
+        assert second_pass == []
+        assert WALRecovery.find_orphaned_claims(sdd) == []
+
+        # And the WAL file itself is untouched -- close is non-destructive.
+        wal_file = sdd / "runtime" / "wal" / f"{run_id}.wal.jsonl"
+        assert wal_file.exists()
+        lines = [ln for ln in wal_file.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 5  # 2 committed + 3 uncommitted, preserved
+
+    def test_close_wal_does_not_affect_other_runs(self, tmp_path: Path) -> None:
+        """Closing one run's WAL leaves other runs visible to the scan."""
+        sdd = tmp_path / ".sdd"
+        sdd.mkdir()
+        w1 = WALWriter(run_id="run-a", sdd_dir=sdd)
+        w1.append("task_claimed", {"task_id": "T-a"}, {}, "lifecycle", committed=False)
+        w2 = WALWriter(run_id="run-b", sdd_dir=sdd)
+        w2.append("task_claimed", {"task_id": "T-b"}, {}, "lifecycle", committed=False)
+
+        WALRecovery.close_wal("run-a", sdd)
+
+        result = WALRecovery.scan_all_uncommitted(sdd)
+        run_ids = [r for r, _ in result]
+        assert run_ids == ["run-b"]


### PR DESCRIPTION
## Summary
- Add a `.closed` sidecar marker written by `WALRecovery.close_wal()` next to each `{run_id}.wal.jsonl`; `scan_all_uncommitted()` and `find_orphaned_claims()` now skip any WAL whose marker exists, so the orchestrator does not re-scan the same uncommitted entries on every boot.
- `_recover_from_wal()` closes the union of run_ids that held uncommitted entries and run_ids that held orphaned claims after acking/retrying, recording the closed run_ids in the current run's recorder trace.
- Adds `TestWALRecoveryClosedMarker` (6 tests) covering marker absence, write + payload contents, scan-skip behaviour, orphan-skip behaviour, a full recover-then-close round-trip, and close-isolation between runs.

## Root cause
Before this change, recovery read all uncommitted entries but had no way to mark a WAL as "handled". Every subsequent orchestrator boot would re-read the same entries and re-retry the same orphaned claims forever, causing unbounded log growth and repeated `/tasks/{id}/force-claim` traffic.

## Test plan
- [x] `uv run ruff check` on modified files — clean
- [x] `uv run ruff format --check` on modified files — clean
- [x] `uv run pytest tests/unit/test_wal.py -x -q` — 54 passed