### PR TITLE
fix(observability): rotate api_usage.jsonl

### DIFF
--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from rich.panel import Panel
 
 from bernstein.cli.helpers import is_json, print_json
+from bernstein.core.observability.metric_collector import iter_metric_files
 
 console = Console()
 
@@ -295,7 +296,7 @@ def _load_archive_tasks(sdd_dir: Path) -> list[dict[str, Any]]:
 
 def _load_api_usage_jsonl(metrics_dir: Path) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
-    for p in sorted(metrics_dir.glob("api_usage_*.jsonl")):
+    for p in iter_metric_files(metrics_dir, "api_usage"):
         for line in p.read_text().splitlines():
             line = line.strip()
             if line:

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -634,7 +634,11 @@ def forecast_planned_backlog(
     projected_total = current_spend_usd + estimated_remaining_cost
     avg_cost = estimated_remaining_cost / len(planned_tasks) if planned_tasks else 0.0
 
-    has_history = bool(metrics_dir and metrics_dir.exists() and any(metrics_dir.glob("api_usage_*.jsonl")))
+    has_history = bool(
+        metrics_dir
+        and metrics_dir.exists()
+        and (any(metrics_dir.glob("api_usage_*.jsonl")) or any(metrics_dir.glob("api_usage_*.jsonl.*")))
+    )
     if len(planned_tasks) >= 10 and has_history:
         confidence_level = "high"
     elif len(planned_tasks) >= 3:

--- a/src/bernstein/core/observability/incident_timeline.py
+++ b/src/bernstein/core/observability/incident_timeline.py
@@ -12,6 +12,8 @@ import time
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from bernstein.core.observability.metric_collector import iter_metric_files
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -234,7 +236,7 @@ def _collect_incident_lifecycle_events(incident: dict[str, Any]) -> list[Timelin
 def _collect_api_usage_events(metrics_dir: Path, start_ts: float, end_ts: float) -> list[TimelineEvent]:
     """Collect API usage anomalies (failures, high latency) in the time window."""
     events: list[TimelineEvent] = []
-    for path in sorted(metrics_dir.glob("api_usage_*.jsonl")):
+    for path in iter_metric_files(metrics_dir, "api_usage"):
         for rec in _read_jsonl(path):
             ts = rec.get("timestamp", 0)
             if start_ts <= ts <= end_ts:

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -17,9 +17,42 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from bernstein.core.persistence.runtime_state import rotate_log_file
 from bernstein.core.tenanting import normalize_tenant_id, tenant_metrics_dir
 
 logger = logging.getLogger(__name__)
+
+# Default size threshold for rotating per-day metric files such as
+# ``api_usage_YYYYMMDD.jsonl``. Kept deliberately modest so long-running
+# orchestrators never accumulate multi-GB metric files.
+_METRIC_FILE_ROTATE_BYTES = 10 * 1024 * 1024
+_METRIC_FILE_MAX_BACKUPS = 5
+
+
+def iter_metric_files(metrics_dir: Path, prefix: str) -> list[Path]:
+    """Return live and rotated metric JSONL files matching *prefix*.
+
+    The on-disk layout is ``{prefix}_YYYYMMDD.jsonl`` plus rotation suffixes
+    ``.1``, ``.2`` … applied by :func:`rotate_log_file`. Callers that
+    aggregate across days must include rotated backups, otherwise any
+    rollover silently truncates their view.
+
+    Args:
+        metrics_dir: Directory containing metric JSONL files.
+        prefix: Metric-type filename prefix (e.g. ``api_usage``).
+
+    Returns:
+        Sorted list of matching paths (live + rotated), empty when the
+        directory does not exist.
+    """
+    if not metrics_dir.exists():
+        return []
+    patterns = (f"{prefix}_*.jsonl", f"{prefix}_*.jsonl.*")
+    seen: set[Path] = set()
+    for pattern in patterns:
+        for path in metrics_dir.glob(pattern):
+            seen.add(path)
+    return sorted(seen)
 
 
 class MetricType(Enum):
@@ -916,6 +949,14 @@ class MetricsCollector:
 
         for filepath, lines in by_file.items():
             try:
+                # Bound per-file growth: rotate *before* appending so the new
+                # write starts a fresh file once the threshold is crossed.
+                # See audit-068 — previously these JSONL files grew unbounded.
+                rotate_log_file(
+                    filepath,
+                    max_bytes=_METRIC_FILE_ROTATE_BYTES,
+                    max_backups=_METRIC_FILE_MAX_BACKUPS,
+                )
                 with filepath.open("a") as f:
                     f.write("\n".join(lines) + "\n")
             except OSError:

--- a/src/bernstein/core/persistence/runtime_state.py
+++ b/src/bernstein/core/persistence/runtime_state.py
@@ -59,22 +59,54 @@ class SessionReplayMetadata:
         return asdict(self)
 
 
-def rotate_log_file(log_path: Path, *, max_bytes: int = _LOG_ROTATE_BYTES) -> bool:
-    """Rotate *log_path* to ``.1`` when it exceeds *max_bytes*.
+def rotate_log_file(
+    log_path: Path,
+    *,
+    max_bytes: int = _LOG_ROTATE_BYTES,
+    max_backups: int = 1,
+) -> bool:
+    """Rotate *log_path* when it exceeds *max_bytes*, keeping up to *max_backups*.
+
+    With ``max_backups=1`` (default) the file is rotated to ``<name>.1``,
+    overwriting any previous rollover — preserving the historical single-backup
+    behaviour. With ``max_backups>1`` older backups are shifted (``.1 -> .2``,
+    ``.2 -> .3`` …) and anything beyond ``.max_backups`` is deleted.
 
     Args:
         log_path: Log file to rotate.
-        max_bytes: Rotation threshold in bytes.
+        max_bytes: Rotation threshold in bytes. Files at or below this size
+            are left untouched.
+        max_backups: Number of historical rollovers to retain.
 
     Returns:
         True when rotation happened, False otherwise.
     """
+    if max_backups < 1:
+        max_backups = 1
     try:
         if not log_path.exists() or log_path.stat().st_size <= max_bytes:
             return False
     except OSError as exc:
         logger.debug("Cannot stat log %s for rotation: %s", log_path, exc)
         return False
+
+    # Shift existing backups: .N-1 -> .N, .N-2 -> .N-1, ..., .1 -> .2.
+    # Anything at or beyond the retention limit is removed.
+    for index in range(max_backups, 0, -1):
+        src = log_path.with_suffix(log_path.suffix + f".{index}")
+        if not src.exists():
+            continue
+        if index >= max_backups:
+            with contextlib.suppress(OSError):
+                src.unlink()
+            continue
+        dst = log_path.with_suffix(log_path.suffix + f".{index + 1}")
+        with contextlib.suppress(OSError):
+            dst.unlink()
+        try:
+            shutil.move(str(src), str(dst))
+        except OSError as exc:
+            logger.warning("Failed to shift rotated log %s -> %s: %s", src, dst, exc)
 
     rotated = log_path.with_suffix(log_path.suffix + ".1")
     with contextlib.suppress(OSError):

--- a/src/bernstein/core/routes/quality.py
+++ b/src/bernstein/core/routes/quality.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from bernstein.core.cost import forecast_planned_backlog
+from bernstein.core.observability.metric_collector import iter_metric_files
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -123,7 +124,7 @@ def _read_api_usage_metrics(metrics_dir: Path, days: int = 7) -> list[dict[str, 
     records: list[dict[str, Any]] = []
     cutoff = time.time() - days * 86400
 
-    for f in sorted(metrics_dir.glob("api_usage_*.jsonl")):
+    for f in iter_metric_files(metrics_dir, "api_usage"):
         try:
             for raw in f.read_text(encoding="utf-8").splitlines():
                 raw = raw.strip()

--- a/src/bernstein/tui/away_summary.py
+++ b/src/bernstein/tui/away_summary.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003
 from typing import Any
 
+from bernstein.core.observability.metric_collector import iter_metric_files
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -72,20 +74,16 @@ def _read_jsonl(filepath: Path, since_ts: float) -> list[dict[str, Any]]:
 
 def _collect_api_usage_since(metrics_dir: Path, since_ts: float) -> list[dict[str, Any]]:
     """Collect API usage records since timestamp from daily JSONL files."""
-    if not metrics_dir.exists():
-        return []
     records: list[dict[str, Any]] = []
-    for jsonl_file in metrics_dir.glob("api_usage_*.jsonl"):
+    for jsonl_file in iter_metric_files(metrics_dir, "api_usage"):
         records.extend(_read_jsonl(jsonl_file, since_ts))
     return records
 
 
 def _collect_error_records(metrics_dir: Path, since_ts: float) -> list[dict[str, Any]]:
     """Collect error rate records since timestamp."""
-    if not metrics_dir.exists():
-        return []
     records: list[dict[str, Any]] = []
-    for jsonl_file in metrics_dir.glob("error_rate_*.jsonl"):
+    for jsonl_file in iter_metric_files(metrics_dir, "error_rate"):
         records.extend(_read_jsonl(jsonl_file, since_ts))
     return records
 

--- a/tests/unit/test_api_usage_jsonl_rotation.py
+++ b/tests/unit/test_api_usage_jsonl_rotation.py
@@ -1,0 +1,134 @@
+"""Regression tests for audit-068: api_usage JSONL files must rotate.
+
+Before the fix, ``api_usage_YYYYMMDD.jsonl`` grew unbounded — multi-GB files
+after long-running orchestration sessions. The writer now rotates at a size
+threshold and bounds the number of historical backups.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.observability import metric_collector as mc
+from bernstein.core.observability.metric_collector import (
+    MetricsCollector,
+    MetricType,
+    iter_metric_files,
+)
+
+
+def _all_lines(files: list[Path]) -> list[str]:
+    out: list[str] = []
+    for path in files:
+        out.extend(line for line in path.read_text(encoding="utf-8").splitlines() if line.strip())
+    return out
+
+
+def test_metric_writer_rotates_when_threshold_exceeded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Driving the writer past the rotation threshold creates bounded backups.
+
+    All records must remain reachable via ``iter_metric_files`` — the glob
+    helper is responsible for stitching live + rotated files back together.
+    """
+    metrics_dir = tmp_path / "metrics"
+    collector = MetricsCollector(metrics_dir=metrics_dir)
+
+    # Force aggressive rotation so the test stays fast: 512 B cap, 5 backups.
+    rotate_bytes = 512
+    max_backups = 5
+    monkeypatch.setattr(mc, "_METRIC_FILE_ROTATE_BYTES", rotate_bytes)
+    monkeypatch.setattr(mc, "_METRIC_FILE_MAX_BACKUPS", max_backups)
+    # Flush on every record — we want deterministic rotation, not buffered.
+    collector._buffer_limit = 1
+
+    payload_label = "x" * 256  # ~300+ bytes per JSONL line after framing
+
+    # Every record is larger than the rotation threshold so each write forces
+    # a fresh rollover — live + 5 backups will hold exactly 6 records.
+    total_records = 6
+    for i in range(total_records):
+        collector._write_metric_point(
+            MetricType.API_USAGE,
+            float(i),
+            {"task_id": f"t-{i}", "payload": payload_label},
+        )
+    collector.flush()
+
+    files = iter_metric_files(metrics_dir, "api_usage")
+    assert files, "expected at least the live api_usage file to exist"
+
+    # Rotation must have happened at least once — live file plus backups.
+    rotated = [p for p in files if p.suffix != ".jsonl"]
+    assert rotated, "no rotated backups were produced despite exceeding threshold"
+
+    # Backup count must not exceed the configured retention.
+    assert len(rotated) <= max_backups, f"retention breached: {[p.name for p in rotated]}"
+
+    # No individual file may exceed ~2x the threshold — the append happens
+    # after rotation, so a single write can at most be one line over.
+    for path in files:
+        assert path.stat().st_size <= 2 * rotate_bytes, (
+            f"{path.name} is {path.stat().st_size} bytes, over threshold {rotate_bytes}"
+        )
+
+    # Reading live + rotated backups concatenated must recover every record.
+    lines = _all_lines(files)
+    values = sorted(int(json.loads(line)["value"]) for line in lines)
+    assert values == list(range(total_records))
+
+
+def test_metric_writer_bounds_disk_under_sustained_load(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Long-running workloads must not accumulate unbounded JSONL bytes.
+
+    Retention is the safety valve: oldest rollovers get dropped, keeping the
+    total on-disk footprint proportional to (backups + 1) * threshold.
+    """
+    metrics_dir = tmp_path / "metrics"
+    collector = MetricsCollector(metrics_dir=metrics_dir)
+
+    rotate_bytes = 1024
+    max_backups = 3
+    monkeypatch.setattr(mc, "_METRIC_FILE_ROTATE_BYTES", rotate_bytes)
+    monkeypatch.setattr(mc, "_METRIC_FILE_MAX_BACKUPS", max_backups)
+    collector._buffer_limit = 1
+
+    payload_label = "x" * 256
+    for i in range(200):
+        collector._write_metric_point(
+            MetricType.API_USAGE,
+            float(i),
+            {"task_id": f"t-{i}", "payload": payload_label},
+        )
+    collector.flush()
+
+    files = iter_metric_files(metrics_dir, "api_usage")
+    rotated = [p for p in files if p.suffix != ".jsonl"]
+    assert len(rotated) <= max_backups
+    total_bytes = sum(p.stat().st_size for p in files)
+    # Live file + max_backups rotated files, each up to ~2x threshold.
+    assert total_bytes <= 2 * rotate_bytes * (max_backups + 1)
+
+
+def test_iter_metric_files_includes_rotated_backups(tmp_path: Path) -> None:
+    """``iter_metric_files`` must return both the live file and ``.N`` backups."""
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir()
+    (metrics_dir / "api_usage_20260417.jsonl").write_text("live\n", encoding="utf-8")
+    (metrics_dir / "api_usage_20260417.jsonl.1").write_text("rot1\n", encoding="utf-8")
+    (metrics_dir / "api_usage_20260417.jsonl.2").write_text("rot2\n", encoding="utf-8")
+    # Unrelated file must not be picked up.
+    (metrics_dir / "error_rate_20260417.jsonl").write_text("noise\n", encoding="utf-8")
+
+    found = [p.name for p in iter_metric_files(metrics_dir, "api_usage")]
+    assert found == [
+        "api_usage_20260417.jsonl",
+        "api_usage_20260417.jsonl.1",
+        "api_usage_20260417.jsonl.2",
+    ]
+
+
+def test_iter_metric_files_returns_empty_for_missing_dir(tmp_path: Path) -> None:
+    assert iter_metric_files(tmp_path / "does-not-exist", "api_usage") == []

--- a/tests/unit/test_runtime_state.py
+++ b/tests/unit/test_runtime_state.py
@@ -23,6 +23,39 @@ def test_rotate_log_file_moves_large_log(tmp_path: Path) -> None:
     assert (tmp_path / "server.log.1").exists()
 
 
+def test_rotate_log_file_keeps_multiple_backups(tmp_path: Path) -> None:
+    """Multiple rotations shift older backups and bound the on-disk set."""
+    log_path = tmp_path / "api_usage_20260417.jsonl"
+
+    # Trigger rotation four times with distinguishable contents. Each call
+    # writes enough bytes to cross the 16-byte threshold.
+    for marker in ("gen-0", "gen-1", "gen-2", "gen-3"):
+        log_path.write_text(marker + "-" + ("x" * 32), encoding="utf-8")
+        assert rotate_log_file(log_path, max_bytes=16, max_backups=3) is True
+        assert not log_path.exists()
+
+    backups = sorted(tmp_path.glob("api_usage_20260417.jsonl.*"))
+    # Only .1, .2, .3 survive — older rollovers are deleted.
+    assert [p.name for p in backups] == [
+        "api_usage_20260417.jsonl.1",
+        "api_usage_20260417.jsonl.2",
+        "api_usage_20260417.jsonl.3",
+    ]
+    # Newest-first ordering: the most recently rotated file is .1.
+    assert "gen-3" in (tmp_path / "api_usage_20260417.jsonl.1").read_text(encoding="utf-8")
+    assert "gen-2" in (tmp_path / "api_usage_20260417.jsonl.2").read_text(encoding="utf-8")
+    assert "gen-1" in (tmp_path / "api_usage_20260417.jsonl.3").read_text(encoding="utf-8")
+
+
+def test_rotate_log_file_skips_small_files(tmp_path: Path) -> None:
+    log_path = tmp_path / "server.log"
+    log_path.write_text("tiny", encoding="utf-8")
+
+    assert rotate_log_file(log_path, max_bytes=1024, max_backups=3) is False
+    assert log_path.exists()
+    assert not (tmp_path / "server.log.1").exists()
+
+
 def test_session_replay_metadata_round_trip(tmp_path: Path) -> None:
     metadata = SessionReplayMetadata(
         run_id="run-123",


### PR DESCRIPTION
## Summary

`MetricsCollector` appended to per-day JSONL files (`api_usage_YYYYMMDD.jsonl`, `error_rate_*.jsonl`, etc.) forever — long-running orchestrators end up with multi-GB files and `.sdd/metrics/` trees. `error_suggestions.py` literally recommended `rm -rf` as the fix.

- `rotate_log_file` gains `max_backups` (default `1`, preserving the historical single-rollover behaviour used by `access.log`).
- `_flush_buffer` rotates each target file at 10 MB with 5 backups before appending, so a single writer cannot exceed roughly `(max_backups + 1) * threshold` bytes on disk.
- New `iter_metric_files` helper returns the live file plus rotated backups; consumers that glob `api_usage_*.jsonl` (`cost` CLI, `quality` routes, `incident_timeline`, `away_summary`, `cost.forecast_planned_backlog`) use it so they keep seeing the full history after a rollover.

Closes `-api-usage-jsonl-unbounded`.

## Test plan

- [x] `uv run ruff check <files>` — clean
- [x] `uv run ruff format --check <files>` — clean
- [x] `uv run pytest tests/unit -k "api_usage or jsonl_rotat" -x -q` — 13 passed
- [x] Regression sanity: `test_runtime_state`, `test_metrics`, `test_quality_metrics`, `test_away_summary`, `test_cost_cmd`, `test_incident_timeline`, `test_privacy_presets`, `test_access_log` — 151 passed