### PR TITLE
fix(build): wheel missing 18 core sub-packages + 3 cli helpers (hotfix)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,33 +170,20 @@ bernstein-worker = "bernstein.core.worker:main"
 # my_sink = "my_pkg.storage:MyArtifactSink"
 
 [tool.hatch.build]
+# NOTE: do NOT add src/bernstein/ entries here.  Every file under src/
+# ships production code that the runtime imports -- either directly or
+# via the _CoreRedirectFinder in core/__init__.py.  Previously 18 core/
+# sub-packages plus three cli/run_*.py helpers were excluded (v1.8.7..
+# v1.8.9 wheels on PyPI are all broken because of this); `pip install
+# bernstein && bernstein --version` failed with `ModuleNotFoundError:
+# No module named 'bernstein.core.config'` and similar because the
+# redirect map / import chain points to files stripped from the wheel.
 exclude = [
     ".sdd/",
     "tests/",
     "scripts/",
     "docs/",
     ".github/",
-    "src/bernstein/core/orchestration/",
-    "src/bernstein/core/agents/",
-    "src/bernstein/core/tasks/",
-    "src/bernstein/core/quality/",
-    "src/bernstein/core/cost/",
-    "src/bernstein/core/tokens/",
-    "src/bernstein/core/security/",
-    "src/bernstein/core/config/",
-    "src/bernstein/core/observability/",
-    "src/bernstein/core/protocols/",
-    "src/bernstein/core/plugins_core/",
-    "src/bernstein/core/knowledge/",
-    "src/bernstein/core/communication/",
-    "src/bernstein/core/routing/",
-    "src/bernstein/core/planning/",
-    "src/bernstein/core/persistence/",
-    "src/bernstein/core/git/",
-    "src/bernstein/core/server/",
-    "src/bernstein/cli/run_confirm.py",
-    "src/bernstein/cli/run_preflight.py",
-    "src/bernstein/cli/run_bootstrap.py",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

Every wheel published since v1.8.7 is broken. `pip install bernstein && bernstein --version` crashes with:

```
ModuleNotFoundError: No module named 'bernstein.core.config'
```

and a cascade of similar errors for other core/ sub-packages.

### Root cause

`[tool.hatch.build]` exclude list in `pyproject.toml` drops 18 core sub-packages (`orchestration`, `agents`, `tasks`, `quality`, `cost`, `tokens`, `security`, **`config`**, `observability`, `protocols`, `plugins_core`, `knowledge`, `communication`, `routing`, `planning`, `persistence`, `git`, `server`) plus three `cli/run_*.py` helpers from the packaged wheel. The runtime imports all of them — either directly or via the `_CoreRedirectFinder` in `core/__init__.py` — so stripping them from the wheel breaks every `bernstein` CLI entry point for anyone who installs from PyPI.

It only worked in CI and local dev because `uv run` uses an editable install that sees every file under `src/`.

### Fix

Drop every `src/` entry from the exclude list. Keep only `.sdd/`, `tests/`, `scripts/`, `docs/`, `.github/`. Added an inline NOTE so this regression can't sneak back in.

### Verified locally

```console
$ uv build --wheel
Successfully built dist/bernstein-1.8.8-py3-none-any.whl

$ python3.12 -m venv /tmp/bs_verify
$ /tmp/bs_verify/bin/pip install dist/bernstein-*.whl
...
$ /tmp/bs_verify/bin/bernstein --version
bernstein, version 1.8.8
```

Before the fix: crashed with `ModuleNotFoundError: No module named 'bernstein.core.config'`.

## Test plan

- [ ] Full CI green on this branch
- [ ] After merge: `pip install bernstein==<new-release>` and `bernstein --version` works from a fresh venv (auto-release will cut v1.8.10)
- [ ] No unrelated test regressions