### PR TITLE
fix(hooks): wire HookEvent enum

### DIFF
--- a/src/bernstein/core/communication/notifications.py
+++ b/src/bernstein/core/communication/notifications.py
@@ -41,6 +41,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 
+from bernstein.core.hook_events import HookEvent
+
 if TYPE_CHECKING:
     from bernstein.core.models import SmtpConfig
 
@@ -49,10 +51,15 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Event name constants
 # ---------------------------------------------------------------------------
+#
+# Values that overlap :class:`bernstein.core.hook_events.HookEvent` members
+# are sourced from the enum so that the canonical taxonomy has exactly one
+# source of truth.  Events that are notification-only (``run.*``,
+# ``task.deadline_*``, ``predictive.*``) continue to live as literals.
 
 EVENT_RUN_STARTED = "run.started"
-EVENT_TASK_COMPLETED = "task.completed"
-EVENT_TASK_FAILED = "task.failed"
+EVENT_TASK_COMPLETED = HookEvent.TASK_COMPLETED.value
+EVENT_TASK_FAILED = HookEvent.TASK_FAILED.value
 EVENT_RUN_COMPLETED = "run.completed"
 EVENT_BUDGET_WARNING = "budget.warning"
 EVENT_BUDGET_EXHAUSTED = "budget.exhausted"

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -65,6 +65,7 @@ from bernstein.core.fast_path import (
 )
 from bernstein.core.file_locks import FileLockManager
 from bernstein.core.graph import TaskGraph
+from bernstein.core.hook_events import HookEvent
 from bernstein.core.incident import IncidentManager
 from bernstein.core.manifest import build_manifest, save_manifest
 from bernstein.core.memory_guard import MemoryGuard
@@ -3499,7 +3500,7 @@ def _collect_notify_targets(seed: Any, targets: list[NotificationTarget]) -> Non
             NotificationTarget(
                 type="desktop",
                 url="",
-                events=["task.completed", _EVENT_TASK_FAILED],
+                events=[_EVENT_TASK_COMPLETED, _EVENT_TASK_FAILED],
             )
         )
 
@@ -3523,7 +3524,7 @@ def _collect_smtp_targets(seed: Any, targets: list[NotificationTarget]) -> None:
         NotificationTarget(
             type="email",
             url="",
-            events=["task.completed", _EVENT_TASK_FAILED, "approval.needed", _EVENT_RUN_COMPLETED],
+            events=[_EVENT_TASK_COMPLETED, _EVENT_TASK_FAILED, "approval.needed", _EVENT_RUN_COMPLETED],
         )
     )
 
@@ -4022,7 +4023,8 @@ from bernstein.core.orchestration.nudge_manager import nudge_orchestrator as nud
 
 _EVENT_RUN_COMPLETED = "run.completed"
 
-_EVENT_TASK_FAILED = "task.failed"
+_EVENT_TASK_COMPLETED = HookEvent.TASK_COMPLETED.value
+_EVENT_TASK_FAILED = HookEvent.TASK_FAILED.value
 
 _TESTS_DIR = "tests/"
 

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -33,6 +33,7 @@ from bernstein.core.fast_path import (
     get_l1_model_config,
     try_fast_path_batch,
 )
+from bernstein.core.hook_events import HookEvent
 from bernstein.core.janitor import verify_task
 from bernstein.core.metrics import get_collector
 from bernstein.core.router import RouterError
@@ -2243,7 +2244,7 @@ def _post_completion_bulletin(
     if janitor_passed:
         orch._post_bulletin("status", f"task completed: {task.title} ({task.id})")
         orch._notify(
-            "task.completed",
+            HookEvent.TASK_COMPLETED.value,
             f"Task completed: {task.title}",
             task.result_summary or "",
             task_id=task.id,
@@ -2254,7 +2255,7 @@ def _post_completion_bulletin(
     else:
         orch._post_bulletin("alert", f"task failed janitor: {task.title} ({task.id})")
         orch._notify(
-            "task.failed",
+            HookEvent.TASK_FAILED.value,
             f"Task failed: {task.title}",
             task.result_summary or "Janitor verification did not pass.",
             task_id=task.id,

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -22,6 +22,7 @@ from fastapi import HTTPException
 from typing_extensions import TypedDict
 
 from bernstein.core.defaults import TASK as _TASK_DEFAULTS
+from bernstein.core.hook_events import HookEvent
 from bernstein.core.tasks.lifecycle import IllegalTransitionError, transition_agent, transition_task
 from bernstein.core.tasks.models import (
     AgentSession,
@@ -785,7 +786,7 @@ class TaskStore:
             input_data = {"title": task.title, "role": task.role, "priority": task.priority}
             output_data = {"task_id": task.id, "status": task.status.value}
             audit.log(
-                event_type="task.created",
+                event_type=HookEvent.TASK_CREATED.value,
                 actor="task_store",
                 resource_type="task",
                 resource_id=task.id,
@@ -925,7 +926,7 @@ class TaskStore:
                 input_data = {"title": task.title, "role": task.role, "priority": task.priority}
                 output_data = {"task_id": task.id, "status": task.status.value}
                 audit.log(
-                    event_type="task.created",
+                    event_type=HookEvent.TASK_CREATED.value,
                     actor="task_store",
                     resource_type="task",
                     resource_id=task.id,

--- a/tests/unit/test_hook_events.py
+++ b/tests/unit/test_hook_events.py
@@ -387,3 +387,76 @@ class TestBlockingHookPayload:
         p = BlockingHookPayload(event=HookEvent.PRE_SPAWN, action="spawn")
         d = p.to_dict()
         assert "context" not in d
+
+
+# ---------------------------------------------------------------------------
+# Emit-site parity (audit-152)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitSiteParity:
+    """audit-152 — every task/agent/merge emit site must use HookEvent values.
+
+    These regression tests ensure that when a module fires a task / agent /
+    merge hook it goes through ``HookEvent.<MEMBER>.value`` (or a constant
+    that is itself sourced from the enum).  Raw string literals for those
+    canonical events are a typo hazard and undermine the enum as a single
+    source of truth.
+    """
+
+    def test_task_lifecycle_emits_use_enum(self) -> None:
+        """``_post_completion_bulletin`` emits via ``HookEvent.*.value``."""
+        from bernstein.core.tasks import task_lifecycle
+
+        src = _read_module_source(task_lifecycle)
+        # The old literals must be gone from the emit path.
+        assert '"task.completed"' not in src, (
+            "task_lifecycle.py still contains the raw 'task.completed' literal; "
+            "it must emit via HookEvent.TASK_COMPLETED.value"
+        )
+        assert '"task.failed"' not in src, (
+            "task_lifecycle.py still contains the raw 'task.failed' literal; "
+            "it must emit via HookEvent.TASK_FAILED.value"
+        )
+        # The enum members must be referenced.
+        assert "HookEvent.TASK_COMPLETED.value" in src
+        assert "HookEvent.TASK_FAILED.value" in src
+
+    def test_task_store_audit_logs_use_enum(self) -> None:
+        """``TaskStore.create`` / ``create_batch`` audit-log via ``HookEvent``."""
+        from bernstein.core.tasks import task_store_core
+
+        src = _read_module_source(task_store_core)
+        assert 'event_type="task.created"' not in src, (
+            "task_store_core.py still uses the raw 'task.created' literal for "
+            "audit events; it must emit via HookEvent.TASK_CREATED.value"
+        )
+        assert "HookEvent.TASK_CREATED.value" in src
+
+    def test_notifications_constants_sourced_from_enum(self) -> None:
+        """Notification event constants overlap HookEvent where applicable."""
+        from bernstein.core.hook_events import HookEvent as _HE
+
+        from bernstein.core.communication import notifications
+
+        assert _HE.TASK_COMPLETED.value == notifications.EVENT_TASK_COMPLETED
+        assert _HE.TASK_FAILED.value == notifications.EVENT_TASK_FAILED
+
+    def test_orchestrator_task_failed_alias_uses_enum(self) -> None:
+        """Orchestrator module-level aliases derive from the enum."""
+        from bernstein.core.hook_events import HookEvent as _HE
+
+        from bernstein.core.orchestration import orchestrator
+
+        assert _HE.TASK_FAILED.value == orchestrator._EVENT_TASK_FAILED
+        assert _HE.TASK_COMPLETED.value == orchestrator._EVENT_TASK_COMPLETED
+
+
+def _read_module_source(module: object) -> str:
+    """Return the source text for a module (used by parity tests)."""
+    import inspect
+
+    path = inspect.getsourcefile(module)  # type: ignore[arg-type]
+    assert path is not None
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()


### PR DESCRIPTION
## Summary
- the `HookEvent` enum in `src/bernstein/core/config/hook_events.py` was defined with 28+ canonical events but zero emission sites referenced it — hooks were dispatched via raw string literals, making the enum dead documentation.
- Wired `HookEvent.*.value` into the task lifecycle emit sites (`_post_completion_bulletin`), the task store audit-log calls (`TaskStore.create`, `TaskStore.create_batch`), the overlapping notification event constants, and the orchestrator's webhook/email target lists.
- Added a `TestEmitSiteParity` regression guard in `tests/unit/test_hook_events.py` asserting that the converted sites keep using the enum rather than silently drifting back to raw literals.

## Test plan
- [x] `uv run ruff check` on the touched files — clean
- [x] `uv run ruff format --check` on the touched files — clean
- [x] `uv run pytest tests/unit -k "hook_event or hooks_receiver" -x -q` — 94 passed