### PR TITLE
fix(tui+cli): empty Tasks panel — missing Authorization header

### DIFF
--- a/src/bernstein/cli/commands/graph_cmd.py
+++ b/src/bernstein/cli/commands/graph_cmd.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 import click
 import httpx
 
-from bernstein.cli.helpers import SERVER_URL, console
+from bernstein.cli.helpers import SERVER_URL, auth_headers, console
 from bernstein.core.knowledge_graph import query_impact
 
 # Shared cast-type constants to avoid string duplication (Sonar S1192).
@@ -42,7 +42,7 @@ def graph_impact(file_query: str) -> None:
 def _fetch_task_graph() -> dict[str, Any]:
     """Fetch the structured task dependency graph from the task server."""
     try:
-        resp = httpx.get(f"{SERVER_URL}/tasks/graph", timeout=5.0)
+        resp = httpx.get(f"{SERVER_URL}/tasks/graph", timeout=5.0, headers=auth_headers())
         resp.raise_for_status()
     except httpx.ConnectError:
         console.print("[red]Cannot connect to task server.[/red]")

--- a/src/bernstein/cli/commands/quickstart_cmd.py
+++ b/src/bernstein/cli/commands/quickstart_cmd.py
@@ -11,6 +11,7 @@ import httpx
 
 from bernstein.cli.helpers import (
     SDD_DIRS,
+    auth_headers,
     console,
     is_alive,
     print_banner,
@@ -175,7 +176,7 @@ def _poll_until_done(server_url: str, deadline: float) -> None:
 
         while time.monotonic() < deadline:
             try:
-                resp = httpx.get(f"{server_url}/status", timeout=3.0)
+                resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
                 if resp.status_code == 200:
                     payload = resp.json()
                     tasks_list: list[dict[str, Any]] = payload.get("tasks", [])
@@ -241,7 +242,7 @@ def _print_quickstart_summary(
     tasks_data: list[dict[str, Any]] = []
     total_cost: float = 0.0
     try:
-        resp = httpx.get(f"{server_url}/status", timeout=3.0)
+        resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
         if resp.status_code == 200:
             payload = resp.json()
             tasks_data = payload.get("tasks", [])

--- a/src/bernstein/cli/dashboard_app.py
+++ b/src/bernstein/cli/dashboard_app.py
@@ -1176,7 +1176,16 @@ class BernsteinApp(App[None]):
 
         # 1. Ask the server to shut down gracefully
         with contextlib.suppress(Exception):
-            httpx.post(f"{SERVER_URL}/shutdown", json={"reason": "hot restart"}, timeout=2.0)
+            _shutdown_headers: dict[str, str] = {}
+            _shutdown_token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
+            if _shutdown_token:
+                _shutdown_headers["Authorization"] = f"Bearer {_shutdown_token}"
+            httpx.post(
+                f"{SERVER_URL}/shutdown",
+                json={"reason": "hot restart"},
+                timeout=2.0,
+                headers=_shutdown_headers,
+            )
 
         # 2. Kill spawner and watchdog
         for pid_path in (SDD_PID_SPAWNER, SDD_PID_WATCHDOG):

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -27,11 +28,29 @@ _SPARK_CHARS = "▁▂▃▄▅▆▇█"
 # -- Data fetching (sync -- called via run_worker in a thread) -----
 
 
+def _auth_headers() -> dict[str, str]:
+    """Return Authorization header dict when BERNSTEIN_AUTH_TOKEN is set.
+
+    The TUI runs inside the main Bernstein process and inherits the
+    token that ``_resolve_auth_token`` stashes into ``os.environ``
+    during bootstrap.  Without this header the SSO middleware rejects
+    every request with 401, leaving the Tasks panel empty.
+    """
+    token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
 def _get(path: str) -> Any:
     import httpx
 
     try:
-        return httpx.get(f"{SERVER_URL}{path}", timeout=10.0).json()
+        return httpx.get(
+            f"{SERVER_URL}{path}",
+            timeout=10.0,
+            headers=_auth_headers(),
+        ).json()
     except Exception as exc:
         logger.warning("Dashboard GET %s failed: %s", path, exc)
         return None
@@ -41,7 +60,12 @@ def _post(path: str, body: dict[str, Any] | None = None) -> Any:
     import httpx
 
     try:
-        return httpx.post(f"{SERVER_URL}{path}", json=body or {}, timeout=2.0).json()
+        return httpx.post(
+            f"{SERVER_URL}{path}",
+            json=body or {},
+            timeout=2.0,
+            headers=_auth_headers(),
+        ).json()
     except Exception as exc:
         logger.warning("Dashboard POST %s failed: %s", path, exc)
         return None

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -29,12 +29,13 @@ _SPARK_CHARS = "▁▂▃▄▅▆▇█"
 
 
 def _auth_headers() -> dict[str, str]:
-    """Return Authorization header dict when BERNSTEIN_AUTH_TOKEN is set.
+    """Return Authorization header when ``BERNSTEIN_AUTH_TOKEN`` is set.
 
-    The TUI runs inside the main Bernstein process and inherits the
-    token that ``_resolve_auth_token`` stashes into ``os.environ``
-    during bootstrap.  Without this header the SSO middleware rejects
-    every request with 401, leaving the Tasks panel empty.
+    The TUI runs inside the main Bernstein process, so it inherits the
+    token that ``_resolve_auth_token`` stashes into ``os.environ`` during
+    bootstrap (see ``core.server.server_launch``). Without this header the
+    SSO middleware rejects every request with 401, leaving the Tasks
+    panel empty.
     """
     token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
     if token:

--- a/src/bernstein/cli/live.py
+++ b/src/bernstein/cli/live.py
@@ -6,6 +6,7 @@ from task-server data, plus a simple sparkline renderer for cost over time.
 
 from __future__ import annotations
 
+import os
 import time
 from collections import deque
 from typing import Any
@@ -115,8 +116,12 @@ class LiveView:
         Returns:
             Parsed JSON response, or None on error.
         """
+        headers: dict[str, str] = {}
+        token = os.environ.get("BERNSTEIN_AUTH_TOKEN")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
         try:
-            resp = httpx.get(f"{self._server_url}{path}", timeout=2.0)
+            resp = httpx.get(f"{self._server_url}{path}", timeout=2.0, headers=headers)
             result: dict[str, Any] | list[Any] = resp.json()
             return result
         except Exception:

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -12,6 +12,7 @@ import httpx
 
 from bernstein.cli.helpers import (
     SDD_DIRS,
+    auth_headers,
     console,
     is_alive,
     print_banner,
@@ -449,7 +450,7 @@ def _print_demo_summary(project_dir: Path, server_url: str, elapsed_secs: float 
     tasks_data: list[dict[str, Any]] = []
     total_cost: float = 0.0
     try:
-        resp = httpx.get(f"{server_url}/status", timeout=3.0)
+        resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
         if resp.status_code == 200:
             payload = resp.json()
             tasks_data = payload.get("tasks", [])
@@ -582,7 +583,7 @@ def _poll_demo_completion(server_url: str, deadline: float) -> None:
 
         while time.monotonic() < deadline:
             try:
-                resp = httpx.get(f"{server_url}/status", timeout=3.0)
+                resp = httpx.get(f"{server_url}/status", timeout=3.0, headers=auth_headers())
                 if resp.status_code == 200:
                     payload = resp.json()
                     tasks_list: list[dict[str, Any]] = payload.get("tasks", [])


### PR DESCRIPTION
## Problem

After PR #895 made auth ON-by-default with an auto-generated token, the TUI Tasks panel stayed empty and several CLI helpers started 401-ing. The server log was spammed with:

\`\`\`
GET /status     401 Unauthorized
GET /costs      401 Unauthorized
GET /quality    401 Unauthorized
GET /routing/bandit  401 Unauthorized
GET /tasks      401 Unauthorized
\`\`\`

Root cause: the SSO middleware (\`_compute_auth_configured\`) treats the server as auth-configured whenever any backend is wired — and the agent-identity store is *always* wired. So every request now needs a Bearer token. Meanwhile:

- \`src/bernstein/cli/dashboard_polling.py\` (main TUI polling) sent no \`Authorization\` header
- \`src/bernstein/cli/live.LiveView._get\` (classic live view) sent no header
- \`src/bernstein/cli/commands/graph_cmd.py\` (graph viewer) sent no header
- \`src/bernstein/cli/commands/quickstart_cmd.py\` (\`bernstein quickstart\`) sent no header
- \`src/bernstein/cli/run_confirm.py\` (run-confirm polling) sent no header
- \`src/bernstein/cli/dashboard_app.py\` (hot-restart \`/shutdown\` call) sent no header

## Fix

All six call sites now pull the token from \`os.environ["BERNSTEIN_AUTH_TOKEN"]\` and attach the \`Authorization: Bearer …\` header. The token is the one bootstrap auto-generates in the main process (PR #895), which the TUI inherits because it runs inside the same Python process.

\`dashboard_polling\` gets a module-level \`_auth_headers()\` helper; other sites reuse \`bernstein.cli.helpers.auth_headers\` or read the env inline where importing the helper would create a cycle.

No behaviour change for operators who pin \`BERNSTEIN_AUTH_TOKEN\` or set \`BERNSTEIN_AUTH_DISABLED=1\`.

## Test plan

- Fresh \`bernstein\` run: Tasks panel populates, \`/status\`, \`/costs\`, \`/quality\`, \`/routing/bandit\`, \`/tasks\` all return 200 in \`.sdd/runtime/server.log\`
- Ctrl+\`r\` hot restart exits cleanly instead of silently failing on \`/shutdown\`
- \`bernstein quickstart\` and \`bernstein cook ... --dry-run\` still work