### PR TITLE
fix(persistence): atomic writes via temp+rename

### DIFF
--- a/src/bernstein/core/persistence/agent_checkpoint.py
+++ b/src/bernstein/core/persistence/agent_checkpoint.py
@@ -14,6 +14,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 _CHECKPOINT_FILENAME = "checkpoint.json"
 
 
@@ -55,9 +57,8 @@ def save_checkpoint(checkpoint: AgentCheckpoint, runtime_dir: Path) -> Path:
         Path to the written checkpoint file.
     """
     agent_dir = runtime_dir / "agents" / checkpoint.agent_id
-    agent_dir.mkdir(parents=True, exist_ok=True)
     path = agent_dir / _CHECKPOINT_FILENAME
-    path.write_text(json.dumps(asdict(checkpoint), sort_keys=True))
+    write_atomic_json(path, asdict(checkpoint), indent=None, sort_keys=True)
     return path
 
 

--- a/src/bernstein/core/persistence/atomic_write.py
+++ b/src/bernstein/core/persistence/atomic_write.py
@@ -101,10 +101,12 @@ def write_atomic_bytes(path: Path, data: bytes) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = _tmp_path_for(path)
     try:
+        # 0o600 — owner-only. Runtime state may carry task metadata, session
+        # tokens, or other material that should not be world-readable.
         fd = os.open(
             str(tmp),
             os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            0o644,
+            0o600,
         )
         try:
             with os.fdopen(fd, "wb") as fh:

--- a/src/bernstein/core/persistence/atomic_write.py
+++ b/src/bernstein/core/persistence/atomic_write.py
@@ -1,0 +1,164 @@
+"""Atomic file write helpers for crash-safe persistence.
+
+Writing runtime state via the naive ``path.write_text(...)`` pattern is
+non-atomic: ``open(path, 'w')`` truncates the target before any bytes are
+written, and a crash (SIGKILL, power loss) between the ``open`` and the
+final flush leaves an empty or half-written file that downstream loaders
+will misinterpret or fail on.
+
+This module centralises the crash-safe ``temp + fsync + os.replace``
+pattern for all ``.sdd/runtime/`` writes. POSIX and Windows both
+guarantee that :func:`os.replace` swaps the directory entry atomically,
+so readers see either the old contents or the new contents — never a
+torn mix.
+
+Typical usage::
+
+    from bernstein.core.persistence.atomic_write import (
+        write_atomic_bytes,
+        write_atomic_json,
+        write_atomic_text,
+    )
+
+    write_atomic_json(path, payload)
+
+Append-only JSONL files (e.g. ``replay.jsonl``, ``wal.jsonl``) should
+continue to use direct appends with ``fsync`` — per-line atomicity is
+provided by the OS at write boundaries below ``PIPE_BUF`` and the
+on-disk state is already crash-safe at line granularity.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _tmp_path_for(path: Path) -> Path:
+    """Build a unique sibling temp path for *path*.
+
+    Incorporating both the PID and ``os.urandom`` disambiguates concurrent
+    writers and interrupted previous runs so we never collide on the tmp
+    slot.
+    """
+    suffix = f".tmp.{os.getpid()}.{os.urandom(4).hex()}"
+    return path.with_name(path.name + suffix)
+
+
+def _fsync_dir(directory: Path) -> None:
+    """Fsync *directory* so the rename is durable on POSIX.
+
+    Windows does not expose directory fsync; the call is skipped there.
+    Best-effort: failures are logged at debug level only — the rename
+    itself is already atomic from the perspective of concurrent readers.
+    """
+    if os.name == "nt":
+        return
+    try:
+        fd = os.open(str(directory), os.O_RDONLY)
+    except OSError as exc:
+        logger.debug("Cannot open directory %s for fsync: %s", directory, exc)
+        return
+    try:
+        try:
+            os.fsync(fd)
+        except OSError as exc:
+            logger.debug("Cannot fsync directory %s: %s", directory, exc)
+    finally:
+        os.close(fd)
+
+
+def write_atomic_bytes(path: Path, data: bytes) -> None:
+    """Atomically write *data* to *path* via temp-file + ``os.replace``.
+
+    The sequence is:
+
+    1. Create parent directory if missing.
+    2. Write bytes to ``<path>.tmp.<pid>.<rand>`` and ``fsync`` the fd.
+    3. ``os.replace`` the temp file onto *path* (atomic rename).
+    4. ``fsync`` the containing directory so the rename is durable.
+
+    On any error the temp file is unlinked so the filesystem does not
+    accumulate stale ``.tmp.*`` entries.
+
+    Args:
+        path: Final destination file.
+        data: Byte payload to write.
+
+    Raises:
+        OSError: Propagated from the underlying filesystem calls after
+            the temp file is cleaned up. Callers that prefer silent
+            best-effort writes should catch this at the call site.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _tmp_path_for(path)
+    try:
+        fd = os.open(
+            str(tmp),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o644,
+        )
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())
+        except BaseException:
+            # os.fdopen took ownership; close is idempotent via contextmanager.
+            raise
+        os.replace(str(tmp), str(path))
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        raise
+    _fsync_dir(path.parent)
+
+
+def write_atomic_text(path: Path, data: str, *, encoding: str = "utf-8") -> None:
+    """Atomically write *data* as text to *path*.
+
+    Thin wrapper over :func:`write_atomic_bytes` that handles encoding.
+
+    Args:
+        path: Final destination file.
+        data: Text payload to write.
+        encoding: Text encoding (default UTF-8).
+    """
+    write_atomic_bytes(path, data.encode(encoding))
+
+
+def write_atomic_json(
+    path: Path,
+    payload: Any,
+    *,
+    indent: int | None = 2,
+    sort_keys: bool = False,
+    default: Any = None,
+) -> None:
+    """Atomically serialise *payload* as JSON to *path*.
+
+    Args:
+        path: Final destination file.
+        payload: JSON-serialisable value.
+        indent: JSON indent (``None`` for compact output).
+        sort_keys: Pass through to :func:`json.dumps`.
+        default: Pass through to :func:`json.dumps` for non-serialisable
+            fallbacks (e.g. ``default=str``).
+    """
+    encoded = json.dumps(payload, indent=indent, sort_keys=sort_keys, default=default)
+    write_atomic_text(path, encoded)
+
+
+__all__ = [
+    "write_atomic_bytes",
+    "write_atomic_json",
+    "write_atomic_text",
+]

--- a/src/bernstein/core/persistence/file_locks.py
+++ b/src/bernstein/core/persistence/file_locks.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import sys
 import threading
 import time

--- a/src/bernstein/core/persistence/file_locks.py
+++ b/src/bernstein/core/persistence/file_locks.py
@@ -40,6 +40,8 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import IO, TYPE_CHECKING
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
@@ -329,19 +331,16 @@ class FileLockManager:
             self._locks = {}
 
     def _save(self) -> None:
-        """Persist current lock state to disk atomically.
+        """Persist current lock state to disk atomically (audit-076, audit-077).
 
         Callers must hold the cross-process OS lock (via :meth:`_guard`).
-        The write goes to a sibling temp file and is promoted via
-        :func:`os.replace` so readers either see the old payload or the new
-        one — never a truncated mid-write document.
+        Routes through :func:`write_atomic_json` which does temp-file +
+        fsync + ``os.replace`` so readers either see the old payload or the
+        new one — never a truncated mid-write document.
         """
         try:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
             data = [asdict(lock) for lock in self._locks.values()]
-            tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
-            tmp_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
-            os.replace(tmp_path, self._path)
+            write_atomic_json(self._path, data)
         except OSError as exc:
             logger.warning("Could not persist file locks to %s: %s", self._path, exc)
 

--- a/src/bernstein/core/persistence/runtime_state.py
+++ b/src/bernstein/core/persistence/runtime_state.py
@@ -16,6 +16,8 @@ import sys
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -89,9 +91,8 @@ def rotate_log_file(log_path: Path, *, max_bytes: int = _LOG_ROTATE_BYTES) -> bo
 def write_supervisor_state(workdir: Path, snapshot: SupervisorStateSnapshot) -> Path:
     """Persist the current supervisor snapshot under ``.sdd/runtime``."""
     runtime_dir = workdir / ".sdd" / "runtime"
-    runtime_dir.mkdir(parents=True, exist_ok=True)
     path = runtime_dir / _SUPERVISOR_STATE_FILE
-    path.write_text(json.dumps(snapshot.to_dict(), indent=2), encoding="utf-8")
+    write_atomic_json(path, snapshot.to_dict())
     return path
 
 
@@ -118,9 +119,8 @@ def read_supervisor_state(sdd_dir: Path) -> SupervisorStateSnapshot | None:
 def write_session_replay_metadata(sdd_dir: Path, metadata: SessionReplayMetadata) -> Path:
     """Persist replay metadata next to the run's ``replay.jsonl`` file."""
     run_dir = sdd_dir / "runs" / metadata.run_id
-    run_dir.mkdir(parents=True, exist_ok=True)
     path = run_dir / _SESSION_METADATA_FILE
-    path.write_text(json.dumps(metadata.to_dict(), indent=2), encoding="utf-8")
+    write_atomic_json(path, metadata.to_dict())
     return path
 
 
@@ -156,7 +156,6 @@ def write_config_state(
 ) -> Path:
     """Persist the latest loaded ``bernstein.yaml`` metadata."""
     runtime_dir = sdd_dir / "runtime"
-    runtime_dir.mkdir(parents=True, exist_ok=True)
     path = runtime_dir / _CONFIG_STATE_FILE
     payload = {
         "config_hash": config_hash,
@@ -164,7 +163,7 @@ def write_config_state(
         "reloaded_at": reloaded_at,
         "last_diff": last_diff,
     }
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    write_atomic_json(path, payload)
     return path
 
 

--- a/src/bernstein/core/persistence/session.py
+++ b/src/bernstein/core/persistence/session.py
@@ -14,6 +14,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 DEFAULT_STALE_MINUTES: int = 30
 _SESSION_FILE = Path(".sdd") / "runtime" / "session.json"
 _STARTUP_GATES_FILE = Path(".sdd") / "runtime" / "startup_gates.json"
@@ -86,8 +88,7 @@ def save_session(workdir: Path, state: SessionState) -> None:
         state: Session state to persist.
     """
     session_path = workdir / _SESSION_FILE
-    session_path.parent.mkdir(parents=True, exist_ok=True)
-    session_path.write_text(json.dumps(state.to_dict(), indent=2))
+    write_atomic_json(session_path, state.to_dict())
 
 
 def load_session(
@@ -255,7 +256,7 @@ def save_checkpoint(workdir: Path, state: CheckpointState) -> Path:
     ts = int(state.timestamp)
     filename = f"{ts}-checkpoint.json"
     path = sessions_dir / filename
-    path.write_text(json.dumps(state.to_dict(), indent=2))
+    write_atomic_json(path, state.to_dict())
     return path
 
 
@@ -292,7 +293,7 @@ def save_wrapup(workdir: Path, brief: WrapUpBrief) -> Path:
     ts = int(brief.timestamp)
     filename = f"{ts}-wrapup.json"
     path = sessions_dir / filename
-    path.write_text(json.dumps(brief.to_dict(), indent=2))
+    write_atomic_json(path, brief.to_dict())
     return path
 
 
@@ -357,9 +358,8 @@ def latch_session_flags(workdir: Path, flags: dict[str, object]) -> None:
         flags: Mapping of flag name → value to latch.
     """
     latch_path = workdir / _LATCH_FILE
-    latch_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {"latched_at": time.time(), "flags": flags}
-    latch_path.write_text(json.dumps(payload, default=str), encoding="utf-8")
+    write_atomic_json(latch_path, payload, indent=None, default=str)
 
 
 def load_latched_flags(workdir: Path) -> dict[str, object]:
@@ -697,11 +697,7 @@ def save_startup_gate_checkpoints(
         checkpoints: Gate checkpoints captured at startup.
     """
     path = workdir / _STARTUP_GATES_FILE
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps([c.to_dict() for c in checkpoints], indent=2),
-        encoding="utf-8",
-    )
+    write_atomic_json(path, [c.to_dict() for c in checkpoints])
 
 
 def load_startup_gate_checkpoints(workdir: Path) -> list[StartupGateCheckpoint]:

--- a/src/bernstein/core/persistence/session_checkpoint.py
+++ b/src/bernstein/core/persistence/session_checkpoint.py
@@ -8,6 +8,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -65,7 +67,7 @@ class SessionCheckpointManager:
         timestamp = int(checkpoint.timestamp)
         checkpoint_file = self._checkpoint_dir / f"{checkpoint.session_id}_{timestamp}.json"
 
-        checkpoint_file.write_text(json.dumps(checkpoint.to_dict(), indent=2))
+        write_atomic_json(checkpoint_file, checkpoint.to_dict())
         logger.info(
             "Saved checkpoint for session %s at %s",
             checkpoint.session_id,

--- a/src/bernstein/core/persistence/session_continuity.py
+++ b/src/bernstein/core/persistence/session_continuity.py
@@ -20,6 +20,8 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.atomic_write import write_atomic_text
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -187,12 +189,8 @@ class SessionContinuityStore:
         Returns:
             Path to the written file.
         """
-        self._state_dir.mkdir(parents=True, exist_ok=True)
         path = self._snapshot_path(snapshot.session_id)
-        path.write_text(
-            json.dumps(snapshot.to_dict(), indent=2) + "\n",
-            encoding="utf-8",
-        )
+        write_atomic_text(path, json.dumps(snapshot.to_dict(), indent=2) + "\n")
         logger.info("Saved session snapshot for %s at %s", snapshot.session_id, path)
         return path
 

--- a/src/bernstein/core/persistence/team_state.py
+++ b/src/bernstein/core/persistence/team_state.py
@@ -16,6 +16,8 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -125,15 +127,13 @@ class TeamStateStore:
             return {}
 
     def _write_all(self, members: dict[str, TeamMember]) -> None:
-        """Atomically persist the full team roster."""
+        """Atomically persist the full team roster (audit-076)."""
         payload = {
             "updated_at": time.time(),
             "members": [m.to_dict() for m in members.values()],
         }
-        tmp_path = self._team_path.with_suffix(".tmp")
         try:
-            tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-            tmp_path.replace(self._team_path)
+            write_atomic_json(self._team_path, payload)
         except OSError as exc:
             logger.warning("Failed to write team state to %s: %s", self._team_path, exc)
 

--- a/src/bernstein/core/persistence/workspace.py
+++ b/src/bernstein/core/persistence/workspace.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
 if TYPE_CHECKING:
     from bernstein.core.models import Task
 
@@ -366,13 +368,12 @@ def grant_workspace_trust(workdir: Path, *, granted_by: str = "operator") -> Non
     import time
 
     trust_path = workdir / _TRUST_FILE
-    trust_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "trusted": True,
         "granted_at": time.time(),
         "granted_by": granted_by,
     }
-    trust_path.write_text(_json.dumps(payload), encoding="utf-8")
+    write_atomic_json(trust_path, payload, indent=None)
     logger.info("Workspace trust granted by '%s' at %s", granted_by, workdir)
 
 

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -212,7 +212,7 @@ def test_persistence_write_session_json_atomic(tmp_path: Path) -> None:
     session_path = tmp_path / ".sdd" / "runtime" / "session.json"
     assert session_path.exists()
     data = json.loads(session_path.read_text(encoding="utf-8"))
-    assert data["saved_at"] == 123.0
+    assert data["saved_at"] == pytest.approx(123.0)
     assert data["goal"] == "test"
     # No stray temp files.
     runtime = session_path.parent

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -1,0 +1,249 @@
+"""Unit tests for :mod:`bernstein.core.persistence.atomic_write` (audit-076).
+
+These tests cover the crash-safe persistence contract:
+
+* Repeated writes to the same path never produce a corrupt or empty
+  reader view — the file is either old-content or new-content at any
+  observation point.
+* A simulated mid-write crash (exception between temp creation and
+  ``os.replace``) cleans up the stray ``.tmp.*`` file and leaves the
+  pre-existing target intact.
+* Concurrent writers never expose a partial payload to readers —
+  every successful read returns a fully-parseable JSON document.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.core.persistence.atomic_write import (
+    write_atomic_bytes,
+    write_atomic_json,
+    write_atomic_text,
+)
+
+
+def test_atomic_write_bytes_creates_file(tmp_path: Path) -> None:
+    target = tmp_path / "runtime" / "payload.bin"
+    write_atomic_bytes(target, b"hello-world")
+    assert target.read_bytes() == b"hello-world"
+
+
+def test_atomic_write_text_encodes_utf8(tmp_path: Path) -> None:
+    target = tmp_path / "runtime" / "payload.txt"
+    write_atomic_text(target, "héllo")
+    assert target.read_text(encoding="utf-8") == "héllo"
+
+
+def test_atomic_write_json_round_trip(tmp_path: Path) -> None:
+    target = tmp_path / "runtime" / "state.json"
+    payload = {"a": 1, "b": [1, 2, 3], "c": None}
+    write_atomic_json(target, payload)
+    assert json.loads(target.read_text(encoding="utf-8")) == payload
+
+
+def test_atomic_write_json_overwrites_existing(tmp_path: Path) -> None:
+    target = tmp_path / "state.json"
+    write_atomic_json(target, {"v": 1})
+    write_atomic_json(target, {"v": 2})
+    assert json.loads(target.read_text(encoding="utf-8")) == {"v": 2}
+
+
+def test_atomic_write_leaves_no_tmp_files_on_success(tmp_path: Path) -> None:
+    """After successful write there are no stray ``.tmp.*`` siblings."""
+    target = tmp_path / "state.json"
+    write_atomic_json(target, {"v": 1})
+    write_atomic_json(target, {"v": 2})
+    leftovers = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+    assert leftovers == []
+
+
+def test_atomic_write_repeated_writes_never_corrupt(tmp_path: Path) -> None:
+    """After many repeated writes the file always parses cleanly."""
+    target = tmp_path / "state.json"
+    for i in range(100):
+        write_atomic_json(target, {"i": i, "s": "x" * i})
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["i"] == 99
+    assert data["s"] == "x" * 99
+
+
+def test_atomic_write_crash_before_replace_preserves_old(tmp_path: Path) -> None:
+    """A mid-write crash must leave the pre-existing target intact."""
+    target = tmp_path / "state.json"
+    write_atomic_json(target, {"v": "old"})
+
+    real_replace = os.replace
+
+    def boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated crash before rename")
+
+    with patch("bernstein.core.persistence.atomic_write.os.replace", side_effect=boom):
+        with pytest.raises(OSError, match="simulated crash"):
+            write_atomic_json(target, {"v": "new"})
+
+    # Old content survives the failed write.
+    assert json.loads(target.read_text(encoding="utf-8")) == {"v": "old"}
+    # Temp file was cleaned up.
+    leftovers = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+    assert leftovers == []
+    # sanity: real os.replace is unchanged
+    assert os.replace is real_replace
+
+
+def test_atomic_write_crash_during_write_cleans_tmp(tmp_path: Path) -> None:
+    """If writing to the temp file itself fails, no target is created and no tmp survives."""
+    target = tmp_path / "state.json"
+
+    original_fsync = os.fsync
+    fsync_calls: list[int] = []
+
+    def failing_fsync(fd: int) -> None:
+        fsync_calls.append(fd)
+        # Fail on the file fsync (first call), before the directory fsync.
+        raise OSError("simulated fsync failure")
+
+    with patch("bernstein.core.persistence.atomic_write.os.fsync", side_effect=failing_fsync):
+        with pytest.raises(OSError, match="simulated fsync failure"):
+            write_atomic_json(target, {"v": "new"})
+
+    assert not target.exists()
+    leftovers = [p for p in tmp_path.iterdir() if ".tmp." in p.name]
+    assert leftovers == []
+    assert fsync_calls, "fsync should have been attempted"
+    # sanity: real os.fsync is unchanged
+    assert os.fsync is original_fsync
+
+
+def test_atomic_write_tmp_path_unique_per_call(tmp_path: Path) -> None:
+    """Two concurrent writers must use distinct temp names to avoid collision."""
+    target = tmp_path / "state.json"
+
+    seen: list[str] = []
+    real_fsync = os.fsync
+
+    def observe_fsync(fd: int) -> None:
+        # Snapshot sibling .tmp.* entries each time a file fd is fsynced.
+        siblings = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+        seen.extend(siblings)
+        real_fsync(fd)
+
+    # Perform two writes serially, captured through fsync.
+    with patch("bernstein.core.persistence.atomic_write.os.fsync", side_effect=observe_fsync):
+        write_atomic_json(target, {"v": 1})
+        write_atomic_json(target, {"v": 2})
+
+    # Each call creates a uniquely-named temp sibling.
+    unique = {name for name in seen if name != "state.json"}
+    assert len(unique) >= 2
+
+
+def test_atomic_write_reads_during_concurrent_writes_see_old_or_new(tmp_path: Path) -> None:
+    """Readers running while another thread repeatedly overwrites the target
+    must always see a fully-parseable JSON document — never a partial/torn
+    write. ``os.replace`` guarantees this atomicity; this test pins the
+    behaviour against regressions that reintroduce plain ``write_text``.
+    """
+    target = tmp_path / "state.json"
+    write_atomic_json(target, {"v": 0})
+
+    stop = threading.Event()
+    errors: list[str] = []
+    observed_versions: set[int] = set()
+
+    def writer() -> None:
+        i = 1
+        while not stop.is_set():
+            try:
+                write_atomic_json(target, {"v": i, "pad": "x" * 4096})
+            except OSError as exc:  # pragma: no cover - should not happen
+                errors.append(f"write failed: {exc}")
+                return
+            i += 1
+
+    def reader() -> None:
+        while not stop.is_set():
+            try:
+                raw = target.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                errors.append(f"torn read: {exc!r} on {raw[:80]!r}")
+                return
+            v = data.get("v")
+            if isinstance(v, int):
+                observed_versions.add(v)
+
+    w = threading.Thread(target=writer)
+    readers = [threading.Thread(target=reader) for _ in range(4)]
+    w.start()
+    for r in readers:
+        r.start()
+
+    # Let them race for a short while.
+    threading.Event().wait(0.5)
+    stop.set()
+
+    w.join(timeout=5)
+    for r in readers:
+        r.join(timeout=5)
+
+    assert errors == [], f"concurrent access produced torn reads: {errors}"
+    # We should have observed many distinct versions — proves the reader/writer
+    # actually interleaved.
+    assert len(observed_versions) >= 5
+
+
+def test_persistence_write_session_json_atomic(tmp_path: Path) -> None:
+    """End-to-end check that save_session routes through the atomic helper."""
+    from bernstein.core.persistence.session import SessionState, save_session
+
+    state = SessionState(saved_at=123.0, goal="test", cost_spent=1.5)
+    save_session(tmp_path, state)
+
+    session_path = tmp_path / ".sdd" / "runtime" / "session.json"
+    assert session_path.exists()
+    data = json.loads(session_path.read_text(encoding="utf-8"))
+    assert data["saved_at"] == 123.0
+    assert data["goal"] == "test"
+    # No stray temp files.
+    runtime = session_path.parent
+    assert [p.name for p in runtime.iterdir() if ".tmp." in p.name] == []
+
+
+def test_runtime_write_supervisor_state_atomic(tmp_path: Path) -> None:
+    """write_supervisor_state uses atomic semantics and cleans tmp files."""
+    from bernstein.core.persistence.runtime_state import (
+        SupervisorStateSnapshot,
+        write_supervisor_state,
+    )
+
+    snap = SupervisorStateSnapshot(started_at=1.0, restart_count=0, current_pid=os.getpid())
+    path = write_supervisor_state(tmp_path, snap)
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["current_pid"] == os.getpid()
+    assert [p.name for p in path.parent.iterdir() if ".tmp." in p.name] == []
+
+
+def test_runtime_write_file_locks_atomic(tmp_path: Path) -> None:
+    """FileLockManager._save routes through the atomic helper."""
+    from bernstein.core.persistence.file_locks import FileLockManager
+
+    manager = FileLockManager(tmp_path)
+    conflicts = manager.acquire(["src/foo.py"], agent_id="agent-1", task_id="t1")
+    assert conflicts == []
+
+    lock_path = tmp_path / ".sdd" / "runtime" / "file_locks.json"
+    assert lock_path.exists()
+    data = json.loads(lock_path.read_text(encoding="utf-8"))
+    assert any(entry["file_path"] == "src/foo.py" for entry in data)
+    assert [p.name for p in lock_path.parent.iterdir() if ".tmp." in p.name] == []


### PR DESCRIPTION
## Summary

: ten+ call sites in `.sdd/runtime/` writers used `Path.write_text`, which truncates the target before any bytes land. A SIGKILL mid-write left empty or half-written JSON that crashed the next load — losing file locks, session state, supervisor metadata, startup-gate checkpoints, latched flags, and agent/session checkpoints.

- New helper `src/bernstein/core/persistence/atomic_write.py` with `write_atomic_bytes` / `write_atomic_text` / `write_atomic_json`. Pattern: write to `<path>.tmp.<pid>.<rand>` -> `fsync` -> `os.replace` -> `fsync` parent directory. Temp file is unlinked on any error so we never leak `.tmp.*` siblings.
- All previously non-atomic runtime writes now route through the helper: `file_locks.py`, `session.py` (session, checkpoint, wrapup, latched flags, startup gates), `runtime_state.py` (supervisor state, replay metadata, config state), `session_checkpoint.py`, `team_state.py`, `workspace.py` (trust), `agent_checkpoint.py`, `session_continuity.py`.
- Append-only JSONLs (replay, wal, bridge_lineage, etc.) are intentionally left untouched — per-line atomicity is already provided by the OS.

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` on all touched files: clean.
- [x] `uv run pytest tests/unit -k "atomic_write or persistence_write or runtime_write" -x -q` — 13/13 new tests pass.
- [x] `uv run pytest tests/unit -k "file_lock or session_state or session_checkpoint or runtime_state or team_state or workspace_trust or agent_checkpoint or session_continuity" -x -q` — 135/135 existing tests still pass (no regressions).
- [x] Tests cover: basic round-trip, overwrite semantics, no stray `.tmp.*` after success, 100-write hot loop stays uncorrupted, simulated crash before `os.replace` preserves old contents and cleans tmp, fsync failure leaves no tmp/target, unique tmp path per call, 1 writer + 4 reader threads for 500 ms observe zero torn reads, plus end-to-end smoke tests through `save_session`, `write_supervisor_state`, `FileLockManager.acquire`.

.