### PR TITLE
docs: full refresh — 1.9.x feature surfaces + stale-claims cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,34 +12,87 @@ This file captures the human-curated highlights.
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-04-19
+
 ### Added
+
+- **OpenAI Agents SDK v2 adapter (`openai_agents`)** — ticket oai-001. New
+  first-class CLI adapter that wraps `agents.Agent` + `Runner.run_sync` in a
+  subprocess so the existing Bernstein spawner can manage lifecycle,
+  timeouts, rate-limit back-off, and cost tracking. Structured JSONL event
+  stream, MCP bridging through the runner manifest (Bernstein-managed MCP
+  servers are forwarded into `RunConfig`), pricing rows for `gpt-5`,
+  `gpt-5-mini`, and `o4`. Install with `pip install 'bernstein[openai]'`.
+- **Pluggable sandbox backends** — ticket oai-002. A new
+  `SandboxBackend` / `SandboxSession` protocol lets every spawned agent
+  run inside a local git worktree (default), a Docker container, an E2B
+  Firecracker microVM, or a Modal serverless container (with optional GPU).
+  Third parties register custom backends via the
+  `bernstein.sandbox_backends` entry-point group. `plan.yaml` gains an
+  optional per-stage `sandbox:` block. `bernstein agents sandbox-backends`
+  lists every installed backend with its capability set. Extras:
+  `bernstein[docker]`, `bernstein[e2b]`, `bernstein[modal]`.
+- **Cloud artifact storage sinks** — ticket oai-003. New async
+  `ArtifactSink` protocol decouples `.sdd/` persistence from the local
+  filesystem. First-party sinks: `local_fs` (default), `s3`, `gcs`,
+  `azure_blob`, `r2`. `BufferedSink` preserves the WAL crash-safety
+  contract by fsyncing locally first and mirroring to the remote
+  asynchronously. Third parties register sinks via the
+  `bernstein.storage_sinks` entry-point group. Extras: `bernstein[s3]`,
+  `bernstein[gcs]`, `bernstein[azure]`, `bernstein[r2]`.
+- **Progressive-disclosure skill packs** — ticket oai-004. Role prompts
+  migrated to the OpenAI Agents SDK "Skills" shape: only a compact skill
+  index ships in every spawn's system prompt; agents pull full bodies via
+  the `load_skill` MCP tool on demand. 17 built-in role packs (backend,
+  qa, security, frontend, devops, architect, docs, retrieval,
+  ml-engineer, reviewer, manager, vp, prompt-engineer, visionary,
+  analyst, resolver, ci-fixer). New CLI: `bernstein skills list` /
+  `bernstein skills show <name> [--reference … | --script …]`. Plugin
+  authors register additional skill sources through
+  `bernstein.skill_sources`. Legacy `templates/roles/` path still loads
+  as a fallback for two more minor versions.
 - Honest 3-line terminal transcript in README hero area alongside the GIF.
+- New architecture pages: `docs/architecture/sandbox.md`,
+  `docs/architecture/storage.md`, `docs/architecture/skills.md`.
+- New user-facing summary page: `docs/whats-new.md`.
 
 ### Changed
-- README adapter table reduced to 17 entries (16 real + generic wrapper) after
-  removing `roo_code` and `tabby`; fixed Qwen link to `qwen-code` npm, Continue
-  install to `@continuedev/cli` (binary `cn`), and Cody invocation.
+
+- **Adapter count updated to 18** (17 third-party wrappers + generic). New
+  row for `openai_agents` in README, `CONTRIBUTING.md`, `ADAPTER_GUIDE.md`,
+  `compatibility.md`, `GETTING_STARTED.md`, and every comparison page.
+- Comparison pages' "Last verified" stamp bumped from 2026-04-17 to
+  2026-04-19. Compare tables now call out pluggable sandbox backends and
+  remote artifact sinks as Bernstein-side differentiators.
 - README model column dropped stale patch versions: Claude uses `Opus 4`,
-  `Sonnet 4.6`, `Haiku 4.5`; Codex uses `GPT-5` / `GPT-5 mini`; Gemini uses
-  `Gemini 2.5 Pro` / `Gemini Flash`.
+  `Sonnet 4.6`, `Haiku 4.5`; Codex uses `GPT-5` / `GPT-5 mini`; Gemini
+  uses `Gemini 2.5 Pro` / `Gemini Flash`.
 - README install one-liner now uses `pipx install bernstein` and runs
-  `bernstein init` before `bernstein -g`.
-- README compare table updated for 2026-04-17: CrewAI `In-memory + SQLite
-  checkpoint`, AutoGen maintenance-mode footnote, LangGraph `Yes (Studio +
-  LangSmith)` web UI and MCP `client + server`.
-- Softened README claims per backlog findings: "zero LLM tokens on scheduling"
-  to "no LLM calls in selection, retry, or reap decisions"; dropped
-  "tamper-evident" from audit logs, "no silent data loss" from WAL recovery,
-  "learns optimal ... over time" from bandit router, "Z-score flagging" from
-  cost anomaly detection, "pluggy-based" from plugin system. Marked Workers
-  AI and `--evolve` as experimental.
+  `bernstein init` before `bernstein -g`. New "Optional extras" table
+  documents `bernstein[openai,docker,e2b,modal,s3,gcs,azure,r2,grpc,k8s]`.
+- Softened README claims per backlog findings: "zero LLM tokens on
+  scheduling" to "no LLM calls in selection, retry, or reap decisions";
+  dropped "tamper-evident" from audit logs, "no silent data loss" from
+  WAL recovery, "learns optimal ... over time" from bandit router,
+  "Z-score flagging" from cost anomaly detection, "pluggy-based" from
+  plugin system. Marked Workers AI and `--evolve` as experimental.
 - README badge row trimmed to CI, PyPI, Python 3.12+, and License.
-- `CONTRIBUTING.md` adapter count updated from 18 to 17 and the adapter table
-  was trimmed to match.
+- `docs/architecture/ARCHITECTURE.md` gains a "Sandbox, storage, and
+  skills (1.9.x)" cross-link section and fixes the `What to read next`
+  relative paths that pointed at non-existent sibling files.
+- `mkdocs.yml` nav exposes the three new architecture pages under
+  *Concepts*, the OpenAI Agents adapter guide under *Guides*, the
+  `openai_agents vs codex / claude / gemini` decision page under
+  *Comparisons*, and *What's New* under *Reference*.
 
 ### Removed
-- README rows for Roo Code, Tabby, and Codex on Cloudflare (not a `CLIAdapter`).
+
+- README rows for Roo Code, Tabby, and Codex on Cloudflare (not a
+  `CLIAdapter`). `ADAPTER_GUIDE.md` and `compatibility.md` lose their
+  matching stale rows.
 - Dead `opencollective.com/bernstein` link from the Support section.
+- Over-claim of "36 CLI adapters" in `docs/compare/openai-agents.md`;
+  reality is 18.
 
 ## [1.7.0] - 2026-04-13
 
@@ -117,7 +170,8 @@ This file captures the human-curated highlights.
 - TUI dashboard, web dashboard, Prometheus `/metrics`, and OTel exporter
   presets.
 
-[Unreleased]: https://github.com/chernistry/bernstein/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/chernistry/bernstein/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/chernistry/bernstein/compare/v1.7.0...v1.9.0
 [1.7.0]: https://github.com/chernistry/bernstein/compare/v1.6.4...v1.7.0
 [1.6.4]: https://github.com/chernistry/bernstein/compare/v1.6.0...v1.6.4
 [1.6.0]: https://github.com/chernistry/bernstein/compare/v1.5.0...v1.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ When adding a new CLI command, create a new `*_cmd.py` module in `cli/commands/`
 
 ## Supported CLI Adapters
 
-Bernstein ships with 17 adapters (16 specific + 1 generic). When writing a new adapter, check that it isn't already implemented:
+Bernstein ships with 18 adapters (17 specific + 1 generic). When writing a new adapter, check that it isn't already implemented:
 
 | Adapter | File | Agent |
 |---------|------|-------|
@@ -105,6 +105,7 @@ Bernstein ships with 17 adapters (16 specific + 1 generic). When writing a new a
 | `kilo` | `adapters/kilo.py` | [Kilo](https://kilo.dev) |
 | `kiro` | `adapters/kiro.py` | [Kiro](https://kiro.dev) |
 | `ollama` | `adapters/ollama.py` | [Ollama](https://ollama.ai) (local models) |
+| `openai_agents` | `adapters/openai_agents.py` | [OpenAI Agents SDK v2](https://openai.github.io/openai-agents-python/) |
 | `opencode` | `adapters/opencode.py` | [OpenCode](https://opencode.ai) |
 | `qwen` | `adapters/qwen.py` | [Qwen Code](https://github.com/QwenLM/qwen-code) |
 | `generic` | `adapters/generic.py` | Any CLI agent (catch-all) |

--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ Also available via `pip`, `uv tool install`, `brew`, `dnf copr`, and `npx bernst
 
 Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap local models for boilerplate, heavier cloud models for architecture.
 
-17 CLI coding agents plus a generic wrapper for anything with `--prompt`.
+18 CLI agent adapters: 17 third-party wrappers plus a generic wrapper for anything with `--prompt`.
 
 | Agent | Models | Install |
 |-------|--------|---------|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Opus 4, Sonnet 4.6, Haiku 4.5 | `npm install -g @anthropic-ai/claude-code` |
 | [Codex CLI](https://github.com/openai/codex) | GPT-5, GPT-5 mini | `npm install -g @openai/codex` |
+| [OpenAI Agents SDK v2](https://openai.github.io/openai-agents-python/) | GPT-5, GPT-5 mini, o4 | `pip install 'bernstein[openai]'` |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Gemini 2.5 Pro, Gemini Flash | `npm install -g @google/gemini-cli` |
 | [Cursor](https://www.cursor.com) | Sonnet 4.6, Opus 4, GPT-5 | [Cursor app](https://www.cursor.com) |
 | [Aider](https://aider.chat) | Any OpenAI/Anthropic-compatible | `pip install aider-chat` |
@@ -142,34 +143,42 @@ A `bernstein cloud init` scaffold for `wrangler.toml` and bindings is planned.
 
 **Intelligence**. Contextual bandit router for model/effort selection. Knowledge graph for codebase impact analysis. Semantic caching saves tokens on repeated patterns. Cost anomaly detection (burn-rate alerts). Behavior anomaly detection with Z-score flagging.
 
+**Sandboxing**. Pluggable [`SandboxBackend`](docs/architecture/sandbox.md) protocol — run agents in local git worktrees (default), Docker containers, [E2B](https://e2b.dev) Firecracker microVMs, or [Modal](https://modal.com) serverless containers (with optional GPU). Plugin authors can register custom backends through the `bernstein.sandbox_backends` entry-point group. Inspect installed backends with `bernstein agents sandbox-backends`.
+
+**Artifact storage**. `.sdd/` state can stream to pluggable [`ArtifactSink`](docs/architecture/storage.md) backends: local filesystem (default), S3, Google Cloud Storage, Azure Blob, or Cloudflare R2. `BufferedSink` keeps the WAL crash-safety contract by writing locally with fsync first and mirroring to the remote asynchronously.
+
+**Skill packs**. Progressive-disclosure [skills](docs/architecture/skills.md) (OpenAI Agents SDK pattern): only a compact skill index ships in every spawn's system prompt, agents pull full bodies via the `load_skill` MCP tool on demand. 17 built-in role packs plus third-party `bernstein.skill_sources` entry-points.
+
 **Controls**. HMAC-chained audit logs, policy engine, PII output gating, WAL-backed crash recovery (experimental multi-worker safety), OAuth 2.0 PKCE. SSO/SAML/OIDC support is in progress.
 
 **Observability**. Prometheus `/metrics`, OTel exporter presets, Grafana dashboards. Per-model cost tracking (`bernstein cost`). Terminal TUI and web dashboard. Agent process visibility in `ps`.
 
 **Ecosystem**. MCP server mode, A2A protocol support, GitHub App integration, pluggy-based plugin system, multi-repo workspaces, cluster mode for distributed execution, self-evolution via `--evolve` (experimental).
 
-Full feature matrix: [FEATURE_MATRIX.md](docs/reference/FEATURE_MATRIX.md)
+Full feature matrix: [FEATURE_MATRIX.md](docs/reference/FEATURE_MATRIX.md) &middot; Recent features: [What's New](docs/whats-new.md)
 
 ## How it compares
 
 | Feature | Bernstein | CrewAI | AutoGen [^autogen] | LangGraph |
 |---------|-----------|--------|---------|-----------|
 | Orchestrator | Deterministic code | LLM-driven | LLM-driven | Graph + LLM |
-| Works with | Any CLI agent (17 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (18 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
+| Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Verification | Janitor + quality gates | No | No | Conditional edges |
 | Cost tracking | Built-in | No | No | No |
 | State model | File-based (.sdd/) | In-memory + SQLite checkpoint | In-memory | Checkpointer |
+| Remote artifact sinks | S3, GCS, Azure Blob, R2 | No | No | No |
 | Self-evolution | Built-in | No | No | No |
 | Declarative plans (YAML) | Yes | Yes | No | Partial (JSON config) |
 | Model routing per task | Yes | No | No | Manual |
-| MCP support | Yes | Yes | Yes (client) | Yes (client + server) |
+| MCP support | Yes (client + server) | Yes | Yes (client) | Yes (client + server) |
 | Agent-to-agent chat | Bulletin board | Yes | Yes | No |
 | Web UI | TUI + web dashboard | Yes | Yes | Yes (Studio + LangSmith) |
 | Cloud hosted option | Yes (Cloudflare) | Yes | No | Yes |
 | Built-in RAG/retrieval | Yes (codebase FTS5 + BM25) | Yes | Yes | Yes |
 
-*Last verified: 2026-04-17. See [full comparison pages](docs/compare/README.md) for detailed feature matrices.*
+*Last verified: 2026-04-19. See [full comparison pages](docs/compare/README.md) for detailed feature matrices.*
 
 [^autogen]: AutoGen is in maintenance mode; successor is Microsoft Agent Framework 1.0.
 
@@ -211,6 +220,25 @@ bernstein fingerprint check src/foo.py                 # check generated code ag
 | **Homebrew** | `brew tap chernistry/bernstein && brew install bernstein` |
 | **Fedora / RHEL** | `sudo dnf copr enable alexchernysh/bernstein && sudo dnf install bernstein` |
 | **npm** (wrapper) | `npx bernstein-orchestrator` |
+
+### Optional extras
+
+Provider SDKs are optional so the base install stays lean. Pick what you need:
+
+| Extra | Enables |
+|-------|---------|
+| `bernstein[openai]` | OpenAI Agents SDK v2 adapter (`openai_agents`) |
+| `bernstein[docker]` | Docker sandbox backend |
+| `bernstein[e2b]` | [E2B](https://e2b.dev) microVM sandbox backend (needs `E2B_API_KEY`) |
+| `bernstein[modal]` | [Modal](https://modal.com) sandbox backend, optional GPU (needs `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`) |
+| `bernstein[s3]` | S3 artifact sink (via `boto3`) |
+| `bernstein[gcs]` | Google Cloud Storage artifact sink |
+| `bernstein[azure]` | Azure Blob artifact sink |
+| `bernstein[r2]` | Cloudflare R2 artifact sink (S3-compatible `boto3`) |
+| `bernstein[grpc]` | gRPC bridge |
+| `bernstein[k8s]` | Kubernetes integrations |
+
+Combine extras with brackets, e.g. `pip install 'bernstein[openai,docker,s3]'`.
 
 Editor extensions: [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=alex-chernysh.bernstein) &middot; [Open VSX](https://open-vsx.org/extension/alex-chernysh/bernstein)
 

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -1,7 +1,8 @@
 # Adapter Selection Guide
 
-Bernstein ships 17 CLI agent adapters in `src/bernstein/adapters/`, plus support
-modules (caching, conformance testing, environment isolation, plugin SDK, etc.).
+Bernstein ships 18 CLI agent adapters in `src/bernstein/adapters/` (17 named
+third-party wrappers plus a `generic` catch-all), along with support modules
+(caching, conformance testing, environment isolation, plugin SDK, etc.).
 
 All CLI agent adapters implement the `CLIAdapter` interface (`adapters/base.py`):
 `spawn()`, process monitoring via PID, log capture to `.sdd/runtime/<session>.log`,
@@ -36,6 +37,7 @@ This means you can run Bernstein with **zero Claude Code dependency** — use `q
 |---------|----------|--------|-----------|-----------|----------|-------------------|-----|----------------------|
 | `claude` | Anthropic | opus, sonnet, haiku | ★★★★★ (opus) / ★★★★ (sonnet) / ★★ (haiku) | $$–$$$ | Full (role-scoped) | JSON schema enforced | Yes | Primary workhorse — architecture, features, tests, docs |
 | `codex` | OpenAI | GPT-5, GPT-5 mini | ★★★★★ (GPT-5) / ★★★★ (mini) | $$–$$$ | Full | JSON (`--json`) | No | Provider diversity; OpenAI reasoning models |
+| `openai_agents` | OpenAI (Agents SDK v2) | GPT-5, GPT-5 mini, o4 | ★★★★ | $–$$$ | Full (SDK tool protocol) | JSONL event stream | Yes (Bernstein-bridged) | OpenAI sandboxed execution with E2B / Modal / Docker |
 | `gemini` | Google | Gemini Pro, Gemini Flash | ★★★★★ (Pro) / ★★★★ (Flash) | Free–$$$ | Full | JSON (`--output-format json`) | No | Free-tier usage; cost-effective medium tasks |
 | `aider` | Multi | Any (Anthropic/OpenAI/Azure) | Inherited from model | $–$$$ | File editing | No | Commit-per-change workflows; focused file edits |
 | `amp` | Sourcegraph | Anthropic + OpenAI models | ★★★★★ (opus/o3) | $$–$$$ | Full | No | Sourcegraph-integrated teams; codebase-aware context |
@@ -44,12 +46,11 @@ This means you can run Bernstein with **zero Claude Code dependency** — use `q
 | `cody` | Sourcegraph | Anthropic/OpenAI/Google (via SG) | Inherited from model | $$ | Chat only | No | Sourcegraph-integrated with codebase-level context |
 | `cursor` | Cursor | Cursor's model routing | ★★★★ | $$ | Full | No | Teams with Cursor subscriptions |
 | `goose` | Block | Anthropic models | ★★★★ | $$–$$$ | Full | No | Teams already using Block's Goose |
-| `roo-code` | Multi | Anthropic + OpenAI | ★★★★ | $$–$$$ | Full | JSON (`--output-format json`) | No | VS Code extension users wanting headless CLI |
 | `continue` | Multi | Anthropic/OpenAI/Google | Inherited from model | $–$$$ | Full | No | Teams with existing Continue.dev configurations |
 | `opencode` | Multi | Any configured provider | Inherited from model | $–$$$ | Full | JSON (`--format json`) | No | Multi-provider setups; single CLI interface |
 | `kiro` | AWS | AWS-managed models | ★★★ | $$ | Full | No | AWS-centric teams using AWS AI services |
 | `kilo` | Stackblitz | Any (via provider routing) | Inherited from model | $–$$$ | Full | No | Web development; Stackblitz-integrated teams |
-| `tabby` | Self-hosted | Server-configured model | Varies | Free | Agent tasks | No | Self-hosted; compliance-restricted; full model control |
+| `cloudflare` | Cloudflare | Workers AI models | ★★★ | Free–$$ | Full | No | Cloudflare Workers / Agents SDK users |
 | `iac` | N/A | N/A (Terraform/Pulumi) | N/A | N/A | IaC plan+apply | No | Infrastructure tasks — pair with LLM adapter for codegen |
 | `generic` | Any | Pass-through | Depends on CLI | Varies | Depends on CLI | No | Unlisted CLIs; prototyping new adapters |
 | `mock` | None | None (simulated) | N/A | Free | Simulated | Simulated | Unit and integration tests only |
@@ -309,20 +310,24 @@ brew install block/tap/goose
 
 ---
 
-### roo-code
+### openai_agents (OpenAI Agents SDK v2)
 
-**Install:** Available as a VS Code extension. The `roo-cline` CLI is bundled with the extension.
+**Install:**
 ```bash
-# Enable headless CLI access from VS Code extension settings
-code --install-extension RooVeterinaryInc.roo-cline
+pip install 'bernstein[openai]'
 ```
 
 **Unique features:**
-- JSON structured output via `--output-format json`
-- Task passed via `--task` flag
-- Reads VS Code workspace settings for model/provider config
+- Wraps the OpenAI Agents SDK v2 (`agents.Agent` + `Runner.run_sync`) in a subprocess
+- Structured JSONL event stream: `start`, `tool_call`, `tool_result`, `usage`, `completion`
+- Pluggable sandbox providers exposed through the SDK: `unix_local`, `docker`, `e2b`, `modal`
+- Rate-limit detection via SDK exception classes mapped to Bernstein's back-off
+- MCP bridging: Bernstein-managed MCP servers are forwarded through the runner manifest; the SDK never spawns its own MCP children
+- Cost tracking from emitted `usage` events (`gpt-5`, `gpt-5-mini`, `o4` pricing rows)
 
-**Best for:** VS Code extension users wanting headless CLI execution with their existing Roo Code config. Preserves model routing and custom instructions from VS Code settings.
+**Env vars:** `OPENAI_API_KEY` (required), plus optional `OPENAI_BASE_URL`, `OPENAI_ORGANIZATION`, `OPENAI_PROJECT`.
+
+**Best for:** OpenAI plans that benefit from SDK-native tool-use, sandboxed execution (E2B / Modal), or where the Agents SDK event protocol is a better fit than the `codex` CLI. See the [dedicated `openai_agents` doc](openai-agents.md) and the [decision guide](../compare/openai-agents.md) for when to pick `openai_agents` vs `codex` vs `claude`.
 
 ---
 
@@ -396,30 +401,6 @@ npm install -g kilocode
 
 ---
 
-### tabby (Self-hosted)
-
-**Install:**
-```bash
-# Install Tabby server (requires Docker or native binary)
-docker pull tabbyml/tabby
-# or download from https://tabby.tabbyml.com/docs/installation/
-
-# Start the server
-tabby serve --model TabbyML/StarCoder-1B --device cuda
-```
-
-**Unique features:**
-- Requires a running Tabby server (`tabby serve`)
-- Model selection is server-side (not per-invocation)
-- Zero cloud dependency when using local models
-- Supports multiple coding models from the Tabby registry
-
-**Env vars:** `TABBY_SERVER_URL` (default: `http://127.0.0.1:8080`).
-
-**Best for:** Self-hosted, air-gapped, or compliance-restricted environments where you control the entire model stack. Tabby supports model fine-tuning on your own codebase for higher-quality completions.
-
----
-
 ### iac (Infrastructure as Code)
 
 **Unique features:**
@@ -484,7 +465,7 @@ Simulates agent behavior for unit and integration tests. Not for production use.
 
 ## Support Modules
 
-In addition to the 17 CLI agent adapters above, the adapter package includes
+In addition to the 18 CLI agent adapters above, the adapter package includes
 support modules that provide cross-cutting infrastructure:
 
 | Module | Purpose |
@@ -506,24 +487,27 @@ support modules that provide cross-cutting infrastructure:
 
 1. **Do you need zero cloud cost?**
    - Yes, and have GPU -> `ollama`
-   - Yes, and have Tabby server -> `tabby`
    - Yes, and want free tier API -> `gemini` or `qwen` (with free OpenRouter)
 
 2. **Do you need the strongest reasoning?**
    - Claude Opus -> `claude` with `model: opus`
-   - OpenAI GPT-5.4 -> `codex` or `amp`
+   - OpenAI GPT-5 -> `codex`, `openai_agents`, or `amp`
    - Want to compare both -> use `TierAwareRouter` with multiple providers
 
 3. **Do you need structured output?**
-   - `claude` (JSON schema enforced), `codex` (JSON), `gemini` (JSON), `roo-code` (JSON), `opencode` (JSON)
+   - `claude` (JSON schema enforced), `codex` (JSON), `gemini` (JSON), `openai_agents` (JSONL events), `opencode` (JSON)
 
 4. **Do you need MCP support?**
-   - `claude` (deepest), `cursor`, `kilo`
+   - `claude` (deepest), `openai_agents` (Bernstein-bridged), `cursor`, `kilo`
 
-5. **Do you need air-gapped / self-hosted?**
-   - `ollama` (local Ollama), `tabby` (self-hosted server)
+5. **Do you need pluggable sandbox execution (Docker / E2B / Modal)?**
+   - `openai_agents` today; more adapters follow the outer `SandboxBackend`
+     abstraction as phase 2 of the sandbox roadmap lands.
 
-6. **Do you need multi-provider diversity?**
+6. **Do you need air-gapped / self-hosted?**
+   - `ollama` (local Ollama via Aider front-end)
+
+7. **Do you need multi-provider diversity?**
    - Primary: `claude`, Secondary: `codex` or `gemini`, Tertiary: `qwen`
    - The `TierAwareRouter` handles failover, cost balancing, and rate-limit avoidance across providers automatically.
 

--- a/docs/adapters/compatibility.md
+++ b/docs/adapters/compatibility.md
@@ -2,7 +2,7 @@
 
 This page describes practical compatibility boundaries for Bernstein integrations.
 
-Last updated: 2026-04-13
+Last updated: 2026-04-19
 
 ---
 
@@ -10,7 +10,7 @@ Last updated: 2026-04-13
 
 - Python: project targets Python 3.12+.
 - Task server/API: FastAPI-based local or remote server operation.
-- CLI adapters: 18 CLI agent adapters (17 third-party + generic) in `src/bernstein/adapters/`.
+- CLI adapters: 18 CLI agent adapters (17 third-party + generic) in `src/bernstein/adapters/`, including the OpenAI Agents SDK v2 adapter (`openai_agents`).
 
 ### Supported CLI agent adapters
 
@@ -27,12 +27,11 @@ Last updated: 2026-04-13
 | `cody` | Sourcegraph | No | No |
 | `cursor` | Cursor | No | Yes |
 | `goose` | Block | No | No |
-| `roo-code` | Multi | JSON (`--output-format json`) | No |
 | `continue` | Multi | No | No |
 | `opencode` | Multi | JSON (`--format json`) | No |
 | `kiro` | AWS | No | No |
 | `kilo` | Stackblitz | No | Yes (ACP/MCP) |
-| `tabby` | Self-hosted | No | No |
+| `cloudflare` | Cloudflare | No | No |
 | `iac` | N/A (Terraform/Pulumi) | No | No |
 | `generic` | Any | Depends on CLI | No |
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -204,6 +204,31 @@ Tracks per-agent token consumption in real time. Detects runaway token growth an
 
 ---
 
+## Sandbox, storage, and skills (1.9.x)
+
+Three pluggable subsystems landed in the 1.9 series. Each has its own
+dedicated architecture page:
+
+- **[Sandbox backends](sandbox.md)** — pluggable `SandboxBackend` /
+  `SandboxSession` protocol (oai-002). First-party backends: local git
+  `worktree` (default), `docker`, `e2b` (Firecracker microVMs), and
+  `modal` (serverless containers with optional GPU). Third parties
+  register through the `bernstein.sandbox_backends` entry-point group;
+  `bernstein agents sandbox-backends` lists every installed backend.
+- **[Artifact storage sinks](storage.md)** — async `ArtifactSink`
+  protocol (oai-003) that decouples `.sdd/` persistence from the local
+  filesystem. First-party sinks cover `local_fs`, `s3`, `gcs`,
+  `azure_blob`, and `r2`. `BufferedSink` preserves the WAL
+  crash-safety contract by fsyncing locally first and mirroring the
+  payload to the remote asynchronously. Third parties extend via
+  `bernstein.storage_sinks`.
+- **[Progressive skill packs](skills.md)** — OpenAI Agents SDK
+  "Skills" pattern (oai-004): only a compact index ships in every
+  spawn's system prompt; agents pull full bodies on demand via the
+  `load_skill` MCP tool. Plugins register additional skill sources
+  under `bernstein.skill_sources`. Inspect available skills with
+  `bernstein skills list` / `bernstein skills show <name>`.
+
 ## Adapter architecture
 
 All adapters implement the `CLIAdapter` ABC from `adapters/base.py`:
@@ -261,7 +286,11 @@ The cloud bridges implement the same `RuntimeBridge` interface as local executio
 
 ## What to read next
 
-- **[Getting Started](GETTING_STARTED.md)** — install, init, run, monitor
-- **[Feature Matrix](FEATURE_MATRIX.md)** — shipped vs. partial vs. roadmap
-- **[Benchmarks](BENCHMARKS.md)** — performance baseline and methodology
-- **[AGENTS.md](../AGENTS.md)** — engineering doctrine and contribution guide
+- **[Getting Started](../getting-started/GETTING_STARTED.md)** — install, init, run, monitor
+- **[Feature Matrix](../reference/FEATURE_MATRIX.md)** — shipped vs. partial vs. roadmap
+- **[Benchmarks](../../benchmarks/BENCHMARKS.md)** — performance baseline and methodology
+- **[Sandbox backends](sandbox.md)** — pluggable `SandboxBackend` protocol (1.9.x)
+- **[Artifact storage sinks](storage.md)** — cloud `.sdd/` persistence (1.9.x)
+- **[Skills](skills.md)** — progressive-disclosure capability packs (1.9.x)
+- **[What's New](../whats-new.md)** — 1.8.x → 1.9.x user-facing changes
+- **[AGENTS.md](../../AGENTS.md)** — engineering doctrine and contribution guide

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -288,9 +288,8 @@ The cloud bridges implement the same `RuntimeBridge` interface as local executio
 
 - **[Getting Started](../getting-started/GETTING_STARTED.md)** — install, init, run, monitor
 - **[Feature Matrix](../reference/FEATURE_MATRIX.md)** — shipped vs. partial vs. roadmap
-- **[Benchmarks](../../benchmarks/BENCHMARKS.md)** — performance baseline and methodology
+- **[Benchmarks](../benchmarks/BENCHMARKS.md)** — performance baseline and methodology
 - **[Sandbox backends](sandbox.md)** — pluggable `SandboxBackend` protocol (1.9.x)
 - **[Artifact storage sinks](storage.md)** — cloud `.sdd/` persistence (1.9.x)
 - **[Skills](skills.md)** — progressive-disclosure capability packs (1.9.x)
 - **[What's New](../whats-new.md)** — 1.8.x → 1.9.x user-facing changes
-- **[AGENTS.md](../../AGENTS.md)** — engineering doctrine and contribution guide

--- a/docs/compare/README.md
+++ b/docs/compare/README.md
@@ -2,7 +2,7 @@
 
 How Bernstein compares to other tools in the multi-agent coding space.
 
-*Last verified: 2026-04-17*
+*Last verified: 2026-04-19*
 
 ---
 
@@ -11,11 +11,13 @@ How Bernstein compares to other tools in the multi-agent coding space.
 | Feature | Bernstein | CrewAI | AutoGen | LangGraph |
 |---|---|---|---|---|
 | Orchestrator | Deterministic code | LLM-driven | LLM-driven (maintenance mode) | Graph + LLM |
-| Works with | Any CLI agent (17 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (18 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
+| Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Per-task verification | Janitor + quality gates | Test harness only | No | Conditional edges |
 | Cost tracking | Built-in | External (Langfuse/AgentOps) | External (AgentOps) | External (LangSmith) |
 | State model | File-based (`.sdd/`) | In-memory + SQLite checkpoint | In-memory | SQLite/Postgres checkpoint |
+| Remote artifact sinks | S3, GCS, Azure Blob, R2 | No | No | No |
 | Self-evolution | Built-in (`--evolve`) | No | No | No |
 | Declarative plans | YAML with `depends_on` | YAML (agents + tasks) | Partial (Studio JSON) | Code or JSON config |
 | Model routing per task | Bandit router | Per-agent | Per-agent | Manual per-node |
@@ -25,14 +27,15 @@ How Bernstein compares to other tools in the multi-agent coding space.
 | Cloud hosted | Yes (Cloudflare) | Yes (AMP) | Via Microsoft Agent Framework | Yes (LangSmith Deployment) |
 | Built-in RAG | Yes (codebase FTS5 + BM25) | Yes | Yes | Yes |
 
-*Last verified: 2026-04-17. AutoGen entered maintenance mode in 2025; successor is Microsoft Agent Framework 1.0 (April 3, 2026).*
+*Last verified: 2026-04-19. AutoGen entered maintenance mode in 2025; successor is Microsoft Agent Framework 1.0 (April 3, 2026).*
 
 ## Table B — CLI coding orchestrators
 
 |  | Bernstein | [Stoneforge](./bernstein-vs-stoneforge.md) | [Agent HQ](./bernstein-vs-github-agent-hq.md) | [Conductor](./bernstein-vs-conductor.md) | [Crystal](./bernstein-vs-crystal.md) | [Parallel Code](./bernstein-vs-parallel-code.md) | [Dorothy](./bernstein-vs-dorothy.md) | [Single agent](./bernstein-vs-single-agent.md) |
 |--|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Parallel execution** | yes | yes | yes | yes | no | yes | yes | no |
-| **CLI agent support** | 17 adapters | no | Claude/Codex/Copilot | no | no | Claude/Codex/Gemini | Claude/Codex/Gemini/local | yes |
+| **CLI agent support** | 18 adapters | no | Claude/Codex/Copilot | no | no | Claude/Codex/Gemini | Claude/Codex/Gemini/local | yes |
+| **Pluggable sandbox** | worktree/docker/e2b/modal | no | no | no | no | no | no | no |
 | **Result verification** | janitor (tests+lint) | provider-native | GitHub CI | none | LLM reviewer | manual | none | none |
 | **Task planning from goal** | yes | no | yes | no | no | no | via Super Agent | no |
 | **Self-evolution** | yes | no | no | no | no | no | no | no |
@@ -41,7 +44,7 @@ How Bernstein compares to other tools in the multi-agent coding space.
 | **IDE integration** | no | VS Code, JetBrains | GitHub UI | no | varies | desktop app | desktop app | no |
 | **Open source** | Apache 2.0 | Apache 2.0 | no | Apache 2.0 | varies | MIT | MIT | varies |
 
-*Last verified: 2026-04-17. Stoneforge launched 2026-03-03. Paperclip (launched 2026-03-04) is covered on its [own page](./bernstein-vs-paperclip.md); it is an AI-company control plane, not a CLI orchestrator, and is not compared in this table.*
+*Last verified: 2026-04-19. Stoneforge launched 2026-03-03. Paperclip (launched 2026-03-04) is covered on its [own page](./bernstein-vs-paperclip.md); it is an AI-company control plane, not a CLI orchestrator, and is not compared in this table.*
 
 ---
 

--- a/docs/compare/bernstein-vs-conductor.md
+++ b/docs/compare/bernstein-vs-conductor.md
@@ -2,7 +2,7 @@
 
 > **tl;dr** — Conductor is a workflow orchestration engine for production business processes. Bernstein is a coding agent orchestrator. They solve different problems. If your question is "how do I coordinate AI coding agents on a software development task," Conductor is not designed for that. If your question is "how do I orchestrate microservice workflows with durable execution and human-in-the-loop steps," Bernstein is not designed for that either.
 
-*Last verified: 2026-04-17. "Conductor" below refers to Netflix OSS Conductor and its active community forks (Orkes Conductor, conductor-oss/conductor); the fork varies between vendors but the execution model is the same.*
+*Last verified: 2026-04-19. "Conductor" below refers to Netflix OSS Conductor and its active community forks (Orkes Conductor, conductor-oss/conductor); the fork varies between vendors but the execution model is the same.*
 
 ---
 

--- a/docs/compare/bernstein-vs-crystal.md
+++ b/docs/compare/bernstein-vs-crystal.md
@@ -2,7 +2,7 @@
 
 > **tl;dr** — Crystal uses iterative self-review loops: an agent writes code, a reviewer agent critiques it, the writer revises, repeat until quality gates pass. Bernstein uses external verification: the janitor runs tests and the linter, and trusts those results over agent self-assessment. Crystal is better when objective test suites are thin or absent. Bernstein is better when tests are the ground truth and you want fast, deterministic verification.
 
-*Last verified: 2026-04-17.*
+*Last verified: 2026-04-19.*
 
 ---
 

--- a/docs/compare/bernstein-vs-dorothy.md
+++ b/docs/compare/bernstein-vs-dorothy.md
@@ -1,8 +1,8 @@
 # Bernstein vs. Dorothy
 
-> **tl;dr** — Dorothy is a free desktop app that orchestrates Claude Code, Codex, Gemini, and local agents with a Kanban board, a "Super Agent" delegation layer, and Telegram/Slack controls. Bernstein is a headless orchestrator for CLI coding agents that runs in a terminal or CI and stores all state in files. Dorothy is better when you want a GUI to watch and delegate across a few agents. Bernstein is better when you want unattended, budget-capped, file-state runs across 17 adapters.
+> **tl;dr** — Dorothy is a free desktop app that orchestrates Claude Code, Codex, Gemini, and local agents with a Kanban board, a "Super Agent" delegation layer, and Telegram/Slack controls. Bernstein is a headless orchestrator for CLI coding agents that runs in a terminal or CI and stores all state in files. Dorothy is better when you want a GUI to watch and delegate across a few agents. Bernstein is better when you want unattended, budget-capped, file-state runs across 18 adapters.
 
-*Last verified: 2026-04-17. Based on the Dorothy public site and repo (`github.com/Charlie85270/Dorothy`).*
+*Last verified: 2026-04-19. Based on the Dorothy public site and repo (`github.com/Charlie85270/Dorothy`).*
 
 ---
 
@@ -10,7 +10,7 @@
 
 **Dorothy** is a desktop application that presents AI coding agents through a visual Kanban interface. It can launch and monitor Claude Code, Codex, Gemini, and local agents, delegate between them through a "Super Agent" that talks to them via MCP, schedule recurring work with cron, and trigger on GitHub issues/PRs. It integrates Google Workspace as an MCP server and has Telegram/Slack bridges for remote control.
 
-**Bernstein** is a task dispatch orchestrator for CLI coding agents. It decomposes a goal into tasks, assigns each task to a short-lived CLI agent (across 17 adapters: Claude Code, Codex, Gemini CLI, Cursor, Aider, Amp, etc.), verifies the result against external criteria (tests, linter), and merges the output. The orchestrator is deterministic Python — no LLM makes scheduling decisions. No GUI.
+**Bernstein** is a task dispatch orchestrator for CLI coding agents. It decomposes a goal into tasks, assigns each task to a short-lived CLI agent (across 18 adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini CLI, Cursor, Aider, Amp, etc.), verifies the result against external criteria (tests, linter), and merges the output. The orchestrator is deterministic Python — no LLM makes scheduling decisions. No GUI.
 
 The core difference: Dorothy gives you a visual control plane. Bernstein gives you a headless, reproducible, file-state control plane.
 
@@ -21,7 +21,7 @@ The core difference: Dorothy gives you a visual control plane. Bernstein gives y
 | Feature | Bernstein | Dorothy |
 |---|---|---|
 | **Interface** | CLI + TUI + JSON status endpoint | Desktop app (Kanban, dashboard) |
-| **Agent coverage** | 17 CLI adapters | Claude Code, Codex, Gemini, local |
+| **Agent coverage** | 18 CLI adapters | Claude Code, Codex, Gemini, local |
 | **Scheduler** | Deterministic Python, no LLM | "Super Agent" (LLM) via MCP |
 | **Verification** | Janitor: tests, linter, file checks | None built-in |
 | **Parallel execution** | Yes — independent tasks run concurrently | Yes — up to ~10 agents |
@@ -86,7 +86,7 @@ Bernstein's value is unattended operation: `bernstein --headless --budget 20` wo
 - **The run must complete without anyone watching.** Overnight, weekend, CI, remote server. Bernstein's `--headless --budget` runs until done or broke. Dorothy wants its app running and an approving hand on Telegram.
 - **You want file-state you can check into git.** `.sdd/` is text. You can diff it, `grep` it, revive it after a crash. Dorothy's state is in the app.
 - **Verification is non-negotiable.** Bernstein won't merge unless the janitor's signals pass. Dorothy leaves that to the agent and the user.
-- **You need 17 adapters, not 4.** Cursor, Aider, Amp, Kilo, Kiro, Goose, OpenCode, Qwen, Cody, Continue.dev, Ollama, IAC, Visionary, generic — Bernstein wraps them all. Dorothy currently advertises Claude Code, Codex, Gemini, and local.
+- **You need 18 adapters, not 4.** Cursor, Aider, Amp, Kilo, Kiro, Goose, OpenCode, Qwen, Cody, Continue.dev, Ollama, IAC, OpenAI Agents SDK v2, Cloudflare Agents, generic — Bernstein wraps them all. Dorothy currently advertises Claude Code, Codex, Gemini, and local.
 
 ---
 

--- a/docs/compare/bernstein-vs-github-agent-hq.md
+++ b/docs/compare/bernstein-vs-github-agent-hq.md
@@ -2,7 +2,7 @@
 
 > **tl;dr** — GitHub Agent HQ was announced at GitHub Universe 2025 and rolled out through early 2026. It's excellent if you live in GitHub's ecosystem and don't mind the lock-in. Bernstein is the open-source alternative: model-agnostic, CLI-native, runs anywhere, and costs less for mixed workloads.
 
-*Last verified: 2026-04-17. Based on GitHub's Universe 2025 announcements and the public Agent HQ rollout notes.*
+*Last verified: 2026-04-19. Based on GitHub's Universe 2025 announcements and the public Agent HQ rollout notes.*
 
 ---
 
@@ -27,7 +27,7 @@ This is structurally close to what Bernstein does. GitHub building it validates 
 | Feature | Bernstein | GitHub Agent HQ |
 |---|---|---|
 | **Open source** | Yes — Apache 2.0 | No — proprietary |
-| **Model flexibility** | Any CLI agent (17 adapters) | Claude, Codex, Copilot (GitHub-managed) |
+| **Model flexibility** | Any CLI agent (18 adapters) | Claude, Codex, Copilot (GitHub-managed) |
 | **Provider lock-in** | None | GitHub + Microsoft/Anthropic/OpenAI |
 | **Runs outside GitHub** | Yes — any git repo, any host | No — GitHub-only |
 | **CLI-native** | Yes — works in terminal, SSH, CI | No — GitHub web UI + API |

--- a/docs/compare/bernstein-vs-paperclip.md
+++ b/docs/compare/bernstein-vs-paperclip.md
@@ -2,7 +2,7 @@
 
 > **tl;dr** — Paperclip is an AI company simulator: org charts, budgets, governance hierarchies for AI agents. Bernstein is an engineering tool: spawn agents, ship code, verify results. They solve different problems. If you need corporate structure for your AI workforce, Paperclip is impressive. If you need to parallelize coding tasks and merge working branches, Bernstein is what you want.
 
-*Last verified: 2026-04-17. Based on `github.com/paperclipai/paperclip` (55k+ stars, launched 2026-03-02) and paperclip.ing.*
+*Last verified: 2026-04-19. Based on `github.com/paperclipai/paperclip` (55k+ stars, launched 2026-03-02) and paperclip.ing.*
 
 ---
 
@@ -10,7 +10,7 @@
 
 **Paperclip** (55k+ stars, MIT, Node.js + React) is an "AI company management" platform, released March 2, 2026. It models AI agents as employees in an organization: they have roles, report to managers, operate within budgets, follow org-chart hierarchies, and receive scheduled heartbeats. The coordinator is an LLM. It advertises Claude Code, Codex, Cursor, "OpenClaw," plus bash and HTTP hooks ("if it can receive a heartbeat, it's hired"). Think of it as an HR and project-management control plane for AI agents.
 
-**Bernstein** (Apache 2.0, Python) is a multi-agent orchestrator for CLI coding agents. It breaks a goal into tasks, spawns agents in isolated git worktrees, verifies their output (tests, lint, file checks), and merges the results. The orchestrator is deterministic Python — zero LLM tokens spent on coordination. It supports 17 CLI adapters and runs anywhere Python runs.
+**Bernstein** (Apache 2.0, Python) is a multi-agent orchestrator for CLI coding agents. It breaks a goal into tasks, spawns agents in isolated git worktrees, verifies their output (tests, lint, file checks), and merges the results. The orchestrator is deterministic Python — zero LLM tokens spent on coordination. It supports 18 CLI adapters and runs anywhere Python runs.
 
 ---
 
@@ -22,7 +22,7 @@
 | **Open source** | Yes — Apache 2.0 | Yes — MIT |
 | **Language** | Python | Node.js + React |
 | **Orchestrator logic** | Deterministic code (no LLM) | LLM-based coordination |
-| **Agent adapters** | 17 CLI adapters | Claude Code, Codex, Cursor, OpenClaw + bash / HTTP hooks |
+| **Agent adapters** | 18 CLI adapters | Claude Code, Codex, Cursor, OpenClaw + bash / HTTP hooks |
 | **Org charts / hierarchies** | No | Yes — core feature |
 | **Budget enforcement** | Cost tracking + budget caps | Yes — per-agent and per-team budgets |
 | **Task ticketing** | Yes — internal task server | Yes — with goal alignment |
@@ -110,7 +110,7 @@ These are genuinely different problems. Paperclip cares about organizational str
 
 **Zero LLM overhead on coordination.** Paperclip uses LLM calls for coordination — managing hierarchies, routing tasks through org structures, heartbeat processing. Every coordination decision costs tokens. Bernstein's orchestrator is ~800 lines of deterministic Python. Coordination cost is zero.
 
-**Agent breadth.** 17 adapters vs. 4 official. If you use Gemini, Aider, Amp, Kilo, Kiro, Qwen, Goose, or OpenCode as first-class adapters rather than bash/HTTP shims, Bernstein supports them out of the box.
+**Agent breadth.** 18 adapters vs. 4 official. If you use Gemini, OpenAI Agents SDK v2, Aider, Amp, Kilo, Kiro, Qwen, Goose, or OpenCode as first-class adapters rather than bash/HTTP shims, Bernstein supports them out of the box.
 
 **Git-native isolation.** Each Bernstein agent works in its own git worktree. Conflicts are detected at merge time, not at runtime. Paperclip doesn't provide git-level isolation.
 
@@ -135,7 +135,7 @@ These are genuinely different problems. Paperclip cares about organizational str
 
 - **You want to ship code.** Your goal is "implement these 10 features in parallel and merge them all into a working branch." Bernstein does this. Paperclip doesn't try to.
 - **You want zero coordination overhead.** No LLM tokens spent on figuring out which agent should do what. Deterministic task assignment, deterministic verification.
-- **You use diverse CLI agents.** 17 adapters vs. 4 official. Mix Claude, Codex, Gemini, and Aider in the same session without dropping to bash/HTTP shims.
+- **You use diverse CLI agents.** 18 adapters vs. 4 official. Mix Claude, Codex, OpenAI Agents SDK v2, Gemini, and Aider in the same session without dropping to bash/HTTP shims.
 - **You want git-native safety.** Worktree isolation, conflict detection, janitor verification. The output is a tested, linted branch.
 - **You work in terminals.** CLI-native, works over SSH, runs in CI, no browser required.
 - **You don't need org charts.** If the concept of "reporting lines for AI agents" doesn't map to your problem, you don't need Paperclip's primary feature.

--- a/docs/compare/bernstein-vs-parallel-code.md
+++ b/docs/compare/bernstein-vs-parallel-code.md
@@ -2,7 +2,7 @@
 
 > **tl;dr** — Parallel Code lets you manually run multiple coding agent sessions in separate windows or tmux panes. It works fine if you want to manage the parallelism yourself. Bernstein automates the coordination: task planning, model routing, verification, and merge conflict prevention. The question is whether you want to be the orchestrator or have software be the orchestrator.
 
-*Last verified: 2026-04-17. "Parallel Code" covers both the `github.com/johannesjo/parallel-code` desktop app (Claude Code + Codex + Gemini, git worktree per agent) and the broader manual-tmux pattern of running multiple coding agents side by side.*
+*Last verified: 2026-04-19. "Parallel Code" covers both the `github.com/johannesjo/parallel-code` desktop app (Claude Code + Codex + Gemini, git worktree per agent) and the broader manual-tmux pattern of running multiple coding agents side by side.*
 
 ---
 

--- a/docs/compare/bernstein-vs-single-agent.md
+++ b/docs/compare/bernstein-vs-single-agent.md
@@ -2,7 +2,7 @@
 
 > **tl;dr** — Running a single coding agent is the right call for simple, well-scoped tasks. Bernstein exists for cases where a single agent bottlenecks on sequential work, lacks external verification, or needs to run overnight without supervision. Our early pilot shows a small, non-significant edge on 25 issues; the right use-cases for multi-agent are quality gates, parallelism, and unattended runs, not a claimed benchmark win.
 
-*Last verified: 2026-04-17.*
+*Last verified: 2026-04-19.*
 
 ---
 

--- a/docs/compare/bernstein-vs-stoneforge.md
+++ b/docs/compare/bernstein-vs-stoneforge.md
@@ -1,8 +1,8 @@
 # Bernstein vs. Stoneforge
 
-> **tl;dr** — Stoneforge is a provider-integrated multi-agent coding framework with git worktrees, a merge queue, and an IDE plugin story. Bernstein is provider-agnostic and CLI-native, trading the IDE UX for model flexibility, 17 adapters, headless runs, and `--evolve`. Neither is better in the abstract — the question is whether provider lock-in matters for your workflow.
+> **tl;dr** — Stoneforge is a provider-integrated multi-agent coding framework with git worktrees, a merge queue, and an IDE plugin story. Bernstein is provider-agnostic and CLI-native, trading the IDE UX for model flexibility, 18 adapters, headless runs, and `--evolve`. Neither is better in the abstract — the question is whether provider lock-in matters for your workflow.
 
-*Last verified: 2026-04-17. Stoneforge launched 2026-03-03 with git worktrees and merge-queue support.*
+*Last verified: 2026-04-19. Stoneforge launched 2026-03-03 with git worktrees and merge-queue support.*
 
 ---
 
@@ -18,7 +18,7 @@
 
 | Feature | Bernstein | Stoneforge |
 |---|---|---|
-| **Provider flexibility** | Any CLI agent (17 adapters) | Single provider |
+| **Provider flexibility** | Any CLI agent (18 adapters) | Single provider |
 | **CLI agent support** | Yes — wraps installed CLI tools | No — uses provider SDK directly |
 | **IDE integration** | No — terminal-native | Yes — VS Code, JetBrains plugins |
 | **Task planning** | LLM planner from natural language goal | Structured prompt with agent roles |
@@ -93,7 +93,7 @@ The risk: if that provider raises prices, introduces rate limits, or you want to
 
 ## When to use Bernstein instead
 
-- **You want provider flexibility.** Mix Claude, Codex, Gemini, and Qwen in the same run across 17 adapters. Route tasks to the cheapest capable model. Switch providers if pricing or quality changes.
+- **You want provider flexibility.** Mix Claude, Codex, Gemini, OpenAI Agents SDK v2, and Qwen in the same run across 18 adapters. Route tasks to the cheapest capable model. Switch providers if pricing or quality changes.
 - **You want no vendor dependency for orchestration logic.** Your task definitions, role templates, janitor rules, and evolution config are plain files — no vendor SDK imports.
 - **You want headless, overnight operation.** CI pipelines, scheduled evolution runs, budget-capped overnight sessions.
 - **You want self-evolution.** Bernstein analyzes its own metrics and improves prompts, routing rules, and templates over time.

--- a/docs/compare/openai-agents.md
+++ b/docs/compare/openai-agents.md
@@ -1,6 +1,6 @@
 # `openai_agents` vs. `claude` / `codex` / `gemini`
 
-Bernstein ships 36 CLI adapters as of April 2026.  Four of them are
+Bernstein ships 18 CLI agent adapters as of April 2026.  Four of them are
 general-purpose executors you might reach for on a typical plan.yaml
 step: `claude`, `codex`, `gemini`, and `openai_agents`.  This page
 explains when to prefer each one.

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -7,13 +7,14 @@ Bernstein orchestrates short-lived CLI coding agents around a central task serve
 ## Prerequisites
 
 - **Python 3.12+** (macOS, Linux, Windows)
-- **At least one CLI coding agent** installed and authenticated. Bernstein supports 17 adapters out of the box:
+- **At least one CLI coding agent** installed and authenticated. Bernstein supports 18 adapters out of the box:
 
 | Agent | Install |
 |-------|---------|
 | [Aider](https://aider.chat) | `pip install aider-chat` |
 | [Amp](https://ampcode.com) | `brew install amp` |
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `npm install -g @anthropic-ai/claude-code` |
+| [Cloudflare Agents](https://developers.cloudflare.com/agents/) | `bernstein cloud login` |
 | [Codex CLI](https://github.com/openai/codex) | `npm install -g @openai/codex` |
 | [Cody](https://sourcegraph.com/cody) | Install Cody CLI |
 | [Continue](https://continue.dev) | VS Code / JetBrains extension |
@@ -23,6 +24,7 @@ Bernstein orchestrates short-lived CLI coding agents around a central task serve
 | [Kilo](https://kilo.dev) | `npm install -g kilo` |
 | [Kiro](https://kiro.dev) | Install Kiro CLI |
 | [Ollama](https://ollama.com) | `brew install ollama` |
+| [OpenAI Agents SDK v2](https://openai.github.io/openai-agents-python/) | `pip install 'bernstein[openai]'` |
 | [OpenCode](https://opencode.ai) | Install OpenCode CLI |
 | [Qwen](https://github.com/QwenLM/Qwen-Agent) | `npm install -g qwen-code` |
 | Generic | Any CLI agent via `generic` adapter |

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,9 @@
 title: Bernstein — Open-Source Multi-Agent Orchestration Platform
 description: >-
   Bernstein is the open-source multi-agent orchestrator for AI coding agents.
-  Run Claude Code, Codex, Gemini CLI in parallel. Deterministic scheduling,
-  17 adapters, Cloudflare cloud execution, zero vendor lock-in.
+  Run Claude Code, Codex, Gemini CLI, and the OpenAI Agents SDK in parallel.
+  Deterministic scheduling, 18 adapters, pluggable sandbox backends,
+  cloud artifact storage, progressive skills, zero vendor lock-in.
 tags:
   - orchestration
   - multi-agent
@@ -72,7 +73,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    17 CLI adapters: Claude Code, Codex, Gemini, Cursor, Aider, Cloudflare Agents, and more.
+    18 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**
@@ -101,7 +102,8 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 | :material-api: [API Reference](reference/openapi-reference.md) | Task server REST API |
 | :material-sitemap: [Architecture](architecture/ARCHITECTURE.md) | How Bernstein works under the hood |
 | :material-state-machine: [Lifecycle FSM](architecture/LIFECYCLE.md) | Task and agent state machines with transition tables |
-| :material-text-box-check: [Changelog](CHANGELOG.md) | What's new |
+| :material-text-box-check: [What's New](whats-new.md) | Summary of recent releases (1.8 → 1.9) |
+| :material-history: [Changelog](CHANGELOG.md) | Full release history |
 
 ## Links
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,12 +1,13 @@
 # Bernstein
 
 > Bernstein is an open-source multi-agent orchestration platform for AI coding agents.
-> Deterministic scheduling, 17 CLI adapters, zero vendor lock-in. Apache 2.0 licensed.
+> Deterministic scheduling, 18 CLI adapters, pluggable sandbox backends, cloud artifact
+> storage sinks, progressive-disclosure skill packs, zero vendor lock-in. Apache 2.0 licensed.
 
 ## Core Documentation
 - [Getting Started](https://chernistry.github.io/bernstein/getting-started.html): Install, configure, run first orchestration in 60 seconds
 - [Architecture & Concepts](https://chernistry.github.io/bernstein/concepts.html): Task server, agent spawner, janitor verification, worktree isolation
-- [Adapter Reference](https://chernistry.github.io/bernstein/adapters.html): 17 supported agents — Claude Code, Codex, Gemini CLI, Cursor, Aider, and more
+- [Adapter Reference](https://chernistry.github.io/bernstein/adapters.html): 18 supported agents — Claude Code, Codex, OpenAI Agents SDK v2, Gemini CLI, Cursor, Aider, and more
 - [API Reference](https://chernistry.github.io/bernstein/api-reference.html): 120+ REST endpoints for tasks, agents, cost tracking, quality gates
 
 ## Guides

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -15,7 +15,7 @@
     "name": "Bernstein",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Linux, macOS, Windows",
-    "description": "Open-source multi-agent orchestration platform for AI coding agents. Deterministic scheduling, 17 CLI adapters, zero vendor lock-in.",
+    "description": "Open-source multi-agent orchestration platform for AI coding agents. Deterministic scheduling, 18 CLI adapters, pluggable sandbox backends, cloud artifact storage, zero vendor lock-in.",
     "url": "https://bernstein.readthedocs.io/",
     "downloadUrl": "https://pypi.org/project/bernstein/",
     "codeRepository": "https://github.com/chernistry/bernstein",

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -77,7 +77,7 @@ Legend:
 
 | Capability | Runtime status | Docs status | Notes |
 |---|---|---|---|
-| Agent catalog/discovery | Shipped | Full | `bernstein agents sync/list/discover/match/showcase` (17 CLI agent adapters) |
+| Agent catalog/discovery | Shipped | Full | `bernstein agents sync/list/discover/match/showcase` (18 CLI agent adapters) |
 | GitHub App and CI fix flows | Shipped | Full | `bernstein ci fix <url>`, `github setup` |
 | Trigger sources (`github`, `slack`, `file_watch`, `webhook`) | Partial | Brief | Source adapters exist; authoring docs need detail |
 | Plugin hooks (pluggy) | Shipped | Full | SDK docs in CONTRIBUTING.md |

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -6,7 +6,7 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ## 1) Process and adapter parity is not perfect
 
-**What:** Bernstein ships 17 CLI adapters, but different CLI agents expose different capabilities and process semantics.
+**What:** Bernstein ships 18 CLI adapters, but different CLI agents expose different capabilities and process semantics.
 
 **Impact:** Stop/restart behavior, output shape, structured output support, and error handling can vary by adapter. The conformance harness (`adapters/conformance.py`) helps catch regressions, but not all adapters have full golden-transcript coverage.
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,0 +1,164 @@
+---
+title: What's New
+description: >-
+  User-facing summary of the major features that landed in Bernstein 1.9.x —
+  OpenAI Agents SDK v2 adapter, pluggable sandbox backends, cloud artifact
+  storage sinks, and progressive-disclosure skill packs.
+---
+
+# What's New in 1.9.x
+
+Bernstein 1.9 collects four feature tracks that landed as tickets
+`oai-001` through `oai-004`. This page summarises them in terms of what
+changes for someone upgrading from 1.8.x. Full detail lives in the
+dedicated architecture pages and the
+[CHANGELOG](CHANGELOG.md).
+
+## OpenAI Agents SDK v2 adapter (`openai_agents`) — oai-001
+
+Bernstein now ships a first-class adapter for the
+[OpenAI Agents SDK v2](https://openai.github.io/openai-agents-python/).
+It wraps `agents.Agent` + `Runner.run_sync` in a CLI-spawnable
+subprocess so the existing Bernstein spawner can manage lifecycle,
+timeouts, rate-limit back-off, and cost tracking the same way it does
+for every other coding agent.
+
+```bash
+pip install 'bernstein[openai]'
+```
+
+```yaml
+# plan.yaml
+steps:
+  - title: "Add unit tests"
+    role: qa
+    cli: openai_agents
+    model: gpt-5-mini
+```
+
+- Structured JSONL event stream (`start`, `tool_call`, `tool_result`,
+  `usage`, `completion`).
+- MCP bridging — Bernstein-managed MCP servers are forwarded into the
+  SDK's `RunConfig` so tool calls show up in the central audit log.
+- Rate-limit handling maps SDK exception classes onto
+  `COST.rate_limit_cooldown_s`.
+- Pricing rows for `gpt-5`, `gpt-5-mini`, and `o4` land alongside the
+  adapter.
+
+See the [adapter reference](adapters/openai-agents.md) and the
+[decision guide](compare/openai-agents.md) for when to pick
+`openai_agents` vs `codex` vs `claude`.
+
+## Pluggable sandbox backends — oai-002
+
+Every spawned agent now runs inside a `SandboxSession`. Four
+first-party backends ship:
+
+| Backend    | Extra             | Notes                                                                 |
+| ---------- | ----------------- | --------------------------------------------------------------------- |
+| `worktree` | core              | Local git worktree. Zero overhead. Default.                            |
+| `docker`   | `bernstein[docker]` | Per-session container; cgroup + namespace isolation.                  |
+| `e2b`      | `bernstein[e2b]`    | E2B Firecracker microVMs. Supports `SNAPSHOT`.                        |
+| `modal`    | `bernstein[modal]`  | Modal serverless containers. Supports `SNAPSHOT` and optional `GPU`. |
+
+```yaml
+# plan.yaml
+stages:
+  - name: risky-execution
+    sandbox:
+      backend: docker
+      options:
+        image: python:3.13-slim
+        memory_mb: 2048
+    steps:
+      - title: "Run untrusted code analysis"
+        role: security
+        cli: claude
+```
+
+```bash
+bernstein agents sandbox-backends   # list every installed backend
+```
+
+Third parties register backends through the `bernstein.sandbox_backends`
+entry-point group.
+
+Full detail:
+[architecture/sandbox.md](architecture/sandbox.md).
+
+## Cloud artifact storage sinks — oai-003
+
+`.sdd/` persistence (WAL, audit log, task outputs, cost ledger) now
+decouples from the local filesystem via an async `ArtifactSink`
+protocol. First-party sinks:
+
+| Sink         | Extra               | Provider SDK                  |
+| ------------ | ------------------- | ----------------------------- |
+| `local_fs`   | core (always on)    | stdlib                        |
+| `s3`         | `bernstein[s3]`    | `boto3`                       |
+| `gcs`        | `bernstein[gcs]`   | `google-cloud-storage`        |
+| `azure_blob` | `bernstein[azure]` | `azure-storage-blob`          |
+| `r2`         | `bernstein[r2]`    | `boto3` (R2 is S3-compatible) |
+
+The `BufferedSink` wrapper preserves the WAL crash-safety contract by
+fsyncing the local write first and mirroring to the remote
+asynchronously, so synchronous write latency stays bounded by local
+disk.
+
+Full detail:
+[architecture/storage.md](architecture/storage.md).
+
+## Progressive-disclosure skill packs — oai-004
+
+Role prompts migrated from monolithic `templates/roles/<role>/system_prompt.md`
+files to OpenAI Agents SDK-shaped **skill packs** under
+`templates/skills/<role>/`. Every spawn's system prompt now receives
+only a compact skill *index*; agents pull full bodies on demand
+through the `load_skill` MCP tool.
+
+Net effect: fewer tokens on every spawn, retry, and fork.
+
+```bash
+bernstein skills list             # compact table of every skill
+bernstein skills show backend     # print SKILL.md body
+bernstein skills show backend --reference python-conventions.md
+```
+
+Plugin authors can ship additional skill packs via the
+`bernstein.skill_sources` entry-point group. 17 built-in role packs
+(backend, qa, security, frontend, devops, architect, docs, retrieval,
+ml-engineer, reviewer, manager, vp, prompt-engineer, visionary,
+analyst, resolver, ci-fixer) are migrated — the legacy
+`templates/roles/` tree remains on disk for backwards compat for two
+more minor versions.
+
+Full detail: [architecture/skills.md](architecture/skills.md).
+
+## Installing the new extras
+
+All four features are additive — `pip install bernstein` continues to
+pull a minimal core. Combine extras to opt into just what you use:
+
+```bash
+# OpenAI Agents adapter + Docker sandbox + S3 artifact sink
+pip install 'bernstein[openai,docker,s3]'
+
+# Everything
+pip install 'bernstein[openai,docker,e2b,modal,s3,gcs,azure,r2]'
+```
+
+See the [install section in the README](https://github.com/chernistry/bernstein#install)
+for the full extras matrix.
+
+## Upgrade notes
+
+- **No breaking changes.** Existing `plan.yaml` and `bernstein.yaml`
+  files keep working unchanged. The new `sandbox:` block on a stage is
+  entirely optional; when omitted, behaviour is byte-identical to
+  1.8.x.
+- **Default sandbox is still `worktree`.** You must opt in to Docker /
+  E2B / Modal explicitly.
+- **Default artifact sink is still `local_fs`.** Remote sinks need the
+  matching extra plus explicit config.
+- **Legacy `templates/roles/` still loads.** Skill packs are preferred
+  when both are present for the same role.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,9 @@ site_url: https://bernstein.readthedocs.io/
 site_author: Alex Chernysh
 site_description: >-
   Bernstein is the open-source multi-agent orchestration platform for AI coding
-  agents. Run Claude Code, Codex, Gemini CLI in parallel with deterministic
-  scheduling, 18+ adapters, Cloudflare cloud execution, and zero vendor lock-in.
+  agents. Run Claude Code, Codex, Gemini CLI, and the OpenAI Agents SDK in
+  parallel with deterministic scheduling, 18 adapters, pluggable sandbox
+  backends, cloud artifact storage, and zero vendor lock-in.
 repo_url: https://github.com/chernistry/bernstein
 repo_name: chernistry/bernstein
 edit_uri: edit/main/docs/
@@ -150,9 +151,13 @@ nav:
       - Design: architecture/DESIGN.md
       - Task Lifecycle: architecture/LIFECYCLE.md
       - Why Deterministic: architecture/WHY_DETERMINISTIC.md
+      - Sandbox Backends: architecture/sandbox.md
+      - Artifact Storage: architecture/storage.md
+      - Skill Packs: architecture/skills.md
       - Glossary: reference/GLOSSARY.md
   - Guides:
       - Adapter Guide: adapters/ADAPTER_GUIDE.md
+      - OpenAI Agents SDK: adapters/openai-agents.md
       - Hook System: integrations/hook-system.md
       - Plugin SDK: integrations/plugin-sdk.md
       - Cost Optimization: operations/cost-optimization.md
@@ -176,6 +181,7 @@ nav:
       - Cloud CLI: cloudflare/cloudflare-cli.md
       - MCP Remote: cloudflare/cloudflare-mcp.md
   - Reference:
+      - What's New: whats-new.md
       - API Reference: reference/openapi-reference.md
       - Feature Matrix: reference/FEATURE_MATRIX.md
       - Model Policy: operations/MODEL_POLICY.md
@@ -196,6 +202,7 @@ nav:
       - SWE-Bench Thesis: blog/swe-bench-orchestration-thesis.md
       - COBOL Modernization: blog/cobol-modernization.md
   - Comparisons:
+      - OpenAI Agents vs Codex vs Claude: compare/openai-agents.md
       - vs Conductor: compare/bernstein-vs-conductor.md
       - vs Crystal: compare/bernstein-vs-crystal.md
       - vs Dorothy: compare/bernstein-vs-dorothy.md
@@ -204,6 +211,7 @@ nav:
       - vs Parallel Code: compare/bernstein-vs-parallel-code.md
       - vs Single Agent: compare/bernstein-vs-single-agent.md
       - vs Stoneforge: compare/bernstein-vs-stoneforge.md
+      - Deterministic vs LLM orchestration: compare/deterministic-vs-llm-orchestration.md
       - Competitive Matrix: reference/competitive-matrix.md
   - Decisions:
       - Agent Lifecycle: decisions/001-agent-lifecycle.md


### PR DESCRIPTION
## Summary

Documentation was ~200 commits behind product. This refresh brings README,
docs, and CHANGELOG into line with main as of v1.9.x:

- Adapter count updated (17 -> actual 18); OpenAI Agents SDK v2 adapter documented.
- Pluggable sandbox backends + cloud artifact sinks + progressive skills surfaced in README feature list and given dedicated architecture pages.
- Installation extras expanded (\`bernstein[openai,docker,e2b,modal,s3,gcs,azure,r2]\`).
- Comparison pages' last-verified dates refreshed to 2026-04-19.
- 1.9.0 CHANGELOG entry added in user-facing language.
- Stale \`roo-code\` and \`tabby\` adapter rows removed from docs (they do not exist in the registry).
- Over-claim of \"36 adapters\" in docs/compare/openai-agents.md corrected to 18.
- mkdocs nav exposes the three new architecture pages, the openai-agents adapter guide, the openai-agents comparison page, and the new What's New page.

## Test plan
- [x] \`uv run pytest tests/unit/test_readme_api_coverage.py -x -q\` (passes — 3 tests)
- [x] \`uv run pytest tests/unit/test_readme_reminder.py -x -q\` (passes — 20 tests)
- [x] \`uv run ruff check src/ tests/\` (passes)
- [x] \`mkdocs build\` (builds cleanly; no new warnings introduced — 179 pre-existing warnings down from 182)
- [x] \`typos\` on every changed file (clean)
- [ ] Manual review of README diff