### PR TITLE
fix(git): salvage uncommitted work before worktree cleanup

### DIFF
--- a/src/bernstein/core/git/salvage.py
+++ b/src/bernstein/core/git/salvage.py
@@ -1,0 +1,395 @@
+"""Salvage uncommitted agent work before worktree cleanup (audit-088).
+
+When an agent fails, is killed, or its worktree is otherwise reaped while it
+still has dirty state, ``git worktree remove --force`` silently discards the
+work.  Diffs and untracked files are lost — not even ``git reflog`` can
+recover them because no ref ever pointed at the work.
+
+This module adds a lightweight pre-cleanup step that captures any dirty
+state into a durable location *before* the worktree is removed:
+
+1. ``salvage/<session-id>`` branch created in the repo with a WIP commit
+   containing every tracked modification + untracked file (except
+   ``.gitignore`` matches).  Preferred path — the branch is easy to inspect
+   with ``git log`` / ``git diff`` and ``git checkout``.
+2. If the branch cannot be pushed to ``origin`` (no remote, network error,
+   etc.) a filesystem fallback writes the diff + untracked file inventory
+   to ``.sdd/runtime/salvage/<session-id>-<timestamp>/``.
+
+The functions here are intentionally best-effort: any exception raised by
+a salvage step is logged and swallowed so that cleanup itself never fails
+because of a salvage failure — we'd rather lose the salvage than block the
+orchestrator.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.git.git_basic import run_git
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_SALVAGE_DIR_REL = ".sdd/runtime/salvage"
+_SALVAGE_BRANCH_PREFIX = "salvage/"
+_SALVAGE_TIMEOUT_S = 30
+
+
+@dataclass(frozen=True)
+class SalvageResult:
+    """Outcome of a salvage attempt.
+
+    Attributes:
+        salvaged: True if anything was salvaged (dirty state was present
+            and was successfully captured in at least one location).
+        had_changes: True if the worktree had uncommitted or untracked
+            changes at the time of salvage.  ``salvaged`` implies
+            ``had_changes`` but not vice-versa (dirty state could fail to
+            be captured anywhere).
+        branch: Name of the salvage branch created (if any).
+        branch_pushed: True if the salvage branch was successfully pushed
+            to the remote.
+        patch_path: Filesystem path to the saved diff, if the patch
+            fallback was used.  ``None`` when only the branch path was
+            used.
+        untracked_files: List of untracked file paths that were captured
+            (purely informational).
+        errors: Any non-fatal errors that occurred during salvage.
+    """
+
+    salvaged: bool
+    had_changes: bool
+    branch: str | None = None
+    branch_pushed: bool = False
+    patch_path: Path | None = None
+    untracked_files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def _collect_status(worktree_path: Path) -> tuple[bool, list[str]]:
+    """Return ``(has_changes, untracked_files)`` for the worktree.
+
+    Uses ``git status --porcelain`` which already honours ``.gitignore``
+    — ignored files do not appear in the output.
+
+    Args:
+        worktree_path: Path to the worktree directory.
+
+    Returns:
+        Tuple of (has_changes, untracked_files).  ``has_changes`` is True
+        when the output is non-empty.  ``untracked_files`` lists paths
+        prefixed with ``??`` in the porcelain output.
+    """
+    result = run_git(["status", "--porcelain"], worktree_path, timeout=_SALVAGE_TIMEOUT_S)
+    if not result.ok:
+        return False, []
+    untracked: list[str] = []
+    has_any = False
+    for raw in result.stdout.splitlines():
+        if not raw.strip():
+            continue
+        has_any = True
+        if raw.startswith("?? "):
+            untracked.append(raw[3:].strip())
+    return has_any, untracked
+
+
+def _salvage_dir(repo_root: Path, session_id: str, ts: int) -> Path:
+    """Return (and create) the per-session salvage directory.
+
+    Layout: ``.sdd/runtime/salvage/<session-id>-<timestamp>/``.
+    """
+    base = repo_root / _SALVAGE_DIR_REL
+    out = base / f"{session_id}-{ts}"
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _write_patch_fallback(
+    worktree_path: Path,
+    repo_root: Path,
+    session_id: str,
+    untracked_files: list[str],
+    ts: int,
+    diff_text: str,
+) -> tuple[Path | None, list[str]]:
+    """Dump the worktree's dirty state to a filesystem salvage directory.
+
+    Produces two artefacts inside ``.sdd/runtime/salvage/<id>-<ts>/``:
+
+    - ``diff.patch``: pre-captured ``git diff HEAD`` (tracked modifications
+      only).  Must be captured *before* the branch path runs because
+      ``_try_salvage_branch`` commits the work and advances HEAD.
+    - ``untracked.json``: list of untracked file paths *and* their raw
+      bytes base64-encoded so the content is recoverable without needing
+      the original worktree.
+
+    Args:
+        worktree_path: Path to the dirty worktree.
+        repo_root: Repository root used to resolve the salvage directory.
+        session_id: Agent session identifier.
+        untracked_files: Untracked paths previously collected from
+            ``git status --porcelain``.
+        ts: Unix timestamp used in the salvage directory name.
+        diff_text: Pre-captured diff contents (``git diff HEAD``).
+
+    Returns:
+        Tuple of (salvage directory path, errors).  The path is ``None``
+        if nothing was saved.
+    """
+    errors: list[str] = []
+    out_dir = _salvage_dir(repo_root, session_id, ts)
+
+    # 1. Tracked diff — pre-captured so it reflects the worktree state *before*
+    #    the branch path committed the changes.
+    patch_path = out_dir / "diff.patch"
+    try:
+        patch_path.write_text(diff_text, encoding="utf-8")
+    except OSError as exc:
+        errors.append(f"write diff.patch: {exc}")
+        return None, errors
+
+    # 2. Untracked files — dump name + base64 bytes so binary blobs survive.
+    import base64
+
+    untracked_payload: list[dict[str, str]] = []
+    for rel in untracked_files:
+        src = worktree_path / rel
+        if not src.is_file():
+            continue
+        try:
+            raw = src.read_bytes()
+        except OSError as exc:
+            errors.append(f"read untracked {rel}: {exc}")
+            continue
+        untracked_payload.append(
+            {
+                "path": rel,
+                "base64": base64.b64encode(raw).decode("ascii"),
+            }
+        )
+    try:
+        (out_dir / "untracked.json").write_text(
+            json.dumps({"session_id": session_id, "files": untracked_payload}, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        errors.append(f"write untracked.json: {exc}")
+
+    # 3. Human-readable marker so operators can spot the salvage at a glance.
+    try:
+        (out_dir / "README.txt").write_text(
+            "Salvaged uncommitted worktree state (audit-088).\n"
+            f"session_id: {session_id}\n"
+            f"timestamp: {ts}\n"
+            f"untracked_count: {len(untracked_payload)}\n"
+            "\n"
+            "Restore with:\n"
+            "  git apply diff.patch\n"
+            '  python -c \'import json,base64,os;d=json.load(open("untracked.json"));\\\n'
+            '    [open(f["path"],"wb").write(base64.b64decode(f["base64"])) for f in d["files"]]\'\n',
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        errors.append(f"write README.txt: {exc}")
+
+    return out_dir, errors
+
+
+def _try_salvage_branch(
+    worktree_path: Path,
+    repo_root: Path,
+    session_id: str,
+) -> tuple[str | None, bool, list[str]]:
+    """Attempt to capture dirty state as a ``salvage/<id>`` branch.
+
+    Strategy:
+    1. ``git add -A`` inside the worktree so tracked edits + new files land
+       on the index.  ``.gitignore`` matches are skipped by ``git add`` —
+       no explicit filter needed.
+    2. ``git commit -m "WIP: salvage <id>"`` (allowed-empty so we still
+       leave an audit marker when the diff is trivial).
+    3. Rename the current branch ref to ``salvage/<id>`` via
+       ``git branch -M`` so the worktree's agent branch becomes the
+       salvage branch (the worktree is about to be removed anyway).
+    4. Push ``salvage/<id>`` to the remote (best-effort).
+
+    Args:
+        worktree_path: Path to the dirty worktree.
+        repo_root: Repository root (used to resolve the main repo for
+            remote queries if needed — currently unused but kept for
+            future extensions).
+        session_id: Agent session identifier.
+
+    Returns:
+        Tuple of (branch name, pushed, errors).  ``branch`` is ``None``
+        if the branch could not be created for any reason.
+    """
+    del repo_root  # reserved for future use
+    errors: list[str] = []
+    branch = f"{_SALVAGE_BRANCH_PREFIX}{session_id}"
+
+    # 1. Stage everything (including untracked files, skipping .gitignore).
+    add_r = run_git(["add", "-A"], worktree_path, timeout=_SALVAGE_TIMEOUT_S)
+    if not add_r.ok:
+        errors.append(f"git add -A: {add_r.stderr.strip()}")
+        return None, False, errors
+
+    # 2. Commit.  --allow-empty so we leave a breadcrumb even when the diff
+    #    is purely whitespace or already staged-and-reverted.
+    msg = f"WIP: salvage {session_id} (audit-088)"
+    commit_r = run_git(
+        [
+            "-c",
+            "user.email=bernstein@salvage.local",
+            "-c",
+            "user.name=bernstein-salvage",
+            "commit",
+            "--allow-empty",
+            "-m",
+            msg,
+        ],
+        worktree_path,
+        timeout=_SALVAGE_TIMEOUT_S,
+    )
+    if not commit_r.ok:
+        errors.append(f"git commit: {commit_r.stderr.strip()}")
+        return None, False, errors
+
+    # 3. Rename current branch to salvage/<id>.
+    rename_r = run_git(["branch", "-M", branch], worktree_path, timeout=_SALVAGE_TIMEOUT_S)
+    if not rename_r.ok:
+        errors.append(f"git branch -M {branch}: {rename_r.stderr.strip()}")
+        return None, False, errors
+
+    # 4. Push best-effort.
+    push_r = run_git(
+        ["push", "--set-upstream", "origin", branch],
+        worktree_path,
+        timeout=60,
+    )
+    pushed = push_r.ok
+    if not pushed:
+        errors.append(f"git push origin {branch}: {push_r.stderr.strip()}")
+
+    return branch, pushed, errors
+
+
+def salvage_worktree(
+    repo_root: Path,
+    worktree_path: Path,
+    session_id: str,
+    *,
+    push: bool = True,
+) -> SalvageResult:
+    """Capture any uncommitted work from *worktree_path* before it is removed.
+
+    The preferred strategy is a salvage branch — it's the easiest to
+    inspect (``git log salvage/<id>``, ``git diff main...salvage/<id>``).
+    When the branch cannot be pushed to the remote we still keep the
+    local ref, *and* we always write a filesystem patch as a belt-and-
+    braces fallback so the salvage survives even if the local ref is
+    garbage-collected.
+
+    Args:
+        repo_root: Repository root (used to locate ``.sdd/runtime/salvage``).
+        worktree_path: Path to the worktree about to be cleaned up.
+        session_id: Agent session identifier (used for branch + directory
+            names).
+        push: When False, skip the ``git push`` step (useful for tests
+            and offline runs).
+
+    Returns:
+        SalvageResult describing what was saved.  Callers should log the
+        return value so the operator can find the salvage later.
+    """
+    errors: list[str] = []
+
+    if not worktree_path.exists():
+        return SalvageResult(salvaged=False, had_changes=False, errors=["worktree path does not exist"])
+
+    # Quick status probe — if the worktree is clean we exit immediately with no
+    # side effects.  This is the common case for successful agent runs.
+    try:
+        has_changes, untracked = _collect_status(worktree_path)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("salvage: status probe failed for %s: %s", session_id, exc)
+        return SalvageResult(salvaged=False, had_changes=False, errors=[f"status probe: {exc}"])
+
+    if not has_changes:
+        return SalvageResult(salvaged=False, had_changes=False)
+
+    ts = int(time.time())
+    branch: str | None = None
+    pushed = False
+    patch_path: Path | None = None
+
+    # 0. Capture the diff BEFORE the branch path — ``_try_salvage_branch``
+    #    commits the dirty state, which advances HEAD and makes ``git diff HEAD``
+    #    empty.  We still want the fs fallback to contain the real diff.
+    diff_r = run_git(["diff", "HEAD"], worktree_path, timeout=_SALVAGE_TIMEOUT_S)
+    diff_text = diff_r.stdout if diff_r.ok else ""
+    if not diff_r.ok:
+        errors.append(f"git diff HEAD (pre-capture): {diff_r.stderr.strip()}")
+
+    # 1. Try the branch path first (preferred).
+    try:
+        branch, pushed, branch_errors = _try_salvage_branch(worktree_path, repo_root, session_id)
+        errors.extend(branch_errors)
+        if not push and branch is not None:
+            # Caller asked us not to push — reset the flag so the result is accurate.
+            pushed = False
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("salvage: branch path failed for %s: %s", session_id, exc)
+        errors.append(f"branch path: {exc}")
+
+    # 2. Always write the filesystem patch fallback.  Cheap insurance — even
+    #    a successful branch push can be overwritten or force-deleted later.
+    try:
+        patch_path, patch_errors = _write_patch_fallback(
+            worktree_path,
+            repo_root,
+            session_id,
+            untracked,
+            ts,
+            diff_text,
+        )
+        errors.extend(patch_errors)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("salvage: patch fallback failed for %s: %s", session_id, exc)
+        errors.append(f"patch fallback: {exc}")
+
+    salvaged = branch is not None or patch_path is not None
+
+    if salvaged:
+        logger.warning(
+            "Salvaged uncommitted work for session %s: branch=%s pushed=%s patch=%s untracked=%d",
+            session_id,
+            branch,
+            pushed,
+            patch_path,
+            len(untracked),
+        )
+    else:
+        logger.error(
+            "Failed to salvage uncommitted work for session %s — changes may be lost. errors=%s",
+            session_id,
+            errors,
+        )
+
+    return SalvageResult(
+        salvaged=salvaged,
+        had_changes=True,
+        branch=branch,
+        branch_pushed=pushed,
+        patch_path=patch_path,
+        untracked_files=list(untracked),
+        errors=errors,
+    )

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from bernstein.core.git.git_ops import branch_delete, worktree_add, worktree_list, worktree_remove
+from bernstein.core.git.salvage import SalvageResult, salvage_worktree
 from bernstein.core.git.worktree_isolation import validate_worktree_isolation
 from bernstein.core.platform_compat import process_alive
 
@@ -351,11 +352,17 @@ class WorktreeManager:
         self,
         repo_root: Path,
         setup_config: WorktreeSetupConfig | None = None,
+        *,
+        salvage_on_cleanup: bool = True,
+        salvage_push: bool = True,
     ) -> None:
         self.repo_root = repo_root.resolve()
         self._base_dir = self.repo_root / _WORKTREE_BASE
         self._setup_config = setup_config
+        self._salvage_on_cleanup = salvage_on_cleanup
+        self._salvage_push = salvage_push
         self._shutdown_event: threading.Event | None = None
+        self._last_salvage: SalvageResult | None = None
 
     def set_shutdown_event(self, shutdown_event: threading.Event | None) -> None:
         """Attach a shutdown event used to reject new worktree creation."""
@@ -440,11 +447,34 @@ class WorktreeManager:
         Best-effort: logs warnings for individual failures but does not raise.
         Safe to call even if the worktree was never created or already cleaned.
 
+        Before the destructive ``git worktree remove --force`` call, any
+        uncommitted work in the worktree is salvaged via
+        :func:`~bernstein.core.git.salvage.salvage_worktree` so the diff is
+        recoverable post-cleanup (audit-088).  The salvage step is purely
+        best-effort: on failure the original cleanup proceeds as before.
+
         Args:
             session_id: The session whose worktree should be removed.
         """
         worktree_path = self._base_dir / session_id
         branch_name = f"agent/{session_id}"
+
+        # 0. Salvage uncommitted work BEFORE anything destructive happens (audit-088).
+        self._last_salvage = None
+        if self._salvage_on_cleanup and worktree_path.exists():
+            try:
+                self._last_salvage = salvage_worktree(
+                    self.repo_root,
+                    worktree_path,
+                    session_id,
+                    push=self._salvage_push,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Salvage step crashed for %s (continuing cleanup): %s",
+                    session_id,
+                    exc,
+                )
 
         # 1. Remove the worktree (--force handles dirty state)
         try:
@@ -459,6 +489,9 @@ class WorktreeManager:
             logger.warning("Failed to remove worktree for %s: %s", session_id, exc)
 
         # 2. Delete the branch
+        #    When salvage moved the branch to salvage/<id> the original agent
+        #    branch no longer exists; branch_delete will report "not found"
+        #    which we already swallow below.
         try:
             result = branch_delete(self.repo_root, branch_name)
             if not result.ok and "not found" not in result.stderr:
@@ -474,6 +507,16 @@ class WorktreeManager:
         remove_worktree_lock(self.repo_root, session_id)
 
         logger.info("Cleaned up worktree for session %s", session_id)
+
+    @property
+    def last_salvage(self) -> SalvageResult | None:
+        """Return the salvage result from the most recent cleanup call.
+
+        ``None`` if no cleanup has been invoked yet or salvage was disabled.
+        Useful for tests and for operators who want to log/emit metrics on
+        the salvage outcome.
+        """
+        return self._last_salvage
 
     def cleanup_all_stale(self) -> int:
         """Remove all worktrees under the base dir from prior runs.

--- a/tests/unit/test_worktree_salvage.py
+++ b/tests/unit/test_worktree_salvage.py
@@ -1,0 +1,245 @@
+"""Tests for worktree cleanup salvage (audit-088).
+
+These tests use a real git repo + real ``git worktree add`` because the salvage
+codepath shells out to ``git`` for status, add, commit, branch -M, and diff —
+mocking all of that would defeat the purpose.  Each test runs in ``tmp_path``
+so no state escapes the sandbox.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.git.salvage import salvage_worktree
+from bernstein.core.git.worktree import WorktreeManager
+
+
+def _run(cmd: list[str], cwd: Path) -> None:
+    """Run a git command, raising on failure — test helper."""
+    subprocess.run(
+        cmd,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def repo_with_worktree(tmp_path: Path) -> tuple[Path, Path, str]:
+    """Create a real git repo with a real worktree checked out on a fresh branch.
+
+    Returns:
+        (repo_root, worktree_path, session_id)
+    """
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+
+    # Init with a named default branch so we do not depend on the user's
+    # global ``init.defaultBranch`` setting.
+    _run(["git", "init", "-b", "main"], repo_root)
+    _run(["git", "config", "user.email", "test@example.com"], repo_root)
+    _run(["git", "config", "user.name", "Test User"], repo_root)
+    # commit.gpgsign may be on globally; turn it off so the test does not
+    # block on a signing prompt.
+    _run(["git", "config", "commit.gpgsign", "false"], repo_root)
+
+    # Seed an initial commit so HEAD is valid (salvage needs HEAD to diff against).
+    seed = repo_root / "README.md"
+    seed.write_text("seed\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], repo_root)
+    _run(["git", "commit", "-m", "seed"], repo_root)
+
+    session_id = "test-salvage-session"
+    worktree_path = repo_root / ".sdd" / "worktrees" / session_id
+    worktree_path.parent.mkdir(parents=True, exist_ok=True)
+    _run(
+        ["git", "worktree", "add", "-b", f"agent/{session_id}", str(worktree_path)],
+        repo_root,
+    )
+    # The worktree inherits config from the main repo for user.email/name +
+    # commit.gpgsign, so no extra setup is needed inside the worktree.
+
+    return repo_root, worktree_path, session_id
+
+
+def _dirty_the_worktree(worktree_path: Path) -> tuple[str, str]:
+    """Make both a tracked edit and an untracked addition.
+
+    Returns:
+        (tracked_content, untracked_content)
+    """
+    tracked_content = "seed\nmodified by agent\n"
+    (worktree_path / "README.md").write_text(tracked_content, encoding="utf-8")
+
+    untracked_content = "brand new file\n"
+    (worktree_path / "new_feature.py").write_text(untracked_content, encoding="utf-8")
+
+    return tracked_content, untracked_content
+
+
+def test_salvage_on_clean_worktree_is_noop(repo_with_worktree: tuple[Path, Path, str]) -> None:
+    """A clean worktree should report nothing to salvage and not touch disk."""
+    repo_root, worktree_path, session_id = repo_with_worktree
+
+    result = salvage_worktree(repo_root, worktree_path, session_id, push=False)
+
+    assert result.had_changes is False
+    assert result.salvaged is False
+    assert result.branch is None
+    assert result.patch_path is None
+    # No salvage dir should have been created for a clean tree.
+    assert not (repo_root / ".sdd" / "runtime" / "salvage").exists()
+
+
+def test_salvage_creates_branch_and_filesystem_fallback(
+    repo_with_worktree: tuple[Path, Path, str],
+) -> None:
+    """Dirty worktree -> salvage/<id> branch exists + filesystem fallback written."""
+    repo_root, worktree_path, session_id = repo_with_worktree
+    _dirty_the_worktree(worktree_path)
+
+    # push=False because the fixture has no remote; we still want the branch path.
+    result = salvage_worktree(repo_root, worktree_path, session_id, push=False)
+
+    assert result.had_changes is True
+    assert result.salvaged is True
+
+    # 1. Salvage branch must exist locally.
+    assert result.branch == f"salvage/{session_id}"
+    branches = subprocess.run(
+        ["git", "branch", "--list", result.branch],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout
+    assert result.branch in branches, f"salvage branch missing: {branches!r}"
+
+    # 2. Filesystem fallback must also exist.
+    assert result.patch_path is not None
+    assert result.patch_path.is_dir()
+    assert (result.patch_path / "diff.patch").is_file()
+    assert (result.patch_path / "untracked.json").is_file()
+    assert (result.patch_path / "README.txt").is_file()
+
+    # 3. The recorded untracked list must mention our new file.
+    assert "new_feature.py" in result.untracked_files
+
+    # 4. Branch was not pushed (no remote).
+    assert result.branch_pushed is False
+
+
+def test_salvage_diff_is_recoverable_from_branch(
+    repo_with_worktree: tuple[Path, Path, str],
+) -> None:
+    """The salvage branch's tree should contain both the modified + new file."""
+    repo_root, worktree_path, session_id = repo_with_worktree
+    _dirty_the_worktree(worktree_path)
+
+    result = salvage_worktree(repo_root, worktree_path, session_id, push=False)
+    assert result.salvaged
+    assert result.branch is not None
+
+    # The tracked edit should show up in ``git diff main...salvage/<id>``.
+    diff = subprocess.run(
+        ["git", "diff", f"main...{result.branch}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout
+    assert "modified by agent" in diff, f"tracked edit missing from salvage diff: {diff!r}"
+    # And the untracked file is now a new-file hunk on the branch.
+    assert "new_feature.py" in diff, f"untracked file missing from salvage diff: {diff!r}"
+
+
+def test_salvage_diff_is_recoverable_from_filesystem_fallback(
+    repo_with_worktree: tuple[Path, Path, str],
+) -> None:
+    """Even without the branch, ``diff.patch`` + ``untracked.json`` recover the work."""
+    import base64
+    import json
+
+    repo_root, worktree_path, session_id = repo_with_worktree
+    _, untracked_content = _dirty_the_worktree(worktree_path)
+
+    result = salvage_worktree(repo_root, worktree_path, session_id, push=False)
+    assert result.patch_path is not None
+
+    patch = (result.patch_path / "diff.patch").read_text(encoding="utf-8")
+    assert "modified by agent" in patch, f"tracked diff not captured: {patch!r}"
+
+    payload = json.loads((result.patch_path / "untracked.json").read_text(encoding="utf-8"))
+    names = [entry["path"] for entry in payload["files"]]
+    assert "new_feature.py" in names
+
+    # base64-decoded bytes must match what we wrote into the worktree.
+    new_feature_entry = next(e for e in payload["files"] if e["path"] == "new_feature.py")
+    recovered = base64.b64decode(new_feature_entry["base64"]).decode("utf-8")
+    assert recovered == untracked_content
+
+
+def test_worktree_manager_cleanup_runs_salvage_before_remove(
+    repo_with_worktree: tuple[Path, Path, str],
+) -> None:
+    """End-to-end: WorktreeManager.cleanup() salvages dirty state before deleting."""
+    repo_root, worktree_path, session_id = repo_with_worktree
+    _dirty_the_worktree(worktree_path)
+
+    mgr = WorktreeManager(repo_root=repo_root, salvage_on_cleanup=True, salvage_push=False)
+    mgr.cleanup(session_id)
+
+    # 1. Worktree directory is gone.
+    assert not worktree_path.exists(), "worktree should have been removed"
+
+    # 2. salvage/<id> branch exists.
+    branches = subprocess.run(
+        ["git", "branch", "--list", f"salvage/{session_id}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout
+    assert f"salvage/{session_id}" in branches, f"salvage branch missing: {branches!r}"
+
+    # 3. Manager exposes the salvage result for observability.
+    assert mgr.last_salvage is not None
+    assert mgr.last_salvage.had_changes is True
+    assert mgr.last_salvage.salvaged is True
+    assert mgr.last_salvage.branch == f"salvage/{session_id}"
+
+    # 4. Filesystem fallback is still there after the worktree is gone.
+    assert mgr.last_salvage.patch_path is not None
+    assert (mgr.last_salvage.patch_path / "diff.patch").is_file()
+
+
+def test_worktree_manager_cleanup_with_salvage_disabled(
+    repo_with_worktree: tuple[Path, Path, str],
+) -> None:
+    """When salvage is disabled, dirty state is lost (regression guard)."""
+    repo_root, worktree_path, session_id = repo_with_worktree
+    _dirty_the_worktree(worktree_path)
+
+    mgr = WorktreeManager(repo_root=repo_root, salvage_on_cleanup=False)
+    mgr.cleanup(session_id)
+
+    assert not worktree_path.exists()
+    # No salvage branch, no last_salvage.
+    branches = subprocess.run(
+        ["git", "branch", "--list", f"salvage/{session_id}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=True,
+    ).stdout.strip()
+    assert branches == "", f"expected no salvage branch when disabled, got {branches!r}"
+    assert mgr.last_salvage is None


### PR DESCRIPTION
## Summary

When an agent dies, is killed, or its worktree is otherwise reaped while it still has dirty state, ``git worktree remove --force`` silently discards the work. Diffs and untracked files are lost — not even ``git reflog`` can recover them because no ref ever pointed at the work.

This PR introduces a best-effort salvage step that runs **before** the destructive remove so that dirty state is durably captured.

### What the salvage does

1. **Preferred path — ``salvage/<session-id>`` branch.** Stages everything (``git add -A``, respects ``.gitignore``), commits with a WIP marker, renames the branch via ``git branch -M``, and pushes to ``origin`` (best-effort). The salvage branch is easy to inspect with ``git log salvage/<id>`` / ``git diff main...salvage/<id>`` and can be cherry-picked back.
2. **Always-on fallback — filesystem dump at ``.sdd/runtime/salvage/<id>-<ts>/``.** Contains:
   - ``diff.patch`` — ``git diff HEAD`` captured **before** the branch commit (otherwise HEAD has already moved and the diff would be empty).
   - ``untracked.json`` — list of untracked file paths plus their raw bytes, base64-encoded, so binary blobs survive too.
   - ``README.txt`` — human-readable restore instructions.

### Wiring

``WorktreeManager.cleanup()`` now calls ``salvage_worktree()`` first; any crash in the salvage step is logged and swallowed so the cleanup path itself never fails because of salvage. The manager exposes the result via ``last_salvage`` so operators can surface it in metrics / TUI. Opt out with ``WorktreeManager(salvage_on_cleanup=False)``; skip remote push with ``salvage_push=False`` (useful in offline runs + tests).

### Why this matters

Addresses the ``deep_audit_findings`` call-out on work loss when agents are killed mid-task. With salvage in place, an operator can always recover the dirty state after the fact, either from the ``salvage/*`` branch on the remote or from the local filesystem dump.

## Test plan

- [x] ``uv run ruff check src/bernstein/core/git/ tests/unit/test_worktree_salvage.py`` — clean
- [x] ``uv run ruff format --check src/bernstein/core/git/ tests/unit/test_worktree_salvage.py`` — clean
- [x] ``uv run pytest tests/unit -k "salvage or worktree_salvage" -x -q`` — 6 passed (new tests exercise: clean-worktree no-op, dirty-worktree branch + fs fallback, diff recoverability from branch, diff recoverability from fs fallback, end-to-end ``WorktreeManager.cleanup`` runs salvage, opt-out regression guard)
- [x] Existing worktree suite unaffected: ``uv run pytest tests/unit/test_worktree*.py -x -q`` — 81 passed