### PR TITLE
fix(server): include all routers under /api/v1

### DIFF
--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -690,162 +690,94 @@ def create_app(
 
     # WEB-011: Paginated task search — must precede tasks_router so /tasks/search
     # is matched before /tasks/{task_id}.
-    from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
-
-    application.include_router(paginated_tasks_router)
-
-    # Mount routers
-    application.include_router(agents_router)
-    application.include_router(auth_router)
-    application.include_router(tasks_router)
-    application.include_router(status_router)
-    application.include_router(workspace_router)
-    application.include_router(webhooks_router)
-    application.include_router(discord_router)
-    application.include_router(slack_router)
-    application.include_router(costs_router)
-    application.include_router(dashboard_router)
-    application.include_router(team_dashboard_router)
-    application.include_router(graph_router)
-    application.include_router(observability_router)
-    application.include_router(quality_router)
-
-    # Per-file code health score routes
-    from bernstein.core.routes.file_health import router as file_health_router
-
-    application.include_router(file_health_router)
-
-    # Graceful drain routes — freeze/unfreeze claim acceptance
-    from bernstein.core.routes.drain import router as drain_router
-
-    application.include_router(drain_router)
-
-    # Agent identity lifecycle routes
-    from bernstein.core.routes.identities import router as identities_router
-
-    application.include_router(identities_router)
-
-    # ACP (Agent Communication Protocol) routes — editor ecosystem visibility
     from bernstein.core.routes.acp import router as acp_router
-
-    application.include_router(acp_router)
-
-    # Approval routes for interactive TUI/HTTP approval gate management
+    from bernstein.core.routes.agent_comparison import router as agent_comparison_router
+    from bernstein.core.routes.api_v1 import router as api_v1_router
     from bernstein.core.routes.approvals import router as approvals_router
-
-    application.include_router(approvals_router)
-
-    # Plan approval routes (always mounted; returns 503 if plan_mode is off)
-    from bernstein.core.routes.plans import router as plans_router
-
-    application.include_router(plans_router)
-
-    # Gateway metrics — active only when a gateway session is running
-    from bernstein.core.routes.gateway import router as gateway_router
-
-    application.include_router(gateway_router)
-    application.state.mcp_gateway = None  # type: ignore[attr-defined]
-
-    # SLO and error budget endpoints
-    from bernstein.core.routes.slo import router as slo_router
-
-    application.include_router(slo_router)
-
-    # Custom metrics (OBS-148): user-defined formula-based KPIs
+    from bernstein.core.routes.audit_log import router as audit_log_router
+    from bernstein.core.routes.batch_ops import router as batch_ops_router
     from bernstein.core.routes.custom_metrics import router as custom_metrics_router
-
-    application.include_router(custom_metrics_router)
-
-    # SBOM generation and artifact listing (supply-chain security)
-    from bernstein.core.routes.sbom import router as sbom_router
-
-    application.include_router(sbom_router)
-
-    # Claude Code hook receiver — real-time tool-use and lifecycle events
+    from bernstein.core.routes.drain import router as drain_router
+    from bernstein.core.routes.export import router as export_router
+    from bernstein.core.routes.file_health import router as file_health_router
+    from bernstein.core.routes.gateway import router as gateway_router
+    from bernstein.core.routes.graduation import router as graduation_router
+    from bernstein.core.routes.grafana import router as grafana_router
+    from bernstein.core.routes.graphql_api import router as graphql_router
+    from bernstein.core.routes.health import router as health_deps_router
     from bernstein.core.routes.hooks import router as hooks_router
-
-    application.include_router(hooks_router)
-
-    # WEB-006: WebSocket live dashboard
+    from bernstein.core.routes.identities import router as identities_router
+    from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
+    from bernstein.core.routes.plans import router as plans_router
+    from bernstein.core.routes.predictive import router as predictive_router
+    from bernstein.core.routes.provider_latency import router as provider_latency_router
+    from bernstein.core.routes.sbom import router as sbom_router
+    from bernstein.core.routes.slo import router as slo_router
+    from bernstein.core.routes.task_detail import router as task_detail_router
+    from bernstein.core.routes.team import router as team_router
     from bernstein.core.routes.websocket import router as ws_router
 
-    application.include_router(ws_router)
+    # Full roster of application routers.
+    #
+    # AUDIT-126 — the /api/v1 mount used to receive only a hand-picked subset
+    # (tasks, status, costs, export, grafana, health, batch_ops, etc.), so
+    # newer routes silently lacked a versioned counterpart. Collecting every
+    # router here and iterating once guarantees that adding a new router
+    # mounts it under both the legacy root path and /api/v1 in lockstep.
+    #
+    # Order matters: paginated_tasks_router must precede tasks_router so that
+    # /tasks/search is matched before the /tasks/{task_id} catch-all.
+    all_routers = [
+        paginated_tasks_router,
+        agents_router,
+        auth_router,
+        tasks_router,
+        status_router,
+        workspace_router,
+        webhooks_router,
+        discord_router,
+        slack_router,
+        costs_router,
+        dashboard_router,
+        team_dashboard_router,
+        graph_router,
+        observability_router,
+        quality_router,
+        file_health_router,
+        drain_router,
+        identities_router,
+        acp_router,
+        approvals_router,
+        plans_router,
+        gateway_router,
+        slo_router,
+        custom_metrics_router,
+        sbom_router,
+        hooks_router,
+        ws_router,
+        export_router,
+        grafana_router,
+        task_detail_router,
+        health_deps_router,
+        batch_ops_router,
+        agent_comparison_router,
+        audit_log_router,
+        graphql_router,
+        graduation_router,
+        team_router,
+        provider_latency_router,
+        predictive_router,
+    ]
 
-    # WEB-008: Data export endpoints
-    from bernstein.core.routes.export import router as export_router
+    for r in all_routers:
+        application.include_router(r)
+        # WEB-007 / AUDIT-126: expose the same router under /api/v1/* so the
+        # versioned surface stays in parity with the legacy root paths.
+        api_v1_router.include_router(r)
 
-    application.include_router(export_router)
+    # Gateway metrics — active only when a gateway session is running.
+    application.state.mcp_gateway = None  # type: ignore[attr-defined]
 
-    # WEB-009: Grafana dashboard endpoint
-    from bernstein.core.routes.grafana import router as grafana_router
-
-    application.include_router(grafana_router)
-
-    # WEB-012: Dashboard task detail with live log streaming
-    from bernstein.core.routes.task_detail import router as task_detail_router
-
-    application.include_router(task_detail_router)
-
-    # WEB-013: Health endpoint with dependency status
-    from bernstein.core.routes.health import router as health_deps_router
-
-    application.include_router(health_deps_router)
-
-    # WEB-017: Batch operations endpoint
-    from bernstein.core.routes.batch_ops import router as batch_ops_router
-
-    application.include_router(batch_ops_router)
-
-    # WEB-018: Agent comparison view
-    from bernstein.core.routes.agent_comparison import router as agent_comparison_router
-
-    application.include_router(agent_comparison_router)
-
-    # WEB-019: Audit log endpoint with search and filtering
-    from bernstein.core.routes.audit_log import router as audit_log_router
-
-    application.include_router(audit_log_router)
-
-    # WEB-021: GraphQL API alongside REST
-    from bernstein.core.routes.graphql_api import router as graphql_router
-
-    application.include_router(graphql_router)
-
-    # Graduation framework — stage inspection and promotion
-    from bernstein.core.routes.graduation import router as graduation_router
-
-    application.include_router(graduation_router)
-
-    # Team state — current roster visibility for CLI/TUI
-    from bernstein.core.routes.team import router as team_router
-
-    application.include_router(team_router)
-
-    # ROAD-155: Provider latency percentile tracker
-    from bernstein.core.routes.provider_latency import router as provider_latency_router
-
-    application.include_router(provider_latency_router)
-
-    # ROAD-157: Predictive alerting — forecast issues before they impact the run
-    from bernstein.core.routes.predictive import router as predictive_router
-
-    application.include_router(predictive_router)
-
-    # WEB-007: API v1 versioned routes — mount all existing routers under /api/v1/
-    from bernstein.core.routes.api_v1 import router as api_v1_router
-
-    api_v1_router.include_router(paginated_tasks_router)
-    api_v1_router.include_router(tasks_router)
-    api_v1_router.include_router(status_router)
-    api_v1_router.include_router(agents_router)
-    api_v1_router.include_router(costs_router)
-    api_v1_router.include_router(export_router)
-    api_v1_router.include_router(grafana_router)
-    api_v1_router.include_router(health_deps_router)
-    api_v1_router.include_router(batch_ops_router)
-    api_v1_router.include_router(agent_comparison_router)
-    api_v1_router.include_router(audit_log_router)
-    api_v1_router.include_router(graphql_router)
     application.include_router(api_v1_router)
 
     return application

--- a/tests/unit/test_api_v1_routing.py
+++ b/tests/unit/test_api_v1_routing.py
@@ -7,9 +7,29 @@ from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
+from fastapi.routing import APIRoute, APIWebSocketRoute
 from httpx import ASGITransport, AsyncClient
+from starlette.routing import WebSocketRoute
 
 from bernstein.core.server import create_app
+
+# Paths that FastAPI/Starlette register on the root app for infrastructure
+# (OpenAPI schema, interactive docs, root landing redirect). These are
+# intentionally not mirrored under /api/v1/ because they describe the whole
+# app rather than a specific API surface.
+_INFRASTRUCTURE_PATHS: frozenset[str] = frozenset(
+    {
+        "/",
+        "/docs",
+        "/docs/oauth2-redirect",
+        "/openapi.json",
+        "/redoc",
+        # The versioned router mount point itself shows up as a bare "/api/v1"
+        # route — its own counterpart would be "/api/v1/api/v1", which is
+        # nonsense. Skip it from both sides of the diff.
+        "/api/v1",
+    }
+)
 
 
 @pytest.fixture()
@@ -70,3 +90,73 @@ class TestAPIVersioning:
         """GET /api/v1/export/tasks should work."""
         resp = await client.get("/api/v1/export/tasks")
         assert resp.status_code == 200
+
+
+def _collect_paths(app: FastAPI) -> tuple[set[str], set[str]]:
+    """Return (root_paths, v1_relative_paths) registered on ``app``.
+
+    ``root_paths`` holds every non-versioned path. ``v1_relative_paths`` holds
+    the same paths with the ``/api/v1`` prefix stripped so the two sets can
+    be compared directly.
+    """
+    root: set[str] = set()
+    v1_relative: set[str] = set()
+    for route in app.routes:
+        if not isinstance(route, APIRoute | APIWebSocketRoute | WebSocketRoute):
+            continue
+        path = route.path
+        if path.startswith("/api/v1/"):
+            v1_relative.add(path[len("/api/v1") :])
+        elif path == "/api/v1":
+            # Mount point itself — recorded in _INFRASTRUCTURE_PATHS.
+            continue
+        else:
+            root.add(path)
+    return root, v1_relative
+
+
+class TestVersionedRoutesParity:
+    """AUDIT-126: every root-mounted route must also exist under /api/v1/*."""
+
+    def test_every_root_route_has_v1_counterpart(self, app: FastAPI) -> None:
+        """Fail if a route is reachable at /foo but not at /api/v1/foo.
+
+        This guards against the drift described in audit-126, where new
+        routers were added to the outer app but never copied into the
+        api_v1_router, leaving versioned clients with silent 404s.
+        """
+        root_paths, v1_relative = _collect_paths(app)
+
+        missing = {path for path in root_paths if path not in _INFRASTRUCTURE_PATHS and path not in v1_relative}
+
+        assert not missing, (
+            "Routes registered on the root app are missing under /api/v1/. "
+            "Add them to the `all_routers` list in "
+            "bernstein.core.server.server_app.create_app, or extend "
+            "_INFRASTRUCTURE_PATHS if they are intentionally unversioned. "
+            f"Missing: {sorted(missing)}"
+        )
+
+    def test_every_v1_route_has_root_counterpart(self, app: FastAPI) -> None:
+        """The /api/v1 surface must not contain orphan paths.
+
+        Parity is bidirectional: versioned routes are always re-mounts of
+        root routers, never new endpoints. A v1-only path would be an
+        accidental divergence.
+        """
+        root_paths, v1_relative = _collect_paths(app)
+
+        orphans = v1_relative - root_paths
+        assert not orphans, f"Routes exist only under /api/v1/* but not on the root app. Orphans: {sorted(orphans)}"
+
+    def test_versioned_router_covers_meaningful_surface(self, app: FastAPI) -> None:
+        """Sanity check: the versioned surface is non-trivial.
+
+        If someone inadvertently unplugs the ``all_routers`` loop, the
+        parity check above still passes vacuously. This guards against
+        that regression by requiring at least 40 mirrored paths.
+        """
+        _root_paths, v1_relative = _collect_paths(app)
+        assert len(v1_relative) >= 40, (
+            f"Only {len(v1_relative)} paths under /api/v1 — the routers list may have been truncated."
+        )


### PR DESCRIPTION
## Summary

- `/api/v1/*` only mirrored 12 of the 39 routers on the root app, so routes added after the initial scaffolding (bulletin, auth, dashboard, discord, slack, observability, quality, webhooks, workspace, drain, acp, approvals, plans, gateway, slo, custom_metrics, sbom, hooks, websocket, identities, task_detail, file_health, graduation, team, provider_latency, predictive, etc.) silently lacked a versioned counterpart.
- Refactor `create_app` in `src/bernstein/core/server/server_app.py` to build a single `all_routers` list and mount every router on both the root app and `api_v1_router` in one loop — adding a new router now automatically mirrors it under `/api/v1`.
- Add a parity test in `tests/unit/test_api_v1_routing.py` (`TestVersionedRoutesParity`) that walks `app.routes` and asserts every non-infrastructure root path has a matching `/api/v1/<path>` entry (and vice versa). Only `/`, `/docs`, `/docs/oauth2-redirect`, `/openapi.json`, `/redoc`, and the `/api/v1` mount point itself are on the infrastructure allowlist.

## Test plan

- [x] `uv run ruff check src/bernstein/core/server/server_app.py tests/unit/test_api_v1_routing.py` — clean
- [x] `uv run ruff format --check src/bernstein/core/server/server_app.py tests/unit/test_api_v1_routing.py` — clean
- [x] `uv run pytest tests/unit -k "api_v1 or versioned_routes" -x -q` — 9 passed
- [x] Verified `create_app()` produces 174 paths under `/api/v1` mirroring 174 root paths, with only the 5 FastAPI infrastructure endpoints unmirrored