### PR TITLE
fix(boot): startup fails — stale LOCKED_FILES + no auth token

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -142,8 +142,16 @@ def _load_dry_run_tasks(plan_file: Path | None) -> list[Any]:
             console.print(f"[red]Plan load error:[/red] {exc}")
             raise SystemExit(1) from exc
 
+    _headers: dict[str, str] = {}
+    _token = os.environ.get("BERNSTEIN_AUTH_TOKEN", "")
+    if _token:
+        _headers["Authorization"] = f"Bearer {_token}"
     try:
-        resp = httpx.get("http://127.0.0.1:8052/tasks?status=open", timeout=5.0)
+        resp = httpx.get(
+            "http://127.0.0.1:8052/tasks?status=open",
+            headers=_headers,
+            timeout=5.0,
+        )
         resp.raise_for_status()
         tasks_data = resp.json()
     except httpx.ConnectError as err:

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -362,7 +362,12 @@ def _sync_and_plan_tasks(
     )
 
     task_filter = os.environ.get("BERNSTEIN_TASK_FILTER")
-    sync_result = sync_backlog_to_server(workdir, server_url=server_url, task_filter=task_filter)
+    sync_result = sync_backlog_to_server(
+        workdir,
+        server_url=server_url,
+        task_filter=task_filter,
+        auth_token=auth_token,
+    )
     backlog_count = len(sync_result.created) + len(sync_result.skipped)
 
     # Import unchecked items from TODO.md / TASKS.md / .plan if present.
@@ -801,7 +806,12 @@ def _goal_sync_and_plan(
 
     task_filter = os.environ.get("BERNSTEIN_TASK_FILTER")
     with Status("[bold]Loading tasks...[/bold]", console=console):
-        sync_result = sync_backlog_to_server(workdir, server_url=server_url, task_filter=task_filter)
+        sync_result = sync_backlog_to_server(
+            workdir,
+            server_url=server_url,
+            task_filter=task_filter,
+            auth_token=auth_token,
+        )
     backlog_count = len(sync_result.created) + len(sync_result.skipped)
 
     # Import unchecked items from TODO.md / TASKS.md / .plan if present.

--- a/src/bernstein/core/persistence/sync.py
+++ b/src/bernstein/core/persistence/sync.py
@@ -284,6 +284,7 @@ def sync_backlog_to_server(
     *,
     client: httpx.Client | None = None,
     task_filter: str | None = None,
+    auth_token: str | None = None,
 ) -> SyncResult:
     """Sync ``.sdd/backlog/open/`` and ``issues/`` files with the task server.
 
@@ -315,7 +316,10 @@ def sync_backlog_to_server(
     backlog_done.mkdir(parents=True, exist_ok=True)
 
     owned_client = client is None
-    _client = client or httpx.Client(timeout=10.0)
+    _client_headers: dict[str, str] = {}
+    if auth_token:
+        _client_headers["Authorization"] = f"Bearer {auth_token}"
+    _client = client or httpx.Client(timeout=10.0, headers=_client_headers)
 
     try:
         # Build a set of slugs for all existing server tasks

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -460,8 +460,33 @@ def _resolve_bind_host() -> str:
 
 
 def _resolve_auth_token() -> str | None:
-    """Read auth token from env var."""
-    return os.environ.get("BERNSTEIN_AUTH_TOKEN")
+    """Resolve the Bearer token used by bootstrap to talk to its own server.
+
+    Precedence:
+        1. Explicit ``BERNSTEIN_AUTH_TOKEN`` env var (operator-configured).
+        2. Ephemeral auto-generated token when auth is enabled but no token is
+           set and no opt-out is active. The generated token is written into
+           ``os.environ`` so both the server subprocess (which inherits env in
+           ``_start_server``) and the bootstrap client see the same value.
+        3. ``None`` when ``BERNSTEIN_AUTH_DISABLED=1`` — the middleware
+           short-circuits in that mode so no header is required.
+    """
+    existing = os.environ.get("BERNSTEIN_AUTH_TOKEN")
+    if existing:
+        return existing
+    # Honour the explicit opt-out — the middleware will accept anonymous
+    # requests, so we do not auto-generate a token that no one will check.
+    if os.environ.get("BERNSTEIN_AUTH_DISABLED", "").strip().lower() in ("1", "true", "yes"):
+        return None
+    import secrets
+
+    token = secrets.token_urlsafe(32)
+    os.environ["BERNSTEIN_AUTH_TOKEN"] = token
+    logger.info(
+        "Auto-generated BERNSTEIN_AUTH_TOKEN for this session (not persisted; "
+        "set BERNSTEIN_AUTH_TOKEN to pin or BERNSTEIN_AUTH_DISABLED=1 to opt out).",
+    )
+    return token
 
 
 def _detect_project_type(workdir: Path) -> str:


### PR DESCRIPTION
## Problem

\`bernstein\` fails to start with two independent issues:

1. **Invariant violation / missing files.** \`.sdd/invariants.lock\` records baseline hashes for paths that no longer exist after the \`core/\` decomposition — \`src/bernstein/core/{janitor,server,orchestrator}.py\` were moved into sub-packages, but \`LOCKED_FILES\` in \`evolution/invariants.py\` still pointed at the old paths. Every boot now logs \`Locked file not found\` + \`INVARIANT VIOLATION\`.
2. **401 on manager task.** Auth middleware treats the server as "auth configured" whenever the agent-identity store is wired (always), so every \`/tasks\` request now needs a Bearer token. Bootstrap's internal HTTP calls only attached \`Authorization\` when \`BERNSTEIN_AUTH_TOKEN\` was set in the environment, so a vanilla \`bernstein\` invocation got \`401 {"detail":"Missing or invalid Authorization header"}\` from \`_inject_manager_task\` and from the backlog-sync GETs.

## Fix

- \`invariants.LOCKED_FILES\`: point at the post-refactor paths (\`orchestration/orchestrator.py\`, \`quality/janitor.py\`, \`server/server_app.py\`). Ops need to delete any pre-existing \`.sdd/invariants.lock\` once so it gets regenerated from the new paths.
- \`server_launch._resolve_auth_token\`: when auth is enabled-by-default (no \`BERNSTEIN_AUTH_DISABLED\`) and no \`BERNSTEIN_AUTH_TOKEN\` is set, generate an ephemeral token via \`secrets.token_urlsafe(32)\` and stash it in \`os.environ\`. Both the server subprocess (inherits env in \`_start_server\`) and the bootstrap client (reads env) converge on the same token. Operators pinning a token or opting out of auth see no behaviour change.
- Thread \`auth_token\` through \`sync_backlog_to_server\` and the preview GET in \`cli/run_bootstrap.py\` so backlog sync and plan preview stop 401-ing.

## Test plan

- \`bernstein\` in a clean workspace with neither env var set: server starts, manager task created, backlog syncs.
- \`BERNSTEIN_AUTH_DISABLED=1 bernstein\`: no token generated, anonymous requests accepted.
- \`BERNSTEIN_AUTH_TOKEN=pin bernstein\`: uses the pinned token.