### PR TITLE
security(audit): split audit key from log storage

### DIFF
--- a/docs/security/security-hardening.md
+++ b/docs/security/security-hardening.md
@@ -436,8 +436,12 @@ Rotate the JWT signing secret and audit log HMAC key periodically:
 export BERNSTEIN_JWT_SECRET="$(openssl rand -hex 32)"
 bernstein stop && bernstein run   # Restart to pick up new secret
 
-# Rotate the audit log HMAC key
-cp .sdd/config/audit-key .sdd/config/audit-key.bak
+# Rotate the audit log HMAC key (audit-043: key lives OUTSIDE .sdd/ by default).
+# Default location: $XDG_STATE_HOME/bernstein/audit.key
+#   (falls back to ~/.local/state/bernstein/audit.key)
+# Override with: export BERNSTEIN_AUDIT_KEY_PATH=/secure/path/audit.key
+KEY_PATH="${BERNSTEIN_AUDIT_KEY_PATH:-${XDG_STATE_HOME:-$HOME/.local/state}/bernstein/audit.key}"
+cp "$KEY_PATH" "${KEY_PATH}.bak"
 bernstein admin rotate-audit-key
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -413,6 +413,7 @@ addopts = [
 markers = [
     "ci: tests that run as part of CI for every release",
     "auth_enabled: opt out of the autouse auth-disabled shim (tests that exercise auth defaults)",
+    "audit_key_real: opt out of the autouse audit-key path isolation (tests that exercise the real resolution logic)",
 ]
 # Visible warnings without converting to errors; individual tests or runs
 # can tighten via `pytest -W error::DeprecationWarning`.

--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -4,24 +4,32 @@ Every audit event carries an HMAC that chains to the previous event's HMAC,
 forming a tamper-evident sequence.  Daily log rotation produces one JSONL
 file per day; the chain carries across file boundaries.
 
-HMAC key is read from ``.sdd/config/audit-key`` (auto-generated if absent).
+Security (audit-043): the HMAC key lives OUTSIDE the audit log directory so
+an attacker with write access to ``.sdd/audit/*.jsonl`` cannot also read or
+rotate the signing key. The default key location is
+``$XDG_STATE_HOME/bernstein/audit.key`` (falling back to
+``~/.local/state/bernstein/audit.key``) and is overridable via the
+``BERNSTEIN_AUDIT_KEY_PATH`` environment variable. The key file is required
+to be mode ``0600``; a world- or group-readable key is treated as a hard
+error at load time.
 """
 
 from __future__ import annotations
 
+import contextlib
 import gzip
 import hashlib
 import hmac as _hmac
 import json
 import logging
+import os
 import secrets
 import shutil
+import stat
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
+from typing import Any
 
 _JSONL_GLOB = "*.jsonl"
 
@@ -30,6 +38,100 @@ logger = logging.getLogger(__name__)
 _GENESIS_HMAC = "0" * 64
 
 DEFAULT_RETENTION_DAYS = 90
+
+#: Environment variable that overrides the audit key path.
+AUDIT_KEY_ENV = "BERNSTEIN_AUDIT_KEY_PATH"
+
+#: Required mode for the audit key file (0600 — owner read/write only).
+_REQUIRED_KEY_MODE = 0o600
+
+
+class AuditKeyPermissionError(RuntimeError):
+    """Raised when the audit key file has permissions looser than 0600."""
+
+
+def _default_audit_key_path() -> Path:
+    """Return the default HMAC key path outside of ``.sdd/``.
+
+    Resolution order:
+
+    1. ``$BERNSTEIN_AUDIT_KEY_PATH`` (explicit override).
+    2. ``$XDG_STATE_HOME/bernstein/audit.key`` if ``XDG_STATE_HOME`` is set.
+    3. ``~/.local/state/bernstein/audit.key`` (XDG default).
+    """
+    override = os.environ.get(AUDIT_KEY_ENV)
+    if override:
+        return Path(override).expanduser()
+
+    xdg_state = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg_state).expanduser() if xdg_state else Path.home() / ".local" / "state"
+    return base / "bernstein" / "audit.key"
+
+
+def _enforce_key_permissions(key_path: Path) -> None:
+    """Ensure the key file is readable only by its owner (mode 0600).
+
+    Raises:
+        AuditKeyPermissionError: If group or world bits are set on the file.
+    """
+    try:
+        file_mode = stat.S_IMODE(key_path.stat().st_mode)
+    except OSError as exc:  # pragma: no cover - filesystem race
+        raise AuditKeyPermissionError(f"Cannot stat audit key {key_path}: {exc}") from exc
+
+    if file_mode & 0o077:
+        raise AuditKeyPermissionError(
+            f"Audit key {key_path} has insecure permissions {file_mode:04o}; "
+            f"required {_REQUIRED_KEY_MODE:04o} (owner-only)."
+        )
+
+
+def load_or_create_audit_key(key_path: Path | None = None) -> bytes:
+    """Load the audit HMAC key, generating one on first boot if absent.
+
+    The key path is resolved by the following precedence:
+
+    1. Explicit ``key_path`` argument.
+    2. ``$BERNSTEIN_AUDIT_KEY_PATH`` environment variable.
+    3. ``$XDG_STATE_HOME/bernstein/audit.key`` (or the XDG default).
+
+    On first boot, a fresh 32-byte hex key is generated, the parent directory
+    is created with mode ``0700``, and the key file is written with mode
+    ``0600``. On subsequent boots the existing permissions are enforced.
+
+    Args:
+        key_path: Optional explicit override. Useful for tests.
+
+    Returns:
+        The raw key bytes suitable for ``hmac.new``.
+
+    Raises:
+        AuditKeyPermissionError: If the existing key file is readable by
+            anyone besides its owner.
+    """
+    resolved = key_path if key_path is not None else _default_audit_key_path()
+
+    if resolved.exists():
+        _enforce_key_permissions(resolved)
+        return resolved.read_bytes().strip()
+
+    parent = resolved.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    # Best-effort harden the directory: owner-only if we just created it.
+    with contextlib.suppress(PermissionError, OSError):
+        parent.chmod(0o700)
+
+    key = secrets.token_hex(32).encode()
+    # Create with restrictive mode from the start — never widen then narrow.
+    fd = os.open(str(resolved), os.O_WRONLY | os.O_CREAT | os.O_EXCL, _REQUIRED_KEY_MODE)
+    try:
+        os.write(fd, key)
+    finally:
+        os.close(fd)
+    # Re-assert mode in case umask or filesystem behavior dropped bits.
+    resolved.chmod(_REQUIRED_KEY_MODE)
+    logger.info("Generated new audit HMAC key at %s", resolved)
+    return key
 
 
 @dataclass(frozen=True)
@@ -144,28 +246,33 @@ class AuditLog:
 
     Args:
         audit_dir: Directory for daily JSONL log files.
-        key: HMAC key bytes.  If ``None``, the key is loaded from
-            ``<audit_dir>/../config/audit-key`` (created if absent).
+        key: HMAC key bytes.  If ``None``, the key is loaded from the path
+            resolved by :func:`load_or_create_audit_key` — which by default
+            lives *outside* ``audit_dir`` so a log-writer cannot also read
+            or rotate the signing key.
+        key_path: Optional explicit key file path. Overrides the environment
+            variable ``BERNSTEIN_AUDIT_KEY_PATH``. Ignored if ``key`` is
+            provided directly.
+
+    Raises:
+        AuditKeyPermissionError: If the resolved key file exists on disk but
+            is readable by anyone besides its owner.
     """
 
-    def __init__(self, audit_dir: Path, key: bytes | None = None) -> None:
+    def __init__(
+        self,
+        audit_dir: Path,
+        key: bytes | None = None,
+        *,
+        key_path: Path | None = None,
+    ) -> None:
         self._audit_dir = audit_dir
         self._audit_dir.mkdir(parents=True, exist_ok=True)
-        self._key = key if key is not None else self._load_or_create_key()
+        if key is not None:
+            self._key = key
+        else:
+            self._key = load_or_create_audit_key(key_path)
         self._prev_hmac = self._recover_chain_tail()
-
-    # -- key management -----------------------------------------------------
-
-    def _load_or_create_key(self) -> bytes:
-        """Read the HMAC key from disk, or generate one."""
-        key_path = self._audit_dir.parent / "config" / "audit-key"
-        if key_path.exists():
-            return key_path.read_bytes().strip()
-        key_path.parent.mkdir(parents=True, exist_ok=True)
-        key = secrets.token_hex(32).encode()
-        key_path.write_bytes(key)
-        key_path.chmod(0o600)
-        return key
 
     # -- chain recovery -----------------------------------------------------
 

--- a/src/bernstein/core/security/audit_integrity.py
+++ b/src/bernstein/core/security/audit_integrity.py
@@ -13,6 +13,13 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.security.audit import (
+    AUDIT_KEY_ENV,
+    AuditKeyPermissionError,
+    _default_audit_key_path,
+    _enforce_key_permissions,
+)
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -115,18 +122,44 @@ def _compute_hmac(key: bytes, prev_hmac: str, entry: dict[str, Any]) -> str:
 
 
 def _load_audit_key(audit_dir: Path) -> bytes | None:
-    """Load the HMAC key from the config directory.
+    """Load the HMAC key for integrity verification.
+
+    Resolution order:
+
+    1. ``$BERNSTEIN_AUDIT_KEY_PATH`` environment variable.
+    2. XDG state default (``~/.local/state/bernstein/audit.key``).
+    3. Legacy location ``<audit_dir>/../config/audit-key`` — retained as a
+       read-only fallback so systems that have not yet migrated can still
+       verify their chain. Permissions are enforced in all cases.
 
     Args:
-        audit_dir: Audit log directory (key is at ``../config/audit-key``).
+        audit_dir: Audit log directory. Used only for the legacy fallback.
 
     Returns:
-        Key bytes, or None if the key file is missing.
+        Key bytes, or ``None`` if no key file is found.
+
+    Raises:
+        AuditKeyPermissionError: If the key file exists but is readable by
+            anyone besides its owner.
     """
-    key_path = audit_dir.parent / "config" / "audit-key"
-    if not key_path.exists():
-        return None
-    return key_path.read_bytes().strip()
+    primary = _default_audit_key_path()
+    if primary.exists():
+        _enforce_key_permissions(primary)
+        return primary.read_bytes().strip()
+
+    legacy = audit_dir.parent / "config" / "audit-key"
+    if legacy.exists():
+        _enforce_key_permissions(legacy)
+        logger.warning(
+            "Loading audit key from legacy co-located path %s. "
+            "Move it to %s (or set %s) to restore tamper-evidence guarantees.",
+            legacy,
+            primary,
+            AUDIT_KEY_ENV,
+        )
+        return legacy.read_bytes().strip()
+
+    return None
 
 
 def _verify_entry_chain(
@@ -204,10 +237,16 @@ def verify_audit_integrity(
     Args:
         audit_dir: Directory containing audit log files.
         count: Number of tail entries to verify (default 100).
-        key: HMAC key bytes. If None, loaded from ``audit_dir/../config/audit-key``.
+        key: HMAC key bytes. If None, loaded via ``_load_audit_key`` which
+            consults ``$BERNSTEIN_AUDIT_KEY_PATH`` and the XDG default.
 
     Returns:
         IntegrityCheckResult with verification outcome.
+
+    Raises:
+        AuditKeyPermissionError: If the key file exists but has insecure
+            permissions. This is surfaced to callers so the orchestrator
+            refuses to start on a compromised key.
     """
     start = time.monotonic()
     errors: list[str] = []
@@ -277,9 +316,17 @@ def verify_on_startup(
 
     Returns:
         IntegrityCheckResult.
+
+    Raises:
+        AuditKeyPermissionError: If the audit key file is readable by
+            anyone besides its owner. Orchestrator must refuse to start.
     """
     audit_dir = sdd_dir / "audit"
-    result = verify_audit_integrity(audit_dir, count=count)
+    try:
+        result = verify_audit_integrity(audit_dir, count=count)
+    except AuditKeyPermissionError:
+        logger.exception("AUDIT KEY REJECTED: insecure permissions on HMAC key; refusing to start.")
+        raise
 
     if not result.valid:
         logger.warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,27 @@ def _stable_adaptive_parallelism(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
+def _isolate_audit_key(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Point the audit HMAC key path at a per-test tmpdir.
+
+    Without this, ``AuditLog(...)`` calls that omit ``key=`` would read or
+    create a file at ``~/.local/state/bernstein/audit.key`` — polluting the
+    developer's home directory with state from the test run. Tests that
+    specifically exercise key-path resolution opt out via
+    ``pytest.mark.audit_key_real``.
+    """
+
+    if request.node.get_closest_marker("audit_key_real") is not None:
+        return
+    key_path = tmp_path_factory.mktemp("audit-key") / "audit.key"
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_path))
+
+
+@pytest.fixture(autouse=True)
 def _disable_auth_for_tests(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
     """Disable Bernstein auth by default in the test suite.
 

--- a/tests/unit/test_audit_integrity.py
+++ b/tests/unit/test_audit_integrity.py
@@ -67,11 +67,16 @@ def audit_dir(sdd_dir: Path) -> Path:
 
 
 @pytest.fixture()
-def hmac_key(sdd_dir: Path) -> bytes:
+def hmac_key(sdd_dir: Path, monkeypatch: pytest.MonkeyPatch) -> bytes:
     key = b"test-hmac-key-for-audit"
     key_dir = sdd_dir / "config"
     key_dir.mkdir(parents=True)
-    (key_dir / "audit-key").write_bytes(key)
+    key_file = key_dir / "audit-key"
+    key_file.write_bytes(key)
+    # audit-043: the loader enforces 0600 on all key paths (primary and legacy).
+    key_file.chmod(0o600)
+    # Also expose via the split-key env so verifiers use this fixture's key.
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
     return key
 
 

--- a/tests/unit/test_audit_key.py
+++ b/tests/unit/test_audit_key.py
@@ -1,0 +1,206 @@
+"""Tests for audit-043: HMAC audit key lives outside the audit log directory.
+
+Covers:
+    * Auto-generation on first boot (fresh install).
+    * Mode-0600 enforcement: world/group-readable keys are rejected.
+    * Path override via ``BERNSTEIN_AUDIT_KEY_PATH``.
+    * Tamper detection still works when the split key is in use.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+from bernstein.core.audit import (
+    AUDIT_KEY_ENV,
+    AuditKeyPermissionError,
+    AuditLog,
+    _default_audit_key_path,  # pyright: ignore[reportPrivateUsage]
+    load_or_create_audit_key,
+)
+
+pytestmark = pytest.mark.audit_key_real
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip any inherited audit-key env so each test controls resolution."""
+    monkeypatch.delenv(AUDIT_KEY_ENV, raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+
+
+def test_key_auto_generated_on_first_boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """First boot with no pre-existing key must create one with 0600 perms."""
+    key_path = tmp_path / "state" / "audit.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+    assert not key_path.exists()
+
+    key = load_or_create_audit_key()
+
+    assert key_path.exists(), "load_or_create_audit_key did not persist the key"
+    assert len(key) == 64, "expected 32-byte hex key (64 chars)"
+    mode = stat.S_IMODE(key_path.stat().st_mode)
+    assert mode == 0o600, f"new key should be 0600, got {mode:04o}"
+
+
+def test_key_path_configurable_via_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """BERNSTEIN_AUDIT_KEY_PATH overrides the default XDG location."""
+    custom = tmp_path / "custom" / "my-audit.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(custom))
+
+    resolved = _default_audit_key_path()
+    assert resolved == custom
+
+    load_or_create_audit_key()
+    assert custom.exists()
+
+
+def test_default_path_is_outside_sdd_runtime(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default path must NOT live under ``.sdd/`` — that was the audit-043 bug."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+
+    path = _default_audit_key_path()
+
+    parts = set(path.parts)
+    assert ".sdd" not in parts, f"audit key must not live inside .sdd/: {path}"
+    assert "audit" not in parts, f"audit key must not live in an audit/ dir: {path}"
+    assert path.name == "audit.key"
+
+
+def test_key_load_rejects_world_readable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A key file with group or world bits set must fail loading."""
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"a" * 64)
+    key_path.chmod(0o644)  # world-readable — insecure
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    with pytest.raises(AuditKeyPermissionError) as excinfo:
+        load_or_create_audit_key()
+    assert "insecure permissions" in str(excinfo.value)
+
+
+def test_key_load_rejects_group_readable_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Group-readable (0640) is rejected — only owner may read the key."""
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"a" * 64)
+    key_path.chmod(0o640)
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    with pytest.raises(AuditKeyPermissionError):
+        load_or_create_audit_key()
+
+
+def test_key_load_accepts_0600(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The canonical 0600 mode loads without error."""
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"b" * 64)
+    key_path.chmod(0o600)
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    loaded = load_or_create_audit_key()
+    assert loaded == b"b" * 64
+
+
+def test_auditlog_uses_split_key_location(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AuditLog constructed without an explicit key reads from the split path —
+    NOT from ``<audit_dir>/../config/audit-key``.
+    """
+    audit_dir = tmp_path / ".sdd" / "audit"
+    key_path = tmp_path / "state" / "audit.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    log = AuditLog(audit_dir)
+    log.log("test.event", "tester", "task", "T-1")
+
+    # Key lives at the env-override path, not next to the log.
+    assert key_path.exists()
+    legacy = audit_dir.parent / "config" / "audit-key"
+    assert not legacy.exists(), "audit-043 regression: key written next to log"
+
+
+def test_auditlog_rejects_insecure_key_at_boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AuditLog() must refuse to start on an insecure key file."""
+    audit_dir = tmp_path / "audit"
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"x" * 64)
+    key_path.chmod(0o644)
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    with pytest.raises(AuditKeyPermissionError):
+        AuditLog(audit_dir)
+
+
+def test_tampered_log_detected_with_split_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: split key is loaded, events are chained, tamper is detected."""
+    audit_dir = tmp_path / ".sdd" / "audit"
+    key_path = tmp_path / "state" / "audit.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    log = AuditLog(audit_dir)
+    log.log("e1", "a1", "r", "i1")
+    log.log("e2", "a2", "r", "i2")
+
+    valid, errors = log.verify()
+    assert valid, f"chain should verify clean, got errors: {errors}"
+
+    # Tamper with the log file content.
+    log_files = sorted(audit_dir.glob("*.jsonl"))
+    assert log_files, "no log files written"
+    content = log_files[0].read_text()
+    tampered = content.replace('"a2"', '"attacker"', 1)
+    assert tampered != content, "tamper fixture did not find a field to replace"
+    log_files[0].write_text(tampered)
+
+    # Fresh AuditLog reloads the split key and detects tampering.
+    fresh = AuditLog(audit_dir)
+    valid_after, errors_after = fresh.verify()
+    assert valid_after is False
+    assert any("HMAC mismatch" in e for e in errors_after)
+
+
+def test_explicit_key_path_arg_overrides_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passing ``key_path=`` to ``load_or_create_audit_key`` wins over the env."""
+    env_path = tmp_path / "from-env.key"
+    arg_path = tmp_path / "from-arg.key"
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(env_path))
+
+    load_or_create_audit_key(key_path=arg_path)
+
+    assert arg_path.exists()
+    assert not env_path.exists()
+
+
+def test_auditlog_accepts_key_path_arg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """AuditLog(key_path=...) honours the explicit override."""
+    audit_dir = tmp_path / "audit"
+    explicit = tmp_path / "explicit.key"
+    monkeypatch.delenv(AUDIT_KEY_ENV, raising=False)
+
+    AuditLog(audit_dir, key_path=explicit)
+
+    assert explicit.exists()
+    mode = stat.S_IMODE(explicit.stat().st_mode)
+    assert mode == 0o600
+
+
+def test_xdg_state_home_used_when_env_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falling back to ``$XDG_STATE_HOME/bernstein/audit.key`` when override is unset."""
+    monkeypatch.delenv(AUDIT_KEY_ENV, raising=False)
+    state = tmp_path / "xdg_state"
+    monkeypatch.setenv("XDG_STATE_HOME", str(state))
+
+    path = _default_audit_key_path()
+    assert path == state / "bernstein" / "audit.key"
+
+
+def test_home_fallback_when_no_xdg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fall back to ``$HOME/.local/state/bernstein/audit.key`` as XDG default."""
+    monkeypatch.delenv(AUDIT_KEY_ENV, raising=False)
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    path = _default_audit_key_path()
+    assert path == tmp_path / ".local" / "state" / "bernstein" / "audit.key"

--- a/tests/unit/test_soc2_report.py
+++ b/tests/unit/test_soc2_report.py
@@ -61,11 +61,16 @@ def audit_dir(sdd_dir: Path) -> Path:
 
 
 @pytest.fixture()
-def hmac_key(sdd_dir: Path) -> bytes:
+def hmac_key(sdd_dir: Path, monkeypatch: pytest.MonkeyPatch) -> bytes:
     key = b"test-hmac-key-for-soc2"
     key_dir = sdd_dir / "config"
     key_dir.mkdir(parents=True)
-    (key_dir / "audit-key").write_bytes(key)
+    key_file = key_dir / "audit-key"
+    key_file.write_bytes(key)
+    # audit-043: the loader enforces 0600 on all key paths (primary and legacy).
+    key_file.chmod(0o600)
+    # Point the split-key loader at the same fixture key so AuditLog(...) sees it.
+    monkeypatch.setenv("BERNSTEIN_AUDIT_KEY_PATH", str(key_file))
     return key
 
 


### PR DESCRIPTION
## SECURITY — P0, 

**Vulnerability.** The HMAC audit-log signing key lived at
`.sdd/config/audit-key`, on the same filesystem (and same UID) as the
audit logs it signs. Any process that could write `.sdd/audit/*.jsonl`
could also read the key, recompute the entire chain, and bypass
`verify_audit_integrity` — collapsing the tamper-evidence guarantee.

**Fix.** The key now lives outside `.sdd/`:

- Default path: `$XDG_STATE_HOME/bernstein/audit.key`
 (falls back to `~/.local/state/bernstein/audit.key`).
- Override with `BERNSTEIN_AUDIT_KEY_PATH=/secure/path/audit.key`.
- File is created with `O_EXCL` + mode `0600`; parent directory is
 hardened to `0700` on first creation.
- `AuditKeyPermissionError` is raised if the key file has any group
 or world bits set. `AuditLog(...)` and `verify_on_startup()` both
 refuse to continue.
- Legacy `.sdd/config/audit-key` is still honoured as a read-only
 fallback so existing chains can be verified during migration — a
 loud warning is logged pointing at the new location.

## Summary

- `src/bernstein/core/security/audit.py`: new `load_or_create_audit_key`
 helper, `_default_audit_key_path`, `_enforce_key_permissions`,
 `AuditKeyPermissionError`, `AUDIT_KEY_ENV`. `AuditLog.__init__`
 gains a `key_path=` kwarg and reads from the split location by
 default.
- `src/bernstein/core/security/audit_integrity.py`: `_load_audit_key`
 prefers the split path and warns when it falls back to the legacy
 path. `verify_on_startup` surfaces `AuditKeyPermissionError` so the
 orchestrator aborts on an insecure key.
- `tests/unit/test_audit_key.py` (new, 12 cases): auto-generation on
 first boot, 0600 enforcement on load, XDG/HOME fallbacks, env-var
 override, `AuditLog` integration, end-to-end tamper detection.
- `tests/conftest.py`: autouse `_isolate_audit_key` fixture points
 every test at a tmpdir so the suite never writes to the developer's
 real `~/.local/state/bernstein/`.
- `docs/security/security-hardening.md`: updated key-rotation snippet.

## Test plan

- [x] `uv run ruff check` on changed files — clean.
- [x] `uv run ruff format --check` on changed files — clean.
- [x] `uv run pytest tests/unit -k "audit_integrity or audit_key" -x -q`
 → **27 passed**.
- [x] Broader regression: `uv run pytest tests/unit -k "audit or
 compliance or hipaa or soc2 or gdpr" -q` → **519 passed**.
- [ ] Reviewer: confirm the legacy-path fallback window is acceptable
 (default is "read legacy, warn, prefer split"). Next ticket
 should remove the fallback entirely after one release.
- [ ] Reviewer: confirm XDG default is appropriate on the production
 host profile, or set `BERNSTEIN_AUDIT_KEY_PATH` in the
 deployment template.