### PR TITLE
feat: one-line install script (curl | sh) with OS detection

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,32 +1,89 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
 # Detect OS and architecture
-$OS = (Get-CimInstance -ClassName Win32_OperatingSystem).Caption
-$ARCH = (Get-CimInstance -ClassName Win32_Processor).AddressWidth
+$OS = (Get-CimInstance Win32_OperatingSystem).Caption
+$ARCH = (Get-CimInstance Win32_Processor).AddressWidth
 
 Write-Host "Installing Bernstein on $OS ($ARCH-bit)..."
 
-# Check for Python 3.12+
-if (-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
-    Write-Host "Error: Python 3.12+ required. Install from python.org"
+# Detect Python (python or python3)
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCmd) {
+    $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+}
+
+if (-not $pythonCmd) {
+    Write-Host "Error: Python 3.12+ required. Install from https://www.python.org/"
     exit 1
 }
 
-$PYTHON_VERSION = (python3 --version).Split(" ")[1]
-if ([version]$PYTHON_VERSION -lt [version]"3.12") {
-    Write-Host "Error: Python 3.12+ required. Current version: $PYTHON_VERSION"
+$pythonExe = $pythonCmd.Source
+$pythonVersion = & $pythonExe -c "import sys; print('.'.join(str(x) for x in sys.version_info[:3]))"
+
+if ([version]$pythonVersion -lt [version]"3.12.0") {
+    Write-Host "Error: Python 3.12+ required. Current version: $pythonVersion"
     exit 1
+}
+
+try {
+    & $pythonExe -m pip --version | Out-Null
+} catch {
+    & $pythonExe -m ensurepip --upgrade | Out-Null
+}
+
+# Get user scripts directory dynamically
+$USER_SCRIPTS = & $pythonExe -c "import os, site; print(os.path.join(site.USER_BASE, 'Scripts'))"
+
+function Invoke-Pipx {
+    param([Parameter(ValueFromRemainingArguments = $true)] [string[]]$Args)
+    $pipxCmd = Get-Command pipx -ErrorAction SilentlyContinue
+    if ($pipxCmd) {
+        & $pipxCmd.Source @Args
+    } else {
+        & $pythonExe -m pipx @Args
+    }
 }
 
 # Install pipx if not present
 if (-not (Get-Command pipx -ErrorAction SilentlyContinue)) {
-    Write-Host "Installing pipx..."
-    python3 -m pip install --user pipx
-    python3 -m pipx ensurepath
-    $env:Path += ";$HOME\.local\bin"
+    try {
+        & $pythonExe -m pipx --version | Out-Null
+    } catch {
+    Write-Host "pipx not found. Installing..."
+        & $pythonExe -m pip install --user --upgrade pipx
+
+        # Ensure pipx paths for future sessions
+        & $pythonExe -m pipx ensurepath | Out-Null
+    }
 }
 
-# Install Bernstein
-pipx install bernstein
+# Add scripts directory to CURRENT session
+if (-not ($env:Path -split ";" | Where-Object { $_ -eq $USER_SCRIPTS })) {
+    $env:Path += ";$USER_SCRIPTS"
+}
+
+# Verify pipx works
+try {
+    Invoke-Pipx --version | Out-Null
+} catch {
+    Write-Host "Error: pipx installed but not found in PATH."
+    Write-Host "Try restarting your terminal or running:"
+    Write-Host "  python -m pipx ensurepath"
+    exit 1
+}
+
+# Install or upgrade Bernstein
+Write-Host "Installing Bernstein..."
+try {
+    Invoke-Pipx install bernstein
+} catch {
+    Invoke-Pipx upgrade bernstein
+}
 
 Write-Host ""
-Write-Host "Bernstein installed! Run: bernstein --version"
-Write-Host "Get started: bernstein -g 'your goal here'"
+Write-Host "Bernstein installed successfully!"
+Write-Host ""
+Write-Host "Try:"
+Write-Host "  bernstein --version"
+Write-Host "  bernstein -g 'your goal here'"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,32 @@
+# Detect OS and architecture
+$OS = (Get-CimInstance -ClassName Win32_OperatingSystem).Caption
+$ARCH = (Get-CimInstance -ClassName Win32_Processor).AddressWidth
+
+Write-Host "Installing Bernstein on $OS ($ARCH-bit)..."
+
+# Check for Python 3.12+
+if (-not (Get-Command python3 -ErrorAction SilentlyContinue)) {
+    Write-Host "Error: Python 3.12+ required. Install from python.org"
+    exit 1
+}
+
+$PYTHON_VERSION = (python3 --version).Split(" ")[1]
+if ([version]$PYTHON_VERSION -lt [version]"3.12") {
+    Write-Host "Error: Python 3.12+ required. Current version: $PYTHON_VERSION"
+    exit 1
+}
+
+# Install pipx if not present
+if (-not (Get-Command pipx -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing pipx..."
+    python3 -m pip install --user pipx
+    python3 -m pipx ensurepath
+    $env:Path += ";$HOME\.local\bin"
+}
+
+# Install Bernstein
+pipx install bernstein
+
+Write-Host ""
+Write-Host "Bernstein installed! Run: bernstein --version"
+Write-Host "Get started: bernstein -g 'your goal here'"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -7,19 +7,43 @@ $ARCH = (Get-CimInstance Win32_Processor).AddressWidth
 
 Write-Host "Installing Bernstein on $OS ($ARCH-bit)..."
 
-# Detect Python (python or python3)
-$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
-if (-not $pythonCmd) {
-    $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+# Select Python launcher (prefer py -3 on Windows)
+$pythonMode = ""
+$pythonExe = ""
+
+if (Get-Command py -ErrorAction SilentlyContinue) {
+    $pythonMode = "py"
+} else {
+    $pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $pythonCmd) {
+        $pythonCmd = Get-Command python3 -ErrorAction SilentlyContinue
+    }
+    if ($pythonCmd) {
+        $pythonMode = "exe"
+        $pythonExe = $pythonCmd.Source
+    }
 }
 
-if (-not $pythonCmd) {
+if (-not $pythonMode) {
     Write-Host "Error: Python 3.12+ required. Install from https://www.python.org/"
     exit 1
 }
 
-$pythonExe = $pythonCmd.Source
-$pythonVersion = & $pythonExe -c "import sys; print('.'.join(str(x) for x in sys.version_info[:3]))"
+function Invoke-Python {
+    param([Parameter(ValueFromRemainingArguments = $true)] [string[]]$Args)
+    if ($pythonMode -eq "py") {
+        & py -3 @Args
+    } else {
+        & $pythonExe @Args
+    }
+}
+
+try {
+    $pythonVersion = Invoke-Python -c "import sys; print('.'.join(str(x) for x in sys.version_info[:3]))"
+} catch {
+    Write-Host "Error: Python 3.12+ required. Could not run Python."
+    exit 1
+}
 
 if ([version]$pythonVersion -lt [version]"3.12.0") {
     Write-Host "Error: Python 3.12+ required. Current version: $pythonVersion"
@@ -27,13 +51,13 @@ if ([version]$pythonVersion -lt [version]"3.12.0") {
 }
 
 try {
-    & $pythonExe -m pip --version | Out-Null
+    Invoke-Python -m pip --version | Out-Null
 } catch {
-    & $pythonExe -m ensurepip --upgrade | Out-Null
+    Invoke-Python -m ensurepip --upgrade | Out-Null
 }
 
 # Get user scripts directory dynamically
-$USER_SCRIPTS = & $pythonExe -c "import os, site; print(os.path.join(site.USER_BASE, 'Scripts'))"
+$USER_SCRIPTS = Invoke-Python -c "import os, site; print(os.path.join(site.USER_BASE, 'Scripts'))"
 
 function Invoke-Pipx {
     param([Parameter(ValueFromRemainingArguments = $true)] [string[]]$Args)
@@ -41,20 +65,20 @@ function Invoke-Pipx {
     if ($pipxCmd) {
         & $pipxCmd.Source @Args
     } else {
-        & $pythonExe -m pipx @Args
+        Invoke-Python -m pipx @Args
     }
 }
 
 # Install pipx if not present
 if (-not (Get-Command pipx -ErrorAction SilentlyContinue)) {
     try {
-        & $pythonExe -m pipx --version | Out-Null
+        Invoke-Python -m pipx --version | Out-Null
     } catch {
-    Write-Host "pipx not found. Installing..."
-        & $pythonExe -m pip install --user --upgrade pipx
+        Write-Host "pipx not found. Installing..."
+        Invoke-Python -m pip install --user --upgrade pipx
 
         # Ensure pipx paths for future sessions
-        & $pythonExe -m pipx ensurepath | Out-Null
+        Invoke-Python -m pipx ensurepath | Out-Null
     }
 }
 
@@ -69,7 +93,11 @@ try {
 } catch {
     Write-Host "Error: pipx installed but not found in PATH."
     Write-Host "Try restarting your terminal or running:"
-    Write-Host "  python -m pipx ensurepath"
+    if ($pythonMode -eq "py") {
+        Write-Host "  py -3 -m pipx ensurepath"
+    } else {
+        Write-Host "  python -m pipx ensurepath"
+    }
     exit 1
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,9 +22,20 @@ fi
 # Install pipx if not present
 if ! command -v pipx >/dev/null 2>&1; then
   echo "Installing pipx..."
-  python3 -m pip install --user pipx
-  python3 -m pipx ensurepath
-  export PATH="$PATH:~/.local/bin"
+  if [ "$OS" = "darwin" ]; then
+    # Use Homebrew to install pipx on macOS
+    if ! command -v brew >/dev/null 2>&1; then
+      echo "Error: Homebrew is not installed. Install Homebrew first: https://brew.sh/"
+      exit 1
+    fi
+    brew install pipx
+    pipx ensurepath
+  else
+    # Use pip to install pipx on other systems
+    python3 -m pip install --user pipx
+    python3 -m pipx ensurepath
+    export PATH="$PATH:~/.local/bin"
+  fi
 fi
 
 # Install Bernstein

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env sh
-set -e
+#!/bin/sh
+set -eu
 
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -13,47 +13,53 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
-PYTHON_VERSION=$(python3 --version | awk '{print $2}')
-if [ "$(printf '%s\n' "3.12" "$PYTHON_VERSION" | sort -V | head -n1)" != "3.12" ]; then
+PYTHON_BIN="python3"
+if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' >/dev/null 2>&1; then
+  PYTHON_VERSION=$("$PYTHON_BIN" -c 'import sys; print(".".join(str(part) for part in sys.version_info[:3]))')
   echo "Error: Python 3.12+ required. Current version: $PYTHON_VERSION"
   exit 1
 fi
 
-# Install pipx if not present
-if ! command -v pipx >/dev/null 2>&1; then
-  echo "pipx not found. Installing..."
-
-  if [ "$OS" = "darwin" ]; then
-    if ! command -v brew >/dev/null 2>&1; then
-      echo "Error: Homebrew is not installed. Install it from https://brew.sh/"
-      exit 1
-    fi
-    brew install pipx
-  else
-    python3 -m pip install --user pipx
-  fi
+if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+  "$PYTHON_BIN" -m ensurepip --upgrade >/dev/null 2>&1 || true
 fi
 
-# Ensure pipx is usable in THIS shell (critical fix)
-export PATH="$HOME/.local/bin:$PATH"
+# Install pipx if not present
+if ! command -v pipx >/dev/null 2>&1 && ! "$PYTHON_BIN" -m pipx --version >/dev/null 2>&1; then
+  echo "pipx not found. Installing..."
+  "$PYTHON_BIN" -m pip install --user --upgrade pipx
+fi
+
+# Ensure pipx/bernstein bin paths are usable in THIS shell
+USER_BIN=$("$PYTHON_BIN" -c 'import os, site; print(os.path.join(site.USER_BASE, "bin"))')
+export PATH="$USER_BIN:$HOME/.local/bin:$PATH"
+
+run_pipx() {
+  if command -v pipx >/dev/null 2>&1; then
+    pipx "$@"
+  else
+    "$PYTHON_BIN" -m pipx "$@"
+  fi
+}
 
 # Also ensure pipx paths are configured
-python3 -m pipx ensurepath >/dev/null 2>&1 || true
+run_pipx ensurepath >/dev/null 2>&1 || true
 
 # Verify pipx works
-if ! command -v pipx >/dev/null 2>&1; then
+if ! run_pipx --version >/dev/null 2>&1; then
   echo "Error: pipx is installed but not available in PATH."
-  echo "Try restarting your terminal or running:"
-  echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+  echo "Try restarting your terminal or running: python3 -m pipx ensurepath"
   exit 1
 fi
 
 # Install Bernstein
 echo "Installing Bernstein..."
-pipx install bernstein
+if ! run_pipx install bernstein; then
+  run_pipx upgrade bernstein
+fi
 
 echo ""
-echo "Bernstein installed successfully! 🎉"
+echo "Bernstein installed successfully!"
 echo ""
 echo "Try:"
 echo "  bernstein --version"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,14 +9,14 @@ echo "Installing Bernstein on $OS/$ARCH..."
 
 # Check for Python 3.12+
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: Python 3.12+ required. Install from https://www.python.org/"
+  echo "Error: Python 3.12+ required. Install from https://www.python.org/" >&2
   exit 1
 fi
 
 PYTHON_BIN="python3"
 if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 12) else 1)' >/dev/null 2>&1; then
   PYTHON_VERSION=$("$PYTHON_BIN" -c 'import sys; print(".".join(str(part) for part in sys.version_info[:3]))')
-  echo "Error: Python 3.12+ required. Current version: $PYTHON_VERSION"
+  echo "Error: Python 3.12+ required. Current version: $PYTHON_VERSION" >&2
   exit 1
 fi
 
@@ -37,8 +37,10 @@ export PATH="$USER_BIN:$HOME/.local/bin:$PATH"
 run_pipx() {
   if command -v pipx >/dev/null 2>&1; then
     pipx "$@"
+    return $?
   else
     "$PYTHON_BIN" -m pipx "$@"
+    return $?
   fi
 }
 
@@ -47,8 +49,8 @@ run_pipx ensurepath >/dev/null 2>&1 || true
 
 # Verify pipx works
 if ! run_pipx --version >/dev/null 2>&1; then
-  echo "Error: pipx is installed but not available in PATH."
-  echo "Try restarting your terminal or running: python3 -m pipx ensurepath"
+  echo "Error: pipx is installed but not available in PATH." >&2
+  echo "Try restarting your terminal or running: python3 -m pipx ensurepath" >&2
   exit 1
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 
 # Detect OS and architecture
@@ -9,7 +9,7 @@ echo "Installing Bernstein on $OS/$ARCH..."
 
 # Check for Python 3.12+
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: Python 3.12+ required. Install from python.org"
+  echo "Error: Python 3.12+ required. Install from https://www.python.org/"
   exit 1
 fi
 
@@ -21,26 +21,40 @@ fi
 
 # Install pipx if not present
 if ! command -v pipx >/dev/null 2>&1; then
-  echo "Installing pipx..."
+  echo "pipx not found. Installing..."
+
   if [ "$OS" = "darwin" ]; then
-    # Use Homebrew to install pipx on macOS
     if ! command -v brew >/dev/null 2>&1; then
-      echo "Error: Homebrew is not installed. Install Homebrew first: https://brew.sh/"
+      echo "Error: Homebrew is not installed. Install it from https://brew.sh/"
       exit 1
     fi
     brew install pipx
-    pipx ensurepath
   else
-    # Use pip to install pipx on other systems
     python3 -m pip install --user pipx
-    python3 -m pipx ensurepath
-    export PATH="$PATH:~/.local/bin"
   fi
 fi
 
+# Ensure pipx is usable in THIS shell (critical fix)
+export PATH="$HOME/.local/bin:$PATH"
+
+# Also ensure pipx paths are configured
+python3 -m pipx ensurepath >/dev/null 2>&1 || true
+
+# Verify pipx works
+if ! command -v pipx >/dev/null 2>&1; then
+  echo "Error: pipx is installed but not available in PATH."
+  echo "Try restarting your terminal or running:"
+  echo "export PATH=\"\$HOME/.local/bin:\$PATH\""
+  exit 1
+fi
+
 # Install Bernstein
+echo "Installing Bernstein..."
 pipx install bernstein
 
 echo ""
-echo "Bernstein installed! Run: bernstein --version"
-echo "Get started: bernstein -g 'your goal here'"
+echo "Bernstein installed successfully! 🎉"
+echo ""
+echo "Try:"
+echo "  bernstein --version"
+echo "  bernstein -g 'your goal here'"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+# Detect OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+echo "Installing Bernstein on $OS/$ARCH..."
+
+# Check for Python 3.12+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: Python 3.12+ required. Install from python.org"
+  exit 1
+fi
+
+PYTHON_VERSION=$(python3 --version | awk '{print $2}')
+if [ "$(printf '%s\n' "3.12" "$PYTHON_VERSION" | sort -V | head -n1)" != "3.12" ]; then
+  echo "Error: Python 3.12+ required. Current version: $PYTHON_VERSION"
+  exit 1
+fi
+
+# Install pipx if not present
+if ! command -v pipx >/dev/null 2>&1; then
+  echo "Installing pipx..."
+  python3 -m pip install --user pipx
+  python3 -m pipx ensurepath
+  export PATH="$PATH:~/.local/bin"
+fi
+
+# Install Bernstein
+pipx install bernstein
+
+echo ""
+echo "Bernstein installed! Run: bernstein --version"
+echo "Get started: bernstein -g 'your goal here'"


### PR DESCRIPTION
## What

Add scripts/install.sh and scripts/install.ps1 to make one-line install more reliable across imperfect user environments.
## Why

Some users hit bootstrap failures (notably No module named pipx on Windows) when pipx was installed under a different Python launcher than the one used later in the script. These scripts should make the installation more resilient. 
## How

- Hardened Python version checks (>=3.12) using interpreter-native checks.
- Added pip bootstrap fallback (ensurepip) before attempting pipx install.
- Improved pipx invocation to work via command or module path.


## Checklist

- [ ] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [ ] New code has type hints
- [ ] Docs updated if needed
