### PR TITLE
fix(core): point cheaper_retry/retry_budget redirects at cost.planned

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -85,13 +85,7 @@ jobs:
           # Use junitxml export if available (mutmut >= 2.0 supports it)
           uv run mutmut junitxml > mutmut_junit.xml 2>/dev/null || true
 
-          # Compute score from mutmut summary
-          SUMMARY=$(uv run mutmut run --no-progress 2>&1 | tail -5 || true)
-
-          # Parse "X/Y mutants killed" from the summary output
-          TOTAL_LINE=$(uv run mutmut results 2>/dev/null | grep -E "^[0-9]" | head -1 || true)
-
-          # Alternative: use mutmut show for detailed summary
+          # Use mutmut show for detailed summary
           MUTMUT_OUTPUT=$(uv run mutmut results 2>&1 || true)
           KILLED_COUNT=$(printf '%s\n' "$MUTMUT_OUTPUT" | grep -c "^[0-9].*Killed" || true)
           SURVIVED_COUNT=$(printf '%s\n' "$MUTMUT_OUTPUT" | grep -c "^[0-9].*Survived\|^[0-9].*Suspicious" || true)
@@ -106,21 +100,25 @@ jobs:
 
           if [ "$TOTAL" -eq 0 ]; then
             echo "::warning::No mutations were generated or mutmut output could not be parsed"
-            echo "score=0" >> "$GITHUB_OUTPUT"
-            echo "killed=0" >> "$GITHUB_OUTPUT"
-            echo "total=0" >> "$GITHUB_OUTPUT"
+            {
+              echo "score=0"
+              echo "killed=0"
+              echo "total=0"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           # Score = killed / (killed + survived + timeout) * 100
           SCORE=$(( KILLED_COUNT * 100 / TOTAL ))
 
-          echo "score=$SCORE" >> "$GITHUB_OUTPUT"
-          echo "killed=$KILLED_COUNT" >> "$GITHUB_OUTPUT"
-          echo "survived=$SURVIVED_COUNT" >> "$GITHUB_OUTPUT"
-          echo "timeout=$TIMEOUT_COUNT" >> "$GITHUB_OUTPUT"
-          echo "total=$TOTAL" >> "$GITHUB_OUTPUT"
-          echo "threshold=$THRESHOLD" >> "$GITHUB_OUTPUT"
+          {
+            echo "score=$SCORE"
+            echo "killed=$KILLED_COUNT"
+            echo "survived=$SURVIVED_COUNT"
+            echo "timeout=$TIMEOUT_COUNT"
+            echo "total=$TOTAL"
+            echo "threshold=$THRESHOLD"
+          } >> "$GITHUB_OUTPUT"
 
           echo "Mutation score: $SCORE% ($KILLED_COUNT/$TOTAL killed)"
           echo "Threshold: $THRESHOLD%"

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -92,7 +92,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "cascading_failure_circuit_breaker": "bernstein.core.observability.cascading_failure_circuit_breaker",
     "cascading_token_counter": "bernstein.core.tokens.cascading_token_counter",
     "changelog": "bernstein.core.git.changelog",
-    "cheaper_retry": "bernstein.core.cost.cheaper_retry",
+    "cheaper_retry": "bernstein.core.cost.planned.cheaper_retry",
     "checkpoint": "bernstein.core.persistence.checkpoint",
     "ci_fix": "bernstein.core.quality.ci_fix",
     "ci_log_parser": "bernstein.core.quality.ci_log_parser",
@@ -411,7 +411,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "researcher": "bernstein.core.knowledge.researcher",
     "resource_limits": "bernstein.core.security.resource_limits",
     "retrospective": "bernstein.core.quality.retrospective",
-    "retry_budget": "bernstein.core.cost.retry_budget",
+    "retry_budget": "bernstein.core.cost.planned.retry_budget",
     "review_rubric": "bernstein.core.quality.review_rubric",
     # reviewer: removed in audit-192 — dead code, no production importers.
     "roadmap_runtime": "bernstein.core.planning.roadmap_runtime",


### PR DESCRIPTION
## Summary
- `_REDIRECT_MAP` targeted `bernstein.core.cost.{cheaper_retry,retry_budget}`, but both modules live in `bernstein.core.cost.planned`. Collection of `tests/unit/test_cheaper_retry.py` and `tests/unit/test_retry_budget.py` failed with `ModuleNotFoundError`, reddening `Test (ubuntu-3.12/3.13)` and `Test (macos-3.13)` on main (run 24611581681).
- Clean up `mutation-testing.yml`: fold consecutive `>> "$GITHUB_OUTPUT"` redirects into `{ … } >>` blocks (shellcheck SC2129), and drop unused `SUMMARY` / `TOTAL_LINE` captures (SC2034).

Precedent for the redirect fix is `dd3e84e6` — `api_usage.py` was moved out of `planned/` for the same reason. Here, no production code imports either module yet, so keeping them in `planned/` and retargeting the redirect is the lighter-touch fix.

## Test plan
- [x] `uv run pytest tests/unit/test_cheaper_retry.py tests/unit/test_retry_budget.py -q` → 20 passed locally
- [x] `actionlint .github/workflows/mutation-testing.yml` clean
- [x] `ruff check` / `ruff format --check` clean
- [ ] CI green on PR