### PR TITLE
fix(catalog): split exact-role threshold from fuzzy threshold

### DIFF
--- a/src/bernstein/agents/catalog.py
+++ b/src/bernstein/agents/catalog.py
@@ -474,41 +474,54 @@ class CatalogRegistry:
     ) -> CatalogAgent | None:
         """Pick the best agent from an exact-role match list.
 
-        Returns None when no agent has meaningful capability or keyword
-        overlap with the task description — lets the spawner fall back
-        to template-based prompts instead of injecting an irrelevant
-        catalog persona.
+        Returns None when no agent has meaningful capability overlap with
+        the task description — lets the spawner fall back to template-based
+        prompts instead of injecting an irrelevant catalog persona.
+
+        Agents that declare no capabilities at all (legacy ``load_from_agency``
+        path, simple test fixtures) bypass the score threshold and are
+        selected by priority — there's nothing meaningful to score against.
         """
-        if keywords:
-            scored_exact = [(_capability_score(a, desc_lower, keywords), a) for a in exact]
-            scored_exact.sort(key=lambda t: (-t[0], t[1].priority))
-            winner = scored_exact[0][1]
-            best_score = scored_exact[0][0]
-            if best_score < _MIN_FUZZY_SCORE:
-                logger.debug(
-                    "Catalog exact match rejected: best capability score %d < %d for role '%s'",
-                    best_score,
-                    _MIN_FUZZY_SCORE,
-                    role,
-                )
-                return None
+        # No-capability cohort: fall through to priority-only selection so
+        # legacy agents loaded without capability metadata remain matchable.
+        if not any(a.capabilities for a in exact):
+            exact.sort(key=lambda a: a.priority)
+            winner = exact[0]
             logger.debug(
-                "Catalog exact match: '%s' (score=%d) for '%s'",
+                "Catalog exact match (no capability metadata): '%s' for '%s'",
                 winner.name,
-                best_score,
                 role,
             )
             return winner
 
-        exact.sort(key=lambda a: a.priority)
-        winner = exact[0]
+        if not keywords:
+            # Generic task description against capability-bearing agents —
+            # too risky to pick a specialised persona without signal.
+            logger.debug(
+                "Catalog exact match skipped for '%s': task has no keywords (>3 chars)",
+                role,
+            )
+            return None
+
+        scored_exact = [(_capability_score(a, desc_lower, keywords), a) for a in exact]
+        scored_exact.sort(key=lambda t: (-t[0], t[1].priority))
+        winner = scored_exact[0][1]
+        best_score = scored_exact[0][0]
+        if best_score < _MIN_EXACT_SCORE:
+            logger.debug(
+                "Catalog exact match rejected: best capability score %d < %d for role '%s'",
+                best_score,
+                _MIN_EXACT_SCORE,
+                role,
+            )
+            return None
         logger.debug(
-            "Catalog exact match by role only (no keywords): '%s' for '%s' — returning None, "
-            "role-only match is too weak without task description keywords",
+            "Catalog exact match: '%s' (score=%d) for '%s'",
             winner.name,
+            best_score,
             role,
         )
-        return None
+        return winner
 
     def _match_affine_role(
         self,
@@ -608,7 +621,11 @@ _ROLE_AFFINITY: dict[str, frozenset[str]] = {
 
 _AFFINITY_BONUS_EXACT = 5  # bonus when agent.role == requested role
 _AFFINITY_BONUS_RELATED = 1  # bonus for affine (related) role
-_MIN_FUZZY_SCORE = 3  # minimum composite score to accept a fuzzy match
+_MIN_FUZZY_SCORE = 3  # minimum composite score to accept a fuzzy (cross-role) match
+_MIN_EXACT_SCORE = 1  # minimum capability score to accept an exact-role match
+# Exact-role matching is more permissive than fuzzy: the role itself is a
+# strong signal, so a single overlapping capability is enough. Fuzzy/affine
+# matches need more signal because they're crossing role boundaries.
 
 
 def _capability_score(agent: CatalogAgent, desc_lower: str, keywords: set[str]) -> int:


### PR DESCRIPTION
## Summary

Post-merge of #960 the next CI run on main ([24997651864](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/24997651864)) hit nine more failures in `test_catalog_matching.py` and `test_spawner.py` — same root cause as the earlier round, surfaced once `pytest -x` got past the first failure I'd seen.

c19d7c33 / 110dd0a3 reused `_MIN_FUZZY_SCORE = 3` for both exact-role and fuzzy matches. That made:

- A backend agent with `capabilities=[authentication, jwt]` un-matchable for a task `Implement JWT authentication` (score 2 < 3).
- Every agent loaded via the legacy `load_from_agency` (no capability metadata at all) permanently un-matchable for any task.

## Fix

- `_MIN_EXACT_SCORE = 1` for exact-role matching — the role match itself is already a strong signal; one cap-word overlap is plenty. `_MIN_FUZZY_SCORE = 3` stays for cross-role / affine matching, where weaker signal is rightly rejected.
- No-capability cohort (legacy `AgencyAgent` loader, simple test fixtures) bypasses scoring entirely and falls through to priority order — nothing meaningful to compare against.
- Brendan's reject case (`'Mobile App Builder'` with `capabilities=[mobile-development, ios, android, ...]` for `'implement add and subtract'`) still resolves to `None` (verified live: cap_score = 0 < 1).

## Test plan
- [x] `uv run pytest tests/unit/test_catalog_matching.py tests/unit/test_spawner.py tests/unit/test_agency_provider.py -q` (123 passed)
- [x] Manual check: 'Mobile App Builder' for 'implement add and subtract' → `None`
- [x] `ruff check` + `ruff format --check` (clean)
- [ ] Full CI on this branch