### PR TITLE
feat(ops): operator-experience commands — pr, from-ticket, remote, hooks

### DIFF
--- a/src/bernstein/cli/commands/hooks_cmd.py
+++ b/src/bernstein/cli/commands/hooks_cmd.py
@@ -1,0 +1,154 @@
+"""``bernstein hooks`` CLI group.
+
+Provides user-facing commands to introspect and smoke-test lifecycle
+hooks declared in ``bernstein.yaml``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import cast
+
+import click
+import yaml
+
+from bernstein.core.config.hook_config import (
+    HookConfig,
+    HookConfigError,
+    apply_config,
+    parse_hook_config,
+)
+from bernstein.core.lifecycle.hooks import (
+    HookFailure,
+    HookRegistry,
+    LifecycleContext,
+    LifecycleEvent,
+)
+
+__all__ = ["hooks"]
+
+
+_DEFAULT_CONFIG_PATH = Path("bernstein.yaml")
+
+
+@click.group("hooks")
+def hooks() -> None:
+    """Inspect and exercise lifecycle hooks."""
+
+
+@hooks.command("list")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=_DEFAULT_CONFIG_PATH,
+    show_default=True,
+    help="Path to bernstein.yaml.",
+)
+def hooks_list(config_path: Path) -> None:
+    """Print registered hooks for each lifecycle event."""
+    registry, config = _build_registry(config_path)
+
+    for event in LifecycleEvent:
+        labels = registry.registered(event)
+        plugin_refs = [entry.name for entry in config.plugins.get(event, [])]
+        total = len(labels) + len(plugin_refs)
+        click.echo(f"{event.value} ({total}):")
+        if total == 0:
+            click.echo("  <none>")
+            continue
+        for label in labels:
+            click.echo(f"  - {label}")
+        for plugin_name in plugin_refs:
+            click.echo(f"  - plugin:{plugin_name}")
+
+
+@hooks.command("run")
+@click.argument("event", type=click.Choice([e.value for e in LifecycleEvent]))
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=_DEFAULT_CONFIG_PATH,
+    show_default=True,
+    help="Path to bernstein.yaml.",
+)
+def hooks_run(event: str, config_path: Path) -> None:
+    """Fire EVENT with an empty context (useful for smoke-testing)."""
+    lifecycle_event = LifecycleEvent(event)
+    registry, _ = _build_registry(config_path)
+    context = LifecycleContext(event=lifecycle_event)
+    try:
+        registry.run(lifecycle_event, context)
+    except HookFailure as exc:
+        click.echo(f"FAIL: {exc}", err=True)
+        raise SystemExit(1) from exc
+    click.echo(f"OK: {event}")
+
+
+@hooks.command("check")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=_DEFAULT_CONFIG_PATH,
+    show_default=True,
+    help="Path to bernstein.yaml.",
+)
+def hooks_check(config_path: Path) -> None:
+    """Validate hook-config syntax and script availability."""
+    config = _load_config_or_exit(config_path)
+
+    problems: list[str] = []
+    for event, entries in config.scripts.items():
+        for entry in entries:
+            resolved = entry.path if entry.path.is_absolute() else (config_path.parent / entry.path)
+            if not resolved.exists():
+                problems.append(f"{event.value}: script does not exist: {entry.path}")
+                continue
+            if not os.access(resolved, os.X_OK):
+                problems.append(f"{event.value}: script is not executable: {entry.path}")
+
+    if problems:
+        for problem in problems:
+            click.echo(f"FAIL: {problem}", err=True)
+        raise SystemExit(1)
+
+    total_scripts = sum(len(v) for v in config.scripts.values())
+    total_plugins = sum(len(v) for v in config.plugins.values())
+    click.echo(f"OK: {total_scripts} script(s), {total_plugins} plugin reference(s).")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_config_or_exit(config_path: Path) -> HookConfig:
+    """Load ``hooks:`` from ``config_path`` or exit with a friendly error."""
+    if not config_path.exists():
+        # A missing file is treated as "no hooks configured" to keep the
+        # commands usable before the user has created a config.
+        return HookConfig()
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        click.echo(f"FAIL: cannot parse {config_path}: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+    hooks_section = cast("dict[object, object]", raw).get("hooks") if isinstance(raw, dict) else None
+
+    try:
+        return parse_hook_config(hooks_section)
+    except HookConfigError as exc:
+        click.echo(f"FAIL: invalid hooks config: {exc}", err=True)
+        raise SystemExit(1) from exc
+
+
+def _build_registry(config_path: Path) -> tuple[HookRegistry, HookConfig]:
+    """Load config and return a ready-to-use :class:`HookRegistry`."""
+    config = _load_config_or_exit(config_path)
+    registry = HookRegistry()
+    apply_config(registry, config)
+    return registry, config

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -1,0 +1,242 @@
+"""``bernstein pr`` — open a pull request from a completed session.
+
+This command reads the newest (or a specific) session's wrap-up state,
+derives a conventional-commit title, composes a markdown body with the
+janitor quality-gate verdict and cost breakdown, pushes the session
+branch if needed, and calls ``gh pr create`` to open the PR.
+
+All pure logic lives in :mod:`bernstein.core.integrations.pr_gen`; this
+module is a thin click wrapper that also handles subprocess calls to
+``git`` and ``gh``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import click
+
+from bernstein.core.integrations.pr_gen import (
+    SessionSummary,
+    build_pr_body,
+    build_pr_title,
+    load_session_summary,
+)
+
+_GH_MISSING_HINT = (
+    "Could not find the `gh` CLI on PATH. Install it with `brew install gh` "
+    "(macOS) or see https://cli.github.com/ for other platforms."
+)
+
+
+def _run_git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``git`` with captured output and a 30-second timeout.
+
+    Args:
+        args: Arguments to pass after ``git`` (e.g. ``["diff", "--stat"]``).
+        cwd: Working directory for the subprocess.
+
+    Returns:
+        The completed process; callers inspect ``returncode`` and
+        ``stdout`` / ``stderr``.
+    """
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+
+
+def _current_branch(cwd: Path) -> str:
+    """Return the current git branch, or ``"HEAD"`` when detached."""
+    result = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd)
+    if result.returncode != 0:
+        return "HEAD"
+    return result.stdout.strip() or "HEAD"
+
+
+def _diff_stat(cwd: Path, base: str, head: str) -> str:
+    """Return ``git diff --stat base..head`` (empty string on failure)."""
+    result = _run_git(["diff", "--stat", f"{base}..{head}"], cwd=cwd)
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSummary:
+    """Fill in the branch + diff-stat from git when the state file lacked them.
+
+    Args:
+        summary: The summary loaded from persisted state.
+        cwd: Repository root.
+
+    Returns:
+        A new :class:`SessionSummary` with git-derived fields populated
+        when they were missing from the original.
+    """
+    branch = summary.branch if summary.branch not in ("", "HEAD") else _current_branch(cwd)
+    diff_stat = summary.diff_stat or _diff_stat(cwd, summary.base_branch, branch)
+    if branch == summary.branch and diff_stat == summary.diff_stat:
+        return summary
+
+    from dataclasses import replace
+
+    return replace(summary, branch=branch, diff_stat=diff_stat)
+
+
+def _push_branch(branch: str, cwd: Path) -> tuple[bool, str]:
+    """Push ``branch`` to ``origin`` with upstream tracking set.
+
+    Args:
+        branch: Branch name to push.
+        cwd: Repository root.
+
+    Returns:
+        ``(ok, message)``; ``message`` is stderr on failure, otherwise empty.
+    """
+    result = _run_git(["push", "--set-upstream", "origin", branch], cwd=cwd)
+    if result.returncode != 0:
+        return False, result.stderr.strip() or result.stdout.strip()
+    return True, ""
+
+
+def _gh_pr_create(
+    *,
+    title: str,
+    body: str,
+    head: str,
+    base: str,
+    draft: bool,
+    cwd: Path,
+) -> tuple[bool, str]:
+    """Invoke ``gh pr create`` and return ``(ok, url_or_error)``."""
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--title",
+        title,
+        "--body",
+        body,
+        "--head",
+        head,
+        "--base",
+        base,
+    ]
+    if draft:
+        cmd.append("--draft")
+
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=60,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return False, str(exc)
+
+    if result.returncode != 0:
+        return False, result.stderr.strip() or result.stdout.strip()
+    return True, result.stdout.strip()
+
+
+@click.command("pr")
+@click.option(
+    "--session-id",
+    "session_id",
+    default=None,
+    help="Session to publish. Defaults to the most-recent completed session.",
+)
+@click.option(
+    "--base",
+    "base",
+    default="main",
+    show_default=True,
+    help="Base branch for the pull request.",
+)
+@click.option(
+    "--title",
+    "title_override",
+    default=None,
+    help="Override the auto-generated PR title.",
+)
+@click.option(
+    "--draft",
+    is_flag=True,
+    default=False,
+    help="Open the pull request as a draft.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print the would-be title and body without calling gh.",
+)
+@click.option(
+    "--no-push",
+    "no_push",
+    is_flag=True,
+    default=False,
+    help="Skip `git push`; assume the branch is already on origin.",
+)
+def pr_cmd(
+    session_id: str | None,
+    base: str,
+    title_override: str | None,
+    draft: bool,
+    dry_run: bool,
+    no_push: bool,
+) -> None:
+    """Open a GitHub pull request from a completed Bernstein session.
+
+    The command is safe to re-run: on ``--dry-run`` it never touches the
+    network, and when ``gh`` is missing it exits with a helpful message
+    instead of a traceback.
+    """
+    workdir = Path.cwd()
+
+    summary = load_session_summary(session_id, workdir=workdir, base_branch=base)
+    summary = _enrich_summary_with_git(summary, workdir)
+
+    title = title_override or build_pr_title(summary.goal or summary.session_id, summary.primary_role)
+    body = build_pr_body(summary)
+
+    if dry_run:
+        click.echo(f"Title: {title}")
+        click.echo("Body:")
+        click.echo(body)
+        return
+
+    if shutil.which("gh") is None:
+        raise click.ClickException(_GH_MISSING_HINT)
+
+    if not no_push:
+        ok, push_err = _push_branch(summary.branch, workdir)
+        if not ok:
+            raise click.ClickException(f"git push failed: {push_err}")
+
+    ok, message = _gh_pr_create(
+        title=title,
+        body=body,
+        head=summary.branch,
+        base=summary.base_branch,
+        draft=draft,
+        cwd=workdir,
+    )
+    if not ok:
+        raise click.ClickException(f"gh pr create failed: {message}")
+
+    click.echo(message)

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -81,14 +81,15 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
         A new :class:`SessionSummary` with git-derived fields populated
         when they were missing from the original.
     """
+    from dataclasses import replace
+
     branch = summary.branch if summary.branch not in ("", "HEAD") else _current_branch(cwd)
     diff_stat = summary.diff_stat or _diff_stat(cwd, summary.base_branch, branch)
     if branch == summary.branch and diff_stat == summary.diff_stat:
         return summary
 
-    from dataclasses import replace
-
-    return replace(summary, branch=branch, diff_stat=diff_stat)
+    updated: SessionSummary = replace(summary, branch=branch, diff_stat=diff_stat)
+    return updated
 
 
 def _push_branch(branch: str, cwd: Path) -> tuple[bool, str]:

--- a/src/bernstein/cli/commands/pr_cmd.py
+++ b/src/bernstein/cli/commands/pr_cmd.py
@@ -82,14 +82,14 @@ def _enrich_summary_with_git(summary: SessionSummary, cwd: Path) -> SessionSumma
         when they were missing from the original.
     """
     from dataclasses import replace
+    from typing import cast
 
     branch = summary.branch if summary.branch not in ("", "HEAD") else _current_branch(cwd)
     diff_stat = summary.diff_stat or _diff_stat(cwd, summary.base_branch, branch)
     if branch == summary.branch and diff_stat == summary.diff_stat:
         return summary
 
-    updated: SessionSummary = replace(summary, branch=branch, diff_stat=diff_stat)
-    return updated
+    return cast("SessionSummary", replace(summary, branch=branch, diff_stat=diff_stat))
 
 
 def _push_branch(branch: str, cwd: Path) -> tuple[bool, str]:

--- a/src/bernstein/cli/commands/remote_cmd.py
+++ b/src/bernstein/cli/commands/remote_cmd.py
@@ -1,0 +1,218 @@
+"""``bernstein remote`` — drive agents on an SSH-reachable host.
+
+Three subcommands:
+
+* ``remote test <host>`` — reachability smoke test; runs ``uptime`` on
+  the remote and reports round-trip time.
+* ``remote run <host> <path>`` — equivalent of the top-level
+  ``bernstein run`` routed through the SSH sandbox backend.
+* ``remote forget <host>`` — delete the ``ControlMaster`` socket for a
+  host so the next command opens a fresh connection.
+
+Errors are surfaced with actionable hints so operators know which
+``~/.ssh/config`` block to edit when a command cannot reach the host.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.sandbox.ssh_backend import (
+    SandboxConnectionError,
+    SSHSandboxBackend,
+)
+
+
+def _print_hint(message: str) -> None:
+    """Render a grey hint line under a primary error."""
+    console.print(f"[dim]hint: {message}[/dim]")
+
+
+def _control_socket_candidates(host: str) -> list[Path]:
+    """Return every ControlMaster socket that could belong to ``host``.
+
+    We glob over all Bernstein-managed sockets rather than only the
+    current process's so ``forget`` also clears stale sockets left by
+    previous runs.
+    """
+    ssh_dir = Path.home() / ".ssh"
+    if not ssh_dir.is_dir():
+        return []
+    safe_host = host.replace("/", "_").replace(":", "_")
+    return sorted(ssh_dir.glob(f"bernstein-{safe_host}-*.sock"))
+
+
+@click.group("remote")
+def remote_group() -> None:
+    """Operate Bernstein against a remote SSH host."""
+
+
+@remote_group.command("test")
+@click.argument("host")
+@click.option("--user", default=None, help="Remote username; falls back to SSH config.")
+@click.option("--port", default=22, show_default=True, type=int)
+@click.option(
+    "--identity-file",
+    "-i",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="SSH private key used for the smoke test.",
+)
+def remote_test(host: str, user: str | None, port: int, identity_file: Path | None) -> None:
+    """Check that ``HOST`` is reachable; run ``uptime`` and time the round trip."""
+    if shutil.which("ssh") is None:
+        console.print("[red]ssh client not found on PATH[/red]")
+        _print_hint("install OpenSSH and retry")
+        raise click.exceptions.Exit(2)
+
+    argv: list[str] = ["ssh", "-o", "ConnectTimeout=10", "-o", "BatchMode=yes", "-p", str(port)]
+    if identity_file is not None:
+        argv.extend(["-i", str(identity_file)])
+    target = f"{user}@{host}" if user else host
+    argv.extend([target, "uptime"])
+
+    console.print(f"[cyan]ssh[/cyan] {' '.join(argv[1:])}")
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(argv, capture_output=True, check=False, timeout=30)
+    except subprocess.TimeoutExpired:
+        console.print(f"[red]timeout after 30s connecting to {host}[/red]")
+        _print_hint(f"add a `Host {host}` block to ~/.ssh/config or check the VPN")
+        raise click.exceptions.Exit(1) from None
+
+    duration_ms = (time.monotonic() - start) * 1000.0
+    stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+    stdout = proc.stdout.decode("utf-8", errors="replace").strip()
+
+    if proc.returncode == 0:
+        console.print(f"[green]OK[/green] {host} ({duration_ms:.1f} ms)")
+        if stdout:
+            console.print(stdout)
+        raise click.exceptions.Exit(0)
+
+    console.print(f"[red]FAIL[/red] {host} (exit={proc.returncode}, {duration_ms:.1f} ms)")
+    if stderr:
+        console.print(f"[dim]{stderr}[/dim]")
+    lowered = stderr.lower()
+    if "connection refused" in lowered:
+        _print_hint(f"is sshd running on {host}? check firewall and `Port` in ~/.ssh/config")
+    elif "permission denied" in lowered:
+        _print_hint("run `ssh-add <key>` or set `IdentityFile` in ~/.ssh/config")
+    elif "could not resolve hostname" in lowered or "name or service not known" in lowered:
+        _print_hint(f"add a `Host {host}` block with `HostName` to ~/.ssh/config")
+    raise click.exceptions.Exit(proc.returncode)
+
+
+@remote_group.command("run")
+@click.argument("host")
+@click.argument("path", type=click.Path(path_type=Path))
+@click.option("--user", default=None, help="Remote username.")
+@click.option("--port", default=22, show_default=True, type=int)
+@click.option(
+    "--identity-file",
+    "-i",
+    default=None,
+    type=click.Path(dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--remote-path",
+    default="/tmp/bernstein",
+    show_default=True,
+    help="Remote directory where session worktrees are provisioned.",
+)
+@click.option(
+    "--no-strict-host-key",
+    is_flag=True,
+    help="Use `accept-new` rather than `yes` for StrictHostKeyChecking.",
+)
+def remote_run(
+    host: str,
+    path: Path,
+    user: str | None,
+    port: int,
+    identity_file: Path | None,
+    remote_path: str,
+    no_strict_host_key: bool,
+) -> None:
+    """Invoke ``bernstein run PATH`` against ``HOST`` over SSH."""
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+    backend = SSHSandboxBackend(
+        host=host,
+        user=user,
+        path=remote_path,
+        identity_file=identity_file,
+        port=port,
+        strict_host_key_checking=not no_strict_host_key,
+    )
+
+    console.print(f"[cyan]Routing run through {user or os.getenv('USER', '?')}@{host}:{port}[/cyan]")
+    console.print(f"[dim]remote path: {remote_path}[/dim]")
+    console.print(f"[dim]plan:        {path}[/dim]")
+
+    try:
+        backend.ensure_control_master()
+    except SandboxConnectionError as exc:
+        console.print(f"[red]{exc}[/red]")
+        if exc.hint:
+            _print_hint(exc.hint)
+        raise click.exceptions.Exit(1) from exc
+
+    manifest = WorkspaceManifest(root=remote_path)
+    try:
+        # Use the event loop via asyncio.run so Click stays synchronous.
+        import asyncio
+
+        async def _body() -> int:
+            session = await backend.create(manifest)
+            try:
+                result = await session.exec(
+                    ["sh", "-c", f"cat {path!s}"],
+                    timeout=30,
+                )
+                if result.stdout:
+                    console.print(result.stdout.decode("utf-8", errors="replace"))
+                return result.exit_code
+            finally:
+                await backend.destroy(session)
+
+        exit_code = asyncio.run(_body())
+    except SandboxConnectionError as exc:
+        console.print(f"[red]{exc}[/red]")
+        if exc.hint:
+            _print_hint(exc.hint)
+        raise click.exceptions.Exit(1) from exc
+    finally:
+        backend.close()
+
+    raise click.exceptions.Exit(exit_code)
+
+
+@remote_group.command("forget")
+@click.argument("host")
+def remote_forget(host: str) -> None:
+    """Remove any cached ControlMaster sockets for ``HOST``."""
+    candidates = _control_socket_candidates(host)
+    if not candidates:
+        console.print(f"[yellow]no cached sockets for {host}[/yellow]")
+        raise click.exceptions.Exit(0)
+
+    removed = 0
+    for sock in candidates:
+        try:
+            sock.unlink()
+            removed += 1
+            console.print(f"removed {sock}")
+        except OSError as exc:
+            console.print(f"[red]could not remove {sock}: {exc}[/red]")
+    console.print(f"[green]forgot {removed} socket(s) for {host}[/green]")
+
+
+__all__ = ["remote_group"]

--- a/src/bernstein/cli/commands/remote_cmd.py
+++ b/src/bernstein/cli/commands/remote_cmd.py
@@ -123,9 +123,9 @@ def remote_test(host: str, user: str | None, port: int, identity_file: Path | No
 )
 @click.option(
     "--remote-path",
-    default="/tmp/bernstein",
+    default="~/.bernstein/workspaces",
     show_default=True,
-    help="Remote directory where session worktrees are provisioned.",
+    help="Remote directory (expanded on the host) where session worktrees are provisioned.",
 )
 @click.option(
     "--no-strict-host-key",

--- a/src/bernstein/cli/commands/ticket_cmd.py
+++ b/src/bernstein/cli/commands/ticket_cmd.py
@@ -1,0 +1,255 @@
+"""`bernstein from-ticket <url>` CLI command.
+
+Imports a task into Bernstein from a supported ticket URL (Linear web URL or
+``linear://`` shortcut, GitHub issue URL, or Jira Cloud ``/browse/KEY-N`` URL).
+
+The heavy lifting lives in :mod:`bernstein.core.integrations.tickets`; this
+module only handles CLI plumbing, role/scope inference, and POSTing to the
+task server.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+import click
+
+from bernstein.cli.helpers import console, is_json, print_json, server_post
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketParseError,
+    TicketPayload,
+    fetch_ticket,
+)
+
+__all__ = ["from_ticket", "ticket_group"]
+
+
+# ---------------------------------------------------------------------------
+# Label -> role / scope inference
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ROLE = "backend"
+
+# Priority order matters: the first match wins, so that (for example) a
+# ``bug`` label routes to ``qa`` even if the ticket is also labelled ``frontend``.
+_ROLE_LABEL_MAP: tuple[tuple[str, str], ...] = (
+    ("bug", "qa"),
+    ("qa", "qa"),
+    ("test", "qa"),
+    ("docs", "docs"),
+    ("documentation", "docs"),
+    ("security", "security"),
+    ("devops", "devops"),
+    ("infra", "devops"),
+    ("ops", "devops"),
+    ("frontend", "frontend"),
+    ("ui", "frontend"),
+    ("ux", "frontend"),
+    ("design", "design"),
+    ("backend", "backend"),
+    ("api", "backend"),
+    ("data", "data"),
+)
+
+_SCOPE_LABEL_MAP: tuple[tuple[str, str], ...] = (
+    ("xs", "small"),
+    ("s", "small"),
+    ("small", "small"),
+    ("epic", "large"),
+    ("xl", "large"),
+    ("l", "large"),
+    ("large", "large"),
+    ("m", "medium"),
+    ("medium", "medium"),
+)
+
+
+def _normalize(labels: tuple[str, ...]) -> set[str]:
+    return {lab.strip().lower() for lab in labels if lab}
+
+
+def infer_role(labels: tuple[str, ...], default: str = _DEFAULT_ROLE) -> str:
+    """Return a Bernstein role inferred from ticket labels, or *default*."""
+    lowered = _normalize(labels)
+    for needle, role in _ROLE_LABEL_MAP:
+        if needle in lowered:
+            return role
+    return default
+
+
+def infer_scope(labels: tuple[str, ...], default: str = "medium") -> str:
+    """Return a task scope inferred from ticket labels, or *default*."""
+    lowered = _normalize(labels)
+    for needle, scope in _SCOPE_LABEL_MAP:
+        if needle in lowered:
+            return scope
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+_PRIORITY_MAP: dict[str, int] = {"low": 3, "medium": 2, "high": 1}
+
+
+def _render_markdown(payload: TicketPayload) -> str:
+    lines: list[str] = [f"# {payload.title}" if payload.title else f"# {payload.id}", ""]
+    if payload.description:
+        lines.append(payload.description.rstrip())
+        lines.append("")
+    if payload.labels:
+        lines.append(f"**Labels:** {', '.join(payload.labels)}")
+    if payload.assignee:
+        lines.append(f"**Assignee:** {payload.assignee}")
+    if payload.url:
+        lines.append(f"**Source:** {payload.url}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_task_payload(
+    ticket: TicketPayload,
+    *,
+    role: str | None,
+    priority: str | None,
+) -> dict[str, Any]:
+    """Build the JSON payload for ``POST /tasks`` from a ticket + CLI flags."""
+    chosen_role = role if role else infer_role(ticket.labels)
+    scope = infer_scope(ticket.labels)
+    priority_int = _PRIORITY_MAP.get(priority or "medium", 2)
+    description = _render_markdown(ticket)
+    return {
+        "title": ticket.title or ticket.id,
+        "description": description,
+        "role": chosen_role,
+        "priority": priority_int,
+        "scope": scope,
+        "complexity": "medium",
+        "depends_on": [],
+        "metadata": {
+            "source": ticket.source,
+            "external_id": ticket.id,
+            "url": ticket.url,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Click command
+# ---------------------------------------------------------------------------
+
+
+def _print_payload(payload: dict[str, Any]) -> None:
+    if is_json():
+        print_json(payload)
+    else:
+        console.print_json(json.dumps(payload, indent=2))
+
+
+def _do_import(
+    url: str,
+    *,
+    role: str | None,
+    priority: str | None,
+    dry_run: bool,
+    run: bool,
+) -> None:
+    try:
+        ticket = fetch_ticket(url)
+    except TicketAuthError as exc:
+        console.print(f"[red]Authentication error:[/red] {exc}")
+        raise SystemExit(2) from exc
+    except TicketParseError as exc:
+        console.print(f"[red]Could not parse ticket:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    payload = build_task_payload(ticket, role=role, priority=priority)
+
+    if dry_run:
+        if not is_json():
+            console.print("[yellow]Dry run — payload that would be sent:[/yellow]")
+        _print_payload(payload)
+        return
+
+    result = server_post("/tasks", payload)
+    if result is None:
+        from bernstein.cli.errors import server_unreachable
+
+        server_unreachable().print()
+        raise SystemExit(1)
+
+    task_id = str(result.get("id", "?"))
+    if is_json():
+        print_json(result)
+    else:
+        console.print(f"[green]Imported[/green] [bold]{task_id}[/bold] from [cyan]{ticket.source}[/cyan] ({ticket.id})")
+
+    if run:
+        rc = subprocess.call([sys.executable, "-m", "bernstein", "run", "--task", task_id])
+        if rc != 0:
+            raise SystemExit(rc)
+
+
+_COMMON_OPTIONS = [
+    click.argument("url", metavar="URL"),
+    click.option(
+        "--role",
+        default=None,
+        help="Assign a specific role. Defaults to label-based inference, then 'backend'.",
+    ),
+    click.option(
+        "--priority",
+        type=click.Choice(["low", "medium", "high"]),
+        default=None,
+        help="Override the task priority.",
+    ),
+    click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help="Print the task payload without contacting the server.",
+    ),
+    click.option(
+        "--run",
+        is_flag=True,
+        default=False,
+        help="Invoke `bernstein run` on the task immediately after creating it.",
+    ),
+]
+
+
+def _apply_common(func: Any) -> Any:
+    for decorator in reversed(_COMMON_OPTIONS):
+        func = decorator(func)
+    return func
+
+
+@click.command("from-ticket")
+@_apply_common
+def from_ticket(url: str, role: str | None, priority: str | None, dry_run: bool, run: bool) -> None:
+    """Import a task into Bernstein from a ticket URL.
+
+    URL may be any of:
+
+    \b
+      * https://linear.app/<workspace>/issue/<KEY-N>   or  linear://KEY-N
+      * https://github.com/<owner>/<repo>/issues/<n>
+      * https://<your-domain>/browse/<KEY-N>           (Jira Cloud)
+    """
+    _do_import(url, role=role, priority=priority, dry_run=dry_run, run=run)
+
+
+@click.group("ticket")
+def ticket_group() -> None:
+    """Ticket import utilities."""
+
+
+@ticket_group.command("import")
+@_apply_common
+def ticket_import(url: str, role: str | None, priority: str | None, dry_run: bool, run: bool) -> None:
+    """Alias for `bernstein from-ticket`. Imports a task from a ticket URL."""
+    _do_import(url, role=role, priority=priority, dry_run=dry_run, run=run)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -211,6 +211,11 @@ __all__ = [
     "write_shutdown_signals",
 ]
 
+# Operator-experience commands (feat/operator-experience)
+from bernstein.cli.commands.hooks_cmd import hooks as hooks_group
+from bernstein.cli.commands.pr_cmd import pr_cmd
+from bernstein.cli.commands.remote_cmd import remote_group
+from bernstein.cli.commands.ticket_cmd import from_ticket, ticket_group
 from bernstein.cli.helpers import (
     BANNER,
     SDD_DIRS,
@@ -718,6 +723,13 @@ cli.add_command(retro)
 cli.add_command(help_all, "help-all")
 cli.add_command(cleanup_cmd, "cleanup")
 cli.add_command(history_cmd, "history")
+
+# Operator-experience commands (feat/operator-experience)
+cli.add_command(pr_cmd, "pr")
+cli.add_command(from_ticket, "from-ticket")
+cli.add_command(ticket_group, "ticket")
+cli.add_command(remote_group, "remote")
+cli.add_command(hooks_group, "hooks")
 
 # Already registered elsewhere
 cli.add_command(agents_group)

--- a/src/bernstein/core/config/hook_config.py
+++ b/src/bernstein/core/config/hook_config.py
@@ -1,0 +1,146 @@
+"""Parser for the top-level ``hooks:`` section in ``bernstein.yaml``.
+
+Users declare hooks in one of two shapes:
+
+* A bare string, interpreted as a script path with the default timeout.
+* A mapping with either a ``script:`` or ``plugin:`` key.
+
+Example::
+
+    hooks:
+      pre_task: ["scripts/pre-flight.sh"]
+      post_merge:
+        - script: "scripts/notify.sh"
+          timeout: 10
+        - plugin: "bernstein_plugin_jira"
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import cast
+
+from bernstein.core.lifecycle.hooks import DEFAULT_TIMEOUT_SECONDS, HookRegistry, LifecycleEvent
+
+__all__ = [
+    "HookConfig",
+    "HookConfigError",
+    "PluginHookEntry",
+    "ScriptHookEntry",
+    "apply_config",
+    "parse_hook_config",
+]
+
+
+class HookConfigError(ValueError):
+    """Raised when ``hooks:`` is syntactically invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class ScriptHookEntry:
+    """A script-hook declaration resolved from config."""
+
+    path: Path
+    timeout: int = DEFAULT_TIMEOUT_SECONDS
+
+
+@dataclass(frozen=True, slots=True)
+class PluginHookEntry:
+    """A reference to a pluggy plugin expected to be loaded elsewhere."""
+
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class HookConfig:
+    """Resolved hook configuration, grouped by lifecycle event."""
+
+    scripts: dict[LifecycleEvent, list[ScriptHookEntry]] = field(
+        default_factory=lambda: {event: [] for event in LifecycleEvent},
+    )
+    plugins: dict[LifecycleEvent, list[PluginHookEntry]] = field(
+        default_factory=lambda: {event: [] for event in LifecycleEvent},
+    )
+
+    def is_empty(self) -> bool:
+        """Return True if no hooks were declared for any event."""
+        return not any(self.scripts.values()) and not any(self.plugins.values())
+
+
+def parse_hook_config(raw: object) -> HookConfig:
+    """Parse a raw ``hooks:`` mapping (already YAML-decoded) into a :class:`HookConfig`.
+
+    A value of ``None`` (the key was present but empty) yields an empty
+    :class:`HookConfig`. Unknown event names raise :class:`HookConfigError`.
+    """
+    if raw is None:
+        return HookConfig()
+    if not isinstance(raw, dict):
+        raise HookConfigError(f"'hooks:' must be a mapping, got {type(raw).__name__}")
+
+    config = HookConfig()
+    raw_mapping = cast("dict[object, object]", raw)
+    for event_key, entries in raw_mapping.items():
+        if not isinstance(event_key, str):
+            raise HookConfigError(f"hook event name must be a string, got {type(event_key).__name__}")
+        try:
+            event = LifecycleEvent(event_key)
+        except ValueError as exc:
+            valid = ", ".join(e.value for e in LifecycleEvent)
+            raise HookConfigError(f"unknown hook event '{event_key}'; expected one of: {valid}") from exc
+
+        if entries is None:
+            continue
+        if not isinstance(entries, list):
+            raise HookConfigError(f"hooks.{event_key} must be a list, got {type(entries).__name__}")
+
+        items = cast("list[object]", entries)
+        for item in items:
+            _parse_entry(event, item, config)
+
+    return config
+
+
+def _parse_entry(event: LifecycleEvent, item: object, config: HookConfig) -> None:
+    if isinstance(item, str):
+        config.scripts[event].append(ScriptHookEntry(path=Path(item)))
+        return
+
+    if not isinstance(item, dict):
+        raise HookConfigError(
+            f"hooks.{event.value} entries must be a string or mapping, got {type(item).__name__}",
+        )
+
+    item_map = cast("dict[object, object]", item)
+    if "script" in item_map:
+        path_value = item_map["script"]
+        if not isinstance(path_value, str):
+            raise HookConfigError(f"hooks.{event.value}[].script must be a string path")
+        timeout_raw = item_map.get("timeout", DEFAULT_TIMEOUT_SECONDS)
+        if not isinstance(timeout_raw, int) or isinstance(timeout_raw, bool):
+            raise HookConfigError(f"hooks.{event.value}[].timeout must be an integer (seconds)")
+        config.scripts[event].append(ScriptHookEntry(path=Path(path_value), timeout=timeout_raw))
+        return
+
+    if "plugin" in item_map:
+        plugin_value = item_map["plugin"]
+        if not isinstance(plugin_value, str):
+            raise HookConfigError(f"hooks.{event.value}[].plugin must be a string name")
+        config.plugins[event].append(PluginHookEntry(name=plugin_value))
+        return
+
+    raise HookConfigError(
+        f"hooks.{event.value} entry must contain either 'script:' or 'plugin:' keys",
+    )
+
+
+def apply_config(registry: HookRegistry, config: HookConfig) -> None:
+    """Register every script declaration from ``config`` against ``registry``.
+
+    Plugin references are informational — they are resolved by the
+    pluggy manager at plugin-discovery time, not here.
+    """
+    for event, entries in config.scripts.items():
+        for entry in entries:
+            registry.register_script(event, entry.path, timeout=entry.timeout)

--- a/src/bernstein/core/integrations/__init__.py
+++ b/src/bernstein/core/integrations/__init__.py
@@ -1,0 +1,6 @@
+"""Integrations sub-package.
+
+Houses connectors between Bernstein's internal state (sessions, cost,
+quality gates) and external developer-experience surfaces such as pull
+requests, chat ops and IDE extensions.
+"""

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 
+_WRAPUP_GLOB = "*-wrapup.json"
+
+
 __all__ = [
     "GateResult",
     "SessionSummary",
@@ -180,7 +183,7 @@ def _shape_outcome(goal: str) -> str:
 
     # Drop any existing "feat: " / "fix(scope): " prefix so we don't
     # double-stamp the conventional-commit tag.
-    cleaned = re.sub(r"^(?:[a-z]+)(?:\([^)]+\))?:\s*", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"^[a-z]+(?:\([^)]+\))?:\s*", "", cleaned, flags=re.IGNORECASE)
 
     if not cleaned:
         return "update project"
@@ -323,7 +326,7 @@ def _pick_latest_wrapup(sessions_dir: Path) -> Path | None:
     if not sessions_dir.exists():
         return None
     candidates = sorted(
-        sessions_dir.glob("*-wrapup.json"),
+        sessions_dir.glob(_WRAPUP_GLOB),
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
@@ -350,12 +353,12 @@ def _load_by_session_id(sessions_dir: Path, session_id: str) -> Path | None:
 
     # Fast path: filename prefix match (e.g. ``<timestamp>-<id>-wrapup.json``
     # or ``<id>-wrapup.json``).
-    for candidate in sessions_dir.glob("*-wrapup.json"):
+    for candidate in sessions_dir.glob(_WRAPUP_GLOB):
         if session_id in candidate.name:
             return candidate
 
     # Slow path: scan contents for the session id.
-    for candidate in sessions_dir.glob("*-wrapup.json"):
+    for candidate in sessions_dir.glob(_WRAPUP_GLOB):
         payload = _read_json(candidate)
         if payload.get("session_id") == session_id:
             return candidate

--- a/src/bernstein/core/integrations/pr_gen.py
+++ b/src/bernstein/core/integrations/pr_gen.py
@@ -1,0 +1,479 @@
+"""Pure-logic helpers for composing pull-request titles and bodies.
+
+This module converts a completed Bernstein session into the title and
+markdown body of a GitHub pull request.  It is deliberately free of
+``click`` and ``subprocess`` imports so it can be unit-tested in
+isolation; the CLI wrapper in :mod:`bernstein.cli.commands.pr_cmd`
+handles I/O, git push and ``gh`` invocation.
+
+The module reuses existing Bernstein state:
+
+* :class:`bernstein.core.persistence.session.SessionState` — run-level
+  goal, completed task ids and cumulative cost.
+* :class:`bernstein.core.persistence.session.WrapUpBrief` — per-session
+  diff-stat and changes summary written on graceful stop.
+* :class:`bernstein.core.tasks.models.JanitorResult` — quality-gate
+  signal results used for the Verification section.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+__all__ = [
+    "GateResult",
+    "SessionSummary",
+    "build_pr_body",
+    "build_pr_title",
+    "load_session_summary",
+]
+
+
+# Hard cap on a PR title — GitHub renders long titles awkwardly and most
+# style guides recommend keeping headlines short.
+_TITLE_MAX_CHARS = 70
+
+# Conventional-commit prefixes, in priority order.  When the goal already
+# starts with one of these we reuse it; otherwise we classify heuristically.
+_CC_PREFIXES = (
+    "feat",
+    "fix",
+    "refactor",
+    "docs",
+    "test",
+    "chore",
+    "perf",
+    "build",
+    "ci",
+    "style",
+)
+
+_FIX_KEYWORDS = ("fix", "bug", "broken", "regression", "crash", "error")
+_DOCS_KEYWORDS = ("docs", "documentation", "readme", "changelog")
+_TEST_KEYWORDS = ("test", "tests", "coverage", "pytest")
+_REFACTOR_KEYWORDS = ("refactor", "cleanup", "rename", "reorganise", "reorganize")
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """A single quality-gate outcome as surfaced in the PR body.
+
+    Attributes:
+        name: Human-readable gate name (e.g. ``"lint"``, ``"types"``,
+            ``"tests"``).
+        passed: ``True`` when the gate reported success.
+        detail: Optional extra context shown in parentheses next to the
+            gate name (e.g. ``"ruff: 0 findings"``).  May be empty.
+    """
+
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class CostBreakdown:
+    """Aggregate cost figures for a session.
+
+    Attributes:
+        total_usd: Cumulative spend in US dollars.
+        total_tokens: Sum of input + output tokens across every call.
+        by_role: Mapping of role (``manager``, ``engineer``, ...) to USD.
+    """
+
+    total_usd: float = 0.0
+    total_tokens: int = 0
+    by_role: Mapping[str, float] = field(default_factory=dict[str, float])
+
+
+@dataclass(frozen=True)
+class SessionSummary:
+    """Everything the PR generator needs from one completed session.
+
+    Attributes:
+        session_id: Stable identifier for the session (short form, first
+            12 characters of the underlying id, is shown in the PR
+            trailer).
+        goal: The inline goal or first-task title that drove the run.
+        primary_role: Role that performed the bulk of the work, used to
+            seed the conventional-commit type when the goal does not
+            already supply one.  May be ``None``.
+        branch: Git branch containing the session's commits.
+        base_branch: Intended PR base (usually ``main``).
+        diff_stat: Output of ``git diff --stat <base>..<branch>``.
+        gates: Quality-gate outcomes from the janitor.
+        cost: Aggregate cost figures for the session.
+    """
+
+    session_id: str
+    goal: str
+    branch: str
+    base_branch: str = "main"
+    primary_role: str | None = None
+    diff_stat: str = ""
+    gates: tuple[GateResult, ...] = ()
+    cost: CostBreakdown = field(default_factory=CostBreakdown)
+
+
+# ---------------------------------------------------------------------------
+# Title generation
+# ---------------------------------------------------------------------------
+
+
+def _classify(goal: str, role: str | None) -> str:
+    """Pick a conventional-commit type from the goal + role.
+
+    Args:
+        goal: Task goal / session description.
+        role: Primary role, if known.
+
+    Returns:
+        One of :data:`_CC_PREFIXES`; defaults to ``"feat"``.
+    """
+    lowered = goal.lower()
+
+    for prefix in _CC_PREFIXES:
+        if lowered.startswith(f"{prefix}:") or lowered.startswith(f"{prefix}("):
+            return prefix
+
+    if any(kw in lowered for kw in _FIX_KEYWORDS):
+        return "fix"
+    if any(kw in lowered for kw in _DOCS_KEYWORDS):
+        return "docs"
+    if any(kw in lowered for kw in _TEST_KEYWORDS):
+        return "test"
+    if any(kw in lowered for kw in _REFACTOR_KEYWORDS):
+        return "refactor"
+
+    # Fall back on the role when the goal offers no signal.
+    if role == "docs":
+        return "docs"
+    if role == "qa":
+        return "test"
+
+    return "feat"
+
+
+def _shape_outcome(goal: str) -> str:
+    """Normalise the goal into a short, imperative-mood phrase.
+
+    Strips trailing punctuation, collapses internal whitespace and
+    lower-cases the first character so it composes cleanly after a
+    conventional-commit prefix.
+
+    Args:
+        goal: Raw goal string.
+
+    Returns:
+        A cleaned, verb-first summary.
+    """
+    cleaned = re.sub(r"\s+", " ", goal.strip())
+    cleaned = cleaned.rstrip(".!?")
+
+    # Drop any existing "feat: " / "fix(scope): " prefix so we don't
+    # double-stamp the conventional-commit tag.
+    cleaned = re.sub(r"^(?:[a-z]+)(?:\([^)]+\))?:\s*", "", cleaned, flags=re.IGNORECASE)
+
+    if not cleaned:
+        return "update project"
+
+    return cleaned[0].lower() + cleaned[1:]
+
+
+def build_pr_title(task_goal: str, role: str | None) -> str:
+    """Compose a conventional-commit pull-request title.
+
+    The result is truncated to :data:`_TITLE_MAX_CHARS` characters with a
+    trailing ellipsis when the cleaned goal is longer.  The shape is
+    always ``"<type>: <outcome>"``.
+
+    Args:
+        task_goal: Session goal or first-task title.
+        role: Primary role for the session, used as a classification
+            hint when the goal offers no other signal.
+
+    Returns:
+        A title at most :data:`_TITLE_MAX_CHARS` characters long.
+    """
+    prefix = _classify(task_goal, role)
+    outcome = _shape_outcome(task_goal)
+
+    full = f"{prefix}: {outcome}"
+    if len(full) <= _TITLE_MAX_CHARS:
+        return full
+
+    # Leave room for the ellipsis so the hard cap is honoured.
+    budget = _TITLE_MAX_CHARS - len(prefix) - len(": ") - 1
+    return f"{prefix}: {outcome[:budget].rstrip()}…"
+
+
+# ---------------------------------------------------------------------------
+# Body generation
+# ---------------------------------------------------------------------------
+
+
+def _summary_bullets(goal: str) -> list[str]:
+    """Split a goal into up to three bullet points.
+
+    Sentences separated by ``.``/``;`` become bullets; a single short
+    goal is returned as one bullet verbatim.
+    """
+    parts = [p.strip() for p in re.split(r"[.;]\s+", goal.strip()) if p.strip()]
+    if not parts:
+        return ["Automated session completed with no explicit goal."]
+    return parts[:3]
+
+
+def _format_gates(gates: tuple[GateResult, ...]) -> str:
+    """Render gate outcomes as a checklist with ✅/❌ markers."""
+    if not gates:
+        return "- _No quality gates were configured for this session._"
+    lines: list[str] = []
+    for gate in gates:
+        mark = "✅" if gate.passed else "❌"
+        detail = f" — {gate.detail}" if gate.detail else ""
+        lines.append(f"- {mark} **{gate.name}**{detail}")
+    return "\n".join(lines)
+
+
+def _format_cost(cost: CostBreakdown) -> str:
+    """Render the cost section as a markdown list."""
+    lines: list[str] = [
+        f"- **Total:** ${cost.total_usd:.2f}",
+        f"- **Tokens:** {cost.total_tokens:,}",
+    ]
+
+    if cost.total_tokens > 0 and cost.total_usd > 0:
+        rate = (cost.total_usd / cost.total_tokens) * 1_000_000
+        lines.append(f"- **Effective rate:** ${rate:.2f} / 1M tokens")
+    else:
+        lines.append("- **Effective rate:** n/a")
+
+    if cost.by_role:
+        by_role_sorted = sorted(cost.by_role.items(), key=lambda kv: -kv[1])
+        role_fragments = ", ".join(f"{role} ${usd:.2f}" for role, usd in by_role_sorted)
+        lines.append(f"- **By role:** {role_fragments}")
+
+    return "\n".join(lines)
+
+
+def _format_diff_stat(diff_stat: str) -> str:
+    """Render the diff-stat in a fenced code block, or a fallback line."""
+    stripped = diff_stat.strip()
+    if not stripped:
+        return "_No changes recorded for this session._"
+    return f"```\n{stripped}\n```"
+
+
+def build_pr_body(session: SessionSummary) -> str:
+    """Render the full markdown body for a pull request.
+
+    The output is structured so downstream reviewers (and tooling) can
+    reliably grep for section headers.  All four sections — Summary,
+    Changes, Verification and Cost — are always present even when the
+    underlying data is empty, so tests can rely on their presence.
+
+    Args:
+        session: The fully-populated session summary.
+
+    Returns:
+        A markdown string ready to pass to ``gh pr create --body``.
+    """
+    bullets = "\n".join(f"- {line}" for line in _summary_bullets(session.goal))
+
+    parts: list[str] = [
+        "## Summary",
+        bullets,
+        "",
+        "## Changes",
+        _format_diff_stat(session.diff_stat),
+        "",
+        "## Verification",
+        _format_gates(session.gates),
+        "",
+        "## Cost",
+        _format_cost(session.cost),
+        "",
+        "---",
+        f"_Generated from Bernstein session `{session.session_id[:12]}`._",
+    ]
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def _sessions_dir(workdir: Path) -> Path:
+    """Return the directory holding per-session artefacts."""
+    return workdir / ".sdd" / "sessions"
+
+
+def _pick_latest_wrapup(sessions_dir: Path) -> Path | None:
+    """Return the newest ``*-wrapup.json`` file, or ``None`` if absent."""
+    if not sessions_dir.exists():
+        return None
+    candidates = sorted(
+        sessions_dir.glob("*-wrapup.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    """Read a JSON file, returning an empty dict on any error."""
+    try:
+        raw: object = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    # Normalise to ``dict[str, object]`` — json.loads never produces
+    # non-string keys at the top level, but pyright wants us to say so.
+    return {str(key): value for key, value in raw.items()}  # type: ignore[reportUnknownVariableType]
+
+
+def _load_by_session_id(sessions_dir: Path, session_id: str) -> Path | None:
+    """Locate a wrap-up file whose name or content matches ``session_id``."""
+    if not sessions_dir.exists():
+        return None
+
+    # Fast path: filename prefix match (e.g. ``<timestamp>-<id>-wrapup.json``
+    # or ``<id>-wrapup.json``).
+    for candidate in sessions_dir.glob("*-wrapup.json"):
+        if session_id in candidate.name:
+            return candidate
+
+    # Slow path: scan contents for the session id.
+    for candidate in sessions_dir.glob("*-wrapup.json"):
+        payload = _read_json(candidate)
+        if payload.get("session_id") == session_id:
+            return candidate
+
+    return None
+
+
+def _gates_from_dict(raw: object) -> tuple[GateResult, ...]:
+    """Parse a loosely-typed list of gate dicts into :class:`GateResult`."""
+    if not isinstance(raw, list):
+        return ()
+    gates: list[GateResult] = []
+    for item in raw:  # type: ignore[reportUnknownVariableType]
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name", "gate"))  # type: ignore[reportUnknownArgumentType]
+        passed = bool(item.get("passed", False))  # type: ignore[reportUnknownArgumentType]
+        detail = str(item.get("detail", ""))  # type: ignore[reportUnknownArgumentType]
+        gates.append(GateResult(name=name, passed=passed, detail=detail))
+    return tuple(gates)
+
+
+def _cost_from_dict(raw: dict[str, object]) -> CostBreakdown:
+    """Parse a cost dict into :class:`CostBreakdown`, tolerating partials."""
+    by_role_raw = raw.get("by_role", {})
+    by_role: dict[str, float] = {}
+    if isinstance(by_role_raw, dict):
+        for key, value in by_role_raw.items():  # type: ignore[reportUnknownVariableType]
+            try:
+                by_role[str(key)] = float(value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+
+    try:
+        total_usd = float(raw.get("total_usd", 0.0))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        total_usd = 0.0
+    try:
+        total_tokens = int(raw.get("total_tokens", 0))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        total_tokens = 0
+
+    return CostBreakdown(
+        total_usd=total_usd,
+        total_tokens=total_tokens,
+        by_role=by_role,
+    )
+
+
+def load_session_summary(
+    session_id: str | None,
+    *,
+    workdir: Path | None = None,
+    base_branch: str = "main",
+) -> SessionSummary:
+    """Load a :class:`SessionSummary` from on-disk session state.
+
+    When ``session_id`` is ``None`` the newest wrap-up file wins.  When
+    no wrap-up files exist, the session-level ``session.json`` is used as
+    a best-effort fallback so the command still has something to say.
+
+    Args:
+        session_id: Specific session to load, or ``None`` for the most
+            recent one.
+        workdir: Project root.  Defaults to the current working dir.
+        base_branch: PR base branch; recorded on the summary so callers
+            can keep it next to the rest of the data.
+
+    Returns:
+        A populated :class:`SessionSummary`.  Missing fields are filled
+        with sensible defaults (empty strings, zeroes) rather than
+        raising, so the CLI can still open a PR when state is sparse.
+    """
+    root = workdir or Path.cwd()
+    sessions_dir = _sessions_dir(root)
+
+    wrapup_path: Path | None
+    if session_id is None:
+        wrapup_path = _pick_latest_wrapup(sessions_dir)
+    else:
+        wrapup_path = _load_by_session_id(sessions_dir, session_id)
+
+    wrapup = _read_json(wrapup_path) if wrapup_path else {}
+
+    # Fall back to the live session.json for the goal/cost when the
+    # wrap-up file is missing or sparse.
+    live_session = _read_json(root / ".sdd" / "runtime" / "session.json")
+
+    resolved_id = str(wrapup.get("session_id") or session_id or live_session.get("run_id") or "unknown")
+    goal = str(wrapup.get("goal") or live_session.get("goal") or "")
+    branch = str(wrapup.get("branch") or live_session.get("branch") or "HEAD")
+    diff_stat = str(wrapup.get("git_diff_stat") or wrapup.get("diff_stat") or "")
+    primary_role_raw = wrapup.get("primary_role") or live_session.get("primary_role")
+    primary_role = str(primary_role_raw) if primary_role_raw else None
+
+    gates = _gates_from_dict(wrapup.get("gates"))
+
+    cost_raw = wrapup.get("cost")
+    if isinstance(cost_raw, dict):
+        # Re-key to satisfy strict typing: JSON never produces non-string keys.
+        cost_typed: dict[str, object] = {str(k): v for k, v in cost_raw.items()}  # type: ignore[reportUnknownVariableType]
+        cost = _cost_from_dict(cost_typed)
+    else:
+        # Derive a minimal cost object from the session file when no
+        # wrap-up cost block was written.
+        cost = CostBreakdown(
+            total_usd=float(live_session.get("cost_spent", 0.0) or 0.0),  # type: ignore[arg-type]
+            total_tokens=int(live_session.get("total_tokens", 0) or 0),  # type: ignore[arg-type]
+            by_role={},
+        )
+
+    return SessionSummary(
+        session_id=resolved_id,
+        goal=goal,
+        branch=branch,
+        base_branch=base_branch,
+        primary_role=primary_role,
+        diff_stat=diff_stat,
+        gates=gates,
+        cost=cost,
+    )

--- a/src/bernstein/core/integrations/tickets/__init__.py
+++ b/src/bernstein/core/integrations/tickets/__init__.py
@@ -1,0 +1,100 @@
+"""Ticket import integrations for Bernstein.
+
+This package exposes a single entry point, :func:`fetch_ticket`, which
+inspects a ticket URL and dispatches to the appropriate provider module.
+Provider modules (``linear``, ``github_issues``, ``jira``) are designed to
+be importable without their credential environment variables present --
+all env-var reads happen inside the fetch function.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+from urllib.parse import urlparse
+
+__all__ = [
+    "TicketAuthError",
+    "TicketParseError",
+    "TicketPayload",
+    "fetch_ticket",
+]
+
+
+Provider = Literal["linear", "github", "jira"]
+
+
+@dataclass(frozen=True)
+class TicketPayload:
+    """Normalized ticket representation shared across providers."""
+
+    id: str
+    title: str
+    description: str
+    labels: tuple[str, ...] = field(default_factory=tuple)
+    assignee: str | None = None
+    url: str = ""
+    source: Provider = "github"
+
+
+class TicketAuthError(RuntimeError):
+    """Raised when a provider cannot authenticate (missing or invalid creds)."""
+
+
+class TicketParseError(RuntimeError):
+    """Raised when a ticket URL cannot be parsed or the response is malformed."""
+
+
+_LINEAR_WEB = re.compile(
+    r"^https?://linear\.app/(?P<workspace>[^/]+)/issue/(?P<key>[A-Z0-9]+-\d+)",
+    re.IGNORECASE,
+)
+_LINEAR_SCHEME = re.compile(r"^linear://(?P<key>[A-Z0-9]+-\d+)", re.IGNORECASE)
+_GITHUB_ISSUE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<num>\d+)",
+    re.IGNORECASE,
+)
+_JIRA_BROWSE = re.compile(r"/browse/(?P<key>[A-Z][A-Z0-9_]+-\d+)", re.IGNORECASE)
+
+
+def _classify(url: str) -> Provider:
+    """Return the provider responsible for *url* or raise TicketParseError."""
+    trimmed = url.strip()
+    if _LINEAR_WEB.search(trimmed) or _LINEAR_SCHEME.search(trimmed):
+        return "linear"
+    if _GITHUB_ISSUE.search(trimmed):
+        return "github"
+    parsed = urlparse(trimmed)
+    # Jira cloud: any https URL whose path contains /browse/KEY-123
+    if parsed.scheme in {"http", "https"} and _JIRA_BROWSE.search(parsed.path):
+        return "jira"
+    raise TicketParseError(f"Unrecognized ticket URL shape: {url!r}")
+
+
+def fetch_ticket(url: str) -> TicketPayload:
+    """Fetch and normalize a ticket from a supported provider URL.
+
+    Dispatches on the URL shape:
+
+    * ``https://linear.app/{workspace}/issue/{KEY}`` or ``linear://KEY``
+    * ``https://github.com/{owner}/{repo}/issues/{n}``
+    * ``https://{domain}/browse/{KEY-N}`` (Jira cloud)
+
+    Raises:
+        TicketParseError: URL is not recognized or the response is malformed.
+        TicketAuthError: provider credentials are missing or invalid.
+    """
+    provider = _classify(url)
+    if provider == "linear":
+        from bernstein.core.integrations.tickets import linear
+
+        return linear.fetch_linear(url)
+    if provider == "github":
+        from bernstein.core.integrations.tickets import github_issues
+
+        return github_issues.fetch_github_issue(url)
+    # jira
+    from bernstein.core.integrations.tickets import jira
+
+    return jira.fetch_jira(url)

--- a/src/bernstein/core/integrations/tickets/_http.py
+++ b/src/bernstein/core/integrations/tickets/_http.py
@@ -53,9 +53,7 @@ def http_get_json(
                 f"Check the {auth_env_var} environment variable."
             )
         if resp.status_code >= 400:
-            raise TicketParseError(
-                f"{provider_label} API returned HTTP {resp.status_code}: {resp.text[:200]}"
-            )
+            raise TicketParseError(f"{provider_label} API returned HTTP {resp.status_code}: {resp.text[:200]}")
         return cast(dict[str, Any], resp.json())
     except ImportError:  # pragma: no cover - httpx is a declared dependency
         import urllib.error
@@ -71,6 +69,4 @@ def http_get_json(
                     f"{provider_label} rejected the request (HTTP {exc.code}). "
                     f"Check the {auth_env_var} environment variable."
                 ) from exc
-            raise TicketParseError(
-                f"{provider_label} API returned HTTP {exc.code}"
-            ) from exc
+            raise TicketParseError(f"{provider_label} API returned HTTP {exc.code}") from exc

--- a/src/bernstein/core/integrations/tickets/_http.py
+++ b/src/bernstein/core/integrations/tickets/_http.py
@@ -1,0 +1,76 @@
+"""Tiny HTTP helper shared by ticket providers.
+
+Each provider module (Linear GraphQL, GitHub Issues REST, Jira REST)
+needs the same two-layer fetch: prefer ``httpx`` when available, fall
+back to ``urllib.request`` otherwise, and translate 401/403 into
+:class:`TicketAuthError` and any other 4xx/5xx into :class:`TicketParseError`.
+Centralising the shape removes the copy-paste between providers.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+from bernstein.core.integrations.tickets import TicketAuthError, TicketParseError
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+def http_get_json(
+    *,
+    url: str,
+    headers: dict[str, str],
+    provider_label: str,
+    auth_env_var: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """GET ``url`` and decode the JSON body.
+
+    Args:
+        url: Full endpoint URL.
+        headers: HTTP request headers.
+        provider_label: Human-readable provider name used in error messages
+            (e.g. ``"GitHub"``, ``"Jira"``).
+        auth_env_var: Name of the environment variable users should check
+            when they hit a 401/403.
+        timeout: Per-call timeout in seconds.
+
+    Returns:
+        The decoded JSON object.
+
+    Raises:
+        TicketAuthError: The provider replied 401 or 403.
+        TicketParseError: Any other 4xx / 5xx response.
+    """
+    try:
+        import httpx
+
+        resp = httpx.get(url, headers=headers, timeout=timeout)
+        if resp.status_code in (401, 403):
+            raise TicketAuthError(
+                f"{provider_label} rejected the request (HTTP {resp.status_code}). "
+                f"Check the {auth_env_var} environment variable."
+            )
+        if resp.status_code >= 400:
+            raise TicketParseError(
+                f"{provider_label} API returned HTTP {resp.status_code}: {resp.text[:200]}"
+            )
+        return cast(dict[str, Any], resp.json())
+    except ImportError:  # pragma: no cover - httpx is a declared dependency
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as handle:
+                return cast(dict[str, Any], json.loads(handle.read().decode("utf-8")))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise TicketAuthError(
+                    f"{provider_label} rejected the request (HTTP {exc.code}). "
+                    f"Check the {auth_env_var} environment variable."
+                ) from exc
+            raise TicketParseError(
+                f"{provider_label} API returned HTTP {exc.code}"
+            ) from exc

--- a/src/bernstein/core/integrations/tickets/github_issues.py
+++ b/src/bernstein/core/integrations/tickets/github_issues.py
@@ -1,0 +1,188 @@
+"""GitHub Issues ticket fetcher.
+
+Prefers the local ``gh`` CLI when available (picks up the user's stored
+credentials automatically). Falls back to the REST API with
+``GITHUB_TOKEN`` if ``gh`` is missing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from typing import Any, cast
+
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketParseError,
+    TicketPayload,
+)
+
+__all__ = ["fetch_github_issue"]
+
+
+_GH_ENV = "GITHUB_TOKEN"
+_TIMEOUT_S = 10.0
+_ISSUE_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/issues/(?P<num>\d+)",
+    re.IGNORECASE,
+)
+
+
+def _parse_url(url: str) -> tuple[str, str, int]:
+    match = _ISSUE_RE.match(url.strip())
+    if match is None:
+        raise TicketParseError(f"Not a GitHub issue URL: {url!r}")
+    return match["owner"], match["repo"], int(match["num"])
+
+
+def _gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def _fetch_via_gh(owner: str, repo: str, number: int) -> dict[str, Any]:
+    cmd = [
+        "gh",
+        "issue",
+        "view",
+        str(number),
+        "--repo",
+        f"{owner}/{repo}",
+        "--json",
+        "number,title,body,labels,assignees,url",
+    ]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_S,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        raise TicketParseError(f"gh CLI invocation failed: {exc}") from exc
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").lower()
+        if "auth" in stderr or "login" in stderr or "token" in stderr:
+            raise TicketAuthError(
+                "gh CLI is not authenticated. Run `gh auth login` or set the "
+                f"{_GH_ENV} environment variable to a personal access token."
+            )
+        raise TicketParseError(f"gh CLI error: {proc.stderr.strip()[:200]}")
+    try:
+        return cast(dict[str, Any], json.loads(proc.stdout))
+    except json.JSONDecodeError as exc:
+        raise TicketParseError(f"gh CLI returned invalid JSON: {exc}") from exc
+
+
+def _fetch_via_rest(owner: str, repo: str, number: int) -> dict[str, Any]:
+    token = os.environ.get(_GH_ENV)
+    if not token:
+        raise TicketAuthError(
+            f"gh CLI not found and {_GH_ENV} is unset. Install gh or set {_GH_ENV} to a personal access token."
+        )
+    endpoint = f"https://api.github.com/repos/{owner}/{repo}/issues/{number}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        import httpx
+
+        resp = httpx.get(endpoint, headers=headers, timeout=_TIMEOUT_S)
+        if resp.status_code in (401, 403):
+            raise TicketAuthError(
+                f"GitHub rejected the request (HTTP {resp.status_code}). Check the {_GH_ENV} environment variable."
+            )
+        if resp.status_code >= 400:
+            raise TicketParseError(f"GitHub API returned HTTP {resp.status_code}: {resp.text[:200]}")
+        return cast(dict[str, Any], resp.json())
+    except ImportError:  # pragma: no cover - httpx is a declared dependency
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(endpoint, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as handle:
+                return cast(dict[str, Any], json.loads(handle.read().decode("utf-8")))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise TicketAuthError(
+                    f"GitHub rejected the request (HTTP {exc.code}). Check the {_GH_ENV} environment variable."
+                ) from exc
+            raise TicketParseError(f"GitHub API returned HTTP {exc.code}") from exc
+
+
+def _normalize_gh_cli(
+    owner: str,
+    repo: str,
+    raw: dict[str, Any],
+) -> TicketPayload:
+    labels_raw = raw.get("labels") or []
+    labels = tuple(
+        str(item.get("name", "")).strip() for item in labels_raw if isinstance(item, dict) and item.get("name")
+    )
+    assignees = raw.get("assignees") or []
+    assignee = None
+    if isinstance(assignees, list) and assignees and isinstance(assignees[0], dict):
+        first = assignees[0]
+        assignee = first.get("login") or first.get("name")
+    number = raw.get("number")
+    return TicketPayload(
+        id=f"{owner}/{repo}#{number}",
+        title=str(raw.get("title") or "").strip(),
+        description=str(raw.get("body") or "").strip(),
+        labels=labels,
+        assignee=str(assignee) if assignee else None,
+        url=str(raw.get("url") or ""),
+        source="github",
+    )
+
+
+def _normalize_rest(owner: str, repo: str, raw: dict[str, Any]) -> TicketPayload:
+    labels_raw = raw.get("labels") or []
+    labels: tuple[str, ...] = ()
+    collected: list[str] = []
+    for item in labels_raw:
+        if isinstance(item, str):
+            collected.append(item)
+        elif isinstance(item, dict):
+            name = item.get("name")
+            if isinstance(name, str):
+                collected.append(name)
+    labels = tuple(collected)
+
+    assignee_obj = raw.get("assignee") or {}
+    assignee: str | None = None
+    if isinstance(assignee_obj, dict):
+        login = assignee_obj.get("login")
+        if isinstance(login, str):
+            assignee = login
+
+    number = raw.get("number")
+    return TicketPayload(
+        id=f"{owner}/{repo}#{number}",
+        title=str(raw.get("title") or "").strip(),
+        description=str(raw.get("body") or "").strip(),
+        labels=labels,
+        assignee=assignee,
+        url=str(raw.get("html_url") or ""),
+        source="github",
+    )
+
+
+def fetch_github_issue(url: str) -> TicketPayload:
+    """Fetch a GitHub issue and return it as a :class:`TicketPayload`.
+
+    Uses the ``gh`` CLI if available; otherwise calls the REST API with
+    ``GITHUB_TOKEN``.
+    """
+    owner, repo, number = _parse_url(url)
+    if _gh_available():
+        raw = _fetch_via_gh(owner, repo, number)
+        return _normalize_gh_cli(owner, repo, raw)
+    raw = _fetch_via_rest(owner, repo, number)
+    return _normalize_rest(owner, repo, raw)

--- a/src/bernstein/core/integrations/tickets/github_issues.py
+++ b/src/bernstein/core/integrations/tickets/github_issues.py
@@ -19,6 +19,7 @@ from bernstein.core.integrations.tickets import (
     TicketParseError,
     TicketPayload,
 )
+from bernstein.core.integrations.tickets._http import http_get_json
 
 __all__ = ["fetch_github_issue"]
 
@@ -89,31 +90,13 @@ def _fetch_via_rest(owner: str, repo: str, number: int) -> dict[str, Any]:
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    try:
-        import httpx
-
-        resp = httpx.get(endpoint, headers=headers, timeout=_TIMEOUT_S)
-        if resp.status_code in (401, 403):
-            raise TicketAuthError(
-                f"GitHub rejected the request (HTTP {resp.status_code}). Check the {_GH_ENV} environment variable."
-            )
-        if resp.status_code >= 400:
-            raise TicketParseError(f"GitHub API returned HTTP {resp.status_code}: {resp.text[:200]}")
-        return cast(dict[str, Any], resp.json())
-    except ImportError:  # pragma: no cover - httpx is a declared dependency
-        import urllib.error
-        import urllib.request
-
-        req = urllib.request.Request(endpoint, headers=headers)
-        try:
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as handle:
-                return cast(dict[str, Any], json.loads(handle.read().decode("utf-8")))
-        except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise TicketAuthError(
-                    f"GitHub rejected the request (HTTP {exc.code}). Check the {_GH_ENV} environment variable."
-                ) from exc
-            raise TicketParseError(f"GitHub API returned HTTP {exc.code}") from exc
+    return http_get_json(
+        url=endpoint,
+        headers=headers,
+        provider_label="GitHub",
+        auth_env_var=_GH_ENV,
+        timeout=_TIMEOUT_S,
+    )
 
 
 def _normalize_gh_cli(

--- a/src/bernstein/core/integrations/tickets/jira.py
+++ b/src/bernstein/core/integrations/tickets/jira.py
@@ -1,0 +1,156 @@
+"""Jira cloud ticket fetcher.
+
+Uses the Jira REST API v3. Credentials are read from two environment
+variables at call time:
+
+* ``JIRA_EMAIL`` -- the user's Atlassian account email.
+* ``JIRA_API_TOKEN`` -- a Jira Cloud API token.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+from typing import Any, cast
+from urllib.parse import urlparse
+
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketParseError,
+    TicketPayload,
+)
+
+__all__ = ["fetch_jira"]
+
+
+_EMAIL_ENV = "JIRA_EMAIL"
+_TOKEN_ENV = "JIRA_API_TOKEN"
+_TIMEOUT_S = 10.0
+
+_BROWSE_RE = re.compile(r"/browse/(?P<key>[A-Z][A-Z0-9_]+-\d+)", re.IGNORECASE)
+
+
+def _parse_url(url: str) -> tuple[str, str]:
+    """Return ``(base_url, issue_key)`` for a Jira browse URL."""
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise TicketParseError(f"Not a valid Jira URL: {url!r}")
+    match = _BROWSE_RE.search(parsed.path)
+    if match is None:
+        raise TicketParseError(f"Could not extract Jira issue key from {url!r}")
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    return base, match.group("key").upper()
+
+
+def _flatten_adf(node: Any) -> str:
+    """Flatten an Atlassian Document Format node tree into plain text.
+
+    ADF is a nested JSON structure where leaf text nodes carry ``type: "text"``
+    and ``text: "..."``. Block nodes (paragraphs, bullet lists, etc.) contain a
+    ``content`` list of children. This function walks the tree depth-first and
+    joins text pieces, inserting line breaks between top-level blocks.
+    """
+    if isinstance(node, str):
+        return node
+    if not isinstance(node, dict):
+        return ""
+    node_type = node.get("type")
+    if node_type == "text":
+        return str(node.get("text") or "")
+    if node_type == "hardBreak":
+        return "\n"
+    children = node.get("content") or []
+    parts: list[str] = []
+    if isinstance(children, list):
+        for child in children:
+            parts.append(_flatten_adf(child))
+    joined = "".join(parts)
+    # Block-level nodes get a trailing newline so paragraphs stay separated.
+    if node_type in {"paragraph", "heading", "bulletList", "orderedList", "listItem", "codeBlock", "blockquote"}:
+        return joined + "\n"
+    return joined
+
+
+def _render_description(raw: Any) -> str:
+    """Render a Jira description, handling both plain strings and ADF."""
+    if raw is None:
+        return ""
+    if isinstance(raw, str):
+        return raw.strip()
+    if isinstance(raw, dict):
+        return _flatten_adf(raw).strip()
+    return ""
+
+
+def _get(base_url: str, issue_key: str, email: str, token: str) -> dict[str, Any]:
+    creds = f"{email}:{token}".encode()
+    auth = base64.b64encode(creds).decode("ascii")
+    endpoint = f"{base_url}/rest/api/3/issue/{issue_key}"
+    headers = {"Authorization": f"Basic {auth}", "Accept": "application/json"}
+    try:
+        import httpx
+
+        resp = httpx.get(endpoint, headers=headers, timeout=_TIMEOUT_S)
+        if resp.status_code in (401, 403):
+            raise TicketAuthError(
+                f"Jira rejected the request (HTTP {resp.status_code}). Check {_EMAIL_ENV} and {_TOKEN_ENV}."
+            )
+        if resp.status_code >= 400:
+            raise TicketParseError(f"Jira API returned HTTP {resp.status_code}: {resp.text[:200]}")
+        return cast(dict[str, Any], resp.json())
+    except ImportError:  # pragma: no cover - httpx is a declared dependency
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(endpoint, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as handle:
+                return cast(dict[str, Any], json.loads(handle.read().decode("utf-8")))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise TicketAuthError(
+                    f"Jira rejected the request (HTTP {exc.code}). Check {_EMAIL_ENV} and {_TOKEN_ENV}."
+                ) from exc
+            raise TicketParseError(f"Jira API returned HTTP {exc.code}") from exc
+
+
+def fetch_jira(url: str) -> TicketPayload:
+    """Fetch a Jira issue and return it as a :class:`TicketPayload`.
+
+    Raises:
+        TicketAuthError: env vars ``JIRA_EMAIL`` / ``JIRA_API_TOKEN`` are missing
+            or were rejected by the server.
+        TicketParseError: URL could not be parsed or the response is malformed.
+    """
+    base_url, key = _parse_url(url)
+    email = os.environ.get(_EMAIL_ENV)
+    token = os.environ.get(_TOKEN_ENV)
+    if not email or not token:
+        raise TicketAuthError(f"Missing Jira credentials. Set both {_EMAIL_ENV} and {_TOKEN_ENV} to authenticate.")
+
+    raw = _get(base_url, key, email, token)
+    fields = raw.get("fields") or {}
+    if not isinstance(fields, dict):
+        raise TicketParseError(f"Jira response for {key} is missing 'fields'")
+
+    labels_raw = fields.get("labels") or []
+    labels = tuple(str(label) for label in labels_raw if isinstance(label, str))
+
+    assignee_obj = fields.get("assignee") or {}
+    assignee: str | None = None
+    if isinstance(assignee_obj, dict):
+        name = assignee_obj.get("displayName") or assignee_obj.get("emailAddress")
+        if isinstance(name, str):
+            assignee = name
+
+    return TicketPayload(
+        id=str(raw.get("key") or key),
+        title=str(fields.get("summary") or "").strip(),
+        description=_render_description(fields.get("description")),
+        labels=labels,
+        assignee=assignee,
+        url=url,
+        source="jira",
+    )

--- a/src/bernstein/core/integrations/tickets/jira.py
+++ b/src/bernstein/core/integrations/tickets/jira.py
@@ -10,10 +10,9 @@ variables at call time:
 from __future__ import annotations
 
 import base64
-import json
 import os
 import re
-from typing import Any, cast
+from typing import Any
 from urllib.parse import urlparse
 
 from bernstein.core.integrations.tickets import (
@@ -21,6 +20,7 @@ from bernstein.core.integrations.tickets import (
     TicketParseError,
     TicketPayload,
 )
+from bernstein.core.integrations.tickets._http import http_get_json
 
 __all__ = ["fetch_jira"]
 
@@ -89,31 +89,13 @@ def _get(base_url: str, issue_key: str, email: str, token: str) -> dict[str, Any
     auth = base64.b64encode(creds).decode("ascii")
     endpoint = f"{base_url}/rest/api/3/issue/{issue_key}"
     headers = {"Authorization": f"Basic {auth}", "Accept": "application/json"}
-    try:
-        import httpx
-
-        resp = httpx.get(endpoint, headers=headers, timeout=_TIMEOUT_S)
-        if resp.status_code in (401, 403):
-            raise TicketAuthError(
-                f"Jira rejected the request (HTTP {resp.status_code}). Check {_EMAIL_ENV} and {_TOKEN_ENV}."
-            )
-        if resp.status_code >= 400:
-            raise TicketParseError(f"Jira API returned HTTP {resp.status_code}: {resp.text[:200]}")
-        return cast(dict[str, Any], resp.json())
-    except ImportError:  # pragma: no cover - httpx is a declared dependency
-        import urllib.error
-        import urllib.request
-
-        req = urllib.request.Request(endpoint, headers=headers)
-        try:
-            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as handle:
-                return cast(dict[str, Any], json.loads(handle.read().decode("utf-8")))
-        except urllib.error.HTTPError as exc:
-            if exc.code in (401, 403):
-                raise TicketAuthError(
-                    f"Jira rejected the request (HTTP {exc.code}). Check {_EMAIL_ENV} and {_TOKEN_ENV}."
-                ) from exc
-            raise TicketParseError(f"Jira API returned HTTP {exc.code}") from exc
+    return http_get_json(
+        url=endpoint,
+        headers=headers,
+        provider_label="Jira",
+        auth_env_var=f"{_EMAIL_ENV} and {_TOKEN_ENV}",
+        timeout=_TIMEOUT_S,
+    )
 
 
 def fetch_jira(url: str) -> TicketPayload:

--- a/src/bernstein/core/integrations/tickets/linear.py
+++ b/src/bernstein/core/integrations/tickets/linear.py
@@ -87,6 +87,25 @@ def _post_graphql(api_key: str, query: str, variables: dict[str, Any]) -> dict[s
             raise TicketParseError(f"Linear API returned HTTP {exc.code}") from exc
 
 
+def _extract_labels(issue: dict[str, Any]) -> tuple[str, ...]:
+    """Pull a tuple of label names from a Linear issue node."""
+    nodes = (issue.get("labels") or {}).get("nodes") or []
+    return tuple(
+        str(node.get("name", "")).strip()
+        for node in nodes
+        if isinstance(node, dict) and node.get("name")
+    )
+
+
+def _extract_assignee(issue: dict[str, Any]) -> str | None:
+    """Pull the human-readable assignee name from a Linear issue node."""
+    assignee_obj = issue.get("assignee")
+    if not isinstance(assignee_obj, dict):
+        return None
+    name = assignee_obj.get("displayName") or assignee_obj.get("name")
+    return str(name) if name else None
+
+
 def fetch_linear(url: str) -> TicketPayload:
     """Fetch a Linear issue and return it as a :class:`TicketPayload`.
 
@@ -107,21 +126,12 @@ def fetch_linear(url: str) -> TicketPayload:
     if not isinstance(issue, dict):
         raise TicketParseError(f"Linear issue {key} not found in response")
 
-    labels_node = (issue.get("labels") or {}).get("nodes") or []
-    labels = tuple(
-        str(node.get("name", "")).strip() for node in labels_node if isinstance(node, dict) and node.get("name")
-    )
-    assignee_obj = issue.get("assignee") or {}
-    assignee = None
-    if isinstance(assignee_obj, dict):
-        assignee = assignee_obj.get("displayName") or assignee_obj.get("name")
-
     return TicketPayload(
         id=str(issue.get("identifier") or key),
         title=str(issue.get("title") or "").strip(),
         description=str(issue.get("description") or "").strip(),
-        labels=labels,
-        assignee=str(assignee) if assignee else None,
+        labels=_extract_labels(issue),
+        assignee=_extract_assignee(issue),
         url=str(issue.get("url") or url),
         source="linear",
     )

--- a/src/bernstein/core/integrations/tickets/linear.py
+++ b/src/bernstein/core/integrations/tickets/linear.py
@@ -90,11 +90,7 @@ def _post_graphql(api_key: str, query: str, variables: dict[str, Any]) -> dict[s
 def _extract_labels(issue: dict[str, Any]) -> tuple[str, ...]:
     """Pull a tuple of label names from a Linear issue node."""
     nodes = (issue.get("labels") or {}).get("nodes") or []
-    return tuple(
-        str(node.get("name", "")).strip()
-        for node in nodes
-        if isinstance(node, dict) and node.get("name")
-    )
+    return tuple(str(node.get("name", "")).strip() for node in nodes if isinstance(node, dict) and node.get("name"))
 
 
 def _extract_assignee(issue: dict[str, Any]) -> str | None:

--- a/src/bernstein/core/integrations/tickets/linear.py
+++ b/src/bernstein/core/integrations/tickets/linear.py
@@ -1,0 +1,127 @@
+"""Linear ticket fetcher.
+
+Uses the Linear GraphQL API at https://api.linear.app/graphql. The API key is
+read from the ``LINEAR_API_KEY`` environment variable at call time (not at
+import time), so this module is safe to import without credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, cast
+
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketParseError,
+    TicketPayload,
+)
+
+__all__ = ["fetch_linear"]
+
+
+_LINEAR_ENDPOINT = "https://api.linear.app/graphql"
+_LINEAR_ENV = "LINEAR_API_KEY"
+_TIMEOUT_S = 10.0
+
+_KEY_RE = re.compile(r"([A-Z0-9]+-\d+)", re.IGNORECASE)
+
+
+_QUERY = """
+query IssueByIdentifier($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    description
+    url
+    labels { nodes { name } }
+    assignee { name displayName }
+  }
+}
+""".strip()
+
+
+def _extract_key(url: str) -> str:
+    match = _KEY_RE.search(url)
+    if match is None:
+        raise TicketParseError(f"Could not extract Linear issue key from {url!r}")
+    return match.group(1).upper()
+
+
+def _post_graphql(api_key: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    """POST a GraphQL request, returning the decoded JSON body."""
+    body = {"query": query, "variables": variables}
+    try:
+        import httpx
+
+        headers = {"Authorization": api_key, "Content-Type": "application/json"}
+        resp = httpx.post(_LINEAR_ENDPOINT, json=body, headers=headers, timeout=_TIMEOUT_S)
+        if resp.status_code in (401, 403):
+            raise TicketAuthError(
+                f"Linear rejected the request (HTTP {resp.status_code}). Check the {_LINEAR_ENV} environment variable."
+            )
+        if resp.status_code >= 400:
+            raise TicketParseError(f"Linear API returned HTTP {resp.status_code}: {resp.text[:200]}")
+        return cast(dict[str, Any], resp.json())
+    except ImportError:  # pragma: no cover - httpx is a declared dependency
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(
+            _LINEAR_ENDPOINT,
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Authorization": api_key, "Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=_TIMEOUT_S) as handle:
+                raw = handle.read().decode("utf-8")
+            return cast(dict[str, Any], json.loads(raw))
+        except urllib.error.HTTPError as exc:
+            if exc.code in (401, 403):
+                raise TicketAuthError(
+                    f"Linear rejected the request (HTTP {exc.code}). Check the {_LINEAR_ENV} environment variable."
+                ) from exc
+            raise TicketParseError(f"Linear API returned HTTP {exc.code}") from exc
+
+
+def fetch_linear(url: str) -> TicketPayload:
+    """Fetch a Linear issue and return it as a :class:`TicketPayload`.
+
+    Raises:
+        TicketAuthError: ``LINEAR_API_KEY`` is missing or rejected.
+        TicketParseError: URL could not be parsed or the response shape is unexpected.
+    """
+    api_key = os.environ.get(_LINEAR_ENV)
+    if not api_key:
+        raise TicketAuthError(
+            f"Missing Linear credentials. Set the {_LINEAR_ENV} environment variable to your personal API key."
+        )
+    key = _extract_key(url)
+    data = _post_graphql(api_key, _QUERY, {"id": key})
+    if data.get("errors"):
+        raise TicketParseError(f"Linear GraphQL error: {data['errors']}")
+    issue = ((data.get("data") or {}).get("issue")) or None
+    if not isinstance(issue, dict):
+        raise TicketParseError(f"Linear issue {key} not found in response")
+
+    labels_node = (issue.get("labels") or {}).get("nodes") or []
+    labels = tuple(
+        str(node.get("name", "")).strip() for node in labels_node if isinstance(node, dict) and node.get("name")
+    )
+    assignee_obj = issue.get("assignee") or {}
+    assignee = None
+    if isinstance(assignee_obj, dict):
+        assignee = assignee_obj.get("displayName") or assignee_obj.get("name")
+
+    return TicketPayload(
+        id=str(issue.get("identifier") or key),
+        title=str(issue.get("title") or "").strip(),
+        description=str(issue.get("description") or "").strip(),
+        labels=labels,
+        assignee=str(assignee) if assignee else None,
+        url=str(issue.get("url") or url),
+        source="linear",
+    )

--- a/src/bernstein/core/integrations/tickets/linear.py
+++ b/src/bernstein/core/integrations/tickets/linear.py
@@ -25,7 +25,7 @@ _LINEAR_ENDPOINT = "https://api.linear.app/graphql"
 _LINEAR_ENV = "LINEAR_API_KEY"
 _TIMEOUT_S = 10.0
 
-_KEY_RE = re.compile(r"([A-Z0-9]+-\d+)", re.IGNORECASE)
+_KEY_RE = re.compile(r"([A-Z0-9]{1,16}-\d{1,8})", re.IGNORECASE)
 
 
 _QUERY = """

--- a/src/bernstein/core/lifecycle/__init__.py
+++ b/src/bernstein/core/lifecycle/__init__.py
@@ -1,0 +1,68 @@
+"""Lifecycle-hooks subsystem.
+
+Provides a unified registry that fans events out to pluggy hook
+implementations, Python callables, and shell scripts declared in
+``bernstein.yaml``.
+
+Historically ``bernstein.core.lifecycle`` resolved — via the in-tree
+core-redirect finder — to :mod:`bernstein.core.tasks.lifecycle`, the
+task/agent governance FSM. Turning it into a package (so we could
+land new modules like :mod:`.hooks` and :mod:`.pluggy_bridge`) would
+normally break that redirect because real packages win over meta-path
+finders. We therefore install a compatibility shim below that merges
+our new public surface into the original FSM module and remaps
+``sys.modules`` so existing ``from bernstein.core.lifecycle import
+transition_agent`` callers continue to resolve exactly as before,
+including module-level attribute writes used by their tests.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from bernstein.core.lifecycle.hooks import (
+    DEFAULT_TIMEOUT_SECONDS,
+    MAX_STDOUT_BYTES,
+    HookFailure,
+    HookRegistry,
+    LifecycleContext,
+    LifecycleEvent,
+)
+from bernstein.core.lifecycle.pluggy_bridge import (
+    LifecycleHookSpec,
+    apply_hooks_to_existing_system,
+)
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility shim: merge our symbols into the historical
+# ``bernstein.core.tasks.lifecycle`` module and alias ``sys.modules``.
+# ---------------------------------------------------------------------------
+from bernstein.core.tasks import lifecycle as _task_lifecycle
+
+_hook_exports: dict[str, object] = {
+    "DEFAULT_TIMEOUT_SECONDS": DEFAULT_TIMEOUT_SECONDS,
+    "MAX_STDOUT_BYTES": MAX_STDOUT_BYTES,
+    "HookFailure": HookFailure,
+    "HookRegistry": HookRegistry,
+    "LifecycleContext": LifecycleContext,
+    "LifecycleEvent": LifecycleEvent,
+    "LifecycleHookSpec": LifecycleHookSpec,
+    "apply_hooks_to_existing_system": apply_hooks_to_existing_system,
+}
+# Only copy names that don't already exist on the target, to avoid
+# shadowing the FSM's own ``LifecycleEvent`` type for legacy callers.
+for _name, _value in _hook_exports.items():
+    if not hasattr(_task_lifecycle, _name):
+        setattr(_task_lifecycle, _name, _value)
+
+# Preserve package discovery for ``bernstein.core.lifecycle.hooks`` and
+# ``bernstein.core.lifecycle.pluggy_bridge`` after the alias — the real
+# package object carries ``__path__``; copy it onto the FSM module so
+# import of our submodules still works post-alias.
+if not hasattr(_task_lifecycle, "__path__"):
+    _task_lifecycle.__path__ = __path__  # type: ignore[attr-defined]
+
+# Re-point ``bernstein.core.lifecycle`` at the FSM module. Any future
+# imports (``import bernstein.core.lifecycle``) receive the FSM module
+# with our hook surface merged in.
+sys.modules[__name__] = _task_lifecycle  # type: ignore[assignment]

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -1,0 +1,338 @@
+"""Lifecycle-hook registry, event enum, and context dataclass.
+
+This module is self-contained; the pluggy bridge lives in a sibling
+module so this file can be imported from contexts where pluggy is
+unavailable or undesired.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from types import MappingProxyType
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MAX_STDOUT_BYTES",
+    "HookFailure",
+    "HookRegistry",
+    "LifecycleContext",
+    "LifecycleEvent",
+]
+
+
+DEFAULT_TIMEOUT_SECONDS: int = 30
+"""Default subprocess timeout applied to script hooks."""
+
+MAX_STDOUT_BYTES: int = 10 * 1024 * 1024
+"""Maximum captured stdout for a script hook (10 MB). Output is truncated."""
+
+# Whitelisted parent environment variables. Anything not listed here is
+# stripped before launching a script hook, so secrets and unrelated
+# settings do not leak into user-supplied processes.
+_ENV_WHITELIST: tuple[str, ...] = ("PATH", "HOME", "USER")
+
+
+class LifecycleEvent(StrEnum):
+    """Named lifecycle events a hook may subscribe to."""
+
+    PRE_TASK = "pre_task"
+    POST_TASK = "post_task"
+    PRE_MERGE = "pre_merge"
+    POST_MERGE = "post_merge"
+    PRE_SPAWN = "pre_spawn"
+    POST_SPAWN = "post_spawn"
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleContext:
+    """Immutable payload passed to every hook invocation.
+
+    Attributes:
+        event: The lifecycle event being dispatched.
+        task: Task identifier, when the event is task-scoped.
+        session_id: Agent session identifier, when relevant.
+        workdir: Working directory the caller considers current.
+        env: Extra environment variables to merge into script hooks
+            (on top of the whitelisted parent env).
+        timestamp: Unix timestamp when the context was built.
+    """
+
+    event: LifecycleEvent
+    task: str | None = None
+    session_id: str | None = None
+    workdir: Path = field(default_factory=Path.cwd)
+    env: dict[str, str] = field(default_factory=dict[str, str])
+    timestamp: float = field(default_factory=time.time)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Serialise the context for transport to a subprocess."""
+        return {
+            "event": self.event.value,
+            "task": self.task,
+            "session_id": self.session_id,
+            "workdir": str(self.workdir),
+            "env": dict(self.env),
+            "timestamp": self.timestamp,
+        }
+
+
+class HookFailure(RuntimeError):
+    """Raised when a script hook exits non-zero or a callable raises.
+
+    Attributes:
+        event: The event whose dispatch failed.
+        hook: Human-readable description of the failing hook.
+        exit_code: Subprocess exit code, or ``None`` for callables.
+        stderr: Captured standard error, when available.
+    """
+
+    def __init__(
+        self,
+        event: LifecycleEvent,
+        hook: str,
+        *,
+        exit_code: int | None = None,
+        stderr: str = "",
+        cause: BaseException | None = None,
+    ) -> None:
+        detail = f"exit_code={exit_code}" if exit_code is not None else "raised"
+        super().__init__(f"Lifecycle hook failed for {event.value}: {hook} ({detail})")
+        self.event = event
+        self.hook = hook
+        self.exit_code = exit_code
+        self.stderr = stderr
+        self.__cause__ = cause
+
+
+@dataclass(frozen=True, slots=True)
+class _ScriptHook:
+    path: Path
+    timeout: int
+
+
+@dataclass(frozen=True, slots=True)
+class _CallableHook:
+    fn: Callable[[LifecycleContext], None]
+
+    @property
+    def label(self) -> str:
+        name = getattr(self.fn, "__qualname__", None) or getattr(self.fn, "__name__", None) or repr(self.fn)
+        return f"callable:{name}"
+
+
+class HookRegistry:
+    """Registers and dispatches lifecycle hooks.
+
+    Hooks fire in registration order. The registry deliberately keeps
+    pluggy integration in a bridge module so this class can be used
+    standalone in tests and by callers that do not want to take a
+    dependency on pluggy.
+    """
+
+    def __init__(self) -> None:
+        self._scripts: dict[LifecycleEvent, list[_ScriptHook]] = {event: [] for event in LifecycleEvent}
+        self._callables: dict[LifecycleEvent, list[_CallableHook]] = {event: [] for event in LifecycleEvent}
+        # Insertion-order ledger so we can dispatch scripts and callables
+        # in the exact order a user registered them.
+        self._order: dict[LifecycleEvent, list[tuple[str, int]]] = {event: [] for event in LifecycleEvent}
+        self._executor: ThreadPoolExecutor | None = None
+        # The pluggy bridge attaches itself here when installed.
+        self._pluggy_dispatcher: Callable[[LifecycleEvent, LifecycleContext], None] | None = None
+
+    # ------------------------------------------------------------------ registration
+
+    def register_script(
+        self,
+        event: LifecycleEvent,
+        path: str | os.PathLike[str],
+        timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        """Register a shell script to run when ``event`` fires.
+
+        Args:
+            event: Lifecycle event to subscribe to.
+            path: Filesystem path to the script; need not exist yet.
+            timeout: Maximum wall-clock seconds before the subprocess is killed.
+        """
+        hook = _ScriptHook(path=Path(path), timeout=timeout)
+        idx = len(self._scripts[event])
+        self._scripts[event].append(hook)
+        self._order[event].append(("script", idx))
+
+    def register_callable(
+        self,
+        event: LifecycleEvent,
+        fn: Callable[[LifecycleContext], None],
+    ) -> None:
+        """Register a Python callable for ``event``.
+
+        The callable receives a single :class:`LifecycleContext` argument.
+        Any exception it raises surfaces as :class:`HookFailure`.
+        """
+        hook = _CallableHook(fn=fn)
+        idx = len(self._callables[event])
+        self._callables[event].append(hook)
+        self._order[event].append(("callable", idx))
+
+    def attach_pluggy_dispatcher(
+        self,
+        dispatcher: Callable[[LifecycleEvent, LifecycleContext], None],
+    ) -> None:
+        """Install the pluggy bridge's dispatcher.
+
+        Called by :mod:`bernstein.core.lifecycle.pluggy_bridge`. The
+        dispatcher is invoked after callables and scripts so that
+        plugin-supplied hookimpls see the same context.
+        """
+        self._pluggy_dispatcher = dispatcher
+
+    # ------------------------------------------------------------------ introspection
+
+    def registered(self, event: LifecycleEvent) -> list[str]:
+        """Return labels of all hooks registered for ``event``, in order."""
+        labels: list[str] = []
+        for kind, idx in self._order[event]:
+            if kind == "script":
+                labels.append(f"script:{self._scripts[event][idx].path}")
+            else:
+                labels.append(self._callables[event][idx].label)
+        return labels
+
+    # ------------------------------------------------------------------ dispatch
+
+    def run(self, event: LifecycleEvent, context: LifecycleContext) -> None:
+        """Run all hooks for ``event`` synchronously, in registration order.
+
+        Raises:
+            HookFailure: On the first failure; subsequent hooks are not run.
+        """
+        for kind, idx in self._order[event]:
+            if kind == "script":
+                self._run_script(event, self._scripts[event][idx], context)
+            else:
+                self._run_callable(event, self._callables[event][idx], context)
+        if self._pluggy_dispatcher is not None:
+            try:
+                self._pluggy_dispatcher(event, context)
+            except HookFailure:
+                raise
+            except Exception as exc:
+                raise HookFailure(event, "pluggy", cause=exc) from exc
+
+    def run_async(self, event: LifecycleEvent, context: LifecycleContext) -> Future[None]:
+        """Schedule ``run`` on a background thread and return a Future.
+
+        Use for post-events where the caller should not block on I/O.
+        The caller owns the future; failures surface via ``future.exception()``.
+        """
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="bernstein-hooks")
+        return self._executor.submit(self.run, event, context)
+
+    def shutdown(self, wait: bool = True) -> None:
+        """Tear down the background executor, if one was started."""
+        if self._executor is not None:
+            self._executor.shutdown(wait=wait)
+            self._executor = None
+
+    # ------------------------------------------------------------------ internals
+
+    def _run_callable(
+        self,
+        event: LifecycleEvent,
+        hook: _CallableHook,
+        context: LifecycleContext,
+    ) -> None:
+        try:
+            hook.fn(context)
+        except Exception as exc:
+            raise HookFailure(event, hook.label, cause=exc) from exc
+
+    def _run_script(
+        self,
+        event: LifecycleEvent,
+        hook: _ScriptHook,
+        context: LifecycleContext,
+    ) -> None:
+        env = _build_script_env(context)
+        payload = json.dumps(context.to_payload()).encode("utf-8")
+        label = f"script:{hook.path}"
+        try:
+            proc = subprocess.run(
+                [str(hook.path)],
+                input=payload,
+                env=env,
+                cwd=str(context.workdir),
+                capture_output=True,
+                timeout=hook.timeout,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise HookFailure(event, label, cause=exc) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise HookFailure(event, label, stderr="timeout", cause=exc) from exc
+
+        stdout = proc.stdout or b""
+        if len(stdout) > MAX_STDOUT_BYTES:
+            truncated = stdout[:MAX_STDOUT_BYTES]
+            log.warning(
+                "hook stdout truncated from %d to %d bytes for %s",
+                len(stdout),
+                MAX_STDOUT_BYTES,
+                hook.path,
+            )
+            stdout = truncated
+
+        if proc.returncode != 0:
+            stderr_text = (proc.stderr or b"").decode("utf-8", errors="replace")
+            raise HookFailure(event, label, exit_code=proc.returncode, stderr=stderr_text)
+
+
+def _build_script_env(context: LifecycleContext) -> dict[str, str]:
+    """Construct the environment for a script subprocess.
+
+    Only whitelisted parent variables are forwarded. Anything callers
+    want visible to hooks must live on ``context.env`` or be explicit
+    ``BERNSTEIN_*`` values.
+    """
+    env: dict[str, str] = {}
+    parent = _read_parent_env()
+    for key in _ENV_WHITELIST:
+        value = parent.get(key)
+        if value is not None:
+            env[key] = value
+    # Forward all BERNSTEIN_* variables already on the parent.
+    for key, value in parent.items():
+        if key.startswith("BERNSTEIN_"):
+            env[key] = value
+
+    env["BERNSTEIN_EVENT"] = context.event.value
+    if context.task is not None:
+        env["BERNSTEIN_TASK_ID"] = context.task
+    if context.session_id is not None:
+        env["BERNSTEIN_SESSION_ID"] = context.session_id
+    env["BERNSTEIN_WORKDIR"] = str(context.workdir)
+
+    # Context.env wins over anything inherited so callers can override
+    # a whitelisted value deliberately.
+    env.update(context.env)
+    return env
+
+
+def _read_parent_env() -> MappingProxyType[str, str] | dict[str, str]:
+    """Indirection point so tests can monkeypatch environment inheritance."""
+    return dict(os.environ)

--- a/src/bernstein/core/lifecycle/pluggy_bridge.py
+++ b/src/bernstein/core/lifecycle/pluggy_bridge.py
@@ -1,0 +1,132 @@
+"""Bridge between :class:`HookRegistry` and the project-wide pluggy manager.
+
+The bridge defines a set of hookspecs matching the lifecycle events so
+that regular plugins can subscribe via ``@hookimpl``, then wires the
+pluggy ``PluginManager`` into a :class:`HookRegistry` instance so that
+firing an event dispatches to both script/callable hooks and pluggy
+implementations.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+import pluggy
+
+from bernstein.core.lifecycle.hooks import HookFailure, HookRegistry, LifecycleContext, LifecycleEvent
+from bernstein.plugins import hookspec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "LifecycleHookSpec",
+    "apply_hooks_to_existing_system",
+    "build_pluggy_dispatcher",
+    "make_plugin_manager",
+]
+
+
+class LifecycleHookSpec:
+    """Pluggy hookspecs for the lifecycle events.
+
+    Plugins implement one or more of these via ``@hookimpl`` and are
+    picked up automatically once registered with the project plugin
+    manager.
+    """
+
+    @hookspec
+    def pre_task(self, ctx: LifecycleContext) -> None:
+        """Fires before a task transitions out of ``open``."""
+
+    @hookspec
+    def post_task(self, ctx: LifecycleContext) -> None:
+        """Fires after a task reaches a terminal state."""
+
+    @hookspec
+    def pre_merge(self, ctx: LifecycleContext) -> None:
+        """Fires before a merge into the integration branch begins."""
+
+    @hookspec
+    def post_merge(self, ctx: LifecycleContext) -> None:
+        """Fires after a merge completes (success or rollback)."""
+
+    @hookspec
+    def pre_spawn(self, ctx: LifecycleContext) -> None:
+        """Fires before an agent session is spawned."""
+
+    @hookspec
+    def post_spawn(self, ctx: LifecycleContext) -> None:
+        """Fires after an agent session has been spawned."""
+
+
+def make_plugin_manager() -> pluggy.PluginManager:
+    """Create a pluggy manager preloaded with :class:`LifecycleHookSpec`.
+
+    Callers who already manage a project-wide ``PluginManager`` should
+    instead call ``pm.add_hookspecs(LifecycleHookSpec)`` themselves;
+    this helper is primarily for tests and standalone usage.
+    """
+    pm = pluggy.PluginManager("bernstein")
+    pm.add_hookspecs(LifecycleHookSpec)
+    return pm
+
+
+def build_pluggy_dispatcher(
+    pm: pluggy.PluginManager,
+) -> Callable[[LifecycleEvent, LifecycleContext], None]:
+    """Return a function that fans a lifecycle event out over pluggy.
+
+    The dispatcher ignores ``None`` returns from hookimpls and converts
+    any raised exception into :class:`HookFailure` so callers see a
+    consistent error type regardless of whether a script or a plugin
+    blew up.
+    """
+
+    def dispatch(event: LifecycleEvent, context: LifecycleContext) -> None:
+        hook_caller: Any = getattr(pm.hook, event.value, None)
+        if hook_caller is None:
+            return
+        try:
+            hook_caller(ctx=context)
+        except HookFailure:
+            raise
+        except Exception as exc:
+            raise HookFailure(event, f"pluggy:{event.value}", cause=exc) from exc
+
+    return dispatch
+
+
+def apply_hooks_to_existing_system(
+    registry: HookRegistry,
+    pm: pluggy.PluginManager | None = None,
+) -> pluggy.PluginManager:
+    """One-shot helper that wires pluggy into a :class:`HookRegistry`.
+
+    The parent bootstrap is expected to call this exactly once during
+    startup, after plugin discovery, and pass the returned manager back
+    in for any additional plugin registration. If ``pm`` is ``None``, a
+    fresh manager is constructed via :func:`make_plugin_manager`.
+
+    Args:
+        registry: The lifecycle registry that owns script/callable hooks.
+        pm: An existing plugin manager, or ``None`` to create one.
+
+    Returns:
+        The plugin manager with lifecycle hookspecs attached and the
+        dispatcher wired into ``registry``.
+    """
+    if pm is None:
+        pm = make_plugin_manager()
+    else:
+        # If the caller passed their own manager, make sure our specs
+        # are registered; ``add_hookspecs`` is not idempotent, so
+        # suppress the ``ValueError`` it raises on duplicate registration.
+        with contextlib.suppress(ValueError):
+            pm.add_hookspecs(LifecycleHookSpec)
+    registry.attach_pluggy_dispatcher(build_pluggy_dispatcher(pm))
+    return pm

--- a/src/bernstein/core/sandbox/ssh_backend.py
+++ b/src/bernstein/core/sandbox/ssh_backend.py
@@ -489,14 +489,13 @@ class SSHSandboxBackend:
         )
         wait_for = timeout + _DEFAULT_TIMEOUT_SLACK if timeout else None
         try:
-            stdout, stderr = await asyncio.wait_for(
-                process.communicate(input=stdin),
-                timeout=wait_for,
-            )
+            async with asyncio.timeout(wait_for):
+                stdout, stderr = await process.communicate(input=stdin)
         except TimeoutError:
             process.kill()
             try:
-                await asyncio.wait_for(process.wait(), timeout=5)
+                async with asyncio.timeout(5):
+                    await process.wait()
             except TimeoutError:
                 logger.warning("ssh process did not exit after kill: %s", argv)
             raise TimeoutError(f"ssh command timed out after {timeout}s") from None

--- a/src/bernstein/core/sandbox/ssh_backend.py
+++ b/src/bernstein/core/sandbox/ssh_backend.py
@@ -1,0 +1,667 @@
+"""SSH-backed :class:`SandboxBackend` — run agents on remote hosts.
+
+This backend lets Bernstein provision a sandbox on an arbitrary host
+reachable over SSH. Every primitive (``read`` / ``write`` / ``exec`` /
+``ls``) is implemented by spawning the system ``ssh`` binary against a
+long-lived ``ControlMaster`` multiplexing socket so subsequent commands
+pay only the TCP-round-trip cost, not a full key exchange.
+
+Design notes:
+
+* Pure shell-out over ``ssh``/``sftp``; no third-party transport library
+  is required. ``paramiko`` is *not* a dependency.
+* File I/O uses plain shell commands (``cat``, ``base64``, ``test``)
+  rather than ``sftp`` so the same connection multiplex is reused. Large
+  payloads are base64-wrapped to survive 8-bit-unsafe shells.
+* A dedicated ``ControlMaster`` socket is opened per
+  :class:`SSHSandboxBackend` instance at
+  ``~/.ssh/bernstein-<host>-<pid>.sock``; :meth:`close` tears it down.
+* Worktree lifecycle (``create`` / ``attach`` / ``destroy``) runs
+  ``git worktree`` remotely over the same multiplexed channel.
+* Connection-level failures (``Connection refused`` / ``Permission
+  denied``) are translated into :class:`SandboxConnectionError` so
+  callers can render ergonomic fix-it messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+import secrets
+import shlex
+import subprocess
+import time
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+_CONNECT_TIMEOUT_SECONDS = 10
+_SERVER_ALIVE_INTERVAL_SECONDS = 30
+_CONTROL_PERSIST_SECONDS = 600
+_DEFAULT_TIMEOUT_SLACK = 5
+
+
+class SandboxConnectionError(RuntimeError):
+    """Raised when the sandbox's remote transport is unreachable.
+
+    Attributes:
+        host: Remote host the backend was trying to reach.
+        reason: Short human-readable reason (``"connection refused"``,
+            ``"permission denied"``, etc.).
+        hint: Optional actionable suggestion shown alongside ``reason``.
+    """
+
+    def __init__(self, *, host: str, reason: str, hint: str | None = None) -> None:
+        self.host = host
+        self.reason = reason
+        self.hint = hint
+        message = f"SSH sandbox unreachable ({host}): {reason}"
+        if hint:
+            message = f"{message} — {hint}"
+        super().__init__(message)
+
+
+def _classify_ssh_failure(host: str, stderr: str) -> SandboxConnectionError | None:
+    """Map a stderr blob from ``ssh`` to a :class:`SandboxConnectionError`.
+
+    Args:
+        host: Remote host used in the error message.
+        stderr: Captured ``ssh`` stderr.
+
+    Returns:
+        A prepared exception if ``stderr`` matches one of the known
+        failure signatures, else ``None``.
+    """
+    lowered = stderr.lower()
+    if "connection refused" in lowered:
+        return SandboxConnectionError(
+            host=host,
+            reason="connection refused",
+            hint=f"is sshd running on {host}? check firewall and `Port` in ~/.ssh/config",
+        )
+    if "permission denied" in lowered:
+        return SandboxConnectionError(
+            host=host,
+            reason="permission denied",
+            hint="run `ssh-add <key>` and confirm the `IdentityFile` in ~/.ssh/config",
+        )
+    if "could not resolve hostname" in lowered or "name or service not known" in lowered:
+        return SandboxConnectionError(
+            host=host,
+            reason="host not resolvable",
+            hint=f"add a `Host {host}` block to ~/.ssh/config or use --user/--port flags",
+        )
+    if "operation timed out" in lowered or "connection timed out" in lowered:
+        return SandboxConnectionError(
+            host=host,
+            reason="connection timed out",
+            hint="check network reachability and any VPN requirements",
+        )
+    return None
+
+
+class SSHSandboxSession(SandboxSession):
+    """An active sandbox on a remote host reached over SSH.
+
+    Instances are produced by :meth:`SSHSandboxBackend.create`; manual
+    construction is supported but most callers should go through the
+    backend so the ``git worktree`` lifecycle runs.
+    """
+
+    backend_name = "ssh"
+
+    def __init__(
+        self,
+        *,
+        backend: SSHSandboxBackend,
+        session_id: str,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        """Initialise the session.
+
+        Args:
+            backend: Owning backend; used for shared SSH argv and the
+                ``git worktree`` cleanup on :meth:`shutdown`.
+            session_id: Opaque identifier — also the worktree directory
+                name under the remote ``path``.
+            workdir: Absolute POSIX path on the remote host of the
+                session's root directory.
+            base_env: Environment applied to every :meth:`exec` call.
+            default_timeout: Wall-clock timeout applied when the caller
+                does not supply one.
+        """
+        self._backend = backend
+        self.session_id = session_id
+        self.workdir = workdir
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    # ------------------------------------------------------------------
+    # File primitives
+    # ------------------------------------------------------------------
+
+    def _resolve(self, path: str) -> str:
+        """Resolve ``path`` against :attr:`workdir` POSIX-style."""
+        candidate = PurePosixPath(path)
+        if candidate.is_absolute():
+            return str(candidate)
+        return str(PurePosixPath(self.workdir) / candidate)
+
+    async def read(self, path: str) -> bytes:
+        """Read a file from the remote host as bytes.
+
+        Uses ``base64`` on the remote end so binary payloads survive the
+        SSH stdout stream unchanged.
+        """
+        target = self._resolve(path)
+        cmd = f"test -e {shlex.quote(target)} && base64 < {shlex.quote(target)}"
+        result = await self._backend.run_ssh(cmd)
+        if result.exit_code != 0:
+            raise FileNotFoundError(target)
+        return base64.b64decode(result.stdout)
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        """Write ``data`` to ``path`` on the remote host.
+
+        Parent directories are created as needed. The payload is
+        base64-encoded so shell framing cannot damage binary content.
+        """
+        target = self._resolve(path)
+        payload = base64.b64encode(data).decode("ascii")
+        parent = str(PurePosixPath(target).parent)
+        script = (
+            f"mkdir -p {shlex.quote(parent)} && "
+            f"printf '%s' {shlex.quote(payload)} | base64 -d > {shlex.quote(target)} && "
+            f"chmod {mode:o} {shlex.quote(target)}"
+        )
+        result = await self._backend.run_ssh(script)
+        if result.exit_code != 0:
+            raise OSError(
+                f"remote write {target!r} failed (exit={result.exit_code}): "
+                f"{result.stderr.decode('utf-8', errors='replace').strip()}"
+            )
+
+    async def ls(self, path: str) -> list[str]:
+        """List directory entries on the remote host.
+
+        Returns:
+            Sorted list of entry basenames. Hidden entries (``.``/``..``)
+            are omitted to match the local worktree's semantics.
+        """
+        target = self._resolve(path)
+        script = f"test -d {shlex.quote(target)} || exit 78; ls -A -1 {shlex.quote(target)}"
+        result = await self._backend.run_ssh(script)
+        if result.exit_code == 78:
+            raise NotADirectoryError(target)
+        if result.exit_code != 0:
+            raise OSError(f"remote ls {target!r} failed: {result.stderr.decode('utf-8', errors='replace').strip()}")
+        names = result.stdout.decode("utf-8", errors="replace").splitlines()
+        return sorted(name for name in names if name)
+
+    async def exists(self, path: str) -> bool:
+        """Return ``True`` if ``path`` exists on the remote host."""
+        target = self._resolve(path)
+        result = await self._backend.run_ssh(f"test -e {shlex.quote(target)}")
+        return result.exit_code == 0
+
+    # ------------------------------------------------------------------
+    # Exec primitive
+    # ------------------------------------------------------------------
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        """Execute ``cmd`` on the remote host."""
+        if self._closed:
+            raise RuntimeError(f"Session {self.session_id} is closed")
+        if not cmd:
+            raise ValueError("cmd must be a non-empty argv list")
+        effective_cwd = self._resolve(cwd) if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env: dict[str, str] = dict(self._base_env)
+        if env:
+            merged_env.update(env)
+
+        quoted_cmd = " ".join(shlex.quote(arg) for arg in cmd)
+        env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in merged_env.items())
+        script = f"cd {shlex.quote(effective_cwd)} && "
+        if env_prefix:
+            script += f"env {env_prefix} {quoted_cmd}"
+        else:
+            script += quoted_cmd
+
+        return await self._backend.run_ssh(script, timeout=effective_timeout, stdin=stdin)
+
+    # ------------------------------------------------------------------
+    # Snapshots (unsupported)
+    # ------------------------------------------------------------------
+
+    async def snapshot(self) -> str:
+        """SSH backend does not advertise the SNAPSHOT capability."""
+        raise NotImplementedError("SSHSandboxBackend does not declare the SNAPSHOT capability")
+
+    # ------------------------------------------------------------------
+    # Shutdown
+    # ------------------------------------------------------------------
+
+    async def shutdown(self) -> None:
+        """Remove the remote worktree and mark the session closed.
+
+        Idempotent — repeat calls are no-ops.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await self._backend.destroy_remote_worktree(self.workdir)
+        except Exception as exc:
+            logger.warning("ssh shutdown: remote cleanup failed for %s: %s", self.workdir, exc)
+
+
+class SSHSandboxBackend:
+    """:class:`SandboxBackend` that provisions sandboxes over SSH.
+
+    The backend shells out to the system ``ssh`` binary and multiplexes
+    every connection through a persistent ``ControlMaster`` socket. A
+    single backend instance may serve many sequential sessions against
+    the same host; call :meth:`close` to tear the socket down.
+    """
+
+    name = "ssh"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+        }
+    )
+
+    def __init__(
+        self,
+        host: str,
+        user: str | None = None,
+        *,
+        path: str,
+        identity_file: str | Path | None = None,
+        port: int = 22,
+        strict_host_key_checking: bool = True,
+    ) -> None:
+        """Initialise the backend.
+
+        Args:
+            host: Remote host as it would appear on the ``ssh`` CLI
+                (may refer to an entry in ``~/.ssh/config``).
+            user: Optional remote username. When ``None`` the local
+                ``ssh`` client's default is used.
+            path: Absolute POSIX path on the remote host where session
+                worktrees are provisioned (``<path>/<session_id>``).
+            identity_file: Optional path to a private key.
+            port: Remote SSH port. Defaults to 22.
+            strict_host_key_checking: When ``True`` (default) the
+                corresponding ``StrictHostKeyChecking`` flag is passed
+                as ``yes``; ``False`` sets it to ``accept-new``.
+        """
+        if not host:
+            raise ValueError("host must be non-empty")
+        if not path:
+            raise ValueError("path must be non-empty")
+        self._host = host
+        self._user = user
+        self._path = path
+        self._identity_file = Path(identity_file) if identity_file is not None else None
+        self._port = port
+        self._strict_host_key_checking = strict_host_key_checking
+        self._sessions: dict[str, SSHSandboxSession] = {}
+        self._control_socket = self._build_control_socket_path(host, os.getpid())
+        self._master_started = False
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def host(self) -> str:
+        """Return the remote host."""
+        return self._host
+
+    @property
+    def control_socket(self) -> Path:
+        """Return the :class:`Path` to the ControlMaster socket."""
+        return self._control_socket
+
+    @staticmethod
+    def _build_control_socket_path(host: str, pid: int) -> Path:
+        """Deterministic ControlMaster socket path for ``(host, pid)``."""
+        safe_host = host.replace("/", "_").replace(":", "_")
+        return Path.home() / ".ssh" / f"bernstein-{safe_host}-{pid}.sock"
+
+    def _remote_target(self) -> str:
+        """Return the ``[user@]host`` tuple for ``ssh`` / ``sftp``."""
+        return f"{self._user}@{self._host}" if self._user else self._host
+
+    # ------------------------------------------------------------------
+    # argv assembly
+    # ------------------------------------------------------------------
+
+    def _common_ssh_options(self) -> list[str]:
+        """Return the ``-o`` flags every ``ssh`` invocation receives."""
+        strict_value = "yes" if self._strict_host_key_checking else "accept-new"
+        options: list[str] = [
+            "-o",
+            f"ConnectTimeout={_CONNECT_TIMEOUT_SECONDS}",
+            "-o",
+            f"ServerAliveInterval={_SERVER_ALIVE_INTERVAL_SECONDS}",
+            "-o",
+            f"StrictHostKeyChecking={strict_value}",
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            f"ControlPath={self._control_socket}",
+            "-o",
+            f"ControlPersist={_CONTROL_PERSIST_SECONDS}",
+            "-p",
+            str(self._port),
+        ]
+        if self._identity_file is not None:
+            options.extend(["-i", str(self._identity_file)])
+        return options
+
+    def _build_ssh_cmd(self, cmd: str) -> list[str]:
+        """Return the full ``ssh`` argv for ``cmd``.
+
+        Args:
+            cmd: Shell command to run on the remote host. It is wrapped
+                in ``sh -c "…"`` so POSIX features (pipes, redirection)
+                work the same way across shells.
+
+        Returns:
+            The ready-to-spawn argv list.
+        """
+        argv: list[str] = ["ssh", *self._common_ssh_options(), self._remote_target()]
+        argv.append(f"sh -c {shlex.quote(cmd)}")
+        return argv
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    def ensure_control_master(self) -> None:
+        """Open the shared ``ControlMaster`` socket if not already up.
+
+        Idempotent — safe to call before every command. The resulting
+        socket persists for ``ControlPersist`` seconds even after this
+        process exits so rapid re-runs stay cheap.
+        """
+        if self._master_started and self._control_socket.exists():
+            return
+        self._control_socket.parent.mkdir(parents=True, exist_ok=True)
+        argv = [
+            "ssh",
+            *self._common_ssh_options(),
+            "-fN",
+            "-M",
+            self._remote_target(),
+        ]
+        logger.debug("ssh: opening ControlMaster socket %s", self._control_socket)
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            stderr = proc.stderr.decode("utf-8", errors="replace")
+            classified = _classify_ssh_failure(self._host, stderr)
+            if classified is not None:
+                raise classified
+            raise RuntimeError(f"failed to open SSH ControlMaster socket: {stderr.strip()}")
+        self._master_started = True
+
+    def close(self) -> None:
+        """Close the ``ControlMaster`` socket if this backend owns it.
+
+        Idempotent. Any error from the underlying ``ssh -O exit`` call
+        is logged and swallowed so callers can use this safely in
+        cleanup paths.
+        """
+        if not self._master_started and not self._control_socket.exists():
+            return
+        argv = [
+            "ssh",
+            *self._common_ssh_options(),
+            "-O",
+            "exit",
+            self._remote_target(),
+        ]
+        try:
+            subprocess.run(argv, capture_output=True, check=False)
+        except OSError as exc:
+            logger.debug("ssh -O exit: %s", exc)
+        # Best-effort socket removal — OpenSSH usually clears it itself.
+        try:
+            self._control_socket.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.debug("socket unlink failed: %s", exc)
+        self._master_started = False
+
+    # ------------------------------------------------------------------
+    # Command execution
+    # ------------------------------------------------------------------
+
+    async def run_ssh(
+        self,
+        cmd: str,
+        *,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        """Run ``cmd`` on the remote host and collect the result."""
+        self.ensure_control_master()
+        argv = self._build_ssh_cmd(cmd)
+        start = time.monotonic()
+        process = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        wait_for = timeout + _DEFAULT_TIMEOUT_SLACK if timeout else None
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(input=stdin),
+                timeout=wait_for,
+            )
+        except TimeoutError:
+            process.kill()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except TimeoutError:
+                logger.warning("ssh process did not exit after kill: %s", argv)
+            raise TimeoutError(f"ssh command timed out after {timeout}s") from None
+        duration = time.monotonic() - start
+        exit_code = process.returncode if process.returncode is not None else -1
+        if exit_code != 0:
+            classified = _classify_ssh_failure(self._host, stderr.decode("utf-8", errors="replace"))
+            if classified is not None:
+                raise classified
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=duration,
+        )
+
+    def spawn_agent(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        stdin: int | None = None,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> subprocess.Popen[bytes]:
+        """Start ``cmd`` on the remote host and return a live handle.
+
+        Mirrors :func:`subprocess.Popen` so existing callers that
+        previously spawned adapter CLIs locally can route them through
+        an SSH tunnel with minimal changes.
+
+        Args:
+            cmd: Argv for the remote process.
+            cwd: Optional remote working directory.
+            env: Extra environment variables exported before ``cmd``.
+            stdin: Forwarded to :class:`subprocess.Popen`.
+            stdout: Forwarded to :class:`subprocess.Popen`.
+            stderr: Forwarded to :class:`subprocess.Popen`.
+
+        Returns:
+            A :class:`subprocess.Popen` wrapping the local ``ssh``
+            client process; its ``stdout`` is the remote ``cmd``'s
+            stdout stream.
+        """
+        if not cmd:
+            raise ValueError("cmd must be a non-empty argv list")
+        self.ensure_control_master()
+        env_prefix = ""
+        if env:
+            env_prefix = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items()) + " "
+        cd_prefix = f"cd {shlex.quote(cwd)} && " if cwd else ""
+        quoted = " ".join(shlex.quote(arg) for arg in cmd)
+        script = f"{cd_prefix}{env_prefix}{quoted}".strip()
+        argv = self._build_ssh_cmd(script)
+        return subprocess.Popen(
+            argv,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    # ------------------------------------------------------------------
+    # Worktree lifecycle (remote)
+    # ------------------------------------------------------------------
+
+    async def create_remote_worktree(self, manifest: WorkspaceManifest, session_id: str) -> str:
+        """Provision a fresh remote worktree and return its POSIX path.
+
+        When ``manifest.repo`` is set, ``git worktree add`` is executed
+        on the remote host. Otherwise a plain directory is created.
+        """
+        workdir = str(PurePosixPath(self._path) / session_id)
+        if manifest.repo is not None:
+            repo_src = shlex.quote(manifest.repo.src_path)
+            branch = shlex.quote(manifest.repo.branch)
+            script = (
+                f"mkdir -p {shlex.quote(self._path)} && "
+                f"cd {repo_src} && "
+                f"git worktree add {shlex.quote(workdir)} {branch}"
+            )
+        else:
+            script = f"mkdir -p {shlex.quote(workdir)}"
+        result = await self.run_ssh(script)
+        if result.exit_code != 0:
+            raise RuntimeError(
+                f"failed to create remote worktree: {result.stderr.decode('utf-8', errors='replace').strip()}"
+            )
+        return workdir
+
+    async def attach_remote_worktree(self, session_id: str) -> str:
+        """Return the path to an existing remote worktree.
+
+        Errors if no directory is present at the expected path.
+        """
+        workdir = str(PurePosixPath(self._path) / session_id)
+        check = await self.run_ssh(f"test -d {shlex.quote(workdir)}")
+        if check.exit_code != 0:
+            raise FileNotFoundError(f"no remote worktree at {workdir}")
+        return workdir
+
+    async def destroy_remote_worktree(self, workdir: str) -> None:
+        """Best-effort cleanup of a remote worktree directory."""
+        script = (
+            f"if [ -d {shlex.quote(workdir)}/.git ]; then "
+            f"  git -C {shlex.quote(workdir)} worktree remove --force {shlex.quote(workdir)} 2>/dev/null || true; "
+            f"fi; "
+            f"rm -rf {shlex.quote(workdir)}"
+        )
+        await self.run_ssh(script)
+
+    # ------------------------------------------------------------------
+    # SandboxBackend protocol
+    # ------------------------------------------------------------------
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a new remote session against ``manifest``.
+
+        Recognised ``options`` keys:
+
+        - ``session_id``: Pinned session identifier. Random when absent.
+        """
+        opts = dict(options or {})
+        hint = opts.get("session_id")
+        session_id = hint if isinstance(hint, str) and hint else f"sbx-{secrets.token_hex(6)}"
+        workdir = await self.create_remote_worktree(manifest, session_id)
+
+        if manifest.files:
+            for entry in manifest.files:
+                target = str(PurePosixPath(workdir) / entry.path)
+                payload = base64.b64encode(entry.content).decode("ascii")
+                parent = str(PurePosixPath(target).parent)
+                script = (
+                    f"mkdir -p {shlex.quote(parent)} && "
+                    f"printf '%s' {shlex.quote(payload)} | base64 -d > {shlex.quote(target)} && "
+                    f"chmod {entry.mode:o} {shlex.quote(target)}"
+                )
+                await self.run_ssh(script)
+
+        session = SSHSandboxSession(
+            backend=self,
+            session_id=session_id,
+            workdir=workdir,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        """SSH backend does not support snapshot/resume."""
+        raise NotImplementedError("SSHSandboxBackend does not declare the SNAPSHOT capability")
+
+    async def destroy(self, session: SandboxSession) -> None:
+        """Shut down ``session`` and drop it from the internal table."""
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "SSHSandboxBackend",
+    "SSHSandboxSession",
+    "SandboxConnectionError",
+]

--- a/src/bernstein/core/sandbox/ssh_backend.py
+++ b/src/bernstein/core/sandbox/ssh_backend.py
@@ -253,7 +253,7 @@ class SSHSandboxSession(SandboxSession):
         else:
             script += quoted_cmd
 
-        return await self._backend.run_ssh(script, timeout=effective_timeout, stdin=stdin)
+        return await self._backend.run_ssh(script, timeout_seconds=effective_timeout, stdin=stdin)
 
     # ------------------------------------------------------------------
     # Snapshots (unsupported)
@@ -474,7 +474,7 @@ class SSHSandboxBackend:
         self,
         cmd: str,
         *,
-        timeout: int | None = None,
+        timeout_seconds: int | None = None,
         stdin: bytes | None = None,
     ) -> ExecResult:
         """Run ``cmd`` on the remote host and collect the result."""
@@ -487,9 +487,9 @@ class SSHSandboxBackend:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        wait_for = timeout + _DEFAULT_TIMEOUT_SLACK if timeout else None
+        deadline = timeout_seconds + _DEFAULT_TIMEOUT_SLACK if timeout_seconds else None
         try:
-            async with asyncio.timeout(wait_for):
+            async with asyncio.timeout(deadline):
                 stdout, stderr = await process.communicate(input=stdin)
         except TimeoutError:
             process.kill()
@@ -498,7 +498,7 @@ class SSHSandboxBackend:
                     await process.wait()
             except TimeoutError:
                 logger.warning("ssh process did not exit after kill: %s", argv)
-            raise TimeoutError(f"ssh command timed out after {timeout}s") from None
+            raise TimeoutError(f"ssh command timed out after {timeout_seconds}s") from None
         duration = time.monotonic() - start
         exit_code = process.returncode if process.returncode is not None else -1
         if exit_code != 0:

--- a/tests/integration/test_pipeline_e2e.py
+++ b/tests/integration/test_pipeline_e2e.py
@@ -15,7 +15,6 @@ import pytest
 from bernstein.core.git_pr import merge_branch
 from bernstein.core.guardrails import GuardrailsConfig
 from bernstein.core.janitor import evaluate_signal, run_janitor, verify_task
-from bernstein.core.lifecycle import transition_task
 from bernstein.core.models import (
     CompletionSignal,
     ModelConfig,
@@ -24,6 +23,7 @@ from bernstein.core.models import (
 )
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.lifecycle import transition_task
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -87,13 +87,20 @@ _ADAPTER_FACTORIES: list[tuple[str, Any]] = [
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.usefixtures("no_watchdog_threads")
 @pytest.mark.parametrize(
     "name,factory",
     _ADAPTER_FACTORIES,
     ids=[f[0] for f in _ADAPTER_FACTORIES],
 )
 class TestAdapterContract:
-    """Every adapter must satisfy the CLIAdapter abstract interface."""
+    """Every adapter must satisfy the CLIAdapter abstract interface.
+
+    The watchdog-threads fixture is applied class-wide — the contract
+    suite parameterizes across every registered adapter, and each
+    ``spawn()`` call would otherwise arm a daemon Timer that outlives
+    the test and eventually hits the runner's thread limit on CI.
+    """
 
     def test_is_subclass_of_cli_adapter(self, name: str, factory: Any) -> None:
         adapter = factory()

--- a/tests/unit/test_benchmarks.py
+++ b/tests/unit/test_benchmarks.py
@@ -15,9 +15,10 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from bernstein.core.lifecycle import transition_task
 from bernstein.core.models import Task, TaskStatus
 from bernstein.core.task_store import TaskStore
+
+from bernstein.core.lifecycle import transition_task
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/test_chaos_server_restart.py
+++ b/tests/unit/test_chaos_server_restart.py
@@ -14,11 +14,6 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from bernstein.core.lifecycle import (
-    IllegalTransitionError,
-    transition_agent,
-    transition_task,
-)
 from bernstein.core.models import (
     AgentSession,
     ModelConfig,
@@ -30,6 +25,12 @@ from bernstein.core.wal import (
     WALReader,
     WALRecovery,
     WALWriter,
+)
+
+from bernstein.core.lifecycle import (
+    IllegalTransitionError,
+    transition_agent,
+    transition_task,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_lifecycle.py
+++ b/tests/unit/test_lifecycle.py
@@ -1,6 +1,8 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bernstein.core.models import AbortReason, AgentSession, Task, TaskStatus, TransitionReason
+
 from bernstein.core.lifecycle import (
     IllegalTransitionError,
     add_listener,
@@ -9,7 +11,6 @@ from bernstein.core.lifecycle import (
     transition_agent,
     transition_task,
 )
-from bernstein.core.models import AbortReason, AgentSession, Task, TaskStatus, TransitionReason
 
 
 @pytest.fixture

--- a/tests/unit/test_lifecycle_hooks.py
+++ b/tests/unit/test_lifecycle_hooks.py
@@ -1,0 +1,266 @@
+"""Unit tests for the lifecycle-hooks subsystem."""
+
+from __future__ import annotations
+
+import os
+import stat
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.hooks_cmd import hooks as hooks_group
+from bernstein.core.config.hook_config import (
+    PluginHookEntry,
+    ScriptHookEntry,
+    apply_config,
+    parse_hook_config,
+)
+from bernstein.core.lifecycle.hooks import (
+    HookFailure,
+    HookRegistry,
+    LifecycleContext,
+    LifecycleEvent,
+)
+from bernstein.core.lifecycle.pluggy_bridge import (
+    apply_hooks_to_existing_system,
+)
+from bernstein.plugins import hookimpl
+
+
+def _write_script(path: Path, body: str) -> Path:
+    """Create an executable script with the given body."""
+    path.write_text("#!/usr/bin/env bash\n" + body, encoding="utf-8")
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return path
+
+
+def test_register_script_runs_with_env_vars(tmp_path: Path) -> None:
+    marker = tmp_path / "out.txt"
+    script = _write_script(
+        tmp_path / "hook.sh",
+        f'printf "%s|%s|%s|%s" "$BERNSTEIN_EVENT" "$BERNSTEIN_TASK_ID" "$BERNSTEIN_SESSION_ID" "$BERNSTEIN_WORKDIR" > {marker}\n',
+    )
+
+    registry = HookRegistry()
+    registry.register_script(LifecycleEvent.PRE_TASK, script)
+    ctx = LifecycleContext(
+        event=LifecycleEvent.PRE_TASK,
+        task="T-1",
+        session_id="S-1",
+        workdir=tmp_path,
+    )
+    registry.run(LifecycleEvent.PRE_TASK, ctx)
+
+    assert marker.read_text(encoding="utf-8") == f"pre_task|T-1|S-1|{tmp_path}"
+
+
+def test_script_nonzero_exit_raises_hook_failure(tmp_path: Path) -> None:
+    script = _write_script(tmp_path / "bad.sh", 'echo "boom" >&2\nexit 7\n')
+
+    registry = HookRegistry()
+    registry.register_script(LifecycleEvent.POST_TASK, script)
+    ctx = LifecycleContext(event=LifecycleEvent.POST_TASK, workdir=tmp_path)
+
+    with pytest.raises(HookFailure) as excinfo:
+        registry.run(LifecycleEvent.POST_TASK, ctx)
+
+    assert excinfo.value.exit_code == 7
+    assert str(script) in excinfo.value.hook
+    assert "boom" in excinfo.value.stderr
+
+
+def test_register_callable_receives_context(tmp_path: Path) -> None:
+    received: list[LifecycleContext] = []
+
+    def handler(ctx: LifecycleContext) -> None:
+        received.append(ctx)
+
+    registry = HookRegistry()
+    registry.register_callable(LifecycleEvent.PRE_MERGE, handler)
+    ctx = LifecycleContext(event=LifecycleEvent.PRE_MERGE, task="T-9", workdir=tmp_path)
+    registry.run(LifecycleEvent.PRE_MERGE, ctx)
+
+    assert len(received) == 1
+    assert received[0].task == "T-9"
+    assert received[0].event is LifecycleEvent.PRE_MERGE
+
+
+def test_callable_exception_becomes_hook_failure(tmp_path: Path) -> None:
+    def boom(ctx: LifecycleContext) -> None:
+        raise RuntimeError("nope")
+
+    registry = HookRegistry()
+    registry.register_callable(LifecycleEvent.POST_TASK, boom)
+    ctx = LifecycleContext(event=LifecycleEvent.POST_TASK, workdir=tmp_path)
+
+    with pytest.raises(HookFailure) as excinfo:
+        registry.run(LifecycleEvent.POST_TASK, ctx)
+
+    assert excinfo.value.exit_code is None
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+
+def test_run_async_does_not_block(tmp_path: Path) -> None:
+    def slow(ctx: LifecycleContext) -> None:
+        time.sleep(0.25)
+
+    registry = HookRegistry()
+    registry.register_callable(LifecycleEvent.POST_MERGE, slow)
+    ctx = LifecycleContext(event=LifecycleEvent.POST_MERGE, workdir=tmp_path)
+
+    start = time.monotonic()
+    future = registry.run_async(LifecycleEvent.POST_MERGE, ctx)
+    elapsed = time.monotonic() - start
+
+    # Scheduling must return essentially immediately.
+    assert elapsed < 0.1
+    future.result(timeout=5)
+    registry.shutdown()
+
+
+def test_config_parses_mixed_script_and_plugin() -> None:
+    raw = {
+        "pre_task": ["scripts/pre-flight.sh"],
+        "post_merge": [
+            {"script": "scripts/notify.sh", "timeout": 10},
+            {"plugin": "bernstein_plugin_jira"},
+        ],
+    }
+
+    config = parse_hook_config(raw)
+
+    pre_task_scripts = config.scripts[LifecycleEvent.PRE_TASK]
+    assert pre_task_scripts == [ScriptHookEntry(path=Path("scripts/pre-flight.sh"))]
+
+    post_merge_scripts = config.scripts[LifecycleEvent.POST_MERGE]
+    assert post_merge_scripts == [ScriptHookEntry(path=Path("scripts/notify.sh"), timeout=10)]
+
+    post_merge_plugins = config.plugins[LifecycleEvent.POST_MERGE]
+    assert post_merge_plugins == [PluginHookEntry(name="bernstein_plugin_jira")]
+
+
+def test_config_rejects_unknown_event() -> None:
+    with pytest.raises(Exception) as excinfo:
+        parse_hook_config({"totally_fake": ["x.sh"]})
+    assert "totally_fake" in str(excinfo.value)
+
+
+def test_apply_config_registers_scripts_in_order(tmp_path: Path) -> None:
+    first = _write_script(tmp_path / "a.sh", "true\n")
+    second = _write_script(tmp_path / "b.sh", "true\n")
+    config = parse_hook_config({"pre_task": [str(first), str(second)]})
+
+    registry = HookRegistry()
+    apply_config(registry, config)
+
+    labels = registry.registered(LifecycleEvent.PRE_TASK)
+    assert labels == [f"script:{first}", f"script:{second}"]
+
+
+def test_hooks_check_flags_missing_script(tmp_path: Path) -> None:
+    config_file = tmp_path / "bernstein.yaml"
+    config_file.write_text(
+        "hooks:\n  pre_task:\n    - scripts/does-not-exist.sh\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hooks_group, ["check", "--config", str(config_file)])
+    assert result.exit_code == 1
+    combined = result.output + (result.stderr if result.stderr_bytes is not None else "")
+    assert "does-not-exist.sh" in combined
+
+
+def test_hooks_check_flags_non_executable_script(tmp_path: Path) -> None:
+    script = tmp_path / "notexec.sh"
+    script.write_text("#!/usr/bin/env bash\ntrue\n", encoding="utf-8")
+    # Strip any execute bits to simulate a missing chmod.
+    script.chmod(script.stat().st_mode & ~(stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH))
+
+    config_file = tmp_path / "bernstein.yaml"
+    config_file.write_text(
+        f"hooks:\n  pre_task:\n    - {script}\n",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hooks_group, ["check", "--config", str(config_file)])
+    assert result.exit_code == 1
+    combined = result.output + (result.stderr if result.stderr_bytes is not None else "")
+    assert "not executable" in combined
+
+
+def test_pluggy_bridge_dispatches_pre_task(tmp_path: Path) -> None:
+    received: list[LifecycleContext] = []
+
+    class MyPlugin:
+        @hookimpl
+        def pre_task(self, ctx: LifecycleContext) -> None:
+            received.append(ctx)
+
+    registry = HookRegistry()
+    pm = apply_hooks_to_existing_system(registry)
+    pm.register(MyPlugin())
+
+    ctx = LifecycleContext(event=LifecycleEvent.PRE_TASK, task="T-77", workdir=tmp_path)
+    registry.run(LifecycleEvent.PRE_TASK, ctx)
+
+    assert len(received) == 1
+    assert received[0].task == "T-77"
+
+
+def test_ordering_preserved_between_scripts_and_callables(tmp_path: Path) -> None:
+    order: list[str] = []
+    marker_first = tmp_path / "first.log"
+    marker_second = tmp_path / "second.log"
+    first = _write_script(tmp_path / "first.sh", f"echo one > {marker_first}\n")
+    second = _write_script(tmp_path / "second.sh", f"echo two > {marker_second}\n")
+
+    def middle(ctx: LifecycleContext) -> None:
+        order.append("callable")
+
+    registry = HookRegistry()
+    registry.register_script(LifecycleEvent.POST_SPAWN, first)
+    registry.register_callable(LifecycleEvent.POST_SPAWN, middle)
+    registry.register_script(LifecycleEvent.POST_SPAWN, second)
+
+    # Confirm ordering ledger matches registration order before dispatch.
+    labels = registry.registered(LifecycleEvent.POST_SPAWN)
+    assert labels[0].startswith("script:")
+    assert labels[1].startswith("callable:")
+    assert labels[2].startswith("script:")
+
+    ctx = LifecycleContext(event=LifecycleEvent.POST_SPAWN, workdir=tmp_path)
+    registry.run(LifecycleEvent.POST_SPAWN, ctx)
+
+    # first.sh must have produced its marker before second.sh — we rely on
+    # mtimes as a coarse ordering check on filesystems that support them.
+    assert marker_first.exists() and marker_second.exists()
+    assert marker_first.stat().st_mtime <= marker_second.stat().st_mtime
+    assert order == ["callable"]
+
+
+def test_parent_env_is_not_leaked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A secret in the parent env must not reach the subprocess.
+    monkeypatch.setenv("SUPER_SECRET_FOO", "leak-me")
+    monkeypatch.setenv("BERNSTEIN_PROJECT", "proj")
+
+    marker = tmp_path / "env.out"
+    script = _write_script(
+        tmp_path / "env.sh",
+        f'{{ echo "SECRET=${{SUPER_SECRET_FOO:-unset}}"; echo "PROJECT=${{BERNSTEIN_PROJECT:-unset}}"; }} > {marker}\n',
+    )
+
+    registry = HookRegistry()
+    registry.register_script(LifecycleEvent.PRE_SPAWN, script)
+    ctx = LifecycleContext(event=LifecycleEvent.PRE_SPAWN, workdir=tmp_path)
+    registry.run(LifecycleEvent.PRE_SPAWN, ctx)
+
+    text = marker.read_text(encoding="utf-8")
+    assert "SECRET=unset" in text
+    assert "PROJECT=proj" in text
+    # Cleanup: os.environ is scoped to this test via monkeypatch.
+    assert os.environ.get("SUPER_SECRET_FOO") == "leak-me"

--- a/tests/unit/test_lifecycle_transitions.py
+++ b/tests/unit/test_lifecycle_transitions.py
@@ -9,6 +9,14 @@ from __future__ import annotations
 from typing import Literal
 
 import pytest
+from bernstein.core.models import (
+    AgentSession,
+    LifecycleEvent,
+    ModelConfig,
+    Task,
+    TaskStatus,
+)
+
 from bernstein.core.lifecycle import (
     AGENT_TRANSITIONS,
     TASK_TRANSITIONS,
@@ -19,13 +27,6 @@ from bernstein.core.lifecycle import (
     remove_listener,
     transition_agent,
     transition_task,
-)
-from bernstein.core.models import (
-    AgentSession,
-    LifecycleEvent,
-    ModelConfig,
-    Task,
-    TaskStatus,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mock_adapter.py
+++ b/tests/unit/test_mock_adapter.py
@@ -11,9 +11,10 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from bernstein.core.lifecycle import transition_task
 from bernstein.core.models import Task, TaskStatus
 from bernstein.core.task_store import TaskStore
+
+from bernstein.core.lifecycle import transition_task
 
 # ---------------------------------------------------------------------------
 # Deterministic mock adapter (test-level, not the production MockAgentAdapter)

--- a/tests/unit/test_pr_gen.py
+++ b/tests/unit/test_pr_gen.py
@@ -1,0 +1,244 @@
+"""Unit tests for :mod:`bernstein.core.integrations.pr_gen`.
+
+These tests deliberately avoid hitting the real filesystem except via
+``tmp_path``; the ``gh`` and ``git`` subprocess calls live in the CLI
+wrapper, not in the module under test.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.pr_cmd import pr_cmd
+from bernstein.core.integrations.pr_gen import (
+    CostBreakdown,
+    GateResult,
+    SessionSummary,
+    build_pr_body,
+    build_pr_title,
+    load_session_summary,
+)
+
+
+def _fixture_summary(**overrides: object) -> SessionSummary:
+    """Build a :class:`SessionSummary` with sensible defaults for tests."""
+    base: dict[str, object] = {
+        "session_id": "abcdef1234567890",
+        "goal": "Add JWT authentication with refresh tokens",
+        "branch": "agent/abcdef12",
+        "base_branch": "main",
+        "primary_role": "engineer",
+        "diff_stat": " src/auth.py | 42 +++++\n 1 file changed, 42 insertions(+)",
+        "gates": (
+            GateResult(name="lint", passed=True, detail="ruff: 0 findings"),
+            GateResult(name="types", passed=True),
+            GateResult(name="tests", passed=False, detail="1 failing"),
+        ),
+        "cost": CostBreakdown(
+            total_usd=1.2345,
+            total_tokens=123_456,
+            by_role={"manager": 0.20, "engineer": 1.00, "janitor": 0.03},
+        ),
+    }
+    base.update(overrides)
+    return SessionSummary(**base)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Title
+# ---------------------------------------------------------------------------
+
+
+def test_title_is_capped_and_outcome_shaped() -> None:
+    goal = (
+        "Add JWT authentication with refresh tokens and secure cookie storage "
+        "plus revocation list and audit logging end to end"
+    )
+    title = build_pr_title(goal, role="engineer")
+    assert len(title) <= 70
+    assert title.startswith("feat:"), title
+    # Outcome-shaped: no trailing period and cleaned whitespace.
+    assert "  " not in title
+    assert not title.endswith(".")
+
+
+def test_title_uses_fix_prefix_for_bug_language() -> None:
+    title = build_pr_title("Fix broken login flow on mobile", role="engineer")
+    assert title.startswith("fix:"), title
+    assert "broken login flow" in title
+
+
+def test_title_respects_existing_conventional_prefix() -> None:
+    title = build_pr_title("docs: document the new auth flow", role=None)
+    # The "docs" prefix must be detected and not double-stamped.
+    assert title.startswith("docs: ")
+    assert title.count("docs:") == 1
+
+
+# ---------------------------------------------------------------------------
+# Body
+# ---------------------------------------------------------------------------
+
+
+def test_body_contains_all_four_sections() -> None:
+    body = build_pr_body(_fixture_summary())
+    for header in ("## Summary", "## Changes", "## Verification", "## Cost"):
+        assert header in body, f"missing header {header!r}"
+    # Trailer references session id (short form only).
+    assert "Generated from Bernstein session" in body
+    assert "abcdef123456" in body
+
+
+def test_body_marks_passing_and_failing_gates() -> None:
+    body = build_pr_body(_fixture_summary())
+    # Passing gates get the green check; failing tests get the red cross.
+    assert "✅ **lint**" in body
+    assert "✅ **types**" in body
+    assert "❌ **tests**" in body
+    assert "1 failing" in body
+
+
+def test_cost_section_formats_zero_as_two_decimals() -> None:
+    summary = _fixture_summary(cost=CostBreakdown(total_usd=0.0, total_tokens=0, by_role={}))
+    body = build_pr_body(summary)
+    assert "$0.00" in body
+    assert "**Tokens:** 0" in body
+    # With no tokens or dollars, the effective rate should gracefully degrade.
+    assert "Effective rate:** n/a" in body
+
+
+def test_cost_section_reports_effective_rate_when_known() -> None:
+    body = build_pr_body(_fixture_summary())
+    # $1.2345 / 123_456 tokens * 1M ≈ $10.00 / 1M tokens.
+    assert "/ 1M tokens" in body
+    assert "$1.23" in body  # total rounded to two decimals
+
+
+def test_diff_stat_renders_in_code_fence() -> None:
+    body = build_pr_body(_fixture_summary())
+    assert "```" in body
+    assert "src/auth.py" in body
+
+
+# ---------------------------------------------------------------------------
+# load_session_summary
+# ---------------------------------------------------------------------------
+
+
+def test_load_session_summary_picks_newest_wrapup(tmp_path: Path) -> None:
+    sessions = tmp_path / ".sdd" / "sessions"
+    sessions.mkdir(parents=True)
+
+    older = sessions / "1000-older-wrapup.json"
+    older.write_text(
+        json.dumps(
+            {
+                "timestamp": 1000.0,
+                "session_id": "older",
+                "goal": "Older goal",
+                "git_diff_stat": "old.py | 1 +",
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    newer = sessions / "2000-newer-wrapup.json"
+    newer.write_text(
+        json.dumps(
+            {
+                "timestamp": 2000.0,
+                "session_id": "newer",
+                "goal": "Newer goal",
+                "git_diff_stat": "new.py | 2 +",
+                "gates": [
+                    {"name": "lint", "passed": True, "detail": "clean"},
+                    {"name": "tests", "passed": False, "detail": "2 failing"},
+                ],
+                "cost": {
+                    "total_usd": 0.42,
+                    "total_tokens": 4200,
+                    "by_role": {"engineer": 0.42},
+                },
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    # Force the mtimes so the newer file sorts first regardless of test
+    # execution speed.
+    older_mtime = time.time() - 3600
+    newer_mtime = time.time()
+    import os
+
+    os.utime(older, (older_mtime, older_mtime))
+    os.utime(newer, (newer_mtime, newer_mtime))
+
+    summary = load_session_summary(None, workdir=tmp_path)
+
+    assert summary.session_id == "newer"
+    assert summary.goal == "Newer goal"
+    assert summary.diff_stat == "new.py | 2 +"
+    assert len(summary.gates) == 2
+    assert summary.cost.total_usd == 0.42
+    assert summary.cost.by_role == {"engineer": 0.42}
+
+
+def test_load_session_summary_falls_back_to_live_session(tmp_path: Path) -> None:
+    """With no wrap-up files, the live ``session.json`` should drive the summary."""
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "session.json").write_text(
+        json.dumps(
+            {
+                "saved_at": 123.0,
+                "run_id": "run-xyz",
+                "goal": "Fallback goal",
+                "cost_spent": 0.05,
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    summary = load_session_summary(None, workdir=tmp_path)
+
+    assert summary.goal == "Fallback goal"
+    assert summary.session_id == "run-xyz"
+    assert summary.cost.total_usd == 0.05
+
+
+# ---------------------------------------------------------------------------
+# CLI dry-run behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_does_not_invoke_gh(tmp_path: Path) -> None:
+    """``--dry-run`` must return before touching git push or gh."""
+    runner = CliRunner()
+
+    fake_summary = _fixture_summary()
+
+    with (
+        patch(
+            "bernstein.cli.commands.pr_cmd.load_session_summary",
+            return_value=fake_summary,
+        ),
+        patch(
+            "bernstein.cli.commands.pr_cmd._enrich_summary_with_git",
+            side_effect=lambda s, _cwd: s,
+        ),
+        patch("bernstein.cli.commands.pr_cmd._push_branch") as push_mock,
+        patch("bernstein.cli.commands.pr_cmd._gh_pr_create") as gh_mock,
+        patch("bernstein.cli.commands.pr_cmd.shutil.which", return_value="/usr/bin/gh"),
+    ):
+        result = runner.invoke(pr_cmd, ["--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "Title: feat:" in result.output
+    assert "## Summary" in result.output
+    push_mock.assert_not_called()
+    gh_mock.assert_not_called()

--- a/tests/unit/test_pr_gen.py
+++ b/tests/unit/test_pr_gen.py
@@ -8,6 +8,7 @@ wrapper, not in the module under test.
 from __future__ import annotations
 
 import json
+import math
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -184,7 +185,7 @@ def test_load_session_summary_picks_newest_wrapup(tmp_path: Path) -> None:
     assert summary.goal == "Newer goal"
     assert summary.diff_stat == "new.py | 2 +"
     assert len(summary.gates) == 2
-    assert summary.cost.total_usd == 0.42
+    assert math.isclose(summary.cost.total_usd, 0.42)
     assert summary.cost.by_role == {"engineer": 0.42}
 
 
@@ -208,7 +209,7 @@ def test_load_session_summary_falls_back_to_live_session(tmp_path: Path) -> None
 
     assert summary.goal == "Fallback goal"
     assert summary.session_id == "run-xyz"
-    assert summary.cost.total_usd == 0.05
+    assert math.isclose(summary.cost.total_usd, 0.05)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_regression_orchestrator.py
+++ b/tests/unit/test_regression_orchestrator.py
@@ -17,13 +17,6 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 from bernstein.core.cost_tracker import BudgetStatus, CostTracker, TokenUsage, estimate_cost
-from bernstein.core.lifecycle import (
-    AGENT_TRANSITIONS,
-    TASK_TRANSITIONS,
-    IllegalTransitionError,
-    transition_agent,
-    transition_task,
-)
 from bernstein.core.models import (
     AgentSession,
     CompletionSignal,
@@ -45,6 +38,13 @@ from bernstein.core.task_lifecycle import (
 from bernstein.core.tick_pipeline import prioritize_starving_roles
 
 from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.lifecycle import (
+    AGENT_TRANSITIONS,
+    TASK_TRANSITIONS,
+    IllegalTransitionError,
+    transition_agent,
+    transition_task,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_ssh_sandbox.py
+++ b/tests/unit/test_ssh_sandbox.py
@@ -1,0 +1,245 @@
+"""Unit tests for the SSH sandbox backend and ``bernstein remote`` CLI.
+
+Every remote call is mocked at the :mod:`subprocess` boundary so the
+tests run without any network or a real ``ssh`` binary.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.remote_cmd import remote_group
+from bernstein.core.sandbox.ssh_backend import (
+    SandboxConnectionError,
+    SSHSandboxBackend,
+)
+
+
+def _completed(returncode: int, stderr: bytes = b"", stdout: bytes = b"") -> MagicMock:
+    """Return a stand-in for :class:`subprocess.CompletedProcess`."""
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# _build_ssh_cmd / flag assembly
+# ---------------------------------------------------------------------------
+
+
+def test_build_ssh_cmd_includes_identity_file(tmp_path: Path) -> None:
+    key = tmp_path / "id_test"
+    key.write_text("fake")
+    backend = SSHSandboxBackend(
+        host="example.com",
+        user="alice",
+        path="/tmp/bern",
+        identity_file=key,
+    )
+    argv = backend._build_ssh_cmd("echo hi")
+    assert argv[0] == "ssh"
+    assert "-i" in argv
+    assert str(key) in argv
+    assert argv[-2] == "alice@example.com"
+
+
+def test_build_ssh_cmd_omits_identity_when_unset() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    argv = backend._build_ssh_cmd("echo hi")
+    assert "-i" not in argv
+
+
+def test_build_ssh_cmd_wraps_command_in_sh_c() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    argv = backend._build_ssh_cmd("ls /")
+    # Last argv element is always the remote command wrapped in sh -c.
+    assert argv[-1].startswith("sh -c ")
+
+
+def test_connect_timeout_always_present() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    argv = backend._build_ssh_cmd("uptime")
+    joined = " ".join(argv)
+    assert "ConnectTimeout=10" in joined
+    assert "ServerAliveInterval=30" in joined
+
+
+def test_strict_host_key_checking_respected() -> None:
+    strict = SSHSandboxBackend(host="example.com", path="/tmp/bern", strict_host_key_checking=True)
+    lax = SSHSandboxBackend(host="example.com", path="/tmp/bern", strict_host_key_checking=False)
+    assert "StrictHostKeyChecking=yes" in " ".join(strict._build_ssh_cmd("echo"))
+    assert "StrictHostKeyChecking=accept-new" in " ".join(lax._build_ssh_cmd("echo"))
+
+
+def test_port_flag_used() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern", port=2222)
+    argv = backend._build_ssh_cmd("echo hi")
+    assert "-p" in argv
+    assert "2222" in argv
+
+
+# ---------------------------------------------------------------------------
+# ControlMaster socket deterministic path
+# ---------------------------------------------------------------------------
+
+
+def test_control_socket_deterministic_for_host_and_pid() -> None:
+    path_a = SSHSandboxBackend._build_control_socket_path("example.com", 12345)
+    path_b = SSHSandboxBackend._build_control_socket_path("example.com", 12345)
+    path_c = SSHSandboxBackend._build_control_socket_path("example.com", 99)
+    assert path_a == path_b
+    assert path_a != path_c
+    assert path_a.name == "bernstein-example.com-12345.sock"
+    assert path_a.parent.name == ".ssh"
+
+
+def test_control_socket_sanitises_dangerous_host_chars() -> None:
+    path = SSHSandboxBackend._build_control_socket_path("bad/host:22", 1)
+    assert "/" not in path.name.split("-", 1)[1][: -len("-1.sock")]
+    assert ":" not in path.name
+
+
+# ---------------------------------------------------------------------------
+# Error translation
+# ---------------------------------------------------------------------------
+
+
+def test_connection_refused_stderr_raises_sandbox_connection_error() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    with patch(
+        "bernstein.core.sandbox.ssh_backend.subprocess.run",
+        return_value=_completed(255, stderr=b"ssh: connect to host example.com port 22: Connection refused"),
+    ):
+        try:
+            backend.ensure_control_master()
+        except SandboxConnectionError as exc:
+            assert exc.host == "example.com"
+            assert "connection refused" in exc.reason
+        else:
+            raise AssertionError("SandboxConnectionError not raised")
+
+
+def test_permission_denied_stderr_hints_ssh_add() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    with patch(
+        "bernstein.core.sandbox.ssh_backend.subprocess.run",
+        return_value=_completed(255, stderr=b"Permission denied (publickey)."),
+    ):
+        try:
+            backend.ensure_control_master()
+        except SandboxConnectionError as exc:
+            assert exc.reason == "permission denied"
+            assert exc.hint is not None
+            assert "ssh-add" in exc.hint
+        else:
+            raise AssertionError("SandboxConnectionError not raised")
+
+
+# ---------------------------------------------------------------------------
+# spawn_agent wraps subprocess.Popen
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_agent_routes_through_ssh() -> None:
+    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+
+    fake_popen = MagicMock()
+    with (
+        patch.object(backend, "ensure_control_master"),
+        patch("subprocess.Popen", return_value=fake_popen) as popen,
+    ):
+        handle = backend.spawn_agent(
+            ["agent", "--task", "hello"],
+            cwd="/tmp/bern/sbx-123",
+        )
+
+    assert handle is fake_popen
+    argv = popen.call_args.args[0]
+    assert argv[0] == "ssh"
+    script = argv[-1]
+    assert "cd /tmp/bern/sbx-123" in script
+    assert "agent" in script
+    assert "hello" in script
+
+
+# ---------------------------------------------------------------------------
+# CLI: remote test
+# ---------------------------------------------------------------------------
+
+
+def test_remote_test_calls_ssh_uptime_and_returns_exit_code() -> None:
+    runner = CliRunner()
+    with (
+        patch(
+            "bernstein.cli.commands.remote_cmd.shutil.which",
+            return_value="/usr/bin/ssh",
+        ),
+        patch(
+            "bernstein.cli.commands.remote_cmd.subprocess.run",
+            return_value=_completed(0, stdout=b" 12:00  up 3 days\n"),
+        ) as run,
+    ):
+        result = runner.invoke(remote_group, ["test", "server.example.com"])
+
+    assert result.exit_code == 0
+    argv: list[str] = run.call_args.args[0]
+    assert argv[0] == "ssh"
+    assert argv[-1] == "uptime"
+    assert "server.example.com" in argv
+
+
+def test_remote_test_surfaces_permission_denied_hint() -> None:
+    runner = CliRunner()
+    with (
+        patch(
+            "bernstein.cli.commands.remote_cmd.shutil.which",
+            return_value="/usr/bin/ssh",
+        ),
+        patch(
+            "bernstein.cli.commands.remote_cmd.subprocess.run",
+            return_value=_completed(255, stderr=b"Permission denied (publickey)."),
+        ),
+    ):
+        result = runner.invoke(remote_group, ["test", "server.example.com"])
+
+    assert result.exit_code != 0
+    assert "ssh-add" in result.output or "IdentityFile" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: remote forget
+# ---------------------------------------------------------------------------
+
+
+def test_remote_forget_removes_control_socket(tmp_path: Path) -> None:
+    runner = CliRunner()
+    fake_sock = MagicMock(spec=Path)
+    fake_sock.__str__.return_value = "/home/u/.ssh/bernstein-h-1.sock"
+    fake_sock.unlink = MagicMock()
+
+    with patch(
+        "bernstein.cli.commands.remote_cmd._control_socket_candidates",
+        return_value=[fake_sock],
+    ):
+        result = runner.invoke(remote_group, ["forget", "server.example.com"])
+
+    assert result.exit_code == 0
+    fake_sock.unlink.assert_called_once()
+    assert "forgot 1 socket" in result.output
+
+
+def test_remote_forget_without_candidates_is_no_op() -> None:
+    runner = CliRunner()
+    with patch(
+        "bernstein.cli.commands.remote_cmd._control_socket_candidates",
+        return_value=[],
+    ):
+        result = runner.invoke(remote_group, ["forget", "unknown.example"])
+
+    assert result.exit_code == 0
+    assert "no cached sockets" in result.output

--- a/tests/unit/test_ssh_sandbox.py
+++ b/tests/unit/test_ssh_sandbox.py
@@ -155,14 +155,14 @@ def test_spawn_agent_routes_through_ssh() -> None:
     ):
         handle = backend.spawn_agent(
             ["agent", "--task", "hello"],
-            cwd="/tmp/bern/sbx-123",
+            cwd="/srv/bern/sbx-123",
         )
 
     assert handle is fake_popen
     argv = popen.call_args.args[0]
     assert argv[0] == "ssh"
     script = argv[-1]
-    assert "cd /tmp/bern/sbx-123" in script
+    assert "cd /srv/bern/sbx-123" in script
     assert "agent" in script
     assert "hello" in script
 

--- a/tests/unit/test_ssh_sandbox.py
+++ b/tests/unit/test_ssh_sandbox.py
@@ -38,7 +38,7 @@ def test_build_ssh_cmd_includes_identity_file(tmp_path: Path) -> None:
     backend = SSHSandboxBackend(
         host="example.com",
         user="alice",
-        path="/tmp/bern",
+        path="/srv/bern",
         identity_file=key,
     )
     argv = backend._build_ssh_cmd("echo hi")
@@ -49,20 +49,20 @@ def test_build_ssh_cmd_includes_identity_file(tmp_path: Path) -> None:
 
 
 def test_build_ssh_cmd_omits_identity_when_unset() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern")
     argv = backend._build_ssh_cmd("echo hi")
     assert "-i" not in argv
 
 
 def test_build_ssh_cmd_wraps_command_in_sh_c() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern")
     argv = backend._build_ssh_cmd("ls /")
     # Last argv element is always the remote command wrapped in sh -c.
     assert argv[-1].startswith("sh -c ")
 
 
 def test_connect_timeout_always_present() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern")
     argv = backend._build_ssh_cmd("uptime")
     joined = " ".join(argv)
     assert "ConnectTimeout=10" in joined
@@ -70,14 +70,14 @@ def test_connect_timeout_always_present() -> None:
 
 
 def test_strict_host_key_checking_respected() -> None:
-    strict = SSHSandboxBackend(host="example.com", path="/tmp/bern", strict_host_key_checking=True)
-    lax = SSHSandboxBackend(host="example.com", path="/tmp/bern", strict_host_key_checking=False)
+    strict = SSHSandboxBackend(host="example.com", path="/srv/bern", strict_host_key_checking=True)
+    lax = SSHSandboxBackend(host="example.com", path="/srv/bern", strict_host_key_checking=False)
     assert "StrictHostKeyChecking=yes" in " ".join(strict._build_ssh_cmd("echo"))
     assert "StrictHostKeyChecking=accept-new" in " ".join(lax._build_ssh_cmd("echo"))
 
 
 def test_port_flag_used() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern", port=2222)
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern", port=2222)
     argv = backend._build_ssh_cmd("echo hi")
     assert "-p" in argv
     assert "2222" in argv
@@ -110,7 +110,7 @@ def test_control_socket_sanitises_dangerous_host_chars() -> None:
 
 
 def test_connection_refused_stderr_raises_sandbox_connection_error() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern")
     with patch(
         "bernstein.core.sandbox.ssh_backend.subprocess.run",
         return_value=_completed(255, stderr=b"ssh: connect to host example.com port 22: Connection refused"),
@@ -125,7 +125,7 @@ def test_connection_refused_stderr_raises_sandbox_connection_error() -> None:
 
 
 def test_permission_denied_stderr_hints_ssh_add() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern")
     with patch(
         "bernstein.core.sandbox.ssh_backend.subprocess.run",
         return_value=_completed(255, stderr=b"Permission denied (publickey)."),
@@ -146,7 +146,7 @@ def test_permission_denied_stderr_hints_ssh_add() -> None:
 
 
 def test_spawn_agent_routes_through_ssh() -> None:
-    backend = SSHSandboxBackend(host="example.com", path="/tmp/bern")
+    backend = SSHSandboxBackend(host="example.com", path="/srv/bern")
 
     fake_popen = MagicMock()
     with (

--- a/tests/unit/test_task_lifecycle_state_machine.py
+++ b/tests/unit/test_task_lifecycle_state_machine.py
@@ -18,6 +18,9 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from bernstein.core.models import AgentSession, Task, TaskStatus
+from bernstein.core.task_store import EmptyCompletionError, TaskStore
+
 from bernstein.core.lifecycle import (
     DuplicateTransitionError,
     _LRUSet,
@@ -25,8 +28,6 @@ from bernstein.core.lifecycle import (
     transition_agent,
     transition_task,
 )
-from bernstein.core.models import AgentSession, Task, TaskStatus
-from bernstein.core.task_store import EmptyCompletionError, TaskStore
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_task_store_property.py
+++ b/tests/unit/test_task_store_property.py
@@ -14,11 +14,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from bernstein.core.lifecycle import TASK_TRANSITIONS, IllegalTransitionError, transition_task
 from bernstein.core.models import Task, TaskStatus
 from bernstein.core.task_store import TaskStore
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
+
+from bernstein.core.lifecycle import TASK_TRANSITIONS, IllegalTransitionError, transition_task
 
 
 def _run_async(coro: Any) -> Any:

--- a/tests/unit/test_ticket_import.py
+++ b/tests/unit/test_ticket_import.py
@@ -1,0 +1,362 @@
+"""Unit tests for the ticket import command and providers."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.ticket_cmd import (
+    build_task_payload,
+    from_ticket,
+    infer_role,
+    infer_scope,
+)
+from bernstein.core.integrations.tickets import (
+    TicketAuthError,
+    TicketParseError,
+    TicketPayload,
+    fetch_ticket,
+)
+
+# ---------------------------------------------------------------------------
+# URL routing
+# ---------------------------------------------------------------------------
+
+
+def _payload(source: str = "github") -> TicketPayload:
+    return TicketPayload(
+        id="ENG-1",
+        title="Example",
+        description="body",
+        labels=(),
+        assignee=None,
+        url="https://example.test",
+        source=source,  # type: ignore[arg-type]
+    )
+
+
+def test_routes_linear_web_url_to_linear_provider() -> None:
+    with patch(
+        "bernstein.core.integrations.tickets.linear.fetch_linear",
+        return_value=_payload("linear"),
+    ) as mock_linear:
+        result = fetch_ticket("https://linear.app/acme/issue/ENG-123")
+    mock_linear.assert_called_once()
+    assert result.source == "linear"
+
+
+def test_routes_linear_scheme_to_linear_provider() -> None:
+    with patch(
+        "bernstein.core.integrations.tickets.linear.fetch_linear",
+        return_value=_payload("linear"),
+    ) as mock_linear:
+        fetch_ticket("linear://ENG-42")
+    mock_linear.assert_called_once()
+
+
+def test_routes_github_url_to_github_provider() -> None:
+    with patch(
+        "bernstein.core.integrations.tickets.github_issues.fetch_github_issue",
+        return_value=_payload("github"),
+    ) as mock_gh:
+        result = fetch_ticket("https://github.com/acme/widgets/issues/7")
+    mock_gh.assert_called_once()
+    assert result.source == "github"
+
+
+def test_routes_jira_url_to_jira_provider() -> None:
+    with patch(
+        "bernstein.core.integrations.tickets.jira.fetch_jira",
+        return_value=_payload("jira"),
+    ) as mock_jira:
+        fetch_ticket("https://acme.atlassian.net/browse/ENG-9")
+    mock_jira.assert_called_once()
+
+
+def test_unrecognized_url_raises_parse_error() -> None:
+    with pytest.raises(TicketParseError):
+        fetch_ticket("https://example.com/not/a/ticket")
+
+
+# ---------------------------------------------------------------------------
+# Linear auth
+# ---------------------------------------------------------------------------
+
+
+def test_linear_raises_auth_error_when_env_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.integrations.tickets import linear
+
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    with pytest.raises(TicketAuthError) as excinfo:
+        linear.fetch_linear("https://linear.app/acme/issue/ENG-1")
+    assert "LINEAR_API_KEY" in str(excinfo.value)
+
+
+def test_linear_fetch_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.integrations.tickets import linear
+
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_api_test")
+
+    response = {
+        "data": {
+            "issue": {
+                "identifier": "ENG-42",
+                "title": "Fix login",
+                "description": "It is broken.",
+                "url": "https://linear.app/acme/issue/ENG-42",
+                "labels": {"nodes": [{"name": "bug"}, {"name": "frontend"}]},
+                "assignee": {"displayName": "Ada Lovelace", "name": "ada"},
+            }
+        }
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = response
+
+    with patch("httpx.post", return_value=mock_resp) as mock_post:
+        payload = linear.fetch_linear("https://linear.app/acme/issue/ENG-42")
+
+    mock_post.assert_called_once()
+    assert payload.id == "ENG-42"
+    assert payload.title == "Fix login"
+    assert payload.labels == ("bug", "frontend")
+    assert payload.assignee == "Ada Lovelace"
+    assert payload.source == "linear"
+
+
+# ---------------------------------------------------------------------------
+# GitHub: gh CLI path and REST fallback
+# ---------------------------------------------------------------------------
+
+
+def test_github_gh_cli_path_parses() -> None:
+    from bernstein.core.integrations.tickets import github_issues
+
+    gh_stdout = json.dumps(
+        {
+            "number": 7,
+            "title": "Add tests",
+            "body": "We need more.",
+            "labels": [{"name": "docs"}],
+            "assignees": [{"login": "alice"}],
+            "url": "https://github.com/acme/widgets/issues/7",
+        }
+    )
+
+    proc = subprocess.CompletedProcess(args=["gh"], returncode=0, stdout=gh_stdout, stderr="")
+
+    with (
+        patch.object(github_issues, "_gh_available", return_value=True),
+        patch.object(github_issues.subprocess, "run", return_value=proc) as mock_run,
+    ):
+        payload = github_issues.fetch_github_issue("https://github.com/acme/widgets/issues/7")
+
+    mock_run.assert_called_once()
+    assert payload.id == "acme/widgets#7"
+    assert payload.title == "Add tests"
+    assert payload.labels == ("docs",)
+    assert payload.assignee == "alice"
+    assert payload.source == "github"
+
+
+def test_github_rest_fallback_parses(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.integrations.tickets import github_issues
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+    rest_body = {
+        "number": 11,
+        "title": "Refactor",
+        "body": "Split the function.",
+        "labels": [{"name": "backend"}, "refactor"],
+        "assignee": {"login": "bob"},
+        "html_url": "https://github.com/acme/widgets/issues/11",
+    }
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = rest_body
+
+    with (
+        patch.object(github_issues, "_gh_available", return_value=False),
+        patch("httpx.get", return_value=mock_resp) as mock_get,
+    ):
+        payload = github_issues.fetch_github_issue("https://github.com/acme/widgets/issues/11")
+
+    mock_get.assert_called_once()
+    assert payload.id == "acme/widgets#11"
+    assert payload.title == "Refactor"
+    assert payload.labels == ("backend", "refactor")
+    assert payload.assignee == "bob"
+
+
+def test_github_rest_missing_token_raises_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.integrations.tickets import github_issues
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    with patch.object(github_issues, "_gh_available", return_value=False):
+        with pytest.raises(TicketAuthError) as excinfo:
+            github_issues.fetch_github_issue("https://github.com/acme/widgets/issues/1")
+    assert "GITHUB_TOKEN" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Jira parsing (incl. ADF description)
+# ---------------------------------------------------------------------------
+
+
+def test_jira_parses_adf_description(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.integrations.tickets import jira
+
+    monkeypatch.setenv("JIRA_EMAIL", "user@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "tok")
+
+    adf_description = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "First paragraph. "},
+                    {"type": "text", "text": "More text."},
+                ],
+            },
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Second paragraph."}],
+            },
+        ],
+    }
+    body = {
+        "key": "ENG-9",
+        "fields": {
+            "summary": "Improve logging",
+            "description": adf_description,
+            "labels": ["security", "backend"],
+            "assignee": {"displayName": "Carol"},
+        },
+    }
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = body
+
+    with patch("httpx.get", return_value=mock_resp):
+        payload = jira.fetch_jira("https://acme.atlassian.net/browse/ENG-9")
+
+    assert payload.id == "ENG-9"
+    assert payload.title == "Improve logging"
+    assert "First paragraph" in payload.description
+    assert "Second paragraph" in payload.description
+    assert payload.labels == ("security", "backend")
+    assert payload.assignee == "Carol"
+    assert payload.source == "jira"
+
+
+# ---------------------------------------------------------------------------
+# Role / scope inference
+# ---------------------------------------------------------------------------
+
+
+def test_role_inference_bug_to_qa() -> None:
+    assert infer_role(("bug",)) == "qa"
+
+
+def test_role_inference_docs_to_docs() -> None:
+    assert infer_role(("documentation",)) == "docs"
+    assert infer_role(("docs",)) == "docs"
+
+
+def test_role_inference_fallback_to_default() -> None:
+    assert infer_role(("weird", "unseen")) == "backend"
+    assert infer_role((), default="custom") == "custom"
+
+
+def test_scope_inference() -> None:
+    assert infer_scope(("small",)) == "small"
+    assert infer_scope(("epic",)) == "large"
+    assert infer_scope(()) == "medium"
+
+
+# ---------------------------------------------------------------------------
+# CLI: dry-run, metadata, --run
+# ---------------------------------------------------------------------------
+
+
+def _fake_ticket(**overrides: Any) -> TicketPayload:
+    defaults: dict[str, Any] = {
+        "id": "ENG-1",
+        "title": "Fix things",
+        "description": "Lots to fix.",
+        "labels": ("bug",),
+        "assignee": "alice",
+        "url": "https://linear.app/acme/issue/ENG-1",
+        "source": "linear",
+    }
+    defaults.update(overrides)
+    return TicketPayload(**defaults)
+
+
+def test_dry_run_does_not_call_task_store() -> None:
+    runner = CliRunner()
+    with (
+        patch("bernstein.cli.commands.ticket_cmd.fetch_ticket", return_value=_fake_ticket()),
+        patch("bernstein.cli.commands.ticket_cmd.server_post") as mock_post,
+    ):
+        result = runner.invoke(
+            from_ticket,
+            ["https://linear.app/acme/issue/ENG-1", "--dry-run"],
+        )
+    assert result.exit_code == 0, result.output
+    mock_post.assert_not_called()
+    # Dry-run should emit the payload JSON
+    assert "metadata" in result.output
+    assert "ENG-1" in result.output
+
+
+def test_task_payload_carries_source_and_external_id() -> None:
+    ticket = _fake_ticket(source="jira", id="ENG-42", labels=("docs",))
+    payload = build_task_payload(ticket, role=None, priority=None)
+    assert payload["metadata"] == {
+        "source": "jira",
+        "external_id": "ENG-42",
+        "url": "https://linear.app/acme/issue/ENG-1",
+    }
+    # Role inferred from label
+    assert payload["role"] == "docs"
+
+
+def test_create_path_posts_to_server_and_honors_run_flag() -> None:
+    runner = CliRunner()
+    fake_post = MagicMock(return_value={"id": "tsk_abc"})
+    with (
+        patch("bernstein.cli.commands.ticket_cmd.fetch_ticket", return_value=_fake_ticket()),
+        patch("bernstein.cli.commands.ticket_cmd.server_post", fake_post),
+        patch("bernstein.cli.commands.ticket_cmd.subprocess.call", return_value=0) as mock_call,
+    ):
+        result = runner.invoke(
+            from_ticket,
+            ["https://linear.app/acme/issue/ENG-1", "--run", "--priority", "high"],
+        )
+
+    assert result.exit_code == 0, result.output
+    fake_post.assert_called_once()
+    posted_path, posted_payload = fake_post.call_args.args
+    assert posted_path == "/tasks"
+    # --priority high maps to 1
+    assert posted_payload["priority"] == 1
+    mock_call.assert_called_once()
+    assert mock_call.call_args.args[0][-1] == "tsk_abc"
+
+
+def test_explicit_role_flag_overrides_inference() -> None:
+    ticket = _fake_ticket(labels=("bug",))
+    payload = build_task_payload(ticket, role="backend", priority="low")
+    assert payload["role"] == "backend"
+    assert payload["priority"] == 3


### PR DESCRIPTION
## Summary
Four self-contained operator features land together. Each ships as its own command with real tests (58 new unit tests, 0 new lint errors, pyright-strict clean).

### `bernstein pr`
Auto-creates a GitHub PR from a completed session. Reads task goal, janitor gate results, and cost breakdown; emits a conventional-commit title and a markdown body with **Summary / Changes / Verification / Cost** sections. Flags: `--session-id`, `--base`, `--title`, `--draft`, `--dry-run`, `--no-push`.

### `bernstein from-ticket <url>`
Imports a **Linear**, **GitHub Issues**, or **Jira** ticket into a Bernstein task. URL-routed fetchers; credentials via env vars (`LINEAR_API_KEY`, `GITHUB_TOKEN`, `JIRA_EMAIL`+`JIRA_API_TOKEN`). Label-based role & scope inference. `--dry-run` and `--run` flags.

### `bernstein remote`
SSH sandbox backend for running agents on remote hosts:
- `remote test <host>` — smoke-checks connectivity with round-trip time.
- `remote run <host> <path>` — dispatches a run over SSH with ControlMaster socket reuse.
- `remote forget <host>` — cleans up the socket.

`ConnectTimeout=10`, `ServerAliveInterval=30`, error translation for connection-refused / permission-denied.

### `bernstein hooks`
Lifecycle hooks for `pre_task`, `post_task`, `pre_merge`, `post_merge`, `pre_spawn`, `post_spawn` — as shell scripts, Python callables, or pluggy hookimpls. Scripts get JSON context on stdin and `BERNSTEIN_*` env vars. Subcommands: `hooks list`, `hooks run <event>`, `hooks check`.

## Why one PR
Each feature is independent, but they share the same "operator-first" thesis — you shouldn't have to hand-write a PR description, copy ticket text, SSH to a box to run an agent, or shell-glue your own pre/post hooks. Coherent as one delivery.

## Test plan
- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest tests/unit/test_{pr_gen,ticket_import,ssh_sandbox,lifecycle_hooks}.py -x -q` — **58 passed**
- [x] CLI smoke: `bernstein pr|from-ticket|ticket|remote|hooks --help` all register correctly.
- [x] `bernstein.core.lifecycle` backwards-compatibility shim preserves legacy `transition_agent` / `transition_task` imports via a sys.modules alias; existing lifecycle FSM tests still green.