### PR TITLE
fix(tasks): invoke DLQ when retry limit exceeded

### DIFF
--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -431,6 +431,7 @@ def _try_compact_and_retry(
             max_task_retries=0,  # force permanent fail
             retried_task_ids=orch._retried_task_ids,
             tasks_snapshot=tasks_snapshot,
+            workdir=getattr(orch, "_workdir", None),
         )
         return False
 
@@ -468,6 +469,7 @@ def _try_compact_and_retry(
             max_task_retries=orch._config.max_task_retries,
             retried_task_ids=orch._retried_task_ids,
             tasks_snapshot=tasks_snapshot,
+            workdir=getattr(orch, "_workdir", None),
         )
         return False
 
@@ -498,6 +500,7 @@ def _try_compact_and_retry(
         max_task_retries=orch._config.max_task_retries,
         retried_task_ids=orch._retried_task_ids,
         tasks_snapshot=tasks_snapshot,
+        workdir=getattr(orch, "_workdir", None),
     )
 
     # Patch the newly created retry task with compacted description and meta-message.
@@ -882,6 +885,7 @@ def _handle_orphan_no_signals(
             server_url=base,
             max_task_retries=orch._config.max_task_retries,
             retried_task_ids=orch._retried_task_ids,
+            workdir=getattr(orch, "_workdir", None),
         )
         logger.warning(
             "Task '%s' failed — agent died without output. "
@@ -1046,6 +1050,7 @@ def handle_orphaned_task(
                     server_url=base,
                     max_task_retries=orch._config.max_task_retries,
                     retried_task_ids=orch._retried_task_ids,
+                    workdir=getattr(orch, "_workdir", None),
                 )
                 logger.info(
                     "Orphaned task %s retry/failed (janitor failed: %s) after agent %s died",
@@ -1406,6 +1411,7 @@ def _reap_heartbeat_timeout(
                 max_task_retries=orch._config.max_task_retries,
                 retried_task_ids=orch._retried_task_ids,
                 tasks_snapshot=tasks_snapshot,
+                workdir=getattr(orch, "_workdir", None),
             )
         except httpx.HTTPError as exc:
             logger.error("Failed to retry/fail task %s: %s", task_id, exc)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -2120,6 +2120,7 @@ class Orchestrator:
                     server_url=self._config.server_url,
                     max_task_retries=self._config.max_task_retries,
                     retried_task_ids=self._retried_task_ids,
+                    workdir=self._workdir,
                 )
 
     def _reap_dead_agents(self, result: TickResult, tasks_snapshot: dict[str, list[Task]]) -> None:
@@ -2411,6 +2412,7 @@ class Orchestrator:
             max_task_retries=self._config.max_task_retries,
             retried_task_ids=self._retried_task_ids,
             tasks_snapshot=tasks_snapshot,
+            workdir=self._workdir,
         )
 
     def _check_file_overlap(self, batch: list[Task]) -> bool:

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -541,6 +541,60 @@ def _dynamic_retry_limit(reason: str, default_max: int) -> int:
     return default_max
 
 
+def _enqueue_dlq_if_workdir(
+    *,
+    workdir: Path | None,
+    task: Task,
+    retry_count: int,
+    reason: str,
+    original_error: str,
+) -> None:
+    """Record a permanently-failed task in the Dead Letter Queue (audit-019).
+
+    Looks up ``<workdir>/.sdd`` and appends an entry to ``runtime/dlq.jsonl``.
+    A ``None`` workdir preserves legacy behaviour (no DLQ), and any OS or
+    serialisation error is logged and suppressed — the DLQ must never block
+    the primary failure path.
+
+    Args:
+        workdir: Orchestrator working directory, or ``None`` to skip.
+        task: The task being moved to the DLQ.
+        retry_count: Number of retries already attempted.
+        reason: Short failure tag (e.g. ``"max_retries_exceeded"``).
+        original_error: Last error / reason string from the final attempt.
+    """
+    if workdir is None:
+        return
+    try:
+        from bernstein.core.tasks.dead_letter_queue import DeadLetterQueue
+
+        dlq = DeadLetterQueue(sdd_dir=workdir / ".sdd")
+        dlq.enqueue(
+            task_id=task.id,
+            title=task.title,
+            role=task.role,
+            reason=reason,
+            retry_count=retry_count,
+            original_error=original_error,
+            metadata={
+                "priority": task.priority,
+                "scope": task.scope.value,
+                "complexity": task.complexity.value,
+                "model": task.model or "",
+                "effort": task.effort or "",
+                "original_task_id": task.metadata.get("original_task_id", task.id),
+            },
+        )
+    except Exception as exc:
+        # DLQ must never break the primary failure path — log and swallow.
+        logger.warning(
+            "DLQ enqueue failed for task %s (%s): %s",
+            task.id,
+            reason,
+            exc,
+        )
+
+
 def retry_or_fail_task(
     task_id: str,
     reason: str,
@@ -550,6 +604,7 @@ def retry_or_fail_task(
     max_task_retries: int,
     retried_task_ids: set[str],
     tasks_snapshot: dict[str, list[Task]] | None = None,
+    workdir: Path | None = None,
 ) -> None:
     """Re-queue a task for retry, or fail it permanently if max retries reached.
 
@@ -558,7 +613,8 @@ def retry_or_fail_task(
     verbatim; no ``[RETRY N]`` / ``[retry:N]`` markers are written.  If the
     typed counter is below ``min(task.max_retries, dynamic_limit(reason))`` a
     new open task is created with ``retry_count`` incremented; otherwise the
-    task is failed with a "Max retries exceeded" reason (DLQ threshold).
+    task is moved to the Dead Letter Queue (audit-019) and failed with a
+    ``"Max retries exceeded"`` reason.
 
     Args:
         task_id: ID of the task to retry or fail.
@@ -570,6 +626,11 @@ def retry_or_fail_task(
         retried_task_ids: Set of already-retried task IDs (mutated in-place).
         tasks_snapshot: Optional pre-fetched tasks snapshot to avoid an
             extra HTTP round-trip when the task is already in cache.
+        workdir: Orchestrator working directory.  When provided, tasks that
+            exhaust their retry budget are also enqueued into the Dead Letter
+            Queue under ``<workdir>/.sdd/runtime/dlq.jsonl`` (audit-019).
+            Callers without a workdir (e.g. ad-hoc scripts or legacy tests)
+            fall back to the historical behaviour of plain failure.
     """
     base = server_url
     dynamic_limit = _dynamic_retry_limit(reason, max_task_retries)
@@ -693,13 +754,31 @@ def retry_or_fail_task(
             )
         except httpx.HTTPError as exc:
             logger.error("Failed to re-create task %s for retry: %s", task_id, exc)
-            # Fall through to permanent fail
+            # Fall through to permanent fail (DLQ-eligible: re-create failure
+            # is effectively an exhausted retry — the task will not run again).
+            _enqueue_dlq_if_workdir(
+                workdir=workdir,
+                task=task,
+                retry_count=retry_count,
+                reason=f"retry_recreate_failed: {exc}",
+                original_error=reason,
+            )
             fail_task(client, base, task_id, f"Max retries exceeded: {reason}")
             return
         # Fail the old task silently (it has been replaced)
         with contextlib.suppress(httpx.HTTPError):
             fail_task(client, base, task_id, f"Retried: {reason}")
     else:
+        # audit-019: retry budget exhausted — move to Dead Letter Queue
+        # before marking the task failed so permanently-failed work is not
+        # silently dropped.
+        _enqueue_dlq_if_workdir(
+            workdir=workdir,
+            task=task,
+            retry_count=retry_count,
+            reason="max_retries_exceeded",
+            original_error=reason,
+        )
         fail_task(client, base, task_id, f"Max retries exceeded: {reason}")
 
 

--- a/tests/unit/test_dlq_retry_integration.py
+++ b/tests/unit/test_dlq_retry_integration.py
@@ -1,0 +1,219 @@
+"""Tests for Dead Letter Queue integration with retry_or_fail_task (audit-019).
+
+Verifies that when a task exhausts its retry budget, it is enqueued into the
+DLQ under ``<workdir>/.sdd/runtime/dlq.jsonl`` — instead of being silently
+dropped with a ``fail_task`` call.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+
+from bernstein.core.tasks.dead_letter_queue import DeadLetterQueue
+from bernstein.core.tasks.task_lifecycle import retry_or_fail_task
+
+
+class _MockScope:
+    value = "small"
+
+
+class _MockComplexity:
+    value = "low"
+
+
+class _MockTaskType:
+    value = "feature"
+
+
+class _MockTask:
+    """Minimal Task stand-in matching the attributes touched by retry_or_fail_task."""
+
+    def __init__(
+        self,
+        task_id: str,
+        *,
+        retry_count: int = 0,
+        max_retries: int = 3,
+    ) -> None:
+        self.id = task_id
+        self.title = "Test Task"
+        self.description = "body"
+        self.role = "backend"
+        self.priority = 1
+        self.scope = _MockScope()
+        self.complexity = _MockComplexity()
+        self.estimated_minutes = 10
+        self.depends_on = []
+        self.owned_files = []
+        self.task_type = _MockTaskType()
+        self.model = "sonnet"
+        self.effort = "high"
+        self.max_output_tokens = None
+        self.meta_messages: list[str] = []
+        self.completion_signals: list[object] = []
+        self.metadata: dict[str, object] = {}
+        self.retry_count = retry_count
+        self.max_retries = max_retries
+        self.retry_delay_s = 0.0
+        self.terminal_reason = None
+
+
+def _make_client() -> MagicMock:
+    """Create an httpx.Client mock whose POST returns a successful response."""
+    client = MagicMock(spec=httpx.Client)
+    ok = MagicMock()
+    ok.raise_for_status = MagicMock()
+    client.post.return_value = ok
+    return client
+
+
+def test_task_under_threshold_is_retried_not_dlq(tmp_path: Path) -> None:
+    """A task below its retry ceiling is re-queued and NOT added to the DLQ."""
+    client = _make_client()
+    task = _MockTask("task-alpha", retry_count=0, max_retries=3)
+
+    retry_or_fail_task(
+        task_id="task-alpha",
+        reason="Agent died",
+        client=client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=set(),
+        tasks_snapshot={"active": [task]},
+        workdir=tmp_path,
+    )
+
+    # A retry POST should have been issued.
+    posted_urls = [call.args[0] for call in client.post.call_args_list]
+    assert any(url.endswith("/tasks") for url in posted_urls), f"expected retry POST to /tasks but saw {posted_urls}"
+
+    # DLQ file should NOT exist for a task below threshold.
+    dlq_file = tmp_path / ".sdd" / "runtime" / "dlq.jsonl"
+    assert not dlq_file.exists(), "under-threshold task must not be enqueued to DLQ"
+
+
+def test_task_at_threshold_goes_to_dlq(tmp_path: Path) -> None:
+    """A task at its retry ceiling is enqueued into the DLQ with rich metadata."""
+    client = _make_client()
+    # retry_count == max_retries — we're past the budget.
+    task = _MockTask("task-beta", retry_count=3, max_retries=3)
+
+    retry_or_fail_task(
+        task_id="task-beta",
+        reason="Agent died permanently",
+        client=client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=set(),
+        tasks_snapshot={"active": [task]},
+        workdir=tmp_path,
+    )
+
+    # DLQ file must exist and contain exactly one entry for task-beta.
+    dlq = DeadLetterQueue(sdd_dir=tmp_path / ".sdd")
+    entries = dlq.list_entries()
+    assert len(entries) == 1, f"expected 1 DLQ entry, got {len(entries)}"
+    entry = entries[0]
+    assert entry.task_id == "task-beta"
+    assert entry.role == "backend"
+    assert entry.reason == "max_retries_exceeded"
+    assert entry.retry_count == 3
+    assert "Agent died permanently" in entry.original_error
+    # Metadata preserves enough context for a replay decision.
+    assert entry.metadata["priority"] == 1
+    assert entry.metadata["scope"] == "small"
+    assert entry.metadata["complexity"] == "low"
+
+    # The task should also have been marked failed via the HTTP fail endpoint.
+    posted_urls = [call.args[0] for call in client.post.call_args_list]
+    assert any(url.endswith("/task-beta/fail") for url in posted_urls), f"expected fail POST but saw {posted_urls}"
+    # And NO retry POST to /tasks.
+    assert not any(url.endswith("/tasks") for url in posted_urls), "exhausted task must not be re-queued"
+
+
+def test_dlq_entries_are_listable_and_not_rescheduled(tmp_path: Path) -> None:
+    """Tasks in the DLQ are listable, pending-only, and do not auto-retry.
+
+    We enqueue a task directly into the DLQ and verify that:
+    * ``list_entries`` returns the entry
+    * ``list_entries(pending_only=True)`` includes it until marked replayed
+    * ``retry_or_fail_task`` with an already-exhausted task does not create
+      a new open task (no second entry into the scheduler).
+    """
+    dlq = DeadLetterQueue(sdd_dir=tmp_path / ".sdd")
+    dlq.enqueue(
+        task_id="task-gamma",
+        title="Repro",
+        role="qa",
+        reason="max_retries_exceeded",
+        retry_count=3,
+        original_error="upstream 500",
+    )
+
+    entries = dlq.list_entries()
+    assert len(entries) == 1
+    assert entries[0].task_id == "task-gamma"
+    assert entries[0].replayed is False
+
+    # pending_only filter should include an un-replayed entry.
+    pending = dlq.list_entries(pending_only=True)
+    assert len(pending) == 1
+
+    # Now simulate the scheduler re-touching an exhausted task: retry_or_fail_task
+    # must NOT create a new open task — it should flow into the DLQ branch and
+    # issue a fail_task call only (and append to the same DLQ file).
+    client = _make_client()
+    task = _MockTask("task-gamma", retry_count=3, max_retries=3)
+    retry_or_fail_task(
+        task_id="task-gamma",
+        reason="another transient spike",
+        client=client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=set(),
+        tasks_snapshot={"active": [task]},
+        workdir=tmp_path,
+    )
+
+    posted_urls = [call.args[0] for call in client.post.call_args_list]
+    assert not any(url.endswith("/tasks") for url in posted_urls), (
+        "DLQ-bound task must not be re-queued into the scheduler"
+    )
+    # Must have been failed via HTTP.
+    assert any(url.endswith("/task-gamma/fail") for url in posted_urls)
+
+    # And the DLQ now has a second entry for the same task id — confirming
+    # the retry path appended rather than silently dropped.
+    dlq2 = DeadLetterQueue(sdd_dir=tmp_path / ".sdd")
+    all_entries = dlq2.list_entries()
+    assert len(all_entries) == 2
+    assert {e.task_id for e in all_entries} == {"task-gamma"}
+
+
+def test_workdir_none_preserves_legacy_fail_path(tmp_path: Path) -> None:
+    """Without a workdir, exhausted tasks still fail — just without DLQ persistence.
+
+    This guards the opt-in shape of the API: callers that omit ``workdir``
+    keep the pre-audit-019 behaviour (fail_task only, no file writes).
+    """
+    client = _make_client()
+    task = _MockTask("task-delta", retry_count=3, max_retries=3)
+
+    retry_or_fail_task(
+        task_id="task-delta",
+        reason="boom",
+        client=client,
+        server_url="http://test",
+        max_task_retries=3,
+        retried_task_ids=set(),
+        tasks_snapshot={"active": [task]},
+        # workdir intentionally omitted
+    )
+
+    posted_urls = [call.args[0] for call in client.post.call_args_list]
+    assert any(url.endswith("/task-delta/fail") for url in posted_urls)
+    # No DLQ file because we passed no workdir.
+    assert not (tmp_path / ".sdd" / "runtime" / "dlq.jsonl").exists()


### PR DESCRIPTION
## Summary

- Wires `DeadLetterQueue.enqueue` into `retry_or_fail_task` so tasks that exhaust their retry budget are persisted under `<workdir>/.sdd/runtime/dlq.jsonl` instead of silently dropping.
- Reads the typed `task.retry_count` (consolidated earlier) as the single source of truth for threshold checks.
- New optional `workdir` kwarg plumbed from the orchestrator and from every `agent_lifecycle` call site; `workdir=None` preserves the legacy fail-only behaviour for tests and ad-hoc scripts.
- DLQ failures are logged but never break the primary `fail_task` path.

## Why

`DeadLetterQueue` was fully implemented (371 LOC) but had zero production call sites. Permanently failed tasks vanished — no replay, no audit trail, no visibility.

## Test plan

- [x] `uv run ruff check` on all modified files
- [x] `uv run ruff format --check` on all modified files
- [x] `uv run pytest tests/unit -k "dlq or dead_letter" -x -q` — 25 passed (21 existing + 4 new)
- [x] `uv run pytest tests/unit/test_retry_or_fail_task.py tests/unit/test_retry_consolidation.py tests/unit/test_failure_reduction.py tests/unit/test_failure_aware_retry.py -x -q` — 41 passed (no regressions)

## New tests (`tests/unit/test_dlq_retry_integration.py`)

- `test_task_under_threshold_is_retried_not_dlq` — retries create open task, no DLQ file written.
- `test_task_at_threshold_goes_to_dlq` — DLQ entry has correct role, reason, retry_count, original_error, and metadata; fail POST still issued.
- `test_dlq_entries_are_listable_and_not_rescheduled` — listable + pending-only filter work; repeated retries on exhausted task append to DLQ instead of re-queuing.
- `test_workdir_none_preserves_legacy_fail_path` — no-workdir callers keep pre- behaviour.

## Follow-ups (out of scope)

- `dlq.jsonl` rotation / retention policy.
- `/dlq` HTTP routes for list + replay (called out in the ticket's proposed fix).