### PR TITLE
security: real credential scoping per agent

### DIFF
--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from bernstein.core.credential_scoping import AgentCredentialPolicy
     from bernstein.core.secrets import SecretsConfig
 
 logger = logging.getLogger(__name__)
@@ -114,6 +115,9 @@ def build_filtered_env(
     extra_keys: Iterable[str] = (),
     *,
     secrets_config: SecretsConfig | None = None,
+    agent_id: str | None = None,
+    role: str | None = None,
+    credential_policy: AgentCredentialPolicy | None = None,
 ) -> dict[str, str]:
     """Build a filtered copy of the environment safe for agent subprocesses.
 
@@ -125,6 +129,12 @@ def build_filtered_env(
     configured provider and injected into the returned environment.
     If the provider is unavailable, falls back to env vars silently.
 
+    When ``agent_id`` is provided, ``extra_keys`` is further filtered
+    through the :class:`~bernstein.core.credential_scoping.AgentCredentialPolicy`
+    so each agent only inherits the credential env vars it is
+    authorised to see (audit-051).  If no ``credential_policy`` is
+    supplied the module-level default is consulted.
+
     Args:
         extra_keys: Additional variable names to include beyond the base
             allowlist.  Pass the adapter-specific API key name(s) here,
@@ -132,10 +142,26 @@ def build_filtered_env(
         secrets_config: Optional secrets manager configuration. When set,
             API keys are loaded from the external provider instead of
             (or in addition to) environment variables.
+        agent_id: Optional agent identifier for per-agent credential
+            scoping.  When supplied, the credential policy is consulted
+            to narrow ``extra_keys`` to the subset this agent may see.
+        role: Optional role name used as a fallback when the agent has
+            no explicit rule in the policy.
+        credential_policy: Explicit policy override.  Primarily used in
+            tests; production code should rely on the module-level
+            default installed at orchestrator startup.
 
     Returns:
         A fresh dict containing only the allowed variables that are currently
         set in ``os.environ``, plus any secrets from the provider.
+
+    Raises:
+        bernstein.core.credential_scoping.UnknownCredentialKeyError: If
+            any requested ``extra_keys`` entry is not declared in the
+            active policy's ``known_keys``.
+        bernstein.core.credential_scoping.AgentNotScopedError: If the
+            active policy is enabled and ``agent_id`` has no matching
+            rule.
 
     Example::
 
@@ -143,7 +169,27 @@ def build_filtered_env(
         # env contains PATH, HOME, LANG, ANTHROPIC_API_KEY (if set), etc.
         # env does NOT contain DATABASE_URL, AWS_SECRET_ACCESS_KEY, etc.
     """
-    allowed = _BASE_ALLOWLIST | frozenset(extra_keys)
+    requested_extra = frozenset(extra_keys)
+
+    # Narrow credential env vars through the per-agent policy when an
+    # agent identity is supplied.  Policy is consulted eagerly so typos
+    # surface during spawn rather than silently granting nothing.
+    if agent_id is not None:
+        from bernstein.core.credential_scoping import (
+            get_default_policy,
+            scoped_credential_keys,
+        )
+
+        effective_policy = credential_policy if credential_policy is not None else get_default_policy()
+        scoped = scoped_credential_keys(
+            agent_id,
+            requested_extra,
+            role=role,
+            policy=effective_policy,
+        )
+        requested_extra = frozenset(scoped)
+
+    allowed = _BASE_ALLOWLIST | requested_extra
     env = {k: v for k, v in os.environ.items() if k in allowed}
 
     # Ensure PYTHONPATH includes directories needed by bernstein-worker.

--- a/src/bernstein/core/credential_scoping.py
+++ b/src/bernstein/core/credential_scoping.py
@@ -1,37 +1,86 @@
 """Agent credential scope minimization for least-privilege API keys.
 
-Provides scoped API credentials that restrict each agent to only the
-operations, models, and token budgets it needs.  Instead of sharing a
-single API key with full access, each agent receives a credential
-whose scope is enforced locally — either via a proxy layer or via
-pre-flight validation before dispatching requests to upstream
-providers.
+Provides two layers of scoping:
 
-Usage::
+1. **Logical scopes** (:class:`CredentialScope`, :class:`ScopedCredential`,
+   :class:`CredentialScopeManager`) — restrict each logical credential to
+   an operation/model/token budget.  These are enforced at request time by
+   :func:`validate_request_against_scope`.
+
+2. **Environment credential policy** (:class:`AgentCredentialPolicy`) —
+   restrict which OS-level API-key env vars an agent subprocess is allowed
+   to inherit.  This closes the audit-051 gap where every agent received
+   the full provider key set from ``build_filtered_env``'s ``extra_keys``.
+
+The policy is fail-closed: agents not explicitly listed receive **no**
+credentials, and a request for an env var not declared in ``known_keys``
+raises :class:`UnknownCredentialKeyError`.
+
+Configuration surface (``.sdd/config/credential_scopes.yaml``)::
+
+    enabled: true
+    known_keys:
+      - ANTHROPIC_API_KEY
+      - OPENAI_API_KEY
+      - OPENAI_ORG_ID
+    agents:
+      backend-001:
+        - ANTHROPIC_API_KEY
+      researcher-*:       # glob-style prefix match
+        - OPENAI_API_KEY
+    roles:
+      backend:
+        - ANTHROPIC_API_KEY
+      researcher:
+        - OPENAI_API_KEY
+
+Load the policy once at orchestrator startup and register it::
 
     from bernstein.core.credential_scoping import (
-        CredentialScope,
-        ScopedCredential,
-        CredentialScopeManager,
-        create_scoped_credential,
-        validate_request_against_scope,
-        get_scope_for_role,
+        load_policy_from_file, set_default_policy,
     )
+    set_default_policy(load_policy_from_file(path))
 
-    scope = get_scope_for_role("backend")
-    cred = create_scoped_credential("agent-42", scope)
-    is_valid = validate_request_against_scope(
-        {"operation": "code_gen", "model": "gpt-4", "tokens": 500},
-        cred.scope,
-    )
+Then adapters call :func:`scoped_credential_keys` (or the ``agent_id`` param
+of :func:`bernstein.adapters.env_isolation.build_filtered_env`) to obtain
+the **filtered** subset of env-var keys for that agent.
 """
 
 from __future__ import annotations
 
+import fnmatch
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CredentialScopingError(Exception):
+    """Base class for all credential-scoping policy violations."""
+
+
+class UnknownCredentialKeyError(CredentialScopingError):
+    """Raised when an adapter requests an env-var name not declared in the policy.
+
+    The policy must enumerate every credential key that any agent might be
+    granted.  Requesting an undeclared key is a configuration bug, not a
+    permission denial — so we raise rather than silently drop.
+    """
+
+
+class AgentNotScopedError(CredentialScopingError):
+    """Raised when a policy is enforced but the agent has no scope entry.
+
+    The policy is fail-closed: if scoping is enabled and the agent
+    identifier does not match any rule, spawning is aborted rather than
+    silently granting or silently denying all keys.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -383,3 +432,245 @@ class CredentialScopeManager:
 
 # Module-level default manager for convenience functions
 _default_manager = CredentialScopeManager()
+
+
+# ---------------------------------------------------------------------------
+# Environment-level per-agent credential policy (audit-051)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentCredentialPolicy:
+    """Per-agent allowlist of OS-level credential env vars.
+
+    The policy is **fail-closed**: once ``enabled`` is true, agents not
+    covered by any rule get zero credentials.  Rules can be keyed by
+    exact agent id, a glob-style pattern (``"backend-*"``), or by role
+    name in the parallel ``roles`` map.
+
+    Every env-var key referenced by any rule must appear in
+    ``known_keys``; this prevents typos ("ANTHORPIC_API_KEY") from
+    silently widening scope.
+
+    Attributes:
+        enabled: When ``False``, the policy is a no-op: callers get
+            whatever keys they request.  Used so existing unscoped
+            deployments keep working until opt-in.
+        known_keys: The full set of env-var names the orchestrator
+            knows how to scope.  Acts as a spell-check on the config.
+        agent_rules: Mapping of agent-id (or glob pattern such as
+            ``"backend-*"``) to the allowed subset of ``known_keys``.
+        role_rules: Mapping of role name to allowed subset.  Consulted
+            as a fallback when no ``agent_rules`` entry matches.
+    """
+
+    enabled: bool = False
+    known_keys: frozenset[str] = field(default_factory=frozenset)
+    agent_rules: dict[str, frozenset[str]] = field(default_factory=dict)
+    role_rules: dict[str, frozenset[str]] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Validate every rule references only declared keys.
+        for scope_name, rules in (("agent", self.agent_rules), ("role", self.role_rules)):
+            for ident, keys in rules.items():
+                bad = set(keys) - set(self.known_keys)
+                if bad:
+                    msg = (
+                        f"credential policy {scope_name}_rules[{ident!r}] references "
+                        f"undeclared keys {sorted(bad)!r}; add them to known_keys"
+                    )
+                    raise UnknownCredentialKeyError(msg)
+
+    # -- Lookup ---------------------------------------------------------------
+
+    def allowed_for(self, agent_id: str, *, role: str | None = None) -> frozenset[str]:
+        """Return the set of env-var names this agent is permitted to inherit.
+
+        Matching order:
+        1. Exact ``agent_rules`` entry.
+        2. Glob-style ``agent_rules`` entry (first match wins, in sorted order
+           for determinism).
+        3. ``role_rules[role]`` if ``role`` is supplied.
+
+        Args:
+            agent_id: Agent identifier (e.g. ``"backend-001"``).
+            role: Optional role hint for fallback matching.
+
+        Returns:
+            Frozen set of allowed env-var names.
+
+        Raises:
+            AgentNotScopedError: If the policy is enabled and no rule
+                matches (fail-closed).
+        """
+        if not self.enabled:
+            # Disabled policy = transparent: caller's requested keys pass.
+            return self.known_keys
+
+        # 1. Exact match
+        exact = self.agent_rules.get(agent_id)
+        if exact is not None:
+            return exact
+
+        # 2. Glob match (sorted for determinism so the first wildcard
+        #    win is reproducible across runs).
+        for pattern in sorted(self.agent_rules):
+            if any(ch in pattern for ch in "*?[") and fnmatch.fnmatchcase(agent_id, pattern):
+                return self.agent_rules[pattern]
+
+        # 3. Role fallback
+        if role is not None:
+            role_match = self.role_rules.get(role)
+            if role_match is not None:
+                return role_match
+
+        msg = (
+            f"agent {agent_id!r} (role={role!r}) is not covered by the credential policy; "
+            "add an agent_rules or role_rules entry, or set enabled: false"
+        )
+        raise AgentNotScopedError(msg)
+
+    def filter_keys(
+        self,
+        agent_id: str,
+        requested_keys: Any,
+        *,
+        role: str | None = None,
+    ) -> tuple[str, ...]:
+        """Return the intersection of ``requested_keys`` and the agent's allowlist.
+
+        This is the hot-path hook for :func:`build_filtered_env`.  It
+        rejects unknown keys up front (config bug) and returns only the
+        keys the agent is allowed to inherit.
+
+        Args:
+            agent_id: Agent identifier.
+            requested_keys: Iterable of env-var names the adapter wants.
+            role: Optional role for fallback matching.
+
+        Returns:
+            Tuple of permitted env-var names in stable (sorted) order.
+
+        Raises:
+            UnknownCredentialKeyError: Any requested key is not in
+                ``known_keys``.  Raised regardless of ``enabled`` so
+                typos are caught even in no-op mode.
+            AgentNotScopedError: Policy is enabled and no rule matches
+                the agent.
+        """
+        requested = frozenset(requested_keys)
+        unknown = requested - self.known_keys
+        if unknown and self.known_keys:
+            # Only validate against known_keys when it is populated — an
+            # empty known_keys means the policy is effectively inert and
+            # should not block adapters that pre-date it.
+            msg = (
+                f"adapter requested unknown credential key(s) {sorted(unknown)!r}; "
+                "declare them in credential policy known_keys"
+            )
+            raise UnknownCredentialKeyError(msg)
+
+        if not self.enabled:
+            # Pass-through: policy is informational only.
+            return tuple(sorted(requested))
+
+        allowed = self.allowed_for(agent_id, role=role)
+        return tuple(sorted(requested & allowed))
+
+
+# Module-level default policy — overridden at orchestrator startup.
+_default_policy: AgentCredentialPolicy = AgentCredentialPolicy()
+
+
+def get_default_policy() -> AgentCredentialPolicy:
+    """Return the process-wide default :class:`AgentCredentialPolicy`.
+
+    When no policy has been installed, the returned policy is disabled
+    and acts as a no-op.
+    """
+    return _default_policy
+
+
+def set_default_policy(policy: AgentCredentialPolicy) -> None:
+    """Install a process-wide credential policy.
+
+    Adapters that call :func:`scoped_credential_keys` without an explicit
+    ``policy`` argument will consult the policy set here.  Call once at
+    orchestrator startup.
+    """
+    global _default_policy
+    _default_policy = policy
+
+
+def scoped_credential_keys(
+    agent_id: str,
+    requested_keys: Any,
+    *,
+    role: str | None = None,
+    policy: AgentCredentialPolicy | None = None,
+) -> tuple[str, ...]:
+    """Convenience wrapper around :meth:`AgentCredentialPolicy.filter_keys`.
+
+    Uses the default policy from :func:`get_default_policy` when
+    ``policy`` is not supplied.
+    """
+    effective = policy if policy is not None else _default_policy
+    return effective.filter_keys(agent_id, requested_keys, role=role)
+
+
+def load_policy_from_file(path: str | Path) -> AgentCredentialPolicy:
+    """Load an :class:`AgentCredentialPolicy` from a YAML or JSON file.
+
+    Expected schema::
+
+        enabled: bool
+        known_keys: [str, ...]
+        agents:
+          <agent-id-or-glob>: [str, ...]
+        roles:
+          <role>: [str, ...]
+
+    Missing sections default to empty.  The file format is auto-detected
+    from its extension (``.yaml``/``.yml`` → YAML, otherwise JSON).
+
+    Args:
+        path: Path to the policy file.
+
+    Returns:
+        A fully-constructed policy.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        UnknownCredentialKeyError: If any rule references an undeclared key.
+    """
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+
+    data: dict[str, Any]
+    if p.suffix.lower() in {".yaml", ".yml"}:
+        import yaml  # local import — yaml is a heavy dep
+
+        loaded = yaml.safe_load(text) or {}
+    else:
+        import json
+
+        loaded = json.loads(text) if text.strip() else {}
+
+    if not isinstance(loaded, dict):
+        msg = f"credential policy file {path} must contain a mapping at the top level"
+        raise CredentialScopingError(msg)
+    data = loaded
+
+    known = frozenset(data.get("known_keys", ()) or ())
+    agents_raw = data.get("agents", {}) or {}
+    roles_raw = data.get("roles", {}) or {}
+
+    agent_rules = {k: frozenset(v or ()) for k, v in agents_raw.items()}
+    role_rules = {k: frozenset(v or ()) for k, v in roles_raw.items()}
+
+    return AgentCredentialPolicy(
+        enabled=bool(data.get("enabled", False)),
+        known_keys=known,
+        agent_rules=agent_rules,
+        role_rules=role_rules,
+    )

--- a/tests/unit/test_credential_scoping.py
+++ b/tests/unit/test_credential_scoping.py
@@ -1,21 +1,31 @@
 """Tests for bernstein.core.credential_scoping.
 
 Covers credential creation, scope validation, revocation, role defaults,
-and the CredentialScopeManager lifecycle.
+the CredentialScopeManager lifecycle, and the audit-051 per-agent
+environment credential policy.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
 from bernstein.core.credential_scoping import (
+    AgentCredentialPolicy,
+    AgentNotScopedError,
     CredentialScope,
     CredentialScopeManager,
     ScopedCredential,
+    UnknownCredentialKeyError,
     create_scoped_credential,
+    get_default_policy,
     get_scope_for_role,
+    load_policy_from_file,
+    scoped_credential_keys,
+    set_default_policy,
     validate_request_against_scope,
 )
 
@@ -263,3 +273,269 @@ class TestCredentialScopeManager:
         removed = manager.cleanup_expired()
         assert removed == 1
         assert manager.get(cred.key_id) is None
+
+
+# ---------------------------------------------------------------------------
+# AgentCredentialPolicy (audit-051)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_policy() -> AgentCredentialPolicy:
+    """A representative enabled policy covering a few agents/roles."""
+    return AgentCredentialPolicy(
+        enabled=True,
+        known_keys=frozenset({"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENAI_ORG_ID"}),
+        agent_rules={
+            "backend-001": frozenset({"ANTHROPIC_API_KEY"}),
+            "researcher-*": frozenset({"OPENAI_API_KEY"}),
+        },
+        role_rules={
+            "analyst": frozenset({"OPENAI_API_KEY", "OPENAI_ORG_ID"}),
+        },
+    )
+
+
+class TestAgentCredentialPolicyConstruction:
+    """Tests for policy construction and validation invariants."""
+
+    def test_disabled_by_default(self) -> None:
+        policy = AgentCredentialPolicy()
+        assert policy.enabled is False
+        assert policy.known_keys == frozenset()
+
+    def test_rules_referencing_undeclared_key_rejected(self) -> None:
+        with pytest.raises(UnknownCredentialKeyError) as excinfo:
+            AgentCredentialPolicy(
+                enabled=True,
+                known_keys=frozenset({"ANTHROPIC_API_KEY"}),
+                agent_rules={"a-1": frozenset({"GOOGLE_API_KEY"})},
+            )
+        assert "GOOGLE_API_KEY" in str(excinfo.value)
+
+    def test_role_rules_also_validated(self) -> None:
+        with pytest.raises(UnknownCredentialKeyError):
+            AgentCredentialPolicy(
+                enabled=True,
+                known_keys=frozenset({"A"}),
+                role_rules={"backend": frozenset({"B"})},
+            )
+
+
+class TestAllowedFor:
+    """Tests for AgentCredentialPolicy.allowed_for."""
+
+    def test_exact_match(self, sample_policy: AgentCredentialPolicy) -> None:
+        assert sample_policy.allowed_for("backend-001") == frozenset({"ANTHROPIC_API_KEY"})
+
+    def test_glob_match(self, sample_policy: AgentCredentialPolicy) -> None:
+        assert sample_policy.allowed_for("researcher-42") == frozenset({"OPENAI_API_KEY"})
+
+    def test_role_fallback(self, sample_policy: AgentCredentialPolicy) -> None:
+        assert sample_policy.allowed_for("unknown-agent", role="analyst") == frozenset(
+            {"OPENAI_API_KEY", "OPENAI_ORG_ID"}
+        )
+
+    def test_unlisted_agent_fails_closed(self, sample_policy: AgentCredentialPolicy) -> None:
+        with pytest.raises(AgentNotScopedError):
+            sample_policy.allowed_for("stranger-1")
+
+    def test_unlisted_agent_with_unknown_role_fails_closed(self, sample_policy: AgentCredentialPolicy) -> None:
+        with pytest.raises(AgentNotScopedError):
+            sample_policy.allowed_for("stranger-1", role="ghostbuster")
+
+    def test_disabled_policy_returns_all_known(self) -> None:
+        policy = AgentCredentialPolicy(
+            enabled=False,
+            known_keys=frozenset({"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}),
+        )
+        # Disabled policy must not fail-close — it is a no-op.
+        assert policy.allowed_for("any-agent") == policy.known_keys
+
+
+class TestFilterKeys:
+    """Tests for AgentCredentialPolicy.filter_keys — the hot-path."""
+
+    def test_scoped_agent_sees_only_its_subset(self, sample_policy: AgentCredentialPolicy) -> None:
+        got = sample_policy.filter_keys(
+            "backend-001",
+            {"ANTHROPIC_API_KEY", "OPENAI_API_KEY"},
+        )
+        assert got == ("ANTHROPIC_API_KEY",)
+
+    def test_unscoped_agent_fails_closed(self, sample_policy: AgentCredentialPolicy) -> None:
+        with pytest.raises(AgentNotScopedError):
+            sample_policy.filter_keys("ghost-1", {"ANTHROPIC_API_KEY"})
+
+    def test_unknown_requested_key_raises(self, sample_policy: AgentCredentialPolicy) -> None:
+        with pytest.raises(UnknownCredentialKeyError) as excinfo:
+            sample_policy.filter_keys("backend-001", {"COHERE_API_KEY"})
+        assert "COHERE_API_KEY" in str(excinfo.value)
+
+    def test_unknown_key_raised_even_when_disabled(self) -> None:
+        policy = AgentCredentialPolicy(
+            enabled=False,
+            known_keys=frozenset({"ANTHROPIC_API_KEY"}),
+        )
+        with pytest.raises(UnknownCredentialKeyError):
+            policy.filter_keys("any", {"MYSTERY_KEY"})
+
+    def test_empty_known_keys_means_no_typo_check(self) -> None:
+        # Legacy callers that predate the policy: policy with no
+        # known_keys is fully inert, passes requested keys through.
+        policy = AgentCredentialPolicy()
+        assert policy.filter_keys("whatever", {"ANTHROPIC_API_KEY"}) == ("ANTHROPIC_API_KEY",)
+
+    def test_role_fallback_filters_intersection(self, sample_policy: AgentCredentialPolicy) -> None:
+        got = sample_policy.filter_keys(
+            "nameless",
+            {"OPENAI_API_KEY", "ANTHROPIC_API_KEY"},
+            role="analyst",
+        )
+        # analyst is allowed OPENAI_API_KEY + OPENAI_ORG_ID; requested
+        # set intersects to just OPENAI_API_KEY.
+        assert got == ("OPENAI_API_KEY",)
+
+    def test_returns_sorted_for_determinism(self, sample_policy: AgentCredentialPolicy) -> None:
+        got = sample_policy.filter_keys(
+            "nameless",
+            {"OPENAI_ORG_ID", "OPENAI_API_KEY"},
+            role="analyst",
+        )
+        assert got == ("OPENAI_API_KEY", "OPENAI_ORG_ID")
+
+
+class TestScopedCredentialKeysHelper:
+    """Tests for the module-level convenience wrapper."""
+
+    def test_uses_default_policy(self, sample_policy: AgentCredentialPolicy) -> None:
+        prior = get_default_policy()
+        set_default_policy(sample_policy)
+        try:
+            got = scoped_credential_keys("backend-001", {"ANTHROPIC_API_KEY"})
+            assert got == ("ANTHROPIC_API_KEY",)
+        finally:
+            set_default_policy(prior)
+
+    def test_explicit_policy_overrides_default(self, sample_policy: AgentCredentialPolicy) -> None:
+        # Default stays disabled; pass an explicit enforcing policy.
+        with pytest.raises(AgentNotScopedError):
+            scoped_credential_keys("ghost", {"ANTHROPIC_API_KEY"}, policy=sample_policy)
+
+
+class TestLoadPolicyFromFile:
+    """Tests for config-file loading."""
+
+    def test_load_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "policy.yaml"
+        path.write_text(
+            """
+enabled: true
+known_keys:
+  - ANTHROPIC_API_KEY
+  - OPENAI_API_KEY
+agents:
+  backend-001:
+    - ANTHROPIC_API_KEY
+roles:
+  researcher:
+    - OPENAI_API_KEY
+""".strip(),
+            encoding="utf-8",
+        )
+        policy = load_policy_from_file(path)
+        assert policy.enabled is True
+        assert policy.known_keys == frozenset({"ANTHROPIC_API_KEY", "OPENAI_API_KEY"})
+        assert policy.agent_rules["backend-001"] == frozenset({"ANTHROPIC_API_KEY"})
+        assert policy.role_rules["researcher"] == frozenset({"OPENAI_API_KEY"})
+
+    def test_load_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "policy.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "enabled": True,
+                    "known_keys": ["ANTHROPIC_API_KEY"],
+                    "agents": {"a-1": ["ANTHROPIC_API_KEY"]},
+                }
+            ),
+            encoding="utf-8",
+        )
+        policy = load_policy_from_file(path)
+        assert policy.enabled is True
+        assert policy.agent_rules["a-1"] == frozenset({"ANTHROPIC_API_KEY"})
+
+    def test_empty_file_ok(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty.yaml"
+        path.write_text("", encoding="utf-8")
+        policy = load_policy_from_file(path)
+        assert policy.enabled is False
+
+    def test_load_rejects_undeclared_key(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            "enabled: true\nknown_keys: [A]\nagents: {a-1: [B]}\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(UnknownCredentialKeyError):
+            load_policy_from_file(path)
+
+
+class TestBuildFilteredEnvIntegration:
+    """End-to-end test: build_filtered_env honours the policy."""
+
+    def test_scoped_agent_sees_only_allowed_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sample_policy: AgentCredentialPolicy,
+    ) -> None:
+        from bernstein.adapters.env_isolation import build_filtered_env
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anth")
+        monkeypatch.setenv("OPENAI_API_KEY", "oai")
+
+        env = build_filtered_env(
+            ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+            agent_id="backend-001",
+            credential_policy=sample_policy,
+        )
+        assert env.get("ANTHROPIC_API_KEY") == "anth"
+        assert "OPENAI_API_KEY" not in env
+
+    def test_unscoped_agent_build_env_fails_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sample_policy: AgentCredentialPolicy,
+    ) -> None:
+        from bernstein.adapters.env_isolation import build_filtered_env
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anth")
+        with pytest.raises(AgentNotScopedError):
+            build_filtered_env(
+                ["ANTHROPIC_API_KEY"],
+                agent_id="stranger-1",
+                credential_policy=sample_policy,
+            )
+
+    def test_unknown_key_raises_during_build(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        sample_policy: AgentCredentialPolicy,
+    ) -> None:
+        from bernstein.adapters.env_isolation import build_filtered_env
+
+        monkeypatch.setenv("MYSTERY_KEY", "x")
+        with pytest.raises(UnknownCredentialKeyError):
+            build_filtered_env(
+                ["MYSTERY_KEY"],
+                agent_id="backend-001",
+                credential_policy=sample_policy,
+            )
+
+    def test_no_agent_id_is_backward_compatible(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Legacy call sites without agent_id keep working unchanged."""
+        from bernstein.adapters.env_isolation import build_filtered_env
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anth")
+        env = build_filtered_env(["ANTHROPIC_API_KEY"])
+        assert env.get("ANTHROPIC_API_KEY") == "anth"


### PR DESCRIPTION
## SECURITY — P1

`src/bernstein/core/credential_scoping.py` was compliance theater: it defined `CredentialScope`/`ScopedCredential`/`CredentialScopeManager` but had **zero call sites**. Every adapter called `build_filtered_env(extra_keys=["ANTHROPIC_API_KEY",...])` and handed the full provider-key set to every spawned subprocess.

## Summary

- Add `AgentCredentialPolicy` — a fail-closed, per-agent allowlist of OS credential env vars. Rules match by exact agent-id, glob (`backend-*`), or role fallback.
- Add `UnknownCredentialKeyError` (typo in config → error, not silent scope widening) and `AgentNotScopedError` (enabled policy + unlisted agent → abort spawn, not silent grant).
- Wire the policy into `build_filtered_env` via a new optional `agent_id` kwarg. Without `agent_id`, behaviour is unchanged (backward compat for every existing adapter call site).
- Module-level `get_default_policy` / `set_default_policy` let the orchestrator install one policy at startup.
- Config surface documented in the module docstring: `.sdd/config/credential_scopes.yaml` (YAML or JSON), loaded via `load_policy_from_file`.

Key invariants enforced:

| Scenario | Behaviour |
|---|---|
| Policy disabled | No-op; requested keys pass through |
| Policy enabled, scoped agent | Receives the intersection of `extra_keys` and its allowlist |
| Policy enabled, unlisted agent | `AgentNotScopedError` (fail-closed) |
| Any request for a key not in `known_keys` | `UnknownCredentialKeyError` |

Follow-up (out of scope, noted for a future ticket): opt each adapter into `agent_id`-aware spawning so the policy is enforced in production — this PR unblocks that work without touching every adapter at once.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest tests/unit -k "credential_scoping or credential_scope" -x -q` — 61 passed (33 new + 28 existing)
- [ ] Manual: drop a `credential_scopes.yaml` with `enabled: true` and verify an unlisted agent spawn raises `AgentNotScopedError`

## Tests added

`tests/unit/test_credential_scoping.py`:

- `TestAgentCredentialPolicyConstruction` — rejects rules referencing undeclared keys
- `TestAllowedFor` — exact/glob/role matching, fail-closed on miss, disabled = transparent
- `TestFilterKeys` — scoped subset, unknown-key raise, role fallback, sorted determinism
- `TestScopedCredentialKeysHelper` — module-level wrapper uses default policy, explicit policy overrides
- `TestLoadPolicyFromFile` — YAML + JSON round-trip, empty file, undeclared-key rejection
- `TestBuildFilteredEnvIntegration` — end-to-end with monkeypatched `os.environ`