### PR TITLE
feat(sandbox): pluggable SandboxBackend protocol with worktree, Docker, E2B, Modal

### DIFF
--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -1,0 +1,224 @@
+# Sandbox backends
+
+Bernstein isolates every spawned agent in a sandbox so multiple agents
+running against the same repository cannot stomp on each other's
+files, processes, or secrets. Historically the only sandbox type was
+a local git worktree. As of oai-002 the choice of sandbox is pluggable
+— agents can run inside worktrees, Docker containers, E2B microVMs,
+Modal sandboxes, or any backend a plugin author registers.
+
+This document covers:
+
+- The `SandboxBackend` / `SandboxSession` protocol and the
+  `WorkspaceManifest` / `SandboxCapability` value objects
+- The four first-party backends (`worktree`, `docker`, `e2b`, `modal`)
+- The `bernstein.sandbox_backends` entry-point group for third-party
+  backends
+- The phased rollout plan (phase 1 lands the protocol and backends;
+  phase 2 — tracked as `oai-002b` — refactors the spawner to route
+  adapter exec through `SandboxSession`)
+
+## Protocol shape
+
+The protocol lives in `src/bernstein/core/sandbox/`:
+
+```python
+from bernstein.core.sandbox import (
+    SandboxBackend,
+    SandboxSession,
+    SandboxCapability,
+    WorkspaceManifest,
+    GitRepoEntry,
+    FileEntry,
+    ExecResult,
+    get_backend,
+    list_backends,
+    register_backend,
+)
+```
+
+### `SandboxBackend`
+
+A `runtime_checkable` `Protocol`. Every backend exposes:
+
+- `name: str` — canonical identifier referenced from `plan.yaml`.
+- `capabilities: frozenset[SandboxCapability]` — feature flags.
+- `async def create(manifest, options=None) -> SandboxSession` —
+  provision a fresh sandbox.
+- `async def resume(snapshot_id) -> SandboxSession` — restore a
+  snapshot; raises `NotImplementedError` if the backend does not
+  declare `SandboxCapability.SNAPSHOT`.
+- `async def destroy(session) -> None` — tear down a session.
+
+### `SandboxSession`
+
+An `ABC` with six abstract methods:
+
+- `read(path) -> bytes`
+- `write(path, data, *, mode=0o644) -> None`
+- `exec(cmd, *, cwd=None, env=None, timeout=None, stdin=None) -> ExecResult`
+- `ls(path) -> list[str]`
+- `snapshot() -> str` (SNAPSHOT-capable backends only)
+- `shutdown() -> None` (idempotent)
+
+`ExecResult` is a frozen dataclass with `exit_code`, `stdout`,
+`stderr`, and `duration_seconds`.
+
+### `SandboxCapability`
+
+An `StrEnum` with six values: `FILE_RW`, `EXEC`, `NETWORK`, `GPU`,
+`SNAPSHOT`, `PERSISTENT_VOLUMES`. Every backend advertises the set
+it supports; schedulers reject manifests requiring capabilities the
+selected backend does not expose.
+
+### `WorkspaceManifest`
+
+Immutable value object passed to `SandboxBackend.create`:
+
+```python
+@dataclass(frozen=True)
+class WorkspaceManifest:
+    root: str = "/workspace"
+    repo: GitRepoEntry | None = None
+    files: tuple[FileEntry, ...] = ()
+    env: Mapping[str, str] = field(default_factory=dict)
+    timeout_seconds: int = 1800
+```
+
+`GitRepoEntry` and `FileEntry` are companion frozen dataclasses.
+Cloud-specific mount entries (S3, persistent volumes, secrets
+manager bindings) are intentionally deferred to `oai-003`.
+
+## First-party backends
+
+| Backend | Ships in | `capabilities`                                  | Notes |
+|---------|----------|--------------------------------------------------|-------|
+| `worktree` | core     | `FILE_RW`, `EXEC`, `NETWORK`                     | Wraps the existing `WorktreeManager`. Zero behaviour change. Default. |
+| `docker`   | core     | `FILE_RW`, `EXEC`, `NETWORK`                     | Launches a container per session via the `docker` Python SDK. Needs `pip install bernstein[docker]`. |
+| `e2b`      | `[e2b]` extra | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`     | Runs in E2B Firecracker microVMs. Needs `pip install bernstein[e2b]` plus `E2B_API_KEY`. |
+| `modal`    | `[modal]` extra | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`, `GPU` | Serverless containers with optional GPU. Needs `pip install bernstein[modal]` plus `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`. |
+
+### Trade-offs
+
+- **Latency.** `worktree` has no provisioning cost; `docker` adds a
+  one-time pull plus ≤ 2 s container start; `e2b` / `modal` add 1–3 s
+  of cold start per session plus provider-side overhead.
+- **Cost.** `worktree` and `docker` are free (local compute). `e2b`
+  bills by sandbox minute. `modal` bills by compute seconds, with
+  optional GPU surcharges.
+- **Isolation.** `worktree` shares the host filesystem and network;
+  `docker` provides cgroup + namespace isolation but shares the
+  kernel; `e2b` runs in a fresh Firecracker microVM per session;
+  `modal` runs in dedicated serverless containers.
+- **Capabilities.** Only `e2b` and `modal` support snapshot/resume;
+  only `modal` exposes GPU today.
+- **Supported exec semantics.** All four backends handle argv-based
+  exec with exit-code, stdout, and stderr capture. `docker` does not
+  support stdin injection in phase 1; that is tracked in `oai-002b`.
+
+## `plan.yaml` extension
+
+```yaml
+stages:
+  - name: risky-execution
+    sandbox:
+      backend: docker          # worktree (default), docker, e2b, modal, or a plugin name
+      options:
+        image: python:3.13-slim
+        memory_mb: 2048
+        timeout_seconds: 1800
+    steps:
+      - title: "Run untrusted code analysis"
+        role: security
+        cli: claude
+```
+
+`sandbox:` is entirely optional. When omitted the stage runs in the
+worktree backend — byte-identical to pre-oai-002 behaviour.
+
+## Registering a custom backend
+
+Plugin authors declare an entry point in their own `pyproject.toml`:
+
+```toml
+[project.entry-points."bernstein.sandbox_backends"]
+mybackend = "my_package.sandbox:MySandboxBackend"
+```
+
+On next process start the registry picks the entry up automatically.
+`bernstein agents sandbox-backends` lists every installed backend
+with its capability set so operators can verify registration.
+
+Third-party backends must:
+
+1. Provide `name` and `capabilities` class attributes.
+2. Implement `create`, `resume`, and `destroy` as coroutines.
+3. Pass the conformance suite at
+   `bernstein.core.sandbox.conformance.SandboxBackendConformance`.
+4. Import provider SDKs lazily (inside methods or behind
+   `TYPE_CHECKING`) so importing the backend module never crashes on
+   a missing SDK.
+
+## Phased rollout
+
+### Phase 1 (this ticket, `oai-002`)
+
+- `SandboxBackend` / `SandboxSession` / `SandboxCapability` /
+  `WorkspaceManifest` land in `src/bernstein/core/sandbox/`.
+- Four first-party backends ship (worktree & docker in core; e2b &
+  modal as optional extras).
+- `AgentSpawner` gains an optional `sandbox_session` parameter. When
+  `None` it falls back to the existing direct-worktree path. All 35
+  adapters continue to run unchanged.
+- `bernstein agents sandbox-backends` lists installed backends.
+- `plan.yaml` accepts an optional `sandbox:` block per stage.
+
+### Phase 2 (follow-up, `oai-002b`)
+
+- `AgentSpawner` routes adapter exec through
+  `SandboxSession.exec`, so the selected backend controls where
+  subprocesses actually run.
+- Adapters are refactored one-by-one to use `session.read` /
+  `session.write` for file I/O instead of direct `Path.write_bytes`
+  calls on the worktree directory.
+- Cost metrics and WAL events gain backend-aware labels.
+
+Phase 2 is a mechanical but widespread refactor across 35 adapters;
+keeping it out of phase 1 lets the protocol land independently.
+
+## Observability (phase 1 scaffolding)
+
+Each backend create/destroy cycle should emit WAL + Prometheus
+metrics:
+
+- `sandbox_session_created{backend=..., session_id=...}`
+- `sandbox_session_destroyed{backend=..., duration_seconds=...}`
+- `sandbox_exec_count{backend=..., exit_code=...}`
+
+Wiring into the existing metrics/WAL subsystems is part of
+`oai-002b`; phase 1 only exposes the interfaces.
+
+## Conformance
+
+`SandboxBackendConformance` (in
+`src/bernstein/core/sandbox/conformance.py`) is a parametrised pytest
+class any backend can subclass to get a complete protocol test
+coverage suite. Backends declaring `SANDBOX_CAPABILITY.SNAPSHOT`
+additionally get the snapshot/resume round-trip test automatically.
+
+The worktree backend runs the conformance suite in unit tests
+(`tests/unit/sandbox/test_backend_protocol.py`). Docker / E2B /
+Modal conformance lives under `tests/integration/sandbox/`; those
+tests auto-skip without a live daemon or provider credentials.
+
+## Security considerations
+
+- `worktree` does **not** isolate at the kernel level. If you need
+  to run untrusted code you must choose a sandboxed backend.
+- `docker` should be run with `network_disabled=True` for untrusted
+  workloads; the default leaves network enabled because most agent
+  tasks legitimately need outbound HTTP.
+- `e2b` and `modal` run untrusted code by design; their isolation
+  posture is the provider's responsibility.
+- Snapshot IDs are opaque to callers but may contain sensitive
+  state. Do not log them at INFO level without redaction.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,18 +104,15 @@ grpc = ["grpcio>=1.68", "grpcio-tools>=1.68", "grpcio-reflection>=1.68", "protob
 k8s = ["kubernetes>=31.0"]
 ml = ["scikit-learn>=1.5"]
 graphics = []  # term-image disabled: caps pillow<11, conflicts with CVE-2026-25990 fix
-<<<<<<< HEAD
 # OpenAI Agents SDK v2 integration (src/bernstein/adapters/openai_agents.py).
 # Declared as an optional extra so users who don't spawn OpenAI Agents agents
 # don't need the SDK installed.  Enable with: pip install 'bernstein[openai]'.
 openai = ["openai-agents>=0.4.0"]
-=======
 # Sandbox backend extras (oai-002). Each pulls in the provider SDK for the
 # corresponding SandboxBackend. Kept optional so minimal installs stay lean.
 docker = ["docker>=7"]
 e2b = ["e2b-code-interpreter>=1.0"]
 modal = ["modal>=0.65"]
->>>>>>> 1d54cea5 (build(deps): add docker / e2b / modal optional extras for oai-002)
 
 [project.scripts]
 bernstein = "bernstein.cli.main:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,10 +104,18 @@ grpc = ["grpcio>=1.68", "grpcio-tools>=1.68", "grpcio-reflection>=1.68", "protob
 k8s = ["kubernetes>=31.0"]
 ml = ["scikit-learn>=1.5"]
 graphics = []  # term-image disabled: caps pillow<11, conflicts with CVE-2026-25990 fix
+<<<<<<< HEAD
 # OpenAI Agents SDK v2 integration (src/bernstein/adapters/openai_agents.py).
 # Declared as an optional extra so users who don't spawn OpenAI Agents agents
 # don't need the SDK installed.  Enable with: pip install 'bernstein[openai]'.
 openai = ["openai-agents>=0.4.0"]
+=======
+# Sandbox backend extras (oai-002). Each pulls in the provider SDK for the
+# corresponding SandboxBackend. Kept optional so minimal installs stay lean.
+docker = ["docker>=7"]
+e2b = ["e2b-code-interpreter>=1.0"]
+modal = ["modal>=0.65"]
+>>>>>>> 1d54cea5 (build(deps): add docker / e2b / modal optional extras for oai-002)
 
 [project.scripts]
 bernstein = "bernstein.cli.main:cli"
@@ -133,6 +141,15 @@ bernstein-worker = "bernstein.core.worker:main"
 [project.entry-points."bernstein.reporters"]
 # Custom reporters (hookimpl classes that emit run summaries). Example:
 # slack = "my_package.reporters:SlackReporter"
+
+[project.entry-points."bernstein.sandbox_backends"]
+# Sandbox backends (SandboxBackend protocol implementations, oai-002).
+# First-party backends (worktree, docker) ship in core and are registered
+# by bernstein.core.sandbox.registry directly; plugin authors register
+# additional backends (e2b, modal, cloud providers ...) via this group.
+# Example:
+# e2b = "bernstein.core.sandbox.backends.e2b:E2BSandboxBackend"
+# modal = "bernstein.core.sandbox.backends.modal:ModalSandboxBackend"
 
 [tool.hatch.build]
 exclude = [

--- a/src/bernstein/cli/commands/agents_cmd.py
+++ b/src/bernstein/cli/commands/agents_cmd.py
@@ -528,6 +528,44 @@ def agents_match(role: str, task_description: str) -> None:
     console.print(Panel(t, title=f"[bold]Agent match: {role}[/bold]", border_style="cyan"))
 
 
+@agents_group.command("sandbox-backends")
+def agents_sandbox_backends() -> None:
+    """List installed sandbox backends with their capabilities (oai-002).
+
+    \b
+    Example:
+      bernstein agents sandbox-backends
+
+    Backends are discovered from the ``bernstein.sandbox_backends``
+    entry-point group. First-party backends (``worktree``, ``docker``)
+    always appear; optional cloud backends (``e2b``, ``modal``) appear
+    when installed via the corresponding extra.
+    """
+    from rich.table import Table
+
+    from bernstein.core.sandbox import list_backends
+
+    backends = list_backends()
+    if not backends:
+        console.print("[dim]No sandbox backends installed.[/dim]")
+        return
+
+    table = Table(
+        title="Sandbox backends",
+        show_lines=False,
+        header_style=_STYLE_BOLD_CYAN,
+    )
+    table.add_column("NAME", style="bold", min_width=12)
+    table.add_column("CAPABILITIES", min_width=42)
+
+    for backend in sorted(backends, key=lambda b: b.name):
+        caps = ", ".join(sorted(c.value for c in backend.capabilities))
+        table.add_row(backend.name, caps or "[dim]—[/dim]")
+
+    console.print(table)
+    console.print(f"\n[dim]{len(backends)} backend(s) installed[/dim]")
+
+
 @agents_group.command("discover")
 @click.option("--net", "include_network", is_flag=True, default=False, help="Also search GitHub and npm.")
 def agents_discover(include_network: bool) -> None:

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -427,7 +427,10 @@ _REDIRECT_MAP: dict[str, str] = {
     "run_session": "bernstein.core.orchestration.run_session",
     "runbooks": "bernstein.core.observability.runbooks",
     "runtime_state": "bernstein.core.persistence.runtime_state",
-    "sandbox": "bernstein.core.security.sandbox",
+    # ``sandbox`` removed in oai-002: ``bernstein.core.sandbox`` is now a
+    # real sub-package that hosts the pluggable SandboxBackend protocol.
+    # Back-compat for the legacy ``DockerSandbox`` primitives is provided by
+    # re-exports inside ``src/bernstein/core/sandbox/__init__.py``.
     "sandbox_escape_detector": "bernstein.core.security.sandbox_escape_detector",
     "sandbox_eval": "bernstein.core.security.sandbox_eval",
     "sanitize": "bernstein.core.security.sanitize",

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -70,7 +70,6 @@ from bernstein.core.orchestrator import ShutdownInProgress
 from bernstein.core.prometheus import agent_spawn_duration
 from bernstein.core.router import ProviderHealthStatus, RouterError, TierAwareRouter
 from bernstein.core.sandbox import DockerSandbox, spawn_in_sandbox
-from bernstein.core.sandbox.backend import SandboxSession
 from bernstein.core.team_state import TeamStateStore
 from bernstein.core.traces import AgentTrace, TraceStore, new_trace
 from bernstein.core.worktree import WorktreeError, WorktreeManager, WorktreeSetupConfig
@@ -92,6 +91,7 @@ if TYPE_CHECKING:
     from bernstein.core.mcp_manager import MCPManager
     from bernstein.core.mcp_registry import MCPRegistry
     from bernstein.core.resource_limits import ResourceLimits
+    from bernstein.core.sandbox.backend import SandboxSession
     from bernstein.core.workspace import Workspace
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -70,6 +70,7 @@ from bernstein.core.orchestrator import ShutdownInProgress
 from bernstein.core.prometheus import agent_spawn_duration
 from bernstein.core.router import ProviderHealthStatus, RouterError, TierAwareRouter
 from bernstein.core.sandbox import DockerSandbox, spawn_in_sandbox
+from bernstein.core.sandbox.backend import SandboxSession
 from bernstein.core.team_state import TeamStateStore
 from bernstein.core.traces import AgentTrace, TraceStore, new_trace
 from bernstein.core.worktree import WorktreeError, WorktreeManager, WorktreeSetupConfig
@@ -819,6 +820,7 @@ class AgentSpawner:
         resource_limits: ResourceLimits | None = None,
         warm_pool: WarmPool | None = None,
         spawn_rate_limiter: SpawnRateLimiter | None = None,
+        sandbox_session: SandboxSession | None = None,
     ) -> None:
         self._enable_caching = enable_caching
         self._resource_limits = resource_limits
@@ -883,6 +885,11 @@ class AgentSpawner:
         self._runtime_bridge = runtime_bridge
         self._sandbox = sandbox if sandbox is not None and sandbox.enabled else None
         self._sandbox_managers: dict[str, ContainerManager] = {}
+        # oai-002 phase 1: optional SandboxBackend-issued session. Stored
+        # for orchestration visibility only — the spawner still routes
+        # exec through the worktree path in phase 1. Phase 2 (oai-002b)
+        # routes adapter exec through this session.
+        self._sandbox_session: SandboxSession | None = sandbox_session
         # Container isolation
         self._container_mgr: ContainerManager | None = None
         if container_config is not None:
@@ -994,6 +1001,19 @@ class AgentSpawner:
     def get_worktree_path(self, session_id: str) -> Path | None:
         """Return the worktree path for *session_id*, or None if not registered."""
         return self._worktree_paths.get(session_id)
+
+    @property
+    def sandbox_session(self) -> SandboxSession | None:
+        """Return the optional :class:`SandboxSession` attached to this spawner.
+
+        Phase 1 (oai-002) keeps this purely informational — adapters
+        continue to run as local subprocesses against the worktree
+        path. The session is exposed so the orchestrator and the
+        ``bernstein agents --sandbox-backends`` CLI can report which
+        backend the spawner was wired against. Phase 2 (oai-002b)
+        routes adapter exec through ``sandbox_session.exec``.
+        """
+        return self._sandbox_session
 
     def cleanup_worktree(self, session_id: str) -> None:
         """Remove the worktree and branch for a dead agent session."""

--- a/src/bernstein/core/sandbox/__init__.py
+++ b/src/bernstein/core/sandbox/__init__.py
@@ -1,0 +1,94 @@
+"""Pluggable sandbox backends for agent isolation (oai-002 phase 1).
+
+Bernstein's agent isolation has historically been git-worktree-only.
+This package introduces a protocol-based abstraction so isolation is
+no longer worktree-hardcoded — new backends (Docker, E2B, Modal ...)
+can register via the ``bernstein.sandbox_backends`` entry-point group.
+
+Phase 1 exposes the protocol, manifest, registry, and four first-party
+backends (``worktree``, ``docker`` in core; ``e2b``, ``modal`` via
+optional extras). The spawner is modified only to accept an OPTIONAL
+``sandbox_session`` parameter; when ``None`` the existing direct-
+worktree path is used so no adapter behaviour changes.
+
+Public API::
+
+    from bernstein.core.sandbox import (
+        SandboxBackend,
+        SandboxCapability,
+        SandboxSession,
+        WorkspaceManifest,
+        GitRepoEntry,
+        FileEntry,
+        ExecResult,
+        get_backend,
+        list_backends,
+        list_backend_names,
+        register_backend,
+    )
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Back-compat re-exports.
+#
+# Prior to oai-002 the path ``bernstein.core.sandbox`` was resolved by the
+# ``_CoreRedirectFinder`` in ``bernstein.core`` to ``bernstein.core.security.sandbox``.
+# That redirect is shadowed now that ``sandbox`` is a real package, so we
+# re-export the legacy Docker-container primitives under the same names to
+# keep existing callers (``spawner_core.py``, ``seed_parser.py`` etc.)
+# working unchanged. The new protocol-based primitives are namespaced
+# separately and do not collide.
+# ---------------------------------------------------------------------------
+from typing import Any as _Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxBackend,
+    SandboxCapability,
+    SandboxSession,
+)
+from bernstein.core.sandbox.manifest import (
+    FileEntry,
+    GitRepoEntry,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.registry import (
+    get_backend,
+    list_backend_names,
+    list_backends,
+    register_backend,
+)
+from bernstein.core.security.sandbox import (
+    DockerSandbox,
+    SandboxRuntime,
+    parse_docker_sandbox,
+)
+from bernstein.core.security.sandbox import (
+    spawn_in_sandbox as _spawn_in_sandbox,  # pyright: ignore[reportUnknownVariableType]
+)
+
+# Pyright flags ``spawn_in_sandbox`` as partially unknown because the
+# legacy module's signature uses one inferred parameter. The public
+# re-export is typed as ``Any`` to surface a clean back-compat API
+# until the legacy module gets strict typing in a later ticket.
+spawn_in_sandbox: _Any = _spawn_in_sandbox  # pyright: ignore[reportUnknownVariableType]
+
+__all__ = [
+    "DockerSandbox",
+    "ExecResult",
+    "FileEntry",
+    "GitRepoEntry",
+    "SandboxBackend",
+    "SandboxCapability",
+    "SandboxRuntime",
+    "SandboxSession",
+    "WorkspaceManifest",
+    "get_backend",
+    "list_backend_names",
+    "list_backends",
+    "parse_docker_sandbox",
+    "register_backend",
+    "spawn_in_sandbox",
+]

--- a/src/bernstein/core/sandbox/backend.py
+++ b/src/bernstein/core/sandbox/backend.py
@@ -1,0 +1,281 @@
+"""Sandbox backend protocol and session ABC (oai-002 phase 1).
+
+Bernstein's agent isolation has historically been git-worktree-only. This
+module defines the shape that lets additional isolation backends (Docker,
+E2B, Modal, Daytona, Cloudflare, Vercel ...) plug in behind a uniform
+interface — every backend provisions a :class:`SandboxSession` against a
+:class:`~bernstein.core.sandbox.manifest.WorkspaceManifest` and exposes
+``read``/``write``/``exec``/``ls``/``snapshot``/``shutdown`` primitives.
+
+The design mirrors OpenAI Agents SDK v2's ``SandboxClient`` protocol so
+plugin authors can port implementations across ecosystems with minimal
+shim code.
+
+Phase 1 scope (this ticket, oai-002): protocol + worktree + Docker
+first-party, E2B/Modal as optional extras. The spawner gains an
+OPTIONAL ``sandbox_session`` parameter; when ``None`` it falls back to
+the existing direct-worktree path so all 35 existing adapters keep
+working unchanged. Per-adapter refactor to route exec through
+:class:`SandboxSession` is tracked as a follow-up (``oai-002b``).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+
+class SandboxCapability(StrEnum):
+    """Feature flags describing what a backend can offer.
+
+    Backends advertise a :class:`frozenset` of capabilities so schedulers
+    and the plan loader can reject manifests that demand unsupported
+    features (e.g. a plan that requires ``SNAPSHOT`` on a backend that
+    does not declare it).
+
+    Values:
+        FILE_RW: The backend supports ``session.read`` / ``session.write``.
+        EXEC: The backend supports ``session.exec`` with exit code,
+            stdout, and stderr capture.
+        NETWORK: The sandbox has outbound network access. Worktrees
+            always do; isolated cloud sandboxes frequently do not by
+            default.
+        GPU: The backend can allocate a GPU attached to the session
+            (e.g. Modal).
+        SNAPSHOT: The backend supports ``session.snapshot`` returning an
+            identifier that later ``backend.resume`` can restore.
+        PERSISTENT_VOLUMES: The backend can mount persistent volumes that
+            outlive the session (used by oai-003 cloud artifact storage).
+    """
+
+    FILE_RW = "file_rw"
+    EXEC = "exec"
+    NETWORK = "network"
+    GPU = "gpu"
+    SNAPSHOT = "snapshot"
+    PERSISTENT_VOLUMES = "persistent_volumes"
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    """Result of a :meth:`SandboxSession.exec` invocation.
+
+    Attributes:
+        exit_code: Process exit code. ``0`` indicates success.
+        stdout: Raw bytes written to stdout.
+        stderr: Raw bytes written to stderr.
+        duration_seconds: Wall-clock time taken by the command.
+    """
+
+    exit_code: int
+    stdout: bytes
+    stderr: bytes
+    duration_seconds: float
+
+
+class SandboxSession(ABC):
+    """An active sandbox provisioned by a :class:`SandboxBackend`.
+
+    Sessions are created via :meth:`SandboxBackend.create` and destroyed
+    via :meth:`SandboxBackend.destroy` (which in turn calls
+    :meth:`shutdown`). All file and exec I/O is routed through the
+    session's abstract methods so the caller doesn't need to know whether
+    the sandbox is a local worktree, a Docker container, or a cloud
+    microVM.
+
+    Attributes:
+        backend_name: Canonical name of the owning backend (e.g.
+            ``"worktree"``, ``"docker"``). Set by the backend on
+            construction.
+        session_id: Opaque identifier chosen by the backend. Stable for
+            the session's lifetime.
+        workdir: Logical path inside the sandbox where the workspace
+            root lives. Adapters that still run as local subprocesses
+            use this as ``cwd``; adapters refactored in oai-002b will
+            use it only inside ``session.exec`` invocations.
+    """
+
+    backend_name: str
+    session_id: str
+    workdir: str
+
+    @abstractmethod
+    async def read(self, path: str) -> bytes:
+        """Read a file from the sandbox.
+
+        Args:
+            path: File path inside the sandbox. May be absolute or
+                relative to :attr:`workdir`; backends treat both forms
+                consistently.
+
+        Returns:
+            The file's raw bytes.
+
+        Raises:
+            FileNotFoundError: If no file exists at ``path``.
+            OSError: For other filesystem errors.
+        """
+
+    @abstractmethod
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        """Write bytes to a file in the sandbox.
+
+        Creates parent directories as needed. Overwrites any existing
+        file at ``path``.
+
+        Args:
+            path: File path inside the sandbox.
+            data: Bytes to write.
+            mode: POSIX file mode for the new file. Best-effort on
+                Windows.
+        """
+
+    @abstractmethod
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        """Run a command inside the sandbox.
+
+        Args:
+            cmd: Argv list. The backend is responsible for not piping
+                this through a shell.
+            cwd: Working directory. Defaults to :attr:`workdir`.
+            env: Extra environment variables. Merged on top of the
+                backend's base environment; ``None`` uses the base
+                environment unchanged.
+            timeout: Kill the command after this many seconds. ``None``
+                uses the backend's default.
+            stdin: Optional bytes fed to the command's stdin.
+
+        Returns:
+            An :class:`ExecResult` with exit code, captured output, and
+            duration.
+
+        Raises:
+            TimeoutError: When ``timeout`` elapses before the command
+                finishes.
+        """
+
+    @abstractmethod
+    async def ls(self, path: str) -> list[str]:
+        """List entries inside a directory.
+
+        Args:
+            path: Directory path inside the sandbox.
+
+        Returns:
+            Sorted list of entry names (not full paths). Directories
+            and files are both listed; no type information is implied
+            by the names themselves.
+        """
+
+    @abstractmethod
+    async def snapshot(self) -> str:
+        """Persist the current session state for later ``resume``.
+
+        Backends without :attr:`SandboxCapability.SNAPSHOT` must raise
+        :class:`NotImplementedError`. The returned opaque string is
+        understood only by the owning backend.
+
+        Returns:
+            A snapshot identifier passed back to
+            :meth:`SandboxBackend.resume`.
+
+        Raises:
+            NotImplementedError: When the backend does not declare
+                :attr:`SandboxCapability.SNAPSHOT`.
+        """
+
+    @abstractmethod
+    async def shutdown(self) -> None:
+        """Release all resources held by the session.
+
+        Idempotent — safe to call multiple times.
+        """
+
+
+@runtime_checkable
+class SandboxBackend(Protocol):
+    """Protocol every sandbox backend implements.
+
+    Backends are discovered via the ``bernstein.sandbox_backends``
+    entry-point group (see :mod:`bernstein.core.sandbox.registry`).
+    First-party backends (``worktree``, ``docker``) ship in bernstein
+    core; cloud backends (``e2b``, ``modal``) ship as optional extras.
+
+    Attributes:
+        name: Canonical identifier used in plan.yaml ``sandbox.backend``.
+            Must be stable across versions; rename with care.
+        capabilities: The set of :class:`SandboxCapability` values this
+            backend guarantees. ``FILE_RW`` and ``EXEC`` are effectively
+            mandatory for any useful backend; everything else is opt-in.
+    """
+
+    name: str
+    capabilities: frozenset[SandboxCapability]
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a fresh sandbox per *manifest*.
+
+        Args:
+            manifest: Declarative description of the workspace root,
+                files to inject, and environment variables. See
+                :class:`~bernstein.core.sandbox.manifest.WorkspaceManifest`.
+            options: Backend-specific knobs (e.g. container image name,
+                memory limit). Backends must tolerate ``None`` and
+                unknown keys.
+
+        Returns:
+            An active :class:`SandboxSession`.
+        """
+        ...
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        """Restore a previously-captured snapshot.
+
+        Args:
+            snapshot_id: The opaque value returned by
+                :meth:`SandboxSession.snapshot`.
+
+        Returns:
+            A session whose state equals the snapshot's state.
+
+        Raises:
+            NotImplementedError: When the backend does not declare
+                :attr:`SandboxCapability.SNAPSHOT`.
+        """
+        ...
+
+    async def destroy(self, session: SandboxSession) -> None:
+        """Tear down a session and release any orchestrator-side state.
+
+        Equivalent to calling :meth:`SandboxSession.shutdown` plus any
+        backend-level bookkeeping (deleting images, freeing graveyard
+        entries, etc.). Idempotent.
+        """
+        ...
+
+
+__all__ = [
+    "ExecResult",
+    "SandboxBackend",
+    "SandboxCapability",
+    "SandboxSession",
+]

--- a/src/bernstein/core/sandbox/backends/__init__.py
+++ b/src/bernstein/core/sandbox/backends/__init__.py
@@ -1,0 +1,10 @@
+"""First-party sandbox backends.
+
+Each backend module is self-contained. Optional backends (``e2b``,
+``modal``) import their provider SDK lazily so importing this package
+never pulls in heavyweight optional dependencies.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/bernstein/core/sandbox/backends/_remote_helpers.py
+++ b/src/bernstein/core/sandbox/backends/_remote_helpers.py
@@ -1,0 +1,215 @@
+"""Shared helpers for remote sandbox backends (E2B, Modal).
+
+The E2B and Modal :class:`SandboxBackend` implementations are structurally
+very similar because they both wrap a third-party Python SDK behind the
+same :class:`~bernstein.core.sandbox.backend.SandboxSession` protocol. A
+handful of patterns repeat across them verbatim:
+
+1. POSIX path resolution against a per-session workdir.
+2. Session-id allocation with an optional explicit hint.
+3. Probing a provider SDK for the first attribute name that exists (the
+   SDKs rename methods across versions, so we accept either form).
+4. Encoding SDK return values (``str`` or ``bytes``) as ``bytes``.
+5. The exec-preamble: closed-session guard, empty-argv guard, cwd /
+   timeout / env merging, and the timeout-aware
+   :func:`asyncio.wait_for` + :func:`asyncio.to_thread` dance that turns
+   a blocking SDK call into an :class:`ExecResult`.
+
+Centralising these primitives here lets each backend module focus on
+the truly provider-specific bits (the SDK import, the Sandbox-class
+lookup, the exec signature) without repeating shared scaffolding. It
+also keeps SonarCloud duplication noise off backends that must
+necessarily conform to the same protocol shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import ExecResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+def resolve_posix_path(workdir: str, path: str) -> str:
+    """Resolve ``path`` inside a POSIX sandbox rooted at ``workdir``.
+
+    Absolute paths are returned unchanged; relative paths are joined
+    onto ``workdir``. Mirrors the behaviour every remote backend needs
+    so it does not get re-implemented per module.
+
+    Args:
+        workdir: Absolute POSIX path of the sandbox working directory.
+        path: Caller-supplied path, absolute or relative.
+
+    Returns:
+        The fully-qualified POSIX path.
+    """
+    candidate = PurePosixPath(path)
+    if candidate.is_absolute():
+        return str(candidate)
+    return str(PurePosixPath(workdir) / candidate)
+
+
+def allocate_session_id(prefix: str, hint: str | None = None) -> str:
+    """Return a deterministic-looking session id.
+
+    If ``hint`` is provided it is used verbatim (callers supply this to
+    pin a specific identifier, typically for resume). Otherwise a fresh
+    ``{prefix}-{rand12}`` identifier is minted.
+
+    Args:
+        prefix: Backend name used as the id prefix (e.g. ``"bernstein-e2b"``).
+        hint: Optional explicit id. When non-empty, returned unchanged.
+
+    Returns:
+        The chosen session identifier.
+    """
+    if hint:
+        return hint
+    return f"{prefix}-{secrets.token_hex(6)}"
+
+
+def resolve_sdk_attr(obj: Any, *names: str) -> Any | None:
+    """Return the first non-``None`` attribute from ``obj`` by name.
+
+    Provider SDKs rename methods across versions (``files.read`` vs
+    ``filesystem.read``, ``commands.run`` vs ``process.run``, etc.). We
+    probe each candidate in order and return the first hit, or ``None``
+    if no candidate is exposed. Callers raise a friendly
+    ``RuntimeError`` when ``None`` comes back.
+
+    Args:
+        obj: The provider SDK handle to probe.
+        *names: Candidate attribute names, tried in order.
+
+    Returns:
+        The resolved attribute, or ``None`` if none exist.
+    """
+    for name in names:
+        candidate = getattr(obj, name, None)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def encode_as_bytes(value: Any) -> bytes:
+    """Normalise a ``str``/``bytes`` value returned by a provider SDK.
+
+    Many SDK calls (file reads, stdout streams) return either ``str`` or
+    ``bytes`` depending on the SDK version. The Bernstein contract
+    surfaces bytes; this helper hides the provider-side variability.
+
+    Args:
+        value: Value returned by the SDK, typically ``str`` or ``bytes``.
+
+    Returns:
+        The value coerced to ``bytes``.
+    """
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return bytes(value)
+
+
+def merge_exec_env(
+    base_env: Mapping[str, str],
+    extra: Mapping[str, str] | None,
+) -> dict[str, str]:
+    """Merge per-call env overrides on top of the session's base env.
+
+    Args:
+        base_env: Base environment captured at session-create time.
+        extra: Optional per-call overrides. ``None`` leaves the base
+            environment unchanged.
+
+    Returns:
+        A fresh dict; callers own the result.
+    """
+    merged = dict(base_env)
+    if extra:
+        merged.update(extra)
+    return merged
+
+
+def guard_exec_preconditions(closed: bool, session_id: str, cmd: list[str]) -> None:
+    """Raise if the session is closed or ``cmd`` is empty.
+
+    Every backend runs this guard before touching the SDK. Centralising
+    it means all backends produce identical error messages.
+
+    Args:
+        closed: ``True`` if :meth:`SandboxSession.shutdown` has run.
+        session_id: Session identifier for the error message.
+        cmd: Argv list the caller wants to execute.
+
+    Raises:
+        RuntimeError: If the session has been shut down.
+        ValueError: If ``cmd`` is empty.
+    """
+    if closed:
+        raise RuntimeError(f"Session {session_id} is closed")
+    if not cmd:
+        raise ValueError("cmd must be a non-empty argv list")
+
+
+async def run_exec_with_timeout(
+    runner: Callable[[], tuple[int, bytes, bytes]],
+    *,
+    cmd: list[str],
+    timeout: int,
+    timeout_slack: int = 5,
+) -> ExecResult:
+    """Run a blocking SDK call in a worker thread with timeout handling.
+
+    The provider SDKs expose synchronous call patterns; every remote
+    backend wraps them with :func:`asyncio.to_thread` and enforces a
+    wall-clock cap via :func:`asyncio.wait_for`. This helper wires that
+    up and converts the result into an :class:`ExecResult` so callers
+    only supply the provider-specific ``runner`` closure.
+
+    Args:
+        runner: Blocking callable returning ``(exit_code, stdout_b,
+            stderr_b)``.
+        cmd: Argv list, used solely for the error message on timeout.
+        timeout: Caller-visible timeout, in seconds.
+        timeout_slack: Extra seconds to give the worker thread over the
+            SDK-side timeout. Defaults to 5s (matches the prior
+            hand-rolled implementations). Pass ``0`` when the SDK does
+            not have its own timeout (Docker-style).
+
+    Returns:
+        An :class:`ExecResult` with the runner's output and the measured
+        wall-clock duration.
+
+    Raises:
+        TimeoutError: When the runner does not complete within
+            ``timeout + timeout_slack`` seconds.
+    """
+    start = time.monotonic()
+    wait_for = timeout + timeout_slack if timeout_slack else timeout
+    try:
+        exit_code, stdout_b, stderr_b = await asyncio.wait_for(asyncio.to_thread(runner), timeout=wait_for)
+    except TimeoutError:
+        raise TimeoutError(f"Command {cmd!r} timed out after {timeout}s") from None
+    return ExecResult(
+        exit_code=exit_code,
+        stdout=stdout_b,
+        stderr=stderr_b,
+        duration_seconds=time.monotonic() - start,
+    )
+
+
+__all__ = [
+    "allocate_session_id",
+    "encode_as_bytes",
+    "guard_exec_preconditions",
+    "merge_exec_env",
+    "resolve_posix_path",
+    "resolve_sdk_attr",
+    "run_exec_with_timeout",
+]

--- a/src/bernstein/core/sandbox/backends/docker.py
+++ b/src/bernstein/core/sandbox/backends/docker.py
@@ -192,7 +192,7 @@ class DockerSandboxSession(SandboxSession):
             # traversal primitive. ``_safe_extract_single_file``
             # refuses any member whose name does not resolve to the
             # exact file we requested.
-            with tarfile.open(fileobj=buf, mode="r") as tf:
+            with tarfile.open(fileobj=buf, mode="r") as tf:  # NOSONAR S5042
                 return _safe_extract_single_file(tf, expected_name=expected_name, resolved=resolved)
 
         return await asyncio.to_thread(_do_read)
@@ -217,7 +217,7 @@ class DockerSandboxSession(SandboxSession):
             # the only consumer is the docker daemon, which treats the
             # single member as the file to place under ``parent``.
             buf = BytesIO()
-            with tarfile.open(fileobj=buf, mode="w") as tf:
+            with tarfile.open(fileobj=buf, mode="w") as tf:  # NOSONAR S5042
                 info = tarfile.TarInfo(name=name)
                 info.size = len(data)
                 info.mode = mode

--- a/src/bernstein/core/sandbox/backends/docker.py
+++ b/src/bernstein/core/sandbox/backends/docker.py
@@ -59,6 +59,81 @@ def _import_docker() -> Any:
     return docker
 
 
+def _safe_extract_single_file(tf: tarfile.TarFile, *, expected_name: str, resolved: str) -> bytes:
+    """Extract exactly one file from ``tf`` whose name matches ``expected_name``.
+
+    Defence-in-depth against path traversal in the tar members
+    produced by ``docker.container.get_archive``. Although the archive
+    comes from a container we control, we still validate each member:
+
+    * Reject any member whose name does not equal ``expected_name``
+      (the basename of the requested path) or the absolute-path form
+      ``resolved.lstrip("/")``. This prevents a crafted or buggy tar
+      from smuggling in a member called ``../etc/shadow`` or a
+      symlink-style entry that resolves outside our intended target.
+    * Reject non-file members (directories, symlinks, devices) —
+      ``session.read`` only ever wants a single file's bytes.
+    * Reject any absolute-path member whose name starts with ``/`` or
+      contains a ``..`` segment after normalisation. Even a matching
+      name must be "inside" the requested target to be accepted.
+
+    Args:
+        tf: Open tar archive streamed from ``container.get_archive``.
+        expected_name: Basename of the path the caller requested.
+        resolved: The full POSIX path the caller requested. Used for
+            the error message and for the alternate absolute-form
+            member-name comparison.
+
+    Returns:
+        The bytes of the single file member.
+
+    Raises:
+        FileNotFoundError: No matching file member was found.
+        IsADirectoryError: The archive held only directory entries.
+    """
+    members = tf.getmembers()
+    if not members:
+        raise FileNotFoundError(resolved)
+
+    # Docker's get_archive can emit either basename-only members (the
+    # common case) or absolute-path members on some daemon versions.
+    # We accept both forms; anything else is rejected.
+    absolute_form = resolved.lstrip("/")
+
+    acceptable: list[tarfile.TarInfo] = []
+    saw_any_file = False
+    for member in members:
+        if not member.isfile():
+            continue
+        saw_any_file = True
+
+        # Normalise once: reject absolute-path traversal (e.g.
+        # ``../etc/shadow``). PurePosixPath normalises redundant
+        # separators but keeps ``..`` segments explicit.
+        parts = PurePosixPath(member.name).parts
+        if ".." in parts:
+            continue
+        if member.name.startswith("/"):
+            continue
+
+        if member.name == expected_name or member.name == absolute_form:
+            acceptable.append(member)
+
+    if not acceptable:
+        if saw_any_file:
+            # A file member existed but its name did not match. Surface
+            # as FileNotFoundError to match the documented contract —
+            # the caller asked for a file that is not present under the
+            # name they provided.
+            raise FileNotFoundError(resolved)
+        raise IsADirectoryError(resolved)
+
+    extracted = tf.extractfile(acceptable[0])
+    if extracted is None:
+        raise FileNotFoundError(resolved)
+    return extracted.read()
+
+
 class DockerSandboxSession(SandboxSession):
     """A session backed by a running Docker container.
 
@@ -101,6 +176,7 @@ class DockerSandboxSession(SandboxSession):
 
     async def read(self, path: str) -> bytes:
         resolved = self._resolve_posix(path)
+        expected_name = PurePosixPath(resolved).name
 
         def _do_read() -> bytes:
             archive, _ = self._container.get_archive(resolved)
@@ -108,17 +184,16 @@ class DockerSandboxSession(SandboxSession):
             for chunk in archive:
                 buf.write(chunk)
             buf.seek(0)
+            # ``get_archive`` returns a tar stream sourced from a
+            # container we own. The tar is not from an untrusted
+            # origin, but we still validate members before extraction
+            # so a docker-daemon bug (or future change to
+            # ``get_archive``) cannot turn ``session.read`` into a path
+            # traversal primitive. ``_safe_extract_single_file``
+            # refuses any member whose name does not resolve to the
+            # exact file we requested.
             with tarfile.open(fileobj=buf, mode="r") as tf:
-                members = tf.getmembers()
-                if not members:
-                    raise FileNotFoundError(resolved)
-                file_member = next((m for m in members if m.isfile()), None)
-                if file_member is None:
-                    raise IsADirectoryError(resolved)
-                extracted = tf.extractfile(file_member)
-                if extracted is None:
-                    raise FileNotFoundError(resolved)
-                return extracted.read()
+                return _safe_extract_single_file(tf, expected_name=expected_name, resolved=resolved)
 
         return await asyncio.to_thread(_do_read)
 
@@ -132,6 +207,15 @@ class DockerSandboxSession(SandboxSession):
             mkdir = self._container.exec_run(["mkdir", "-p", parent])
             if mkdir.exit_code != 0:
                 raise OSError(f"mkdir -p {parent} failed: {mkdir.output.decode('utf-8', 'replace')}")
+            # Build a single-member tar in memory. The archive is
+            # constructed *here* from trusted inputs (``name`` derives
+            # from ``self._resolve_posix`` which pins paths under
+            # :attr:`workdir`; ``data`` is caller-supplied bytes with
+            # no path component) — it is then streamed straight to
+            # ``put_archive``. There is no extraction step on our
+            # side, so S5042 "tar extraction" guidance does not apply:
+            # the only consumer is the docker daemon, which treats the
+            # single member as the file to place under ``parent``.
             buf = BytesIO()
             with tarfile.open(fileobj=buf, mode="w") as tf:
                 info = tarfile.TarInfo(name=name)

--- a/src/bernstein/core/sandbox/backends/docker.py
+++ b/src/bernstein/core/sandbox/backends/docker.py
@@ -1,0 +1,380 @@
+"""Docker-daemon :class:`SandboxBackend` — first-party, ships in core.
+
+The Docker backend launches a long-running container per session and
+proxies file I/O through ``docker cp`` and command execution through
+``docker exec``. The ``docker`` Python SDK is an optional install —
+when it is missing the backend module still imports cleanly, but
+instantiating :class:`DockerSandboxBackend` raises a clear error so the
+registry can report the state via
+:func:`~bernstein.core.sandbox.registry.list_backends`.
+
+Phase 1 scope: the backend is first-party and ships in core so
+integration tests can cover Docker without an optional extra; the
+``docker`` SDK dependency is captured in the ``[docker]`` extra so
+minimal installs remain lean.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import tarfile
+import time
+from io import BytesIO
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_IMAGE = "python:3.13-slim"
+_DEFAULT_MEMORY_MB = 2048
+_DEFAULT_CPU_QUOTA = 200000  # 2 CPUs when period=100000
+
+
+class DockerUnavailableError(RuntimeError):
+    """Raised when the ``docker`` Python SDK or daemon is unreachable."""
+
+
+def _import_docker() -> Any:
+    """Import the ``docker`` SDK lazily, raising a friendly error on miss."""
+    try:
+        import docker  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise DockerUnavailableError(
+            "Install the 'docker' extra to use DockerSandboxBackend: "
+            "`pip install bernstein[docker]` or `uv sync --extra docker`."
+        ) from exc
+    return docker
+
+
+class DockerSandboxSession(SandboxSession):
+    """A session backed by a running Docker container.
+
+    Construction is internal — obtain instances via
+    :meth:`DockerSandboxBackend.create`.
+    """
+
+    backend_name = "docker"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        container: Any,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._container = container
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # Path normalisation
+    # ------------------------------------------------------------------
+
+    def _resolve_posix(self, path: str) -> str:
+        """Resolve *path* inside the container, rooted at ``workdir``."""
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute():
+            return str(candidate)
+        return str(PurePosixPath(self.workdir) / candidate)
+
+    # ------------------------------------------------------------------
+    # File primitives
+    # ------------------------------------------------------------------
+
+    async def read(self, path: str) -> bytes:
+        resolved = self._resolve_posix(path)
+
+        def _do_read() -> bytes:
+            archive, _ = self._container.get_archive(resolved)
+            buf = BytesIO()
+            for chunk in archive:
+                buf.write(chunk)
+            buf.seek(0)
+            with tarfile.open(fileobj=buf, mode="r") as tf:
+                members = tf.getmembers()
+                if not members:
+                    raise FileNotFoundError(resolved)
+                file_member = next((m for m in members if m.isfile()), None)
+                if file_member is None:
+                    raise IsADirectoryError(resolved)
+                extracted = tf.extractfile(file_member)
+                if extracted is None:
+                    raise FileNotFoundError(resolved)
+                return extracted.read()
+
+        return await asyncio.to_thread(_do_read)
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = self._resolve_posix(path)
+        parent = str(PurePosixPath(resolved).parent)
+        name = PurePosixPath(resolved).name
+
+        def _do_write() -> None:
+            # Ensure parent dir exists.
+            mkdir = self._container.exec_run(["mkdir", "-p", parent])
+            if mkdir.exit_code != 0:
+                raise OSError(f"mkdir -p {parent} failed: {mkdir.output.decode('utf-8', 'replace')}")
+            buf = BytesIO()
+            with tarfile.open(fileobj=buf, mode="w") as tf:
+                info = tarfile.TarInfo(name=name)
+                info.size = len(data)
+                info.mode = mode
+                info.mtime = int(time.time())
+                tf.addfile(info, BytesIO(data))
+            buf.seek(0)
+            ok = self._container.put_archive(parent, buf.getvalue())
+            if not ok:
+                raise OSError(f"put_archive failed for {resolved}")
+
+        await asyncio.to_thread(_do_write)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = self._resolve_posix(path)
+
+        def _do_ls() -> list[str]:
+            result = self._container.exec_run(["ls", "-1", resolved])
+            if result.exit_code != 0:
+                raise OSError(f"ls {resolved} failed: {result.output.decode('utf-8', 'replace')}")
+            output = result.output.decode("utf-8", "replace")
+            entries = [line for line in output.splitlines() if line]
+            return sorted(entries)
+
+        return await asyncio.to_thread(_do_ls)
+
+    # ------------------------------------------------------------------
+    # Exec primitive
+    # ------------------------------------------------------------------
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        if self._closed:
+            raise RuntimeError(f"Session {self.session_id} is closed")
+        if not cmd:
+            raise ValueError("cmd must be a non-empty argv list")
+        if stdin is not None:
+            raise NotImplementedError("Docker backend does not yet support stdin injection; tracked in oai-002b")
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = dict(self._base_env)
+        if env:
+            merged_env.update(env)
+        env_list = [f"{key}={value}" for key, value in merged_env.items()]
+
+        start = time.monotonic()
+
+        def _run() -> tuple[int, bytes, bytes]:
+            # ``exec_run`` with ``demux=True`` gives (stdout, stderr) bytes.
+            result = self._container.exec_run(
+                cmd,
+                workdir=effective_cwd,
+                environment=env_list,
+                demux=True,
+            )
+            stdout_b, stderr_b = result.output  # type: ignore[misc]
+            return (
+                int(result.exit_code),
+                stdout_b or b"",
+                stderr_b or b"",
+            )
+
+        try:
+            exit_code, stdout_b, stderr_b = await asyncio.wait_for(asyncio.to_thread(_run), timeout=effective_timeout)
+        except TimeoutError:
+            # Best-effort: kill a stuck exec by killing the container.
+            # More surgical cleanup belongs in oai-002b where the
+            # spawner owns the exec lifecycle.
+            try:
+                self._container.kill()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Failed to kill container after timeout: %s", exc)
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=stdout_b,
+            stderr=stderr_b,
+            duration_seconds=time.monotonic() - start,
+        )
+
+    # ------------------------------------------------------------------
+    # Snapshots (unsupported in phase 1)
+    # ------------------------------------------------------------------
+
+    async def snapshot(self) -> str:
+        raise NotImplementedError("DockerSandboxBackend does not declare the SNAPSHOT capability in phase 1")
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        def _teardown() -> None:
+            try:
+                self._container.stop(timeout=5)
+            except Exception as exc:
+                logger.debug("container.stop failed: %s", exc)
+            try:
+                self._container.remove(force=True)
+            except Exception as exc:
+                logger.debug("container.remove failed: %s", exc)
+
+        await asyncio.to_thread(_teardown)
+
+
+class DockerSandboxBackend:
+    """SandboxBackend that runs each session inside a Docker container."""
+
+    name = "docker"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+        }
+    )
+
+    def __init__(self, *, client: Any | None = None) -> None:
+        """Create the backend.
+
+        Args:
+            client: Optional pre-built ``docker.DockerClient`` instance.
+                Tests pass a mock; production callers let the backend
+                build one via ``docker.from_env`` on first use. The
+                client is NOT instantiated at construction time so the
+                registry can list the backend without requiring a live
+                Docker daemon.
+        """
+        self._client = client
+        self._sessions: dict[str, DockerSandboxSession] = {}
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            docker_mod = _import_docker()
+            try:
+                self._client = docker_mod.from_env()
+            except Exception as exc:
+                raise DockerUnavailableError(f"Could not connect to Docker daemon: {exc}") from exc
+        return self._client
+
+    @staticmethod
+    def _allocate_session_id(hint: str | None = None) -> str:
+        if hint:
+            return hint
+        return f"bernstein-sbx-{secrets.token_hex(6)}"
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Start a container per *manifest* and return the session.
+
+        Recognised ``options``:
+
+        - ``image``: Docker image to run. Default ``python:3.13-slim``.
+        - ``memory_mb``: Memory limit (int MB). Default 2048.
+        - ``cpu_quota``: CFS quota (int microseconds). Default 200000
+          (≈ 2 CPU when period=100000).
+        - ``network_disabled``: Bool, default False. Set True to create
+          the container with ``--network=none``.
+        - ``session_id``: Explicit container name suffix.
+        - ``labels``: Extra labels to attach for discovery.
+        """
+        opts = dict(options or {})
+        image = opts.get("image", _DEFAULT_IMAGE)
+        memory_mb = int(opts.get("memory_mb", _DEFAULT_MEMORY_MB))
+        cpu_quota = int(opts.get("cpu_quota", _DEFAULT_CPU_QUOTA))
+        network_disabled = bool(opts.get("network_disabled", False))
+        session_id = self._allocate_session_id(opts.get("session_id"))
+
+        env_list = [f"{k}={v}" for k, v in manifest.env.items()]
+        labels = {
+            "bernstein.sandbox": "docker",
+            "bernstein.sandbox.session_id": session_id,
+        }
+        extra_labels: Any = opts.get("labels")
+        if isinstance(extra_labels, dict):
+            for raw_key, raw_value in extra_labels.items():  # pyright: ignore[reportUnknownVariableType]
+                labels[str(raw_key)] = str(raw_value)  # pyright: ignore[reportUnknownArgumentType]
+
+        client = self._get_client()
+
+        def _spawn_container() -> Any:
+            container = client.containers.run(
+                image=image,
+                name=f"bernstein-{session_id}",
+                command=["sleep", "infinity"],
+                detach=True,
+                tty=False,
+                working_dir=manifest.root,
+                environment=env_list,
+                mem_limit=f"{memory_mb}m",
+                cpu_period=100000,
+                cpu_quota=cpu_quota,
+                network_disabled=network_disabled,
+                labels=labels,
+            )
+            # Ensure the workdir exists inside the container.
+            mkdir = container.exec_run(["mkdir", "-p", manifest.root])
+            if mkdir.exit_code != 0:
+                raise RuntimeError(
+                    f"mkdir -p {manifest.root} failed in container: {mkdir.output.decode('utf-8', 'replace')}"
+                )
+            return container
+
+        container = await asyncio.to_thread(_spawn_container)
+        session = DockerSandboxSession(
+            session_id=session_id,
+            container=container,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        # Inject byte files after the session is constructed so we can
+        # reuse its ``write`` helper for path resolution.
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        raise NotImplementedError("DockerSandboxBackend does not declare the SNAPSHOT capability in phase 1")
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "DockerSandboxBackend",
+    "DockerSandboxSession",
+    "DockerUnavailableError",
+]

--- a/src/bernstein/core/sandbox/backends/e2b.py
+++ b/src/bernstein/core/sandbox/backends/e2b.py
@@ -1,0 +1,329 @@
+"""E2B cloud sandbox backend (optional extra).
+
+E2B runs agent workloads inside ephemeral Firecracker microVMs. It is
+an optional Bernstein extra: ``pip install bernstein[e2b]`` pulls in
+``e2b_code_interpreter`` and registers this backend. When the SDK is
+not installed the module still imports cleanly — instantiation is
+where the error surfaces.
+
+Snapshots are supported by the E2B SDK; the backend therefore declares
+:attr:`~bernstein.core.sandbox.backend.SandboxCapability.SNAPSHOT` so
+callers can persist state across orchestrator restarts.
+
+This implementation ships in phase 1 as a functional skeleton: the
+actual wiring against a live E2B session is exercised by integration
+tests gated on ``E2B_API_KEY``; unit tests rely on mocks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+
+class E2BUnavailableError(RuntimeError):
+    """Raised when the ``e2b_code_interpreter`` SDK is not installed."""
+
+
+def _import_e2b() -> Any:
+    """Import the E2B SDK lazily. Keeps the module safe to import without deps."""
+    try:
+        import e2b_code_interpreter  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise E2BUnavailableError("Install the 'e2b' extra: `pip install bernstein[e2b]`") from exc
+    return e2b_code_interpreter
+
+
+class E2BSandboxSession(SandboxSession):
+    """A session backed by an E2B microVM sandbox."""
+
+    backend_name = "e2b"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        sandbox: Any,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._sandbox = sandbox
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    def _resolve_posix(self, path: str) -> str:
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute():
+            return str(candidate)
+        return str(PurePosixPath(self.workdir) / candidate)
+
+    async def read(self, path: str) -> bytes:
+        resolved = self._resolve_posix(path)
+
+        def _do_read() -> bytes:
+            # The E2B SDK exposes either ``files.read`` or ``filesystem.read``
+            # depending on the version; both return bytes or str.
+            fs = getattr(self._sandbox, "files", None) or getattr(self._sandbox, "filesystem", None)
+            if fs is None:
+                raise RuntimeError("E2B SDK did not expose a filesystem interface")
+            data = fs.read(resolved)
+            if isinstance(data, str):
+                return data.encode("utf-8")
+            return bytes(data)
+
+        return await asyncio.to_thread(_do_read)
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = self._resolve_posix(path)
+
+        def _do_write() -> None:
+            fs = getattr(self._sandbox, "files", None) or getattr(self._sandbox, "filesystem", None)
+            if fs is None:
+                raise RuntimeError("E2B SDK did not expose a filesystem interface")
+            fs.write(resolved, data)
+            # The E2B SDK does not expose chmod explicitly in every
+            # version; skip best-effort rather than fail if missing.
+            chmod = getattr(fs, "chmod", None)
+            if chmod is not None:
+                try:
+                    chmod(resolved, mode)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("E2B chmod %o on %s failed: %s", mode, resolved, exc)
+
+        await asyncio.to_thread(_do_write)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = self._resolve_posix(path)
+
+        def _do_ls() -> list[str]:
+            fs = getattr(self._sandbox, "files", None) or getattr(self._sandbox, "filesystem", None)
+            if fs is None:
+                raise RuntimeError("E2B SDK did not expose a filesystem interface")
+            entries = fs.list(resolved)
+            names = [getattr(e, "name", str(e)) for e in entries]
+            return sorted(names)
+
+        return await asyncio.to_thread(_do_ls)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        if self._closed:
+            raise RuntimeError(f"Session {self.session_id} is closed")
+        if not cmd:
+            raise ValueError("cmd must be a non-empty argv list")
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = dict(self._base_env)
+        if env:
+            merged_env.update(env)
+
+        start = time.monotonic()
+
+        def _run() -> tuple[int, bytes, bytes]:
+            commands = getattr(self._sandbox, "commands", None) or getattr(self._sandbox, "process", None)
+            if commands is None:
+                raise RuntimeError("E2B SDK did not expose a commands interface")
+            result = commands.run(
+                cmd if isinstance(cmd, str) else " ".join(_quote(part) for part in cmd),
+                cwd=effective_cwd,
+                envs=merged_env,
+                timeout=effective_timeout,
+            )
+            exit_code = int(getattr(result, "exit_code", 0) or 0)
+            stdout = getattr(result, "stdout", "") or ""
+            stderr = getattr(result, "stderr", "") or ""
+            return (
+                exit_code,
+                stdout.encode("utf-8") if isinstance(stdout, str) else bytes(stdout),
+                stderr.encode("utf-8") if isinstance(stderr, str) else bytes(stderr),
+            )
+
+        try:
+            exit_code, stdout_b, stderr_b = await asyncio.wait_for(
+                asyncio.to_thread(_run), timeout=effective_timeout + 5
+            )
+        except TimeoutError:
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=stdout_b,
+            stderr=stderr_b,
+            duration_seconds=time.monotonic() - start,
+        )
+
+    async def snapshot(self) -> str:
+        def _do_snapshot() -> str:
+            pause = getattr(self._sandbox, "pause", None)
+            if pause is not None:
+                snap_id = pause()
+                return str(snap_id) if snap_id is not None else self.session_id
+            raise NotImplementedError("Installed E2B SDK does not expose a snapshot entry point")
+
+        return await asyncio.to_thread(_do_snapshot)
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        def _do_shutdown() -> None:
+            kill = getattr(self._sandbox, "kill", None) or getattr(self._sandbox, "close", None)
+            if kill is None:
+                logger.debug("E2B SDK did not expose a shutdown entry point")
+                return
+            try:
+                kill()
+            except Exception as exc:
+                logger.debug("E2B shutdown raised: %s", exc)
+
+        await asyncio.to_thread(_do_shutdown)
+
+
+def _quote(arg: str) -> str:
+    """Shell-quote a single argv element for E2B's string exec API."""
+    if not arg:
+        return "''"
+    safe = all(ch.isalnum() or ch in "@%+=:,./-" for ch in arg)
+    if safe:
+        return arg
+    return "'" + arg.replace("'", "'\\''") + "'"
+
+
+class E2BSandboxBackend:
+    """Cloud SandboxBackend powered by E2B."""
+
+    name = "e2b"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.SNAPSHOT,
+        }
+    )
+
+    def __init__(self, *, client_factory: Any | None = None) -> None:
+        """Create the backend.
+
+        Args:
+            client_factory: Optional callable used by tests to build an
+                E2B Sandbox object. Defaults to constructing one via
+                the real SDK at ``create`` time so importing this
+                module doesn't require the SDK.
+        """
+        self._client_factory = client_factory
+        self._sessions: dict[str, E2BSandboxSession] = {}
+
+    @staticmethod
+    def _allocate_session_id(hint: str | None = None) -> str:
+        if hint:
+            return hint
+        return f"bernstein-e2b-{secrets.token_hex(6)}"
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a fresh E2B sandbox per *manifest*.
+
+        Recognised ``options``:
+
+        - ``template``: E2B template name. Default ``code-interpreter-v1``.
+        - ``api_key``: Override E2B_API_KEY. Default reads from env.
+        - ``session_id``: Explicit session identifier.
+        """
+        opts = dict(options or {})
+        template = opts.get("template", "code-interpreter-v1")
+        api_key = opts.get("api_key")
+        session_id = self._allocate_session_id(opts.get("session_id"))
+
+        def _build() -> Any:
+            if self._client_factory is not None:
+                return self._client_factory(
+                    template=template,
+                    api_key=api_key,
+                    manifest=manifest,
+                )
+            module = _import_e2b()
+            sandbox_cls = getattr(module, "Sandbox", None) or getattr(module, "AsyncSandbox", None)
+            if sandbox_cls is None:
+                raise E2BUnavailableError("E2B SDK missing Sandbox class")
+            kwargs: dict[str, Any] = {"template": template}
+            if api_key:
+                kwargs["api_key"] = api_key
+            return sandbox_cls(**kwargs)
+
+        sandbox = await asyncio.to_thread(_build)
+        session = E2BSandboxSession(
+            session_id=session_id,
+            sandbox=sandbox,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        if self._client_factory is not None:
+            sandbox = self._client_factory(resume=snapshot_id)
+        else:
+            module = _import_e2b()
+            sandbox_cls = getattr(module, "Sandbox", None)
+            if sandbox_cls is None:
+                raise E2BUnavailableError("E2B SDK missing Sandbox class")
+            resume_method = getattr(sandbox_cls, "resume", None)
+            if resume_method is None:
+                raise NotImplementedError("Installed E2B SDK does not expose a resume entry point")
+            sandbox = resume_method(snapshot_id)
+        session = E2BSandboxSession(
+            session_id=snapshot_id,
+            sandbox=sandbox,
+            workdir="/home/user",
+            base_env={},
+            default_timeout=1800,
+        )
+        self._sessions[snapshot_id] = session
+        return session
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "E2BSandboxBackend",
+    "E2BSandboxSession",
+    "E2BUnavailableError",
+]

--- a/src/bernstein/core/sandbox/backends/e2b.py
+++ b/src/bernstein/core/sandbox/backends/e2b.py
@@ -13,21 +13,32 @@ callers can persist state across orchestrator restarts.
 This implementation ships in phase 1 as a functional skeleton: the
 actual wiring against a live E2B session is exercised by integration
 tests gated on ``E2B_API_KEY``; unit tests rely on mocks.
+
+Scaffolding that is structurally identical to
+:mod:`bernstein.core.sandbox.backends.modal` lives in
+:mod:`bernstein.core.sandbox.backends._remote_helpers`; this module
+keeps only the E2B-specific SDK import and API-attribute probing.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import secrets
-import time
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.sandbox.backend import (
     ExecResult,
     SandboxCapability,
     SandboxSession,
+)
+from bernstein.core.sandbox.backends._remote_helpers import (
+    allocate_session_id,
+    encode_as_bytes,
+    guard_exec_preconditions,
+    merge_exec_env,
+    resolve_posix_path,
+    resolve_sdk_attr,
+    run_exec_with_timeout,
 )
 
 if TYPE_CHECKING:
@@ -51,6 +62,14 @@ def _import_e2b() -> Any:
     return e2b_code_interpreter
 
 
+def _e2b_filesystem(sandbox: Any) -> Any:
+    """Return the filesystem handle exposed by the installed E2B SDK version."""
+    fs = resolve_sdk_attr(sandbox, "files", "filesystem")
+    if fs is None:
+        raise RuntimeError("E2B SDK did not expose a filesystem interface")
+    return fs
+
+
 class E2BSandboxSession(SandboxSession):
     """A session backed by an E2B microVM sandbox."""
 
@@ -72,35 +91,21 @@ class E2BSandboxSession(SandboxSession):
         self._default_timeout = default_timeout
         self._closed = False
 
-    def _resolve_posix(self, path: str) -> str:
-        candidate = PurePosixPath(path)
-        if candidate.is_absolute():
-            return str(candidate)
-        return str(PurePosixPath(self.workdir) / candidate)
-
     async def read(self, path: str) -> bytes:
-        resolved = self._resolve_posix(path)
+        resolved = resolve_posix_path(self.workdir, path)
 
         def _do_read() -> bytes:
             # The E2B SDK exposes either ``files.read`` or ``filesystem.read``
             # depending on the version; both return bytes or str.
-            fs = getattr(self._sandbox, "files", None) or getattr(self._sandbox, "filesystem", None)
-            if fs is None:
-                raise RuntimeError("E2B SDK did not expose a filesystem interface")
-            data = fs.read(resolved)
-            if isinstance(data, str):
-                return data.encode("utf-8")
-            return bytes(data)
+            return encode_as_bytes(_e2b_filesystem(self._sandbox).read(resolved))
 
         return await asyncio.to_thread(_do_read)
 
     async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
-        resolved = self._resolve_posix(path)
+        resolved = resolve_posix_path(self.workdir, path)
 
         def _do_write() -> None:
-            fs = getattr(self._sandbox, "files", None) or getattr(self._sandbox, "filesystem", None)
-            if fs is None:
-                raise RuntimeError("E2B SDK did not expose a filesystem interface")
+            fs = _e2b_filesystem(self._sandbox)
             fs.write(resolved, data)
             # The E2B SDK does not expose chmod explicitly in every
             # version; skip best-effort rather than fail if missing.
@@ -114,13 +119,10 @@ class E2BSandboxSession(SandboxSession):
         await asyncio.to_thread(_do_write)
 
     async def ls(self, path: str) -> list[str]:
-        resolved = self._resolve_posix(path)
+        resolved = resolve_posix_path(self.workdir, path)
 
         def _do_ls() -> list[str]:
-            fs = getattr(self._sandbox, "files", None) or getattr(self._sandbox, "filesystem", None)
-            if fs is None:
-                raise RuntimeError("E2B SDK did not expose a filesystem interface")
-            entries = fs.list(resolved)
+            entries = _e2b_filesystem(self._sandbox).list(resolved)
             names = [getattr(e, "name", str(e)) for e in entries]
             return sorted(names)
 
@@ -135,20 +137,13 @@ class E2BSandboxSession(SandboxSession):
         timeout: int | None = None,
         stdin: bytes | None = None,
     ) -> ExecResult:
-        if self._closed:
-            raise RuntimeError(f"Session {self.session_id} is closed")
-        if not cmd:
-            raise ValueError("cmd must be a non-empty argv list")
+        guard_exec_preconditions(self._closed, self.session_id, cmd)
         effective_cwd = cwd if cwd is not None else self.workdir
         effective_timeout = timeout if timeout is not None else self._default_timeout
-        merged_env = dict(self._base_env)
-        if env:
-            merged_env.update(env)
-
-        start = time.monotonic()
+        merged_env = merge_exec_env(self._base_env, env)
 
         def _run() -> tuple[int, bytes, bytes]:
-            commands = getattr(self._sandbox, "commands", None) or getattr(self._sandbox, "process", None)
+            commands = resolve_sdk_attr(self._sandbox, "commands", "process")
             if commands is None:
                 raise RuntimeError("E2B SDK did not expose a commands interface")
             result = commands.run(
@@ -160,24 +155,9 @@ class E2BSandboxSession(SandboxSession):
             exit_code = int(getattr(result, "exit_code", 0) or 0)
             stdout = getattr(result, "stdout", "") or ""
             stderr = getattr(result, "stderr", "") or ""
-            return (
-                exit_code,
-                stdout.encode("utf-8") if isinstance(stdout, str) else bytes(stdout),
-                stderr.encode("utf-8") if isinstance(stderr, str) else bytes(stderr),
-            )
+            return (exit_code, encode_as_bytes(stdout), encode_as_bytes(stderr))
 
-        try:
-            exit_code, stdout_b, stderr_b = await asyncio.wait_for(
-                asyncio.to_thread(_run), timeout=effective_timeout + 5
-            )
-        except TimeoutError:
-            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
-        return ExecResult(
-            exit_code=exit_code,
-            stdout=stdout_b,
-            stderr=stderr_b,
-            duration_seconds=time.monotonic() - start,
-        )
+        return await run_exec_with_timeout(_run, cmd=cmd, timeout=effective_timeout)
 
     async def snapshot(self) -> str:
         def _do_snapshot() -> str:
@@ -195,7 +175,7 @@ class E2BSandboxSession(SandboxSession):
         self._closed = True
 
         def _do_shutdown() -> None:
-            kill = getattr(self._sandbox, "kill", None) or getattr(self._sandbox, "close", None)
+            kill = resolve_sdk_attr(self._sandbox, "kill", "close")
             if kill is None:
                 logger.debug("E2B SDK did not expose a shutdown entry point")
                 return
@@ -242,12 +222,6 @@ class E2BSandboxBackend:
         self._client_factory = client_factory
         self._sessions: dict[str, E2BSandboxSession] = {}
 
-    @staticmethod
-    def _allocate_session_id(hint: str | None = None) -> str:
-        if hint:
-            return hint
-        return f"bernstein-e2b-{secrets.token_hex(6)}"
-
     async def create(
         self,
         manifest: WorkspaceManifest,
@@ -264,7 +238,7 @@ class E2BSandboxBackend:
         opts = dict(options or {})
         template = opts.get("template", "code-interpreter-v1")
         api_key = opts.get("api_key")
-        session_id = self._allocate_session_id(opts.get("session_id"))
+        session_id = allocate_session_id("bernstein-e2b", opts.get("session_id"))
 
         def _build() -> Any:
             if self._client_factory is not None:
@@ -274,7 +248,7 @@ class E2BSandboxBackend:
                     manifest=manifest,
                 )
             module = _import_e2b()
-            sandbox_cls = getattr(module, "Sandbox", None) or getattr(module, "AsyncSandbox", None)
+            sandbox_cls = resolve_sdk_attr(module, "Sandbox", "AsyncSandbox")
             if sandbox_cls is None:
                 raise E2BUnavailableError("E2B SDK missing Sandbox class")
             kwargs: dict[str, Any] = {"template": template}

--- a/src/bernstein/core/sandbox/backends/modal.py
+++ b/src/bernstein/core/sandbox/backends/modal.py
@@ -1,0 +1,316 @@
+"""Modal cloud sandbox backend (optional extra).
+
+Modal provides serverless container execution with GPU support, which
+makes it the natural choice for ML-heavy tasks. This backend runs each
+session inside a Modal Sandbox; the Modal SDK is pulled in via the
+``[modal]`` extra.
+
+Snapshots are supported by Modal sandboxes so the backend declares
+:attr:`~bernstein.core.sandbox.backend.SandboxCapability.SNAPSHOT`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+import time
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+
+class ModalUnavailableError(RuntimeError):
+    """Raised when the ``modal`` SDK is not installed."""
+
+
+def _import_modal() -> Any:
+    try:
+        import modal  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise ModalUnavailableError("Install the 'modal' extra: `pip install bernstein[modal]`") from exc
+    return modal
+
+
+class ModalSandboxSession(SandboxSession):
+    """Session backed by a Modal sandbox."""
+
+    backend_name = "modal"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        sandbox: Any,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._sandbox = sandbox
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    def _resolve_posix(self, path: str) -> str:
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute():
+            return str(candidate)
+        return str(PurePosixPath(self.workdir) / candidate)
+
+    async def read(self, path: str) -> bytes:
+        resolved = self._resolve_posix(path)
+
+        def _do_read() -> bytes:
+            reader = getattr(self._sandbox, "read_file", None) or getattr(self._sandbox, "open", None)
+            if reader is None:
+                raise RuntimeError("Modal SDK did not expose a file-read API")
+            data = reader(resolved)
+            if isinstance(data, str):
+                return data.encode("utf-8")
+            return bytes(data)
+
+        return await asyncio.to_thread(_do_read)
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = self._resolve_posix(path)
+
+        def _do_write() -> None:
+            writer = getattr(self._sandbox, "write_file", None) or getattr(self._sandbox, "put", None)
+            if writer is None:
+                raise RuntimeError("Modal SDK did not expose a file-write API")
+            writer(resolved, data)
+            chmod = getattr(self._sandbox, "chmod", None)
+            if chmod is not None:
+                try:
+                    chmod(resolved, mode)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug("Modal chmod %o on %s failed: %s", mode, resolved, exc)
+
+        await asyncio.to_thread(_do_write)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = self._resolve_posix(path)
+
+        def _do_ls() -> list[str]:
+            lister = getattr(self._sandbox, "list_files", None) or getattr(self._sandbox, "ls", None)
+            if lister is None:
+                raise RuntimeError("Modal SDK did not expose a listing API")
+            entries = lister(resolved)
+            names = [getattr(e, "name", str(e)) for e in entries]
+            return sorted(names)
+
+        return await asyncio.to_thread(_do_ls)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        if self._closed:
+            raise RuntimeError(f"Session {self.session_id} is closed")
+        if not cmd:
+            raise ValueError("cmd must be a non-empty argv list")
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = dict(self._base_env)
+        if env:
+            merged_env.update(env)
+
+        start = time.monotonic()
+
+        def _run() -> tuple[int, bytes, bytes]:
+            exec_fn = getattr(self._sandbox, "exec", None) or getattr(self._sandbox, "run", None)
+            if exec_fn is None:
+                raise RuntimeError("Modal SDK did not expose an exec API")
+            process = exec_fn(
+                *cmd,
+                workdir=effective_cwd,
+                env=merged_env,
+                timeout=effective_timeout,
+            )
+            # Modal sandboxes return a process handle with ``.wait()``,
+            # ``.stdout``, ``.stderr`` streams; tests cover these via
+            # mocks. Real integration tests live under the ``modal``
+            # gate.
+            exit_code = int(process.wait())
+            stdout_val = getattr(process.stdout, "read", lambda: b"")()
+            stderr_val = getattr(process.stderr, "read", lambda: b"")()
+            return (
+                exit_code,
+                stdout_val.encode("utf-8") if isinstance(stdout_val, str) else bytes(stdout_val),
+                stderr_val.encode("utf-8") if isinstance(stderr_val, str) else bytes(stderr_val),
+            )
+
+        try:
+            exit_code, stdout_b, stderr_b = await asyncio.wait_for(
+                asyncio.to_thread(_run), timeout=effective_timeout + 5
+            )
+        except TimeoutError:
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=stdout_b,
+            stderr=stderr_b,
+            duration_seconds=time.monotonic() - start,
+        )
+
+    async def snapshot(self) -> str:
+        def _do_snapshot() -> str:
+            snap = getattr(self._sandbox, "snapshot", None)
+            if snap is None:
+                raise NotImplementedError("Installed Modal SDK does not expose a snapshot entry point")
+            return str(snap())
+
+        return await asyncio.to_thread(_do_snapshot)
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        def _do_shutdown() -> None:
+            terminate = getattr(self._sandbox, "terminate", None) or getattr(self._sandbox, "close", None)
+            if terminate is None:
+                logger.debug("Modal SDK did not expose a terminate API")
+                return
+            try:
+                terminate()
+            except Exception as exc:
+                logger.debug("Modal shutdown raised: %s", exc)
+
+        await asyncio.to_thread(_do_shutdown)
+
+
+class ModalSandboxBackend:
+    """Cloud SandboxBackend powered by Modal."""
+
+    name = "modal"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.SNAPSHOT,
+            SandboxCapability.GPU,
+        }
+    )
+
+    def __init__(self, *, client_factory: Any | None = None) -> None:
+        """Create the backend.
+
+        Args:
+            client_factory: Optional callable used by tests to build a
+                Modal sandbox. Defaults to constructing one via the
+                real SDK at ``create`` time.
+        """
+        self._client_factory = client_factory
+        self._sessions: dict[str, ModalSandboxSession] = {}
+
+    @staticmethod
+    def _allocate_session_id(hint: str | None = None) -> str:
+        if hint:
+            return hint
+        return f"bernstein-modal-{secrets.token_hex(6)}"
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a fresh Modal sandbox per *manifest*.
+
+        Recognised ``options``:
+
+        - ``image``: Modal image reference (e.g. ``python:3.13``).
+        - ``gpu``: Optional GPU type string (e.g. ``"A10G"``). Requires
+          Modal plan that supports GPUs.
+        - ``session_id``: Explicit session identifier.
+        """
+        opts = dict(options or {})
+        image_ref = opts.get("image")
+        gpu = opts.get("gpu")
+        session_id = self._allocate_session_id(opts.get("session_id"))
+
+        def _build() -> Any:
+            if self._client_factory is not None:
+                return self._client_factory(
+                    image=image_ref,
+                    gpu=gpu,
+                    manifest=manifest,
+                )
+            modal = _import_modal()
+            sandbox_factory = getattr(modal, "Sandbox", None)
+            if sandbox_factory is None:
+                raise ModalUnavailableError("Modal SDK missing Sandbox class")
+            kwargs: dict[str, Any] = {}
+            if image_ref:
+                kwargs["image"] = image_ref
+            if gpu:
+                kwargs["gpu"] = gpu
+            return sandbox_factory.create(**kwargs)
+
+        sandbox = await asyncio.to_thread(_build)
+        session = ModalSandboxSession(
+            session_id=session_id,
+            sandbox=sandbox,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        def _do_resume() -> Any:
+            if self._client_factory is not None:
+                return self._client_factory(resume=snapshot_id)
+            modal = _import_modal()
+            sandbox_cls = getattr(modal, "Sandbox", None)
+            if sandbox_cls is None:
+                raise ModalUnavailableError("Modal SDK missing Sandbox class")
+            resume_fn = getattr(sandbox_cls, "resume", None)
+            if resume_fn is None:
+                raise NotImplementedError("Installed Modal SDK does not expose a resume entry point")
+            return resume_fn(snapshot_id)
+
+        sandbox = await asyncio.to_thread(_do_resume)
+        session = ModalSandboxSession(
+            session_id=snapshot_id,
+            sandbox=sandbox,
+            workdir="/workspace",
+            base_env={},
+            default_timeout=1800,
+        )
+        self._sessions[snapshot_id] = session
+        return session
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "ModalSandboxBackend",
+    "ModalSandboxSession",
+    "ModalUnavailableError",
+]

--- a/src/bernstein/core/sandbox/backends/modal.py
+++ b/src/bernstein/core/sandbox/backends/modal.py
@@ -7,21 +7,32 @@ session inside a Modal Sandbox; the Modal SDK is pulled in via the
 
 Snapshots are supported by Modal sandboxes so the backend declares
 :attr:`~bernstein.core.sandbox.backend.SandboxCapability.SNAPSHOT`.
+
+Scaffolding that is structurally identical to
+:mod:`bernstein.core.sandbox.backends.e2b` lives in
+:mod:`bernstein.core.sandbox.backends._remote_helpers`; this module
+keeps only the Modal-specific SDK import and API-attribute probing.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-import secrets
-import time
-from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from bernstein.core.sandbox.backend import (
     ExecResult,
     SandboxCapability,
     SandboxSession,
+)
+from bernstein.core.sandbox.backends._remote_helpers import (
+    allocate_session_id,
+    encode_as_bytes,
+    guard_exec_preconditions,
+    merge_exec_env,
+    resolve_posix_path,
+    resolve_sdk_attr,
+    run_exec_with_timeout,
 )
 
 if TYPE_CHECKING:
@@ -65,31 +76,22 @@ class ModalSandboxSession(SandboxSession):
         self._default_timeout = default_timeout
         self._closed = False
 
-    def _resolve_posix(self, path: str) -> str:
-        candidate = PurePosixPath(path)
-        if candidate.is_absolute():
-            return str(candidate)
-        return str(PurePosixPath(self.workdir) / candidate)
-
     async def read(self, path: str) -> bytes:
-        resolved = self._resolve_posix(path)
+        resolved = resolve_posix_path(self.workdir, path)
 
         def _do_read() -> bytes:
-            reader = getattr(self._sandbox, "read_file", None) or getattr(self._sandbox, "open", None)
+            reader = resolve_sdk_attr(self._sandbox, "read_file", "open")
             if reader is None:
                 raise RuntimeError("Modal SDK did not expose a file-read API")
-            data = reader(resolved)
-            if isinstance(data, str):
-                return data.encode("utf-8")
-            return bytes(data)
+            return encode_as_bytes(reader(resolved))
 
         return await asyncio.to_thread(_do_read)
 
     async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
-        resolved = self._resolve_posix(path)
+        resolved = resolve_posix_path(self.workdir, path)
 
         def _do_write() -> None:
-            writer = getattr(self._sandbox, "write_file", None) or getattr(self._sandbox, "put", None)
+            writer = resolve_sdk_attr(self._sandbox, "write_file", "put")
             if writer is None:
                 raise RuntimeError("Modal SDK did not expose a file-write API")
             writer(resolved, data)
@@ -103,10 +105,10 @@ class ModalSandboxSession(SandboxSession):
         await asyncio.to_thread(_do_write)
 
     async def ls(self, path: str) -> list[str]:
-        resolved = self._resolve_posix(path)
+        resolved = resolve_posix_path(self.workdir, path)
 
         def _do_ls() -> list[str]:
-            lister = getattr(self._sandbox, "list_files", None) or getattr(self._sandbox, "ls", None)
+            lister = resolve_sdk_attr(self._sandbox, "list_files", "ls")
             if lister is None:
                 raise RuntimeError("Modal SDK did not expose a listing API")
             entries = lister(resolved)
@@ -124,20 +126,13 @@ class ModalSandboxSession(SandboxSession):
         timeout: int | None = None,
         stdin: bytes | None = None,
     ) -> ExecResult:
-        if self._closed:
-            raise RuntimeError(f"Session {self.session_id} is closed")
-        if not cmd:
-            raise ValueError("cmd must be a non-empty argv list")
+        guard_exec_preconditions(self._closed, self.session_id, cmd)
         effective_cwd = cwd if cwd is not None else self.workdir
         effective_timeout = timeout if timeout is not None else self._default_timeout
-        merged_env = dict(self._base_env)
-        if env:
-            merged_env.update(env)
-
-        start = time.monotonic()
+        merged_env = merge_exec_env(self._base_env, env)
 
         def _run() -> tuple[int, bytes, bytes]:
-            exec_fn = getattr(self._sandbox, "exec", None) or getattr(self._sandbox, "run", None)
+            exec_fn = resolve_sdk_attr(self._sandbox, "exec", "run")
             if exec_fn is None:
                 raise RuntimeError("Modal SDK did not expose an exec API")
             process = exec_fn(
@@ -153,24 +148,9 @@ class ModalSandboxSession(SandboxSession):
             exit_code = int(process.wait())
             stdout_val = getattr(process.stdout, "read", lambda: b"")()
             stderr_val = getattr(process.stderr, "read", lambda: b"")()
-            return (
-                exit_code,
-                stdout_val.encode("utf-8") if isinstance(stdout_val, str) else bytes(stdout_val),
-                stderr_val.encode("utf-8") if isinstance(stderr_val, str) else bytes(stderr_val),
-            )
+            return (exit_code, encode_as_bytes(stdout_val), encode_as_bytes(stderr_val))
 
-        try:
-            exit_code, stdout_b, stderr_b = await asyncio.wait_for(
-                asyncio.to_thread(_run), timeout=effective_timeout + 5
-            )
-        except TimeoutError:
-            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
-        return ExecResult(
-            exit_code=exit_code,
-            stdout=stdout_b,
-            stderr=stderr_b,
-            duration_seconds=time.monotonic() - start,
-        )
+        return await run_exec_with_timeout(_run, cmd=cmd, timeout=effective_timeout)
 
     async def snapshot(self) -> str:
         def _do_snapshot() -> str:
@@ -187,7 +167,7 @@ class ModalSandboxSession(SandboxSession):
         self._closed = True
 
         def _do_shutdown() -> None:
-            terminate = getattr(self._sandbox, "terminate", None) or getattr(self._sandbox, "close", None)
+            terminate = resolve_sdk_attr(self._sandbox, "terminate", "close")
             if terminate is None:
                 logger.debug("Modal SDK did not expose a terminate API")
                 return
@@ -224,12 +204,6 @@ class ModalSandboxBackend:
         self._client_factory = client_factory
         self._sessions: dict[str, ModalSandboxSession] = {}
 
-    @staticmethod
-    def _allocate_session_id(hint: str | None = None) -> str:
-        if hint:
-            return hint
-        return f"bernstein-modal-{secrets.token_hex(6)}"
-
     async def create(
         self,
         manifest: WorkspaceManifest,
@@ -247,7 +221,7 @@ class ModalSandboxBackend:
         opts = dict(options or {})
         image_ref = opts.get("image")
         gpu = opts.get("gpu")
-        session_id = self._allocate_session_id(opts.get("session_id"))
+        session_id = allocate_session_id("bernstein-modal", opts.get("session_id"))
 
         def _build() -> Any:
             if self._client_factory is not None:

--- a/src/bernstein/core/sandbox/backends/worktree.py
+++ b/src/bernstein/core/sandbox/backends/worktree.py
@@ -1,0 +1,343 @@
+"""Worktree-backed :class:`SandboxBackend` — default, zero behaviour change.
+
+This backend wraps the existing :class:`~bernstein.core.git.worktree.WorktreeManager`
+without changing any of its internals — the graveyard salvage path,
+stale-lock detection, and post-create isolation validation all continue
+to run exactly as before. Its purpose in phase 1 is to give callers a
+uniform :class:`SandboxBackend` handle even when they ultimately want
+the existing local-worktree behaviour.
+
+Every session wraps a single worktree directory on the host filesystem.
+``read``/``write``/``exec`` use :mod:`asyncio.to_thread` to avoid
+blocking the event loop; sync filesystem ops would otherwise monopolise
+the loop when agents churn on large files.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.git.worktree import WorktreeManager, validate_worktree_slug
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+
+class WorktreeSandboxSession(SandboxSession):
+    """A session whose workspace is a local git worktree.
+
+    Callers instantiate sessions only via
+    :meth:`WorktreeSandboxBackend.create`. Manual construction is
+    allowed (kept public) but most users should go through the backend
+    so the lifecycle is managed.
+    """
+
+    backend_name = "worktree"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        worktree_path: Path,
+        manager: WorktreeManager,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        """Initialise the session.
+
+        Args:
+            session_id: Opaque session identifier, also the worktree
+                directory name.
+            worktree_path: Absolute path to the worktree on the host.
+            manager: The :class:`WorktreeManager` that owns this
+                session — used on shutdown to run the existing cleanup
+                pipeline (salvage, graveyard, branch delete).
+            base_env: Environment applied to every :meth:`exec`.
+            default_timeout: Default wall-clock timeout for
+                :meth:`exec` when the caller doesn't supply one.
+        """
+        self.session_id = session_id
+        self.workdir = str(worktree_path)
+        self._worktree_path = worktree_path
+        self._manager = manager
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # File primitives
+    # ------------------------------------------------------------------
+
+    def _resolve(self, path: str) -> Path:
+        """Resolve *path* against the worktree, blocking traversal.
+
+        Args:
+            path: Caller-supplied path. Absolute paths must lie under
+                the worktree; relative paths are joined onto it.
+
+        Raises:
+            ValueError: If the resolved path escapes the worktree root.
+        """
+        candidate = Path(path)
+        resolved = candidate.resolve() if candidate.is_absolute() else (self._worktree_path / candidate).resolve()
+        root = self._worktree_path.resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            raise ValueError(f"Path {path!r} escapes worktree root {self._worktree_path}") from exc
+        return resolved
+
+    async def read(self, path: str) -> bytes:
+        """Read a file from the worktree."""
+        target = self._resolve(path)
+        return await asyncio.to_thread(target.read_bytes)
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        """Write *data* to *path*, creating parent dirs as needed."""
+        target = self._resolve(path)
+
+        def _do_write() -> None:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(data)
+            try:
+                target.chmod(mode)
+            except OSError:
+                # Windows / noexec mounts: chmod may fail, data is still
+                # written so surface a debug-level log and move on.
+                logger.debug("chmod(%o) failed for %s", mode, target)
+
+        await asyncio.to_thread(_do_write)
+
+    async def ls(self, path: str) -> list[str]:
+        """List entries in a directory inside the worktree."""
+        target = self._resolve(path)
+
+        def _do_ls() -> list[str]:
+            if not target.is_dir():
+                raise NotADirectoryError(f"Not a directory: {target}")
+            return sorted(p.name for p in target.iterdir())
+
+        return await asyncio.to_thread(_do_ls)
+
+    # ------------------------------------------------------------------
+    # Exec primitive
+    # ------------------------------------------------------------------
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        """Run *cmd* as a subprocess inside the worktree.
+
+        Uses :mod:`asyncio.subprocess` so the call integrates cleanly
+        with the orchestrator's event loop.
+        """
+        if self._closed:
+            raise RuntimeError(f"Session {self.session_id} is closed")
+        if not cmd:
+            raise ValueError("cmd must be a non-empty argv list")
+        effective_cwd = self._resolve(cwd) if cwd is not None else self._worktree_path
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        effective_env = dict(os.environ)
+        effective_env.update(self._base_env)
+        if env:
+            effective_env.update(env)
+
+        start = time.monotonic()
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(effective_cwd),
+            env=effective_env,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(input=stdin),
+                timeout=effective_timeout,
+            )
+        except TimeoutError:
+            process.kill()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except TimeoutError:
+                logger.warning("Process did not exit after kill within 5s: %s", cmd)
+            duration = time.monotonic() - start
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        duration = time.monotonic() - start
+        return ExecResult(
+            exit_code=process.returncode if process.returncode is not None else -1,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=duration,
+        )
+
+    # ------------------------------------------------------------------
+    # Snapshots (unsupported)
+    # ------------------------------------------------------------------
+
+    async def snapshot(self) -> str:
+        """Worktree backend does not support snapshots."""
+        raise NotImplementedError("WorktreeSandboxBackend does not declare the SNAPSHOT capability")
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    async def shutdown(self) -> None:
+        """Clean up the worktree via the underlying manager.
+
+        Idempotent — repeat calls are no-ops. Runs the existing
+        :meth:`WorktreeManager.cleanup` so salvage, graveyard capture,
+        branch delete, and lock removal all happen in their usual
+        order.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        await asyncio.to_thread(self._manager.cleanup, self.session_id)
+
+
+class WorktreeSandboxBackend:
+    """:class:`SandboxBackend` that provisions local git worktrees.
+
+    Produces one :class:`WorktreeSandboxSession` per call to
+    :meth:`create`. Backed by a cache of
+    :class:`WorktreeManager` instances keyed by repository root so
+    multiple manifests pointing at the same repo share the existing
+    graveyard, lock, and salvage state.
+
+    Snapshots are not supported because git worktrees don't have a
+    natural restore primitive that survives the host process.
+    """
+
+    name = "worktree"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+        }
+    )
+
+    def __init__(self) -> None:
+        self._managers: dict[Path, WorktreeManager] = {}
+        self._sessions: dict[str, WorktreeSandboxSession] = {}
+
+    def _manager_for(self, repo_root: Path) -> WorktreeManager:
+        resolved = repo_root.resolve()
+        cached = self._managers.get(resolved)
+        if cached is not None:
+            return cached
+        manager = WorktreeManager(resolved)
+        self._managers[resolved] = manager
+        return manager
+
+    @staticmethod
+    def _allocate_session_id(hint: str | None = None) -> str:
+        """Pick a fresh session ID, validating it for worktree use."""
+        if hint:
+            return validate_worktree_slug(hint)
+        # 12 hex chars keeps dir names readable while avoiding collisions.
+        return validate_worktree_slug(f"sbx-{secrets.token_hex(6)}")
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a new worktree session.
+
+        Recognised ``options`` keys:
+
+        - ``session_id``: Explicit session ID. Must pass
+          :func:`validate_worktree_slug`. Default: random.
+        - ``repo_root``: Host path to the repo that owns the worktree.
+          Falls back to ``manifest.repo.src_path`` and finally to the
+          current directory.
+
+        The manifest's ``root`` is treated as informational — worktrees
+        always live at ``<repo_root>/.sdd/worktrees/<session_id>``
+        for compatibility with existing tooling. This is intentional:
+        phase 1 promises zero behaviour change for worktree users.
+        """
+        opts = dict(options or {})
+        session_id = self._allocate_session_id(opts.get("session_id"))
+        repo_root_opt = opts.get("repo_root")
+        if repo_root_opt is not None:
+            repo_root = Path(repo_root_opt)
+        elif manifest.repo is not None:
+            repo_root = Path(manifest.repo.src_path)
+        else:
+            repo_root = Path.cwd()
+        manager = await asyncio.to_thread(self._manager_for, repo_root)
+        worktree_path = await asyncio.to_thread(manager.create, session_id)
+
+        # Byte-injected files land at manifest.root for cloud backends,
+        # but for the worktree they belong inside the worktree root so
+        # relative paths behave identically.
+        if manifest.files:
+
+            def _inject_files() -> None:
+                for entry in manifest.files:
+                    target = (worktree_path / entry.path).resolve()
+                    root = worktree_path.resolve()
+                    try:
+                        target.relative_to(root)
+                    except ValueError:
+                        logger.warning("Skipping file %r: path escapes worktree root", entry.path)
+                        continue
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    target.write_bytes(entry.content)
+                    try:
+                        target.chmod(entry.mode)
+                    except OSError:
+                        logger.debug("chmod(%o) failed for %s", entry.mode, target)
+
+            await asyncio.to_thread(_inject_files)
+
+        session = WorktreeSandboxSession(
+            session_id=session_id,
+            worktree_path=worktree_path,
+            manager=manager,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        """Worktree backend does not support snapshot/resume."""
+        raise NotImplementedError("WorktreeSandboxBackend does not declare the SNAPSHOT capability")
+
+    async def destroy(self, session: SandboxSession) -> None:
+        """Shut down *session* and drop it from the internal table."""
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "WorktreeSandboxBackend",
+    "WorktreeSandboxSession",
+]

--- a/src/bernstein/core/sandbox/conformance.py
+++ b/src/bernstein/core/sandbox/conformance.py
@@ -1,0 +1,218 @@
+"""Protocol conformance helpers for :class:`SandboxBackend` implementations.
+
+A single reusable test base class lives here so backend-specific test
+modules only have to supply a fixture that yields a ``(backend,
+manifest)`` pair. The class intentionally uses plain ``async def``
+test methods with ``@pytest.mark.asyncio`` so it slots into the
+existing pytest-asyncio setup.
+
+Subclass it like::
+
+    class TestWorktreeConformance(SandboxBackendConformance):
+        @pytest.fixture
+        async def backend(self, tmp_path):
+            ...
+            yield backend
+
+        @pytest.fixture
+        def manifest(self, tmp_path):
+            return WorkspaceManifest(...)
+
+Test runners that cannot accept fixtures at the method level (e.g.
+``doctest``) are not supported — the conformance contract is pytest-only.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.sandbox.backend import (
+    SandboxBackend,
+    SandboxCapability,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+
+class SandboxBackendConformance:
+    """Reusable conformance suite for any :class:`SandboxBackend`.
+
+    Subclasses supply two pytest fixtures:
+
+    - ``backend``: an async fixture yielding a fresh
+      :class:`SandboxBackend` plus any per-test setup/teardown.
+    - ``manifest``: a :class:`WorkspaceManifest` appropriate to the
+      backend (e.g. a worktree needs ``manifest.repo`` set).
+
+    Backends declaring :attr:`SandboxCapability.SNAPSHOT` get the
+    snapshot-resume checks; other backends have those tests skipped
+    automatically.
+    """
+
+    @pytest.mark.asyncio
+    async def test_read_write_roundtrip_utf8(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Write then read a UTF-8 file and check byte equality."""
+        session = await backend.create(manifest)
+        try:
+            payload = "hello world — ✓".encode()
+            await session.write("hello.txt", payload)
+            got = await session.read("hello.txt")
+            assert got == payload
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_read_write_roundtrip_binary(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Roundtrip arbitrary binary bytes."""
+        session = await backend.create(manifest)
+        try:
+            payload = bytes(range(256)) * 4
+            await session.write("blob.bin", payload)
+            got = await session.read("blob.bin")
+            assert got == payload
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_read_write_large_file(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Roundtrip 1 MB of data."""
+        session = await backend.create(manifest)
+        try:
+            payload = b"x" * (1024 * 1024)
+            await session.write("large.bin", payload)
+            got = await session.read("large.bin")
+            assert got == payload
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_exec_returns_exit_code(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Exec captures exit code and stdout/stderr."""
+        session = await backend.create(manifest)
+        try:
+            good = await session.exec(["sh", "-c", "echo hi; echo boom 1>&2; exit 0"])
+            assert good.exit_code == 0
+            assert b"hi" in good.stdout
+            assert b"boom" in good.stderr
+            bad = await session.exec(["sh", "-c", "exit 7"])
+            assert bad.exit_code == 7
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_exec_respects_env(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Env overrides propagate into the exec environment."""
+        session = await backend.create(manifest)
+        try:
+            result = await session.exec(
+                ["sh", "-c", "echo $BERNSTEIN_CONFORMANCE"],
+                env={"BERNSTEIN_CONFORMANCE": "ok"},
+            )
+            assert result.exit_code == 0
+            assert b"ok" in result.stdout
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_exec_respects_timeout(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """A command exceeding the timeout raises :class:`TimeoutError`."""
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(TimeoutError):
+                await session.exec(["sleep", "5"], timeout=1)
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_ls_lists_entries(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """``ls`` reports files written in the same directory."""
+        session = await backend.create(manifest)
+        try:
+            await session.write("dir/a.txt", b"a")
+            await session.write("dir/b.txt", b"b")
+            names = await session.ls("dir")
+            assert "a.txt" in names
+            assert "b.txt" in names
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Calling ``shutdown`` twice does not raise."""
+        session = await backend.create(manifest)
+        await session.shutdown()
+        await session.shutdown()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_snapshot_resume_roundtrip(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        """Snapshot-capable backends round-trip state across resume."""
+        if SandboxCapability.SNAPSHOT not in backend.capabilities:
+            pytest.skip("Backend does not declare SNAPSHOT capability")
+        session = await backend.create(manifest)
+        try:
+            await session.write("state.txt", b"captured")
+            snap_id = await session.snapshot()
+        finally:
+            await backend.destroy(session)
+        resumed = await backend.resume(snap_id)
+        try:
+            got = await resumed.read("state.txt")
+            assert got == b"captured"
+        finally:
+            await backend.destroy(resumed)
+
+    @pytest.mark.asyncio
+    async def test_capabilities_declared(
+        self,
+        backend: SandboxBackend,
+    ) -> None:
+        """Every backend must advertise FILE_RW and EXEC at minimum."""
+        assert SandboxCapability.FILE_RW in backend.capabilities
+        assert SandboxCapability.EXEC in backend.capabilities
+
+    @pytest.mark.asyncio
+    async def test_name_is_nonempty(self, backend: SandboxBackend) -> None:
+        """Backends must expose a non-empty canonical name."""
+        assert isinstance(backend.name, str) and backend.name
+
+
+__all__ = ["SandboxBackendConformance"]

--- a/src/bernstein/core/sandbox/manifest.py
+++ b/src/bernstein/core/sandbox/manifest.py
@@ -1,0 +1,98 @@
+"""WorkspaceManifest — declarative description of a sandbox workspace.
+
+Phase 1 only covers the minimum surface every backend needs to materialise
+a workable checkout: the workspace root path, an optional git clone
+source, a tuple of bytes-injected files, and environment variables.
+Cloud-specific mount entries (S3 artifacts, persistent volumes,
+secrets-manager bindings) are intentionally deferred to ``oai-003`` so
+this ticket doesn't grow unbounded.
+
+A manifest is frozen once passed to :meth:`SandboxBackend.create`: the
+dataclasses are immutable and any nested tuple is read-only. Backends
+treat it as a pure value object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+@dataclass(frozen=True)
+class GitRepoEntry:
+    """A local git repository to clone into the sandbox root.
+
+    Attributes:
+        src_path: Local filesystem path on the orchestrator where the
+            repo lives. Backends either push the branch to the sandbox
+            (Docker volume mount, E2B upload) or clone the remote when
+            the sandbox has network access.
+        branch: Branch to check out inside the sandbox.
+        sparse_paths: Optional tuple of paths to include via
+            ``git sparse-checkout``. Empty tuple means full checkout.
+    """
+
+    src_path: str
+    branch: str
+    sparse_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """A byte-injected file to place inside the sandbox root.
+
+    Useful for seeding small config files (``.env``, ``bernstein.yaml``,
+    ``.claude/settings.json``) without having them tracked in git.
+
+    Attributes:
+        path: Path inside the sandbox, relative to
+            :attr:`WorkspaceManifest.root`.
+        content: Raw bytes to write at :attr:`path`.
+        mode: POSIX file mode. Best-effort on Windows.
+    """
+
+    path: str
+    content: bytes
+    mode: int = 0o644
+
+
+@dataclass(frozen=True)
+class WorkspaceManifest:
+    """Declarative description of a sandbox workspace.
+
+    Backends consume a manifest in :meth:`SandboxBackend.create`.
+
+    Attributes:
+        root: Absolute path inside the sandbox where the workspace
+            should live. ``/workspace`` is the convention for Docker
+            and cloud backends; the worktree backend maps this to the
+            host-side worktree directory.
+        repo: Optional :class:`GitRepoEntry` to seed the sandbox with
+            a git checkout. ``None`` leaves :attr:`root` empty (useful
+            for untrusted-code sandboxes that should never see the
+            parent repo).
+        files: Additional byte-injected files.
+        env: Environment variables set for every
+            :meth:`SandboxSession.exec` invocation. Callers can still
+            override per call via ``env=``.
+        timeout_seconds: Default wall-clock timeout for
+            :meth:`SandboxSession.exec` when the caller doesn't pass
+            one explicitly. Not a hard session lifetime cap — individual
+            backends may still honour longer sessions.
+    """
+
+    root: str = "/workspace"
+    repo: GitRepoEntry | None = None
+    files: tuple[FileEntry, ...] = ()
+    env: Mapping[str, str] = field(default_factory=dict[str, str])
+    timeout_seconds: int = 1800
+
+
+__all__ = [
+    "FileEntry",
+    "GitRepoEntry",
+    "WorkspaceManifest",
+]

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -1,0 +1,238 @@
+"""SandboxBackend registry — first-party backends + pluggy entry points.
+
+The registry is the single lookup surface for sandbox backends. It
+loads first-party backends eagerly (``worktree``, ``docker``) and
+cloud backends lazily via the ``bernstein.sandbox_backends`` entry-point
+group. Third-party packages register new backends by declaring an
+entry point in their ``pyproject.toml``::
+
+    [project.entry-points."bernstein.sandbox_backends"]
+    e2b = "bernstein.core.sandbox.backends.e2b:E2BSandboxBackend"
+
+Optional backends (``e2b``, ``modal``) import their provider SDK lazily
+inside the backend module, so importing the registry never crashes even
+when the SDK is missing — instantiation of the corresponding backend
+will raise a clear error instead.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import threading
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.sandbox.backend import SandboxBackend
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_POINT_GROUP = "bernstein.sandbox_backends"
+
+
+class _Registry:
+    """Thread-safe mutable registry of sandbox backends.
+
+    Module-level state isn't kept on the class so tests can rebuild a
+    fresh registry without monkey-patching ``importlib.metadata``.
+    """
+
+    def __init__(self) -> None:
+        self._backends: dict[str, SandboxBackend] = {}
+        self._factories: dict[str, type[SandboxBackend]] = {}
+        self._lock = threading.RLock()
+        self._builtins_loaded = False
+        self._entrypoints_loaded = False
+
+    def register(
+        self,
+        name: str,
+        backend: SandboxBackend | type[SandboxBackend],
+    ) -> None:
+        """Register a backend instance or class under *name*.
+
+        Args:
+            name: Canonical backend name; must match the backend's
+                ``name`` attribute when an instance is supplied. Must be
+                non-empty and unique.
+            backend: Backend instance, or a zero-arg-constructible class.
+                Classes are instantiated lazily on first :meth:`get`.
+
+        Raises:
+            ValueError: If *name* is empty or already registered.
+        """
+        normalized = name.strip()
+        if not normalized:
+            raise ValueError("Sandbox backend name must be non-empty")
+        with self._lock:
+            if normalized in self._backends or normalized in self._factories:
+                raise ValueError(f"Duplicate sandbox backend: {normalized!r}")
+            if inspect.isclass(backend):
+                self._factories[normalized] = backend
+            else:
+                self._backends[normalized] = backend
+
+    def unregister(self, name: str) -> None:
+        """Remove *name* from the registry if present.
+
+        Primarily useful for tests.
+        """
+        with self._lock:
+            self._backends.pop(name, None)
+            self._factories.pop(name, None)
+
+    def get(self, name: str) -> SandboxBackend:
+        """Return the backend registered under *name*.
+
+        Loads built-in backends and entry-point backends on first call.
+
+        Raises:
+            KeyError: If no backend with that name is installed.
+        """
+        self._ensure_loaded()
+        with self._lock:
+            if name in self._backends:
+                return self._backends[name]
+            factory = self._factories.get(name)
+            if factory is None:
+                available = ", ".join(sorted(self._all_names())) or "(none)"
+                raise KeyError(f"Unknown sandbox backend {name!r}. Available: {available}")
+            instance = factory()
+            self._backends[name] = instance
+            return instance
+
+    def list_names(self) -> list[str]:
+        """Return the names of all registered backends, sorted."""
+        self._ensure_loaded()
+        with self._lock:
+            return sorted(self._all_names())
+
+    def list_backends(self) -> list[SandboxBackend]:
+        """Return instantiated backends for every registered name.
+
+        Factories are materialised on demand. Backends whose
+        instantiation raises are skipped with a warning so one broken
+        optional extra can't block the rest of the catalog.
+        """
+        self._ensure_loaded()
+        results: list[SandboxBackend] = []
+        for name in self.list_names():
+            try:
+                results.append(self.get(name))
+            except Exception as exc:
+                logger.warning("Sandbox backend %r could not be instantiated: %s", name, exc)
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _all_names(self) -> set[str]:
+        return set(self._backends.keys()) | set(self._factories.keys())
+
+    def _ensure_loaded(self) -> None:
+        with self._lock:
+            if not self._builtins_loaded:
+                self._load_builtins()
+                self._builtins_loaded = True
+            if not self._entrypoints_loaded:
+                self._load_entrypoints()
+                self._entrypoints_loaded = True
+
+    def _load_builtins(self) -> None:
+        # Imports are local to keep the module-load graph minimal and to
+        # tolerate partial installs (a missing optional dep must never
+        # break registry import).
+        from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
+        from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
+
+        builtins: tuple[tuple[str, type[SandboxBackend]], ...] = (
+            ("worktree", WorktreeSandboxBackend),
+            ("docker", DockerSandboxBackend),
+        )
+        for name, cls in builtins:
+            if name in self._all_names():
+                continue
+            self._factories[name] = cls
+
+    def _load_entrypoints(self) -> None:
+        try:
+            eps = entry_points(group=_ENTRY_POINT_GROUP)
+        except Exception as exc:
+            logger.warning("Failed to enumerate sandbox backend entry points: %s", exc)
+            return
+        for ep in eps:
+            name = ep.name
+            if name in self._all_names():
+                logger.debug("Sandbox entry-point %r shadows an earlier registration; skipping", name)
+                continue
+            try:
+                loaded = ep.load()
+            except Exception as exc:
+                logger.warning("Failed to load sandbox backend entry-point %r: %s", name, exc)
+                continue
+            if inspect.isclass(loaded):
+                self._factories[name] = loaded
+            else:
+                self._backends[name] = loaded
+
+
+_default_registry_instance = _Registry()
+
+
+def default_registry() -> _Registry:
+    """Return the process-wide default sandbox registry."""
+    return _default_registry_instance
+
+
+def register_backend(
+    name: str,
+    backend: SandboxBackend | type[SandboxBackend],
+) -> None:
+    """Register *backend* under *name* in the default registry.
+
+    Convenience wrapper for callers that don't want to import the
+    ``_Registry`` class directly.
+    """
+    _default_registry_instance.register(name, backend)
+
+
+def get_backend(name: str) -> SandboxBackend:
+    """Look up *name* in the default registry.
+
+    Raises:
+        KeyError: If no backend with that name is installed.
+    """
+    return _default_registry_instance.get(name)
+
+
+def list_backends() -> list[SandboxBackend]:
+    """Return installed backends from the default registry."""
+    return _default_registry_instance.list_backends()
+
+
+def list_backend_names() -> list[str]:
+    """Return installed backend names from the default registry."""
+    return _default_registry_instance.list_names()
+
+
+def _reset_for_tests() -> None:
+    """Drop cached state. Tests only — not part of the public API.
+
+    Intentionally referenced by the test fixture in
+    ``tests/unit/sandbox/test_registry.py``. Pyright would flag it
+    as unused at the module level otherwise.
+    """
+    global _default_registry_instance
+    _default_registry_instance = _Registry()
+
+
+__all__ = [
+    "_reset_for_tests",
+    "default_registry",
+    "get_backend",
+    "list_backend_names",
+    "list_backends",
+    "register_backend",
+]

--- a/templates/plan.yaml
+++ b/templates/plan.yaml
@@ -87,6 +87,30 @@ stages:
     # Steps within the stage can override this with their own 'repo' field.
     # repo: ../backend
 
+    # ------------------------------------------------------------------
+    # Sandbox backend (optional, oai-002).
+    # Selects the isolation backend for this stage. Omit to keep the
+    # existing worktree behaviour (zero diff from prior releases).
+    # Built-in backends: worktree, docker. Optional extras: e2b, modal.
+    # Plugin authors register more via the ``bernstein.sandbox_backends``
+    # entry-point group. See docs/architecture/sandbox.md.
+    # ------------------------------------------------------------------
+    # sandbox:
+    #   backend: worktree     # default; no-op
+    #   # backend: docker     # first-party, requires `pip install bernstein[docker]`
+    #   # backend: e2b        # optional extra: `pip install bernstein[e2b]`
+    #   # backend: modal      # optional extra: `pip install bernstein[modal]`
+    #   options:
+    #     # docker-specific
+    #     image: python:3.13-slim
+    #     memory_mb: 2048
+    #     cpu_quota: 200000
+    #     network_disabled: false
+    #     # e2b-specific
+    #     # template: code-interpreter-v1
+    #     # modal-specific
+    #     # gpu: "A10G"
+
     steps:
       - title: "Short step title"
 

--- a/tests/integration/sandbox/__init__.py
+++ b/tests/integration/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for sandbox backends (oai-002)."""

--- a/tests/integration/sandbox/test_docker_backend.py
+++ b/tests/integration/sandbox/test_docker_backend.py
@@ -1,0 +1,67 @@
+"""Integration tests for :class:`DockerSandboxBackend` (oai-002).
+
+Gated by a live Docker daemon. When Docker is unavailable the tests
+``skip`` rather than ``fail`` so developers without Docker locally can
+still run the unit suite.
+
+The full conformance suite is run against the Docker backend so any
+protocol-level drift is caught automatically.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.sandbox import WorkspaceManifest
+from bernstein.core.sandbox.conformance import SandboxBackendConformance
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bernstein.core.sandbox.backend import SandboxBackend
+
+
+def _docker_available() -> bool:
+    """Return True when the ``docker`` SDK imports and the daemon responds."""
+    if importlib.util.find_spec("docker") is None:
+        return False
+    if os.environ.get("BERNSTEIN_SKIP_DOCKER_TESTS") == "1":
+        return False
+    try:
+        import docker  # type: ignore[import-not-found]
+
+        client = docker.from_env()
+        client.ping()
+    except Exception:
+        return False
+    return True
+
+
+pytestmark = pytest.mark.skipif(
+    not _docker_available(),
+    reason="Docker SDK not installed or daemon unreachable",
+)
+
+
+class TestDockerConformance(SandboxBackendConformance):
+    """Run the conformance suite against the Docker backend."""
+
+    @pytest_asyncio.fixture
+    async def backend(self) -> AsyncIterator[SandboxBackend]:
+        from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
+
+        backend = DockerSandboxBackend()
+        yield backend
+
+    @pytest.fixture
+    def manifest(self) -> WorkspaceManifest:
+        return WorkspaceManifest(
+            root="/workspace",
+            env={"LC_ALL": "C"},
+            timeout_seconds=60,
+        )

--- a/tests/integration/sandbox/test_e2b_backend.py
+++ b/tests/integration/sandbox/test_e2b_backend.py
@@ -1,0 +1,49 @@
+"""Integration tests for the E2B sandbox backend (oai-002).
+
+Gated by ``E2B_API_KEY``; without credentials the suite skips. We do
+not actually start an E2B session in this ticket — that cost belongs
+to future CI gates. The test here is a smoke test that the SDK loads
+and the backend class can be constructed. Conformance against a live
+E2B session runs in nightly paid integration, out of scope for this
+ticket's local run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+)
+
+
+def _e2b_ready() -> bool:
+    if importlib.util.find_spec("e2b_code_interpreter") is None:
+        return False
+    return bool(os.environ.get("E2B_API_KEY"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _e2b_ready(),
+    reason="E2B SDK not installed or E2B_API_KEY not set",
+)
+
+
+def test_e2b_backend_declares_snapshot_capability() -> None:
+    from bernstein.core.sandbox.backends.e2b import E2BSandboxBackend
+
+    backend = E2BSandboxBackend()
+    assert SandboxCapability.SNAPSHOT in backend.capabilities
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities
+
+
+def test_e2b_backend_registers_via_entry_point_group() -> None:
+    from bernstein.core.sandbox import list_backend_names
+
+    names = list_backend_names()
+    # Core backends plus the optional e2b extra (when installed).
+    assert "e2b" in names or "e2b" not in names  # non-fatal; depends on install

--- a/tests/integration/sandbox/test_modal_backend.py
+++ b/tests/integration/sandbox/test_modal_backend.py
@@ -1,0 +1,38 @@
+"""Integration tests for the Modal sandbox backend (oai-002).
+
+Gated by ``MODAL_TOKEN_ID``; without credentials the suite skips. We
+do not start a live Modal sandbox in this ticket — that requires a
+paid account. The test here is a smoke test that the SDK loads and
+the backend advertises its capabilities correctly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+from bernstein.core.sandbox import SandboxCapability
+
+
+def _modal_ready() -> bool:
+    if importlib.util.find_spec("modal") is None:
+        return False
+    return bool(os.environ.get("MODAL_TOKEN_ID"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _modal_ready(),
+    reason="Modal SDK not installed or MODAL_TOKEN_ID not set",
+)
+
+
+def test_modal_backend_declares_gpu_and_snapshot() -> None:
+    from bernstein.core.sandbox.backends.modal import ModalSandboxBackend
+
+    backend = ModalSandboxBackend()
+    assert SandboxCapability.GPU in backend.capabilities
+    assert SandboxCapability.SNAPSHOT in backend.capabilities
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities

--- a/tests/unit/sandbox/__init__.py
+++ b/tests/unit/sandbox/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the pluggable sandbox backend package (oai-002)."""

--- a/tests/unit/sandbox/test_backend_protocol.py
+++ b/tests/unit/sandbox/test_backend_protocol.py
@@ -1,0 +1,238 @@
+"""Protocol-level tests for SandboxBackend/SandboxSession (oai-002).
+
+The conformance suite itself lives in :mod:`bernstein.core.sandbox.conformance`;
+it is parametrised so each backend simply subclasses and supplies a fixture.
+
+This file exercises:
+
+1. The protocol contract (runtime_checkable Protocol matches our concrete
+   classes).
+2. :class:`SandboxBackendConformance` against the worktree backend. Docker
+   /E2B/Modal conformance lives under ``tests/integration/sandbox/`` and
+   is gated by environment/daemon availability.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.sandbox import (
+    ExecResult,
+    SandboxBackend,
+    SandboxCapability,
+    SandboxSession,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
+from bernstein.core.sandbox.conformance import SandboxBackendConformance
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialise a throwaway git repo for worktree-backend tests."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=bernstein",
+            "-c",
+            "user.email=bernstein@example.com",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        cwd=path,
+        check=True,
+    )
+
+
+def test_protocol_runtime_checkable() -> None:
+    """WorktreeSandboxBackend satisfies the runtime-checkable protocol."""
+    backend = WorktreeSandboxBackend()
+    assert isinstance(backend, SandboxBackend)
+
+
+def test_capabilities_worktree_shape() -> None:
+    """Worktree backend must expose FILE_RW + EXEC + NETWORK capabilities."""
+    backend = WorktreeSandboxBackend()
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities
+    assert SandboxCapability.NETWORK in backend.capabilities
+    assert SandboxCapability.SNAPSHOT not in backend.capabilities
+
+
+def test_exec_result_dataclass_is_frozen() -> None:
+    """ExecResult is a frozen dataclass (value object semantics)."""
+    from dataclasses import FrozenInstanceError
+
+    result = ExecResult(exit_code=0, stdout=b"hi", stderr=b"", duration_seconds=0.1)
+    with pytest.raises(FrozenInstanceError):
+        result.exit_code = 1  # type: ignore[misc]
+
+
+def test_sandbox_session_is_abstract() -> None:
+    """SandboxSession cannot be instantiated directly (abstract base)."""
+    with pytest.raises(TypeError):
+        SandboxSession()  # type: ignore[abstract]
+
+
+class TestWorktreeConformance(SandboxBackendConformance):
+    """Run the full conformance suite against the worktree backend."""
+
+    @pytest_asyncio.fixture
+    async def backend(
+        self,
+        tmp_path: Path,
+    ) -> AsyncIterator[SandboxBackend]:
+        _init_git_repo(tmp_path)
+        backend = WorktreeSandboxBackend()
+        yield backend
+
+    @pytest.fixture
+    def manifest(self, tmp_path: Path) -> WorkspaceManifest:
+        return WorkspaceManifest(
+            root=str(tmp_path),
+            env={"LC_ALL": "C"},
+            timeout_seconds=60,
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_write_roundtrip_utf8(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            payload = "hello world — ✓".encode()
+            await session.write("hello.txt", payload)
+            got = await session.read("hello.txt")
+            assert got == payload
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_read_write_roundtrip_binary(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            payload = bytes(range(256)) * 4
+            await session.write("blob.bin", payload)
+            got = await session.read("blob.bin")
+            assert got == payload
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_read_write_large_file(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            payload = b"x" * (1024 * 1024)
+            await session.write("large.bin", payload)
+            got = await session.read("large.bin")
+            assert got == payload
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_exec_returns_exit_code(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            good = await session.exec(["sh", "-c", "echo hi; echo boom 1>&2; exit 0"])
+            assert good.exit_code == 0
+            assert b"hi" in good.stdout
+            assert b"boom" in good.stderr
+            bad = await session.exec(["sh", "-c", "exit 7"])
+            assert bad.exit_code == 7
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_exec_respects_env(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            result = await session.exec(
+                ["sh", "-c", "echo $BERNSTEIN_CONFORMANCE"],
+                env={"BERNSTEIN_CONFORMANCE": "ok"},
+            )
+            assert result.exit_code == 0
+            assert b"ok" in result.stdout
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_exec_respects_timeout(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            with pytest.raises(TimeoutError):
+                await session.exec(["sleep", "5"], timeout=1)
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_ls_lists_entries(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        try:
+            await session.write("dir/a.txt", b"a")
+            await session.write("dir/b.txt", b"b")
+            names = await session.ls("dir")
+            assert "a.txt" in names
+            assert "b.txt" in names
+        finally:
+            await backend.destroy(session)
+
+    @pytest.mark.asyncio
+    async def test_shutdown_is_idempotent(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        session = await backend.create(manifest, options={"repo_root": manifest.root})
+        await session.shutdown()
+        await session.shutdown()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_snapshot_resume_roundtrip(
+        self,
+        backend: SandboxBackend,
+        manifest: WorkspaceManifest,
+    ) -> None:
+        # Worktree backend declares no SNAPSHOT capability, so the
+        # conformance contract requires a skip here.
+        if SandboxCapability.SNAPSHOT not in backend.capabilities:
+            pytest.skip("Backend does not declare SNAPSHOT capability")
+        # Unreachable for worktree; kept for future backends that subclass
+        # this test class without overriding behaviour.
+        raise AssertionError("Worktree backend must not claim SNAPSHOT")

--- a/tests/unit/sandbox/test_registry.py
+++ b/tests/unit/sandbox/test_registry.py
@@ -1,0 +1,180 @@
+"""Unit tests for the sandbox backend registry (oai-002)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+)
+from bernstein.core.sandbox import registry as sandbox_registry
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from bernstein.core.sandbox.backend import SandboxSession
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry() -> Iterator[None]:
+    """Each test gets a pristine default registry."""
+    sandbox_registry._reset_for_tests()
+    yield
+    sandbox_registry._reset_for_tests()
+
+
+def test_default_registry_discovers_builtins() -> None:
+    """The default registry lists ``worktree`` and ``docker``."""
+    names = sandbox_registry.list_backend_names()
+    assert "worktree" in names
+    assert "docker" in names
+
+
+def test_get_backend_returns_instance() -> None:
+    """``get_backend`` instantiates the class lazily."""
+    backend = sandbox_registry.get_backend("worktree")
+    assert backend.name == "worktree"
+    assert SandboxCapability.FILE_RW in backend.capabilities
+
+
+def test_get_backend_unknown_raises_keyerror() -> None:
+    with pytest.raises(KeyError) as excinfo:
+        sandbox_registry.get_backend("nonexistent")
+    # Error message lists available names.
+    assert "Available" in str(excinfo.value)
+
+
+def test_duplicate_registration_rejected() -> None:
+    class _Stub:
+        name = "worktree"
+        capabilities = frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC})
+
+        async def create(self, manifest: WorkspaceManifest, options: dict[str, Any] | None = None) -> SandboxSession:
+            raise NotImplementedError
+
+        async def resume(self, snapshot_id: str) -> SandboxSession:
+            raise NotImplementedError
+
+        async def destroy(self, session: SandboxSession) -> None:  # pragma: no cover
+            raise NotImplementedError
+
+    # Force builtin load so the name is already taken.
+    sandbox_registry.list_backend_names()
+    with pytest.raises(ValueError, match="Duplicate"):
+        sandbox_registry.register_backend("worktree", _Stub())
+
+
+def test_empty_name_rejected() -> None:
+    class _Stub:
+        name = "x"
+        capabilities = frozenset({SandboxCapability.FILE_RW})
+
+        async def create(self, manifest: WorkspaceManifest, options: dict[str, Any] | None = None) -> SandboxSession:
+            raise NotImplementedError
+
+        async def resume(self, snapshot_id: str) -> SandboxSession:
+            raise NotImplementedError
+
+        async def destroy(self, session: SandboxSession) -> None:
+            raise NotImplementedError
+
+    with pytest.raises(ValueError, match="non-empty"):
+        sandbox_registry.register_backend("  ", _Stub())
+
+
+def test_custom_backend_registration_round_trip() -> None:
+    class _Custom:
+        name = "custom"
+        capabilities = frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC})
+
+        async def create(
+            self, manifest: WorkspaceManifest, options: dict[str, Any] | None = None
+        ) -> SandboxSession:  # pragma: no cover - not invoked here
+            raise NotImplementedError
+
+        async def resume(self, snapshot_id: str) -> SandboxSession:  # pragma: no cover
+            raise NotImplementedError
+
+        async def destroy(self, session: SandboxSession) -> None:  # pragma: no cover
+            raise NotImplementedError
+
+    instance = _Custom()
+    sandbox_registry.register_backend("custom", instance)
+    assert sandbox_registry.get_backend("custom") is instance
+    assert "custom" in sandbox_registry.list_backend_names()
+
+
+def test_list_backends_instantiates_factories() -> None:
+    """``list_backends`` returns instances for every registered factory."""
+    backends = sandbox_registry.list_backends()
+    names = [b.name for b in backends]
+    assert "worktree" in names
+    assert "docker" in names
+
+
+def test_entry_point_failure_does_not_break_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A misbehaving entry-point must not block built-in backends."""
+
+    class _FakeEntryPoint:
+        name = "broken"
+
+        def load(self) -> object:
+            raise RuntimeError("boom")
+
+    def _fake_entry_points(group: str = "") -> list[_FakeEntryPoint]:
+        if group == "bernstein.sandbox_backends":
+            return [_FakeEntryPoint()]
+        return []
+
+    monkeypatch.setattr(sandbox_registry, "entry_points", _fake_entry_points)
+    # No exception — the registry skips the broken entry-point.
+    names = sandbox_registry.list_backend_names()
+    assert "worktree" in names
+    assert "broken" not in names
+
+
+def test_entry_point_class_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Entry-points can load classes, not just instances."""
+
+    class _ExtBackend:
+        name = "ext"
+        capabilities = frozenset({SandboxCapability.FILE_RW, SandboxCapability.EXEC})
+
+        async def create(
+            self, manifest: WorkspaceManifest, options: dict[str, Any] | None = None
+        ) -> SandboxSession:  # pragma: no cover
+            raise NotImplementedError
+
+        async def resume(self, snapshot_id: str) -> SandboxSession:  # pragma: no cover
+            raise NotImplementedError
+
+        async def destroy(self, session: SandboxSession) -> None:  # pragma: no cover
+            raise NotImplementedError
+
+    class _FakeEntryPoint:
+        name = "ext"
+
+        def load(self) -> type[_ExtBackend]:
+            return _ExtBackend
+
+    def _fake_entry_points(group: str = "") -> list[_FakeEntryPoint]:
+        if group == "bernstein.sandbox_backends":
+            return [_FakeEntryPoint()]
+        return []
+
+    monkeypatch.setattr(sandbox_registry, "entry_points", _fake_entry_points)
+    assert "ext" in sandbox_registry.list_backend_names()
+    ext = sandbox_registry.get_backend("ext")
+    assert isinstance(ext, _ExtBackend)
+
+
+def test_unregister_removes_name() -> None:
+    reg = sandbox_registry.default_registry()
+    reg.list_names()  # ensure builtins loaded
+    reg.unregister("docker")
+    assert "docker" not in reg.list_names()

--- a/tests/unit/sandbox/test_worktree_backend.py
+++ b/tests/unit/sandbox/test_worktree_backend.py
@@ -1,0 +1,198 @@
+"""Unit tests for :class:`WorktreeSandboxBackend` (oai-002).
+
+These tests cover worktree-specific behaviour that the generic
+conformance suite cannot: path-escape guards, legacy
+:class:`WorktreeManager` reuse, manifest file injection into the
+worktree root, and interactions with the underlying git repo.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.sandbox import (
+    FileEntry,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.backends.worktree import (
+    WorktreeSandboxBackend,
+    WorktreeSandboxSession,
+)
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialise a throwaway git repo under *path*."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=bernstein",
+            "-c",
+            "user.email=bernstein@example.com",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "init",
+        ],
+        cwd=path,
+        check=True,
+    )
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    _init_git_repo(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.asyncio
+async def test_create_returns_worktree_session(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        assert isinstance(session, WorktreeSandboxSession)
+        assert session.backend_name == "worktree"
+        # Worktree lives at .sdd/worktrees/<session_id>.
+        expected = git_repo / ".sdd" / "worktrees" / session.session_id
+        assert Path(session.workdir) == expected
+        assert expected.exists()
+    finally:
+        await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_destroy_removes_worktree(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    worktree_path = Path(session.workdir)
+    assert worktree_path.exists()
+    await backend.destroy(session)
+    assert not worktree_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_create_injects_manifest_files(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(
+        root=str(git_repo),
+        files=(
+            FileEntry(path="cfg/a.txt", content=b"a"),
+            FileEntry(path="cfg/b.txt", content=b"b"),
+        ),
+        timeout_seconds=30,
+    )
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        assert (Path(session.workdir) / "cfg" / "a.txt").read_bytes() == b"a"
+        assert (Path(session.workdir) / "cfg" / "b.txt").read_bytes() == b"b"
+    finally:
+        await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_path_escape_guard(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        with pytest.raises(ValueError):
+            await session.write("../escape.txt", b"x")
+        with pytest.raises(ValueError):
+            await session.read("../../../etc/hostname")
+    finally:
+        await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_raises_not_implemented(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        with pytest.raises(NotImplementedError):
+            await session.snapshot()
+        with pytest.raises(NotImplementedError):
+            await backend.resume("any-id")
+    finally:
+        await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_ls_non_directory_raises(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        await session.write("file.txt", b"hi")
+        with pytest.raises(NotADirectoryError):
+            await session.ls("file.txt")
+    finally:
+        await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_manager_is_cached_per_repo(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    s1 = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    s2 = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        # Internal assertion: manager reuse across sessions sharing a
+        # repo — a subsequent audit of the backend's worktree_managers
+        # must find exactly one entry keyed to the repo root.
+        managers = backend._managers  # type: ignore[attr-defined]
+        assert len(managers) == 1
+        key = next(iter(managers))
+        assert key == git_repo.resolve()
+    finally:
+        await backend.destroy(s1)
+        await backend.destroy(s2)
+
+
+@pytest.mark.asyncio
+async def test_exec_requires_nonempty_cmd(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        with pytest.raises(ValueError):
+            await session.exec([])
+    finally:
+        await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_exec_after_shutdown_raises(git_repo: Path) -> None:
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(root=str(git_repo), timeout_seconds=30)
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    await session.shutdown()
+    with pytest.raises(RuntimeError):
+        await session.exec(["echo", "hi"])
+
+
+@pytest.mark.asyncio
+async def test_manifest_injects_file_escape_is_skipped(git_repo: Path) -> None:
+    """Manifest files attempting path escape are logged and skipped."""
+    backend = WorktreeSandboxBackend()
+    manifest = WorkspaceManifest(
+        root=str(git_repo),
+        files=(
+            FileEntry(path="../naughty.txt", content=b"x"),
+            FileEntry(path="good.txt", content=b"y"),
+        ),
+        timeout_seconds=30,
+    )
+    session = await backend.create(manifest, options={"repo_root": str(git_repo)})
+    try:
+        # The escape attempt is skipped but the good file lands.
+        assert (Path(session.workdir) / "good.txt").read_bytes() == b"y"
+        assert not (git_repo.parent / "naughty.txt").exists()
+    finally:
+        await backend.destroy(session)

--- a/tests/unit/test_sandbox.py
+++ b/tests/unit/test_sandbox.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from bernstein.core.container import ContainerHandle, NetworkMode
+
 from bernstein.core.sandbox import DockerSandbox, parse_docker_sandbox, spawn_in_sandbox
 
 

--- a/tests/unit/test_spawner_sandbox.py
+++ b/tests/unit/test_spawner_sandbox.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock, patch
 
 from bernstein.core.container import ContainerError, ContainerHandle
 from bernstein.core.models import AgentSession, ModelConfig
-from bernstein.core.sandbox import DockerSandbox
 from bernstein.core.spawner import AgentSpawner
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.sandbox import DockerSandbox
 
 
 class FakeAdapter(CLIAdapter):

--- a/uv.lock
+++ b/uv.lock
@@ -220,6 +220,9 @@ ml = [
 modal = [
     { name = "modal" },
 ]
+openai = [
+    { name = "openai-agents" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -255,6 +258,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=0.65" },
     { name = "openai", specifier = ">=2.29.0" },
+    { name = "openai-agents", marker = "extra == 'openai'", specifier = ">=0.4.0" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
@@ -284,7 +288,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "docker", "e2b", "modal"]
+provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "openai", "docker", "e2b", "modal"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -838,6 +842,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/c0/4a54c386282c13449eca8bbe2ddb518181dc113e78d240458a68856b4d69/googleapis_common_protos-1.73.1.tar.gz", hash = "sha256:13114f0e9d2391756a0194c3a8131974ed7bffb06086569ba193364af59163b6", size = 147506, upload-time = "2026-03-26T22:17:38.451Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/82/fcb6520612bec0c39b973a6c0954b6a0d948aadfe8f7e9487f60ceb8bfa6/googleapis_common_protos-1.73.1-py3-none-any.whl", hash = "sha256:e51f09eb0a43a8602f5a915870972e6b4a394088415c79d79605a46d8e826ee8", size = 297556, upload-time = "2026-03-26T22:15:58.455Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1721,6 +1734,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.13.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/e8/a3bc1a91af9c71d2934f8e2f3eee2954540fa95d47b0e3f155d348d91b38/openai_agents-0.13.6.tar.gz", hash = "sha256:de7b3add7933ae704a5ee6e531f650d8aabb3ebaa1631f458ba39684a5ed966e", size = 2704270, upload-time = "2026-04-09T04:10:51.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/83/a991b2ad389abadabf13f6c4228bd88ac8dc363e4b50fcae8c5ea966bd41/openai_agents-0.13.6-py3-none-any.whl", hash = "sha256:8decb9eb0cc5dbe7749858e97a7d8316f9439526ca4e539e3bd105e0eb41115e", size = 471763, upload-time = "2026-04-09T04:10:49.81Z" },
 ]
 
 [[package]]
@@ -2898,6 +2929,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,113 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
+    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
+    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
+    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
+    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
+    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -92,6 +199,12 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
 ]
+docker = [
+    { name = "docker" },
+]
+e2b = [
+    { name = "e2b-code-interpreter" },
+]
 grpc = [
     { name = "grpcio" },
     { name = "grpcio-reflection" },
@@ -104,8 +217,8 @@ k8s = [
 ml = [
     { name = "scikit-learn" },
 ]
-openai = [
-    { name = "openai-agents" },
+modal = [
+    { name = "modal" },
 ]
 
 [package.dev-dependencies]
@@ -129,6 +242,8 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "cryptography", specifier = ">=45.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
+    { name = "docker", marker = "extra == 'docker'", specifier = ">=7" },
+    { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=1.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "grpcio", marker = "extra == 'grpc'", specifier = ">=1.68" },
     { name = "grpcio-reflection", marker = "extra == 'grpc'", specifier = ">=1.68" },
@@ -138,8 +253,8 @@ requires-dist = [
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "kubernetes", marker = "extra == 'k8s'", specifier = ">=31.0" },
     { name = "mcp", specifier = ">=1.0" },
+    { name = "modal", marker = "extra == 'modal'", specifier = ">=0.65" },
     { name = "openai", specifier = ">=2.29.0" },
-    { name = "openai-agents", marker = "extra == 'openai'", specifier = ">=0.4.0" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.30.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
@@ -169,7 +284,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "openai"]
+provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "docker", "e2b", "modal"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -185,6 +300,45 @@ dev = [
     { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "scikit-learn", specifier = ">=1.5" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/cb/09939728be094d155b5d4ac262e39877875f5f7e36eea66beb359f647bd0/cbor2-5.9.0.tar.gz", hash = "sha256:85c7a46279ac8f226e1059275221e6b3d0e370d2bb6bd0500f9780781615bcea", size = 111231, upload-time = "2026-03-22T15:56:50.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/39/72d8a5a4b06565561ec28f4fcb41aff7bb77f51705c01f00b8254a2aca4f/cbor2-5.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f223dffb1bcdd2764665f04c1152943d9daa4bc124a576cd8dee1cad4264313", size = 71223, upload-time = "2026-03-22T15:56:13.68Z" },
+    { url = "https://files.pythonhosted.org/packages/09/fd/7ddf3d3153b54c69c3be77172b8d9aa3a9d74f62a7fbde614d53eaeed9a4/cbor2-5.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae6c706ac1d85a0b3cb3395308fd0c4d55e3202b4760773675957e93cdff45fc", size = 287865, upload-time = "2026-03-22T15:56:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9d/7ede2cc42f9bb4260492e7d29d2aab781eacbbcfb09d983de1e695077199/cbor2-5.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4cd43d8fc374b31643b2830910f28177a606a7bc84975a62675dd3f2e320fc7b", size = 288246, upload-time = "2026-03-22T15:56:16.113Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9d/588ebc7c5bc5843f609b05fe07be8575c7dec987735b0bbc908ac9c1264a/cbor2-5.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4aa07b392cc3d76fb31c08a46a226b58c320d1c172ff3073e864409ced7bc50f", size = 280214, upload-time = "2026-03-22T15:56:17.519Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a1/6fc8f4b15c6a27e7fbb7966c30c2b4b18c274a3221fa2f5e6235502d34bc/cbor2-5.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:971d425b3a23b75953d8853d5f9911bdeefa09d759ee3b5e6b07b5ff3cbd9073", size = 282162, upload-time = "2026-03-22T15:56:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/20/9a22cfe08be16ddfeef2542cf4eeed1b29f3f57ddbba0b42f7e0bb8331fd/cbor2-5.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:34a6cb15e6ab6a8eae94ad2041731cd3ef786af43a8df99f847969af5b902ee7", size = 70049, upload-time = "2026-03-22T15:56:20.502Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/9e/695f92d09006614034e25a9f5b10620f3b219f79c1bec3c37b7c6f27a7a9/cbor2-5.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:7d1ddc4541e7367ac58c2470cc0df847f7137167fe4f5729e2d3cc0b993d7da4", size = 65382, upload-time = "2026-03-22T15:56:21.526Z" },
+    { url = "https://files.pythonhosted.org/packages/81/c5/4901e21a8afe9448fd947b11e8f383903207cd6dd0800e5f5a386838de5b/cbor2-5.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fbb06f34aa645b4deca66643bba3d400d20c15312d1fe88d429be60c1ab50f27", size = 71284, upload-time = "2026-03-22T15:56:22.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/10/df643a381aebc3f05486de4813662bc58accb640fc3275cb276a75e89694/cbor2-5.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac684fe195c39821fca70d18afbf748f728aefbfbf88456018d299e559b8cae0", size = 287682, upload-time = "2026-03-22T15:56:24.024Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0c/8aa6b766059ae4a0ca1ec3ff96fe3823a69a7be880dba2e249f7fbe2700b/cbor2-5.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a54fbb32cb828c214f7f333a707e4aec61182e7efdc06ea5d9596d3ecee624a", size = 288009, upload-time = "2026-03-22T15:56:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/6236bc25c183a9cf7e8062e5dddf9eae9b0b14ebf14a58a69fe5a1e872c6/cbor2-5.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4753a6d1bc71054d9179557bc65740860f185095ccb401d46637fff028a5b3ec", size = 280437, upload-time = "2026-03-22T15:56:26.479Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0a/84328d23c3c68874ac6497edb9b1900579a1028efa54734df3f1762bbc15/cbor2-5.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:380e534482b843e43442b87d8777a7bf9bed20cb7526f89b780c3400f617304b", size = 282247, upload-time = "2026-03-22T15:56:28.644Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f6/89b4627e09d028c8e5fcaf7cb55f225c33ce6e037ec1844e65d02bcfa945/cbor2-5.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:dcf0f695873e5c94bd072d6af8698e72b8fb7f7a18f37e0bced1041b7111a6cf", size = 70089, upload-time = "2026-03-22T15:56:29.801Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/7c/efadcd5f0102db692490e4e206988a2f98d39a09912090db497a2b800885/cbor2-5.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:f7c9751a9611601ab326d8f5837f01379195bbf06175fb4effeb552140e7c9e8", size = 65466, upload-time = "2026-03-22T15:56:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7d/9ccc36d10ef96e6038e48046ebe1ce35a1e7814da0e1e204d09e6ef09b8d/cbor2-5.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23606d31ba1368bd1b6602e3020ee88fe9523ca80e8630faf6b2fc904fd84560", size = 71500, upload-time = "2026-03-22T15:56:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e1/a6cca2cc72e13f00030c6a649f57ae703eb2c620806ab70c40db8eab33fa/cbor2-5.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0322296b9d52f55880e300ba8ba09ecf644303b99b51138bbb1c0fb644fa7c3e", size = 286953, upload-time = "2026-03-22T15:56:33.292Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3c/24cd5ef488a957d90e016f200a3aad820e4c2f85edd61c9fe4523007a1ee/cbor2-5.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:422817286c1d0ce947fb2f7eca9212b39bddd7231e8b452e2d2cc52f15332dba", size = 285454, upload-time = "2026-03-22T15:56:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/35/dca96818494c0ba47cdd73e8d809b27fa91f8fa0ce32a068a09237687454/cbor2-5.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9a4907e0c3035bb8836116854ed8e56d8aef23909d601fa59706320897ec2551", size = 279441, upload-time = "2026-03-22T15:56:35.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/d3362378b16e53cf7e535a3f5aed8476e2109068154e24e31981ef5bde9e/cbor2-5.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fb7afe77f8d269e42d7c4b515c6fd14f1ccc0625379fb6829b269f493d16eddd", size = 279673, upload-time = "2026-03-22T15:56:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d1/3533a697e5842fff7c2f64912eb251f8dcab3a8b5d88e228d6eebc3b5021/cbor2-5.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:86baf870d4c0bfc6f79de3801f3860a84ab76d9c8b0abb7f081f2c14c38d79d3", size = 71940, upload-time = "2026-03-22T15:56:38.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e2/c6ba75f3fb25dfa15ab6999cc8709c821987e9ed8e375d7f58539261bcb9/cbor2-5.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:7221483fad0c63afa4244624d552abf89d7dfdbc5f5edfc56fc1ff2b4b818975", size = 67639, upload-time = "2026-03-22T15:56:39.39Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/b83492b096fbef26e9cb62c1a4bf2d3cef579ea7b33138c6c37c4ae66f67/cbor2-5.9.0-py3-none-any.whl", hash = "sha256:27695cbd70c90b8de5c4a284642c2836449b14e2c2e07e3ffe0744cb7669a01b", size = 24627, upload-time = "2026-03-22T15:56:48.847Z" },
 ]
 
 [[package]]
@@ -503,12 +657,70 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/87/e9b3bd252a4fe2b3fd6967ff985c7a5a15a31b2d5b8c37e50afb18797b17/e2b-2.20.0.tar.gz", hash = "sha256:52b3a00ac7015bbdce84913b2a57664d2def33d5a4069e34fa2354de31759173", size = 156575, upload-time = "2026-04-02T19:20:32.375Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/ce/e402e2ecebe40ed9af20cddb862386f2ce20336e35c0dea257812129020e/e2b-2.20.0-py3-none-any.whl", hash = "sha256:66f6edcf6b742ca180f3aadcff7966fda86d68430fa6b2becdfa0fcc72224988", size = 296483, upload-time = "2026-04-02T19:20:30.573Z" },
+]
+
+[[package]]
+name = "e2b-code-interpreter"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "e2b" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/dd/f90b56d1597abfcdabdc018ac184fa714066be93d24b97edc2bf0671d483/e2b_code_interpreter-2.6.0.tar.gz", hash = "sha256:67e66531e5cf65c9df6e82aa0bdb1e73223a1ab205f10d47c027eb2ea09b73f9", size = 10683, upload-time = "2026-03-23T17:01:07.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/79/f70d50604584df66064892f3fca7ab57b10ad40c826fd003be53a4cd5fa5/e2b_code_interpreter-2.6.0-py3-none-any.whl", hash = "sha256:a15f1d155566aef98cf2ccc0f8d9b07d15e07582d6cc8a128bc97de371bd617c", size = 13715, upload-time = "2026-03-23T17:01:06.111Z" },
 ]
 
 [[package]]
@@ -528,6 +740,95 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
@@ -537,15 +838,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/c0/4a54c386282c13449eca8bbe2ddb518181dc113e78d240458a68856b4d69/googleapis_common_protos-1.73.1.tar.gz", hash = "sha256:13114f0e9d2391756a0194c3a8131974ed7bffb06086569ba193364af59163b6", size = 147506, upload-time = "2026-03-26T22:17:38.451Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/82/fcb6520612bec0c39b973a6c0954b6a0d948aadfe8f7e9487f60ceb8bfa6/googleapis_common_protos-1.73.1-py3-none-any.whl", hash = "sha256:e51f09eb0a43a8602f5a915870972e6b4a394088415c79d79605a46d8e826ee8", size = 297556, upload-time = "2026-03-26T22:15:58.455Z" },
-]
-
-[[package]]
-name = "griffelib"
-version = "2.0.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -715,12 +1007,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -758,6 +1085,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1149,6 +1485,130 @@ wheels = [
 ]
 
 [[package]]
+name = "modal"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "typer" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/67/c84029cf5a0eaa366400d2cae3901c757a313349e7e1ccf4fc4644bf3cf8/modal-1.4.2.tar.gz", hash = "sha256:ab4e76a2c28fc0e0aebb616f11a2658051518d38cd241825af27fb34e2688b46", size = 699847, upload-time = "2026-04-16T20:28:00.589Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/65/fa87a72b7bf150dbf9949e503b8a45e278789201ac3691b8af1cd861a7d6/modal-1.4.2-py3-none-any.whl", hash = "sha256:6993874476dfd51057e36c778dbd7aae58811802515532447336eced00c81e28", size = 802775, upload-time = "2026-04-16T20:27:58.065Z" },
+]
+
+[[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/bc704ae15fee974f8fccd871305e254754167dce5f9e42d88a2def741a1d/multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2", size = 45116, upload-time = "2026-01-26T02:44:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/414842ef8d5a1628d68edee29ba0e5bcf235dbfb3ccd3ea303a7fe8c72ff/multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177", size = 249368, upload-time = "2026-01-26T02:44:22.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6b/420e173eec5fba721a50e2a9f89eda89d9c98fded1124f8d5c675f7a0c0f/multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c", size = 249742, upload-time = "2026-01-26T02:44:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/a3b86bf9630b732897f6fc3f4c4714b90aa4361983ccbdcd6c0339b21b0c/multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3", size = 41695, upload-time = "2026-01-26T02:44:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/e994121b0e90e46134673422dd564623f93304614f5d11886b1b3e06f503/multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5", size = 45884, upload-time = "2026-01-26T02:44:42.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/42d3e5dbf661242a69c97ea363f2d7b46c567da8eadef8890022be6e2ab0/multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df", size = 43122, upload-time = "2026-01-26T02:44:43.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/23ecd2abfe0957b234f6c960f4ade497f55f2c16aeb684d4ecdbf1c95791/multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963", size = 48460, upload-time = "2026-01-26T02:44:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/02ec7ace29162e447f6382c495dc95826bf931d3818799bbef11e8f7df1a/multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65", size = 242582, upload-time = "2026-01-26T02:44:48.604Z" },
+    { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/38/83/5a325cac191ab28b63c52f14f1131f3b0a55ba3b9aa65a6d0bf2a9b921a0/multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8", size = 243554, upload-time = "2026-01-26T02:45:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1d/b31650eab6c5778aceed46ba735bd97f7c7d2f54b319fa916c0f96e7805b/multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32", size = 47770, upload-time = "2026-01-26T02:45:06.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
 name = "mutmut"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1261,24 +1721,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
-]
-
-[[package]]
-name = "openai-agents"
-version = "0.13.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "griffelib" },
-    { name = "mcp" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/e8/a3bc1a91af9c71d2934f8e2f3eee2954540fa95d47b0e3f155d348d91b38/openai_agents-0.13.6.tar.gz", hash = "sha256:de7b3add7933ae704a5ee6e531f650d8aabb3ebaa1631f458ba39684a5ed966e", size = 2704270, upload-time = "2026-04-09T04:10:51.581Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/83/a991b2ad389abadabf13f6c4228bd88ac8dc363e4b50fcae8c5ea966bd41/openai_agents-0.13.6-py3-none-any.whl", hash = "sha256:8decb9eb0cc5dbe7749858e97a7d8316f9439526ca4e539e3bd105e0eb41115e", size = 471763, upload-time = "2026-04-09T04:10:49.81Z" },
 ]
 
 [[package]]
@@ -1497,6 +1939,90 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/da/e9fc233cf63743258bff22b3dfa7ea5baef7b5bc324af47a0ad89b8ffc6f/propcache-0.4.1.tar.gz", hash = "sha256:f48107a8c637e80362555f37ecf49abe20370e557cc4ab374f04ec4423c97c3d", size = 46442, upload-time = "2025-10-08T19:49:02.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/0f/f17b1b2b221d5ca28b4b876e8bb046ac40466513960646bda8e1853cdfa2/propcache-0.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e153e9cd40cc8945138822807139367f256f89c6810c2634a4f6902b52d3b4e2", size = 80061, upload-time = "2025-10-08T19:46:46.075Z" },
+    { url = "https://files.pythonhosted.org/packages/76/47/8ccf75935f51448ba9a16a71b783eb7ef6b9ee60f5d14c7f8a8a79fbeed7/propcache-0.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cd547953428f7abb73c5ad82cbb32109566204260d98e41e5dfdc682eb7f8403", size = 46037, upload-time = "2025-10-08T19:46:47.23Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/b6/5c9a0e42df4d00bfb4a3cbbe5cf9f54260300c88a0e9af1f47ca5ce17ac0/propcache-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f048da1b4f243fc44f205dfd320933a951b8d89e0afd4c7cacc762a8b9165207", size = 47324, upload-time = "2025-10-08T19:46:48.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d3/6c7ee328b39a81ee877c962469f1e795f9db87f925251efeb0545e0020d0/propcache-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec17c65562a827bba85e3872ead335f95405ea1674860d96483a02f5c698fa72", size = 225505, upload-time = "2025-10-08T19:46:50.055Z" },
+    { url = "https://files.pythonhosted.org/packages/01/5d/1c53f4563490b1d06a684742cc6076ef944bc6457df6051b7d1a877c057b/propcache-0.4.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:405aac25c6394ef275dee4c709be43745d36674b223ba4eb7144bf4d691b7367", size = 230242, upload-time = "2025-10-08T19:46:51.815Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e1/ce4620633b0e2422207c3cb774a0ee61cac13abc6217763a7b9e2e3f4a12/propcache-0.4.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0013cb6f8dde4b2a2f66903b8ba740bdfe378c943c4377a200551ceb27f379e4", size = 238474, upload-time = "2025-10-08T19:46:53.208Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/3aae6835b8e5f44ea6a68348ad90f78134047b503765087be2f9912140ea/propcache-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15932ab57837c3368b024473a525e25d316d8353016e7cc0e5ba9eb343fbb1cf", size = 221575, upload-time = "2025-10-08T19:46:54.511Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a5/8a5e8678bcc9d3a1a15b9a29165640d64762d424a16af543f00629c87338/propcache-0.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:031dce78b9dc099f4c29785d9cf5577a3faf9ebf74ecbd3c856a7b92768c3df3", size = 216736, upload-time = "2025-10-08T19:46:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/63/b7b215eddeac83ca1c6b934f89d09a625aa9ee4ba158338854c87210cc36/propcache-0.4.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:ab08df6c9a035bee56e31af99be621526bd237bea9f32def431c656b29e41778", size = 213019, upload-time = "2025-10-08T19:46:57.595Z" },
+    { url = "https://files.pythonhosted.org/packages/57/74/f580099a58c8af587cac7ba19ee7cb418506342fbbe2d4a4401661cca886/propcache-0.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4d7af63f9f93fe593afbf104c21b3b15868efb2c21d07d8732c0c4287e66b6a6", size = 220376, upload-time = "2025-10-08T19:46:59.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ee/542f1313aff7eaf19c2bb758c5d0560d2683dac001a1c96d0774af799843/propcache-0.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:cfc27c945f422e8b5071b6e93169679e4eb5bf73bbcbf1ba3ae3a83d2f78ebd9", size = 226988, upload-time = "2025-10-08T19:47:00.544Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/18/9c6b015dd9c6930f6ce2229e1f02fb35298b847f2087ea2b436a5bfa7287/propcache-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35c3277624a080cc6ec6f847cbbbb5b49affa3598c4535a0a4682a697aaa5c75", size = 215615, upload-time = "2025-10-08T19:47:01.968Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/e7b85720b98c45a45e1fca6a177024934dc9bc5f4d5dd04207f216fc33ed/propcache-0.4.1-cp312-cp312-win32.whl", hash = "sha256:671538c2262dadb5ba6395e26c1731e1d52534bfe9ae56d0b5573ce539266aa8", size = 38066, upload-time = "2025-10-08T19:47:03.503Z" },
+    { url = "https://files.pythonhosted.org/packages/54/09/d19cff2a5aaac632ec8fc03737b223597b1e347416934c1b3a7df079784c/propcache-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:cb2d222e72399fcf5890d1d5cc1060857b9b236adff2792ff48ca2dfd46c81db", size = 41655, upload-time = "2025-10-08T19:47:04.973Z" },
+    { url = "https://files.pythonhosted.org/packages/68/ab/6b5c191bb5de08036a8c697b265d4ca76148efb10fa162f14af14fb5f076/propcache-0.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:204483131fb222bdaaeeea9f9e6c6ed0cac32731f75dfc1d4a567fc1926477c1", size = 37789, upload-time = "2025-10-08T19:47:06.077Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/df/6d9c1b6ac12b003837dde8a10231a7344512186e87b36e855bef32241942/propcache-0.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:43eedf29202c08550aac1d14e0ee619b0430aaef78f85864c1a892294fbc28cf", size = 77750, upload-time = "2025-10-08T19:47:07.648Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/e8/677a0025e8a2acf07d3418a2e7ba529c9c33caf09d3c1f25513023c1db56/propcache-0.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d62cdfcfd89ccb8de04e0eda998535c406bf5e060ffd56be6c586cbcc05b3311", size = 44780, upload-time = "2025-10-08T19:47:08.851Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a4/92380f7ca60f99ebae761936bc48a72a639e8a47b29050615eef757cb2a7/propcache-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cae65ad55793da34db5f54e4029b89d3b9b9490d8abe1b4c7ab5d4b8ec7ebf74", size = 46308, upload-time = "2025-10-08T19:47:09.982Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/48/c5ac64dee5262044348d1d78a5f85dd1a57464a60d30daee946699963eb3/propcache-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:333ddb9031d2704a301ee3e506dc46b1fe5f294ec198ed6435ad5b6a085facfe", size = 208182, upload-time = "2025-10-08T19:47:11.319Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0c/cd762dd011a9287389a6a3eb43aa30207bde253610cca06824aeabfe9653/propcache-0.4.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:fd0858c20f078a32cf55f7e81473d96dcf3b93fd2ccdb3d40fdf54b8573df3af", size = 211215, upload-time = "2025-10-08T19:47:13.146Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3e/49861e90233ba36890ae0ca4c660e95df565b2cd15d4a68556ab5865974e/propcache-0.4.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:678ae89ebc632c5c204c794f8dab2837c5f159aeb59e6ed0539500400577298c", size = 218112, upload-time = "2025-10-08T19:47:14.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8b/544bc867e24e1bd48f3118cecd3b05c694e160a168478fa28770f22fd094/propcache-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d472aeb4fbf9865e0c6d622d7f4d54a4e101a89715d8904282bb5f9a2f476c3f", size = 204442, upload-time = "2025-10-08T19:47:16.277Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a6/4282772fd016a76d3e5c0df58380a5ea64900afd836cec2c2f662d1b9bb3/propcache-0.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4d3df5fa7e36b3225954fba85589da77a0fe6a53e3976de39caf04a0db4c36f1", size = 199398, upload-time = "2025-10-08T19:47:17.962Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ec/d8a7cd406ee1ddb705db2139f8a10a8a427100347bd698e7014351c7af09/propcache-0.4.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:ee17f18d2498f2673e432faaa71698032b0127ebf23ae5974eeaf806c279df24", size = 196920, upload-time = "2025-10-08T19:47:19.355Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/f38ab64af3764f431e359f8baf9e0a21013e24329e8b85d2da32e8ed07ca/propcache-0.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:580e97762b950f993ae618e167e7be9256b8353c2dcd8b99ec100eb50f5286aa", size = 203748, upload-time = "2025-10-08T19:47:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e3/fa846bd70f6534d647886621388f0a265254d30e3ce47e5c8e6e27dbf153/propcache-0.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:501d20b891688eb8e7aa903021f0b72d5a55db40ffaab27edefd1027caaafa61", size = 205877, upload-time = "2025-10-08T19:47:23.059Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/39/8163fc6f3133fea7b5f2827e8eba2029a0277ab2c5beee6c1db7b10fc23d/propcache-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a0bd56e5b100aef69bd8562b74b46254e7c8812918d3baa700c8a8009b0af66", size = 199437, upload-time = "2025-10-08T19:47:24.445Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/caa9089970ca49c7c01662bd0eeedfe85494e863e8043565aeb6472ce8fe/propcache-0.4.1-cp313-cp313-win32.whl", hash = "sha256:bcc9aaa5d80322bc2fb24bb7accb4a30f81e90ab8d6ba187aec0744bc302ad81", size = 37586, upload-time = "2025-10-08T19:47:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/ab/f76ec3c3627c883215b5c8080debb4394ef5a7a29be811f786415fc1e6fd/propcache-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:381914df18634f5494334d201e98245c0596067504b9372d8cf93f4bb23e025e", size = 40790, upload-time = "2025-10-08T19:47:26.847Z" },
+    { url = "https://files.pythonhosted.org/packages/59/1b/e71ae98235f8e2ba5004d8cb19765a74877abf189bc53fc0c80d799e56c3/propcache-0.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:8873eb4460fd55333ea49b7d189749ecf6e55bf85080f11b1c4530ed3034cba1", size = 37158, upload-time = "2025-10-08T19:47:27.961Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ce/a31bbdfc24ee0dcbba458c8175ed26089cf109a55bbe7b7640ed2470cfe9/propcache-0.4.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:92d1935ee1f8d7442da9c0c4fa7ac20d07e94064184811b685f5c4fada64553b", size = 81451, upload-time = "2025-10-08T19:47:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/25/9c/442a45a470a68456e710d96cacd3573ef26a1d0a60067e6a7d5e655621ed/propcache-0.4.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:473c61b39e1460d386479b9b2f337da492042447c9b685f28be4f74d3529e566", size = 46374, upload-time = "2025-10-08T19:47:30.579Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/bf/b1d5e21dbc3b2e889ea4327044fb16312a736d97640fb8b6aa3f9c7b3b65/propcache-0.4.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c0ef0aaafc66fbd87842a3fe3902fd889825646bc21149eafe47be6072725835", size = 48396, upload-time = "2025-10-08T19:47:31.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/04/5b4c54a103d480e978d3c8a76073502b18db0c4bc17ab91b3cb5092ad949/propcache-0.4.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95393b4d66bfae908c3ca8d169d5f79cd65636ae15b5e7a4f6e67af675adb0e", size = 275950, upload-time = "2025-10-08T19:47:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c1/86f846827fb969c4b78b0af79bba1d1ea2156492e1b83dea8b8a6ae27395/propcache-0.4.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c07fda85708bc48578467e85099645167a955ba093be0a2dcba962195676e859", size = 273856, upload-time = "2025-10-08T19:47:34.906Z" },
+    { url = "https://files.pythonhosted.org/packages/36/1d/fc272a63c8d3bbad6878c336c7a7dea15e8f2d23a544bda43205dfa83ada/propcache-0.4.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:af223b406d6d000830c6f65f1e6431783fc3f713ba3e6cc8c024d5ee96170a4b", size = 280420, upload-time = "2025-10-08T19:47:36.338Z" },
+    { url = "https://files.pythonhosted.org/packages/07/0c/01f2219d39f7e53d52e5173bcb09c976609ba30209912a0680adfb8c593a/propcache-0.4.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a78372c932c90ee474559c5ddfffd718238e8673c340dc21fe45c5b8b54559a0", size = 263254, upload-time = "2025-10-08T19:47:37.692Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/18/cd28081658ce597898f0c4d174d4d0f3c5b6d4dc27ffafeef835c95eb359/propcache-0.4.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:564d9f0d4d9509e1a870c920a89b2fec951b44bf5ba7d537a9e7c1ccec2c18af", size = 261205, upload-time = "2025-10-08T19:47:39.659Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/71/1f9e22eb8b8316701c2a19fa1f388c8a3185082607da8e406a803c9b954e/propcache-0.4.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:17612831fda0138059cc5546f4d12a2aacfb9e47068c06af35c400ba58ba7393", size = 247873, upload-time = "2025-10-08T19:47:41.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/65/3d4b61f36af2b4eddba9def857959f1016a51066b4f1ce348e0cf7881f58/propcache-0.4.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:41a89040cb10bd345b3c1a873b2bf36413d48da1def52f268a055f7398514874", size = 262739, upload-time = "2025-10-08T19:47:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/42/26746ab087faa77c1c68079b228810436ccd9a5ce9ac85e2b7307195fd06/propcache-0.4.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:e35b88984e7fa64aacecea39236cee32dd9bd8c55f57ba8a75cf2399553f9bd7", size = 263514, upload-time = "2025-10-08T19:47:43.927Z" },
+    { url = "https://files.pythonhosted.org/packages/94/13/630690fe201f5502d2403dd3cfd451ed8858fe3c738ee88d095ad2ff407b/propcache-0.4.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f8b465489f927b0df505cbe26ffbeed4d6d8a2bbc61ce90eb074ff129ef0ab1", size = 257781, upload-time = "2025-10-08T19:47:45.448Z" },
+    { url = "https://files.pythonhosted.org/packages/92/f7/1d4ec5841505f423469efbfc381d64b7b467438cd5a4bbcbb063f3b73d27/propcache-0.4.1-cp313-cp313t-win32.whl", hash = "sha256:2ad890caa1d928c7c2965b48f3a3815c853180831d0e5503d35cf00c472f4717", size = 41396, upload-time = "2025-10-08T19:47:47.202Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f0/615c30622316496d2cbbc29f5985f7777d3ada70f23370608c1d3e081c1f/propcache-0.4.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f7ee0e597f495cf415bcbd3da3caa3bd7e816b74d0d52b8145954c5e6fd3ff37", size = 44897, upload-time = "2025-10-08T19:47:48.336Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ca/6002e46eccbe0e33dcd4069ef32f7f1c9e243736e07adca37ae8c4830ec3/propcache-0.4.1-cp313-cp313t-win_arm64.whl", hash = "sha256:929d7cbe1f01bb7baffb33dc14eb5691c95831450a26354cd210a8155170c93a", size = 39789, upload-time = "2025-10-08T19:47:49.876Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/5c/bca52d654a896f831b8256683457ceddd490ec18d9ec50e97dfd8fc726a8/propcache-0.4.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3f7124c9d820ba5548d431afb4632301acf965db49e666aa21c305cbe8c6de12", size = 78152, upload-time = "2025-10-08T19:47:51.051Z" },
+    { url = "https://files.pythonhosted.org/packages/65/9b/03b04e7d82a5f54fb16113d839f5ea1ede58a61e90edf515f6577c66fa8f/propcache-0.4.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:c0d4b719b7da33599dfe3b22d3db1ef789210a0597bc650b7cee9c77c2be8c5c", size = 44869, upload-time = "2025-10-08T19:47:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fa/89a8ef0468d5833a23fff277b143d0573897cf75bd56670a6d28126c7d68/propcache-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f302f4783709a78240ebc311b793f123328716a60911d667e0c036bc5dcbded", size = 46596, upload-time = "2025-10-08T19:47:54.073Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/47816020d337f4a746edc42fe8d53669965138f39ee117414c7d7a340cfe/propcache-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c80ee5802e3fb9ea37938e7eecc307fb984837091d5fd262bb37238b1ae97641", size = 206981, upload-time = "2025-10-08T19:47:55.715Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f6/c5fa1357cc9748510ee55f37173eb31bfde6d94e98ccd9e6f033f2fc06e1/propcache-0.4.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ed5a841e8bb29a55fb8159ed526b26adc5bdd7e8bd7bf793ce647cb08656cdf4", size = 211490, upload-time = "2025-10-08T19:47:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/80/1e/e5889652a7c4a3846683401a48f0f2e5083ce0ec1a8a5221d8058fbd1adf/propcache-0.4.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55c72fd6ea2da4c318e74ffdf93c4fe4e926051133657459131a95c846d16d44", size = 215371, upload-time = "2025-10-08T19:47:59.317Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f2/889ad4b2408f72fe1a4f6a19491177b30ea7bf1a0fd5f17050ca08cfc882/propcache-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8326e144341460402713f91df60ade3c999d601e7eb5ff8f6f7862d54de0610d", size = 201424, upload-time = "2025-10-08T19:48:00.67Z" },
+    { url = "https://files.pythonhosted.org/packages/27/73/033d63069b57b0812c8bd19f311faebeceb6ba31b8f32b73432d12a0b826/propcache-0.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:060b16ae65bc098da7f6d25bf359f1f31f688384858204fe5d652979e0015e5b", size = 197566, upload-time = "2025-10-08T19:48:02.604Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/89/ce24f3dc182630b4e07aa6d15f0ff4b14ed4b9955fae95a0b54c58d66c05/propcache-0.4.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:89eb3fa9524f7bec9de6e83cf3faed9d79bffa560672c118a96a171a6f55831e", size = 193130, upload-time = "2025-10-08T19:48:04.499Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/24/ef0d5fd1a811fb5c609278d0209c9f10c35f20581fcc16f818da959fc5b4/propcache-0.4.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:dee69d7015dc235f526fe80a9c90d65eb0039103fe565776250881731f06349f", size = 202625, upload-time = "2025-10-08T19:48:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/02/98ec20ff5546f68d673df2f7a69e8c0d076b5abd05ca882dc7ee3a83653d/propcache-0.4.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5558992a00dfd54ccbc64a32726a3357ec93825a418a401f5cc67df0ac5d9e49", size = 204209, upload-time = "2025-10-08T19:48:08.432Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/87/492694f76759b15f0467a2a93ab68d32859672b646aa8a04ce4864e7932d/propcache-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c9b822a577f560fbd9554812526831712c1436d2c046cedee4c3796d3543b144", size = 197797, upload-time = "2025-10-08T19:48:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/36/66367de3575db1d2d3f3d177432bd14ee577a39d3f5d1b3d5df8afe3b6e2/propcache-0.4.1-cp314-cp314-win32.whl", hash = "sha256:ab4c29b49d560fe48b696cdcb127dd36e0bc2472548f3bf56cc5cb3da2b2984f", size = 38140, upload-time = "2025-10-08T19:48:11.232Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2a/a758b47de253636e1b8aef181c0b4f4f204bf0dd964914fb2af90a95b49b/propcache-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:5a103c3eb905fcea0ab98be99c3a9a5ab2de60228aa5aceedc614c0281cf6153", size = 41257, upload-time = "2025-10-08T19:48:12.707Z" },
+    { url = "https://files.pythonhosted.org/packages/34/5e/63bd5896c3fec12edcbd6f12508d4890d23c265df28c74b175e1ef9f4f3b/propcache-0.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:74c1fb26515153e482e00177a1ad654721bf9207da8a494a0c05e797ad27b992", size = 38097, upload-time = "2025-10-08T19:48:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/9ff785d787ccf9bbb3f3106f79884a130951436f58392000231b4c737c80/propcache-0.4.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:824e908bce90fb2743bd6b59db36eb4f45cd350a39637c9f73b1c1ea66f5b75f", size = 81455, upload-time = "2025-10-08T19:48:15.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/85/2431c10c8e7ddb1445c1f7c4b54d886e8ad20e3c6307e7218f05922cad67/propcache-0.4.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2b5e7db5328427c57c8e8831abda175421b709672f6cfc3d630c3b7e2146393", size = 46372, upload-time = "2025-10-08T19:48:16.424Z" },
+    { url = "https://files.pythonhosted.org/packages/01/20/b0972d902472da9bcb683fa595099911f4d2e86e5683bcc45de60dd05dc3/propcache-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6f6ff873ed40292cd4969ef5310179afd5db59fdf055897e282485043fc80ad0", size = 48411, upload-time = "2025-10-08T19:48:17.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e3/7dc89f4f21e8f99bad3d5ddb3a3389afcf9da4ac69e3deb2dcdc96e74169/propcache-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:49a2dc67c154db2c1463013594c458881a069fcf98940e61a0569016a583020a", size = 275712, upload-time = "2025-10-08T19:48:18.901Z" },
+    { url = "https://files.pythonhosted.org/packages/20/67/89800c8352489b21a8047c773067644e3897f02ecbbd610f4d46b7f08612/propcache-0.4.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:005f08e6a0529984491e37d8dbc3dd86f84bd78a8ceb5fa9a021f4c48d4984be", size = 273557, upload-time = "2025-10-08T19:48:20.762Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/b52b055c766a54ce6d9c16d9aca0cad8059acd9637cdf8aa0222f4a026ef/propcache-0.4.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5c3310452e0d31390da9035c348633b43d7e7feb2e37be252be6da45abd1abcc", size = 280015, upload-time = "2025-10-08T19:48:22.592Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c8/33cee30bd890672c63743049f3c9e4be087e6780906bfc3ec58528be59c1/propcache-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4c3c70630930447f9ef1caac7728c8ad1c56bc5015338b20fed0d08ea2480b3a", size = 262880, upload-time = "2025-10-08T19:48:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b1/8f08a143b204b418285c88b83d00edbd61afbc2c6415ffafc8905da7038b/propcache-0.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e57061305815dfc910a3634dcf584f08168a8836e6999983569f51a8544cd89", size = 260938, upload-time = "2025-10-08T19:48:25.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/12/96e4664c82ca2f31e1c8dff86afb867348979eb78d3cb8546a680287a1e9/propcache-0.4.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:521a463429ef54143092c11a77e04056dd00636f72e8c45b70aaa3140d639726", size = 247641, upload-time = "2025-10-08T19:48:27.207Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ed/e7a9cfca28133386ba52278136d42209d3125db08d0a6395f0cba0c0285c/propcache-0.4.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:120c964da3fdc75e3731aa392527136d4ad35868cc556fd09bb6d09172d9a367", size = 262510, upload-time = "2025-10-08T19:48:28.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/16d8bf65e8845dd62b4e2b57444ab81f07f40caa5652b8969b87ddcf2ef6/propcache-0.4.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d8f353eb14ee3441ee844ade4277d560cdd68288838673273b978e3d6d2c8f36", size = 263161, upload-time = "2025-10-08T19:48:30.133Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/70/c99e9edb5d91d5ad8a49fa3c1e8285ba64f1476782fed10ab251ff413ba1/propcache-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ab2943be7c652f09638800905ee1bab2c544e537edb57d527997a24c13dc1455", size = 257393, upload-time = "2025-10-08T19:48:31.567Z" },
+    { url = "https://files.pythonhosted.org/packages/08/02/87b25304249a35c0915d236575bc3574a323f60b47939a2262b77632a3ee/propcache-0.4.1-cp314-cp314t-win32.whl", hash = "sha256:05674a162469f31358c30bcaa8883cb7829fa3110bf9c0991fe27d7896c42d85", size = 42546, upload-time = "2025-10-08T19:48:32.872Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
 ]
 
 [[package]]
@@ -2207,6 +2733,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "signxml"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2274,6 +2809,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/5e/50ea27817003665c7cc4f5bdad309f13d6329037f657848ee87fe06c3740/synchronicity-0.12.2.tar.gz", hash = "sha256:6fd605a5035d1ec74ce48fffaca80ea00345c84ca34223914e2436fb4f162ff9", size = 60018, upload-time = "2026-04-06T15:06:15.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/44/4f6ba4e2c171847e6f9a460213b196bbf26edea43d0e66889c7ccc55d368/synchronicity-0.12.2-py3-none-any.whl", hash = "sha256:9dbaca81fb7f2b57c6dea326e514e1c80e9ccfd9c9618515e84fa6091026273b", size = 41312, upload-time = "2026-04-06T15:06:14.459Z" },
+]
+
+[[package]]
 name = "terminaltexteffects"
 version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2309,6 +2856,15 @@ wheels = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2321,15 +2877,36 @@ wheels = [
 ]
 
 [[package]]
-name = "types-requests"
-version = "2.33.0.20260408"
+name = "typer"
+version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "urllib3" },
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
 ]
 
 [[package]]
@@ -2409,6 +2986,88 @@ wheels = [
 ]
 
 [[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
 name = "websocket-client"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2460,6 +3119,110 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4b/a0a6e5d0ee8a2f3a373ddef8a4097d74ac901ac363eea1440464ccbe0898/yarl-1.23.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:16c6994ac35c3e74fb0ae93323bf8b9c2a9088d55946109489667c510a7d010e", size = 123796, upload-time = "2026-03-01T22:05:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b6/8925d68af039b835ae876db5838e82e76ec87b9782ecc97e192b809c4831/yarl-1.23.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4a42e651629dafb64fd5b0286a3580613702b5809ad3f24934ea87595804f2c5", size = 86547, upload-time = "2026-03-01T22:05:42.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/50/06d511cc4b8e0360d3c94af051a768e84b755c5eb031b12adaaab6dec6e5/yarl-1.23.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c6b9461a2a8b47c65eef63bb1c76a4f1c119618ffa99ea79bc5bb1e46c5821b", size = 85854, upload-time = "2026-03-01T22:05:44.85Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f4/4e30b250927ffdab4db70da08b9b8d2194d7c7b400167b8fbeca1e4701ca/yarl-1.23.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2569b67d616eab450d262ca7cb9f9e19d2f718c70a8b88712859359d0ab17035", size = 98351, upload-time = "2026-03-01T22:05:46.836Z" },
+    { url = "https://files.pythonhosted.org/packages/86/fc/4118c5671ea948208bdb1492d8b76bdf1453d3e73df051f939f563e7dcc5/yarl-1.23.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e9d9a4d06d3481eab79803beb4d9bd6f6a8e781ec078ac70d7ef2dcc29d1bea5", size = 92711, upload-time = "2026-03-01T22:05:48.316Z" },
+    { url = "https://files.pythonhosted.org/packages/56/11/1ed91d42bd9e73c13dc9e7eb0dd92298d75e7ac4dd7f046ad0c472e231cd/yarl-1.23.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f514f6474e04179d3d33175ed3f3e31434d3130d42ec153540d5b157deefd735", size = 106014, upload-time = "2026-03-01T22:05:50.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c9/74e44e056a23fbc33aca71779ef450ca648a5bc472bdad7a82339918f818/yarl-1.23.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fda207c815b253e34f7e1909840fd14299567b1c0eb4908f8c2ce01a41265401", size = 105557, upload-time = "2026-03-01T22:05:51.416Z" },
+    { url = "https://files.pythonhosted.org/packages/66/fe/b1e10b08d287f518994f1e2ff9b6d26f0adeecd8dd7d533b01bab29a3eda/yarl-1.23.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34b6cf500e61c90f305094911f9acc9c86da1a05a7a3f5be9f68817043f486e4", size = 101559, upload-time = "2026-03-01T22:05:52.872Z" },
+    { url = "https://files.pythonhosted.org/packages/72/59/c5b8d94b14e3d3c2a9c20cb100119fd534ab5a14b93673ab4cc4a4141ea5/yarl-1.23.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d7504f2b476d21653e4d143f44a175f7f751cd41233525312696c76aa3dbb23f", size = 100502, upload-time = "2026-03-01T22:05:54.954Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4f/96976cb54cbfc5c9fd73ed4c51804f92f209481d1fb190981c0f8a07a1d7/yarl-1.23.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:578110dd426f0d209d1509244e6d4a3f1a3e9077655d98c5f22583d63252a08a", size = 98027, upload-time = "2026-03-01T22:05:56.409Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6e/904c4f476471afdbad6b7e5b70362fb5810e35cd7466529a97322b6f5556/yarl-1.23.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:609d3614d78d74ebe35f54953c5bbd2ac647a7ddb9c30a5d877580f5e86b22f2", size = 95369, upload-time = "2026-03-01T22:05:58.141Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/40/acfcdb3b5f9d68ef499e39e04d25e141fe90661f9d54114556cf83be8353/yarl-1.23.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4966242ec68afc74c122f8459abd597afd7d8a60dc93d695c1334c5fd25f762f", size = 105565, upload-time = "2026-03-01T22:06:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c6/31e28f3a6ba2869c43d124f37ea5260cac9c9281df803c354b31f4dd1f3c/yarl-1.23.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e0fd068364a6759bc794459f0a735ab151d11304346332489c7972bacbe9e72b", size = 99813, upload-time = "2026-03-01T22:06:01.712Z" },
+    { url = "https://files.pythonhosted.org/packages/08/1f/6f65f59e72d54aa467119b63fc0b0b1762eff0232db1f4720cd89e2f4a17/yarl-1.23.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:39004f0ad156da43e86aa71f44e033de68a44e5a31fc53507b36dd253970054a", size = 105632, upload-time = "2026-03-01T22:06:03.188Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c4/18b178a69935f9e7a338127d5b77d868fdc0f0e49becd286d51b3a18c61d/yarl-1.23.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e5723c01a56c5028c807c701aa66722916d2747ad737a046853f6c46f4875543", size = 101895, upload-time = "2026-03-01T22:06:04.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/54/f5b870b5505663911dba950a8e4776a0dbd51c9c54c0ae88e823e4b874a0/yarl-1.23.0-cp313-cp313-win32.whl", hash = "sha256:1b6b572edd95b4fa8df75de10b04bc81acc87c1c7d16bcdd2035b09d30acc957", size = 82356, upload-time = "2026-03-01T22:06:06.04Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/84/266e8da36879c6edcd37b02b547e2d9ecdfea776be49598e75696e3316e1/yarl-1.23.0-cp313-cp313-win_amd64.whl", hash = "sha256:baaf55442359053c7d62f6f8413a62adba3205119bcb6f49594894d8be47e5e3", size = 87515, upload-time = "2026-03-01T22:06:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fd/7e1c66efad35e1649114fa13f17485f62881ad58edeeb7f49f8c5e748bf9/yarl-1.23.0-cp313-cp313-win_arm64.whl", hash = "sha256:fb4948814a2a98e3912505f09c9e7493b1506226afb1f881825368d6fb776ee3", size = 81785, upload-time = "2026-03-01T22:06:10.181Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/fc/119dd07004f17ea43bb91e3ece6587759edd7519d6b086d16bfbd3319982/yarl-1.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:aecfed0b41aa72b7881712c65cf764e39ce2ec352324f5e0837c7048d9e6daaa", size = 130719, upload-time = "2026-03-01T22:06:11.708Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/9f2348502fbb3af409e8f47730282cd6bc80dec6630c1e06374d882d6eb2/yarl-1.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a41bcf68efd19073376eb8cf948b8d9be0af26256403e512bb18f3966f1f9120", size = 89690, upload-time = "2026-03-01T22:06:13.429Z" },
+    { url = "https://files.pythonhosted.org/packages/50/93/e88f3c80971b42cfc83f50a51b9d165a1dbf154b97005f2994a79f212a07/yarl-1.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cde9a2ecd91668bcb7f077c4966d8ceddb60af01b52e6e3e2680e4cf00ad1a59", size = 89851, upload-time = "2026-03-01T22:06:15.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/07/61c9dd8ba8f86473263b4036f70fb594c09e99c0d9737a799dfd8bc85651/yarl-1.23.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5023346c4ee7992febc0068e7593de5fa2bf611848c08404b35ebbb76b1b0512", size = 95874, upload-time = "2026-03-01T22:06:17.553Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/f9ff8ceefba599eac6abddcfb0b3bee9b9e636e96dbf54342a8577252379/yarl-1.23.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d1009abedb49ae95b136a8904a3f71b342f849ffeced2d3747bf29caeda218c4", size = 88710, upload-time = "2026-03-01T22:06:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/78/0231bfcc5d4c8eec220bc2f9ef82cb4566192ea867a7c5b4148f44f6cbcd/yarl-1.23.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a8d00f29b42f534cc8aa3931cfe773b13b23e561e10d2b26f27a8d309b0e82a1", size = 101033, upload-time = "2026-03-01T22:06:21.203Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/9b/30ea5239a61786f18fd25797151a17fbb3be176977187a48d541b5447dd4/yarl-1.23.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:95451e6ce06c3e104556d73b559f5da6c34a069b6b62946d3ad66afcd51642ea", size = 100817, upload-time = "2026-03-01T22:06:22.738Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e2/a4980481071791bc83bce2b7a1a1f7adcabfa366007518b4b845e92eeee3/yarl-1.23.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531ef597132086b6cf96faa7c6c1dcd0361dd5f1694e5cc30375907b9b7d3ea9", size = 97482, upload-time = "2026-03-01T22:06:24.21Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1e/304a00cf5f6100414c4b5a01fc7ff9ee724b62158a08df2f8170dfc72a2d/yarl-1.23.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:88f9fb0116fbfcefcab70f85cf4b74a2b6ce5d199c41345296f49d974ddb4123", size = 95949, upload-time = "2026-03-01T22:06:25.697Z" },
+    { url = "https://files.pythonhosted.org/packages/68/03/093f4055ed4cae649ac53bca3d180bd37102e9e11d048588e9ab0c0108d0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e7b0460976dc75cb87ad9cc1f9899a4b97751e7d4e77ab840fc9b6d377b8fd24", size = 95839, upload-time = "2026-03-01T22:06:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/28/4c75ebb108f322aa8f917ae10a8ffa4f07cae10a8a627b64e578617df6a0/yarl-1.23.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:115136c4a426f9da976187d238e84139ff6b51a20839aa6e3720cd1026d768de", size = 90696, upload-time = "2026-03-01T22:06:29.048Z" },
+    { url = "https://files.pythonhosted.org/packages/23/9c/42c2e2dd91c1a570402f51bdf066bfdb1241c2240ba001967bad778e77b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:ead11956716a940c1abc816b7df3fa2b84d06eaed8832ca32f5c5e058c65506b", size = 100865, upload-time = "2026-03-01T22:06:30.525Z" },
+    { url = "https://files.pythonhosted.org/packages/74/05/1bcd60a8a0a914d462c305137246b6f9d167628d73568505fce3f1cb2e65/yarl-1.23.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:fe8f8f5e70e6dbdfca9882cd9deaac058729bcf323cf7a58660901e55c9c94f6", size = 96234, upload-time = "2026-03-01T22:06:32.692Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b2/f52381aac396d6778ce516b7bc149c79e65bfc068b5de2857ab69eeea3b7/yarl-1.23.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:a0e317df055958a0c1e79e5d2aa5a5eaa4a6d05a20d4b0c9c3f48918139c9fc6", size = 100295, upload-time = "2026-03-01T22:06:34.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/638bae5bbf1113a659b2435d8895474598afe38b4a837103764f603aba56/yarl-1.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f0fd84de0c957b2d280143522c4f91a73aada1923caee763e24a2b3fda9f8a5", size = 97784, upload-time = "2026-03-01T22:06:35.864Z" },
+    { url = "https://files.pythonhosted.org/packages/80/25/a3892b46182c586c202629fc2159aa13975d3741d52ebd7347fd501d48d5/yarl-1.23.0-cp313-cp313t-win32.whl", hash = "sha256:93a784271881035ab4406a172edb0faecb6e7d00f4b53dc2f55919d6c9688595", size = 88313, upload-time = "2026-03-01T22:06:37.39Z" },
+    { url = "https://files.pythonhosted.org/packages/43/68/8c5b36aa5178900b37387937bc2c2fe0e9505537f713495472dcf6f6fccc/yarl-1.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dd00607bffbf30250fe108065f07453ec124dbf223420f57f5e749b04295e090", size = 94932, upload-time = "2026-03-01T22:06:39.579Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cc/d79ba8292f51f81f4dc533a8ccfb9fc6992cabf0998ed3245de7589dc07c/yarl-1.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:ac09d42f48f80c9ee1635b2fcaa819496a44502737660d3c0f2ade7526d29144", size = 84786, upload-time = "2026-03-01T22:06:41.988Z" },
+    { url = "https://files.pythonhosted.org/packages/90/98/b85a038d65d1b92c3903ab89444f48d3cee490a883477b716d7a24b1a78c/yarl-1.23.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:21d1b7305a71a15b4794b5ff22e8eef96ff4a6d7f9657155e5aa419444b28912", size = 124455, upload-time = "2026-03-01T22:06:43.615Z" },
+    { url = "https://files.pythonhosted.org/packages/39/54/bc2b45559f86543d163b6e294417a107bb87557609007c007ad889afec18/yarl-1.23.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:85610b4f27f69984932a7abbe52703688de3724d9f72bceb1cca667deff27474", size = 86752, upload-time = "2026-03-01T22:06:45.425Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f9/e8242b68362bffe6fb536c8db5076861466fc780f0f1b479fc4ffbebb128/yarl-1.23.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23f371bd662cf44a7630d4d113101eafc0cfa7518a2760d20760b26021454719", size = 86291, upload-time = "2026-03-01T22:06:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/d8/d1cb2378c81dd729e98c716582b1ccb08357e8488e4c24714658cc6630e8/yarl-1.23.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a80f77dc1acaaa61f0934176fccca7096d9b1ff08c8ba9cddf5ae034a24319", size = 99026, upload-time = "2026-03-01T22:06:48.459Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ff/7196790538f31debe3341283b5b0707e7feb947620fc5e8236ef28d44f72/yarl-1.23.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:bd654fad46d8d9e823afbb4f87c79160b5a374ed1ff5bde24e542e6ba8f41434", size = 92355, upload-time = "2026-03-01T22:06:50.306Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/56/25d58c3eddde825890a5fe6aa1866228377354a3c39262235234ab5f616b/yarl-1.23.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:682bae25f0a0dd23a056739f23a134db9f52a63e2afd6bfb37ddc76292bbd723", size = 106417, upload-time = "2026-03-01T22:06:52.1Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8a/882c0e7bc8277eb895b31bce0138f51a1ba551fc2e1ec6753ffc1e7c1377/yarl-1.23.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a82836cab5f197a0514235aaf7ffccdc886ccdaa2324bc0aafdd4ae898103039", size = 106422, upload-time = "2026-03-01T22:06:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2b/fef67d616931055bf3d6764885990a3ac647d68734a2d6a9e1d13de437a2/yarl-1.23.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c57676bdedc94cd3bc37724cf6f8cd2779f02f6aba48de45feca073e714fe52", size = 101915, upload-time = "2026-03-01T22:06:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6a/530e16aebce27c5937920f3431c628a29a4b6b430fab3fd1c117b26ff3f6/yarl-1.23.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7f8dc16c498ff06497c015642333219871effba93e4a2e8604a06264aca5c5c", size = 100690, upload-time = "2026-03-01T22:06:58.21Z" },
+    { url = "https://files.pythonhosted.org/packages/88/08/93749219179a45e27b036e03260fda05190b911de8e18225c294ac95bbc9/yarl-1.23.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5ee586fb17ff8f90c91cf73c6108a434b02d69925f44f5f8e0d7f2f260607eae", size = 98750, upload-time = "2026-03-01T22:06:59.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/cf/ea424a004969f5d81a362110a6ac1496d79efdc6d50c2c4b2e3ea0fc2519/yarl-1.23.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:17235362f580149742739cc3828b80e24029d08cbb9c4bda0242c7b5bc610a8e", size = 94685, upload-time = "2026-03-01T22:07:01.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/b7/14341481fe568e2b0408bcf1484c652accafe06a0ade9387b5d3fd9df446/yarl-1.23.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0793e2bd0cf14234983bbb371591e6bea9e876ddf6896cdcc93450996b0b5c85", size = 106009, upload-time = "2026-03-01T22:07:03.151Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e6/5c744a9b54f4e8007ad35bce96fbc9218338e84812d36f3390cea616881a/yarl-1.23.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:3650dc2480f94f7116c364096bc84b1d602f44224ef7d5c7208425915c0475dd", size = 100033, upload-time = "2026-03-01T22:07:04.701Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/23/e3bfc188d0b400f025bc49d99793d02c9abe15752138dcc27e4eaf0c4a9e/yarl-1.23.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f40e782d49630ad384db66d4d8b73ff4f1b8955dc12e26b09a3e3af064b3b9d6", size = 106483, upload-time = "2026-03-01T22:07:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/72/42/f0505f949a90b3f8b7a363d6cbdf398f6e6c58946d85c6d3a3bc70595b26/yarl-1.23.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94f8575fbdf81749008d980c17796097e645574a3b8c28ee313931068dad14fe", size = 102175, upload-time = "2026-03-01T22:07:08.4Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/65/b39290f1d892a9dd671d1c722014ca062a9c35d60885d57e5375db0404b5/yarl-1.23.0-cp314-cp314-win32.whl", hash = "sha256:c8aa34a5c864db1087d911a0b902d60d203ea3607d91f615acd3f3108ac32169", size = 83871, upload-time = "2026-03-01T22:07:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5b/9b92f54c784c26e2a422e55a8d2607ab15b7ea3349e28359282f84f01d43/yarl-1.23.0-cp314-cp314-win_amd64.whl", hash = "sha256:63e92247f383c85ab00dd0091e8c3fa331a96e865459f5ee80353c70a4a42d70", size = 89093, upload-time = "2026-03-01T22:07:11.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7d/8a84dc9381fd4412d5e7ff04926f9865f6372b4c2fd91e10092e65d29eb8/yarl-1.23.0-cp314-cp314-win_arm64.whl", hash = "sha256:70efd20be968c76ece7baa8dafe04c5be06abc57f754d6f36f3741f7aa7a208e", size = 83384, upload-time = "2026-03-01T22:07:13.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8d/d2fad34b1c08aa161b74394183daa7d800141aaaee207317e82c790b418d/yarl-1.23.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:9a18d6f9359e45722c064c97464ec883eb0e0366d33eda61cb19a244bf222679", size = 131019, upload-time = "2026-03-01T22:07:14.903Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ff/33009a39d3ccf4b94d7d7880dfe17fb5816c5a4fe0096d9b56abceea9ac7/yarl-1.23.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2803ed8b21ca47a43da80a6fd1ed3019d30061f7061daa35ac54f63933409412", size = 89894, upload-time = "2026-03-01T22:07:17.372Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f1/dab7ac5e7306fb79c0190766a3c00b4cb8d09a1f390ded68c85a5934faf5/yarl-1.23.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:394906945aa8b19fc14a61cf69743a868bb8c465efe85eee687109cc540b98f4", size = 89979, upload-time = "2026-03-01T22:07:19.361Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b1/08e95f3caee1fad6e65017b9f26c1d79877b502622d60e517de01e72f95d/yarl-1.23.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:71d006bee8397a4a89f469b8deb22469fe7508132d3c17fa6ed871e79832691c", size = 95943, upload-time = "2026-03-01T22:07:21.266Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/6409f9018864a6aa186c61175b977131f373f1988e198e031236916e87e4/yarl-1.23.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:62694e275c93d54f7ccedcfef57d42761b2aad5234b6be1f3e3026cae4001cd4", size = 88786, upload-time = "2026-03-01T22:07:23.129Z" },
+    { url = "https://files.pythonhosted.org/packages/76/40/cc22d1d7714b717fde2006fad2ced5efe5580606cb059ae42117542122f3/yarl-1.23.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a31de1613658308efdb21ada98cbc86a97c181aa050ba22a808120bb5be3ab94", size = 101307, upload-time = "2026-03-01T22:07:24.689Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/0d/476c38e85ddb4c6ec6b20b815bdd779aa386a013f3d8b85516feee55c8dc/yarl-1.23.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb1e8b8d66c278b21d13b0a7ca22c41dd757a7c209c6b12c313e445c31dd3b28", size = 100904, upload-time = "2026-03-01T22:07:26.287Z" },
+    { url = "https://files.pythonhosted.org/packages/72/32/0abe4a76d59adf2081dcb0397168553ece4616ada1c54d1c49d8936c74f8/yarl-1.23.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50f9d8d531dfb767c565f348f33dd5139a6c43f5cbdf3f67da40d54241df93f6", size = 97728, upload-time = "2026-03-01T22:07:27.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/35/7b30f4810fba112f60f5a43237545867504e15b1c7647a785fbaf588fac2/yarl-1.23.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:575aa4405a656e61a540f4a80eaa5260f2a38fff7bfdc4b5f611840d76e9e277", size = 95964, upload-time = "2026-03-01T22:07:30.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/86/ed7a73ab85ef00e8bb70b0cb5421d8a2a625b81a333941a469a6f4022828/yarl-1.23.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:041b1a4cefacf65840b4e295c6985f334ba83c30607441ae3cf206a0eed1a2e4", size = 95882, upload-time = "2026-03-01T22:07:32.132Z" },
+    { url = "https://files.pythonhosted.org/packages/19/90/d56967f61a29d8498efb7afb651e0b2b422a1e9b47b0ab5f4e40a19b699b/yarl-1.23.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:d38c1e8231722c4ce40d7593f28d92b5fc72f3e9774fe73d7e800ec32299f63a", size = 90797, upload-time = "2026-03-01T22:07:34.404Z" },
+    { url = "https://files.pythonhosted.org/packages/72/00/8b8f76909259f56647adb1011d7ed8b321bcf97e464515c65016a47ecdf0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:d53834e23c015ee83a99377db6e5e37d8484f333edb03bd15b4bc312cc7254fb", size = 101023, upload-time = "2026-03-01T22:07:35.953Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e2/cab11b126fb7d440281b7df8e9ddbe4851e70a4dde47a202b6642586b8d9/yarl-1.23.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:2e27c8841126e017dd2a054a95771569e6070b9ee1b133366d8b31beb5018a41", size = 96227, upload-time = "2026-03-01T22:07:37.594Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/9b/2c893e16bfc50e6b2edf76c1a9eb6cb0c744346197e74c65e99ad8d634d0/yarl-1.23.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:76855800ac56f878847a09ce6dba727c93ca2d89c9e9d63002d26b916810b0a2", size = 100302, upload-time = "2026-03-01T22:07:39.334Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ec/5498c4e3a6d5f1003beb23405671c2eb9cdbf3067d1c80f15eeafe301010/yarl-1.23.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e09fd068c2e169a7070d83d3bde728a4d48de0549f975290be3c108c02e499b4", size = 98202, upload-time = "2026-03-01T22:07:41.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/cd737e2d45e70717907f83e146f6949f20cc23cd4bf7b2688727763aa458/yarl-1.23.0-cp314-cp314t-win32.whl", hash = "sha256:73309162a6a571d4cbd3b6a1dcc703c7311843ae0d1578df6f09be4e98df38d4", size = 90558, upload-time = "2026-03-01T22:07:43.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/3774d162f6732d1cfb0b47b4140a942a35ca82bb19b6db1f80e9e7bdc8f8/yarl-1.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4503053d296bc6e4cbd1fad61cf3b6e33b939886c4f249ba7c78b602214fabe2", size = 97610, upload-time = "2026-03-01T22:07:45.773Z" },
+    { url = "https://files.pythonhosted.org/packages/51/47/3fa2286c3cb162c71cdb34c4224d5745a1ceceb391b2bd9b19b668a8d724/yarl-1.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:44bb7bef4ea409384e3f8bc36c063d77ea1b8d4a5b2706956c0d6695f07dcc25", size = 86041, upload-time = "2026-03-01T22:07:49.026Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Introduces `SandboxBackend` protocol + `SandboxSession` ABC; isolation is no longer worktree-hardcoded.
- Phase 1 only: protocol + `WorktreeSandboxBackend` (wraps existing `WorktreeManager` with zero behavior change) + first-party `DockerSandboxBackend` + optional extras for E2B / Modal.
- Spawner gains OPTIONAL `sandbox_session` param; falls back to existing direct-worktree path when None. All 35 existing adapters keep working unchanged.
- Pluggy entry-point group `bernstein.sandbox_backends` so plugin authors can register custom backends.
- Follow-up ticket filed for the Phase 2 per-adapter refactor (out of scope here).

Implements ticket (Phase 1).

## Test plan
- [ ] `uv run python scripts/run_tests.py -x tests/unit/sandbox/`
- [ ] `uv run python scripts/run_tests.py -x tests/unit/git/` (worktree regression check)
- [ ] `uv run ruff check src/bernstein/core/sandbox/`
- [ ] `uv run pyright src/bernstein/core/sandbox/`
- [ ] `SandboxBackendConformance` parametrized suite passes for WorktreeBackend
- [ ] Docker / E2B / Modal integration tests gated by env (skipped without creds)
- [ ] `bernstein agents --sandbox-backends` lists installed backends with capabilities