### PR TITLE
fix(agents): correct adapter autodetect binary names

### DIFF
--- a/src/bernstein/core/agents/adapter_autodetect.py
+++ b/src/bernstein/core/agents/adapter_autodetect.py
@@ -25,7 +25,13 @@ logger = logging.getLogger(__name__)
 # Known CLI tool -> adapter mappings
 # ---------------------------------------------------------------------------
 
-# Maps binary names to their adapter registry names.
+# Maps binary names (as they appear on PATH) to their adapter registry names.
+#
+# IMPORTANT: The key must match the binary name each adapter actually spawns
+# (see ``src/bernstein/adapters/<name>.py`` ``cmd = [...]``). Multiple binaries
+# may map to a single adapter (e.g. both ``terraform`` and ``pulumi`` satisfy
+# the ``iac`` adapter). Ordering is not significant — ``scan_for_adapters``
+# iterates the map in sorted order.
 _KNOWN_BINARIES: dict[str, str] = {
     "claude": "claude",
     "codex": "codex",
@@ -38,9 +44,11 @@ _KNOWN_BINARIES: dict[str, str] = {
     "cn": "continue",
     "goose": "goose",
     "kilo": "kilo",
-    "kiro": "kiro",
+    "kiro-cli": "kiro",
     "ollama": "ollama",
     "opencode": "opencode",
+    "terraform": "iac",
+    "pulumi": "iac",
 }
 
 

--- a/tests/unit/test_adapter_autodetect.py
+++ b/tests/unit/test_adapter_autodetect.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from unittest.mock import patch
 
 from bernstein.core.adapter_autodetect import (
@@ -11,6 +13,23 @@ from bernstein.core.adapter_autodetect import (
     auto_register_adapters,
     scan_for_adapters,
 )
+
+# Adapter registry names that do not have a 1:1 source file under
+# ``src/bernstein/adapters/`` (handled by a module with a different stem).
+_ADAPTER_FILE_OVERRIDES: dict[str, str] = {
+    "continue": "continue_dev.py",
+}
+
+# Adapter registry names whose binary is intentionally different from what the
+# adapter's own ``cmd = [...]`` line spawns (e.g. ``ollama`` adapter shells out
+# to ``aider`` but we detect the ollama server binary as a proxy for the
+# integration being usable; ``iac`` adapter spawns ``bash`` to wrap the real
+# tool call, so we match against the ``_TOOL_DEFS`` table instead).
+_BINARY_FILE_OVERRIDES: dict[str, tuple[str, ...]] = {
+    "ollama": ("ollama.py",),
+    "terraform": ("iac.py",),
+    "pulumi": ("iac.py",),
+}
 
 
 class TestScanForAdapters:
@@ -72,3 +91,89 @@ class TestAutoRegisterAdapters:
         assert "claude" in _KNOWN_BINARIES
         assert "codex" in _KNOWN_BINARIES
         assert "gemini" in _KNOWN_BINARIES
+
+    def test_kiro_binary_uses_cli_suffix(self) -> None:
+        # Regression test for audit-130: real binary is ``kiro-cli``, not ``kiro``.
+        assert "kiro-cli" in _KNOWN_BINARIES
+        assert _KNOWN_BINARIES["kiro-cli"] == "kiro"
+        assert "kiro" not in _KNOWN_BINARIES
+
+    def test_iac_binaries_registered(self) -> None:
+        # Regression test for audit-130: ``iac`` adapter needs terraform/pulumi entries.
+        assert _KNOWN_BINARIES.get("terraform") == "iac"
+        assert _KNOWN_BINARIES.get("pulumi") == "iac"
+
+
+class TestKnownBinariesMatchAdapterSources:
+    """Every ``_KNOWN_BINARIES`` entry must match what the adapter really spawns.
+
+    Iterates the map and, for each ``(binary, adapter_name)`` pair, reads the
+    corresponding adapter source file under ``src/bernstein/adapters/`` and
+    asserts that the binary name appears verbatim as a quoted string
+    (i.e. in a ``cmd = [...]`` call or an equivalent tool-definitions table).
+    This catches autodetect/adapter drift like kiro→kiro when the adapter
+    actually exec's ``kiro-cli``.
+    """
+
+    @staticmethod
+    def _adapters_dir() -> Path:
+        import bernstein.adapters as _adapters_pkg
+
+        return Path(_adapters_pkg.__file__).parent
+
+    def _adapter_files_for(self, binary: str, adapter_name: str) -> list[Path]:
+        adapters_dir = self._adapters_dir()
+        overrides = _BINARY_FILE_OVERRIDES.get(binary)
+        if overrides is not None:
+            return [adapters_dir / name for name in overrides]
+        filename = _ADAPTER_FILE_OVERRIDES.get(adapter_name, f"{adapter_name}.py")
+        return [adapters_dir / filename]
+
+    @staticmethod
+    def _binary_in_source(binary: str, source: str) -> bool:
+        """Return True iff ``binary`` appears as a cmd/tool token in ``source``.
+
+        Looks for the binary as a standalone quoted literal (``"kiro-cli"``)
+        or as a bare identifier with CLI word boundaries (so ``kiro`` does not
+        match ``kiro-cli``). The latter catches cases like ``ollama`` which
+        is embedded in help text, env var names, and f-strings.
+        """
+        if f'"{binary}"' in source or f"'{binary}'" in source:
+            return True
+        # CLI word boundary: anything except another identifier char or a hyphen/slash.
+        pattern = rf"(?<![A-Za-z0-9_\-/]){re.escape(binary)}(?![A-Za-z0-9_\-])"
+        return re.search(pattern, source) is not None
+
+    def test_every_binary_appears_in_adapter_source(self) -> None:
+        missing: list[tuple[str, str, Path]] = []
+        for binary, adapter_name in _KNOWN_BINARIES.items():
+            for adapter_file in self._adapter_files_for(binary, adapter_name):
+                assert adapter_file.is_file(), (
+                    f"Adapter source file {adapter_file} does not exist "
+                    f"for binary {binary!r} -> adapter {adapter_name!r}"
+                )
+                source = adapter_file.read_text(encoding="utf-8")
+                if not self._binary_in_source(binary, source):
+                    missing.append((binary, adapter_name, adapter_file))
+        assert not missing, "Binary names in _KNOWN_BINARIES do not appear in their adapter source files: " + ", ".join(
+            f"{b!r} ({a} @ {p.name})" for b, a, p in missing
+        )
+
+    def test_kiro_adapter_spawns_kiro_cli(self) -> None:
+        """Regression guard for audit-130.
+
+        The kiro adapter must spawn ``kiro-cli`` (not ``kiro``) as the
+        first argument of its ``cmd`` list — if anyone changes that, the
+        autodetect entry ``kiro-cli → kiro`` also needs to change.
+        """
+        adapter_file = self._adapters_dir() / "kiro.py"
+        source = adapter_file.read_text(encoding="utf-8")
+        assert '"kiro-cli"' in source
+        # And the autodetect key must agree.
+        assert "kiro-cli" in _KNOWN_BINARIES
+
+    def test_every_adapter_name_is_registered(self) -> None:
+        from bernstein.adapters.registry import _ADAPTERS
+
+        unknown = {adapter for adapter in _KNOWN_BINARIES.values() if adapter not in _ADAPTERS}
+        assert not unknown, f"Autodetect references adapters missing from registry: {sorted(unknown)}"


### PR DESCRIPTION
## Summary
- `_KNOWN_BINARIES` in `src/bernstein/core/agents/adapter_autodetect.py` mapped adapter names to themselves, but the kiro adapter actually spawns `kiro-cli` and the IaC adapter spawns `terraform` or `pulumi`. `scan_for_adapters()` therefore silently reported these adapters as missing even when the real tools were on PATH.
- Renames the kiro key from `kiro` to `kiro-cli` (adapter name unchanged) and adds `terraform → iac` / `pulumi → iac`. Keeps `cody → cody` — the standalone Sourcegraph Cody CLI really is `cody`; the ticket's `sg cody` claim did not match `src/bernstein/adapters/cody.py` L91-96.
- Adds a consistency test that iterates every `_KNOWN_BINARIES` entry and asserts the binary name appears in the corresponding adapter source file, plus a registry-presence check and an explicit regression test for the kiro-cli case.

## Test plan
- [x] `uv run ruff check src/bernstein/core/agents/adapter_autodetect.py tests/unit/test_adapter_autodetect.py`
- [x] `uv run ruff format --check src/bernstein/core/agents/adapter_autodetect.py tests/unit/test_adapter_autodetect.py`
- [x] `uv run pytest tests/unit -k "adapter_autodetect or autodetect" -x -q` -> 13 passed
- [ ] CI green

Ticket: `.sdd/backlog/closed/-adapter-autodetect-binary-mismatch.yaml`