### PR TITLE
docs(blog): v1.9 — four commands that close the last-mile gap

### DIFF
--- a/docs/blog/v1.9-four-commands-last-mile.md
+++ b/docs/blog/v1.9-four-commands-last-mile.md
@@ -1,0 +1,104 @@
+# The four commands that made Bernstein feel like infrastructure
+
+**Published:** 2026-04-26
+**Reading time:** ~6 minutes
+
+---
+
+The v1.8 cycle was mostly plumbing. Chat bridges, a tunnel wrapper, daemon installer, cluster mode, Helm charts. The kind of work that makes the next thing possible without being visible itself. By the end of it, Bernstein could supervise agents across multiple repositories and expose itself to external tools — but an operator still had to wire up four common workflows by hand: sharing a live preview of what the agent built, cleaning up CI failures automatically, rotating credentials safely, and connecting an IDE.
+
+v1.9 closes those four gaps. Each one gets a dedicated command.
+
+---
+
+### `bernstein acp serve --stdio`
+
+Most editors that want to speak to an AI backend speak ACP — the Agent Client Protocol used by Zed and similar tools. Before v1.9, you could point an ACP-aware editor at Bernstein only by standing up a custom bridge, which meant maintaining glue code that lived outside the normal upgrade path.
+
+`bernstein acp serve --stdio` implements a native ACP bridge. The command runs in stdio mode, making it directly usable as an IDE's backend entry in config. The bridge routes agent capability queries, task creation, and streaming progress to the underlying orchestrator without any intermediate process.
+
+```bash
+# In your editor config (Zed example):
+# "lsp": { "bernstein": { "command": "bernstein", "args": ["acp", "serve", "--stdio"] } }
+bernstein acp serve --stdio
+```
+
+For operators running Bernstein as a shared service, there is also `bernstein acp serve --port 9700` for TCP mode. The [acp-bridge docs](/reference/acp-bridge/) cover both modes and the capability negotiation protocol.
+
+---
+
+### `bernstein autofix`
+
+When an agent opens a PR and CI fails, the usual loop is: read the failure log, decide if it is flake or real, dispatch a repair run, wait, check again. For a single PR this takes two minutes. For ten concurrent PRs this becomes the thing that blocks your afternoon.
+
+`bernstein autofix` is a daemon that runs that loop automatically. It polls open Bernstein-owned PRs using `gh run view --log-failed`, identifies fixable failures — lint, type errors, straightforward test breaks — and dispatches a scoped repair agent. Each attempt is capped (three by default), label-gated so you can pin PRs that need human review, and written to the HMAC audit log so every automated change is attributable.
+
+```bash
+# Start the autofix daemon, polling every 60 seconds
+bernstein autofix --interval 60 --max-attempts 3
+
+# Or run once against a specific PR
+bernstein autofix --pr 123 --once
+```
+
+The daemon does not try to interpret ambiguous failures. If the CI log does not contain a pattern it recognises as fixable, it labels the PR `needs-human` and stops. The design goal is to eliminate the mechanical repair loop, not to replace judgment on real failures.
+
+---
+
+### `bernstein connect <provider>`
+
+Bernstein integrates with a growing number of providers — model APIs, code hosts, notification sinks, cloud backends. Each integration needs a credential. The path of least resistance for most setups has been a `.env` file or an environment variable export in a shell profile, which means tokens end up in shell history, screen shares, and occasionally in repository commits when `.env` is not in `.gitignore`.
+
+`bernstein connect` stores credentials in the OS keychain — Keychain on macOS, the Secret Service on Linux, Windows Credential Manager on Windows. The orchestrator retrieves them at runtime without ever writing them to disk in plaintext. Scoping is per-provider, so you can store a different API key for staging and production without environment variable collisions.
+
+```bash
+# Store credentials for a provider
+bernstein connect anthropic
+bernstein connect github
+bernstein connect openai
+
+# List configured providers
+bernstein connect --list
+
+# Verify a stored credential without revealing it
+bernstein connect anthropic --verify
+```
+
+The credential system integrates with the existing [security policy engine](/reference/security/policy-engine/) — if a policy requires that a given provider credential be present before agents are dispatched, the orchestrator checks the keychain at startup rather than at the point of use, so missing credentials surface early.
+
+---
+
+### `bernstein preview`
+
+When an agent finishes a front-end feature or an API change, the natural next step is to show someone. Before v1.9 that meant figuring out which port the dev server bound to inside the agent's sandbox, manually forwarding it, and either sharing credentials or leaving it open. The tunnel wrapper existed, but wiring it to an agent's output required knowing which sandbox backend the run used and what the bound port was.
+
+`bernstein preview` resolves the port automatically from the agent's sandbox metadata, feeds it to the tunnel wrapper, and returns a public HTTPS URL with a configurable expiry and optional auth mode. From the operator's perspective: the agent finishes, you run one command, you paste a link.
+
+```bash
+# Expose the latest completed agent's dev server
+bernstein preview
+
+# Specify a task explicitly, set a 2-hour expiry, require a bearer token
+bernstein preview --task abc123 --ttl 2h --auth token
+
+# Print the URL only (useful in scripts)
+bernstein preview --task abc123 --quiet
+```
+
+The command works with the local tunnel backend by default. For teams running Bernstein on remote infrastructure, `--tunnel-backend cloudflare` uses the Cloudflare tunnel integration covered in the [cloud deployment docs](/cloudflare/cloudflare-bridges/).
+
+---
+
+## What comes next
+
+v1.9 was designed to be a usable floor, not a one-time feature push. The orchestrator can now supervise itself across fleets — Bernstein running agents on its own codebase and on external repositories under the same supervisor — so the next cycle is about depth rather than breadth: more adapter coverage for the seventeen already-wired CLI agents, tighter editor integration through the ACP bridge, and a feedback loop from `bernstein autofix` data into the cost-aware router so repair runs use the cheapest model that actually fixes the class of failure.
+
+There is no roadmap promise here. The self-evolution loop is the roadmap.
+
+---
+
+**Bernstein 1.9.0: `pip install bernstein`. Full changelog at [github.com/chernistry/bernstein/releases/tag/v1.9.0](https://github.com/chernistry/bernstein/releases/tag/v1.9.0).**
+
+---
+
+*Bernstein orchestrates short-lived AI coding agents — Claude Code, Codex, Gemini CLI, and more — through a deterministic Python dispatcher. State lives in files, not agent memory. Apache-2.0. [github.com/chernistry/bernstein](https://github.com/chernistry/bernstein).*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
   - Reference:
       - What's New: whats-new.md
       - API Reference: reference/openapi-reference.md
+      - ACP Bridge: reference/acp-bridge.md
       - Feature Matrix: reference/FEATURE_MATRIX.md
       - Model Policy: operations/MODEL_POLICY.md
       - Compatibility: adapters/compatibility.md
@@ -197,6 +198,7 @@ nav:
       - From LangGraph: migrations/migration-from-langgraph.md
   - Blog:
       - Ten Agents One Release: blog/ten-agents-one-release.md
+      - v1.9 — Four Commands That Close the Last-Mile Gap: blog/v1.9-four-commands-last-mile.md
       - Zero-LLM Coordination: blog/zero-llm-coordination.md
       - Multi-Agent Benchmark: blog/multi-agent-benchmark.md
       - Self-Evolution 30 Days: blog/self-evolution-30-days.md


### PR DESCRIPTION
## Summary

- Adds `docs/blog/v1.9-four-commands-last-mile.md`: operator-focused product narrative for v1.9.0
- Covers the four new CLI entry points (`bernstein acp serve`, `bernstein autofix`, `bernstein connect`, `bernstein preview`) — each with a problem statement, a solution description, and a usage example
- Updates `mkdocs.yml` nav to place the post immediately after the ten-agents-one-release process post
- Does not duplicate the engineering postmortem in `ten-agents-one-release.md`; focuses on operator leverage, not release mechanics

## Test plan

- [ ] Verify post renders correctly under MkDocs (`mkdocs serve`)
- [ ] Confirm nav entry appears in correct position under Blog
- [ ] Check all internal doc links resolve (`/reference/acp-bridge/`, `/reference/security/policy-engine/`, `/cloudflare/cloudflare-bridges/`)
- [ ] Read through for tone: senior-engineer prose, no marketing language, no emojis