### PR TITLE
fix(ci): register CI log parsers in bootstrap

### DIFF
--- a/src/bernstein/adapters/ci/__init__.py
+++ b/src/bernstein/adapters/ci/__init__.py
@@ -1,4 +1,11 @@
-"""CI system adapters for log parsing and failure extraction."""
+"""CI system adapters for log parsing and failure extraction.
+
+Importing this package registers every built-in CI log parser with the
+global registry (:mod:`bernstein.core.ci_log_parser`). The registration
+is idempotent, so calling :func:`register_built_in_ci_parsers` again —
+as :mod:`bernstein.core.orchestration.bootstrap` does explicitly — has
+no additional effect.
+"""
 
 from __future__ import annotations
 
@@ -6,14 +13,26 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["register_built_in_ci_parsers"]
+
+# Track whether the built-ins have already been registered in this process
+# so import-time and explicit bootstrap calls do not double-register.
+_BUILTINS_REGISTERED = False
+
 
 def register_built_in_ci_parsers() -> None:
-    """Register all built-in CI log parsers at startup.
+    """Register all built-in CI log parsers with the global registry.
 
     Call this during bootstrap so that ``cifix --parser gitlab_ci``
     and pipeline self-healing both find their parsers without the caller
-    having to import and register them manually.
+    having to import and register them manually. Repeat calls are a
+    no-op — the registry keys on parser ``name`` so re-registering the
+    same parser would only overwrite itself with an equivalent instance,
+    but we guard with a module-level flag to avoid needless work.
     """
+    global _BUILTINS_REGISTERED
+    if _BUILTINS_REGISTERED:
+        return
 
     from bernstein.adapters.ci.github_actions import GitHubActionsParser
     from bernstein.adapters.ci.gitlab_ci import GitLabCIParser
@@ -23,3 +42,12 @@ def register_built_in_ci_parsers() -> None:
     logger.debug("Registered CI log parser: github_actions")
     register_parser(GitLabCIParser())
     logger.debug("Registered CI log parser: gitlab_ci")
+
+    _BUILTINS_REGISTERED = True
+
+
+# Register built-ins at import time so ``from bernstein.adapters.ci import ...``
+# (or any transitive import via ``bernstein.core.quality.ci_fix``) is enough
+# to populate the registry. The explicit call in bootstrap remains for clarity
+# and for code paths that never import this package directly.
+register_built_in_ci_parsers()

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -291,6 +291,23 @@ def _apply_compliance_env() -> None:
     ComplianceConfig.from_preset(CompliancePreset(compliance_env.lower()))
 
 
+def _register_ci_parsers() -> None:
+    """Populate the CI log parser registry with all built-in adapters.
+
+    Without this call the registry is empty at runtime, so
+    ``bernstein ci fix --parser gitlab_ci`` and the self-healing CI
+    pipeline silently no-op (see audit-031). The helper in
+    :mod:`bernstein.adapters.ci` is idempotent, so calling it here on
+    top of the import-time side-effect is safe.
+    """
+    try:
+        from bernstein.adapters.ci import register_built_in_ci_parsers
+
+        register_built_in_ci_parsers()
+    except ImportError as exc:
+        logger.warning("CI adapters unavailable — skipping parser registration: %s", exc)
+
+
 def _load_secrets_provider(seed: Any) -> None:
     """Load secrets provider if configured in seed."""
     if not seed.secrets:
@@ -459,6 +476,10 @@ def bootstrap_from_seed(
     ).lower() in ("1", "true", "yes")
 
     _apply_compliance_env()
+
+    # Populate CI log parser registry so `bernstein ci fix` and pipeline
+    # self-healing can find GitHub Actions / GitLab CI parsers (audit-031).
+    _register_ci_parsers()
 
     # 3. Load secrets provider if configured
     _load_secrets_provider(seed)
@@ -956,6 +977,9 @@ def _bootstrap_from_goal_impl(
             for v in violations:
                 console.print(f"  [red]{v}[/red]")
         write_lockfile(workdir)
+
+    # Populate CI log parser registry (audit-031).
+    _register_ci_parsers()
 
     bind_host = _resolve_bind_host()
     auth_token = _resolve_auth_token()

--- a/tests/unit/test_ci_parser_registration.py
+++ b/tests/unit/test_ci_parser_registration.py
@@ -1,0 +1,116 @@
+"""Tests for built-in CI log parser registration (audit-031).
+
+Without these guarantees, ``bernstein ci fix --parser gitlab_ci`` and the
+self-healing CI pipeline would silently no-op because the registry would
+be empty at runtime.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from bernstein.core import ci_log_parser
+
+
+@pytest.fixture
+def _fresh_registry(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Reset the CI parser registry to a clean state for the test.
+
+    The registry is a module-level singleton, so we replace its internal
+    dict with an empty one and restore it after the test via monkeypatch's
+    teardown.
+    """
+    empty: dict[str, object] = {}
+    monkeypatch.setattr(ci_log_parser, "_PARSERS", empty)
+    return empty
+
+
+def test_register_built_in_ci_parsers_populates_registry(
+    _fresh_registry: dict[str, object],
+) -> None:
+    """Calling ``register_built_in_ci_parsers`` registers both built-ins."""
+    # Re-import the module with a flag reset so register runs again against
+    # the freshly-empty registry.
+    from bernstein.adapters import ci as ci_pkg
+
+    ci_pkg._BUILTINS_REGISTERED = False
+    ci_pkg.register_built_in_ci_parsers()
+
+    names = ci_log_parser.list_parsers()
+    assert "github_actions" in names
+    assert "gitlab_ci" in names
+
+
+def test_importing_ci_package_registers_built_ins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Importing ``bernstein.adapters.ci`` alone populates the registry.
+
+    This is the critical invariant that audit-031 fixes: any code path that
+    touches the CI adapter package (for example, ``bernstein ci fix``)
+    should find the built-in parsers without an explicit bootstrap call.
+    """
+    # Clear the registry and force a fresh import of the adapter package so
+    # the module-level ``register_built_in_ci_parsers()`` side-effect runs.
+    monkeypatch.setattr(ci_log_parser, "_PARSERS", {})
+
+    import bernstein.adapters.ci as ci_pkg
+
+    ci_pkg._BUILTINS_REGISTERED = False
+    importlib.reload(ci_pkg)
+
+    names = ci_log_parser.list_parsers()
+    assert "github_actions" in names
+    assert "gitlab_ci" in names
+
+
+def test_ci_parsers_discoverable_by_name(_fresh_registry: dict[str, object]) -> None:
+    """Each registered parser is retrievable by its canonical name."""
+    from bernstein.adapters import ci as ci_pkg
+    from bernstein.adapters.ci.github_actions import GitHubActionsParser
+    from bernstein.adapters.ci.gitlab_ci import GitLabCIParser
+
+    ci_pkg._BUILTINS_REGISTERED = False
+    ci_pkg.register_built_in_ci_parsers()
+
+    gha = ci_log_parser.get_parser("github_actions")
+    gitlab = ci_log_parser.get_parser("gitlab_ci")
+
+    assert isinstance(gha, GitHubActionsParser)
+    assert isinstance(gitlab, GitLabCIParser)
+    assert gha.name == "github_actions"
+    assert gitlab.name == "gitlab_ci"
+
+
+def test_register_built_in_ci_parsers_is_idempotent(
+    _fresh_registry: dict[str, object],
+) -> None:
+    """Calling the registrar twice does not duplicate or error."""
+    from bernstein.adapters import ci as ci_pkg
+
+    ci_pkg._BUILTINS_REGISTERED = False
+    ci_pkg.register_built_in_ci_parsers()
+    first = set(ci_log_parser.list_parsers())
+
+    ci_pkg.register_built_in_ci_parsers()  # second call — must be a no-op
+    second = set(ci_log_parser.list_parsers())
+
+    assert first == second
+    assert {"github_actions", "gitlab_ci"}.issubset(second)
+
+
+def test_bootstrap_registers_ci_parsers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The orchestrator bootstrap helper populates the registry."""
+    monkeypatch.setattr(ci_log_parser, "_PARSERS", {})
+
+    from bernstein.adapters import ci as ci_pkg
+
+    ci_pkg._BUILTINS_REGISTERED = False
+
+    from bernstein.core.orchestration.bootstrap import _register_ci_parsers
+
+    _register_ci_parsers()
+
+    names = ci_log_parser.list_parsers()
+    assert "github_actions" in names
+    assert "gitlab_ci" in names


### PR DESCRIPTION
## Summary

- `register_built_in_ci_parsers()` was defined in `bernstein.adapters.ci` but never called, so the CI log parser registry (`bernstein.core.ci_log_parser`) stayed empty at runtime.
- Consequence: `get_parser("github_actions")` / `get_parser("gitlab_ci")` returned `None`, `bernstein ci fix --parser gitlab_ci` silently no-op'd, and pipeline self-healing had no parsers to dispatch to.
- Fix wires the registrar in two ways: an idempotent import-time side-effect on `bernstein.adapters.ci`, plus an explicit `_register_ci_parsers()` call in both orchestrator bootstrap paths (`bootstrap_from_seed` and `_bootstrap_from_goal_impl`). Belt-and-braces so any code path — CLI ci fix, orchestrator startup, or direct adapter import — finds the parsers.

## Changes

- `src/bernstein/adapters/ci/__init__.py`: guard the registrar with a module-level `_BUILTINS_REGISTERED` flag (idempotent), call it at import time, expose `__all__`.
- `src/bernstein/core/orchestration/bootstrap.py`: add `_register_ci_parsers()` helper, invoke it from both bootstrap entry points after compliance/invariant setup.
- `tests/unit/test_ci_parser_registration.py`: new file, 5 tests covering explicit-call registration, import-time side-effect, by-name discovery, idempotency, and the bootstrap helper wiring.

## Test plan

- [x] `uv run ruff check` on touched files — clean
- [x] `uv run ruff format --check` on touched files — already formatted
- [x] `uv run pytest tests/unit -k "ci_parser or ci_register or ci_adapters" -x -q` — 5 passed
- [x] `uv run pytest tests/unit/test_ci_log_parser.py tests/unit/test_gitlab_ci_adapter.py tests/unit/test_ci_fix.py` — 58 passed, 1 skipped (no regressions)
- [x] Manual: `uv run python -c "from bernstein.core.ci_log_parser import list_parsers; import bernstein.adapters.ci; print(list_parsers())"` now prints `['github_actions', 'gitlab_ci']` (was `[]` before).

.