### PR TITLE
fix(git): preserve unmerged agent branches during hygiene

### DIFF
--- a/src/bernstein/cli/commands/maintenance_cmd.py
+++ b/src/bernstein/cli/commands/maintenance_cmd.py
@@ -168,22 +168,44 @@ def _format_relative_age(timestamp: float) -> str:
     help="Project root containing .sdd/runtime and .sdd/worktrees.",
 )
 @click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
-def cleanup_cmd(workdir: Path, yes: bool) -> None:
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help=(
+        "Also delete agent branches that are NOT merged into main. Dangerous — "
+        "may discard in-flight work. Only use after manually confirming the "
+        "branches contain nothing you want to keep."
+    ),
+)
+def cleanup_cmd(workdir: Path, yes: bool, force: bool) -> None:
     """Remove Bernstein worktrees that no longer back active tasks."""
     resolved_workdir = workdir.resolve()
     if not yes and not click.confirm("Remove inactive Bernstein worktrees and prune git state?", default=True):
         raise SystemExit(1)
+    if force and not yes and not click.confirm("--force will DELETE unmerged agent branches. Continue?", default=False):
+        raise SystemExit(1)
 
-    candidates = _cleanup_candidates(resolved_workdir)
+    store = _load_task_store(resolved_workdir)
+    active_sessions = _active_session_ids(store)
     manager = WorktreeManager(resolved_workdir)
+    candidates = sorted(session_id for session_id in manager.list_active() if session_id not in active_sessions)
     for session_id in candidates:
         manager.cleanup(session_id)
 
-    hygiene = run_hygiene(resolved_workdir, full=True)
+    hygiene = run_hygiene(
+        resolved_workdir,
+        full=True,
+        active_session_ids=active_sessions,
+        force_unmerged=force,
+    )
+    skipped = hygiene.get("branches_skipped", 0)
     console.print(
         "[green]Cleanup complete.[/green] "
         f"Removed {len(candidates)} inactive worktree(s); "
-        f"pruned {hygiene['branches_deleted']} branch(es) and {hygiene['stash_dropped']} stash(es)."
+        f"pruned {hygiene['branches_deleted']} branch(es), "
+        f"preserved {skipped} unmerged branch(es), "
+        f"dropped {hygiene['stash_dropped']} stash(es)."
     )
 
 

--- a/src/bernstein/core/git/git_hygiene.py
+++ b/src/bernstein/core/git/git_hygiene.py
@@ -121,28 +121,57 @@ def _rmtree_powershell_fallback(path: Path) -> bool:
         return False
 
 
-def run_hygiene(workdir: Path, *, full: bool = False) -> dict[str, int]:
+DEFAULT_TARGET_BRANCH = "main"
+
+
+def run_hygiene(
+    workdir: Path,
+    *,
+    full: bool = False,
+    target_branch: str = DEFAULT_TARGET_BRANCH,
+    active_session_ids: frozenset[str] | set[str] | None = None,
+    force_unmerged: bool = False,
+) -> dict[str, int]:
     """Run git hygiene checks and cleanup.
 
     Args:
         workdir: Repository root.
         full: If True, run all checks (shutdown mode).
               If False, only quick checks (periodic mode).
+        target_branch: Branch that agent work must be merged into before a
+            local agent/* branch can be safely deleted. Defaults to ``main``.
+        active_session_ids: Session identifiers whose branches must be
+            preserved regardless of merge status (branches currently being
+            committed to by live agents).
+        force_unmerged: **Dangerous.** When True, delete agent branches even
+            if they are not merged into ``target_branch``. This is a
+            privileged opt-in — automated periodic/bootstrap/shutdown
+            cleanup must never set it. Only an explicit CLI command with a
+            ``--force`` flag should pass ``True``.
 
     Returns:
-        Dict with counts: worktrees_cleaned, branches_deleted, stash_dropped.
+        Dict with counts: worktrees_cleaned, branches_deleted, stash_dropped,
+        branches_skipped (new: unmerged branches left alone for safety).
     """
     stats: dict[str, int] = {
         "worktrees_cleaned": 0,
         "branches_deleted": 0,
+        "branches_skipped": 0,
         "stash_dropped": 0,
     }
 
     # 1. Clean stale worktrees
     stats["worktrees_cleaned"] = _clean_stale_worktrees(workdir)
 
-    # 2. Delete merged agent branches
-    stats["branches_deleted"] = _delete_merged_agent_branches(workdir)
+    # 2. Delete merged agent branches (preserves unmerged work by default)
+    deleted, skipped = _delete_merged_agent_branches(
+        workdir,
+        target_branch=target_branch,
+        active_session_ids=active_session_ids or frozenset(),
+        force_unmerged=force_unmerged,
+    )
+    stats["branches_deleted"] = deleted
+    stats["branches_skipped"] = skipped
 
     # 3. Prune git worktree registry
     run_git(["worktree", "prune"], workdir, timeout=10)
@@ -157,9 +186,11 @@ def run_hygiene(workdir: Path, *, full: bool = False) -> dict[str, int]:
     total = sum(stats.values())
     if total > 0:
         logger.info(
-            "Git hygiene: cleaned %d worktree(s), %d branch(es), %d stash(es)",
+            "Git hygiene: cleaned %d worktree(s), %d branch(es) deleted, "
+            "%d branch(es) preserved (unmerged), %d stash(es)",
             stats["worktrees_cleaned"],
             stats["branches_deleted"],
+            stats["branches_skipped"],
             stats["stash_dropped"],
         )
 
@@ -193,24 +224,131 @@ def _clean_stale_worktrees(workdir: Path) -> int:
     return cleaned
 
 
-def _delete_merged_agent_branches(workdir: Path) -> int:
-    """Delete local agent/* branches that have been merged or are stale."""
+def _is_branch_merged(workdir: Path, branch: str, target_branch: str) -> bool:
+    """Return True when *branch* is fully contained in *target_branch*.
+
+    Uses ``git merge-base --is-ancestor`` which reports success (exit 0)
+    only when every commit on *branch* is reachable from *target_branch* —
+    i.e. there is no unmerged work that would be lost by deleting *branch*.
+
+    Args:
+        workdir: Repository root.
+        branch: Candidate branch name (e.g. ``agent/abc123``).
+        target_branch: Integration branch (usually ``main``).
+
+    Returns:
+        True iff *branch* is an ancestor of *target_branch*; False when the
+        branch still has unique commits or the check could not be run
+        (missing target, transient git failure). When in doubt we return
+        False — callers must preserve the branch on uncertainty.
+    """
+    result = run_git(
+        ["merge-base", "--is-ancestor", branch, target_branch],
+        workdir,
+        timeout=10,
+    )
+    return result.ok
+
+
+def _session_id_from_branch(branch: str) -> str:
+    """Extract the session id suffix from an ``agent/<session>`` branch.
+
+    Args:
+        branch: Branch name.
+
+    Returns:
+        Portion after the ``agent/`` prefix, or the original branch when it
+        does not match the expected layout.
+    """
+    prefix = "agent/"
+    return branch[len(prefix) :] if branch.startswith(prefix) else branch
+
+
+def _delete_merged_agent_branches(
+    workdir: Path,
+    *,
+    target_branch: str = DEFAULT_TARGET_BRANCH,
+    active_session_ids: frozenset[str] | set[str] = frozenset(),
+    force_unmerged: bool = False,
+) -> tuple[int, int]:
+    """Delete local ``agent/*`` branches that are safe to remove.
+
+    A branch is only deleted when ALL of the following hold:
+
+    1. Its session id is NOT in *active_session_ids* (no live agent is
+       committing to it).
+    2. Every commit on it is already reachable from *target_branch* (i.e.
+       ``git merge-base --is-ancestor`` succeeds) — unless *force_unmerged*
+       is explicitly True.
+
+    Args:
+        workdir: Repository root.
+        target_branch: Branch to check ancestry against. Defaults to
+            :data:`DEFAULT_TARGET_BRANCH`.
+        active_session_ids: Session identifiers whose branches must not be
+            touched because live agents are still using them.
+        force_unmerged: **Dangerous.** Skip the merge-ancestry check and
+            delete unmerged branches too. Reserved for privileged CLI paths
+            that explicitly opt in; automated cleanup MUST leave this False.
+
+    Returns:
+        ``(deleted_count, skipped_count)`` — skipped counts branches that
+        were preserved because they were unmerged or in use.
+    """
     result = run_git(["branch", "--list", "agent/*"], workdir, timeout=10)
     if not result.ok or not result.stdout.strip():
-        return 0
+        return 0, 0
 
     deleted = 0
+    skipped = 0
     for line in result.stdout.strip().splitlines():
         branch = line.strip().lstrip("* ")
         if not branch.startswith("agent/"):
             continue
-        # Force delete — these are disposable agent branches
-        del_result = run_git(["branch", "-D", branch], workdir, timeout=10)
+
+        # Guard 1: live agents own these branches — never touch them.
+        session_id = _session_id_from_branch(branch)
+        if session_id in active_session_ids:
+            logger.info(
+                "Preserving agent branch %s — session %s is active",
+                branch,
+                session_id,
+            )
+            skipped += 1
+            continue
+
+        # Guard 2: only delete fully-merged branches unless force was given.
+        merged = _is_branch_merged(workdir, branch, target_branch)
+        if not merged and not force_unmerged:
+            logger.warning(
+                "Preserving unmerged agent branch %s — not an ancestor of %s; "
+                "pass force_unmerged=True via a privileged CLI path to override",
+                branch,
+                target_branch,
+            )
+            skipped += 1
+            continue
+
+        del_args = ["branch", "-D"] if (force_unmerged and not merged) else ["branch", "-d"]
+        del_result = run_git([*del_args, branch], workdir, timeout=10)
         if del_result.ok:
             deleted += 1
-            logger.debug("Deleted agent branch: %s", branch)
+            if merged:
+                logger.info("Deleted merged agent branch: %s", branch)
+            else:
+                logger.warning(
+                    "Force-deleted UNMERGED agent branch %s (force_unmerged=True)",
+                    branch,
+                )
+        else:
+            logger.warning(
+                "Failed to delete agent branch %s: %s",
+                branch,
+                del_result.stderr.strip() or del_result.stdout.strip(),
+            )
+            skipped += 1
 
-    return deleted
+    return deleted, skipped
 
 
 def _drop_stale_stashes(workdir: Path) -> int:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1246,7 +1246,8 @@ class Orchestrator:
             try:
                 from bernstein.core.git_hygiene import run_hygiene
 
-                run_hygiene(self._workdir)
+                active_ids = {s.id for s in self._agents.values() if s.status != "dead"}
+                run_hygiene(self._workdir, active_session_ids=active_ids)
             except Exception:
                 pass
 

--- a/src/bernstein/core/orchestration/orchestrator_cleanup.py
+++ b/src/bernstein/core/orchestration/orchestrator_cleanup.py
@@ -173,11 +173,19 @@ def cleanup(orch: Any) -> None:
         except Exception:
             logger.warning("Merkle seal generation on shutdown failed", exc_info=True)
 
-    # Full git hygiene on shutdown
+    # Full git hygiene on shutdown. Never force-delete unmerged branches —
+    # agents shutting down may have unpushed work we need to preserve.
     try:
         from bernstein.core.git_hygiene import run_hygiene
 
-        run_hygiene(orch._workdir, full=True)
+        active_ids: set[str] = set()
+        try:
+            active_ids = {s.id for s in orch._agents.values() if s.status != "dead"}
+        except Exception:
+            # Best-effort: if we cannot enumerate live agents, fall back to
+            # an empty set. The merge-ancestry guard still prevents data loss.
+            active_ids = set()
+        run_hygiene(orch._workdir, full=True, active_session_ids=active_ids)
     except Exception:
         logger.debug("Git hygiene on shutdown failed (non-critical)", exc_info=True)
 

--- a/tests/unit/test_git_hygiene.py
+++ b/tests/unit/test_git_hygiene.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
@@ -36,21 +37,131 @@ def test_clean_stale_worktrees_removes_only_untracked_dirs(tmp_path: Path) -> No
     assert not stale.exists()
 
 
-def test_delete_merged_agent_branches_deletes_only_agent_branches(tmp_path: Path) -> None:
-    """_delete_merged_agent_branches deletes every listed agent/* branch."""
+def test_delete_merged_branch_is_removed(tmp_path: Path) -> None:
+    """A fully-merged agent branch is deleted with ``branch -d``."""
     with patch(
         "bernstein.core.git_hygiene.run_git",
         side_effect=[
-            GitResult(0, "  agent/a\n* agent/b\n", ""),
+            # `branch --list agent/*`
+            GitResult(0, "  agent/merged\n", ""),
+            # `merge-base --is-ancestor agent/merged main` -> success
             GitResult(0, "", ""),
+            # `branch -d agent/merged`
             GitResult(0, "", ""),
         ],
     ) as mock_run_git:
-        deleted = _delete_merged_agent_branches(tmp_path)
+        deleted, skipped = _delete_merged_agent_branches(tmp_path)
 
-    assert deleted == 2
-    assert mock_run_git.call_args_list[1].args[0] == ["branch", "-D", "agent/a"]
-    assert mock_run_git.call_args_list[2].args[0] == ["branch", "-D", "agent/b"]
+    assert deleted == 1
+    assert skipped == 0
+    # Safe delete (-d), NOT force delete (-D).
+    assert mock_run_git.call_args_list[2].args[0] == ["branch", "-d", "agent/merged"]
+
+
+def test_delete_unmerged_branch_is_preserved(tmp_path: Path, caplog: object) -> None:
+    """An unmerged agent branch is NOT deleted and a warning is logged."""
+    assert hasattr(caplog, "at_level")  # satisfy type checker
+
+    with (
+        caplog.at_level(logging.WARNING, logger="bernstein.core.git.git_hygiene"),  # type: ignore[attr-defined]
+        patch(
+            "bernstein.core.git_hygiene.run_git",
+            side_effect=[
+                # `branch --list agent/*`
+                GitResult(0, "* agent/unmerged\n", ""),
+                # `merge-base --is-ancestor` -> non-zero (not an ancestor)
+                GitResult(1, "", ""),
+            ],
+        ) as mock_run_git,
+    ):
+        deleted, skipped = _delete_merged_agent_branches(tmp_path)
+
+    assert deleted == 0
+    assert skipped == 1
+    # Only two git calls: list + ancestry probe. No branch deletion happened.
+    assert len(mock_run_git.call_args_list) == 2
+    delete_calls = [
+        call for call in mock_run_git.call_args_list if call.args[0][:1] == ["branch"] and "-D" in call.args[0]
+    ]
+    assert delete_calls == []
+    # Warning message mentions the branch and preservation.
+    messages = [r.getMessage() for r in caplog.records]  # type: ignore[attr-defined]
+    assert any("agent/unmerged" in m and "Preserving" in m for m in messages)
+
+
+def test_delete_active_session_branch_is_preserved(tmp_path: Path) -> None:
+    """Branches owned by live agents are never touched, even if merged."""
+    with patch(
+        "bernstein.core.git_hygiene.run_git",
+        side_effect=[
+            GitResult(0, "agent/alive-session\n", ""),
+        ],
+    ) as mock_run_git:
+        deleted, skipped = _delete_merged_agent_branches(tmp_path, active_session_ids={"alive-session"})
+
+    assert deleted == 0
+    assert skipped == 1
+    # Only the list call — no ancestry check, no deletion.
+    assert len(mock_run_git.call_args_list) == 1
+
+
+def test_force_unmerged_true_deletes_unmerged_branch(tmp_path: Path) -> None:
+    """The privileged ``force_unmerged`` opt-in uses ``branch -D``."""
+    with patch(
+        "bernstein.core.git_hygiene.run_git",
+        side_effect=[
+            GitResult(0, "agent/unmerged\n", ""),
+            # ancestry probe -> not merged
+            GitResult(1, "", ""),
+            # forced delete
+            GitResult(0, "", ""),
+        ],
+    ) as mock_run_git:
+        deleted, skipped = _delete_merged_agent_branches(tmp_path, force_unmerged=True)
+
+    assert deleted == 1
+    assert skipped == 0
+    assert mock_run_git.call_args_list[2].args[0] == ["branch", "-D", "agent/unmerged"]
+
+
+def test_delete_mix_of_branches(tmp_path: Path) -> None:
+    """Mixed list: merged branch deleted, unmerged preserved, active preserved."""
+    with patch(
+        "bernstein.core.git_hygiene.run_git",
+        side_effect=[
+            GitResult(0, "agent/merged\nagent/unmerged\nagent/live\n", ""),
+            # ancestry of agent/merged -> ok
+            GitResult(0, "", ""),
+            # delete agent/merged -> ok
+            GitResult(0, "", ""),
+            # ancestry of agent/unmerged -> not ancestor
+            GitResult(1, "", ""),
+            # agent/live is skipped BEFORE any git call because its session id
+            # is in active_session_ids.
+        ],
+    ) as mock_run_git:
+        deleted, skipped = _delete_merged_agent_branches(tmp_path, active_session_ids={"live"})
+
+    assert deleted == 1
+    assert skipped == 2
+    # Confirm only four git invocations: list + ancestry + delete + ancestry.
+    assert len(mock_run_git.call_args_list) == 4
+
+
+def test_non_agent_branches_are_ignored(tmp_path: Path) -> None:
+    """Lines that aren't agent/* branches are skipped entirely."""
+    with patch(
+        "bernstein.core.git_hygiene.run_git",
+        side_effect=[
+            GitResult(0, "main\nfeature/x\n", ""),
+        ],
+    ) as mock_run_git:
+        deleted, skipped = _delete_merged_agent_branches(tmp_path)
+
+    assert deleted == 0
+    assert skipped == 0
+    # Only the initial list call — we never touch non-agent branches.
+    assert len(mock_run_git.call_args_list) == 1
 
 
 def test_drop_stale_stashes_counts_entries_and_clears_when_present(tmp_path: Path) -> None:
@@ -83,12 +194,41 @@ def test_run_hygiene_full_accumulates_counts_and_runs_full_cleanup(tmp_path: Pat
     """run_hygiene(full=True) aggregates helper counts and performs runtime cleanup."""
     with (
         patch("bernstein.core.git.git_hygiene._clean_stale_worktrees", return_value=2),
-        patch("bernstein.core.git.git_hygiene._delete_merged_agent_branches", return_value=3),
+        patch("bernstein.core.git.git_hygiene._delete_merged_agent_branches", return_value=(3, 1)),
         patch("bernstein.core.git.git_hygiene._drop_stale_stashes", return_value=1),
         patch("bernstein.core.git.git_hygiene._clean_stale_runtime") as mock_runtime,
         patch("bernstein.core.git.git_hygiene.run_git", return_value=GitResult(0, "", "")),
     ):
         stats = run_hygiene(tmp_path, full=True)
 
-    assert stats == {"worktrees_cleaned": 2, "branches_deleted": 3, "stash_dropped": 1}
+    assert stats == {
+        "worktrees_cleaned": 2,
+        "branches_deleted": 3,
+        "branches_skipped": 1,
+        "stash_dropped": 1,
+    }
     mock_runtime.assert_called_once_with(tmp_path)
+
+
+def test_run_hygiene_forwards_active_sessions_and_force_flag(tmp_path: Path) -> None:
+    """run_hygiene threads active_session_ids and force_unmerged to the helper."""
+    with (
+        patch("bernstein.core.git.git_hygiene._clean_stale_worktrees", return_value=0),
+        patch(
+            "bernstein.core.git.git_hygiene._delete_merged_agent_branches",
+            return_value=(0, 0),
+        ) as mock_delete,
+        patch("bernstein.core.git.git_hygiene.run_git", return_value=GitResult(0, "", "")),
+    ):
+        run_hygiene(
+            tmp_path,
+            active_session_ids={"abc123"},
+            force_unmerged=True,
+            target_branch="develop",
+        )
+
+    mock_delete.assert_called_once()
+    _args, kwargs = mock_delete.call_args
+    assert kwargs["target_branch"] == "develop"
+    assert kwargs["force_unmerged"] is True
+    assert "abc123" in kwargs["active_session_ids"]


### PR DESCRIPTION
## Summary
- `_delete_merged_agent_branches` now verifies each `agent/*` branch is an ancestor of `main` (via `git merge-base --is-ancestor`) before deletion; unmerged branches are preserved and logged at WARNING.
- Live agents' branches are protected via an `active_session_ids` set threaded through `run_hygiene`; orchestrator tick + shutdown both pass live session ids.
- Force-deleting unmerged branches now requires the explicit `bernstein cleanup --force` flag (with a second confirm prompt). Automated paths never set it.
- `run_hygiene` returns a new `branches_skipped` counter so operators can surface preserved work.

## Why
Previously hygiene ran `git branch -D agent/*` unconditionally and destroyed commits whenever an agent branch hadn't merged to `main` yet (crash, recycle, or pre-PR state). Commits vanished on the next periodic tick.

## Test plan
- [x] `uv run pytest tests/unit/test_git_hygiene.py -x -q` — 11 passed
- [x] `uv run ruff check` on all 5 modified files — pass
- [x] `uv run ruff format --check` on all 5 modified files — pass
- [ ] Manual: run `bernstein cleanup` on a repo with a mix of merged/unmerged agent branches and verify only merged ones disappear
- [ ] Manual: run `bernstein cleanup --force` and confirm the extra prompt fires