### PR TITLE
test: cover hook env passthrough + 500-char title cap

### DIFF
--- a/tests/unit/test_env_isolation.py
+++ b/tests/unit/test_env_isolation.py
@@ -49,6 +49,28 @@ class TestBuildFilteredEnv:
         assert "PATH" in result
         assert "HOME" in result
 
+    def test_bernstein_auth_env_passes_through(self) -> None:
+        """BERNSTEIN_AUTH_TOKEN / BERNSTEIN_HOOK_SECRET must reach the agent.
+
+        The agent's Claude-Code hook runner signs ``/hooks/{session_id}``
+        POSTs with ``SECRET="${BERNSTEIN_HOOK_SECRET:-$BERNSTEIN_AUTH_TOKEN}"``.
+        If the allowlist strips these vars, openssl HMACs over the empty
+        string and every hook event returns 401 — which silently kills
+        token-tracking, context-util %, and completion markers.
+        """
+        env = {
+            "PATH": "/bin",
+            "HOME": "/home/u",
+            "BERNSTEIN_AUTH_TOKEN": "ephemeral-token",
+            "BERNSTEIN_HOOK_SECRET": "shared-secret",
+            "BERNSTEIN_AUTH_DISABLED": "0",
+        }
+        with patch("bernstein.adapters.env_isolation.os.environ", env):
+            result = build_filtered_env()
+        assert result["BERNSTEIN_AUTH_TOKEN"] == "ephemeral-token"
+        assert result["BERNSTEIN_HOOK_SECRET"] == "shared-secret"
+        assert result["BERNSTEIN_AUTH_DISABLED"] == "0"
+
     def test_extra_keys_included(self) -> None:
         """API key names passed via extra_keys are included."""
         env = {"PATH": "/bin", "ANTHROPIC_API_KEY": "sk-ant-abc", "UNRELATED_SECRET": "boom"}

--- a/tests/unit/test_task_create_bounds.py
+++ b/tests/unit/test_task_create_bounds.py
@@ -32,16 +32,33 @@ from bernstein.core.server.server_models import TaskCreate
 # ---------------------------------------------------------------------------
 
 
-def test_task_create_title_capped_at_200() -> None:
-    """title longer than 200 chars is rejected with ValidationError."""
+def test_task_create_title_capped_at_500() -> None:
+    """title longer than 500 chars is rejected with ValidationError.
+
+    Raised from 200 to 500 so real-world backlog/audit titles (up to
+    ~210 chars) no longer 422 the batch ingest endpoint every tick.
+    """
     with pytest.raises(ValidationError):
-        TaskCreate(title="x" * 201, description="ok")
+        TaskCreate(title="x" * 501, description="ok")
 
 
 def test_task_create_title_at_limit_accepted() -> None:
-    """title exactly 200 chars is accepted."""
-    t = TaskCreate(title="x" * 200, description="ok")
-    assert len(t.title) == 200
+    """title exactly 500 chars is accepted."""
+    t = TaskCreate(title="x" * 500, description="ok")
+    assert len(t.title) == 500
+
+
+def test_task_create_accepts_long_descriptive_title() -> None:
+    """Real audit-169-style title (~210 chars) must round-trip cleanly."""
+    long_title = (
+        "audit-169-knowledge-test-only-modules — 10 test-only knowledge "
+        "modules: doc_generator, file_relevance, graduated_memory_guard, "
+        "memory_extractor/sanitizer, repo_index, semantic_diff, synthesis, "
+        "web_graph"
+    )
+    assert len(long_title) > 200
+    t = TaskCreate(title=long_title, description="ok")
+    assert t.title == long_title
 
 
 def test_task_create_description_capped_at_100k() -> None:


### PR DESCRIPTION
## Context

Adds regression coverage for the two proactive fixes that landed in \`02330f81\` (env_isolation allowlist) and the title-cap change / batch-422 fallback. Those source edits were bundled into an unrelated SonarCloud commit by an agent mid-session; this PR ships the tests that should have gone with them.

## What the source fixes did

1. **Hook auth passthrough** — \`_BASE_ALLOWLIST\` in \`adapters/env_isolation.py\` now includes \`BERNSTEIN_AUTH_TOKEN\`, \`BERNSTEIN_HOOK_SECRET\`, \`BERNSTEIN_AUTH_DISABLED\`. Before, every spawned agent lost these vars, the hook runner's \`SECRET=\"\${BERNSTEIN_HOOK_SECRET:-\$BERNSTEIN_AUTH_TOKEN}\"\` expanded to empty, openssl HMAC'd over \`\"\"\`, and every \`POST /hooks/{session_id}\` returned 401. Consequence: orchestrator dashboard showed \`tokens=0 ctx=0%\` for every agent and only fired the completion-marker watchdog at 120s instead of in-line.
2. **Title cap + batch fallback** — \`_MAX_TITLE_LEN\` raised from 200 to 500 ('s real title is 206 chars). \`ingest_backlog\` now falls back to one-by-one ingest on 422 (as it already did on 404), so one oversized title can't poison the whole batch every tick.

## Tests in this PR

- \`test_bernstein_auth_env_passes_through\` — confirms the three env vars survive \`build_filtered_env\`
- \`test_task_create_title_capped_at_500\` — replaces the 200-char test
- \`test_task_create_accepts_long_descriptive_title\` — real -shaped title round-trips