### PR TITLE
fix(tasks): wire cancel cascade on parent cancel

### DIFF
--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -805,19 +805,48 @@ async def close_task(task_id: str, request: Request) -> TaskResponse:
     responses={404: {"description": "Task not found"}, 409: {"description": "Invalid state transition"}},
 )
 async def cancel_task(task_id: str, body: TaskCancelRequest, request: Request) -> TaskResponse:
-    """Cancel a task that has not yet finished."""
+    """Cancel a task and cascade to all of its descendant subtasks.
+
+    Walks the subtask tree (``parent_task_id`` references) via
+    ``TaskStore.cancel_cascade`` so that children are not left running
+    after the parent is aborted.  Returns the root task.
+    """
     store = _get_store(request)
+    sse_bus = _get_sse_bus(request)
     try:
         existing_task = store.get_task(task_id)
         if existing_task is None:
             raise KeyError
         _require_task_access(existing_task, request)
-        task = await store.cancel(task_id, body.reason)
+        # Preserve the legacy 409 for a root task that is already terminal —
+        # ``cancel_cascade`` silently skips terminal tasks, so we check here.
+        cancellable = {
+            "open",
+            "claimed",
+            "in_progress",
+            "blocked",
+            "waiting_for_subtasks",
+            "planned",
+        }
+        if existing_task.status.value not in cancellable:
+            raise ValueError(
+                f"Task '{task_id}' cannot be cancelled from status '{existing_task.status.value}'",
+            )
+        cancelled_tasks = await store.cancel_cascade(task_id, body.reason)
     except KeyError:
         raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from None
-    return task_to_response(task)
+
+    # Publish an SSE event for every cancelled task (root + descendants) so
+    # the dashboard and any waiting watchers can react immediately.
+    root_task = next((t for t in cancelled_tasks if t.id == task_id), cancelled_tasks[0])
+    for cancelled in cancelled_tasks:
+        sse_bus.publish(
+            "task_update",
+            json.dumps({"id": cancelled.id, "status": cancelled.status.value}),
+        )
+    return task_to_response(root_task)
 
 
 @router.post(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -458,6 +458,46 @@ async def test_cancel_no_reason(client: AsyncClient) -> None:
     assert resp.json()["status"] == "cancelled"
 
 
+@pytest.mark.anyio
+async def test_cancel_task_cascade_cancels_children(client: AsyncClient) -> None:
+    """POST /tasks/{id}/cancel cascades to open subtasks (audit-021)."""
+    parent_resp = await client.post("/tasks", json=TASK_PAYLOAD)
+    assert parent_resp.status_code == 201
+    parent_id = parent_resp.json()["id"]
+
+    # Create two subtasks via the self-create endpoint (links parent_task_id).
+    child_ids: list[str] = []
+    for i in range(2):
+        sub_resp = await client.post(
+            "/tasks/self-create",
+            json={
+                "parent_task_id": parent_id,
+                "title": f"Subtask {i}",
+                "description": f"Child task {i}",
+                "role": "backend",
+                "priority": 2,
+            },
+        )
+        assert sub_resp.status_code == 201
+        child_ids.append(sub_resp.json()["id"])
+
+    # Cancel the parent and assert every child is now cancelled too.
+    cancel_resp = await client.post(
+        f"/tasks/{parent_id}/cancel",
+        json={"reason": "project scrapped"},
+    )
+    assert cancel_resp.status_code == 200
+    assert cancel_resp.json()["status"] == "cancelled"
+    assert cancel_resp.json()["id"] == parent_id
+
+    for child_id in child_ids:
+        child_resp = await client.get(f"/tasks/{child_id}")
+        assert child_resp.status_code == 200
+        assert child_resp.json()["status"] == "cancelled", (
+            f"child {child_id} still has status {child_resp.json()['status']}"
+        )
+
+
 # -- GET /tasks -------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

`POST /tasks/{id}/cancel` called the non-cascading `store.cancel()`, so cancelling a parent left every child with `parent_task_id` pointing at it stuck in `OPEN`/`CLAIMED`/`IN_PROGRESS`. The `cancel_cascade` helper already existed on `TaskStore` but was only referenced by its own unit tests.

- Route now calls `store.cancel_cascade()` and emits a `task_update` SSE event for every cancelled task (root + descendants).
- Legacy 409 for an already-terminal root is preserved by pre-checking status before invoking cascade (the helper silently skips terminal tasks).
- Added unit test in `tests/unit/test_server.py::test_cancel_task_cascade_cancels_children` that creates a parent + two subtasks via `/tasks/self-create`, cancels the parent, and asserts both children transition to `cancelled`.

.

## Test plan

- [x] `uv run ruff check src/bernstein/core/routes/task_crud.py tests/unit/test_server.py` — clean
- [x] `uv run ruff format --check` — 2 files already formatted
- [x] `uv run pytest tests/unit -k "cancel_cascade or cancel_task" -x -q` — 8 passed
- [x] `uv run pytest tests/unit/test_server.py -k cancel -x -q` — 6 passed (no regressions on existing cancel route tests)