### PR TITLE
ci(release): strip internal ticket refs from generated notes

### DIFF
--- a/scripts/format_release_notes.py
+++ b/scripts/format_release_notes.py
@@ -38,13 +38,73 @@ _CATEGORIES: OrderedDict[str, str] = OrderedDict(
 )
 
 _SKIP_PREFIXES: tuple[str, ...] = ("chore: auto-bump",)
+_BATCH_SUMMARY_PREFIXES: tuple[str, ...] = ("audit batch ", "batch ")
 # Trailing PR ref, e.g. " (#123)". Inputs come from ``git log --pretty='%s'``
 # so subjects are a single line — the explicit ``[^\n]`` bound and required
 # single leading space avoid any quadratic-backtracking surface Sonar flags.
 _PR_SUFFIX_RE = re.compile(r" \(#\d+\)$")
-_CC_RE = re.compile(
-    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)\n]+)\))?!?: (?P<subject>[^\n]+)$"
-)
+# Trailing parenthesised single internal-ticket ref, e.g. " (audit-123)".
+# Single-pass only — for multi-ticket refs ``_strip_internal_refs`` loops.
+# No nested repetition and no alternation under a quantifier, so this is
+# linear-time regardless of input.
+_TICKET_SUFFIX_RE = re.compile(r" \((?:audit|rt)-\d+\)$", re.IGNORECASE)
+# Internal-ticket scope, e.g. "fix(audit-160): ..." — keep the subject,
+# drop the scope so the reader sees "- ..." instead of "- **audit-160:** ...".
+_TICKET_SCOPE_RE = re.compile(r"^(?:audit|rt)-\d+$", re.IGNORECASE)
+_CC_RE = re.compile(r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)\n]+)\))?!?: (?P<subject>[^\n]+)$")
+
+
+def _is_batch_summary(subject: str) -> bool:
+    """Detect "Audit batch 6 (final): 9 tickets (142, 154, ...)" merge lines.
+
+    Uses plain string ops (no regex) because the pattern is a fixed
+    prefix followed by bounded keywords, and we want to keep the file
+    free of Sonar ReDoS hotspots.
+    """
+    lowered = subject.lower()
+    if not lowered.startswith(_BATCH_SUMMARY_PREFIXES):
+        return False
+    colon = subject.find(":")
+    if colon == -1:
+        return False
+    tail = subject[colon + 1 :].lstrip()
+    # Expect: "<N> ticket[s] (…"
+    count, _, rest = tail.partition(" ")
+    if not count.isdigit():
+        return False
+    word, _, rest = rest.partition(" ")
+    return word in ("ticket", "tickets") and rest.startswith("(")
+
+
+def _strip_internal_refs(text: str) -> str:
+    """Remove trailing internal-ticket refs like " (audit-123)" from a subject.
+
+    Loops a linear-time regex for multi-ticket cases such as
+    " (audit-123, audit-456)", stripping one ref per pass. Bounded by
+    the subject length so termination is guaranteed.
+    """
+    result = text
+    # Multi-ticket refs are rendered by git as " (audit-123, audit-456)";
+    # strip the parentheses first when we see that shape, then let the
+    # single-ref regex take over.
+    while True:
+        stripped = _TICKET_SUFFIX_RE.sub("", result)
+        if stripped != result:
+            result = stripped
+            continue
+        # Handle " (audit-123, audit-456[, ...])" by chopping one ref at a
+        # time from the right inside the parentheses.
+        if result.endswith(")") and ", " in result:
+            open_paren = result.rfind("(")
+            if open_paren == -1:
+                break
+            inside = result[open_paren + 1 : -1]
+            refs = inside.split(", ")
+            if all(_TICKET_SCOPE_RE.match(r) for r in refs):
+                result = result[:open_paren].rstrip()
+                continue
+        break
+    return result
 
 
 def format_notes(version: str, prev_tag: str, repo: str, commits: list[str]) -> str:
@@ -56,18 +116,27 @@ def format_notes(version: str, prev_tag: str, repo: str, commits: list[str]) -> 
         subject = raw.strip()
         if not subject or any(subject.startswith(p) for p in _SKIP_PREFIXES):
             continue
+        # Audit-batch merge summaries list internal ticket IDs with no
+        # description of what actually changed. The real work shows up on
+        # the per-fix commits, so drop the summary line entirely.
+        if _is_batch_summary(subject):
+            continue
         match = _CC_RE.match(subject)
         if not match:
-            other.append(subject)
+            other.append(_strip_internal_refs(_PR_SUFFIX_RE.sub("", subject)))
             continue
         commit_type = match.group("type")
         scope = match.group("scope") or ""
-        text = _PR_SUFFIX_RE.sub("", match.group("subject").strip())
+        text = _strip_internal_refs(_PR_SUFFIX_RE.sub("", match.group("subject").strip()))
+        # Ticket-only scopes (e.g. ``fix(audit-160): …``) add noise —
+        # keep the fix description, drop the ticket scope marker.
+        if _TICKET_SCOPE_RE.match(scope):
+            scope = ""
         bullet = f"**{scope}:** {text}" if scope else text
         if commit_type in buckets:
             buckets[commit_type].append(bullet)
         else:
-            other.append(subject)
+            other.append(bullet)
 
     out: list[str] = [f"## v{version}", ""]
 


### PR DESCRIPTION
## Summary
- Generator now drops trailing " (audit-NNN)" / " (rt-NNN)" suffixes so subjects like "validate PKCE state parameter" land as "validate PKCE state parameter".
- Ticket-only scopes — e.g. "fix: …" — render without the scope marker, so the reader sees "delete dead bulletin_board.py — zero production importers" instead of "**:** …".
- "Audit batch N (final): N tickets (…)" merge-summary lines are dropped entirely. They list internal IDs but don't describe what changed; the real per-fix commits surface regardless.

Tested by running the script against a sample of representative commits from the v1.8.x history — output is free of internal identifiers and reads as release notes rather than a commit dump.

## Test plan
- [x] `uv run pytest tests/unit/test_release_notes.py -q` → 11 passed (covers the fetch/display side; no tests exist for the generator itself)
- [x] Manual run of `scripts/format_release_notes.py` on ~10 sample commit subjects — ticket refs stripped, batch summaries gone.
- [ ] Verified on next auto-release