### PR TITLE
fix(adapters): bump opus → claude-opus-4-7 across aider/amp/cody/goose

### DIFF
--- a/src/bernstein/adapters/aider.py
+++ b/src/bernstein/adapters/aider.py
@@ -16,8 +16,10 @@ from bernstein.adapters.env_isolation import build_filtered_env
 # Map Bernstein short model names to aider model identifiers.
 # Aider accepts provider-prefixed names (e.g. "openai/gpt-5.4", "anthropic/claude-3-5-sonnet").
 # Short names are mapped to the most common aider-compatible IDs; unknown names pass through.
+# Updated 2026-04-17 (audit-140) — keep Opus alias in sync with claude.py canonical ID.
 _MODEL_MAP: dict[str, str] = {
-    "opus": "anthropic/claude-opus-4-6",
+    "opus": "anthropic/claude-opus-4-7",
+    "opus-4-6": "anthropic/claude-opus-4-6",  # pinned fallback
     "sonnet": "anthropic/claude-sonnet-4-6",
     "haiku": "anthropic/claude-haiku-4-5-20251001",
     "gpt-5.4": "openai/gpt-5.4",

--- a/src/bernstein/adapters/amp.py
+++ b/src/bernstein/adapters/amp.py
@@ -16,8 +16,10 @@ from bernstein.adapters.env_isolation import build_filtered_env
 # Map Bernstein short model names to Amp model identifiers.
 # Amp accepts provider-prefixed names (e.g. "anthropic:claude-sonnet-4-6", "openai:gpt-5.4").
 # Short names are mapped to the most common Amp-compatible IDs; unknown names pass through.
+# Updated 2026-04-17 (audit-140) — keep Opus alias in sync with claude.py canonical ID.
 _MODEL_MAP: dict[str, str] = {
-    "opus": "anthropic:claude-opus-4-6",
+    "opus": "anthropic:claude-opus-4-7",
+    "opus-4-6": "anthropic:claude-opus-4-6",  # pinned fallback
     "sonnet": "anthropic:claude-sonnet-4-6",
     "haiku": "anthropic:claude-haiku-4-5-20251001",
     "gpt-5.4": "openai:gpt-5.4",

--- a/src/bernstein/adapters/cody.py
+++ b/src/bernstein/adapters/cody.py
@@ -28,8 +28,10 @@ logger = logging.getLogger(__name__)
 
 # Map Bernstein logical model names to Cody model identifiers.
 # Cody uses Sourcegraph model IDs in the form ``provider::version::model``.
+# Updated 2026-04-17 (audit-140) — keep Opus alias in sync with claude.py canonical ID.
 _MODEL_MAP: dict[str, str] = {
-    "opus": "anthropic::2025-05-14::claude-opus-4-6",
+    "opus": "anthropic::2025-05-14::claude-opus-4-7",
+    "opus-4-6": "anthropic::2025-05-14::claude-opus-4-6",  # pinned fallback
     "sonnet": "anthropic::2025-05-14::claude-sonnet-4-6",
     "haiku": "anthropic::2024-10-22::claude-haiku-4-5-20251001",
     "gpt-5.4": "openai::2026-03-05::gpt-5.4",

--- a/src/bernstein/adapters/goose.py
+++ b/src/bernstein/adapters/goose.py
@@ -26,8 +26,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Model mapping: Bernstein logical names → Goose model IDs
+# Updated 2026-04-17 (audit-140) — keep Opus alias in sync with claude.py canonical ID.
 _MODEL_MAP: dict[str, str] = {
-    "opus": "claude-opus-4-6",
+    "opus": "claude-opus-4-7",
+    "opus-4-6": "claude-opus-4-6",  # pinned fallback
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5-20251001",
 }

--- a/tests/unit/test_adapter_aider.py
+++ b/tests/unit/test_adapter_aider.py
@@ -95,7 +95,7 @@ class TestAiderAdapterSpawn:
                 session_id="aider-s4",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert inner[inner.index("--model") + 1] == "anthropic/claude-opus-4-6"
+        assert inner[inner.index("--model") + 1] == "anthropic/claude-opus-4-7"
 
     def test_unknown_model_passes_through(self, tmp_path: Path) -> None:
         adapter = AiderAdapter()

--- a/tests/unit/test_adapter_amp.py
+++ b/tests/unit/test_adapter_amp.py
@@ -90,7 +90,7 @@ class TestAmpAdapterSpawn:
                 session_id="amp-s3",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert inner[inner.index("--model") + 1] == "anthropic:claude-opus-4-6"
+        assert inner[inner.index("--model") + 1] == "anthropic:claude-opus-4-7"
 
     def test_model_map_haiku(self, tmp_path: Path) -> None:
         adapter = AmpAdapter()

--- a/tests/unit/test_adapter_stale_model_ids.py
+++ b/tests/unit/test_adapter_stale_model_ids.py
@@ -1,0 +1,71 @@
+"""Cross-adapter model_id consistency checks (audit-140).
+
+These tests guard against model-id drift between the Claude adapter — which
+owns the canonical Opus pin — and the secondary adapters that wrap other
+CLI tools (aider, amp, cody, goose).  Whenever the Claude adapter bumps
+``opus`` to a new generation, the secondary adapters must follow in the
+form each tool expects.
+
+Rules enforced:
+
+1. Every adapter's ``opus`` alias resolves to an identifier containing
+   the canonical Opus generation string (``claude-opus-4-7``).
+2. No adapter references the previous generation (``claude-opus-4-6``)
+   anywhere in ``_MODEL_MAP`` *except* via an explicit ``opus-4-6``
+   pinned-fallback key.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.adapters.aider import _MODEL_MAP as AIDER_MAP
+from bernstein.adapters.amp import _MODEL_MAP as AMP_MAP
+from bernstein.adapters.claude import _MODEL_MAP as CLAUDE_MAP
+from bernstein.adapters.cody import _MODEL_MAP as CODY_MAP
+from bernstein.adapters.goose import _MODEL_MAP as GOOSE_MAP
+
+# Canonical identifier segment every Anthropic-capable adapter must pin for
+# ``opus``.  Bump this string together with ``claude.py::_MODEL_MAP["opus"]``.
+CURRENT_OPUS = "claude-opus-4-7"
+PREVIOUS_OPUS = "claude-opus-4-6"
+
+# Anthropic-capable adapters (exclude openai/gemini-only providers).
+ANTHROPIC_ADAPTERS: dict[str, dict[str, str]] = {
+    "claude": CLAUDE_MAP,
+    "aider": AIDER_MAP,
+    "amp": AMP_MAP,
+    "cody": CODY_MAP,
+    "goose": GOOSE_MAP,
+}
+
+
+@pytest.mark.parametrize(("name", "model_map"), list(ANTHROPIC_ADAPTERS.items()))
+def test_opus_alias_points_to_current_generation(name: str, model_map: dict[str, str]) -> None:
+    """Every adapter's ``opus`` alias must resolve to the current Opus ID."""
+    assert "opus" in model_map, f"{name} adapter missing 'opus' alias"
+    resolved = model_map["opus"]
+    assert CURRENT_OPUS in resolved, (
+        f"{name} adapter 'opus' alias resolves to {resolved!r}, expected to contain {CURRENT_OPUS!r}. "
+        "Bump the adapter to match claude.py's canonical Opus pin."
+    )
+
+
+@pytest.mark.parametrize(("name", "model_map"), list(ANTHROPIC_ADAPTERS.items()))
+def test_no_stale_opus_except_pinned_fallback(name: str, model_map: dict[str, str]) -> None:
+    """Previous-gen Opus may appear only under the explicit ``opus-4-6`` key."""
+    offenders: list[tuple[str, str]] = []
+    for alias, model_id in model_map.items():
+        if PREVIOUS_OPUS in model_id and alias != "opus-4-6":
+            offenders.append((alias, model_id))
+    assert not offenders, (
+        f"{name} adapter has stale {PREVIOUS_OPUS} references outside the pinned fallback: {offenders}. "
+        "Only the 'opus-4-6' alias is allowed to pin the previous generation."
+    )
+
+
+def test_opus_ids_agree_on_generation_across_adapters() -> None:
+    """All Anthropic-capable adapters agree on the same Opus generation."""
+    pins = {name: mp["opus"] for name, mp in ANTHROPIC_ADAPTERS.items()}
+    mismatches = {name: pin for name, pin in pins.items() if CURRENT_OPUS not in pin}
+    assert not mismatches, f"Adapters disagree on Opus generation (expected {CURRENT_OPUS}): {mismatches}"


### PR DESCRIPTION
## Summary

The Claude adapter bumped its canonical `opus` pin to `claude-opus-4-7` on 2026-04-16, but the secondary adapters (aider, amp, cody, goose) kept pointing `opus` at `claude-opus-4-6`. Mixed runs therefore got silent, inconsistent downgrades.

- Bump `_MODEL_MAP["opus"]` in `aider.py`, `amp.py`, `cody.py`, `goose.py` to the 4-7 generation in the form each CLI expects.
- Add an explicit `opus-4-6` pinned-fallback alias in each adapter, mirroring `claude.py`, so callers can still opt into the previous generation deliberately.
- Add `tests/unit/test_adapter_stale_model_ids.py`: asserts every Anthropic-capable adapter's `opus` alias resolves to the current Opus generation and that no adapter carries `claude-opus-4-6` outside the explicit `opus-4-6` fallback key — catching future drift automatically.
- Update existing aider/amp adapter unit tests to the new 4-7 identifier.

Closes `.sdd/backlog/open/-stale-model-ids.yaml`.

## Test plan

- [x] `uv run ruff check` on the four adapters + new test — passes.
- [x] `uv run ruff format --check` — passes.
- [x] `uv run pytest tests/unit -k "model_id or model_map or stale_model" -x -q` — 19 passed.
- [ ] CI green on PR.