### PR TITLE
test(caching_adapter): use pytest.approx for float equality (Sonar S1244)

### DIFF
--- a/tests/unit/test_caching_adapter.py
+++ b/tests/unit/test_caching_adapter.py
@@ -174,7 +174,7 @@ def test_spawn_forwards_budget_multiplier_and_system_addendum(
     assert mock_inner.spawn.call_count == 1
 
     kwargs = mock_inner.spawn.call_args.kwargs
-    assert kwargs["budget_multiplier"] == 2.5
+    assert kwargs["budget_multiplier"] == pytest.approx(2.5)
     assert kwargs["system_addendum"] == "x"
     # Sanity: other kwargs from the base interface are still forwarded.
     assert kwargs["prompt"] == "task that will miss the cache"


### PR DESCRIPTION
SonarCloud flagged `tests/unit/test_caching_adapter.py:177` as S1244 (float equality). This bug pushed `new_reliability_rating` to C on main, failing the quality gate.

Fix: wrap the 2.5 comparison in `pytest.approx` — same semantics, no float-tolerance surprise.