### PR TITLE
fix(git): abort merge on rebase-or-merge fallback failure

### DIFF
--- a/src/bernstein/core/git/git_basic.py
+++ b/src/bernstein/core/git/git_basic.py
@@ -321,8 +321,30 @@ def fetch(cwd: Path, remote: str = "origin") -> GitResult:
     return run_git(["fetch", remote], cwd, timeout=60)
 
 
+def _safe_abort(cwd: Path, kind: str) -> None:
+    """Best-effort ``git <kind> --abort`` that never raises.
+
+    Used on fallback failure paths to guarantee the repository is not left
+    in a conflicted MERGING or REBASING state.  Swallows subprocess errors
+    so the caller can always surface the original failure to its caller.
+
+    Args:
+        cwd: Repository root.
+        kind: Either ``"rebase"`` or ``"merge"``.
+    """
+    try:
+        run_git([kind, "--abort"], cwd, timeout=10)
+    except (subprocess.SubprocessError, OSError) as exc:  # pragma: no cover - defensive
+        logger.warning("git %s --abort failed: %s", kind, exc)
+
+
 def _rebase_or_merge(cwd: Path, remote: str, branch: str) -> GitResult | None:
     """Attempt rebase, falling back to merge on failure.
+
+    On any failure path (rebase exception, merge exception, merge conflict)
+    the repository is cleaned up with ``git rebase --abort`` and/or
+    ``git merge --abort`` so the next caller does not trip over a
+    pre-existing MERGING/REBASING state.
 
     Args:
         cwd: Repository root.
@@ -332,14 +354,31 @@ def _rebase_or_merge(cwd: Path, remote: str, branch: str) -> GitResult | None:
     Returns:
         Failed merge result if both rebase and merge fail, else None.
     """
-    rebase_r = run_git(["rebase", f"{remote}/{branch}"], cwd, timeout=120)
+    try:
+        rebase_r = run_git(["rebase", f"{remote}/{branch}"], cwd, timeout=120)
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.error("Rebase raised %s; aborting rebase", exc)
+        _safe_abort(cwd, "rebase")
+        return GitResult(returncode=1, stdout="", stderr=f"rebase raised: {exc}")
+
     if rebase_r.ok:
         return None
+
     logger.warning("Rebase failed, aborting and falling back to merge")
-    run_git(["rebase", "--abort"], cwd)
-    merge_r = run_git(["merge", f"{remote}/{branch}", "--no-edit"], cwd, timeout=120)
+    _safe_abort(cwd, "rebase")
+
+    try:
+        merge_r = run_git(["merge", f"{remote}/{branch}", "--no-edit"], cwd, timeout=120)
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.error("Merge fallback raised %s; aborting merge", exc)
+        _safe_abort(cwd, "merge")
+        return GitResult(returncode=1, stdout="", stderr=f"merge raised: {exc}")
+
     if not merge_r.ok:
         logger.error("Merge fallback also failed: %s", merge_r.stderr)
+        # Ensure the repo is not left in a conflicted MERGING state so the
+        # next safe_push iteration (or any other git write) is not blocked.
+        _safe_abort(cwd, "merge")
         return merge_r
     return None
 

--- a/tests/unit/test_git_ops.py
+++ b/tests/unit/test_git_ops.py
@@ -414,6 +414,70 @@ class TestSafePush:
         result = safe_push(REPO, "main")
         assert result.ok
 
+    @patch("bernstein.core.git_basic.run_git")
+    @patch("bernstein.core.git.git_basic.fetch")
+    def test_merge_fallback_conflict_triggers_merge_abort(self, mock_fetch: MagicMock, mock_run: MagicMock) -> None:
+        """On rebase+merge fallback failure, repo must not be left in MERGING state.
+
+        Regression test for audit-096: previous implementation returned the
+        failed merge result without running ``git merge --abort``, so the
+        next safe_push iteration failed with
+        'you cannot start another merge until the current one is aborted'.
+        """
+        mock_fetch.return_value = GitResult(0, "", "")
+        mock_run.side_effect = [
+            GitResult(0, "2\n", ""),  # rev-list: 2 behind
+            GitResult(1, "", "rebase conflict"),  # rebase fails
+            GitResult(0, "", ""),  # rebase --abort (cleanup)
+            GitResult(1, "", "CONFLICT (content): Merge conflict in foo.py"),  # merge fails
+            GitResult(0, "", ""),  # merge --abort (the fix)
+        ]
+        result = safe_push(REPO, "main")
+
+        # safe_push must surface the merge failure to the caller
+        assert not result.ok
+        assert "CONFLICT" in result.stderr
+
+        # Verify the cleanup abort was invoked before returning
+        invoked = [call.args[0] for call in mock_run.call_args_list]
+        assert ["merge", "--abort"] in invoked, (
+            f"git merge --abort was not invoked on merge-conflict failure. Commands invoked: {invoked}"
+        )
+        # Rebase --abort must also run before attempting merge
+        assert ["rebase", "--abort"] in invoked
+        # And no push should have been attempted
+        assert not any(cmd[:1] == ["push"] for cmd in invoked)
+
+    @patch("bernstein.core.git_basic.run_git")
+    @patch("bernstein.core.git.git_basic.fetch")
+    def test_merge_fallback_subprocess_exception_still_aborts(self, mock_fetch: MagicMock, mock_run: MagicMock) -> None:
+        """If the merge subprocess itself raises, we still must call merge --abort."""
+        mock_fetch.return_value = GitResult(0, "", "")
+
+        calls: list[list[str]] = []
+
+        def _side_effect(args: list[str], _cwd: Path, **_kwargs: object) -> GitResult:
+            calls.append(args)
+            if args[0] == "rev-list":
+                return GitResult(0, "1\n", "")
+            if args == ["rebase", "origin/main"]:
+                return GitResult(1, "", "rebase conflict")
+            if args == ["rebase", "--abort"]:
+                return GitResult(0, "", "")
+            if args == ["merge", "origin/main", "--no-edit"]:
+                raise subprocess.TimeoutExpired(cmd="git", timeout=120)
+            if args == ["merge", "--abort"]:
+                return GitResult(0, "", "")
+            return GitResult(0, "", "")
+
+        mock_run.side_effect = _side_effect
+
+        result = safe_push(REPO, "main")
+
+        assert not result.ok
+        assert "merge raised" in result.stderr
+        assert ["merge", "--abort"] in calls
+
 
 class TestBranching:
     """Tests for branch operations."""


### PR DESCRIPTION
## Summary

. In `src/bernstein/core/git/git_basic.py::_rebase_or_merge`, the merge-fallback path returned the failed `GitResult` without running `git merge --abort`, leaving the repository in a conflicted MERGING state. The next `safe_push` iteration (or any other git write) then died with `you cannot start another merge until the current one is aborted`.

## Changes

- `_rebase_or_merge` now wraps both rebase and merge in `try/except` so subprocess failures (timeouts, signals) also trigger cleanup.
- On any failure path it runs `git rebase --abort` and/or `git merge --abort` via a new best-effort `_safe_abort` helper before returning the error.
- The helper swallows subprocess exceptions so the original error is always surfaced to the caller.

## Test plan

- [x] New unit test `test_merge_fallback_conflict_triggers_merge_abort` — forces merge conflict via mocked subprocess, asserts `['merge', '--abort']` was invoked before the failure returned, and that no push was attempted.
- [x] New unit test `test_merge_fallback_subprocess_exception_still_aborts` — merge raises `TimeoutExpired`; verifies `git merge --abort` still runs.
- [x] Existing `test_behind_rebase_fails_merge_fallback` still passes (happy merge-fallback path, no abort needed).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on touched files.
- [x] `uv run pytest tests/unit -k "git_basic or safe_push or rebase_or_merge" -x -q` — 4 passed.
- [x] `uv run pytest tests/unit/test_git_ops.py tests/unit/test_git_basic.py -x -q` — 96 passed.

Refs: -safe-push-conflicted-merge-left