### PR TITLE
fix(cli): post-run summary tolerates bare-string agent entries; cleanup runs even on render failure (#953)

### DIFF
--- a/src/bernstein/cli/live.py
+++ b/src/bernstein/cli/live.py
@@ -160,9 +160,11 @@ class LiveView:
         Returns:
             A Rich Group renderable.
         """
+        from bernstein.cli.run import _normalize_agent_entries
+
         status: dict[str, Any] = data.get("status", {})
         tasks: list[dict[str, Any]] = data.get("tasks", [])
-        agents_raw: list[dict[str, Any]] = data.get("agents", [])
+        agents_raw = _normalize_agent_entries(data.get("agents", []))
         costs: dict[str, Any] = data.get("costs", {})
 
         summary = TaskSummary.from_dict(status)

--- a/src/bernstein/cli/run.py
+++ b/src/bernstein/cli/run.py
@@ -6,7 +6,7 @@ Components are imported from :mod:`bernstein.cli.ui`.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from rich.console import Console, Group
 from rich.live import Live
@@ -174,6 +174,32 @@ def render_run_summary(stats: RunStats, *, console: Console | None = None) -> No
     )
 
 
+def _normalize_agent_entries(payload: object) -> list[dict[str, Any]]:
+    """Normalize the ``agents`` field from a ``/status`` payload.
+
+    The task server's ``/status`` endpoint emits ``agents`` as a section dict
+    of the form ``{"count": N, "items": [{...}, ...]}``.  Older callers (and
+    legacy tests) sometimes pass a bare ``list[dict]``.  This helper accepts
+    either shape and returns the underlying list of agent dicts, dropping
+    any non-dict entries defensively.
+
+    Args:
+        payload: Raw value of ``data["agents"]`` from the status response.
+
+    Returns:
+        List of agent dicts suitable for :meth:`AgentInfo.from_dict`.
+    """
+    if isinstance(payload, list):
+        raw_items: list[object] = cast("list[object]", payload)
+    elif isinstance(payload, dict):
+        section = cast("dict[str, Any]", payload)
+        nested = section.get("items", [])
+        raw_items = cast("list[object]", nested) if isinstance(nested, list) else []
+    else:
+        raw_items = []
+    return [cast("dict[str, Any]", item) for item in raw_items if isinstance(item, dict)]
+
+
 def render_run_summary_from_dict(data: dict[str, Any], *, console: Console | None = None) -> None:
     """Convenience wrapper that builds RunStats from a raw API dict.
 
@@ -182,7 +208,7 @@ def render_run_summary_from_dict(data: dict[str, Any], *, console: Console | Non
         console: Optional Rich Console to use.
     """
     summary_raw: dict[str, Any] = data.get("summary", data)
-    agents_raw: list[dict[str, Any]] = data.get("agents", [])
+    agents_raw = _normalize_agent_entries(data.get("agents", []))
 
     stats = RunStats(
         summary=TaskSummary.from_dict(summary_raw),

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import logging
 import os
 import sys
 from dataclasses import dataclass
@@ -13,6 +14,7 @@ from typing import Any
 import click
 
 from bernstein.cli.helpers import (
+    SERVER_URL,
     console,
     find_seed_file,
 )
@@ -21,6 +23,8 @@ from bernstein.cli.ui import make_console
 from bernstein.core.cost import estimate_run_cost
 from bernstein.core.plan_loader import load_plan_from_yaml
 from bernstein.core.runtime_state import directory_size_bytes
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Post-run summary helper
@@ -40,6 +44,36 @@ def _show_run_summary() -> None:
     force_no_color = not sys.stdout.isatty()
     con = make_console(no_color=force_no_color)
     render_run_summary_from_dict(data, console=con)
+
+
+def _drain_completed_backlog_files() -> None:
+    """Move backlog files for terminal tasks from ``claimed/`` to ``closed/``.
+
+    This is the post-run safety-net for the periodic sync tick: if the
+    orchestrator stops before its next sync, completed tickets can stay
+    pinned in ``.sdd/backlog/claimed/``.  We invoke the same logic the
+    sync loop uses, but only the move step (no task creation), and we
+    swallow any exception so a cleanup failure never aborts shutdown.
+
+    Safe to call when the task server is already gone; in that case the
+    httpx connection raises, we log at debug, and return.
+    """
+    import httpx
+
+    from bernstein.core.sync import SyncResult, _move_completed_files
+
+    workdir = Path.cwd()
+    backlog_open = workdir / ".sdd" / "backlog" / "open"
+    backlog_issues = workdir / ".sdd" / "backlog" / "issues"
+    if not (workdir / ".sdd" / "backlog" / "claimed").exists():
+        return
+
+    result = SyncResult()
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            _move_completed_files(workdir, client, SERVER_URL, backlog_open, backlog_issues, result)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Post-run claimed/ drain failed: %s: %s", type(exc).__name__, exc)
 
 
 @dataclass(frozen=True)
@@ -240,39 +274,51 @@ def _finalize_run_output(*, quiet: bool) -> None:
     Uses terminal capability detection (TUI-003) to choose between the
     full Textual TUI and a Rich-based fallback for unsupported terminals.
 
+    Cleanup ordering (gh-953): the ``claimed/`` drain is wrapped in a
+    ``try/finally`` around the renderer so that a UI crash (e.g. a shape
+    mismatch in the run-summary payload) cannot leave completed tickets
+    pinned in ``.sdd/backlog/claimed/`` indefinitely.  ``try/finally`` was
+    chosen over reordering because (a) it preserves the existing render-then-
+    cleanup ordering on the happy path so the summary still reflects the
+    pre-drain state, and (b) it keeps cleanup correct even when the renderer
+    raises ``SystemExit`` or ``KeyboardInterrupt``.
+
     Args:
         quiet: When True, wait for quiescence and print only the terminal summary.
     """
     from bernstein.cli.run_bootstrap import _wait_for_run_completion, exec_restart
 
-    if quiet:
-        _wait_for_run_completion()
-        _show_run_summary()
-        return
+    try:
+        if quiet:
+            _wait_for_run_completion()
+            _show_run_summary()
+            return
 
-    from bernstein.cli.terminal_caps import detect_capabilities
+        from bernstein.cli.terminal_caps import detect_capabilities
 
-    caps = detect_capabilities()
+        caps = detect_capabilities()
 
-    if caps.supports_textual:
-        try:
-            from bernstein.cli.dashboard import BernsteinApp as DashboardApp
+        if caps.supports_textual:
+            try:
+                from bernstein.cli.dashboard import BernsteinApp as DashboardApp
 
-            app = DashboardApp()
-            with contextlib.suppress(SystemExit):
-                app.run()
-            # Hot restart: server+orchestrator already killed by the TUI,
-            # re-exec the full `bernstein run` so everything restarts cleanly.
-            if getattr(app, "_restart_on_exit", False):
-                exec_restart()
-        except Exception:
-            # Textual failed at runtime -- fall through to fallback
+                app = DashboardApp()
+                with contextlib.suppress(SystemExit):
+                    app.run()
+                # Hot restart: server+orchestrator already killed by the TUI,
+                # re-exec the full `bernstein run` so everything restarts cleanly.
+                if getattr(app, "_restart_on_exit", False):
+                    exec_restart()
+            except Exception:
+                # Textual failed at runtime -- fall through to fallback
+                _try_fallback_display()
+        elif caps.is_tty:
+            # TTY but Textual not supported -- use Rich fallback (TUI-003)
             _try_fallback_display()
-    elif caps.is_tty:
-        # TTY but Textual not supported -- use Rich fallback (TUI-003)
-        _try_fallback_display()
-    else:
-        _show_run_summary()
+        else:
+            _show_run_summary()
+    finally:
+        _drain_completed_backlog_files()
 
 
 def _try_fallback_display() -> None:

--- a/src/bernstein/cli/ui.py
+++ b/src/bernstein/cli/ui.py
@@ -133,15 +133,23 @@ class AgentInfo:
         return min(100.0, (self.tokens_used / self.token_budget) * 100)
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> AgentInfo:
+    def from_dict(cls, data: str | dict[str, Any]) -> AgentInfo:
         """Build an AgentInfo from a raw dict (e.g. from agents.json).
 
+        Accepts either a full agent record or a bare agent-id string.  The
+        string form is treated as ``{"id": value}`` with all other fields
+        falling back to their defaults; this is a belt-and-braces guard
+        against producers that occasionally serialize partial/cancelled
+        agents to just their identifier.
+
         Args:
-            data: Raw dict with agent fields.
+            data: Raw dict with agent fields, or a bare string agent id.
 
         Returns:
             Populated AgentInfo instance.
         """
+        if isinstance(data, str):
+            data = {"id": data}
         return cls(
             agent_id=str(data.get("id", "")),
             role=str(data.get("role", "")),

--- a/tests/unit/test_cli_ui.py
+++ b/tests/unit/test_cli_ui.py
@@ -45,6 +45,31 @@ class TestAgentInfo:
         assert info.token_budget == 0
         assert info.context_utilization_pct == pytest.approx(0.0)
 
+    def test_from_dict_accepts_bare_string_id(self) -> None:
+        """gh-953 layer 2: defensive parser tolerates bare-string entries.
+
+        Some producers serialize partial/cancelled agents as just an
+        identifier string.  ``from_dict`` must treat ``"agent-id"`` as
+        ``{"id": "agent-id"}`` rather than crashing on ``str.get``.
+        """
+        info = AgentInfo.from_dict("agent-id-only-as-string")
+        assert info.agent_id == "agent-id-only-as-string"
+        # Sane defaults for everything else.
+        assert info.role == ""
+        assert info.model == ""
+        assert info.status == "idle"
+        assert info.task_ids == []
+        assert info.runtime_s == pytest.approx(0.0)
+        assert info.tokens_used == 0
+        assert info.token_budget == 0
+        assert info.context_utilization_pct == pytest.approx(0.0)
+
+    def test_from_dict_empty_string_yields_empty_id(self) -> None:
+        """Empty bare string should not crash; it just yields empty id."""
+        info = AgentInfo.from_dict("")
+        assert info.agent_id == ""
+        assert info.status == "idle"
+
 
 # --- TestAgentStatusTableTokenDisplay ---
 

--- a/tests/unit/test_run_summary_issue_953.py
+++ b/tests/unit/test_run_summary_issue_953.py
@@ -1,0 +1,245 @@
+"""Regression tests for issue gh-953.
+
+Three layers from the bug report are covered:
+
+1. **Producer/consumer shape mismatch** — the task server's ``/status``
+   endpoint emits ``agents`` as ``{"count": N, "items": [...]}`` (matching
+   the ``tasks`` section), but the run-summary consumer used to iterate it
+   as a flat ``list[dict]``, which yielded the dict's string keys
+   (``"count"``, ``"items"``) and crashed on ``str.get``.  We assert the
+   normalization helper extracts ``items`` correctly and that the ``items``
+   list always contains dicts (never bare strings) for partial/cancelled
+   agents.
+
+2. **Defensive parser** — covered by ``test_cli_ui.py`` (bare-string id is
+   accepted).  Re-asserted here at the call-site level via
+   ``render_run_summary_from_dict``.
+
+3. **Cleanup ordering** — ``_finalize_run_output`` must drain
+   ``.sdd/backlog/claimed/`` even when the summary renderer raises.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.cli.run import _normalize_agent_entries, render_run_summary_from_dict
+from bernstein.cli.ui import AgentInfo
+from bernstein.core.routes.status_dashboard import _status_agent_items
+
+# ---------------------------------------------------------------------------
+# Layer 1: producer/consumer shape
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAgentEntries:
+    """The consumer-side normalizer must accept either shape."""
+
+    def test_section_dict_shape_returns_items(self) -> None:
+        """``/status`` emits ``{"count": N, "items": [...]}``."""
+        payload: dict[str, Any] = {
+            "count": 2,
+            "items": [
+                {"id": "a1", "role": "backend"},
+                {"id": "a2", "role": "qa"},
+            ],
+        }
+        out = _normalize_agent_entries(payload)
+        assert len(out) == 2
+        assert out[0]["id"] == "a1"
+        assert out[1]["id"] == "a2"
+
+    def test_legacy_list_shape_passthrough(self) -> None:
+        """Older callers still pass a flat list — keep working."""
+        payload: list[dict[str, Any]] = [{"id": "a1"}, {"id": "a2"}]
+        out = _normalize_agent_entries(payload)
+        assert [a["id"] for a in out] == ["a1", "a2"]
+
+    def test_drops_non_dict_items(self) -> None:
+        """Bare strings inside ``items`` are dropped (not crashed on)."""
+        payload: dict[str, Any] = {
+            "count": 2,
+            "items": [{"id": "a1"}, "stray-id-string", 42],
+        }
+        out = _normalize_agent_entries(payload)
+        assert len(out) == 1
+        assert out[0]["id"] == "a1"
+
+    def test_empty_or_unexpected_payload_returns_empty(self) -> None:
+        assert _normalize_agent_entries(None) == []
+        assert _normalize_agent_entries("garbage") == []
+        assert _normalize_agent_entries({}) == []
+        assert _normalize_agent_entries({"items": "not-a-list"}) == []
+
+
+class TestStatusAgentItemsProducer:
+    """Layer 1 (producer): ``_status_agent_items`` must always emit dicts.
+
+    The reporter hinted that "partial/cancelled agents serialize to just
+    their ID".  We assert here that the producer always returns full dicts
+    even when fed a snapshot-only path with no live agents.
+    """
+
+    def test_emits_dicts_from_snapshots_only(self) -> None:
+        store = MagicMock()
+        store.agents = {}
+        snapshots = {
+            "agent-x": {
+                "id": "agent-x",
+                "role": "backend",
+                "status": "dead",
+            }
+        }
+        items = _status_agent_items(store, snapshots, {}, now=1000.0)
+        assert len(items) == 1
+        assert isinstance(items[0], dict)
+        assert items[0]["id"] == "agent-x"
+        # Must not be a bare string anywhere.
+        assert all(isinstance(item, dict) for item in items)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: end-to-end via the renderer
+# ---------------------------------------------------------------------------
+
+
+class TestRenderRunSummaryFromDict:
+    """The renderer must survive both shapes without raising."""
+
+    def test_section_dict_shape_does_not_crash(self) -> None:
+        """Reproduction of gh-953: ``agents`` is a section dict.
+
+        Pre-fix this raised ``AttributeError: 'str' object has no attribute
+        'get'`` because the comprehension iterated dict keys.
+        """
+        data: dict[str, Any] = {
+            "summary": {"total": 1, "open": 0, "claimed": 0, "done": 1, "failed": 0},
+            "agents": {
+                "count": 1,
+                "items": [
+                    {
+                        "id": "backend-d3c7c7bb",
+                        "role": "backend",
+                        "model": "sonnet",
+                        "status": "done",
+                        "tokens_used": 12_345,
+                    }
+                ],
+            },
+            "elapsed_seconds": 30.4,
+            "total_cost_usd": 0.0123,
+        }
+        # Should not raise.
+        render_run_summary_from_dict(data, console=MagicMock())
+
+    def test_legacy_list_shape_still_works(self) -> None:
+        data: dict[str, Any] = {
+            "summary": {"total": 0},
+            "agents": [{"id": "a1", "role": "qa"}],
+        }
+        render_run_summary_from_dict(data, console=MagicMock())
+
+    def test_bare_string_inside_items_does_not_crash(self) -> None:
+        """Belt-and-braces: even if a bare string sneaks past, no crash."""
+        data: dict[str, Any] = {
+            "summary": {"total": 0},
+            "agents": {"count": 1, "items": ["stray-id"]},
+        }
+        # ``_normalize_agent_entries`` drops non-dicts; renderer is happy.
+        render_run_summary_from_dict(data, console=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Layer 3: cleanup ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupOrdering:
+    """``_finalize_run_output`` must drain ``claimed/`` even on render crash."""
+
+    def test_drain_runs_after_successful_summary(self) -> None:
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion"),
+            patch("bernstein.cli.run_preflight._show_run_summary") as show_summary,
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            _finalize_run_output(quiet=True)
+
+        show_summary.assert_called_once()
+        drain.assert_called_once()
+
+    def test_drain_runs_when_renderer_raises(self) -> None:
+        """gh-953 layer 3: a UI crash must NOT leak claimed tickets."""
+        from bernstein.cli.run_preflight import _finalize_run_output
+
+        with (
+            patch("bernstein.cli.run_bootstrap._wait_for_run_completion"),
+            patch(
+                "bernstein.cli.run_preflight._show_run_summary",
+                side_effect=AttributeError("'str' object has no attribute 'get'"),
+            ) as show_summary,
+            patch("bernstein.cli.run_preflight._drain_completed_backlog_files") as drain,
+        ):
+            with pytest.raises(AttributeError):
+                _finalize_run_output(quiet=True)
+
+        show_summary.assert_called_once()
+        # The whole point: cleanup ran even though rendering exploded.
+        drain.assert_called_once()
+
+    def test_drain_is_a_noop_when_no_claimed_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``.sdd/backlog/claimed/`` doesn't exist, drain returns silently."""
+        from bernstein.cli.run_preflight import _drain_completed_backlog_files
+
+        monkeypatch.chdir(tmp_path)
+        # No .sdd/ at all — must not raise, must not call sync internals.
+        with patch("bernstein.core.sync._move_completed_files") as move_files:
+            _drain_completed_backlog_files()
+        move_files.assert_not_called()
+
+    def test_drain_invokes_move_completed_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``claimed/`` exists, drain calls the sync mover."""
+        from bernstein.cli.run_preflight import _drain_completed_backlog_files
+
+        claimed = tmp_path / ".sdd" / "backlog" / "claimed"
+        claimed.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        with patch("bernstein.core.sync._move_completed_files") as move_files:
+            _drain_completed_backlog_files()
+        move_files.assert_called_once()
+
+    def test_drain_swallows_internal_exceptions(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failure inside the mover must not propagate (cleanup is best-effort)."""
+        from bernstein.cli.run_preflight import _drain_completed_backlog_files
+
+        claimed = tmp_path / ".sdd" / "backlog" / "claimed"
+        claimed.mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        with patch(
+            "bernstein.core.sync._move_completed_files",
+            side_effect=RuntimeError("server gone"),
+        ):
+            # Must not raise.
+            _drain_completed_backlog_files()
+
+
+# ---------------------------------------------------------------------------
+# Type sanity
+# ---------------------------------------------------------------------------
+
+
+def test_agent_info_from_dict_str_or_dict_typing() -> None:
+    """Layer 2 sanity: both shapes return AgentInfo with consistent type."""
+    a = AgentInfo.from_dict({"id": "a1", "role": "backend"})
+    b = AgentInfo.from_dict("a1")
+    assert isinstance(a, AgentInfo)
+    assert isinstance(b, AgentInfo)
+    assert a.agent_id == b.agent_id == "a1"


### PR DESCRIPTION
Closes #953.

After a successful `bernstein --auto-approve` run, the post-run summary renderer crashed with `AttributeError: 'str' object has no attribute 'get'` in `cli/ui.py:146` `AgentInfo.from_dict()`. The orchestrator exited 1 even though the work succeeded, and as a side-effect completed tickets stayed pinned in `.sdd/backlog/claimed/` because the next sync tick that would have moved them never ran.

## Root cause

The task server's `/status` endpoint emits `agents` as a section dict (`{"count": N, "items": [...]}`) — same shape as `tasks` — but `render_run_summary_from_dict` in `cli/run.py` iterated it as a flat `list[dict]`, which yielded the dict's string keys (`"count"`, `"items"`) and crashed on `str.get`. `cli/status.py` already used a `_dict_items_list` helper for this exact situation; `cli/run.py` and `cli/live.py` did not.

## Fix (three layers, all required)

1. **Producer/consumer normalizer (`cli/run.py`).** New `_normalize_agent_entries` helper accepts both the legacy flat list and the section-dict shape, drops non-dict items defensively, and is reused from `cli/live.py`. The producer (`_status_agent_items` in `core/routes/status_dashboard.py`) is already correct — it always emits dicts — and a producer test pins that contract so a future regression that leaks bare strings will fail loudly.
2. **Defensive parser (`cli/ui.py:AgentInfo.from_dict`).** Now accepts `str | dict[str, Any]`. A bare string is treated as `{\"id\": value}` with sane defaults for everything else. Belt-and-braces, not a substitute for layer 1.
3. **Cleanup ordering (`cli/run_preflight.py:_finalize_run_output`).** Wraps the renderer in `try/finally` and unconditionally calls a new `_drain_completed_backlog_files`, which invokes the same `_move_completed_files` step the periodic sync tick uses. Chose `try/finally` over reordering because (a) the summary still reflects pre-drain state on the happy path, and (b) cleanup remains correct even on `SystemExit` / `KeyboardInterrupt`.

## Tests

New `tests/unit/test_run_summary_issue_953.py` covers all three layers:

- `_normalize_agent_entries` accepts both shapes and drops bad items.
- `_status_agent_items` always returns dicts (producer-side contract).
- `render_run_summary_from_dict` survives the section-dict, legacy list, and stray-bare-string inputs.
- `_finalize_run_output` calls `_drain_completed_backlog_files` both on success and when `_show_run_summary` raises.
- `_drain_completed_backlog_files` no-ops when `claimed/` doesn't exist, calls the mover when it does, and swallows internal exceptions.

Plus two cases in `tests/unit/test_cli_ui.py` for the `AgentInfo.from_dict` bare-string path.

## Test plan

- [x] `uv run pytest tests/unit/test_cli_ui.py tests/unit/test_run_summary_issue_953.py tests/unit/test_run_cmd_track_b.py tests/unit/test_cli_status.py tests/unit/test_live_visuals.py tests/unit/test_sync.py tests/unit/test_sync_batch.py tests/unit/test_bootstrap.py -x -q` (74 passed)
- [x] `uv run ruff check src/ tests/` (clean)
- [x] `uv run ruff format --check` on touched files (clean)
- [ ] Manual repro from the issue: run a single-task backlog end-to-end and confirm exit 0 + `.sdd/backlog/claimed/` is empty.