### PR TITLE
fix(adapters): forward all spawn kwargs through caching wrapper

### DIFF
--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -175,7 +175,11 @@ class CachingAdapter(CLIAdapter):
                 log_path=workdir / f"{session_id}.log",
             )
 
-        # 4. Cache miss: delegate to inner adapter
+        # 4. Cache miss: delegate to inner adapter.
+        # Forward ALL kwargs from the base CLIAdapter.spawn interface explicitly
+        # so that type checkers catch future drift — missing budget_multiplier
+        # or system_addendum silently broke retry budgets and role-scoped
+        # system prompts (audit-129).
         return self._inner.spawn(
             prompt=prompt,
             workdir=workdir,
@@ -184,6 +188,8 @@ class CachingAdapter(CLIAdapter):
             mcp_config=mcp_config,
             timeout_seconds=timeout_seconds,
             task_scope=task_scope,
+            budget_multiplier=budget_multiplier,
+            system_addendum=system_addendum,
         )
 
     def name(self) -> str:

--- a/tests/unit/test_caching_adapter.py
+++ b/tests/unit/test_caching_adapter.py
@@ -151,6 +151,37 @@ def test_is_alive_always_false_for_pid_0(adapter: CachingAdapter, mock_inner: Ma
     mock_inner.is_alive.assert_called_with(1234)
 
 
+def test_spawn_forwards_budget_multiplier_and_system_addendum(
+    adapter: CachingAdapter,
+    mock_inner: MagicMock,
+) -> None:
+    """Regression for audit-129: cache miss must forward all base-interface kwargs.
+
+    The wrapper previously dropped ``budget_multiplier`` and ``system_addendum``
+    when delegating to the inner adapter, silently disabling retry budget
+    scaling and role-scoped system prompt injection.
+    """
+    res = adapter.spawn(
+        prompt="task that will miss the cache",
+        workdir=Path("/tmp"),
+        model_config=_model_config("sonnet"),
+        session_id="audit-129",
+        budget_multiplier=2.5,
+        system_addendum="x",
+    )
+
+    assert res.pid == 1234
+    assert mock_inner.spawn.call_count == 1
+
+    kwargs = mock_inner.spawn.call_args.kwargs
+    assert kwargs["budget_multiplier"] == 2.5
+    assert kwargs["system_addendum"] == "x"
+    # Sanity: other kwargs from the base interface are still forwarded.
+    assert kwargs["prompt"] == "task that will miss the cache"
+    assert kwargs["session_id"] == "audit-129"
+    assert kwargs["task_scope"] == "medium"
+
+
 def test_concurrency_safe_spawns(adapter: CachingAdapter, mock_inner: MagicMock) -> None:
     """Verify that multiple threads can safely spawn through the adapter."""
     import threading


### PR DESCRIPTION
## Summary

- `CachingAdapter.spawn()` accepted `budget_multiplier` and `system_addendum` but dropped them when delegating to the inner adapter — every retry at `budget_multiplier=2.0` silently fell back to 1.0, and every role-scoped `system_addendum` was lost (undoing commit e1e117f2).
- Forward all kwargs from the base `CLIAdapter.spawn` interface explicitly so type checkers catch future drift instead of silently losing kwargs again.
- Added regression test that spawns through the wrapper with `budget_multiplier=2.5` and `system_addendum="x"` and asserts both reach the inner adapter.

Ticket: `-caching-adapter-drops-kwargs`.

## Test plan

- [x] `uv run ruff check src/bernstein/adapters/caching_adapter.py tests/unit/test_caching_adapter.py` — clean
- [x] `uv run ruff format --check src/bernstein/adapters/caching_adapter.py tests/unit/test_caching_adapter.py` — formatted
- [x] `uv run pytest tests/unit -k "caching_adapter" -x -q` — 18 passed