### PR TITLE
feat(adapters): add 13 CLI adapters to leapfrog emdash coverage (31 total)

### DIFF
--- a/src/bernstein/adapters/auggie.py
+++ b/src/bernstein/adapters/auggie.py
@@ -1,0 +1,108 @@
+"""Auggie (Augment Code) CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class AuggieAdapter(CLIAdapter):
+    """Spawn and monitor Auggie (Augment Code) CLI sessions.
+
+    Auggie is Augment Code's CLI coding agent.  It is invoked with a
+    positional prompt and the ``--allow-indexing`` flag, which is kept
+    always-on so Auggie does not block the session waiting for an
+    interactive indexing confirmation.
+
+    See https://docs.augmentcode.com/cli/overview for details.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch an Auggie process with the given prompt.
+
+        Args:
+            prompt: The task prompt for the agent (passed positionally).
+            workdir: Working directory for the Auggie process.
+            model_config: Model and effort configuration (unused — Auggie
+                selects the model via its own configuration).
+            session_id: Unique session identifier used for log naming.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope label (unused by this adapter).
+            budget_multiplier: Retry budget multiplier (unused by this adapter).
+            system_addendum: Protocol-critical instructions (unused — Auggie
+                accepts only a single positional prompt).
+
+        Returns:
+            SpawnResult describing the spawned process.
+
+        Raises:
+            RuntimeError: The ``auggie`` binary is missing from PATH or
+                cannot be executed due to permissions.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # --allow-indexing is always-on; otherwise Auggie prompts each session.
+        cmd = ["auggie", "--allow-indexing", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["AUGMENT_API_KEY", "AUGMENT_TOKEN"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "auggie not found in PATH. "
+                    "Install: npm install -g @augmentcode/auggie "
+                    "(see https://docs.augmentcode.com/cli/overview)"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing auggie: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Auggie"

--- a/src/bernstein/adapters/autohand.py
+++ b/src/bernstein/adapters/autohand.py
@@ -1,0 +1,103 @@
+"""Autohand Code CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class AutohandAdapter(CLIAdapter):
+    """Spawn and monitor Autohand Code CLI sessions.
+
+    Autohand is a CLI coding agent installed via ``npm install -g
+    autohand-cli``.  It runs with ``--unrestricted`` for non-interactive
+    execution and accepts the task prompt via the ``-p`` flag.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Spawn an Autohand Code session.
+
+        Args:
+            prompt: The task prompt for the agent.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope label (unused).
+            budget_multiplier: Budget multiplier (unused).
+            system_addendum: Protocol-critical instructions (unused).
+
+        Returns:
+            A :class:`SpawnResult` describing the spawned process.
+
+        Raises:
+            RuntimeError: If the ``autohand`` binary cannot be found or
+                executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "autohand",
+            "--unrestricted",
+            "-p",
+            prompt,
+        ]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["AUTOHAND_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "autohand not found in PATH. Install: npm install -g autohand-cli (see https://autohand.ai/code/)"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing autohand: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Autohand"

--- a/src/bernstein/adapters/charm.py
+++ b/src/bernstein/adapters/charm.py
@@ -1,0 +1,103 @@
+"""Charm Crush CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class CharmAdapter(CLIAdapter):
+    """Spawn and monitor Charm Crush CLI sessions.
+
+    Charm Crush (``crush``) is Charmbracelet's CLI coding agent installed
+    via ``npm install -g @charmland/crush``. The ``--yolo`` flag disables
+    per-tool approval prompts so the session runs non-interactively.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Spawn a Crush session.
+
+        Args:
+            prompt: The task prompt for the agent.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope label (unused).
+            budget_multiplier: Budget multiplier (unused).
+            system_addendum: Protocol-critical instructions (unused).
+
+        Returns:
+            A :class:`SpawnResult` describing the spawned process.
+
+        Raises:
+            RuntimeError: If the ``crush`` binary cannot be found or
+                executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["crush", "--yolo", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "GROQ_API_KEY"]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "crush not found in PATH. Install: npm install -g @charmland/crush "
+                    "(see https://github.com/charmbracelet/crush)"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing crush: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Charm"

--- a/src/bernstein/adapters/cline.py
+++ b/src/bernstein/adapters/cline.py
@@ -1,0 +1,105 @@
+"""Cline CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class ClineAdapter(CLIAdapter):
+    """Spawn and monitor Cline CLI sessions.
+
+    Cline is a CLI coding agent invoked directly as ``cline``.  The
+    ``--yolo`` flag enables auto-approval for tool invocations so sessions
+    can run unattended.
+
+    See: https://docs.cline.bot/cline-cli/overview
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Spawn a Cline CLI session.
+
+        Args:
+            prompt: Task prompt passed positionally to ``cline``.
+            workdir: Project working directory.
+            model_config: Model and effort configuration (passed through as
+                metadata only; Cline selects its own model).
+            session_id: Unique session identifier used for log/pid metadata.
+            mcp_config: Unused; accepted for interface compatibility.
+            timeout_seconds: Watchdog timeout for the spawned process.
+            task_scope: Unused; accepted for interface compatibility.
+            budget_multiplier: Unused; accepted for interface compatibility.
+            system_addendum: Unused; accepted for interface compatibility.
+
+        Returns:
+            SpawnResult describing the launched worker process.
+
+        Raises:
+            RuntimeError: If ``cline`` is not installed or is not executable.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["cline", "--yolo", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            ["CLINE_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "cline not found in PATH. Install with: npm install -g cline "
+                    "(see https://docs.cline.bot/cline-cli/overview)"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing cline: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Cline"

--- a/src/bernstein/adapters/codebuff.py
+++ b/src/bernstein/adapters/codebuff.py
@@ -1,0 +1,103 @@
+"""Codebuff CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class CodebuffAdapter(CLIAdapter):
+    """Spawn and monitor Codebuff CLI sessions.
+
+    Codebuff is an npm-distributed CLI coding agent. The CLI accepts a
+    task prompt as a single positional argument and has no dedicated
+    auto-approve or headless flag (see
+    https://www.codebuff.com/docs/help/quick-start).
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Codebuff session.
+
+        Args:
+            prompt: Task prompt passed as the single positional argument.
+            workdir: Working directory for the agent process.
+            model_config: Model configuration (unused; Codebuff selects
+                its own model via its own config).
+            session_id: Unique session identifier used for the log file.
+            mcp_config: Unused. Codebuff manages its own integrations.
+            timeout_seconds: Watchdog timeout in seconds.
+            task_scope: Unused scope hint.
+            budget_multiplier: Unused budget multiplier.
+            system_addendum: Unused system-prompt addendum.
+
+        Returns:
+            :class:`SpawnResult` describing the launched process.
+
+        Raises:
+            RuntimeError: If the ``codebuff`` binary is missing or not
+                executable.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["codebuff", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["CODEBUFF_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "codebuff not found in PATH. Install: npm install -g codebuff "
+                    "or see https://www.codebuff.com/docs/help/quick-start"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing codebuff: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Codebuff"

--- a/src/bernstein/adapters/copilot.py
+++ b/src/bernstein/adapters/copilot.py
@@ -1,0 +1,100 @@
+"""GitHub Copilot CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class CopilotAdapter(CLIAdapter):
+    """Spawn and monitor GitHub Copilot CLI sessions.
+
+    The CLI is invoked as ``copilot --allow-all-tools -i <prompt>`` where
+    ``--allow-all-tools`` is the auto-approval flag and ``-i`` supplies the
+    initial prompt.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a GitHub Copilot CLI session.
+
+        Args:
+            prompt: The initial prompt supplied via ``-i``.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (retained for
+                interface compatibility; the Copilot CLI selects its own
+                model internally).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by Copilot).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``copilot`` binary is missing from PATH
+                or cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["copilot", "--allow-all-tools", "-i", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["GITHUB_TOKEN", "GH_TOKEN", "GITHUB_COPILOT_TOKEN"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "copilot not found in PATH. Install: npm install -g @github/copilot"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing copilot: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "GitHub Copilot"

--- a/src/bernstein/adapters/droid.py
+++ b/src/bernstein/adapters/droid.py
@@ -1,0 +1,103 @@
+"""Droid (Factory AI) CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class DroidAdapter(CLIAdapter):
+    """Spawn and monitor Droid (Factory AI) CLI sessions.
+
+    Droid is Factory AI's CLI coding agent.  The CLI accepts the prompt as
+    a positional argument (``droid <prompt>``); there is no dedicated
+    ``--prompt``/``-i`` flag for the initial prompt.  A ``-r``/resume flag
+    exists but is unused at spawn time.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Droid CLI session.
+
+        Args:
+            prompt: The task prompt (passed as a positional argument).
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (not consumed by
+                the Droid CLI, retained for interface compatibility).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by Droid).
+            budget_multiplier: Multiplier on scope budget (unused by Droid).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the Droid CLI is not installed or not
+                executable on the configured PATH.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["droid", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["FACTORY_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "droid not found in PATH. Install: "
+                    "curl -fsSL https://app.factory.ai/cli | sh"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing droid: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Droid"

--- a/src/bernstein/adapters/forge.py
+++ b/src/bernstein/adapters/forge.py
@@ -1,0 +1,106 @@
+"""Forge CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class ForgeAdapter(CLIAdapter):
+    """Spawn and monitor Forge CLI sessions.
+
+    Forge (forgecode.dev) is a CLI coding agent that accepts prompts via the
+    ``-p`` flag. The ``--conversation-id`` flag exists for resuming sessions,
+    but Bernstein spawns each session fresh and does not use it.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Forge CLI process for the given prompt.
+
+        Args:
+            prompt: Task prompt passed via the ``-p`` flag.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (passed through for
+                metadata; Forge selects providers via env vars).
+            session_id: Unique session identifier used for log and PID files.
+            mcp_config: Optional MCP server definitions (unused by Forge).
+            timeout_seconds: Seconds before the watchdog sends SIGTERM.
+            task_scope: Task scope label (unused by Forge).
+            budget_multiplier: Scope-budget multiplier (unused by Forge).
+            system_addendum: Protocol-critical instructions (unused by Forge).
+
+        Returns:
+            A :class:`SpawnResult` with the child PID and log path.
+
+        Raises:
+            RuntimeError: The ``forge`` binary is missing from PATH or the
+                current user lacks permission to execute it.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["forge", "-p", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            [
+                "FORGE_API_KEY",
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+                "OPENROUTER_API_KEY",
+            ]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "forge not found in PATH. Install: curl -fsSL https://forgecode.dev/cli | sh (see https://forgecode.dev/docs/)"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing forge: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Forge"

--- a/src/bernstein/adapters/hermes.py
+++ b/src/bernstein/adapters/hermes.py
@@ -1,0 +1,104 @@
+"""Hermes Agent (Nous Research) CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class HermesAdapter(CLIAdapter):
+    """Spawn and monitor Hermes Agent CLI sessions.
+
+    Hermes Agent is Nous Research's CLI coding agent. For non-interactive
+    spawn the prompt is passed positionally; the interactive TUI's
+    keystroke-injection mode is bypassed here.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Spawn a Hermes Agent session.
+
+        Args:
+            prompt: The task prompt for the agent.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope label (unused).
+            budget_multiplier: Budget multiplier (unused).
+            system_addendum: Protocol-critical instructions (unused).
+
+        Returns:
+            A :class:`SpawnResult` describing the spawned process.
+
+        Raises:
+            RuntimeError: If the ``hermes`` binary cannot be found or
+                executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["hermes", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            ["HERMES_API_KEY", "NOUS_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "hermes not found in PATH. Install: curl -fsSL "
+                    "https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash "
+                    "(see https://hermes-agent.nousresearch.com/docs/)"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing hermes: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Hermes Agent"

--- a/src/bernstein/adapters/kimi.py
+++ b/src/bernstein/adapters/kimi.py
@@ -1,0 +1,107 @@
+"""Kimi CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class KimiAdapter(CLIAdapter):
+    """Spawn and monitor Kimi CLI sessions.
+
+    Kimi CLI is Moonshot's coding agent.  It is invoked with ``--yolo``
+    (auto-approve tool calls) and ``-c`` (initial prompt flag).
+
+    See https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html
+    for installation and usage details.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Kimi CLI process with the given prompt.
+
+        Args:
+            prompt: The task prompt for the agent (passed via ``-c``).
+            workdir: Working directory for the Kimi process.
+            model_config: Model and effort configuration (unused — Kimi
+                selects the model via its own configuration).
+            session_id: Unique session identifier used for log naming.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope label (unused by this adapter).
+            budget_multiplier: Retry budget multiplier (unused by this adapter).
+            system_addendum: Protocol-critical instructions (unused — Kimi
+                does not expose a separate system-prompt channel).
+
+        Returns:
+            SpawnResult describing the spawned process.
+
+        Raises:
+            RuntimeError: The ``kimi`` binary is missing from PATH or
+                cannot be executed due to permissions.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # --yolo auto-approves tool calls; -c supplies the initial prompt.
+        cmd = ["kimi", "--yolo", "-c", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["KIMI_API_KEY", "MOONSHOT_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "kimi not found in PATH. "
+                    "Install: uv tool install kimi-cli "
+                    "(see https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html)"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing kimi: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Kimi"

--- a/src/bernstein/adapters/mistral.py
+++ b/src/bernstein/adapters/mistral.py
@@ -1,0 +1,102 @@
+"""Mistral Vibe CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class MistralAdapter(CLIAdapter):
+    """Spawn and monitor Mistral Vibe CLI sessions.
+
+    Mistral Vibe is a CLI coding agent by Mistral.  It runs with
+    ``--auto-approve`` for non-interactive execution and accepts the task
+    prompt via the ``--prompt`` flag.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Spawn a Mistral Vibe session.
+
+        Args:
+            prompt: The task prompt for the agent.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope label (unused).
+            budget_multiplier: Budget multiplier (unused).
+            system_addendum: Protocol-critical instructions (unused).
+
+        Returns:
+            A :class:`SpawnResult` describing the spawned process.
+
+        Raises:
+            RuntimeError: If the ``vibe`` binary cannot be found or executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "vibe",
+            "--auto-approve",
+            "--prompt",
+            prompt,
+        ]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["MISTRAL_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "vibe not found in PATH. Install: curl -LsSf https://mistral.ai/vibe/install.sh | bash"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing vibe: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Mistral Vibe"

--- a/src/bernstein/adapters/pi.py
+++ b/src/bernstein/adapters/pi.py
@@ -1,0 +1,106 @@
+"""Pi (pi-coding-agent) CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class PiAdapter(CLIAdapter):
+    """Spawn and monitor Pi (``pi-coding-agent``) CLI sessions.
+
+    Pi is an npm-distributed coding agent
+    (``@mariozechner/pi-coding-agent``).  The CLI takes the task prompt
+    as a positional argument; ``-c`` exists for resume but is not used
+    when spawning a fresh session.  See
+    https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Pi coding-agent session.
+
+        Args:
+            prompt: Task prompt passed as the single positional argument.
+            workdir: Working directory for the agent process.
+            model_config: Model configuration (unused by ``pi`` which
+                selects its own model via its own settings).
+            session_id: Unique session identifier used for the log file.
+            mcp_config: Unused. Pi manages its own integrations.
+            timeout_seconds: Watchdog timeout in seconds.
+            task_scope: Unused scope hint.
+            budget_multiplier: Unused budget multiplier.
+            system_addendum: Unused system-prompt addendum.
+
+        Returns:
+            :class:`SpawnResult` describing the launched process.
+
+        Raises:
+            RuntimeError: If the ``pi`` binary is missing or not
+                executable.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["pi", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            ["PI_API_KEY", "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"],
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "pi not found in PATH. Install: npm install -g @mariozechner/pi-coding-agent "
+                    "or see https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing pi: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Pi"

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -8,46 +8,72 @@ from importlib.metadata import entry_points
 
 from bernstein.adapters.aider import AiderAdapter
 from bernstein.adapters.amp import AmpAdapter
+from bernstein.adapters.auggie import AuggieAdapter
+from bernstein.adapters.autohand import AutohandAdapter
 from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.charm import CharmAdapter
 from bernstein.adapters.claude import ClaudeCodeAdapter
+from bernstein.adapters.cline import ClineAdapter
 from bernstein.adapters.cloudflare_agents import CloudflareAgentsAdapter
+from bernstein.adapters.codebuff import CodebuffAdapter
 from bernstein.adapters.codex import CodexAdapter
 from bernstein.adapters.cody import CodyAdapter
 from bernstein.adapters.continue_dev import ContinueDevAdapter
+from bernstein.adapters.copilot import CopilotAdapter
 from bernstein.adapters.cursor import CursorAdapter
+from bernstein.adapters.droid import DroidAdapter
+from bernstein.adapters.forge import ForgeAdapter
 from bernstein.adapters.gemini import GeminiAdapter
 from bernstein.adapters.generic import GenericAdapter
 from bernstein.adapters.goose import GooseAdapter
+from bernstein.adapters.hermes import HermesAdapter
 from bernstein.adapters.iac import IaCAdapter
 from bernstein.adapters.kilo import KiloAdapter
+from bernstein.adapters.kimi import KimiAdapter
 from bernstein.adapters.kiro import KiroAdapter
+from bernstein.adapters.mistral import MistralAdapter
 from bernstein.adapters.mock import MockAgentAdapter
 from bernstein.adapters.ollama import OllamaAdapter
 from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
 from bernstein.adapters.opencode import OpenCodeAdapter
+from bernstein.adapters.pi import PiAdapter
 from bernstein.adapters.qwen import QwenAdapter
+from bernstein.adapters.rovo import RovoAdapter
 
 logger = logging.getLogger(__name__)
 
 _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
-    "amp": AmpAdapter,
     "aider": AiderAdapter,
+    "amp": AmpAdapter,
+    "auggie": AuggieAdapter,
+    "autohand": AutohandAdapter,
+    "charm": CharmAdapter,
     "claude": ClaudeCodeAdapter,
+    "cline": ClineAdapter,
     "cloudflare": CloudflareAgentsAdapter,
-    "cody": CodyAdapter,
+    "codebuff": CodebuffAdapter,
     "codex": CodexAdapter,
+    "cody": CodyAdapter,
     "continue": ContinueDevAdapter,
+    "copilot": CopilotAdapter,
     "cursor": CursorAdapter,
+    "droid": DroidAdapter,
+    "forge": ForgeAdapter,
     "gemini": GeminiAdapter,
     "goose": GooseAdapter,
+    "hermes": HermesAdapter,
     "iac": IaCAdapter,
     "kilo": KiloAdapter,
+    "kimi": KimiAdapter,
     "kiro": KiroAdapter,
+    "mistral": MistralAdapter,
     "mock": MockAgentAdapter,
     "ollama": OllamaAdapter,
     "openai_agents": OpenAIAgentsAdapter,
     "opencode": OpenCodeAdapter,
+    "pi": PiAdapter,
     "qwen": QwenAdapter,
+    "rovo": RovoAdapter,
 }
 
 _entrypoints_loaded = False

--- a/src/bernstein/adapters/rovo.py
+++ b/src/bernstein/adapters/rovo.py
@@ -1,0 +1,106 @@
+"""Atlassian Rovo Dev CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+
+class RovoAdapter(CLIAdapter):
+    """Spawn and monitor Atlassian Rovo Dev CLI sessions.
+
+    Rovo Dev is Atlassian's CLI coding agent, invoked through the Atlassian
+    CLI (``acli``) using the ``rovodev`` subcommand.  The ``--yolo`` flag
+    enables auto-approval for tool invocations so sessions can run
+    unattended.
+
+    See: https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Spawn a Rovo Dev CLI session.
+
+        Args:
+            prompt: Task prompt passed positionally to ``acli rovodev run``.
+            workdir: Project working directory.
+            model_config: Model and effort configuration (passed through as
+                metadata only; Rovo Dev selects its own model).
+            session_id: Unique session identifier used for log/pid metadata.
+            mcp_config: Unused; accepted for interface compatibility.
+            timeout_seconds: Watchdog timeout for the spawned process.
+            task_scope: Unused; accepted for interface compatibility.
+            budget_multiplier: Unused; accepted for interface compatibility.
+            system_addendum: Unused; accepted for interface compatibility.
+
+        Returns:
+            SpawnResult describing the launched worker process.
+
+        Raises:
+            RuntimeError: If ``acli`` is not installed or is not executable.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["acli", "rovodev", "run", "--yolo", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            ["ATLASSIAN_API_TOKEN", "ACLI_TOKEN", "ANTHROPIC_API_KEY", "OPENAI_API_KEY"],
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "acli not found in PATH. Rovo Dev requires the Atlassian CLI. "
+                    "Install acli and authenticate with: acli rovodev auth login"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing acli: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Rovo Dev"

--- a/tests/unit/test_adapter_auggie.py
+++ b/tests/unit/test_adapter_auggie.py
@@ -1,0 +1,77 @@
+"""Unit tests for AuggieAdapter spawn command construction."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.auggie import AuggieAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestAuggieAdapterSpawn:
+    """AuggieAdapter.spawn() builds correct command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = AuggieAdapter()
+        proc_mock = _make_popen_mock(pid=700)
+        with patch("bernstein.adapters.auggie.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="auggie-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner[:2] == ["auggie", "--allow-indexing"]
+        assert inner[-1] == "fix the bug"
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = AuggieAdapter()
+        with (
+            patch(
+                "bernstein.adapters.auggie.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="auggie-missing",
+            )
+        msg = str(exc_info.value)
+        assert "auggie not found" in msg
+        assert "npm install -g @augmentcode/auggie" in msg
+
+
+class TestAuggieAdapterName:
+    def test_name(self) -> None:
+        assert AuggieAdapter().name() == "Auggie"

--- a/tests/unit/test_adapter_autohand.py
+++ b/tests/unit/test_adapter_autohand.py
@@ -1,0 +1,73 @@
+"""Unit tests for AutohandAdapter spawn/name."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.autohand import AutohandAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestAutohandAdapterSpawn:
+    """AutohandAdapter.spawn() builds the expected command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = AutohandAdapter()
+        proc_mock = _make_popen_mock(pid=800)
+        with patch("bernstein.adapters.autohand.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="autohand-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["autohand", "--unrestricted", "-p", "fix the bug"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = AutohandAdapter()
+        with (
+            patch(
+                "bernstein.adapters.autohand.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match="not found in PATH"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="autohand-missing",
+            )
+
+
+class TestAutohandAdapterName:
+    def test_name(self) -> None:
+        assert AutohandAdapter().name() == "Autohand"

--- a/tests/unit/test_adapter_charm.py
+++ b/tests/unit/test_adapter_charm.py
@@ -1,0 +1,70 @@
+"""Unit tests for CharmAdapter spawn/name."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.charm import CharmAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestCharmAdapterSpawn:
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = CharmAdapter()
+        proc_mock = _make_popen_mock(pid=950)
+        with patch("bernstein.adapters.charm.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="refactor the module",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="charm-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["crush", "--yolo", "refactor the module"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = CharmAdapter()
+        with (
+            patch(
+                "bernstein.adapters.charm.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match=r"crush not found.*@charmland/crush"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="charm-missing",
+            )
+
+
+class TestCharmAdapterName:
+    def test_name(self) -> None:
+        assert CharmAdapter().name() == "Charm"

--- a/tests/unit/test_adapter_cline.py
+++ b/tests/unit/test_adapter_cline.py
@@ -1,0 +1,76 @@
+"""Unit tests for ClineAdapter spawn/name."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.cline import ClineAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestClineAdapterSpawn:
+    """ClineAdapter.spawn() builds the expected command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = ClineAdapter()
+        proc_mock = _make_popen_mock(pid=800)
+        with patch("bernstein.adapters.cline.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="refactor module",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="cline-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner[:2] == ["cline", "--yolo"]
+        assert inner[-1] == "refactor module"
+
+
+class TestClineSpawnMissingBinary:
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = ClineAdapter()
+        with (
+            patch(
+                "bernstein.adapters.cline.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match="not found in PATH"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="cline-missing",
+            )
+
+
+class TestClineAdapterName:
+    def test_name(self) -> None:
+        assert ClineAdapter().name() == "Cline"

--- a/tests/unit/test_adapter_codebuff.py
+++ b/tests/unit/test_adapter_codebuff.py
@@ -1,0 +1,74 @@
+"""Unit tests for CodebuffAdapter."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.codebuff import CodebuffAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestCodebuffAdapterSpawn:
+    """CodebuffAdapter.spawn() builds correct command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = CodebuffAdapter()
+        proc_mock = _make_popen_mock(pid=700)
+        with patch("bernstein.adapters.codebuff.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="codebuff-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["codebuff", "fix the bug"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = CodebuffAdapter()
+        with (
+            patch(
+                "bernstein.adapters.codebuff.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match="codebuff not found") as excinfo,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="codebuff-missing",
+            )
+        assert "npm install -g codebuff" in str(excinfo.value)
+
+
+class TestCodebuffAdapterName:
+    def test_name(self) -> None:
+        assert CodebuffAdapter().name() == "Codebuff"

--- a/tests/unit/test_adapter_copilot.py
+++ b/tests/unit/test_adapter_copilot.py
@@ -1,0 +1,74 @@
+"""Unit tests for CopilotAdapter."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.copilot import CopilotAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    mock = MagicMock(spec=subprocess.Popen)
+    mock.pid = pid
+    mock.wait.return_value = None
+    return mock
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = CopilotAdapter()
+    proc_mock = _make_popen_mock(800)
+
+    with patch("bernstein.adapters.copilot.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="copilot-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = _inner_cmd(cmd)
+    assert inner[:3] == ["copilot", "--allow-all-tools", "-i"]
+    assert inner[-1] == "fix the bug"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = CopilotAdapter()
+    with (
+        patch(
+            "bernstein.adapters.copilot.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="copilot not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="copilot-missing",
+        )
+
+
+def test_name() -> None:
+    assert CopilotAdapter().name() == "GitHub Copilot"

--- a/tests/unit/test_adapter_droid.py
+++ b/tests/unit/test_adapter_droid.py
@@ -1,0 +1,77 @@
+"""Unit tests for DroidAdapter."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.droid import DroidAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    mock = MagicMock(spec=subprocess.Popen)
+    mock.pid = pid
+    mock.wait.return_value = None
+    return mock
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = DroidAdapter()
+    proc_mock = _make_popen_mock(700)
+
+    with patch("bernstein.adapters.droid.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="droid-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = _inner_cmd(cmd)
+    assert inner == ["droid", "fix the bug"]
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = DroidAdapter()
+    with (
+        patch(
+            "bernstein.adapters.droid.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError) as excinfo,
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="droid-missing",
+        )
+
+    message = str(excinfo.value)
+    assert "droid not found" in message
+    assert "https://app.factory.ai/cli" in message
+
+
+def test_name() -> None:
+    assert DroidAdapter().name() == "Droid"

--- a/tests/unit/test_adapter_forge.py
+++ b/tests/unit/test_adapter_forge.py
@@ -1,0 +1,76 @@
+"""Unit tests for ForgeAdapter spawn and metadata."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.forge import ForgeAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    """Return a ``subprocess.Popen`` mock with the given PID."""
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestForgeAdapterSpawn:
+    """ForgeAdapter.spawn() builds the correct command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = ForgeAdapter()
+        proc_mock = _make_popen_mock(pid=700)
+        with patch("bernstein.adapters.forge.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="forge-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["forge", "-p", "fix the bug"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = ForgeAdapter()
+        with (
+            patch(
+                "bernstein.adapters.forge.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match=r"forge not found.*forgecode\.dev"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="forge-missing",
+            )
+
+
+class TestForgeAdapterName:
+    """ForgeAdapter.name() returns the human-readable label."""
+
+    def test_name(self) -> None:
+        assert ForgeAdapter().name() == "Forge"

--- a/tests/unit/test_adapter_hermes.py
+++ b/tests/unit/test_adapter_hermes.py
@@ -1,0 +1,70 @@
+"""Unit tests for HermesAdapter spawn/name."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.hermes import HermesAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestHermesAdapterSpawn:
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = HermesAdapter()
+        proc_mock = _make_popen_mock(pid=900)
+        with patch("bernstein.adapters.hermes.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="ship the feature",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="hermes-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["hermes", "ship the feature"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = HermesAdapter()
+        with (
+            patch(
+                "bernstein.adapters.hermes.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match=r"hermes not found.*NousResearch/hermes-agent"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="hermes-missing",
+            )
+
+
+class TestHermesAdapterName:
+    def test_name(self) -> None:
+        assert HermesAdapter().name() == "Hermes Agent"

--- a/tests/unit/test_adapter_kimi.py
+++ b/tests/unit/test_adapter_kimi.py
@@ -1,0 +1,77 @@
+"""Unit tests for KimiAdapter spawn command construction."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.kimi import KimiAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestKimiAdapterSpawn:
+    """KimiAdapter.spawn() builds correct command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = KimiAdapter()
+        proc_mock = _make_popen_mock(pid=800)
+        with patch("bernstein.adapters.kimi.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="kimi-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner[:3] == ["kimi", "--yolo", "-c"]
+        assert inner[-1] == "fix the bug"
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = KimiAdapter()
+        with (
+            patch(
+                "bernstein.adapters.kimi.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="kimi-missing",
+            )
+        msg = str(exc_info.value)
+        assert "kimi not found" in msg
+        assert "uv tool install kimi-cli" in msg
+
+
+class TestKimiAdapterName:
+    def test_name(self) -> None:
+        assert KimiAdapter().name() == "Kimi"

--- a/tests/unit/test_adapter_mistral.py
+++ b/tests/unit/test_adapter_mistral.py
@@ -1,0 +1,73 @@
+"""Unit tests for MistralAdapter spawn/name."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.mistral import MistralAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestMistralAdapterSpawn:
+    """MistralAdapter.spawn() builds the expected command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = MistralAdapter()
+        proc_mock = _make_popen_mock(pid=700)
+        with patch("bernstein.adapters.mistral.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="mistral-large", effort="high"),
+                session_id="mistral-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["vibe", "--auto-approve", "--prompt", "fix the bug"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = MistralAdapter()
+        with (
+            patch(
+                "bernstein.adapters.mistral.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match=r"vibe not found.*mistral\.ai"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="mistral-large", effort="high"),
+                session_id="mistral-missing",
+            )
+
+
+class TestMistralAdapterName:
+    def test_name(self) -> None:
+        assert MistralAdapter().name() == "Mistral Vibe"

--- a/tests/unit/test_adapter_pi.py
+++ b/tests/unit/test_adapter_pi.py
@@ -1,0 +1,74 @@
+"""Unit tests for PiAdapter."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.pi import PiAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the actual CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestPiAdapterSpawn:
+    """PiAdapter.spawn() builds correct command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = PiAdapter()
+        proc_mock = _make_popen_mock(pid=800)
+        with patch("bernstein.adapters.pi.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="pi-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner == ["pi", "fix the bug"]
+
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = PiAdapter()
+        with (
+            patch(
+                "bernstein.adapters.pi.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match="pi not found") as excinfo,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="pi-missing",
+            )
+        assert "npm install -g @mariozechner/pi-coding-agent" in str(excinfo.value)
+
+
+class TestPiAdapterName:
+    def test_name(self) -> None:
+        assert PiAdapter().name() == "Pi"

--- a/tests/unit/test_adapter_rovo.py
+++ b/tests/unit/test_adapter_rovo.py
@@ -1,0 +1,80 @@
+"""Unit tests for RovoAdapter spawn/name."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Generator
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.rovo import RovoAdapter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _no_watchdog_threads() -> Generator[None, None, None]:
+    """Disable watchdog threads to avoid 'can't start new thread' on CI."""
+    with patch("bernstein.adapters.base.CLIAdapter._start_timeout_watchdog", return_value=None):
+        yield
+
+
+def _make_popen_mock(pid: int) -> MagicMock:
+    m = MagicMock(spec=subprocess.Popen)
+    m.pid = pid
+    return m
+
+
+def _inner_cmd(full_cmd: list[str]) -> list[str]:
+    """Extract the CLI command after the '--' worker separator."""
+    sep = full_cmd.index("--")
+    return full_cmd[sep + 1 :]
+
+
+class TestRovoAdapterSpawn:
+    """RovoAdapter.spawn() builds the expected command."""
+
+    def test_spawn_builds_run_command(self, tmp_path: Path) -> None:
+        adapter = RovoAdapter()
+        proc_mock = _make_popen_mock(pid=700)
+        with patch("bernstein.adapters.rovo.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="rovo-s1",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert inner[:4] == ["acli", "rovodev", "run", "--yolo"]
+        assert inner[-1] == "fix the bug"
+
+
+class TestRovoSpawnMissingBinary:
+    def test_spawn_translates_missing_cli(self, tmp_path: Path) -> None:
+        adapter = RovoAdapter()
+        with (
+            patch(
+                "bernstein.adapters.rovo.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="rovo-missing",
+            )
+        message = str(excinfo.value)
+        assert "acli not found" in message
+        assert "rovodev" in message
+        assert "acli rovodev auth login" in message
+
+
+class TestRovoAdapterName:
+    def test_name(self) -> None:
+        assert RovoAdapter().name() == "Rovo Dev"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.8.12"
+version = "1.8.13"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Adds 13 new CLI-agent adapters: **droid** (Factory AI), **copilot** (GitHub Copilot), **hermes** (Nous Research), **charm** (Charm Crush), **auggie** (Augment Code), **kimi** (Moonshot Kimi CLI), **rovo** (Atlassian Rovo Dev), **cline**, **codebuff**, **pi** (pi-coding-agent), **mistral** (Mistral Vibe), **autohand** (Autohand Code), **forge** (forgecode.dev).
- Comparison lifted from [emdash's provider registry](https://github.com/generalaction/emdash/blob/main/src/shared/providers/registry.ts). Bernstein now ships **31 adapters** vs emdash's 24 — we cover every emdash provider plus our own (aider, cloudflare_agents, cody, generic, iac, ollama, openai_agents).
- All 13 follow the existing `CLIAdapter` contract modelled on `amp.py` / `opencode.py`: worker-wrapped command, `build_filtered_env`-scoped env, `start_new_session=True` Popen, `FileNotFoundError` → `RuntimeError` with install hint, watchdog, `SpawnResult`.
- Registry entries alphabetized in `adapters/registry.py`.
- `uv.lock` picks up the v1.8.13 version bump from the recent release — unrelated to the adapter work but required for lockfile sync.

## What's NOT in this PR
- No changes to `ProviderType` enum — those entries are only required for adapters that implement `detect_tier()`. The new adapters don't yet (can be added incrementally as auth-file detection patterns mature).
- No landing-page update (`bernstein_landing`) to surface the new count — separate commit on that repo.
- No deliberate change to `generic.py` fallback semantics.

## Test plan
- [x] `uv run ruff check src/bernstein/adapters/ tests/unit/test_adapter_*.py` — clean
- [x] `uv run pytest tests/unit/test_adapter_{droid,copilot,hermes,charm,auggie,kimi,rovo,cline,codebuff,pi,mistral,autohand,forge}.py -x -q` — **39 passed**
- [x] `uv run pytest tests/unit/test_adapter_registry.py -x -q` — 9 passed (no regression)
- [x] `get_adapter("<name>").name()` smoke-check round-trips all 13 names

## Acceptance
Close: "we have more adapters than emdash" — done (31 > 24).