### PR TITLE
fix(server): disable uvicorn reload in evolve mode

### DIFF
--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -408,8 +408,10 @@ def bootstrap_from_seed(
         cells: Number of parallel cells. If None, reads from seed config.
         remote: If True, bind to 0.0.0.0 for remote access.
         force_fresh: Ignore any saved session and start from scratch.
-        evolve_mode: When True, start the server with ``--reload`` so that
-            source changes by agents are picked up without killing agents.
+        evolve_mode: Retained for back-compat. Uvicorn ``--reload`` was
+            removed 2026-04-17 (audit-115); this flag no longer alters
+            the server launch. Agents pick up source changes only when
+            the supervisor restarts the server for real (crash/health).
         cli: Optional CLI override (e.g. "claude", "codex"). Overrides seed config.
         model: Optional model override (e.g. "opus", "sonnet"). Overrides seed config.
 

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -230,9 +230,12 @@ def _start_server(
         bind_host: Host to bind to. Use "0.0.0.0" for remote access.
         cluster_enabled: Enable cluster endpoints and node reaper.
         auth_token: Bearer token for API auth.
-        evolve_mode: When True, start uvicorn with ``--reload`` so that
-            source changes made by agents are picked up automatically
-            without killing running agents (they communicate via HTTP).
+        evolve_mode: Retained for signature compatibility. Uvicorn
+            ``--reload`` was removed 2026-04-17 per audit-115 because
+            auto-reload is catastrophic in self-modifying runs
+            (file writes → restart → dropped HTTP connections → WAL
+            replay duplicate claims). The flag no longer affects the
+            launched uvicorn argv.
 
     Returns:
         PID of the server process.
@@ -271,12 +274,13 @@ def _start_server(
         "--port",
         str(port),
     ]
-    if evolve_mode:
-        # In self-development mode, let uvicorn watch for source changes
-        # and auto-reload.  Agents survive because they communicate via
-        # HTTP — they see a brief connection error during reload and retry.
-        src_dir = str(workdir / "src" / "bernstein")
-        server_cmd.extend(["--reload", "--reload-dir", src_dir])
+    # ``--reload`` was removed 2026-04-17 per audit-115 / incident
+    # 2026-04-11.  Bernstein agents continuously edit src/bernstein/*.py,
+    # so auto-reload causes a uvicorn restart on every write — in-flight
+    # requests drop, the bind port races, and WAL replay produces
+    # duplicate task claims.  evolve_mode is preserved in the signature
+    # for back-compat but no longer toggles reload.
+    _ = evolve_mode  # intentional: parameter retained for compatibility
 
     log_path = workdir / ".sdd" / "runtime" / "server.log"
     rotate_log_file(log_path)

--- a/src/bernstein/core/server/server_supervisor.py
+++ b/src/bernstein/core/server/server_supervisor.py
@@ -23,11 +23,14 @@ import subprocess
 import sys
 import threading
 import time
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from bernstein.core.platform_compat import kill_process
 from bernstein.core.process_utils import is_process_alive
 from bernstein.core.runtime_state import SupervisorStateSnapshot, rotate_log_file, write_supervisor_state
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -155,19 +158,16 @@ def _launch_server(state: _SupervisorState) -> int:
         "--port",
         str(port),
     ]
-    # ``--reload`` is gated on ``evolve_mode``. In a self-modifying system
-    # (bernstein agents constantly edit src/bernstein/*.py) ``--reload``
-    # is catastrophic: every file write triggers a uvicorn restart, which
-    # drops in-flight HTTP connections, races on port 8052 ("Address already
-    # in use"), and replays the WAL with duplicate task claims. Incident
-    # 2026-04-11 03:19 — server hung 127s, orchestrator gave up. Production
-    # runs MUST not auto-reload; only the explicit dev/evolve flow may.
-    if state.evolve_mode:
-        src_dir = str(workdir / "src" / "bernstein")
-        if Path(src_dir).is_dir():
-            server_cmd.extend(["--reload", "--reload-dir", src_dir])
-        else:
-            server_cmd.append("--reload")
+    # ``--reload`` was removed 2026-04-17 per audit-115 / incident 2026-04-11.
+    # In a self-modifying system (bernstein agents constantly edit
+    # src/bernstein/*.py) uvicorn --reload is catastrophic: every file write
+    # triggers a uvicorn restart, which drops in-flight HTTP connections,
+    # races on the bind port ("Address already in use"), and replays the WAL
+    # with duplicate task claims. Evolve cycles already restart via the
+    # supervisor on real crashes — auto-reload is never wanted here.
+    # ``state.evolve_mode`` is intentionally not consulted when building the
+    # uvicorn argv; if you're tempted to re-add --reload, read audit-115
+    # first.
 
     log_path = workdir / ".sdd" / "runtime" / "server.log"
     rotate_log_file(log_path)

--- a/tests/unit/test_uvicorn_reload_disabled.py
+++ b/tests/unit/test_uvicorn_reload_disabled.py
@@ -1,0 +1,125 @@
+"""Regression tests for audit-115 — uvicorn ``--reload`` must never be enabled.
+
+Context:
+    On 2026-04-11 a bernstein evolve run launched uvicorn with ``--reload`` so
+    that source changes made by agents would be hot-reloaded. Every file write
+    by an agent triggered a uvicorn restart, which dropped in-flight HTTP
+    connections, raced on the bind port, and replayed the WAL with duplicate
+    task claims. The server hung for 127s and the orchestrator gave up.
+
+    Audit-115 removes ``--reload`` from the production launch paths entirely.
+    Evolve mode is the self-modifying flow — it MUST NOT enable auto-reload.
+
+These tests ensure both server-launch code paths (``server_supervisor`` and
+``server_launch``) never pass ``--reload`` / ``reload=True`` to uvicorn,
+regardless of the ``evolve_mode`` flag.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.server_launch import _start_server
+
+from bernstein.core import server_supervisor
+
+
+def _popen_argv(mock_popen: object) -> list[str]:
+    """Return the argv list passed to the most recent Popen call."""
+    call = mock_popen.call_args  # type: ignore[attr-defined]
+    assert call is not None, "subprocess.Popen was not invoked"
+    return list(call.args[0])
+
+
+@pytest.mark.parametrize("evolve_mode", [False, True])
+def test_server_supervisor_never_passes_reload_flag(tmp_path: Path, evolve_mode: bool) -> None:
+    """``_launch_server`` must never include ``--reload`` in the uvicorn argv.
+
+    Regression for audit-115: in evolve mode every agent file write used to
+    trigger a uvicorn restart → dropped requests, WAL replay duplicates.
+    """
+    (tmp_path / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+    # Create src/bernstein so the old buggy code path (which extended the
+    # argv with --reload-dir on directory presence) would have fired.
+    (tmp_path / "src" / "bernstein").mkdir(parents=True, exist_ok=True)
+
+    state = server_supervisor._SupervisorState(
+        workdir=tmp_path,
+        port=8052,
+        bind_host="127.0.0.1",
+        cluster_enabled=False,
+        auth_token=None,
+        evolve_mode=evolve_mode,
+    )
+
+    with (
+        patch("bernstein.core.server.server_supervisor.rotate_log_file"),
+        patch("bernstein.core.server.server_supervisor.write_supervisor_state"),
+        patch(
+            "bernstein.core.server.server_supervisor.subprocess.Popen",
+            return_value=SimpleNamespace(pid=4242),
+        ) as mock_popen,
+    ):
+        server_supervisor._launch_server(state)
+
+    argv = _popen_argv(mock_popen)
+    assert "--reload" not in argv, f"supervisor must not pass --reload (evolve_mode={evolve_mode}); argv={argv}"
+    assert "--reload-dir" not in argv, f"supervisor must not pass --reload-dir; argv={argv}"
+
+
+@pytest.mark.parametrize("evolve_mode", [False, True])
+def test_server_launch_start_server_never_passes_reload_flag(tmp_path: Path, evolve_mode: bool) -> None:
+    """``_start_server`` must never include ``--reload`` in the uvicorn argv.
+
+    Regression for audit-115.  Evolve mode is the self-modifying flow and
+    must not enable auto-reload.
+    """
+    (tmp_path / ".sdd" / "runtime").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "src" / "bernstein").mkdir(parents=True, exist_ok=True)
+
+    with (
+        patch("bernstein.core.server.server_launch._read_pid", return_value=None),
+        patch("bernstein.core.server.server_launch._is_alive", return_value=False),
+        patch("bernstein.core.server.server_launch.rotate_log_file"),
+        patch(
+            "bernstein.core.server.server_launch.subprocess.Popen",
+            return_value=SimpleNamespace(pid=5353),
+        ) as mock_popen,
+    ):
+        _start_server(tmp_path, 8052, evolve_mode=evolve_mode)
+
+    argv = _popen_argv(mock_popen)
+    assert "--reload" not in argv, f"server_launch must not pass --reload (evolve_mode={evolve_mode}); argv={argv}"
+    assert "--reload-dir" not in argv, f"server_launch must not pass --reload-dir; argv={argv}"
+
+
+def test_server_supervisor_module_has_no_reload_literal() -> None:
+    """Static check: the supervisor source must contain no ``--reload`` argv literal.
+
+    A future contributor who re-adds ``--reload`` to the uvicorn command will
+    trip this test. (Comment text mentioning ``--reload`` in documentation is
+    allowed; what we forbid is a raw string literal that would end up in argv.)
+    """
+    source = Path(server_supervisor.__file__).read_text(encoding="utf-8")
+    # The only tolerated occurrences are inside comments / docstrings.
+    # Strip comment lines before checking for the literal argv string.
+    code_lines = [ln for ln in source.splitlines() if not ln.lstrip().startswith("#")]
+    code_body = "\n".join(code_lines)
+    assert '"--reload"' not in code_body, "server_supervisor must not pass '--reload' to uvicorn (audit-115)"
+    assert "'--reload'" not in code_body, "server_supervisor must not pass '--reload' to uvicorn (audit-115)"
+
+
+def test_server_launch_module_has_no_reload_literal() -> None:
+    """Static check: server_launch source must contain no ``--reload`` argv literal."""
+    from bernstein.core.server import server_launch
+
+    source = Path(server_launch.__file__).read_text(encoding="utf-8")
+    code_lines = [ln for ln in source.splitlines() if not ln.lstrip().startswith("#")]
+    code_body = "\n".join(code_lines)
+    assert '"--reload"' not in code_body, "server_launch must not pass '--reload' to uvicorn (audit-115)"
+    assert "'--reload'" not in code_body, "server_launch must not pass '--reload' to uvicorn (audit-115)"


### PR DESCRIPTION
## Summary

P0 regression fix — uvicorn ``--reload`` was still enabled whenever the
server was launched with ``evolve_mode=True``. In self-modifying runs,
every agent file write triggered a uvicorn restart, which dropped
in-flight HTTP connections, raced on the bind port, and replayed the
WAL with duplicate task claims. Incident 2026-04-11 03:19 — server
hung 127s, orchestrator gave up.

- Removed ``--reload`` branch from ``server_supervisor._launch_server``
- Removed ``--reload`` branch from ``server_launch._start_server``
- ``evolve_mode`` kept in both signatures for back-compat (no behavior change)
- Updated ``bootstrap.py`` docstring to match
- Added ``tests/unit/test_uvicorn_reload_disabled.py`` with parametrized
  regression coverage and static-source checks that forbid future
  reintroduction of the ``--reload`` argv literal

## Test plan

- [x] ``uv run ruff check`` on all four touched files — clean
- [x] ``uv run ruff format --check`` on all four touched files — clean
- [x] ``uv run pytest tests/unit -k "server_supervisor or server_launch or uvicorn_reload" -x -q`` → 16 passed
- [ ] CI green on the PR