### PR TITLE
fix(git): add missing f-prefix in worktree stderr log

### DIFF
--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -412,8 +412,7 @@ class WorktreeManager:
             stderr = result.stderr.strip()
             if "already exists" in stderr:
                 raise WorktreeError(
-                    f"Branch '{branch_name}' already exists. "
-                    "Delete it manually or call cleanup() first. Git: {stderr}"
+                    f"Branch '{branch_name}' already exists. Delete it manually or call cleanup() first. Git: {stderr}"
                 )
             raise WorktreeError(f"git worktree add failed for session '{session_id}': {stderr}")
 

--- a/tests/unit/test_worktree.py
+++ b/tests/unit/test_worktree.py
@@ -62,6 +62,25 @@ def test_worktree_manager_create_branch_exists(manager: WorktreeManager, repo_ro
             manager.create(session_id)
 
 
+def test_worktree_manager_create_branch_exists_interpolates_stderr(manager: WorktreeManager, repo_root: Path) -> None:
+    """Regression test for audit-100: the 'Branch already exists' error must
+    interpolate the actual git stderr, not leak the literal ``{stderr}``
+    placeholder.
+    """
+    session_id = "test-session"
+    git_stderr = "fatal: 'agent/test-session' already exists — distinctive marker"
+
+    with patch("bernstein.core.git.worktree.worktree_add") as mock_add:
+        mock_add.return_value = GitResult(1, "", git_stderr)
+
+        with pytest.raises(WorktreeError) as exc_info:
+            manager.create(session_id)
+
+    message = str(exc_info.value)
+    assert "distinctive marker" in message
+    assert "{stderr}" not in message
+
+
 def test_worktree_manager_cleanup(manager: WorktreeManager, repo_root: Path) -> None:
     session_id = "test-session"
     worktree_path = repo_root / ".sdd/worktrees" / session_id


### PR DESCRIPTION
## Summary
- `WorktreeManager.create` raised `WorktreeError` with a concatenated message where only the first fragment was an f-string. The second fragment contained `{stderr}` verbatim, so the actual git stderr was never interpolated when a branch already existed.
- Added the missing `f` prefix (ruff then merged the adjacent string literals) so operators now see the real git error text.
- Added a regression test `test_worktree_manager_create_branch_exists_interpolates_stderr` that asserts the raised message contains the mocked stderr and does not contain the literal `{stderr}`.

.

## Test plan
- [x] `uv run ruff check src/bernstein/core/git/worktree.py tests/unit/test_worktree.py`
- [x] `uv run ruff format --check src/bernstein/core/git/worktree.py tests/unit/test_worktree.py`
- [x] `uv run pytest tests/unit -k "worktree" -x -q` (175 passed, 4 skipped)
- [x] `uv run pytest tests/unit/test_worktree.py::test_worktree_manager_create_branch_exists_interpolates_stderr -v` (1 passed)