### PR TITLE
fix(quality): wire QualityGateCoalescer

### DIFF
--- a/src/bernstein/core/quality/quality_gate_coalescer.py
+++ b/src/bernstein/core/quality/quality_gate_coalescer.py
@@ -1,17 +1,24 @@
-"""Trailing-run coalescence for quality gate executions.
+"""Serialized quality gate executions with per-caller result delivery.
 
-Prevents duplicate gate runs when tasks complete in rapid succession.
-The behaviour mirrors the pattern used in Claude Code's extractMemories service:
+Prevents concurrent gate runs from clobbering shared state (git index, cache
+directories, metrics files) by serializing execution through a single FIFO
+queue.  Every caller's task is validated against its own diff — no request is
+silently dropped or masked with a spurious ``passed=True``.
+
+Flow:
 
 - If no run is in progress → start immediately, set ``in_progress = True``.
-- If a run is already active → store the request as *pending* (replacing any
-  previous pending request; only the trailing run matters).
-- When the active run finishes → check for a pending request; if one exists,
-  execute exactly **one** trailing run to cover all accumulated completions.
+- If a run is already active → enqueue the request with a private
+  :class:`threading.Event` + result slot and **block** on the event.
+- When the active run finishes → pop the next queued request, execute its
+  gates, store the result in its slot, and fire its event.  The blocked caller
+  wakes up and returns its own real result.
 
-This guarantees that rapid task completions never produce more than two gate
-runs (the current run + one trailing run), regardless of how many completions
-arrive during the first run.
+Previously this class returned a lightweight ``passed=True`` for coalesced
+callers — a silent gate bypass under concurrent completions (audit-037).  The
+"trailing-run-only" optimisation is unsafe because each task has its own
+worktree and its own diff; reusing one run's result for another task means
+gates are never actually executed against the second task's changes.
 
 Usage::
 
@@ -21,8 +28,10 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import threading
+from collections import deque
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -37,19 +46,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Default timeout (seconds) a queued caller will wait for its turn before
+# giving up and failing the task.  Gate runs that legitimately exceed this
+# budget signal a deeper problem (hung subprocess, runaway tests); blocking
+# the orchestrator indefinitely is worse than surfacing the stuck gate.
+_DEFAULT_QUEUE_TIMEOUT_S: float = 900.0  # 15 minutes
+
+
 # ---------------------------------------------------------------------------
-# Internal pending-run descriptor
+# Internal queued-run descriptor
 # ---------------------------------------------------------------------------
 
 
 @dataclass
-class _PendingRun:
-    """A queued gate run request waiting for the in-progress run to finish."""
+class _QueuedRun:
+    """A queued gate run waiting for the in-progress run to finish.
+
+    Each queued caller owns a private :class:`threading.Event` and a result
+    slot.  When the coalescer pops this entry, it runs gates for ``task``,
+    writes the outcome to ``result`` (or the raised exception to ``error``),
+    and sets ``event`` to wake the caller.
+    """
 
     task: Task
     run_dir: Path
     workdir: Path
     kwargs: dict[str, Any] = field(default_factory=dict[str, Any])
+    event: threading.Event = field(default_factory=threading.Event)
+    result: QualityGatesResult | None = None
+    error: BaseException | None = None
+
+
+# Back-compat alias: older call sites / tests referenced ``_PendingRun``.
+# Kept as an alias so imports continue to work while the semantics are
+# expressed through :class:`_QueuedRun`.
+_PendingRun = _QueuedRun
 
 
 # ---------------------------------------------------------------------------
@@ -58,23 +89,22 @@ class _PendingRun:
 
 
 class QualityGateCoalescer:
-    """Coalesces quality gate runs to prevent duplicate execution.
+    """Serializes quality gate runs, one task at a time, FIFO order.
 
-    When tasks complete in rapid succession, multiple calls to
-    :func:`~bernstein.core.quality_gates.run_quality_gates` would execute
-    concurrently.  This class ensures that only one run is active at a time
-    and that any requests arriving during an active run are merged into a
-    single trailing run after the current one completes.
+    Concurrent calls to :meth:`run` are queued; each request blocks until its
+    turn, then executes gates against its own task and returns its own real
+    :class:`~bernstein.core.quality_gates.QualityGatesResult`.
 
     Attributes:
         in_progress: ``True`` when a gate run is currently executing.
-        pending_count: Number of requests coalesced into the next trailing run.
+        pending_count: Number of queued callers waiting for their turn.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, queue_timeout_s: float = _DEFAULT_QUEUE_TIMEOUT_S) -> None:
         self._lock = threading.Lock()
         self._in_progress: bool = False
-        self._pending: _PendingRun | None = None
+        self._queue: deque[_QueuedRun] = deque()
+        self._queue_timeout_s = queue_timeout_s
 
     # ------------------------------------------------------------------
     # Properties (thread-safe reads)
@@ -88,9 +118,25 @@ class QualityGateCoalescer:
 
     @property
     def pending_count(self) -> int:
-        """1 if a trailing run is queued, 0 otherwise."""
+        """Number of callers currently queued behind the active run."""
         with self._lock:
-            return 1 if self._pending is not None else 0
+            return len(self._queue)
+
+    # Back-compat for tests/callers that peeked at ``_pending``: expose the
+    # tail of the queue (the most recently enqueued request), or ``None``.
+    @property
+    def _pending(self) -> _QueuedRun | None:
+        with self._lock:
+            return self._queue[-1] if self._queue else None
+
+    @_pending.setter
+    def _pending(self, value: _QueuedRun | None) -> None:
+        # Test-only hook: assign ``None`` to clear the queue, or a single
+        # :class:`_QueuedRun` to seed the queue with one entry.
+        with self._lock:
+            self._queue.clear()
+            if value is not None:
+                self._queue.append(value)
 
     # ------------------------------------------------------------------
     # Public API
@@ -104,13 +150,12 @@ class QualityGateCoalescer:
         config: QualityGatesConfig,
         **kwargs: Any,
     ) -> QualityGatesResult:
-        """Run quality gates with trailing-run coalescence.
+        """Run quality gates, serialized across concurrent callers.
 
-        If no run is in progress, the gate run starts immediately.  If a run
-        is already active, this request is coalesced into a pending slot; the
-        *caller receives a no-op pass result* rather than blocking, and the
-        trailing run will execute on behalf of this (and any other coalesced)
-        request when the active run finishes.
+        If no run is in progress, execute immediately.  Otherwise, enqueue
+        the request and block on a per-caller event until its turn comes
+        up, then return the real :class:`QualityGatesResult` for *this*
+        caller's task.
 
         Args:
             task: The completed task to validate.
@@ -121,55 +166,95 @@ class QualityGateCoalescer:
                 :func:`~bernstein.core.quality_gates.run_quality_gates`.
 
         Returns:
-            :class:`~bernstein.core.quality_gates.QualityGatesResult` for the
-            gate run that executed.  When coalesced, returns a lightweight
-            pass result for the caller so it is never blocked.
+            The actual :class:`~bernstein.core.quality_gates.QualityGatesResult`
+            produced by running gates against ``task``.
+
+        Raises:
+            TimeoutError: If the caller has been queued longer than
+                ``queue_timeout_s`` without its turn coming up.
         """
         with self._lock:
             if self._in_progress:
-                # Coalesce: replace any existing pending slot with the latest request
-                self._pending = _PendingRun(task=task, run_dir=run_dir, workdir=workdir, kwargs=kwargs)
+                queued = _QueuedRun(task=task, run_dir=run_dir, workdir=workdir, kwargs=kwargs)
+                self._queue.append(queued)
                 logger.debug(
-                    "quality_gate_coalescer: run in progress — coalesced task=%s into pending slot",
+                    "quality_gate_coalescer: run in progress — queued task=%s at position %d",
                     task.id,
+                    len(self._queue),
                 )
-                # Return a lightweight pass so the caller is not blocked
-                return QualityGatesResult(task_id=task.id, passed=True)
+            else:
+                # No run in progress — claim the slot and run immediately.
+                self._in_progress = True
+                queued = None
 
-            # No run in progress — claim the slot and run immediately
-            self._in_progress = True
+        if queued is not None:
+            return self._wait_for_queued(queued)
 
-        result = self._execute(task, run_dir, workdir, config, **kwargs)
-
-        # After the run, check for a coalesced trailing request
-        with self._lock:
-            pending = self._pending
-            self._pending = None
-            if pending is None:
-                self._in_progress = False
-
-        if pending is not None:
-            logger.info(
-                "quality_gate_coalescer: executing trailing run for coalesced task=%s",
-                pending.task.id,
-            )
-            try:
-                result = self._execute(
-                    pending.task,
-                    pending.run_dir,
-                    pending.workdir,
-                    config,
-                    **pending.kwargs,
-                )
-            finally:
-                with self._lock:
-                    self._in_progress = False
+        # We are the active runner — execute our own task, then drain the queue.
+        try:
+            result = self._execute(task, run_dir, workdir, config, **kwargs)
+        finally:
+            self._drain_queue(config)
 
         return result
 
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _wait_for_queued(self, queued: _QueuedRun) -> QualityGatesResult:
+        """Block until ``queued`` is serviced and return its result.
+
+        Raises:
+            TimeoutError: If the configured queue timeout elapses.
+            BaseException: Re-raises any exception captured by the runner.
+        """
+        if not queued.event.wait(timeout=self._queue_timeout_s):
+            # Best-effort cleanup: remove the entry so it isn't executed later.
+            with self._lock, contextlib.suppress(ValueError):
+                # ValueError means the runner already popped us — benign race.
+                self._queue.remove(queued)
+            raise TimeoutError(
+                f"quality_gate_coalescer: task {queued.task.id} timed out "
+                f"after {self._queue_timeout_s:.0f}s waiting for gate slot",
+            )
+
+        if queued.error is not None:
+            # Preserve the original traceback when re-raising.
+            raise queued.error
+        # Invariant: event set ⇒ either result or error was populated.
+        assert queued.result is not None
+        return queued.result
+
+    def _drain_queue(self, config: QualityGatesConfig) -> None:
+        """Service queued requests FIFO.  Each runs with its own parameters."""
+        while True:
+            with self._lock:
+                if not self._queue:
+                    self._in_progress = False
+                    return
+                queued = self._queue.popleft()
+
+            logger.info(
+                "quality_gate_coalescer: servicing queued task=%s (queue_depth_after=%d)",
+                queued.task.id,
+                len(self._queue),
+            )
+            try:
+                queued.result = self._execute(
+                    queued.task,
+                    queued.run_dir,
+                    queued.workdir,
+                    config,
+                    **queued.kwargs,
+                )
+            except BaseException as exc:
+                # Capture ANY exception (including KeyboardInterrupt/SystemExit-adjacent
+                # runtime errors from subprocess gates) so the blocked caller receives
+                # it rather than hanging forever on its event.
+                queued.error = exc
+            finally:
+                queued.event.set()
 
     def _execute(
         self,
@@ -179,6 +264,6 @@ class QualityGateCoalescer:
         config: QualityGatesConfig,
         **kwargs: Any,
     ) -> QualityGatesResult:
-        """Call run_quality_gates and return the result."""
+        """Call ``run_quality_gates`` and return the result."""
         logger.debug("quality_gate_coalescer: executing gate run for task=%s", task.id)
         return run_quality_gates(task, run_dir, workdir, config, **kwargs)

--- a/tests/unit/test_quality_gate_coalescer.py
+++ b/tests/unit/test_quality_gate_coalescer.py
@@ -1,13 +1,21 @@
-"""Tests for trailing-run coalescence in quality gates (quality_gate_coalescer.py)."""
+"""Tests for serialized gate execution in :mod:`quality_gate_coalescer`.
+
+Regression coverage for **audit-037**: prior to the fix, a second caller
+arriving during an active gate run received ``passed=True`` with an empty
+``gate_results`` list — a silent bypass.  The coalescer now serializes all
+callers through a FIFO queue and returns each caller its own real result.
+"""
 
 from __future__ import annotations
 
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from bernstein.core.models import Complexity, Scope, Task
-from bernstein.core.quality_gate_coalescer import QualityGateCoalescer, _PendingRun
+from bernstein.core.quality_gate_coalescer import QualityGateCoalescer, _PendingRun, _QueuedRun
 from bernstein.core.quality_gates import QualityGatesConfig, QualityGatesResult
 
 # ---------------------------------------------------------------------------
@@ -97,126 +105,238 @@ class TestSingleRun:
 
 
 # ---------------------------------------------------------------------------
-# Coalescence during active run
+# Serialization under contention (audit-037 regression)
 # ---------------------------------------------------------------------------
 
 
-class TestCoalescence:
-    def test_coalesced_request_returns_pass_immediately(self, tmp_path: Path) -> None:
-        """A request arriving during an active run returns a lightweight pass result."""
-        coalescer = QualityGateCoalescer()
-        # Manually set in_progress without holding the lock (safe in tests)
-        coalescer._in_progress = True
-
-        task = _make_task("T-002")
-        config = QualityGatesConfig(enabled=False)
-        result = coalescer.run(task, tmp_path, tmp_path, config)
-
-        assert result.passed
-        assert result.task_id == "T-002"
-        assert coalescer.pending_count == 1
-
-    def test_only_latest_pending_request_kept(self, tmp_path: Path) -> None:
-        """Multiple coalesced requests replace each other — only the latest is kept."""
-        coalescer = QualityGateCoalescer()
-        coalescer._in_progress = True
-
-        config = QualityGatesConfig(enabled=False)
-        for i in range(5):
-            coalescer.run(_make_task(f"T-{i:03d}"), tmp_path, tmp_path, config)
-
-        assert coalescer.pending_count == 1
-        assert coalescer._pending is not None
-        assert coalescer._pending.task.id == "T-004"  # last one wins
-
-    def test_rapid_completions_produce_one_trailing_run(self, tmp_path: Path) -> None:
-        """When tasks complete rapidly, only ONE trailing run is performed."""
+class TestSerializedExecution:
+    def test_each_queued_request_runs_its_own_gates(self, tmp_path: Path) -> None:
+        """Every concurrent caller must get its OWN task's gate result — no silent bypass."""
         config = QualityGatesConfig(enabled=False)
         call_log: list[str] = []
+        first_started = threading.Event()
+        release_first = threading.Event()
+        log_lock = threading.Lock()
 
-        coalescer = QualityGateCoalescer()
-        barrier = threading.Barrier(2)
-        first_run_released = threading.Event()
-
-        def slow_run_qg(
+        def fake_run_qg(
             task: Task, run_dir: Path, workdir: Path, cfg: QualityGatesConfig, **kw: object
         ) -> QualityGatesResult:
-            call_log.append(task.id)
-            barrier.wait(timeout=5)  # signal: first run started
-            first_run_released.wait(timeout=5)  # wait: coalesced tasks queued
-            return _pass_result(task.id)
-
-        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=slow_run_qg):
-            coalescer_thread_result: list[QualityGatesResult] = []
-
-            def run_first() -> None:
-                result = coalescer.run(_make_task("T-first"), tmp_path, tmp_path, config)
-                coalescer_thread_result.append(result)
-
-            t = threading.Thread(target=run_first, daemon=True)
-            t.start()
-
-            # Wait until the first run has started
-            barrier.wait(timeout=5)
-
-            # These arrive while first run is active — should all coalesce into one slot
-            for i in range(3):
-                coalescer.run(_make_task(f"T-rapid-{i}"), tmp_path, tmp_path, config)
-
-            # Release the first run to finish
-            first_run_released.set()
-            t.join(timeout=10)
-
-        # First run + exactly ONE trailing run = 2 total calls
-        assert len(call_log) == 2, f"Expected 2 calls, got {len(call_log)}: {call_log}"
-        assert call_log[0] == "T-first"
-        assert call_log[1] == "T-rapid-2"  # last coalesced task
-
-    def test_state_clean_after_trailing_run(self, tmp_path: Path) -> None:
-        """After the trailing run completes, in_progress is False and pending is 0."""
-        config = QualityGatesConfig(enabled=False)
-        coalescer = QualityGateCoalescer()
-
-        calls: list[str] = []
-
-        barrier = threading.Barrier(2)
-        released = threading.Event()
-
-        def slow_run(
-            task: Task, run_dir: Path, workdir: Path, cfg: QualityGatesConfig, **kw: object
-        ) -> QualityGatesResult:
-            calls.append(task.id)
+            with log_lock:
+                call_log.append(task.id)
             if task.id == "T-first":
-                barrier.wait(timeout=5)
-                released.wait(timeout=5)
+                first_started.set()
+                release_first.wait(timeout=5)
             return _pass_result(task.id)
 
-        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=slow_run):
-            t = threading.Thread(
-                target=coalescer.run, args=(_make_task("T-first"), tmp_path, tmp_path, config), daemon=True
-            )
-            t.start()
-            barrier.wait(timeout=5)
-            coalescer.run(_make_task("T-pending"), tmp_path, tmp_path, config)
-            released.set()
-            t.join(timeout=10)
+        coalescer = QualityGateCoalescer()
+        results: dict[str, QualityGatesResult] = {}
+        threads: list[threading.Thread] = []
+
+        def invoke(task_id: str) -> None:
+            results[task_id] = coalescer.run(_make_task(task_id), tmp_path, tmp_path, config)
+
+        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=fake_run_qg):
+            first_thread = threading.Thread(target=invoke, args=("T-first",), daemon=True)
+            first_thread.start()
+            assert first_started.wait(timeout=5)
+
+            for i in range(3):
+                t = threading.Thread(target=invoke, args=(f"T-q-{i}",), daemon=True)
+                t.start()
+                threads.append(t)
+
+            # Give queued threads a moment to actually enqueue.
+            time.sleep(0.05)
+            assert coalescer.pending_count == 3
+
+            release_first.set()
+            first_thread.join(timeout=10)
+            for t in threads:
+                t.join(timeout=10)
+
+        # Every task got its own real gate run.
+        assert sorted(call_log) == ["T-first", "T-q-0", "T-q-1", "T-q-2"]
+        # Every caller received a result tagged with its own task id.
+        for task_id in ("T-first", "T-q-0", "T-q-1", "T-q-2"):
+            assert results[task_id].task_id == task_id
+            assert results[task_id].passed
+
+    def test_queued_caller_receives_fail_result_not_silent_pass(self, tmp_path: Path) -> None:
+        """If a queued caller's own gate run fails, the fail result propagates — no bypass."""
+        config = QualityGatesConfig(enabled=False)
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def fake_run_qg(
+            task: Task, run_dir: Path, workdir: Path, cfg: QualityGatesConfig, **kw: object
+        ) -> QualityGatesResult:
+            if task.id == "T-first":
+                first_started.set()
+                release_first.wait(timeout=5)
+                return _pass_result(task.id)
+            # Queued task fails its gates.
+            return _fail_result(task.id)
+
+        coalescer = QualityGateCoalescer()
+        results: dict[str, QualityGatesResult] = {}
+
+        def invoke(task_id: str) -> None:
+            results[task_id] = coalescer.run(_make_task(task_id), tmp_path, tmp_path, config)
+
+        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=fake_run_qg):
+            t1 = threading.Thread(target=invoke, args=("T-first",), daemon=True)
+            t1.start()
+            assert first_started.wait(timeout=5)
+
+            t2 = threading.Thread(target=invoke, args=("T-queued",), daemon=True)
+            t2.start()
+            # Ensure T-queued has actually enqueued before we release T-first.
+            for _ in range(100):
+                if coalescer.pending_count >= 1:
+                    break
+                time.sleep(0.01)
+
+            release_first.set()
+            t1.join(timeout=10)
+            t2.join(timeout=10)
+
+        assert results["T-first"].passed is True
+        # Critical regression assertion: queued caller gets its REAL fail result,
+        # not a silent passed=True.
+        assert results["T-queued"].passed is False
+        assert results["T-queued"].task_id == "T-queued"
+
+    def test_fifo_order_of_execution(self, tmp_path: Path) -> None:
+        """Queued callers run in the order they enqueued."""
+        config = QualityGatesConfig(enabled=False)
+        call_log: list[str] = []
+        log_lock = threading.Lock()
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def fake_run_qg(
+            task: Task, run_dir: Path, workdir: Path, cfg: QualityGatesConfig, **kw: object
+        ) -> QualityGatesResult:
+            with log_lock:
+                call_log.append(task.id)
+            if task.id == "T-first":
+                first_started.set()
+                release_first.wait(timeout=5)
+            return _pass_result(task.id)
+
+        coalescer = QualityGateCoalescer()
+
+        def invoke(task_id: str) -> None:
+            coalescer.run(_make_task(task_id), tmp_path, tmp_path, config)
+
+        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=fake_run_qg):
+            t0 = threading.Thread(target=invoke, args=("T-first",), daemon=True)
+            t0.start()
+            assert first_started.wait(timeout=5)
+
+            ordered = [f"T-{i:02d}" for i in range(4)]
+            threads: list[threading.Thread] = []
+            for task_id in ordered:
+                t = threading.Thread(target=invoke, args=(task_id,), daemon=True)
+                t.start()
+                threads.append(t)
+                # Tiny spacing so enqueue order is deterministic.
+                time.sleep(0.02)
+
+            release_first.set()
+            t0.join(timeout=10)
+            for t in threads:
+                t.join(timeout=10)
+
+        assert call_log[0] == "T-first"
+        assert call_log[1:] == ordered  # FIFO
+
+    def test_state_clean_after_queue_drained(self, tmp_path: Path) -> None:
+        """After all queued callers finish, in_progress is False and queue is empty."""
+        config = QualityGatesConfig(enabled=False)
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def fake_run_qg(
+            task: Task, run_dir: Path, workdir: Path, cfg: QualityGatesConfig, **kw: object
+        ) -> QualityGatesResult:
+            if task.id == "T-first":
+                first_started.set()
+                release_first.wait(timeout=5)
+            return _pass_result(task.id)
+
+        coalescer = QualityGateCoalescer()
+
+        def invoke(task_id: str) -> None:
+            coalescer.run(_make_task(task_id), tmp_path, tmp_path, config)
+
+        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=fake_run_qg):
+            t0 = threading.Thread(target=invoke, args=("T-first",), daemon=True)
+            t0.start()
+            assert first_started.wait(timeout=5)
+
+            t1 = threading.Thread(target=invoke, args=("T-queued",), daemon=True)
+            t1.start()
+            for _ in range(100):
+                if coalescer.pending_count >= 1:
+                    break
+                time.sleep(0.01)
+
+            release_first.set()
+            t0.join(timeout=10)
+            t1.join(timeout=10)
 
         assert not coalescer.in_progress
         assert coalescer.pending_count == 0
 
+    def test_queue_timeout_raises_timeout_error(self, tmp_path: Path) -> None:
+        """A queued caller that waits beyond the timeout raises ``TimeoutError``."""
+        config = QualityGatesConfig(enabled=False)
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def fake_run_qg(
+            task: Task, run_dir: Path, workdir: Path, cfg: QualityGatesConfig, **kw: object
+        ) -> QualityGatesResult:
+            first_started.set()
+            release_first.wait(timeout=5)
+            return _pass_result(task.id)
+
+        # Aggressive timeout so the test is fast.
+        coalescer = QualityGateCoalescer(queue_timeout_s=0.1)
+
+        with patch("bernstein.core.quality.quality_gate_coalescer.run_quality_gates", side_effect=fake_run_qg):
+            t0 = threading.Thread(
+                target=coalescer.run,
+                args=(_make_task("T-first"), tmp_path, tmp_path, config),
+                daemon=True,
+            )
+            t0.start()
+            assert first_started.wait(timeout=5)
+
+            with pytest.raises(TimeoutError, match="T-queued"):
+                coalescer.run(_make_task("T-queued"), tmp_path, tmp_path, config)
+
+            release_first.set()
+            t0.join(timeout=5)
+
 
 # ---------------------------------------------------------------------------
-# _PendingRun dataclass
+# Back-compat internals
 # ---------------------------------------------------------------------------
 
 
-class TestPendingRun:
-    def test_pending_run_stores_task(self, tmp_path: Path) -> None:
+class TestQueuedRunDataclass:
+    def test_queued_run_stores_task(self, tmp_path: Path) -> None:
         task = _make_task("T-99")
-        pr = _PendingRun(task=task, run_dir=tmp_path, workdir=tmp_path)
+        pr = _QueuedRun(task=task, run_dir=tmp_path, workdir=tmp_path)
         assert pr.task.id == "T-99"
 
-    def test_pending_run_default_kwargs(self, tmp_path: Path) -> None:
+    def test_queued_run_default_kwargs(self, tmp_path: Path) -> None:
         task = _make_task()
-        pr = _PendingRun(task=task, run_dir=tmp_path, workdir=tmp_path)
+        pr = _QueuedRun(task=task, run_dir=tmp_path, workdir=tmp_path)
         assert pr.kwargs == {}
+
+    def test_pending_run_alias_is_queued_run(self) -> None:
+        """Legacy ``_PendingRun`` symbol resolves to :class:`_QueuedRun`."""
+        assert _PendingRun is _QueuedRun


### PR DESCRIPTION
## Summary

: `QualityGateCoalescer` previously returned `passed=True` with an empty `gate_results` list for any caller arriving during an active gate run. Under concurrent task completions this was a **silent gate bypass** — a second task could merge even with lint/type/test failures because its diff was never actually checked.

## Change

- Replaced the trailing-run-only optimisation with **FIFO serialization**. Concurrent callers are queued on a thread-safe `deque`; each has its own `threading.Event` and result slot, blocks until its turn, and returns a real `QualityGatesResult` computed against its own task's diff.
- Exceptions raised by the underlying `run_quality_gates` are captured and re-raised on the blocked caller (no deadlock on subprocess failures).
- A queued caller that waits past the configurable `queue_timeout_s` (default 15 min) raises `TimeoutError` instead of hanging the orchestrator.
- Back-compat: `_PendingRun` remains exported as an alias for `_QueuedRun`, and the `_pending` getter/setter hook still works for existing callers/tests.
- No changes needed in `task_lifecycle.py` or `orchestrator.py` — they already call `coalescer.run(...)` and consume the returned result.

## Test plan

- [x] `uv run ruff check src/bernstein/core/quality/quality_gate_coalescer.py tests/unit/test_quality_gate_coalescer.py`
- [x] `uv run ruff format --check …`
- [x] `uv run pytest tests/unit -k "gate_coalescer or coalesce" -x -q` — **15 passed** (existing single-run coverage + new contention/FIFO/fail-propagation/timeout regressions)
- [ ] CI full suite