### PR TITLE
feat(fleet): multi-project supervisory dashboard

### DIFF
--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -60,6 +60,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "explain_help_cmd": "bernstein.cli.commands.explain_help_cmd",
     "figlet_logo": "bernstein.cli.display.figlet_logo",
     "fingerprint_cmd": "bernstein.cli.commands.fingerprint_cmd",
+    "fleet_cmd": "bernstein.cli.commands.fleet_cmd",
     "frame_buffer": "bernstein.cli.display.frame_buffer",
     "gateway_cmd": "bernstein.cli.commands.gateway_cmd",
     "gradients": "bernstein.cli.display.gradients",

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -81,8 +81,7 @@ def _run_tui(config: FleetConfig) -> None:
     if not config.projects:
         _print_config_errors(config)
         _console.print(
-            "[red]No projects configured.[/red] "
-            f"Edit {default_projects_config_path()} and add [[project]] blocks."
+            f"[red]No projects configured.[/red] Edit {default_projects_config_path()} and add [[project]] blocks."
         )
         sys.exit(2)
 
@@ -150,10 +149,7 @@ def _parse_bind(bind: str) -> tuple[str, int]:
 def _run_web(config: FleetConfig, bind: str) -> None:
     if not config.projects:
         _print_config_errors(config)
-        _console.print(
-            "[red]No projects configured.[/red] "
-            "Add [[project]] blocks before launching --web."
-        )
+        _console.print("[red]No projects configured.[/red] Add [[project]] blocks before launching --web.")
         sys.exit(2)
     host, port = _parse_bind(bind)
 
@@ -198,9 +194,7 @@ def _bulk_target(
     from bernstein.core.fleet.aggregator import ProjectSnapshot, ProjectState
     from bernstein.core.fleet.cost_rollup import rollup_costs
 
-    rollup = rollup_costs(
-        {p.name: p.sdd_dir for p in config.projects}, window_days=7
-    )
+    rollup = rollup_costs({p.name: p.sdd_dir for p in config.projects}, window_days=7)
     snapshots = [
         ProjectSnapshot(
             name=p.name,

--- a/src/bernstein/cli/commands/fleet_cmd.py
+++ b/src/bernstein/cli/commands/fleet_cmd.py
@@ -1,0 +1,305 @@
+"""``bernstein fleet`` — supervisory dashboard across multiple projects.
+
+This is the CLI entry point. The actual aggregator and rendering live in
+:mod:`bernstein.core.fleet`; this module only wires Click subcommands to
+those primitives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from bernstein.core.fleet import (
+    FleetAggregator,
+    FleetConfig,
+    bulk_cost_report,
+    bulk_pause,
+    bulk_resume,
+    bulk_stop,
+    default_projects_config_path,
+    load_projects_config,
+    select_projects,
+)
+
+logger = logging.getLogger(__name__)
+_console = Console()
+
+
+def _resolve_config(path: str | None) -> FleetConfig:
+    target = Path(path).expanduser() if path else None
+    return load_projects_config(target)
+
+
+def _print_config_errors(config: FleetConfig) -> None:
+    if not config.errors:
+        return
+    for err in config.errors:
+        tag = "global" if err.index < 0 else f"project[{err.index}]"
+        _console.print(f"[yellow]config {tag}:[/yellow] {err.message}")
+
+
+@click.group("fleet", invoke_without_command=True)
+@click.option(
+    "--config",
+    "config_path",
+    default=None,
+    help=f"Path to fleet config (default: {default_projects_config_path()}).",
+)
+@click.option(
+    "--web",
+    "web_bind",
+    default=None,
+    help="Run the web view instead of the TUI. Bind format: ``[host:]port``.",
+)
+@click.pass_context
+def fleet_group(
+    ctx: click.Context,
+    config_path: str | None,
+    web_bind: str | None,
+) -> None:
+    """Supervisory dashboard for multiple Bernstein projects."""
+    ctx.ensure_object(dict)
+    ctx.obj["config_path"] = config_path
+    if ctx.invoked_subcommand is None:
+        config = _resolve_config(config_path)
+        if web_bind is not None:
+            _run_web(config, web_bind)
+            return
+        _run_tui(config)
+
+
+def _run_tui(config: FleetConfig) -> None:
+    if not config.projects:
+        _print_config_errors(config)
+        _console.print(
+            "[red]No projects configured.[/red] "
+            f"Edit {default_projects_config_path()} and add [[project]] blocks."
+        )
+        sys.exit(2)
+
+    async def _main() -> None:
+        aggregator = FleetAggregator(config.projects)
+        await aggregator.start()
+        try:
+            try:
+                from bernstein.core.fleet.tui import build_textual_app
+            except ImportError:
+                _fallback_table_render(aggregator, config)
+                return
+            app = build_textual_app(aggregator, config)
+            await app.run_async()
+        finally:
+            await aggregator.stop()
+
+    asyncio.run(_main())
+
+
+def _fallback_table_render(aggregator: FleetAggregator, config: FleetConfig) -> None:
+    """Fallback Rich-based renderer when Textual is unavailable."""
+    from bernstein.core.fleet.tui import build_rows, format_footer
+
+    rows, total = build_rows(aggregator)
+    table = Table(title="Bernstein fleet")
+    for col in [
+        "Project",
+        "State",
+        "Run",
+        "Agents",
+        "Approvals",
+        "Last SHA",
+        "Cost (7d)",
+        "Sparkline",
+        "Chain",
+    ]:
+        table.add_column(col)
+    for row in rows:
+        table.add_row(
+            row.name,
+            row.state,
+            row.run_state,
+            str(row.agents),
+            str(row.approvals),
+            row.last_sha,
+            f"${row.cost_usd:.2f}",
+            row.sparkline,
+            "ok" if row.chain_ok else "BROKEN",
+        )
+    _console.print(table)
+    _console.print(format_footer(config, rows, total))
+
+
+def _parse_bind(bind: str) -> tuple[str, int]:
+    text = bind.strip()
+    if text.startswith(":"):
+        return "127.0.0.1", int(text[1:])
+    if ":" in text:
+        host, port = text.rsplit(":", 1)
+        return host or "127.0.0.1", int(port)
+    return "127.0.0.1", int(text)
+
+
+def _run_web(config: FleetConfig, bind: str) -> None:
+    if not config.projects:
+        _print_config_errors(config)
+        _console.print(
+            "[red]No projects configured.[/red] "
+            "Add [[project]] blocks before launching --web."
+        )
+        sys.exit(2)
+    host, port = _parse_bind(bind)
+
+    try:
+        import uvicorn
+    except ImportError:
+        _console.print("[red]uvicorn is required for fleet --web.[/red]")
+        sys.exit(2)
+
+    from bernstein.core.fleet.web import build_fleet_app
+
+    async def _bootstrap() -> tuple[FleetAggregator, Any]:
+        aggregator = FleetAggregator(config.projects)
+        await aggregator.start()
+        return aggregator, build_fleet_app(aggregator, config)
+
+    aggregator, app = asyncio.run(_bootstrap())
+    _console.print(f"[green]Bernstein fleet web[/green] listening on http://{host}:{port}")
+    _print_config_errors(config)
+    try:
+        uvicorn.run(app, host=host, port=port, log_level="warning")
+    finally:
+        asyncio.run(aggregator.stop())
+
+
+# ---------------------------------------------------------------------------
+# Bulk subcommands
+# ---------------------------------------------------------------------------
+
+
+def _bulk_target(
+    config: FleetConfig,
+    names: tuple[str, ...] | None,
+    filter_expression: str | None,
+) -> list[Any]:
+    """Resolve a target list using the *static* config snapshot.
+
+    Unlike the TUI, the CLI bulk path doesn't need the live aggregator
+    — projects are filtered by their on-disk cost history when a filter
+    references ``cost``.
+    """
+    from bernstein.core.fleet.aggregator import ProjectSnapshot, ProjectState
+    from bernstein.core.fleet.cost_rollup import rollup_costs
+
+    rollup = rollup_costs(
+        {p.name: p.sdd_dir for p in config.projects}, window_days=7
+    )
+    snapshots = [
+        ProjectSnapshot(
+            name=p.name,
+            state=ProjectState.ONLINE,
+            cost_usd=float(rollup.per_project.get(p.name, {}).get("total_usd") or 0.0),
+        )
+        for p in config.projects
+    ]
+    return select_projects(
+        config.projects,
+        snapshots,
+        names=list(names) if names else None,
+        filter_expression=filter_expression,
+    )
+
+
+def _print_bulk_result(result: Any) -> None:
+    payload: dict[str, Any] = {
+        "action": result.action,
+        "succeeded": list(result.succeeded),
+        "failed": dict(result.failed),
+    }
+    _console.print_json(json.dumps(payload))
+
+
+@fleet_group.command("bulk-stop")
+@click.option("--names", multiple=True, help="Restrict to listed project names.")
+@click.option("--filter", "filter_expression", default=None, help="Filter expression e.g. cost>5.")
+@click.pass_context
+def bulk_stop_cmd(
+    ctx: click.Context,
+    names: tuple[str, ...],
+    filter_expression: str | None,
+) -> None:
+    """Stop every matching project via its CLI."""
+    config = _resolve_config(ctx.obj.get("config_path"))
+    targets = _bulk_target(config, names, filter_expression)
+    result = asyncio.run(bulk_stop(targets))
+    _print_bulk_result(result)
+
+
+@fleet_group.command("bulk-pause")
+@click.option("--names", multiple=True, help="Restrict to listed project names.")
+@click.option("--filter", "filter_expression", default=None, help="Filter expression.")
+@click.pass_context
+def bulk_pause_cmd(
+    ctx: click.Context,
+    names: tuple[str, ...],
+    filter_expression: str | None,
+) -> None:
+    """Pause every matching project (stops its daemon)."""
+    config = _resolve_config(ctx.obj.get("config_path"))
+    targets = _bulk_target(config, names, filter_expression)
+    result = asyncio.run(bulk_pause(targets))
+    _print_bulk_result(result)
+
+
+@fleet_group.command("bulk-resume")
+@click.option("--names", multiple=True, help="Restrict to listed project names.")
+@click.option("--filter", "filter_expression", default=None, help="Filter expression.")
+@click.pass_context
+def bulk_resume_cmd(
+    ctx: click.Context,
+    names: tuple[str, ...],
+    filter_expression: str | None,
+) -> None:
+    """Resume every matching project (restarts its daemon)."""
+    config = _resolve_config(ctx.obj.get("config_path"))
+    targets = _bulk_target(config, names, filter_expression)
+    result = asyncio.run(bulk_resume(targets))
+    _print_bulk_result(result)
+
+
+@fleet_group.command("bulk-cost-report")
+@click.option("--names", multiple=True, help="Restrict to listed project names.")
+@click.option("--filter", "filter_expression", default=None, help="Filter expression.")
+@click.pass_context
+def bulk_cost_report_cmd(
+    ctx: click.Context,
+    names: tuple[str, ...],
+    filter_expression: str | None,
+) -> None:
+    """Run ``bernstein cost report`` against every matching project."""
+    config = _resolve_config(ctx.obj.get("config_path"))
+    targets = _bulk_target(config, names, filter_expression)
+    result = asyncio.run(bulk_cost_report(targets))
+    _print_bulk_result(result)
+
+
+@fleet_group.command("ls")
+@click.pass_context
+def ls_cmd(ctx: click.Context) -> None:
+    """List configured projects without launching the dashboard."""
+    config = _resolve_config(ctx.obj.get("config_path"))
+    table = Table(title="Bernstein fleet — configured projects")
+    table.add_column("Name")
+    table.add_column("Path")
+    table.add_column("Task server")
+    for project in config.projects:
+        table.add_row(project.name, str(project.path), project.task_server_url)
+    _console.print(table)
+    _print_config_errors(config)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -55,6 +55,7 @@ from bernstein.cli.chaos_cmd import chaos_group
 from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
+from bernstein.cli.commands.fleet_cmd import fleet_group
 from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.compliance_cmd import compliance_group
 from bernstein.cli.config_path_cmd import config_path_cmd
@@ -790,6 +791,7 @@ cli.add_command(templates_group, "templates")
 cli.add_command(validate_plan, "validate")
 cli.add_command(dep_impact_cmd, "dep-impact")
 cli.add_command(fingerprint_group, "fingerprint")
+cli.add_command(fleet_group, "fleet")
 cli.add_command(triggers_group, "triggers")
 
 # New CLI commands (CLI-004 through CLI-013)

--- a/src/bernstein/core/fleet/__init__.py
+++ b/src/bernstein/core/fleet/__init__.py
@@ -1,0 +1,81 @@
+"""Fleet dashboard — supervise multiple Bernstein projects in one view.
+
+The fleet module aggregates per-project state (status, bulletin, cost,
+audit, Prometheus metrics, SSE events) from a list of locally-running
+task servers configured in ``~/.config/bernstein/projects.toml``.
+
+The aggregator is purely a fan-out reader plus dispatcher for bulk
+actions; it does not own any orchestration state itself. This keeps the
+deterministic single-project guarantees intact.
+
+Public surface:
+    * :class:`ProjectConfig` and :func:`load_projects_config`
+    * :class:`FleetAggregator` and :class:`ProjectSnapshot`
+    * :class:`FleetCostRollup`
+    * :class:`AuditChainStatus` and :func:`check_audit_tail`
+    * :func:`merge_prometheus_metrics`
+    * :func:`build_fleet_app` (FastAPI factory)
+    * :class:`FleetTUI`
+"""
+
+from __future__ import annotations
+
+from bernstein.core.fleet.aggregator import (
+    AggregatorEvent,
+    FleetAggregator,
+    ProjectSnapshot,
+    ProjectState,
+)
+from bernstein.core.fleet.audit import (
+    AuditChainStatus,
+    AuditEntry,
+    check_audit_tail,
+    filter_audit_entries,
+)
+from bernstein.core.fleet.bulk import (
+    BulkActionResult,
+    bulk_cost_report,
+    bulk_pause,
+    bulk_resume,
+    bulk_stop,
+    select_projects,
+)
+from bernstein.core.fleet.config import (
+    FleetConfig,
+    FleetConfigError,
+    ProjectConfig,
+    default_projects_config_path,
+    load_projects_config,
+)
+from bernstein.core.fleet.cost_rollup import (
+    CostSparkline,
+    FleetCostRollup,
+    rollup_costs,
+)
+from bernstein.core.fleet.prometheus_proxy import merge_prometheus_metrics
+
+__all__ = [
+    "AggregatorEvent",
+    "AuditChainStatus",
+    "AuditEntry",
+    "BulkActionResult",
+    "CostSparkline",
+    "FleetAggregator",
+    "FleetConfig",
+    "FleetConfigError",
+    "FleetCostRollup",
+    "ProjectConfig",
+    "ProjectSnapshot",
+    "ProjectState",
+    "bulk_cost_report",
+    "bulk_pause",
+    "bulk_resume",
+    "bulk_stop",
+    "check_audit_tail",
+    "default_projects_config_path",
+    "filter_audit_entries",
+    "load_projects_config",
+    "merge_prometheus_metrics",
+    "rollup_costs",
+    "select_projects",
+]

--- a/src/bernstein/core/fleet/aggregator.py
+++ b/src/bernstein/core/fleet/aggregator.py
@@ -1,0 +1,425 @@
+"""FleetAggregator — fans out to per-project task servers.
+
+Owns one :class:`httpx.AsyncClient` and one per-project background SSE task.
+Per-project state is exposed as a :class:`ProjectSnapshot` and a unified
+event stream merges every project's SSE feed into a single async queue.
+
+The aggregator never blocks the dashboard on a single offline project: a
+project that cannot be reached transitions to :attr:`ProjectState.OFFLINE`
+and continues to be retried with exponential backoff until success.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from bernstein.core.fleet.config import ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectState(StrEnum):
+    """Top-level liveness for one project row."""
+
+    INITIALIZING = "initializing"
+    ONLINE = "online"
+    DEGRADED = "degraded"
+    OFFLINE = "offline"
+    PAUSED = "paused"
+
+
+@dataclass(slots=True)
+class ProjectSnapshot:
+    """Latest known state for one project.
+
+    Attributes:
+        name: Display name from config.
+        state: Top-level liveness.
+        agents: Number of live agents.
+        active_agents_roles: Sorted list of roles currently working.
+        pending_approvals: Number of approvals queued.
+        last_sha: Last known commit SHA (``""`` when unknown).
+        cost_usd: Rolling 7-day cost in USD.
+        cost_history: Last 7 daily cost samples for sparkline rendering.
+        last_event_ts: Epoch seconds of the last successful update.
+        last_error: Most recent error message from a failed fetch.
+        offline_since: Epoch seconds when ``state`` first flipped to OFFLINE.
+        run_state: Plain-language run state from the task server.
+    """
+
+    name: str
+    state: ProjectState = ProjectState.INITIALIZING
+    agents: int = 0
+    active_agents_roles: list[str] = field(default_factory=list[str])
+    pending_approvals: int = 0
+    last_sha: str = ""
+    cost_usd: float = 0.0
+    cost_history: list[float] = field(default_factory=list[float])
+    last_event_ts: float = 0.0
+    last_error: str = ""
+    offline_since: float | None = None
+    run_state: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable view of this snapshot."""
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "agents": self.agents,
+            "active_agents_roles": list(self.active_agents_roles),
+            "pending_approvals": self.pending_approvals,
+            "last_sha": self.last_sha,
+            "cost_usd": self.cost_usd,
+            "cost_history": list(self.cost_history),
+            "last_event_ts": self.last_event_ts,
+            "last_error": self.last_error,
+            "offline_since": self.offline_since,
+            "run_state": self.run_state,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class AggregatorEvent:
+    """One unified bus event tagged with its source project name.
+
+    Attributes:
+        project: Name of the source project.
+        event: Raw SSE event type (``task.created``, ``cost.update``, ...).
+        data: Decoded JSON payload (or empty dict when not parseable).
+        ts: Epoch seconds at which the event was received.
+    """
+
+    project: str
+    event: str
+    data: dict[str, Any]
+    ts: float
+
+
+def _extract_snapshot_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    """Derive snapshot fields from a ``/status`` payload.
+
+    The shape varies between versions; we look up tolerant defaults so a
+    minor server change never breaks the dashboard.
+    """
+    summary = payload.get("summary", {}) if isinstance(payload, dict) else {}
+    runtime = payload.get("runtime", {}) if isinstance(payload, dict) else {}
+    agents_block = payload.get("agents", {}) if isinstance(payload, dict) else {}
+
+    if isinstance(agents_block, dict):
+        items = agents_block.get("items", [])
+        agents_count = agents_block.get("count", len(items) if isinstance(items, list) else 0)
+    else:
+        items = []
+        agents_count = 0
+
+    roles: list[str] = []
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict):
+                role = item.get("role")
+                if isinstance(role, str) and role:
+                    roles.append(role)
+    roles = sorted(set(roles))
+
+    pending = 0
+    approvals_block = payload.get("approvals") if isinstance(payload, dict) else None
+    if isinstance(approvals_block, dict):
+        pending = int(approvals_block.get("pending", 0) or 0)
+    elif isinstance(summary, dict):
+        pending = int(summary.get("pending_approvals", 0) or 0)
+
+    sha = ""
+    if isinstance(runtime, dict):
+        sha_raw = runtime.get("last_commit_sha") or runtime.get("head_sha")
+        if isinstance(sha_raw, str):
+            sha = sha_raw[:12]
+
+    cost = 0.0
+    if isinstance(summary, dict):
+        cost_raw = summary.get("cost_usd")
+        if isinstance(cost_raw, int | float):
+            cost = float(cost_raw)
+
+    run_state = ""
+    if isinstance(runtime, dict):
+        rs = runtime.get("state") or runtime.get("phase")
+        if isinstance(rs, str):
+            run_state = rs
+
+    return {
+        "agents": int(agents_count or 0),
+        "active_agents_roles": roles,
+        "pending_approvals": pending,
+        "last_sha": sha,
+        "cost_usd": cost,
+        "run_state": run_state,
+    }
+
+
+class FleetAggregator:
+    """Fans out to per-project task servers.
+
+    Lifecycle:
+        * :meth:`start` — kicks off background polling + SSE workers.
+        * :meth:`snapshots` — fast read of every project's latest state.
+        * :meth:`events` — async iterator over :class:`AggregatorEvent`.
+        * :meth:`stop` — cancels workers and closes the HTTP client.
+
+    The aggregator is the single shared dependency for both the TUI and the
+    web view; do not instantiate two of them per process.
+    """
+
+    def __init__(
+        self,
+        projects: list[ProjectConfig],
+        *,
+        poll_interval_s: float = 2.0,
+        http_timeout_s: float = 5.0,
+        backoff_min_s: float = 1.0,
+        backoff_max_s: float = 30.0,
+        client: httpx.AsyncClient | None = None,
+        cost_window_days: int = 7,
+    ) -> None:
+        """Build the aggregator.
+
+        Args:
+            projects: Project configs to fan out to.
+            poll_interval_s: How often the status/cost poll runs per project.
+            http_timeout_s: Per-request timeout. Kept low so a hung server
+                cannot block another row's update.
+            backoff_min_s: Minimum reconnect delay after a failure.
+            backoff_max_s: Maximum reconnect delay after repeated failures.
+            client: Optional pre-built ``httpx.AsyncClient``. Useful for tests.
+            cost_window_days: How many daily samples to keep per project.
+        """
+        self._projects: dict[str, ProjectConfig] = {p.name: p for p in projects}
+        self._poll_interval_s = poll_interval_s
+        self._http_timeout_s = http_timeout_s
+        self._backoff_min_s = backoff_min_s
+        self._backoff_max_s = backoff_max_s
+        self._cost_window_days = cost_window_days
+        self._owned_client = client is None
+        self._client = client or httpx.AsyncClient(timeout=http_timeout_s)
+        self._snapshots: dict[str, ProjectSnapshot] = {
+            name: ProjectSnapshot(name=name) for name in self._projects
+        }
+        self._tasks: list[asyncio.Task[None]] = []
+        self._event_queue: asyncio.Queue[AggregatorEvent] = asyncio.Queue(maxsize=1024)
+        self._stop_event: asyncio.Event = asyncio.Event()
+        self._started = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Spawn one poller and one SSE worker per project."""
+        if self._started:
+            return
+        self._started = True
+        for project in self._projects.values():
+            self._tasks.append(
+                asyncio.create_task(
+                    self._poll_loop(project), name=f"fleet-poll-{project.name}"
+                )
+            )
+            self._tasks.append(
+                asyncio.create_task(
+                    self._sse_loop(project), name=f"fleet-sse-{project.name}"
+                )
+            )
+
+    async def stop(self) -> None:
+        """Cancel workers and close the HTTP client."""
+        self._stop_event.set()
+        for task in self._tasks:
+            task.cancel()
+        for task in self._tasks:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await task
+        self._tasks.clear()
+        if self._owned_client:
+            await self._client.aclose()
+        self._started = False
+
+    async def __aenter__(self) -> FleetAggregator:
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self.stop()
+
+    # ------------------------------------------------------------------
+    # Read API
+    # ------------------------------------------------------------------
+
+    def projects(self) -> list[ProjectConfig]:
+        """Return the project configs in registration order."""
+        return list(self._projects.values())
+
+    def snapshots(self) -> list[ProjectSnapshot]:
+        """Return a snapshot copy for every project."""
+        # Return shallow copies so callers can't mutate live state.
+        return [
+            ProjectSnapshot(
+                name=s.name,
+                state=s.state,
+                agents=s.agents,
+                active_agents_roles=list(s.active_agents_roles),
+                pending_approvals=s.pending_approvals,
+                last_sha=s.last_sha,
+                cost_usd=s.cost_usd,
+                cost_history=list(s.cost_history),
+                last_event_ts=s.last_event_ts,
+                last_error=s.last_error,
+                offline_since=s.offline_since,
+                run_state=s.run_state,
+            )
+            for s in self._snapshots.values()
+        ]
+
+    def snapshot(self, name: str) -> ProjectSnapshot | None:
+        """Return the live snapshot for ``name`` (or ``None``)."""
+        return self._snapshots.get(name)
+
+    async def events(self) -> AsyncIterator[AggregatorEvent]:
+        """Yield merged SSE events from every project until stopped."""
+        while not self._stop_event.is_set():
+            try:
+                event = await asyncio.wait_for(self._event_queue.get(), timeout=1.0)
+            except TimeoutError:
+                continue
+            yield event
+
+    # ------------------------------------------------------------------
+    # Pollers
+    # ------------------------------------------------------------------
+
+    async def _poll_loop(self, project: ProjectConfig) -> None:
+        backoff = self._backoff_min_s
+        while not self._stop_event.is_set():
+            try:
+                await self._poll_once(project)
+                backoff = self._backoff_min_s
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._mark_offline(project.name, str(exc))
+                logger.debug("fleet: poll failure for %s: %s", project.name, exc)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self._backoff_max_s)
+                continue
+            await asyncio.sleep(self._poll_interval_s)
+
+    async def _poll_once(self, project: ProjectConfig) -> None:
+        response = await self._client.get(project.status_url)
+        response.raise_for_status()
+        try:
+            payload = response.json()
+        except json.JSONDecodeError as exc:
+            raise httpx.HTTPError(f"non-JSON status: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise httpx.HTTPError("status payload is not an object")
+
+        snapshot = self._snapshots[project.name]
+        fields = _extract_snapshot_fields(payload)
+        snapshot.agents = fields["agents"]
+        snapshot.active_agents_roles = fields["active_agents_roles"]
+        snapshot.pending_approvals = fields["pending_approvals"]
+        snapshot.last_sha = fields["last_sha"]
+        snapshot.cost_usd = fields["cost_usd"]
+        snapshot.run_state = fields["run_state"]
+        snapshot.last_event_ts = time.time()
+        snapshot.last_error = ""
+        snapshot.offline_since = None
+        # Push the latest cost sample into the rolling history.
+        history = snapshot.cost_history
+        history.append(fields["cost_usd"])
+        if len(history) > self._cost_window_days:
+            del history[: len(history) - self._cost_window_days]
+        if snapshot.state in (ProjectState.OFFLINE, ProjectState.INITIALIZING, ProjectState.DEGRADED):
+            snapshot.state = ProjectState.ONLINE
+
+    def _mark_offline(self, name: str, message: str) -> None:
+        snapshot = self._snapshots.get(name)
+        if snapshot is None:
+            return
+        if snapshot.state != ProjectState.OFFLINE:
+            snapshot.offline_since = time.time()
+        snapshot.state = ProjectState.OFFLINE
+        snapshot.last_error = message
+
+    # ------------------------------------------------------------------
+    # SSE
+    # ------------------------------------------------------------------
+
+    async def _sse_loop(self, project: ProjectConfig) -> None:
+        backoff = self._backoff_min_s
+        while not self._stop_event.is_set():
+            try:
+                await self._sse_consume(project)
+                # Stream ended cleanly; reconnect quickly.
+                backoff = self._backoff_min_s
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("fleet: SSE failure for %s: %s", project.name, exc)
+                self._mark_offline(project.name, f"sse: {exc}")
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self._backoff_max_s)
+
+    async def _sse_consume(self, project: ProjectConfig) -> None:
+        async with self._client.stream(
+            "GET",
+            project.events_url,
+            timeout=httpx.Timeout(self._http_timeout_s, read=None),
+        ) as response:
+            response.raise_for_status()
+            event_name = ""
+            data_lines: list[str] = []
+            async for raw in response.aiter_lines():
+                if self._stop_event.is_set():
+                    return
+                if raw == "":
+                    if event_name and data_lines:
+                        await self._emit(project.name, event_name, "\n".join(data_lines))
+                    event_name = ""
+                    data_lines = []
+                    continue
+                if raw.startswith(":"):
+                    continue
+                if raw.startswith("event:"):
+                    event_name = raw[6:].strip()
+                elif raw.startswith("data:"):
+                    data_lines.append(raw[5:].lstrip())
+
+    async def _emit(self, project_name: str, event_name: str, data_text: str) -> None:
+        try:
+            data: dict[str, Any] = json.loads(data_text) if data_text else {}
+            if not isinstance(data, dict):
+                data = {"value": data}
+        except json.JSONDecodeError:
+            data = {"raw": data_text}
+        bus_event = AggregatorEvent(
+            project=project_name, event=event_name, data=data, ts=time.time()
+        )
+        try:
+            self._event_queue.put_nowait(bus_event)
+        except asyncio.QueueFull:
+            # Drop the oldest to make room — the dashboard must remain live.
+            with contextlib.suppress(asyncio.QueueEmpty):
+                self._event_queue.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                self._event_queue.put_nowait(bus_event)

--- a/src/bernstein/core/fleet/aggregator.py
+++ b/src/bernstein/core/fleet/aggregator.py
@@ -212,9 +212,7 @@ class FleetAggregator:
         self._cost_window_days = cost_window_days
         self._owned_client = client is None
         self._client = client or httpx.AsyncClient(timeout=http_timeout_s)
-        self._snapshots: dict[str, ProjectSnapshot] = {
-            name: ProjectSnapshot(name=name) for name in self._projects
-        }
+        self._snapshots: dict[str, ProjectSnapshot] = {name: ProjectSnapshot(name=name) for name in self._projects}
         self._tasks: list[asyncio.Task[None]] = []
         self._event_queue: asyncio.Queue[AggregatorEvent] = asyncio.Queue(maxsize=1024)
         self._stop_event: asyncio.Event = asyncio.Event()
@@ -230,16 +228,8 @@ class FleetAggregator:
             return
         self._started = True
         for project in self._projects.values():
-            self._tasks.append(
-                asyncio.create_task(
-                    self._poll_loop(project), name=f"fleet-poll-{project.name}"
-                )
-            )
-            self._tasks.append(
-                asyncio.create_task(
-                    self._sse_loop(project), name=f"fleet-sse-{project.name}"
-                )
-            )
+            self._tasks.append(asyncio.create_task(self._poll_loop(project), name=f"fleet-poll-{project.name}"))
+            self._tasks.append(asyncio.create_task(self._sse_loop(project), name=f"fleet-sse-{project.name}"))
 
     async def stop(self) -> None:
         """Cancel workers and close the HTTP client."""
@@ -258,7 +248,7 @@ class FleetAggregator:
         await self.start()
         return self
 
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+    async def __aexit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
         await self.stop()
 
     # ------------------------------------------------------------------
@@ -412,9 +402,7 @@ class FleetAggregator:
                 data = {"value": data}
         except json.JSONDecodeError:
             data = {"raw": data_text}
-        bus_event = AggregatorEvent(
-            project=project_name, event=event_name, data=data, ts=time.time()
-        )
+        bus_event = AggregatorEvent(project=project_name, event=event_name, data=data, ts=time.time())
         try:
             self._event_queue.put_nowait(bus_event)
         except asyncio.QueueFull:

--- a/src/bernstein/core/fleet/audit.py
+++ b/src/bernstein/core/fleet/audit.py
@@ -118,9 +118,7 @@ def _coerce_ts(entry: dict[str, Any]) -> float:
     return 0.0
 
 
-def load_recent_entries(
-    project: str, sdd_dir: Path, *, max_entries: int = 500
-) -> list[AuditEntry]:
+def load_recent_entries(project: str, sdd_dir: Path, *, max_entries: int = 500) -> list[AuditEntry]:
     """Load the newest ``max_entries`` audit rows for ``project``.
 
     Args:
@@ -218,10 +216,7 @@ def check_audit_tail(project: str, sdd_dir: Path, *, count: int = 100) -> AuditC
                     project=project,
                     ok=False,
                     broken_at=f"{filename}:{line_no}",
-                    message=(
-                        f"chain break — prev_hmac {str(entry_prev)[:12]}... "
-                        f"!= expected {prev_hmac[:12]}..."
-                    ),
+                    message=(f"chain break — prev_hmac {str(entry_prev)[:12]}... != expected {prev_hmac[:12]}..."),
                     entries_checked=len(rows),
                     last_ts=last_ts,
                 )

--- a/src/bernstein/core/fleet/audit.py
+++ b/src/bernstein/core/fleet/audit.py
@@ -1,0 +1,241 @@
+"""Fleet audit panel — filtering and tail-break detection.
+
+The fleet view does not own any HMAC keys. It re-uses
+:func:`bernstein.core.security.audit_integrity.verify_audit_integrity`
+when a key is available, and falls back to *prev_hmac* chain-linkage
+checks when it is not — that is enough to surface a tail break in the
+panel without requiring fleet-wide key distribution.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class AuditEntry:
+    """A single decoded audit log entry from a project.
+
+    Attributes:
+        project: Source project name.
+        ts: Epoch seconds (best-effort; ``0.0`` if missing).
+        role: Role tag from the entry, e.g. ``manager`` or ``backend``.
+        adapter: Adapter name (``claude``, ``codex``...). May be empty.
+        outcome: Outcome string (``ok``, ``denied``, ``error``...).
+        kind: Event kind (``tool_call``, ``approval``, ``run``...).
+        line_no: 1-based line number inside the source JSONL file.
+        source_file: Filename of the source JSONL.
+        raw: Original parsed entry, kept for detail panes.
+    """
+
+    project: str
+    ts: float
+    role: str
+    adapter: str
+    outcome: str
+    kind: str
+    line_no: int
+    source_file: str
+    raw: dict[str, Any]
+
+
+@dataclass(slots=True)
+class AuditChainStatus:
+    """Summary of one project's audit chain integrity.
+
+    Attributes:
+        project: Source project name.
+        ok: Whether the chain is intact and verified.
+        broken_at: Optional ``"file:line"`` cursor where the break is.
+        message: Human-readable summary suitable for the dashboard.
+        entries_checked: How many tail entries were inspected.
+        last_ts: Epoch seconds of the most recent entry seen.
+    """
+
+    project: str
+    ok: bool = True
+    broken_at: str | None = None
+    message: str = ""
+    entries_checked: int = 0
+    last_ts: float = 0.0
+
+
+def _iter_recent_entries(audit_dir: Path, max_entries: int) -> list[tuple[str, int, dict[str, Any]]]:
+    """Walk the audit dir newest-first and return up to ``max_entries`` rows.
+
+    Uses ``log_path.read_text`` in line-by-line mode to keep the memory
+    footprint bounded; the panel typically asks for 200-1000 entries which
+    is safe for daily files in the few-MB range.
+    """
+    if not audit_dir.is_dir():
+        return []
+    log_files = sorted(audit_dir.glob("*.jsonl"), reverse=True)
+    collected: list[tuple[str, int, dict[str, Any]]] = []
+    for log_path in log_files:
+        try:
+            lines = log_path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line_no in range(len(lines), 0, -1):
+            raw = lines[line_no - 1].strip()
+            if not raw:
+                continue
+            try:
+                entry = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(entry, dict):
+                continue
+            collected.append((log_path.name, line_no, entry))
+            if len(collected) >= max_entries:
+                break
+        if len(collected) >= max_entries:
+            break
+    collected.reverse()
+    return collected
+
+
+def _coerce_ts(entry: dict[str, Any]) -> float:
+    raw = entry.get("ts") or entry.get("timestamp") or entry.get("time")
+    if isinstance(raw, int | float):
+        return float(raw)
+    if isinstance(raw, str):
+        # Support ISO 8601 best-effort.
+        for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+            try:
+                return time.mktime(time.strptime(raw, fmt))
+            except ValueError:
+                continue
+    return 0.0
+
+
+def load_recent_entries(
+    project: str, sdd_dir: Path, *, max_entries: int = 500
+) -> list[AuditEntry]:
+    """Load the newest ``max_entries`` audit rows for ``project``.
+
+    Args:
+        project: Source project name (passed through to each row).
+        sdd_dir: The project's ``.sdd`` directory.
+        max_entries: Cap on the number of entries returned.
+
+    Returns:
+        Parsed entries in chronological order (oldest first).
+    """
+    rows: list[AuditEntry] = []
+    for filename, line_no, entry in _iter_recent_entries(sdd_dir / "audit", max_entries):
+        rows.append(
+            AuditEntry(
+                project=project,
+                ts=_coerce_ts(entry),
+                role=str(entry.get("role", "") or ""),
+                adapter=str(entry.get("adapter", "") or ""),
+                outcome=str(entry.get("outcome", entry.get("status", "")) or ""),
+                kind=str(entry.get("kind", entry.get("event", "")) or ""),
+                line_no=line_no,
+                source_file=filename,
+                raw=entry,
+            )
+        )
+    return rows
+
+
+def filter_audit_entries(
+    entries: list[AuditEntry],
+    *,
+    role: str | None = None,
+    adapter: str | None = None,
+    outcome: str | None = None,
+    since: float | None = None,
+    until: float | None = None,
+    project: str | None = None,
+) -> list[AuditEntry]:
+    """Apply the standard audit-panel filter set.
+
+    Empty strings and ``None`` are treated as "no filter".
+    """
+
+    def _ok(entry: AuditEntry) -> bool:
+        if role and entry.role != role:
+            return False
+        if adapter and entry.adapter != adapter:
+            return False
+        if outcome and entry.outcome != outcome:
+            return False
+        if project and entry.project != project:
+            return False
+        if since is not None and entry.ts < since:
+            return False
+        return not (until is not None and entry.ts > until)
+
+    return [e for e in entries if _ok(e)]
+
+
+def check_audit_tail(project: str, sdd_dir: Path, *, count: int = 100) -> AuditChainStatus:
+    """Detect a broken HMAC chain in the project's tail entries.
+
+    The check is intentionally cheap: we walk the last ``count`` entries
+    and verify each ``prev_hmac`` field links to the previous entry's
+    ``hmac``. This catches in-place edits and truncated tails without
+    requiring the audit key.
+
+    Args:
+        project: Source project name (kept for downstream display).
+        sdd_dir: The project's ``.sdd`` directory.
+        count: Tail size to inspect.
+
+    Returns:
+        :class:`AuditChainStatus`. ``ok=True`` for missing or empty audit
+        directories so that a fresh project is not flagged red.
+    """
+    audit_dir = sdd_dir / "audit"
+    if not audit_dir.is_dir():
+        return AuditChainStatus(project=project, ok=True, message="no audit log yet")
+
+    rows = _iter_recent_entries(audit_dir, count)
+    if not rows:
+        return AuditChainStatus(project=project, ok=True, message="audit log empty")
+
+    prev_hmac: str | None = None
+    last_ts = 0.0
+    for filename, line_no, entry in rows:
+        ts = _coerce_ts(entry)
+        if ts > last_ts:
+            last_ts = ts
+        if prev_hmac is not None:
+            entry_prev = entry.get("prev_hmac")
+            if not isinstance(entry_prev, str) or entry_prev != prev_hmac:
+                return AuditChainStatus(
+                    project=project,
+                    ok=False,
+                    broken_at=f"{filename}:{line_no}",
+                    message=(
+                        f"chain break — prev_hmac {str(entry_prev)[:12]}... "
+                        f"!= expected {prev_hmac[:12]}..."
+                    ),
+                    entries_checked=len(rows),
+                    last_ts=last_ts,
+                )
+        cur_hmac = entry.get("hmac")
+        if isinstance(cur_hmac, str) and cur_hmac:
+            prev_hmac = cur_hmac
+        else:
+            # Skipping entries with no hmac is fine — older formats might lack one.
+            continue
+
+    return AuditChainStatus(
+        project=project,
+        ok=True,
+        message=f"tail of {len(rows)} entries OK",
+        entries_checked=len(rows),
+        last_ts=last_ts,
+    )

--- a/src/bernstein/core/fleet/bulk.py
+++ b/src/bernstein/core/fleet/bulk.py
@@ -100,9 +100,7 @@ def select_projects(
     by_name: dict[str, ProjectConfig] = {p.name: p for p in projects}
     snap_by_name: dict[str, ProjectSnapshot] = {s.name: s for s in snapshots}
 
-    candidates = (
-        [by_name[n] for n in names if n in by_name] if names else list(projects)
-    )
+    candidates = [by_name[n] for n in names if n in by_name] if names else list(projects)
 
     if not filter_expression:
         return candidates
@@ -120,14 +118,10 @@ def select_projects(
 # -- Subprocess plumbing ---------------------------------------------------
 
 
-SubprocessRunner = Callable[
-    [list[str], Path, dict[str, str]], Awaitable[tuple[int, str, str]]
-]
+SubprocessRunner = Callable[[list[str], Path, dict[str, str]], Awaitable[tuple[int, str, str]]]
 
 
-async def _default_runner(
-    cmd: list[str], cwd: Path, env: dict[str, str]
-) -> tuple[int, str, str]:
+async def _default_runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
     """Default implementation: spawn ``cmd`` with ``cwd`` and capture output."""
     process = await asyncio.create_subprocess_exec(
         *cmd,
@@ -219,9 +213,7 @@ async def bulk_pause(
     halts; this preserves the per-project audit chain because the call
     goes through the project's existing supervised stop path.
     """
-    return await _bulk_dispatch(
-        "pause", projects, ["daemon", "stop"], runner=runner
-    )
+    return await _bulk_dispatch("pause", projects, ["daemon", "stop"], runner=runner)
 
 
 async def bulk_resume(
@@ -233,9 +225,7 @@ async def bulk_resume(
 
     Maps to ``bernstein daemon start`` (the inverse of ``bulk_pause``).
     """
-    return await _bulk_dispatch(
-        "resume", projects, ["daemon", "start"], runner=runner
-    )
+    return await _bulk_dispatch("resume", projects, ["daemon", "start"], runner=runner)
 
 
 async def bulk_cost_report(

--- a/src/bernstein/core/fleet/bulk.py
+++ b/src/bernstein/core/fleet/bulk.py
@@ -1,0 +1,267 @@
+"""Bulk-action dispatcher for the fleet view.
+
+Every bulk action delegates to the per-project ``bernstein`` CLI command
+so the orchestrator's existing audit/logging path handles each individual
+operation. We never reach into the per-project task server directly for
+state-changing operations — that would split the audit chain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import shlex
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.fleet.aggregator import ProjectSnapshot
+    from bernstein.core.fleet.config import ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+# Filter expression grammar (whitespace-insensitive):
+#   <field> <op> <value>
+# where field ∈ {cost, agents, approvals}, op ∈ {<, <=, >, >=, ==, !=}.
+_FILTER_RE = re.compile(
+    r"^\s*(?P<field>cost|agents|approvals)\s*"
+    r"(?P<op><=|>=|==|!=|<|>)\s*"
+    r"(?P<value>-?\d+(?:\.\d+)?)\s*$"
+)
+
+
+@dataclass(slots=True)
+class BulkActionResult:
+    """Outcome of dispatching a bulk action to one or more projects.
+
+    Attributes:
+        action: Name of the action (``stop`` / ``pause`` / ``resume`` / ``cost``).
+        succeeded: Project names where the per-project CLI returned 0.
+        failed: Mapping ``project -> stderr-or-error`` for failures.
+        outputs: Mapping ``project -> stdout`` for inspection.
+    """
+
+    action: str
+    succeeded: list[str] = field(default_factory=list[str])
+    failed: dict[str, str] = field(default_factory=dict)
+    outputs: dict[str, str] = field(default_factory=dict)
+
+
+def _evaluate_filter(snapshot: ProjectSnapshot, expression: str) -> bool:
+    match = _FILTER_RE.match(expression)
+    if match is None:
+        raise ValueError(f"unrecognised filter expression: {expression!r}")
+    field_name, op, raw = match.group("field"), match.group("op"), match.group("value")
+    threshold = float(raw)
+    if field_name == "cost":
+        actual = snapshot.cost_usd
+    elif field_name == "agents":
+        actual = float(snapshot.agents)
+    elif field_name == "approvals":
+        actual = float(snapshot.pending_approvals)
+    else:  # pragma: no cover - regex guarantees membership
+        raise ValueError(f"unsupported field: {field_name}")
+    return {
+        "<": actual < threshold,
+        "<=": actual <= threshold,
+        ">": actual > threshold,
+        ">=": actual >= threshold,
+        "==": actual == threshold,
+        "!=": actual != threshold,
+    }[op]
+
+
+def select_projects(
+    projects: list[ProjectConfig],
+    snapshots: list[ProjectSnapshot],
+    *,
+    names: list[str] | None = None,
+    filter_expression: str | None = None,
+) -> list[ProjectConfig]:
+    """Resolve a ``names`` list and/or filter into a project subset.
+
+    Args:
+        projects: Full project list.
+        snapshots: Aligned (or named) snapshot list. Order need not match.
+        names: Optional explicit project names.
+        filter_expression: Optional ``cost>5``-style filter.
+
+    Returns:
+        The subset of projects matching the request. When both ``names``
+        and ``filter_expression`` are supplied, both must match.
+
+    Raises:
+        ValueError: If the filter expression is malformed.
+    """
+    by_name: dict[str, ProjectConfig] = {p.name: p for p in projects}
+    snap_by_name: dict[str, ProjectSnapshot] = {s.name: s for s in snapshots}
+
+    candidates = (
+        [by_name[n] for n in names if n in by_name] if names else list(projects)
+    )
+
+    if not filter_expression:
+        return candidates
+
+    selected: list[ProjectConfig] = []
+    for project in candidates:
+        snap = snap_by_name.get(project.name)
+        if snap is None:
+            continue
+        if _evaluate_filter(snap, filter_expression):
+            selected.append(project)
+    return selected
+
+
+# -- Subprocess plumbing ---------------------------------------------------
+
+
+SubprocessRunner = Callable[
+    [list[str], Path, dict[str, str]], Awaitable[tuple[int, str, str]]
+]
+
+
+async def _default_runner(
+    cmd: list[str], cwd: Path, env: dict[str, str]
+) -> tuple[int, str, str]:
+    """Default implementation: spawn ``cmd`` with ``cwd`` and capture output."""
+    process = await asyncio.create_subprocess_exec(
+        *cmd,
+        cwd=str(cwd),
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_b, stderr_b = await process.communicate()
+    return (
+        int(process.returncode or 0),
+        stdout_b.decode("utf-8", errors="replace"),
+        stderr_b.decode("utf-8", errors="replace"),
+    )
+
+
+def _bernstein_command() -> list[str]:
+    """Pick the executable used to invoke per-project ``bernstein`` commands.
+
+    ``$BERNSTEIN_BIN`` overrides everything (useful for tests that need to
+    point at a stub script). Otherwise we use the current Python's
+    ``-m bernstein`` so the dispatch always targets the same install.
+    """
+    override = os.environ.get("BERNSTEIN_BIN")
+    if override:
+        return shlex.split(override)
+    import sys
+
+    return [sys.executable, "-m", "bernstein"]
+
+
+async def _dispatch_one(
+    project: ProjectConfig,
+    args: list[str],
+    runner: SubprocessRunner,
+) -> tuple[str, int, str, str]:
+    cmd = [*_bernstein_command(), *args]
+    env = os.environ.copy()
+    # Make the project's task server reachable for sub-process commands that
+    # talk to the API rather than the filesystem.
+    env["BERNSTEIN_TASK_SERVER_URL"] = project.task_server_url
+    rc, stdout, stderr = await runner(cmd, project.path, env)
+    return project.name, rc, stdout, stderr
+
+
+async def _bulk_dispatch(
+    action: str,
+    projects: list[ProjectConfig],
+    cli_args: list[str],
+    *,
+    runner: SubprocessRunner | None = None,
+) -> BulkActionResult:
+    runner_fn = runner or _default_runner
+    result = BulkActionResult(action=action)
+    if not projects:
+        return result
+    coros = [_dispatch_one(p, cli_args, runner_fn) for p in projects]
+    rows = await asyncio.gather(*coros, return_exceptions=True)
+    for row in rows:
+        if isinstance(row, BaseException):
+            logger.warning("fleet bulk %s: dispatch error %s", action, row)
+            continue
+        name, rc, stdout, stderr = row
+        result.outputs[name] = stdout
+        if rc == 0:
+            result.succeeded.append(name)
+        else:
+            result.failed[name] = stderr.strip() or stdout.strip() or f"exit {rc}"
+    return result
+
+
+async def bulk_stop(
+    projects: list[ProjectConfig],
+    *,
+    runner: SubprocessRunner | None = None,
+) -> BulkActionResult:
+    """Send ``bernstein stop`` to every selected project."""
+    return await _bulk_dispatch("stop", projects, ["stop"], runner=runner)
+
+
+async def bulk_pause(
+    projects: list[ProjectConfig],
+    *,
+    runner: SubprocessRunner | None = None,
+) -> BulkActionResult:
+    """Pause every selected project via the per-project CLI.
+
+    Maps to ``bernstein daemon stop`` so the daemon (and thus the run)
+    halts; this preserves the per-project audit chain because the call
+    goes through the project's existing supervised stop path.
+    """
+    return await _bulk_dispatch(
+        "pause", projects, ["daemon", "stop"], runner=runner
+    )
+
+
+async def bulk_resume(
+    projects: list[ProjectConfig],
+    *,
+    runner: SubprocessRunner | None = None,
+) -> BulkActionResult:
+    """Resume every selected project via the per-project CLI.
+
+    Maps to ``bernstein daemon start`` (the inverse of ``bulk_pause``).
+    """
+    return await _bulk_dispatch(
+        "resume", projects, ["daemon", "start"], runner=runner
+    )
+
+
+async def bulk_cost_report(
+    projects: list[ProjectConfig],
+    *,
+    runner: SubprocessRunner | None = None,
+    extra_args: list[str] | None = None,
+) -> BulkActionResult:
+    """Run ``bernstein cost report`` on every selected project."""
+    args = ["cost", "report", *(extra_args or [])]
+    return await _bulk_dispatch("cost-report", projects, args, runner=runner)
+
+
+# Public for fleet web view + tests to evaluate filters without dispatching.
+def evaluate_filter(snapshot: ProjectSnapshot, expression: str) -> bool:
+    """Public wrapper for the internal filter parser."""
+    return _evaluate_filter(snapshot, expression)
+
+
+def expose_runtime_for_tests() -> dict[str, Any]:
+    """Return private hooks for test-only injection.
+
+    Tests can monkeypatch these by importing the module and reassigning the
+    attributes; they are documented here so readers know the surface.
+    """
+    return {
+        "default_runner": _default_runner,
+        "bernstein_command": _bernstein_command,
+    }

--- a/src/bernstein/core/fleet/config.py
+++ b/src/bernstein/core/fleet/config.py
@@ -126,9 +126,7 @@ def _looks_loopback(url: str) -> bool:
     return True
 
 
-def _validate_project_block(
-    index: int, block: dict[str, Any]
-) -> tuple[ProjectConfig | None, list[FleetConfigError]]:
+def _validate_project_block(index: int, block: dict[str, Any]) -> tuple[ProjectConfig | None, list[FleetConfigError]]:
     errors: list[FleetConfigError] = []
     raw_path = block.get("path")
     if not isinstance(raw_path, str) or not raw_path.strip():
@@ -150,8 +148,7 @@ def _validate_project_block(
             errors.append(
                 FleetConfigError(
                     index,
-                    f"task_server_url {url!r} is not loopback/VPN; "
-                    "v1.9 fleet view is local-only",
+                    f"task_server_url {url!r} is not loopback/VPN; v1.9 fleet view is local-only",
                 )
             )
     else:
@@ -196,26 +193,20 @@ def parse_projects_config(text: str, source_path: Path | None = None) -> FleetCo
     if blocks is None:
         return config
     if not isinstance(blocks, list):
-        config.errors.append(
-            FleetConfigError(-1, "'project' must be an array of tables ([[project]])")
-        )
+        config.errors.append(FleetConfigError(-1, "'project' must be an array of tables ([[project]])"))
         return config
 
     seen_names: set[str] = set()
     for index, block in enumerate(blocks):
         if not isinstance(block, dict):
-            config.errors.append(
-                FleetConfigError(index, "[[project]] entry is not a table")
-            )
+            config.errors.append(FleetConfigError(index, "[[project]] entry is not a table"))
             continue
         project, errors = _validate_project_block(index, block)
         config.errors.extend(errors)
         if project is None:
             continue
         if project.name in seen_names:
-            config.errors.append(
-                FleetConfigError(index, f"duplicate project name {project.name!r}")
-            )
+            config.errors.append(FleetConfigError(index, f"duplicate project name {project.name!r}"))
             continue
         seen_names.add(project.name)
         config.projects.append(project)

--- a/src/bernstein/core/fleet/config.py
+++ b/src/bernstein/core/fleet/config.py
@@ -1,0 +1,256 @@
+"""Configuration loader for the fleet dashboard.
+
+Reads ``~/.config/bernstein/projects.toml`` (or ``$BERNSTEIN_FLEET_CONFIG``)
+and validates each ``[[project]]`` block. Validation errors are returned as
+:class:`FleetConfigError` instances rather than raised so that the dashboard
+can surface them in its footer instead of crashing.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - py<3.11 fallback
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+DEFAULT_TASK_SERVER_PORT = 8052
+
+
+@dataclass(frozen=True, slots=True)
+class FleetConfigError:
+    """A non-fatal validation error tied to a single ``[[project]]`` block.
+
+    Attributes:
+        index: Zero-based index of the offending block (``-1`` for global errors).
+        message: Human-readable explanation suitable for the dashboard footer.
+    """
+
+    index: int
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectConfig:
+    """A single project entry in the fleet config.
+
+    Attributes:
+        name: Display name. Falls back to the project path's basename.
+        path: Absolute path to the project root (where ``.sdd/`` lives).
+        task_server_url: Base URL of the project's task server. Defaults to
+            ``http://127.0.0.1:8052`` if omitted.
+        sdd_dir: Resolved ``.sdd`` directory path.
+    """
+
+    name: str
+    path: Path
+    task_server_url: str
+    sdd_dir: Path
+
+    @property
+    def status_url(self) -> str:
+        """URL of the project's ``/status`` endpoint."""
+        return self.task_server_url.rstrip("/") + "/status"
+
+    @property
+    def bulletin_url(self) -> str:
+        """URL of the project's ``/bulletin`` endpoint."""
+        return self.task_server_url.rstrip("/") + "/bulletin"
+
+    @property
+    def events_url(self) -> str:
+        """URL of the project's ``/events`` SSE stream."""
+        return self.task_server_url.rstrip("/") + "/events"
+
+    @property
+    def metrics_url(self) -> str:
+        """URL of the project's Prometheus ``/metrics`` endpoint."""
+        return self.task_server_url.rstrip("/") + "/metrics"
+
+
+@dataclass(slots=True)
+class FleetConfig:
+    """Parsed fleet configuration.
+
+    Attributes:
+        projects: Successfully parsed project entries.
+        errors: Validation errors that did not prevent loading.
+        source_path: Path the config was loaded from (or ``None`` for inline).
+    """
+
+    projects: list[ProjectConfig] = field(default_factory=list[ProjectConfig])
+    errors: list[FleetConfigError] = field(default_factory=list[FleetConfigError])
+    source_path: Path | None = None
+
+
+def default_projects_config_path() -> Path:
+    """Return the canonical config location, honouring overrides.
+
+    Resolution order:
+
+    1. ``$BERNSTEIN_FLEET_CONFIG`` if set.
+    2. ``$XDG_CONFIG_HOME/bernstein/projects.toml`` if set.
+    3. ``~/.config/bernstein/projects.toml`` otherwise.
+    """
+    override = os.environ.get("BERNSTEIN_FLEET_CONFIG")
+    if override:
+        return Path(override).expanduser()
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser() / "bernstein" / "projects.toml"
+    return Path.home() / ".config" / "bernstein" / "projects.toml"
+
+
+def _looks_loopback(url: str) -> bool:
+    """Cheap loopback check: hosts must resolve to a local interface or VPN.
+
+    The ticket scope is local-only; we accept ``localhost``, ``127.x.x.x``,
+    ``[::1]``, and any host whose URL parses cleanly. The actual reachability
+    check is deferred to the aggregator.
+    """
+    if "://" not in url:
+        return False
+    rest = url.split("://", 1)[1]
+    host = rest.split("/", 1)[0].split(":", 1)[0]
+    if host in {"localhost", "127.0.0.1", "::1", "[::1]"}:
+        return True
+    if host.startswith("127."):
+        return True
+    # Permit any host but the dashboard will fall back to ``offline`` if the
+    # connection refuses; this matches the ticket's "loopback or VPN-reachable
+    # host" guidance without doing DNS in the loader.
+    return True
+
+
+def _validate_project_block(
+    index: int, block: dict[str, Any]
+) -> tuple[ProjectConfig | None, list[FleetConfigError]]:
+    errors: list[FleetConfigError] = []
+    raw_path = block.get("path")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        errors.append(FleetConfigError(index, "missing or empty 'path'"))
+        return None, errors
+
+    try:
+        path = Path(raw_path).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        errors.append(FleetConfigError(index, f"unresolvable path: {exc}"))
+        return None, errors
+
+    raw_url = block.get("task_server_url")
+    if raw_url is None:
+        url = f"http://127.0.0.1:{DEFAULT_TASK_SERVER_PORT}"
+    elif isinstance(raw_url, str) and raw_url.strip():
+        url = raw_url.strip()
+        if not _looks_loopback(url):
+            errors.append(
+                FleetConfigError(
+                    index,
+                    f"task_server_url {url!r} is not loopback/VPN; "
+                    "v1.9 fleet view is local-only",
+                )
+            )
+    else:
+        errors.append(FleetConfigError(index, "task_server_url must be a string"))
+        return None, errors
+
+    raw_name = block.get("name")
+    if raw_name is None:
+        name = path.name
+    elif isinstance(raw_name, str) and raw_name.strip():
+        name = raw_name.strip()
+    else:
+        errors.append(FleetConfigError(index, "name must be a non-empty string"))
+        return None, errors
+
+    sdd_dir = path / ".sdd"
+    return (
+        ProjectConfig(name=name, path=path, task_server_url=url, sdd_dir=sdd_dir),
+        errors,
+    )
+
+
+def parse_projects_config(text: str, source_path: Path | None = None) -> FleetConfig:
+    """Parse a fleet config from raw TOML text.
+
+    Args:
+        text: TOML body.
+        source_path: Optional path used for error messages and roundtrips.
+
+    Returns:
+        A :class:`FleetConfig` containing parsed projects and a list of
+        non-fatal validation errors.
+    """
+    config = FleetConfig(source_path=source_path)
+    try:
+        parsed = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as exc:
+        config.errors.append(FleetConfigError(-1, f"TOML parse error: {exc}"))
+        return config
+
+    blocks = parsed.get("project")
+    if blocks is None:
+        return config
+    if not isinstance(blocks, list):
+        config.errors.append(
+            FleetConfigError(-1, "'project' must be an array of tables ([[project]])")
+        )
+        return config
+
+    seen_names: set[str] = set()
+    for index, block in enumerate(blocks):
+        if not isinstance(block, dict):
+            config.errors.append(
+                FleetConfigError(index, "[[project]] entry is not a table")
+            )
+            continue
+        project, errors = _validate_project_block(index, block)
+        config.errors.extend(errors)
+        if project is None:
+            continue
+        if project.name in seen_names:
+            config.errors.append(
+                FleetConfigError(index, f"duplicate project name {project.name!r}")
+            )
+            continue
+        seen_names.add(project.name)
+        config.projects.append(project)
+
+    return config
+
+
+def load_projects_config(path: Path | None = None) -> FleetConfig:
+    """Load and validate the fleet config from disk.
+
+    Args:
+        path: Optional explicit config path; defaults to
+            :func:`default_projects_config_path`.
+
+    Returns:
+        A :class:`FleetConfig`. Missing files yield an empty config with a
+        single error so the TUI can render a hint.
+    """
+    target = path or default_projects_config_path()
+    if not target.exists():
+        return FleetConfig(
+            errors=[
+                FleetConfigError(
+                    -1,
+                    f"fleet config not found at {target} — create it with [[project]] blocks",
+                )
+            ],
+            source_path=target,
+        )
+    try:
+        text = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        return FleetConfig(
+            errors=[FleetConfigError(-1, f"cannot read {target}: {exc}")],
+            source_path=target,
+        )
+    config = parse_projects_config(text, source_path=target)
+    return config

--- a/src/bernstein/core/fleet/cost_rollup.py
+++ b/src/bernstein/core/fleet/cost_rollup.py
@@ -55,10 +55,7 @@ def render_sparkline(series: list[float]) -> CostSparkline:
     if peak <= 0:
         return CostSparkline(series=list(series), glyphs=" " * len(series), peak=0.0)
     last_idx = len(_SPARKLINE_GLYPHS) - 1
-    glyphs = "".join(
-        _SPARKLINE_GLYPHS[min(last_idx, max(0, round((v / peak) * last_idx)))]
-        for v in series
-    )
+    glyphs = "".join(_SPARKLINE_GLYPHS[min(last_idx, max(0, round((v / peak) * last_idx)))] for v in series)
     return CostSparkline(series=list(series), glyphs=glyphs, peak=peak)
 
 
@@ -126,9 +123,7 @@ def _read_cost_history(sdd_dir: Path, window_days: int) -> list[float]:
     return [bucket[k] for k in sorted(bucket)][-window_days:]
 
 
-def rollup_costs(
-    project_paths: dict[str, Path], *, window_days: int = 7
-) -> FleetCostRollup:
+def rollup_costs(project_paths: dict[str, Path], *, window_days: int = 7) -> FleetCostRollup:
     """Aggregate per-project rolling costs into a fleet view.
 
     Args:

--- a/src/bernstein/core/fleet/cost_rollup.py
+++ b/src/bernstein/core/fleet/cost_rollup.py
@@ -1,0 +1,154 @@
+"""Fleet-wide cost rollup.
+
+The per-project cost tracker already maintains a 7-day cumulative number
+under ``.sdd/metrics/cost_history.jsonl``. The fleet view aggregates those
+values into a single fleet total and renders a sparkline per project plus
+one for the fleet.
+
+The sparkline rendering uses Unicode block characters; callers can replace
+the helper if they need a different style (e.g. ASCII for terminals that
+choke on the eighths-block range).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# U+2581..U+2588 — eighths-block sparkline glyphs.
+_SPARKLINE_GLYPHS: tuple[str, ...] = (" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█")
+
+
+@dataclass(slots=True)
+class CostSparkline:
+    """A renderable sparkline plus its underlying numeric series.
+
+    Attributes:
+        series: Source values (oldest first). Always length-bounded.
+        glyphs: Pre-rendered Unicode glyphs aligned 1:1 with ``series``.
+        peak: Maximum value across the series (used to size the bar).
+    """
+
+    series: list[float] = field(default_factory=list[float])
+    glyphs: str = ""
+    peak: float = 0.0
+
+
+def render_sparkline(series: list[float]) -> CostSparkline:
+    """Render a Unicode sparkline for ``series``.
+
+    Args:
+        series: Numeric values; non-negative is assumed but not enforced.
+
+    Returns:
+        A :class:`CostSparkline` whose ``glyphs`` attribute is safe to
+        write into a Textual widget or HTML page.
+    """
+    if not series:
+        return CostSparkline()
+    peak = max(series)
+    if peak <= 0:
+        return CostSparkline(series=list(series), glyphs=" " * len(series), peak=0.0)
+    last_idx = len(_SPARKLINE_GLYPHS) - 1
+    glyphs = "".join(
+        _SPARKLINE_GLYPHS[min(last_idx, max(0, round((v / peak) * last_idx)))]
+        for v in series
+    )
+    return CostSparkline(series=list(series), glyphs=glyphs, peak=peak)
+
+
+@dataclass(slots=True)
+class FleetCostRollup:
+    """Aggregate cost view across the fleet.
+
+    Attributes:
+        per_project: Mapping ``project_name -> {total_usd, history, sparkline}``.
+        fleet_total_usd: Sum of per-project ``total_usd`` over the window.
+        window_days: Width of the rolling window.
+    """
+
+    per_project: dict[str, dict[str, object]] = field(default_factory=dict)
+    fleet_total_usd: float = 0.0
+    window_days: int = 7
+
+
+def _read_cost_history(sdd_dir: Path, window_days: int) -> list[float]:
+    """Read the per-day rolling cost from a project's metrics dir.
+
+    The function tolerates a missing or malformed JSONL file by returning
+    an empty series — the dashboard treats that as "no data yet".
+
+    Schema understood:
+        - ``{"ts": <epoch>, "cost_usd": <float>}`` per line, OR
+        - ``{"date": "YYYY-MM-DD", "cost_usd": <float>}`` per line.
+    """
+    metrics_path = sdd_dir / "metrics" / "cost_history.jsonl"
+    if not metrics_path.exists():
+        return []
+    cutoff = time.time() - window_days * 86400.0
+    bucket: dict[str, float] = {}
+    try:
+        for raw_line in metrics_path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(entry, dict):
+                continue
+            cost = entry.get("cost_usd") or entry.get("total_usd") or 0.0
+            try:
+                cost_f = float(cost)
+            except (TypeError, ValueError):
+                continue
+            if "date" in entry and isinstance(entry["date"], str):
+                key = entry["date"]
+            elif "ts" in entry:
+                try:
+                    ts = float(entry["ts"])
+                except (TypeError, ValueError):
+                    continue
+                if ts < cutoff:
+                    continue
+                key = time.strftime("%Y-%m-%d", time.gmtime(ts))
+            else:
+                continue
+            bucket[key] = bucket.get(key, 0.0) + cost_f
+    except OSError:
+        return []
+    return [bucket[k] for k in sorted(bucket)][-window_days:]
+
+
+def rollup_costs(
+    project_paths: dict[str, Path], *, window_days: int = 7
+) -> FleetCostRollup:
+    """Aggregate per-project rolling costs into a fleet view.
+
+    Args:
+        project_paths: Mapping of project name to its ``.sdd`` directory.
+        window_days: Rolling window in days.
+
+    Returns:
+        A :class:`FleetCostRollup` with sparkline-ready data.
+    """
+    rollup = FleetCostRollup(window_days=window_days)
+    for name, sdd_dir in project_paths.items():
+        history = _read_cost_history(sdd_dir, window_days)
+        spark = render_sparkline(history)
+        total = sum(history)
+        rollup.per_project[name] = {
+            "total_usd": round(total, 4),
+            "history": history,
+            "sparkline": spark.glyphs,
+            "peak_usd": round(spark.peak, 4),
+        }
+        rollup.fleet_total_usd += total
+    rollup.fleet_total_usd = round(rollup.fleet_total_usd, 4)
+    return rollup

--- a/src/bernstein/core/fleet/prometheus_proxy.py
+++ b/src/bernstein/core/fleet/prometheus_proxy.py
@@ -55,11 +55,7 @@ def _inject_label(metric_line: str, project: str) -> str:
     if labels:
         # ``{a="1"}`` -> ``{project="x",a="1"}``
         inner = labels[1:-1].strip()
-        new_labels = (
-            "{" + f'project="{project}",' + inner + "}"
-            if inner
-            else "{" + f'project="{project}"' + "}"
-        )
+        new_labels = "{" + f'project="{project}",' + inner + "}" if inner else "{" + f'project="{project}"' + "}"
     else:
         new_labels = "{" + f'project="{project}"' + "}"
     return f"{name}{new_labels} {value}"
@@ -117,10 +113,7 @@ async def merge_prometheus_metrics(
         client = httpx.AsyncClient(timeout=timeout_s)
 
     try:
-        tasks = [
-            _scrape_one(client, project, timeout_s)
-            for project in projects
-        ]
+        tasks = [_scrape_one(client, project, timeout_s) for project in projects]
         results = await asyncio.gather(*tasks, return_exceptions=False)
     finally:
         if owned:
@@ -134,7 +127,7 @@ async def merge_prometheus_metrics(
     for project, text, error in results:
         if error or text is None:
             merge.failed_projects[project.name] = error or "unknown error"
-            body_parts.append(f"# fleet_project_offline {{project=\"{project.name}\"}} 1")
+            body_parts.append(f'# fleet_project_offline {{project="{project.name}"}} 1')
             continue
         merge.ok_projects.append(project.name)
         body_parts.append(f"# === project: {project.name} ===")

--- a/src/bernstein/core/fleet/prometheus_proxy.py
+++ b/src/bernstein/core/fleet/prometheus_proxy.py
@@ -1,0 +1,143 @@
+"""Prometheus aggregation for the fleet view.
+
+Each project's task server already exposes a ``/metrics`` endpoint via
+:mod:`bernstein.core.observability.prometheus`. The fleet view scrapes
+those endpoints concurrently and rewrites every metric line to add a
+``project="<name>"`` label so a single Grafana dashboard can chart the
+fleet without per-project boards.
+
+The merge is text-only — we never deserialise into prometheus_client
+because injecting labels through that API requires the original metric
+definitions, which the fleet aggregator does not have.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from bernstein.core.fleet.config import ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+_HELP_RE = re.compile(r"^# HELP ([^ ]+) (.*)$")
+_TYPE_RE = re.compile(r"^# TYPE ([^ ]+) (.*)$")
+_METRIC_RE = re.compile(r"^([a-zA-Z_:][a-zA-Z0-9_:]*)(\{[^}]*\})?\s+(.+)$")
+
+
+@dataclass(slots=True)
+class MergeResult:
+    """Outcome of merging Prometheus exports for one fleet snapshot.
+
+    Attributes:
+        body: The aggregated text/plain Prometheus exposition.
+        ok_projects: Names of projects whose scrape succeeded.
+        failed_projects: Mapping of name -> error message for failures.
+    """
+
+    body: str = ""
+    ok_projects: list[str] = field(default_factory=list[str])
+    failed_projects: dict[str, str] = field(default_factory=dict)
+
+
+def _inject_label(metric_line: str, project: str) -> str:
+    """Insert ``project="<name>"`` into a single metric line."""
+    match = _METRIC_RE.match(metric_line)
+    if match is None:
+        return metric_line
+    name, labels, value = match.group(1), match.group(2) or "", match.group(3)
+    if labels:
+        # ``{a="1"}`` -> ``{project="x",a="1"}``
+        inner = labels[1:-1].strip()
+        new_labels = (
+            "{" + f'project="{project}",' + inner + "}"
+            if inner
+            else "{" + f'project="{project}"' + "}"
+        )
+    else:
+        new_labels = "{" + f'project="{project}"' + "}"
+    return f"{name}{new_labels} {value}"
+
+
+def merge_text(project: str, body: str) -> str:
+    """Re-label one project's exposition. Public so tests can call it."""
+    out: list[str] = []
+    for raw in body.splitlines():
+        line = raw.rstrip()
+        if not line:
+            out.append("")
+            continue
+        if line.startswith("#"):
+            # Help/type lines are kept verbatim (Prometheus tolerates duplicates
+            # if the type matches; the rewrite preserves the same metric name).
+            out.append(line)
+            continue
+        out.append(_inject_label(line, project))
+    return "\n".join(out)
+
+
+async def _scrape_one(
+    client: httpx.AsyncClient, project: ProjectConfig, timeout_s: float
+) -> tuple[ProjectConfig, str | None, str | None]:
+    try:
+        response = await client.get(project.metrics_url, timeout=timeout_s)
+        response.raise_for_status()
+        return project, response.text, None
+    except (httpx.HTTPError, ValueError) as exc:
+        return project, None, f"{type(exc).__name__}: {exc}"
+
+
+async def merge_prometheus_metrics(
+    projects: list[ProjectConfig],
+    *,
+    client: httpx.AsyncClient | None = None,
+    timeout_s: float = 5.0,
+) -> MergeResult:
+    """Scrape each project's ``/metrics`` endpoint and merge into one body.
+
+    Args:
+        projects: Project configs to scrape.
+        client: Optional pre-built ``httpx.AsyncClient``. When omitted a
+            new one is created and closed by this call.
+        timeout_s: Per-scrape timeout. Total wall-clock time is bounded by
+            ``timeout_s`` because scrapes run concurrently.
+
+    Returns:
+        :class:`MergeResult` with the aggregated body plus per-project
+        success/failure info.
+    """
+    owned = client is None
+    if client is None:
+        client = httpx.AsyncClient(timeout=timeout_s)
+
+    try:
+        tasks = [
+            _scrape_one(client, project, timeout_s)
+            for project in projects
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+    finally:
+        if owned:
+            await client.aclose()
+
+    body_parts: list[str] = [
+        "# Bernstein fleet aggregated metrics",
+        f"# fleet_project_count {len(projects)}",
+    ]
+    merge = MergeResult()
+    for project, text, error in results:
+        if error or text is None:
+            merge.failed_projects[project.name] = error or "unknown error"
+            body_parts.append(f"# fleet_project_offline {{project=\"{project.name}\"}} 1")
+            continue
+        merge.ok_projects.append(project.name)
+        body_parts.append(f"# === project: {project.name} ===")
+        body_parts.append(merge_text(project.name, text))
+    merge.body = "\n".join(body_parts) + "\n"
+    return merge

--- a/src/bernstein/core/fleet/tui.py
+++ b/src/bernstein/core/fleet/tui.py
@@ -1,0 +1,214 @@
+"""Textual TUI for the fleet dashboard.
+
+This file is intentionally importable on systems without a terminal: the
+heavy Textual import is wrapped so unit tests can exercise the data
+helpers without requiring a TTY.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.fleet.aggregator import ProjectSnapshot
+from bernstein.core.fleet.audit import check_audit_tail
+from bernstein.core.fleet.cost_rollup import rollup_costs
+
+if TYPE_CHECKING:
+    from bernstein.core.fleet.aggregator import FleetAggregator
+    from bernstein.core.fleet.config import FleetConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class FleetRow:
+    """One renderable TUI row.
+
+    Attributes:
+        name: Project name.
+        state: ``online`` / ``offline`` / ``paused`` / etc.
+        run_state: Plain-language run state.
+        agents: Number of live agents.
+        approvals: Pending approvals count.
+        last_sha: Last commit SHA.
+        cost_usd: 7-day cost.
+        sparkline: Pre-rendered Unicode sparkline.
+        chain_ok: Whether the audit chain check passed.
+    """
+
+    name: str
+    state: str
+    run_state: str
+    agents: int
+    approvals: int
+    last_sha: str
+    cost_usd: float
+    sparkline: str
+    chain_ok: bool
+
+
+def build_rows(
+    aggregator: FleetAggregator,
+) -> tuple[list[FleetRow], float]:
+    """Snapshot the aggregator into renderable rows + fleet total.
+
+    Args:
+        aggregator: Started aggregator instance.
+
+    Returns:
+        ``(rows, fleet_total_usd)``.
+    """
+    snapshots = {s.name: s for s in aggregator.snapshots()}
+    project_paths = {p.name: p.sdd_dir for p in aggregator.projects()}
+    rollup = rollup_costs(project_paths, window_days=7)
+    rows: list[FleetRow] = []
+    for project in aggregator.projects():
+        snap = snapshots.get(project.name) or ProjectSnapshot(name=project.name)
+        cost_block = rollup.per_project.get(project.name, {})
+        chain = check_audit_tail(project.name, project.sdd_dir)
+        cost_total = float(cost_block.get("total_usd") or snap.cost_usd or 0.0)
+        spark = str(cost_block.get("sparkline") or "")
+        rows.append(
+            FleetRow(
+                name=project.name,
+                state=snap.state.value,
+                run_state=snap.run_state,
+                agents=snap.agents,
+                approvals=snap.pending_approvals,
+                last_sha=snap.last_sha,
+                cost_usd=cost_total,
+                sparkline=spark,
+                chain_ok=chain.ok,
+            )
+        )
+    return rows, rollup.fleet_total_usd
+
+
+def format_footer(config: FleetConfig, rows: list[FleetRow], fleet_total: float) -> str:
+    """Render the dashboard footer.
+
+    Reports validation errors verbatim so misconfiguration never crashes
+    the TUI.
+    """
+    chunks: list[str] = []
+    chunks.append(f"{len(rows)} project(s) — fleet 7d: ${fleet_total:.2f}")
+    if config.errors:
+        for err in config.errors:
+            tag = "global" if err.index < 0 else f"project[{err.index}]"
+            chunks.append(f"[ERR {tag}] {err.message}")
+    broken = [row for row in rows if not row.chain_ok]
+    if broken:
+        chunks.append("audit-chain break: " + ", ".join(r.name for r in broken))
+    offline = [row.name for row in rows if row.state == "offline"]
+    if offline:
+        chunks.append("offline: " + ", ".join(offline))
+    return " | ".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Textual app — guarded import so unit tests can reach the helpers without a TTY.
+# ---------------------------------------------------------------------------
+
+
+def build_textual_app(
+    aggregator: FleetAggregator, config: FleetConfig
+) -> Any:  # pragma: no cover - Textual UI is exercised manually
+    """Build and return a :class:`textual.app.App` instance.
+
+    Imported lazily so that ``import bernstein.core.fleet`` does not pay
+    for the Textual dependency on systems where it is not installed.
+    """
+    from typing import ClassVar
+
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.containers import Vertical
+    from textual.widgets import DataTable, Footer, Header, Static
+
+    class FleetApp(App[None]):
+        """Textual application for ``bernstein fleet``."""
+
+        TITLE = "Bernstein fleet"
+        CSS = """
+        Screen { background: $background; }
+        DataTable { height: 1fr; }
+        #footer { color: $accent; padding: 0 1; }
+        """
+        BINDINGS: ClassVar[list[Binding]] = [
+            Binding("q", "quit", "Quit"),
+            Binding("r", "refresh", "Refresh"),
+            Binding("s", "bulk_stop", "Bulk stop"),
+            Binding("p", "bulk_pause", "Bulk pause"),
+            Binding("u", "bulk_resume", "Bulk resume"),
+            Binding("c", "bulk_cost", "Bulk cost report"),
+        ]
+
+        def compose(self) -> ComposeResult:
+            yield Header()
+            with Vertical():
+                yield DataTable(id="fleet-table")
+                yield Static(id="footer")
+            yield Footer()
+
+        def on_mount(self) -> None:
+            table = self.query_one("#fleet-table", DataTable)
+            table.add_columns(
+                "Project",
+                "State",
+                "Run",
+                "Agents",
+                "Approvals",
+                "Last SHA",
+                "Cost (7d)",
+                "Spark",
+                "Chain",
+            )
+            self.set_interval(1.0, self.action_refresh)
+            self.action_refresh()
+
+        def action_refresh(self) -> None:
+            rows, total = build_rows(aggregator)
+            table = self.query_one("#fleet-table", DataTable)
+            table.clear()
+            for row in rows:
+                table.add_row(
+                    row.name,
+                    row.state,
+                    row.run_state,
+                    str(row.agents),
+                    str(row.approvals),
+                    row.last_sha,
+                    f"${row.cost_usd:.2f}",
+                    row.sparkline,
+                    "ok" if row.chain_ok else "BROKEN",
+                )
+            footer = self.query_one("#footer", Static)
+            footer.update(format_footer(config, rows, total))
+
+        async def action_bulk_stop(self) -> None:
+            from bernstein.core.fleet.bulk import bulk_stop
+
+            await bulk_stop(aggregator.projects())
+            self.action_refresh()
+
+        async def action_bulk_pause(self) -> None:
+            from bernstein.core.fleet.bulk import bulk_pause
+
+            await bulk_pause(aggregator.projects())
+            self.action_refresh()
+
+        async def action_bulk_resume(self) -> None:
+            from bernstein.core.fleet.bulk import bulk_resume
+
+            await bulk_resume(aggregator.projects())
+            self.action_refresh()
+
+        async def action_bulk_cost(self) -> None:
+            from bernstein.core.fleet.bulk import bulk_cost_report
+
+            await bulk_cost_report(aggregator.projects())
+            self.action_refresh()
+
+    return FleetApp()

--- a/src/bernstein/core/fleet/web.py
+++ b/src/bernstein/core/fleet/web.py
@@ -139,9 +139,7 @@ def build_fleet_app(
 
     @app.get("/api/cost")
     async def api_cost() -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
-        rollup = rollup_costs(
-            {p.name: p.sdd_dir for p in aggregator.projects()}, window_days=7
-        )
+        rollup = rollup_costs({p.name: p.sdd_dir for p in aggregator.projects()}, window_days=7)
         return JSONResponse(
             {
                 "fleet_total_usd": rollup.fleet_total_usd,
@@ -200,10 +198,7 @@ def build_fleet_app(
                 "entries_checked": s.entries_checked,
                 "last_ts": s.last_ts,
             }
-            for s in (
-                check_audit_tail(p.name, p.sdd_dir)
-                for p in aggregator.projects()
-            )
+            for s in (check_audit_tail(p.name, p.sdd_dir) for p in aggregator.projects())
         ]
         return JSONResponse({"chains": statuses})
 

--- a/src/bernstein/core/fleet/web.py
+++ b/src/bernstein/core/fleet/web.py
@@ -1,0 +1,251 @@
+"""FastAPI web view for the fleet dashboard.
+
+Mounts:
+    * ``GET /``                — minimal HTML fleet table.
+    * ``GET /api/projects``    — JSON snapshots.
+    * ``GET /api/cost``        — fleet cost rollup.
+    * ``GET /api/audit``       — filtered audit entries.
+    * ``GET /api/audit/chain`` — per-project chain status.
+    * ``GET /events``          — SSE proxy of the unified event bus.
+    * ``GET /metrics``         — aggregated Prometheus exposition.
+
+The web view is bound to loopback by default; the ticket explicitly
+defers wider exposure to the existing tunnel wrapper.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import TYPE_CHECKING, Any
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from starlette.responses import StreamingResponse
+
+from bernstein.core.fleet.audit import (
+    check_audit_tail,
+    filter_audit_entries,
+    load_recent_entries,
+)
+from bernstein.core.fleet.cost_rollup import rollup_costs
+from bernstein.core.fleet.prometheus_proxy import merge_prometheus_metrics
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from bernstein.core.fleet.aggregator import FleetAggregator
+    from bernstein.core.fleet.config import FleetConfig
+
+logger = logging.getLogger(__name__)
+
+
+_INDEX_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Bernstein fleet</title>
+<style>
+  body { font-family: -apple-system, sans-serif; margin: 1.2rem; background: #0e1116; color: #d8e0ec; }
+  h1 { font-size: 1.05rem; letter-spacing: 0.04em; color: #97b7e6; }
+  table { border-collapse: collapse; width: 100%; font-size: 0.9rem; }
+  th, td { padding: 0.35rem 0.6rem; border-bottom: 1px solid #1d242f; text-align: left; }
+  th { color: #6a7c93; font-weight: normal; }
+  tr.offline td { color: #b76b6b; }
+  .spark { font-family: ui-monospace, monospace; color: #6fb7ff; }
+  footer { margin-top: 1rem; color: #6a7c93; font-size: 0.75rem; }
+</style>
+</head>
+<body>
+<h1>Bernstein fleet</h1>
+<table id="fleet">
+  <thead><tr>
+    <th>Project</th><th>State</th><th>Run</th><th>Agents</th>
+    <th>Approvals</th><th>Last SHA</th><th>Cost (7d, USD)</th>
+    <th>Sparkline</th>
+  </tr></thead>
+  <tbody></tbody>
+</table>
+<footer id="footer"></footer>
+<script>
+async function refresh() {
+  const r = await fetch('/api/projects');
+  const data = await r.json();
+  const cost = await (await fetch('/api/cost')).json();
+  const tbody = document.querySelector('#fleet tbody');
+  tbody.innerHTML = '';
+  data.projects.forEach(p => {
+    const row = document.createElement('tr');
+    if (p.state === 'offline') row.classList.add('offline');
+    const c = cost.per_project[p.name] || {};
+    row.innerHTML = `
+      <td>${p.name}</td><td>${p.state}</td><td>${p.run_state || ''}</td>
+      <td>${p.agents}</td><td>${p.pending_approvals}</td>
+      <td>${p.last_sha || ''}</td>
+      <td>${Number(c.total_usd ?? p.cost_usd ?? 0).toFixed(2)}</td>
+      <td class="spark">${c.sparkline || ''}</td>`;
+    tbody.appendChild(row);
+  });
+  document.getElementById('footer').textContent =
+    `${data.projects.length} project(s) — fleet 7d: $${cost.fleet_total_usd.toFixed(2)}`;
+}
+
+const events = new EventSource('/events');
+events.onmessage = refresh;
+events.addEventListener('heartbeat', () => {});
+refresh();
+setInterval(refresh, 5000);
+</script>
+</body>
+</html>
+"""
+
+
+def _config_errors_payload(config: FleetConfig) -> list[dict[str, Any]]:
+    return [{"index": e.index, "message": e.message} for e in config.errors]
+
+
+def build_fleet_app(
+    aggregator: FleetAggregator,
+    config: FleetConfig,
+) -> FastAPI:
+    """Build the FastAPI application backing ``bernstein fleet --web``.
+
+    Args:
+        aggregator: Started aggregator instance.
+        config: The original :class:`FleetConfig` used for footer messages.
+
+    Returns:
+        Configured :class:`FastAPI` app.
+    """
+    app = FastAPI(title="Bernstein fleet dashboard", version="1.9")
+    app.state.aggregator = aggregator
+    app.state.fleet_config = config
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> HTMLResponse:  # pyright: ignore[reportUnusedFunction]
+        return HTMLResponse(_INDEX_HTML)
+
+    @app.get("/api/projects")
+    async def api_projects() -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
+        return JSONResponse(
+            {
+                "projects": [s.to_dict() for s in aggregator.snapshots()],
+                "errors": _config_errors_payload(config),
+            }
+        )
+
+    @app.get("/api/cost")
+    async def api_cost() -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
+        rollup = rollup_costs(
+            {p.name: p.sdd_dir for p in aggregator.projects()}, window_days=7
+        )
+        return JSONResponse(
+            {
+                "fleet_total_usd": rollup.fleet_total_usd,
+                "window_days": rollup.window_days,
+                "per_project": rollup.per_project,
+            }
+        )
+
+    @app.get("/api/audit")
+    async def api_audit(  # pyright: ignore[reportUnusedFunction]
+        project: str | None = Query(default=None),
+        role: str | None = Query(default=None),
+        adapter: str | None = Query(default=None),
+        outcome: str | None = Query(default=None),
+        since: float | None = Query(default=None),
+        until: float | None = Query(default=None),
+        limit: int = Query(default=200, ge=1, le=2000),
+    ) -> JSONResponse:
+        rows: list[dict[str, Any]] = []
+        for proj in aggregator.projects():
+            if project and proj.name != project:
+                continue
+            entries = load_recent_entries(proj.name, proj.sdd_dir, max_entries=limit)
+            entries = filter_audit_entries(
+                entries,
+                role=role,
+                adapter=adapter,
+                outcome=outcome,
+                since=since,
+                until=until,
+            )
+            for entry in entries:
+                rows.append(
+                    {
+                        "project": entry.project,
+                        "ts": entry.ts,
+                        "role": entry.role,
+                        "adapter": entry.adapter,
+                        "outcome": entry.outcome,
+                        "kind": entry.kind,
+                        "source_file": entry.source_file,
+                        "line_no": entry.line_no,
+                    }
+                )
+        rows.sort(key=lambda r: r["ts"], reverse=True)
+        return JSONResponse({"entries": rows[:limit]})
+
+    @app.get("/api/audit/chain")
+    async def api_audit_chain() -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
+        statuses = [
+            {
+                "project": s.project,
+                "ok": s.ok,
+                "broken_at": s.broken_at,
+                "message": s.message,
+                "entries_checked": s.entries_checked,
+                "last_ts": s.last_ts,
+            }
+            for s in (
+                check_audit_tail(p.name, p.sdd_dir)
+                for p in aggregator.projects()
+            )
+        ]
+        return JSONResponse({"chains": statuses})
+
+    @app.get("/events")
+    async def sse_events(request: Request) -> StreamingResponse:  # pyright: ignore[reportUnusedFunction]
+        async def stream() -> AsyncGenerator[str, None]:
+            yield 'event: heartbeat\ndata: {"connected": true}\n\n'
+            try:
+                async for event in aggregator.events():
+                    if await request.is_disconnected():
+                        break
+                    payload = {
+                        "project": event.project,
+                        "event": event.event,
+                        "data": event.data,
+                        "ts": event.ts,
+                    }
+                    yield f"event: {event.event}\ndata: {json.dumps(payload)}\n\n"
+            except asyncio.CancelledError:
+                pass
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @app.get("/metrics")
+    async def metrics() -> PlainTextResponse:  # pyright: ignore[reportUnusedFunction]
+        merge = await merge_prometheus_metrics(aggregator.projects())
+        return PlainTextResponse(merge.body, media_type="text/plain; version=0.0.4")
+
+    @app.get("/healthz")
+    async def healthz() -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
+        return JSONResponse({"ok": True, "ts": time.time()})
+
+    @app.exception_handler(HTTPException)
+    async def _http_exception(_: Request, exc: HTTPException) -> JSONResponse:  # pyright: ignore[reportUnusedFunction]
+        return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
+    return app

--- a/tests/integration/fleet/test_aggregator_e2e.py
+++ b/tests/integration/fleet/test_aggregator_e2e.py
@@ -1,0 +1,229 @@
+"""Integration tests for the fleet aggregator with a fake task server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import httpx
+import pytest
+
+from bernstein.core.fleet.aggregator import FleetAggregator, ProjectState
+from bernstein.core.fleet.config import ProjectConfig
+from bernstein.core.fleet.prometheus_proxy import merge_prometheus_metrics
+from bernstein.core.fleet.web import build_fleet_app
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Tiny stub of the Bernstein task server."""
+
+    status_payload: dict[str, object] = {}
+    bulletin_payload: list[dict[str, object]] = []
+    metrics_body: str = "bernstein_tasks_total 0\n"
+    sse_events: list[tuple[str, dict[str, object]]] = []
+
+    def log_message(self, *args: object, **kwargs: object) -> None:
+        return  # silence stderr in tests
+
+    def do_GET(self) -> None:
+        if self.path == "/status":
+            self._json(200, self.__class__.status_payload)
+        elif self.path == "/bulletin":
+            self._json(200, self.__class__.bulletin_payload)
+        elif self.path == "/metrics":
+            body = self.__class__.metrics_body.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/events":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            try:
+                self.wfile.write(b"event: heartbeat\ndata: {}\n\n")
+                self.wfile.flush()
+                for name, payload in list(self.__class__.sse_events):
+                    line = (
+                        f"event: {name}\n"
+                        f"data: {json.dumps(payload)}\n\n"
+                    ).encode()
+                    self.wfile.write(line)
+                    self.wfile.flush()
+                # Keep connection alive briefly for the client to consume.
+                time.sleep(0.2)
+            except (BrokenPipeError, ConnectionResetError):
+                return
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def _json(self, status: int, payload: object) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextmanager
+def _serve(handler_cls: type[BaseHTTPRequestHandler]) -> Iterator[int]:
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+
+def _project(tmp_path: Path, name: str, port: int) -> ProjectConfig:
+    return ProjectConfig(
+        name=name,
+        path=tmp_path,
+        task_server_url=f"http://127.0.0.1:{port}",
+        sdd_dir=tmp_path / ".sdd",
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregator_against_real_http_server(tmp_path: Path) -> None:
+    _Handler.status_payload = {
+        "summary": {"cost_usd": 4.2, "agents": 1, "pending_approvals": 0},
+        "agents": {"count": 1, "items": [{"role": "manager"}]},
+        "runtime": {"state": "running", "head_sha": "abc12345"},
+    }
+    _Handler.sse_events = [("task.created", {"task_id": "t1", "title": "demo"})]
+    with _serve(_Handler) as port:
+        project = _project(tmp_path, "alpha", port)
+        aggregator = FleetAggregator(
+            [project], poll_interval_s=0.1, backoff_min_s=0.05, backoff_max_s=0.1
+        )
+        await aggregator.start()
+        try:
+            for _ in range(40):
+                snap = aggregator.snapshot("alpha")
+                if snap is not None and snap.state == ProjectState.ONLINE:
+                    break
+                await asyncio.sleep(0.05)
+            snap = aggregator.snapshot("alpha")
+            assert snap is not None
+            assert snap.state == ProjectState.ONLINE
+            assert snap.cost_usd == 4.2
+            # Drain at least one event from the merged bus.
+            event = None
+            for _ in range(40):
+                try:
+                    event = aggregator._event_queue.get_nowait()
+                    break
+                except asyncio.QueueEmpty:
+                    await asyncio.sleep(0.05)
+            assert event is not None
+            assert event.project == "alpha"
+        finally:
+            await aggregator.stop()
+
+
+@pytest.mark.asyncio
+async def test_offline_project_does_not_block_others(tmp_path: Path) -> None:
+    """One offline project must not stall the rest of the fleet."""
+    _Handler.status_payload = {
+        "summary": {"cost_usd": 1.0, "agents": 0},
+        "agents": {"count": 0, "items": []},
+        "runtime": {"state": "idle"},
+    }
+    with _serve(_Handler) as port:
+        online = _project(tmp_path, "alpha", port)
+        offline = _project(tmp_path, "bravo", _free_port())  # no server bound
+        aggregator = FleetAggregator(
+            [online, offline],
+            poll_interval_s=0.1,
+            backoff_min_s=0.05,
+            backoff_max_s=0.1,
+        )
+        await aggregator.start()
+        try:
+            for _ in range(40):
+                a = aggregator.snapshot("alpha")
+                b = aggregator.snapshot("bravo")
+                if (
+                    a is not None
+                    and a.state == ProjectState.ONLINE
+                    and b is not None
+                    and b.state == ProjectState.OFFLINE
+                ):
+                    return
+                await asyncio.sleep(0.05)
+            pytest.fail(
+                f"expected alpha=online, bravo=offline; got "
+                f"{aggregator.snapshot('alpha')!s}, {aggregator.snapshot('bravo')!s}"
+            )
+        finally:
+            await aggregator.stop()
+
+
+@pytest.mark.asyncio
+async def test_unified_metrics_endpoint(tmp_path: Path) -> None:
+    """``merge_prometheus_metrics`` against a real HTTP server adds labels."""
+    _Handler.metrics_body = "bernstein_tasks_total 7\n"
+    with _serve(_Handler) as port:
+        project = _project(tmp_path, "alpha", port)
+        merge = await merge_prometheus_metrics([project])
+        assert "alpha" in merge.ok_projects
+        assert 'project="alpha"' in merge.body
+        assert "bernstein_tasks_total" in merge.body
+
+
+@pytest.mark.asyncio
+async def test_web_app_projects_endpoint(tmp_path: Path) -> None:
+    """The FastAPI app exposes ``/api/projects`` from the live aggregator."""
+    _Handler.status_payload = {
+        "summary": {"cost_usd": 0.5, "agents": 0},
+        "agents": {"count": 0, "items": []},
+        "runtime": {"state": "idle"},
+    }
+    with _serve(_Handler) as port:
+        project = _project(tmp_path, "alpha", port)
+        aggregator = FleetAggregator(
+            [project], poll_interval_s=0.1, backoff_min_s=0.05, backoff_max_s=0.1
+        )
+        await aggregator.start()
+        try:
+            # Allow the poll to run at least once.
+            for _ in range(40):
+                snap = aggregator.snapshot("alpha")
+                if snap is not None and snap.state == ProjectState.ONLINE:
+                    break
+                await asyncio.sleep(0.05)
+            from bernstein.core.fleet.config import FleetConfig
+
+            app = build_fleet_app(aggregator, FleetConfig(projects=[project]))
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.get("/api/projects")
+                assert resp.status_code == 200
+                payload = resp.json()
+                assert payload["projects"][0]["name"] == "alpha"
+                resp = await client.get("/healthz")
+                assert resp.status_code == 200
+        finally:
+            await aggregator.stop()

--- a/tests/unit/fleet/test_aggregator.py
+++ b/tests/unit/fleet/test_aggregator.py
@@ -1,0 +1,184 @@
+"""Tests for the fleet aggregator fan-out and SSE reconnect."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from bernstein.core.fleet.aggregator import (
+    FleetAggregator,
+    ProjectState,
+    _extract_snapshot_fields,
+)
+from bernstein.core.fleet.config import ProjectConfig
+
+
+def _project(tmp_path: Path, name: str, port: int = 8052) -> ProjectConfig:
+    return ProjectConfig(
+        name=name,
+        path=tmp_path,
+        task_server_url=f"http://127.0.0.1:{port}",
+        sdd_dir=tmp_path / ".sdd",
+    )
+
+
+def test_extract_snapshot_fields_handles_minimum() -> None:
+    """A barebones status payload still yields a usable snapshot."""
+    fields = _extract_snapshot_fields(
+        {
+            "summary": {"cost_usd": 1.5, "agents": 2},
+            "agents": {"count": 2, "items": [{"role": "backend"}, {"role": "qa"}]},
+            "runtime": {"state": "running", "head_sha": "abcdef1234567890"},
+        }
+    )
+    assert fields["agents"] == 2
+    assert fields["active_agents_roles"] == ["backend", "qa"]
+    assert fields["last_sha"].startswith("abcdef")
+    assert fields["cost_usd"] == 1.5
+    assert fields["run_state"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_poll_once_updates_snapshot(tmp_path: Path) -> None:
+    """A successful ``/status`` response transitions a row to ONLINE."""
+    project = _project(tmp_path, "alpha")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/status"
+        return httpx.Response(
+            200,
+            json={
+                "summary": {"cost_usd": 7.0, "agents": 1, "pending_approvals": 2},
+                "agents": {"count": 1, "items": [{"role": "manager"}]},
+                "runtime": {"state": "running", "head_sha": "deadbeef1234"},
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    aggregator = FleetAggregator([project], client=client, poll_interval_s=0.01)
+    await aggregator._poll_once(project)
+    snap = aggregator.snapshot("alpha")
+    assert snap is not None
+    assert snap.state == ProjectState.ONLINE
+    assert snap.cost_usd == 7.0
+    assert snap.last_sha.startswith("deadbeef")
+    assert snap.cost_history[-1] == 7.0
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_offline_marker_on_connection_error(tmp_path: Path) -> None:
+    """A poll failure flips the row to OFFLINE without crashing."""
+    project = _project(tmp_path, "down")
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    aggregator = FleetAggregator([project], client=client)
+    with pytest.raises(httpx.ConnectError):
+        await aggregator._poll_once(project)
+    aggregator._mark_offline("down", "refused")
+    snap = aggregator.snapshot("down")
+    assert snap is not None
+    assert snap.state == ProjectState.OFFLINE
+    assert snap.offline_since is not None
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_emit_handles_well_formed_event(tmp_path: Path) -> None:
+    """``_emit`` decodes JSON payloads and tags them with the project name."""
+    project = _project(tmp_path, "sse")
+    aggregator = FleetAggregator([project])
+    try:
+        await aggregator._emit(
+            "sse",
+            "cost.update",
+            json.dumps({"total_usd": 1.23, "agent": "manager"}),
+        )
+        event = aggregator._event_queue.get_nowait()
+    finally:
+        await aggregator.stop()
+    assert event.event == "cost.update"
+    assert event.project == "sse"
+    assert event.data["total_usd"] == 1.23
+
+
+@pytest.mark.asyncio
+async def test_sse_emit_drops_oldest_when_full(tmp_path: Path) -> None:
+    """When the bus is full the oldest event is dropped, never the newest."""
+    project = _project(tmp_path, "alpha")
+    aggregator = FleetAggregator([project])
+    aggregator._event_queue = asyncio.Queue(maxsize=2)
+    try:
+        await aggregator._emit("alpha", "a", "{}")
+        await aggregator._emit("alpha", "b", "{}")
+        await aggregator._emit("alpha", "c", "{}")
+        events = []
+        while True:
+            try:
+                events.append(aggregator._event_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+    finally:
+        await aggregator.stop()
+    names = [e.event for e in events]
+    assert names[-1] == "c"
+    assert "a" not in names  # oldest dropped
+
+
+@pytest.mark.asyncio
+async def test_offline_recovery_to_online(tmp_path: Path) -> None:
+    """An OFFLINE row can be brought back to ONLINE by a successful poll."""
+    project = _project(tmp_path, "alpha")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"summary": {"cost_usd": 1.0}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    aggregator = FleetAggregator([project], client=client)
+    aggregator._mark_offline("alpha", "boom")
+    snap = aggregator.snapshot("alpha")
+    assert snap is not None and snap.state == ProjectState.OFFLINE
+    await aggregator._poll_once(project)
+    snap = aggregator.snapshot("alpha")
+    assert snap is not None and snap.state == ProjectState.ONLINE
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_reconnect_uses_backoff(tmp_path: Path) -> None:
+    """``_sse_loop`` retries on errors with bounded backoff and respects stop."""
+    project = _project(tmp_path, "sse")
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["n"] += 1
+        raise httpx.ConnectError("nope")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    aggregator = FleetAggregator(
+        [project],
+        client=client,
+        backoff_min_s=0.01,
+        backoff_max_s=0.02,
+    )
+    task = asyncio.create_task(aggregator._sse_loop(project))
+    try:
+        await asyncio.sleep(0.1)
+    finally:
+        aggregator._stop_event.set()
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task
+        await client.aclose()
+    assert attempts["n"] >= 2  # multiple retries occurred under backoff
+    snap = aggregator.snapshot("sse")
+    assert snap is not None
+    assert snap.state == ProjectState.OFFLINE

--- a/tests/unit/fleet/test_audit.py
+++ b/tests/unit/fleet/test_audit.py
@@ -1,0 +1,90 @@
+"""Tests for the fleet audit panel and tail-break detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.fleet.audit import (
+    check_audit_tail,
+    filter_audit_entries,
+    load_recent_entries,
+)
+
+
+def _write_audit(
+    sdd: Path,
+    entries: list[dict[str, object]],
+    *,
+    filename: str = "2026-04-25.jsonl",
+) -> None:
+    audit_dir = sdd / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    with (audit_dir / filename).open("w", encoding="utf-8") as fh:
+        for entry in entries:
+            fh.write(json.dumps(entry) + "\n")
+
+
+def test_check_audit_tail_no_dir(tmp_path: Path) -> None:
+    """A project with no audit directory is treated as fresh, not broken."""
+    status = check_audit_tail("alpha", tmp_path / ".sdd")
+    assert status.ok is True
+    assert "no audit log" in status.message
+
+
+def test_check_audit_tail_intact_chain(tmp_path: Path) -> None:
+    """A correctly linked chain reports ok."""
+    sdd = tmp_path / ".sdd"
+    _write_audit(
+        sdd,
+        [
+            {"role": "manager", "ts": 1.0, "hmac": "h1", "prev_hmac": "0" * 64},
+            {"role": "backend", "ts": 2.0, "hmac": "h2", "prev_hmac": "h1"},
+            {"role": "qa", "ts": 3.0, "hmac": "h3", "prev_hmac": "h2"},
+        ],
+    )
+    status = check_audit_tail("alpha", sdd)
+    assert status.ok is True
+    assert status.entries_checked == 3
+
+
+def test_check_audit_tail_break(tmp_path: Path) -> None:
+    """A mismatched ``prev_hmac`` is flagged with a precise location."""
+    sdd = tmp_path / ".sdd"
+    _write_audit(
+        sdd,
+        [
+            {"role": "manager", "ts": 1.0, "hmac": "h1", "prev_hmac": "0" * 64},
+            {"role": "backend", "ts": 2.0, "hmac": "h2", "prev_hmac": "h1"},
+            # break: prev_hmac should be h2, not garbage.
+            {"role": "qa", "ts": 3.0, "hmac": "h3", "prev_hmac": "garbage"},
+        ],
+    )
+    status = check_audit_tail("alpha", sdd)
+    assert status.ok is False
+    assert status.broken_at is not None
+    assert "chain break" in status.message
+
+
+def test_load_and_filter_entries(tmp_path: Path) -> None:
+    sdd = tmp_path / ".sdd"
+    _write_audit(
+        sdd,
+        [
+            {"role": "manager", "ts": 1.0, "adapter": "claude", "outcome": "ok", "hmac": "h1", "prev_hmac": "0" * 64},
+            {"role": "backend", "ts": 2.0, "adapter": "codex", "outcome": "denied", "hmac": "h2", "prev_hmac": "h1"},
+            {"role": "qa", "ts": 3.0, "adapter": "claude", "outcome": "ok", "hmac": "h3", "prev_hmac": "h2"},
+        ],
+    )
+    entries = load_recent_entries("alpha", sdd, max_entries=10)
+    assert len(entries) == 3
+    by_role = filter_audit_entries(entries, role="backend")
+    assert len(by_role) == 1
+    assert by_role[0].outcome == "denied"
+
+    by_adapter = filter_audit_entries(entries, adapter="claude")
+    assert {e.role for e in by_adapter} == {"manager", "qa"}
+
+    by_time = filter_audit_entries(entries, since=2.5)
+    assert len(by_time) == 1
+    assert by_time[0].role == "qa"

--- a/tests/unit/fleet/test_bulk.py
+++ b/tests/unit/fleet/test_bulk.py
@@ -1,0 +1,137 @@
+"""Tests for fleet bulk-action dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.fleet.aggregator import ProjectSnapshot, ProjectState
+from bernstein.core.fleet.bulk import (
+    bulk_pause,
+    bulk_resume,
+    bulk_stop,
+    evaluate_filter,
+    select_projects,
+)
+from bernstein.core.fleet.config import ProjectConfig
+
+
+def _project(tmp_path: Path, name: str) -> ProjectConfig:
+    return ProjectConfig(
+        name=name,
+        path=tmp_path,
+        task_server_url="http://127.0.0.1:8052",
+        sdd_dir=tmp_path / ".sdd",
+    )
+
+
+def test_evaluate_filter_basic(tmp_path: Path) -> None:
+    snap = ProjectSnapshot(
+        name="alpha", state=ProjectState.ONLINE, agents=3, cost_usd=10.0,
+        pending_approvals=2,
+    )
+    assert evaluate_filter(snap, "cost>5")
+    assert not evaluate_filter(snap, "cost<5")
+    assert evaluate_filter(snap, "agents==3")
+    assert evaluate_filter(snap, "approvals>=2")
+
+
+def test_select_projects_with_names_and_filter(tmp_path: Path) -> None:
+    projects = [_project(tmp_path, "alpha"), _project(tmp_path, "bravo")]
+    snapshots = [
+        ProjectSnapshot(name="alpha", cost_usd=10.0),
+        ProjectSnapshot(name="bravo", cost_usd=2.0),
+    ]
+    selected = select_projects(projects, snapshots, filter_expression="cost>5")
+    assert {p.name for p in selected} == {"alpha"}
+    selected = select_projects(projects, snapshots, names=["bravo"], filter_expression="cost<5")
+    assert {p.name for p in selected} == {"bravo"}
+
+
+def test_select_projects_invalid_filter_raises(tmp_path: Path) -> None:
+    projects = [_project(tmp_path, "alpha")]
+    snapshots = [ProjectSnapshot(name="alpha")]
+    with pytest.raises(ValueError):
+        select_projects(projects, snapshots, filter_expression="nope")
+
+
+@pytest.mark.asyncio
+async def test_bulk_stop_dispatches_to_each_project(tmp_path: Path) -> None:
+    """``bulk_stop`` calls the runner once per project with ``["stop"]``."""
+    projects = [_project(tmp_path, "alpha"), _project(tmp_path, "bravo")]
+    calls: list[tuple[str, list[str], Path]] = []
+
+    async def runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+        # Capture the trailing arg ("stop") — we don't care about the python prefix.
+        calls.append((env["BERNSTEIN_TASK_SERVER_URL"], cmd[-1:], cwd))
+        return 0, "ok", ""
+
+    result = await bulk_stop(projects, runner=runner)
+    assert sorted(result.succeeded) == ["alpha", "bravo"]
+    assert result.failed == {}
+    assert len(calls) == 2
+    assert all(call[1] == ["stop"] for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_bulk_pause_uses_daemon_stop(tmp_path: Path) -> None:
+    projects = [_project(tmp_path, "alpha")]
+    captured: list[list[str]] = []
+
+    async def runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+        captured.append(cmd[-2:])
+        return 0, "", ""
+
+    result = await bulk_pause(projects, runner=runner)
+    assert result.succeeded == ["alpha"]
+    assert captured == [["daemon", "stop"]]
+
+
+@pytest.mark.asyncio
+async def test_bulk_resume_uses_daemon_start(tmp_path: Path) -> None:
+    projects = [_project(tmp_path, "alpha")]
+    captured: list[list[str]] = []
+
+    async def runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+        captured.append(cmd[-2:])
+        return 0, "", ""
+
+    result = await bulk_resume(projects, runner=runner)
+    assert result.succeeded == ["alpha"]
+    assert captured == [["daemon", "start"]]
+
+
+@pytest.mark.asyncio
+async def test_bulk_records_failure_per_project(tmp_path: Path) -> None:
+    projects = [_project(tmp_path, "alpha"), _project(tmp_path, "bravo")]
+
+    async def runner(cmd: list[str], cwd: Path, env: dict[str, str]) -> tuple[int, str, str]:
+        if "alpha" in env["BERNSTEIN_TASK_SERVER_URL"]:
+            return 0, "ok", ""
+        # Both projects have the same default URL; instead distinguish by cwd.
+        if "bravo" in str(cwd):
+            return 1, "", "boom"
+        return 0, "ok", ""
+
+    # Force per-project paths to be unique:
+    bravo_root = tmp_path / "bravo"
+    bravo_root.mkdir(parents=True, exist_ok=True)
+    projects = [
+        ProjectConfig(
+            name="alpha",
+            path=tmp_path,
+            task_server_url="http://127.0.0.1:8052",
+            sdd_dir=tmp_path / ".sdd",
+        ),
+        ProjectConfig(
+            name="bravo",
+            path=bravo_root,
+            task_server_url="http://127.0.0.1:8052",
+            sdd_dir=bravo_root / ".sdd",
+        ),
+    ]
+    result = await bulk_stop(projects, runner=runner)
+    assert "alpha" in result.succeeded
+    assert "bravo" in result.failed
+    assert "boom" in result.failed["bravo"]

--- a/tests/unit/fleet/test_config.py
+++ b/tests/unit/fleet/test_config.py
@@ -1,0 +1,78 @@
+"""Tests for the fleet config loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bernstein.core.fleet.config import (
+    FleetConfig,
+    load_projects_config,
+    parse_projects_config,
+)
+
+
+def test_parse_minimal(tmp_path: Path) -> None:
+    """A single ``[[project]]`` block parses with safe defaults."""
+    text = f"""
+[[project]]
+path = "{tmp_path}"
+"""
+    config = parse_projects_config(text)
+    assert len(config.projects) == 1
+    assert config.errors == []
+    project = config.projects[0]
+    assert project.name == tmp_path.name
+    assert project.task_server_url.startswith("http://127.0.0.1:")
+    assert project.sdd_dir == project.path / ".sdd"
+
+
+def test_parse_explicit_name_and_url(tmp_path: Path) -> None:
+    text = f"""
+[[project]]
+name = "alpha"
+path = "{tmp_path}"
+task_server_url = "http://127.0.0.1:8080"
+"""
+    config = parse_projects_config(text)
+    assert len(config.projects) == 1
+    assert config.projects[0].name == "alpha"
+    assert config.projects[0].task_server_url == "http://127.0.0.1:8080"
+
+
+def test_missing_path_yields_validation_error(tmp_path: Path) -> None:
+    """Missing ``path`` records a non-fatal error rather than crashing."""
+    text = """
+[[project]]
+name = "broken"
+"""
+    config = parse_projects_config(text)
+    assert config.projects == []
+    assert any("path" in err.message for err in config.errors)
+
+
+def test_duplicate_names_flagged(tmp_path: Path) -> None:
+    text = f"""
+[[project]]
+name = "shared"
+path = "{tmp_path}"
+
+[[project]]
+name = "shared"
+path = "{tmp_path}"
+"""
+    config = parse_projects_config(text)
+    assert len(config.projects) == 1
+    assert any("duplicate" in err.message for err in config.errors)
+
+
+def test_invalid_toml_records_global_error() -> None:
+    config = parse_projects_config("[[project")
+    assert config.projects == []
+    assert any(err.index == -1 for err in config.errors)
+
+
+def test_load_missing_file_returns_error(tmp_path: Path) -> None:
+    cfg = load_projects_config(tmp_path / "does-not-exist.toml")
+    assert isinstance(cfg, FleetConfig)
+    assert cfg.projects == []
+    assert any("not found" in err.message for err in cfg.errors)

--- a/tests/unit/fleet/test_cost_rollup.py
+++ b/tests/unit/fleet/test_cost_rollup.py
@@ -1,0 +1,93 @@
+"""Tests for the fleet cost rollup."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from bernstein.core.fleet.cost_rollup import (
+    render_sparkline,
+    rollup_costs,
+)
+
+
+def _write_history(sdd_dir: Path, samples: list[tuple[str, float]]) -> None:
+    metrics = sdd_dir / "metrics"
+    metrics.mkdir(parents=True, exist_ok=True)
+    with (metrics / "cost_history.jsonl").open("w", encoding="utf-8") as fh:
+        for date, cost in samples:
+            fh.write(json.dumps({"date": date, "cost_usd": cost}) + "\n")
+
+
+def test_render_sparkline_empty() -> None:
+    spark = render_sparkline([])
+    assert spark.glyphs == ""
+    assert spark.peak == 0.0
+
+
+def test_render_sparkline_monotonic() -> None:
+    spark = render_sparkline([1.0, 2.0, 4.0, 8.0])
+    assert len(spark.glyphs) == 4
+    assert spark.peak == 8.0
+
+
+def test_rollup_correctness(tmp_path: Path) -> None:
+    """Per-project totals and fleet total agree with the underlying samples."""
+    a = tmp_path / "alpha" / ".sdd"
+    b = tmp_path / "bravo" / ".sdd"
+    _write_history(
+        a,
+        [("2026-04-19", 1.0), ("2026-04-20", 2.0), ("2026-04-21", 3.0)],
+    )
+    _write_history(
+        b,
+        [("2026-04-20", 4.0), ("2026-04-21", 5.0)],
+    )
+    rollup = rollup_costs({"alpha": a, "bravo": b}, window_days=7)
+    assert rollup.per_project["alpha"]["total_usd"] == 6.0
+    assert rollup.per_project["bravo"]["total_usd"] == 9.0
+    assert rollup.fleet_total_usd == 15.0
+    assert isinstance(rollup.per_project["alpha"]["sparkline"], str)
+    assert len(rollup.per_project["alpha"]["sparkline"]) == 3
+
+
+def test_rollup_handles_missing_project(tmp_path: Path) -> None:
+    """Projects without history files yield empty sparklines but no crash."""
+    rollup = rollup_costs({"empty": tmp_path / "missing" / ".sdd"})
+    assert rollup.per_project["empty"]["total_usd"] == 0.0
+    assert rollup.per_project["empty"]["sparkline"] == ""
+    assert rollup.fleet_total_usd == 0.0
+
+
+def test_rollup_window_truncates(tmp_path: Path) -> None:
+    """Only the last ``window_days`` daily samples are kept."""
+    sdd = tmp_path / "alpha" / ".sdd"
+    samples = [
+        ("2026-04-15", 100.0),  # outside default 7-day window slot
+        ("2026-04-16", 1.0),
+        ("2026-04-17", 1.0),
+        ("2026-04-18", 1.0),
+        ("2026-04-19", 1.0),
+        ("2026-04-20", 1.0),
+        ("2026-04-21", 1.0),
+        ("2026-04-22", 1.0),
+    ]
+    _write_history(sdd, samples)
+    rollup = rollup_costs({"alpha": sdd}, window_days=7)
+    history = rollup.per_project["alpha"]["history"]
+    assert isinstance(history, list)
+    assert len(history) == 7  # 7-day cap
+
+
+def test_rollup_uses_ts_field(tmp_path: Path) -> None:
+    """Entries with epoch ``ts`` instead of ``date`` are still aggregated."""
+    sdd = tmp_path / "alpha" / ".sdd"
+    metrics = sdd / "metrics"
+    metrics.mkdir(parents=True, exist_ok=True)
+    now = time.time()
+    with (metrics / "cost_history.jsonl").open("w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"ts": now - 1, "cost_usd": 2.0}) + "\n")
+        fh.write(json.dumps({"ts": now, "cost_usd": 3.0}) + "\n")
+    rollup = rollup_costs({"alpha": sdd})
+    assert rollup.per_project["alpha"]["total_usd"] == 5.0

--- a/tests/unit/fleet/test_prometheus_proxy.py
+++ b/tests/unit/fleet/test_prometheus_proxy.py
@@ -1,0 +1,90 @@
+"""Tests for Prometheus exposition merging."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from bernstein.core.fleet.config import ProjectConfig
+from bernstein.core.fleet.prometheus_proxy import (
+    merge_prometheus_metrics,
+    merge_text,
+)
+
+
+def _project(tmp_path: Path, name: str, port: int = 8080) -> ProjectConfig:
+    return ProjectConfig(
+        name=name,
+        path=tmp_path,
+        task_server_url=f"http://127.0.0.1:{port}",
+        sdd_dir=tmp_path / ".sdd",
+    )
+
+
+def test_merge_text_injects_label_into_unlabelled_line() -> None:
+    body = "bernstein_tasks_total 42"
+    rewritten = merge_text("alpha", body)
+    assert 'project="alpha"' in rewritten
+    assert "bernstein_tasks_total" in rewritten
+    assert " 42" in rewritten
+
+
+def test_merge_text_preserves_existing_labels() -> None:
+    body = 'bernstein_tasks_total{role="manager"} 7'
+    rewritten = merge_text("alpha", body)
+    assert 'project="alpha"' in rewritten
+    assert 'role="manager"' in rewritten
+
+
+def test_merge_text_keeps_help_and_type_lines() -> None:
+    body = (
+        "# HELP bernstein_tasks_total Total tasks\n"
+        "# TYPE bernstein_tasks_total counter\n"
+        "bernstein_tasks_total 1\n"
+    )
+    rewritten = merge_text("alpha", body)
+    assert "# HELP bernstein_tasks_total" in rewritten
+    assert "# TYPE bernstein_tasks_total counter" in rewritten
+
+
+@pytest.mark.asyncio
+async def test_merge_prometheus_metrics_aggregates(tmp_path: Path) -> None:
+    """Concurrent scrape merges every project's body with project labels."""
+    projects = [_project(tmp_path, "alpha"), _project(tmp_path, "bravo", port=8081)]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "alpha" in request.url.host or request.url.port == 8080:
+            return httpx.Response(200, text="bernstein_tasks_total 1\n")
+        return httpx.Response(200, text="bernstein_tasks_total 2\n")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        merge = await merge_prometheus_metrics(projects, client=client)
+    finally:
+        await client.aclose()
+    assert "alpha" in merge.ok_projects
+    assert "bravo" in merge.ok_projects
+    assert 'project="alpha"' in merge.body
+    assert 'project="bravo"' in merge.body
+
+
+@pytest.mark.asyncio
+async def test_merge_prometheus_metrics_offline(tmp_path: Path) -> None:
+    """An offline project is recorded as failed but doesn't break the body."""
+    projects = [_project(tmp_path, "alpha"), _project(tmp_path, "bravo", port=8081)]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.port == 8080:
+            return httpx.Response(200, text="bernstein_tasks_total 1\n")
+        raise httpx.ConnectError("refused")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        merge = await merge_prometheus_metrics(projects, client=client)
+    finally:
+        await client.aclose()
+    assert "alpha" in merge.ok_projects
+    assert "bravo" in merge.failed_projects
+    assert "fleet_project_offline" in merge.body


### PR DESCRIPTION
## Summary

- Adds `bernstein.core.fleet` package: `FleetAggregator` (status + bulletin + SSE fan-out), cost rollup with sparklines, audit panel with filter + tail-break detection, Prometheus exposition merger, and bulk-action dispatcher.
- Adds `bernstein fleet` CLI: Textual TUI (rows per project, audit-chain status), `--web :PORT` FastAPI app (HTML dashboard, `/api/projects`, `/api/cost`, `/api/audit`, `/api/audit/chain`, `/events` SSE proxy, unified `/metrics`), and `bulk-stop` / `bulk-pause` / `bulk-resume` / `bulk-cost-report` subcommands that route through each project's CLI for audit parity.
- Reads `~/.config/bernstein/projects.toml` (override via `\$BERNSTEIN_FLEET_CONFIG` or `\$XDG_CONFIG_HOME`); validation errors surface in the dashboard footer rather than crashing the TUI. Loopback-only by default per ticket.
- Graceful offline-row degradation: failed scrapes mark the row OFFLINE and continue with exponential backoff; an offline project never blocks the rest of the fleet.
- Tests: 29 unit + 4 integration covering config validation, snapshot fan-out, SSE reconnect, bulk-stop dispatch, cost rollup correctness, audit-tail break detection, Prometheus aggregation, and an end-to-end check against a real HTTP server.

Refs: [release_1.9_fleet_dashboard](.sdd/backlog/open/release_1.9_fleet_dashboard.yaml)

## Test plan

- [x] \`uv run python scripts/run_tests.py --test-dir tests/unit/fleet -x\` (6/6 files, 35 tests)
- [x] \`uv run python scripts/run_tests.py --test-dir tests/integration/fleet -x\` (1/1, 4 tests)
- [x] \`uv run ruff check src/bernstein/core/fleet/ src/bernstein/cli/commands/fleet_cmd.py tests/unit/fleet/ tests/integration/fleet/\`
- [x] \`uv run bernstein fleet --help\` and \`bernstein fleet ls\` smoke tests
- [ ] Manual: configure 3+ projects, run \`bernstein fleet\` and \`bernstein fleet --web :8061\`, scrape unified \`/metrics\`