### PR TITLE
fix(tasks): flush recover_stale release to JSONL

### DIFF
--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -368,21 +368,68 @@ class TaskStore:
         fresh agent can pick them up.  Call this once after ``replay_jsonl()``
         during startup.
 
+        The release is persisted to the JSONL log synchronously (bug
+        ``audit-015``): without this, the in-memory reset is lost on crash and
+        the stale CLAIMED line replays on the next restart, enabling duplicate
+        execution.
+
         Returns:
             Number of tasks reset to open.
         """
         reset_count = 0
+        reset_tasks: list[Task] = []
         for stale_status in (TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS):
             for task in list(self._by_status.get(stale_status, {}).values()):
                 self._index_remove(task)
-                task.status = TaskStatus.OPEN
+                # Use the FSM for the transition so audit/telemetry fire and
+                # any illegal jump is caught.  CLAIMED→OPEN and
+                # IN_PROGRESS→OPEN are both allow-listed in
+                # ``lifecycle.TASK_TRANSITIONS``.
+                transition_task(
+                    task,
+                    TaskStatus.OPEN,
+                    actor="task_store",
+                    reason="recover_stale_after_restart",
+                )
                 task.claimed_at = None
                 task.claimed_by_session = None
                 self._index_add(task)
+                reset_tasks.append(task)
                 reset_count += 1
         if reset_count:
+            # Flush release records to the JSONL log so the reset survives a
+            # subsequent crash.  Without this flush, a kill before the task's
+            # next mutation replays the CLAIMED line and a new agent can claim
+            # a task another agent was already running (work duplication).
+            for task in reset_tasks:
+                self._append_jsonl_sync(self._task_to_record(task))
             logger.info("recover_stale_claimed_tasks: reset %d task(s) to open after restart", reset_count)
         return reset_count
+
+    def _append_jsonl_sync(self, record: TaskRecord) -> None:
+        """Synchronously append a record to the JSONL log.
+
+        Used during startup recovery where the async
+        :meth:`_append_jsonl` cannot be awaited (the caller is sync) and we
+        still need the mutation durable on disk before returning.  Mirrors
+        the tenant-scoped backlog file the async path writes.
+        """
+        line = json.dumps(record, default=str) + "\n"
+        self._jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._jsonl_path.open("a") as handle:
+            handle.write(line)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        try:
+            tenant_paths = ensure_tenant_layout(self._sdd_dir, str(record["tenant_id"]))
+            target_path = tenant_paths.backlog_dir / "tasks.jsonl"
+            with target_path.open("a", encoding="utf-8") as handle:
+                handle.write(line)
+        except OSError as exc:
+            # Tenant mirror is best-effort during recovery; the authoritative
+            # JSONL log above is already durable.
+            logger.warning("Failed to mirror recover_stale record to tenant backlog: %s", exc)
 
     _BUFFER_MAX: int = 1
 

--- a/tests/unit/test_recover_stale_jsonl_flush.py
+++ b/tests/unit/test_recover_stale_jsonl_flush.py
@@ -1,0 +1,123 @@
+"""Regression test for audit-015: recover_stale_claimed_tasks must flush to JSONL.
+
+Before the fix, ``recover_stale_claimed_tasks`` only mutated in-memory state.
+If the server crashed again before the task's next lifecycle write, replay
+from JSONL would re-load the stale CLAIMED line on restart and a fresh agent
+could duplicate work already in flight on another process.
+
+This test simulates that scenario: seed a CLAIMED task on disk, call
+``recover_stale_claimed_tasks``, discard the store (crash), re-open a fresh
+store from the same JSONL, and assert the task replays as OPEN.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.task_store import TaskStore
+
+from bernstein.core.tasks.models import TaskStatus
+
+
+def _write_task_jsonl(
+    jsonl: Path,
+    task_id: str,
+    *,
+    status: str,
+    assigned_agent: str | None = None,
+    claimed_by_session: str | None = None,
+) -> None:
+    """Write a minimal task record to a JSONL file."""
+
+    jsonl.parent.mkdir(parents=True, exist_ok=True)
+    record: dict[str, object] = {
+        "id": task_id,
+        "title": f"task {task_id}",
+        "description": "",
+        "role": "backend",
+        "priority": 3,
+        "status": status,
+    }
+    if assigned_agent is not None:
+        record["assigned_agent"] = assigned_agent
+    if claimed_by_session is not None:
+        record["claimed_by_session"] = claimed_by_session
+    with jsonl.open("a") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+
+def test_recover_stale_release_is_flushed_to_jsonl(tmp_path: Path) -> None:
+    """audit-015: stale CLAIMED reset must survive a crash.
+
+    After ``recover_stale_claimed_tasks`` re-queues a stale CLAIMED task, a
+    fresh TaskStore reading the same JSONL must observe the task as OPEN.
+    """
+
+    jsonl = tmp_path / "runtime" / "tasks.jsonl"
+    task_id = "audit-015-stale-001"
+
+    # Simulate a server that died mid-task: a CLAIMED row is on disk.
+    _write_task_jsonl(
+        jsonl,
+        task_id,
+        status="claimed",
+        assigned_agent="agent-dead",
+        claimed_by_session="session-dead",
+    )
+
+    # First "server lifetime": replay + recover.
+    store = TaskStore(jsonl_path=jsonl)
+    store.replay_jsonl()
+    assert store.get_task(task_id).status == TaskStatus.CLAIMED  # type: ignore[union-attr]
+
+    reset_count = store.recover_stale_claimed_tasks()
+    assert reset_count == 1
+
+    # In-memory: released.
+    in_mem = store.get_task(task_id)
+    assert in_mem is not None
+    assert in_mem.status == TaskStatus.OPEN
+    assert in_mem.claimed_by_session is None
+
+    # Simulate crash: drop the store and re-open from the same JSONL.  Prior
+    # to the fix the release was never written, so replay would see only the
+    # original CLAIMED line and resurrect the stale claim.
+    del store
+
+    store2 = TaskStore(jsonl_path=jsonl)
+    store2.replay_jsonl()
+    replayed = store2.get_task(task_id)
+    assert replayed is not None, "task missing after restart"
+    assert replayed.status == TaskStatus.OPEN, (
+        f"expected OPEN after restart, got {replayed.status.value!r} — recover_stale release not persisted"
+    )
+
+
+def test_recover_stale_multiple_statuses_flushed_to_jsonl(tmp_path: Path) -> None:
+    """Both CLAIMED and IN_PROGRESS releases must persist across a restart."""
+
+    jsonl = tmp_path / "runtime" / "tasks.jsonl"
+    _write_task_jsonl(jsonl, "t-claimed", status="claimed", assigned_agent="a1")
+    _write_task_jsonl(jsonl, "t-inprog", status="in_progress", assigned_agent="a2")
+    _write_task_jsonl(jsonl, "t-open", status="open")
+    _write_task_jsonl(jsonl, "t-done", status="done")
+
+    store = TaskStore(jsonl_path=jsonl)
+    store.replay_jsonl()
+    reset_count = store.recover_stale_claimed_tasks()
+    assert reset_count == 2
+
+    del store
+
+    store2 = TaskStore(jsonl_path=jsonl)
+    store2.replay_jsonl()
+
+    t_claimed = store2.get_task("t-claimed")
+    t_inprog = store2.get_task("t-inprog")
+    t_open = store2.get_task("t-open")
+    t_done = store2.get_task("t-done")
+    assert t_claimed is not None and t_claimed.status == TaskStatus.OPEN
+    assert t_inprog is not None and t_inprog.status == TaskStatus.OPEN
+    assert t_open is not None and t_open.status == TaskStatus.OPEN
+    assert t_done is not None and t_done.status == TaskStatus.DONE


### PR DESCRIPTION
## Summary

: `recover_stale_claimed_tasks` in `task_store_core.py` reset stale `CLAIMED`/`IN_PROGRESS` tasks to `OPEN` in the in-memory dict but never appended the release to the JSONL log. If the server crashed again before the task's next lifecycle write, `replay_jsonl` on restart only saw the original `CLAIMED` line and resurrected the stale claim — a second agent could then pick up work another process had already started (duplicate execution).

## Fix

- Route the reset through `transition_task(task, TaskStatus.OPEN, actor="task_store", reason="recover_stale_after_restart")` so the FSM's audit/telemetry hooks fire and illegal jumps are rejected. `CLAIMED→OPEN` and `IN_PROGRESS→OPEN` are already allow-listed in `lifecycle.TASK_TRANSITIONS`.
- Append the resulting record via a new synchronous helper `_append_jsonl_sync` before returning. The helper fsyncs the primary JSONL and mirrors the tenant-scoped backlog file the async path writes. A sync helper is required because `recover_stale_claimed_tasks` is called from the FastAPI lifespan before the event loop owns the store, and making the method async would break the many existing sync call sites (chaos tests, WAL HA docs, etc.).

## Test plan

- [x] New `tests/unit/test_recover_stale_jsonl_flush.py` simulates the crash loop: seed a `CLAIMED` row, call `recover_stale_claimed_tasks`, drop the store, re-open a fresh `TaskStore` from the same JSONL, assert status replays as `OPEN`. Covers both `CLAIMED` and `IN_PROGRESS`, leaves `OPEN`/`DONE` untouched.
- [x] `uv run ruff check` + `uv run ruff format --check` on changed files — clean.
- [x] `uv run pytest tests/unit -k "recover_stale or stale_recover" -x -q` — 4 passed.
- [x] `uv run pytest tests/unit/test_chaos.py -x -q` — 32 passed (existing `recover_stale_claimed_tasks` tests still green).

## Risks / scope

- `transition_task` now runs during startup recovery; both relevant edges are already whitelisted so no new entries are needed in `TASK_TRANSITIONS`.
- The secondary `replay_jsonl` quirk where previously-existing tasks do not propagate `claimed_by_session` on re-apply is orthogonal and left for a separate ticket; the fix here guarantees `status=OPEN` survives the crash, which is the invariant calls out.