### PR TITLE
fix(cost): wire budget policy evaluation

### DIFF
--- a/src/bernstein/core/cost/budget_actions.py
+++ b/src/bernstein/core/cost/budget_actions.py
@@ -204,3 +204,61 @@ def suggest_downgrade(current_model: str) -> str | None:
         if tier in current_lower and i > 0:
             return _MODEL_TIER_ORDER[i - 1]
     return None
+
+
+# ---------------------------------------------------------------------------
+# Policy application (wires BudgetPolicy into orchestrator spawn decisions)
+# ---------------------------------------------------------------------------
+
+
+def apply_policy(
+    policy: BudgetPolicy,
+    percentage_used: float,
+    *,
+    tasks: list[Any] | None = None,
+) -> BudgetActionResult:
+    """Evaluate ``policy`` and mutate task model fields if downgrade is required.
+
+    This is the integration point used by the orchestrator tick: given the
+    current spend ratio and the pending task batch, this returns the policy
+    action and — for ``DOWNGRADE_MODEL`` — rewrites each task's ``model``
+    attribute to a cheaper tier where possible.  Callers use the returned
+    :class:`BudgetActionResult` to gate spawning (``ABORT``/``PAUSE``) or
+    emit warnings.
+
+    Mutation of tasks is deliberate: downstream spawn code already consults
+    ``task.model``, so mutating here ensures the downgrade takes effect
+    without threading a separate override parameter through every spawn
+    path.
+
+    Args:
+        policy: The budget policy to evaluate.
+        percentage_used: Current spend as a fraction of the budget
+            (0.0-1.0+).
+        tasks: Optional list of task-like objects with a mutable ``model``
+            attribute.  Only used when the evaluated action is
+            ``DOWNGRADE_MODEL``; safely ignored otherwise.
+
+    Returns:
+        The :class:`BudgetActionResult` produced by
+        :meth:`BudgetPolicy.evaluate`.
+    """
+    result = policy.evaluate(percentage_used)
+    if result.action == BudgetAction.DOWNGRADE_MODEL and tasks:
+        for task in tasks:
+            current = getattr(task, "model", None) or ""
+            if not current:
+                # Task uses default model — mark with cheapest tier so the
+                # spawner picks it up.
+                try:
+                    task.model = _MODEL_TIER_ORDER[0]
+                except (AttributeError, TypeError):
+                    continue
+                continue
+            cheaper = suggest_downgrade(current)
+            if cheaper is not None:
+                try:
+                    task.model = cheaper
+                except (AttributeError, TypeError):
+                    continue
+    return result

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -51,6 +51,7 @@ from bernstein.core.bulletin import BulletinBoard, BulletinMessage
 from bernstein.core.cluster import NodeHeartbeatClient
 from bernstein.core.context import refresh_knowledge_base
 from bernstein.core.context_recommendations import RecommendationEngine
+from bernstein.core.cost.budget_actions import BudgetAction, BudgetPolicy, apply_policy
 from bernstein.core.cost_tracker import CostTracker
 from bernstein.core.defaults import ORCHESTRATOR
 from bernstein.core.dep_validator import DependencyValidator
@@ -447,6 +448,13 @@ class Orchestrator:
             budget_usd=config.budget_usd,
         )
         self._cost_cap_killed_agents: set[str] = set()
+
+        # Budget enforcement policy: evaluated each tick against the cost
+        # tracker to decide whether to pause, downgrade, or abort spawning.
+        # Kept as an attribute so tests (and seed config) can override.
+        self._budget_policy: BudgetPolicy = BudgetPolicy.default()
+        # Track last-seen policy action so we only notify on transitions.
+        self._last_budget_action: BudgetAction = BudgetAction.CONTINUE
 
         # Cost anomaly detector: layered on top of cost_tracker, fires
         # AnomalySignals the orchestrator acts on (log/stop/kill).
@@ -880,6 +888,51 @@ class Orchestrator:
         payload = NotificationPayload(event=event, title=title, body=body, metadata=dict(metadata))
         self._notifier.notify(event, payload)
 
+    def _evaluate_budget_policy(self, tasks: list[Task]) -> Any | None:
+        """Evaluate the budget policy for this tick and apply model downgrades.
+
+        When ``budget_usd`` is 0 (unlimited) the policy is not evaluated and
+        ``None`` is returned. Otherwise the policy is evaluated against the
+        current spend ratio; on ``DOWNGRADE_MODEL`` the task model fields are
+        rewritten in place so downstream spawn code picks up the cheaper
+        tier. Transitions between actions emit a single notification so the
+        operator is warned on escalation without log spam.
+
+        Args:
+            tasks: Ready tasks eligible for spawn this tick.
+
+        Returns:
+            The :class:`BudgetActionResult` produced by
+            :func:`apply_policy`, or ``None`` when no budget is configured.
+        """
+        if self._cost_tracker.budget_usd <= 0:
+            return None
+        status = self._cost_tracker.status()
+        result = apply_policy(self._budget_policy, status.percentage_used, tasks=tasks)
+        if result.action != self._last_budget_action:
+            logger.info(
+                "Budget policy transition: %s -> %s at %.1f%% spend (threshold %.0f%%) — %s",
+                self._last_budget_action.value,
+                result.action.value,
+                result.percentage_used * 100,
+                result.threshold_pct * 100,
+                result.message,
+            )
+            # Fire a structured notification on every transition so operators
+            # have a single event per escalation (pause/downgrade/abort).
+            if result.action != BudgetAction.CONTINUE:
+                self._notify(
+                    f"budget.policy.{result.action.value}",
+                    f"Budget policy: {result.action.value}",
+                    result.message
+                    or (f"{result.percentage_used * 100:.1f}% of budget used; action={result.action.value}."),
+                    action=result.action.value,
+                    threshold_pct=round(result.threshold_pct, 4),
+                    percentage_used=round(result.percentage_used, 4),
+                )
+            self._last_budget_action = result.action
+        return result
+
     # -- Core tick -----------------------------------------------------------
 
     def tick(self) -> TickResult:
@@ -1203,7 +1256,14 @@ class Orchestrator:
             },
         )
 
-        # 3c. Claim tasks and spawn agents for ready batches (skip if budget is exhausted)
+        # 3c. Claim tasks and spawn agents for ready batches. Consult the
+        # BudgetPolicy first: evaluate() maps the current spend ratio to a
+        # PAUSE / DOWNGRADE_MODEL / ABORT action. apply_policy() mutates
+        # batched tasks' model fields in place for DOWNGRADE_MODEL so the
+        # spawner picks up the cheaper tier.
+        budget_decision = self._evaluate_budget_policy(
+            [t for b in batches for t in b],
+        )
         if self._config.dry_run:
             for batch in batches:
                 for task in batch:
@@ -1215,7 +1275,7 @@ class Orchestrator:
                         task.effort,
                     )
                     result.dry_run_planned.append((task.role, task.title, task.model, task.effort))
-        elif self._cost_tracker.budget_usd > 0 and self._cost_tracker.status().should_stop:
+        elif budget_decision is not None and budget_decision.action == BudgetAction.ABORT:
             _bs = self._cost_tracker.status()
             logger.warning(
                 "Budget exhausted — $%.2f spent of $%.2f budget. "
@@ -1233,6 +1293,14 @@ class Orchestrator:
                 spent_usd=round(_bs.spent_usd, 4),
                 percent_used=round(_bs.percentage_used * 100, 1),
             )
+        elif budget_decision is not None and budget_decision.action == BudgetAction.PAUSE:
+            _bs = self._cost_tracker.status()
+            logger.warning(
+                "Budget policy PAUSE triggered at %.1f%% — holding spawns until approval",
+                _bs.percentage_used * 100,
+            )
+            # Fire a one-shot notification when the action first transitions.
+            # (apply_policy writes this into self._last_budget_action.)
         else:
             claim_and_spawn_batches(self, batches, alive_count, assigned_task_ids, done_ids, result)
 

--- a/tests/unit/test_budget_actions.py
+++ b/tests/unit/test_budget_actions.py
@@ -2,13 +2,24 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from bernstein.core.budget_actions import (
     BudgetAction,
     BudgetActionResult,
     BudgetPolicy,
     BudgetThresholdRule,
+    apply_policy,
     suggest_downgrade,
 )
+
+
+@dataclass
+class _FakeTask:
+    """Minimal task-like object used to exercise apply_policy() mutation."""
+
+    id: str
+    model: str = ""
 
 
 def test_default_policy_creation() -> None:
@@ -118,3 +129,94 @@ def test_suggest_downgrade_haiku() -> None:
 def test_suggest_downgrade_unknown() -> None:
     """Unknown model returns None."""
     assert suggest_downgrade("unknown-model-xyz") is None
+
+
+# ---------------------------------------------------------------------------
+# apply_policy() — policy evaluation + task-model mutation (audit-058)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_policy_continue_leaves_tasks_untouched() -> None:
+    """Under all thresholds no tasks are mutated and action is CONTINUE."""
+    policy = BudgetPolicy.default()
+    tasks = [_FakeTask(id="t1", model="opus"), _FakeTask(id="t2", model="sonnet")]
+    result = apply_policy(policy, 0.2, tasks=tasks)
+    assert result.action == BudgetAction.CONTINUE
+    assert tasks[0].model == "opus"
+    assert tasks[1].model == "sonnet"
+
+
+def test_apply_policy_pause_does_not_mutate_tasks() -> None:
+    """PAUSE is a spawn-gate signal and must not rewrite model fields."""
+    policy = BudgetPolicy.default()
+    tasks = [_FakeTask(id="t1", model="opus")]
+    result = apply_policy(policy, 0.85, tasks=tasks)
+    assert result.action == BudgetAction.PAUSE
+    assert tasks[0].model == "opus"
+
+
+def test_apply_policy_downgrade_rewrites_task_model() -> None:
+    """DOWNGRADE_MODEL mutates each task's model to the cheaper tier."""
+    policy = BudgetPolicy.default()
+    tasks = [
+        _FakeTask(id="t1", model="opus"),
+        _FakeTask(id="t2", model="sonnet"),
+        _FakeTask(id="t3", model="haiku"),
+    ]
+    result = apply_policy(policy, 0.92, tasks=tasks)
+    assert result.action == BudgetAction.DOWNGRADE_MODEL
+    assert tasks[0].model == "sonnet"  # opus -> sonnet
+    assert tasks[1].model == "haiku"  # sonnet -> haiku
+    assert tasks[2].model == "haiku"  # already cheapest, unchanged
+
+
+def test_apply_policy_downgrade_defaults_empty_model_to_cheapest() -> None:
+    """Tasks with an unset model get the cheapest tier explicitly set."""
+    policy = BudgetPolicy.default()
+    tasks = [_FakeTask(id="t1", model="")]
+    result = apply_policy(policy, 0.95, tasks=tasks)
+    assert result.action == BudgetAction.DOWNGRADE_MODEL
+    assert tasks[0].model == "haiku"
+
+
+def test_apply_policy_abort_leaves_tasks_untouched() -> None:
+    """ABORT is a spawn-stop signal; mutation is pointless and must not occur."""
+    policy = BudgetPolicy.default()
+    tasks = [_FakeTask(id="t1", model="opus")]
+    result = apply_policy(policy, 1.05, tasks=tasks)
+    assert result.action == BudgetAction.ABORT
+    assert tasks[0].model == "opus"
+
+
+def test_apply_policy_handles_none_tasks() -> None:
+    """apply_policy without a task list is a pure evaluation."""
+    policy = BudgetPolicy.default()
+    result = apply_policy(policy, 0.92, tasks=None)
+    assert result.action == BudgetAction.DOWNGRADE_MODEL
+
+
+def test_apply_policy_custom_policy_switch_model_rule() -> None:
+    """A single switch-model rule triggers downgrade at its threshold."""
+    policy = BudgetPolicy(
+        rules=[
+            BudgetThresholdRule(
+                threshold_pct=0.5,
+                action=BudgetAction.DOWNGRADE_MODEL,
+                message="Half-budget; switch model.",
+            ),
+        ]
+    )
+    tasks = [_FakeTask(id="t1", model="opus")]
+    result = apply_policy(policy, 0.6, tasks=tasks)
+    assert result.action == BudgetAction.DOWNGRADE_MODEL
+    assert tasks[0].model == "sonnet"
+
+
+def test_apply_policy_returns_result_with_metadata() -> None:
+    """The returned BudgetActionResult carries threshold + spend data."""
+    policy = BudgetPolicy.default()
+    result = apply_policy(policy, 0.82, tasks=None)
+    assert isinstance(result, BudgetActionResult)
+    assert result.threshold_pct == 0.80
+    assert abs(result.percentage_used - 0.82) < 1e-9
+    assert result.message != ""


### PR DESCRIPTION
## Summary

- `BudgetPolicy.evaluate()` / `BudgetAction` DSL were declared but never invoked. The orchestrator used only a hardcoded `should_stop` branch, so PAUSE / DOWNGRADE_MODEL rules at 80% / 90% were dead configuration.
- Wires policy evaluation into the spawn hot path via a new `apply_policy()` helper that evaluates the policy and mutates each ready task's `model` field in place for `DOWNGRADE_MODEL` (downstream spawn code already honors `task.model`).
- Orchestrator now owns a `BudgetPolicy.default()` and calls `_evaluate_budget_policy()` before `claim_and_spawn_batches()`: `CONTINUE` spawns, `PAUSE` holds with warning, `DOWNGRADE_MODEL` rewrites models then spawns, `ABORT` replaces the old `should_stop` branch with the same notification payload. One notification per action transition (`budget.policy.<action>`).

## Test plan

- [x] `uv run ruff check src/bernstein/core/cost/budget_actions.py src/bernstein/core/cost/cost_autopilot.py src/bernstein/core/orchestration/orchestrator.py` — passes
- [x] `uv run ruff format --check` on the same files — passes
- [x] `uv run pytest tests/unit -k "budget_actions or budget_policy or cost_autopilot" -x -q` — 31 passed
- [x] `uv run pytest tests/unit/test_orchestrator.py -x -q` — 211 passed (no regressions)

## Tests added

- `test_apply_policy_continue_leaves_tasks_untouched`
- `test_apply_policy_pause_does_not_mutate_tasks`
- `test_apply_policy_downgrade_rewrites_task_model` (opus→sonnet, sonnet→haiku, haiku unchanged)
- `test_apply_policy_downgrade_defaults_empty_model_to_cheapest`
- `test_apply_policy_abort_leaves_tasks_untouched`
- `test_apply_policy_handles_none_tasks`
- `test_apply_policy_custom_policy_switch_model_rule`
- `test_apply_policy_returns_result_with_metadata`

.