### PR TITLE
fix(ci+security): unblock catalog tests, sanitize approval logs, bump uuid

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -9511,13 +9511,17 @@
       "optional": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -109,5 +109,8 @@
     "jest": "^29.7",
     "ts-jest": "^29.1",
     "typescript": "^5.4"
+  },
+  "overrides": {
+    "uuid": "^14.0.0"
   }
 }

--- a/src/bernstein/core/approval/queue.py
+++ b/src/bernstein/core/approval/queue.py
@@ -32,6 +32,7 @@ from bernstein.core.approval.models import (
     PendingApproval,
     ResolvedApproval,
 )
+from bernstein.core.sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -254,7 +255,7 @@ class ApprovalQueue:
         try:
             self._pending_path(approval_id).unlink(missing_ok=True)
         except OSError as exc:
-            logger.debug("Could not remove pending file for %s: %s", approval_id, exc)
+            logger.debug("Could not remove pending file for %s: %s", sanitize_log(approval_id), exc)
 
         # Signal any awaiting wait_for(). Event.set() is thread-safe but
         # must be scheduled on the loop that created the Event.
@@ -265,7 +266,7 @@ class ApprovalQueue:
             event.set()
         logger.info(
             "Resolved approval %s decision=%s",
-            approval_id,
+            sanitize_log(approval_id),
             decision.value,
         )
         return resolution

--- a/src/bernstein/core/routes/approvals.py
+++ b/src/bernstein/core/routes/approvals.py
@@ -29,6 +29,7 @@ from pydantic import BaseModel
 from bernstein.core.approval.models import ApprovalDecision
 from bernstein.core.approval.models import PendingApproval as QueuedApproval
 from bernstein.core.approval.queue import get_default_queue, promote_to_always_allow
+from bernstein.core.sanitize import sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -296,7 +297,7 @@ def resolve_queued_approval(approval_id: str, body: ResolveRequest) -> dict[str,
         try:
             promote_to_always_allow(approval)
         except OSError as exc:
-            logger.warning("Could not promote approval %s: %s", approval_id, exc)
+            logger.warning("Could not promote approval %s: %s", sanitize_log(approval_id), exc)
     return {"status": "resolved", "id": approval_id, "decision": resolution.decision.value}
 
 

--- a/tests/unit/test_agency_provider.py
+++ b/tests/unit/test_agency_provider.py
@@ -361,8 +361,10 @@ class TestCatalogRegistryIntegration:
         for a in agents:
             registry.register_agent(a)
 
-        # Code Reviewer is now inferred as "reviewer" role, not "backend"
-        match = registry.match("reviewer", "review code quality")
+        # Code Reviewer is now inferred as "reviewer" role, not "backend".
+        # Description hits all three capabilities (code-review, security-analysis,
+        # static-analysis) to clear _MIN_FUZZY_SCORE=3.
+        match = registry.match("reviewer", "code review with security analysis and static analysis")
         assert match is not None
         assert match.name == "Code Reviewer"
 
@@ -382,7 +384,7 @@ class TestCatalogRegistryIntegration:
             registry.register_agent(a)
 
         # Code Reviewer is now inferred as "reviewer" role
-        match = registry.match("reviewer", "review code")
+        match = registry.match("reviewer", "code review with security analysis and static analysis")
         assert match is not None
         assert "Code Reviewer" in match.system_prompt
 
@@ -446,7 +448,7 @@ class TestCatalogRegistryIntegration:
         for a in agents:
             registry.register_agent(a)
 
-        match = registry.match("reviewer", "review code")
+        match = registry.match("reviewer", "code review with security analysis and static analysis")
         assert match is not None
         assert match.tools == ["ruff", "mypy", "pytest"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.8.15"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **Failing CI test** ([run 24987448051](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/24987448051)): `TestCatalogRegistryIntegration::test_fetched_agents_matchable_by_role` was wedged on macOS / Ubuntu after [c19d7c33](https://github.com/sipyourdrink-ltd/bernstein/commit/c19d7c33) and [110dd0a3](https://github.com/sipyourdrink-ltd/bernstein/commit/110dd0a3) raised the `_MIN_FUZZY_SCORE` for exact-role catalog matches. Three integration tests used task descriptions (`"review code quality"`, `"review code"`) that scored below the new threshold. Updated them to use `"code review with security analysis and static analysis"`, which overlaps all three of the Code Reviewer agent's capabilities (`code-review`, `security-analysis`, `static-analysis`) and clears the threshold without weakening intent.
- **Code-scanning alerts** ([#119](https://github.com/sipyourdrink-ltd/bernstein/security/code-scanning/119), [#120](https://github.com/sipyourdrink-ltd/bernstein/security/code-scanning/120), [#121](https://github.com/sipyourdrink-ltd/bernstein/security/code-scanning/121) — `py/log-injection`): `approval_id` flows from the URL path into three `logger.*` calls. Route handler validates the format (`[a-zA-Z0-9_-]+`), but CodeQL can't follow that. Routed all three sites through the existing `bernstein.core.sanitize.sanitize_log` helper.
- **Dependabot alert** ([#16](https://github.com/sipyourdrink-ltd/bernstein/security/dependabot/16) — `GHSA-w5hq-g745-h8pq`): vulnerable `uuid@8.3.2` was a dev-only transitive via `@vscode/vsce` → `@azure/msal-node`. Added an `overrides` entry in `packages/vscode/package.json` pinning `uuid` to `^14.0.0` and regenerated the lockfile.

Drive-by: synced the editable `bernstein` entry in `uv.lock` to `1.9.0` (already in `pyproject.toml`).

## Test plan
- [x] `uv run pytest tests/unit/test_agency_provider.py -x -q` (37 passed)
- [x] `uv run pytest tests/unit/test_approval_queue.py tests/unit/test_approval_hook.py tests/unit/test_approval_cli.py -x -q` (25 passed)
- [x] `uv run ruff check` + `ruff format --check` on touched files (clean)
- [x] `npm install --package-lock-only --ignore-scripts` in `packages/vscode/` resolves with no audit findings
- [ ] Full CI run on this branch