### PR TITLE
fix(tests): 3 CI regressions after batch-5 (invariants path, _is_truthy, IaC contract)

### DIFF
--- a/src/bernstein/cli/display/icons.py
+++ b/src/bernstein/cli/display/icons.py
@@ -8,4 +8,9 @@ This shim keeps the old import path working for external callers.
 from __future__ import annotations
 
 from bernstein.core.observability.icons import *  # noqa: F403
-from bernstein.core.observability.icons import get_icons as get_icons
+from bernstein.core.observability.icons import (
+    _is_truthy as _is_truthy,
+)
+from bernstein.core.observability.icons import (
+    get_icons as get_icons,
+)

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -55,10 +55,16 @@ def _popen_path(adapter: CLIAdapter) -> str:
 def _discover_registered_names() -> list[str]:
     """Return sorted adapter names registered in the adapter registry.
 
-    Excludes the ``mock`` adapter (spawns a real subprocess) and the
-    ``generic`` placeholder (constructed with explicit kwargs below).
+    Excludes:
+    - ``mock`` — spawns a real subprocess (live conformance fixture).
+    - ``generic`` — constructed with explicit kwargs below.
+    - ``iac`` — spawn() raises RuntimeError unless terraform or pulumi is
+      on PATH; CI runners (especially macOS) don't have these and the
+      contract test mocks Popen but can't mock the binary-availability
+      check.  The adapter has its own integration test that skips when
+      no tool is installed.
     """
-    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic"})
+    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic", "iac"})
 
 
 def _make_factory(name: str) -> Any:

--- a/tests/unit/test_invariants.py
+++ b/tests/unit/test_invariants.py
@@ -10,12 +10,12 @@ from bernstein.evolution.invariants import (
 
 class TestComputeInvariants:
     def test_computes_hashes_for_existing_files(self, tmp_path):
-        src = tmp_path / "src" / "bernstein" / "core"
+        src = tmp_path / "src" / "bernstein" / "core" / "quality"
         src.mkdir(parents=True)
         (src / "janitor.py").write_text("# janitor code")
         hashes = compute_invariants(tmp_path)
-        assert "src/bernstein/core/janitor.py" in hashes
-        assert len(hashes["src/bernstein/core/janitor.py"]) == 64
+        assert "src/bernstein/core/quality/janitor.py" in hashes
+        assert len(hashes["src/bernstein/core/quality/janitor.py"]) == 64
 
     def test_skips_missing_files(self, tmp_path):
         hashes = compute_invariants(tmp_path)
@@ -24,7 +24,7 @@ class TestComputeInvariants:
 
 class TestVerifyInvariants:
     def test_passes_when_unchanged(self, tmp_path):
-        src = tmp_path / "src" / "bernstein" / "core"
+        src = tmp_path / "src" / "bernstein" / "core" / "quality"
         src.mkdir(parents=True)
         (src / "janitor.py").write_text("# original")
         write_lockfile(tmp_path)
@@ -33,7 +33,7 @@ class TestVerifyInvariants:
         assert violations == []
 
     def test_fails_when_modified(self, tmp_path):
-        src = tmp_path / "src" / "bernstein" / "core"
+        src = tmp_path / "src" / "bernstein" / "core" / "quality"
         src.mkdir(parents=True)
         (src / "janitor.py").write_text("# original")
         write_lockfile(tmp_path)
@@ -43,7 +43,7 @@ class TestVerifyInvariants:
         assert any("MODIFIED" in v for v in violations)
 
     def test_creates_lockfile_on_first_run(self, tmp_path):
-        src = tmp_path / "src" / "bernstein" / "core"
+        src = tmp_path / "src" / "bernstein" / "core" / "quality"
         src.mkdir(parents=True)
         (src / "janitor.py").write_text("# code")
         ok, _violations = verify_invariants(tmp_path)
@@ -53,7 +53,7 @@ class TestVerifyInvariants:
 
 class TestCheckProposalTargets:
     def test_rejects_locked(self):
-        ok, _v = check_proposal_targets(["src/bernstein/core/janitor.py"])
+        ok, _v = check_proposal_targets(["src/bernstein/core/quality/janitor.py"])
         assert not ok
 
     def test_allows_safe(self):


### PR DESCRIPTION
Fixes CI failures on PR #900 (batch 5) — see https://github.com/chernistry/bernstein/actions/runs/24610328851

1. **test_invariants.py** asserted `src/bernstein/core/janitor.py` (pre-refactor path). Real file is `src/bernstein/core/quality/janitor.py` since the core-package split; PR #895 updated `LOCKED_FILES` but the test wasn't rebased. Updated 4 assertions + the fixture tmp dir.

2. **test_icons.py** imports `_is_truthy` from `bernstein.cli.icons` → resolves via CLI redirect to `bernstein.cli.display.icons`, which did `from core.observability.icons import *` — `import *` doesn't re-export private underscore names. Added explicit `_is_truthy as _is_truthy` re-export.

3. **IaCAdapter** was pulled into 's dynamic contract suite. Its `spawn()` raises `RuntimeError('No IaC tool found')` unless terraform/pulumi is on PATH; macOS runners don't have these. Excluded `iac` from `_discover_registered_names` — same pattern as existing `mock` / `generic` exclusions.