### PR TITLE
fix(tasks): route batch transitions through FSM

### DIFF
--- a/src/bernstein/core/tasks/batch_transitions.py
+++ b/src/bernstein/core/tasks/batch_transitions.py
@@ -3,6 +3,11 @@
 When all tasks in a plan stage complete, this module transitions them
 atomically to ensure consistent state.  If any transition in the batch
 fails, all transitions are rolled back.
+
+All status changes MUST flow through :func:`transition_task` so the FSM
+allowed-transitions table, guard predicates, Prometheus counters, HMAC
+audit log, and lifecycle event stream are consulted uniformly.  Writing
+``task.status`` directly bypasses every guardrail and is prohibited.
 """
 
 from __future__ import annotations
@@ -12,6 +17,7 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from bernstein.core.tasks.lifecycle import IllegalTransitionError, transition_task
 from bernstein.core.tasks.models import TaskStatus
 
 if TYPE_CHECKING:
@@ -85,16 +91,26 @@ def _check_preconditions(
 def apply_batch_transition(
     tasks: Sequence[Task],
     specs: Sequence[TransitionSpec],
+    *,
+    actor: str = "batch",
+    reason: str = "batch_transition",
 ) -> BatchTransitionResult:
     """Apply a batch of status transitions atomically.
 
-    If any task's precondition fails (wrong current status, missing task),
-    the entire batch is aborted.  If a transition fails mid-batch, all
-    previously applied transitions are rolled back.
+    Every transition is delegated to :func:`transition_task`, which
+    enforces the FSM allowed-transitions table, runs guard predicates,
+    emits lifecycle events, and writes to the HMAC audit log.  If any
+    task's precondition fails (wrong current status, missing task) the
+    entire batch is aborted before any transitions are applied.  If a
+    transition fails mid-batch (illegal transition, guard rejection),
+    all previously applied transitions are rolled back by driving them
+    back through :func:`transition_task`.
 
     Args:
         tasks: All tasks (used for lookup and mutation).
         specs: Transition specifications to apply.
+        actor: Who triggered this batch (recorded in audit log).
+        reason: Human-readable reason for the batch (recorded in audit log).
 
     Returns:
         BatchTransitionResult with outcome details.
@@ -115,8 +131,16 @@ def apply_batch_transition(
         task = task_map[spec.task_id]
         originals[spec.task_id] = task.status
         try:
-            task.status = spec.to_status
+            transition_task(
+                task,
+                spec.to_status,
+                actor=actor,
+                reason=reason,
+            )
             transitioned.append(spec.task_id)
+        except IllegalTransitionError as exc:
+            failed.append((spec.task_id, str(exc)))
+            break
         except Exception as exc:
             failed.append((spec.task_id, str(exc)))
             break
@@ -124,7 +148,26 @@ def apply_batch_transition(
     # Phase 3: If any failed mid-batch, rollback
     if failed:
         for tid in transitioned:
-            task_map[tid].status = originals[tid]
+            task = task_map[tid]
+            original = originals[tid]
+            try:
+                transition_task(
+                    task,
+                    original,
+                    actor=actor,
+                    reason=f"{reason}:rollback",
+                )
+            except IllegalTransitionError:
+                # FSM has no reverse edge: record and restore by direct assignment
+                # as a last resort, but log loudly so the bypass is visible.
+                logger.exception(
+                    "Rollback requires FSM-illegal transition %s -> %s for task %s; "
+                    "forcing direct restore. Add reverse edge to TASK_TRANSITIONS.",
+                    task.status.value,
+                    original.value,
+                    tid,
+                )
+                task.status = original
         logger.warning(
             "Batch transition rolled back: %d transitioned, %d failed",
             len(transitioned),
@@ -178,7 +221,7 @@ def complete_stage(
         return BatchTransitionResult(success=True, transitioned=[])
 
     now = time.time()
-    result = apply_batch_transition(tasks, specs)
+    result = apply_batch_transition(tasks, specs, actor="batch", reason="stage_complete")
     if result.success:
         for tid in result.transitioned:
             task_map[tid].completed_at = now
@@ -221,7 +264,7 @@ def fail_stage(
     if not specs:
         return BatchTransitionResult(success=True, transitioned=[])
 
-    result = apply_batch_transition(tasks, specs)
+    result = apply_batch_transition(tasks, specs, actor="batch", reason=f"stage_fail:{reason}")
     if result.success:
         for tid in result.transitioned:
             task_map[tid].result_summary = reason

--- a/src/bernstein/core/tasks/lifecycle.py
+++ b/src/bernstein/core/tasks/lifecycle.py
@@ -150,10 +150,12 @@ TASK_TRANSITIONS: dict[tuple[TaskStatus, TaskStatus], Callable[[Task], bool]] = 
     # Plan mode
     (TaskStatus.PLANNED, TaskStatus.OPEN): _always,
     (TaskStatus.PLANNED, TaskStatus.CANCELLED): _always,
+    (TaskStatus.PLANNED, TaskStatus.FAILED): _always,  # batch stage failure
     # Claiming
     (TaskStatus.OPEN, TaskStatus.CLAIMED): _always,
     (TaskStatus.OPEN, TaskStatus.WAITING_FOR_SUBTASKS): _always,
     (TaskStatus.OPEN, TaskStatus.CANCELLED): _always,
+    (TaskStatus.OPEN, TaskStatus.FAILED): _always,  # batch stage failure on unclaimed task
     # Work progression from CLAIMED
     (TaskStatus.CLAIMED, TaskStatus.IN_PROGRESS): _always,
     (TaskStatus.CLAIMED, TaskStatus.OPEN): _always,  # force-claim / unclaim
@@ -177,9 +179,11 @@ TASK_TRANSITIONS: dict[tuple[TaskStatus, TaskStatus], Callable[[Task], bool]] = 
     # Recovery from blocked
     (TaskStatus.BLOCKED, TaskStatus.OPEN): _always,
     (TaskStatus.BLOCKED, TaskStatus.CANCELLED): _always,
+    (TaskStatus.BLOCKED, TaskStatus.FAILED): _always,  # batch stage failure
     (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.DONE): _always,
     (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.BLOCKED): _always,  # subtask timeout escalation
     (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.CANCELLED): _always,
+    (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.FAILED): _always,  # batch stage failure
     # Retry from failed
     (TaskStatus.FAILED, TaskStatus.OPEN): _always,
     # Verification gate (orchestrator closes after janitor + merge)

--- a/tests/unit/test_batch_transitions.py
+++ b/tests/unit/test_batch_transitions.py
@@ -1,7 +1,17 @@
-"""Tests for atomic batch transitions (TASK-011)."""
+"""Tests for atomic batch transitions (TASK-011, audit-024).
+
+Every batch transition MUST flow through the FSM ``transition_task``.
+These tests verify that:
+  * Legal batch transitions succeed and emit ``LifecycleEvent``s.
+  * Illegal batch transitions fail, trigger rollback, and surface the
+    FSM error reason — never silently mutate ``task.status``.
+"""
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import pytest
 from bernstein.core.batch_transitions import (
     TransitionSpec,
     apply_batch_transition,
@@ -9,6 +19,16 @@ from bernstein.core.batch_transitions import (
     fail_stage,
 )
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus
+
+from bernstein.core.tasks.lifecycle import (
+    IllegalTransitionError,
+    add_listener,
+    remove_listener,
+    transition_task,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import LifecycleEvent
 
 
 def _t(id: str, status: str = "open") -> Task:
@@ -124,3 +144,105 @@ class TestFailStage:
     def test_empty_stage_fail(self) -> None:
         result = fail_stage([], [])
         assert result.success
+
+
+# ---------------------------------------------------------------------------
+# FSM routing contract (audit-024)
+# ---------------------------------------------------------------------------
+
+
+class TestBatchFsmRouting:
+    """Batch transitions must go through transition_task and the FSM."""
+
+    def test_fsm_batch_emits_lifecycle_events_for_each_transition(self) -> None:
+        events: list[LifecycleEvent] = []
+        add_listener(events.append)
+        try:
+            tasks = [_t("t1", "claimed"), _t("t2", "in_progress")]
+            result = complete_stage(tasks, ["t1", "t2"])
+            assert result.success
+        finally:
+            remove_listener(events.append)
+
+        # One LifecycleEvent per transitioned task, all marked entity_type=task
+        # and with to_status=done
+        task_events = [e for e in events if e.entity_type == "task" and e.to_status == "done"]
+        emitted_ids = {e.entity_id for e in task_events}
+        assert emitted_ids == {"t1", "t2"}
+        assert all(e.actor == "batch" for e in task_events)
+
+    def test_fsm_batch_rejects_illegal_transition_and_rolls_back(self) -> None:
+        # CLOSED is terminal; there is no CLOSED -> OPEN edge.  An
+        # apply_batch_transition attempting this must NOT bypass the FSM;
+        # the first spec succeeds (open -> claimed) then the second fails
+        # and triggers rollback so t1 returns to OPEN.
+        tasks = [_t("t1", "open"), _t("t2", "closed")]
+        specs = [
+            TransitionSpec("t1", TaskStatus.OPEN, TaskStatus.CLAIMED),
+            TransitionSpec("t2", TaskStatus.CLOSED, TaskStatus.OPEN),  # illegal FSM edge
+        ]
+
+        result = apply_batch_transition(tasks, specs)
+
+        assert not result.success
+        assert result.rolled_back
+        assert len(result.failed) == 1
+        assert result.failed[0][0] == "t2"
+        assert "Illegal" in result.failed[0][1] or "illegal" in result.failed[0][1].lower()
+        # Rollback must restore t1 to OPEN and leave t2 CLOSED
+        assert tasks[0].status == TaskStatus.OPEN
+        assert tasks[1].status == TaskStatus.CLOSED
+
+    def test_fsm_batch_direct_illegal_transition_raises(self) -> None:
+        # Direct transition_task on CLOSED -> OPEN must raise — we rely on
+        # this contract inside apply_batch_transition.
+        task = _t("t1", "closed")
+        with pytest.raises(IllegalTransitionError):
+            transition_task(task, TaskStatus.OPEN, actor="test")
+
+    def test_fsm_batch_fail_stage_allows_open_to_failed(self) -> None:
+        # audit-024 adds the OPEN -> FAILED edge so fail_stage can legitimately
+        # fail unclaimed tasks without bypassing the FSM.
+        tasks = [_t("t1", "open"), _t("t2", "blocked"), _t("t3", "waiting_for_subtasks")]
+        result = fail_stage(tasks, ["t1", "t2", "t3"], reason="ci gate failed")
+        assert result.success
+        assert set(result.transitioned) == {"t1", "t2", "t3"}
+        assert tasks[0].status == TaskStatus.FAILED
+        assert tasks[1].status == TaskStatus.FAILED
+        assert tasks[2].status == TaskStatus.FAILED
+
+    def test_fsm_batch_complete_stage_refuses_open_to_done(self) -> None:
+        # complete_stage only targets CLAIMED/IN_PROGRESS — an OPEN task must
+        # be skipped, not force-transitioned to DONE by bypassing the FSM.
+        tasks = [_t("t1", "open"), _t("t2", "in_progress")]
+        result = complete_stage(tasks, ["t1", "t2"])
+        assert result.success
+        # Only t2 transitioned; t1 stayed OPEN (complete_stage filter).
+        assert result.transitioned == ["t2"]
+        assert tasks[0].status == TaskStatus.OPEN
+        assert tasks[1].status == TaskStatus.DONE
+
+    def test_batch_transition_mode_rollback_emits_events(self) -> None:
+        # Ensure the rollback path also routes through transition_task
+        # where possible, producing a second set of lifecycle events.
+        events: list[LifecycleEvent] = []
+        add_listener(events.append)
+        try:
+            tasks = [_t("t1", "open"), _t("t2", "closed")]
+            specs = [
+                TransitionSpec("t1", TaskStatus.OPEN, TaskStatus.CLAIMED),
+                TransitionSpec("t2", TaskStatus.CLOSED, TaskStatus.OPEN),  # illegal
+            ]
+            result = apply_batch_transition(tasks, specs)
+            assert not result.success
+            assert result.rolled_back
+        finally:
+            remove_listener(events.append)
+
+        # Forward: t1 open->claimed, rollback: t1 claimed->open — both legal.
+        t1_events = [e for e in events if e.entity_id == "t1" and e.entity_type == "task"]
+        forward = [e for e in t1_events if e.from_status == "open" and e.to_status == "claimed"]
+        rollback = [e for e in t1_events if e.from_status == "claimed" and e.to_status == "open"]
+        assert len(forward) == 1
+        assert len(rollback) == 1
+        assert rollback[0].reason.endswith(":rollback")


### PR DESCRIPTION
## Summary
- `batch_transitions.apply_batch_transition` mutated `task.status` directly, bypassing `transition_task` — no FSM check, no guard, no `LifecycleEvent`, no HMAC audit log entry, no Prometheus transition counter. This PR routes every batch-mode transition through `transition_task(actor="batch")` so the FSM allowed-transitions table and audit log are consulted uniformly.
- Rollbacks also replay through `transition_task` when possible. If the FSM has no reverse edge for a particular forward transition, rollback falls back to a direct restore but logs loudly — this keeps the bypass visible rather than silent.
- Added FSM edges `OPEN -> FAILED`, `BLOCKED -> FAILED`, `WAITING_FOR_SUBTASKS -> FAILED`, `PLANNED -> FAILED` so `fail_stage` can legitimately fail non-terminal tasks in a failing plan stage without bypassing the FSM.

## Test plan
- [x] `uv run ruff check src/bernstein/core/tasks/batch_transitions.py src/bernstein/core/tasks/lifecycle.py tests/unit/test_batch_transitions.py`
- [x] `uv run ruff format --check` on the same files
- [x] `uv run pytest tests/unit -k "batch_transition or fsm_batch or batch_mode" -x -q` — 32 passed
- [x] `uv run pytest tests/unit/test_lifecycle_transitions.py -x -q` — 190 passed (FSM additions don't break existing contracts)
- [x] `TERMINAL_TASK_STATUSES` precomputed frozenset still yields `{closed, cancelled, pending_approval}` as expected

## Ticket
Closes `-batch-transitions-fsm-bypass`.