### PR TITLE
fix(git): incremental merge rejects overwrite of main

### DIFF
--- a/src/bernstein/core/git/incremental_merge.py
+++ b/src/bernstein/core/git/incremental_merge.py
@@ -76,6 +76,9 @@ class IncrementalMergeResult:
         uncommitted_files: Files the agent has not yet committed to its branch
             (skipped — caller must commit them in the worktree first).
         conflicting_files: Files whose content conflicted during checkout.
+        dirty_files: Files the operator has modified in the main workdir
+            (staged or unstaged) and that would be clobbered by the merge.
+            When non-empty, the merge aborts without touching the working tree.
         commit_sha: SHA of the incremental commit, or empty string if nothing
             was committed (e.g. all files skipped).
         error: Human-readable error message on failure, empty on success.
@@ -88,6 +91,7 @@ class IncrementalMergeResult:
     conflicting_files: list[str]
     commit_sha: str
     error: str
+    dirty_files: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -243,6 +247,59 @@ def _checkout_files_from_branch(workdir: Path, branch: str, files: list[str]) ->
     return list(files)
 
 
+def _dirty_target_files(workdir: Path, files: list[str]) -> list[str]:
+    """Return which of *files* have uncommitted changes (staged or unstaged) in *workdir*.
+
+    ``git checkout <branch> -- <files>`` unconditionally overwrites the working
+    tree, so if an operator has local edits to any of the target files the
+    incremental merge would silently clobber them.  We must refuse the merge
+    in that case.
+
+    Args:
+        workdir: Main repository root.
+        files: Repo-relative paths the merge wants to overwrite.
+
+    Returns:
+        Subset of *files* that appear as modified/added/staged in
+        ``git status --porcelain``.  An empty list means it is safe to proceed.
+    """
+    if not files:
+        return []
+    # Use path-scoped porcelain status so we only see entries for *files*.
+    result = run_git(["status", "--porcelain", "--", *files], workdir)
+    if not result.ok:
+        # Conservative fallback: if we cannot inspect the status, treat every
+        # requested file as dirty so we do not silently overwrite operator work.
+        logger.warning(
+            "git status --porcelain failed for %s; refusing incremental merge: %s",
+            workdir,
+            result.stderr.strip(),
+        )
+        return list(files)
+    dirty: list[str] = []
+    requested = set(files)
+    for line in result.stdout.splitlines():
+        # Porcelain v1 format: "XY <path>" where XY are two status codes and the
+        # path starts at column 3.  Untracked entries ("??") are not a conflict
+        # with checkout, so we skip them.
+        if len(line) < 4:
+            continue
+        xy = line[:2]
+        path = line[3:].strip()
+        # Strip renames: "XY old -> new" — we care about the destination path.
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1].strip()
+        # Remove surrounding quotes that git adds for paths with special chars.
+        if path.startswith('"') and path.endswith('"'):
+            path = path[1:-1]
+        if xy == "??":
+            continue
+        if path in requested:
+            dirty.append(path)
+    # Preserve the caller's input order so error messages are deterministic.
+    return [f for f in files if f in set(dirty)]
+
+
 def _rev_parse(workdir: Path, ref: str) -> str:
     """Return the full SHA of *ref*, or empty string on failure."""
     result = run_git(["rev-parse", ref], workdir)
@@ -340,8 +397,32 @@ def incremental_merge_files(
                 error=(f"None of the requested files are committed in {branch}. Commit them in the worktree first."),
             )
 
-        # Perform the checkout under the external merge_lock (if provided)
+        # Perform the checkout under the external merge_lock (if provided).
+        # The dirty-workdir check MUST run under the same lock as the checkout:
+        # otherwise an operator edit that lands between the check and the
+        # checkout would still be silently clobbered.
         def _do_merge() -> IncrementalMergeResult:
+            dirty = _dirty_target_files(workdir, to_checkout)
+            if dirty:
+                logger.warning(
+                    "Incremental merge aborted for %s: dirty target files in main workdir: %s",
+                    session_id,
+                    ", ".join(dirty),
+                )
+                return IncrementalMergeResult(
+                    success=False,
+                    merged_files=[],
+                    skipped_already_merged=already_merged_requested,
+                    uncommitted_files=uncommitted,
+                    conflicting_files=[],
+                    commit_sha="",
+                    error=(
+                        f"Refusing incremental merge: main workdir has uncommitted changes to "
+                        f"{len(dirty)} target file(s) ({', '.join(dirty[:3])}"
+                        f"{' ...' if len(dirty) > 3 else ''}). Commit, stash, or discard them first."
+                    ),
+                    dirty_files=dirty,
+                )
             return _execute_incremental_merge(
                 workdir,
                 branch,

--- a/tests/unit/test_incremental_merge.py
+++ b/tests/unit/test_incremental_merge.py
@@ -10,6 +10,7 @@ import pytest
 from bernstein.core.git_basic import GitResult
 from bernstein.core.incremental_merge import (
     IncrementalMergeState,
+    _dirty_target_files,
     _files_committed_in_branch,
     _load_state,
     _save_state,
@@ -160,6 +161,7 @@ class TestIncrementalMergeFiles:
 
         call_results = [
             _ok("src/foo.py\nsrc/bar.py\n"),  # ls-tree
+            _ok(""),  # status --porcelain: clean workdir
             _ok(""),  # git checkout
             _ok(""),  # git add
             _ok("1 file changed"),  # git commit
@@ -188,6 +190,7 @@ class TestIncrementalMergeFiles:
 
         call_results = [
             _ok("src/foo.py\n"),  # ls-tree
+            _ok(""),  # status --porcelain: clean workdir
             _ok(""),  # git checkout
             _ok(""),  # git add
             _fail("nothing to commit, working tree clean"),  # git commit
@@ -209,6 +212,7 @@ class TestIncrementalMergeFiles:
 
         call_results = [
             _ok("src/foo.py\n"),  # ls-tree
+            _ok(""),  # status --porcelain: clean workdir
             _fail("checkout conflict"),  # git checkout fails
         ]
 
@@ -230,6 +234,7 @@ class TestIncrementalMergeFiles:
         commit_sha = "a" * 40
         call_seq = [
             _ok("src/foo.py\n"),  # ls-tree
+            _ok(""),  # status --porcelain: clean workdir
             _ok(""),  # checkout
             _ok(""),  # add
             _ok(""),  # commit
@@ -262,6 +267,7 @@ class TestIncrementalMergeFiles:
         # ls-tree reports only src/new.py as committed (src/notyet.py is missing)
         call_results = [
             _ok("src/new.py\n"),  # ls-tree for candidates
+            _ok(""),  # status --porcelain: clean workdir
             _ok(""),  # checkout
             _ok(""),  # add
             _ok("1 file"),  # commit
@@ -306,3 +312,199 @@ class TestStateSerialisation:
         assert state.merged_files == []
         assert state.merge_commits == []
         assert state.last_merged_ts == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# _dirty_target_files — guards main workdir against operator-edit clobber
+# ---------------------------------------------------------------------------
+
+
+class TestDirtyTargetFiles:
+    """audit-090: must flag operator-modified files before `git checkout` overwrite."""
+
+    def test_empty_files_returns_empty(self, tmp_path: Path) -> None:
+        result = _dirty_target_files(tmp_path, [])
+        assert result == []
+
+    def test_clean_workdir_returns_empty(self, tmp_path: Path) -> None:
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            return_value=_ok(""),
+        ):
+            result = _dirty_target_files(tmp_path, ["src/api.py", "src/util.py"])
+        assert result == []
+
+    def test_unstaged_modification_is_dirty(self, tmp_path: Path) -> None:
+        # Porcelain " M path" → unstaged modification to tracked file.
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            return_value=_ok(" M src/api.py\n"),
+        ):
+            result = _dirty_target_files(tmp_path, ["src/api.py", "src/util.py"])
+        assert result == ["src/api.py"]
+
+    def test_staged_modification_is_dirty(self, tmp_path: Path) -> None:
+        # "M  path" → staged modification.
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            return_value=_ok("M  src/api.py\n"),
+        ):
+            result = _dirty_target_files(tmp_path, ["src/api.py"])
+        assert result == ["src/api.py"]
+
+    def test_untracked_file_is_not_dirty(self, tmp_path: Path) -> None:
+        # "?? path" is untracked; it does not conflict with `git checkout -- path`
+        # because checkout writes tracked content and untracked files are
+        # undisturbed.
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            return_value=_ok("?? src/new.py\n"),
+        ):
+            result = _dirty_target_files(tmp_path, ["src/new.py"])
+        assert result == []
+
+    def test_status_failure_is_conservative(self, tmp_path: Path) -> None:
+        # If `git status` cannot be run we must NOT proceed with the clobbering
+        # checkout — treat every requested file as dirty.
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            return_value=_fail("fatal: not a git repository"),
+        ):
+            result = _dirty_target_files(tmp_path, ["src/api.py"])
+        assert result == ["src/api.py"]
+
+    def test_only_non_target_changes_returns_empty(self, tmp_path: Path) -> None:
+        # status output contains an unrelated file; target list is clean.
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            return_value=_ok(" M docs/readme.md\n"),
+        ):
+            result = _dirty_target_files(tmp_path, ["src/api.py"])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# incremental_merge_files — concurrent write / operator-edit guard (audit-090)
+# ---------------------------------------------------------------------------
+
+
+class TestAuditNinetyConcurrentWrite:
+    """Regression: the merge MUST abort instead of overwriting main-workdir edits.
+
+    The historical bug: `git checkout agent/<sid> -- file.py` ran
+    unconditionally, silently replacing any uncommitted operator changes to
+    `file.py` in the main repo working tree.  The fix makes the merge run
+    `git status --porcelain -- <files>` under the merge lock and refuse to
+    proceed if any target file is modified.
+    """
+
+    def test_dirty_target_aborts_without_checkout(self, tmp_path: Path) -> None:
+        """If operator has unstaged edits to a target file, the merge aborts.
+
+        This simulates: operator edits src/api.py (uncommitted), then an agent
+        completes work and posts an incremental-merge for the same file.  The
+        merge must abort *before* `git checkout`, and must NOT call `git add`
+        or `git commit`.
+        """
+        runtime_dir = tmp_path / "runtime"
+
+        call_results = [
+            # 1) ls-tree — src/api.py is committed in the agent branch
+            _ok("src/api.py\n"),
+            # 2) status --porcelain — operator has an unstaged edit to src/api.py
+            _ok(" M src/api.py\n"),
+            # Any further calls would be a bug: checkout/add/commit must NOT run.
+        ]
+
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            side_effect=call_results,
+        ) as mock_git:
+            result = incremental_merge_files(tmp_path, runtime_dir, "sess-race", ["src/api.py"])
+
+        assert not result.success
+        assert result.dirty_files == ["src/api.py"]
+        assert result.merged_files == []
+        assert result.commit_sha == ""
+        assert "uncommitted" in result.error.lower() or "refusing" in result.error.lower()
+
+        # Exactly two git calls: ls-tree and status.  No checkout, add, or
+        # commit — otherwise operator edits would have been overwritten.
+        assert mock_git.call_count == 2
+        commands = [call.args[0][0] for call in mock_git.call_args_list]
+        assert "checkout" not in commands
+        assert "add" not in commands
+        assert "commit" not in commands
+
+        # State must not record the file as merged.
+        loaded = _load_state(runtime_dir, "sess-race")
+        assert loaded.merged_files == []
+        assert loaded.merge_commits == []
+
+    def test_clean_target_proceeds_normally(self, tmp_path: Path) -> None:
+        """When the main workdir is clean the merge proceeds as before."""
+        runtime_dir = tmp_path / "runtime"
+        commit_sha = "c" * 40
+
+        call_results = [
+            _ok("src/api.py\n"),  # ls-tree
+            _ok(""),  # status --porcelain: clean
+            _ok(""),  # checkout
+            _ok(""),  # add
+            _ok("1 file changed"),  # commit
+            _ok(commit_sha),  # rev-parse HEAD
+        ]
+
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            side_effect=call_results,
+        ):
+            result = incremental_merge_files(tmp_path, runtime_dir, "sess-clean", ["src/api.py"])
+
+        assert result.success
+        assert result.merged_files == ["src/api.py"]
+        assert result.dirty_files == []
+        assert result.commit_sha == commit_sha
+
+    def test_dirty_check_runs_under_merge_lock(self, tmp_path: Path) -> None:
+        """The dirty-check must happen while the merge_lock is held.
+
+        Otherwise a concurrent final-merge (which also holds merge_lock) could
+        race the dirty-check and clobber main.  We assert the lock is held
+        during both the status call and (if reached) the checkout call.
+        """
+        runtime_dir = tmp_path / "runtime"
+        lock = threading.Lock()
+        lock_state: list[bool] = []
+
+        def record_lock(args: list[str], *_a: object, **_kw: object) -> GitResult:
+            lock_state.append(lock.locked())
+            if args[0] == "ls-tree":
+                return _ok("src/api.py\n")
+            if args[0] == "status":
+                return _ok(" M src/api.py\n")
+            # Should not be reached — dirty check aborts first.
+            return _ok("")
+
+        with patch(
+            "bernstein.core.incremental_merge.run_git",
+            side_effect=record_lock,
+        ):
+            result = incremental_merge_files(
+                tmp_path,
+                runtime_dir,
+                "sess-locked",
+                ["src/api.py"],
+                merge_lock=lock,
+            )
+
+        assert not result.success
+        assert result.dirty_files == ["src/api.py"]
+        # Both the ls-tree call and the status call must have been made with
+        # the merge lock held (ls-tree happens before merge_lock acquisition
+        # only if we moved code — current impl holds merge_lock during status).
+        # We require AT LEAST the status call (index 1) to be under the lock.
+        assert len(lock_state) >= 2
+        assert lock_state[1] is True, "status --porcelain must run under merge_lock"
+        # Lock released after return.
+        assert not lock.locked()


### PR DESCRIPTION
## Summary

- Incremental merge (`git checkout agent/<sid> -- file.py`) silently clobbered operator edits in the main workdir — no clean-state check.
- Add `_dirty_target_files()` that runs `git status --porcelain -- <files>` under the merge lock; abort with structured error if any target file has staged/unstaged changes.
- Untracked entries (`??`) are ignored (checkout cannot clobber them); `git status` failures are treated conservatively (refuse the merge).
- `IncrementalMergeResult` gains a `dirty_files` field so callers can distinguish operator-edit aborts from conflicts.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` clean on modified files
- [x] `uv run pytest tests/unit/test_incremental_merge.py -x -q` — 27 passed
- [x] New regression tests cover: empty input, clean workdir, staged/unstaged target, untracked non-target, `git status` failure fallback, non-target changes ignored, full abort-before-checkout behaviour under `merge_lock`, and normal-path flow still succeeds.

.