### PR TITLE
fix(persistence): Windows-safe PID liveness check

### DIFF
--- a/src/bernstein/core/persistence/agent_checkpoint.py
+++ b/src/bernstein/core/persistence/agent_checkpoint.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -111,13 +112,32 @@ def _read_pid(pid_path: Path) -> int | None:
 
 
 def _pid_alive(pid: int) -> bool:
-    try:
-        import os
+    """Return True if ``pid`` refers to a running process.
 
+    Uses the standard POSIX ``os.kill(pid, 0)`` probe. On Windows this can
+    raise ``OSError(WinError 87) "The parameter is incorrect"`` for PIDs
+    that do not correspond to a live process (instead of the expected
+    ``ProcessLookupError``), so we treat any ``OSError`` from ``os.kill``
+    on Windows as "not alive". ``PermissionError`` always means the PID
+    exists but is not ours; that still counts as alive.
+    """
+    import os
+
+    try:
         os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
+    except ProcessLookupError:
         return False
+    except PermissionError:
+        # PID exists, owned by another user — still a live process.
+        return True
+    except OSError:
+        # On Windows, os.kill raises OSError(WinError 87) for dead/invalid
+        # PIDs instead of ProcessLookupError. Treat any OSError on Windows
+        # as "not alive"; on POSIX, re-raise so genuine bugs surface.
+        if sys.platform == "win32":
+            return False
+        raise
+    return True
 
 
 def is_checkpoint_recoverable(checkpoint: AgentCheckpoint) -> tuple[bool, str]:


### PR DESCRIPTION
## Summary

- Fixes `tests/unit/test_agent_checkpoint.py::test_scan_orphans_finds_dead_pid` flaking on the Windows CI matrix by hardening `_pid_alive` against `OSError(WinError 87)` that Windows raises for dead/invalid PIDs instead of the POSIX-standard `ProcessLookupError`.
- Also corrects the POSIX `PermissionError` branch: EPERM on `kill(pid, 0)` means the PID exists but isn't ours, which is still a live process — the old code incorrectly reported it as dead.
- On POSIX, unexpected `OSError`s are now re-raised so genuine bugs still surface.

## CodeQL (Issue 2) — N/A

No open CodeQL alerts on main at the time of this PR:

```
$ gh api '/repos/chernistry/bernstein/code-scanning/alerts?state=open' -q length
0
```

The most recent `CodeQL Security Analysis` runs on main have been `success`, so the "red check" premise does not currently reproduce. No alerts to fix or dismiss.

## Test plan

- [x] `uv run ruff check src/bernstein/core/persistence/` — clean
- [x] `uv run pytest tests/unit/test_agent_checkpoint.py -x -q` — 23/23 green on Linux/macOS
- [ ] Windows CI matrix will re-verify `test_scan_orphans_finds_dead_pid` on push