### PR TITLE
fix(git): enqueue concurrent merges through merge_queue

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -866,8 +866,17 @@ class AgentSpawner:
         self._warm_pool_entries: dict[str, PoolSlot] = {}
         # Per-repo lock to serialize pushes and prevent non-fast-forward races
         self._push_locks: dict[Path, threading.Lock] = {}
-        # Per-repo lock to serialize merges and prevent concurrent index corruption
+        # Per-repo lock to serialize merges and prevent concurrent index corruption.
+        # Used as a fallback when no :class:`MergeQueue` has been wired in via
+        # :meth:`set_merge_queue` (e.g. in unit tests that construct a bare
+        # spawner).  Production callers should route through the merge queue
+        # injected by the orchestrator.
         self._merge_locks: dict[Path, threading.Lock] = {}
+        # Set by the orchestrator via :meth:`set_merge_queue` after construction.
+        # When present, merges are serialised through the FIFO queue so the
+        # dashboard can observe pending jobs and so merge-tree conflict checks
+        # can be inserted on the queue's boundary (audit-091 fix).
+        self._merge_queue: Any = None
         self._traces: dict[str, AgentTrace] = {}
         self._trace_store = TraceStore(workdir / ".sdd" / "traces")
         self._runtime_bridge = runtime_bridge
@@ -1015,6 +1024,16 @@ class AgentSpawner:
 
     # -- Merge and reap (delegated to spawner_merge) ---------------------------
 
+    def set_merge_queue(self, merge_queue: Any) -> None:
+        """Wire in the orchestrator's :class:`MergeQueue` for FIFO merges.
+
+        Called after construction because the orchestrator owns the queue
+        and constructs the spawner before itself.  When set, all agent
+        merges enqueue through this queue instead of using the ad-hoc
+        per-repo lock dict -- fixing audit-091.
+        """
+        self._merge_queue = merge_queue
+
     def _merge_and_cleanup_worktree(
         self,
         session: AgentSession,
@@ -1034,6 +1053,7 @@ class AgentSpawner:
             warm_pool=self._warm_pool,
             workdir=self._workdir,
             merge_worktree_branch_fn=self._merge_worktree_branch,
+            merge_queue=self._merge_queue,
         )
 
     def _pending_pushes_path(self) -> Path:
@@ -1092,6 +1112,7 @@ class AgentSpawner:
             merge_worktree_branch_fn=self._merge_worktree_branch,
             traces=self._traces,
             trace_store=self._trace_store,
+            merge_queue=self._merge_queue,
         )
 
     def update_trace_outcome(self, session_id: str, outcome: str) -> None:

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from bernstein.core.agents.container import ContainerManager
     from bernstein.core.agents.in_process_agent import InProcessAgent
     from bernstein.core.agents.warm_pool import PoolSlot, WarmPool
+    from bernstein.core.merge_queue import MergeQueue
     from bernstein.core.worktree import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -47,45 +48,75 @@ def _sanitise_for_log(value: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _run_merge_and_push(
+    session: AgentSession,
+    worktree_root: Path,
+    merge_worktree_branch_fn: Any,
+) -> MergeResult | None:
+    """Run the merge subprocess, record metrics, and push on success.
+
+    Caller must already hold whatever serialisation primitive is in use
+    (:class:`MergeQueue` submit context or a per-repo lock).  Kept as a
+    private helper so the two entry points below stay thin.
+    """
+    merge_start = time.perf_counter()
+    merge_result = merge_worktree_branch_fn(session.id, repo_root=worktree_root)
+    merge_duration.observe(time.perf_counter() - merge_start)
+
+    from bernstein.core.metric_collector import get_collector
+
+    merge_ok = merge_result is not None and merge_result.success
+    for task_id in session.task_ids:
+        get_collector().record_merge_result(task_id, success=merge_ok)
+
+    if merge_result and merge_result.success:
+        from bernstein.core.git_ops import safe_push
+
+        push_result = safe_push(worktree_root, "main")
+        if push_result.ok:
+            logger.info("Pushed merged work from %s to origin/main", session.id)
+        else:
+            logger.warning("Push failed after merge for %s: %s", session.id, push_result.stderr)
+
+    return merge_result
+
+
 def _do_merge(
     session: AgentSession,
     worktree_root: Path,
     merge_locks: dict[Path, threading.Lock],
     merge_worktree_branch_fn: Any,
+    merge_queue: MergeQueue | None = None,
 ) -> MergeResult | None:
     """Execute the merge under a lock, record metrics, and push.
+
+    When ``merge_queue`` is provided, the job is enqueued and processed in
+    strict FIFO order under :attr:`MergeQueue.merge_lock` -- this fixes
+    audit-091 where the queue was instantiated but never fed.  The legacy
+    per-repo ``merge_locks`` path is kept as a fallback for callers (and
+    tests) that don't plumb a queue through.
 
     Args:
         session: Agent session being merged.
         worktree_root: Root of the repo/worktree.
-        merge_locks: Lock map keyed by repo root.
+        merge_locks: Lock map keyed by repo root (fallback path only).
         merge_worktree_branch_fn: Callable(session_id, repo_root) -> MergeResult.
+        merge_queue: Optional :class:`MergeQueue` for serialized FIFO merges
+            across concurrent agents.  When None, falls back to the
+            per-repo lock.
 
     Returns:
         The MergeResult.
     """
+    if merge_queue is not None:
+        task_id = session.task_ids[0] if session.task_ids else ""
+        task_title = getattr(session, "task_title", "") or ""
+        with merge_queue.submit(session.id, task_id=task_id, task_title=task_title):
+            return _run_merge_and_push(session, worktree_root, merge_worktree_branch_fn)
+
     merge_lock = merge_locks.setdefault(worktree_root, threading.Lock())
     with merge_lock:
-        merge_start = time.perf_counter()
-        merge_result = merge_worktree_branch_fn(session.id, repo_root=worktree_root)
-        merge_duration.observe(time.perf_counter() - merge_start)
-
-        from bernstein.core.metric_collector import get_collector
-
-        merge_ok = merge_result is not None and merge_result.success
-        for task_id in session.task_ids:
-            get_collector().record_merge_result(task_id, success=merge_ok)
-
-        if merge_result and merge_result.success:
-            from bernstein.core.git_ops import safe_push
-
-            push_result = safe_push(worktree_root, "main")
-            if push_result.ok:
-                logger.info("Pushed merged work from %s to origin/main", session.id)
-            else:
-                logger.warning("Push failed after merge for %s: %s", session.id, push_result.stderr)
-
-    return merge_result
+        return _run_merge_and_push(session, worktree_root, merge_worktree_branch_fn)
 
 
 def _do_cleanup(
@@ -115,6 +146,7 @@ def merge_and_cleanup_worktree(
     warm_pool: WarmPool | None,
     workdir: Path,
     merge_worktree_branch_fn: Any,
+    merge_queue: MergeQueue | None = None,
 ) -> MergeResult | None:
     """Merge worktree branch back and optionally clean up.
 
@@ -134,6 +166,10 @@ def merge_and_cleanup_worktree(
         warm_pool: Optional warm pool.
         workdir: Project working directory.
         merge_worktree_branch_fn: Callable(session_id, repo_root) -> MergeResult.
+        merge_queue: Optional :class:`MergeQueue` to serialize concurrent
+            merges through a FIFO queue.  Preferred over the ad-hoc
+            ``merge_locks`` dict; when None the legacy per-repo lock path
+            is used (preserves single-agent behaviour and test harnesses).
 
     Returns:
         MergeResult when worktrees are enabled and skip_merge is False
@@ -152,7 +188,13 @@ def merge_and_cleanup_worktree(
 
     merge_result: MergeResult | None = None
     if not skip_merge:
-        merge_result = _do_merge(session, worktree_root, merge_locks, merge_worktree_branch_fn)
+        merge_result = _do_merge(
+            session,
+            worktree_root,
+            merge_locks,
+            merge_worktree_branch_fn,
+            merge_queue=merge_queue,
+        )
 
     if not defer_cleanup:
         _do_cleanup(session.id, worktree_mgr, warm_pool_entries, warm_pool)
@@ -495,6 +537,7 @@ def reap_completed_agent(
     merge_worktree_branch_fn: Any,
     traces: dict[str, AgentTrace],
     trace_store: TraceStore,
+    merge_queue: MergeQueue | None = None,
 ) -> MergeResult | None:
     """Terminate and wait on the subprocess for a completed agent.
 
@@ -537,6 +580,7 @@ def reap_completed_agent(
                 warm_pool=warm_pool,
                 workdir=workdir,
                 merge_worktree_branch_fn=merge_worktree_branch_fn,
+                merge_queue=merge_queue,
             )
             outcome = "completed" if session.status != "dead" else "timed_out"
             get_plugin_manager().fire_agent_reaped(session_id=session.id, role=session.role, outcome=outcome)
@@ -555,6 +599,7 @@ def reap_completed_agent(
         warm_pool=warm_pool,
         workdir=workdir,
         merge_worktree_branch_fn=merge_worktree_branch_fn,
+        merge_queue=merge_queue,
     )
     outcome = "completed" if session.status != "dead" else "timed_out"
     get_plugin_manager().fire_agent_reaped(session_id=session.id, role=session.role, outcome=outcome)

--- a/src/bernstein/core/git/merge_queue.py
+++ b/src/bernstein/core/git/merge_queue.py
@@ -11,6 +11,7 @@ index are never touched during the check.
 from __future__ import annotations
 
 import collections
+import contextlib
 import logging
 import re
 import threading
@@ -20,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 from bernstein.core.git.git_basic import run_git
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -218,28 +220,37 @@ class MergeQueue:
     """
 
     def __init__(self) -> None:
+        # Condition guards the queue deque so enqueue/dequeue and head-of-line
+        # waits stay consistent.  ``merge_lock`` (below) is a separate coarse
+        # lock the caller holds while the git merge subprocess runs.
+        self._cond = threading.Condition()
         self._queue: collections.deque[MergeJob] = collections.deque()
-        self._queue_lock = threading.Lock()
         # Held during each git merge operation so concurrent callers block.
         self.merge_lock = threading.Lock()
 
-    def enqueue(self, session_id: str, task_id: str, task_title: str = "") -> None:
+    def enqueue(self, session_id: str, task_id: str, task_title: str = "") -> MergeJob:
         """Add a merge job to the end of the queue.
 
         Args:
             session_id: The agent session whose branch to merge.
             task_id: The task the agent was working on.
             task_title: Human-readable task title (for conflict task body).
+
+        Returns:
+            The enqueued :class:`MergeJob` (identity used by ``submit`` to
+            match the job against the queue head).
         """
         job = MergeJob(session_id=session_id, task_id=task_id, task_title=task_title)
-        with self._queue_lock:
+        with self._cond:
             self._queue.append(job)
+            self._cond.notify_all()
         logger.debug(
             "MergeQueue: enqueued session %s (task %s), depth=%d",
             session_id,
             task_id,
             len(self),
         )
+        return job
 
     def dequeue(self) -> MergeJob | None:
         """Remove and return the oldest job, or None if the queue is empty.
@@ -247,8 +258,11 @@ class MergeQueue:
         Returns:
             The oldest MergeJob or None.
         """
-        with self._queue_lock:
-            return self._queue.popleft() if self._queue else None
+        with self._cond:
+            job = self._queue.popleft() if self._queue else None
+            if job is not None:
+                self._cond.notify_all()
+            return job
 
     def peek(self) -> MergeJob | None:
         """Return the oldest job without removing it, or None if empty.
@@ -256,8 +270,67 @@ class MergeQueue:
         Returns:
             The oldest MergeJob or None.
         """
-        with self._queue_lock:
+        with self._cond:
             return self._queue[0] if self._queue else None
+
+    @contextlib.contextmanager
+    def submit(
+        self,
+        session_id: str,
+        task_id: str,
+        task_title: str = "",
+    ) -> Iterator[MergeJob]:
+        """Enqueue a merge job and block until it's the caller's turn.
+
+        Serializes concurrent merges in strict FIFO order.  The job is
+        enqueued, then the caller blocks on a condition until it reaches
+        the head of the queue; at that point :attr:`merge_lock` is acquired
+        and the context manager yields the :class:`MergeJob`.  On exit the
+        job is dequeued, the lock is released, and other waiters are woken.
+
+        This is the intended entry point for production callers — it
+        guarantees ``enqueue`` is actually called (fixing audit-091) and
+        keeps the ordering invariant even when multiple threads contend.
+
+        Usage::
+
+            with queue.submit(session_id, task_id="T-1", task_title="...") as job:
+                result = spawner._merge_worktree_branch(job.session_id)
+
+        Args:
+            session_id: The agent session whose branch to merge.
+            task_id: The task the agent was working on.
+            task_title: Human-readable task title (for conflict task body).
+
+        Yields:
+            The :class:`MergeJob` that was enqueued (now at the head of the
+            queue and still present until the ``with`` block exits).
+        """
+        job = self.enqueue(session_id, task_id=task_id, task_title=task_title)
+        # Wait until we're at the head of the queue, then grab merge_lock.
+        # The merge_lock acquisition happens *inside* the condition so a
+        # concurrent dequeue cannot race ahead of us.
+        with self._cond:
+            while self._queue and self._queue[0] is not job:
+                self._cond.wait()
+        # Acquire the coarse merge_lock outside the condition so long-running
+        # git operations don't block readers of snapshot()/peek()/len().
+        self.merge_lock.acquire()
+        try:
+            yield job
+        finally:
+            try:
+                with self._cond:
+                    # Remove our job from the head (tolerate drift if a test
+                    # or edge case already dequeued it).
+                    if self._queue and self._queue[0] is job:
+                        self._queue.popleft()
+                    else:
+                        with contextlib.suppress(ValueError):
+                            self._queue.remove(job)
+                    self._cond.notify_all()
+            finally:
+                self.merge_lock.release()
 
     def snapshot(self) -> dict[str, Any]:
         """Return current queue state as a serialisable dict.
@@ -269,7 +342,7 @@ class MergeQueue:
             Dict with keys ``jobs`` (list[dict]), ``depth`` (int), and
             ``is_merging`` (bool).
         """
-        with self._queue_lock:
+        with self._cond:
             jobs: list[dict[str, str]] = [
                 {
                     "session_id": job.session_id,
@@ -286,7 +359,7 @@ class MergeQueue:
         }
 
     def __len__(self) -> int:
-        with self._queue_lock:
+        with self._cond:
             return len(self._queue)
 
     def __bool__(self) -> bool:

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -529,6 +529,11 @@ class Orchestrator:
         # Conflict resolution tasks are created by process_completed_tasks when
         # a MergeResult reports conflicting_files.
         self._merge_queue = MergeQueue()
+        # Audit-091 fix: wire the queue into the spawner so every agent merge
+        # enqueues through it.  The spawner is constructed before the
+        # orchestrator, so the hook is applied here via a setter.
+        if hasattr(self._spawner, "set_merge_queue"):
+            self._spawner.set_merge_queue(self._merge_queue)
 
         # Convergence guard: blocks spawn waves when merge queue, active
         # agent count, error rate, or spawn rate exceed safe thresholds.

--- a/tests/unit/test_merge_queue.py
+++ b/tests/unit/test_merge_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -470,3 +471,137 @@ class TestCreateConflictResolutionTask:
 
         body = mock_client.post.call_args[1]["json"]
         assert body["priority"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# MergeQueue.submit (audit-091: FIFO serialization of concurrent merges)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeQueueSubmit:
+    """submit() is the production entry point that ties enqueue/dequeue
+    together under merge_lock so concurrent agent merges serialise in
+    strict FIFO order.
+    """
+
+    def test_submit_enqueues_job(self) -> None:
+        """submit() must enqueue the job before yielding."""
+        q = MergeQueue()
+        with q.submit("session-a", task_id="T-1", task_title="hello") as job:
+            # While inside the block, the job is at the head.
+            assert job.session_id == "session-a"
+            assert q.peek() is not None
+            assert q.peek().session_id == "session-a"  # type: ignore[union-attr]
+            assert q.merge_lock.locked()
+        # After the block, queue drained and lock released.
+        assert q.peek() is None
+        assert not q.merge_lock.locked()
+
+    def test_submit_dequeues_of_empty_queue_returns_none(self) -> None:
+        """After submit() completes the queue is empty and dequeue is None."""
+        q = MergeQueue()
+        with q.submit("s1", task_id="T-1"):
+            pass
+        assert q.dequeue() is None
+
+    def test_submit_concurrent_two_merges_serialize_fifo(self) -> None:
+        """Two concurrent submit()s observe strict FIFO order under merge_lock.
+
+        Reproduces audit-091 scenario: without the fix the merge lock was
+        acquired ad-hoc so ordering was non-deterministic and the queue
+        stayed empty.  With submit() the first thread to enqueue is the
+        first to execute, and the second thread blocks until the first
+        exits the context manager.
+        """
+        q = MergeQueue()
+        order: list[str] = []
+        inside_events: dict[str, threading.Event] = {
+            "a_inside": threading.Event(),
+            "a_can_exit": threading.Event(),
+            "b_started": threading.Event(),
+        }
+
+        def worker_a() -> None:
+            with q.submit("session-a", task_id="T-1"):
+                inside_events["a_inside"].set()
+                order.append("a-start")
+                # Wait until thread B has definitely enqueued and is
+                # blocked behind A before A releases the lock.
+                assert inside_events["b_started"].wait(timeout=2.0)
+                # Give B a moment to try (and fail) to overtake.
+                inside_events["a_can_exit"].wait(timeout=0.1)
+                order.append("a-end")
+
+        def worker_b() -> None:
+            inside_events["b_started"].set()
+            with q.submit("session-b", task_id="T-2"):
+                order.append("b-start")
+                order.append("b-end")
+
+        ta = threading.Thread(target=worker_a)
+        tb = threading.Thread(target=worker_b)
+        ta.start()
+        # Ensure A has reached the head of the queue and acquired merge_lock
+        # before B enqueues — this is what pins down "FIFO by enqueue order".
+        assert inside_events["a_inside"].wait(timeout=2.0)
+        tb.start()
+        inside_events["a_can_exit"].set()
+        ta.join(timeout=5.0)
+        tb.join(timeout=5.0)
+        assert not ta.is_alive()
+        assert not tb.is_alive()
+        # A started and finished before B started — serialized.
+        assert order == ["a-start", "a-end", "b-start", "b-end"]
+
+    def test_submit_fifo_preserved_with_many_waiters(self) -> None:
+        """When N threads enqueue in order s0..sN-1, they execute in that order."""
+        q = MergeQueue()
+        start_barrier = threading.Event()
+        executed: list[str] = []
+        executed_lock = threading.Lock()
+        n = 5
+
+        # Gate thread-submit ordering: only enqueue after the previous
+        # thread has enqueued, so FIFO enqueue order is deterministic.
+        enqueue_gates = [threading.Event() for _ in range(n)]
+        enqueue_gates[0].set()  # first thread can enqueue immediately
+
+        def worker(i: int) -> None:
+            enqueue_gates[i].wait(timeout=2.0)
+            # Enqueue in strict order; allow next thread to enqueue after us.
+            start_barrier.wait(timeout=2.0)
+            with q.submit(f"s{i}", task_id=f"T-{i}"):
+                with executed_lock:
+                    executed.append(f"s{i}")
+                # Let next thread enqueue as soon as we've reached the head
+                # (enqueue happens at submit() entry, before the lock grab).
+                if i + 1 < n:
+                    enqueue_gates[i + 1].set()
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        # Release the barrier so the first waiter enqueues.
+        start_barrier.set()
+        for t in threads:
+            t.join(timeout=5.0)
+            assert not t.is_alive()
+
+        assert executed == [f"s{i}" for i in range(n)]
+        # Queue drained.
+        assert len(q) == 0
+        assert not q.merge_lock.locked()
+
+    def test_submit_releases_lock_on_exception(self) -> None:
+        """If the caller raises inside submit(), the lock is released and the
+        job is removed from the queue.
+        """
+        q = MergeQueue()
+        with contextlib.suppress(RuntimeError):
+            with q.submit("s1", task_id="T-1"):
+                raise RuntimeError("boom")
+        assert len(q) == 0
+        assert not q.merge_lock.locked()
+        # Second submit() still works.
+        with q.submit("s2", task_id="T-2") as job:
+            assert job.session_id == "s2"

--- a/tests/unit/test_spawner_merge_queue_wiring.py
+++ b/tests/unit/test_spawner_merge_queue_wiring.py
@@ -1,0 +1,196 @@
+"""Spawner-merge integration tests for audit-091.
+
+Verifies that the spawner merge path routes through
+:class:`bernstein.core.merge_queue.MergeQueue` when one is provided so
+concurrent agent merges serialise in strict FIFO order and are observable
+via the queue snapshot.  When no queue is provided the legacy per-repo
+:class:`threading.Lock` path is still exercised (backward compatibility
+for single-agent runs and bare unit tests).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from bernstein.core.merge_queue import MergeQueue
+
+from bernstein.core.agents.spawner_merge import _do_merge
+
+
+def _make_session(session_id: str, task_id: str = "T-1") -> Any:
+    """Build a minimal duck-typed AgentSession stub for _do_merge."""
+
+    class _Stub:
+        pass
+
+    s = _Stub()
+    s.id = session_id
+    s.task_ids = [task_id]
+    return s
+
+
+class _RecordingMergeFn:
+    """Callable that records merge invocations in-order and can pause.
+
+    The pause lets us freeze one merge in-flight while another thread
+    enqueues, so we can observe the MergeQueue state transitions.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.in_flight = threading.Event()
+        self.release = threading.Event()
+
+    def __call__(self, session_id: str, repo_root: Path) -> Any:
+        self.calls.append(session_id)
+        self.in_flight.set()
+        # Wait for the test to release us (bounded so a hang fails fast).
+        self.release.wait(timeout=2.0)
+
+        class _Result:
+            success = True
+            conflicting_files: list[str] = []
+            error = None
+
+        return _Result()
+
+
+def test_do_merge_with_queue_enqueues_and_processes() -> None:
+    """With a MergeQueue provided, _do_merge enqueues the job and the
+    queue snapshot reflects it while the merge runs.
+    """
+    q = MergeQueue()
+    session = _make_session("backend-abc", task_id="T-42")
+    fn = _RecordingMergeFn()
+
+    # Patch safe_push so _do_merge doesn't touch git.
+    with patch("bernstein.core.git_ops.safe_push") as safe_push:
+        safe_push.return_value.ok = True
+        safe_push.return_value.stderr = ""
+
+        started = threading.Event()
+
+        def run() -> None:
+            started.set()
+            _do_merge(session, Path("/tmp"), {}, fn, merge_queue=q)
+
+        t = threading.Thread(target=run)
+        t.start()
+        # Wait until the merge function is inside its critical section.
+        assert fn.in_flight.wait(timeout=2.0)
+
+        snap = q.snapshot()
+        # While the merge is held, the job is still in the queue (submit()
+        # only pops it on exit) and is_merging should be True.
+        assert snap["depth"] == 1
+        assert snap["jobs"][0]["session_id"] == "backend-abc"
+        assert snap["is_merging"] is True
+
+        # Release and let the worker finish.
+        fn.release.set()
+        t.join(timeout=5.0)
+        assert not t.is_alive()
+
+    assert fn.calls == ["backend-abc"]
+    # Queue drained and lock released.
+    assert q.snapshot()["depth"] == 0
+    assert not q.merge_lock.locked()
+
+
+def test_do_merge_without_queue_uses_legacy_lock_path() -> None:
+    """Backwards-compat: _do_merge still works when no queue is provided.
+
+    Uses the per-repo ``merge_locks`` dict so single-agent callers and
+    existing tests continue to function unchanged.
+    """
+    session = _make_session("solo-1")
+    merge_locks: dict[Path, threading.Lock] = {}
+
+    def fake_merge(session_id: str, repo_root: Path) -> Any:
+        class _Result:
+            success = False  # don't trigger the push branch
+            conflicting_files: list[str] = []
+            error = None
+
+        return _Result()
+
+    result = _do_merge(session, Path("/tmp/repo"), merge_locks, fake_merge, merge_queue=None)
+    assert result is not None
+    assert not result.success
+    # Legacy path installs a lock for the repo root.
+    assert Path("/tmp/repo") in merge_locks
+
+
+def test_concurrent_do_merges_serialize_via_queue_fifo() -> None:
+    """Two concurrent _do_merge calls serialise through the queue in FIFO
+    order (audit-091 reproduction).  Without the fix both merges would race
+    on the ad-hoc per-repo lock with non-deterministic ordering and the
+    queue would stay empty.
+    """
+    q = MergeQueue()
+    completion_order: list[str] = []
+    completion_lock = threading.Lock()
+
+    # First-started fn holds the lock until we release it; second fn is fast.
+    blocking_fn = _RecordingMergeFn()
+
+    def fast_fn(session_id: str, repo_root: Path) -> Any:
+        class _Result:
+            success = False
+            conflicting_files: list[str] = []
+            error = None
+
+        with completion_lock:
+            completion_order.append(session_id)
+        return _Result()
+
+    def wrap_blocking(session_id: str, repo_root: Path) -> Any:
+        r = blocking_fn(session_id, repo_root)
+        with completion_lock:
+            completion_order.append(session_id)
+        return r
+
+    session_a = _make_session("agent-A", task_id="T-A")
+    session_b = _make_session("agent-B", task_id="T-B")
+
+    with patch("bernstein.core.git_ops.safe_push") as safe_push:
+        safe_push.return_value.ok = True
+        safe_push.return_value.stderr = ""
+
+        ta = threading.Thread(
+            target=_do_merge, args=(session_a, Path("/tmp/r"), {}, wrap_blocking), kwargs={"merge_queue": q}
+        )
+        tb = threading.Thread(
+            target=_do_merge, args=(session_b, Path("/tmp/r"), {}, fast_fn), kwargs={"merge_queue": q}
+        )
+
+        ta.start()
+        # Ensure A is inside its merge before B enqueues.  This pins down
+        # the enqueue order so FIFO is meaningful.
+        assert blocking_fn.in_flight.wait(timeout=2.0)
+        # Queue should show A pending and currently merging.
+        snap = q.snapshot()
+        assert snap["depth"] == 1
+        assert snap["is_merging"] is True
+        tb.start()
+        # Give B a moment to enqueue behind A.
+        time.sleep(0.05)
+        snap = q.snapshot()
+        # Now both A and B are queued, A at the head.
+        assert snap["depth"] == 2
+        assert snap["jobs"][0]["session_id"] == "agent-A"
+        assert snap["jobs"][1]["session_id"] == "agent-B"
+
+        # Release A; B should run only after A exits the submit block.
+        blocking_fn.release.set()
+        ta.join(timeout=5.0)
+        tb.join(timeout=5.0)
+        assert not ta.is_alive()
+        assert not tb.is_alive()
+
+    assert completion_order == ["agent-A", "agent-B"]
+    assert q.snapshot()["depth"] == 0


### PR DESCRIPTION
## Summary

: the `MergeQueue` was constructed in the orchestrator but nothing called `enqueue`/`dequeue`, so concurrent agent merges fell back to an ad-hoc per-repo `threading.Lock` dict in `spawner_merge`. FIFO order was not preserved, the dashboard always showed `depth=0`, and the `merge-tree` pre-conflict check had no insertion point.

- Add `MergeQueue.submit()` — a context-manager helper that enqueues a job, blocks on a `Condition` until the job reaches the head of the queue, acquires `merge_lock`, and dequeues on exit (with exception safety). Strict FIFO across threads.
- Plumb an optional `merge_queue` parameter through `spawner_merge._do_merge`, `merge_and_cleanup_worktree`, and `reap_completed_agent`. When provided, merges route through `submit()`; otherwise the legacy per-repo lock path is used (backwards-compat for single-agent runs and bare unit tests).
- `AgentSpawner.set_merge_queue()`: orchestrator wires its `MergeQueue` into the spawner right after construction.

## Test plan

- [x] `uv run ruff check <files>` — clean
- [x] `uv run ruff format --check <files>` — clean
- [x] `uv run pytest tests/unit -k "merge_queue or spawner_merge" -x -q` — **43 passed**
- [x] Related suites unaffected: `test_conflict_resolution`, `test_chaos`, `test_task_lifecycle` — 70 passed
- [x] New tests cover: concurrent merges serialise FIFO via the queue, snapshot reports `depth>0` while in-flight, exception inside the `submit()` block still drains the queue and releases the lock, empty `dequeue()` returns `None`, single-agent path still works without a queue