### PR TITLE
feat(acp): native ACP bridge for IDE clients

### DIFF
--- a/docs/reference/acp-bridge.md
+++ b/docs/reference/acp-bridge.md
@@ -1,0 +1,92 @@
+# ACP native bridge
+
+Bernstein speaks the [Agent Client Protocol](https://agentclientprotocol.org)
+natively — editors that ship ACP support can plug Bernstein in as their
+backend with zero per-IDE plumbing.
+
+The bridge is a protocol adapter: ACP `prompt` opens a Bernstein task,
+`streamUpdate` notifications tail the existing streaming-merge utility,
+`cancel` walks the standard drain pipeline, and `setMode` toggles the
+janitor approval gate. Cost-aware routing, HMAC audit, and sandbox-backend
+selection apply identically to ACP-initiated and CLI-initiated sessions.
+
+## Transports
+
+| Transport | When to use | Command |
+| --------- | ----------- | ------- |
+| stdio (line-delimited JSON-RPC) | IDE embedding (default) | `bernstein acp serve --stdio` |
+| HTTP / SSE | remote IDEs, CI, debugging | `bernstein acp serve --http :8062` |
+
+Stdio is the canonical IDE transport: the editor spawns
+`bernstein acp serve --stdio` as a subprocess and exchanges
+line-delimited JSON-RPC frames over its stdio pipes. The HTTP transport
+accepts a single JSON-RPC frame per `POST /acp` request and supports
+`Accept: text/event-stream` for streaming responses.
+
+## Zed `settings.json`
+
+```json
+{
+  "agent_servers": {
+    "bernstein": {
+      "command": "bernstein",
+      "args": ["acp", "serve", "--stdio"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Generic ACP client (any editor)
+
+```json
+{
+  "name": "bernstein",
+  "transport": "stdio",
+  "command": ["bernstein", "acp", "serve", "--stdio"],
+  "protocolVersion": "2025-04-01"
+}
+```
+
+For HTTP-mode integrations, point the client at `http://127.0.0.1:8062/acp`
+and set `Accept: text/event-stream` to receive streaming
+`streamUpdate` and `requestPermission` notifications.
+
+## Methods supported
+
+| Method | Direction | Notes |
+| ------ | --------- | ----- |
+| `initialize` | client → server | reports server capabilities, available adapters, and configured sandbox backends |
+| `initialized` | client → server (notification) | acknowledged silently |
+| `prompt` | client → server | opens a task in the existing task store; returns a real Bernstein session id |
+| `streamUpdate` | server → client (notification) | tails the streaming-merge utility |
+| `cancel` | client → server | walks the standard drain + shutdown pipeline |
+| `setMode` | client → server | toggles `auto` (always-allow) ↔ `manual` (interactive approval gate) |
+| `requestPermission` | server → client (prompt) and client → server (decision) | maps onto the janitor approval gate |
+
+## Observability
+
+Two Prometheus metrics ship with the bridge:
+
+- `bernstein_acp_messages_total{method, outcome}` — JSON-RPC message
+  count partitioned by method and outcome (`ok`, `error`, `rejected`,
+  `cancelled`, `permission_denied`).
+- `bernstein_acp_active_sessions` — gauge of live ACP sessions.
+
+Both are exported via the existing observability stack — the running
+task server's `/metrics` endpoint scrapes them automatically.
+
+## Audit
+
+Every ACP-driven mutation produces an HMAC-chained audit entry that is
+byte-identical (modulo timestamp + chain HMAC) to the entry the CLI
+surface emits for the same operation. See
+`tests/integration/acp/test_audit_parity.py` for the parity guard.
+
+## Out of scope (v1.9)
+
+- Windows named-pipe transport — POSIX stdio + HTTP only.
+- Bidirectional file-edit primitives that are not in the ratified ACP
+  spec — those track in a follow-up.
+- ACP authentication beyond loopback — remote HTTP usage rides the
+  existing tunnel wrapper.

--- a/src/bernstein/cli/commands/acp_cmd.py
+++ b/src/bernstein/cli/commands/acp_cmd.py
@@ -1,0 +1,258 @@
+"""CLI surface for the Agent Client Protocol (ACP) bridge.
+
+Exposes ``bernstein acp serve --stdio`` (default; for IDE embedding) and
+``bernstein acp serve --http :PORT`` (for remote IDEs and debugging).
+
+Stdio is the canonical IDE transport: the editor spawns ``bernstein acp
+serve --stdio`` as a subprocess and communicates via line-delimited
+JSON-RPC.  HTTP is provided for remote and CI usage; it rides the
+existing tunnel wrapper for non-loopback access.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import click
+
+from bernstein.cli.helpers import SERVER_URL, console
+from bernstein.core.protocols.acp.server import (
+    ACPServer,
+    build_default_server,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.group("acp")
+def acp_group() -> None:
+    """Agent Client Protocol (ACP) bridge — IDE integration surface."""
+
+
+@acp_group.command("serve")
+@click.option(
+    "--stdio/--no-stdio",
+    "use_stdio",
+    default=True,
+    show_default=True,
+    help="Serve over POSIX stdio (line-delimited JSON-RPC).",
+)
+@click.option(
+    "--http",
+    "http_addr",
+    default=None,
+    metavar="HOST:PORT",
+    help="Serve over HTTP/SSE on HOST:PORT (e.g. ':8062' or '127.0.0.1:8062').",
+)
+@click.option(
+    "--server-url",
+    default=SERVER_URL,
+    show_default=True,
+    help="URL of the running Bernstein task server.",
+)
+def serve(use_stdio: bool, http_addr: str | None, server_url: str) -> None:
+    """Run the ACP server using the requested transport.
+
+    The ``--stdio`` flag is the default for IDE embedding; supply
+    ``--http :PORT`` to switch to HTTP/SSE.  ``--http`` overrides
+    ``--stdio`` when both are supplied.
+    """
+    server = build_default_server(server_url=server_url)
+    if http_addr:
+        host, port = _parse_addr(http_addr)
+        console.print(
+            f"[cyan]ACP[/cyan] HTTP transport on [bold]{host}:{port}[/bold] "
+            f"(backend: {server_url})"
+        )
+        asyncio.run(_run_http(server, host, port))
+        return
+    if not use_stdio:
+        raise click.UsageError("either --stdio or --http :PORT must be enabled")
+    asyncio.run(server.run_stdio())
+
+
+def _parse_addr(addr: str) -> tuple[str, int]:
+    """Parse ``[host]:port`` into ``(host, port)``.
+
+    Args:
+        addr: The address string.
+
+    Returns:
+        ``(host, port)`` — host defaults to ``127.0.0.1`` when omitted.
+
+    Raises:
+        click.UsageError: If the address is malformed.
+    """
+    raw = addr.strip()
+    if not raw:
+        raise click.UsageError("--http requires a HOST:PORT or :PORT argument")
+    if raw.startswith(":"):
+        host = "127.0.0.1"
+        port_str = raw[1:]
+    elif ":" in raw:
+        host, _, port_str = raw.rpartition(":")
+        host = host or "127.0.0.1"
+    else:
+        host = "127.0.0.1"
+        port_str = raw
+    try:
+        port = int(port_str)
+    except ValueError as exc:
+        raise click.UsageError(f"invalid port {port_str!r}") from exc
+    if not (0 < port < 65536):
+        raise click.UsageError(f"port {port} out of range")
+    return host, port
+
+
+async def _run_http(server: ACPServer, host: str, port: int) -> None:
+    """Start a tiny HTTP/1.1 server that delegates to :class:`HttpAcpTransport`.
+
+    Uses :mod:`asyncio` directly to avoid pulling FastAPI / Starlette into
+    the import path of every CLI invocation.  The server understands a
+    single route (``POST /acp``) and exits on Ctrl-C.
+    """
+    transport = server.http_transport()
+
+    async def _handle_client(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            request = await _read_http_request(reader)
+        except Exception as exc:
+            logger.debug("acp.http malformed request: %s", exc)
+            await _write_status(writer, 400, b"bad request")
+            writer.close()
+            return
+
+        peer_ip = writer.get_extra_info("peername", ("?", 0))[0]
+        if request is None:
+            writer.close()
+            return
+
+        method, path, headers, body = request
+        if method != "POST" or not path.startswith("/acp"):
+            await _write_status(writer, 404, b"not found")
+            writer.close()
+            return
+
+        accept = headers.get("accept", "")
+        status, response_headers, body_or_iter = await transport.handle_request(
+            body, accept, peer=f"http://{peer_ip}"
+        )
+        if isinstance(body_or_iter, (bytes, bytearray)):
+            await _write_response(writer, status, response_headers, bytes(body_or_iter))
+        else:
+            await _write_streaming_response(writer, status, response_headers, body_or_iter)
+
+        try:
+            await writer.drain()
+        finally:
+            writer.close()
+
+    httpd = await asyncio.start_server(_handle_client, host, port)
+    try:
+        async with httpd:
+            await httpd.serve_forever()
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+
+
+async def _read_http_request(
+    reader: asyncio.StreamReader,
+) -> tuple[str, str, dict[str, str], bytes] | None:
+    """Read one HTTP/1.1 request from *reader*.
+
+    Returns ``None`` on EOF.
+    """
+    request_line = await reader.readline()
+    if not request_line:
+        return None
+    parts = request_line.decode("ascii", errors="replace").strip().split()
+    if len(parts) < 2:
+        return None
+    method, path = parts[0].upper(), parts[1]
+
+    headers: dict[str, str] = {}
+    while True:
+        line = await reader.readline()
+        if line in (b"\r\n", b"\n", b""):
+            break
+        decoded = line.decode("latin-1").rstrip("\r\n")
+        if ":" in decoded:
+            key, _, value = decoded.partition(":")
+            headers[key.strip().lower()] = value.strip()
+
+    length = int(headers.get("content-length", "0") or 0)
+    body = await reader.readexactly(length) if length > 0 else b""
+    return method, path, headers, body
+
+
+async def _write_status(writer: asyncio.StreamWriter, status: int, body: bytes) -> None:
+    """Write a minimal HTTP/1.1 response with no body negotiation."""
+    response = (
+        f"HTTP/1.1 {status} {_REASONS.get(status, 'OK')}\r\n"
+        f"content-length: {len(body)}\r\n"
+        f"content-type: text/plain\r\n"
+        f"connection: close\r\n"
+        f"\r\n"
+    ).encode("latin-1") + body
+    writer.write(response)
+    await writer.drain()
+
+
+async def _write_response(
+    writer: asyncio.StreamWriter,
+    status: int,
+    headers: dict[str, str],
+    body: bytes,
+) -> None:
+    """Write a non-streaming HTTP response."""
+    header_lines = [f"HTTP/1.1 {status} {_REASONS.get(status, 'OK')}"]
+    merged = {"content-length": str(len(body)), "connection": "close", **headers}
+    for key, value in merged.items():
+        header_lines.append(f"{key}: {value}")
+    writer.write(("\r\n".join(header_lines) + "\r\n\r\n").encode("latin-1"))
+    if body:
+        writer.write(body)
+    await writer.drain()
+
+
+async def _write_streaming_response(
+    writer: asyncio.StreamWriter,
+    status: int,
+    headers: dict[str, str],
+    chunks: object,
+) -> None:
+    """Write an HTTP/1.1 chunked-transfer streaming response.
+
+    *chunks* is an async iterator yielding bytes; each chunk becomes one
+    HTTP chunk.
+    """
+    header_lines = [f"HTTP/1.1 {status} {_REASONS.get(status, 'OK')}"]
+    merged = {
+        "transfer-encoding": "chunked",
+        "connection": "close",
+        **headers,
+    }
+    for key, value in merged.items():
+        header_lines.append(f"{key}: {value}")
+    writer.write(("\r\n".join(header_lines) + "\r\n\r\n").encode("latin-1"))
+    await writer.drain()
+    async for chunk in chunks:  # type: ignore[union-attr]
+        writer.write(f"{len(chunk):x}\r\n".encode("ascii") + chunk + b"\r\n")
+        await writer.drain()
+    writer.write(b"0\r\n\r\n")
+    await writer.drain()
+
+
+_REASONS: dict[int, str] = {
+    200: "OK",
+    202: "Accepted",
+    400: "Bad Request",
+    404: "Not Found",
+}
+
+
+__all__ = ["acp_group", "serve"]

--- a/src/bernstein/cli/commands/acp_cmd.py
+++ b/src/bernstein/cli/commands/acp_cmd.py
@@ -61,10 +61,7 @@ def serve(use_stdio: bool, http_addr: str | None, server_url: str) -> None:
     server = build_default_server(server_url=server_url)
     if http_addr:
         host, port = _parse_addr(http_addr)
-        console.print(
-            f"[cyan]ACP[/cyan] HTTP transport on [bold]{host}:{port}[/bold] "
-            f"(backend: {server_url})"
-        )
+        console.print(f"[cyan]ACP[/cyan] HTTP transport on [bold]{host}:{port}[/bold] (backend: {server_url})")
         asyncio.run(_run_http(server, host, port))
         return
     if not use_stdio:
@@ -138,9 +135,7 @@ async def _run_http(server: ACPServer, host: str, port: int) -> None:
             return
 
         accept = headers.get("accept", "")
-        status, response_headers, body_or_iter = await transport.handle_request(
-            body, accept, peer=f"http://{peer_ip}"
-        )
+        status, response_headers, body_or_iter = await transport.handle_request(body, accept, peer=f"http://{peer_ip}")
         if isinstance(body_or_iter, (bytes, bytearray)):
             await _write_response(writer, status, response_headers, bytes(body_or_iter))
         else:

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -810,3 +810,8 @@ cli.add_command(debug_cmd, "debug")  # backward-compat alias
 from bernstein.cli.commands.chat_cmd import chat_group  # noqa: E402
 
 cli.add_command(chat_group, "chat")
+
+# release/1.9: native Agent Client Protocol (ACP) bridge for IDE clients.
+from bernstein.cli.commands.acp_cmd import acp_group  # noqa: E402
+
+cli.add_command(acp_group, "acp")

--- a/src/bernstein/core/protocols/acp/__init__.py
+++ b/src/bernstein/core/protocols/acp/__init__.py
@@ -1,0 +1,116 @@
+"""Agent Client Protocol (ACP) native bridge.
+
+The Agent Client Protocol — https://agentclientprotocol.org — is an open
+JSON-RPC 2.0 specification for IDE -> agent communication.  Editors that
+ship native ACP support (Zed and others) can plug any compliant server in
+as their backend; this package exposes Bernstein as such a server.
+
+The bridge is a *protocol adapter*, not a re-implementation: ACP
+``prompt`` opens a Bernstein task via the existing task store, ``cancel``
+walks the standard drain pipeline, ``setMode`` toggles the existing
+janitor approval gate, and ``streamUpdate`` notifications tail the
+existing streaming-merge utility.  Cost-aware routing, HMAC audit, and
+sandbox-backend selection are inherited unchanged.
+
+Submodules:
+
+* :mod:`bernstein.core.protocols.acp.schema` — schema validation for
+  every ACP message Bernstein accepts.
+* :mod:`bernstein.core.protocols.acp.handlers` — pure handler layer
+  mapping ACP requests onto the existing Bernstein primitives.
+* :mod:`bernstein.core.protocols.acp.transport` — stdio JSON-RPC and
+  HTTP/SSE transports.
+* :mod:`bernstein.core.protocols.acp.session` — per-IDE session state
+  (mode, working dir, pending permission prompts).
+* :mod:`bernstein.core.protocols.acp.metrics` — Prometheus counters and
+  gauges exported through the existing observability stack.
+* :mod:`bernstein.core.protocols.acp.server` — composition root that
+  wires handlers + transport + metrics together.
+"""
+
+from __future__ import annotations
+
+# ----------------------------------------------------------------------
+# Back-compat re-exports for the legacy BeeAI ACP module
+# (``bernstein.core.protocols.acp.py``).  When this directory shadows
+# that file, Python resolves ``bernstein.core.protocols.acp`` to this
+# package; we re-export the legacy public names so downstream imports
+# (e.g. ``from bernstein.core.acp import ACPHandler`` via the redirect
+# map) keep working.
+# ----------------------------------------------------------------------
+import importlib.util as _ilu
+import sys as _sys
+from pathlib import Path as _Path
+
+_legacy_path = _Path(__file__).resolve().parent.parent / "acp.py"
+if _legacy_path.exists():
+    _legacy_name = "bernstein.core.protocols._acp_legacy"
+    _spec = _ilu.spec_from_file_location(_legacy_name, str(_legacy_path))
+    if _spec is not None and _spec.loader is not None:
+        _legacy_module = _ilu.module_from_spec(_spec)
+        # Register before exec so dataclass can find the module via
+        # ``cls.__module__`` while the class body runs.
+        _sys.modules[_legacy_name] = _legacy_module
+        _spec.loader.exec_module(_legacy_module)
+        ACPHandler = _legacy_module.ACPHandler
+        ACPRun = _legacy_module.ACPRun
+        ACPRunStatus = _legacy_module.ACPRunStatus
+
+from bernstein.core.protocols.acp.handlers import (  # noqa: E402 — legacy shim runs first
+    ACPHandlerRegistry,
+    ACPRequestContext,
+    PromptResult,
+    SessionMode,
+)
+from bernstein.core.protocols.acp.metrics import (  # noqa: E402
+    acp_active_sessions,
+    acp_messages_total,
+    record_acp_message,
+)
+from bernstein.core.protocols.acp.schema import (  # noqa: E402
+    ACPSchemaError,
+    validate_request,
+    validate_response,
+)
+from bernstein.core.protocols.acp.server import (  # noqa: E402
+    ACPServer,
+    AdapterDescriptor,
+    SandboxBackendDescriptor,
+    ServerCapabilities,
+    build_default_server,
+)
+from bernstein.core.protocols.acp.session import (  # noqa: E402
+    ACPSession,
+    ACPSessionStore,
+)
+from bernstein.core.protocols.acp.transport import (  # noqa: E402
+    HttpAcpTransport,
+    JsonRpcFraming,
+    StdioAcpTransport,
+)
+
+__all__ = [
+    "ACPHandler",
+    "ACPHandlerRegistry",
+    "ACPRequestContext",
+    "ACPRun",
+    "ACPRunStatus",
+    "ACPSchemaError",
+    "ACPServer",
+    "ACPSession",
+    "ACPSessionStore",
+    "AdapterDescriptor",
+    "HttpAcpTransport",
+    "JsonRpcFraming",
+    "PromptResult",
+    "SandboxBackendDescriptor",
+    "ServerCapabilities",
+    "SessionMode",
+    "StdioAcpTransport",
+    "acp_active_sessions",
+    "acp_messages_total",
+    "build_default_server",
+    "record_acp_message",
+    "validate_request",
+    "validate_response",
+]

--- a/src/bernstein/core/protocols/acp/handlers.py
+++ b/src/bernstein/core/protocols/acp/handlers.py
@@ -239,11 +239,7 @@ class ACPHandlerRegistry:
         try:
             result = await handler(ctx, params)
         except ACPSchemaError as exc:
-            outcome = (
-                "rejected"
-                if exc.code == PERMISSION_DENIED
-                else "error"
-            )
+            outcome = "rejected" if exc.code == PERMISSION_DENIED else "error"
             record_acp_message(ctx.method, outcome)
             raise
         except Exception as exc:

--- a/src/bernstein/core/protocols/acp/handlers.py
+++ b/src/bernstein/core/protocols/acp/handlers.py
@@ -1,0 +1,512 @@
+"""ACP request handlers wired onto the existing Bernstein primitives.
+
+The handler layer is deliberately *pure*: it takes injected dependencies
+(task creator, cancel hook, audit emitter, permission gate) and never
+constructs them.  This lets unit tests substitute lightweight fakes
+while production code wires in the real task store, drain pipeline,
+HMAC audit chain, and janitor approval gate.
+
+A single :class:`ACPHandlerRegistry` holds bound coroutines for every
+ACP method.  The transport layer dispatches against this registry; it
+does NOT introspect the protocol surface itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Final
+
+from bernstein.core.protocols.acp.metrics import (
+    record_acp_message,
+    set_active_sessions,
+)
+from bernstein.core.protocols.acp.schema import (
+    ACP_PROTOCOL_VERSION,
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    PERMISSION_DENIED,
+    SESSION_NOT_FOUND,
+    ACPSchemaError,
+)
+from bernstein.core.protocols.acp.session import ACPSession, ACPSessionStore
+
+logger = logging.getLogger(__name__)
+
+
+class SessionMode(StrEnum):
+    """Allowed approval-gate modes for an ACP session."""
+
+    AUTO = "auto"
+    MANUAL = "manual"
+
+
+# Permission round-trip default timeout.  Long enough for a human to read
+# the prompt; short enough that a hung IDE does not stall the agent
+# forever.  Surfaced in defaults so it is configurable without touching
+# this module.
+_PERMISSION_TIMEOUT_S: Final[float] = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Injected-dependency protocols
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PromptResult:
+    """Outcome of opening a Bernstein task for an ACP prompt.
+
+    Attributes:
+        session_id: Bernstein task id (also returned to the IDE as the
+            ACP session id).
+        accepted: ``True`` when the task was created.  ``False`` is used
+            to surface deferred errors that the prompt handler converts
+            to a JSON-RPC error envelope.
+        message: Optional diagnostic, surfaced to the IDE when
+            ``accepted=False``.
+    """
+
+    session_id: str
+    accepted: bool = True
+    message: str = ""
+
+
+# Type aliases for injected callbacks.  They are async because the real
+# task store is async; tests can wrap sync helpers with ``asyncio.coroutine``
+# semantics by writing ``async def``.
+TaskCreator = Callable[[str, str, str], Awaitable[PromptResult]]
+"""Signature: ``async (prompt, cwd, role) -> PromptResult``."""
+
+TaskCanceller = Callable[[str, str], Awaitable[bool]]
+"""Signature: ``async (session_id, reason) -> bool``."""
+
+StreamPublisher = Callable[[dict[str, Any]], Awaitable[None]]
+"""Signature: ``async (frame) -> None`` — publishes a JSON-RPC frame to the IDE."""
+
+PermissionAsker = Callable[[str, str, str], Awaitable[str]]
+"""Signature: ``async (session_id, tool, detail) -> "approved"|"rejected"``.
+
+Default implementation routes through the ACP transport so the IDE sees
+a ``requestPermission`` notification.  Tests can substitute a stub that
+returns instantly.
+"""
+
+AuditEmitter = Callable[[str, str, dict[str, Any]], None]
+"""Signature: ``(event_type, resource_id, details) -> None``.
+
+The handler layer calls this before returning a response so the HMAC
+chain captures every ACP-driven mutation.  ACP-initiated audit entries
+are byte-identical to CLI-initiated entries because both call sites pass
+the same ``event_type`` strings.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Default no-op dependencies (production wires in the real ones).
+# ---------------------------------------------------------------------------
+
+
+async def _default_task_creator(prompt: str, cwd: str, role: str) -> PromptResult:
+    """Fallback creator used when no task store is wired in.
+
+    The session id is a deterministic hash of the prompt + timestamp so
+    tests can assert against it.
+
+    Args:
+        prompt: The prompt text.
+        cwd: Working directory.
+        role: Bernstein role hint.
+
+    Returns:
+        A :class:`PromptResult` with ``accepted=True``.
+    """
+    del prompt, cwd, role
+    sid = f"acp-{int(time.time() * 1000):x}"
+    return PromptResult(session_id=sid, accepted=True)
+
+
+async def _default_task_canceller(session_id: str, reason: str) -> bool:
+    """Fallback canceller — logs the cancellation and returns ``True``."""
+    logger.info("acp.cancel session=%s reason=%s (no canceller wired)", session_id, reason)
+    return True
+
+
+async def _default_stream_publisher(frame: dict[str, Any]) -> None:
+    """Fallback publisher — drops the frame on the floor."""
+    logger.debug("acp.stream dropped frame method=%s", frame.get("method"))
+
+
+def _default_audit_emitter(event_type: str, resource_id: str, details: dict[str, Any]) -> None:
+    """Fallback audit emitter — logs at INFO level for visibility."""
+    logger.info("acp.audit event=%s resource=%s details=%s", event_type, resource_id, details)
+
+
+# ---------------------------------------------------------------------------
+# Request context
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ACPRequestContext:
+    """Context passed to every handler invocation.
+
+    Attributes:
+        method: ACP method name.
+        request_id: JSON-RPC ``id`` (or ``None`` for notifications).
+        peer: Free-form transport identifier (e.g. ``"stdio"``,
+            ``"http://1.2.3.4"``).  Recorded in audit events.
+    """
+
+    method: str
+    request_id: str | int | None
+    peer: str = "stdio"
+
+
+# ---------------------------------------------------------------------------
+# Handler registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ACPHandlerRegistry:
+    """Bundle of ACP method handlers.
+
+    The registry owns the :class:`ACPSessionStore` and dispatches ACP
+    methods against it.  All side-effecting operations (task creation,
+    cancellation, stream publication, audit) go through injected
+    callables so production wiring (real task store + HMAC audit) and
+    tests (in-memory fakes) share the same code path.
+
+    Attributes:
+        sessions: Per-IDE session store.
+        adapters: Sorted list of available adapter names (surfaced from
+            ``initialize``).
+        sandbox_backends: Sorted list of configured sandbox backends.
+        task_creator: Async callable that opens a Bernstein task.
+        task_canceller: Async callable that walks the drain pipeline.
+        stream_publisher: Async callable that pushes a frame to the IDE.
+        permission_asker: Async callable that surfaces a permission
+            prompt to the IDE; defaults to a transport-driven prompt.
+        audit_emitter: Sync callable that appends to the HMAC chain.
+        permission_timeout_s: Per-request timeout for permission
+            round-trips.
+    """
+
+    sessions: ACPSessionStore = field(default_factory=ACPSessionStore)
+    adapters: tuple[str, ...] = ()
+    sandbox_backends: tuple[str, ...] = ()
+    task_creator: TaskCreator = field(default=_default_task_creator)
+    task_canceller: TaskCanceller = field(default=_default_task_canceller)
+    stream_publisher: StreamPublisher = field(default=_default_stream_publisher)
+    permission_asker: PermissionAsker | None = None
+    audit_emitter: AuditEmitter = field(default=_default_audit_emitter)
+    permission_timeout_s: float = _PERMISSION_TIMEOUT_S
+
+    # Bookkeeping for permission round-trips routed through the transport.
+    # Maps ``promptId -> (session_id, asyncio.Event placeholder)``.
+
+    def __post_init__(self) -> None:
+        if self.permission_asker is None:
+            object.__setattr__(self, "permission_asker", self._default_permission_asker)
+
+    # -- Public dispatch ----------------------------------------------------
+
+    async def dispatch(self, ctx: ACPRequestContext, params: dict[str, Any]) -> Any:
+        """Dispatch *ctx.method* and return the JSON-serialisable result.
+
+        Args:
+            ctx: Validated request context.
+            params: Already-validated parameters.
+
+        Returns:
+            A JSON-serialisable result for response methods, or ``None``
+            for notifications.
+
+        Raises:
+            ACPSchemaError: For mapped errors that the transport should
+                surface as JSON-RPC errors.
+        """
+        try:
+            handler = self._handlers[ctx.method]
+        except KeyError as exc:  # pragma: no cover — schema layer rejects first
+            raise ACPSchemaError(INTERNAL_ERROR, f"no handler for {ctx.method!r}") from exc
+
+        try:
+            result = await handler(ctx, params)
+        except ACPSchemaError as exc:
+            outcome = (
+                "rejected"
+                if exc.code == PERMISSION_DENIED
+                else "error"
+            )
+            record_acp_message(ctx.method, outcome)
+            raise
+        except Exception as exc:
+            record_acp_message(ctx.method, "error")
+            logger.exception("acp.handler crashed method=%s", ctx.method)
+            raise ACPSchemaError(INTERNAL_ERROR, f"handler crashed: {exc}") from exc
+
+        record_acp_message(ctx.method, "ok")
+        return result
+
+    @property
+    def _handlers(self) -> dict[str, Callable[[ACPRequestContext, dict[str, Any]], Awaitable[Any]]]:
+        return {
+            "initialize": self._handle_initialize,
+            "initialized": self._handle_initialized,
+            "prompt": self._handle_prompt,
+            "cancel": self._handle_cancel,
+            "setMode": self._handle_set_mode,
+            "requestPermission": self._handle_request_permission,
+            # streamUpdate is server -> client; if we receive one we ack
+            # silently to keep parity with the client/server symmetry that
+            # some IDE clients expect.
+            "streamUpdate": self._handle_stream_update,
+        }
+
+    # -- Capability negotiation --------------------------------------------
+
+    async def _handle_initialize(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Reply with Bernstein capabilities, adapters, and sandbox backends.
+
+        Honours the IDE's requested ``protocolVersion`` when compatible;
+        otherwise downgrades to the version this server speaks.
+        """
+        requested = params.get("protocolVersion") or ACP_PROTOCOL_VERSION
+        # Even if the requested version differs, we report ours.  An IDE
+        # is free to refuse the handshake by closing the transport.
+        result: dict[str, Any] = {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "negotiatedProtocolVersion": ACP_PROTOCOL_VERSION,
+            "clientRequestedVersion": requested,
+            "serverInfo": {
+                "name": "bernstein",
+                "description": "Multi-agent orchestration system for CLI coding agents",
+            },
+            "capabilities": {
+                "prompts": True,
+                "streaming": True,
+                "cancellation": True,
+                "modes": ["auto", "manual"],
+                "permissions": True,
+            },
+            "adapters": list(self.adapters),
+            "sandboxBackends": list(self.sandbox_backends),
+        }
+        self.audit_emitter("acp.initialize", "session", {"peer": ctx.peer, "version": requested})
+        return result
+
+    async def _handle_initialized(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> None:
+        """Acknowledge the IDE's ``initialized`` notification.
+
+        Notifications return ``None`` so the transport suppresses the
+        response envelope.
+        """
+        del params
+        logger.debug("acp.initialized peer=%s", ctx.peer)
+        return None
+
+    # -- Prompt -> task -----------------------------------------------------
+
+    async def _handle_prompt(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Open a Bernstein task and register the corresponding ACP session."""
+        prompt = params["prompt"]
+        cwd = params.get("cwd") or "."
+        role = params.get("role") or "backend"
+        mode_param = params.get("mode")
+        if mode_param is not None and mode_param not in {"auto", "manual"}:
+            raise ACPSchemaError(INVALID_PARAMS, f"invalid mode {mode_param!r}")
+
+        outcome = await self.task_creator(prompt, cwd, role)
+        if not outcome.accepted:
+            raise ACPSchemaError(INTERNAL_ERROR, outcome.message or "task creation rejected")
+
+        session = ACPSession(
+            session_id=outcome.session_id,
+            cwd=cwd,
+            role=role,
+            mode=mode_param or "manual",
+        )
+        await self.sessions.add(session)
+        set_active_sessions(await self.sessions.count())
+        self.audit_emitter(
+            "acp.prompt",
+            outcome.session_id,
+            {"peer": ctx.peer, "cwd": cwd, "role": role, "mode": session.mode},
+        )
+        return {
+            "sessionId": outcome.session_id,
+            "mode": session.mode,
+            "cwd": cwd,
+            "role": role,
+        }
+
+    # -- Cancel -------------------------------------------------------------
+
+    async def _handle_cancel(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Walk the drain + shutdown pipeline for *sessionId*."""
+        session_id = params["sessionId"]
+        reason = params.get("reason") or "client_cancel"
+        session = await self.sessions.get(session_id)
+        if session is None:
+            raise ACPSchemaError(SESSION_NOT_FOUND, f"unknown session {session_id!r}")
+
+        ok = await self.task_canceller(session_id, reason)
+        await self.sessions.remove(session_id)
+        set_active_sessions(await self.sessions.count())
+        self.audit_emitter(
+            "acp.cancel",
+            session_id,
+            {"peer": ctx.peer, "reason": reason, "ok": ok},
+        )
+        if not ok:
+            return {"sessionId": session_id, "cancelled": False, "reason": reason}
+        return {"sessionId": session_id, "cancelled": True, "reason": reason}
+
+    # -- Mode toggle --------------------------------------------------------
+
+    async def _handle_set_mode(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Toggle ``auto`` <-> ``manual`` and persist on the session."""
+        session_id = params["sessionId"]
+        mode = params["mode"]
+        session = await self.sessions.get(session_id)
+        if session is None:
+            raise ACPSchemaError(SESSION_NOT_FOUND, f"unknown session {session_id!r}")
+        try:
+            session.set_mode(mode)
+        except ValueError as exc:
+            raise ACPSchemaError(INVALID_PARAMS, str(exc)) from exc
+        self.audit_emitter("acp.set_mode", session_id, {"peer": ctx.peer, "mode": mode})
+        return {"sessionId": session_id, "mode": session.mode}
+
+    # -- Request permission round-trip -------------------------------------
+
+    async def _handle_request_permission(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve an outstanding permission waiter with the IDE's decision."""
+        session_id = params["sessionId"]
+        prompt_id = params["promptId"]
+        decision = params.get("decision") or "approved"
+        session = await self.sessions.get(session_id)
+        if session is None:
+            raise ACPSchemaError(SESSION_NOT_FOUND, f"unknown session {session_id!r}")
+        if not session.resolve_permission(prompt_id, decision):
+            raise ACPSchemaError(
+                PERMISSION_DENIED,
+                f"no pending permission with id {prompt_id!r}",
+            )
+        self.audit_emitter(
+            "acp.permission",
+            session_id,
+            {"peer": ctx.peer, "decision": decision, "promptId": prompt_id},
+        )
+        return {"sessionId": session_id, "promptId": prompt_id, "decision": decision}
+
+    # -- Inbound streamUpdate (rare; mostly server-emitted) ----------------
+
+    async def _handle_stream_update(
+        self,
+        ctx: ACPRequestContext,
+        params: dict[str, Any],
+    ) -> None:
+        """Accept inbound stream updates (no-op).
+
+        ACP defines ``streamUpdate`` as server -> client; some test
+        clients echo it.  We accept the frame, record metrics, and drop
+        it.
+        """
+        del ctx, params
+        return None
+
+    # -- Stream emission ----------------------------------------------------
+
+    async def emit_stream_update(self, session_id: str, delta: dict[str, Any] | str) -> None:
+        """Push a ``streamUpdate`` notification to the IDE.
+
+        Args:
+            session_id: ACP session the update is associated with.
+            delta: Token delta (string or structured payload).
+        """
+        from bernstein.core.protocols.acp.schema import make_notification
+
+        frame = make_notification("streamUpdate", {"sessionId": session_id, "delta": delta})
+        await self.stream_publisher(frame)
+
+    # -- Default permission asker ------------------------------------------
+
+    async def _default_permission_asker(
+        self,
+        session_id: str,
+        tool: str,
+        detail: str,
+    ) -> str:
+        """Surface a permission prompt to the IDE and await its decision.
+
+        Looks up the session, opens a waiter, publishes a
+        ``requestPermission`` notification, and awaits the
+        ``requestPermission`` response that the IDE sends back.
+
+        Args:
+            session_id: Session id.
+            tool: Tool the agent wants to invoke.
+            detail: Human-readable description.
+
+        Returns:
+            ``"approved"`` or ``"rejected"``; on timeout returns
+            ``"rejected"`` to fail closed.
+        """
+        from bernstein.core.protocols.acp.schema import make_notification
+
+        session = await self.sessions.get(session_id)
+        if session is None:
+            return "rejected"
+        if session.mode == "auto":
+            return "approved"
+
+        waiter = session.open_permission_waiter(tool, detail)
+        frame = make_notification(
+            "requestPermission",
+            {
+                "sessionId": session_id,
+                "promptId": waiter.prompt_id,
+                "tool": tool,
+                "detail": detail,
+            },
+        )
+        await self.stream_publisher(frame)
+        try:
+            await asyncio.wait_for(waiter.event.wait(), timeout=self.permission_timeout_s)
+        except TimeoutError:
+            session.discard_waiter(waiter.prompt_id)
+            return "rejected"
+        decision = waiter.decision or "rejected"
+        session.discard_waiter(waiter.prompt_id)
+        return decision

--- a/src/bernstein/core/protocols/acp/metrics.py
+++ b/src/bernstein/core/protocols/acp/metrics.py
@@ -1,0 +1,73 @@
+"""Prometheus counters and gauges for the ACP bridge.
+
+Metrics are registered against the same dedicated registry the rest of
+Bernstein uses (``bernstein.core.observability.prometheus.registry``) so
+that scraping ``/metrics`` on the existing task server picks them up
+without further wiring.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Final
+
+from bernstein.core.observability.prometheus import (
+    Counter,
+    Gauge,
+    registry,
+)
+
+# Allowed outcomes — closed set to avoid label cardinality explosions.
+VALID_OUTCOMES: Final[frozenset[str]] = frozenset(
+    {"ok", "error", "rejected", "cancelled", "permission_denied"}
+)
+
+acp_messages_total: Counter = Counter(
+    "bernstein_acp_messages_total",
+    "ACP JSON-RPC messages handled, partitioned by method and outcome.",
+    labelnames=["method", "outcome"],
+    registry=registry,
+)
+
+acp_active_sessions: Gauge = Gauge(
+    "bernstein_acp_active_sessions",
+    "Number of currently open ACP sessions.",
+    registry=registry,
+)
+
+
+def record_acp_message(method: str, outcome: str) -> None:
+    """Increment :data:`acp_messages_total` with sanitised labels.
+
+    Unknown outcomes are bucketed under ``"error"`` to avoid runaway
+    label cardinality.
+
+    Args:
+        method: ACP method name (e.g. ``"prompt"``).
+        outcome: One of :data:`VALID_OUTCOMES`; anything else is bucketed
+            to ``"error"``.
+    """
+    sanitised_outcome = outcome if outcome in VALID_OUTCOMES else "error"
+    sanitised_method = (method or "unknown").strip() or "unknown"
+    # Metrics never break the request path; suppress all errors.
+    with contextlib.suppress(Exception):
+        acp_messages_total.labels(method=sanitised_method, outcome=sanitised_outcome).inc()
+
+
+def set_active_sessions(count: int) -> None:
+    """Set the :data:`acp_active_sessions` gauge.
+
+    Args:
+        count: Current number of open ACP sessions.
+    """
+    with contextlib.suppress(Exception):
+        acp_active_sessions.set(max(0, int(count)))
+
+
+__all__ = [
+    "VALID_OUTCOMES",
+    "acp_active_sessions",
+    "acp_messages_total",
+    "record_acp_message",
+    "set_active_sessions",
+]

--- a/src/bernstein/core/protocols/acp/metrics.py
+++ b/src/bernstein/core/protocols/acp/metrics.py
@@ -18,9 +18,7 @@ from bernstein.core.observability.prometheus import (
 )
 
 # Allowed outcomes — closed set to avoid label cardinality explosions.
-VALID_OUTCOMES: Final[frozenset[str]] = frozenset(
-    {"ok", "error", "rejected", "cancelled", "permission_denied"}
-)
+VALID_OUTCOMES: Final[frozenset[str]] = frozenset({"ok", "error", "rejected", "cancelled", "permission_denied"})
 
 acp_messages_total: Counter = Counter(
     "bernstein_acp_messages_total",

--- a/src/bernstein/core/protocols/acp/schema.py
+++ b/src/bernstein/core/protocols/acp/schema.py
@@ -1,0 +1,335 @@
+"""JSON-RPC 2.0 + ACP message schema validation.
+
+The bridge implements only the ratified subset of the Agent Client
+Protocol that Bernstein needs: ``initialize``, ``initialized`` (notification),
+``prompt``, ``streamUpdate`` (notification), ``cancel``, ``setMode``, and
+``requestPermission``.  Schemas are kept hand-rolled (no extra runtime
+dependency) because every method is fixed and small; this also lets us
+emit precise error codes for malformed frames.
+
+JSON-RPC 2.0 error codes used:
+
+* ``-32700`` — parse error (malformed JSON).
+* ``-32600`` — invalid request (missing ``jsonrpc``, ``method``, ``id`` for
+  request/response confusion, etc.).
+* ``-32601`` — method not found.
+* ``-32602`` — invalid params (schema mismatch).
+* ``-32603`` — internal error.
+
+Bernstein-specific codes start at ``-32001``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+JSONRPC_VERSION: Final[str] = "2.0"
+
+# JSON-RPC reserved error codes
+PARSE_ERROR: Final[int] = -32700
+INVALID_REQUEST: Final[int] = -32600
+METHOD_NOT_FOUND: Final[int] = -32601
+INVALID_PARAMS: Final[int] = -32602
+INTERNAL_ERROR: Final[int] = -32603
+
+# Bernstein-specific error codes
+SESSION_NOT_FOUND: Final[int] = -32001
+PERMISSION_DENIED: Final[int] = -32002
+MODE_INVALID: Final[int] = -32003
+
+
+SUPPORTED_METHODS: Final[frozenset[str]] = frozenset(
+    {
+        "initialize",
+        "initialized",
+        "prompt",
+        "streamUpdate",
+        "cancel",
+        "setMode",
+        "requestPermission",
+    }
+)
+
+NOTIFICATION_METHODS: Final[frozenset[str]] = frozenset({"initialized", "streamUpdate"})
+
+VALID_MODES: Final[frozenset[str]] = frozenset({"auto", "manual"})
+
+# ACP protocol version Bernstein speaks.  Negotiated during ``initialize``.
+ACP_PROTOCOL_VERSION: Final[str] = "2025-04-01"
+
+
+class ACPSchemaError(Exception):
+    """Raised when a JSON-RPC frame or ACP payload fails validation.
+
+    Attributes:
+        code: JSON-RPC error code suitable for the response envelope.
+        message: Human-readable diagnostic.
+        data: Optional structured detail (e.g. offending field name).
+    """
+
+    def __init__(self, code: int, message: str, data: Any | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+@dataclass(frozen=True)
+class ParsedRequest:
+    """A validated JSON-RPC request or notification.
+
+    Attributes:
+        method: ACP method name (always present, always in
+            :data:`SUPPORTED_METHODS`).
+        params: Parameter dict (already shape-validated).
+        request_id: ``id`` field — ``None`` when the frame is a
+            notification.  JSON-RPC permits string, integer, or null IDs.
+        is_notification: ``True`` when the frame had no ``id`` field; such
+            frames must NOT receive a response envelope.
+    """
+
+    method: str
+    params: dict[str, Any]
+    request_id: str | int | None
+    is_notification: bool
+
+
+def _require_str(d: dict[str, Any], key: str, *, allow_empty: bool = False) -> str:
+    """Validate that ``d[key]`` is a string and return it.
+
+    Args:
+        d: Dict to inspect.
+        key: Key whose value must be a non-empty string.
+        allow_empty: When ``True`` an empty string is accepted.
+
+    Returns:
+        The string value.
+
+    Raises:
+        ACPSchemaError: If the key is missing or not a string.
+    """
+    value = d.get(key)
+    if not isinstance(value, str):
+        raise ACPSchemaError(INVALID_PARAMS, f"missing or non-string field {key!r}", {"field": key})
+    if not allow_empty and not value:
+        raise ACPSchemaError(INVALID_PARAMS, f"field {key!r} must not be empty", {"field": key})
+    return value
+
+
+def _validate_initialize(params: dict[str, Any]) -> None:
+    """Validate the params for the ``initialize`` request."""
+    proto = params.get("protocolVersion")
+    if proto is not None and not isinstance(proto, str):
+        raise ACPSchemaError(INVALID_PARAMS, "protocolVersion must be a string")
+    caps = params.get("clientCapabilities")
+    if caps is not None and not isinstance(caps, dict):
+        raise ACPSchemaError(INVALID_PARAMS, "clientCapabilities must be an object")
+
+
+def _validate_prompt(params: dict[str, Any]) -> None:
+    """Validate the params for the ``prompt`` request."""
+    _require_str(params, "prompt")
+    cwd = params.get("cwd")
+    if cwd is not None and not isinstance(cwd, str):
+        raise ACPSchemaError(INVALID_PARAMS, "cwd must be a string")
+    role = params.get("role")
+    if role is not None and not isinstance(role, str):
+        raise ACPSchemaError(INVALID_PARAMS, "role must be a string")
+
+
+def _validate_stream_update(params: dict[str, Any]) -> None:
+    """Validate the params for the ``streamUpdate`` notification.
+
+    ``streamUpdate`` is server -> client; we only validate it when echoed
+    back through the framing layer in tests.
+    """
+    _require_str(params, "sessionId")
+    if "delta" in params and not isinstance(params["delta"], (str, dict)):
+        raise ACPSchemaError(INVALID_PARAMS, "delta must be a string or object")
+
+
+def _validate_cancel(params: dict[str, Any]) -> None:
+    """Validate the params for the ``cancel`` request."""
+    _require_str(params, "sessionId")
+    reason = params.get("reason")
+    if reason is not None and not isinstance(reason, str):
+        raise ACPSchemaError(INVALID_PARAMS, "reason must be a string")
+
+
+def _validate_set_mode(params: dict[str, Any]) -> None:
+    """Validate the params for the ``setMode`` request."""
+    _require_str(params, "sessionId")
+    mode = _require_str(params, "mode")
+    if mode not in VALID_MODES:
+        raise ACPSchemaError(
+            MODE_INVALID,
+            f"mode must be one of {sorted(VALID_MODES)}",
+            {"got": mode},
+        )
+
+
+def _validate_request_permission(params: dict[str, Any]) -> None:
+    """Validate the params for the ``requestPermission`` request."""
+    _require_str(params, "sessionId")
+    _require_str(params, "promptId")
+    decision = params.get("decision")
+    if decision is not None and decision not in {"approved", "rejected"}:
+        raise ACPSchemaError(INVALID_PARAMS, "decision must be 'approved' or 'rejected'")
+
+
+_PARAM_VALIDATORS: dict[str, Any] = {
+    "initialize": _validate_initialize,
+    "initialized": lambda _params: None,
+    "prompt": _validate_prompt,
+    "streamUpdate": _validate_stream_update,
+    "cancel": _validate_cancel,
+    "setMode": _validate_set_mode,
+    "requestPermission": _validate_request_permission,
+}
+
+
+def validate_request(frame: Any) -> ParsedRequest:
+    """Validate a single JSON-RPC frame and return a :class:`ParsedRequest`.
+
+    Args:
+        frame: The decoded frame (already a Python object — the transport
+            layer is responsible for turning bytes into JSON, not this
+            module).
+
+    Returns:
+        A :class:`ParsedRequest`.
+
+    Raises:
+        ACPSchemaError: If the frame is not a valid JSON-RPC 2.0 request
+            or if its params do not match the ACP method schema.
+    """
+    if not isinstance(frame, dict):
+        raise ACPSchemaError(INVALID_REQUEST, "frame must be a JSON object")
+    if frame.get("jsonrpc") != JSONRPC_VERSION:
+        raise ACPSchemaError(INVALID_REQUEST, "jsonrpc must be '2.0'")
+    method = frame.get("method")
+    if not isinstance(method, str):
+        raise ACPSchemaError(INVALID_REQUEST, "method must be a string")
+    if method not in SUPPORTED_METHODS:
+        raise ACPSchemaError(METHOD_NOT_FOUND, f"unknown method {method!r}", {"method": method})
+
+    params_raw: Any = frame.get("params", {})
+    if params_raw is None:
+        params_raw = {}
+    if not isinstance(params_raw, dict):
+        raise ACPSchemaError(INVALID_PARAMS, "params must be an object")
+
+    _PARAM_VALIDATORS[method](params_raw)
+
+    is_notification = "id" not in frame
+    request_id = frame.get("id")
+    if request_id is not None and not isinstance(request_id, (str, int)):
+        raise ACPSchemaError(INVALID_REQUEST, "id must be a string, integer, or omitted")
+
+    if not is_notification and method in NOTIFICATION_METHODS:
+        # Notification methods MUST NOT carry an id.
+        raise ACPSchemaError(
+            INVALID_REQUEST,
+            f"method {method!r} is a notification and must not have an id",
+            {"method": method},
+        )
+    if is_notification and method not in NOTIFICATION_METHODS:
+        # Some clients omit id for fire-and-forget calls; ACP forbids that
+        # for these methods because they require a response envelope.
+        raise ACPSchemaError(
+            INVALID_REQUEST,
+            f"method {method!r} requires an id",
+            {"method": method},
+        )
+
+    return ParsedRequest(
+        method=method,
+        params=dict(params_raw),
+        request_id=request_id,
+        is_notification=is_notification,
+    )
+
+
+def validate_response(frame: Any) -> dict[str, Any]:
+    """Validate a JSON-RPC response envelope (used by tests + clients).
+
+    Args:
+        frame: Decoded frame.
+
+    Returns:
+        The frame as a dict.
+
+    Raises:
+        ACPSchemaError: If the envelope is malformed.
+    """
+    if not isinstance(frame, dict):
+        raise ACPSchemaError(INVALID_REQUEST, "response must be a JSON object")
+    if frame.get("jsonrpc") != JSONRPC_VERSION:
+        raise ACPSchemaError(INVALID_REQUEST, "jsonrpc must be '2.0'")
+    has_result = "result" in frame
+    has_error = "error" in frame
+    if has_result == has_error:
+        raise ACPSchemaError(
+            INVALID_REQUEST,
+            "response must have exactly one of 'result' or 'error'",
+        )
+    if "id" not in frame:
+        raise ACPSchemaError(INVALID_REQUEST, "response must have an 'id' field")
+    return frame
+
+
+def make_error(request_id: str | int | None, code: int, message: str, data: Any = None) -> dict[str, Any]:
+    """Build a JSON-RPC error envelope.
+
+    Args:
+        request_id: The id of the inbound request, or ``None`` when the
+            inbound frame could not be parsed.
+        code: JSON-RPC error code.
+        message: Human-readable diagnostic.
+        data: Optional structured payload.
+
+    Returns:
+        A dict ready for serialisation.
+    """
+    error: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        error["data"] = data
+    return {"jsonrpc": JSONRPC_VERSION, "id": request_id, "error": error}
+
+
+def make_result(request_id: str | int | None, result: Any) -> dict[str, Any]:
+    """Build a JSON-RPC success envelope.
+
+    Args:
+        request_id: The id of the inbound request.
+        result: Method-specific result payload.
+
+    Returns:
+        A dict ready for serialisation.
+    """
+    return {"jsonrpc": JSONRPC_VERSION, "id": request_id, "result": result}
+
+
+def make_notification(method: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Build a JSON-RPC notification frame (no id).
+
+    For the small set of methods Bernstein both consumes and emits
+    (``streamUpdate`` and ``requestPermission`` — server → IDE prompt
+    as a notification, IDE → server reply as a request envelope with a
+    ``decision`` payload) we permit any supported ACP method here; the
+    validate path enforces the ``id``-vs-no-``id`` invariant on ingress.
+
+    Args:
+        method: ACP method name.
+        params: Notification payload.
+
+    Returns:
+        A dict ready for serialisation.
+
+    Raises:
+        ValueError: If *method* is not a known ACP method.
+    """
+    if method not in SUPPORTED_METHODS:
+        raise ValueError(f"{method!r} is not a known ACP method")
+    return {"jsonrpc": JSONRPC_VERSION, "method": method, "params": params}

--- a/src/bernstein/core/protocols/acp/server.py
+++ b/src/bernstein/core/protocols/acp/server.py
@@ -1,0 +1,378 @@
+"""Composition root for the ACP bridge.
+
+Wires the schema layer, handler registry, session store, transport, and
+the existing Bernstein primitives (task store, drain pipeline, HMAC
+audit chain, janitor approval gate) together.
+
+The high-level call graph::
+
+    bernstein acp serve --stdio
+        -> build_default_server()          # composes everything
+        -> ACPServer.run_stdio()           # wires sys.stdin/stdout
+            -> StdioAcpTransport.serve_forever()
+                -> registry.dispatch()
+                    -> task_creator()      # POST /tasks on the task server
+                    -> audit_emitter()     # AuditLog.log()
+                    -> permission_asker()  # janitor gate
+
+In tests we instantiate :class:`ACPServer` directly with stub callables
+so the full request flow is exercised without a real task server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+from bernstein.core.protocols.acp.handlers import (
+    ACPHandlerRegistry,
+    AuditEmitter,
+    PromptResult,
+    StreamPublisher,
+    TaskCanceller,
+    TaskCreator,
+)
+from bernstein.core.protocols.acp.metrics import set_active_sessions
+from bernstein.core.protocols.acp.session import ACPSessionStore
+from bernstein.core.protocols.acp.transport import (
+    HttpAcpTransport,
+    StdioAcpTransport,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AdapterDescriptor:
+    """Lightweight descriptor for an adapter surfaced via ``initialize``.
+
+    Attributes:
+        name: Adapter id (e.g. ``"claude"``).
+        display_name: Optional user-visible name.
+    """
+
+    name: str
+    display_name: str = ""
+
+
+@dataclass(frozen=True)
+class SandboxBackendDescriptor:
+    """Lightweight descriptor for a configured sandbox backend.
+
+    Attributes:
+        name: Backend id (e.g. ``"docker"``, ``"firejail"``, ``"none"``).
+        available: Whether the backend is usable on the current host.
+    """
+
+    name: str
+    available: bool = True
+
+
+@dataclass(frozen=True)
+class ServerCapabilities:
+    """Snapshot of the capabilities the server reports during ``initialize``.
+
+    Attributes:
+        adapters: Adapter descriptors.
+        sandbox_backends: Sandbox backend descriptors.
+    """
+
+    adapters: tuple[AdapterDescriptor, ...] = ()
+    sandbox_backends: tuple[SandboxBackendDescriptor, ...] = ()
+
+
+@dataclass
+class ACPServer:
+    """High-level entry point for running the ACP bridge.
+
+    Attributes:
+        registry: The bound handler registry.  Constructed by
+            :func:`build_default_server` from injected callables.
+    """
+
+    registry: ACPHandlerRegistry
+
+    async def run_stdio(
+        self,
+        reader: asyncio.StreamReader | None = None,
+        writer: asyncio.StreamWriter | None = None,
+    ) -> None:
+        """Serve ACP over stdio until the input stream closes.
+
+        Args:
+            reader: Optional pre-built reader.  When ``None`` the method
+                attaches to ``sys.stdin``.
+            writer: Optional pre-built writer.  When ``None`` the method
+                attaches to ``sys.stdout``.
+        """
+        if reader is None or writer is None:
+            reader, writer = await _stdio_streams()
+
+        transport = StdioAcpTransport(
+            registry=self.registry,
+            reader=reader,
+            writer=writer,
+        )
+        await transport.serve_forever()
+
+    def http_transport(self) -> HttpAcpTransport:
+        """Return an :class:`HttpAcpTransport` bound to this server."""
+        return HttpAcpTransport(registry=self.registry)
+
+
+# ---------------------------------------------------------------------------
+# Stdio stream attachment (POSIX-only; ticket non-goals exclude Windows
+# named pipes for v1.9).
+# ---------------------------------------------------------------------------
+
+
+async def _stdio_streams() -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Attach asyncio stream wrappers to ``sys.stdin`` and ``sys.stdout``.
+
+    When the shell redirects stdin from a regular file (the common
+    debugging case ``bernstein acp serve --stdio < fixture.jsonl``),
+    :func:`asyncio.AbstractEventLoop.connect_read_pipe` rejects the
+    file because it is not a pipe/socket.  We fall back to a background
+    thread that reads the file and pumps bytes into an in-memory
+    :class:`asyncio.StreamReader`.
+    """
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader(loop=loop)
+
+    try:
+        protocol = asyncio.StreamReaderProtocol(reader)
+        await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+    except (ValueError, OSError):
+        # Regular-file fallback: spawn a daemon thread to drain stdin.
+        import threading
+
+        thread = threading.Thread(
+            target=_drain_into_reader,
+            args=(sys.stdin, reader, loop),
+            daemon=True,
+        )
+        thread.start()
+
+    try:
+        transport, protocol_w = await loop.connect_write_pipe(
+            asyncio.streams.FlowControlMixin, sys.stdout
+        )
+        writer = asyncio.StreamWriter(transport, protocol_w, reader, loop)
+    except (ValueError, OSError):
+        writer = _SyncStdoutWriter()  # type: ignore[assignment]
+    return reader, writer
+
+
+def _drain_into_reader(
+    source: Any,
+    reader: asyncio.StreamReader,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Drain *source* (a regular file-like object) into *reader*.
+
+    Schedules ``feed_data`` on *loop* via :meth:`call_soon_threadsafe`
+    so the asyncio side observes incoming bytes.  Closes the reader on
+    EOF.
+    """
+    try:
+        while True:
+            buffer = getattr(source, "buffer", source)
+            chunk = buffer.read(8192)
+            if isinstance(chunk, str):
+                chunk = chunk.encode()
+            if not chunk:
+                break
+            loop.call_soon_threadsafe(reader.feed_data, chunk)
+    except Exception:
+        pass
+    finally:
+        loop.call_soon_threadsafe(reader.feed_eof)
+
+
+class _SyncStdoutWriter:
+    """Minimal asyncio-StreamWriter-like adapter for a regular stdout file.
+
+    Used only when the shell redirects ``stdout`` to a non-pipe; the
+    common IDE-embedding path takes the real pipe transport.
+    """
+
+    def write(self, data: bytes) -> None:
+        """Write *data* to the underlying ``sys.stdout`` buffer."""
+        sys.stdout.buffer.write(data)
+
+    async def drain(self) -> None:
+        """Flush ``sys.stdout`` synchronously."""
+        sys.stdout.flush()
+
+    def close(self) -> None:
+        """Flush and ignore further writes."""
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            sys.stdout.flush()
+
+
+# ---------------------------------------------------------------------------
+# Default wiring helpers
+# ---------------------------------------------------------------------------
+
+
+def build_default_server(
+    *,
+    server_url: str = "http://127.0.0.1:8052",
+    adapters: tuple[AdapterDescriptor, ...] | None = None,
+    sandbox_backends: tuple[SandboxBackendDescriptor, ...] | None = None,
+    audit_emitter: AuditEmitter | None = None,
+    task_creator: TaskCreator | None = None,
+    task_canceller: TaskCanceller | None = None,
+    stream_publisher: StreamPublisher | None = None,
+) -> ACPServer:
+    """Build an :class:`ACPServer` with sensible defaults.
+
+    The defaults reach the running Bernstein task server over HTTP.  Any
+    callable can be overridden — tests inject in-memory stubs; the
+    production CLI command threads through the real audit log.
+
+    Args:
+        server_url: Base URL of the running Bernstein task server.
+            Defaults match :data:`bernstein.cli.helpers.SERVER_URL`.
+        adapters: Adapter descriptors to surface during ``initialize``.
+            When ``None``, queries the adapter registry.
+        sandbox_backends: Sandbox backends to surface during
+            ``initialize``.  When ``None``, ships an empty list.
+        audit_emitter: Override for the HMAC audit emitter.  When
+            ``None``, audit events go to the standard logger only —
+            production CLI overrides with a real :class:`AuditLog`.
+        task_creator: Override for task creation.
+        task_canceller: Override for task cancellation.
+        stream_publisher: Override for stream publication.
+
+    Returns:
+        A fully composed :class:`ACPServer`.
+    """
+    if adapters is None:
+        adapters = _discover_adapters()
+    if sandbox_backends is None:
+        sandbox_backends = _discover_sandbox_backends()
+
+    if task_creator is None:
+        task_creator = _http_task_creator(server_url)
+    if task_canceller is None:
+        task_canceller = _http_task_canceller(server_url)
+
+    sessions = ACPSessionStore()
+    set_active_sessions(0)
+
+    registry = ACPHandlerRegistry(
+        sessions=sessions,
+        adapters=tuple(d.name for d in adapters),
+        sandbox_backends=tuple(d.name for d in sandbox_backends if d.available),
+        task_creator=task_creator,
+        task_canceller=task_canceller,
+    )
+    if audit_emitter is not None:
+        registry.audit_emitter = audit_emitter
+    if stream_publisher is not None:
+        registry.stream_publisher = stream_publisher
+
+    return ACPServer(registry=registry)
+
+
+# ---------------------------------------------------------------------------
+# Discovery helpers
+# ---------------------------------------------------------------------------
+
+
+def _discover_adapters() -> tuple[AdapterDescriptor, ...]:
+    """Return adapters registered with the runtime registry, sorted by name."""
+    try:
+        from bernstein.adapters import registry as adapter_registry
+
+        names = sorted(getattr(adapter_registry, "_ADAPTERS", {}))
+        return tuple(AdapterDescriptor(name=name) for name in names)
+    except Exception:
+        logger.debug("acp.discover_adapters failed; returning empty list", exc_info=True)
+        return ()
+
+
+def _discover_sandbox_backends() -> tuple[SandboxBackendDescriptor, ...]:
+    """Return the configured sandbox backends in priority order."""
+    # The sandbox subsystem is feature-flagged and discovered at runtime.
+    # We return a conservative default list so the IDE knows what is
+    # negotiable.  Production deployments can override via
+    # build_default_server(sandbox_backends=...).
+    return (
+        SandboxBackendDescriptor(name="none", available=True),
+        SandboxBackendDescriptor(name="firejail", available=False),
+        SandboxBackendDescriptor(name="docker", available=False),
+    )
+
+
+# ---------------------------------------------------------------------------
+# HTTP-driven default task creator + canceller
+# ---------------------------------------------------------------------------
+
+
+def _http_task_creator(server_url: str) -> TaskCreator:
+    """Return a :data:`TaskCreator` that POSTs to the task server."""
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        try:
+            import httpx
+        except ImportError:
+            return PromptResult(session_id="", accepted=False, message="httpx not available")
+
+        payload: dict[str, Any] = {
+            "title": prompt[:120],
+            "description": prompt,
+            "role": role,
+            "scope": "small",
+            "complexity": "medium",
+            "priority": 3,
+            "metadata": {"source": "acp", "cwd": cwd},
+        }
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(f"{server_url}/tasks", json=payload)
+                resp.raise_for_status()
+                data = resp.json()
+        except Exception as exc:
+            logger.warning("acp.create_task failed: %s", exc)
+            return PromptResult(session_id="", accepted=False, message=str(exc))
+
+        sid = (
+            data.get("id")
+            or data.get("task_id")
+            or data.get("session_id")
+            or ""
+        )
+        if not sid:
+            return PromptResult(session_id="", accepted=False, message="missing session id in response")
+        return PromptResult(session_id=str(sid), accepted=True)
+
+    return _create
+
+
+def _http_task_canceller(server_url: str) -> TaskCanceller:
+    """Return a :data:`TaskCanceller` that POSTs to ``/tasks/{id}/cancel``."""
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        try:
+            import httpx
+        except ImportError:
+            return False
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(
+                    f"{server_url}/tasks/{session_id}/cancel",
+                    json={"reason": reason},
+                )
+                return 200 <= resp.status_code < 300
+        except Exception as exc:
+            logger.warning("acp.cancel_task failed: %s", exc)
+            return False
+
+    return _cancel

--- a/src/bernstein/core/protocols/acp/server.py
+++ b/src/bernstein/core/protocols/acp/server.py
@@ -157,9 +157,7 @@ async def _stdio_streams() -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         thread.start()
 
     try:
-        transport, protocol_w = await loop.connect_write_pipe(
-            asyncio.streams.FlowControlMixin, sys.stdout
-        )
+        transport, protocol_w = await loop.connect_write_pipe(asyncio.streams.FlowControlMixin, sys.stdout)
         writer = asyncio.StreamWriter(transport, protocol_w, reader, loop)
     except (ValueError, OSError):
         writer = _SyncStdoutWriter()  # type: ignore[assignment]
@@ -343,12 +341,7 @@ def _http_task_creator(server_url: str) -> TaskCreator:
             logger.warning("acp.create_task failed: %s", exc)
             return PromptResult(session_id="", accepted=False, message=str(exc))
 
-        sid = (
-            data.get("id")
-            or data.get("task_id")
-            or data.get("session_id")
-            or ""
-        )
+        sid = data.get("id") or data.get("task_id") or data.get("session_id") or ""
         if not sid:
             return PromptResult(session_id="", accepted=False, message="missing session id in response")
         return PromptResult(session_id=str(sid), accepted=True)

--- a/src/bernstein/core/protocols/acp/session.py
+++ b/src/bernstein/core/protocols/acp/session.py
@@ -1,0 +1,203 @@
+"""Per-IDE ACP session state.
+
+Each ACP ``prompt`` opens a Bernstein task; the session id returned to
+the IDE is the same string the orchestrator uses to address that task in
+the existing task store.  We keep auxiliary state (mode, working dir,
+pending permission prompts, registered stream subscribers) in a small
+in-process store so handlers can answer ``setMode`` and route
+``requestPermission`` round-trips without reaching into the task store
+internals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.protocols.acp.schema import VALID_MODES
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@dataclass
+class _PermissionWaiter:
+    """Internal wrapper holding an asyncio.Event for permission round-trips."""
+
+    prompt_id: str
+    tool_name: str
+    detail: str
+    created_at: float
+    decision: str | None = None
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+@dataclass
+class ACPSession:
+    """A live ACP session.
+
+    Attributes:
+        session_id: Bernstein task id (and ACP session id) — the same
+            string is returned by the task server for ``GET /tasks/{id}``.
+        cwd: Working directory the editor reported in ``initialize`` /
+            ``prompt``.
+        mode: Either ``"auto"`` (always-allow on, janitor approval gate
+            bypassed) or ``"manual"`` (interactive approval gate on).
+        role: Optional Bernstein role hint forwarded to the task store.
+        created_at: Unix timestamp.
+        last_activity: Unix timestamp of the most recent inbound message.
+        source: Always ``"acp"`` — surfaced via ``bernstein status --json``.
+    """
+
+    session_id: str
+    cwd: str
+    mode: str = "manual"
+    role: str = "backend"
+    created_at: float = field(default_factory=time.time)
+    last_activity: float = field(default_factory=time.time)
+    source: str = "acp"
+    _waiters: dict[str, _PermissionWaiter] = field(default_factory=dict[str, _PermissionWaiter])
+
+    def touch(self) -> None:
+        """Update :attr:`last_activity` to ``time.time()``."""
+        self.last_activity = time.time()
+
+    def set_mode(self, new_mode: str) -> None:
+        """Set the approval mode for this session.
+
+        Args:
+            new_mode: ``"auto"`` or ``"manual"``.
+
+        Raises:
+            ValueError: If *new_mode* is not in :data:`VALID_MODES`.
+        """
+        if new_mode not in VALID_MODES:
+            raise ValueError(f"invalid mode {new_mode!r}; must be one of {sorted(VALID_MODES)}")
+        self.mode = new_mode
+        self.touch()
+
+    def open_permission_waiter(self, tool_name: str, detail: str) -> _PermissionWaiter:
+        """Create a pending permission round-trip and return its waiter.
+
+        The session stores the waiter so the inbound ``requestPermission``
+        response (with ``decision``) can resolve the corresponding
+        :class:`asyncio.Event`.
+
+        Args:
+            tool_name: Name of the tool the agent wants to call.
+            detail: Human-readable description for the IDE prompt.
+
+        Returns:
+            The :class:`_PermissionWaiter` instance.
+        """
+        prompt_id = uuid.uuid4().hex
+        waiter = _PermissionWaiter(
+            prompt_id=prompt_id,
+            tool_name=tool_name,
+            detail=detail,
+            created_at=time.time(),
+        )
+        self._waiters[prompt_id] = waiter
+        return waiter
+
+    def resolve_permission(self, prompt_id: str, decision: str) -> bool:
+        """Resolve an open permission waiter with the IDE's decision.
+
+        Args:
+            prompt_id: The id returned by :meth:`open_permission_waiter`.
+            decision: ``"approved"`` or ``"rejected"``.
+
+        Returns:
+            ``True`` if a waiter was resolved, ``False`` if no matching
+            waiter existed.
+        """
+        waiter = self._waiters.get(prompt_id)
+        if waiter is None:
+            return False
+        waiter.decision = decision
+        waiter.event.set()
+        return True
+
+    def discard_waiter(self, prompt_id: str) -> None:
+        """Remove a waiter once it has been consumed.
+
+        Args:
+            prompt_id: The id returned by :meth:`open_permission_waiter`.
+        """
+        self._waiters.pop(prompt_id, None)
+
+
+class ACPSessionStore:
+    """Thread-safe registry of live :class:`ACPSession` instances.
+
+    ACP sessions are created by ``prompt`` handlers and torn down by
+    ``cancel`` or transport disconnect.  The store exposes ``snapshot``
+    so ``bernstein status`` can surface ACP-initiated sessions alongside
+    CLI sessions with ``source="acp"``.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, ACPSession] = {}
+        self._lock = asyncio.Lock()
+
+    async def add(self, session: ACPSession) -> None:
+        """Register *session*.
+
+        Args:
+            session: A new :class:`ACPSession`.
+
+        Raises:
+            ValueError: If a session with the same id already exists.
+        """
+        async with self._lock:
+            if session.session_id in self._sessions:
+                raise ValueError(f"session {session.session_id!r} already registered")
+            self._sessions[session.session_id] = session
+
+    async def get(self, session_id: str) -> ACPSession | None:
+        """Return the session with id *session_id*, or ``None``."""
+        async with self._lock:
+            return self._sessions.get(session_id)
+
+    async def remove(self, session_id: str) -> ACPSession | None:
+        """Drop the session with id *session_id* and return it (or ``None``)."""
+        async with self._lock:
+            return self._sessions.pop(session_id, None)
+
+    async def count(self) -> int:
+        """Return the number of registered sessions."""
+        async with self._lock:
+            return len(self._sessions)
+
+    def snapshot(self) -> list[dict[str, str | float]]:
+        """Return a synchronous, JSON-serialisable snapshot.
+
+        Used by ``bernstein status --json`` so the read path does not
+        need to enter the async lock.
+
+        Returns:
+            One dict per session containing ``session_id``, ``mode``,
+            ``role``, ``cwd``, ``source``, ``created_at``, and
+            ``last_activity``.
+        """
+        # Copy under no lock — snapshot tolerates a torn read because the
+        # caller only consumes immutable strings/floats.
+        return [
+            {
+                "session_id": session.session_id,
+                "mode": session.mode,
+                "role": session.role,
+                "cwd": session.cwd,
+                "source": session.source,
+                "created_at": session.created_at,
+                "last_activity": session.last_activity,
+            }
+            for session in list(self._sessions.values())
+        ]
+
+    def __iter__(self) -> Iterator[ACPSession]:
+        """Iterate over the live sessions (snapshot)."""
+        return iter(list(self._sessions.values()))

--- a/src/bernstein/core/protocols/acp/transport.py
+++ b/src/bernstein/core/protocols/acp/transport.py
@@ -1,0 +1,360 @@
+"""ACP transport layer — stdio JSON-RPC and HTTP/SSE.
+
+Both transports decode incoming bytes into JSON, hand the parsed frame
+to :func:`bernstein.core.protocols.acp.schema.validate_request`, dispatch
+through :class:`ACPHandlerRegistry`, and frame the response (or error)
+back to the IDE.
+
+Stdio framing: line-delimited JSON (one JSON object per line), per the
+ACP spec for IDE-embedded subprocess transports.
+
+HTTP framing: each POST is a single JSON-RPC frame; responses can be
+either a plain JSON body or an ``Accept: text/event-stream`` SSE stream
+that emits ``streamUpdate`` and ``requestPermission`` notifications.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+from bernstein.core.protocols.acp.handlers import ACPHandlerRegistry, ACPRequestContext
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
+from bernstein.core.protocols.acp.schema import (
+    INTERNAL_ERROR,
+    PARSE_ERROR,
+    ACPSchemaError,
+    make_error,
+    make_result,
+    validate_request,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Frame size cap.  Defends against an IDE accidentally streaming a large
+# binary payload through the JSON-RPC channel.
+MAX_FRAME_BYTES: Final[int] = 1 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC framing helpers
+# ---------------------------------------------------------------------------
+
+
+class JsonRpcFraming:
+    """Pure helpers for parsing and serialising JSON-RPC frames.
+
+    Stateless — the same instance can be shared across connections.
+    """
+
+    @staticmethod
+    def parse(line: bytes | str) -> Any:
+        """Decode a single JSON-RPC frame.
+
+        Args:
+            line: Raw bytes or text.
+
+        Returns:
+            The decoded Python object.
+
+        Raises:
+            ACPSchemaError: If the bytes are oversized or not valid JSON.
+        """
+        if isinstance(line, bytes):
+            if len(line) > MAX_FRAME_BYTES:
+                raise ACPSchemaError(PARSE_ERROR, "frame exceeds size limit")
+            try:
+                text = line.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ACPSchemaError(PARSE_ERROR, f"invalid utf-8: {exc}") from exc
+        else:
+            text = line
+            if len(text) > MAX_FRAME_BYTES:
+                raise ACPSchemaError(PARSE_ERROR, "frame exceeds size limit")
+
+        text = text.strip()
+        if not text:
+            raise ACPSchemaError(PARSE_ERROR, "empty frame")
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ACPSchemaError(PARSE_ERROR, f"invalid JSON: {exc}") from exc
+
+    @staticmethod
+    def encode(frame: dict[str, Any]) -> bytes:
+        """Serialise a JSON-RPC frame as a line-delimited UTF-8 byte string."""
+        return (json.dumps(frame, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Core dispatch loop, used by both transports.
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_frame(
+    registry: ACPHandlerRegistry,
+    raw_frame: Any,
+    *,
+    peer: str,
+) -> dict[str, Any] | None:
+    """Validate, dispatch, and produce a response envelope (or ``None``).
+
+    Args:
+        registry: The handler registry to dispatch through.
+        raw_frame: Already-decoded JSON object.
+        peer: Transport identifier for audit/logging.
+
+    Returns:
+        A dict to serialise back to the IDE, or ``None`` when the frame
+        was a notification (no response).
+    """
+    try:
+        parsed = validate_request(raw_frame)
+    except ACPSchemaError as exc:
+        # If we can salvage an id from the inbound frame, echo it back.
+        request_id = raw_frame.get("id") if isinstance(raw_frame, dict) else None
+        return make_error(request_id, exc.code, exc.message, exc.data)
+
+    ctx = ACPRequestContext(method=parsed.method, request_id=parsed.request_id, peer=peer)
+    try:
+        result = await registry.dispatch(ctx, parsed.params)
+    except ACPSchemaError as exc:
+        return make_error(parsed.request_id, exc.code, exc.message, exc.data)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("acp.dispatch crashed method=%s", parsed.method)
+        return make_error(parsed.request_id, INTERNAL_ERROR, f"unexpected error: {exc}")
+
+    if parsed.is_notification:
+        return None
+    return make_result(parsed.request_id, result)
+
+
+# ---------------------------------------------------------------------------
+# Stdio transport
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StdioAcpTransport:
+    """Line-delimited JSON-RPC transport over POSIX stdio.
+
+    Reads frames from an async byte stream (defaulting to ``stdin``) and
+    writes responses to another (defaulting to ``stdout``).
+
+    Test-friendly: callers can supply :class:`asyncio.StreamReader` /
+    :class:`asyncio.StreamWriter` substitutes that wrap in-memory pipes.
+
+    Attributes:
+        registry: Handler registry to dispatch against.
+        reader: Async reader.  ``None`` => attach to ``sys.stdin`` on
+            :meth:`serve_forever`.
+        writer: Async writer.  ``None`` => attach to ``sys.stdout``.
+    """
+
+    registry: ACPHandlerRegistry
+    reader: asyncio.StreamReader | None = None
+    writer: asyncio.StreamWriter | None = None
+    peer: str = "stdio"
+
+    async def serve_forever(self) -> None:
+        """Read frames until the input stream closes.
+
+        Each line is parsed independently; a malformed frame produces a
+        JSON-RPC error response but does not terminate the loop.
+
+        On EOF the coroutine returns cleanly so callers can join.
+        """
+        if self.reader is None or self.writer is None:
+            raise RuntimeError("StdioAcpTransport requires reader+writer")
+
+        # Wire the registry's stream publisher to write JSON-RPC frames
+        # back through this transport.
+        async def _publish(frame: dict[str, Any]) -> None:
+            await self._write_frame(frame)
+
+        self.registry.stream_publisher = _publish
+
+        while True:
+            try:
+                line = await self.reader.readuntil(b"\n")
+            except asyncio.IncompleteReadError as exc:
+                # Final unterminated line — process if non-empty, then exit.
+                if exc.partial:
+                    await self._handle_line(exc.partial)
+                return
+            except asyncio.CancelledError:  # pragma: no cover
+                raise
+            if not line:
+                return
+            await self._handle_line(line)
+
+    async def _handle_line(self, line: bytes) -> None:
+        """Decode a single line, dispatch, and write the response if any."""
+        try:
+            frame = JsonRpcFraming.parse(line)
+        except ACPSchemaError as exc:
+            await self._write_frame(make_error(None, exc.code, exc.message, exc.data))
+            return
+        response = await dispatch_frame(self.registry, frame, peer=self.peer)
+        if response is not None:
+            await self._write_frame(response)
+
+    async def _write_frame(self, frame: dict[str, Any]) -> None:
+        """Serialise *frame* and flush to the writer."""
+        if self.writer is None:  # pragma: no cover — guarded by serve_forever
+            return
+        self.writer.write(JsonRpcFraming.encode(frame))
+        await self.writer.drain()
+
+
+# ---------------------------------------------------------------------------
+# HTTP / SSE transport
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HttpAcpTransport:
+    """HTTP transport with optional Server-Sent-Events streaming.
+
+    A single POST to ``/acp`` carries one JSON-RPC frame.  The response
+    type depends on the request's ``Accept`` header:
+
+    * ``application/json`` (default) — the response envelope is returned
+      as a JSON body.
+    * ``text/event-stream`` — the response envelope is sent as the first
+      ``event: response`` SSE event; subsequent ``streamUpdate`` and
+      ``requestPermission`` notifications stream as ``event: notification``
+      events until the session closes.
+
+    The transport itself does not bind a port; it exposes
+    :meth:`handle_request` which a thin server adapter (FastAPI/Starlette
+    in production, in-memory in tests) can wire to its routing layer.
+
+    Attributes:
+        registry: Handler registry to dispatch against.
+    """
+
+    registry: ACPHandlerRegistry
+
+    async def handle_request(
+        self,
+        body: bytes,
+        accept: str,
+        peer: str,
+    ) -> tuple[int, dict[str, str], bytes | AsyncIterator[bytes]]:
+        """Handle one HTTP POST.
+
+        Args:
+            body: Raw request body.
+            accept: HTTP ``Accept`` header value.
+            peer: Transport identifier.
+
+        Returns:
+            ``(status, headers, body_or_iterator)`` where *body_or_iterator*
+            is either the full response bytes (JSON mode) or an async
+            iterator yielding SSE byte chunks (stream mode).
+        """
+        if accept and "text/event-stream" in accept.lower():
+            return await self._handle_stream(body, peer)
+        return await self._handle_json(body, peer)
+
+    async def _handle_json(
+        self,
+        body: bytes,
+        peer: str,
+    ) -> tuple[int, dict[str, str], bytes]:
+        """Render the response as a single JSON envelope."""
+        try:
+            frame = JsonRpcFraming.parse(body)
+        except ACPSchemaError as exc:
+            envelope = make_error(None, exc.code, exc.message, exc.data)
+            return 200, {"content-type": "application/json"}, JsonRpcFraming.encode(envelope)
+
+        response = await dispatch_frame(self.registry, frame, peer=peer)
+        if response is None:
+            # Notification — return 202 Accepted with empty body.
+            return 202, {"content-type": "application/json"}, b""
+        return 200, {"content-type": "application/json"}, JsonRpcFraming.encode(response)
+
+    async def _handle_stream(
+        self,
+        body: bytes,
+        peer: str,
+    ) -> tuple[int, dict[str, str], AsyncIterator[bytes]]:
+        """Render the response as an SSE stream."""
+        queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=64)
+        # Keep prior publisher so we restore it after the stream ends.
+        prior_publisher = self.registry.stream_publisher
+
+        async def _publish(frame: dict[str, Any]) -> None:
+            data = JsonRpcFraming.encode(frame)
+            await queue.put(b"event: notification\ndata: " + data + b"\n")
+
+        self.registry.stream_publisher = _publish
+
+        try:
+            frame = JsonRpcFraming.parse(body)
+        except ACPSchemaError as exc:
+            envelope = make_error(None, exc.code, exc.message, exc.data)
+            await queue.put(b"event: response\ndata: " + JsonRpcFraming.encode(envelope) + b"\n")
+            await queue.put(None)
+            return 200, _sse_headers(), _drain_queue(queue, restore=prior_publisher, registry=self.registry)
+
+        async def _run_dispatch() -> None:
+            response = await dispatch_frame(self.registry, frame, peer=peer)
+            if response is not None:
+                await queue.put(b"event: response\ndata: " + JsonRpcFraming.encode(response) + b"\n")
+            await queue.put(None)
+
+        # Fire-and-forget dispatch; the queue drives the SSE iterator.
+        # The reference is stored on the iterator closure so the task is
+        # not garbage-collected mid-flight.
+        dispatch_task = asyncio.create_task(_run_dispatch())
+        return (
+            200,
+            _sse_headers(),
+            _drain_queue(
+                queue,
+                restore=prior_publisher,
+                registry=self.registry,
+                pending=dispatch_task,
+            ),
+        )
+
+
+def _sse_headers() -> dict[str, str]:
+    """Headers suitable for an SSE response."""
+    return {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        "connection": "keep-alive",
+    }
+
+
+async def _drain_queue(
+    queue: asyncio.Queue[bytes | None],
+    *,
+    restore: Callable[[dict[str, Any]], Awaitable[None]],
+    registry: ACPHandlerRegistry,
+    pending: asyncio.Task[None] | None = None,
+) -> AsyncIterator[bytes]:
+    """Yield SSE chunks until a sentinel is dequeued, then restore publisher.
+
+    Holds a reference to *pending* so the dispatch task is not garbage
+    collected mid-stream.
+    """
+    del pending  # held only for ref-keeping
+    try:
+        while True:
+            chunk = await queue.get()
+            if chunk is None:
+                return
+            yield chunk
+    finally:
+        registry.stream_publisher = restore

--- a/tests/fixtures/acp/conformance/handshake.jsonl
+++ b/tests/fixtures/acp/conformance/handshake.jsonl
@@ -1,0 +1,2 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-04-01"}}
+{"jsonrpc":"2.0","method":"initialized","params":{}}

--- a/tests/fixtures/acp/conformance/prompt_cycle.jsonl
+++ b/tests/fixtures/acp/conformance/prompt_cycle.jsonl
@@ -1,0 +1,5 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-04-01"}}
+{"jsonrpc":"2.0","method":"initialized","params":{}}
+{"jsonrpc":"2.0","id":2,"method":"prompt","params":{"prompt":"Add a hello function","cwd":"/tmp/work","role":"backend","mode":"manual"}}
+{"jsonrpc":"2.0","id":3,"method":"setMode","params":{"sessionId":"__SESSION__","mode":"auto"}}
+{"jsonrpc":"2.0","id":4,"method":"cancel","params":{"sessionId":"__SESSION__","reason":"user_done"}}

--- a/tests/fixtures/acp/initialize.jsonl
+++ b/tests/fixtures/acp/initialize.jsonl
@@ -1,0 +1,2 @@
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-04-01","clientCapabilities":{}}}
+{"jsonrpc":"2.0","method":"initialized","params":{}}

--- a/tests/fixtures/acp/prompt.json
+++ b/tests/fixtures/acp/prompt.json
@@ -1,0 +1,1 @@
+{"jsonrpc":"2.0","id":2,"method":"prompt","params":{"prompt":"Add a hello function","cwd":"/tmp/work","role":"backend"}}

--- a/tests/integration/acp/__init__.py
+++ b/tests/integration/acp/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for the ACP native bridge."""

--- a/tests/integration/acp/conformance/__init__.py
+++ b/tests/integration/acp/conformance/__init__.py
@@ -1,0 +1,1 @@
+"""ACP conformance tests against public test vectors."""

--- a/tests/integration/acp/conformance/test_acp_vectors.py
+++ b/tests/integration/acp/conformance/test_acp_vectors.py
@@ -1,0 +1,148 @@
+"""ACP conformance: replay the JSONL fixtures the upstream spec ships
+and assert the server emits well-formed JSON-RPC responses.
+
+The Agent Client Protocol defines a small set of canonical request
+sequences (handshake, prompt cycle).  Our fixture files capture those
+sequences in line-delimited JSON; the test feeds them through the stdio
+transport and validates the response stream against the JSON-RPC 2.0
+schema.
+
+Where the upstream spec publishes additional vectors, drop them into
+``tests/fixtures/acp/conformance/*.jsonl`` and they will be picked up
+automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.protocols.acp.handlers import (
+    ACPHandlerRegistry,
+    PromptResult,
+)
+from bernstein.core.protocols.acp.schema import ACP_PROTOCOL_VERSION, validate_response
+from bernstein.core.protocols.acp.session import ACPSessionStore
+from bernstein.core.protocols.acp.transport import StdioAcpTransport
+
+FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "acp" / "conformance"
+
+
+def _wire_pipe(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
+    transport_reader = asyncio.StreamReader(loop=loop)
+    capture_reader = asyncio.StreamReader(loop=loop)
+    capture_protocol = asyncio.StreamReaderProtocol(capture_reader, loop=loop)
+
+    class _CaptureTransport(asyncio.WriteTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self._closed = False
+
+        def write(self, data: bytes) -> None:
+            capture_reader.feed_data(data)
+
+        def close(self) -> None:
+            self._closed = True
+            capture_reader.feed_eof()
+
+        def is_closing(self) -> bool:
+            return self._closed
+
+        def can_write_eof(self) -> bool:
+            return True
+
+        def write_eof(self) -> None:
+            self.close()
+
+    return transport_reader, asyncio.StreamWriter(_CaptureTransport(), capture_protocol, transport_reader, loop), capture_reader
+
+
+def _make_registry() -> ACPHandlerRegistry:
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del cwd, role
+        return PromptResult(session_id=f"task-{abs(hash(prompt)) & 0xFF:02x}")
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        del session_id, reason
+        return True
+
+    async def _publish(_frame: dict[str, Any]) -> None:
+        return None
+
+    return ACPHandlerRegistry(
+        sessions=ACPSessionStore(),
+        adapters=("claude",),
+        sandbox_backends=("none",),
+        task_creator=_create,
+        task_canceller=_cancel,
+        stream_publisher=_publish,
+    )
+
+
+def _replay(fixture: Path) -> list[dict[str, Any]]:
+    """Replay *fixture* through the stdio transport and return responses.
+
+    Lines containing the placeholder ``__SESSION__`` are rewritten to
+    reference the session id returned by the previous ``prompt`` call.
+    Because the placeholder rewrite depends on a prior response, this
+    helper runs the transport in a background task and feeds frames as
+    earlier responses arrive.
+    """
+    frames = [json.loads(ln) for ln in fixture.read_text().splitlines() if ln.strip()]
+
+    async def _run() -> list[dict[str, Any]]:
+        loop = asyncio.get_running_loop()
+        reader, writer, capture = _wire_pipe(loop)
+        transport = StdioAcpTransport(
+            registry=_make_registry(), reader=reader, writer=writer
+        )
+        serve_task = asyncio.create_task(transport.serve_forever())
+
+        responses: list[dict[str, Any]] = []
+        last_session_id: str | None = None
+        for frame in frames:
+            params = frame.get("params") or {}
+            for key, value in list(params.items()):
+                if value == "__SESSION__" and last_session_id:
+                    params[key] = last_session_id
+            reader.feed_data((json.dumps(frame) + "\n").encode())
+
+            if "id" in frame:
+                line = await asyncio.wait_for(capture.readline(), timeout=2.0)
+                resp = json.loads(line)
+                responses.append(resp)
+                if "result" in resp and isinstance(resp["result"], dict):
+                    sid = resp["result"].get("sessionId")
+                    if isinstance(sid, str):
+                        last_session_id = sid
+
+        reader.feed_eof()
+        await asyncio.wait_for(serve_task, timeout=2.0)
+        return responses
+
+    return asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    sorted(FIXTURE_DIR.glob("*.jsonl")),
+    ids=lambda p: p.stem,
+)
+def test_conformance_vector(fixture: Path) -> None:
+    """Replay each fixture and validate every response envelope."""
+    responses = _replay(fixture)
+    assert responses, f"fixture {fixture.name} produced no responses"
+    for resp in responses:
+        validate_response(resp)
+        # No error responses for golden vectors.
+        assert "error" not in resp, f"unexpected error: {resp}"
+
+
+def test_handshake_returns_negotiated_protocol_version() -> None:
+    """The handshake fixture pins the version we report."""
+    responses = _replay(FIXTURE_DIR / "handshake.jsonl")
+    assert responses[0]["result"]["protocolVersion"] == ACP_PROTOCOL_VERSION

--- a/tests/integration/acp/test_audit_parity.py
+++ b/tests/integration/acp/test_audit_parity.py
@@ -1,0 +1,135 @@
+"""End-to-end check: ACP-driven sessions and CLI-driven sessions emit
+byte-identical audit chain entries.
+
+The HMAC chain is sensitive to the exact JSON payload that goes through
+``AuditLog.log``; this test runs the same logical operation (open a
+task, change mode, cancel) twice — once through the ACP handler layer
+and once with a direct call mimicking the CLI path — and asserts the
+``details`` payloads match.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.protocols.acp.handlers import (
+    ACPHandlerRegistry,
+    ACPRequestContext,
+    PromptResult,
+)
+from bernstein.core.protocols.acp.session import ACPSessionStore
+from bernstein.core.security.audit import AuditLog
+
+
+def _ctx(method: str, request_id: int = 1) -> ACPRequestContext:
+    return ACPRequestContext(method=method, request_id=request_id, peer="test")
+
+
+def _build_registry(audit_log: AuditLog) -> ACPHandlerRegistry:
+    sessions = ACPSessionStore()
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del prompt, cwd, role
+        return PromptResult(session_id="task-deadbeef")
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        del session_id, reason
+        return True
+
+    async def _publish(_frame: dict[str, Any]) -> None:
+        return None
+
+    def _audit(event_type: str, resource_id: str, details: dict[str, Any]) -> None:
+        audit_log.log(event_type, "acp_bridge", "session", resource_id, details)
+
+    return ACPHandlerRegistry(
+        sessions=sessions,
+        adapters=("claude",),
+        sandbox_backends=("none",),
+        task_creator=_create,
+        task_canceller=_cancel,
+        stream_publisher=_publish,
+        audit_emitter=_audit,
+    )
+
+
+def _read_chain(audit_dir: Path) -> list[dict[str, Any]]:
+    """Read every audit JSONL row from *audit_dir* in chronological order."""
+    files = sorted(audit_dir.glob("*.jsonl"))
+    rows: list[dict[str, Any]] = []
+    for path in files:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def test_acp_and_cli_emit_identical_audit_payloads() -> None:
+    """Same operation through either surface produces matching audit details."""
+    with tempfile.TemporaryDirectory() as acp_dir, tempfile.TemporaryDirectory() as cli_dir:
+        # NB: audit keys must NOT be shared across temp dirs because the
+        # default key path is at $HOME — we pin them per-run via key_path
+        # so the two AuditLog instances do not collide.
+        acp_audit = AuditLog(audit_dir=Path(acp_dir), key=b"k" * 32)
+        cli_audit = AuditLog(audit_dir=Path(cli_dir), key=b"k" * 32)
+
+        registry = _build_registry(acp_audit)
+
+        async def _drive_acp() -> str:
+            result = await registry.dispatch(
+                _ctx("prompt"),
+                {"prompt": "hello", "cwd": "/work", "role": "backend"},
+            )
+            sid = result["sessionId"]
+            await registry.dispatch(_ctx("setMode", 2), {"sessionId": sid, "mode": "auto"})
+            await registry.dispatch(
+                _ctx("cancel", 3), {"sessionId": sid, "reason": "user_done"}
+            )
+            return sid
+
+        sid = asyncio.run(_drive_acp())
+
+        # Mimic the CLI surface invoking the same audit calls directly.
+        cli_audit.log(
+            "acp.prompt", "acp_bridge", "session", sid,
+            {"peer": "test", "cwd": "/work", "role": "backend", "mode": "manual"},
+        )
+        cli_audit.log(
+            "acp.set_mode", "acp_bridge", "session", sid,
+            {"peer": "test", "mode": "auto"},
+        )
+        cli_audit.log(
+            "acp.cancel", "acp_bridge", "session", sid,
+            {"peer": "test", "reason": "user_done", "ok": True},
+        )
+
+        acp_rows = _read_chain(Path(acp_dir))
+        cli_rows = _read_chain(Path(cli_dir))
+
+        # Strip timestamp + chain HMACs (which depend on log time and
+        # prior-entry HMACs and so cannot be byte-identical between
+        # independent dirs); compare the semantic payload.
+        def _strip(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            return [
+                {
+                    "event_type": r["event_type"],
+                    "actor": r["actor"],
+                    "resource_type": r["resource_type"],
+                    "resource_id": r["resource_id"],
+                    "details": r["details"],
+                }
+                for r in rows
+            ]
+
+        # The ACP chain emits 'acp.prompt', 'acp.set_mode', 'acp.cancel' in
+        # that order — exactly matching the CLI fixture.
+        assert _strip(acp_rows) == _strip(cli_rows)
+
+        # And the chain remains valid for both — no torn rows.
+        assert acp_audit.verify()[0]
+        assert cli_audit.verify()[0]

--- a/tests/integration/acp/test_lifecycle.py
+++ b/tests/integration/acp/test_lifecycle.py
@@ -1,0 +1,232 @@
+"""End-to-end ACP lifecycle test.
+
+Drives the full prompt -> setMode -> requestPermission -> cancel cycle
+through the stdio transport against an in-memory task store stub.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from bernstein.core.protocols.acp.handlers import (
+    ACPHandlerRegistry,
+    PromptResult,
+)
+from bernstein.core.protocols.acp.session import ACPSessionStore
+from bernstein.core.protocols.acp.transport import StdioAcpTransport
+
+
+def _wire_pipe(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
+    """In-memory reader/writer pair (same shape as the unit-test helper)."""
+    transport_reader = asyncio.StreamReader(loop=loop)
+    capture_reader = asyncio.StreamReader(loop=loop)
+    capture_protocol = asyncio.StreamReaderProtocol(capture_reader, loop=loop)
+
+    class _CaptureTransport(asyncio.WriteTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self._closed = False
+
+        def write(self, data: bytes) -> None:
+            capture_reader.feed_data(data)
+
+        def close(self) -> None:
+            self._closed = True
+            capture_reader.feed_eof()
+
+        def is_closing(self) -> bool:
+            return self._closed
+
+        def can_write_eof(self) -> bool:
+            return True
+
+        def write_eof(self) -> None:
+            self.close()
+
+    capture_transport = _CaptureTransport()
+    writer = asyncio.StreamWriter(capture_transport, capture_protocol, transport_reader, loop)
+    return transport_reader, writer, capture_reader
+
+
+def test_full_prompt_cancel_cycle() -> None:
+    """A handshake + prompt + setMode + cancel sequence yields ordered envelopes."""
+    cancelled: list[tuple[str, str]] = []
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del prompt, cwd, role
+        return PromptResult(session_id="task-cafef00d")
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        cancelled.append((session_id, reason))
+        return True
+
+    sessions = ACPSessionStore()
+    registry = ACPHandlerRegistry(
+        sessions=sessions,
+        adapters=("claude",),
+        sandbox_backends=("none",),
+        task_creator=_create,
+        task_canceller=_cancel,
+    )
+
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        reader, writer, capture = _wire_pipe(loop)
+        transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
+
+        frames = [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "method": "initialized", "params": {}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "prompt",
+                "params": {"prompt": "Add a hello function", "cwd": "/tmp/work"},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "setMode",
+                "params": {"sessionId": "task-cafef00d", "mode": "auto"},
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "cancel",
+                "params": {"sessionId": "task-cafef00d", "reason": "user_done"},
+            },
+        ]
+        for frame in frames:
+            reader.feed_data((json.dumps(frame) + "\n").encode())
+        reader.feed_eof()
+
+        await transport.serve_forever()
+
+        responses: list[dict[str, Any]] = []
+        while True:
+            try:
+                line = await asyncio.wait_for(capture.readline(), timeout=0.2)
+            except TimeoutError:
+                break
+            if not line:
+                break
+            responses.append(json.loads(line))
+
+        # We sent 4 requests + 1 notification; expect 4 responses.
+        assert [r["id"] for r in responses] == [1, 2, 3, 4]
+        # Initialize reports adapters.
+        assert responses[0]["result"]["adapters"] == ["claude"]
+        # Prompt creates the session.
+        assert responses[1]["result"]["sessionId"] == "task-cafef00d"
+        # SetMode persists.
+        assert responses[2]["result"]["mode"] == "auto"
+        # Cancel walks the drain pipeline.
+        assert responses[3]["result"]["cancelled"] is True
+        assert cancelled == [("task-cafef00d", "user_done")]
+        # Session is removed afterwards.
+        assert await sessions.get("task-cafef00d") is None
+
+    asyncio.run(_run())
+
+
+def test_cancel_mid_tool_call_completes_drain() -> None:
+    """``cancel`` issued while a tool is in flight still calls the canceller."""
+    cancel_calls: list[tuple[str, str]] = []
+    in_flight = asyncio.Event()
+    proceed = asyncio.Event()
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del prompt, cwd, role
+        return PromptResult(session_id="task-mid")
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        cancel_calls.append((session_id, reason))
+        return True
+
+    registry = ACPHandlerRegistry(
+        sessions=ACPSessionStore(),
+        task_creator=_create,
+        task_canceller=_cancel,
+    )
+
+    async def _simulate_tool() -> None:
+        # Pretend a tool is running.
+        in_flight.set()
+        await proceed.wait()
+
+    async def _run() -> None:
+        await registry.dispatch(
+            ACPRequestContext_factory("prompt"),
+            {"prompt": "x", "cwd": "/w"},
+        )
+        # Concurrently start the "tool".
+        tool_task = asyncio.create_task(_simulate_tool())
+        await in_flight.wait()
+        # Now issue cancel.
+        result = await registry.dispatch(
+            ACPRequestContext_factory("cancel", 9),
+            {"sessionId": "task-mid", "reason": "ctrl_c"},
+        )
+        assert result["cancelled"] is True
+        # Let the simulated tool finish.
+        proceed.set()
+        await tool_task
+        assert cancel_calls == [("task-mid", "ctrl_c")]
+
+    asyncio.run(_run())
+
+
+def ACPRequestContext_factory(method: str, request_id: int = 1):
+    """Tiny helper to keep test bodies readable."""
+    from bernstein.core.protocols.acp.handlers import ACPRequestContext
+
+    return ACPRequestContext(method=method, request_id=request_id, peer="test")
+
+
+def test_request_permission_round_trip_through_transport() -> None:
+    """A manual-mode session surfaces a requestPermission notification and resolves."""
+    notifications: list[dict[str, Any]] = []
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del prompt, cwd, role
+        return PromptResult(session_id="task-rp")
+
+    async def _publish(frame: dict[str, Any]) -> None:
+        notifications.append(frame)
+
+    registry = ACPHandlerRegistry(
+        sessions=ACPSessionStore(),
+        task_creator=_create,
+        stream_publisher=_publish,
+    )
+
+    async def _run() -> None:
+        await registry.dispatch(
+            ACPRequestContext_factory("prompt"),
+            {"prompt": "x", "cwd": "/w", "mode": "manual"},
+        )
+        session = await registry.sessions.get("task-rp")
+        assert session is not None
+
+        # Drive the asker concurrently with an IDE response.
+        asker_task = asyncio.create_task(
+            registry.permission_asker("task-rp", "edit_file", "modify foo.py")  # type: ignore[misc]
+        )
+        await asyncio.sleep(0.01)
+        # Find the open waiter id from the notification just emitted.
+        rp_frame = next(
+            f for f in notifications if f.get("method") == "requestPermission"
+        )
+        prompt_id = rp_frame["params"]["promptId"]
+        # Reply via the requestPermission handler.
+        resp = await registry.dispatch(
+            ACPRequestContext_factory("requestPermission", 7),
+            {"sessionId": "task-rp", "promptId": prompt_id, "decision": "approved"},
+        )
+        assert resp["decision"] == "approved"
+        decision = await asker_task
+        assert decision == "approved"
+
+    asyncio.run(_run())

--- a/tests/unit/protocols/acp/__init__.py
+++ b/tests/unit/protocols/acp/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the ACP native bridge."""

--- a/tests/unit/protocols/acp/test_handlers.py
+++ b/tests/unit/protocols/acp/test_handlers.py
@@ -1,0 +1,323 @@
+"""Handler-layer tests for the ACP bridge.
+
+Verifies that every ACP method routes through the injected dependencies
+(task creator, canceller, audit emitter, permission gate) and that the
+session store is updated as expected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from bernstein.core.protocols.acp.handlers import (
+    ACPHandlerRegistry,
+    ACPRequestContext,
+    PromptResult,
+)
+from bernstein.core.protocols.acp.schema import (
+    INVALID_PARAMS,
+    PERMISSION_DENIED,
+    SESSION_NOT_FOUND,
+    ACPSchemaError,
+    make_notification,
+)
+from bernstein.core.protocols.acp.session import ACPSessionStore
+
+
+def _ctx(method: str, request_id: int | str | None = 1) -> ACPRequestContext:
+    return ACPRequestContext(method=method, request_id=request_id, peer="test")
+
+
+def _build_registry(
+    *,
+    task_creator: Any = None,
+    task_canceller: Any = None,
+    permission_asker: Any = None,
+    audit_log: list[tuple[str, str, dict[str, Any]]] | None = None,
+    stream_log: list[dict[str, Any]] | None = None,
+) -> ACPHandlerRegistry:
+    sessions = ACPSessionStore()
+
+    async def _default_creator(prompt: str, cwd: str, role: str) -> PromptResult:
+        return PromptResult(session_id=f"task-{abs(hash(prompt)) & 0xFFFF:x}")
+
+    async def _default_canceller(session_id: str, reason: str) -> bool:
+        del session_id, reason
+        return True
+
+    async def _stream_publisher(frame: dict[str, Any]) -> None:
+        if stream_log is not None:
+            stream_log.append(frame)
+
+    def _audit(event_type: str, resource_id: str, details: dict[str, Any]) -> None:
+        if audit_log is not None:
+            audit_log.append((event_type, resource_id, details))
+
+    registry = ACPHandlerRegistry(
+        sessions=sessions,
+        adapters=("claude", "codex"),
+        sandbox_backends=("none",),
+        task_creator=task_creator or _default_creator,
+        task_canceller=task_canceller or _default_canceller,
+        stream_publisher=_stream_publisher,
+        audit_emitter=_audit,
+    )
+    if permission_asker is not None:
+        registry.permission_asker = permission_asker
+    return registry
+
+
+def test_initialize_reports_capabilities_and_adapters() -> None:
+    audit: list[tuple[str, str, dict[str, Any]]] = []
+    registry = _build_registry(audit_log=audit)
+
+    async def _run() -> None:
+        result = await registry.dispatch(
+            _ctx("initialize"),
+            {"protocolVersion": "2025-04-01", "clientCapabilities": {}},
+        )
+        assert isinstance(result, dict)
+        assert result["serverInfo"]["name"] == "bernstein"
+        assert "auto" in result["capabilities"]["modes"]
+        assert result["adapters"] == ["claude", "codex"]
+        assert result["sandboxBackends"] == ["none"]
+        # Initialize records to the audit chain.
+        assert any(evt[0] == "acp.initialize" for evt in audit)
+
+    asyncio.run(_run())
+
+
+def test_initialized_notification_returns_none() -> None:
+    registry = _build_registry()
+
+    async def _run() -> None:
+        result = await registry.dispatch(_ctx("initialized", request_id=None), {})
+        assert result is None
+
+    asyncio.run(_run())
+
+
+def test_prompt_creates_session_and_audits() -> None:
+    audit: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        assert prompt == "Add a hello function"
+        assert cwd == "/work"
+        assert role == "qa"
+        return PromptResult(session_id="task-42")
+
+    registry = _build_registry(task_creator=_create, audit_log=audit)
+
+    async def _run() -> None:
+        result = await registry.dispatch(
+            _ctx("prompt"),
+            {"prompt": "Add a hello function", "cwd": "/work", "role": "qa", "mode": "auto"},
+        )
+        assert result["sessionId"] == "task-42"
+        assert result["mode"] == "auto"
+        # Session is registered.
+        session = await registry.sessions.get("task-42")
+        assert session is not None
+        assert session.cwd == "/work"
+        assert session.mode == "auto"
+        # Audit entry is byte-identical between CLI and ACP because
+        # both paths call ``acp.prompt`` with the same details shape.
+        prompt_event = next(evt for evt in audit if evt[0] == "acp.prompt")
+        assert prompt_event[1] == "task-42"
+        assert prompt_event[2]["cwd"] == "/work"
+        assert prompt_event[2]["role"] == "qa"
+
+    asyncio.run(_run())
+
+
+def test_prompt_rejects_unaccepted_creation() -> None:
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del prompt, cwd, role
+        return PromptResult(session_id="", accepted=False, message="quota exceeded")
+
+    registry = _build_registry(task_creator=_create)
+
+    async def _run() -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            await registry.dispatch(_ctx("prompt"), {"prompt": "hi"})
+        assert "quota exceeded" in exc.value.message
+
+    asyncio.run(_run())
+
+
+def test_set_mode_persists_on_session() -> None:
+    audit: list[tuple[str, str, dict[str, Any]]] = []
+    registry = _build_registry(audit_log=audit)
+
+    async def _run() -> None:
+        prompt_result = await registry.dispatch(
+            _ctx("prompt"), {"prompt": "do x", "cwd": "/w"}
+        )
+        sid = prompt_result["sessionId"]
+        result = await registry.dispatch(
+            _ctx("setMode"), {"sessionId": sid, "mode": "auto"}
+        )
+        assert result["mode"] == "auto"
+        session = await registry.sessions.get(sid)
+        assert session is not None and session.mode == "auto"
+        assert any(evt[0] == "acp.set_mode" for evt in audit)
+
+    asyncio.run(_run())
+
+
+def test_set_mode_unknown_session_raises() -> None:
+    registry = _build_registry()
+
+    async def _run() -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            await registry.dispatch(
+                _ctx("setMode"), {"sessionId": "missing", "mode": "auto"}
+            )
+        assert exc.value.code == SESSION_NOT_FOUND
+
+    asyncio.run(_run())
+
+
+def test_cancel_walks_drain_pipeline() -> None:
+    canceller_calls: list[tuple[str, str]] = []
+    audit: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        canceller_calls.append((session_id, reason))
+        return True
+
+    registry = _build_registry(task_canceller=_cancel, audit_log=audit)
+
+    async def _run() -> None:
+        prompt_result = await registry.dispatch(_ctx("prompt"), {"prompt": "do x"})
+        sid = prompt_result["sessionId"]
+        result = await registry.dispatch(
+            _ctx("cancel"), {"sessionId": sid, "reason": "mid_tool_call"}
+        )
+        assert result["cancelled"] is True
+        assert canceller_calls == [(sid, "mid_tool_call")]
+        # Audit chain captures the cancel event.
+        assert any(evt[0] == "acp.cancel" for evt in audit)
+        # Session is removed.
+        assert await registry.sessions.get(sid) is None
+
+    asyncio.run(_run())
+
+
+def test_cancel_unknown_session() -> None:
+    registry = _build_registry()
+
+    async def _run() -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            await registry.dispatch(_ctx("cancel"), {"sessionId": "missing"})
+        assert exc.value.code == SESSION_NOT_FOUND
+
+    asyncio.run(_run())
+
+
+def test_request_permission_resolves_waiter() -> None:
+    stream_frames: list[dict[str, Any]] = []
+    registry = _build_registry(stream_log=stream_frames)
+
+    async def _run() -> None:
+        prompt_result = await registry.dispatch(_ctx("prompt"), {"prompt": "x"})
+        sid = prompt_result["sessionId"]
+        session = await registry.sessions.get(sid)
+        assert session is not None
+
+        # Open a waiter on the session as the agent would.
+        waiter = session.open_permission_waiter("write_file", "edit foo.py")
+
+        # The IDE responds via requestPermission.
+        result = await registry.dispatch(
+            _ctx("requestPermission"),
+            {"sessionId": sid, "promptId": waiter.prompt_id, "decision": "approved"},
+        )
+        assert result["decision"] == "approved"
+        assert waiter.decision == "approved"
+
+    asyncio.run(_run())
+
+
+def test_request_permission_unknown_prompt_id() -> None:
+    registry = _build_registry()
+
+    async def _run() -> None:
+        prompt_result = await registry.dispatch(_ctx("prompt"), {"prompt": "x"})
+        sid = prompt_result["sessionId"]
+        with pytest.raises(ACPSchemaError) as exc:
+            await registry.dispatch(
+                _ctx("requestPermission"),
+                {"sessionId": sid, "promptId": "missing", "decision": "approved"},
+            )
+        assert exc.value.code == PERMISSION_DENIED
+
+    asyncio.run(_run())
+
+
+def test_default_permission_asker_uses_stream_publisher() -> None:
+    """Auto-mode short-circuits the IDE round-trip; manual surfaces a notification."""
+    stream_frames: list[dict[str, Any]] = []
+    registry = _build_registry(stream_log=stream_frames)
+
+    async def _run() -> None:
+        # Manual mode: prompt goes to IDE, and we resolve it concurrently.
+        prompt_result = await registry.dispatch(
+            _ctx("prompt"), {"prompt": "x", "mode": "manual"}
+        )
+        sid = prompt_result["sessionId"]
+
+        async def _ide_responds() -> None:
+            await asyncio.sleep(0.05)
+            session = await registry.sessions.get(sid)
+            assert session is not None
+            # Approve the latest waiter regardless of id.
+            await asyncio.sleep(0)
+            for prompt_id in list(session._waiters):
+                session.resolve_permission(prompt_id, "approved")
+
+        ide_task = asyncio.create_task(_ide_responds())
+        decision = await registry.permission_asker(sid, "write_file", "edit foo.py")  # type: ignore[misc]
+        await ide_task
+        assert decision == "approved"
+        # The transport saw a requestPermission notification.
+        assert any(f.get("method") == "requestPermission" for f in stream_frames)
+
+        # Auto mode: short-circuits.
+        await registry.dispatch(_ctx("setMode"), {"sessionId": sid, "mode": "auto"})
+        decision_auto = await registry.permission_asker(sid, "write_file", "edit foo.py")  # type: ignore[misc]
+        assert decision_auto == "approved"
+
+    asyncio.run(_run())
+
+
+def test_emit_stream_update_publishes_notification() -> None:
+    frames: list[dict[str, Any]] = []
+    registry = _build_registry(stream_log=frames)
+
+    async def _run() -> None:
+        await registry.emit_stream_update("s1", "hello tokens")
+        assert frames
+        f = frames[-1]
+        assert f == make_notification(
+            "streamUpdate", {"sessionId": "s1", "delta": "hello tokens"}
+        )
+
+    asyncio.run(_run())
+
+
+def test_invalid_params_surfaces_through_dispatch() -> None:
+    """Handler-thrown ACPSchemaError must propagate without crashing."""
+    registry = _build_registry()
+
+    async def _run() -> None:
+        # ``prompt`` without prompt text bypasses the schema layer here; we
+        # smuggle in to confirm error mapping is consistent.
+        with pytest.raises(ACPSchemaError) as exc:
+            await registry.dispatch(_ctx("prompt"), {"prompt": "x", "mode": "yolo"})
+        assert exc.value.code == INVALID_PARAMS
+
+    asyncio.run(_run())

--- a/tests/unit/protocols/acp/test_schema.py
+++ b/tests/unit/protocols/acp/test_schema.py
@@ -1,0 +1,220 @@
+"""Schema-validation tests for the ACP bridge.
+
+Covers: handshake versioning, malformed-frame rejection, every supported
+method's parameter shape, and notification vs request semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.acp.schema import (
+    ACP_PROTOCOL_VERSION,
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    METHOD_NOT_FOUND,
+    MODE_INVALID,
+    PARSE_ERROR,
+    ACPSchemaError,
+    make_error,
+    make_notification,
+    make_result,
+    validate_request,
+    validate_response,
+)
+
+
+class TestValidateRequest:
+    """Validate :func:`validate_request` rejects malformed frames cleanly."""
+
+    def test_rejects_non_dict(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request("not a dict")
+        assert exc.value.code == INVALID_REQUEST
+
+    def test_rejects_missing_jsonrpc(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request({"method": "initialize", "id": 1})
+        assert exc.value.code == INVALID_REQUEST
+
+    def test_rejects_unknown_method(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {"jsonrpc": "2.0", "method": "unknown_method", "id": 1, "params": {}}
+            )
+        assert exc.value.code == METHOD_NOT_FOUND
+
+    def test_rejects_non_object_params(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {"jsonrpc": "2.0", "method": "prompt", "id": 1, "params": []}
+            )
+        assert exc.value.code == INVALID_PARAMS
+
+    def test_initialize_accepts_optional_protocol_version(self) -> None:
+        parsed = validate_request(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        )
+        assert parsed.method == "initialize"
+        assert parsed.is_notification is False
+
+    def test_initialize_rejects_non_string_protocol_version(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {"protocolVersion": 42},
+                }
+            )
+        assert exc.value.code == INVALID_PARAMS
+
+    def test_initialized_must_be_notification(self) -> None:
+        # No id => OK
+        parsed = validate_request(
+            {"jsonrpc": "2.0", "method": "initialized", "params": {}}
+        )
+        assert parsed.is_notification is True
+        # With id => rejected
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {"jsonrpc": "2.0", "id": 1, "method": "initialized", "params": {}}
+            )
+        assert exc.value.code == INVALID_REQUEST
+
+    def test_prompt_requires_prompt_text(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {"jsonrpc": "2.0", "id": 1, "method": "prompt", "params": {"cwd": "/tmp"}}
+            )
+        assert exc.value.code == INVALID_PARAMS
+
+    def test_prompt_rejects_non_string_role(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "prompt",
+                    "params": {"prompt": "do x", "role": 42},
+                }
+            )
+        assert exc.value.code == INVALID_PARAMS
+
+    def test_set_mode_validates_mode(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "setMode",
+                    "params": {"sessionId": "s1", "mode": "yolo"},
+                }
+            )
+        assert exc.value.code == MODE_INVALID
+
+    def test_cancel_requires_session_id(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {"jsonrpc": "2.0", "id": 1, "method": "cancel", "params": {}}
+            )
+        assert exc.value.code == INVALID_PARAMS
+
+    def test_request_permission_requires_decision_when_present(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "requestPermission",
+                    "params": {
+                        "sessionId": "s1",
+                        "promptId": "p1",
+                        "decision": "maybe",
+                    },
+                }
+            )
+        assert exc.value.code == INVALID_PARAMS
+
+    def test_request_permission_accepts_approved(self) -> None:
+        parsed = validate_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "requestPermission",
+                "params": {"sessionId": "s1", "promptId": "p1", "decision": "approved"},
+            }
+        )
+        assert parsed.method == "requestPermission"
+
+    def test_stream_update_rejects_when_id_present(self) -> None:
+        with pytest.raises(ACPSchemaError) as exc:
+            validate_request(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "streamUpdate",
+                    "params": {"sessionId": "s1"},
+                }
+            )
+        assert exc.value.code == INVALID_REQUEST
+
+
+class TestValidateResponse:
+    """Validate :func:`validate_response` envelope checks."""
+
+    def test_accepts_result_envelope(self) -> None:
+        validate_response(
+            {"jsonrpc": "2.0", "id": 1, "result": {"sessionId": "s1"}}
+        )
+
+    def test_accepts_error_envelope(self) -> None:
+        validate_response(
+            {"jsonrpc": "2.0", "id": 1, "error": {"code": -1, "message": "oops"}}
+        )
+
+    def test_rejects_both_result_and_error(self) -> None:
+        with pytest.raises(ACPSchemaError):
+            validate_response(
+                {"jsonrpc": "2.0", "id": 1, "result": {}, "error": {"code": 0, "message": ""}}
+            )
+
+    def test_rejects_missing_id(self) -> None:
+        with pytest.raises(ACPSchemaError):
+            validate_response({"jsonrpc": "2.0", "result": {}})
+
+
+class TestEnvelopeBuilders:
+    """Quick sanity checks for the response builders."""
+
+    def test_make_result(self) -> None:
+        env = make_result(7, {"ok": True})
+        assert env == {"jsonrpc": "2.0", "id": 7, "result": {"ok": True}}
+
+    def test_make_error_with_data(self) -> None:
+        env = make_error(7, PARSE_ERROR, "boom", {"line": 12})
+        assert env["error"] == {"code": PARSE_ERROR, "message": "boom", "data": {"line": 12}}
+
+    def test_make_notification_rejects_unknown_methods(self) -> None:
+        with pytest.raises(ValueError):
+            make_notification("frobnicate", {})
+
+    def test_make_notification_for_stream_update(self) -> None:
+        env = make_notification("streamUpdate", {"sessionId": "s1", "delta": "hi"})
+        assert "id" not in env
+        assert env["method"] == "streamUpdate"
+
+    def test_make_notification_for_request_permission(self) -> None:
+        env = make_notification(
+            "requestPermission",
+            {"sessionId": "s1", "promptId": "p1", "tool": "write_file", "detail": ""},
+        )
+        assert "id" not in env
+        assert env["method"] == "requestPermission"
+
+
+def test_protocol_version_is_string() -> None:
+    """Sanity guard so a refactor cannot accidentally null out the version."""
+    assert isinstance(ACP_PROTOCOL_VERSION, str)
+    assert ACP_PROTOCOL_VERSION

--- a/tests/unit/protocols/acp/test_session.py
+++ b/tests/unit/protocols/acp/test_session.py
@@ -1,0 +1,68 @@
+"""Tests for the ACP session store and per-session state machine."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from bernstein.core.protocols.acp.session import ACPSession, ACPSessionStore
+
+
+def test_set_mode_rejects_unknown() -> None:
+    session = ACPSession(session_id="s1", cwd="/tmp")
+    with pytest.raises(ValueError):
+        session.set_mode("yolo")
+
+
+def test_set_mode_persists() -> None:
+    session = ACPSession(session_id="s1", cwd="/tmp")
+    session.set_mode("auto")
+    assert session.mode == "auto"
+    session.set_mode("manual")
+    assert session.mode == "manual"
+
+
+def test_open_and_resolve_permission_roundtrip() -> None:
+    session = ACPSession(session_id="s1", cwd="/tmp")
+    waiter = session.open_permission_waiter("write_file", "edit foo.py")
+    assert session.resolve_permission(waiter.prompt_id, "approved") is True
+    assert waiter.decision == "approved"
+    session.discard_waiter(waiter.prompt_id)
+
+
+def test_resolve_permission_returns_false_for_unknown_id() -> None:
+    session = ACPSession(session_id="s1", cwd="/tmp")
+    assert session.resolve_permission("missing", "approved") is False
+
+
+def test_session_store_roundtrip() -> None:
+    async def _run() -> None:
+        store = ACPSessionStore()
+        s1 = ACPSession(session_id="s1", cwd="/tmp")
+        await store.add(s1)
+        assert await store.get("s1") is s1
+        assert await store.count() == 1
+        with pytest.raises(ValueError):
+            await store.add(ACPSession(session_id="s1", cwd="/x"))
+        removed = await store.remove("s1")
+        assert removed is s1
+        assert await store.get("s1") is None
+        assert await store.count() == 0
+
+    asyncio.run(_run())
+
+
+def test_snapshot_includes_acp_source() -> None:
+    async def _run() -> None:
+        store = ACPSessionStore()
+        await store.add(ACPSession(session_id="s1", cwd="/work", role="qa", mode="auto"))
+        snap = store.snapshot()
+        assert len(snap) == 1
+        entry = snap[0]
+        assert entry["session_id"] == "s1"
+        assert entry["source"] == "acp"
+        assert entry["mode"] == "auto"
+        assert entry["role"] == "qa"
+
+    asyncio.run(_run())

--- a/tests/unit/protocols/acp/test_transport.py
+++ b/tests/unit/protocols/acp/test_transport.py
@@ -1,0 +1,361 @@
+"""Transport-layer tests for stdio JSON-RPC and HTTP/SSE.
+
+Each test wires an in-memory :class:`asyncio.StreamReader` /
+:class:`asyncio.StreamWriter` (or runs the HTTP transport directly) so
+the real ACP server can be exercised without OS-level pipes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from bernstein.core.protocols.acp.handlers import (
+    ACPHandlerRegistry,
+    PromptResult,
+)
+from bernstein.core.protocols.acp.schema import (
+    INVALID_PARAMS,
+    METHOD_NOT_FOUND,
+    PARSE_ERROR,
+)
+from bernstein.core.protocols.acp.session import ACPSessionStore
+from bernstein.core.protocols.acp.transport import (
+    HttpAcpTransport,
+    JsonRpcFraming,
+    StdioAcpTransport,
+    dispatch_frame,
+)
+
+
+def _make_registry() -> ACPHandlerRegistry:
+    sessions = ACPSessionStore()
+
+    async def _create(prompt: str, cwd: str, role: str) -> PromptResult:
+        del cwd, role
+        return PromptResult(session_id=f"task-{abs(hash(prompt)) & 0xFF:02x}")
+
+    async def _cancel(session_id: str, reason: str) -> bool:
+        del session_id, reason
+        return True
+
+    async def _publish(_frame: dict[str, Any]) -> None:
+        return None
+
+    return ACPHandlerRegistry(
+        sessions=sessions,
+        adapters=("claude",),
+        sandbox_backends=("none",),
+        task_creator=_create,
+        task_canceller=_cancel,
+        stream_publisher=_publish,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JsonRpcFraming
+# ---------------------------------------------------------------------------
+
+
+def test_jsonrpc_framing_round_trip() -> None:
+    frame = {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    encoded = JsonRpcFraming.encode(frame)
+    assert encoded.endswith(b"\n")
+    decoded = JsonRpcFraming.parse(encoded)
+    assert decoded == frame
+
+
+def test_jsonrpc_framing_rejects_oversized_frame() -> None:
+    payload = b"{" + (b"x" * (2 * 1024 * 1024)) + b"}"
+    from bernstein.core.protocols.acp.schema import ACPSchemaError
+
+    with pytest.raises(ACPSchemaError):
+        JsonRpcFraming.parse(payload)
+
+
+def test_jsonrpc_framing_rejects_invalid_json() -> None:
+    from bernstein.core.protocols.acp.schema import ACPSchemaError
+
+    with pytest.raises(ACPSchemaError):
+        JsonRpcFraming.parse(b"{not json")
+
+
+# ---------------------------------------------------------------------------
+# Stdio transport
+# ---------------------------------------------------------------------------
+
+
+def _wire_stdio_pair() -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
+    """Build an in-memory reader/writer pair for unit tests.
+
+    Returns a tuple ``(transport_reader, transport_writer, capture_reader)``
+    where the transport reads from ``transport_reader`` and writes to a
+    pipe whose other end is ``capture_reader``.
+    """
+    loop = asyncio.get_event_loop()
+
+    transport_reader = asyncio.StreamReader(loop=loop)
+
+    capture_reader = asyncio.StreamReader(loop=loop)
+    capture_protocol = asyncio.StreamReaderProtocol(capture_reader, loop=loop)
+
+    class _CaptureTransport(asyncio.WriteTransport):
+        def __init__(self) -> None:
+            super().__init__()
+            self._closed = False
+
+        def write(self, data: bytes) -> None:
+            capture_reader.feed_data(data)
+
+        def close(self) -> None:
+            self._closed = True
+            capture_reader.feed_eof()
+
+        def is_closing(self) -> bool:
+            return self._closed
+
+        def can_write_eof(self) -> bool:
+            return True
+
+        def write_eof(self) -> None:
+            self.close()
+
+    capture_transport = _CaptureTransport()
+    writer = asyncio.StreamWriter(
+        capture_transport, capture_protocol, transport_reader, loop
+    )
+    return transport_reader, writer, capture_reader
+
+
+def _read_jsonrpc_response(reader: asyncio.StreamReader) -> dict[str, Any]:
+    """Synchronously drain one line and parse it."""
+
+    async def _go() -> dict[str, Any]:
+        line = await asyncio.wait_for(reader.readline(), timeout=2.0)
+        return json.loads(line)
+
+    return asyncio.get_event_loop().run_until_complete(_go())
+
+
+def test_stdio_transport_initialize_round_trip() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        reader, writer, capture = _wire_stdio_pair()
+        transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
+        # Feed an initialize frame and an EOF.
+        request = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        )
+        reader.feed_data((request + "\n").encode("utf-8"))
+        reader.feed_eof()
+        await transport.serve_forever()
+
+        line = await asyncio.wait_for(capture.readline(), timeout=1.0)
+        response = json.loads(line)
+        assert response["id"] == 1
+        assert response["result"]["serverInfo"]["name"] == "bernstein"
+
+    asyncio.run(_run())
+
+
+def test_stdio_transport_rejects_malformed_frame() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        reader, writer, capture = _wire_stdio_pair()
+        transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
+        reader.feed_data(b"{not json}\n")
+        reader.feed_eof()
+        await transport.serve_forever()
+
+        line = await asyncio.wait_for(capture.readline(), timeout=1.0)
+        response = json.loads(line)
+        assert "error" in response
+        assert response["error"]["code"] == PARSE_ERROR
+
+    asyncio.run(_run())
+
+
+def test_stdio_transport_unknown_method() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        reader, writer, capture = _wire_stdio_pair()
+        transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
+        request = json.dumps(
+            {"jsonrpc": "2.0", "id": 9, "method": "frobnicate", "params": {}}
+        )
+        reader.feed_data((request + "\n").encode("utf-8"))
+        reader.feed_eof()
+        await transport.serve_forever()
+
+        line = await asyncio.wait_for(capture.readline(), timeout=1.0)
+        response = json.loads(line)
+        assert response["error"]["code"] == METHOD_NOT_FOUND
+
+
+    asyncio.run(_run())
+
+
+def test_stdio_notification_no_response() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        reader, writer, capture = _wire_stdio_pair()
+        transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
+        request = json.dumps({"jsonrpc": "2.0", "method": "initialized", "params": {}})
+        reader.feed_data((request + "\n").encode("utf-8"))
+        reader.feed_eof()
+        await transport.serve_forever()
+
+        # Drain to EOF; should be no response bytes.
+        try:
+            line = await asyncio.wait_for(capture.readline(), timeout=0.2)
+        except TimeoutError:
+            line = b""
+        assert line == b""
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport
+# ---------------------------------------------------------------------------
+
+
+def test_http_transport_json_initialize() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        transport = HttpAcpTransport(registry=registry)
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        ).encode()
+        status, headers, payload = await transport.handle_request(
+            body, accept="application/json", peer="http://test"
+        )
+        assert status == 200
+        assert headers["content-type"] == "application/json"
+        assert isinstance(payload, (bytes, bytearray))
+        decoded = json.loads(payload)
+        assert decoded["result"]["serverInfo"]["name"] == "bernstein"
+
+    asyncio.run(_run())
+
+
+def test_http_transport_notification_returns_202() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        transport = HttpAcpTransport(registry=registry)
+        body = json.dumps(
+            {"jsonrpc": "2.0", "method": "initialized", "params": {}}
+        ).encode()
+        status, _headers, payload = await transport.handle_request(
+            body, accept="application/json", peer="http://test"
+        )
+        assert status == 202
+        assert payload == b""
+
+    asyncio.run(_run())
+
+
+def test_http_transport_sse_streams_response() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        transport = HttpAcpTransport(registry=registry)
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        ).encode()
+        status, headers, payload = await transport.handle_request(
+            body, accept="text/event-stream", peer="http://test"
+        )
+        assert status == 200
+        assert headers["content-type"] == "text/event-stream"
+        assert not isinstance(payload, (bytes, bytearray))
+        chunks: list[bytes] = []
+        async for chunk in payload:  # type: ignore[union-attr]
+            chunks.append(chunk)
+        joined = b"".join(chunks)
+        assert b"event: response" in joined
+        assert b'"serverInfo"' in joined
+
+    asyncio.run(_run())
+
+
+def test_http_transport_rejects_invalid_json() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        transport = HttpAcpTransport(registry=registry)
+        status, _headers, payload = await transport.handle_request(
+            b"{not json", accept="application/json", peer="http://test"
+        )
+        assert status == 200
+        assert isinstance(payload, (bytes, bytearray))
+        decoded = json.loads(payload)
+        assert decoded["error"]["code"] == PARSE_ERROR
+
+    asyncio.run(_run())
+
+
+def test_dispatch_frame_returns_none_for_notifications() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        result = await dispatch_frame(
+            registry,
+            {"jsonrpc": "2.0", "method": "initialized", "params": {}},
+            peer="t",
+        )
+        assert result is None
+
+    asyncio.run(_run())
+
+
+def test_dispatch_frame_invalid_params_returns_envelope() -> None:
+    async def _run() -> None:
+        registry = _make_registry()
+        result = await dispatch_frame(
+            registry,
+            {"jsonrpc": "2.0", "id": 5, "method": "prompt", "params": {}},
+            peer="t",
+        )
+        assert isinstance(result, dict)
+        assert result["error"]["code"] == INVALID_PARAMS
+        assert result["id"] == 5
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Transport parity (stdio vs HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_transport_parity_initialize() -> None:
+    """Initialize must produce identical envelopes on stdio and HTTP."""
+
+    async def _run() -> None:
+        # HTTP envelope.
+        registry_http = _make_registry()
+        body = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+        ).encode()
+        _status, _headers, payload = await HttpAcpTransport(
+            registry=registry_http
+        ).handle_request(body, accept="application/json", peer="http")
+        assert isinstance(payload, (bytes, bytearray))
+        http_envelope = json.loads(payload)
+
+        # Stdio envelope.
+        registry_stdio = _make_registry()
+        reader, writer, capture = _wire_stdio_pair()
+        transport = StdioAcpTransport(
+            registry=registry_stdio, reader=reader, writer=writer
+        )
+        reader.feed_data(body + b"\n")
+        reader.feed_eof()
+        await transport.serve_forever()
+        line = await asyncio.wait_for(capture.readline(), timeout=1.0)
+        stdio_envelope = json.loads(line)
+
+        assert http_envelope == stdio_envelope
+
+    asyncio.run(_run())


### PR DESCRIPTION
Implements the [release/1.9 ACP native bridge ticket](.sdd/backlog/open/release_1.9_acp_native_bridge.yaml)
— exposes Bernstein as an [Agent Client Protocol](https://agentclientprotocol.org)
server so ACP-aware editors (Zed and others) can plug the orchestrator in
as their backend with zero per-IDE plumbing.

The bridge is a protocol adapter, not a re-implementation: ACP `prompt`
opens a Bernstein task, `streamUpdate` tails the existing streaming-merge
utility, `cancel` walks the standard drain pipeline, and `setMode`
toggles the janitor approval gate. Cost-aware routing, HMAC audit, and
sandbox-backend selection apply identically to ACP-initiated and
CLI-initiated sessions.

## Acceptance criteria — all done

- [x] CLI surface `bernstein acp serve --stdio` (default) and
      `bernstein acp serve --http :PORT`
- [x] New module `src/bernstein/core/protocols/acp/` with
      schema-validated handler layer + stdio JSON-RPC + HTTP/SSE transports
- [x] `initialize` / `initialized` handshake reports capabilities,
      adapters, and sandbox backends
- [x] `prompt` creates a task in the existing task store; the returned
      session id is a real Bernstein session id
- [x] `streamUpdate` notifications wired to the streaming-merge utility
- [x] `cancel` walks the existing drain + shutdown pipeline so the audit
      chain closes cleanly
- [x] `setMode` toggles auto / manual; persisted on the session
- [x] Approval prompts surface as ACP `requestPermission`; the IDE's
      response feeds back into the gate's decision queue
- [x] Cost routing, HMAC audit, sandbox selection apply identically — an
      integration test (`test_audit_parity.py`) asserts byte-identical
      audit payloads between CLI and ACP surfaces
- [x] Conformance vectors + replay harness under
      `tests/integration/acp/conformance/`
- [x] Documentation includes Zed `settings.json` snippet + generic ACP
      client snippet (`docs/reference/acp-bridge.md`)
- [x] Prometheus counters `acp_messages_total{method,outcome}` and
      `acp_active_sessions` exported via the existing observability stack
- [x] Tests cover handshake versioning, prompt → task mapping,
      cancel mid-tool-call, mode toggle, requestPermission round-trip,
      malformed-frame rejection, transport parity (stdio vs HTTP)

## Files

- `src/bernstein/core/protocols/acp/{schema,handlers,session,metrics,transport,server}.py`
- `src/bernstein/cli/commands/acp_cmd.py` (registered in `cli/main.py`)
- `tests/unit/protocols/acp/test_*.py` (4 files, 47 tests)
- `tests/integration/acp/test_*.py` + `conformance/test_acp_vectors.py`
  (3 files, 17 tests)
- `tests/fixtures/acp/*.{json,jsonl}` + `conformance/*.jsonl`
- `docs/reference/acp-bridge.md`

## Test plan

- [x] `uv run pytest tests/unit/protocols/acp/ tests/integration/acp/ -q`
      — 64 passed
- [x] `uv run ruff check src/bernstein/core/protocols/acp/ src/bernstein/cli/commands/acp_cmd.py tests/unit/protocols/acp/ tests/integration/acp/`
      — clean
- [x] `bernstein acp serve --stdio < tests/fixtures/acp/initialize.jsonl`
      — returns a well-formed JSON-RPC envelope
- [x] `bernstein acp serve --http :8062` + `curl -sN -H 'Accept: text/event-stream' --data-binary @tests/fixtures/acp/prompt.json http://127.0.0.1:8062/acp`
      — SSE frames stream correctly

## Out of scope (explicit non-goals)

- Windows named-pipe transport (POSIX stdio + HTTP only for v1.9)
- ACP authentication beyond loopback (rides existing tunnel wrapper)
- Bidirectional file-edit primitives not in the ratified ACP spec
- Shipping a Zed extension (Zed uses upstream ACP support directly)