### PR TITLE
fix(cli): dry-run helper now picks up .md/.yaml/.yml tickets in open/ and issues/ (#952)

### DIFF
--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -207,13 +207,24 @@ def print_dry_run_table(workdir: Path) -> None:
     from bernstein.core.router import TierAwareRouter, load_providers_from_yaml
     from bernstein.core.sync import BacklogTask, parse_backlog_file
 
-    backlog_dir = workdir / ".sdd" / "backlog" / "open"
+    open_dir = workdir / ".sdd" / "backlog" / "open"
+    issues_dir = workdir / ".sdd" / "backlog" / "issues"
+    files: list[Path] = []
+    for src_dir in (open_dir, issues_dir):
+        if src_dir.exists():
+            for ext in ("*.md", "*.yaml", "*.yml"):
+                files.extend(src_dir.glob(ext))
+    files.sort()
+
     tasks: list[BacklogTask] = []
-    if backlog_dir.exists():
-        for md_file in sorted(backlog_dir.glob("*.yaml")):
-            bt = parse_backlog_file(md_file)
-            if bt is not None:
-                tasks.append(bt)
+    seen: set[str] = set()
+    for backlog_file in files:
+        if backlog_file.name in seen:
+            continue
+        seen.add(backlog_file.name)
+        bt = parse_backlog_file(backlog_file)
+        if bt is not None:
+            tasks.append(bt)
 
     console.print("\n[bold cyan][DRY RUN] Planned task spawns:[/bold cyan]")
 

--- a/tests/unit/test_cli_helpers_dry_run.py
+++ b/tests/unit/test_cli_helpers_dry_run.py
@@ -1,0 +1,117 @@
+"""Tests for ``print_dry_run_table`` ticket discovery (issue #952)."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from rich.console import Console
+
+from bernstein.cli import helpers
+
+
+def _setup_backlog(workdir: Path) -> None:
+    """Create a backlog with one ``.md``-frontmatter ticket and one ``.yaml`` ticket."""
+    open_dir = workdir / ".sdd" / "backlog" / "open"
+    open_dir.mkdir(parents=True)
+
+    (open_dir / "001-md-ticket.md").write_text(
+        """---
+title: "Add hello function"
+role: backend
+priority: 2
+scope: small
+complexity: low
+---
+# Add hello function
+
+Body of the markdown ticket.
+""",
+        encoding="utf-8",
+    )
+
+    (open_dir / "002-yaml-ticket.yaml").write_text(
+        """---
+title: "Improve CLI output"
+role: frontend
+priority: 3
+scope: medium
+complexity: medium
+---
+# Improve CLI output
+
+A YAML-frontmatter ticket.
+""",
+        encoding="utf-8",
+    )
+
+
+def test_print_dry_run_table_includes_md_and_yaml_tickets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Both ``.md`` and ``.yaml`` tickets should appear in the dry-run table.
+
+    Regression test for issue #952: the previous implementation only globbed
+    ``*.yaml`` from ``.sdd/backlog/open/``, hiding any ``.md``-frontmatter
+    ticket from the dry-run preview even though the orchestrator would
+    happily ingest it.
+    """
+    _setup_backlog(tmp_path)
+
+    buf = io.StringIO()
+    fake_console = Console(file=buf, width=200, force_terminal=False, record=False)
+    monkeypatch.setattr(helpers, "console", fake_console)
+
+    helpers.print_dry_run_table(tmp_path)
+
+    output = buf.getvalue()
+    assert "Add hello function" in output, output
+    assert "Improve CLI output" in output, output
+    assert "No open tasks found" not in output, output
+    assert "Total: 2 task(s)" in output, output
+
+
+def test_print_dry_run_table_includes_issues_dir_tickets(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Tickets under ``.sdd/backlog/issues/`` are picked up too (orchestrator parity)."""
+    issues_dir = tmp_path / ".sdd" / "backlog" / "issues"
+    issues_dir.mkdir(parents=True)
+    (issues_dir / "010-issue.md").write_text(
+        """---
+title: "Investigate flaky test"
+role: qa
+priority: 1
+scope: small
+complexity: low
+---
+# Investigate flaky test
+""",
+        encoding="utf-8",
+    )
+
+    buf = io.StringIO()
+    fake_console = Console(file=buf, width=200, force_terminal=False, record=False)
+    monkeypatch.setattr(helpers, "console", fake_console)
+
+    helpers.print_dry_run_table(tmp_path)
+
+    output = buf.getvalue()
+    assert "Investigate flaky test" in output, output
+    assert "No open tasks found" not in output, output
+
+
+def test_print_dry_run_table_no_backlog(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """With no backlog directories, the helper reports no open tasks."""
+    buf = io.StringIO()
+    fake_console = Console(file=buf, width=200, force_terminal=False, record=False)
+    monkeypatch.setattr(helpers, "console", fake_console)
+
+    helpers.print_dry_run_table(tmp_path)
+
+    assert "No open tasks found" in buf.getvalue()


### PR DESCRIPTION
Closes #952.

`print_dry_run_table()` was only globbing `*.yaml` from `.sdd/backlog/open/`, so any `.md`-frontmatter ticket (the format `bernstein init` and `gen_tickets_*` produce) was invisible to `bernstein --dry-run` even though the real orchestrator picks it up via `_collect_backlog_files()` in `core/orchestration/orchestrator_backlog.py`. This change mirrors the orchestrator: glob `*.md`, `*.yaml`, `*.yml` from both `open/` and `issues/`, with a per-filename dedup guard, then sort and feed the existing `parse_backlog_file()` path.

## Files changed

- `src/bernstein/cli/helpers.py` — replace the single-extension `open/` glob with the orchestrator's three-extension scan over `open/` and `issues/`.
- `tests/unit/test_cli_helpers_dry_run.py` — new regression test.

## Test plan

- [x] `uv run pytest tests/unit/test_cli_helpers_dry_run.py -x -q` — 3 passed.
- [x] `uv run python scripts/run_tests.py -x -k cli_helpers_dry_run` — 1 file, 3 passed.
- [x] `uv run ruff check src/bernstein/cli/helpers.py tests/unit/test_cli_helpers_dry_run.py` — clean.
- [x] `uv run ruff format --check src/bernstein/cli/helpers.py tests/unit/test_cli_helpers_dry_run.py` — clean.

The new test drops one `.md`-frontmatter ticket and one `.yaml`-frontmatter ticket into a tempdir backlog, monkey-patches `helpers.console` to capture rendered Rich output, calls `print_dry_run_table()`, and asserts both titles appear and `"No open tasks found"` does not. A second case puts a ticket under `.sdd/backlog/issues/` to lock in the new directory parity. A third covers the empty-backlog "no open tasks" branch.