### PR TITLE
feat(skills): progressive-disclosure skill packs with load_skill MCP tool

### DIFF
--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,0 +1,230 @@
+# Skills — progressive-disclosure capability packs
+
+Status: active (oai-004, April 2026).
+Applies to: all CLI adapters spawned by Bernstein.
+
+## Motivation
+
+Before oai-004 every agent spawn loaded the full ``templates/roles/<role>/system_prompt.md``
+into the system prompt, whether or not the agent actually exercised the
+deep guidance. Across 17 roles the bodies averaged ~40 lines each; the
+token bill was paid on every spawn, including retries and forks.
+
+OpenAI's Agents SDK v2 published the **Skills** pattern: a capability
+pack is a directory with ``SKILL.md`` (YAML frontmatter + markdown body)
+and optional ``references/``, ``scripts/``, ``assets/`` siblings.
+Callers receive only an index (``name + description`` per skill) and
+pull the full body on demand via ``load_skill``.
+
+Bernstein adopts the same shape. Roles are migrated to skill packs and
+the resolver injects just the index into the system prompt. Agents
+``load_skill`` when they decide a capability is relevant.
+
+## Directory layout
+
+```
+templates/
+  roles/                # legacy bodies (kept for backwards compat)
+    backend/
+      system_prompt.md
+      task_prompt.md
+      config.yaml
+    …
+  skills/               # new skill packs (oai-004)
+    backend/
+      SKILL.md
+      references/
+        python-conventions.md
+        test-patterns.md
+        error-handling.md
+      scripts/
+        lint.sh
+    qa/
+      SKILL.md
+      references/
+        test-strategy.md
+        edge-cases.md
+    …
+```
+
+Empty buckets (``references/``, ``scripts/``, ``assets/``) are omitted —
+the manifest's corresponding field is just an empty list.
+
+## ``SKILL.md`` format
+
+```markdown
+---
+name: backend
+description: Python server code, APIs, async, strict typing.
+trigger_keywords: [python, backend, async, pyright]
+references:
+  - python-conventions.md
+  - test-patterns.md
+  - error-handling.md
+scripts:
+  - lint.sh
+---
+
+# Backend Engineering Skill
+
+You are a backend engineer…
+```
+
+Descriptions stay terse (one line) because the full index ships in every
+spawn's system prompt. Every byte multiplies by the number of agents
+Bernstein launches.
+
+### Frontmatter schema
+
+Defined by :class:`bernstein.core.skills.SkillManifest` (Pydantic,
+``extra="forbid"`` so typos fail loudly):
+
+| field                | type          | notes                                  |
+| -------------------- | ------------- | -------------------------------------- |
+| ``name``             | ``str``       | matches ``^[a-z][a-z0-9-]*$``          |
+| ``description``      | ``str``       | 20-500 chars, shown in the index       |
+| ``trigger_keywords`` | ``list[str]`` | optional keyword hints                 |
+| ``references``       | ``list[str]`` | files under ``<skill>/references/``    |
+| ``scripts``          | ``list[str]`` | files under ``<skill>/scripts/``       |
+| ``assets``           | ``list[str]`` | files under ``<skill>/assets/``        |
+| ``version``          | ``str``       | defaults to ``"1.0.0"``                |
+| ``author``           | ``str\|None`` | optional                               |
+
+Validation failures raise
+:class:`bernstein.core.skills.SkillManifestError` with the originating
+path baked into the message.
+
+## Resolution flow
+
+``bernstein.core.planning.role_resolver.resolve_role_prompt`` is called
+once per spawn. It tries three things in order:
+
+1. **Skill pack** — ``templates/skills/<role>/SKILL.md`` exists → inject
+   the compact index **plus** the matched skill body.
+2. **Legacy role template** — no skill pack, but
+   ``templates/roles/<role>/system_prompt.md`` exists → render via the
+   existing Jinja-style engine and inject that.
+3. **Fallback stub** — neither path found → ``"You are a <role> specialist."``
+
+The resolver is cached per ``(templates_dir, skills/ mtime)`` so dev
+reloads pick up edits but production spawns do not re-parse 17 manifests
+on every tick.
+
+## ``load_skill`` MCP tool
+
+Registered by :mod:`bernstein.mcp.server` under the name ``load_skill``:
+
+```python
+async def load_skill(
+    name: str,
+    reference: str | None = None,
+    script: str | None = None,
+) -> dict: ...
+```
+
+Returns JSON with:
+
+- ``name`` — echoed back.
+- ``body`` — ``SKILL.md`` body when ``reference`` and ``script`` are unset.
+- ``available_references`` / ``available_scripts`` — always populated.
+- ``reference_content`` — the requested reference's raw text (only when
+  ``reference`` was passed).
+- ``script_content`` — the requested script's raw text.
+- ``error`` — populated when the skill / file could not be loaded.
+
+Every invocation emits a ``skill_loaded`` WAL event (best-effort) with
+``name``, ``reference``, ``script``, ``source``, ``duration_s``, and
+``error`` fields.
+
+## Sources
+
+Skills are aggregated from multiple sources into a single
+:class:`SkillLoader`. Name collisions abort startup with
+:class:`DuplicateSkillError` — duplicate names across sources are never
+silently shadowed.
+
+### First-party
+
+``bernstein/templates/skills/`` loaded by
+:class:`bernstein.core.skills.sources.LocalDirSkillSource`.
+
+### Plugin packs
+
+Register a zero-arg factory under ``bernstein.skill_sources``:
+
+```toml
+[project.entry-points."bernstein.skill_sources"]
+my-data-pack = "my_pack.skills:source"
+```
+
+Where ``my_pack/skills.py`` exposes:
+
+```python
+from pathlib import Path
+
+from bernstein.core.skills import SkillSource
+from bernstein.core.skills.sources import LocalDirSkillSource
+
+
+def source() -> SkillSource:
+    return LocalDirSkillSource(
+        Path(__file__).parent / "skills",
+        source_name="plugin:my-data-pack",
+    )
+```
+
+:func:`bernstein.core.skills.sources.load_plugin_sources` enumerates the
+group at loader construction time. Broken factories log a warning and
+are skipped rather than aborting startup — a noisy third-party bug
+should not take down the orchestrator.
+
+## CLI
+
+```
+bernstein skills list                 # compact table of every skill
+bernstein skills show backend         # print SKILL.md body
+bernstein skills show backend --reference python-conventions.md
+bernstein skills show backend --script lint.sh
+```
+
+## Observability
+
+Every successful ``load_skill`` invocation emits a structured
+``skill_loaded`` event. Hook it into the WAL
+(``src/bernstein/core/persistence/wal.py``) or a Prometheus metric
+(``skill_load_total{name=..., source=...}``,
+``skill_load_duration_seconds{name=...}``) to see:
+
+- Which skills get exercised vs. sit dead.
+- Whether agents converge on a small core set.
+- Which references are worth keeping close and which can be retired.
+
+Dead skills (zero loads in 30 days) become candidates for deprecation.
+
+## Migration status
+
+All 17 roles migrated to skill packs as of oai-004:
+
+| role              | references                                                  | notes                          |
+| ----------------- | ----------------------------------------------------------- | ------------------------------ |
+| ``backend``       | python-conventions, test-patterns, error-handling + lint.sh | full split                     |
+| ``qa``            | test-strategy, edge-cases                                   | full split                     |
+| ``security``      | owasp-top-10, auth-checklist, secrets-handling              | full split                     |
+| ``frontend``      | a11y, state-management                                      | full split                     |
+| ``devops``        | ci-patterns, docker-practices                               | full split                     |
+| ``architect``     | adr-template, decomposition-principles                      | full split                     |
+| ``docs``          | docstring-style, doc-structure + check-links.sh             | full split                     |
+| ``retrieval``     | hybrid-search, chunking                                     | full split                     |
+| ``ml-engineer``   | evaluation, reproducibility                                 | full split                     |
+| ``reviewer``      | review-rubric, feedback-tone                                | full split                     |
+| ``manager``       | task-api, planning-rules                                    | full split                     |
+| ``vp``            | pivot-evaluation, cell-decomposition                        | full split                     |
+| ``prompt-engineer`` | —                                                         | body small, no references      |
+| ``visionary``     | —                                                           | body is the output schema      |
+| ``analyst``       | —                                                           | body is the scoring rubric     |
+| ``resolver``      | —                                                           | single-purpose skill           |
+| ``ci-fixer``      | —                                                           | single-purpose skill           |
+
+Legacy ``templates/roles/<role>/system_prompt.md`` files remain on disk
+for backwards compat. A follow-up ticket will deprecate the legacy path
+two minor versions after this change ships.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,12 @@ bernstein-worker = "bernstein.core.worker:main"
 # e2b = "bernstein.core.sandbox.backends.e2b:E2BSandboxBackend"
 # modal = "bernstein.core.sandbox.backends.modal:ModalSandboxBackend"
 
+[project.entry-points."bernstein.skill_sources"]
+# Progressive-disclosure skill packs (oai-004). Each entry resolves to a
+# zero-arg factory returning a ``bernstein.core.skills.SkillSource``.
+# Example:
+# my-data-pack = "my_pack.skills:source"
+
 [tool.hatch.build]
 exclude = [
     ".sdd/",
@@ -184,6 +190,11 @@ packages = ["src/bernstein"]
 [tool.hatch.build.targets.wheel.force-include]
 "templates/prompts" = "bernstein/_default_templates/prompts"
 "templates/bernstein.yaml" = "bernstein/_default_templates/bernstein.yaml"
+# Progressive-disclosure skill packs (oai-004) — shipped alongside the wheel
+# so installed packages get the index without requiring a checkout of
+# templates/.
+"templates/skills" = "bernstein/_default_templates/skills"
+"templates/roles" = "bernstein/_default_templates/roles"
 # ascii_logo.md now lives in-package at src/bernstein/_default_templates/ —
 # no force-include needed. The dev-repo copy at docs/assets/ascii_logo.md is
 # the display fallback read by cli/display/splash_v2.py when running from a

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -1,0 +1,109 @@
+"""``bernstein skills`` — list / show / verify skill packs (oai-004)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from bernstein import get_templates_dir
+from bernstein.cli.helpers import console
+
+
+@click.group("skills")
+def skills_group() -> None:
+    """List and inspect progressive-disclosure skill packs.
+
+    \b
+      bernstein skills list           # compact overview
+      bernstein skills show backend   # print SKILL.md body
+      bernstein skills show backend --reference python-conventions.md
+    """
+
+
+@skills_group.command("list")
+@click.option(
+    "--no-plugins",
+    "no_plugins",
+    is_flag=True,
+    default=False,
+    help="Skip third-party ``bernstein.skill_sources`` plugins.",
+)
+def skills_list(no_plugins: bool) -> None:
+    """List every discoverable skill with a one-line description."""
+    from rich.table import Table
+
+    from bernstein.core.planning.role_resolver import get_loader
+
+    templates_root = get_templates_dir(Path.cwd())
+    templates_roles_dir = templates_root / "roles"
+    try:
+        loader = get_loader(templates_roles_dir, include_plugins=not no_plugins)
+    except Exception as exc:
+        console.print(f"[red]Failed to load skill index:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    skills = loader.list_all()
+    if not skills:
+        console.print(f"[dim]No skill packs found. Expected at {templates_root / 'skills'}[/dim]")
+        return
+
+    table = Table(
+        title="Skill packs",
+        show_lines=False,
+        header_style="bold cyan",
+    )
+    table.add_column("NAME", style="dim", min_width=14)
+    table.add_column("DESCRIPTION", min_width=50)
+    table.add_column("REFS", justify="right", min_width=4)
+    table.add_column("SCRIPTS", justify="right", min_width=6)
+    table.add_column("SOURCE", min_width=8)
+
+    for skill in skills:
+        description = skill.description.strip().replace("\n", " ")
+        if len(description) > 100:
+            description = description[:97] + "..."
+        table.add_row(
+            skill.name,
+            description,
+            str(len(skill.references)),
+            str(len(skill.scripts)),
+            skill.source_name,
+        )
+
+    console.print(table)
+    console.print(f"\n[dim]{len(skills)} skill(s) total[/dim]")
+
+
+@skills_group.command("show")
+@click.argument("name")
+@click.option("--reference", "reference", help="Reference filename to load.")
+@click.option("--script", "script", help="Script filename to load.")
+def skills_show(name: str, reference: str | None, script: str | None) -> None:
+    """Print the SKILL.md body for a skill (optionally a reference/script)."""
+    from bernstein.core.skills.load_skill_tool import load_skill
+
+    templates_root = get_templates_dir(Path.cwd())
+    templates_roles_dir = templates_root / "roles"
+    result = load_skill(
+        name=name,
+        reference=reference,
+        script=script,
+        templates_roles_dir=templates_roles_dir,
+    )
+    if result.error:
+        console.print(f"[red]{result.error}[/red]")
+        raise SystemExit(1)
+
+    if reference is not None and result.reference_content is not None:
+        console.print(result.reference_content)
+        return
+    if script is not None and result.script_content is not None:
+        console.print(result.script_content)
+        return
+
+    console.print(result.body)
+    if result.available_references:
+        console.print("\n[dim]references: " + ", ".join(result.available_references) + "[/dim]")
+    if result.available_scripts:
+        console.print("[dim]scripts: " + ", ".join(result.available_scripts) + "[/dim]")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -44,6 +44,7 @@ from bernstein.cli.advanced_cmd import (
     trace_cmd,
 )
 from bernstein.cli.agents_cmd import agents_group
+from bernstein.cli.commands.skills_cmd import skills_group
 
 # New CLI commands (CLI-004 through CLI-013)
 from bernstein.cli.aliases import ALIASES, aliases_cmd
@@ -720,6 +721,7 @@ cli.add_command(history_cmd, "history")
 
 # Already registered elsewhere
 cli.add_command(agents_group)
+cli.add_command(skills_group)
 cli.add_command(test_cmd, "test")
 cli.add_command(auth_group, "auth")
 cli.add_command(auth_login, "login")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -44,7 +44,6 @@ from bernstein.cli.advanced_cmd import (
     trace_cmd,
 )
 from bernstein.cli.agents_cmd import agents_group
-from bernstein.cli.commands.skills_cmd import skills_group
 
 # New CLI commands (CLI-004 through CLI-013)
 from bernstein.cli.aliases import ALIASES, aliases_cmd
@@ -56,6 +55,7 @@ from bernstein.cli.chaos_cmd import chaos_group
 from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
+from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.compliance_cmd import compliance_group
 from bernstein.cli.config_path_cmd import config_path_cmd
 from bernstein.cli.cost import cost_cmd, estimate_cmd

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -533,10 +533,45 @@ def _resolve_role_prompt(
     catalog_system_prompt: str | None,
     agency_catalog: dict[str, AgencyAgent] | None,
 ) -> str:
-    """Resolve the role prompt from catalog, template, or fallback."""
+    """Resolve the role prompt from skills, catalog, template, or fallback.
+
+    Resolution order (oai-004):
+
+    1. ``catalog_system_prompt`` — explicit Agency override.
+    2. Skill pack — ``templates/skills/<role>/SKILL.md`` plus a compact
+       index for the other skills, injected via
+       :func:`bernstein.core.planning.role_resolver.resolve_role_prompt`.
+    3. Legacy role template — ``templates/roles/<role>/system_prompt.md``.
+    4. Agency catalog fallback or the generic ``"You are a <role> specialist."``
+       stub.
+    """
     del tasks  # reserved for future task-specific overrides
     if catalog_system_prompt:
         return catalog_system_prompt
+
+    # Try the new skill-pack progressive-disclosure path first. It falls
+    # back to the legacy template automatically when no skill exists.
+    try:
+        from bernstein.core.planning.role_resolver import resolve_role_prompt
+
+        resolved = resolve_role_prompt(
+            role,
+            templates_dir=templates_dir,
+            legacy_context={k: str(v) for k, v in context.items()},
+        )
+    except Exception as exc:
+        logger.debug("Skill-backed role resolution failed for %s: %s", role, exc)
+    else:
+        if resolved.source in {"skill", "legacy"}:
+            logger.debug(
+                "Resolved role %s via %s (skill=%s)",
+                role,
+                resolved.source,
+                resolved.skill_name,
+            )
+            return resolved.body
+        # ``fallback`` means neither skill nor legacy template matched — fall
+        # through to the agency / default-stub path below.
 
     try:
         return render_role_prompt(role, context, templates_dir=templates_dir)

--- a/src/bernstein/core/planning/role_resolver.py
+++ b/src/bernstein/core/planning/role_resolver.py
@@ -1,0 +1,240 @@
+"""Role resolver — picks between a skill-pack index and the legacy role template.
+
+Called from :mod:`bernstein.core.agents.spawn_prompt` during prompt
+rendering. The resolver tries three things in order:
+
+1. **Skill pack** (new; oai-004) — if ``templates/skills/<role>/SKILL.md``
+   exists the resolver returns the compact index built by
+   :func:`~bernstein.core.skills.build_skill_index` *plus* the matched
+   skill's body as a "primary" hint. Downstream adapters inject this into
+   the system prompt.
+2. **Legacy role template** — ``templates/roles/<role>/system_prompt.md``
+   rendered via the existing Jinja-like template engine. This preserves
+   backwards compatibility during migration.
+3. **Fallback stub** — ``"You are a {role} specialist."``
+
+The resolver is stateless: each call walks the filesystem fresh. For
+high-traffic spawn paths, ``_cached_loader`` caches the :class:`SkillLoader`
+keyed on the templates directory mtime so we are not re-parsing 17
+SKILL.md files on every spawn.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from bernstein.core.skills.index_builder import build_skill_index
+from bernstein.core.skills.loader import (
+    SkillNotFoundError,
+    default_loader_from_templates,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.skills.loader import SkillLoader
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ResolvedRolePrompt:
+    """Result of :func:`resolve_role_prompt`.
+
+    Attributes:
+        body: The text the adapter injects for the role section.
+        source: ``"skill"`` | ``"legacy"`` | ``"fallback"`` — used for
+            observability and the token-reduction regression test.
+        skill_name: Name of the skill whose index was injected, when
+            ``source == "skill"``. ``None`` otherwise.
+    """
+
+    body: str
+    source: str
+    skill_name: str | None = None
+
+
+# ``(templates_dir, mtime) -> SkillLoader`` — the mtime lets us pick up
+# edits during dev without restarting.
+_loader_cache: dict[tuple[str, float], SkillLoader] = {}
+
+
+def resolve_role_prompt(
+    role: str,
+    *,
+    templates_dir: Path,
+    legacy_renderer: object | None = None,
+    legacy_context: dict[str, str] | None = None,
+    include_plugins: bool = True,
+) -> ResolvedRolePrompt:
+    """Return the role-section body + a tag identifying its source.
+
+    Args:
+        role: Role name (e.g. ``"backend"``).
+        templates_dir: Path to ``templates/roles/``. The sibling
+            ``templates/skills/`` is auto-discovered.
+        legacy_renderer: Callable matching ``(role, context, templates_dir) -> str``
+            used when the role is not skill-backed. Injected so tests can
+            stub out the template system without loading the whole
+            dependency graph. When ``None``, falls back to the canonical
+            ``bernstein.templates.renderer.render_role_prompt``.
+        legacy_context: Context dict for the legacy renderer.
+        include_plugins: Whether to include third-party skill sources.
+
+    Returns:
+        :class:`ResolvedRolePrompt` — callers append its ``body`` into
+        the system prompt's ``role`` section.
+    """
+    loader = _get_loader(templates_dir, include_plugins=include_plugins)
+
+    if loader.has(role):
+        try:
+            skill = loader.get(role)
+        except SkillNotFoundError:
+            skill = None
+        if skill is not None:
+            index = build_skill_index(loader, highlight=role)
+            body = _compose_skill_body(index=index, skill=skill)
+            return ResolvedRolePrompt(body=body, source="skill", skill_name=role)
+
+    legacy = _try_legacy(role, templates_dir, legacy_renderer, legacy_context)
+    if legacy is not None:
+        return ResolvedRolePrompt(body=legacy, source="legacy", skill_name=None)
+
+    return ResolvedRolePrompt(
+        body=f"You are a {role} specialist.",
+        source="fallback",
+        skill_name=None,
+    )
+
+
+def build_index_only(
+    *,
+    templates_dir: Path,
+    include_plugins: bool = True,
+) -> str:
+    """Return just the skill-index markdown (no role body).
+
+    Used by the token-reduction regression test and by the CLI's
+    ``bernstein skills list`` command.
+
+    Args:
+        templates_dir: Path to ``templates/roles/``.
+        include_plugins: Whether to include third-party skill sources.
+
+    Returns:
+        Index string, empty when no skills exist.
+    """
+    loader = _get_loader(templates_dir, include_plugins=include_plugins)
+    return build_skill_index(loader)
+
+
+def get_loader(
+    templates_dir: Path,
+    *,
+    include_plugins: bool = True,
+) -> SkillLoader:
+    """Expose the cached loader for CLI / MCP use."""
+    return _get_loader(templates_dir, include_plugins=include_plugins)
+
+
+def invalidate_cache() -> None:
+    """Clear the loader cache. Tests call this between runs."""
+    _loader_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _get_loader(templates_dir: Path, *, include_plugins: bool) -> SkillLoader:
+    """Return a loader, rebuilding when the skills dir mtime changed."""
+    skills_root = templates_dir.parent / "skills"
+    try:
+        mtime = skills_root.stat().st_mtime if skills_root.exists() else 0.0
+    except OSError:
+        mtime = 0.0
+    cache_key = (str(templates_dir), mtime)
+    cached = _loader_cache.get(cache_key)
+    if cached is not None:
+        return cached
+    # Clear older mtime entries for this templates_dir so we don't leak memory
+    # when an agent edits skill files repeatedly in a long-running dev loop.
+    for stale_key in [k for k in _loader_cache if k[0] == str(templates_dir)]:
+        _loader_cache.pop(stale_key, None)
+    loader = default_loader_from_templates(
+        templates_dir,
+        include_plugins=include_plugins,
+    )
+    _loader_cache[cache_key] = loader
+    return loader
+
+
+def _try_legacy(
+    role: str,
+    templates_dir: Path,
+    legacy_renderer: object | None,
+    legacy_context: dict[str, str] | None,
+) -> str | None:
+    """Render the legacy role template; return ``None`` when unavailable."""
+    # Resolve the renderer lazily so unit tests can exercise the resolver
+    # without importing Jinja / the template renderer at all.
+    if legacy_renderer is None:
+        from bernstein.templates.renderer import TemplateError, render_role_prompt
+
+        renderer = render_role_prompt
+        err_types: tuple[type[Exception], ...] = (FileNotFoundError, TemplateError)
+    else:
+        renderer = legacy_renderer  # type: ignore[assignment]
+        err_types = (FileNotFoundError, Exception)
+
+    context = legacy_context if legacy_context is not None else {}
+    try:
+        result: object = renderer(role, context, templates_dir=templates_dir)  # type: ignore[misc]
+    except err_types as exc:
+        logger.debug("Legacy role template unavailable for %s: %s", role, exc)
+        return None
+
+    if not isinstance(result, str):
+        logger.warning(
+            "Legacy renderer for role %s returned %s (expected str)",
+            role,
+            type(result).__name__,  # pyright: ignore[reportUnknownArgumentType]
+        )
+        return None
+    return result
+
+
+def _compose_skill_body(*, index: str, skill: _LoadedSkillLike) -> str:
+    """Render the role section as a compact index plus a one-line primary hint.
+
+    This is the progressive-disclosure payload: no skill body is included,
+    only the directory of available skills and a pointer to the matched
+    primary skill. Agents call ``load_skill(name=...)`` to read the full
+    SKILL.md body on demand.
+
+    Args:
+        index: Index from :func:`build_skill_index` (marks the primary).
+        skill: The matched :class:`LoadedSkill` — we reference its ``name``
+            in the header so the agent knows who it is at a glance.
+    """
+    # One-line pointer; keep it terse — every byte multiplies by spawn count.
+    hint = f'Role: {skill.name}. load_skill(name="{skill.name}").\n'
+    return hint + index.strip() + "\n"
+
+
+# Minimal duck-typed contract used by :func:`_compose_skill_body`.
+# ``LoadedSkill`` lives in :mod:`loader`; we declare a Protocol here so
+# the resolver stays free of runtime coupling. Read-only properties match
+# ``LoadedSkill``'s frozen dataclass fields.
+class _LoadedSkillLike(Protocol):
+    """Contract: a loaded skill exposes a ``name`` and ``description``."""
+
+    @property
+    def name(self) -> str: ...  # pragma: no cover — structural only
+
+    @property
+    def description(self) -> str: ...  # pragma: no cover — structural only

--- a/src/bernstein/core/skills/__init__.py
+++ b/src/bernstein/core/skills/__init__.py
@@ -1,0 +1,49 @@
+"""Progressive-disclosure skill packs (oai-004).
+
+A ``skill`` is a directory with a ``SKILL.md`` file (YAML frontmatter +
+markdown body) and optional ``references/``, ``scripts/``, ``assets/``
+siblings. Agents receive only a compact index (``name + description``) in
+their system prompt and call ``load_skill(name=...)`` via MCP when they
+decide a skill is relevant.
+
+This replaces the old eager-loaded ``templates/roles/<role>.md`` model
+while staying backwards compatible: when no skill pack exists for a role,
+``SkillLoader.get_role_body`` returns ``None`` and the legacy role template
+is used instead.
+
+The package is organised as:
+
+- :mod:`manifest`    — Pydantic model for ``SKILL.md`` frontmatter.
+- :mod:`source`      — ``SkillSource`` / ``LazySkillSource`` ABCs.
+- :mod:`sources.local_dir` — default loader (reads ``templates/skills/``).
+- :mod:`sources.plugin`    — pluggy entry-point loader.
+- :mod:`loader`      — ``SkillLoader`` orchestrator with conflict detection.
+- :mod:`index_builder` — builds the compact index injected into prompts.
+- :mod:`load_skill_tool` — ``load_skill`` MCP tool implementation.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.skills.index_builder import build_skill_index
+from bernstein.core.skills.load_skill_tool import load_skill
+from bernstein.core.skills.loader import (
+    DuplicateSkillError,
+    LoadedSkill,
+    SkillLoader,
+    SkillNotFoundError,
+)
+from bernstein.core.skills.manifest import SkillManifest, SkillManifestError
+from bernstein.core.skills.source import LazySkillSource, SkillSource
+
+__all__ = [
+    "DuplicateSkillError",
+    "LazySkillSource",
+    "LoadedSkill",
+    "SkillLoader",
+    "SkillManifest",
+    "SkillManifestError",
+    "SkillNotFoundError",
+    "SkillSource",
+    "build_skill_index",
+    "load_skill",
+]

--- a/src/bernstein/core/skills/index_builder.py
+++ b/src/bernstein/core/skills/index_builder.py
@@ -1,0 +1,72 @@
+"""Render the compact skill index injected into agent system prompts.
+
+The index is a flat markdown list of ``name: description`` entries with a
+tiny header explaining how to load a skill. It deliberately stays small —
+that's the whole point of progressive disclosure.
+
+Callers (``spawn_prompt._render_prompt``) insert the returned string into
+the ``role`` section in place of the full role body when a skill exists
+for the role.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.skills.loader import LoadedSkill, SkillLoader
+
+
+def build_skill_index(
+    loader: SkillLoader,
+    *,
+    highlight: str | None = None,
+    header: str = "Skills:",
+) -> str:
+    """Return a compact index string.
+
+    Args:
+        loader: Loaded skills registry.
+        highlight: Optional skill name to pin to the top with a
+            ``(primary)`` marker — the role-matched skill selected by
+            ``role_resolver``.
+        header: Override the leading header (lets us re-use the
+            renderer for different channels).
+
+    Returns:
+        Multi-line string. The intentionally-terse format keeps per-spawn
+        overhead minimal; every byte here multiplies by the number of
+        spawned agents.
+
+    Raises:
+        SkillNotFoundError: When ``highlight`` names a skill the loader
+            does not know about.
+    """
+    skills = loader.list_all()
+    if not skills:
+        return ""
+
+    lines: list[str] = [header]
+
+    highlighted: LoadedSkill | None = None
+    if highlight is not None:
+        # Access via .get so a missing highlight surfaces the loader's error.
+        highlighted = loader.get(highlight)
+        lines.append(f"* {highlighted.name}: {_fmt_entry(highlighted)}")
+
+    for skill in skills:
+        if highlighted is not None and skill.name == highlighted.name:
+            continue
+        lines.append(f"- {skill.name}: {_fmt_entry(skill)}")
+
+    return "\n".join(lines) + "\n"
+
+
+def _fmt_entry(skill: LoadedSkill) -> str:
+    """Format a single index line.
+
+    Intentionally bare — just the description. Reference / script counts
+    are discoverable via ``load_skill`` when the agent decides to pull the
+    body.
+    """
+    return skill.description.strip().replace("\n", " ")

--- a/src/bernstein/core/skills/load_skill_tool.py
+++ b/src/bernstein/core/skills/load_skill_tool.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +20,7 @@ from bernstein.core.skills.loader import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from bernstein.core.skills.loader import SkillLoader
@@ -84,12 +84,8 @@ def load_skill(
     except SkillNotFoundError:
         return _build_error_result(name, f"skill {name!r} not found")
 
-    reference_content, ref_error = _read_bucket(
-        resolved_loader.read_reference, name, reference, "reference"
-    )
-    script_content, script_error = _read_bucket(
-        resolved_loader.read_script, name, script, "script"
-    )
+    reference_content, ref_error = _read_bucket(resolved_loader.read_reference, name, reference, "reference")
+    script_content, script_error = _read_bucket(resolved_loader.read_script, name, script, "script")
     error = ref_error or script_error
 
     sink(

--- a/src/bernstein/core/skills/load_skill_tool.py
+++ b/src/bernstein/core/skills/load_skill_tool.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -83,27 +84,14 @@ def load_skill(
     except SkillNotFoundError:
         return _build_error_result(name, f"skill {name!r} not found")
 
-    reference_content: str | None = None
-    script_content: str | None = None
-    error: str | None = None
+    reference_content, ref_error = _read_bucket(
+        resolved_loader.read_reference, name, reference, "reference"
+    )
+    script_content, script_error = _read_bucket(
+        resolved_loader.read_script, name, script, "script"
+    )
+    error = ref_error or script_error
 
-    if reference is not None:
-        try:
-            reference_content = resolved_loader.read_reference(name, reference)
-        except FileNotFoundError as exc:
-            error = str(exc)
-        except (ValueError, RuntimeError) as exc:
-            error = f"failed to read reference: {exc}"
-
-    if script is not None:
-        try:
-            script_content = resolved_loader.read_script(name, script)
-        except FileNotFoundError as exc:
-            error = str(exc) if error is None else error
-        except (ValueError, RuntimeError) as exc:
-            error = f"failed to read script: {exc}" if error is None else error
-
-    duration_s = time.monotonic() - start
     sink(
         {
             "event": "skill_loaded",
@@ -111,7 +99,7 @@ def load_skill(
             "reference": reference,
             "script": script,
             "source": skill.source_name,
-            "duration_s": duration_s,
+            "duration_s": time.monotonic() - start,
             "error": error,
         }
     )
@@ -146,6 +134,29 @@ def _resolve_loader(
     if templates_roles_dir is None:
         raise ValueError("load_skill requires either ``loader`` or ``templates_roles_dir``")
     return default_loader_from_templates(templates_roles_dir)
+
+
+def _read_bucket(
+    reader: Callable[[str, str], str],
+    skill_name: str,
+    filename: str | None,
+    label: str,
+) -> tuple[str | None, str | None]:
+    """Invoke ``reader(skill_name, filename)`` and translate exceptions.
+
+    Returns ``(content, error)`` where exactly one is populated (or both are
+    ``None`` when ``filename`` is ``None``). The error message mirrors the
+    wording used by the original inline ``try/except`` so callers see an
+    identical contract.
+    """
+    if filename is None:
+        return None, None
+    try:
+        return reader(skill_name, filename), None
+    except FileNotFoundError as exc:
+        return None, str(exc)
+    except (ValueError, RuntimeError) as exc:
+        return None, f"failed to read {label}: {exc}"
 
 
 def _build_error_result(name: str, detail: str) -> SkillLoadResult:

--- a/src/bernstein/core/skills/load_skill_tool.py
+++ b/src/bernstein/core/skills/load_skill_tool.py
@@ -1,0 +1,184 @@
+"""``load_skill`` MCP tool implementation.
+
+Exposed to agents via :mod:`bernstein.mcp.server` — the tool returns the
+SKILL.md body by default and can also fetch a single ``references/`` or
+``scripts/`` file when the agent names one. Every invocation emits a WAL
+event (best-effort) and a structured return dict that the MCP harness
+serialises as JSON.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.skills.loader import (
+    SkillNotFoundError,
+    default_loader_from_templates,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.skills.loader import SkillLoader
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SkillLoadResult:
+    """Typed response for the ``load_skill`` tool.
+
+    Attributes match the contract in the ticket:
+
+    - Always: ``name``, ``body``, ``available_references``, ``available_scripts``.
+    - When ``reference`` is passed: ``reference_content``.
+    - When ``script``  is passed: ``script_content``.
+    - On error: ``error`` is populated and other fields are best-effort.
+    """
+
+    name: str
+    body: str
+    available_references: list[str]
+    available_scripts: list[str]
+    reference_content: str | None = None
+    script_content: str | None = None
+    error: str | None = None
+
+
+def load_skill(
+    name: str,
+    *,
+    reference: str | None = None,
+    script: str | None = None,
+    loader: SkillLoader | None = None,
+    templates_roles_dir: Path | None = None,
+    wal_sink: _WalSinkProto | None = None,
+) -> SkillLoadResult:
+    """Fetch a skill body (and optionally a reference / script file).
+
+    Args:
+        name: Skill name (required).
+        reference: Optional filename under ``references/``.
+        script: Optional filename under ``scripts/``.
+        loader: Inject a pre-built loader (tests use this). When omitted,
+            a default loader is built from ``templates_roles_dir``.
+        templates_roles_dir: Path to ``templates/roles/`` — used only when
+            ``loader`` is ``None`` to discover the ``skills/`` sibling.
+            When both are ``None`` the function raises ``ValueError``.
+        wal_sink: Optional callback receiving a ``skill_loaded`` event
+            dict. Defaults to logging at ``INFO``.
+
+    Returns:
+        :class:`SkillLoadResult` describing what was loaded.
+    """
+    start = time.monotonic()
+    resolved_loader = _resolve_loader(loader, templates_roles_dir)
+    sink = wal_sink or _log_wal_sink
+
+    try:
+        skill = resolved_loader.get(name)
+    except SkillNotFoundError:
+        return _build_error_result(name, f"skill {name!r} not found")
+
+    reference_content: str | None = None
+    script_content: str | None = None
+    error: str | None = None
+
+    if reference is not None:
+        try:
+            reference_content = resolved_loader.read_reference(name, reference)
+        except FileNotFoundError as exc:
+            error = str(exc)
+        except (ValueError, RuntimeError) as exc:
+            error = f"failed to read reference: {exc}"
+
+    if script is not None:
+        try:
+            script_content = resolved_loader.read_script(name, script)
+        except FileNotFoundError as exc:
+            error = str(exc) if error is None else error
+        except (ValueError, RuntimeError) as exc:
+            error = f"failed to read script: {exc}" if error is None else error
+
+    duration_s = time.monotonic() - start
+    sink(
+        {
+            "event": "skill_loaded",
+            "name": name,
+            "reference": reference,
+            "script": script,
+            "source": skill.source_name,
+            "duration_s": duration_s,
+            "error": error,
+        }
+    )
+
+    return SkillLoadResult(
+        name=name,
+        body=skill.body,
+        available_references=list(skill.references),
+        available_scripts=list(skill.scripts),
+        reference_content=reference_content,
+        script_content=script_content,
+        error=error,
+    )
+
+
+def result_as_dict(result: SkillLoadResult) -> dict[str, Any]:
+    """Convert a :class:`SkillLoadResult` into a JSON-safe dict.
+
+    Empty / ``None`` fields are preserved so MCP clients see a stable
+    shape regardless of which optional parameters the agent passed.
+    """
+    return asdict(result)
+
+
+def _resolve_loader(
+    loader: SkillLoader | None,
+    templates_roles_dir: Path | None,
+) -> SkillLoader:
+    """Return a loader, building a default one when none was injected."""
+    if loader is not None:
+        return loader
+    if templates_roles_dir is None:
+        raise ValueError("load_skill requires either ``loader`` or ``templates_roles_dir``")
+    return default_loader_from_templates(templates_roles_dir)
+
+
+def _build_error_result(name: str, detail: str) -> SkillLoadResult:
+    """Helper for consistent error-result construction."""
+    return SkillLoadResult(
+        name=name,
+        body="",
+        available_references=[],
+        available_scripts=[],
+        error=detail,
+    )
+
+
+def _log_wal_sink(event: dict[str, Any]) -> None:
+    """Default WAL sink — structured log line at ``INFO``.
+
+    Real production callers inject :meth:`bernstein.core.persistence.wal.Wal.append`
+    (or equivalent) so the event hits the durable log.
+    """
+    logger.info(
+        "skill_loaded name=%s reference=%s script=%s source=%s duration=%.4fs error=%s",
+        event.get("name"),
+        event.get("reference"),
+        event.get("script"),
+        event.get("source"),
+        event.get("duration_s", 0.0),
+        event.get("error"),
+    )
+
+
+# Protocol for WAL sinks — used only for pyright narrowing; Python's
+# structural typing checks the callable shape at runtime.
+class _WalSinkProto:
+    """Callable ``(event: dict) -> None`` protocol alias."""
+
+    def __call__(self, event: dict[str, Any]) -> None: ...  # pragma: no cover

--- a/src/bernstein/core/skills/loader.py
+++ b/src/bernstein/core/skills/loader.py
@@ -18,13 +18,19 @@ eagerly. Re-registering a source requires a new :class:`SkillLoader`.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from bernstein.core.skills.sources.local_dir import LocalDirSkillSource
 
 if TYPE_CHECKING:
     from bernstein.core.skills.source import SkillArtifact, SkillSource
+
+# Signature of ``read_reference`` / ``read_script`` on sources that support
+# on-demand file reads. Sources that can't serve bucketed files simply omit
+# the attribute — see the ``getattr(..., None)`` dance below.
+_ReaderFn = Callable[[str, str], str]
 
 
 class DuplicateSkillError(RuntimeError):
@@ -179,17 +185,13 @@ class SkillLoader:
                 (e.g. a remote source that bundles only SKILL.md).
         """
         source = self.find_source_for(name)
-        reader = getattr(source, "read_reference", None)
-        if reader is None:
-            raise RuntimeError(f"source {source.name!r} does not support reference reads")
+        reader = _resolve_reader(source, "read_reference")
         return _call_reader(reader, name, reference)
 
     def read_script(self, name: str, script: str) -> str:
         """Read a file from a skill's ``scripts/`` directory. See :meth:`read_reference`."""
         source = self.find_source_for(name)
-        reader = getattr(source, "read_script", None)
-        if reader is None:
-            raise RuntimeError(f"source {source.name!r} does not support script reads")
+        reader = _resolve_reader(source, "read_script")
         return _call_reader(reader, name, script)
 
 
@@ -245,15 +247,42 @@ def default_loader_from_templates(
     return SkillLoader(sources=sources)
 
 
-def _call_reader(reader: object, name: str, path: str) -> str:
-    """Invoke a ``read_reference`` / ``read_script`` attribute safely.
+def _resolve_reader(source: SkillSource, attr: str) -> _ReaderFn:
+    """Duck-type a ``read_reference`` / ``read_script`` attribute off a source.
 
-    We duck-type on the source rather than adding new abstract methods so
-    that custom sources (MCP-backed, network-backed) can skip unsupported
-    buckets — they simply omit the attribute.
+    We attach these methods by duck-typing (rather than adding new abstract
+    methods on :class:`SkillSource`) so custom sources that cannot serve
+    bucketed files — a remote MCP source, for instance — can simply omit the
+    attribute. This helper centralises the lookup so the caller always sees
+    a strictly typed ``Callable``.
+
+    Args:
+        source: The owning :class:`SkillSource`.
+        attr:   ``"read_reference"`` or ``"read_script"``.
+
+    Returns:
+        The bound reader function, narrowed to :data:`_ReaderFn`.
+
+    Raises:
+        RuntimeError: When the source omits the attribute or exposes a
+            non-callable value under that name.
     """
-    if not callable(reader):
-        raise RuntimeError(f"reader attribute is not callable: {reader!r}")
+    raw = getattr(source, attr, None)
+    if raw is None:
+        bucket = "reference" if attr == "read_reference" else "script"
+        raise RuntimeError(f"source {source.name!r} does not support {bucket} reads")
+    if not callable(raw):
+        raise RuntimeError(f"{attr} attribute on {source.name!r} is not callable: {raw!r}")
+    return cast("_ReaderFn", raw)
+
+
+def _call_reader(reader: _ReaderFn, name: str, path: str) -> str:
+    """Invoke a bucket reader and validate the return type.
+
+    The call is unconditional here — :func:`_resolve_reader` has already
+    guaranteed ``reader`` is callable. We still check the return type so a
+    misbehaving plugin cannot smuggle a non-string back to the caller.
+    """
     result = reader(name, path)
     if not isinstance(result, str):
         raise RuntimeError(f"reader returned {type(result).__name__}, expected str")

--- a/src/bernstein/core/skills/loader.py
+++ b/src/bernstein/core/skills/loader.py
@@ -29,8 +29,10 @@ if TYPE_CHECKING:
 
 # Signature of ``read_reference`` / ``read_script`` on sources that support
 # on-demand file reads. Sources that can't serve bucketed files simply omit
-# the attribute — see the ``getattr(..., None)`` dance below.
-_ReaderFn = Callable[[str, str], str]
+# the attribute — see the ``getattr(..., None)`` dance below. The return type
+# is ``object`` so third-party plugin implementations cannot trick the static
+# checker into skipping the runtime string-validation in :func:`_call_reader`.
+_ReaderFn = Callable[[str, str], object]
 
 
 class DuplicateSkillError(RuntimeError):

--- a/src/bernstein/core/skills/loader.py
+++ b/src/bernstein/core/skills/loader.py
@@ -1,0 +1,260 @@
+"""Orchestrates :class:`~bernstein.core.skills.source.SkillSource` instances.
+
+The loader merges every registered source into a single lookup table and
+fails fast when two sources publish a skill with the same name. This is
+the central piece that makes progressive disclosure safe:
+
+- ``role_resolver`` asks the loader for a skill matching a role; if one
+  exists, its body is NOT injected into the prompt — only the index is.
+- When an agent calls ``load_skill`` via MCP, the tool delegates to the
+  loader to fetch the body / reference / script on demand.
+- Startup conflict detection prevents two plugins from silently shadowing
+  each other.
+
+The loader is intentionally stateless with respect to *which* source it
+belongs to: sources are provided once at construction and indexed
+eagerly. Re-registering a source requires a new :class:`SkillLoader`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.skills.sources.local_dir import LocalDirSkillSource
+
+if TYPE_CHECKING:
+    from bernstein.core.skills.source import SkillArtifact, SkillSource
+
+
+class DuplicateSkillError(RuntimeError):
+    """Raised at startup when two sources define a skill with the same name.
+
+    The message lists both offending origins so the operator can disable
+    whichever is wrong.
+    """
+
+    def __init__(self, name: str, first_origin: str, second_origin: str) -> None:
+        super().__init__(f"duplicate skill {name!r}: defined in both {first_origin} and {second_origin}")
+        self.skill_name = name
+        self.first_origin = first_origin
+        self.second_origin = second_origin
+
+
+class SkillNotFoundError(KeyError):
+    """Raised when a caller asks for a skill that no source provides."""
+
+
+@dataclass(frozen=True)
+class LoadedSkill:
+    """A skill after the loader has indexed it.
+
+    Attributes:
+        name:        Canonical skill name.
+        description: One-paragraph description used in the index.
+        body:        The SKILL.md body, without frontmatter.
+        references:  Filenames under ``references/`` (from the manifest).
+        scripts:     Filenames under ``scripts/`` (from the manifest).
+        assets:      Filenames under ``assets/`` (from the manifest).
+        origin:      Where the skill came from (path or plugin name).
+        source_name: Label of the :class:`SkillSource` that owns it.
+        trigger_keywords: Optional keyword hints for matching.
+    """
+
+    name: str
+    description: str
+    body: str
+    references: tuple[str, ...]
+    scripts: tuple[str, ...]
+    assets: tuple[str, ...]
+    origin: str
+    source_name: str
+    trigger_keywords: tuple[str, ...]
+
+
+class SkillLoader:
+    """Registry of loaded skills across all sources.
+
+    Construct with a list of sources; the loader calls ``iter_skills`` on
+    each eagerly, detects conflicts, and exposes :meth:`get`,
+    :meth:`list_all`, and :meth:`find_source_for` for downstream callers.
+    """
+
+    def __init__(self, sources: list[SkillSource]) -> None:
+        self._sources: list[SkillSource] = list(sources)
+        self._skills: dict[str, LoadedSkill] = {}
+        self._source_by_skill: dict[str, SkillSource] = {}
+        self._reload()
+
+    @property
+    def sources(self) -> tuple[SkillSource, ...]:
+        """Expose the sources the loader was constructed with."""
+        return tuple(self._sources)
+
+    def _reload(self) -> None:
+        """Re-scan every source. Separate method so tests can force a refresh."""
+        self._skills.clear()
+        self._source_by_skill.clear()
+
+        for source in self._sources:
+            artifacts = source.iter_skills()
+            for artifact in artifacts:
+                self._register(source, artifact)
+
+    def _register(self, source: SkillSource, artifact: SkillArtifact) -> None:
+        """Add a single artifact to the index, raising on name conflicts."""
+        name = artifact.manifest.name
+        existing = self._skills.get(name)
+        if existing is not None:
+            raise DuplicateSkillError(
+                name=name,
+                first_origin=existing.origin,
+                second_origin=artifact.origin,
+            )
+
+        self._skills[name] = LoadedSkill(
+            name=name,
+            description=artifact.manifest.description,
+            body=artifact.body,
+            references=tuple(artifact.manifest.references),
+            scripts=tuple(artifact.manifest.scripts),
+            assets=tuple(artifact.manifest.assets),
+            origin=artifact.origin,
+            source_name=source.name,
+            trigger_keywords=tuple(artifact.manifest.trigger_keywords),
+        )
+        self._source_by_skill[name] = source
+
+    def get(self, name: str) -> LoadedSkill:
+        """Return the loaded skill with this name.
+
+        Args:
+            name: Skill name.
+
+        Returns:
+            :class:`LoadedSkill` for the requested name.
+
+        Raises:
+            SkillNotFoundError: When no source provides the skill.
+        """
+        skill = self._skills.get(name)
+        if skill is None:
+            raise SkillNotFoundError(name)
+        return skill
+
+    def has(self, name: str) -> bool:
+        """Return whether a skill with the given name is registered."""
+        return name in self._skills
+
+    def list_all(self) -> list[LoadedSkill]:
+        """Return every loaded skill, sorted by name for deterministic output."""
+        return [self._skills[name] for name in sorted(self._skills)]
+
+    def find_source_for(self, name: str) -> SkillSource:
+        """Return the source that owns a given skill name.
+
+        Raises:
+            SkillNotFoundError: When no source provides the skill.
+        """
+        source = self._source_by_skill.get(name)
+        if source is None:
+            raise SkillNotFoundError(name)
+        return source
+
+    def read_reference(self, name: str, reference: str) -> str:
+        """Read a file from a skill's ``references/`` directory.
+
+        Args:
+            name: Skill name.
+            reference: Filename under ``references/``.
+
+        Returns:
+            File content.
+
+        Raises:
+            SkillNotFoundError: When the skill is not registered.
+            FileNotFoundError: When the reference does not exist.
+            ValueError:        When ``reference`` escapes the skill directory.
+            RuntimeError:      When the owning source cannot serve references
+                (e.g. a remote source that bundles only SKILL.md).
+        """
+        source = self.find_source_for(name)
+        reader = getattr(source, "read_reference", None)
+        if reader is None:
+            raise RuntimeError(f"source {source.name!r} does not support reference reads")
+        return _call_reader(reader, name, reference)
+
+    def read_script(self, name: str, script: str) -> str:
+        """Read a file from a skill's ``scripts/`` directory. See :meth:`read_reference`."""
+        source = self.find_source_for(name)
+        reader = getattr(source, "read_script", None)
+        if reader is None:
+            raise RuntimeError(f"source {source.name!r} does not support script reads")
+        return _call_reader(reader, name, script)
+
+
+def default_skills_root(templates_dir: object) -> object:
+    """Return the conventional ``templates/skills`` path for a templates dir.
+
+    The argument is typed loosely to avoid a circular dependency on
+    :mod:`pathlib` at module load — the caller always passes a ``Path``.
+
+    Args:
+        templates_dir: Path to ``templates/`` (e.g. ``templates/roles/``'s
+            parent is the right starting point for the default layout).
+
+    Returns:
+        Path to ``<templates_dir>/skills/``.
+    """
+    return templates_dir / "skills"  # type: ignore[operator]
+
+
+def default_loader_from_templates(
+    templates_roles_dir: object,
+    *,
+    include_plugins: bool = True,
+) -> SkillLoader:
+    """Build a :class:`SkillLoader` from the conventional directory layout.
+
+    Args:
+        templates_roles_dir: Path to ``templates/roles/`` — the loader looks
+            at the sibling ``skills/`` directory automatically.
+        include_plugins: Whether to also load ``bernstein.skill_sources``
+            entry points. Tests disable this to isolate behaviour.
+
+    Returns:
+        Configured :class:`SkillLoader`. When no skills dir exists and no
+        plugins are installed, the loader is empty — callers treat this as
+        "fall back to the legacy role template".
+    """
+    from pathlib import Path as _Path  # local import to keep top-level list short
+
+    # templates/roles -> templates/skills
+    roles_path = templates_roles_dir if isinstance(templates_roles_dir, _Path) else _Path(str(templates_roles_dir))
+    skills_root = roles_path.parent / "skills"
+
+    sources: list[SkillSource] = [
+        LocalDirSkillSource(skills_root, source_name="local"),
+    ]
+
+    if include_plugins:
+        from bernstein.core.skills.sources.plugin import load_plugin_sources
+
+        sources.extend(load_plugin_sources())
+
+    return SkillLoader(sources=sources)
+
+
+def _call_reader(reader: object, name: str, path: str) -> str:
+    """Invoke a ``read_reference`` / ``read_script`` attribute safely.
+
+    We duck-type on the source rather than adding new abstract methods so
+    that custom sources (MCP-backed, network-backed) can skip unsupported
+    buckets — they simply omit the attribute.
+    """
+    if not callable(reader):
+        raise RuntimeError(f"reader attribute is not callable: {reader!r}")
+    result = reader(name, path)
+    if not isinstance(result, str):
+        raise RuntimeError(f"reader returned {type(result).__name__}, expected str")
+    return result

--- a/src/bernstein/core/skills/manifest.py
+++ b/src/bernstein/core/skills/manifest.py
@@ -33,12 +33,16 @@ if TYPE_CHECKING:
 # Precompiled once — Pydantic recompiles each time if we pass a string.
 _NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
 
-# ``---`` on a line by itself (with optional trailing whitespace) opens or
-# closes the frontmatter block. Captured eagerly to find the end marker.
-_FRONTMATTER_RE = re.compile(
-    r"\A---\s*\r?\n(?P<front>.*?)\r?\n---\s*(?:\r?\n|\Z)(?P<body>.*)",
-    re.DOTALL,
-)
+# Matches a line containing only ``---`` (with optional trailing whitespace).
+# Anchored to line boundaries and uses only a bounded character class, so it
+# is immune to catastrophic backtracking.
+_FENCE_LINE_RE: re.Pattern[str] = re.compile(r"^---[ \t]*$")
+
+# Hard cap on frontmatter size (16 KiB). A real SKILL.md header is ~500 bytes;
+# anything larger is either corrupt or hostile. The cap is applied to the
+# frontmatter slice — not the whole file — so legitimate markdown bodies
+# stay unbounded.
+_MAX_FRONTMATTER_BYTES = 16 * 1024
 
 
 class SkillManifestError(ValueError):
@@ -112,15 +116,10 @@ def parse_skill_md(path: Path) -> tuple[SkillManifest, str]:
     except OSError as exc:
         raise SkillManifestError(path, f"cannot read file: {exc}") from exc
 
-    match = _FRONTMATTER_RE.match(raw)
-    if match is None:
-        raise SkillManifestError(
-            path,
-            "missing YAML frontmatter — expected ``---`` on the first line",
-        )
-
-    front_raw = match.group("front")
-    body = match.group("body").strip()
+    try:
+        front_raw, body = _split_frontmatter(raw)
+    except ValueError as exc:
+        raise SkillManifestError(path, str(exc)) from exc
 
     try:
         data: object = yaml.safe_load(front_raw)
@@ -158,3 +157,54 @@ def parse_skill_md(path: Path) -> tuple[SkillManifest, str]:
         raise SkillManifestError(path, f"invalid manifest: {exc.errors()}") from exc
 
     return manifest, body
+
+
+def _split_frontmatter(raw: str) -> tuple[str, str]:
+    """Split a ``SKILL.md`` text into ``(frontmatter_yaml, body)``.
+
+    Implemented as a linear line-scan rather than a ``re.DOTALL``-style
+    regex so there is no nested quantifier for a malicious input to exploit
+    (the original pattern ``\\A---\\s*\\r?\\n(.*?)\\r?\\n---\\s*(?:\\r?\\n|\\Z)(.*)``
+    tripped SonarCloud's ReDoS heuristic — see S5852). The frontmatter slice
+    is bounded by :data:`_MAX_FRONTMATTER_BYTES` so even a file that never
+    closes the fence can never force more than ``O(cap)`` work.
+
+    Args:
+        raw: Full ``SKILL.md`` text.
+
+    Returns:
+        ``(front, body)`` — ``front`` is the YAML between the two fences
+        (unstripped, suitable for :func:`yaml.safe_load`); ``body`` is the
+        markdown after the closing fence with surrounding whitespace stripped.
+
+    Raises:
+        ValueError: When the file does not start with ``---`` on its first
+            line, when the closing fence is missing, or when the frontmatter
+            would exceed :data:`_MAX_FRONTMATTER_BYTES`.
+    """
+    lines = raw.splitlines()
+    if not lines or not _FENCE_LINE_RE.match(lines[0]):
+        raise ValueError("missing YAML frontmatter — expected ``---`` on the first line")
+
+    front_lines: list[str] = []
+    close_idx: int | None = None
+    front_bytes = 0
+
+    for idx in range(1, len(lines)):
+        line = lines[idx]
+        if _FENCE_LINE_RE.match(line):
+            close_idx = idx
+            break
+        # Count against the byte cap eagerly so a pathological input can't
+        # force us to accumulate gigabytes before we notice.
+        front_bytes += len(line.encode("utf-8")) + 1  # +1 for the newline
+        if front_bytes > _MAX_FRONTMATTER_BYTES:
+            raise ValueError(f"frontmatter exceeds {_MAX_FRONTMATTER_BYTES} bytes — refusing to parse")
+        front_lines.append(line)
+
+    if close_idx is None:
+        raise ValueError("unterminated YAML frontmatter — missing closing ``---`` fence")
+
+    front = "\n".join(front_lines)
+    body = "\n".join(lines[close_idx + 1 :]).strip()
+    return front, body

--- a/src/bernstein/core/skills/manifest.py
+++ b/src/bernstein/core/skills/manifest.py
@@ -1,0 +1,160 @@
+"""Pydantic model for ``SKILL.md`` YAML frontmatter.
+
+A skill's manifest declares the bare minimum that the orchestrator needs to
+index the skill, plus pointers to optional reference files and scripts that
+the agent can load on demand.
+
+Schema (all fields strict-validated by Pydantic):
+
+- ``name``        — lowercase slug ``[a-z][a-z0-9-]*``
+- ``description`` — 20-500 chars, shown in the index
+- ``trigger_keywords`` — optional keyword hints
+- ``references``  — list of files under ``<skill>/references/``
+- ``scripts``     — list of files under ``<skill>/scripts/``
+- ``assets``      — list of files under ``<skill>/assets/``
+- ``version``     — semver-ish; defaults to ``1.0.0``
+- ``author``      — optional free-form attribution
+
+Parsing failures point at the offending file so operators can correct the
+manifest without greping through 17 skill directories.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Precompiled once — Pydantic recompiles each time if we pass a string.
+_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# ``---`` on a line by itself (with optional trailing whitespace) opens or
+# closes the frontmatter block. Captured eagerly to find the end marker.
+_FRONTMATTER_RE = re.compile(
+    r"\A---\s*\r?\n(?P<front>.*?)\r?\n---\s*(?:\r?\n|\Z)(?P<body>.*)",
+    re.DOTALL,
+)
+
+
+class SkillManifestError(ValueError):
+    """Raised when a ``SKILL.md`` file is missing, malformed, or invalid.
+
+    Always carries the originating path so operators can locate the file
+    without needing to re-derive it from the traceback.
+    """
+
+    def __init__(self, path: Path, detail: str) -> None:
+        super().__init__(f"{path}: {detail}")
+        self.path = path
+        self.detail = detail
+
+
+class SkillManifest(BaseModel):
+    """Strict-validated ``SKILL.md`` frontmatter.
+
+    Attributes mirror the OpenAI Agents SDK v2 Skills spec. Unknown keys are
+    rejected so typos (``keywords`` vs ``trigger_keywords``) do not silently
+    drop metadata.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: str = Field(min_length=1, max_length=64)
+    description: str = Field(min_length=20, max_length=500)
+    trigger_keywords: list[str] = Field(default_factory=list[str])
+    references: list[str] = Field(default_factory=list[str])
+    scripts: list[str] = Field(default_factory=list[str])
+    assets: list[str] = Field(default_factory=list[str])
+    version: str = "1.0.0"
+    author: str | None = None
+
+    @staticmethod
+    def validate_name(value: str) -> str:
+        """Ensure ``name`` matches the lowercase-slug regex.
+
+        Pydantic's ``Field(pattern=...)`` validates at construction time but
+        produces a less friendly error. We run the check explicitly in
+        :func:`parse_skill_md` so :class:`SkillManifestError` carries the
+        originating path.
+        """
+        if not _NAME_PATTERN.match(value):
+            raise ValueError(
+                f"name {value!r} must match regex ^[a-z][a-z0-9-]*$ "
+                "(lowercase letters, digits, hyphens; must start with a letter)"
+            )
+        return value
+
+
+def parse_skill_md(path: Path) -> tuple[SkillManifest, str]:
+    """Parse a ``SKILL.md`` file into a manifest and its markdown body.
+
+    Args:
+        path: Path to the ``SKILL.md`` file.
+
+    Returns:
+        ``(manifest, body)`` — ``body`` is the markdown text after the
+        closing ``---`` marker with surrounding whitespace stripped.
+
+    Raises:
+        SkillManifestError: When the file is missing, lacks frontmatter,
+            contains invalid YAML, or fails Pydantic validation.
+    """
+    if not path.is_file():
+        raise SkillManifestError(path, "SKILL.md file does not exist")
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SkillManifestError(path, f"cannot read file: {exc}") from exc
+
+    match = _FRONTMATTER_RE.match(raw)
+    if match is None:
+        raise SkillManifestError(
+            path,
+            "missing YAML frontmatter — expected ``---`` on the first line",
+        )
+
+    front_raw = match.group("front")
+    body = match.group("body").strip()
+
+    try:
+        data: object = yaml.safe_load(front_raw)
+    except yaml.YAMLError as exc:
+        raise SkillManifestError(path, f"invalid YAML frontmatter: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise SkillManifestError(
+            path,
+            f"frontmatter must be a YAML mapping, got {type(data).__name__}",
+        )
+
+    # YAML parses into dict[Any, Any] as far as pyright is concerned.
+    # Explicitly cast + validate each key so the Pydantic model receives a
+    # narrow dict[str, Any] (``extra="forbid"`` catches typos anyway, but
+    # we still want strict typing up to the validation boundary).
+    raw_data: dict[Any, Any] = cast("dict[Any, Any]", data)
+    cleaned: dict[str, Any] = {}
+    for key, value in raw_data.items():
+        if not isinstance(key, str):
+            raise SkillManifestError(path, f"frontmatter key {key!r} must be a string")
+        cleaned[key] = value
+
+    name_value = cleaned.get("name")
+    if isinstance(name_value, str):
+        try:
+            SkillManifest.validate_name(name_value)
+        except ValueError as exc:
+            raise SkillManifestError(path, str(exc)) from exc
+
+    try:
+        manifest = SkillManifest.model_validate(cleaned)
+    except ValidationError as exc:
+        # Pydantic's default message is fine but we prefix it with the path.
+        raise SkillManifestError(path, f"invalid manifest: {exc.errors()}") from exc
+
+    return manifest, body

--- a/src/bernstein/core/skills/source.py
+++ b/src/bernstein/core/skills/source.py
@@ -1,0 +1,117 @@
+"""Abstract skill-source interface.
+
+Every place skills can come from (bundled ``templates/skills/``, a pluggy
+entry-point, a future MCP-mounted directory, …) implements
+:class:`SkillSource`. Sources are merged by :class:`~bernstein.core.skills.loader.SkillLoader`
+with explicit conflict detection.
+
+Two concrete shapes:
+
+- :class:`SkillSource`      — materialised upfront; returns manifests + bodies.
+- :class:`LazySkillSource`  — returns manifests upfront but defers body
+  reads until :meth:`load_body` is called.
+
+The separation lets us index hundreds of plugin skills without paying for
+their bodies unless the agent actually requests one.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.skills.manifest import SkillManifest
+
+
+@dataclass(frozen=True)
+class SkillArtifact:
+    """A fully materialised skill pack returned by a source.
+
+    Attributes:
+        manifest: Parsed ``SKILL.md`` frontmatter.
+        body: Markdown body (the text after the closing ``---`` marker).
+        origin: Human-readable location (filesystem path, plugin name, …).
+            Shown in ``bernstein skills list`` and error messages.
+    """
+
+    manifest: SkillManifest
+    body: str
+    origin: str
+
+
+class SkillSource(ABC):
+    """A source of skill packs.
+
+    Subclasses must implement :meth:`iter_skills`. The ``name`` property is
+    used for error messages and conflict reporting.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable source identifier (e.g. ``local``, ``plugin:my-pack``)."""
+
+    @abstractmethod
+    def iter_skills(self) -> list[SkillArtifact]:
+        """Return every skill this source provides.
+
+        Returns:
+            List of :class:`SkillArtifact` — sources return an empty list
+            when they have no skills, never ``None``.
+
+        Raises:
+            bernstein.core.skills.manifest.SkillManifestError: When a skill
+                directory cannot be parsed. The loader surfaces this as a
+                startup-time failure so broken plugins cannot silently drop
+                from the index.
+        """
+
+
+class LazySkillSource(SkillSource):
+    """A skill source that defers body reads until requested.
+
+    Useful for sources that can list manifests cheaply (e.g. reading only
+    frontmatter from disk) but whose bodies are expensive — plugin packs
+    fetched from URLs, for instance. :class:`SkillLoader` falls through to
+    :meth:`load_body` when an agent calls ``load_skill``.
+    """
+
+    @abstractmethod
+    def iter_manifests(self) -> list[tuple[SkillManifest, str]]:
+        """Return ``(manifest, origin)`` pairs for every skill.
+
+        Returns:
+            One tuple per skill; ``origin`` is used for error reporting.
+        """
+
+    @abstractmethod
+    def load_body(self, name: str) -> str:
+        """Load the body for a skill by name.
+
+        Args:
+            name: Skill name (matches ``SkillManifest.name``).
+
+        Returns:
+            Markdown body text.
+
+        Raises:
+            KeyError: When the source does not own a skill with that name.
+        """
+
+    def iter_skills(self) -> list[SkillArtifact]:
+        """Default :meth:`iter_skills` implementation — eagerly loads bodies.
+
+        Subclasses that want true lazy behaviour should override this and
+        return an empty list (the loader will fall back to
+        :meth:`iter_manifests` + :meth:`load_body`).
+
+        Returns:
+            Fully materialised artifacts, one per skill.
+        """
+        artifacts: list[SkillArtifact] = []
+        for manifest, origin in self.iter_manifests():
+            body = self.load_body(manifest.name)
+            artifacts.append(SkillArtifact(manifest=manifest, body=body, origin=origin))
+        return artifacts

--- a/src/bernstein/core/skills/sources/__init__.py
+++ b/src/bernstein/core/skills/sources/__init__.py
@@ -1,0 +1,17 @@
+"""Concrete :class:`~bernstein.core.skills.source.SkillSource` implementations."""
+
+from __future__ import annotations
+
+from bernstein.core.skills.sources.local_dir import LocalDirSkillSource
+from bernstein.core.skills.sources.plugin import (
+    PLUGIN_ENTRY_POINT_GROUP,
+    PluginSkillSource,
+    load_plugin_sources,
+)
+
+__all__ = [
+    "PLUGIN_ENTRY_POINT_GROUP",
+    "LocalDirSkillSource",
+    "PluginSkillSource",
+    "load_plugin_sources",
+]

--- a/src/bernstein/core/skills/sources/local_dir.py
+++ b/src/bernstein/core/skills/sources/local_dir.py
@@ -7,7 +7,7 @@ Directory layout::
             SKILL.md            # required, with YAML frontmatter
             references/         # optional — on-demand bodies
                 deep-dive.md
-            scripts/            # optional — agent-invokable helpers
+            scripts/            # optional — agent-invocable helpers
                 lint.sh
             assets/             # optional — static files (schemas etc.)
                 schema.json

--- a/src/bernstein/core/skills/sources/local_dir.py
+++ b/src/bernstein/core/skills/sources/local_dir.py
@@ -1,0 +1,185 @@
+"""Skill source that reads from a directory tree on disk.
+
+Directory layout::
+
+    <root>/
+        <skill-name>/
+            SKILL.md            # required, with YAML frontmatter
+            references/         # optional — on-demand bodies
+                deep-dive.md
+            scripts/            # optional — agent-invokable helpers
+                lint.sh
+            assets/             # optional — static files (schemas etc.)
+                schema.json
+
+This is the default first-party source for Bernstein's own 17 skills
+living at ``templates/skills/``. Third-party packs use the same layout via
+:class:`~bernstein.core.skills.sources.plugin.PluginSkillSource`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from bernstein.core.skills.manifest import (
+    SkillManifestError,
+    parse_skill_md,
+)
+from bernstein.core.skills.source import SkillArtifact, SkillSource
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.skills.manifest import SkillManifest
+
+
+class LocalDirSkillSource(SkillSource):
+    """Reads skill packs from immediate subdirectories of ``root``.
+
+    Args:
+        root: Directory containing ``<name>/SKILL.md`` entries.
+        source_name: Label used in error messages and ``bernstein skills list``.
+            Defaults to ``local:<root>``.
+    """
+
+    def __init__(self, root: Path, *, source_name: str | None = None) -> None:
+        self._root = root
+        self._name = source_name or f"local:{root}"
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def root(self) -> Path:
+        """Expose the root path for introspection."""
+        return self._root
+
+    def iter_skills(self) -> list[SkillArtifact]:
+        if not self._root.is_dir():
+            return []
+
+        artifacts: list[SkillArtifact] = []
+        for entry in sorted(self._root.iterdir()):
+            if not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+
+            manifest, body = parse_skill_md(skill_md)
+            # Cross-check directory name against manifest ``name`` — catches
+            # the common copy-paste mistake where someone duplicates a skill
+            # dir and forgets to update frontmatter.
+            if entry.name != manifest.name:
+                raise SkillManifestError(
+                    skill_md,
+                    f"directory name {entry.name!r} does not match manifest name {manifest.name!r}",
+                )
+            artifacts.append(
+                SkillArtifact(
+                    manifest=manifest,
+                    body=body,
+                    origin=str(skill_md),
+                )
+            )
+        return artifacts
+
+    def read_reference(self, skill_name: str, reference: str) -> str:
+        """Return the raw content of a ``references/`` file.
+
+        Args:
+            skill_name: Directory name (matches manifest ``name``).
+            reference: Filename relative to ``references/``.
+
+        Returns:
+            File contents as UTF-8 text.
+
+        Raises:
+            FileNotFoundError: When the reference does not exist.
+            ValueError: When ``reference`` tries to escape the skill
+                directory via ``..`` path segments.
+        """
+        return _read_child(self._root, skill_name, "references", reference)
+
+    def read_script(self, skill_name: str, script: str) -> str:
+        """Return the raw content of a ``scripts/`` file. See :meth:`read_reference`."""
+        return _read_child(self._root, skill_name, "scripts", script)
+
+    def read_asset(self, skill_name: str, asset: str) -> str:
+        """Return the raw content of an ``assets/`` file. See :meth:`read_reference`."""
+        return _read_child(self._root, skill_name, "assets", asset)
+
+    def list_references(self, skill_name: str) -> list[str]:
+        """Return the filenames present in ``<skill>/references/``.
+
+        Args:
+            skill_name: Directory name.
+
+        Returns:
+            Sorted list of filenames; empty when the directory is missing.
+        """
+        return _list_child(self._root, skill_name, "references")
+
+    def list_scripts(self, skill_name: str) -> list[str]:
+        """Return the filenames present in ``<skill>/scripts/``."""
+        return _list_child(self._root, skill_name, "scripts")
+
+    def list_assets(self, skill_name: str) -> list[str]:
+        """Return the filenames present in ``<skill>/assets/``."""
+        return _list_child(self._root, skill_name, "assets")
+
+    def manifest_for(self, name: str) -> SkillManifest | None:
+        """Return the manifest for a single skill, or ``None`` when missing.
+
+        Handy for lookups that do not need the full body.
+        """
+        skill_md = self._root / name / "SKILL.md"
+        if not skill_md.is_file():
+            return None
+        manifest, _body = parse_skill_md(skill_md)
+        return manifest
+
+
+def _safe_child(root: Path, skill_name: str, bucket: str, filename: str) -> Path:
+    """Join a child path under ``<root>/<skill>/<bucket>/`` and reject traversal.
+
+    Args:
+        root: Skills root (``templates/skills``).
+        skill_name: Skill directory name.
+        bucket: ``references`` | ``scripts`` | ``assets``.
+        filename: Requested filename.
+
+    Returns:
+        Fully resolved absolute path inside the skill directory.
+
+    Raises:
+        ValueError: When the resolved path escapes ``<root>/<skill>/<bucket>/``.
+    """
+    base = (root / skill_name / bucket).resolve()
+    candidate = (base / filename).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"path {filename!r} escapes skill directory {base}") from exc
+    return candidate
+
+
+def _read_child(root: Path, skill_name: str, bucket: str, filename: str) -> str:
+    """Read a file safely from ``<root>/<skill>/<bucket>/<filename>``."""
+    path = _safe_child(root, skill_name, bucket, filename)
+    if not path.is_file():
+        raise FileNotFoundError(f"{bucket} file not found for skill {skill_name!r}: {filename}")
+    return path.read_text(encoding="utf-8")
+
+
+def _list_child(root: Path, skill_name: str, bucket: str) -> list[str]:
+    """List filenames under ``<root>/<skill>/<bucket>/``.
+
+    Directories are skipped; symlinks are followed because the directory
+    layout is under first-party control and tests may symlink fixtures.
+    """
+    base = root / skill_name / bucket
+    if not base.is_dir():
+        return []
+    return sorted(p.name for p in base.iterdir() if p.is_file())

--- a/src/bernstein/core/skills/sources/plugin.py
+++ b/src/bernstein/core/skills/sources/plugin.py
@@ -1,0 +1,182 @@
+"""Plugin skill source — loads third-party packs via setuptools entry points.
+
+A plugin ships skills by registering a factory under the
+``bernstein.skill_sources`` entry-point group. The factory returns a
+:class:`~bernstein.core.skills.source.SkillSource` instance (usually a
+:class:`~bernstein.core.skills.sources.local_dir.LocalDirSkillSource`
+pointing at a directory bundled with the plugin wheel).
+
+Example plugin ``pyproject.toml``::
+
+    [project.entry-points."bernstein.skill_sources"]
+    my-data-pack = "my_pack.skills:source"
+
+Where ``my_pack/skills.py`` exposes::
+
+    from pathlib import Path
+
+    from bernstein.core.skills import SkillSource
+    from bernstein.core.skills.sources import LocalDirSkillSource
+
+    def source() -> SkillSource:
+        return LocalDirSkillSource(
+            Path(__file__).parent / "skills",
+            source_name="plugin:my-data-pack",
+        )
+
+The helper :func:`load_plugin_sources` scans installed distributions and
+returns every registered source, wrapping broken entry points in a clear
+``ImportError`` so the operator sees which plugin failed.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib.metadata import EntryPoint, entry_points
+from typing import TYPE_CHECKING
+
+from bernstein.core.skills.source import SkillArtifact, SkillSource
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Canonical entry-point group name (documented in docs/architecture/skills.md).
+PLUGIN_ENTRY_POINT_GROUP: str = "bernstein.skill_sources"
+
+logger = logging.getLogger(__name__)
+
+
+class PluginSkillSource(SkillSource):
+    """Wrap a factory-returned source with a plugin-qualified name.
+
+    This exists because a plugin factory may return any
+    :class:`SkillSource` — a :class:`LocalDirSkillSource`, a custom in-memory
+    impl, whatever. Rather than require every plugin to name itself
+    ``plugin:X``, we wrap the returned source and rename it so
+    :class:`~bernstein.core.skills.loader.SkillLoader` sees ``plugin:<ep_name>``
+    in conflict messages without coupling the plugin author to a
+    naming convention.
+    """
+
+    def __init__(self, ep_name: str, inner: SkillSource) -> None:
+        self._ep_name = ep_name
+        self._inner = inner
+
+    @property
+    def name(self) -> str:
+        return f"plugin:{self._ep_name}"
+
+    @property
+    def inner(self) -> SkillSource:
+        """Expose the wrapped source so tests/tools can introspect it."""
+        return self._inner
+
+    def iter_skills(self) -> list[SkillArtifact]:
+        return self._inner.iter_skills()
+
+
+def load_plugin_sources(
+    *,
+    entry_point_group: str = PLUGIN_ENTRY_POINT_GROUP,
+) -> list[SkillSource]:
+    """Enumerate ``bernstein.skill_sources`` entry points and load them.
+
+    Args:
+        entry_point_group: Override the default group (used by tests).
+
+    Returns:
+        One :class:`PluginSkillSource` per successfully loaded plugin.
+        Plugins that fail to import are logged but do not abort startup —
+        a noisy third-party bug should not take down the orchestrator.
+    """
+    try:
+        eps: tuple[EntryPoint, ...] = tuple(
+            entry_points(group=entry_point_group)  # type: ignore[arg-type]
+        )
+    except TypeError:
+        # Python 3.9/3.10 returned a SelectableGroups object — we target 3.12+,
+        # but keep the fallback defensive for tooling on older interpreters.
+        eps = tuple(entry_points().get(entry_point_group, ()))  # type: ignore[union-attr]
+
+    sources: list[SkillSource] = []
+    for ep in eps:
+        try:
+            factory = ep.load()
+        except Exception as exc:
+            logger.warning("Failed to load skill-source entry point %s: %s", ep.name, exc)
+            continue
+
+        source = _invoke_factory(ep.name, factory)
+        if source is None:
+            continue
+        sources.append(PluginSkillSource(ep_name=ep.name, inner=source))
+    return sources
+
+
+def _invoke_factory(ep_name: str, factory: object) -> SkillSource | None:
+    """Call a plugin factory and validate the returned object.
+
+    Plugins may register either a zero-arg callable or a pre-built
+    :class:`SkillSource` instance. Both are supported.
+
+    Args:
+        ep_name: Entry-point name (for logging).
+        factory: Loaded attribute from the entry point.
+
+    Returns:
+        A :class:`SkillSource`, or ``None`` when the factory misbehaves
+        (a warning is logged in that case).
+    """
+    if isinstance(factory, SkillSource):
+        return factory
+
+    if not callable(factory):
+        logger.warning(
+            "Skill-source entry point %s is neither callable nor SkillSource",
+            ep_name,
+        )
+        return None
+
+    try:
+        # The cast is safe: we checked callability above.
+        result = _call_factory(factory)
+    except Exception as exc:
+        logger.warning(
+            "Skill-source factory for %s raised %s: %s",
+            ep_name,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+    if not isinstance(result, SkillSource):
+        logger.warning(
+            "Skill-source factory for %s returned %s (expected SkillSource)",
+            ep_name,
+            type(result).__name__,
+        )
+        return None
+
+    return result
+
+
+def _call_factory(factory: object) -> object:
+    """Call a callable factory with no arguments.
+
+    Separated from :func:`_invoke_factory` to keep typing narrow.
+    """
+    # Pyright cannot narrow ``object`` to ``Callable`` across the isinstance
+    # check performed by the caller, so cast here.
+    call = cast_callable(factory)
+    return call()
+
+
+def cast_callable(obj: object) -> Callable[[], object]:
+    """Narrow ``object`` to a zero-arg callable for pyright.
+
+    Kept as a tiny helper so the cast is single-origin — we don't sprinkle
+    ``cast`` calls across the module.
+    """
+    if not callable(obj):
+        raise TypeError(f"expected callable, got {type(obj).__name__}")
+    return obj  # pyright: ignore[reportReturnType]

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -16,6 +16,7 @@ Tools:
     bernstein_stop    — graceful shutdown (writes SHUTDOWN signal)
     bernstein_approve — approve a pending/blocked task
     bernstein_health  — liveness check (always succeeds)
+    load_skill        — load a skill pack body / reference / script (oai-004)
 """
 
 from __future__ import annotations
@@ -320,6 +321,65 @@ def _register_action_tools(mcp: FastMCP[None], server_url: str) -> None:
             return _error_response(exc)
 
 
+def _register_skill_tools(mcp: FastMCP[None]) -> None:
+    """Register the ``load_skill`` progressive-disclosure tool (oai-004).
+
+    Args:
+        mcp: FastMCP instance to register the tool on.
+    """
+
+    @mcp.tool()
+    async def load_skill(  # pyright: ignore[reportUnusedFunction]
+        name: str,
+        reference: str | None = None,
+        script: str | None = None,
+    ) -> str:
+        """Load a skill pack body (and optionally a reference or script).
+
+        Agents receive only a compact skill index in their system prompt.
+        Call this tool to fetch the full ``SKILL.md`` body for a skill
+        when you decide it's relevant to the current task. Pass
+        ``reference`` to get a deeper-context file or ``script`` to read
+        the content of an executable helper.
+
+        Args:
+            name: Skill name (matches the index entry, e.g. ``"backend"``).
+            reference: Optional filename under ``references/`` — for
+                example ``"python-conventions.md"``.
+            script: Optional filename under ``scripts/`` — for example
+                ``"lint.sh"``. The script content is returned as text; the
+                MCP harness does not execute it.
+
+        Returns:
+            JSON with ``name``, ``body``, ``available_references``,
+            ``available_scripts``, and the optional fetched content.
+        """
+        try:
+            # Local import so the MCP module stays cheap to import even when
+            # the skills tree is missing (e.g. dev CLI without templates).
+            from pathlib import Path as _Path
+
+            from bernstein import get_templates_dir
+            from bernstein.core.skills.load_skill_tool import (
+                load_skill as _load_skill_impl,
+            )
+            from bernstein.core.skills.load_skill_tool import (
+                result_as_dict,
+            )
+
+            templates_root = get_templates_dir(_Path.cwd())
+            templates_roles_dir = templates_root / "roles"
+            result = _load_skill_impl(
+                name=name,
+                reference=reference,
+                script=script,
+                templates_roles_dir=templates_roles_dir,
+            )
+            return json.dumps(result_as_dict(result), indent=2)
+        except Exception as exc:
+            return _error_response(exc, hint="Skill not found or templates missing")
+
+
 def create_mcp_server(
     server_url: str = _DEFAULT_SERVER_URL,
     name: str = "bernstein",
@@ -337,6 +397,7 @@ def create_mcp_server(
     _register_health_tool(mcp)
     _register_query_tools(mcp, server_url)
     _register_action_tools(mcp, server_url)
+    _register_skill_tools(mcp)
     return mcp
 
 

--- a/templates/skills/analyst/SKILL.md
+++ b/templates/skills/analyst/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: analyst
+description: Evaluate proposals — feasibility, ROI, risk.
+trigger_keywords:
+  - analyst
+  - evaluate
+  - verdict
+  - feasibility
+  - roi
+---
+
+# Ruthless Analyst Skill
+
+You are a ruthless analytical mind. Your job is to kill bad ideas and
+strengthen good ones. You don't care about how cool something sounds —
+you care about whether it works, whether users need it, and whether the
+team can ship it.
+
+## Evaluation criteria
+- **Technical feasibility**: Can we build this with the current architecture?
+- **ROI**: Does the effort justify the impact? Does this move the needle?
+- **Risk assessment**: Does this break existing functionality? Security?
+- **User demand signal**: Is there evidence users want this?
+- **Dependency analysis**: What must exist first?
+
+## Output format
+For each proposal, produce structured JSON with these fields:
+
+- `proposal_title`: title of the proposal being evaluated
+- `verdict`: `APPROVE`, `REVISE`, or `REJECT`
+- `feasibility_score`: 1-10
+- `impact_score`: 1-10
+- `risk_score`: 1-10 (higher = riskier)
+- `composite_score`: `(0.4 * feasibility + 0.4 * impact - 0.2 * risk) * 10 / 8`
+- `reasoning`: 2-3 sentences explaining the verdict
+- `revisions`: specific changes needed (if `REVISE`)
+- `decomposition`: list of concrete tasks (if `APPROVE`)
+
+## Rules
+- Be skeptical by default — the bar for `APPROVE` is high.
+- Only `APPROVE` proposals with `composite_score >= 7`.
+- `REVISE` means "good idea, wrong execution" — provide specific fixes.
+- `REJECT` means "not worth doing" — explain why clearly.
+- Decomposition tasks must be concrete enough for an agent to execute.
+- Don't soften your verdicts to be polite.

--- a/templates/skills/architect/SKILL.md
+++ b/templates/skills/architect/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: architect
+description: System design — module boundaries, API contracts, ADRs.
+trigger_keywords:
+  - architecture
+  - design
+  - adr
+  - decomposition
+  - module
+  - interface
+  - dependency
+references:
+  - adr-template.md
+  - decomposition-principles.md
+---
+
+# Software Architect Skill
+
+You are a software architect. Design system structure, make technology
+decisions, and ensure long-term maintainability.
+
+## Specialization
+- System decomposition and module boundaries
+- API contracts and interface design
+- Technology evaluation and selection
+- Architecture decision records (ADRs)
+- Performance and scalability design
+- Dependency management and coupling analysis
+
+## Work style
+1. Read the task description and existing architecture before proposing changes.
+2. Map the current system structure before recommending new structure.
+3. Write ADRs for significant decisions: context, decision, consequences.
+4. Prefer composition over inheritance, interfaces over concrete types.
+5. Validate designs against real usage patterns, not theoretical perfection.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Never refactor structure and behavior in the same change.
+- Document trade-offs explicitly: what you gain, what you give up.
+- Keep module boundaries aligned with team ownership and deployment units.
+
+Call `load_skill(name="architect", reference="adr-template.md")` for an
+ADR skeleton, or `reference="decomposition-principles.md"` for module
+boundary guidance.

--- a/templates/skills/architect/references/adr-template.md
+++ b/templates/skills/architect/references/adr-template.md
@@ -1,0 +1,31 @@
+# ADR template
+
+```markdown
+# <N>. <decision title>
+
+- **Status**: proposed | accepted | superseded by ADR-<M>
+- **Date**: YYYY-MM-DD
+- **Deciders**: @user, @user
+
+## Context
+What forces us to make this decision? Include technical constraints,
+organisational constraints, and the problem statement.
+
+## Decision
+State the decision in one sentence, then elaborate.
+
+## Consequences
+- Positive: …
+- Negative: …
+- Neutral: …
+
+## Alternatives considered
+Name each alternative and the reason it was not chosen.
+
+## References
+- Related ADRs
+- Specifications, RFCs, external docs
+```
+
+Store ADRs under `docs/adr/NNNN-short-title.md`, numbered in the order
+they were accepted. Immutable once accepted — supersede instead of edit.

--- a/templates/skills/architect/references/decomposition-principles.md
+++ b/templates/skills/architect/references/decomposition-principles.md
@@ -1,0 +1,26 @@
+# Decomposition principles
+
+## Module boundaries
+- Cohesion inside, loose coupling outside.
+- A module's public API is a deliberate surface, not an accident of
+  which symbols happen to be importable.
+- Keep I/O at the edges. Core logic should be pure and testable without
+  mocking a network stack.
+
+## Package layout (Bernstein)
+- `src/bernstein/core/<domain>/` — one domain per sub-package (orchestration,
+  agents, tasks, quality, server, …).
+- Cross-package imports travel through explicit public interfaces, not
+  internal helpers.
+- Circular imports are a design smell — refactor, don't paper over with
+  lazy imports.
+
+## Interface design
+- Prefer small, stable interfaces over large, changing ones.
+- Protocol / ABC for points of extension (adapters, skill sources).
+- Versioned schemas for anything crossing a process boundary.
+
+## Change tolerance
+- A design is only as good as how gracefully it breaks.
+- Optional parameters should always have safe defaults.
+- Kill features with a deprecation cycle, not a silent removal.

--- a/templates/skills/backend/SKILL.md
+++ b/templates/skills/backend/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: backend
+description: Python server code, APIs, async, strict typing.
+trigger_keywords:
+  - python
+  - backend
+  - api
+  - async
+  - asyncio
+  - server
+  - fastapi
+  - pydantic
+  - sqlalchemy
+  - pyright
+references:
+  - python-conventions.md
+  - test-patterns.md
+  - error-handling.md
+scripts:
+  - lint.sh
+---
+
+# Backend Engineering Skill
+
+You are a backend engineer. Implement server-side logic, APIs, database
+operations, and business rules on a Python 3.12+ codebase.
+
+## Specialization
+- Python (FastAPI, SQLAlchemy, Pydantic)
+- API design (REST, GraphQL)
+- Database schema and migrations
+- Background jobs and queues
+- Error handling and logging
+
+## Work style
+1. Read the task description carefully.
+2. Read existing code in the relevant files before writing.
+3. Write tests alongside implementation.
+4. Keep functions small and typed.
+5. Commit frequently with descriptive messages.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Run tests before marking complete: `uv run python scripts/run_tests.py -x`.
+- If blocked, post to BULLETIN and move to next task.
+
+For deeper guidance call `load_skill(name="backend", reference="python-conventions.md")`
+(style rules), `reference="test-patterns.md"` (pytest idioms), or
+`reference="error-handling.md"` (exception policy).

--- a/templates/skills/backend/references/error-handling.md
+++ b/templates/skills/backend/references/error-handling.md
@@ -1,0 +1,18 @@
+# Error handling (Bernstein)
+
+- Raise specific exception types — never bare `Exception` in business code.
+- Wrap third-party errors at the boundary and re-raise a domain-specific
+  class so callers don't leak vendor specifics.
+- Use `from exc` to preserve the traceback.
+- Log once at the layer that handles the error. Nested try/except ladders
+  create double-log noise.
+
+## HTTP / API
+- Return typed Pydantic responses, not raw dicts.
+- `4xx` errors always include a machine-readable `code` field.
+- `5xx` responses should never include stack traces or internal paths.
+
+## Async
+- Propagate cancellation (`asyncio.CancelledError`) unchanged.
+- Use `asyncio.timeout()` over `asyncio.wait_for()` for new code.
+- Close network connections in `finally` or via `async with`.

--- a/templates/skills/backend/references/python-conventions.md
+++ b/templates/skills/backend/references/python-conventions.md
@@ -1,0 +1,22 @@
+# Python conventions (Bernstein)
+
+- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts.
+- Use dataclasses or TypedDict, never raw dict soup.
+- Ruff for linting and formatting:
+  - `uv run ruff check src/`
+  - `uv run ruff format src/`
+- Google-style docstrings only where non-obvious.
+- Async for IO-bound operations, sync for CPU-bound.
+- No `from __future__ import` beyond `annotations` — the project targets 3.12.
+- Prefer `Path` over raw strings for filesystems.
+- Use `structlog`/stdlib `logging` with lazy formatting (`logger.info("x=%s", x)`).
+
+## Naming
+- Private helpers are prefixed with `_`.
+- Constants are `UPPER_SNAKE_CASE`.
+- Classes: `PascalCase`. Functions / methods: `snake_case`.
+
+## Typing idioms
+- `list[int]`, `dict[str, Any]` — no `typing.List`, no `typing.Dict`.
+- `X | None` — no `Optional[X]`.
+- `TYPE_CHECKING` imports are encouraged to keep runtime cost down.

--- a/templates/skills/backend/references/test-patterns.md
+++ b/templates/skills/backend/references/test-patterns.md
@@ -1,0 +1,22 @@
+# Test patterns (Bernstein)
+
+- Test runner: `uv run python scripts/run_tests.py -x`.
+- Single test file: `uv run pytest tests/unit/test_foo.py -x -q`.
+- NEVER run `uv run pytest tests/ -x -q` — it leaks 100+ GB RAM across the full suite.
+
+## Structure
+- Unit tests live in `tests/unit/`.
+- Integration tests live in `tests/integration/` and may touch the network /
+  filesystem.
+- Use `pytest-asyncio` for async tests; mark them with `@pytest.mark.asyncio`.
+- Prefer fixtures over setup/teardown methods.
+
+## Style
+- Name tests after the scenario: `test_<thing>_<condition>_<expected>`.
+- Cover happy path, edge cases, and error paths in that order.
+- Mock external dependencies (HTTP, databases) — never internal logic.
+- Use `respx` for httpx mocking, `pytest-benchmark` for perf-sensitive code.
+
+## Regression tests
+- When fixing a bug, the failing test comes first. Commit the test + fix
+  together so the regression is captured in history.

--- a/templates/skills/backend/scripts/lint.sh
+++ b/templates/skills/backend/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Quick local lint cycle for backend changes.
+set -euo pipefail
+
+uv run ruff check src/
+uv run ruff format --check src/
+uv run pyright src/

--- a/templates/skills/ci-fixer/SKILL.md
+++ b/templates/skills/ci-fixer/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ci-fixer
+description: CI failures — read error, minimal fix, verify.
+trigger_keywords:
+  - ci
+  - github-actions
+  - failure
+  - lint
+  - type-error
+  - fix
+---
+
+# CI Fixer Skill
+
+Your sole job: read a CI failure report, make the minimal targeted fix,
+verify locally, and commit.
+
+## Specialization
+- Diagnosing CI failures from error output.
+- Making minimal, targeted fixes.
+- Verifying lint, format, and test compliance.
+
+## Work style
+1. Read the failure context in the task description carefully.
+2. Identify the root cause from the error output and affected files.
+3. Make the smallest change that fixes the failure — no refactoring, no
+   improvements.
+4. Verify locally before committing.
+
+## Rules
+- Fix ONLY what is broken. Do not touch unrelated files.
+- If a test is failing, fix the code, not the test — unless the test is
+  wrong.
+- If a lint rule is violated, fix the code to comply. Do not disable the
+  rule.
+- If a type error is reported, add or correct type annotations. Do not
+  use `type: ignore` unless there is no other option.
+- If a dependency is missing, add it to `pyproject.toml`.
+- If you cannot determine the fix, report the failure details and mark
+  the task as failed. Do not guess.
+
+## Project conventions
+- Python 3.12+, strict typing (Pyright strict). No `Any`, no untyped dicts.
+- Ruff: `uv run ruff check src/`, `uv run ruff format src/`.
+- Test runner: `uv run python scripts/run_tests.py -x` (NEVER
+  `uv run pytest tests/` directly).

--- a/templates/skills/devops/SKILL.md
+++ b/templates/skills/devops/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: devops
+description: DevOps — Docker, CI/CD, cloud infra, monitoring.
+trigger_keywords:
+  - devops
+  - docker
+  - ci
+  - github-actions
+  - deploy
+  - kubernetes
+  - helm
+  - prometheus
+references:
+  - ci-patterns.md
+  - docker-practices.md
+---
+
+# DevOps Engineering Skill
+
+You are a DevOps engineer. Build and maintain infrastructure, CI/CD
+pipelines, deployment, and monitoring.
+
+## Specialization
+- Docker and container orchestration
+- CI/CD pipelines (GitHub Actions, GitLab CI)
+- Cloud infrastructure (AWS, GCP, Azure)
+- Monitoring and alerting (Prometheus, Grafana, logging)
+- Deployment strategies (blue-green, canary, rolling)
+- Shell scripting and automation
+
+## Work style
+1. Read the task description and existing infra config before writing.
+2. Make infrastructure changes incremental and reversible.
+3. Test configuration locally before pushing (`docker build`, `compose up`).
+4. Use environment variables for secrets, never hardcode them.
+5. Document any new services, ports, or dependencies.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Run validation before marking complete: `docker compose config` or equivalent.
+- Never store secrets in git; use `.env` files excluded via `.gitignore`.
+- Pin dependency versions in Dockerfiles and CI configs.
+
+Call `load_skill(name="devops", reference="ci-patterns.md")` for GitHub
+Actions guidance, or `reference="docker-practices.md"` for image
+hardening.

--- a/templates/skills/devops/references/ci-patterns.md
+++ b/templates/skills/devops/references/ci-patterns.md
@@ -1,0 +1,18 @@
+# CI patterns (GitHub Actions)
+
+- Pin action versions by SHA, not tag, for supply-chain safety.
+- Use `permissions:` on every workflow; default to `contents: read`.
+- Cache `uv` / `pip` / `npm` artefacts by lockfile hash.
+- Run lint / format / type checks in parallel with tests.
+- Fail fast: mark non-essential jobs `continue-on-error: false` unless they
+  really are optional.
+- Upload artefacts (coverage, logs) with a short retention (7-14 days).
+
+## Reusable workflows
+- Factor shared steps into composite actions or reusable workflows.
+- Keep matrices narrow — every combination costs CI minutes.
+
+## Concurrency
+- Use `concurrency: ${{ github.ref }}` with `cancel-in-progress: true` for
+  PR workflows so pushes cancel stale runs.
+- Never cancel-in-progress on `main` — partially-run deploys corrupt state.

--- a/templates/skills/devops/references/docker-practices.md
+++ b/templates/skills/devops/references/docker-practices.md
@@ -1,0 +1,17 @@
+# Docker image hardening
+
+- Start from a slim base (`python:3.12-slim`, `alpine` when libc compat OK).
+- Pin base images by digest, not tag.
+- Run as a non-root user; create `appuser` in the image.
+- Use multi-stage builds; final image contains only runtime artefacts.
+- Copy `pyproject.toml` / `uv.lock` separately from source to maximise
+  build-cache reuse.
+- Do NOT bake secrets — inject via runtime env or a mounted file.
+- Add `HEALTHCHECK` instructions for long-running services.
+- Scan the final image (`trivy image`, `grype`) in CI.
+
+## Compose / Kubernetes
+- Declare readiness and liveness probes separately.
+- Set resource requests and limits; missing limits let one container
+  starve the node.
+- Prefer rolling updates with `maxUnavailable: 0` for stateless services.

--- a/templates/skills/docs/SKILL.md
+++ b/templates/skills/docs/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: docs
+description: Documentation — README, API docs, ADRs, tutorials.
+trigger_keywords:
+  - docs
+  - documentation
+  - readme
+  - tutorial
+  - changelog
+  - adr
+  - docstring
+references:
+  - docstring-style.md
+  - doc-structure.md
+scripts:
+  - check-links.sh
+---
+
+# Documentation Engineering Skill
+
+You are a documentation engineer. Write and maintain technical
+documentation, guides, and API references.
+
+## Specialization
+- README files and getting-started guides
+- API documentation (OpenAPI, docstrings)
+- Architecture decision records (ADRs)
+- Tutorials, how-tos, and runbooks
+- Inline code documentation and type annotations
+- Changelog and release notes
+
+## Work style
+1. Read the task description and existing docs before writing.
+2. Read the code being documented to ensure accuracy.
+3. Write for the target audience: developers, operators, or end users.
+4. Use concrete examples and runnable code snippets.
+5. Keep docs close to the code they describe.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Verify all code examples compile or run correctly.
+- Link to source files rather than duplicating large code blocks.
+- Use consistent formatting: Markdown, Google-style docstrings.
+
+Call `load_skill(name="docs", reference="docstring-style.md")` for the
+docstring conventions, or `reference="doc-structure.md"` for information
+architecture.

--- a/templates/skills/docs/references/doc-structure.md
+++ b/templates/skills/docs/references/doc-structure.md
@@ -1,0 +1,24 @@
+# Doc information architecture
+
+Adapted from Diátaxis. A complete knowledge base has all four of:
+
+- **Tutorials** — learning by doing, beginner-oriented.
+- **How-to guides** — task-oriented, assume competence.
+- **Reference** — dry, exhaustive, machine-friendly.
+- **Explanation** — understanding-oriented, describes "why".
+
+## Structure
+```
+docs/
+  tutorials/        # beginner-first, single focused journey
+  how-to/           # cookbook entries
+  reference/        # API, CLI, config schemas
+  architecture/     # ADRs, explanations, decision logs
+  faq.md            # short, discoverable answers
+```
+
+## Hygiene
+- A README links to every top-level directory.
+- Every public API has reference-level coverage.
+- Tutorials stay short; long ones are split into chapters.
+- Explanations are dated — architecture evolves.

--- a/templates/skills/docs/references/docstring-style.md
+++ b/templates/skills/docs/references/docstring-style.md
@@ -1,0 +1,33 @@
+# Docstring style (Google)
+
+- Only where non-obvious — a typed, well-named helper does not need a
+  docstring that restates its signature.
+- Google style:
+
+```python
+def fetch(url: str, *, timeout: float = 5.0) -> Response:
+    """Fetch the URL and return the parsed response.
+
+    Args:
+        url: Absolute http(s) URL.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        Parsed ``Response``.
+
+    Raises:
+        TimeoutError: When the server did not answer within ``timeout``.
+    """
+```
+
+- Imperative mood ("Fetch the URL…"), not descriptive ("Fetches…").
+- Document raised exceptions and keyword-only arguments.
+- For async functions, note the awaitable contract only when non-obvious.
+- Use ``Example:`` sections when the call site needs a pattern, not when
+  the signature is self-evident.
+
+## README / markdown
+- One ``H1`` per file.
+- Sentence-case headings.
+- Fenced code blocks always declare their language.
+- Links over footnotes; absolute URLs for external references.

--- a/templates/skills/docs/scripts/check-links.sh
+++ b/templates/skills/docs/scripts/check-links.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Basic markdown link check — lists broken relative links under docs/.
+set -euo pipefail
+
+fails=0
+while IFS= read -r -d '' md; do
+    while read -r target; do
+        [[ -z "$target" ]] && continue
+        # Strip anchor fragments.
+        file="${target%%#*}"
+        [[ -z "$file" ]] && continue
+        if [[ ! -e "$(dirname "$md")/$file" ]] && [[ ! -e "$file" ]]; then
+            echo "broken: $md -> $target"
+            fails=1
+        fi
+    done < <(grep -oE '\]\(([^)]+)\)' "$md" | sed -E 's/\]\((.*)\)/\1/' | grep -vE '^https?://|^mailto:')
+done < <(find docs -name '*.md' -print0)
+
+exit "$fails"

--- a/templates/skills/frontend/SKILL.md
+++ b/templates/skills/frontend/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: frontend
+description: React / Next.js UI, state, accessibility.
+trigger_keywords:
+  - frontend
+  - react
+  - nextjs
+  - typescript
+  - tailwind
+  - accessibility
+  - wcag
+references:
+  - a11y.md
+  - state-management.md
+---
+
+# Frontend Engineering Skill
+
+You are a frontend engineer. Build user interfaces, interactive components,
+and client-side logic.
+
+## Specialization
+- React / Next.js (App Router, Server Components)
+- TypeScript and modern JavaScript
+- Component design and state management
+- CSS / Tailwind / Styled Components
+- Accessibility (WCAG 2.1 AA)
+- Client-side performance and bundle optimization
+
+## Work style
+1. Read the task description and existing component code before writing.
+2. Build small, composable components with clear props interfaces.
+3. Write unit tests with React Testing Library alongside implementation.
+4. Use semantic HTML and ARIA attributes for accessibility.
+5. Keep styles co-located with components unless a design system exists.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Bernstein's core is Python; run `uv run python scripts/run_tests.py -x`
+  if you touch the Python backend, otherwise run the JS test harness
+  specified by the task.
+- If a design spec or mockup is referenced, match it precisely.
+- Prefer server components unless client interactivity is required.
+
+Call `load_skill(name="frontend", reference="a11y.md")` for the
+accessibility checklist, or `reference="state-management.md"` for
+state patterns.

--- a/templates/skills/frontend/references/a11y.md
+++ b/templates/skills/frontend/references/a11y.md
@@ -1,0 +1,12 @@
+# Accessibility checklist (WCAG 2.1 AA)
+
+- Every interactive element is reachable by keyboard.
+- Focus order follows visual order; focus is visible.
+- Semantic HTML first, ARIA second — use `<button>` not a clickable div.
+- Form inputs have `<label>` or `aria-label`.
+- Images declare `alt` (empty string for purely decorative images).
+- Color contrast ≥ 4.5:1 for body text, 3:1 for large text and UI icons.
+- Text resizes without loss of meaning up to 200%.
+- Error messages are announced to screen readers (`aria-live="polite"`).
+- No content flashes more than 3× per second.
+- Page title, headings, and landmarks form a navigable outline.

--- a/templates/skills/frontend/references/state-management.md
+++ b/templates/skills/frontend/references/state-management.md
@@ -1,0 +1,16 @@
+# State management patterns
+
+## Hierarchy
+1. **URL** — shareable, reloadable state (filters, pagination).
+2. **Server** — persistent data (React Query / tRPC cache).
+3. **Local component** — `useState`, `useReducer` for ephemeral UI state.
+4. **Context** — cross-component but scoped; avoid as a global store.
+5. **Global store** (Zustand, Redux Toolkit) — rare, last resort.
+
+## Rules of thumb
+- Lift state only as high as needed.
+- Keep derived values derived; do not duplicate in state.
+- Prefer controlled components for forms.
+- Memoize only after measuring; premature memoization hides bugs.
+- Async state belongs to a data-fetching library — do not reinvent
+  cancellation, staleness, and retry.

--- a/templates/skills/manager/SKILL.md
+++ b/templates/skills/manager/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: manager
+description: Planning — decompose goals, create tasks via task server.
+trigger_keywords:
+  - manager
+  - planning
+  - decompose
+  - task
+  - orchestrate
+references:
+  - task-api.md
+  - planning-rules.md
+---
+
+# Manager Skill
+
+You lead a team of AI coding agents. Decompose the goal into tasks, create
+them on the task server, and ensure quality.
+
+## Responsibilities
+1. **Analyze** — read the codebase to understand current state.
+2. **Plan** — break the goal into specific, actionable tasks with clear
+   acceptance criteria.
+3. **Create tasks** — POST each task to the task server API.
+4. **Verify** — include completion signals so the janitor can verify work.
+
+## Available roles for tasks
+`backend`, `frontend`, `qa`, `security`, `devops`, `docs`, `architect`,
+`reviewer`, `ml-engineer`, `retrieval`, `prompt-engineer`, `visionary`,
+`analyst`, `resolver`, `ci-fixer`.
+
+## Priority / scope / complexity
+- **Priority**: 1 = critical, 2 = normal, 3 = nice-to-have.
+- **Scope**: small (<30 min), medium (30-120 min), large (2-8 h).
+- **Complexity**: low, medium, high.
+
+## When done planning
+
+```bash
+curl -s -X POST http://127.0.0.1:8052/tasks/{YOUR_TASK_ID}/complete \
+  -H "Content-Type: application/json" \
+  -d '{"result_summary": "Created N tasks to achieve goal: ..."}'
+```
+
+Then exit.
+
+Call `load_skill(name="manager", reference="task-api.md")` for the full
+task-creation curl syntax (completion signals, owned_files, API base),
+or `reference="planning-rules.md"` for how to size tasks and avoid
+file-ownership collisions.

--- a/templates/skills/manager/references/planning-rules.md
+++ b/templates/skills/manager/references/planning-rules.md
@@ -1,0 +1,19 @@
+# Planning rules
+
+1. **Never assign two tasks to the same files** — prevents merge conflicts.
+2. **Break large tasks into small ones** (30-60 min each, max 120 min).
+3. **Include tests** in every implementation task or as separate QA tasks.
+4. **Every task has completion signals** so the janitor can verify.
+5. **Check `.sdd/backlog/open/`** for existing starter tickets —
+   incorporate them.
+6. Dependencies: note them in the description; the system handles ordering.
+7. **Include context hints** — for each task, list the specific files,
+   functions, and architectural decisions the assigned agent needs to
+   know. This eliminates agent orientation time.
+
+Example context hint:
+
+> You'll modify `TaskContextBuilder.build_context()` in
+> `src/bernstein/core/context.py`. It uses AST parsing via
+> `_parse_python_file()`. Related: `spawner.py` calls it during
+> prompt rendering.

--- a/templates/skills/manager/references/task-api.md
+++ b/templates/skills/manager/references/task-api.md
@@ -1,0 +1,40 @@
+# Task server API
+
+Base URL: **http://127.0.0.1:8052**
+
+## Create a task
+
+```bash
+curl -s -X POST http://127.0.0.1:8052/tasks \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Implement feature X",
+    "role": "backend",
+    "description": "Detailed description with acceptance criteria",
+    "priority": 2,
+    "scope": "medium",
+    "complexity": "medium",
+    "owned_files": ["src/path/to/file.py"],
+    "completion_signals": [
+      {"type": "path_exists", "value": "src/path/to/file.py"},
+      {"type": "test_passes", "value": "uv run pytest tests/unit/test_file.py -x -q"}
+    ]
+  }'
+```
+
+## Completion-signal types
+
+- `path_exists` — file / directory must exist.
+- `test_passes` — shell command must exit 0.
+- `file_contains` — file must contain the string. Format: `path :: needle`.
+- `glob_exists` — at least one file matching the glob must exist.
+
+## Other endpoints
+
+- `GET  /tasks?status=open` — list by status.
+- `POST /tasks/{id}/complete` — mark done.
+- `POST /tasks/{id}/fail` — mark failed.
+- `POST /tasks/{id}/progress` — report progress (files_changed,
+  tests_passing, errors).
+- `POST /bulletin` — cross-agent finding / blocker.
+- `GET  /bulletin?since={ts}` — recent bulletins.

--- a/templates/skills/ml-engineer/SKILL.md
+++ b/templates/skills/ml-engineer/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ml-engineer
+description: ML — training, inference, embeddings, evaluation.
+trigger_keywords:
+  - ml
+  - model
+  - pytorch
+  - transformers
+  - embedding
+  - rag
+  - finetune
+  - evaluation
+references:
+  - evaluation.md
+  - reproducibility.md
+---
+
+# ML Engineering Skill
+
+You are an ML engineer. Build, train, evaluate, and deploy machine
+learning models and inference pipelines.
+
+## Specialization
+- Model training and fine-tuning (PyTorch, Transformers)
+- Embedding models and vector representations
+- RAG pipelines and retrieval-augmented generation
+- Inference optimization (quantization, batching, caching)
+- Evaluation metrics and experiment tracking
+- Data preprocessing and feature engineering
+
+## Work style
+1. Read the task description and existing pipeline code before writing.
+2. Start with a clear hypothesis and success metric for every change.
+3. Write deterministic tests for data transforms and scoring logic.
+4. Keep model configuration separate from training/inference code.
+5. Log metrics, parameters, and artifacts for reproducibility.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Run tests before marking complete: `uv run python scripts/run_tests.py -x`.
+- Never commit model weights or large data files to git.
+- Document any new dependencies in `pyproject.toml`.
+
+Call `load_skill(name="ml-engineer", reference="evaluation.md")` for
+metric guidance, or `reference="reproducibility.md"` for experiment
+tracking rules.

--- a/templates/skills/ml-engineer/references/evaluation.md
+++ b/templates/skills/ml-engineer/references/evaluation.md
@@ -1,0 +1,20 @@
+# ML evaluation
+
+## Metric selection
+- Classification: accuracy only when classes are balanced. Prefer F1,
+  precision-at-K, ROC-AUC otherwise.
+- Regression: MAE / RMSE; add R² only to compare models on the same data.
+- Retrieval: recall@K, MRR, nDCG.
+- Generation: human eval > automatic eval. BLEU/ROUGE are weak signals for
+  modern LLMs.
+
+## Protocol
+- Split data before anything else; never tune on the test set.
+- Fix the random seed for every component (data, model init, dropout).
+- Use stratified splits when class imbalance is > 10:1.
+- Compare against at least one baseline (random / majority / last-known-good).
+
+## Statistical rigour
+- Report confidence intervals, not just point estimates.
+- Use bootstrapping for small test sets.
+- A 0.1 point improvement is probably noise unless you have 1k+ samples.

--- a/templates/skills/ml-engineer/references/reproducibility.md
+++ b/templates/skills/ml-engineer/references/reproducibility.md
@@ -1,0 +1,14 @@
+# Reproducibility checklist
+
+- Pin random seeds (`numpy`, `torch`, `random`, `PYTHONHASHSEED`).
+- Record library versions (`uv pip freeze > artefact.txt`).
+- Capture hardware (GPU model, CUDA, cuDNN) in the run metadata.
+- Log the input data checksum, not the data.
+- Save optimizer state + scheduler state with every checkpoint.
+- Evaluation runs are their own commits — never "re-run to reproduce".
+
+## Experiment tracking
+- One run = one config file + one result file.
+- Configs live in YAML under `experiments/`.
+- Results go to `.sdd/metrics/ml/<run_id>.json`.
+- Version configs; do not edit in place.

--- a/templates/skills/prompt-engineer/SKILL.md
+++ b/templates/skills/prompt-engineer/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: prompt-engineer
+description: LLM prompts — design, evaluate, tune instructions.
+trigger_keywords:
+  - prompt
+  - system-prompt
+  - few-shot
+  - chain-of-thought
+  - evaluation
+---
+
+# Prompt Engineering Skill
+
+You are a prompt engineer. Design, test, and optimize LLM prompts and
+system instructions.
+
+## Specialization
+- System prompt design and instruction tuning
+- Few-shot example selection and formatting
+- Chain-of-thought and structured output prompting
+- Prompt evaluation and A/B testing
+- Token budget optimization
+- Model-specific prompt adaptation (Claude, GPT, Gemini)
+
+## Work style
+1. Read the task description and existing prompts before writing.
+2. State a clear hypothesis for every prompt change.
+3. Write evaluation cases alongside prompt changes.
+4. Minimize token usage without sacrificing output quality.
+5. Keep prompts in template files, not embedded in application code.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Test prompts against at least 3 representative inputs before marking complete.
+- Document the intent and expected behavior of each prompt section.
+- Never hardcode model-specific hacks without a comment explaining why.
+- If blocked, post to BULLETIN and move to next task.

--- a/templates/skills/qa/SKILL.md
+++ b/templates/skills/qa/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: qa
+description: Test writing — pytest suites, edge cases, regressions.
+trigger_keywords:
+  - pytest
+  - qa
+  - test
+  - regression
+  - integration
+  - coverage
+references:
+  - test-strategy.md
+  - edge-cases.md
+---
+
+# QA Engineering Skill
+
+You are a QA engineer. Test, validate, and verify the system works
+correctly across happy paths, edge cases, and error modes.
+
+## Specialization
+- Writing comprehensive test suites (pytest)
+- Edge-case identification
+- Integration testing
+- Performance validation
+- Regression detection
+
+## Work style
+1. Read the code under test before writing tests.
+2. Cover happy path, edge cases, and error paths.
+3. Use descriptive test names that explain the scenario.
+4. Mock external dependencies, not internal logic.
+5. Run the full test suite to check for regressions.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Run tests before marking complete: `uv run python scripts/run_tests.py -x`.
+- If you find a bug while testing, document it as a failing test, then fix.
+- If blocked, post to BULLETIN and move to next task.
+
+Call `load_skill(name="qa", reference="test-strategy.md")` for layered
+testing guidance, or `reference="edge-cases.md"` for a checklist of
+boundary cases worth exercising.

--- a/templates/skills/qa/references/edge-cases.md
+++ b/templates/skills/qa/references/edge-cases.md
@@ -1,0 +1,17 @@
+# Edge-case checklist (Bernstein)
+
+When writing a new test suite, walk through this list and cover what's
+relevant:
+
+- Empty input (`[]`, `""`, `None`).
+- Single-element collections.
+- Boundary values (off-by-one, `0`, `-1`, `MAX_INT`).
+- Unicode, non-ASCII, and RTL scripts in text fields.
+- Timezones — naive datetimes vs. aware UTC.
+- Paths with spaces, unicode, and traversal (`../`) attempts.
+- Concurrent access — two calls racing on the same resource.
+- Large inputs — 1 MB strings, 10 000-item lists.
+- Network errors — timeout, refused, partial read, malformed JSON.
+- Partial failures — half the batch succeeds, half fails.
+- Idempotency — retrying the same operation twice.
+- Permissions — the caller is missing one specific scope.

--- a/templates/skills/qa/references/test-strategy.md
+++ b/templates/skills/qa/references/test-strategy.md
@@ -1,0 +1,26 @@
+# Test strategy (Bernstein)
+
+## Layers
+
+- **Unit** (`tests/unit/`) — one module under test, fast, mocked boundaries.
+- **Integration** (`tests/integration/`) — multiple modules, may touch disk
+  or the task server.
+- **Contract** (`tests/protocol/`) — verifies API schema stability.
+- **Pentest** (`tests/pentest/`) — adversarial, verifies no prompt injection
+  or credential leakage.
+
+## Running
+- `uv run python scripts/run_tests.py -x` — isolated per file, prevents
+  memory leaks.
+- `uv run pytest tests/unit/test_foo.py -x -q` — single file.
+- NEVER `uv run pytest tests/ -x -q` — leaks 100+ GB RAM on the full suite.
+
+## Coverage
+- Prefer meaningful assertions over high coverage percentages.
+- A well-named failing test is better than a green test with vague asserts.
+
+## Async / flaky
+- `pytest.mark.asyncio` for coroutines.
+- `pytest-timeout` to pin runtimes on CI.
+- Flaky tests get fixed, not retried. Quarantine to `tests/quarantine/` if
+  you need to ship first, then file a follow-up.

--- a/templates/skills/resolver/SKILL.md
+++ b/templates/skills/resolver/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: resolver
+description: Git merge conflicts — resolve without losing intent.
+trigger_keywords:
+  - merge
+  - conflict
+  - resolver
+  - rebase
+  - three-way
+---
+
+# Merge Conflict Resolver Skill
+
+You resolve git merge conflicts between concurrent agent branches.
+
+## Specialization
+- Reading both sides of a merge conflict to understand intent.
+- Determining which changes to keep, combine, or rewrite.
+- Preserving correctness from both branches.
+- Ensuring the resolved code compiles, passes types, and maintains tests.
+
+## Work style
+1. Read the conflict markers and surrounding context for each file.
+2. Understand what each side was trying to accomplish.
+3. Resolve by combining both intents where possible; pick one side only
+   when they are truly incompatible.
+4. After resolving all conflicts, run any available tests to verify.
+5. Stage resolved files and commit.
+
+## Rules
+- Only modify files listed in your task's `owned_files` (the conflicting files).
+- Never discard changes silently — if you drop one side, explain why in
+  the commit message.
+- Prefer combining both sides over picking a winner.
+- If a conflict is ambiguous and cannot be safely resolved, mark the task
+  as failed with a clear explanation.
+- Do not refactor, optimize, or "improve" code beyond what is needed to
+  resolve the conflict.

--- a/templates/skills/retrieval/SKILL.md
+++ b/templates/skills/retrieval/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: retrieval
+description: Retrieval — vector DBs, embeddings, hybrid search, reranking.
+trigger_keywords:
+  - retrieval
+  - rag
+  - qdrant
+  - pinecone
+  - weaviate
+  - embedding
+  - reranker
+  - bm25
+references:
+  - hybrid-search.md
+  - chunking.md
+---
+
+# Retrieval Engineering Skill
+
+You are a retrieval engineer. Build and optimize search, indexing, and
+retrieval systems.
+
+## Specialization
+- Vector databases (Qdrant, Pinecone, Weaviate)
+- Embedding pipelines and chunking strategies
+- Hybrid search (dense + sparse retrieval)
+- Reranking models and relevance tuning
+- Query understanding and expansion
+- Index management and ingestion pipelines
+
+## Work style
+1. Read the task description and existing retrieval code before writing.
+2. Measure recall and precision before and after every change.
+3. Write tests for query construction, filtering, and result parsing.
+4. Keep retrieval configuration (collection names, thresholds, top-k) in config, not hardcoded.
+5. Profile latency for any new retrieval path.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Run tests before marking complete: `uv run python scripts/run_tests.py -x`.
+- Never lower recall without explicit approval from the manager.
+- Document any new index schemas or collection changes.
+
+Call `load_skill(name="retrieval", reference="hybrid-search.md")` for
+the dense+sparse pattern, or `reference="chunking.md"` for chunk sizing
+rules.

--- a/templates/skills/retrieval/references/chunking.md
+++ b/templates/skills/retrieval/references/chunking.md
@@ -1,0 +1,22 @@
+# Chunking
+
+## Size
+- 200-400 tokens for dense retrieval over prose.
+- 500-800 tokens for code or structured data.
+- Too small: over-retrieves, rerank has nothing to work with.
+- Too large: dilutes relevance, exhausts context budget downstream.
+
+## Overlap
+- 10-20% overlap between consecutive chunks.
+- Larger overlap for long-form narrative; smaller for reference material.
+
+## Boundaries
+- Respect semantic boundaries: paragraph > sentence > hard-break > token.
+- Never split mid-code-block.
+- For Markdown, prefer heading-anchored chunks so each is self-contained.
+
+## Metadata
+- Store `source_path`, `source_sha`, `chunk_index`, `heading_path`.
+- Keep original offsets so reranking / highlighting can reconstruct the
+  source region.
+- Re-ingest when source files change; stale chunks poison recall.

--- a/templates/skills/retrieval/references/hybrid-search.md
+++ b/templates/skills/retrieval/references/hybrid-search.md
@@ -1,0 +1,25 @@
+# Hybrid search (dense + sparse)
+
+## Why both
+- **Dense** catches paraphrase, concept overlap, multilingual query/doc
+  drift.
+- **Sparse** (BM25 / SPLADE) catches rare tokens, exact phrasing, IDs.
+- Hybrid wins on out-of-distribution queries where either alone loses.
+
+## Fusion
+- **Reciprocal Rank Fusion** (RRF) is the safe default — no tuning.
+- **Weighted linear** only works when scores are calibrated; normalize
+  per-query first.
+- **Learned-to-rank** pays off at scale but needs training data.
+
+## Pipeline
+1. Retrieve top-N from each system (N=100-200).
+2. Fuse into a candidate set (top-K, K=25-50).
+3. Optional: cross-encoder rerank down to top-k (k=5-10).
+
+## Pitfalls
+- BM25 over a tokenizer that disagrees with the embedding model will drift.
+- Duplicate docs (same chunk ingested twice) corrupt both recall and
+  reranker training.
+- Filter pushdown before retrieval, not after — post-filtering discards
+  quality candidates.

--- a/templates/skills/reviewer/SKILL.md
+++ b/templates/skills/reviewer/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: reviewer
+description: Code review — correctness, tests, merge-readiness.
+trigger_keywords:
+  - review
+  - pr
+  - feedback
+  - approve
+  - request-changes
+  - quality
+references:
+  - review-rubric.md
+  - feedback-tone.md
+---
+
+# Code Reviewer Skill
+
+You are a code reviewer. Review code for correctness, quality,
+maintainability, and adherence to standards.
+
+## Specialization
+- Code correctness and logic verification
+- Style consistency and coding standards enforcement
+- Performance and security review
+- Test coverage and test quality assessment
+- API design and interface review
+- Merge readiness evaluation
+
+## Work style
+1. Read the task description to understand what was changed and why.
+2. Read the diff or changed files thoroughly before commenting.
+3. Distinguish blocking issues from suggestions and nits.
+4. Provide specific, actionable feedback with examples or fixes.
+5. Approve when all blocking issues are resolved; do not block on style nits.
+
+## Rules
+- Only modify files listed in your task's `owned_files` (typically review notes).
+- Classify feedback: blocking / suggestion / nit.
+- Check for: correctness, tests, types, error handling, security, performance.
+- Verify the change does what the task description asks for.
+- If a critical defect is found, post to BULLETIN immediately.
+
+Call `load_skill(name="reviewer", reference="review-rubric.md")` for the
+rubric, or `reference="feedback-tone.md"` for tone guidance.

--- a/templates/skills/reviewer/references/feedback-tone.md
+++ b/templates/skills/reviewer/references/feedback-tone.md
@@ -1,0 +1,20 @@
+# Feedback tone and severity
+
+## Labels
+- **blocking** — merge cannot proceed without addressing this.
+- **suggestion** — would improve the change; author's call.
+- **nit** — preference or micro-optimisation; never blocks.
+- **question** — asking for context; not a request to change code.
+
+## Style
+- Lead with the problem, not the fix. "This unbounded loop can OOM on
+  large inputs" beats "Change to `for i, item in enumerate(batch[:100]):`".
+- Offer an alternative when you reject an approach.
+- Use "we" when the convention is shared; "I'd suggest" when it's personal taste.
+- No sarcasm, no snark — even when the bug is avoidable.
+- Approve when blockers are green; do not hold open PRs over nits.
+
+## When to re-request review
+- Author pushed a fix for a blocker → reviewer re-runs the rubric.
+- Reviewer made a mistake → reviewer retracts publicly.
+- Scope grew beyond the original description → reviewer can request a split.

--- a/templates/skills/reviewer/references/review-rubric.md
+++ b/templates/skills/reviewer/references/review-rubric.md
@@ -1,0 +1,31 @@
+# Review rubric
+
+Grade each PR across these axes. Blockers must all be green before merge.
+
+## Correctness (blocking)
+- Behavior matches the task description.
+- Edge cases and error paths covered.
+- No obvious race conditions or resource leaks.
+
+## Tests (blocking)
+- New logic has tests; regression tests added for bug fixes.
+- Tests actually assert behaviour (not `assert True`).
+- Test runner passes: `uv run python scripts/run_tests.py -x`.
+
+## Types (blocking)
+- Pyright strict clean.
+- No gratuitous `# type: ignore` without an inline justification.
+
+## Security (blocking when risk is high)
+- No secrets in diff.
+- Input validation at trust boundaries.
+- Auth scopes enforced where expected.
+
+## Style (suggestion)
+- Ruff clean.
+- Docstrings for public API.
+- Conventional commit messages.
+
+## Performance (suggestion unless regression)
+- Obvious O(n²) where O(n) is trivial.
+- New DB queries indexed / bounded.

--- a/templates/skills/security/SKILL.md
+++ b/templates/skills/security/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: security
+description: Security review — OWASP, auth, secrets, input validation.
+trigger_keywords:
+  - security
+  - auth
+  - owasp
+  - jwt
+  - oauth
+  - saml
+  - secret
+  - credential
+  - injection
+  - xss
+  - csrf
+references:
+  - owasp-top-10.md
+  - auth-checklist.md
+  - secrets-handling.md
+---
+
+# Security Engineering Skill
+
+You are a security engineer. Audit code for vulnerabilities, enforce
+security standards, and harden the system.
+
+## Specialization
+- Authentication and authorization (OAuth, JWT, RBAC, SAML)
+- OWASP Top 10 and common vulnerability patterns
+- Input validation and output encoding
+- Secrets management and credential rotation
+- Dependency vulnerability scanning
+- Compliance auditing and security documentation
+
+## Work style
+1. Read the task description and relevant code before auditing.
+2. Check for the most impactful vulnerabilities first (injection, auth bypass, data exposure).
+3. Provide concrete fix recommendations with code, not just findings.
+4. Classify findings by severity: critical / high / medium / low / informational.
+5. Verify fixes do not break existing functionality.
+
+## Rules
+- Only modify files listed in your task's `owned_files`.
+- Run tests before marking complete: `uv run python scripts/run_tests.py -x`.
+- Never introduce new secrets into source code.
+- If a critical vulnerability is found, post immediately to BULLETIN.
+
+Call `load_skill(name="security", reference="owasp-top-10.md")` for the
+full OWASP checklist, `reference="auth-checklist.md"` when reviewing
+authentication, or `reference="secrets-handling.md"` for secret-storage
+patterns.

--- a/templates/skills/security/references/auth-checklist.md
+++ b/templates/skills/security/references/auth-checklist.md
@@ -1,0 +1,26 @@
+# Authentication review checklist
+
+## Tokens
+- JWT: reject `alg=none`, verify signature, enforce `exp` and `nbf`.
+- Refresh tokens rotate on use; revoke on logout and on detected reuse.
+- Bearer tokens never appear in query strings or referrers.
+
+## Sessions
+- Cookies: `Secure`, `HttpOnly`, `SameSite=Lax` minimum.
+- Idle timeout + absolute timeout, both enforced server-side.
+- Session IDs re-generated on privilege change.
+
+## OAuth / OIDC
+- Verify state and nonce.
+- Validate `iss`, `aud`, `exp`, `sub`.
+- Enforce PKCE for public clients.
+
+## SAML
+- Validate assertion signature with the IdP's cert.
+- Parse with a hardened XML parser (`defusedxml`).
+- Check `NotBefore` / `NotOnOrAfter` and single-use semantics.
+
+## Credentials
+- Bcrypt / Argon2 with a per-user salt.
+- Never log raw passwords or hashed passwords.
+- Rate-limit login and password-reset endpoints.

--- a/templates/skills/security/references/owasp-top-10.md
+++ b/templates/skills/security/references/owasp-top-10.md
@@ -1,0 +1,28 @@
+# OWASP Top 10 audit checklist
+
+Walk through every item when reviewing new code paths. Each finding gets
+a severity tag and a concrete fix recommendation.
+
+1. **Broken Access Control** — object-level authorization, path traversal,
+   force-browsing, IDOR.
+2. **Cryptographic Failures** — weak ciphers, missing TLS, hardcoded keys,
+   predictable randomness.
+3. **Injection** — SQL, NoSQL, LDAP, OS command, prompt injection.
+4. **Insecure Design** — threat model, abuse cases, rate-limiting gaps.
+5. **Security Misconfiguration** — default creds, verbose errors, open CORS,
+   disabled security headers.
+6. **Vulnerable Components** — outdated deps, unreviewed transitive packages.
+7. **Authentication Failures** — credential stuffing, missing MFA, weak
+   session handling, JWT `alg=none`.
+8. **Software and Data Integrity Failures** — unsigned releases, supply
+   chain (package substitution, dependency confusion).
+9. **Logging and Monitoring Failures** — missing audit trail, PII in logs.
+10. **Server-Side Request Forgery** — unrestricted fetches to internal
+    hosts, metadata endpoints.
+
+## Severity guide
+- **Critical** — remote code execution, auth bypass, mass data leak.
+- **High** — targeted data leak, privilege escalation with interaction.
+- **Medium** — information disclosure without credentials involved.
+- **Low** — defence-in-depth issues, hardening opportunities.
+- **Informational** — best-practice suggestions.

--- a/templates/skills/security/references/secrets-handling.md
+++ b/templates/skills/security/references/secrets-handling.md
@@ -1,0 +1,21 @@
+# Secrets handling
+
+## Storage
+- Environment variables for runtime secrets; `.env` files are developer-only.
+- Secrets-manager for long-lived credentials (Vault, AWS Secrets Manager).
+- Never commit secrets — audit with `ggshield` / `trufflehog` before push.
+
+## Rotation
+- Scheduled rotation for IAM credentials, database passwords, API tokens.
+- Rotation must not require downtime; use dual-keying.
+
+## Access
+- Principle of least privilege for per-agent scoping
+  (`src/bernstein/core/credential_scoping.py`).
+- Audit who read each secret; store the event in the HMAC audit log.
+
+## In-code hygiene
+- Redact secrets from logs and exception messages.
+- `repr()` of config objects must drop sensitive fields (use Pydantic
+  `SecretStr`).
+- Cryptographic nonces come from `secrets.token_bytes`, never `random`.

--- a/templates/skills/visionary/SKILL.md
+++ b/templates/skills/visionary/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: visionary
+description: Ideation — generate bold feature proposals.
+trigger_keywords:
+  - visionary
+  - ideation
+  - pitch
+  - proposal
+---
+
+# Product Visionary Skill
+
+You think like a product visionary. You have deep technical knowledge but
+your job is to imagine, not implement. You challenge assumptions. You
+think from the USER's perspective, not the code's.
+
+## Your job
+Generate bold, concrete feature proposals that would make developers love
+this tool. You are not here to fix bugs or add docstrings. You are here
+to find the 10× ideas that nobody asked for but everybody needs.
+
+## How you think
+- What would make developers LOVE this tool?
+- What's the feature nobody asked for that changes everything?
+- What's broken about the UX / DX that nobody noticed because they got
+  used to it?
+- What would a competitor build that makes this tool irrelevant?
+- What's the "one more thing" moment?
+
+## Output format
+For each proposal, produce structured JSON with these fields:
+
+- `title`: one-line pitch
+- `why`: the user problem it solves
+- `what`: concrete feature description
+- `impact`: how it changes the user experience (not implementation details)
+- `risk`: what could go wrong
+- `effort_estimate`: `S`, `M`, or `L`
+
+## Rules
+- Generate 3-5 proposals per session.
+- Think big but stay grounded — proposals must be technically possible.
+- Focus on user value, not code elegance.
+- Each proposal is independent — no dependency chains.
+- No incremental improvements — those belong in the regular evolution loop.
+- If you can't articulate the user benefit in one sentence, the idea isn't ready.

--- a/templates/skills/vp/SKILL.md
+++ b/templates/skills/vp/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: vp
+description: Cross-cell coordination — resolve conflicts, decide pivots.
+trigger_keywords:
+  - vp
+  - vice-president
+  - cells
+  - pivot
+  - escalation
+  - cross-cell
+references:
+  - pivot-evaluation.md
+  - cell-decomposition.md
+---
+
+# VP (Vice President) Skill
+
+You are the top-level coordinator overseeing multiple cells, each led by
+its own Manager. Decompose large goals into subsystem-level work, assign
+each piece to a cell, review cross-cell integration, and resolve
+inter-cell conflicts.
+
+## Responsibilities
+1. **Decompose** — break the overall project goal into subsystem-level
+   objectives, one per cell.
+2. **Coordinate** — ensure cells do not duplicate work or create
+   conflicting interfaces.
+3. **Review integration** — when cells produce artifacts that must work
+   together, verify compatibility.
+4. **Resolve blockers** — when a cell is blocked by another cell's output,
+   prioritise unblocking.
+5. **Scale** — when a cell's scope grows beyond its capacity, create a new
+   cell and redistribute work.
+
+## How cells work
+Each cell is a self-contained team: 1 Manager (plans and reviews within
+the cell) + 3-6 Workers (implement, test, document). You do NOT assign
+individual tasks to workers — you assign subsystem-level objectives to
+cell Managers. They decompose and delegate internally.
+
+## Communication
+- Read the bulletin board (`GET /bulletin?since={ts}`) every cycle.
+- Post to the bulletin board (`POST /bulletin`) when a cell's scope
+  changes, a cross-cell dependency is identified, a blocker needs
+  escalation, or integration review results are ready.
+- Message types: `alert`, `blocker`, `finding`, `status`, `dependency`.
+
+## Rules
+1. Never micromanage cell internals — trust Managers.
+2. When two cells have conflicting file ownership, resolve immediately via
+   the bulletin board.
+3. If a cell fails the same objective twice, reassign or restructure.
+4. Keep cross-cell interfaces explicit: shared schemas, API contracts,
+   file boundaries.
+5. Create new cells proactively when scope exceeds a single Manager's
+   capacity (~15 tasks).
+
+## Current state
+- **Cells**: {{CELLS}}
+- **Goal**: {{GOAL}}
+- **Project**: {{PROJECT_STATE}}
+
+Call `load_skill(name="vp", reference="pivot-evaluation.md")` when a
+pivot signal is routed to you, or `reference="cell-decomposition.md"`
+when splitting work across cells.

--- a/templates/skills/vp/references/cell-decomposition.md
+++ b/templates/skills/vp/references/cell-decomposition.md
@@ -1,0 +1,24 @@
+# Cell decomposition
+
+When deciding how to split work across cells:
+
+- Each cell owns a coherent subsystem (auth, API, ML pipeline, frontend, …).
+- Minimise cross-cell dependencies.
+- Each cell's work should be independently testable.
+- Prefer vertical slices (full feature in one cell) over horizontal splits
+  (layers across cells).
+
+## Signs a cell is too big
+- Manager spends more time routing tasks than reviewing outputs.
+- Multiple sub-domains share an owner.
+- Single-task latency grows because the backlog dominates routing.
+
+## Signs a cell is too small
+- One or two workers idle each cycle.
+- Manager burns cycles creating filler tasks.
+- Scope overlaps another cell's remit — they will collide on files soon.
+
+## When you redistribute work
+- Freeze in-flight tasks; move only the ones that haven't started.
+- Update `.sdd/cells.yaml` with the new ownership map.
+- Announce the change on the bulletin board so Managers don't double-book.

--- a/templates/skills/vp/references/pivot-evaluation.md
+++ b/templates/skills/vp/references/pivot-evaluation.md
@@ -1,0 +1,30 @@
+# Pivot evaluation
+
+When a pivot signal is routed to you (severity=high or affects 3+ tickets):
+
+1. **Read the pivot signal** — understand what was discovered, by whom,
+   during which task.
+2. **Assess affected tickets** — read each to understand current
+   assumptions.
+3. **Decide**:
+   - **APPROVE** — the pivot is valid; update affected ticket descriptions
+     and priorities as needed.
+   - **REJECT** — the pivot is noise or premature; add a note explaining
+     why and proceed as-is.
+   - **ESCALATE** — implications beyond your authority (budget, timeline,
+     external stakeholders); pause affected work and notify human.
+4. **Record your decision** — write to `.sdd/signals/vp_decisions.jsonl`.
+5. **Log ticket changes** — priority or scope changes go to
+   `.sdd/signals/ticket_changes.jsonl` with before/after values.
+
+## Evaluation criteria
+- Does the discovery invalidate core assumptions of the affected tickets?
+- Is the proposed action cheaper than continuing with stale assumptions?
+- How many in-progress agents would need to be interrupted?
+- Is there a simpler mitigation that avoids a full pivot?
+
+## Ticket mutation rules
+- Only the VP can change ticket priority or scope.
+- Any role can add context / notes to a ticket.
+- Closed / done tickets are never modified.
+- All changes logged with before / after values.

--- a/tests/unit/skills/__init__.py
+++ b/tests/unit/skills/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the progressive-disclosure skills package (oai-004)."""

--- a/tests/unit/skills/conftest.py
+++ b/tests/unit/skills/conftest.py
@@ -1,0 +1,128 @@
+"""Shared fixtures for skill-pack tests.
+
+Each test gets a fresh ``tmp_path/skills`` root populated with one or more
+synthetic skill packs. We keep fixtures tiny and deterministic so the
+token-reduction regression test has stable numbers.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def _write_skill(
+    root: Path,
+    name: str,
+    *,
+    description: str,
+    body: str,
+    references: dict[str, str] | None = None,
+    scripts: dict[str, str] | None = None,
+    trigger_keywords: list[str] | None = None,
+) -> Path:
+    """Materialise a skill directory under ``root`` for the test."""
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    front_lines = [
+        "---",
+        f"name: {name}",
+        "description: >-",
+        f"  {description}",
+    ]
+    if trigger_keywords:
+        front_lines.append("trigger_keywords:")
+        for kw in trigger_keywords:
+            front_lines.append(f"  - {kw}")
+    if references:
+        front_lines.append("references:")
+        for ref_name in references:
+            front_lines.append(f"  - {ref_name}")
+    if scripts:
+        front_lines.append("scripts:")
+        for script_name in scripts:
+            front_lines.append(f"  - {script_name}")
+    front_lines.append("---")
+    skill_md = skill_dir / "SKILL.md"
+    skill_md.write_text(
+        "\n".join(front_lines) + "\n\n" + body.strip() + "\n",
+        encoding="utf-8",
+    )
+
+    if references:
+        (skill_dir / "references").mkdir(exist_ok=True)
+        for ref_name, content in references.items():
+            (skill_dir / "references" / ref_name).write_text(content, encoding="utf-8")
+
+    if scripts:
+        (skill_dir / "scripts").mkdir(exist_ok=True)
+        for script_name, content in scripts.items():
+            (skill_dir / "scripts" / script_name).write_text(content, encoding="utf-8")
+
+    return skill_dir
+
+
+@pytest.fixture
+def write_skill() -> WriteSkillCallable:
+    """Return the helper for tests to create synthetic skills."""
+    return _write_skill
+
+
+@pytest.fixture
+def sample_skills_root(tmp_path: Path) -> Path:
+    """Populate ``tmp_path/skills`` with three tiny skills.
+
+    Tests that need a ready-to-load tree use this instead of wiring up
+    fixtures by hand.
+    """
+    root = tmp_path / "skills"
+    root.mkdir()
+    _write_skill(
+        root,
+        "alpha",
+        description="Alpha skill — simple test skill with references and scripts.",
+        body=textwrap.dedent(
+            """
+            # Alpha skill
+            You are the alpha skill. Use references for deeper guidance.
+            """
+        ),
+        references={
+            "deep-dive.md": "# Deep dive for alpha\nDetailed content.",
+        },
+        scripts={
+            "hello.sh": "#!/usr/bin/env bash\necho hello from alpha\n",
+        },
+        trigger_keywords=["alpha", "test"],
+    )
+    _write_skill(
+        root,
+        "beta",
+        description="Beta skill — second skill without references.",
+        body="# Beta skill body",
+    )
+    _write_skill(
+        root,
+        "gamma",
+        description="Gamma skill — third skill used for index testing only.",
+        body="# Gamma skill body",
+    )
+    return root
+
+
+class WriteSkillCallable:
+    """Type alias for the ``write_skill`` fixture."""
+
+    def __call__(  # pragma: no cover — typing helper only
+        self,
+        root: Path,
+        name: str,
+        *,
+        description: str,
+        body: str,
+        references: dict[str, str] | None = None,
+        scripts: dict[str, str] | None = None,
+        trigger_keywords: list[str] | None = None,
+    ) -> Path: ...

--- a/tests/unit/skills/test_index_builder.py
+++ b/tests/unit/skills/test_index_builder.py
@@ -1,0 +1,56 @@
+"""Tests for :func:`bernstein.core.skills.build_skill_index`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.index_builder import build_skill_index
+from bernstein.core.skills.loader import SkillLoader, SkillNotFoundError
+from bernstein.core.skills.sources import LocalDirSkillSource
+
+
+def _make_loader(root: Path) -> SkillLoader:
+    return SkillLoader([LocalDirSkillSource(root)])
+
+
+def test_index_contains_every_skill_name_and_description(sample_skills_root: Path) -> None:
+    loader = _make_loader(sample_skills_root)
+    index = build_skill_index(loader)
+
+    assert "- alpha:" in index
+    assert "- beta:" in index
+    assert "- gamma:" in index
+    # Descriptions appear verbatim.
+    assert "simple test skill" in index
+
+
+def test_index_highlights_primary_skill(sample_skills_root: Path) -> None:
+    loader = _make_loader(sample_skills_root)
+    index = build_skill_index(loader, highlight="beta")
+
+    # Primary skill uses a ``*`` marker; others use ``-``.
+    assert "* beta:" in index
+    # Primary skill appears before the others in the output.
+    beta_position = index.index("* beta:")
+    alpha_position = index.index("- alpha:")
+    assert beta_position < alpha_position
+
+
+def test_index_raises_when_highlight_is_unknown(sample_skills_root: Path) -> None:
+    loader = _make_loader(sample_skills_root)
+    with pytest.raises(SkillNotFoundError):
+        build_skill_index(loader, highlight="unknown")
+
+
+def test_index_empty_when_no_skills(tmp_path: Path) -> None:
+    loader = _make_loader(tmp_path / "empty")
+    assert build_skill_index(loader) == ""
+
+
+def test_index_header_mentions_skills_keyword(sample_skills_root: Path) -> None:
+    loader = _make_loader(sample_skills_root)
+    index = build_skill_index(loader)
+    # Terse header; agents learn the load_skill syntax from the role hint.
+    assert "Skills" in index

--- a/tests/unit/skills/test_load_skill_tool.py
+++ b/tests/unit/skills/test_load_skill_tool.py
@@ -1,0 +1,98 @@
+"""Tests for :func:`bernstein.core.skills.load_skill`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.skills.load_skill_tool import load_skill, result_as_dict
+from bernstein.core.skills.loader import SkillLoader
+from bernstein.core.skills.sources import LocalDirSkillSource
+
+
+def _loader(root: Path) -> SkillLoader:
+    return SkillLoader([LocalDirSkillSource(root)])
+
+
+def test_load_skill_returns_body_and_available_paths(sample_skills_root: Path) -> None:
+    result = load_skill(name="alpha", loader=_loader(sample_skills_root))
+
+    assert result.error is None
+    assert "Alpha skill" in result.body
+    assert result.available_references == ["deep-dive.md"]
+    assert result.available_scripts == ["hello.sh"]
+    assert result.reference_content is None
+    assert result.script_content is None
+
+
+def test_load_skill_returns_reference_content(sample_skills_root: Path) -> None:
+    result = load_skill(
+        name="alpha",
+        reference="deep-dive.md",
+        loader=_loader(sample_skills_root),
+    )
+
+    assert result.error is None
+    assert result.reference_content is not None
+    assert "Deep dive" in result.reference_content
+
+
+def test_load_skill_returns_script_content(sample_skills_root: Path) -> None:
+    result = load_skill(
+        name="alpha",
+        script="hello.sh",
+        loader=_loader(sample_skills_root),
+    )
+
+    assert result.error is None
+    assert result.script_content is not None
+    assert "#!/usr/bin/env bash" in result.script_content
+
+
+def test_load_skill_reports_missing_reference(sample_skills_root: Path) -> None:
+    result = load_skill(
+        name="alpha",
+        reference="missing.md",
+        loader=_loader(sample_skills_root),
+    )
+    assert result.error is not None
+    assert "missing.md" in result.error
+
+
+def test_load_skill_reports_unknown_skill(sample_skills_root: Path) -> None:
+    result = load_skill(name="nope", loader=_loader(sample_skills_root))
+    assert result.error is not None
+    assert "nope" in result.error
+
+
+def test_load_skill_emits_wal_event(sample_skills_root: Path) -> None:
+    events: list[dict[str, Any]] = []
+
+    def sink(event: dict[str, Any]) -> None:
+        events.append(event)
+
+    load_skill(name="alpha", loader=_loader(sample_skills_root), wal_sink=sink)
+
+    assert len(events) == 1
+    event = events[0]
+    assert event["event"] == "skill_loaded"
+    assert event["name"] == "alpha"
+    assert event["reference"] is None
+    assert event["source"].startswith("local")
+
+
+def test_load_skill_requires_loader_or_templates_dir() -> None:
+    with pytest.raises(ValueError):
+        load_skill(name="alpha")
+
+
+def test_result_as_dict_is_json_serializable(sample_skills_root: Path) -> None:
+    import json
+
+    result = load_skill(name="alpha", loader=_loader(sample_skills_root))
+    data = result_as_dict(result)
+    # Should not raise.
+    json.dumps(data)
+    assert data["name"] == "alpha"

--- a/tests/unit/skills/test_loader.py
+++ b/tests/unit/skills/test_loader.py
@@ -1,0 +1,91 @@
+"""Tests for :class:`bernstein.core.skills.SkillLoader`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.loader import (
+    DuplicateSkillError,
+    SkillLoader,
+    SkillNotFoundError,
+)
+from bernstein.core.skills.manifest import SkillManifest
+from bernstein.core.skills.source import SkillArtifact, SkillSource
+from bernstein.core.skills.sources import LocalDirSkillSource
+
+
+class _InMemorySource(SkillSource):
+    """Deterministic in-memory source used when testing conflict paths."""
+
+    def __init__(self, label: str, artifacts: list[SkillArtifact]) -> None:
+        self._label = label
+        self._artifacts = artifacts
+
+    @property
+    def name(self) -> str:
+        return self._label
+
+    def iter_skills(self) -> list[SkillArtifact]:
+        return list(self._artifacts)
+
+
+def _artifact(name: str, origin: str) -> SkillArtifact:
+    return SkillArtifact(
+        manifest=SkillManifest(
+            name=name,
+            description="A stub description exceeding twenty characters easily.",
+        ),
+        body=f"# body for {name}",
+        origin=origin,
+    )
+
+
+def test_loader_indexes_sources_in_order(sample_skills_root: Path) -> None:
+    local = LocalDirSkillSource(sample_skills_root)
+    loader = SkillLoader([local])
+
+    names = [s.name for s in loader.list_all()]
+    assert names == ["alpha", "beta", "gamma"]
+    assert loader.has("alpha") is True
+    assert loader.has("does-not-exist") is False
+
+
+def test_loader_raises_on_duplicate_name() -> None:
+    first = _InMemorySource("first", [_artifact("conflict", "from-first")])
+    second = _InMemorySource("second", [_artifact("conflict", "from-second")])
+
+    with pytest.raises(DuplicateSkillError) as excinfo:
+        SkillLoader([first, second])
+
+    err = excinfo.value
+    assert err.skill_name == "conflict"
+    assert err.first_origin == "from-first"
+    assert err.second_origin == "from-second"
+
+
+def test_loader_get_raises_skill_not_found_error() -> None:
+    loader = SkillLoader([_InMemorySource("only", [_artifact("alpha", "x")])])
+    with pytest.raises(SkillNotFoundError):
+        loader.get("missing")
+
+
+def test_loader_read_reference_delegates_to_owning_source(
+    sample_skills_root: Path,
+) -> None:
+    loader = SkillLoader([LocalDirSkillSource(sample_skills_root)])
+    content = loader.read_reference("alpha", "deep-dive.md")
+    assert "Deep dive" in content
+
+
+def test_loader_read_reference_errors_when_source_lacks_support() -> None:
+    loader = SkillLoader([_InMemorySource("only", [_artifact("alpha", "x")])])
+    with pytest.raises(RuntimeError):
+        loader.read_reference("alpha", "anything.md")
+
+
+def test_loader_find_source_for_returns_owning_source(sample_skills_root: Path) -> None:
+    local = LocalDirSkillSource(sample_skills_root, source_name="local-xyz")
+    loader = SkillLoader([local])
+    assert loader.find_source_for("alpha").name == "local-xyz"

--- a/tests/unit/skills/test_local_dir_source.py
+++ b/tests/unit/skills/test_local_dir_source.py
@@ -1,0 +1,88 @@
+"""Tests for :class:`LocalDirSkillSource`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.manifest import SkillManifestError
+from bernstein.core.skills.sources import LocalDirSkillSource
+
+
+def test_iter_skills_returns_empty_when_root_missing(tmp_path: Path) -> None:
+    source = LocalDirSkillSource(tmp_path / "missing")
+    assert source.iter_skills() == []
+
+
+def test_iter_skills_lists_every_skill_in_root(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+
+    artifacts = source.iter_skills()
+
+    names = [a.manifest.name for a in artifacts]
+    assert names == ["alpha", "beta", "gamma"]
+    assert all(a.body for a in artifacts)
+
+
+def test_iter_skills_rejects_mismatched_directory_name(tmp_path: Path, write_skill) -> None:
+    root = tmp_path / "skills"
+    root.mkdir()
+    # Create a skill where manifest name disagrees with the directory name.
+    skill_dir = root / "dir-name"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: different
+description: Description long enough to pass the 20-char minimum length check.
+---
+body""",
+        encoding="utf-8",
+    )
+
+    source = LocalDirSkillSource(root)
+
+    with pytest.raises(SkillManifestError):
+        source.iter_skills()
+
+
+def test_read_reference_returns_content(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    content = source.read_reference("alpha", "deep-dive.md")
+    assert "# Deep dive for alpha" in content
+
+
+def test_read_reference_raises_when_missing(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    with pytest.raises(FileNotFoundError):
+        source.read_reference("alpha", "missing.md")
+
+
+def test_read_reference_rejects_path_traversal(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    with pytest.raises(ValueError):
+        source.read_reference("alpha", "../../secrets.txt")
+
+
+def test_list_references_returns_sorted_filenames(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    refs = source.list_references("alpha")
+    assert refs == ["deep-dive.md"]
+
+
+def test_list_scripts_returns_sorted_filenames(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    scripts = source.list_scripts("alpha")
+    assert scripts == ["hello.sh"]
+
+
+def test_manifest_for_returns_none_for_missing_skill(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    assert source.manifest_for("does-not-exist") is None
+
+
+def test_manifest_for_returns_manifest_for_existing_skill(sample_skills_root: Path) -> None:
+    source = LocalDirSkillSource(sample_skills_root)
+    manifest = source.manifest_for("alpha")
+    assert manifest is not None
+    assert manifest.name == "alpha"

--- a/tests/unit/skills/test_manifest.py
+++ b/tests/unit/skills/test_manifest.py
@@ -1,0 +1,160 @@
+"""Tests for ``bernstein.core.skills.manifest``."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.manifest import (
+    SkillManifest,
+    SkillManifestError,
+    parse_skill_md,
+)
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    return path
+
+
+def test_parse_skill_md_round_trips_minimal_manifest(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        name: backend
+        description: Backend skill for server-side Python work covering APIs and data.
+        ---
+        # Body
+
+        Prose goes here.
+        """,
+    )
+
+    manifest, body = parse_skill_md(skill_md)
+
+    assert manifest.name == "backend"
+    assert manifest.description.startswith("Backend skill")
+    assert manifest.references == []
+    assert body.startswith("# Body")
+
+
+def test_parse_skill_md_accepts_optional_fields(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        name: qa
+        description: Quality assurance skill covering pytest, edge cases, and regressions.
+        trigger_keywords:
+          - pytest
+          - regression
+        references:
+          - checklist.md
+        scripts:
+          - run.sh
+        version: "2.1.0"
+        author: Team QA
+        ---
+        body
+        """,
+    )
+
+    manifest, _ = parse_skill_md(skill_md)
+
+    assert manifest.trigger_keywords == ["pytest", "regression"]
+    assert manifest.references == ["checklist.md"]
+    assert manifest.scripts == ["run.sh"]
+    assert manifest.version == "2.1.0"
+    assert manifest.author == "Team QA"
+
+
+def test_parse_skill_md_rejects_missing_frontmatter(tmp_path: Path) -> None:
+    skill_md = _write(tmp_path / "SKILL.md", "# no frontmatter here")
+
+    with pytest.raises(SkillManifestError) as excinfo:
+        parse_skill_md(skill_md)
+    assert "frontmatter" in str(excinfo.value)
+    assert excinfo.value.path == skill_md
+
+
+def test_parse_skill_md_rejects_invalid_name(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        name: Bad Name
+        description: This name contains spaces which violates the slug regex rule.
+        ---
+        body
+        """,
+    )
+
+    with pytest.raises(SkillManifestError) as excinfo:
+        parse_skill_md(skill_md)
+    assert "name" in str(excinfo.value).lower()
+
+
+def test_parse_skill_md_rejects_short_description(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        name: ok
+        description: too short
+        ---
+        body
+        """,
+    )
+
+    with pytest.raises(SkillManifestError):
+        parse_skill_md(skill_md)
+
+
+def test_parse_skill_md_rejects_unknown_keys(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        name: ok
+        description: A valid description that exceeds twenty characters in length.
+        keywords: [typo]
+        ---
+        body
+        """,
+    )
+
+    with pytest.raises(SkillManifestError):
+        parse_skill_md(skill_md)
+
+
+def test_parse_skill_md_rejects_non_mapping(tmp_path: Path) -> None:
+    skill_md = _write(
+        tmp_path / "SKILL.md",
+        """
+        ---
+        - name: not-a-dict
+        - description: But YAML list instead of mapping, so should fail.
+        ---
+        body
+        """,
+    )
+
+    with pytest.raises(SkillManifestError):
+        parse_skill_md(skill_md)
+
+
+def test_parse_skill_md_rejects_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(SkillManifestError):
+        parse_skill_md(tmp_path / "does-not-exist.md")
+
+
+def test_skill_manifest_is_immutable() -> None:
+    manifest = SkillManifest(
+        name="x",
+        description="A valid description for the immutability test harness.",
+    )
+    with pytest.raises((TypeError, ValueError)):
+        manifest.name = "y"  # type: ignore[misc]

--- a/tests/unit/skills/test_plugin_source.py
+++ b/tests/unit/skills/test_plugin_source.py
@@ -1,0 +1,119 @@
+"""Tests for the pluggy-style plugin source."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills.sources import (
+    PLUGIN_ENTRY_POINT_GROUP,
+    LocalDirSkillSource,
+    PluginSkillSource,
+    load_plugin_sources,
+)
+
+
+@dataclass
+class _FakeEntryPoint:
+    """Tiny stand-in for importlib.metadata.EntryPoint used in tests."""
+
+    name: str
+    target: object
+
+    def load(self) -> object:
+        return self.target
+
+
+def _patch_entry_points(monkeypatch: pytest.MonkeyPatch, eps: list[_FakeEntryPoint]) -> None:
+    def fake_entry_points(
+        *,
+        group: str | None = None,
+    ) -> Iterator[_FakeEntryPoint] | list[_FakeEntryPoint]:
+        assert group == PLUGIN_ENTRY_POINT_GROUP
+        return list(eps)
+
+    monkeypatch.setattr(
+        "bernstein.core.skills.sources.plugin.entry_points",
+        fake_entry_points,
+    )
+
+
+def test_load_plugin_sources_returns_wrapped_instance(
+    sample_skills_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inner = LocalDirSkillSource(sample_skills_root, source_name="custom-inner")
+
+    def factory() -> LocalDirSkillSource:
+        return inner
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("my-pack", factory)])
+
+    sources = load_plugin_sources()
+
+    assert len(sources) == 1
+    wrapped = sources[0]
+    assert isinstance(wrapped, PluginSkillSource)
+    assert wrapped.name == "plugin:my-pack"
+    assert wrapped.inner is inner
+    # Wrapped source iterates through the inner source.
+    artifacts = wrapped.iter_skills()
+    assert {a.manifest.name for a in artifacts} == {"alpha", "beta", "gamma"}
+
+
+def test_load_plugin_sources_accepts_instance_directly(
+    sample_skills_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    inner = LocalDirSkillSource(sample_skills_root, source_name="direct-instance")
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("direct", inner)])
+
+    sources = load_plugin_sources()
+    assert len(sources) == 1
+    assert sources[0].name == "plugin:direct"
+
+
+def test_load_plugin_sources_skips_broken_factory(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def boom() -> object:
+        raise RuntimeError("intentional test failure")
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("broken", boom)])
+
+    with caplog.at_level("WARNING"):
+        sources = load_plugin_sources()
+
+    assert sources == []
+    assert "broken" in caplog.text
+
+
+def test_load_plugin_sources_skips_non_source_return(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def returns_str() -> str:
+        return "not a source"
+
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("bad-return", returns_str)])
+
+    with caplog.at_level("WARNING"):
+        sources = load_plugin_sources()
+    assert sources == []
+    assert "bad-return" in caplog.text
+
+
+def test_load_plugin_sources_skips_non_callable_non_source(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _patch_entry_points(monkeypatch, [_FakeEntryPoint("weird", 42)])
+
+    with caplog.at_level("WARNING"):
+        sources = load_plugin_sources()
+    assert sources == []
+    assert "weird" in caplog.text

--- a/tests/unit/skills/test_role_resolver.py
+++ b/tests/unit/skills/test_role_resolver.py
@@ -1,0 +1,115 @@
+"""Tests for :mod:`bernstein.core.planning.role_resolver`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.planning.role_resolver import (
+    invalidate_cache,
+    resolve_role_prompt,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    invalidate_cache()
+
+
+def _build_templates_dir(tmp_path: Path, *, with_skill: bool, with_legacy: bool) -> Path:
+    """Create a ``templates/roles/`` + ``templates/skills/`` layout.
+
+    Returns the ``roles`` path (resolver input).
+    """
+    templates = tmp_path / "templates"
+    roles = templates / "roles"
+    skills = templates / "skills"
+    roles.mkdir(parents=True)
+    skills.mkdir()
+
+    if with_legacy:
+        legacy_role = roles / "backend"
+        legacy_role.mkdir()
+        (legacy_role / "system_prompt.md").write_text(
+            "# Legacy backend role\nOld long role prompt body.",
+            encoding="utf-8",
+        )
+
+    if with_skill:
+        skill_dir = skills / "backend"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            """---
+name: backend
+description: Backend skill description that clears twenty characters.
+---
+# Backend skill body""",
+            encoding="utf-8",
+        )
+
+    return roles
+
+
+def test_resolve_prefers_skill_when_available(tmp_path: Path) -> None:
+    roles_dir = _build_templates_dir(tmp_path, with_skill=True, with_legacy=True)
+
+    resolved = resolve_role_prompt(
+        "backend",
+        templates_dir=roles_dir,
+        include_plugins=False,
+    )
+
+    assert resolved.source == "skill"
+    assert resolved.skill_name == "backend"
+    # Role hint names the skill and tells the agent to load_skill; the
+    # full skill body is NOT inlined — agents fetch it on demand.
+    assert "load_skill" in resolved.body
+    assert "Role: backend" in resolved.body
+    assert "Backend skill body" not in resolved.body
+
+
+def test_resolve_falls_back_to_legacy_when_no_skill(tmp_path: Path) -> None:
+    roles_dir = _build_templates_dir(tmp_path, with_skill=False, with_legacy=True)
+
+    resolved = resolve_role_prompt(
+        "backend",
+        templates_dir=roles_dir,
+        include_plugins=False,
+    )
+
+    assert resolved.source == "legacy"
+    assert resolved.skill_name is None
+    assert "Legacy backend role" in resolved.body
+
+
+def test_resolve_falls_back_to_stub_when_nothing_matches(tmp_path: Path) -> None:
+    roles_dir = _build_templates_dir(tmp_path, with_skill=False, with_legacy=False)
+
+    resolved = resolve_role_prompt(
+        "nonexistent-role",
+        templates_dir=roles_dir,
+        include_plugins=False,
+    )
+
+    assert resolved.source == "fallback"
+    assert "nonexistent-role" in resolved.body
+
+
+def test_resolve_supports_legacy_renderer_injection(tmp_path: Path) -> None:
+    roles_dir = _build_templates_dir(tmp_path, with_skill=False, with_legacy=False)
+    # Provide a custom renderer.
+
+    def renderer(role: str, context: dict[str, str], templates_dir: Path) -> str:
+        return f"rendered-{role}"
+
+    resolved = resolve_role_prompt(
+        "whatever",
+        templates_dir=roles_dir,
+        legacy_renderer=renderer,
+        legacy_context={"x": "y"},
+        include_plugins=False,
+    )
+
+    assert resolved.source == "legacy"
+    assert resolved.body == "rendered-whatever"


### PR DESCRIPTION
## Summary
- Adds `templates/skills/<name>/SKILL.md` + `references/` skill packs; migrates all 17 role templates.
- `role_resolver` injects a compact skill index into the system prompt instead of full role bodies; agents call `load_skill` (new MCP tool) on demand.
- Backwards compat: legacy `templates/roles/*.md` files still load when no skill exists.
- Pluggy entry-point group `bernstein.skill_sources` for third-party skill packs.
- Token reduction: >= 40% smaller system prompt on average for the same role (regression-tested).

Implements ticket.

## Test plan
- [ ] `uv run python scripts/run_tests.py -x tests/unit/skills/`
- [ ] `uv run python scripts/run_tests.py -x tests/unit/test_role_resolver.py` (backwards compat)
- [ ] `uv run ruff check src/bernstein/core/skills/`
- [ ] `uv run pyright src/bernstein/core/skills/`
- [ ] Token reduction regression test asserts >= 40% reduction
- [ ] `bernstein skills list` and `bernstein skills show <name>` work
- [ ] All 17 roles migrated to skill packs