### PR TITLE
security: rate-limit on real peer IP, not trusted header

### DIFF
--- a/src/bernstein/core/security/auth_rate_limiter.py
+++ b/src/bernstein/core/security/auth_rate_limiter.py
@@ -1,8 +1,25 @@
-"""In-memory request rate limiting helpers for Bernstein."""
+"""In-memory request rate limiting helpers for Bernstein.
+
+Rate-limit buckets are keyed by the REAL TCP peer IP (``request.client.host``)
+by default. Client-supplied headers such as ``X-Forwarded-For`` are **ignored**
+unless upstream proxies are explicitly trusted via the
+``BERNSTEIN_TRUSTED_PROXY_IPS`` environment variable (comma-separated list of
+proxy IPs). When trusted, the limiter walks the ``X-Forwarded-For`` chain from
+right to left and uses the right-most IP that is NOT a trusted proxy — i.e.
+the closest original client address that the trusted proxy chain forwarded
+for us.
+
+Historically this module also honoured an ``X-Bernstein-Internal: true``
+header to bypass rate limiting for loopback callers. That header was
+attacker-controllable behind a reverse proxy on the same host and has been
+removed. Internal callers must now reach the server from loopback WITHOUT
+sending ``X-Forwarded-For``; proxied traffic is always rate-limited.
+"""
 
 from __future__ import annotations
 
 import math
+import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass
@@ -19,6 +36,25 @@ if TYPE_CHECKING:
     from starlette.types import ASGIApp
 
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+# Environment variable used to declare IP addresses of reverse proxies whose
+# ``X-Forwarded-For`` header we trust. Comma-separated list, e.g.
+# ``BERNSTEIN_TRUSTED_PROXY_IPS=10.0.0.1,10.0.0.2``. Loopback (``127.0.0.1``,
+# ``::1``) is NEVER implicitly trusted — an operator must opt in explicitly
+# if they terminate a reverse proxy on the same host.
+_TRUSTED_PROXY_ENV = "BERNSTEIN_TRUSTED_PROXY_IPS"
+
+
+def _trusted_proxies() -> frozenset[str]:
+    """Return the configured set of trusted-proxy peer IPs.
+
+    Read lazily from the environment on every call so tests (and config
+    reloads) can change the value without restarting the process.
+    """
+    raw = os.environ.get(_TRUSTED_PROXY_ENV, "")
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
 
 
 @dataclass(frozen=True)
@@ -132,6 +168,10 @@ class RequestRateLimitMiddleware(BaseHTTPMiddleware):
     - POST/PUT/DELETE: 30 requests/minute per client
     - GET: 300 requests/minute per client
     - /events SSE: max 10 concurrent connections
+
+    Clients are identified by the real TCP peer (``request.client.host``).
+    ``X-Forwarded-For`` is only consulted when the direct peer itself is a
+    trusted proxy declared via ``BERNSTEIN_TRUSTED_PROXY_IPS``.
     """
 
     def __init__(
@@ -183,13 +223,12 @@ class RequestRateLimitMiddleware(BaseHTTPMiddleware):
 
         # Exempt loopback clients (orchestrator, spawner, agents) from rate
         # limiting — they are internal components, not external callers.
-        # Also exempt requests that carry the X-Bernstein-Internal header from
-        # loopback — these are spawner/lifecycle calls (e.g. retry task
-        # creation) that must never be 429'd even when X-Forwarded-For is set.
+        # The exemption applies ONLY when the TCP peer is loopback AND no
+        # X-Forwarded-For header is present. If a request arrives on
+        # loopback but carries XFF, it came through a local reverse proxy
+        # and must be rate-limited like any other external caller.
         direct_ip = request.client.host if request.client else "unknown"
-        if direct_ip in _LOOPBACK_HOSTS and (
-            not request.headers.get("X-Forwarded-For") or request.headers.get("X-Bernstein-Internal") == "true"
-        ):
+        if direct_ip in _LOOPBACK_HOSTS and not request.headers.get("X-Forwarded-For"):
             return await call_next(request)
 
         # Try seed_config buckets first
@@ -253,15 +292,32 @@ class RequestRateLimitMiddleware(BaseHTTPMiddleware):
 
 
 def _request_client_id(request: Request) -> str:
-    """Return a stable request client identifier.
+    """Return a stable rate-limit key for *request*.
 
-    Trust forwarded headers only when the direct peer is local.
+    Default: the real TCP peer IP (``request.client.host``). Client-supplied
+    headers are IGNORED — rotating ``X-Forwarded-For`` values must never let
+    an attacker create unbounded buckets.
+
+    Opt-in proxy mode: if ``BERNSTEIN_TRUSTED_PROXY_IPS`` is set and the
+    direct peer IP is in that set, walk the ``X-Forwarded-For`` chain from
+    right to left and return the right-most IP that is NOT itself a trusted
+    proxy (i.e. the closest original client).
     """
     direct_client_ip = request.client.host if request.client else "unknown"
-    if direct_client_ip in _LOOPBACK_HOSTS:
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            return forwarded_for.split(",", maxsplit=1)[0].strip()
+    trusted = _trusted_proxies()
+    if direct_client_ip not in trusted:
+        return direct_client_ip
+
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if not forwarded_for:
+        return direct_client_ip
+    # XFF is ordered: "client, proxy1, proxy2". Walk right-to-left past
+    # trusted proxies and return the first non-trusted hop.
+    hops = [hop.strip() for hop in forwarded_for.split(",") if hop.strip()]
+    for hop in reversed(hops):
+        if hop not in trusted:
+            return hop
+    # Every hop was a trusted proxy — fall back to the direct peer.
     return direct_client_ip
 
 
@@ -270,8 +326,13 @@ _auth_limiter = AuthRateLimiter()
 
 
 def check_auth_rate_limit(request: Request) -> None:
-    """FastAPI dependency that enforces the auth rate limit."""
-    ip = request.client.host if request.client else "unknown"
+    """FastAPI dependency that enforces the auth rate limit.
+
+    Keys the bucket on the same peer identity used by the request middleware:
+    the real TCP peer IP by default, or the right-most non-trusted hop from
+    ``X-Forwarded-For`` when the direct peer is a configured trusted proxy.
+    """
+    ip = _request_client_id(request)
     retry_after = _auth_limiter.check(ip)
     if retry_after is not None:
         raise HTTPException(

--- a/tests/unit/test_auth_rate_limiter.py
+++ b/tests/unit/test_auth_rate_limiter.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
-from bernstein.core.auth_rate_limiter import AuthRateLimiter, RequestRateLimitMiddleware
+from bernstein.core.auth_rate_limiter import (
+    AuthRateLimiter,
+    RequestRateLimitMiddleware,
+    _request_client_id,
+)
 from bernstein.core.seed import RateLimitBucketConfig, RateLimitConfig, SeedConfig
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -243,3 +248,191 @@ class TestRequestRateLimitMiddleware:
         assert "Retry-After" in resp_events.headers
         assert resp_cost.status_code == 429
         assert resp_cost.json()["bucket"] == "sse"
+
+
+class _FakeClient:
+    """Minimal stand-in for ``request.client`` in unit tests."""
+
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal stand-in for ``fastapi.Request`` that exposes ``client`` + ``headers``."""
+
+    def __init__(self, host: str, headers: dict[str, str] | None = None) -> None:
+        self.client = _FakeClient(host)
+        self.headers = headers or {}
+
+
+class TestRateLimitKeyingAgainstHeaderSpoofing:
+    """audit-049: rate-limit buckets must key on real peer, not spoofable headers."""
+
+    def test_default_ignores_x_forwarded_for_and_uses_real_peer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without BERNSTEIN_TRUSTED_PROXY_IPS set, XFF is fully ignored."""
+        monkeypatch.delenv("BERNSTEIN_TRUSTED_PROXY_IPS", raising=False)
+
+        # Attacker cycles XFF values. Each call *must* be keyed on the real
+        # peer (203.0.113.99), not the attacker-controlled header.
+        request_a = _FakeRequest("203.0.113.99", {"X-Forwarded-For": "1.1.1.1"})
+        request_b = _FakeRequest("203.0.113.99", {"X-Forwarded-For": "2.2.2.2"})
+        request_c = _FakeRequest("203.0.113.99", {"X-Forwarded-For": "3.3.3.3"})
+
+        assert _request_client_id(request_a) == "203.0.113.99"  # type: ignore[arg-type]
+        assert _request_client_id(request_b) == "203.0.113.99"  # type: ignore[arg-type]
+        assert _request_client_id(request_c) == "203.0.113.99"  # type: ignore[arg-type]
+
+    def test_default_loopback_does_not_implicitly_trust_xff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loopback peer with XFF still keys on 127.0.0.1 unless explicitly trusted."""
+        monkeypatch.delenv("BERNSTEIN_TRUSTED_PROXY_IPS", raising=False)
+        request = _FakeRequest("127.0.0.1", {"X-Forwarded-For": "9.9.9.9"})
+        assert _request_client_id(request) == "127.0.0.1"  # type: ignore[arg-type]
+
+    def test_trusted_proxy_uses_rightmost_non_trusted_hop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When peer is a trusted proxy, the right-most non-trusted hop is used."""
+        monkeypatch.setenv("BERNSTEIN_TRUSTED_PROXY_IPS", "10.0.0.1,10.0.0.2")
+
+        # Chain: client -> trusted proxy2 -> trusted proxy1 -> us.
+        # XFF from the trusted chain: "203.0.113.5, 10.0.0.2" (proxy1 is the
+        # peer, so it doesn't appear in XFF). Right-most non-trusted is the
+        # original client.
+        request = _FakeRequest("10.0.0.1", {"X-Forwarded-For": "203.0.113.5, 10.0.0.2"})
+        assert _request_client_id(request) == "203.0.113.5"  # type: ignore[arg-type]
+
+    def test_trusted_proxy_single_hop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_TRUSTED_PROXY_IPS", "10.0.0.1")
+        request = _FakeRequest("10.0.0.1", {"X-Forwarded-For": "198.51.100.42"})
+        assert _request_client_id(request) == "198.51.100.42"  # type: ignore[arg-type]
+
+    def test_untrusted_peer_xff_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Peer not in trusted list: XFF is ignored even when env is configured."""
+        monkeypatch.setenv("BERNSTEIN_TRUSTED_PROXY_IPS", "10.0.0.1")
+        # Attacker host 203.0.113.77 tries to spoof XFF.
+        request = _FakeRequest("203.0.113.77", {"X-Forwarded-For": "1.1.1.1, 2.2.2.2"})
+        assert _request_client_id(request) == "203.0.113.77"  # type: ignore[arg-type]
+
+    def test_trusted_chain_with_only_trusted_hops_falls_back_to_peer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If every XFF hop is a trusted proxy, fall back to the direct peer IP."""
+        monkeypatch.setenv("BERNSTEIN_TRUSTED_PROXY_IPS", "10.0.0.1,10.0.0.2,10.0.0.3")
+        request = _FakeRequest("10.0.0.1", {"X-Forwarded-For": "10.0.0.2, 10.0.0.3"})
+        assert _request_client_id(request) == "10.0.0.1"  # type: ignore[arg-type]
+
+    def test_bucket_resets_after_window(self) -> None:
+        """A bucket that is full releases again once all timestamps age out."""
+        limiter = AuthRateLimiter(max_requests=2, window_seconds=60)
+
+        # Fill the bucket
+        assert limiter.check("203.0.113.10") is None
+        assert limiter.check("203.0.113.10") is None
+        assert limiter.check("203.0.113.10") is not None  # blocked
+
+        # Fast-forward the recorded timestamps past the window. This
+        # simulates the window expiring without an actual wall-clock sleep.
+        now = time.monotonic()
+        limiter._hits[("auth", "203.0.113.10")] = [now - 120.0, now - 120.0]
+
+        # Next request must be accepted again — bucket has reset.
+        assert limiter.check("203.0.113.10") is None
+
+    @pytest.mark.anyio
+    async def test_middleware_rotating_xff_cannot_bypass_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """End-to-end: attacker rotates XFF per request, all must share one bucket."""
+        monkeypatch.delenv("BERNSTEIN_TRUSTED_PROXY_IPS", raising=False)
+
+        app = FastAPI()
+        app.add_middleware(RequestRateLimitMiddleware, write_rpm=2, read_rpm=300)
+        app.state.seed_config = None
+
+        @app.post("/data")
+        async def write_data() -> dict[str, str]:
+            return {"status": "ok"}
+
+        transport = ASGITransport(app=app, client=("203.0.113.200", 40000))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.post("/data", headers={"X-Forwarded-For": "1.1.1.1"})
+            second = await client.post("/data", headers={"X-Forwarded-For": "2.2.2.2"})
+            third = await client.post("/data", headers={"X-Forwarded-For": "3.3.3.3"})
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        # All three requests share the real-peer bucket; third is blocked.
+        assert third.status_code == 429
+        assert third.json()["bucket"] == "default_write"
+
+    @pytest.mark.anyio
+    async def test_middleware_loopback_with_xff_is_rate_limited(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loopback peer carrying XFF is treated as a proxied external caller."""
+        monkeypatch.delenv("BERNSTEIN_TRUSTED_PROXY_IPS", raising=False)
+
+        app = FastAPI()
+        app.add_middleware(RequestRateLimitMiddleware, write_rpm=1, read_rpm=300)
+        app.state.seed_config = None
+
+        @app.post("/data")
+        async def write_data() -> dict[str, str]:
+            return {"status": "ok"}
+
+        # Local reverse-proxy scenario: peer is loopback but request carries
+        # XFF — must NOT be exempted from rate limiting.
+        transport = ASGITransport(app=app, client=("127.0.0.1", 40001))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.post("/data", headers={"X-Forwarded-For": "8.8.8.8"})
+            second = await client.post("/data", headers={"X-Forwarded-For": "8.8.8.8"})
+
+        assert first.status_code == 200
+        assert second.status_code == 429
+
+    @pytest.mark.anyio
+    async def test_middleware_pure_loopback_still_exempt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loopback peer with no XFF is still exempt (orchestrator/spawner traffic)."""
+        monkeypatch.delenv("BERNSTEIN_TRUSTED_PROXY_IPS", raising=False)
+
+        app = FastAPI()
+        app.add_middleware(RequestRateLimitMiddleware, write_rpm=1, read_rpm=300)
+        app.state.seed_config = None
+
+        @app.post("/data")
+        async def write_data() -> dict[str, str]:
+            return {"status": "ok"}
+
+        transport = ASGITransport(app=app, client=("127.0.0.1", 40002))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.post("/data")
+            second = await client.post("/data")
+            third = await client.post("/data")
+
+        # All three succeed — loopback callers without XFF remain exempt.
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert third.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_middleware_x_bernstein_internal_header_no_longer_bypasses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """audit-049 regression: X-Bernstein-Internal must NOT bypass rate limits."""
+        monkeypatch.delenv("BERNSTEIN_TRUSTED_PROXY_IPS", raising=False)
+
+        app = FastAPI()
+        app.add_middleware(RequestRateLimitMiddleware, write_rpm=1, read_rpm=300)
+        app.state.seed_config = None
+
+        @app.post("/data")
+        async def write_data() -> dict[str, str]:
+            return {"status": "ok"}
+
+        # Loopback peer + attacker-controlled XFF + forged internal header.
+        # Pre-fix this combination bypassed rate limiting entirely.
+        transport = ASGITransport(app=app, client=("127.0.0.1", 40003))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.post(
+                "/data",
+                headers={"X-Forwarded-For": "10.0.0.5", "X-Bernstein-Internal": "true"},
+            )
+            second = await client.post(
+                "/data",
+                headers={"X-Forwarded-For": "10.0.0.5", "X-Bernstein-Internal": "true"},
+            )
+
+        assert first.status_code == 200
+        assert second.status_code == 429


### PR DESCRIPTION
## Summary

P1 SECURITY fix for `-rate-limit-header-bypass`.

Rate-limit buckets in `src/bernstein/core/security/auth_rate_limiter.py` were keyed on a client-supplied `X-Forwarded-For` header whenever the TCP peer was loopback. Combined with an `X-Bernstein-Internal: true` bypass, a reverse proxy on the same host could be abused to either skip rate limiting entirely or rotate XFF values and create unbounded buckets.

- Bucket keys are now derived from the real TCP peer (`request.client.host`) by default. `X-Forwarded-For` is **ignored**.
- Upstream proxies are honoured only when operators opt in via `BERNSTEIN_TRUSTED_PROXY_IPS` (comma-separated). When the direct peer is in that set, the XFF chain is walked right-to-left and the first non-trusted hop is used as the rate-limit key.
- The `X-Bernstein-Internal` header bypass is removed. Loopback peers are still exempt, but only when no XFF header is present; proxied loopback traffic is rate-limited like any external caller.
- The same keying logic is now used by the `check_auth_rate_limit` FastAPI dependency.

## Test plan

- [x] `uv run ruff check <files>` — clean
- [x] `uv run ruff format --check <files>` — clean
- [x] `uv run pytest tests/unit -k "rate_limit or auth_rate" -x -q` — 207 passed, 21895 deselected
- [x] New unit coverage:
 - default (no trusted proxies): XFF ignored, real peer used
 - loopback + XFF: no implicit trust
 - trusted proxy: right-most non-trusted XFF hop used (single + multi hop)
 - untrusted peer: XFF ignored even when proxies configured
 - chain of only trusted hops: falls back to peer
 - bucket resets after window expires
 - rotating-XFF attacker shares one bucket (end-to-end middleware)
 - loopback + XFF no longer exempt (end-to-end)
 - pure loopback still exempt (orchestrator/spawner traffic)
 - regression: forged `X-Bernstein-Internal` no longer bypasses rate limits