### PR TITLE
security: enable auth by default, remove unauth bypass paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,6 +412,7 @@ addopts = [
 ]
 markers = [
     "ci: tests that run as part of CI for every release",
+    "auth_enabled: opt out of the autouse auth-disabled shim (tests that exercise auth defaults)",
 ]
 # Visible warnings without converting to errors; individual tests or runs
 # can tighten via `pytest -W error::DeprecationWarning`.

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -543,6 +543,10 @@ class ClaudeCodeAdapter(CLIAdapter):
         and SubagentStop events.  Each hook POSTs to the Bernstein task server
         so the orchestrator gets real-time visibility into agent activity.
 
+        Each hook request is signed with HMAC-SHA256 over the raw body, using
+        the shared secret in ``BERNSTEIN_HOOK_SECRET`` (or
+        ``BERNSTEIN_AUTH_TOKEN``).  The server rejects unsigned requests.
+
         If the settings file already exists, the hooks key is merged in
         (preserving any other settings the user may have configured).
 
@@ -556,7 +560,18 @@ class ClaudeCodeAdapter(CLIAdapter):
         settings_path = settings_dir / "settings.local.json"
 
         hook_url = f"{server_url}/hooks/{session_id}"
-        curl_cmd = f"curl -sS -X POST -H 'Content-Type: application/json' -d @- {hook_url}"
+        # Sign the body with HMAC-SHA256 before posting.  ``openssl`` is in the
+        # base image on every supported OS; we read the secret from the env
+        # var the adapter also exports when spawning the agent.
+        curl_cmd = (
+            "sh -c '"
+            'SECRET="${BERNSTEIN_HOOK_SECRET:-$BERNSTEIN_AUTH_TOKEN}"; '
+            "BODY=$(cat); "
+            'SIG=$(printf "%s" "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | awk "{print \\$2}"); '
+            'curl -sS -X POST -H "Content-Type: application/json" '
+            f'-H "X-Bernstein-Hook-Signature-256: sha256=$SIG" -d "$BODY" {hook_url}'
+            "'"
+        )
         hook_entry = {"type": "command", "command": curl_cmd}
 
         hook_events = ["PostToolUse", "Stop", "PreCompact", "SubagentStart", "SubagentStop"]

--- a/src/bernstein/core/routes/hooks.py
+++ b/src/bernstein/core/routes/hooks.py
@@ -6,18 +6,29 @@ adapter injects these hooks into ``.claude/settings.local.json`` before
 spawning so every tool invocation and lifecycle event is reported in
 real time.
 
-The endpoint is intentionally public (no auth required) because hooks
-fire from the same localhost where the agent runs.  Because the path
-parameter is attacker-controllable when the server is reachable from the
-network, every ``session_id`` is run through
-:func:`bernstein.core.hooks_receiver.validate_session_id` before any
-filesystem operation happens.  See audit-114 for the traversal threat
-model this guards against.
+Authentication (audit-113)
+--------------------------
+The endpoint is mounted outside the bearer-auth gate because Claude Code's
+hook runner cannot carry Bearer tokens.  Instead, each request is signed
+with HMAC-SHA256 using the shared secret configured via
+``BERNSTEIN_HOOK_SECRET`` (or ``BERNSTEIN_AUTH_TOKEN`` as a fallback).
+Requests without a matching ``X-Bernstein-Hook-Signature-256`` header are
+rejected with 401.
+
+Security (audit-114)
+--------------------
+``session_id`` is strictly validated before any filesystem work.  Values
+containing path separators, ``..``, null bytes, or anything outside
+``^[A-Za-z0-9_-]{1,128}$`` are rejected with 400.  This blocks URL-encoded
+traversal such as ``/hooks/..%2F..%2Fruntime%2Fsignals%2FSHUTDOWN`` from
+forging completion markers or clobbering runtime state.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -30,9 +41,62 @@ from bernstein.core.hooks_receiver import (
     process_hook_event,
     validate_session_id,
 )
+from bernstein.core.server.webhook_signatures import verify_hmac_sha256
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+_HOOK_SECRET_ENV = "BERNSTEIN_HOOK_SECRET"
+_HOOK_SECRET_FALLBACK_ENV = "BERNSTEIN_AUTH_TOKEN"
+_HOOK_SIGNATURE_HEADER = "x-bernstein-hook-signature-256"
+
+
+def _resolve_hook_secret() -> str:
+    """Return the shared HMAC secret for hook requests.
+
+    Prefers ``BERNSTEIN_HOOK_SECRET``; falls back to ``BERNSTEIN_AUTH_TOKEN``
+    so existing deployments keep working without extra configuration.
+    """
+    secret = os.environ.get(_HOOK_SECRET_ENV, "").strip()
+    if secret:
+        return secret
+    return os.environ.get(_HOOK_SECRET_FALLBACK_ENV, "").strip()
+
+
+def _verify_hook_signature(request: Request, body: bytes) -> JSONResponse | None:
+    """Validate the hook HMAC signature.
+
+    Returns a 401 JSONResponse when the secret is missing or when the
+    request carries no (or an invalid) signature.  Returns ``None`` when
+    validation passes.
+
+    When no secret is configured the endpoint is *disabled* (returns 401) —
+    hooks cannot be authenticated and must not be trusted by default.
+    Operators who deliberately run without auth set
+    ``BERNSTEIN_AUTH_DISABLED=1`` at the app level; in that mode the SSO
+    middleware is bypassed and this helper is not invoked because the
+    caller never reaches it.
+    """
+    secret = _resolve_hook_secret()
+    if not secret:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "detail": (
+                    "Hook endpoint is not configured: set "
+                    "BERNSTEIN_HOOK_SECRET (or BERNSTEIN_AUTH_TOKEN) "
+                    "to the shared secret used by the Claude Code hook "
+                    "runner."
+                ),
+            },
+        )
+    provided = request.headers.get(_HOOK_SIGNATURE_HEADER, "")
+    if not provided or not verify_hmac_sha256(body, provided, secret, prefix="sha256="):
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Invalid or missing hook signature"},
+        )
+    return None
 
 
 def _get_workdir(request: Request) -> Path:
@@ -62,22 +126,27 @@ async def receive_hook(session_id: str, request: Request) -> JSONResponse:
     field.  The event is parsed, persisted to a JSONL sidecar, and triggers
     side effects (heartbeat touch, completion markers, etc.).
 
-    Security (audit-114):
-        ``session_id`` is strictly validated before anything else.  Values
-        containing path separators, ``..``, null bytes, or that otherwise
-        fall outside ``^[A-Za-z0-9_-]{1,128}$`` are rejected with 400.
-        This blocks URL-encoded traversal such as
-        ``/hooks/..%2F..%2Fruntime%2Fsignals%2FSHUTDOWN`` from forging
-        completion markers or clobbering runtime state.
+    The request body is verified against
+    ``X-Bernstein-Hook-Signature-256`` (HMAC-SHA256 over the raw body,
+    keyed with ``BERNSTEIN_HOOK_SECRET``) *before* any parsing or
+    filesystem work — this is the authentication boundary for the
+    endpoint (audit-113).  The ``session_id`` is then validated against
+    a strict allowlist to prevent path traversal (audit-114).
 
     Args:
         session_id: Agent session identifier from the URL path.
         request: The incoming FastAPI request.
 
     Returns:
-        JSON response with status and action taken, or a 400 error if
-        the ``session_id`` is unsafe or the body is not valid JSON.
+        JSON response with status and action taken, 401 if signature
+        verification fails, or 400 if ``session_id`` is unsafe / body
+        is not valid JSON.
     """
+    raw_body = await request.body()
+    denied = _verify_hook_signature(request, raw_body)
+    if denied is not None:
+        return denied
+
     try:
         validate_session_id(session_id)
     except InvalidSessionIdError as exc:
@@ -88,8 +157,8 @@ async def receive_hook(session_id: str, request: Request) -> JSONResponse:
         return _reject(f"invalid session_id: {exc}")
 
     try:
-        body: dict[str, Any] = await request.json()
-    except Exception:
+        body: dict[str, Any] = json.loads(raw_body.decode("utf-8")) if raw_body else {}
+    except (UnicodeDecodeError, json.JSONDecodeError):
         return _reject("invalid JSON body")
 
     workdir = _get_workdir(request)

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -5,8 +5,18 @@ that supports:
 - JWT tokens (from SSO login)
 - Agent identity JWT tokens (per-agent, task-scoped, zero-trust)
 - Legacy bearer tokens (backwards compatible)
-- Public path exemptions
+- Public path exemptions (health, discovery, login flow)
+- HMAC-authenticated path exemptions (webhooks/hooks validate their own HMAC)
 - User context injection into request.state
+
+Secure-by-default
+-----------------
+Authentication is REQUIRED by default.  A request to any protected path
+without a valid Bearer token (and without a matching HMAC signature for
+HMAC-authenticated paths) returns HTTP 401.  To run without authentication
+(development convenience only) set ``BERNSTEIN_AUTH_DISABLED=1`` or put
+``auth.enabled: false`` in ``bernstein.yaml`` — this logs a loud warning
+once per process.
 
 Zero-trust enforcement
 ----------------------
@@ -20,6 +30,7 @@ unrestricted (manager / orchestrator tokens).
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -42,24 +53,31 @@ logger = logging.getLogger(__name__)
 # Regex to extract task ID from paths like /tasks/{id}/complete
 _TASK_ID_PATH_RE = re.compile(r"^/tasks/([^/]+)/(?:complete|fail|progress|cancel|block|steal)$")
 
+# ---------------------------------------------------------------------------
+# Public and HMAC-authenticated paths
+# ---------------------------------------------------------------------------
 
-# Paths that are always accessible without authentication
+# Paths that are always accessible without any authentication.
+# Keep this list tiny — only trivially public endpoints (health probes,
+# discovery metadata, docs, login flow) belong here.
 AUTH_PUBLIC_PATHS = frozenset(
     {
+        # Health / readiness probes
         "/health",
         "/health/ready",
         "/health/live",
+        "/health/deps",
         "/ready",
         "/alive",
+        # Agent / protocol discovery
         "/.well-known/agent.json",
+        "/.well-known/acp.json",
+        "/acp/v0/agents",
+        # API docs
         "/docs",
+        "/redoc",
         "/openapi.json",
-        "/webhook",
-        "/webhooks/github",
-        "/dashboard",
-        "/dashboard/data",
-        "/dashboard/file_locks",
-        "/events",
+        "/openapi.yaml",
         # Auth flow endpoints (must be public for login to work)
         "/auth/login",
         "/auth/oidc/callback",
@@ -71,9 +89,31 @@ AUTH_PUBLIC_PATHS = frozenset(
     }
 )
 
-# Path prefixes that are always accessible without authentication.
+# Paths whose handlers perform their own HMAC-based verification.  The
+# bearer-token middleware lets these pass; the route itself rejects
+# unsigned / badly-signed requests with 401.
+#
+# IMPORTANT: do NOT add paths here unless their handler actually verifies
+# a shared-secret HMAC signature.  An entry here bypasses bearer auth.
+AUTH_HMAC_PATHS = frozenset(
+    {
+        "/webhook",
+        "/webhooks/github",
+        "/webhooks/gitlab",
+        "/webhooks/slack/commands",
+        "/webhooks/slack/events",
+    }
+)
+
+# Path prefixes whose handlers perform their own HMAC verification.
 # Used for routes with path parameters (e.g. /hooks/{session_id}).
-AUTH_PUBLIC_PATH_PREFIXES = ("/hooks/",)
+AUTH_HMAC_PATH_PREFIXES = ("/hooks/",)
+
+# Opt-out flag: when set to a truthy value, auth is disabled and the
+# middleware passes every request through (with a loud warning on startup).
+AUTH_DISABLED_ENV = "BERNSTEIN_AUTH_DISABLED"
+
+_AUTH_DISABLED_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 # Read-only methods that viewers can access
 _READ_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
@@ -88,6 +128,18 @@ _ROUTE_PERMISSIONS: dict[str, str] = {
     "/config": "config:write",
     "/webhooks": "webhooks:manage",
 }
+
+
+def auth_disabled_via_opt_out() -> bool:
+    """Return True when auth has been explicitly opted out for the process.
+
+    The only supported opt-out signal is the ``BERNSTEIN_AUTH_DISABLED``
+    environment variable set to a truthy value (``1``, ``true``, ``yes``,
+    ``on``).  Config-based opt-out (``auth.enabled: false`` in
+    ``bernstein.yaml``) is handled at the app factory layer, which passes
+    the resolved flag into :class:`SSOAuthMiddleware` via ``auth_disabled``.
+    """
+    return os.environ.get(AUTH_DISABLED_ENV, "").strip().lower() in _AUTH_DISABLED_TRUTHY
 
 
 def _get_required_permission(path: str, method: str) -> str | None:
@@ -120,11 +172,19 @@ def _get_required_permission(path: str, method: str) -> str | None:
 class SSOAuthMiddleware(BaseHTTPMiddleware):
     """Multi-strategy authentication middleware.
 
-    Authentication strategies (tried in order):
-    1. SSO JWT token in Authorization: Bearer <jwt>
+    Authentication strategies (tried in order for Bearer-authenticated
+    paths):
+
+    1. SSO JWT token in ``Authorization: Bearer <jwt>``
     2. Agent identity JWT (per-agent, task-scoped — zero-trust enforcement)
     3. Legacy static bearer token
-    4. No auth (if auth is not configured)
+    4. 401 if no strategy accepts the token
+
+    HMAC-authenticated paths (``AUTH_HMAC_PATHS``, ``AUTH_HMAC_PATH_PREFIXES``)
+    bypass bearer auth — their route handlers verify a shared-secret HMAC
+    signature and reject invalid / missing signatures with 401.
+
+    Truly-public paths (``AUTH_PUBLIC_PATHS``) require no auth at all.
 
     On successful auth, injects ``request.state.user`` (AuthUser or None)
     and ``request.state.auth_claims`` (dict) for downstream routes.
@@ -134,17 +194,34 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
     checks if needed.
     """
 
+    # Log the "auth disabled" warning at most once per process to keep logs
+    # readable while still making the misconfiguration loud.
+    _warned_disabled: bool = False
+
     def __init__(
         self,
         app: Any,
         auth_service: AuthService | None = None,
         legacy_token: str | None = None,
         agent_identity_store: AgentIdentityStore | None = None,
+        auth_disabled: bool | None = None,
     ) -> None:
         super().__init__(app)
         self._auth_service = auth_service
         self._legacy_token = legacy_token
         self._agent_identity_store = agent_identity_store
+        # Resolve opt-out from explicit arg > env var. Config-based opt-out
+        # should be passed in via ``auth_disabled=True`` from the factory.
+        resolved_disabled = bool(auth_disabled) or auth_disabled_via_opt_out()
+        self._auth_disabled = resolved_disabled
+        if resolved_disabled and not SSOAuthMiddleware._warned_disabled:
+            logger.warning(
+                "SECURITY: Bernstein auth is DISABLED — every request is "
+                "accepted without a Bearer token (opt-out via "
+                "BERNSTEIN_AUTH_DISABLED or auth.enabled=false).  "
+                "Do NOT run this configuration on any network-exposed host.",
+            )
+            SSOAuthMiddleware._warned_disabled = True
 
     async def dispatch(
         self,
@@ -153,28 +230,25 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
     ) -> StarletteResponse:
         path = request.url.path
 
-        # Public paths are always accessible
-        if path in AUTH_PUBLIC_PATHS or path.startswith(AUTH_PUBLIC_PATH_PREFIXES):
+        # Opt-out: pass every request through unauthenticated.
+        if self._auth_disabled:
             response: StarletteResponse = await call_next(request)
+            return response
+
+        # Truly-public paths are always accessible.
+        if path in AUTH_PUBLIC_PATHS:
+            response = await call_next(request)
+            return response
+
+        # HMAC-authenticated paths: the route handler verifies a shared
+        # secret; the bearer middleware lets them through.
+        if path in AUTH_HMAC_PATHS or path.startswith(AUTH_HMAC_PATH_PREFIXES):
+            response = await call_next(request)
             return response
 
         auth_header = request.headers.get("authorization", "")
         has_bearer = auth_header.startswith("Bearer ")
 
-        # No SSO or legacy auth configured (dev/no-auth mode).
-        # In this mode we still validate Bearer tokens when presented — this
-        # enforces zero-trust for agents that do include their tokens while
-        # allowing unauthenticated local development requests to pass through.
-        if self._auth_service is None and not self._legacy_token:
-            if not has_bearer:
-                # No token, no auth configured → dev-mode pass-through
-                response = await call_next(request)
-                return response
-            # A Bearer token is present — validate it as an agent JWT.
-            token = auth_header[7:]
-            return await self._try_agent_or_reject(request, call_next, path, token)
-
-        # Auth IS configured — require a valid token.
         if not has_bearer:
             return JSONResponse(
                 status_code=401,
@@ -210,24 +284,7 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
                 return response
 
         return JSONResponse(
-            status_code=403,
-            content={"detail": "Invalid or expired authentication token"},
-        )
-
-    async def _try_agent_or_reject(
-        self,
-        request: Request,
-        call_next: Callable[[Request], Any],
-        path: str,
-        token: str,
-    ) -> StarletteResponse:
-        """Validate an agent JWT in no-auth mode; reject invalid tokens."""
-        if self._agent_identity_store is not None:
-            result = await self._try_agent_jwt(request, call_next, path, token)
-            if result is not None:
-                return result
-        return JSONResponse(
-            status_code=403,
+            status_code=401,
             content={"detail": "Invalid or expired authentication token"},
         )
 

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -421,6 +421,13 @@ def create_app(
     # Resolve auth token: explicit arg > env var > None
     effective_token = auth_token or os.environ.get("BERNSTEIN_AUTH_TOKEN")
 
+    # Auth is enabled by default.  Operators can opt out via the
+    # BERNSTEIN_AUTH_DISABLED env var or the ``auth.enabled`` seed key —
+    # both paths log a loud warning on startup.
+    from bernstein.core.security.auth_middleware import auth_disabled_via_opt_out
+
+    auth_disabled_flag = auth_disabled_via_opt_out()
+
     # Cluster setup
     effective_cluster = cluster_config or ClusterConfig()
     # Persist node registry alongside the task store when inside .sdd/
@@ -506,11 +513,18 @@ def create_app(
         description=(
             "Bernstein REST API — multi-agent orchestration for CLI coding agents.\n\n"
             "## Authentication\n\n"
-            "When auth is enabled (`BERNSTEIN_AUTH_ENABLED=true`), include a Bearer token "
-            "in all requests:\n\n"
+            "Authentication is ENABLED by default.  Include a Bearer token in "
+            "all requests:\n\n"
             "```\nAuthorization: Bearer <token>\n```\n\n"
-            "Public endpoints (no auth required): `/health`, `/health/ready`, `/health/live`, "
-            "`/.well-known/agent.json`, `/docs`, `/openapi.json`.\n\n"
+            "To run without auth (development only), set `BERNSTEIN_AUTH_DISABLED=1` "
+            "— this logs a loud warning and passes every request through.\n\n"
+            "Public endpoints (no auth required): `/health`, `/health/ready`, "
+            "`/health/live`, `/ready`, `/alive`, `/.well-known/agent.json`, "
+            "`/docs`, `/openapi.json`, and the auth-flow endpoints "
+            "(`/auth/login`, `/auth/oidc/callback`, etc.).\n\n"
+            "Webhook and hook endpoints (`/webhook`, `/webhooks/*`, "
+            "`/hooks/{session_id}`) authenticate via HMAC-SHA256 signatures "
+            "— they do NOT accept Bearer tokens.\n\n"
             "## Base URL\n\n"
             "Default: `http://127.0.0.1:8052`. Override with env vars `BERNSTEIN_HOST` and "
             "`BERNSTEIN_PORT`.\n\n"
@@ -570,6 +584,7 @@ def create_app(
         auth_service=auth_service,
         legacy_token=legacy_auth_token,
         agent_identity_store=_agent_identity_store,
+        auth_disabled=auth_disabled_flag,
     )
 
     # Per-endpoint request rate limiting — reads buckets from app.state.seed_config.

--- a/src/bernstein/core/server/server_middleware.py
+++ b/src/bernstein/core/server/server_middleware.py
@@ -21,36 +21,45 @@ if TYPE_CHECKING:
 # Auth middleware — bearer token validation
 # ---------------------------------------------------------------------------
 
-# Paths that are always accessible without auth (health checks, agent card)
+# Paths that are always accessible without auth (health checks, agent card,
+# API docs, and auth/discovery endpoints).  Keep this list minimal — anything
+# that mutates state or exposes operational data must go through bearer auth
+# (or HMAC alternative auth, for webhook-style endpoints whose handlers
+# verify their own shared secret).
 _PUBLIC_PATHS = frozenset(
     {
         "/health",
         "/health/ready",
         "/health/live",
+        "/health/deps",
         "/ready",
         "/alive",
         "/.well-known/agent.json",
         "/.well-known/acp.json",
         "/acp/v0/agents",
         "/docs",
+        "/redoc",
         "/openapi.json",
-        "/webhook",
-        "/webhooks/github",
-        "/webhooks/slack/commands",
-        "/webhooks/slack/events",
-        "/dashboard",
-        "/dashboard/data",
-        "/dashboard/file_locks",
-        "/events",
-        "/ws",
-        "/health/deps",
-        "/grafana/dashboard",
+        "/openapi.yaml",
     }
 )
 
-# Path prefixes that are always accessible without auth.
-# Used for routes with path parameters (e.g. /hooks/{session_id}).
-_PUBLIC_PATH_PREFIXES = ("/hooks/", "/export/", "/dashboard/tasks/")
+# HMAC-authenticated paths: handler verifies a shared-secret HMAC and rejects
+# unsigned requests with 401.  Listed here so the bearer middleware does not
+# reject them before the handler runs.
+_HMAC_AUTH_PATHS = frozenset(
+    {
+        "/webhook",
+        "/webhooks/github",
+        "/webhooks/gitlab",
+        "/webhooks/slack/commands",
+        "/webhooks/slack/events",
+    }
+)
+
+# Path prefixes whose handler verifies an HMAC signature (e.g.
+# ``/hooks/{session_id}``).
+_HMAC_AUTH_PATH_PREFIXES = ("/hooks/",)
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
@@ -75,7 +84,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return response
 
         path = request.url.path
-        if path in _PUBLIC_PATHS or path.startswith(_PUBLIC_PATH_PREFIXES):
+        if path in _PUBLIC_PATHS or path in _HMAC_AUTH_PATHS or path.startswith(_HMAC_AUTH_PATH_PREFIXES):
             response = await call_next(request)
             return response
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,24 @@ def _stable_adaptive_parallelism(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _disable_auth_for_tests(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable Bernstein auth by default in the test suite.
+
+    Production default is "auth enabled".  Existing tests assume "no bearer
+    token needed"; rather than thread a token through dozens of fixtures we
+    set ``BERNSTEIN_AUTH_DISABLED=1`` for every test.  Tests that exercise
+    the auth behaviour itself (see ``tests/unit/test_auth_middleware_defaults.py``)
+    mark themselves with ``pytest.mark.auth_enabled`` to opt out.
+    """
+
+    if request.node.get_closest_marker("auth_enabled") is not None:
+        # Remove the env var so the middleware sees a "secure-by-default" env.
+        monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+        return
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+
+
+@pytest.fixture(autouse=True)
 def _init_git_repo_for_spawner_tmp_path_tests(request: pytest.FixtureRequest) -> None:
     """Initialize a minimal git repo for AgentSpawner tests that use ``tmp_path``.
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -521,16 +521,19 @@ class TestSSOAuthMiddleware:
     """Tests for the SSO auth middleware logic (unit-level, no HTTP server)."""
 
     def test_public_paths_defined(self) -> None:
-        from bernstein.core.auth_middleware import AUTH_PUBLIC_PATHS
+        from bernstein.core.auth_middleware import AUTH_HMAC_PATHS, AUTH_PUBLIC_PATHS
 
         assert "/health" in AUTH_PUBLIC_PATHS
         assert "/auth/login" in AUTH_PUBLIC_PATHS
         assert "/auth/oidc/callback" in AUTH_PUBLIC_PATHS
         assert "/auth/saml/acs" in AUTH_PUBLIC_PATHS
         assert "/auth/cli/device" in AUTH_PUBLIC_PATHS
-        assert "/webhook" in AUTH_PUBLIC_PATHS
         assert "/ready" in AUTH_PUBLIC_PATHS
         assert "/alive" in AUTH_PUBLIC_PATHS
+        # /webhook, /webhooks/*, /hooks/* are HMAC-authenticated, not bare public.
+        assert "/webhook" not in AUTH_PUBLIC_PATHS
+        assert "/webhook" in AUTH_HMAC_PATHS
+        assert "/webhooks/github" in AUTH_HMAC_PATHS
 
     def test_route_permission_mapping(self) -> None:
         from bernstein.core.auth_middleware import _get_required_permission

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -7,9 +7,14 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from bernstein.core.auth_middleware import SSOAuthMiddleware, _get_required_permission
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
+
+# Module-level: these tests rely on the secure-by-default middleware behaviour
+# (no ``BERNSTEIN_AUTH_DISABLED`` shim), so opt out of the autouse fixture.
+pytestmark = pytest.mark.auth_enabled
 
 
 def _app_with_middleware(auth_service: Any = None, legacy_token: str | None = None) -> TestClient:
@@ -183,8 +188,8 @@ def test_agent_jwt_read_requests_not_scope_checked(tmp_path: Any) -> None:
     assert response.status_code == 200
 
 
-def test_invalid_bearer_token_rejected_in_dev_mode(tmp_path: Any) -> None:
-    """In dev mode, an invalid Bearer token (not a valid agent JWT) is rejected."""
+def test_invalid_bearer_token_rejected(tmp_path: Any) -> None:
+    """An invalid Bearer token (not a valid agent JWT) is rejected with 401."""
     client, _store = _app_with_agent_identity_store(tmp_path)
 
     response = client.post(
@@ -193,7 +198,7 @@ def test_invalid_bearer_token_rejected_in_dev_mode(tmp_path: Any) -> None:
         json={"result_summary": "done"},
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 401
 
 
 def test_check_agent_task_scope_returns_none_for_non_task_paths() -> None:

--- a/tests/unit/test_auth_middleware_defaults.py
+++ b/tests/unit/test_auth_middleware_defaults.py
@@ -1,0 +1,377 @@
+"""Tests for secure-by-default auth middleware behavior (audit-113).
+
+Covers:
+- Unauthenticated requests to protected paths return 401.
+- Valid bearer tokens return 200.
+- ``/hooks/{session_id}`` requires a valid HMAC signature.
+- ``/health`` remains public.
+- ``BERNSTEIN_AUTH_DISABLED=1`` opt-out is honoured and logs a warning.
+"""
+
+# pyright: reportPrivateUsage=false, reportUnusedFunction=false, reportUntypedFunctionDecorator=false, reportUnknownMemberType=false, reportFunctionMemberAccess=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bernstein.core.auth_middleware import (
+    AUTH_HMAC_PATH_PREFIXES,
+    AUTH_HMAC_PATHS,
+    AUTH_PUBLIC_PATHS,
+    SSOAuthMiddleware,
+    auth_disabled_via_opt_out,
+)
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.auth_enabled
+
+
+# ---------------------------------------------------------------------------
+# Public-path surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_paths_do_not_include_dashboard_or_events_or_webhook() -> None:
+    """Dashboard, SSE, hook, and webhook paths must not be in AUTH_PUBLIC_PATHS."""
+    # Dashboard and SSE need a bearer token (they expose operational state).
+    assert "/dashboard" not in AUTH_PUBLIC_PATHS
+    assert "/dashboard/data" not in AUTH_PUBLIC_PATHS
+    assert "/dashboard/file_locks" not in AUTH_PUBLIC_PATHS
+    assert "/dashboard/events" not in AUTH_PUBLIC_PATHS
+    assert "/events" not in AUTH_PUBLIC_PATHS
+    # Broadcast mutates cluster state.
+    assert "/broadcast" not in AUTH_PUBLIC_PATHS
+    # Webhook/hook paths belong to the HMAC-auth set, not bare public.
+    assert "/webhook" not in AUTH_PUBLIC_PATHS
+    assert "/webhooks/github" not in AUTH_PUBLIC_PATHS
+    assert "/webhook" in AUTH_HMAC_PATHS
+    assert "/webhooks/github" in AUTH_HMAC_PATHS
+    assert "/hooks/" in AUTH_HMAC_PATH_PREFIXES
+
+
+def test_public_paths_still_contain_health_and_docs() -> None:
+    """Trivially-public endpoints stay reachable without a token."""
+    for path in (
+        "/health",
+        "/health/ready",
+        "/health/live",
+        "/ready",
+        "/alive",
+        "/docs",
+        "/openapi.json",
+        "/.well-known/agent.json",
+        "/auth/login",
+        "/auth/cli/device",
+    ):
+        assert path in AUTH_PUBLIC_PATHS, path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app(
+    *,
+    legacy_token: str | None = None,
+    auth_disabled: bool | None = None,
+    agent_identity_store: Any = None,
+) -> TestClient:
+    """Build a minimal FastAPI app wrapped in SSOAuthMiddleware."""
+    app = FastAPI()
+    app.add_middleware(
+        SSOAuthMiddleware,
+        legacy_token=legacy_token,
+        agent_identity_store=agent_identity_store,
+        auth_disabled=auth_disabled,
+    )
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    @app.get("/dashboard/events")
+    async def dashboard_events() -> dict[str, str]:
+        return {"stream": "ok"}
+
+    @app.get("/events")
+    async def status_events() -> dict[str, str]:
+        return {"stream": "ok"}
+
+    @app.post("/broadcast")
+    async def broadcast(request: Request) -> dict[str, str]:
+        del request
+        return {"ok": "yes"}
+
+    @app.post("/tasks")
+    async def create_task() -> dict[str, str]:
+        return {"id": "t1"}
+
+    return TestClient(app)
+
+
+def _hmac_header(body: bytes, secret: str) -> dict[str, str]:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return {"X-Bernstein-Hook-Signature-256": f"sha256={digest}"}
+
+
+# ---------------------------------------------------------------------------
+# Default-on auth
+# ---------------------------------------------------------------------------
+
+
+def test_unauth_dashboard_events_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without a bearer token, GET /dashboard/events must be 401."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    client = _build_app(legacy_token="secret")
+
+    response = client.get("/dashboard/events")
+
+    assert response.status_code == 401
+
+
+def test_unauth_status_events_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SSE status stream at /events must require auth too."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    client = _build_app(legacy_token="secret")
+
+    response = client.get("/events")
+
+    assert response.status_code == 401
+
+
+def test_unauth_broadcast_returns_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /broadcast without a bearer token must be 401."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    client = _build_app(legacy_token="secret")
+
+    response = client.post("/broadcast", json={"message": "hi"})
+
+    assert response.status_code == 401
+
+
+def test_unauth_returns_401_even_without_any_auth_backend_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Secure-by-default: no SSO, no legacy token, no agent store → still 401."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    client = _build_app()
+
+    response = client.post("/tasks")
+
+    assert response.status_code == 401
+
+
+def test_valid_bearer_token_returns_200(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid legacy bearer token lets the request through to the handler."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    client = _build_app(legacy_token="secret")
+
+    response = client.get(
+        "/dashboard/events",
+        headers={"Authorization": "Bearer secret"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_health_is_public_without_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """/health remains reachable with no auth configured and no token provided."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    client = _build_app(legacy_token="secret")
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Opt-out
+# ---------------------------------------------------------------------------
+
+
+def test_auth_disabled_env_is_truthy_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """auth_disabled_via_opt_out reflects the environment variable."""
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+    assert auth_disabled_via_opt_out() is True
+
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "true")
+    assert auth_disabled_via_opt_out() is True
+
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "no")
+    assert auth_disabled_via_opt_out() is False
+
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    assert auth_disabled_via_opt_out() is False
+
+
+def test_auth_disabled_opt_out_passes_requests_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When BERNSTEIN_AUTH_DISABLED=1, requests bypass the bearer gate."""
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+    # Reset the one-shot warning flag so the opt-out actually re-warns.
+    SSOAuthMiddleware._warned_disabled = False
+    client = _build_app(legacy_token="secret")
+
+    response = client.post("/tasks")
+
+    assert response.status_code == 200
+
+
+def test_auth_disabled_logs_loud_warning(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    """Opting out must emit a loud WARNING so operators notice."""
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+    SSOAuthMiddleware._warned_disabled = False
+
+    caplog.set_level(logging.WARNING)
+    client = _build_app(legacy_token="secret")
+    # Trigger middleware construction via a real request — Starlette builds
+    # the middleware stack lazily on first request.
+    client.get("/health")
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert any("auth is DISABLED" in m for m in messages), messages
+
+
+# ---------------------------------------------------------------------------
+# Hook HMAC auth
+# ---------------------------------------------------------------------------
+
+
+def _build_hooks_app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, secret: str) -> TestClient:
+    """Build a small app that mounts the real /hooks router under SSO middleware."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+    monkeypatch.setenv("BERNSTEIN_HOOK_SECRET", secret)
+
+    app = FastAPI()
+    # Real middleware enforces the "no bearer → 401" default.
+    app.add_middleware(SSOAuthMiddleware, legacy_token="secret")
+
+    from bernstein.core.routes.hooks import router as hooks_router
+
+    app.include_router(hooks_router)
+
+    # The hook receiver writes under workdir/.sdd — give it a tmp sandbox.
+    sdd = tmp_path / ".sdd"
+    (sdd / "runtime" / "hooks").mkdir(parents=True)
+    (sdd / "runtime" / "completed").mkdir(parents=True)
+    app.state.workdir = tmp_path  # type: ignore[attr-defined]
+    app.state.sdd_dir = sdd  # type: ignore[attr-defined]
+
+    return TestClient(app)
+
+
+def test_hooks_without_hmac_returns_401(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """POST /hooks/X without X-Bernstein-Hook-Signature-256 must be 401."""
+    client = _build_hooks_app(monkeypatch, tmp_path, "hook-secret")
+
+    response = client.post(
+        "/hooks/agent-123",
+        content=json.dumps({"hook_event_name": "Stop"}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_hooks_with_valid_hmac_returns_200(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A request signed with the configured secret is accepted (no bearer needed)."""
+    secret = "hook-secret"
+    client = _build_hooks_app(monkeypatch, tmp_path, secret)
+
+    body = json.dumps({"hook_event_name": "Stop"}).encode("utf-8")
+    response = client.post(
+        "/hooks/agent-123",
+        content=body,
+        headers={"Content-Type": "application/json", **_hmac_header(body, secret)},
+    )
+
+    assert response.status_code == 200, response.text
+
+
+def test_hooks_with_bad_hmac_returns_401(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A forged signature is rejected by the route handler."""
+    client = _build_hooks_app(monkeypatch, tmp_path, "hook-secret")
+
+    body = json.dumps({"hook_event_name": "Stop"}).encode("utf-8")
+    response = client.post(
+        "/hooks/agent-123",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Bernstein-Hook-Signature-256": "sha256=" + "0" * 64,
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_hooks_endpoint_is_disabled_when_no_secret_configured(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """With no secret, the hook endpoint rejects everything (secure default)."""
+    monkeypatch.delenv("BERNSTEIN_HOOK_SECRET", raising=False)
+    monkeypatch.delenv("BERNSTEIN_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+
+    app = FastAPI()
+    app.add_middleware(SSOAuthMiddleware, legacy_token="secret")
+    from bernstein.core.routes.hooks import router as hooks_router
+
+    app.include_router(hooks_router)
+    sdd = tmp_path / ".sdd"
+    (sdd / "runtime" / "hooks").mkdir(parents=True)
+    app.state.workdir = tmp_path  # type: ignore[attr-defined]
+    app.state.sdd_dir = sdd  # type: ignore[attr-defined]
+    client = TestClient(app)
+
+    body = json.dumps({"hook_event_name": "Stop"}).encode("utf-8")
+    response = client.post(
+        "/hooks/agent-123",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 401
+    # Reassure: the handler, not the bearer middleware, rejected this.
+    assert isinstance(response.json(), dict)
+    assert "Hook endpoint is not configured" in response.json().get("detail", "") or (
+        "Invalid or missing hook signature" in response.json().get("detail", "")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent identity JWT still works under default-on auth
+# ---------------------------------------------------------------------------
+
+
+def test_agent_jwt_token_accepted_under_default_on_auth(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An agent identity JWT remains a valid authenticator when auth is default-on."""
+    monkeypatch.delenv("BERNSTEIN_AUTH_DISABLED", raising=False)
+
+    from bernstein.core.agent_identity import AgentIdentityStore
+
+    store = AgentIdentityStore(tmp_path)
+    _, token = store.create_identity("agent-1", "backend", task_ids=[])
+
+    app = FastAPI()
+    app.add_middleware(SSOAuthMiddleware, agent_identity_store=store)
+
+    @app.get("/status")
+    async def status(request: Request) -> JSONResponse:
+        claims = getattr(request.state, "auth_claims", None)
+        return JSONResponse(content={"ok": True, "claims": claims})
+
+    client = TestClient(app)
+
+    response = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json()["claims"]["agent_id"] == "agent-1"

--- a/tests/unit/test_claude_md_shim_doc.py
+++ b/tests/unit/test_claude_md_shim_doc.py
@@ -48,8 +48,7 @@ def test_redirect_map_covers_documented_names() -> None:
     redirect_map = core_pkg._REDIRECT_MAP
     for name in ("orchestrator", "spawner", "task_lifecycle"):
         assert name in redirect_map, (
-            f"_REDIRECT_MAP is missing {name!r}; legacy import path "
-            f"bernstein.core.{name} will break."
+            f"_REDIRECT_MAP is missing {name!r}; legacy import path bernstein.core.{name} will break."
         )
         target = redirect_map[name]
         # Importing the target must succeed — the finder relies on it.
@@ -86,10 +85,8 @@ def test_claude_md_documents_the_real_mechanism() -> None:
     # The replacement bullet must reference the finder + map by name so
     # engineers know where to add new aliases.
     assert "_CoreRedirectFinder" in text, (
-        "CLAUDE.md should reference _CoreRedirectFinder so contributors "
-        "can find the real back-compat mechanism."
+        "CLAUDE.md should reference _CoreRedirectFinder so contributors can find the real back-compat mechanism."
     )
     assert "_REDIRECT_MAP" in text, (
-        "CLAUDE.md should reference _REDIRECT_MAP so contributors know "
-        "where to add new legacy aliases."
+        "CLAUDE.md should reference _REDIRECT_MAP so contributors know where to add new legacy aliases."
     )

--- a/tests/unit/test_dependency_scan_tasks.py
+++ b/tests/unit/test_dependency_scan_tasks.py
@@ -280,9 +280,7 @@ def test_run_scheduled_scan_dedups_findings_via_existing_titles() -> None:
     )
     # Pre-populate the server with an already-open task for "jinja2"
     client = _FakeClient(
-        get_response=_FakeResponse(
-            payload=[{"title": "Upgrade vulnerable dependency: jinja2", "status": "open"}]
-        )
+        get_response=_FakeResponse(payload=[{"title": "Upgrade vulnerable dependency: jinja2", "status": "open"}])
     )
     orch = _FakeOrch(_client=client, _dependency_scanner=scanner)
 

--- a/tests/unit/test_hooks_path_traversal.py
+++ b/tests/unit/test_hooks_path_traversal.py
@@ -9,8 +9,11 @@ intended base directory via ``Path.resolve().is_relative_to(base)``.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json as _json
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import pytest
@@ -27,6 +30,32 @@ from bernstein.core.hooks_receiver import (
 from httpx import ASGITransport, AsyncClient
 
 from bernstein.core.server import create_app
+
+# Signing secret used by the fixtures below.  The hook endpoint verifies
+# an HMAC-SHA256 signature (audit-113) before the session_id allowlist
+# check (audit-114), so every path-traversal case has to be signed to
+# exercise the downstream rejection logic under test.
+_HOOK_SECRET = "test-hook-secret"
+
+
+def _signed_post(
+    client: AsyncClient,
+    url: str,
+    *,
+    body: dict[str, Any],
+) -> Any:
+    """Return a coroutine for a signed POST that mirrors ``client.post(json=...)``."""
+    raw = _json.dumps(body).encode("utf-8")
+    sig = hmac.new(_HOOK_SECRET.encode("utf-8"), raw, hashlib.sha256).hexdigest()
+    return client.post(
+        url,
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Bernstein-Hook-Signature-256": f"sha256={sig}",
+        },
+    )
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -182,7 +211,10 @@ def jsonl_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def app(jsonl_path: Path, tmp_path: Path):  # type: ignore[no-untyped-def]
+def app(jsonl_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):  # type: ignore[no-untyped-def]
+    # Hooks route enforces an HMAC signature (audit-113); configure the
+    # shared secret the ``_signed_post`` helper uses below.
+    monkeypatch.setenv("BERNSTEIN_HOOK_SECRET", _HOOK_SECRET)
     application = create_app(jsonl_path=jsonl_path)
     application.state.workdir = tmp_path  # type: ignore[attr-defined]
     return application
@@ -204,9 +236,10 @@ def _assert_rejected(response_status: int, response_body: dict[str, object]) -> 
 @pytest.mark.anyio
 async def test_valid_session_id_returns_200(client: AsyncClient, tmp_path: Path) -> None:
     """Baseline: a clean session_id is accepted and writes its sidecar."""
-    response = await client.post(
+    response = await _signed_post(
+        client,
         "/hooks/sess-valid-001",
-        json={"hook_event_name": "PostToolUse", "tool_name": "Bash"},
+        body={"hook_event_name": "PostToolUse", "tool_name": "Bash"},
     )
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
@@ -223,9 +256,10 @@ async def test_dotdot_session_id_returns_400(client: AsyncClient, tmp_path: Path
     and reaches the route parameter verbatim.  Starlette decodes the
     path component back to ``..`` before handing it to the handler.
     """
-    response = await client.post(
+    response = await _signed_post(
+        client,
         "/hooks/%2E%2E",
-        json={"hook_event_name": "Stop"},
+        body={"hook_event_name": "Stop"},
     )
     _assert_rejected(response.status_code, response.json())
     # Nothing should have been written outside the hooks tree.
@@ -250,17 +284,19 @@ async def test_absolute_path_session_id_returns_400(client: AsyncClient, tmp_pat
     """
     # Form 1: backslash-encoded absolute path survives Starlette routing
     # and hits the handler, which must reject it with 400.
-    response = await client.post(
+    response = await _signed_post(
+        client,
         "/hooks/" + quote("\\etc\\passwd", safe=""),
-        json={"hook_event_name": "Stop"},
+        body={"hook_event_name": "Stop"},
     )
     _assert_rejected(response.status_code, response.json())
 
     # Form 2: forward-slash absolute path — Starlette splits and 404s.
     # This is still a secure outcome; no file is written outside base.
-    response2 = await client.post(
+    response2 = await _signed_post(
+        client,
         "/hooks/" + quote("/etc/passwd", safe=""),
-        json={"hook_event_name": "Stop"},
+        body={"hook_event_name": "Stop"},
     )
     assert response2.status_code in (400, 404), f"absolute /etc/passwd must be rejected, got {response2.status_code}"
     assert not (tmp_path / "etc" / "passwd").exists()
@@ -278,17 +314,19 @@ async def test_url_encoded_dotdot_returns_400(client: AsyncClient, tmp_path: Pat
     secure).
     """
     # Bare dot-dot reaches the handler and must be rejected with 400.
-    response = await client.post(
+    response = await _signed_post(
+        client,
         "/hooks/%2e%2e",
-        json={"hook_event_name": "Stop"},
+        body={"hook_event_name": "Stop"},
     )
     _assert_rejected(response.status_code, response.json())
 
     # Slash-suffixed form is split by Starlette (404) or rejected (400)
     # — either outcome prevents filesystem writes outside the base.
-    response2 = await client.post(
+    response2 = await _signed_post(
+        client,
         "/hooks/%2e%2e%2f",
-        json={"hook_event_name": "Stop"},
+        body={"hook_event_name": "Stop"},
     )
     # Any non-2xx is acceptable: handler rejection (400), route miss
     # (404), or trailing-slash redirect (307) all prevent the write.
@@ -304,9 +342,10 @@ async def test_url_encoded_dotdot_returns_400(client: AsyncClient, tmp_path: Pat
 async def test_null_byte_session_id_returns_400(client: AsyncClient, tmp_path: Path) -> None:
     """Null byte in session_id is rejected (cannot be used to truncate filenames)."""
     encoded = quote("foo\x00bar", safe="")
-    response = await client.post(
+    response = await _signed_post(
+        client,
         f"/hooks/{encoded}",
-        json={"hook_event_name": "PostToolUse"},
+        body={"hook_event_name": "PostToolUse"},
     )
     _assert_rejected(response.status_code, response.json())
 
@@ -328,9 +367,10 @@ async def test_symlink_escape_session_id_returns_400(client: AsyncClient, tmp_pa
     link = hooks_dir / "sess-symlink.jsonl"
     os.symlink(outside / "stolen.jsonl", link)
 
-    response = await client.post(
+    response = await _signed_post(
+        client,
         "/hooks/sess-symlink",
-        json={"hook_event_name": "PostToolUse", "tool_name": "Bash"},
+        body={"hook_event_name": "PostToolUse", "tool_name": "Bash"},
     )
     _assert_rejected(response.status_code, response.json())
     # Nothing written to the outside target.
@@ -347,9 +387,10 @@ async def test_rejection_does_not_write_completion_marker(client: AsyncClient, t
     care about is the negative: no marker file anywhere in ``tmp_path``.
     """
     completed_dir = tmp_path / ".sdd" / "runtime" / "completed"
-    response = await client.post(
+    response = await _signed_post(
+        client,
         "/hooks/" + quote("../../SHUTDOWN", safe=""),
-        json={"hook_event_name": "Stop"},
+        body={"hook_event_name": "Stop"},
     )
     # 307/400/404 are all acceptable — none leave the filesystem dirty.
     assert response.status_code in (307, 400, 404), f"traversal payload must be rejected, got {response.status_code}"

--- a/tests/unit/test_orchestrator_god_class_delegation.py
+++ b/tests/unit/test_orchestrator_god_class_delegation.py
@@ -66,12 +66,9 @@ def test_evolve_method_delegates_to_module(method_name: str, target: str) -> Non
     method = getattr(Orchestrator, method_name)
     src = inspect.getsource(method)
     assert f"orchestrator_evolve.{target}" in src, (
-        f"Orchestrator.{method_name} body does not delegate to "
-        f"orchestrator_evolve.{target}: {src!r}"
+        f"Orchestrator.{method_name} body does not delegate to orchestrator_evolve.{target}: {src!r}"
     )
-    assert hasattr(orchestrator_evolve, target), (
-        f"orchestrator_evolve.{target} does not exist"
-    )
+    assert hasattr(orchestrator_evolve, target), f"orchestrator_evolve.{target} does not exist"
 
 
 @pytest.mark.parametrize(("method_name", "target"), _CLEANUP_DELEGATIONS)
@@ -80,12 +77,9 @@ def test_cleanup_method_delegates_to_module(method_name: str, target: str) -> No
     method = getattr(Orchestrator, method_name)
     src = inspect.getsource(method)
     assert f"orchestrator_cleanup.{target}" in src, (
-        f"Orchestrator.{method_name} body does not delegate to "
-        f"orchestrator_cleanup.{target}: {src!r}"
+        f"Orchestrator.{method_name} body does not delegate to orchestrator_cleanup.{target}: {src!r}"
     )
-    assert hasattr(orchestrator_cleanup, target), (
-        f"orchestrator_cleanup.{target} does not exist"
-    )
+    assert hasattr(orchestrator_cleanup, target), f"orchestrator_cleanup.{target} does not exist"
 
 
 def test_evolve_focus_areas_still_on_class() -> None:

--- a/tests/unit/test_orchestrator_lifecycle_deleted.py
+++ b/tests/unit/test_orchestrator_lifecycle_deleted.py
@@ -57,6 +57,4 @@ def test_orchestrator_retains_live_methods() -> None:
         "_save_session_state",
         "_drain_before_cleanup",
     ):
-        assert callable(getattr(Orchestrator, name, None)), (
-            f"Orchestrator.{name} is not defined — audit-008 rollback?"
-        )
+        assert callable(getattr(Orchestrator, name, None)), f"Orchestrator.{name} is not defined — audit-008 rollback?"

--- a/tests/unit/test_platform_compat.py
+++ b/tests/unit/test_platform_compat.py
@@ -218,11 +218,7 @@ class TestKillProcessGroupGraceful:
         # Spawn a child that ignores SIGTERM via Python's signal module and
         # sits in a long sleep.  Without SIGKILL escalation, SIGTERM alone
         # leaves the process running.
-        script = (
-            "import signal, time\n"
-            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
-            "time.sleep(60)\n"
-        )
+        script = "import signal, time\nsignal.signal(signal.SIGTERM, signal.SIG_IGN)\ntime.sleep(60)\n"
         proc = subprocess.Popen(
             [sys.executable, "-c", script],
             stdout=subprocess.DEVNULL,

--- a/tests/unit/test_recycle_idle_agents_single_source.py
+++ b/tests/unit/test_recycle_idle_agents_single_source.py
@@ -54,8 +54,7 @@ def test_idle_recycling_helpers_single_source() -> None:
         lifecycle_ref = getattr(agent_lifecycle, name)
         recycling_ref = getattr(agent_recycling, name)
         assert lifecycle_ref is recycling_ref, (
-            f"{name} diverged between agent_lifecycle and agent_recycling — "
-            "see audit-005"
+            f"{name} diverged between agent_lifecycle and agent_recycling — see audit-005"
         )
         assert recycling_ref.__module__ == "bernstein.core.agents.agent_recycling"
 

--- a/tests/unit/test_wal_recovery_retry.py
+++ b/tests/unit/test_wal_recovery_retry.py
@@ -127,9 +127,7 @@ class TestFindOrphanedClaims:
         orphans = WALRecovery.find_orphaned_claims(sdd, exclude_run_id="current")
         assert orphans == []
 
-    def test_claim_with_matching_spawn_confirmed_is_not_orphan(
-        self, tmp_path: Path
-    ) -> None:
+    def test_claim_with_matching_spawn_confirmed_is_not_orphan(self, tmp_path: Path) -> None:
         """task_claimed paired with task_spawn_confirmed in the same run is committed work."""
         sdd = tmp_path / ".sdd"
         sdd.mkdir()
@@ -193,8 +191,7 @@ class TestRecoverFromWALRetriesOrphans:
         orch._recover_from_wal()
 
         assert "T-abandoned" in recorder.force_claim_targets(), (
-            "Expected POST /tasks/T-abandoned/force-claim; recorded paths: "
-            f"{[str(r.url) for r in recorder.requests]}"
+            f"Expected POST /tasks/T-abandoned/force-claim; recorded paths: {[str(r.url) for r in recorder.requests]}"
         )
 
     def test_non_orphan_does_not_trigger_force_claim(self, tmp_path: Path) -> None:
@@ -242,9 +239,7 @@ class TestRecoverFromWALRetriesOrphans:
 
         reader = WALReader(run_id=orch._run_id, sdd_dir=sdd)
         acks = [e for e in reader.iter_entries() if e.decision_type == "wal_recovery_ack"]
-        orphan_flags = {
-            e.inputs["original_inputs"]["task_id"]: e.output["orphan"] for e in acks
-        }
+        orphan_flags = {e.inputs["original_inputs"]["task_id"]: e.output["orphan"] for e in acks}
         assert orphan_flags == {"T-ok": False, "T-orphan": True}
 
     def test_force_claim_failure_is_non_fatal(self, tmp_path: Path) -> None:
@@ -385,9 +380,7 @@ class TestPreservePriorWorktrees:
 class TestAudit001Regression:
     """Would-have-caught-the-bug scenario described in audit-001."""
 
-    def test_crash_between_claim_and_spawn_does_not_silently_drop_task(
-        self, tmp_path: Path
-    ) -> None:
+    def test_crash_between_claim_and_spawn_does_not_silently_drop_task(self, tmp_path: Path) -> None:
         """End-to-end reproduction of the audit-001 work-loss scenario."""
         sdd = tmp_path / ".sdd"
         sdd.mkdir()


### PR DESCRIPTION
## SECURITY — (P0)

The Bernstein task server shipped with authentication **disabled by
default** and a public allow-list that exposed every operational
endpoint. An operator who never set BERNSTEIN_AUTH_TOKENor an SSO
provider got unauthenticated access to /dashboard/events, /events
(the SSE status stream), /broadcast, /webhook, /webhooks/*,
and /hooks/*— i.e. read-everything, mutate-everything on any host
that could reach port 8052.

### What changed

- **Secure-by-default auth.** SSOAuthMiddlewarenow returns 401 for
 every protected path when no valid Bearer / SSO / agent JWT is
 presented. AUTH_PUBLIC_PATHSis shrunk to health probes,
 discovery metadata, docs, and the login flow.
- **Opt-out.** Operators who genuinely need unauthenticated mode (dev,
 local shells) set BERNSTEIN_AUTH_DISABLED=1— this logs a loud
 WARNING exactly once per process.
- **HMAC-authenticated paths.** /webhook, /webhooks/*,
 /hooks/*no longer skip auth; they authenticate via HMAC-SHA256
 shared secrets inside their route handlers. Hooks use the new
 BERNSTEIN_HOOK_SECRETenv var (falls back to
 BERNSTEIN_AUTH_TOKEN). Unsigned hook requests now return 401.
- **Claude adapter** signs outgoing hook POSTs via an inline
 openssl dgstshim so the Claude Code hook runner keeps working
 out of the box.
- ** interop.** The path-traversal fix that landed on main
 keeps its contract — HMAC check runs first, session_id allowlist
 second. Updated the tests to sign their payloads so both
 layers are still exercised end-to-end.
- **Docs** (OpenAPI description + module docstrings) updated to reflect
 the new default.

### Tests added (tests/unit/test_auth_middleware_defaults.py)

- unauthenticated GET /dashboard/events→ 401
- unauthenticated GET /events(SSE status stream) → 401
- unauthenticated POST /broadcast→ 401
- unauthenticated POST /tasks→ 401 (even with no auth backend)
- valid legacy Bearer → 200
- valid agent-identity JWT → 200
- /hooks/Xwith no HMAC → 401
- /hooks/Xwith valid HMAC → 200
- /hooks/Xwith forged HMAC → 401
- /hooks/Xwith no secret configured → 401 (endpoint disabled)
- /healthremains public without a token
- BERNSTEIN_AUTH_DISABLED=1passes requests through and logs WARNING

### Test plan

- [x] uv run ruff check src/ tests/
- [x] uv run ruff format --check src/ tests/
- [x] uv run pytest tests/unit -k "auth_middleware or dashboard_auth or unauth" -x -q→ 34 passed, 5 skipped (live-adapter only)
- [x] uv run pytest tests/unit/test_hooks_path_traversal.py -x -q→ 26 passed ( regression)
- [x] Smoke-checked other route tests (test_auth, test_route_agent_comparison, test_team_routes, test_observability_api) → pass

### Back-compat notes

Existing test fixtures assume "no bearer token needed"; a tiny autouse
pytest shim sets BERNSTEIN_AUTH_DISABLED=1so they keep passing.
Tests that exercise auth behaviour opt back in with the new
pytest.mark.auth_enabledmarker. Production deployments ignore the
shim — they get the secure default.