### PR TITLE
security(license): reject empty signing key

### DIFF
--- a/src/bernstein/core/security/license_manager.py
+++ b/src/bernstein/core/security/license_manager.py
@@ -15,12 +15,19 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, cast
 
 logger = logging.getLogger(__name__)
+
+# Environment variable that must be set to "1" to explicitly disable license
+# signature validation (e.g. in local dev). Any other value — including unset —
+# means validation is enforced. This prevents silent bypass when a signing key
+# is accidentally omitted from production config.
+LICENSE_DISABLED_ENV = "BERNSTEIN_LICENSE_DISABLED"
 
 # ---------------------------------------------------------------------------
 # License tiers and features
@@ -166,11 +173,17 @@ def encode_license(
         max_seats: Maximum seats.
         max_nodes: Maximum cluster nodes.
         expires_at: Expiration timestamp.
-        signing_key: HMAC signing key.
+        signing_key: HMAC signing key. Must be non-empty.
 
     Returns:
         Base64-encoded signed license string.
+
+    Raises:
+        ValueError: If ``signing_key`` is empty.
     """
+    if not signing_key:
+        msg = "signing_key must be a non-empty string"
+        raise ValueError(msg)
     payload: dict[str, Any] = {
         "org_id": org_id,
         "tier": tier,
@@ -217,14 +230,24 @@ def validate_license_signature(
 ) -> bool:
     """Validate the HMAC signature on a license payload.
 
+    This function fails closed: an empty or missing ``signing_key`` always
+    returns ``False``, regardless of the payload contents. Callers that
+    intentionally want to skip validation (e.g. in dev mode) must do so
+    explicitly via the :data:`LICENSE_DISABLED_ENV` opt-in.
+
     Args:
         payload: Decoded license payload (including signature).
-        signing_key: Expected signing key.
+        signing_key: Expected signing key. Must be non-empty.
 
     Returns:
-        True if the signature is valid.
+        True if the signature is valid; False if ``signing_key`` is empty
+        or the signature does not match.
     """
+    if not signing_key:
+        return False
     signature = payload.get("signature", "")
+    if not isinstance(signature, str) or not signature:
+        return False
     verify_payload = {k: v for k, v in payload.items() if k != "signature"}
     payload_json = json.dumps(verify_payload, sort_keys=True)
     expected = hmac.new(
@@ -240,11 +263,30 @@ def validate_license_signature(
 # ---------------------------------------------------------------------------
 
 
+def _license_validation_disabled() -> bool:
+    """Return True if signature validation has been explicitly disabled.
+
+    Only the exact value ``"1"`` in :data:`LICENSE_DISABLED_ENV` counts as an
+    opt-in. All other values (including empty string, ``"0"``, ``"true"``,
+    etc.) leave validation enabled. Requiring an exact value prevents silent
+    misconfiguration from disabling signature checks in production.
+    """
+    return os.environ.get(LICENSE_DISABLED_ENV, "") == "1"
+
+
 class LicenseManager:
     """Manages enterprise licenses and feature gates.
 
+    Signature validation is fail-closed: if ``signing_key`` is empty and
+    :envvar:`BERNSTEIN_LICENSE_DISABLED` is not set to ``"1"``, every
+    ``load_license`` call returns ``valid=False``. This prevents the
+    historical bug where an unconfigured signing key silently bypassed
+    signature verification and accepted forged licenses.
+
     Args:
-        signing_key: Key used to validate license signatures.
+        signing_key: Key used to validate license signatures. Must be a
+            non-empty string unless signature validation has been explicitly
+            disabled via :envvar:`BERNSTEIN_LICENSE_DISABLED` = ``"1"``.
     """
 
     def __init__(self, signing_key: str = "") -> None:
@@ -258,6 +300,13 @@ class LicenseManager:
 
     def load_license(self, encoded: str) -> LicenseValidationResult:
         """Load and validate a license from an encoded string.
+
+        Validation rules:
+          * If :envvar:`BERNSTEIN_LICENSE_DISABLED` is ``"1"``, signature
+            validation is skipped and a warning is logged.
+          * Otherwise, the signing key must be non-empty and the HMAC
+            signature on the payload must match. An empty or unset signing
+            key causes the license to be rejected.
 
         Args:
             encoded: Base64-encoded license string.
@@ -273,18 +322,40 @@ class LicenseManager:
                 error=str(exc),
             )
 
-        # Validate signature
-        if self._signing_key and not validate_license_signature(
-            payload,
-            self._signing_key,
-        ):
+        warnings: list[str] = []
+
+        # Decide signature policy. Fail-closed: missing key + no explicit
+        # opt-in means we reject.
+        if _license_validation_disabled():
+            logger.warning(
+                "License signature validation disabled via %s=1; accepting license without signature check",
+                LICENSE_DISABLED_ENV,
+            )
+            warnings.append(
+                f"License signature validation disabled via {LICENSE_DISABLED_ENV}=1",
+            )
+        elif not self._signing_key:
+            logger.error(
+                "License signing key is empty; refusing to validate. "
+                "Configure a signing key or set %s=1 to explicitly disable "
+                "signature validation.",
+                LICENSE_DISABLED_ENV,
+            )
+            return LicenseValidationResult(
+                valid=False,
+                error=(
+                    "License signing key not configured; refusing to "
+                    "validate. Set a signing key or opt out explicitly "
+                    f"with {LICENSE_DISABLED_ENV}=1."
+                ),
+            )
+        elif not validate_license_signature(payload, self._signing_key):
             return LicenseValidationResult(
                 valid=False,
                 error="Invalid license signature",
             )
 
         # Parse fields
-        warnings: list[str] = []
         now = time.time()
         expires_at = float(payload.get("expires_at", 0))
         if expires_at < now:

--- a/tests/unit/test_license_manager.py
+++ b/tests/unit/test_license_manager.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import time
 
 import pytest
 from bernstein.core.license_manager import (
+    LICENSE_DISABLED_ENV,
     Feature,
     LicenseManager,
     LicenseTier,
@@ -124,10 +126,133 @@ class TestLoadLicense:
         assert len(result.warnings) > 0
         assert any("expires" in w.lower() for w in result.warnings)
 
-    def test_no_signing_key_skips_validation(self) -> None:
+    def test_empty_signing_key_rejects_license(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """audit-050: empty signing key must fail closed, not skip check."""
+        monkeypatch.delenv(LICENSE_DISABLED_ENV, raising=False)
         mgr = LicenseManager(signing_key="")
         result = mgr.load_license(_make_license_str())
+        assert not result.valid
+        assert "signing key" in result.error.lower()
+
+    def test_missing_signing_key_rejects_forged_license(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """audit-050: a license forged with empty-string HMAC key is rejected.
+
+        Regression guard: the reproducer in the ticket was
+        ``LicenseManager(signing_key='').load_license(forged_unlimited)``.
+        """
+        monkeypatch.delenv(LICENSE_DISABLED_ENV, raising=False)
+        # Forge a license signed with the empty key (what an attacker would do
+        # to exploit the old bypass path).
+        forged = encode_license(
+            org_id="attacker",
+            tier=LicenseTier.UNLIMITED,
+            features=frozenset({Feature.SSO_OIDC}),
+            max_seats=0,
+            max_nodes=0,
+            expires_at=time.time() + 86400 * 365 * 100,
+            signing_key="x",  # encode_license now refuses "", so use any key
+        )
+        mgr = LicenseManager()  # no signing key configured
+        result = mgr.load_license(forged)
+        assert not result.valid
+        assert mgr.current_license is None
+
+    def test_valid_key_valid_signature_accepts(self) -> None:
+        mgr = LicenseManager(signing_key=SIGNING_KEY)
+        result = mgr.load_license(_make_license_str())
         assert result.valid
+        assert result.license is not None
+        assert result.license.tier == LicenseTier.ENTERPRISE
+
+    def test_valid_key_tampered_payload_rejected(self) -> None:
+        """audit-050: tampered payloads must be rejected even with valid key."""
+        encoded = _make_license_str()
+        payload = decode_license(encoded)
+        # Flip the tier to UNLIMITED without re-signing.
+        payload["tier"] = "unlimited"
+        import base64
+        import json
+
+        tampered = base64.urlsafe_b64encode(
+            json.dumps(payload, sort_keys=True).encode(),
+        ).decode()
+        mgr = LicenseManager(signing_key=SIGNING_KEY)
+        result = mgr.load_license(tampered)
+        assert not result.valid
+        assert "signature" in result.error.lower()
+
+    def test_disabled_env_skips_validation_with_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """audit-050: explicit opt-in disables signature check + logs warning."""
+        monkeypatch.setenv(LICENSE_DISABLED_ENV, "1")
+        # Forge a license with a different key; with validation disabled it
+        # should still load.
+        forged = encode_license(
+            org_id="dev",
+            tier=LicenseTier.ENTERPRISE,
+            features=frozenset(),
+            max_seats=10,
+            max_nodes=1,
+            expires_at=time.time() + 86400,
+            signing_key="not-the-real-key",
+        )
+        mgr = LicenseManager(signing_key=SIGNING_KEY)
+        with caplog.at_level(logging.WARNING):
+            result = mgr.load_license(forged)
+        assert result.valid
+        assert any(LICENSE_DISABLED_ENV in rec.getMessage() for rec in caplog.records)
+        assert any(LICENSE_DISABLED_ENV in w for w in result.warnings)
+
+    def test_disabled_env_wrong_value_still_enforces(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """audit-050: only "1" opts out — "true", "0", "" stay enforcing."""
+        for bad_val in ("0", "true", "yes", "", "TRUE"):
+            monkeypatch.setenv(LICENSE_DISABLED_ENV, bad_val)
+            mgr = LicenseManager(signing_key="")
+            result = mgr.load_license(_make_license_str())
+            assert not result.valid, f"Expected rejection for env value {bad_val!r}"
+
+
+class TestEncodeLicenseValidation:
+    """audit-050: encode_license refuses empty signing keys."""
+
+    def test_empty_signing_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            encode_license(
+                org_id="acme",
+                tier=LicenseTier.COMMUNITY,
+                features=frozenset(),
+                max_seats=1,
+                max_nodes=1,
+                expires_at=time.time() + 3600,
+                signing_key="",
+            )
+
+
+class TestValidateSignatureFailClosed:
+    """audit-050: validate_license_signature fails closed on empty key."""
+
+    def test_empty_key_returns_false(self) -> None:
+        encoded = _make_license_str()
+        payload = decode_license(encoded)
+        assert validate_license_signature(payload, "") is False
+
+    def test_empty_signature_returns_false(self) -> None:
+        encoded = _make_license_str()
+        payload = decode_license(encoded)
+        payload["signature"] = ""
+        assert validate_license_signature(payload, SIGNING_KEY) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

P1 SECURITY. `LicenseManager.load_license()` skipped signature validation when `self._signing_key` was empty (the default), so anyone could forge an `UNLIMITED` license with a faraway expiry and the manager would return `valid=True`. The check was guarded behind `if self._signing_key and not validate_license_signature(...)`, which short-circuits when the key is `""`.

### Fix (fail-closed)
- `encode_license()` now raises `ValueError` on empty `signing_key`.
- `validate_license_signature()` returns `False` when either the key or the payload signature is empty (never short-circuits to True).
- `LicenseManager.load_license()` returns `valid=False` with an explicit error when no signing key is configured.
- Dev-mode opt-out: set `BERNSTEIN_LICENSE_DISABLED=1` (exact match). Any other value — including `"0"`, `"true"`, `""` — keeps validation on. The opt-out path emits a `WARNING` log and attaches a warning to the result so it can't happen silently.

### Scope
LicenseManager had no production callers (latent bug per ticket), so this is a pure hardening change. Public API is backward-compatible except:
- `encode_license(signing_key="")` now raises instead of silently signing with an empty key. This was a bug trap — any real signing flow already passes a non-empty key.
- `LicenseManager(signing_key="").load_license(...)` now rejects by default. Callers relying on the old silent bypass must set `BERNSTEIN_LICENSE_DISABLED=1`.

## Test plan

- [x] `uv run ruff check src/bernstein/core/security/license_manager.py tests/unit/test_license_manager.py` -> All checks passed
- [x] `uv run ruff format --check...` -> 2 files already formatted
- [x] `uv run pytest tests/unit -k "license_manager or license_sign" -x -q` -> **31 passed**
- [x] New regression tests: empty key rejects, missing key rejects forged UNLIMITED license, valid key + valid signature accepts, valid key + tampered payload rejects, `BERNSTEIN_LICENSE_DISABLED=1` skips with warning, other env values still enforce, `encode_license("")` raises.