### PR TITLE
feat(storage): pluggable artifact sinks with S3, GCS, Azure Blob, R2

### DIFF
--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,0 +1,164 @@
+# Artifact Storage Sinks (oai-003)
+
+Bernstein persists its working state under `.sdd/`: the WAL, HMAC
+audit logs, runtime state, task outputs, cost ledger, and metrics
+dumps. On a developer laptop that directory lives on a local disk
+and the story is simple. On ephemeral compute — CI runners, Kubernetes
+pods, cloud sandboxes — the host can disappear between orchestrator
+restarts, taking the recovery state with it.
+
+The storage package decouples `.sdd/` persistence from the local
+filesystem so artifacts can stream to S3, Google Cloud Storage,
+Azure Blob, Cloudflare R2, or a custom plugin while the orchestrator
+logic is unchanged.
+
+## Protocol
+
+Every sink implements the async [`ArtifactSink`][sink] protocol:
+
+```python
+class ArtifactSink(Protocol):
+    name: str
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None: ...
+    async def read(self, key: str) -> bytes: ...
+    async def list(self, prefix: str) -> list[str]: ...
+    async def delete(self, key: str) -> None: ...
+    async def exists(self, key: str) -> bool: ...
+    async def stat(self, key: str) -> ArtifactStat: ...
+    async def close(self) -> None: ...
+```
+
+Keys are forward-slash-delimited logical paths such as
+`runtime/wal/run-123.wal.jsonl`. Implementations map them to whatever
+native addressing their backend uses (object-store keys, filesystem
+paths, ...). The helper module `bernstein.core.storage.keys`
+centralises the canonical key layout so no caller hand-constructs a
+path.
+
+[sink]: ../../src/bernstein/core/storage/sink.py
+
+## First-party sinks
+
+| Name         | Extra         | SDK                        | Ships in                      |
+| ------------ | ------------- | -------------------------- | ----------------------------- |
+| `local_fs`   | — (always on) | stdlib                     | `bernstein` core              |
+| `s3`         | `bernstein[s3]`    | `boto3`                    | optional extra                |
+| `gcs`        | `bernstein[gcs]`   | `google-cloud-storage`     | optional extra                |
+| `azure_blob` | `bernstein[azure]` | `azure-storage-blob`       | optional extra                |
+| `r2`         | `bernstein[r2]`    | `boto3` (R2 is S3-compatible) | optional extra             |
+
+All five pass the shared `ArtifactSinkConformance` test suite
+(`src/bernstein/core/storage/conformance.py`). The unit suite runs it
+only against `LocalFsSink`; the cloud sinks run the same suite in the
+integration folder behind emulator-availability gates.
+
+## Durability: `BufferedSink`
+
+The WAL crash-safety contract requires a `durable=True` write to be on
+stable storage before `write` returns. A synchronous PUT to S3 on every
+WAL append would tank throughput to the network round-trip time; a
+pure-async mirror would break the crash invariant.
+
+`BufferedSink` splits the difference:
+
+```
+WAL.append() ──▶ LocalFsSink.write(durable=True)   ← synchronous fsync
+                        │
+                        └──▶ queue entry
+                                 │
+                                 └──▶ [bg] RemoteSink.write(durable=True)
+```
+
+1. **Local first, synchronously.** The caller's write is committed to
+   the local `.sdd/` with the full `fsync` semantics from
+   `atomic_write.write_atomic_bytes`. If the orchestrator dies after
+   `write` returns, every line is already on the OS page cache barrier.
+2. **Remote next, asynchronously.** The same payload is queued for a
+   best-effort mirror to the configured remote sink. The queue is
+   bounded so a slow remote applies back-pressure rather than growing
+   unbounded.
+3. **Graceful shutdown.** `close()` blocks until every pending mirror
+   has ACKed or failed. The orchestrator calls this on normal exit so
+   nothing is lost.
+
+Reads prefer the remote sink — that's the crash-recovery path where
+the ephemeral local disk may be empty. They fall back to local when
+the remote is unreachable or doesn't have the key (e.g. the mirror is
+still pending).
+
+## Sandbox integration (ties in with oai-002)
+
+`WorkspaceManifest` now carries a tuple of `ArtifactMount` entries
+(`S3Mount`, `GCSMount`, `AzureBlobMount`, `R2Mount`). Cloud sandbox
+backends (oai-002: docker, e2b, modal; future: daytona, cloudflare,
+vercel) translate these into provider-native filesystem bindings
+(`rclone mount` for S3/R2, `gcsfuse` for GCS, `blobfuse2` for Azure)
+so agent writes to the mount path stream straight into the
+orchestrator's artifact sink. The `worktree` backend ignores the
+field — everything already lives on the host filesystem.
+
+## Credential handling
+
+Each sink picks credentials up from environment variables with
+explicit-config overrides. The exhaustive list of env vars consumed
+by the first-party sinks lives in
+`bernstein.core.storage.credential_scoping.STORAGE_CREDENTIAL_ENV_VARS`.
+
+The default agent-spawn path uses whitelist-based env filtering
+(`bernstein.adapters.env_isolation.build_filtered_env`) so sink
+credentials are already stripped before any agent subprocess sees
+them. The `scrub_env` helper is available for spawner paths that
+bypass the whitelist.
+
+## Trade-offs per provider
+
+| Provider           | Write latency (p50)        | Durability               | Cost posture          | Notes                                                |
+| ------------------ | -------------------------- | ------------------------ | --------------------- | ---------------------------------------------------- |
+| `local_fs`         | sub-millisecond (fsync)    | local disk only          | free                  | Default. Zero network dependency.                    |
+| `s3`               | 20–80 ms (same region)     | 99.999999999% (11 nines) | per-GB storage + PUT  | Widely available; best-documented durability guarantee. |
+| `gcs`              | 30–100 ms                  | 99.999999999%            | per-GB + class-A ops  | Good integration with GKE workload identity.         |
+| `azure_blob`       | 40–120 ms                  | 99.999999999%            | per-GB + transactions | LRS/ZRS/GRS replication tiers.                       |
+| `r2`               | 50–150 ms (global)         | 99.999999999% (claimed)  | zero egress           | Best egress economics; no AWS-ecosystem lock-in.     |
+
+Always pair a remote sink with `BufferedSink` in production. The
+synchronous write path is then bounded by local fsync latency (~1 ms)
+while cloud durability catches up in the background.
+
+## Registering custom sinks
+
+Third-party packages add sinks via the `bernstein.storage_sinks`
+entry-point group. Example in `pyproject.toml`:
+
+```toml
+[project.entry-points."bernstein.storage_sinks"]
+my_sink = "mypkg.storage:MyArtifactSink"
+```
+
+At import time `bernstein.core.storage.registry` loads every
+entry-point in the group. Classes are instantiated lazily on first
+`get_sink("my_sink")`; instances are cached across the process
+lifetime.
+
+## Observability
+
+Each sink operation emits Prometheus metrics through the existing
+`bernstein.core.observability` stack (metric names listed in the
+ticket):
+
+- `storage_write_total{sink, durable}`
+- `storage_write_duration_seconds{sink}`
+- `storage_read_bytes_total{sink}`
+- `storage_buffer_pending_writes{sink}` (BufferedSink)
+- `storage_buffer_lag_seconds{sink}` (BufferedSink)
+
+`BufferedSink.stats()` exposes the raw counters as a
+`BufferedSinkStats` dataclass for test assertions and ad-hoc
+debugging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,13 @@ openai = ["openai-agents>=0.4.0"]
 docker = ["docker>=7"]
 e2b = ["e2b-code-interpreter>=1.0"]
 modal = ["modal>=0.65"]
+# Cloud artifact storage sinks (oai-003). Each extra pulls in the provider
+# SDK needed by the corresponding ArtifactSink. Kept optional so local-only
+# installs stay lean. R2 reuses boto3 under the hood.
+s3 = ["boto3>=1.40"]
+gcs = ["google-cloud-storage>=3.0"]
+azure = ["azure-storage-blob>=12.20"]
+r2 = ["boto3>=1.40"]
 
 [project.scripts]
 bernstein = "bernstein.cli.main:cli"
@@ -153,6 +160,14 @@ bernstein-worker = "bernstein.core.worker:main"
 # zero-arg factory returning a ``bernstein.core.skills.SkillSource``.
 # Example:
 # my-data-pack = "my_pack.skills:source"
+
+[project.entry-points."bernstein.storage_sinks"]
+# Pluggable artifact storage sinks (oai-003). First-party sinks
+# (local_fs, s3, gcs, azure_blob, r2) ship in core and are registered
+# eagerly by bernstein.core.storage.registry; plugin authors register
+# additional sinks (custom providers, domain-specific wrappers ...) via
+# this group. Example:
+# my_sink = "my_pkg.storage:MyArtifactSink"
 
 [tool.hatch.build]
 exclude = [

--- a/src/bernstein/core/sandbox/__init__.py
+++ b/src/bernstein/core/sandbox/__init__.py
@@ -50,8 +50,13 @@ from bernstein.core.sandbox.backend import (
     SandboxSession,
 )
 from bernstein.core.sandbox.manifest import (
+    ArtifactMount,
+    AzureBlobMount,
     FileEntry,
+    GCSMount,
     GitRepoEntry,
+    R2Mount,
+    S3Mount,
     WorkspaceManifest,
 )
 from bernstein.core.sandbox.registry import (
@@ -76,10 +81,15 @@ from bernstein.core.security.sandbox import (
 spawn_in_sandbox: _Any = _spawn_in_sandbox  # pyright: ignore[reportUnknownVariableType]
 
 __all__ = [
+    "ArtifactMount",
+    "AzureBlobMount",
     "DockerSandbox",
     "ExecResult",
     "FileEntry",
+    "GCSMount",
     "GitRepoEntry",
+    "R2Mount",
+    "S3Mount",
     "SandboxBackend",
     "SandboxCapability",
     "SandboxRuntime",

--- a/src/bernstein/core/sandbox/manifest.py
+++ b/src/bernstein/core/sandbox/manifest.py
@@ -1,11 +1,20 @@
 """WorkspaceManifest — declarative description of a sandbox workspace.
 
-Phase 1 only covers the minimum surface every backend needs to materialise
-a workable checkout: the workspace root path, an optional git clone
-source, a tuple of bytes-injected files, and environment variables.
-Cloud-specific mount entries (S3 artifacts, persistent volumes,
-secrets-manager bindings) are intentionally deferred to ``oai-003`` so
-this ticket doesn't grow unbounded.
+The manifest is the value object backends consume via
+:meth:`SandboxBackend.create`. Phase 1 (oai-002) covered the minimum
+surface every backend needs to materialise a workable checkout:
+workspace root path, optional git clone source, byte-injected files,
+and environment variables.
+
+oai-003 extends the manifest with cloud-mount entries that describe
+how spawned agents should see their artifact storage. When a non-local
+sandbox backend is selected together with a remote
+:class:`~bernstein.core.storage.sink.ArtifactSink`, the sandbox
+translates each mount into the provider-specific filesystem binding
+(``rclone mount`` inside the container for S3, ``gcsfuse`` for GCS,
+etc.) so agent writes to the mount path stream directly to the
+orchestrator's artifact store. The local-worktree backend ignores the
+mount entries because everything already lives on the host filesystem.
 
 A manifest is frozen once passed to :meth:`SandboxBackend.create`: the
 dataclasses are immutable and any nested tuple is read-only. Backends
@@ -60,6 +69,114 @@ class FileEntry:
 
 
 @dataclass(frozen=True)
+class S3Mount:
+    """An S3 artifact mount to bind into the sandbox (oai-003).
+
+    Cloud sandbox backends translate this into a ``rclone mount`` (or
+    equivalent) so processes inside the sandbox see the bucket as a
+    regular filesystem path. Worktree backends ignore the mount.
+
+    Attributes:
+        bucket: Target S3 bucket.
+        prefix: Optional object-store prefix. Empty by default.
+        mount_path: Path inside the sandbox where the bucket should be
+            visible (e.g. ``/workspace/.sdd``).
+        region: Optional AWS region override.
+        endpoint_url: Optional endpoint (used by LocalStack, R2, MinIO).
+        credentials_env: Tuple of env-var names the sandbox must forward
+            to the mount helper (e.g. ``("AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY")``). The orchestrator strips these
+            from the spawned agent's environment — only the mount tool
+            receives them.
+        read_only: When True, the mount is bound ``ro``. Useful for
+            read-only artifact inspection jobs.
+    """
+
+    bucket: str
+    prefix: str
+    mount_path: str
+    region: str | None = None
+    endpoint_url: str | None = None
+    credentials_env: tuple[str, ...] = ()
+    read_only: bool = False
+
+
+@dataclass(frozen=True)
+class GCSMount:
+    """A Google Cloud Storage artifact mount (oai-003).
+
+    Translated by cloud sandbox backends into ``gcsfuse``.
+
+    Attributes:
+        bucket: GCS bucket to mount.
+        prefix: Optional object-store prefix.
+        mount_path: Path inside the sandbox.
+        project: Optional project override.
+        credentials_env: Env vars forwarded to the mount helper.
+        read_only: Mount read-only when ``True``.
+    """
+
+    bucket: str
+    prefix: str
+    mount_path: str
+    project: str | None = None
+    credentials_env: tuple[str, ...] = ()
+    read_only: bool = False
+
+
+@dataclass(frozen=True)
+class AzureBlobMount:
+    """An Azure Blob Storage artifact mount (oai-003).
+
+    Translated by cloud sandbox backends into ``blobfuse2``.
+
+    Attributes:
+        container: Target blob container.
+        prefix: Optional prefix.
+        mount_path: Path inside the sandbox.
+        account_name: Storage account name.
+        credentials_env: Env vars forwarded to the mount helper.
+        read_only: Mount read-only when ``True``.
+    """
+
+    container: str
+    prefix: str
+    mount_path: str
+    account_name: str | None = None
+    credentials_env: tuple[str, ...] = ()
+    read_only: bool = False
+
+
+@dataclass(frozen=True)
+class R2Mount:
+    """A Cloudflare R2 artifact mount (oai-003).
+
+    R2 is S3-compatible so cloud sandbox backends reuse the same
+    ``rclone mount`` path as :class:`S3Mount`, only with the R2
+    endpoint derived from *account_id*.
+
+    Attributes:
+        bucket: R2 bucket to mount.
+        prefix: Optional prefix.
+        mount_path: Path inside the sandbox.
+        account_id: R2 account ID (determines the endpoint URL).
+        credentials_env: Env vars forwarded to the mount helper.
+        read_only: Mount read-only when ``True``.
+    """
+
+    bucket: str
+    prefix: str
+    mount_path: str
+    account_id: str
+    credentials_env: tuple[str, ...] = ()
+    read_only: bool = False
+
+
+#: Union type covering every provider-specific cloud mount entry.
+ArtifactMount = S3Mount | GCSMount | AzureBlobMount | R2Mount
+
+
+@dataclass(frozen=True)
 class WorkspaceManifest:
     """Declarative description of a sandbox workspace.
 
@@ -82,6 +199,11 @@ class WorkspaceManifest:
             :meth:`SandboxSession.exec` when the caller doesn't pass
             one explicitly. Not a hard session lifetime cap — individual
             backends may still honour longer sessions.
+        artifact_mounts: Tuple of provider-specific cloud mounts
+            (oai-003). Cloud sandbox backends translate these into
+            provider-native filesystem bindings so agent writes stream
+            directly to the orchestrator's artifact sink. Worktree
+            backends ignore the field.
     """
 
     root: str = "/workspace"
@@ -89,10 +211,16 @@ class WorkspaceManifest:
     files: tuple[FileEntry, ...] = ()
     env: Mapping[str, str] = field(default_factory=dict[str, str])
     timeout_seconds: int = 1800
+    artifact_mounts: tuple[ArtifactMount, ...] = ()
 
 
 __all__ = [
+    "ArtifactMount",
+    "AzureBlobMount",
     "FileEntry",
+    "GCSMount",
     "GitRepoEntry",
+    "R2Mount",
+    "S3Mount",
     "WorkspaceManifest",
 ]

--- a/src/bernstein/core/storage/__init__.py
+++ b/src/bernstein/core/storage/__init__.py
@@ -1,0 +1,70 @@
+"""Pluggable artifact storage sinks (oai-003).
+
+Bernstein's ``.sdd/`` layer is the durable substrate behind the WAL,
+HMAC audit log, runtime state, task outputs, metrics dumps, and cost
+ledgers. This package replaces the hard-coded local-filesystem
+writes with a protocol-based abstraction so deployments can redirect
+artifacts to S3, GCS, Azure Blob, or Cloudflare R2 without touching
+business logic.
+
+Public API::
+
+    from bernstein.core.storage import (
+        ArtifactSink,
+        ArtifactSinkConformance,
+        ArtifactStat,
+        BufferedSink,
+        BufferedSinkStats,
+        LocalFsSink,
+        SinkError,
+        get_sink,
+        list_sink_names,
+        list_sinks,
+        register_sink,
+    )
+
+Cloud sinks live in :mod:`bernstein.core.storage.sinks` behind lazy
+imports: the module hierarchy is always importable, but instantiating
+a cloud sink without the corresponding optional SDK raises a clear
+``<Provider>Unavailable`` error pointing at the right extra.
+
+See ``docs/architecture/storage.md`` for the end-to-end design and
+trade-offs per provider.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.storage.buffered import BufferedSink, BufferedSinkStats
+from bernstein.core.storage.conformance import ArtifactSinkConformance
+from bernstein.core.storage.registry import (
+    default_registry,
+    get_sink,
+    list_sink_names,
+    list_sinks,
+    register_sink,
+)
+from bernstein.core.storage.sink import (
+    ArtifactSink,
+    ArtifactStat,
+    SinkError,
+    join_keys,
+    normalise_key,
+)
+from bernstein.core.storage.sinks.local_fs import LocalFsSink
+
+__all__ = [
+    "ArtifactSink",
+    "ArtifactSinkConformance",
+    "ArtifactStat",
+    "BufferedSink",
+    "BufferedSinkStats",
+    "LocalFsSink",
+    "SinkError",
+    "default_registry",
+    "get_sink",
+    "join_keys",
+    "list_sink_names",
+    "list_sinks",
+    "normalise_key",
+    "register_sink",
+]

--- a/src/bernstein/core/storage/buffered.py
+++ b/src/bernstein/core/storage/buffered.py
@@ -1,0 +1,295 @@
+"""Write-through buffered sink for cloud-durability without WAL latency.
+
+The WAL's crash-safety contract requires a ``durable=True`` write to
+be on stable storage before ``write`` returns. Synchronous PUT to S3
+on every append would tank throughput to the network round-trip time,
+while pure-async mirrors would break the crash invariant.
+
+:class:`BufferedSink` splits the difference: the caller's write is
+committed locally with the full fsync semantics of
+:class:`~bernstein.core.storage.sinks.local_fs.LocalFsSink`, then the
+same payload is queued for a best-effort asynchronous mirror to a
+remote sink. The WAL invariant is preserved (local fsync survives a
+process crash) and the cloud durability guarantee is layered on top
+(the mirror survives host loss as soon as the queue drains).
+
+The queue is bounded: when the remote sink lags far enough that the
+queue saturates, producers block until the mirror catches up. This
+gives deterministic back-pressure rather than silently dropping
+mirrors or unbounded memory growth.
+
+``close()`` blocks until every pending mirror has either ACKed or
+failed, so shutdown cleanly flushes the tail — the orchestrator uses
+this when winding down a run so no uploads are lost on a clean exit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+
+from bernstein.core.storage.sink import (
+    ArtifactSink,
+    ArtifactStat,
+    SinkError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingMirror:
+    """One queued mirror job.
+
+    Attributes:
+        key: Logical sink key.
+        data: Payload to upload.
+        content_type: Optional MIME type hint for the remote sink.
+        enqueued_at: Monotonic seconds at enqueue (used for lag metrics).
+    """
+
+    key: str
+    data: bytes
+    content_type: str | None
+    enqueued_at: float = field(default_factory=time.monotonic)
+
+
+@dataclass
+class BufferedSinkStats:
+    """Snapshot of :class:`BufferedSink` observability counters.
+
+    The fields map 1:1 to the Prometheus metrics described in the
+    ticket and are also useful for unit-test assertions without having
+    to stand up the metrics registry.
+
+    Attributes:
+        pending_writes: Size of the queue at observation time.
+        completed_mirrors: Total successful remote mirrors since start.
+        failed_mirrors: Total failed remote mirrors since start.
+        oldest_pending_age_seconds: Age of the oldest queued item
+            (``0.0`` when the queue is empty).
+    """
+
+    pending_writes: int
+    completed_mirrors: int
+    failed_mirrors: int
+    oldest_pending_age_seconds: float
+
+
+class BufferedSink(ArtifactSink):
+    """Local-fsync-then-mirror sink.
+
+    Writes go to *local* synchronously (preserving the WAL fsync
+    invariant); a background task then streams the same payload to
+    *remote*. Reads check the remote sink first — on a fresh startup
+    with an ephemeral local disk this is how the crash-recovery path
+    finds the last committed state — and fall back to local when the
+    remote cannot serve the key.
+
+    The buffer is bounded (``max_pending``): producer writes block
+    when the queue is full so a slow remote sink applies back-pressure
+    instead of being silently dropped.
+    """
+
+    name: str = "buffered"
+
+    def __init__(
+        self,
+        *,
+        local: ArtifactSink,
+        remote: ArtifactSink,
+        max_pending: int = 1024,
+    ) -> None:
+        """Create the buffered sink.
+
+        Args:
+            local: The synchronous, crash-safe sink (normally a
+                :class:`~bernstein.core.storage.sinks.local_fs.LocalFsSink`
+                pointing at ``.sdd/``).
+            remote: The asynchronous, durable sink to mirror to.
+            max_pending: Hard cap on the mirror queue depth. Smaller
+                values give tighter memory bounds at the cost of more
+                producer blocking when the mirror lags.
+        """
+        if max_pending <= 0:
+            raise ValueError("max_pending must be positive")
+        self._local = local
+        self._remote = remote
+        self._queue: asyncio.Queue[_PendingMirror | None] = asyncio.Queue(
+            maxsize=max_pending,
+        )
+        self._worker: asyncio.Task[None] | None = None
+        self._closed = False
+        self._completed = 0
+        self._failed = 0
+        self._stopped = asyncio.Event()
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle
+    # ------------------------------------------------------------------
+
+    def _ensure_worker(self) -> None:
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(
+                self._drain_loop(),
+                name="bernstein-buffered-sink-drain",
+            )
+
+    async def _drain_loop(self) -> None:
+        """Consume queued mirrors one at a time until shutdown."""
+        try:
+            while True:
+                item = await self._queue.get()
+                try:
+                    if item is None:
+                        # Sentinel: drain requested.
+                        return
+                    try:
+                        await self._remote.write(
+                            item.key,
+                            item.data,
+                            durable=True,
+                            content_type=item.content_type,
+                        )
+                        self._completed += 1
+                    except Exception as exc:
+                        self._failed += 1
+                        logger.warning(
+                            "BufferedSink mirror of %r failed: %s",
+                            item.key,
+                            exc,
+                        )
+                finally:
+                    self._queue.task_done()
+        finally:
+            self._stopped.set()
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    def stats(self) -> BufferedSinkStats:
+        """Return a snapshot of the sink's observability counters."""
+        pending = self._queue.qsize()
+        oldest_age = 0.0
+        # Peek at the head without consuming it. ``asyncio.Queue._queue``
+        # is a ``collections.deque`` — accessing it is safe for an
+        # observational peek but pyright can't see through the private
+        # attribute, so the cast to ``list[object]`` keeps strict typing
+        # happy.
+        raw_items: list[object] = list(self._queue._queue)  # type: ignore[attr-defined]
+        if raw_items:
+            oldest = raw_items[0]
+            if isinstance(oldest, _PendingMirror):
+                oldest_age = max(0.0, time.monotonic() - oldest.enqueued_at)
+        return BufferedSinkStats(
+            pending_writes=pending,
+            completed_mirrors=self._completed,
+            failed_mirrors=self._failed,
+            oldest_pending_age_seconds=oldest_age,
+        )
+
+    # ------------------------------------------------------------------
+    # ArtifactSink protocol
+    # ------------------------------------------------------------------
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        if self._closed:
+            raise SinkError("BufferedSink already closed")
+
+        # 1. Synchronously commit locally — preserves WAL fsync invariant.
+        await self._local.write(
+            key,
+            data,
+            durable=durable,
+            content_type=content_type,
+        )
+
+        # 2. Queue the same payload for the remote mirror.
+        self._ensure_worker()
+        pending = _PendingMirror(
+            key=key,
+            data=data,
+            content_type=content_type,
+        )
+        await self._queue.put(pending)
+
+    async def read(self, key: str) -> bytes:
+        # Prefer remote — this is the crash-recovery path where the
+        # local cache may have been on ephemeral storage.
+        try:
+            return await self._remote.read(key)
+        except FileNotFoundError:
+            return await self._local.read(key)
+        except SinkError as exc:
+            logger.debug("BufferedSink remote read for %r failed: %s", key, exc)
+            return await self._local.read(key)
+
+    async def list(self, prefix: str) -> list[str]:
+        # Merge both views: local may have entries not yet mirrored,
+        # remote may have entries the local cache never touched (fresh
+        # recovery).
+        local_keys = await self._local.list(prefix)
+        try:
+            remote_keys = await self._remote.list(prefix)
+        except SinkError as exc:
+            logger.debug("BufferedSink remote list for %r failed: %s", prefix, exc)
+            remote_keys = []
+        merged = sorted(set(local_keys) | set(remote_keys))
+        return merged
+
+    async def delete(self, key: str) -> None:
+        await self._local.delete(key)
+        try:
+            await self._remote.delete(key)
+        except SinkError as exc:
+            logger.warning("BufferedSink remote delete for %r failed: %s", key, exc)
+
+    async def exists(self, key: str) -> bool:
+        if await self._local.exists(key):
+            return True
+        try:
+            return await self._remote.exists(key)
+        except SinkError:
+            return False
+
+    async def stat(self, key: str) -> ArtifactStat:
+        try:
+            return await self._local.stat(key)
+        except FileNotFoundError:
+            return await self._remote.stat(key)
+
+    async def close(self) -> None:
+        """Flush all pending mirrors then shut down."""
+        if self._closed:
+            return
+        self._closed = True
+        # Drain marker: worker will exit once the sentinel is reached.
+        await self._queue.put(None)
+        worker = self._worker
+        if worker is not None:
+            await worker
+        # Close the remote sink so its client pool is released.
+        try:
+            await self._remote.close()
+        except Exception as exc:
+            logger.debug("BufferedSink remote.close raised: %s", exc)
+        try:
+            await self._local.close()
+        except Exception as exc:
+            logger.debug("BufferedSink local.close raised: %s", exc)
+
+
+__all__ = [
+    "BufferedSink",
+    "BufferedSinkStats",
+]

--- a/src/bernstein/core/storage/conformance.py
+++ b/src/bernstein/core/storage/conformance.py
@@ -1,0 +1,201 @@
+"""Protocol conformance helpers for :class:`ArtifactSink` implementations.
+
+A single reusable test base lives here so backend-specific test
+modules only have to supply a fixture that yields a sink instance.
+This mirrors
+:mod:`bernstein.core.sandbox.conformance` so plugin authors familiar
+with sandbox backends find the storage surface predictable.
+
+Subclass it like::
+
+    class TestLocalFsConformance(ArtifactSinkConformance):
+        @pytest.fixture
+        async def sink(self, tmp_path):
+            yield LocalFsSink(tmp_path)
+
+Run-time notes:
+
+- Tests use ``@pytest.mark.asyncio`` so they slot into the existing
+  pytest-asyncio setup.
+- ``concurrent`` tests spawn ``asyncio.gather``-style bursts; cloud
+  sinks running against local emulators should still complete inside
+  a few seconds.
+- ``large_payload`` is 1 MB by default — large enough to exercise
+  chunked upload paths on cloud sinks but small enough to keep CI
+  fast. Sinks needing more aggressive coverage override
+  :attr:`ArtifactSinkConformance.large_payload_bytes`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from bernstein.core.storage.sink import ArtifactSink
+
+
+class ArtifactSinkConformance:
+    """Reusable conformance suite for any :class:`ArtifactSink`.
+
+    Subclasses supply an ``sink`` pytest fixture yielding a ready sink.
+    """
+
+    #: Override in a subclass to change the "large payload" size.
+    large_payload_bytes: int = 1024 * 1024
+
+    @pytest.mark.asyncio
+    async def test_read_write_roundtrip_binary(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Roundtrip arbitrary binary bytes."""
+        payload = bytes(range(256)) * 8
+        await sink.write("conformance/binary.bin", payload)
+        got = await sink.read("conformance/binary.bin")
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_read_write_roundtrip_utf8(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Roundtrip UTF-8 text encoded as bytes."""
+        payload = "hello world — conformance ✓".encode()
+        await sink.write("conformance/utf8.txt", payload)
+        got = await sink.read("conformance/utf8.txt")
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_empty_payload_roundtrip(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Empty writes are legal and readable."""
+        await sink.write("conformance/empty.txt", b"")
+        got = await sink.read("conformance/empty.txt")
+        assert got == b""
+
+    @pytest.mark.asyncio
+    async def test_large_payload_roundtrip(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Large payloads survive intact."""
+        payload = b"x" * self.large_payload_bytes
+        await sink.write("conformance/large.bin", payload)
+        got = await sink.read("conformance/large.bin")
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_list_with_prefix(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """``list`` returns keys with the matching prefix."""
+        await sink.write("conformance/list/a.txt", b"a")
+        await sink.write("conformance/list/b.txt", b"b")
+        await sink.write("conformance/other.txt", b"c")
+        keys = await sink.list("conformance/list")
+        assert "conformance/list/a.txt" in keys
+        assert "conformance/list/b.txt" in keys
+        assert "conformance/other.txt" not in keys
+
+    @pytest.mark.asyncio
+    async def test_list_many_keys_paginates(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Listing more than one page returns every key.
+
+        S3 default page size is 1000 — we use 50 writes here because
+        the conformance suite also runs on emulators where larger
+        payloads are slower. Pagination support is still exercised on
+        sinks that set their page size to 10 or below.
+        """
+        for i in range(50):
+            await sink.write(f"conformance/many/{i:03d}.txt", str(i).encode())
+        keys = await sink.list("conformance/many")
+        assert len(keys) >= 50
+
+    @pytest.mark.asyncio
+    async def test_exists_reports_correctly(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """``exists`` returns True/False."""
+        assert await sink.exists("conformance/missing.txt") is False
+        await sink.write("conformance/present.txt", b"hi")
+        assert await sink.exists("conformance/present.txt") is True
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_key(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """``delete`` removes the key and subsequent read raises."""
+        await sink.write("conformance/delete.txt", b"bye")
+        await sink.delete("conformance/delete.txt")
+        with pytest.raises(FileNotFoundError):
+            await sink.read("conformance/delete.txt")
+
+    @pytest.mark.asyncio
+    async def test_read_missing_raises_file_not_found(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Reading a missing key raises :class:`FileNotFoundError`."""
+        with pytest.raises(FileNotFoundError):
+            await sink.read("conformance/does-not-exist.txt")
+
+    @pytest.mark.asyncio
+    async def test_stat_returns_size_and_mtime(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """``stat`` reports size and mtime after a write."""
+        payload = b"abc123"
+        await sink.write("conformance/stat.txt", payload)
+        st = await sink.stat("conformance/stat.txt")
+        assert st.size_bytes == len(payload)
+        assert st.last_modified_unix >= 0
+
+    @pytest.mark.asyncio
+    async def test_stat_missing_raises_file_not_found(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """``stat`` on a missing key raises :class:`FileNotFoundError`."""
+        with pytest.raises(FileNotFoundError):
+            await sink.stat("conformance/missing-stat.txt")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_do_not_interfere(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Concurrent writes to different keys land correctly."""
+
+        async def _write(i: int) -> None:
+            await sink.write(
+                f"conformance/concurrent/{i:02d}.txt",
+                str(i).encode(),
+            )
+
+        await asyncio.gather(*(_write(i) for i in range(20)))
+        for i in range(20):
+            got = await sink.read(f"conformance/concurrent/{i:02d}.txt")
+            assert got == str(i).encode()
+
+    @pytest.mark.asyncio
+    async def test_name_is_nonempty(
+        self,
+        sink: ArtifactSink,
+    ) -> None:
+        """Every sink must advertise a non-empty canonical name."""
+        assert isinstance(sink.name, str) and sink.name
+
+
+__all__ = ["ArtifactSinkConformance"]

--- a/src/bernstein/core/storage/credential_scoping.py
+++ b/src/bernstein/core/storage/credential_scoping.py
@@ -1,0 +1,81 @@
+"""Storage-sink credential scoping (oai-003).
+
+Sinks resolve their provider credentials from environment variables
+on the *orchestrator* process. Spawned agents must never see these
+credentials — otherwise a compromised agent could exfiltrate the
+orchestrator's long-lived cloud keys.
+
+Bernstein's default env-isolation layer (:mod:`bernstein.adapters.env_isolation`)
+is whitelist-based, so the following list acts as a warning surface:
+any new AWS/GCS/Azure/R2 variable the sinks start consuming must also
+be added here so audits can assert it is never forwarded to an agent.
+
+The list is consumed by two places:
+
+- :func:`list_storage_credential_env_vars` — exposed so documentation
+  and tests can enumerate the current surface.
+- :func:`scrub_env` — strips the listed keys from a given mapping,
+  used in one-off spawner paths that bypass ``build_filtered_env``.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+#: Environment variables consumed by the first-party cloud sinks.
+#: Keep in sync with the constructor fallbacks in
+#: :mod:`bernstein.core.storage.sinks` — every env var read by a sink
+#: must appear here so it can be scrubbed from agent environments.
+STORAGE_CREDENTIAL_ENV_VARS: Final[frozenset[str]] = frozenset(
+    {
+        # S3 + R2 (R2 reuses the S3 boto3 stack)
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION",
+        "AWS_ENDPOINT_URL",
+        "BERNSTEIN_S3_BUCKET",
+        "R2_ACCOUNT_ID",
+        "R2_ACCESS_KEY_ID",
+        "R2_SECRET_ACCESS_KEY",
+        "BERNSTEIN_R2_BUCKET",
+        # GCS
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "BERNSTEIN_GCS_BUCKET",
+        # Azure Blob
+        "AZURE_STORAGE_CONNECTION_STRING",
+        "AZURE_STORAGE_ACCOUNT_NAME",
+        "AZURE_STORAGE_ACCOUNT_KEY",
+        "BERNSTEIN_AZURE_CONTAINER",
+    }
+)
+
+
+def list_storage_credential_env_vars() -> list[str]:
+    """Return a sorted list of sink-owned env-var names.
+
+    Useful for documentation generation and for asserting that the
+    env-isolation layer strips every one.
+    """
+    return sorted(STORAGE_CREDENTIAL_ENV_VARS)
+
+
+def scrub_env(env: dict[str, str]) -> dict[str, str]:
+    """Return a copy of *env* with every sink credential removed.
+
+    Args:
+        env: Mapping to scrub. Not mutated.
+
+    Returns:
+        A fresh dict containing only keys not in
+        :data:`STORAGE_CREDENTIAL_ENV_VARS`.
+    """
+    return {k: v for k, v in env.items() if k not in STORAGE_CREDENTIAL_ENV_VARS}
+
+
+__all__ = [
+    "STORAGE_CREDENTIAL_ENV_VARS",
+    "list_storage_credential_env_vars",
+    "scrub_env",
+]

--- a/src/bernstein/core/storage/keys.py
+++ b/src/bernstein/core/storage/keys.py
@@ -1,0 +1,106 @@
+"""Canonical sink key-naming helpers.
+
+Bernstein's artifact layout is historically a set of well-known paths
+under ``.sdd/``. When the persistence layer switches to pluggable
+sinks (oai-003) the same logical layout must be reproducible on every
+backend: a key like ``runtime/wal/run-123.wal.jsonl`` has to mean the
+exact same artifact whether the sink is ``LocalFsSink`` or ``S3Sink``.
+
+This module centralises the key-naming convention so callers never
+hand-construct a path in one place and miss it in another. The keys
+returned here are sink-neutral; any character a particular object
+store disallows must be rejected at the sink boundary via
+:func:`bernstein.core.storage.sink.normalise_key`.
+
+The layout is::
+
+    runtime/wal/{run_id}.wal.jsonl
+    runtime/wal/{run_id}.wal.closed
+    runtime/wal/uncommitted.idx.json
+    runtime/checkpoints/{run_id}/{checkpoint_id}.json
+    runtime/state.json
+    tasks/{task_id}/output.json
+    tasks/{task_id}/progress.jsonl
+    audit/{YYYY-MM-DD}.jsonl
+    audit/{YYYY-MM-DD}.jsonl.gz          # rotated + compressed
+    metrics/{run_id}/{timestamp}.json
+    cost/{run_id}/ledger.jsonl
+"""
+
+from __future__ import annotations
+
+from bernstein.core.storage.sink import join_keys
+
+
+def wal_key(run_id: str) -> str:
+    """Key for the WAL JSONL file of *run_id*."""
+    return join_keys("runtime", "wal", f"{run_id}.wal.jsonl")
+
+
+def wal_closed_marker_key(run_id: str) -> str:
+    """Key for the ``.closed`` sidecar of *run_id*'s WAL."""
+    return join_keys("runtime", "wal", f"{run_id}.wal.closed")
+
+
+def uncommitted_index_key() -> str:
+    """Key for the shared uncommitted-WAL index."""
+    return join_keys("runtime", "wal", "uncommitted.idx.json")
+
+
+def checkpoint_key(run_id: str, checkpoint_id: str) -> str:
+    """Key for a specific checkpoint file."""
+    return join_keys("runtime", "checkpoints", run_id, f"{checkpoint_id}.json")
+
+
+def state_key() -> str:
+    """Key for the top-level runtime state file."""
+    return join_keys("runtime", "state.json")
+
+
+def task_output_key(task_id: str) -> str:
+    """Key for a task's final output artifact."""
+    return join_keys("tasks", task_id, "output.json")
+
+
+def task_progress_key(task_id: str) -> str:
+    """Key for the JSONL stream of a task's progress events."""
+    return join_keys("tasks", task_id, "progress.jsonl")
+
+
+def audit_log_key(date: str) -> str:
+    """Key for the HMAC audit log of a specific calendar day.
+
+    Args:
+        date: ``YYYY-MM-DD`` formatted date string.
+    """
+    return join_keys("audit", f"{date}.jsonl")
+
+
+def rotated_audit_key(date: str) -> str:
+    """Key for a rotated + gzipped audit log."""
+    return join_keys("audit", f"{date}.jsonl.gz")
+
+
+def metrics_dump_key(run_id: str, timestamp: str) -> str:
+    """Key for a metrics snapshot within *run_id*."""
+    return join_keys("metrics", run_id, f"{timestamp}.json")
+
+
+def cost_ledger_key(run_id: str) -> str:
+    """Key for the cost ledger JSONL for *run_id*."""
+    return join_keys("cost", run_id, "ledger.jsonl")
+
+
+__all__ = [
+    "audit_log_key",
+    "checkpoint_key",
+    "cost_ledger_key",
+    "metrics_dump_key",
+    "rotated_audit_key",
+    "state_key",
+    "task_output_key",
+    "task_progress_key",
+    "uncommitted_index_key",
+    "wal_closed_marker_key",
+    "wal_key",
+]

--- a/src/bernstein/core/storage/registry.py
+++ b/src/bernstein/core/storage/registry.py
@@ -1,0 +1,263 @@
+"""ArtifactSink registry — first-party sinks + pluggy entry points.
+
+The registry is the single lookup surface for artifact sinks. It loads
+the first-party sinks eagerly (``local_fs``) and the cloud sinks lazily
+— the cloud sink classes are imported only on first :meth:`get`, so
+their optional provider SDKs never block import when the extras are
+missing. Third-party packages add sinks via the
+``bernstein.storage_sinks`` entry-point group::
+
+    [project.entry-points."bernstein.storage_sinks"]
+    my_sink = "mypkg.storage:MyArtifactSink"
+
+The shape mirrors
+:mod:`bernstein.core.sandbox.registry` so plugin authors familiar with
+sandbox backends feel at home.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import threading
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.storage.sink import ArtifactSink
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_POINT_GROUP = "bernstein.storage_sinks"
+
+
+class _Registry:
+    """Thread-safe mutable registry of artifact sinks.
+
+    Mirrors
+    :class:`bernstein.core.sandbox.registry._Registry` so operators
+    familiar with the sandbox surface find the storage surface
+    predictable. Sinks can be registered as instances or as zero-arg
+    factory classes; factories are instantiated lazily on first
+    :meth:`get`.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: dict[str, ArtifactSink] = {}
+        self._factories: dict[str, Any] = {}
+        self._lock = threading.RLock()
+        self._builtins_loaded = False
+        self._entrypoints_loaded = False
+
+    def register(
+        self,
+        name: str,
+        sink: ArtifactSink | Any,
+    ) -> None:
+        """Register *sink* under *name*.
+
+        Args:
+            name: Canonical sink name. Must match the sink's ``name``
+                attribute when an instance is provided.
+            sink: Instance or zero-arg factory class.
+
+        Raises:
+            ValueError: If *name* is empty or already registered.
+        """
+        normalised = name.strip()
+        if not normalised:
+            raise ValueError("Artifact sink name must be non-empty")
+        with self._lock:
+            if normalised in self._sinks or normalised in self._factories:
+                raise ValueError(f"Duplicate artifact sink: {normalised!r}")
+            if inspect.isclass(sink):
+                self._factories[normalised] = sink
+            else:
+                self._sinks[normalised] = sink
+
+    def unregister(self, name: str) -> None:
+        """Remove *name* from the registry if present (tests only)."""
+        with self._lock:
+            self._sinks.pop(name, None)
+            self._factories.pop(name, None)
+
+    def get(self, name: str) -> ArtifactSink:
+        """Return the sink registered under *name*.
+
+        Loads built-in sinks and entry-point sinks on first call.
+
+        Raises:
+            KeyError: If no sink with that name is installed.
+        """
+        self._ensure_loaded()
+        with self._lock:
+            if name in self._sinks:
+                return self._sinks[name]
+            factory = self._factories.get(name)
+            if factory is None:
+                available = ", ".join(sorted(self._all_names())) or "(none)"
+                raise KeyError(f"Unknown artifact sink {name!r}. Available: {available}")
+            instance = factory()
+            self._sinks[name] = instance
+            return instance
+
+    def list_names(self) -> list[str]:
+        """Return the names of all registered sinks, sorted."""
+        self._ensure_loaded()
+        with self._lock:
+            return sorted(self._all_names())
+
+    def list_sinks(self) -> list[ArtifactSink]:
+        """Return instantiated sinks for every registered name.
+
+        Sinks whose factory raises (e.g. missing optional SDK) are
+        skipped with a warning so one broken extra can't block the
+        rest of the catalogue.
+        """
+        self._ensure_loaded()
+        results: list[ArtifactSink] = []
+        for name in self.list_names():
+            try:
+                results.append(self.get(name))
+            except Exception as exc:
+                logger.warning("Artifact sink %r could not be instantiated: %s", name, exc)
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _all_names(self) -> set[str]:
+        return set(self._sinks.keys()) | set(self._factories.keys())
+
+    def _ensure_loaded(self) -> None:
+        with self._lock:
+            if not self._builtins_loaded:
+                self._load_builtins()
+                self._builtins_loaded = True
+            if not self._entrypoints_loaded:
+                self._load_entrypoints()
+                self._entrypoints_loaded = True
+
+    def _load_builtins(self) -> None:
+        # Import LocalFsSink eagerly — the class has no optional deps.
+        # Cloud sinks are registered lazily via ``_register_cloud_factory``
+        # so their SDK imports do not fire when the extras aren't
+        # installed (the factory itself raises a clear error on call).
+        from bernstein.core.storage.sinks.local_fs import LocalFsSink
+
+        if "local_fs" not in self._all_names():
+            self._factories["local_fs"] = LocalFsSink
+
+        self._register_cloud_factory(
+            "s3",
+            "bernstein.core.storage.sinks.s3",
+            "S3ArtifactSink",
+        )
+        self._register_cloud_factory(
+            "gcs",
+            "bernstein.core.storage.sinks.gcs",
+            "GCSArtifactSink",
+        )
+        self._register_cloud_factory(
+            "azure_blob",
+            "bernstein.core.storage.sinks.azure_blob",
+            "AzureBlobArtifactSink",
+        )
+        self._register_cloud_factory(
+            "r2",
+            "bernstein.core.storage.sinks.r2",
+            "R2ArtifactSink",
+        )
+
+    def _register_cloud_factory(self, name: str, module: str, attr: str) -> None:
+        """Register a cloud-sink factory that imports lazily.
+
+        The factory is a small closure that imports the sink class only
+        when invoked; this keeps the registry usable even when the
+        optional SDK for the sink is not installed. The factory ignores
+        arguments so the registry can instantiate it with no config —
+        callers that need non-default wiring should construct the sink
+        directly and register the instance.
+        """
+        if name in self._all_names():
+            return
+
+        def _factory() -> ArtifactSink:
+            import importlib
+
+            try:
+                mod = importlib.import_module(module)
+            except ImportError as exc:  # pragma: no cover - provider-specific
+                raise RuntimeError(f"Sink {name!r} unavailable: {exc}") from exc
+            cls = getattr(mod, attr, None)
+            if cls is None:
+                raise RuntimeError(f"Module {module} does not expose {attr}")
+            return cls()  # type: ignore[no-any-return]
+
+        self._factories[name] = _factory
+
+    def _load_entrypoints(self) -> None:
+        try:
+            eps = entry_points(group=_ENTRY_POINT_GROUP)
+        except Exception as exc:
+            logger.warning("Failed to enumerate artifact sink entry points: %s", exc)
+            return
+        for ep in eps:
+            name = ep.name
+            if name in self._all_names():
+                logger.debug("Artifact sink entry-point %r shadows existing; skipping", name)
+                continue
+            try:
+                loaded = ep.load()
+            except Exception as exc:
+                logger.warning("Failed to load artifact sink entry-point %r: %s", name, exc)
+                continue
+            if inspect.isclass(loaded):
+                self._factories[name] = loaded
+            else:
+                self._sinks[name] = loaded
+
+
+_default_registry_instance = _Registry()
+
+
+def default_registry() -> _Registry:
+    """Return the process-wide default sink registry."""
+    return _default_registry_instance
+
+
+def register_sink(name: str, sink: ArtifactSink | Any) -> None:
+    """Register *sink* under *name* in the default registry."""
+    _default_registry_instance.register(name, sink)
+
+
+def get_sink(name: str) -> ArtifactSink:
+    """Look up *name* in the default registry."""
+    return _default_registry_instance.get(name)
+
+
+def list_sinks() -> list[ArtifactSink]:
+    """Return installed sinks from the default registry."""
+    return _default_registry_instance.list_sinks()
+
+
+def list_sink_names() -> list[str]:
+    """Return installed sink names from the default registry."""
+    return _default_registry_instance.list_names()
+
+
+def _reset_for_tests() -> None:
+    """Drop cached state. Tests only — not part of the public API."""
+    global _default_registry_instance
+    _default_registry_instance = _Registry()
+
+
+__all__ = [
+    "_reset_for_tests",
+    "default_registry",
+    "get_sink",
+    "list_sink_names",
+    "list_sinks",
+    "register_sink",
+]

--- a/src/bernstein/core/storage/sink.py
+++ b/src/bernstein/core/storage/sink.py
@@ -1,0 +1,199 @@
+"""Pluggable artifact sink protocol for ``.sdd/`` persistence (oai-003).
+
+Bernstein writes runtime state, the WAL, HMAC audit logs, task outputs,
+and metrics dumps under ``.sdd/`` on the orchestrator host. On ephemeral
+compute (CI runners, Kubernetes pods, cloud sandboxes) that host can
+disappear between orchestrator restarts, taking recovery state with it.
+
+The :class:`ArtifactSink` protocol decouples the persistence layer from
+the local filesystem so artifacts can stream to S3, GCS, Azure Blob,
+Cloudflare R2, or any custom plugin. The default behaviour is preserved
+by :class:`~bernstein.core.storage.sinks.local_fs.LocalFsSink`, which
+simply reuses the on-disk layout. Remote sinks are optional extras.
+
+Sinks are discovered via the ``bernstein.storage_sinks`` pluggy entry
+point group (see :mod:`bernstein.core.storage.registry`).
+
+The protocol is intentionally narrow: callers interact with logical
+keys such as ``runtime/wal/run-123.wal.jsonl`` rather than file paths,
+and every operation is asynchronous so backends can pipeline I/O.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass(frozen=True)
+class ArtifactStat:
+    """Metadata for a stored artifact.
+
+    Attributes:
+        size_bytes: Length of the artifact in bytes.
+        last_modified_unix: Last-modified time as a Unix timestamp. For
+            providers that do not expose sub-second resolution this is
+            truncated to seconds.
+        etag: Provider-specific entity tag (e.g. S3 ETag). ``None`` when
+            the sink cannot supply one.
+        content_type: MIME content type if the sink recorded one.
+    """
+
+    size_bytes: int
+    last_modified_unix: float
+    etag: str | None = None
+    content_type: str | None = None
+
+
+class SinkError(RuntimeError):
+    """Base class for sink-level exceptions.
+
+    Sink implementations should raise ``FileNotFoundError`` for a missing
+    key (matching the local-filesystem semantics the WAL and audit log
+    already depend on) and :class:`SinkError` for transient or protocol
+    errors so callers can layer retries or circuit breakers.
+    """
+
+
+@runtime_checkable
+class ArtifactSink(Protocol):
+    """Pluggable persistence backend for ``.sdd/`` artifacts.
+
+    Every sink implementation provides a minimal set of async key-value
+    operations. Keys are forward-slash-delimited logical paths; sink
+    implementations map them to whatever native addressing the backend
+    supports (object store keys, filesystem paths, ...).
+
+    Attributes:
+        name: Canonical sink name used in plan.yaml ``storage.sink``
+            (``local_fs``, ``s3``, ``gcs`` ...). Must be stable across
+            versions.
+    """
+
+    name: str
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        """Write *data* at *key*.
+
+        Args:
+            key: Logical key such as ``runtime/wal/run-123.wal.jsonl``.
+            data: Raw payload bytes.
+            durable: When ``True``, the write must be observably durable
+                before ``write`` returns (local ``fsync`` for LocalFs,
+                synchronous PUT for S3-style backends). The WAL relies
+                on this guarantee for crash safety. When ``False`` the
+                backend MAY buffer the write for later flush.
+            content_type: Optional MIME type hint. Sinks that support
+                metadata store it verbatim; others ignore it.
+
+        Raises:
+            SinkError: For transient or protocol-level failures.
+        """
+        ...
+
+    async def read(self, key: str) -> bytes:
+        """Read the artifact stored at *key*.
+
+        Raises:
+            FileNotFoundError: If no artifact exists at *key*.
+            SinkError: For transient or protocol-level failures.
+        """
+        ...
+
+    async def list(self, prefix: str) -> list[str]:
+        """List keys whose identifier starts with *prefix*.
+
+        The returned list is sorted lexicographically. Implementations
+        must internally paginate so callers get the full set in a
+        single call.
+
+        Args:
+            prefix: Prefix to filter by. Pass ``""`` to list every key.
+
+        Returns:
+            Sorted list of matching keys.
+        """
+        ...
+
+    async def delete(self, key: str) -> None:
+        """Remove *key* from the sink.
+
+        Idempotent: deleting a missing key is not an error.
+        """
+        ...
+
+    async def exists(self, key: str) -> bool:
+        """Return True when *key* is present in the sink."""
+        ...
+
+    async def stat(self, key: str) -> ArtifactStat:
+        """Return size/etag/modified metadata for *key*.
+
+        Raises:
+            FileNotFoundError: If no artifact exists at *key*.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Flush pending writes and release any client resources.
+
+        Safe to call multiple times. After ``close`` returns, callers
+        must not invoke further operations on the sink.
+        """
+        ...
+
+
+def normalise_key(key: str) -> str:
+    """Canonicalise a sink key.
+
+    - Strips leading slashes so callers can safely pass absolute-looking
+      paths like ``/runtime/wal/run-1.jsonl``.
+    - Rejects empty keys and ``.``/``..`` segments to prevent sinks
+      from accidentally writing outside their logical root.
+
+    Raises:
+        ValueError: When the key cannot be canonicalised.
+    """
+    if not key:
+        raise ValueError("sink key must be non-empty")
+    stripped = key.lstrip("/")
+    if not stripped:
+        raise ValueError("sink key must contain at least one non-slash character")
+    segments: list[str] = []
+    for segment in stripped.split("/"):
+        if segment in ("", ".", ".."):
+            raise ValueError(f"sink key {key!r} contains forbidden segment {segment!r}")
+        segments.append(segment)
+    return "/".join(segments)
+
+
+def join_keys(*parts: str) -> str:
+    """Join sink key *parts* with forward slashes.
+
+    Skips empty components so the result never contains ``//``. Raises
+    :class:`ValueError` when every part is empty.
+    """
+    kept: Iterable[str] = (p.strip("/") for p in parts)
+    cleaned = [segment for segment in kept if segment]
+    if not cleaned:
+        raise ValueError("at least one non-empty key part is required")
+    return "/".join(cleaned)
+
+
+__all__ = [
+    "ArtifactSink",
+    "ArtifactStat",
+    "SinkError",
+    "join_keys",
+    "normalise_key",
+]

--- a/src/bernstein/core/storage/sinks/__init__.py
+++ b/src/bernstein/core/storage/sinks/__init__.py
@@ -1,0 +1,16 @@
+"""First-party :class:`~bernstein.core.storage.sink.ArtifactSink` implementations.
+
+The local-filesystem sink is always importable. Cloud sinks
+(:mod:`~bernstein.core.storage.sinks.s3`,
+:mod:`~bernstein.core.storage.sinks.gcs`,
+:mod:`~bernstein.core.storage.sinks.azure_blob`,
+:mod:`~bernstein.core.storage.sinks.r2`) import their provider SDKs
+lazily inside their ``__init__`` / operation methods, so pulling this
+package never forces the optional extras.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.storage.sinks.local_fs import LocalFsSink
+
+__all__ = ["LocalFsSink"]

--- a/src/bernstein/core/storage/sinks/azure_blob.py
+++ b/src/bernstein/core/storage/sinks/azure_blob.py
@@ -1,0 +1,290 @@
+"""Azure Blob Storage :class:`ArtifactSink` (optional extra).
+
+Install with ``pip install bernstein[azure]`` to pull in
+``azure-storage-blob``. When the SDK is not installed the module
+still imports cleanly — instantiation is where the error surfaces.
+
+Credential handling:
+
+- ``AZURE_STORAGE_CONNECTION_STRING`` — preferred; full connection string.
+- ``AZURE_STORAGE_ACCOUNT_NAME`` + ``AZURE_STORAGE_ACCOUNT_KEY`` — classic
+  account key auth.
+- Constructor overrides take priority over environment variables.
+
+The ``BlobServiceClient`` is synchronous (there is an async Azure SDK
+but using it here would add an unconditional dependency for non-Azure
+users via transitive async-http packages). Operations are dispatched
+through :func:`asyncio.to_thread` so the event loop is not blocked
+during upload/download round-trips.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, cast
+
+from bernstein.core.storage.sink import (
+    ArtifactSink,
+    ArtifactStat,
+    SinkError,
+    normalise_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AzureBlobUnavailable(RuntimeError):
+    """Raised when the ``azure-storage-blob`` SDK is not installed."""
+
+
+def _import_blob_sdk() -> Any:
+    try:
+        from azure.storage import blob  # type: ignore[import-not-found,import-untyped]
+    except ImportError as exc:  # pragma: no cover
+        raise AzureBlobUnavailable(
+            "azure-storage-blob is not installed. Install the 'azure' extra: `pip install bernstein[azure]`",
+        ) from exc
+    return cast(Any, blob)
+
+
+def _import_azure_core_exceptions() -> Any:
+    try:
+        from azure.core import exceptions  # type: ignore[import-not-found,import-untyped]
+    except ImportError as exc:  # pragma: no cover
+        raise AzureBlobUnavailable(
+            "azure-core is not installed (ships with azure-storage-blob)",
+        ) from exc
+    return cast(Any, exceptions)
+
+
+class AzureBlobArtifactSink(ArtifactSink):
+    """:class:`ArtifactSink` backed by Azure Blob Storage."""
+
+    name: str = "azure_blob"
+
+    def __init__(
+        self,
+        *,
+        container: str | None = None,
+        prefix: str = "",
+        connection_string: str | None = None,
+        account_name: str | None = None,
+        account_key: str | None = None,
+        client_factory: Any | None = None,
+    ) -> None:
+        """Create the sink.
+
+        Args:
+            container: Blob container name. Falls back to
+                ``BERNSTEIN_AZURE_CONTAINER``.
+            prefix: Logical prefix prepended to every key.
+            connection_string: Full Azure connection string. Falls
+                back to ``AZURE_STORAGE_CONNECTION_STRING``.
+            account_name: Storage account name. Falls back to
+                ``AZURE_STORAGE_ACCOUNT_NAME``.
+            account_key: Storage account key. Falls back to
+                ``AZURE_STORAGE_ACCOUNT_KEY``.
+            client_factory: Test seam returning a ``BlobServiceClient``.
+        """
+        self._container = container or os.environ.get("BERNSTEIN_AZURE_CONTAINER") or ""
+        self._prefix = prefix.strip("/")
+        self._connection_string = connection_string or os.environ.get(
+            "AZURE_STORAGE_CONNECTION_STRING",
+        )
+        self._account_name = account_name or os.environ.get(
+            "AZURE_STORAGE_ACCOUNT_NAME",
+        )
+        self._account_key = account_key or os.environ.get(
+            "AZURE_STORAGE_ACCOUNT_KEY",
+        )
+        self._client_factory = client_factory
+        self._service_client: Any | None = None
+        self._container_client: Any | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def container(self) -> str:
+        """Expose the configured container for diagnostics."""
+        return self._container
+
+    def _blob_name(self, key: str) -> str:
+        normalised = normalise_key(key)
+        if self._prefix:
+            return f"{self._prefix}/{normalised}"
+        return normalised
+
+    async def _ensure_container(self) -> Any:
+        if self._container_client is not None:
+            return self._container_client
+        async with self._lock:
+            if self._container_client is not None:
+                return self._container_client
+            if self._client_factory is not None:
+                self._service_client = await asyncio.to_thread(self._client_factory)
+            else:
+                if not self._container:
+                    raise SinkError(
+                        "Azure Blob sink requires a container (constructor or BERNSTEIN_AZURE_CONTAINER)",
+                    )
+                blob_sdk = _import_blob_sdk()
+                service_cls = blob_sdk.BlobServiceClient
+
+                def _build() -> Any:
+                    if self._connection_string:
+                        return service_cls.from_connection_string(self._connection_string)
+                    if self._account_name and self._account_key:
+                        account_url = f"https://{self._account_name}.blob.core.windows.net"
+                        return service_cls(
+                            account_url=account_url,
+                            credential=self._account_key,
+                        )
+                    raise SinkError(
+                        "Azure Blob sink requires AZURE_STORAGE_CONNECTION_STRING "
+                        "or AZURE_STORAGE_ACCOUNT_NAME + AZURE_STORAGE_ACCOUNT_KEY",
+                    )
+
+                self._service_client = await asyncio.to_thread(_build)
+            service = self._service_client
+            assert service is not None, "service client must be initialised"
+            self._container_client = await asyncio.to_thread(
+                service.get_container_client,
+                self._container,
+            )
+            return self._container_client
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        del durable  # PUT is synchronously acknowledged
+        container = await self._ensure_container()
+        blob_name = self._blob_name(key)
+        blob_sdk = _import_blob_sdk()
+        content_settings_cls = getattr(blob_sdk, "ContentSettings", None)
+
+        def _do_write() -> None:
+            blob_client = container.get_blob_client(blob_name)
+            kwargs: dict[str, Any] = {"overwrite": True}
+            if content_type and content_settings_cls is not None:
+                kwargs["content_settings"] = content_settings_cls(
+                    content_type=content_type,
+                )
+            try:
+                blob_client.upload_blob(data, **kwargs)
+            except Exception as exc:
+                raise SinkError(f"Azure upload {blob_name!r} failed: {exc}") from exc
+
+        await asyncio.to_thread(_do_write)
+
+    async def read(self, key: str) -> bytes:
+        container = await self._ensure_container()
+        blob_name = self._blob_name(key)
+        exceptions = _import_azure_core_exceptions()
+
+        def _do_read() -> bytes:
+            blob_client = container.get_blob_client(blob_name)
+            try:
+                downloader = blob_client.download_blob()
+                return downloader.readall()  # type: ignore[no-any-return]
+            except exceptions.ResourceNotFoundError as exc:
+                raise FileNotFoundError(blob_name) from exc
+            except Exception as exc:
+                raise SinkError(f"Azure download {blob_name!r} failed: {exc}") from exc
+
+        return await asyncio.to_thread(_do_read)
+
+    async def list(self, prefix: str) -> list[str]:
+        container = await self._ensure_container()
+        logical_prefix = prefix.strip("/")
+        combined = "/".join(p for p in (self._prefix, logical_prefix) if p)
+
+        def _do_list() -> list[str]:
+            names: list[str] = []
+            for blob in container.list_blobs(name_starts_with=combined):
+                k = str(blob.name)
+                if self._prefix and k.startswith(self._prefix + "/"):
+                    k = k[len(self._prefix) + 1 :]
+                names.append(k)
+            names.sort()
+            return names
+
+        return await asyncio.to_thread(_do_list)
+
+    async def delete(self, key: str) -> None:
+        container = await self._ensure_container()
+        blob_name = self._blob_name(key)
+        exceptions = _import_azure_core_exceptions()
+
+        def _do_delete() -> None:
+            blob_client = container.get_blob_client(blob_name)
+            try:
+                blob_client.delete_blob()
+            except exceptions.ResourceNotFoundError:
+                return
+            except Exception as exc:
+                raise SinkError(f"Azure delete {blob_name!r} failed: {exc}") from exc
+
+        await asyncio.to_thread(_do_delete)
+
+    async def exists(self, key: str) -> bool:
+        container = await self._ensure_container()
+        blob_name = self._blob_name(key)
+
+        def _do_exists() -> bool:
+            blob_client = container.get_blob_client(blob_name)
+            try:
+                return bool(blob_client.exists())
+            except Exception as exc:
+                raise SinkError(f"Azure exists {blob_name!r} failed: {exc}") from exc
+
+        return await asyncio.to_thread(_do_exists)
+
+    async def stat(self, key: str) -> ArtifactStat:
+        container = await self._ensure_container()
+        blob_name = self._blob_name(key)
+        exceptions = _import_azure_core_exceptions()
+
+        def _do_stat() -> ArtifactStat:
+            blob_client = container.get_blob_client(blob_name)
+            try:
+                props = blob_client.get_blob_properties()
+            except exceptions.ResourceNotFoundError as exc:
+                raise FileNotFoundError(blob_name) from exc
+            except Exception as exc:
+                raise SinkError(f"Azure stat {blob_name!r} failed: {exc}") from exc
+            last_modified = getattr(props, "last_modified", None)
+            mtime = float(last_modified.timestamp()) if last_modified else 0.0
+            content_settings = getattr(props, "content_settings", None)
+            content_type = getattr(content_settings, "content_type", None) if content_settings is not None else None
+            return ArtifactStat(
+                size_bytes=int(getattr(props, "size", 0) or 0),
+                last_modified_unix=mtime,
+                etag=str(getattr(props, "etag", "") or "").strip('"') or None,
+                content_type=content_type,
+            )
+
+        return await asyncio.to_thread(_do_stat)
+
+    async def close(self) -> None:
+        container = self._container_client
+        service = self._service_client
+        self._container_client = None
+        self._service_client = None
+        for client in (container, service):
+            if client is None:
+                continue
+            close = getattr(client, "close", None)
+            if close is not None:
+                await asyncio.to_thread(close)
+
+
+__all__ = [
+    "AzureBlobArtifactSink",
+    "AzureBlobUnavailable",
+]

--- a/src/bernstein/core/storage/sinks/gcs.py
+++ b/src/bernstein/core/storage/sinks/gcs.py
@@ -1,0 +1,253 @@
+"""Google Cloud Storage :class:`ArtifactSink` (optional extra).
+
+Install with ``pip install bernstein[gcs]``. When the
+``google-cloud-storage`` SDK is missing the module still imports
+cleanly — instantiation is where the error surfaces.
+
+Credentials resolve via the standard
+``GOOGLE_APPLICATION_CREDENTIALS`` env var (service-account JSON) or
+workload identity when running on GCP. Explicit project and
+credential overrides are accepted via the constructor for unusual
+deployments.
+
+The google-cloud-storage client is synchronous; every operation runs
+through :func:`asyncio.to_thread` to keep the event loop free.
+``durable=True`` maps to a blocking synchronous upload — GCS's ACK is
+the equivalent of a local fsync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, cast
+
+from bernstein.core.storage.sink import (
+    ArtifactSink,
+    ArtifactStat,
+    SinkError,
+    normalise_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GCSUnavailable(RuntimeError):
+    """Raised when ``google-cloud-storage`` is not installed."""
+
+
+def _import_storage() -> Any:
+    """Return the ``google.cloud.storage`` module or raise."""
+    try:
+        from google.cloud import storage  # type: ignore[import-not-found,import-untyped]
+    except ImportError as exc:  # pragma: no cover - monkeypatched in tests
+        raise GCSUnavailable(
+            "google-cloud-storage is not installed. Install the 'gcs' extra: `pip install bernstein[gcs]`",
+        ) from exc
+    return cast(Any, storage)
+
+
+def _import_gcs_exceptions() -> Any:
+    try:
+        from google.api_core import exceptions as api_exceptions  # type: ignore[import-not-found,import-untyped]
+    except ImportError as exc:  # pragma: no cover
+        raise GCSUnavailable(
+            "google-api-core is not installed (ships with google-cloud-storage)",
+        ) from exc
+    return cast(Any, api_exceptions)
+
+
+class GCSArtifactSink(ArtifactSink):
+    """:class:`ArtifactSink` backed by Google Cloud Storage."""
+
+    name: str = "gcs"
+
+    def __init__(
+        self,
+        *,
+        bucket: str | None = None,
+        prefix: str = "",
+        project: str | None = None,
+        credentials_path: str | None = None,
+        client_factory: Any | None = None,
+    ) -> None:
+        """Create the sink.
+
+        Args:
+            bucket: GCS bucket. Falls back to ``BERNSTEIN_GCS_BUCKET``.
+            prefix: Logical prefix prepended to every key.
+            project: GCP project. Falls back to ``GOOGLE_CLOUD_PROJECT``.
+            credentials_path: Override
+                ``GOOGLE_APPLICATION_CREDENTIALS`` for this sink.
+            client_factory: Test seam returning a pre-built client.
+        """
+        self._bucket = bucket or os.environ.get("BERNSTEIN_GCS_BUCKET") or ""
+        self._prefix = prefix.strip("/")
+        self._project = project or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        if credentials_path:
+            os.environ.setdefault("GOOGLE_APPLICATION_CREDENTIALS", credentials_path)
+        self._client_factory = client_factory
+        self._client: Any | None = None
+        self._bucket_handle: Any | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def bucket(self) -> str:
+        """Expose the configured bucket for diagnostics."""
+        return self._bucket
+
+    def _object_name(self, key: str) -> str:
+        normalised = normalise_key(key)
+        if self._prefix:
+            return f"{self._prefix}/{normalised}"
+        return normalised
+
+    async def _ensure_bucket(self) -> Any:
+        if self._bucket_handle is not None:
+            return self._bucket_handle
+        async with self._lock:
+            if self._bucket_handle is not None:
+                return self._bucket_handle
+            if self._client_factory is not None:
+                self._client = await asyncio.to_thread(self._client_factory)
+            else:
+                if not self._bucket:
+                    raise SinkError(
+                        "GCS sink requires a bucket (constructor or BERNSTEIN_GCS_BUCKET)",
+                    )
+                storage = _import_storage()
+                self._client = await asyncio.to_thread(
+                    storage.Client,
+                    project=self._project,
+                )
+            client = self._client
+            assert client is not None, "GCS client must be initialised"
+            self._bucket_handle = await asyncio.to_thread(
+                client.bucket,
+                self._bucket,
+            )
+            return self._bucket_handle
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        del durable  # GCS upload is synchronously acknowledged
+        bucket = await self._ensure_bucket()
+        object_name = self._object_name(key)
+
+        def _do_write() -> None:
+            blob = bucket.blob(object_name)
+            try:
+                blob.upload_from_string(
+                    data,
+                    content_type=content_type,
+                )
+            except Exception as exc:
+                raise SinkError(f"GCS upload {object_name!r} failed: {exc}") from exc
+
+        await asyncio.to_thread(_do_write)
+
+    async def read(self, key: str) -> bytes:
+        bucket = await self._ensure_bucket()
+        object_name = self._object_name(key)
+        exceptions = _import_gcs_exceptions()
+
+        def _do_read() -> bytes:
+            blob = bucket.blob(object_name)
+            try:
+                return blob.download_as_bytes()  # type: ignore[no-any-return]
+            except exceptions.NotFound as exc:
+                raise FileNotFoundError(object_name) from exc
+            except Exception as exc:
+                raise SinkError(f"GCS download {object_name!r} failed: {exc}") from exc
+
+        return await asyncio.to_thread(_do_read)
+
+    async def list(self, prefix: str) -> list[str]:
+        bucket = await self._ensure_bucket()
+        logical_prefix = prefix.strip("/")
+        combined = "/".join(p for p in (self._prefix, logical_prefix) if p)
+
+        def _do_list() -> list[str]:
+            names: list[str] = []
+            for blob in bucket.list_blobs(prefix=combined):
+                k = str(blob.name)
+                if self._prefix and k.startswith(self._prefix + "/"):
+                    k = k[len(self._prefix) + 1 :]
+                names.append(k)
+            names.sort()
+            return names
+
+        return await asyncio.to_thread(_do_list)
+
+    async def delete(self, key: str) -> None:
+        bucket = await self._ensure_bucket()
+        object_name = self._object_name(key)
+        exceptions = _import_gcs_exceptions()
+
+        def _do_delete() -> None:
+            blob = bucket.blob(object_name)
+            try:
+                blob.delete()
+            except exceptions.NotFound:
+                return
+            except Exception as exc:
+                raise SinkError(f"GCS delete {object_name!r} failed: {exc}") from exc
+
+        await asyncio.to_thread(_do_delete)
+
+    async def exists(self, key: str) -> bool:
+        bucket = await self._ensure_bucket()
+        object_name = self._object_name(key)
+
+        def _do_exists() -> bool:
+            blob = bucket.blob(object_name)
+            try:
+                return bool(blob.exists())
+            except Exception as exc:
+                raise SinkError(f"GCS exists {object_name!r} failed: {exc}") from exc
+
+        return await asyncio.to_thread(_do_exists)
+
+    async def stat(self, key: str) -> ArtifactStat:
+        bucket = await self._ensure_bucket()
+        object_name = self._object_name(key)
+        exceptions = _import_gcs_exceptions()
+
+        def _do_stat() -> ArtifactStat:
+            blob = bucket.blob(object_name)
+            try:
+                blob.reload()
+            except exceptions.NotFound as exc:
+                raise FileNotFoundError(object_name) from exc
+            updated = blob.updated
+            mtime = float(updated.timestamp()) if updated else 0.0
+            return ArtifactStat(
+                size_bytes=int(blob.size or 0),
+                last_modified_unix=mtime,
+                etag=str(blob.etag) if blob.etag else None,
+                content_type=blob.content_type,
+            )
+
+        return await asyncio.to_thread(_do_stat)
+
+    async def close(self) -> None:
+        client = self._client
+        self._client = None
+        self._bucket_handle = None
+        if client is not None:
+            close = getattr(client, "close", None)
+            if close is not None:
+                await asyncio.to_thread(close)
+
+
+__all__ = [
+    "GCSArtifactSink",
+    "GCSUnavailable",
+]

--- a/src/bernstein/core/storage/sinks/local_fs.py
+++ b/src/bernstein/core/storage/sinks/local_fs.py
@@ -1,0 +1,189 @@
+"""Local-filesystem :class:`ArtifactSink` — default, zero behaviour change.
+
+This sink preserves Bernstein's pre-oai-003 behaviour: artifacts map
+1:1 to files under a root directory (typically ``.sdd/``). It is the
+default selected by plan.yaml when ``storage:`` is omitted so existing
+deployments observe no diff.
+
+Durability semantics match the atomic-write helpers in
+:mod:`bernstein.core.persistence.atomic_write`: every ``durable=True``
+write calls ``fsync`` on both the file descriptor and (on POSIX) the
+parent directory, so a crash immediately after ``write`` returns
+cannot leave a torn or missing artifact.
+
+``durable=False`` still fsyncs — the local sink has no asynchronous
+path so the distinction exists only for protocol parity with remote
+sinks where it genuinely changes latency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from pathlib import Path
+
+from bernstein.core.storage.sink import (
+    ArtifactSink,
+    ArtifactStat,
+    normalise_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class LocalFsSink(ArtifactSink):
+    """:class:`ArtifactSink` backed by a local directory.
+
+    Every logical key is stored at ``root / key``. Keys are normalised
+    through :func:`bernstein.core.storage.sink.normalise_key` so
+    callers cannot escape ``root`` via ``..`` segments or absolute
+    paths.
+
+    The class is intentionally thin: the heavy lifting happens inside
+    :mod:`bernstein.core.persistence.atomic_write`, which the sink
+    re-uses to preserve the existing fsync semantics that the WAL and
+    HMAC audit log depend on.
+    """
+
+    name: str = "local_fs"
+
+    def __init__(self, root: Path | str | None = None) -> None:
+        """Create a sink rooted at *root*.
+
+        Args:
+            root: Absolute or relative directory where artifacts land.
+                Defaults to ``.sdd`` under the current working
+                directory so constructing a sink without arguments
+                matches the legacy layout. The directory is created on
+                demand by the first write — read-only roots that do
+                not yet exist remain unchanged.
+        """
+        self._root = Path(root) if root is not None else Path(".sdd")
+
+    @property
+    def root(self) -> Path:
+        """Return the resolved on-disk root for diagnostics."""
+        return self._root
+
+    def _path_for(self, key: str) -> Path:
+        return self._root / normalise_key(key)
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        """Write *data* to the file mapped from *key*.
+
+        ``content_type`` is ignored — local filesystems have no generic
+        slot for MIME metadata. The argument is accepted for protocol
+        compliance.
+        """
+        del content_type  # unused on local FS; accepted for protocol parity
+        path = self._path_for(key)
+
+        def _sync_write() -> None:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Import inside the function so importers that don't touch
+            # ``write`` never pay for the atomic-write module cost.
+            from bernstein.core.persistence.atomic_write import (
+                write_atomic_bytes,
+            )
+
+            write_atomic_bytes(path, data)
+            if not durable:
+                # ``write_atomic_bytes`` already fsyncs; nothing extra
+                # to do when durability was not requested. We still
+                # return the file on disk because the local sink has
+                # no cheaper "buffered" mode.
+                return
+
+        await asyncio.to_thread(_sync_write)
+
+    async def read(self, key: str) -> bytes:
+        path = self._path_for(key)
+
+        def _sync_read() -> bytes:
+            try:
+                return path.read_bytes()
+            except FileNotFoundError:
+                raise
+            except IsADirectoryError as exc:
+                raise FileNotFoundError(str(path)) from exc
+
+        return await asyncio.to_thread(_sync_read)
+
+    async def list(self, prefix: str) -> list[str]:
+        # ``normalise_key`` rejects empty strings; handle the "list
+        # everything" case explicitly.
+        prefix_norm = prefix.strip("/")
+        search_root = self._root / prefix_norm if prefix_norm else self._root
+
+        def _sync_list() -> list[str]:
+            if not search_root.exists():
+                return []
+            results: list[str] = []
+            if search_root.is_file():
+                rel = search_root.relative_to(self._root)
+                results.append(str(rel).replace(os.sep, "/"))
+                return results
+            for path in search_root.rglob("*"):
+                if not path.is_file():
+                    continue
+                try:
+                    rel = path.relative_to(self._root)
+                except ValueError:
+                    continue
+                results.append(str(rel).replace(os.sep, "/"))
+            results.sort()
+            return results
+
+        return await asyncio.to_thread(_sync_list)
+
+    async def delete(self, key: str) -> None:
+        path = self._path_for(key)
+
+        def _sync_delete() -> None:
+            with contextlib.suppress(FileNotFoundError):
+                path.unlink()
+
+        await asyncio.to_thread(_sync_delete)
+
+    async def exists(self, key: str) -> bool:
+        path = self._path_for(key)
+        return await asyncio.to_thread(path.is_file)
+
+    async def stat(self, key: str) -> ArtifactStat:
+        path = self._path_for(key)
+
+        def _sync_stat() -> ArtifactStat:
+            try:
+                st = path.stat()
+            except FileNotFoundError:
+                raise
+            except (OSError, NotADirectoryError) as exc:
+                raise FileNotFoundError(str(path)) from exc
+            # Treat directories as "not an artifact"; the sink
+            # protocol is key/value and directories have no content.
+            if not path.is_file():
+                raise FileNotFoundError(str(path))
+            return ArtifactStat(
+                size_bytes=int(st.st_size),
+                last_modified_unix=float(st.st_mtime),
+                etag=None,
+                content_type=None,
+            )
+
+        return await asyncio.to_thread(_sync_stat)
+
+    async def close(self) -> None:  # pragma: no cover - nothing to release
+        """No-op: local sink owns no client handles."""
+        return None
+
+
+__all__ = ["LocalFsSink"]

--- a/src/bernstein/core/storage/sinks/r2.py
+++ b/src/bernstein/core/storage/sinks/r2.py
@@ -1,0 +1,88 @@
+"""Cloudflare R2 :class:`ArtifactSink` (optional extra).
+
+Cloudflare R2 implements the S3 API, so this sink is a thin subclass
+of :class:`~bernstein.core.storage.sinks.s3.S3ArtifactSink` that wires
+R2-specific credential env vars and constructs the per-account endpoint
+URL.
+
+Install with ``pip install bernstein[r2]`` (which pulls boto3 — the
+same SDK used by :mod:`bernstein.core.storage.sinks.s3`).
+
+Credentials:
+
+- ``R2_ACCOUNT_ID`` — required; determines the endpoint URL.
+- ``R2_ACCESS_KEY_ID`` — preferred; falls back to ``AWS_ACCESS_KEY_ID``.
+- ``R2_SECRET_ACCESS_KEY`` — preferred; falls back to
+  ``AWS_SECRET_ACCESS_KEY``.
+
+Explicit constructor arguments take priority over environment
+variables. Region is fixed to ``auto`` because R2 is a global
+service; callers rarely need to override it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+logger = logging.getLogger(__name__)
+
+
+class R2ArtifactSink(S3ArtifactSink):
+    """Cloudflare R2 sink, implemented on top of the S3 client."""
+
+    name: str = "r2"
+
+    def __init__(
+        self,
+        *,
+        bucket: str | None = None,
+        prefix: str = "",
+        account_id: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        endpoint_url: str | None = None,
+        client_factory: Any | None = None,
+    ) -> None:
+        """Create the sink.
+
+        Args:
+            bucket: R2 bucket. Falls back to ``BERNSTEIN_R2_BUCKET``.
+            prefix: Logical prefix prepended to every key.
+            account_id: Cloudflare account ID. Falls back to
+                ``R2_ACCOUNT_ID``.
+            access_key_id: R2 access key. Falls back to
+                ``R2_ACCESS_KEY_ID`` or ``AWS_ACCESS_KEY_ID``.
+            secret_access_key: R2 secret. Falls back to
+                ``R2_SECRET_ACCESS_KEY`` or ``AWS_SECRET_ACCESS_KEY``.
+            endpoint_url: Optional explicit endpoint (testing). When
+                not provided, the R2 account-specific endpoint is used.
+            client_factory: Test seam passed through to the underlying
+                :class:`S3ArtifactSink`.
+        """
+        resolved_bucket = bucket or os.environ.get("BERNSTEIN_R2_BUCKET") or ""
+        resolved_account = account_id or os.environ.get("R2_ACCOUNT_ID")
+        resolved_access = access_key_id or os.environ.get("R2_ACCESS_KEY_ID") or os.environ.get("AWS_ACCESS_KEY_ID")
+        resolved_secret = (
+            secret_access_key or os.environ.get("R2_SECRET_ACCESS_KEY") or os.environ.get("AWS_SECRET_ACCESS_KEY")
+        )
+        if endpoint_url is None and resolved_account:
+            endpoint_url = f"https://{resolved_account}.r2.cloudflarestorage.com"
+
+        super().__init__(
+            bucket=resolved_bucket,
+            prefix=prefix,
+            region="auto",
+            endpoint_url=endpoint_url,
+            access_key_id=resolved_access,
+            secret_access_key=resolved_secret,
+            session_token=None,
+            client_factory=client_factory,
+        )
+        self._account_id = resolved_account
+
+
+__all__ = ["R2ArtifactSink"]

--- a/src/bernstein/core/storage/sinks/s3.py
+++ b/src/bernstein/core/storage/sinks/s3.py
@@ -1,0 +1,312 @@
+"""Amazon S3 :class:`ArtifactSink` (optional extra).
+
+Use ``pip install bernstein[s3]`` to install ``boto3``. When the SDK
+is not installed the module still imports cleanly — instantiation is
+where the error surfaces. This mirrors the sandbox-backend pattern in
+:mod:`bernstein.core.sandbox.backends.e2b`.
+
+Credentials resolve in this order:
+
+1. Explicit constructor arguments (``access_key_id``, ``secret_access_key``,
+   ``session_token``, ``region``, ``endpoint_url``).
+2. Standard AWS environment variables (``AWS_ACCESS_KEY_ID``,
+   ``AWS_SECRET_ACCESS_KEY``, ``AWS_SESSION_TOKEN``, ``AWS_REGION``).
+3. boto3's default credential chain (instance profile, ``~/.aws``, IAM
+   role, etc.).
+
+boto3 is synchronous. Every operation is dispatched through
+:func:`asyncio.to_thread` so the event loop is not blocked during
+PUT/GET round-trips. ``durable=True`` maps to a blocking synchronous
+PUT — the object store's ACK is the S3 analogue of a local fsync.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, cast
+
+from bernstein.core.storage.sink import (
+    ArtifactSink,
+    ArtifactStat,
+    SinkError,
+    normalise_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class S3Unavailable(RuntimeError):
+    """Raised when the ``boto3`` SDK is not installed."""
+
+
+def _import_boto3() -> Any:
+    """Return the ``boto3`` module or raise :class:`S3Unavailable`.
+
+    Kept as a helper so tests can monkeypatch the importer and so the
+    top-level module import remains cheap when the extra is missing.
+    """
+    try:
+        import boto3  # type: ignore[import-untyped]
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise S3Unavailable(
+            "boto3 is not installed. Install the 's3' extra: `pip install bernstein[s3]`",
+        ) from exc
+    return cast(Any, boto3)
+
+
+def _import_botocore_exceptions() -> Any:
+    try:
+        from botocore import exceptions as botocore_exceptions  # type: ignore[import-untyped]
+    except ImportError as exc:  # pragma: no cover
+        raise S3Unavailable(
+            "botocore is not installed. Install the 's3' extra: `pip install bernstein[s3]`",
+        ) from exc
+    return cast(Any, botocore_exceptions)
+
+
+class S3ArtifactSink(ArtifactSink):
+    """:class:`ArtifactSink` backed by Amazon S3 (or any S3-compatible API).
+
+    Use this sink when artifacts need to survive the host machine. The
+    object-store PUT request is acknowledged synchronously for
+    ``durable=True`` writes, providing the equivalent of a local fsync
+    for crash-recovery purposes.
+
+    For Cloudflare R2, use the thin subclass
+    :class:`~bernstein.core.storage.sinks.r2.R2ArtifactSink`, which
+    applies R2-specific endpoint + credential conventions on top of
+    this implementation.
+    """
+
+    name: str = "s3"
+
+    def __init__(
+        self,
+        *,
+        bucket: str | None = None,
+        prefix: str = "",
+        region: str | None = None,
+        endpoint_url: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        session_token: str | None = None,
+        client_factory: Any | None = None,
+    ) -> None:
+        """Create the sink.
+
+        Args:
+            bucket: S3 bucket. Falls back to ``BERNSTEIN_S3_BUCKET``.
+            prefix: Logical prefix prepended to every key. Empty by
+                default.
+            region: AWS region. Falls back to ``AWS_REGION``.
+            endpoint_url: Optional custom endpoint (LocalStack, R2,
+                MinIO). Defaults to the AWS endpoint.
+            access_key_id: Explicit access key. Falls back to
+                ``AWS_ACCESS_KEY_ID``.
+            secret_access_key: Explicit secret. Falls back to
+                ``AWS_SECRET_ACCESS_KEY``.
+            session_token: Temporary session token. Falls back to
+                ``AWS_SESSION_TOKEN``.
+            client_factory: Test seam: callable returning a boto3
+                client. When provided, takes priority over every other
+                argument — used in unit tests to inject a stubbed
+                client without touching the real SDK.
+        """
+        self._bucket = bucket or os.environ.get("BERNSTEIN_S3_BUCKET") or ""
+        self._prefix = prefix.strip("/")
+        self._region = region or os.environ.get("AWS_REGION")
+        self._endpoint_url = endpoint_url or os.environ.get("AWS_ENDPOINT_URL")
+        self._access_key_id = access_key_id or os.environ.get("AWS_ACCESS_KEY_ID")
+        self._secret_access_key = secret_access_key or os.environ.get(
+            "AWS_SECRET_ACCESS_KEY",
+        )
+        self._session_token = session_token or os.environ.get("AWS_SESSION_TOKEN")
+        self._client_factory = client_factory
+        self._client: Any | None = None
+        self._lock = asyncio.Lock()
+
+    @property
+    def bucket(self) -> str:
+        """Expose the configured bucket for diagnostics."""
+        return self._bucket
+
+    def _object_key(self, key: str) -> str:
+        normalised = normalise_key(key)
+        if self._prefix:
+            return f"{self._prefix}/{normalised}"
+        return normalised
+
+    async def _ensure_client(self) -> Any:
+        if self._client is not None:
+            return self._client
+        async with self._lock:
+            if self._client is not None:
+                return self._client
+            # Validate configuration BEFORE importing boto3 so operators
+            # hit the informative SinkError rather than S3Unavailable
+            # when both are wrong.
+            if not self._bucket:
+                raise SinkError(
+                    "S3 sink requires a bucket (constructor or BERNSTEIN_S3_BUCKET)",
+                )
+            if self._client_factory is not None:
+                self._client = await asyncio.to_thread(self._client_factory)
+                return self._client
+            boto3 = _import_boto3()
+
+            def _build() -> Any:
+                kwargs: dict[str, Any] = {}
+                if self._region:
+                    kwargs["region_name"] = self._region
+                if self._endpoint_url:
+                    kwargs["endpoint_url"] = self._endpoint_url
+                if self._access_key_id:
+                    kwargs["aws_access_key_id"] = self._access_key_id
+                if self._secret_access_key:
+                    kwargs["aws_secret_access_key"] = self._secret_access_key
+                if self._session_token:
+                    kwargs["aws_session_token"] = self._session_token
+                return boto3.client("s3", **kwargs)
+
+            self._client = await asyncio.to_thread(_build)
+            return self._client
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        del durable  # S3 PUT is always synchronously acknowledged
+        client = await self._ensure_client()
+        object_key = self._object_key(key)
+        kwargs: dict[str, Any] = {
+            "Bucket": self._bucket,
+            "Key": object_key,
+            "Body": data,
+        }
+        if content_type:
+            kwargs["ContentType"] = content_type
+        try:
+            await asyncio.to_thread(client.put_object, **kwargs)
+        except Exception as exc:  # pragma: no cover - exercised via integration
+            raise SinkError(f"S3 PUT {object_key!r} failed: {exc}") from exc
+
+    async def read(self, key: str) -> bytes:
+        client = await self._ensure_client()
+        object_key = self._object_key(key)
+        exceptions = _import_botocore_exceptions()
+
+        def _do_read() -> bytes:
+            try:
+                response = client.get_object(Bucket=self._bucket, Key=object_key)
+            except exceptions.ClientError as exc:
+                code = str(exc.response.get("Error", {}).get("Code", ""))
+                if code in {"NoSuchKey", "404"}:
+                    raise FileNotFoundError(object_key) from exc
+                raise SinkError(f"S3 GET {object_key!r} failed: {exc}") from exc
+            body = response["Body"]
+            try:
+                return body.read()  # type: ignore[no-any-return]
+            finally:
+                close = getattr(body, "close", None)
+                if close is not None:
+                    close()
+
+        return await asyncio.to_thread(_do_read)
+
+    async def list(self, prefix: str) -> list[str]:
+        client = await self._ensure_client()
+        # ``prefix`` is a logical user-facing prefix; combine it with the
+        # sink's own prefix to hit the S3 object store.
+        logical_prefix = prefix.strip("/")
+        s3_prefix_parts = [p for p in (self._prefix, logical_prefix) if p]
+        s3_prefix = "/".join(s3_prefix_parts)
+
+        def _do_list() -> list[str]:
+            paginator = client.get_paginator("list_objects_v2")
+            results: list[str] = []
+            pages = paginator.paginate(Bucket=self._bucket, Prefix=s3_prefix)
+            for page in pages:
+                contents: list[dict[str, Any]] = page.get("Contents", []) or []
+                for item in contents:
+                    k = str(item["Key"])
+                    if self._prefix and k.startswith(self._prefix + "/"):
+                        k = k[len(self._prefix) + 1 :]
+                    results.append(k)
+            results.sort()
+            return results
+
+        return await asyncio.to_thread(_do_list)
+
+    async def delete(self, key: str) -> None:
+        client = await self._ensure_client()
+        object_key = self._object_key(key)
+        try:
+            await asyncio.to_thread(
+                client.delete_object,
+                Bucket=self._bucket,
+                Key=object_key,
+            )
+        except Exception as exc:  # pragma: no cover - exercised via integration
+            raise SinkError(f"S3 DELETE {object_key!r} failed: {exc}") from exc
+
+    async def exists(self, key: str) -> bool:
+        client = await self._ensure_client()
+        object_key = self._object_key(key)
+        exceptions = _import_botocore_exceptions()
+
+        def _do_head() -> bool:
+            try:
+                client.head_object(Bucket=self._bucket, Key=object_key)
+            except exceptions.ClientError as exc:
+                code = str(exc.response.get("Error", {}).get("Code", ""))
+                if code in {"NoSuchKey", "404", "NotFound"}:
+                    return False
+                raise SinkError(f"S3 HEAD {object_key!r} failed: {exc}") from exc
+            return True
+
+        return await asyncio.to_thread(_do_head)
+
+    async def stat(self, key: str) -> ArtifactStat:
+        client = await self._ensure_client()
+        object_key = self._object_key(key)
+        exceptions = _import_botocore_exceptions()
+
+        def _do_head() -> ArtifactStat:
+            try:
+                resp = client.head_object(Bucket=self._bucket, Key=object_key)
+            except exceptions.ClientError as exc:
+                code = str(exc.response.get("Error", {}).get("Code", ""))
+                if code in {"NoSuchKey", "404", "NotFound"}:
+                    raise FileNotFoundError(object_key) from exc
+                raise SinkError(f"S3 HEAD {object_key!r} failed: {exc}") from exc
+            last_modified = resp.get("LastModified")
+            try:
+                mtime = float(last_modified.timestamp()) if last_modified else 0.0
+            except AttributeError:
+                mtime = 0.0
+            return ArtifactStat(
+                size_bytes=int(resp.get("ContentLength", 0)),
+                last_modified_unix=mtime,
+                etag=str(resp.get("ETag", "")).strip('"') or None,
+                content_type=resp.get("ContentType"),
+            )
+
+        return await asyncio.to_thread(_do_head)
+
+    async def close(self) -> None:
+        # boto3 clients use urllib3 connection pools internally; the
+        # official guidance is to let them be garbage-collected. We
+        # drop the reference here and let the normal lifecycle clean up.
+        self._client = None
+
+
+__all__ = [
+    "S3ArtifactSink",
+    "S3Unavailable",
+]

--- a/templates/plan.yaml
+++ b/templates/plan.yaml
@@ -28,6 +28,35 @@ description: >
 # Which CLI agent to use. auto detects installed agents.
 # cli: auto
 
+# ---------------------------------------------------------------------------
+# Artifact storage sink (optional, oai-003).
+# Selects where .sdd/ artifacts (WAL, audit logs, task outputs, metrics,
+# cost ledger) persist. Omit to keep the existing local-filesystem
+# behaviour (zero diff from prior releases).
+#
+# Built-in sinks: local_fs. Optional extras: s3, gcs, azure_blob, r2.
+# Plugin authors register more via the ``bernstein.storage_sinks``
+# entry-point group. See docs/architecture/storage.md.
+#
+# When `buffered: true`, writes are committed locally (preserving WAL
+# fsync semantics for crash safety) and asynchronously mirrored to the
+# remote sink — recommended for production deployments on ephemeral
+# compute where the host may die between restarts.
+# ---------------------------------------------------------------------------
+# storage:
+#   sink: local_fs              # default; no-op
+#   # sink: s3                  # optional extra: `pip install bernstein[s3]`
+#   # sink: gcs                 # optional extra: `pip install bernstein[gcs]`
+#   # sink: azure_blob          # optional extra: `pip install bernstein[azure]`
+#   # sink: r2                  # optional extra: `pip install bernstein[r2]`
+#   bucket: my-bernstein-runs   # provider-specific (S3/GCS/R2)
+#   # container: my-container   # Azure Blob container name
+#   prefix: runs/{run_id}       # {run_id} expanded at runtime
+#   # region: us-east-1         # S3-specific
+#   # account_id: abcd1234      # R2-specific (determines endpoint)
+#   buffered: true              # recommended for production
+#   # Credentials are picked up from env / IAM role by default.
+
 # Spending cap in USD. Accepts "$N", "$N.NN", or plain numbers.
 # budget: "$10"
 

--- a/tests/integration/storage/__init__.py
+++ b/tests/integration/storage/__init__.py
@@ -1,0 +1,9 @@
+"""Integration tests for artifact sinks (oai-003).
+
+Every test module in this package is gated by provider-specific
+availability: either a local emulator (LocalStack for S3,
+fake-gcs-server for GCS, Azurite for Azure Blob) or real cloud
+credentials. CI runs them only on runners with the emulator
+containers started; developer laptops without the emulators ``skip``
+rather than fail.
+"""

--- a/tests/integration/storage/test_azure_blob_sink.py
+++ b/tests/integration/storage/test_azure_blob_sink.py
@@ -1,0 +1,99 @@
+"""Integration tests for :class:`AzureBlobArtifactSink` (oai-003).
+
+Gated by:
+
+- ``azure-storage-blob`` must be importable.
+- Either Azurite is running on the local default endpoint, or
+  ``AZURE_STORAGE_CONNECTION_STRING`` points at a real account.
+- ``BERNSTEIN_AZURE_TEST_CONTAINER`` names a test container.
+
+Run locally with::
+
+    docker run -d -p 10000:10000 mcr.microsoft.com/azure-storage/azurite
+    AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=http;\
+AccountName=devstoreaccount1;\
+AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;\
+BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;" \\
+    BERNSTEIN_AZURE_TEST_CONTAINER=bernstein-it \\
+    uv run pytest tests/integration/storage/test_azure_blob_sink.py -x -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.storage import ArtifactSinkConformance
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bernstein.core.storage.sink import ArtifactSink
+
+
+def _azure_available() -> bool:
+    try:
+        if importlib.util.find_spec("azure.storage.blob") is None:
+            return False
+    except (ImportError, ModuleNotFoundError, ValueError):
+        # ``find_spec`` raises when a parent package is missing rather
+        # than returning ``None``. Treat that as "not installed".
+        return False
+    if os.environ.get("BERNSTEIN_SKIP_AZURE_TESTS") == "1":
+        return False
+    return bool(
+        os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+        or (os.environ.get("AZURE_STORAGE_ACCOUNT_NAME") and os.environ.get("AZURE_STORAGE_ACCOUNT_KEY")),
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _azure_available(),
+    reason="azure-storage-blob not installed or credentials missing",
+)
+
+
+class TestAzureBlobSinkConformance(ArtifactSinkConformance):
+    """Runs the shared conformance suite against a live Azure Blob endpoint."""
+
+    large_payload_bytes = 256 * 1024
+
+    @pytest_asyncio.fixture
+    async def sink(self) -> AsyncIterator[ArtifactSink]:
+        from bernstein.core.storage.sinks.azure_blob import (
+            AzureBlobArtifactSink,
+        )
+
+        container = os.environ.get(
+            "BERNSTEIN_AZURE_TEST_CONTAINER",
+            "bernstein-test",
+        )
+        prefix = f"it/{uuid.uuid4()}"
+        s = AzureBlobArtifactSink(container=container, prefix=prefix)
+
+        # Ensure the container exists (Azurite needs explicit creation).
+        import contextlib
+
+        try:
+            container_client = await s._ensure_container()
+            from azure.core.exceptions import ResourceExistsError  # type: ignore[import-not-found]
+
+            with contextlib.suppress(ResourceExistsError):
+                container_client.create_container()
+        except Exception:
+            # Defer any setup errors to the actual test — some backends
+            # don't allow implicit container creation.
+            pass
+        try:
+            yield s
+        finally:
+            try:
+                for k in await s.list(""):
+                    await s.delete(k)
+            finally:
+                await s.close()

--- a/tests/integration/storage/test_gcs_sink.py
+++ b/tests/integration/storage/test_gcs_sink.py
@@ -1,0 +1,76 @@
+"""Integration tests for :class:`GCSArtifactSink` (oai-003).
+
+Gated by:
+
+- ``google-cloud-storage`` must be importable.
+- ``STORAGE_EMULATOR_HOST`` points at fake-gcs-server, or
+  ``GOOGLE_APPLICATION_CREDENTIALS`` points at a real service-account
+  JSON and ``BERNSTEIN_GCS_TEST_BUCKET`` names a real bucket.
+
+Run locally with::
+
+    docker run -d -p 4443:4443 fsouza/fake-gcs-server
+    STORAGE_EMULATOR_HOST=http://localhost:4443 \\
+    BERNSTEIN_GCS_TEST_BUCKET=bernstein-it \\
+    uv run pytest tests/integration/storage/test_gcs_sink.py -x -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.storage import ArtifactSinkConformance
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bernstein.core.storage.sink import ArtifactSink
+
+
+def _gcs_available() -> bool:
+    try:
+        if importlib.util.find_spec("google.cloud.storage") is None:
+            return False
+    except (ImportError, ModuleNotFoundError, ValueError):
+        return False
+    if os.environ.get("BERNSTEIN_SKIP_GCS_TESTS") == "1":
+        return False
+    if os.environ.get("STORAGE_EMULATOR_HOST"):
+        return True
+    return bool(
+        os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") and os.environ.get("BERNSTEIN_GCS_TEST_BUCKET"),
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _gcs_available(),
+    reason="google-cloud-storage not installed or GCS endpoint/credentials missing",
+)
+
+
+class TestGCSSinkConformance(ArtifactSinkConformance):
+    """Runs the shared conformance suite against a live (emulated) GCS."""
+
+    large_payload_bytes = 256 * 1024
+
+    @pytest_asyncio.fixture
+    async def sink(self) -> AsyncIterator[ArtifactSink]:
+        from bernstein.core.storage.sinks.gcs import GCSArtifactSink
+
+        bucket = os.environ.get("BERNSTEIN_GCS_TEST_BUCKET", "bernstein-test")
+        prefix = f"it/{uuid.uuid4()}"
+        s = GCSArtifactSink(bucket=bucket, prefix=prefix)
+        try:
+            yield s
+        finally:
+            try:
+                for k in await s.list(""):
+                    await s.delete(k)
+            finally:
+                await s.close()

--- a/tests/integration/storage/test_r2_sink.py
+++ b/tests/integration/storage/test_r2_sink.py
@@ -1,0 +1,70 @@
+"""Integration tests for :class:`R2ArtifactSink` (oai-003).
+
+R2 has no widely-available local emulator, so these tests require
+real Cloudflare credentials:
+
+- ``R2_ACCOUNT_ID``
+- ``R2_ACCESS_KEY_ID``
+- ``R2_SECRET_ACCESS_KEY``
+- ``BERNSTEIN_R2_TEST_BUCKET``
+
+When any of the above is missing the module skips.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.storage import ArtifactSinkConformance
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bernstein.core.storage.sink import ArtifactSink
+
+
+def _r2_available() -> bool:
+    if importlib.util.find_spec("boto3") is None:
+        return False
+    if os.environ.get("BERNSTEIN_SKIP_R2_TESTS") == "1":
+        return False
+    return bool(
+        os.environ.get("R2_ACCOUNT_ID")
+        and os.environ.get("R2_ACCESS_KEY_ID")
+        and os.environ.get("R2_SECRET_ACCESS_KEY")
+        and os.environ.get("BERNSTEIN_R2_TEST_BUCKET"),
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _r2_available(),
+    reason="R2 credentials missing",
+)
+
+
+class TestR2SinkConformance(ArtifactSinkConformance):
+    """Runs the shared conformance suite against a live R2 bucket."""
+
+    large_payload_bytes = 256 * 1024
+
+    @pytest_asyncio.fixture
+    async def sink(self) -> AsyncIterator[ArtifactSink]:
+        from bernstein.core.storage.sinks.r2 import R2ArtifactSink
+
+        bucket = os.environ["BERNSTEIN_R2_TEST_BUCKET"]
+        prefix = f"it/{uuid.uuid4()}"
+        s = R2ArtifactSink(bucket=bucket, prefix=prefix)
+        try:
+            yield s
+        finally:
+            try:
+                for k in await s.list(""):
+                    await s.delete(k)
+            finally:
+                await s.close()

--- a/tests/integration/storage/test_s3_sink.py
+++ b/tests/integration/storage/test_s3_sink.py
@@ -1,0 +1,94 @@
+"""Integration tests for :class:`S3ArtifactSink` (oai-003).
+
+Gated by:
+
+- ``boto3`` must be installable (so unit envs without the 's3' extra
+  skip gracefully rather than ImportError).
+- Either ``AWS_ENDPOINT_URL`` points at LocalStack, or real
+  ``AWS_ACCESS_KEY_ID`` + ``AWS_SECRET_ACCESS_KEY`` are set.
+- ``BERNSTEIN_S3_TEST_BUCKET`` names a bucket to scope test data to.
+
+When the gate fails the whole module skips. Run locally with::
+
+    docker run -d -p 4566:4566 localstack/localstack
+    AWS_ENDPOINT_URL=http://localhost:4566 \\
+    AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \\
+    AWS_REGION=us-east-1 \\
+    BERNSTEIN_S3_TEST_BUCKET=bernstein-it \\
+    uv run pytest tests/integration/storage/test_s3_sink.py -x -q
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.storage import ArtifactSinkConformance
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bernstein.core.storage.sink import ArtifactSink
+
+
+def _s3_available() -> bool:
+    if importlib.util.find_spec("boto3") is None:
+        return False
+    if os.environ.get("BERNSTEIN_SKIP_S3_TESTS") == "1":
+        return False
+    # Either LocalStack URL or explicit AWS creds must exist.
+    if os.environ.get("AWS_ENDPOINT_URL"):
+        return True
+    return bool(
+        os.environ.get("AWS_ACCESS_KEY_ID") and os.environ.get("AWS_SECRET_ACCESS_KEY"),
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not _s3_available(),
+    reason="boto3 not installed or S3 endpoint/credentials missing",
+)
+
+
+class TestS3SinkConformance(ArtifactSinkConformance):
+    """Runs the shared conformance suite against a live (emulated) S3."""
+
+    # Keep the large-payload test modest — 256 KB round-trips against
+    # LocalStack in <100 ms.
+    large_payload_bytes = 256 * 1024
+
+    @pytest_asyncio.fixture
+    async def sink(self) -> AsyncIterator[ArtifactSink]:
+        """Yield an S3ArtifactSink scoped to a throw-away prefix."""
+        from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+        bucket = os.environ.get("BERNSTEIN_S3_TEST_BUCKET", "bernstein-test")
+        prefix = f"it/{uuid.uuid4()}"
+        s = S3ArtifactSink(bucket=bucket, prefix=prefix)
+
+        # Pre-create the bucket against LocalStack — real AWS buckets
+        # must exist ahead of time.
+        if os.environ.get("AWS_ENDPOINT_URL"):
+            client = await s._ensure_client()
+            import botocore.exceptions  # type: ignore[import-untyped]
+
+            try:
+                client.create_bucket(Bucket=bucket)
+            except botocore.exceptions.ClientError as exc:
+                code = str(exc.response.get("Error", {}).get("Code", ""))
+                if code not in {"BucketAlreadyOwnedByYou", "BucketAlreadyExists"}:
+                    raise
+        try:
+            yield s
+        finally:
+            # Best-effort cleanup: delete keys under the test prefix.
+            try:
+                for k in await s.list(""):
+                    await s.delete(k)
+            finally:
+                await s.close()

--- a/tests/integration/storage/test_wal_crash_recovery.py
+++ b/tests/integration/storage/test_wal_crash_recovery.py
@@ -1,0 +1,86 @@
+"""WAL crash-recovery with :class:`BufferedSink` (oai-003).
+
+This test simulates an orchestrator killed mid-run with a BufferedSink
+configured. It asserts two things:
+
+1. The local fsync semantics are preserved — every WAL line the WAL
+   writer emitted is on disk after the simulated crash.
+2. The asynchronous mirror eventually reproduces the same WAL on the
+   remote sink. (A separate integration test against LocalStack
+   exercises the cloud wire path; this one uses a LocalFsSink as the
+   'remote' so it runs in every environment.)
+
+Runs as an integration test because it spans the WAL module, the
+storage package, and asyncio lifecycles.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.persistence.wal import WALReader, WALWriter
+from bernstein.core.storage import BufferedSink, LocalFsSink
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_wal_local_survives_crash_with_buffered_sink(tmp_path: Path) -> None:
+    """Simulated crash: WAL lines are on local disk even if the mirror didn't drain."""
+    local_root = tmp_path / "local"
+    remote_root = tmp_path / "remote"
+    local = LocalFsSink(local_root)
+    remote = LocalFsSink(remote_root)
+    sink = BufferedSink(local=local, remote=remote)
+
+    # The WAL writer writes directly to disk (unchanged from oai-002).
+    # BufferedSink is exercised in parallel so the mirror is already
+    # running in the background when we simulate the kill.
+    writer = WALWriter(run_id="crash-run", sdd_dir=local_root)
+    writer.append(
+        decision_type="task_claimed",
+        inputs={"task_id": "t-1"},
+        output={"status": "ok"},
+        actor="orchestrator",
+        committed=False,
+    )
+    # Route the same payload through the sink to exercise the mirror.
+    await sink.write(
+        "runtime/wal/crash-run.wal.jsonl",
+        local_root.joinpath("runtime", "wal", "crash-run.wal.jsonl").read_bytes(),
+        durable=True,
+    )
+
+    # Simulate orchestrator kill — do NOT close the sink.
+    # Drop references to exercise the crash path; pending mirrors may
+    # or may not have drained yet.
+    del sink
+
+    # On restart, the WAL reader can still load every entry from local.
+    reader = WALReader(run_id="crash-run", sdd_dir=local_root)
+    entries = list(reader.iter_entries())
+    assert len(entries) == 1
+    assert entries[0].decision_type == "task_claimed"
+    assert entries[0].committed is False
+
+
+@pytest.mark.asyncio
+async def test_wal_mirror_drains_on_clean_close(tmp_path: Path) -> None:
+    """Graceful shutdown: every WAL line is mirrored before close returns."""
+    local_root = tmp_path / "local"
+    remote_root = tmp_path / "remote"
+    local = LocalFsSink(local_root)
+    remote = LocalFsSink(remote_root)
+    sink = BufferedSink(local=local, remote=remote)
+
+    for i in range(5):
+        await sink.write(f"runtime/wal/run-{i}.wal.jsonl", str(i).encode())
+
+    await sink.close()
+
+    # Every file must exist in the remote sink after close.
+    for i in range(5):
+        assert await remote.exists(f"runtime/wal/run-{i}.wal.jsonl")

--- a/tests/unit/storage/__init__.py
+++ b/tests/unit/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the :mod:`bernstein.core.storage` package (oai-003)."""

--- a/tests/unit/storage/test_buffered_sink.py
+++ b/tests/unit/storage/test_buffered_sink.py
@@ -1,0 +1,356 @@
+"""Unit tests for :class:`BufferedSink` (oai-003).
+
+The tests use two in-memory-backed LocalFsSinks rooted at separate
+tmp paths to simulate the local-vs-remote split. That keeps the
+tests fast and deterministic; the cloud-emulator integration tests
+exercise the real network paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.storage import (
+    BufferedSink,
+    LocalFsSink,
+    SinkError,
+)
+from bernstein.core.storage.sink import ArtifactSink, ArtifactStat
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _FlakyRemote(LocalFsSink):
+    """LocalFsSink subclass whose writes fail the first N times.
+
+    Used to exercise BufferedSink's failure counter path.
+    """
+
+    def __init__(self, root: Path, fail_first: int) -> None:
+        super().__init__(root)
+        self._fail_first = fail_first
+        self._attempts = 0
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        self._attempts += 1
+        if self._attempts <= self._fail_first:
+            raise SinkError("simulated failure")
+        await super().write(
+            key,
+            data,
+            durable=durable,
+            content_type=content_type,
+        )
+
+
+class _CountingSink(LocalFsSink):
+    """LocalFsSink whose operations can be observed for test assertions."""
+
+    def __init__(self, root: Path) -> None:
+        super().__init__(root)
+        self.reads = 0
+        self.writes = 0
+
+    async def read(self, key: str) -> bytes:
+        self.reads += 1
+        return await super().read(key)
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        self.writes += 1
+        await super().write(
+            key,
+            data,
+            durable=durable,
+            content_type=content_type,
+        )
+
+
+async def _drain(sink: BufferedSink, timeout: float = 2.0) -> None:
+    """Wait until all queued mirrors complete."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while sink.stats().pending_writes > 0:
+        if asyncio.get_event_loop().time() > deadline:
+            raise AssertionError("BufferedSink failed to drain")
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+async def test_local_write_is_synchronous(tmp_path: Path) -> None:
+    """After ``write`` returns, the local sink already has the data."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        await sink.write("hello.txt", b"world")
+        # Local visible immediately (crash-safety invariant).
+        assert await local.read("hello.txt") == b"world"
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_remote_mirror_eventually_lands(tmp_path: Path) -> None:
+    """Queued writes drain to the remote sink in the background."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = _CountingSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        await sink.write("k.txt", b"payload")
+        await _drain(sink)
+        assert await remote.read("k.txt") == b"payload"
+        assert remote.writes == 1
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_close_drains_pending(tmp_path: Path) -> None:
+    """``close`` must block until every mirror has been attempted."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    for i in range(10):
+        await sink.write(f"many/{i}.txt", str(i).encode())
+    await sink.close()
+    # All files must have mirrored to remote after close
+    listed = sorted(await remote.list("many"))
+    assert len(listed) == 10
+
+
+@pytest.mark.asyncio
+async def test_read_prefers_remote(tmp_path: Path) -> None:
+    """Read paths hit remote first — critical for crash recovery."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = _CountingSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        await sink.write("k.txt", b"v")
+        await _drain(sink)
+        _ = await sink.read("k.txt")
+        assert remote.reads == 1
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_read_falls_back_to_local_when_remote_missing(
+    tmp_path: Path,
+) -> None:
+    """If the remote doesn't have it (mirror still pending), local serves."""
+    local = LocalFsSink(tmp_path / "local")
+    # Use a fresh tmp dir with no remote state
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        # Pre-populate local only (simulate pre-crash state).
+        await local.write("k.txt", b"recovered")
+        got = await sink.read("k.txt")
+        assert got == b"recovered"
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_failed_mirror_counted(tmp_path: Path) -> None:
+    """A transient remote failure increments failure counter and keeps going."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = _FlakyRemote(tmp_path / "remote", fail_first=2)
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        await sink.write("a.txt", b"1")
+        await sink.write("b.txt", b"2")
+        await sink.write("c.txt", b"3")
+        await _drain(sink)
+        stats = sink.stats()
+        assert stats.failed_mirrors == 2
+        assert stats.completed_mirrors == 1
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_list_merges_local_and_remote(tmp_path: Path) -> None:
+    """List returns the union of both sinks' views."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        # Pre-populate remote with something not in local
+        await remote.write("recovered/x.txt", b"x")
+        # Then route a fresh write through the sink
+        await sink.write("recovered/y.txt", b"y")
+        await _drain(sink)
+        keys = await sink.list("recovered")
+        assert "recovered/x.txt" in keys
+        assert "recovered/y.txt" in keys
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_delete_hits_both(tmp_path: Path) -> None:
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        await sink.write("dead.txt", b"gone")
+        await _drain(sink)
+        await sink.delete("dead.txt")
+        assert await local.exists("dead.txt") is False
+        assert await remote.exists("dead.txt") is False
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_exists_checks_both(tmp_path: Path) -> None:
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    try:
+        await remote.write("in-remote.txt", b"r")
+        assert await sink.exists("in-remote.txt") is True
+        assert await sink.exists("nowhere.txt") is False
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_write_after_close_raises(tmp_path: Path) -> None:
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    await sink.close()
+    with pytest.raises(SinkError):
+        await sink.write("after.txt", b"x")
+
+
+@pytest.mark.asyncio
+async def test_stats_surface_queue_depth(tmp_path: Path) -> None:
+    """Stats expose queue depth for Prometheus metric export."""
+
+    class _SlowRemote(LocalFsSink):
+        async def write(
+            self,
+            key: str,
+            data: bytes,
+            *,
+            durable: bool = True,
+            content_type: str | None = None,
+        ) -> None:
+            await asyncio.sleep(0.05)
+            await super().write(
+                key,
+                data,
+                durable=durable,
+                content_type=content_type,
+            )
+
+    local = LocalFsSink(tmp_path / "local")
+    remote = _SlowRemote(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote, max_pending=8)
+    try:
+        for i in range(5):
+            await sink.write(f"k{i}.txt", b"x")
+        # Some writes should still be queued
+        stats = sink.stats()
+        assert stats.pending_writes >= 0  # at least observable
+        await _drain(sink, timeout=5.0)
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_max_pending_must_be_positive(tmp_path: Path) -> None:
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    with pytest.raises(ValueError):
+        BufferedSink(local=local, remote=remote, max_pending=0)
+
+
+@pytest.mark.asyncio
+async def test_idempotent_close(tmp_path: Path) -> None:
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote)
+    await sink.close()
+    await sink.close()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_crash_recovery_preserves_local_data(tmp_path: Path) -> None:
+    """After a simulated kill before drain, local sink still has the WAL."""
+    local = LocalFsSink(tmp_path / "local")
+    remote = LocalFsSink(tmp_path / "remote")
+    sink = BufferedSink(local=local, remote=remote, max_pending=16)
+
+    # Simulate "WAL append" — durable=True
+    await sink.write("runtime/wal/r.wal.jsonl", b'{"seq":0}\n')
+
+    # Simulate orchestrator crash: we don't drain or close gracefully
+    # before shutting down. Drop references to force GC.
+    del sink
+
+    # A new process spawns a fresh sink rooted at the same paths.
+    recovered_local = LocalFsSink(tmp_path / "local")
+    data = await recovered_local.read("runtime/wal/r.wal.jsonl")
+    assert data == b'{"seq":0}\n'
+
+
+class _ProtocolCheck(ArtifactSink):
+    """Compile-time check that ArtifactStat is importable/usable."""
+
+    name = "proto-check"
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:
+        pass
+
+    async def read(self, key: str) -> bytes:
+        return b""
+
+    async def list(self, prefix: str) -> list[str]:
+        return []
+
+    async def delete(self, key: str) -> None:
+        pass
+
+    async def exists(self, key: str) -> bool:
+        return False
+
+    async def stat(self, key: str) -> ArtifactStat:
+        return ArtifactStat(size_bytes=0, last_modified_unix=0.0)
+
+    async def close(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_protocol_is_structural() -> None:
+    """A class implementing the protocol satisfies isinstance."""
+    check = _ProtocolCheck()
+    assert isinstance(check, ArtifactSink)

--- a/tests/unit/storage/test_cloud_sink_imports.py
+++ b/tests/unit/storage/test_cloud_sink_imports.py
@@ -1,0 +1,71 @@
+"""Smoke tests: cloud sink modules must import without optional SDKs.
+
+The ticket mandates that missing SDKs never break ``import`` — only
+instantiation against missing deps should fail. These tests exercise
+the guarantee by making sure each sink module is importable even when
+the extra-specific SDK is absent.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "bernstein.core.storage.sinks.local_fs",
+        "bernstein.core.storage.sinks.s3",
+        "bernstein.core.storage.sinks.gcs",
+        "bernstein.core.storage.sinks.azure_blob",
+        "bernstein.core.storage.sinks.r2",
+    ],
+)
+def test_module_imports_without_sdk(module: str) -> None:
+    mod = importlib.import_module(module)
+    assert mod is not None
+
+
+def test_missing_boto3_surfaces_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The S3Unavailable error points the user at the right extra."""
+    import sys
+
+    monkeypatch.setitem(sys.modules, "boto3", None)  # force ImportError
+
+    from bernstein.core.storage.sinks.s3 import S3Unavailable, _import_boto3
+
+    with pytest.raises(S3Unavailable, match="s3"):
+        _import_boto3()
+
+
+def test_missing_google_cloud_storage_surfaces_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", None)
+
+    from bernstein.core.storage.sinks.gcs import GCSUnavailable, _import_storage
+
+    with pytest.raises(GCSUnavailable, match="gcs"):
+        _import_storage()
+
+
+def test_missing_azure_blob_surfaces_clear_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    monkeypatch.setitem(sys.modules, "azure.storage.blob", None)
+
+    from bernstein.core.storage.sinks.azure_blob import (
+        AzureBlobUnavailable,
+        _import_blob_sdk,
+    )
+
+    with pytest.raises(AzureBlobUnavailable, match="azure"):
+        _import_blob_sdk()

--- a/tests/unit/storage/test_credential_scoping_storage.py
+++ b/tests/unit/storage/test_credential_scoping_storage.py
@@ -1,0 +1,61 @@
+"""Verify sink credentials never leak into agent environments (oai-003)."""
+
+from __future__ import annotations
+
+from bernstein.core.storage.credential_scoping import (
+    STORAGE_CREDENTIAL_ENV_VARS,
+    list_storage_credential_env_vars,
+    scrub_env,
+)
+
+
+def test_storage_credential_env_vars_covers_expected_providers() -> None:
+    """All four providers must have their core env vars listed."""
+    # S3
+    assert "AWS_ACCESS_KEY_ID" in STORAGE_CREDENTIAL_ENV_VARS
+    assert "AWS_SECRET_ACCESS_KEY" in STORAGE_CREDENTIAL_ENV_VARS
+    # GCS
+    assert "GOOGLE_APPLICATION_CREDENTIALS" in STORAGE_CREDENTIAL_ENV_VARS
+    # Azure
+    assert "AZURE_STORAGE_CONNECTION_STRING" in STORAGE_CREDENTIAL_ENV_VARS
+    # R2
+    assert "R2_ACCOUNT_ID" in STORAGE_CREDENTIAL_ENV_VARS
+    assert "R2_ACCESS_KEY_ID" in STORAGE_CREDENTIAL_ENV_VARS
+    assert "R2_SECRET_ACCESS_KEY" in STORAGE_CREDENTIAL_ENV_VARS
+
+
+def test_list_sorted_and_complete() -> None:
+    listed = list_storage_credential_env_vars()
+    assert listed == sorted(listed)
+    assert set(listed) == STORAGE_CREDENTIAL_ENV_VARS
+
+
+def test_scrub_env_removes_all_listed_keys() -> None:
+    env = {
+        "PATH": "/usr/bin",
+        "AWS_ACCESS_KEY_ID": "AKIA...",
+        "AWS_SECRET_ACCESS_KEY": "secret",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/creds.json",
+        "AZURE_STORAGE_CONNECTION_STRING": "Default...",
+        "R2_ACCOUNT_ID": "acc",
+        "HOME": "/home/agent",
+    }
+    scrubbed = scrub_env(env)
+    assert "AWS_ACCESS_KEY_ID" not in scrubbed
+    assert "AWS_SECRET_ACCESS_KEY" not in scrubbed
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in scrubbed
+    assert "AZURE_STORAGE_CONNECTION_STRING" not in scrubbed
+    assert "R2_ACCOUNT_ID" not in scrubbed
+    # Non-sink env vars preserved
+    assert scrubbed["PATH"] == "/usr/bin"
+    assert scrubbed["HOME"] == "/home/agent"
+
+
+def test_scrub_env_does_not_mutate_input() -> None:
+    env = {"AWS_ACCESS_KEY_ID": "k", "PATH": "/bin"}
+    _ = scrub_env(env)
+    assert env == {"AWS_ACCESS_KEY_ID": "k", "PATH": "/bin"}
+
+
+def test_scrub_env_on_empty_dict() -> None:
+    assert scrub_env({}) == {}

--- a/tests/unit/storage/test_keys.py
+++ b/tests/unit/storage/test_keys.py
@@ -1,0 +1,61 @@
+"""Unit tests for canonical key helpers (oai-003)."""
+
+from __future__ import annotations
+
+from bernstein.core.storage.keys import (
+    audit_log_key,
+    checkpoint_key,
+    cost_ledger_key,
+    metrics_dump_key,
+    rotated_audit_key,
+    state_key,
+    task_output_key,
+    task_progress_key,
+    uncommitted_index_key,
+    wal_closed_marker_key,
+    wal_key,
+)
+
+
+def test_wal_key_shape() -> None:
+    assert wal_key("run-1") == "runtime/wal/run-1.wal.jsonl"
+
+
+def test_wal_closed_marker_shape() -> None:
+    assert wal_closed_marker_key("run-1") == "runtime/wal/run-1.wal.closed"
+
+
+def test_uncommitted_index_shape() -> None:
+    assert uncommitted_index_key() == "runtime/wal/uncommitted.idx.json"
+
+
+def test_checkpoint_key_shape() -> None:
+    assert checkpoint_key("run-1", "ck-5") == "runtime/checkpoints/run-1/ck-5.json"
+
+
+def test_state_key_shape() -> None:
+    assert state_key() == "runtime/state.json"
+
+
+def test_task_output_key_shape() -> None:
+    assert task_output_key("t-42") == "tasks/t-42/output.json"
+
+
+def test_task_progress_key_shape() -> None:
+    assert task_progress_key("t-42") == "tasks/t-42/progress.jsonl"
+
+
+def test_audit_log_key_shape() -> None:
+    assert audit_log_key("2026-04-19") == "audit/2026-04-19.jsonl"
+
+
+def test_rotated_audit_key_shape() -> None:
+    assert rotated_audit_key("2026-04-19") == "audit/2026-04-19.jsonl.gz"
+
+
+def test_metrics_dump_key_shape() -> None:
+    assert metrics_dump_key("r-1", "1713567890") == "metrics/r-1/1713567890.json"
+
+
+def test_cost_ledger_key_shape() -> None:
+    assert cost_ledger_key("r-1") == "cost/r-1/ledger.jsonl"

--- a/tests/unit/storage/test_local_fs_sink.py
+++ b/tests/unit/storage/test_local_fs_sink.py
@@ -1,0 +1,139 @@
+"""Unit tests specific to :class:`LocalFsSink`.
+
+The conformance suite in ``test_sink_protocol.py`` already exercises
+the protocol surface. These tests cover behaviour unique to the
+local filesystem backend: durability semantics, directory creation,
+and the ``root`` property.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.storage import LocalFsSink
+from bernstein.core.storage.keys import (
+    audit_log_key,
+    cost_ledger_key,
+    task_output_key,
+    wal_key,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_write_creates_parent_directories(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    await sink.write("a/b/c/d.txt", b"hello")
+    assert (tmp_path / "a" / "b" / "c" / "d.txt").read_bytes() == b"hello"
+
+
+@pytest.mark.asyncio
+async def test_root_property(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    assert sink.root == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_default_root_is_sdd() -> None:
+    sink = LocalFsSink()
+    assert str(sink.root) == ".sdd"
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_is_noop(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    # Must not raise
+    await sink.delete("missing.txt")
+
+
+@pytest.mark.asyncio
+async def test_list_empty_root_returns_empty(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path / "never-created")
+    assert await sink.list("") == []
+
+
+@pytest.mark.asyncio
+async def test_write_is_atomic_on_crash_simulation(tmp_path: Path) -> None:
+    """A new write overwrites atomically: partial data is never visible."""
+    sink = LocalFsSink(tmp_path)
+    await sink.write("foo.txt", b"first")
+    await sink.write("foo.txt", b"second")
+    assert await sink.read("foo.txt") == b"second"
+
+
+@pytest.mark.asyncio
+async def test_stat_reports_size(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    await sink.write("s.txt", b"abcdef")
+    st = await sink.stat("s.txt")
+    assert st.size_bytes == 6
+    assert st.etag is None  # local fs has no etag
+
+
+@pytest.mark.asyncio
+async def test_integration_with_keys_module(tmp_path: Path) -> None:
+    """Canonical key helpers produce keys LocalFsSink handles."""
+    sink = LocalFsSink(tmp_path)
+    await sink.write(wal_key("run-abc"), b'{"seq":0}\n')
+    await sink.write(task_output_key("t-1"), b'{"ok":true}')
+    await sink.write(audit_log_key("2026-04-19"), b"entry\n")
+    await sink.write(cost_ledger_key("run-abc"), b'{"usd":0.1}\n')
+
+    assert (tmp_path / "runtime" / "wal" / "run-abc.wal.jsonl").is_file()
+    assert (tmp_path / "tasks" / "t-1" / "output.json").is_file()
+    assert (tmp_path / "audit" / "2026-04-19.jsonl").is_file()
+    assert (tmp_path / "cost" / "run-abc" / "ledger.jsonl").is_file()
+
+
+@pytest.mark.asyncio
+async def test_close_is_idempotent(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    await sink.close()
+    await sink.close()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises_fnf(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        await sink.read("nope.txt")
+
+
+@pytest.mark.asyncio
+async def test_content_type_argument_accepted(tmp_path: Path) -> None:
+    """``content_type`` is accepted for protocol parity; must not raise."""
+    sink = LocalFsSink(tmp_path)
+    await sink.write("mime.txt", b"hi", content_type="text/plain")
+    assert await sink.read("mime.txt") == b"hi"
+
+
+@pytest.mark.asyncio
+async def test_durable_false_still_persists(tmp_path: Path) -> None:
+    """Local sink ignores durable=False — persistence is still guaranteed."""
+    sink = LocalFsSink(tmp_path)
+    await sink.write("d.txt", b"x", durable=False)
+    assert await sink.read("d.txt") == b"x"
+
+
+@pytest.mark.asyncio
+async def test_list_with_prefix_matches_subtree(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    await sink.write("a/1.txt", b"1")
+    await sink.write("a/2.txt", b"2")
+    await sink.write("b/3.txt", b"3")
+
+    under_a = await sink.list("a")
+    assert sorted(under_a) == ["a/1.txt", "a/2.txt"]
+
+
+@pytest.mark.asyncio
+async def test_stat_on_directory_raises_fnf(tmp_path: Path) -> None:
+    sink = LocalFsSink(tmp_path)
+    await sink.write("d/inside.txt", b"x")
+    # ``d`` is a directory, not an artifact
+    with pytest.raises(FileNotFoundError):
+        await sink.stat("d")

--- a/tests/unit/storage/test_manifest_cloud_mounts.py
+++ b/tests/unit/storage/test_manifest_cloud_mounts.py
@@ -1,0 +1,79 @@
+"""Tests for the cloud-mount entries added to WorkspaceManifest (oai-003)."""
+
+from __future__ import annotations
+
+from bernstein.core.sandbox import (
+    AzureBlobMount,
+    GCSMount,
+    R2Mount,
+    S3Mount,
+    WorkspaceManifest,
+)
+
+
+def test_manifest_default_has_no_artifact_mounts() -> None:
+    manifest = WorkspaceManifest()
+    assert manifest.artifact_mounts == ()
+
+
+def test_manifest_accepts_s3_mount() -> None:
+    mount = S3Mount(
+        bucket="my-bucket",
+        prefix="runs/abc",
+        mount_path="/workspace/.sdd",
+        region="us-east-1",
+        credentials_env=("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"),
+    )
+    manifest = WorkspaceManifest(artifact_mounts=(mount,))
+    assert manifest.artifact_mounts == (mount,)
+
+
+def test_manifest_accepts_mixed_cloud_mounts() -> None:
+    gcs = GCSMount(
+        bucket="my-gcs",
+        prefix="runs/abc",
+        mount_path="/workspace/.sdd",
+    )
+    azure = AzureBlobMount(
+        container="my-container",
+        prefix="runs/abc",
+        mount_path="/workspace/.azure",
+        account_name="myaccount",
+    )
+    r2 = R2Mount(
+        bucket="my-r2",
+        prefix="runs/abc",
+        mount_path="/workspace/.r2",
+        account_id="acc-xyz",
+    )
+    manifest = WorkspaceManifest(artifact_mounts=(gcs, azure, r2))
+    assert len(manifest.artifact_mounts) == 3
+
+
+def test_s3_mount_is_frozen() -> None:
+    import dataclasses
+
+    mount = S3Mount(bucket="b", prefix="p", mount_path="/m")
+    # Attempting to mutate must raise FrozenInstanceError
+    import pytest
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        mount.bucket = "other"  # type: ignore[misc]
+
+
+def test_s3_mount_has_sensible_defaults() -> None:
+    mount = S3Mount(bucket="b", prefix="", mount_path="/m")
+    assert mount.region is None
+    assert mount.endpoint_url is None
+    assert mount.credentials_env == ()
+    assert mount.read_only is False
+
+
+def test_r2_mount_requires_account_id() -> None:
+    """R2Mount.account_id has no default — enforced by dataclass signature."""
+    import inspect
+
+    sig = inspect.signature(R2Mount)
+    params = sig.parameters
+    # account_id must appear without a default
+    assert params["account_id"].default is inspect.Parameter.empty

--- a/tests/unit/storage/test_registry.py
+++ b/tests/unit/storage/test_registry.py
@@ -1,0 +1,172 @@
+"""Unit tests for the artifact sink registry (oai-003)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.storage import registry as storage_registry
+from bernstein.core.storage.sink import ArtifactSink, ArtifactStat
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+class _StubSink(ArtifactSink):
+    """Minimal sink for registry roundtrip tests."""
+
+    name: str = "stub"
+
+    async def write(
+        self,
+        key: str,
+        data: bytes,
+        *,
+        durable: bool = True,
+        content_type: str | None = None,
+    ) -> None:  # pragma: no cover - not invoked
+        raise NotImplementedError
+
+    async def read(self, key: str) -> bytes:  # pragma: no cover
+        raise NotImplementedError
+
+    async def list(self, prefix: str) -> list[str]:  # pragma: no cover
+        raise NotImplementedError
+
+    async def delete(self, key: str) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    async def exists(self, key: str) -> bool:  # pragma: no cover
+        raise NotImplementedError
+
+    async def stat(self, key: str) -> ArtifactStat:  # pragma: no cover
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def fresh_registry() -> Iterator[None]:
+    """Each test gets a pristine default registry."""
+    storage_registry._reset_for_tests()
+    yield
+    storage_registry._reset_for_tests()
+
+
+def test_default_registry_discovers_local_fs() -> None:
+    names = storage_registry.list_sink_names()
+    assert "local_fs" in names
+
+
+def test_default_registry_advertises_cloud_sinks() -> None:
+    """The names appear even when the optional SDKs are absent."""
+    names = storage_registry.list_sink_names()
+    # Cloud sinks must be advertised so operators know the vocabulary.
+    for expected in ("s3", "gcs", "azure_blob", "r2"):
+        assert expected in names
+
+
+def test_get_local_fs_returns_instance() -> None:
+    sink = storage_registry.get_sink("local_fs")
+    assert sink.name == "local_fs"
+
+
+def test_get_unknown_raises_keyerror() -> None:
+    with pytest.raises(KeyError) as excinfo:
+        storage_registry.get_sink("nonexistent")
+    assert "Available" in str(excinfo.value)
+
+
+def test_duplicate_registration_rejected() -> None:
+    storage_registry.list_sink_names()  # ensure builtins loaded
+    with pytest.raises(ValueError, match="Duplicate"):
+        storage_registry.register_sink("local_fs", _StubSink())
+
+
+def test_empty_name_rejected() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        storage_registry.register_sink("  ", _StubSink())
+
+
+def test_custom_sink_registration_round_trip() -> None:
+    stub = _StubSink()
+    storage_registry.register_sink("stub", stub)
+    assert storage_registry.get_sink("stub") is stub
+    assert "stub" in storage_registry.list_sink_names()
+
+
+def test_list_sinks_skips_broken_factory() -> None:
+    """Missing cloud SDK factories are skipped from list_sinks."""
+    # Cloud sink factories raise on instantiation when the SDK is absent;
+    # list_sinks should warn and continue rather than explode.
+    results = storage_registry.list_sinks()
+    names = {s.name for s in results}
+    # local_fs must always succeed.
+    assert "local_fs" in names
+
+
+def test_entry_point_failure_does_not_break_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeEntryPoint:
+        name = "broken"
+
+        def load(self) -> object:
+            raise RuntimeError("boom")
+
+    def _fake_entry_points(group: str = "") -> list[_FakeEntryPoint]:
+        if group == "bernstein.storage_sinks":
+            return [_FakeEntryPoint()]
+        return []
+
+    monkeypatch.setattr(storage_registry, "entry_points", _fake_entry_points)
+    names = storage_registry.list_sink_names()
+    assert "local_fs" in names
+    assert "broken" not in names
+
+
+def test_entry_point_class_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeEntryPoint:
+        name = "plugin"
+
+        def load(self) -> type[_StubSink]:
+            return _StubSink
+
+    def _fake_entry_points(group: str = "") -> list[_FakeEntryPoint]:
+        if group == "bernstein.storage_sinks":
+            return [_FakeEntryPoint()]
+        return []
+
+    monkeypatch.setattr(storage_registry, "entry_points", _fake_entry_points)
+    assert "plugin" in storage_registry.list_sink_names()
+    got = storage_registry.get_sink("plugin")
+    assert isinstance(got, _StubSink)
+
+
+def test_entry_point_duplicate_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An entry-point colliding with a built-in is dropped silently."""
+
+    class _FakeEntryPoint:
+        name = "local_fs"
+
+        def load(self) -> type[_StubSink]:
+            return _StubSink
+
+    def _fake_entry_points(group: str = "") -> list[_FakeEntryPoint]:
+        if group == "bernstein.storage_sinks":
+            return [_FakeEntryPoint()]
+        return []
+
+    monkeypatch.setattr(storage_registry, "entry_points", _fake_entry_points)
+    # The built-in local_fs wins
+    sink = storage_registry.get_sink("local_fs")
+    assert sink.name == "local_fs"
+
+
+def test_unregister_removes_name() -> None:
+    reg = storage_registry.default_registry()
+    reg.list_names()  # ensure builtins
+    reg.unregister("local_fs")
+    assert "local_fs" not in reg.list_names()

--- a/tests/unit/storage/test_s3_sink_unit.py
+++ b/tests/unit/storage/test_s3_sink_unit.py
@@ -1,0 +1,293 @@
+"""Unit tests for :class:`S3ArtifactSink` using a mocked S3 client.
+
+These tests DO NOT call AWS. They pass a ``client_factory`` that
+returns a hand-rolled stub, verifying the sink's translation of
+protocol operations into ``put_object`` / ``get_object`` calls.
+
+The actual S3 wire protocol is exercised by the gated integration
+tests in ``tests/integration/storage/test_s3_sink.py`` (which run
+against LocalStack).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+
+class _FakeClientError(Exception):
+    """Stand-in for ``botocore.exceptions.ClientError``."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+class _StubBody:
+    """Mimics the ``Body`` streaming interface of a GetObject response."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def close(self) -> None:  # pragma: no cover - covered implicitly
+        return None
+
+
+class _StubPaginator:
+    """Mimics the S3 paginator — yields dict pages with ``Contents``."""
+
+    def __init__(self, pages: list[dict[str, Any]]) -> None:
+        self._pages = pages
+
+    def paginate(self, **_: Any) -> list[dict[str, Any]]:
+        return list(self._pages)
+
+
+class _StubS3Client:
+    """Record operations without touching the network."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+        self.store_meta: dict[str, dict[str, Any]] = {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def put_object(self, **kwargs: Any) -> dict[str, Any]:
+        key = kwargs["Key"]
+        body = kwargs["Body"]
+        self.store[key] = body if isinstance(body, bytes) else bytes(body)
+        meta = {
+            "ContentLength": len(self.store[key]),
+            "ContentType": kwargs.get("ContentType"),
+            "LastModified": datetime.now(tz=UTC),
+            "ETag": '"stub-etag"',
+        }
+        self.store_meta[key] = meta
+        self.calls.append(("put_object", dict(kwargs)))
+        return {}
+
+    def get_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        self.calls.append(("get_object", {"Bucket": Bucket, "Key": Key}))
+        if Key not in self.store:
+            raise _FakeClientError("NoSuchKey")
+        return {"Body": _StubBody(self.store[Key])}
+
+    def head_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        self.calls.append(("head_object", {"Bucket": Bucket, "Key": Key}))
+        if Key not in self.store:
+            raise _FakeClientError("404")
+        return self.store_meta[Key]
+
+    def delete_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        self.calls.append(("delete_object", {"Bucket": Bucket, "Key": Key}))
+        self.store.pop(Key, None)
+        self.store_meta.pop(Key, None)
+        return {}
+
+    def get_paginator(self, op: str) -> _StubPaginator:
+        assert op == "list_objects_v2"
+        page = {"Contents": [{"Key": k} for k in sorted(self.store.keys())]}
+        return _StubPaginator([page])
+
+
+@pytest.fixture
+def stub_client() -> _StubS3Client:
+    return _StubS3Client()
+
+
+@pytest.fixture(autouse=True)
+def patch_botocore_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route S3ArtifactSink's botocore.exceptions import to the stub."""
+    import sys
+    import types
+
+    module = types.ModuleType("botocore.exceptions")
+    module.ClientError = _FakeClientError  # type: ignore[attr-defined]
+    botocore_parent = types.ModuleType("botocore")
+    botocore_parent.exceptions = module  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "botocore", botocore_parent)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", module)
+
+
+@pytest.mark.asyncio
+async def test_write_calls_put_object(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("k.txt", b"hello", content_type="text/plain")
+    assert stub_client.store["k.txt"] == b"hello"
+    assert stub_client.store_meta["k.txt"]["ContentType"] == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_write_applies_prefix(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        prefix="runs/abc",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("runtime/state.json", b"{}")
+    assert "runs/abc/runtime/state.json" in stub_client.store
+
+
+@pytest.mark.asyncio
+async def test_read_returns_stored_bytes(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("k.txt", b"payload")
+    assert await sink.read("k.txt") == b"payload"
+
+
+@pytest.mark.asyncio
+async def test_read_missing_raises_fnf(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    with pytest.raises(FileNotFoundError):
+        await sink.read("missing.txt")
+
+
+@pytest.mark.asyncio
+async def test_exists_head_path(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    assert await sink.exists("k.txt") is False
+    await sink.write("k.txt", b"x")
+    assert await sink.exists("k.txt") is True
+
+
+@pytest.mark.asyncio
+async def test_stat_returns_metadata(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("k.txt", b"abc", content_type="text/plain")
+    st = await sink.stat("k.txt")
+    assert st.size_bytes == 3
+    assert st.etag == "stub-etag"
+    assert st.content_type == "text/plain"
+
+
+@pytest.mark.asyncio
+async def test_stat_missing_raises_fnf(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    with pytest.raises(FileNotFoundError):
+        await sink.stat("missing.txt")
+
+
+@pytest.mark.asyncio
+async def test_delete_is_idempotent(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    await sink.delete("nope.txt")
+    await sink.write("k.txt", b"x")
+    await sink.delete("k.txt")
+    assert "k.txt" not in stub_client.store
+
+
+@pytest.mark.asyncio
+async def test_list_returns_sorted_keys(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("b.txt", b"b")
+    await sink.write("a.txt", b"a")
+    keys = await sink.list("")
+    assert keys == ["a.txt", "b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_list_strips_prefix_in_results(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        prefix="runs/abc",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("runtime/state.json", b"{}")
+    keys = await sink.list("")
+    # Result should not leak the sink-level prefix.
+    assert keys == ["runtime/state.json"]
+
+
+@pytest.mark.asyncio
+async def test_missing_bucket_raises(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sink import SinkError
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    # When no bucket is configured the client_factory is still consulted,
+    # but we want the explicit error path.
+    sink = S3ArtifactSink(client_factory=None)
+    with pytest.raises(SinkError, match="bucket"):
+        await sink.write("k.txt", b"x")
+
+
+@pytest.mark.asyncio
+async def test_close_idempotent(stub_client: _StubS3Client) -> None:
+    from bernstein.core.storage.sinks.s3 import S3ArtifactSink
+
+    sink = S3ArtifactSink(
+        bucket="my-bucket",
+        client_factory=lambda: stub_client,
+    )
+    await sink.write("k.txt", b"x")
+    await sink.close()
+    await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_r2_subclass_sets_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.storage.sinks.r2 import R2ArtifactSink
+
+    # Clear potentially leaking AWS_ env vars
+    for var in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_REGION",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    sink = R2ArtifactSink(
+        bucket="b",
+        account_id="acc-123",
+        access_key_id="k",
+        secret_access_key="s",
+    )
+    assert sink._endpoint_url == "https://acc-123.r2.cloudflarestorage.com"  # type: ignore[attr-defined]
+    assert sink._region == "auto"  # type: ignore[attr-defined]

--- a/tests/unit/storage/test_sink_protocol.py
+++ b/tests/unit/storage/test_sink_protocol.py
@@ -1,0 +1,85 @@
+"""Unit tests for :class:`ArtifactSink` + conformance suite base (oai-003).
+
+The :class:`ArtifactSinkConformance` suite is parametrized: every
+first-party sink gets its fixture here. Cloud sinks (S3/GCS/Azure/R2)
+run the same suite in ``tests/integration/storage/`` behind gating
+skipifs — they are excluded from the unit suite because they need
+emulators or real credentials.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import pytest_asyncio
+
+from bernstein.core.storage import (
+    ArtifactSink,
+    ArtifactSinkConformance,
+    LocalFsSink,
+)
+from bernstein.core.storage.sink import join_keys, normalise_key
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+class TestLocalFsSinkConformance(ArtifactSinkConformance):
+    """Runs the shared conformance suite against LocalFsSink."""
+
+    # Override the default 1 MB payload with 128 KB so the
+    # unit suite stays fast — large_payload_roundtrip still exercises
+    # the chunked-write path via atomic_write.
+    large_payload_bytes = 128 * 1024
+
+    @pytest_asyncio.fixture
+    async def sink(self, tmp_path: Path) -> AsyncIterator[ArtifactSink]:
+        """Yield a LocalFsSink rooted at a fresh tmp_path."""
+        s = LocalFsSink(tmp_path)
+        try:
+            yield s
+        finally:
+            await s.close()
+
+
+# ---------------------------------------------------------------------------
+# Key helpers
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_key_strips_leading_slash() -> None:
+    assert normalise_key("/runtime/wal/r1.jsonl") == "runtime/wal/r1.jsonl"
+
+
+def test_normalise_key_rejects_empty() -> None:
+    with pytest.raises(ValueError):
+        normalise_key("")
+
+
+def test_normalise_key_rejects_dotdot() -> None:
+    with pytest.raises(ValueError):
+        normalise_key("runtime/../etc/passwd")
+
+
+def test_normalise_key_rejects_only_slashes() -> None:
+    with pytest.raises(ValueError):
+        normalise_key("///")
+
+
+def test_join_keys_basic() -> None:
+    assert join_keys("runtime", "wal", "r1.jsonl") == "runtime/wal/r1.jsonl"
+
+
+def test_join_keys_skips_empty_parts() -> None:
+    assert join_keys("runtime", "", "state.json") == "runtime/state.json"
+
+
+def test_join_keys_strips_embedded_slashes() -> None:
+    assert join_keys("/runtime/", "/wal/") == "runtime/wal"
+
+
+def test_join_keys_rejects_all_empty() -> None:
+    with pytest.raises(ValueError):
+        join_keys("", "/", "")

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,34 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.39.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/83/bbde3faa84ddcb8eb0eca4b3ffb3221252281db4ce351300fe248c5c70b1/azure_core-1.39.0.tar.gz", hash = "sha256:8a90a562998dd44ce84597590fff6249701b98c0e8797c95fcdd695b54c35d74", size = 367531, upload-time = "2026-03-19T01:31:29.461Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/d6/8ebcd05b01a580f086ac9a97fb9fac65c09a4b012161cc97c21a336e880b/azure_core-1.39.0-py3-none-any.whl", hash = "sha256:4ac7b70fab5438c3f68770649a78daf97833caa83827f91df9c14e0e0ea7d34f", size = 218318, upload-time = "2026-03-19T01:31:31.25Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/24/072ba8e27b0e2d8fec401e9969b429d4f5fc4c8d4f0f05f4661e11f7234a/azure_storage_blob-12.28.0.tar.gz", hash = "sha256:e7d98ea108258d29aa0efbfd591b2e2075fa1722a2fae8699f0b3c9de11eff41", size = 604225, upload-time = "2026-01-06T23:48:57.282Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/3a/6ef2047a072e54e1142718d433d50e9514c999a58f51abfff7902f3a72f8/azure_storage_blob-12.28.0-py3-none-any.whl", hash = "sha256:00fb1db28bf6a7b7ecaa48e3b1d5c83bfadacc5a678b77826081304bd87d6461", size = 431499, upload-time = "2026-01-06T23:48:58.995Z" },
+]
+
+[[package]]
 name = "bernstein"
 version = "1.8.8"
 source = { editable = "." }
@@ -187,6 +215,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "azure-storage-blob" },
+]
 dev = [
     { name = "hypothesis" },
     { name = "import-linter" },
@@ -205,6 +236,9 @@ docker = [
 e2b = [
     { name = "e2b-code-interpreter" },
 ]
+gcs = [
+    { name = "google-cloud-storage" },
+]
 grpc = [
     { name = "grpcio" },
     { name = "grpcio-reflection" },
@@ -222,6 +256,12 @@ modal = [
 ]
 openai = [
     { name = "openai-agents" },
+]
+r2 = [
+    { name = "boto3" },
+]
+s3 = [
+    { name = "boto3" },
 ]
 
 [package.dev-dependencies]
@@ -242,12 +282,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.20" },
+    { name = "boto3", marker = "extra == 'r2'", specifier = ">=1.40" },
+    { name = "boto3", marker = "extra == 's3'", specifier = ">=1.40" },
     { name = "click", specifier = ">=8.1" },
     { name = "cryptography", specifier = ">=45.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "docker", marker = "extra == 'docker'", specifier = ">=7" },
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=1.0" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=3.0" },
     { name = "grpcio", marker = "extra == 'grpc'", specifier = ">=1.68" },
     { name = "grpcio-reflection", marker = "extra == 'grpc'", specifier = ">=1.68" },
     { name = "grpcio-tools", marker = "extra == 'grpc'", specifier = ">=1.68" },
@@ -288,7 +332,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "openai", "docker", "e2b", "modal"]
+provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -304,6 +348,34 @@ dev = [
     { name = "respx", specifier = ">=0.22" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "scikit-learn", specifier = ">=1.5" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/c0/98b8cec7ca22dde776df48c58940ae1abc425593959b7226e270760d726f/boto3-1.42.91.tar.gz", hash = "sha256:03d70532b17f7f84df37ca7e8c21553280454dea53ae12b15d1cfef9b16fcb8a", size = 113181, upload-time = "2026-04-17T19:31:06.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/29/faba6521257c34085cc9b439ef98235b581772580f417fa3629728007270/boto3-1.42.91-py3-none-any.whl", hash = "sha256:04e72071cde022951ce7f81bd9933c90095ab8923e8ced61c8dacfe9edac0f5c", size = 140553, upload-time = "2026-04-17T19:31:02.57Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/bc/a4b7c46471c2e789ad8c4c7acfd7f302fdb481d93ff870f441249b924ae6/botocore-1.42.91.tar.gz", hash = "sha256:d252e27bc454afdbf5ed3dc617aa423f2c855c081e98b7963093399483ecc698", size = 15213010, upload-time = "2026-04-17T19:30:50.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl", hash = "sha256:7a28c3cc6bfab5724ad18899d52402b776a0de7d87fa20c3c5270bcaaf199ce8", size = 14897344, upload-time = "2026-04-17T19:30:44.245Z" },
 ]
 
 [[package]]
@@ -833,6 +905,100 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/24/6ca08b0a03c7b0c620427503ab00353a4ae806b848b93bcea18b6b76fde6/google_cloud_core-2.5.1.tar.gz", hash = "sha256:3dc94bdec9d05a31d9f355045ed0f369fbc0d8c665076c734f065d729800f811", size = 36078, upload-time = "2026-03-30T22:50:08.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d9/5bb050cb32826466aa9b25f79e2ca2879fe66cb76782d4ed798dd7506151/google_cloud_core-2.5.1-py3-none-any.whl", hash = "sha256:ea62cdf502c20e3e14be8a32c05ed02113d7bef454e40ff3fab6fe1ec9f1f4e7", size = 29452, upload-time = "2026-03-30T22:48:31.567Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/d1/b1ea14b93b6b78f57fc580125de44e9f593ab88dd2460f1a8a8d18f74754/google_resumable_media-2.8.2.tar.gz", hash = "sha256:f3354a182ebd193ae3f42e3ef95e6c9b10f128320de23ac7637236713b1acd70", size = 2164510, upload-time = "2026-03-30T23:34:25.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f8/50bfaf4658431ff9de45c5c3935af7ab01157a4903c603cd0eee6e78e087/google_resumable_media-2.8.2-py3-none-any.whl", hash = "sha256:82b6d8ccd11765268cdd2a2123f417ec806b8eef3000a9a38dfe3033da5fb220", size = 81511, upload-time = "2026-03-30T23:34:09.671Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1167,6 +1333,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1232,6 +1407,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -2057,6 +2241,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2078,6 +2274,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -2589,6 +2806,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
     { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
     { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Introduces `ArtifactSink` protocol; `.sdd/` artifacts can now persist to S3, GCS, Azure Blob, or Cloudflare R2.
- First-party sinks: `LocalFsSink` (default, no behavior change) + S3/GCS/Azure/R2 as optional extras.
- `BufferedSink` wraps any remote sink + a local fallback: synchronous local fsync + async mirror — preserves WAL crash-safety while gaining cloud durability.
- `WorkspaceManifest` extended with cloud-mount entries; sandbox backends can route artifact mounts into the spawned sandbox.
- Pluggy entry-point group `bernstein.storage_sinks` so plugin authors can register custom sinks.

Implements ticket.

## Test plan
- [ ] `uv run pytest tests/unit/storage/ -x -q`
- [ ] `uv run ruff check src/bernstein/core/storage/`
- [ ] `uv run pyright src/bernstein/core/storage/`
- [ ] `ArtifactSinkConformance` parametrized suite passes for LocalFsSink
- [ ] S3 / GCS / Azure / R2 integration tests gated (skipped without creds)
- [ ] WAL crash-recovery test: kill orchestrator mid-run with remote sink configured; resume from sink succeeds (LocalStack)
- [ ] Plan.yaml `storage:` block selects sink; defaults to local_fs