### PR TITLE
feat(plan): per-step `cli:` adapter override

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1281,8 +1281,13 @@ class AgentSpawner:
     ) -> tuple[ModelConfig, str | None, str]:
         """Select provider and model via router or operator config."""
         provider_name: str | None = None
+        # Per-step `cli:` is treated as a synthetic pinned adapter so the
+        # router-skip decision matches the role_model_policy cli case.
+        effective_role_policy: dict[str, Any] = dict(role_policy)
+        if tasks[0].cli and "cli" not in effective_role_policy:
+            effective_role_policy["cli"] = tasks[0].cli
         use_router = _should_use_router(
-            role_policy=role_policy,
+            role_policy=effective_role_policy,
             adapter_name=self._adapter.name(),
             has_router=self._router is not None and bool(self._router.state.providers),
         )
@@ -1403,7 +1408,11 @@ class AgentSpawner:
         model_config = base_config
         provider_name: str | None = None
         role_policy = self._role_model_policy.get(tasks[0].role, {})
-        preferred_provider = role_policy.get("provider")
+        # Per-step CLI override (plan-file `cli:` field) wins over role-level
+        # role_model_policy.provider, which in turn wins over the default
+        # adapter. The string is treated as a provider/adapter identifier and
+        # resolved via _infer_adapter_name_for_provider downstream.
+        preferred_provider = tasks[0].cli or role_policy.get("provider")
 
         if not tasks[0].model and role_policy.get("model"):
             model_config = ModelConfig(

--- a/src/bernstein/core/orchestration/manager.py
+++ b/src/bernstein/core/orchestration/manager.py
@@ -119,6 +119,9 @@ async def _post_task_to_server(
         "owned_files": task.owned_files,
         "task_type": task.task_type.value,
     }
+    # Forward routing hints declared on the task (per-step plan fields).
+    if task.cli:
+        body["cli"] = task.cli
     # Include upgrade_details if present
     if task.upgrade_details:
         body["upgrade_details"] = asdict(task.upgrade_details)

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -254,6 +254,7 @@ def _parse_step(
 
     model_raw = step.get("model")
     effort_raw = step.get("effort")
+    cli_raw = step.get("cli")
     estimated_minutes_raw = step.get("estimated_minutes")
     mode_raw = step.get("mode")
     execution_mode: str | None = str(mode_raw) if mode_raw else None
@@ -278,6 +279,7 @@ def _parse_step(
         completion_signals=signals,
         model=str(model_raw) if model_raw else None,
         effort=str(effort_raw) if effort_raw else None,
+        cli=str(cli_raw) if cli_raw else None,
         execution_mode=execution_mode,
         repo=task_repo,
         depends_on_repo=task_depends_on_repo,

--- a/src/bernstein/core/planning/planner.py
+++ b/src/bernstein/core/planning/planner.py
@@ -76,6 +76,9 @@ async def _post_task_to_server(
         "owned_files": task.owned_files,
         "task_type": task.task_type.value,
     }
+    # Forward routing hints declared on the task (per-step plan fields).
+    if task.cli:
+        body["cli"] = task.cli
     # Include upgrade_details if present
     if task.upgrade_details:
         body["upgrade_details"] = asdict(task.upgrade_details)

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -302,6 +302,7 @@ def task_to_response(task: Task) -> TaskResponse:
         upgrade_details=asdict(task.upgrade_details) if task.upgrade_details else None,
         model=task.model,
         effort=task.effort,
+        cli=task.cli,
         batch_eligible=task.batch_eligible,
         completion_signals=[{"type": s.type, "value": s.value} for s in task.completion_signals],
         slack_context=task.slack_context,

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -89,6 +89,7 @@ class TaskCreate(BaseModel):
     upgrade_details: dict[str, Any] | None = None
     model: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)  # "opus", "sonnet", "haiku"
     effort: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)  # "max", "high", "medium", "low"
+    cli: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)  # adapter override: "claude", "opencode", …
     batch_eligible: bool = False  # Non-urgent: eligible for provider batch APIs at ~50% cost
     completion_signals: list[CompletionSignalSchema] = Field(default_factory=list, max_length=_MAX_LIST_LEN)
     slack_context: dict[str, Any] | None = None  # Slack slash command metadata
@@ -175,6 +176,7 @@ class TaskResponse(BaseModel):
     upgrade_details: dict[str, Any] | None
     model: str | None
     effort: str | None
+    cli: str | None = None
     batch_eligible: bool = False
     completion_signals: list[dict[str, str]] = Field(default_factory=lambda: list[dict[str, str]]())
     slack_context: dict[str, Any] | None = None

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -263,6 +263,7 @@ class Task:
     # Manager-specified routing hints (override auto-routing when set)
     model: str | None = None  # "opus", "sonnet", "haiku"
     effort: str | None = None  # "max", "high", "medium", "low"
+    cli: str | None = None  # adapter override; "claude", "opencode", "codex", … (per-step)
     mcp_servers: list[str] = field(default_factory=list[str])  # MCP server names for this task
     slack_context: dict[str, Any] | None = None  # Slack slash command or event metadata
     metadata: dict[str, Any] = field(default_factory=dict)  # Trigger-source metadata (e.g. issue_number)
@@ -356,6 +357,7 @@ class Task:
             depends_on_repo=raw.get("depends_on_repo"),
             model=raw.get("model"),
             effort=raw.get("effort"),
+            cli=raw.get("cli"),
             mcp_servers=list(raw.get("mcp_servers", [])),
             batch_eligible=(lambda v: None if v is None else bool(v))(raw.get("batch_eligible")),
             eu_ai_act_risk=raw.get("eu_ai_act_risk", "minimal"),

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -169,6 +169,7 @@ class TaskCreateRequest(Protocol):
 
     model: str | None
     effort: str | None
+    cli: str | None
     batch_eligible: bool
     approval_required: bool
     eu_ai_act_risk: str
@@ -897,6 +898,7 @@ class TaskStore:
             upgrade_details=_parse_upgrade_dict(req.upgrade_details),
             model=req.model,
             effort=req.effort,
+            cli=getattr(req, "cli", None),
             batch_eligible=batch_eligible,
             eu_ai_act_risk=getattr(req, "eu_ai_act_risk", "minimal"),
             approval_required=bool(getattr(req, "approval_required", False)),
@@ -1048,6 +1050,7 @@ class TaskStore:
                     upgrade_details=_parse_upgrade_dict(req.upgrade_details),
                     model=req.model,
                     effort=req.effort,
+                    cli=getattr(req, "cli", None),
                     batch_eligible=batch_eligible,
                     eu_ai_act_risk=getattr(req, "eu_ai_act_risk", "minimal"),
                     approval_required=bool(getattr(req, "approval_required", False)),

--- a/templates/plan.yaml
+++ b/templates/plan.yaml
@@ -162,6 +162,12 @@ stages:
         # Effort level (optional): low | normal | high | max
         # effort: normal
 
+        # CLI adapter override (optional). Wins over role_model_policy and
+        # the top-level cli: setting. Use this when one stage needs a
+        # different runtime than the rest of the plan, e.g. opencode for
+        # red/green/refactor and claude for code review.
+        # cli: opencode
+
         # Estimated minutes for the agent to complete.
         # estimated_minutes: 30
 

--- a/tests/unit/test_plan_loader.py
+++ b/tests/unit/test_plan_loader.py
@@ -282,6 +282,41 @@ def test_step_model_effort_default_none(tmp_path: Path) -> None:
     tasks = load_plan_from_yaml(plan_file)
     assert tasks[0].model is None
     assert tasks[0].effort is None
+    assert tasks[0].cli is None
+
+
+def test_step_cli_override(tmp_path: Path) -> None:
+    """Per-step `cli:` is parsed onto Task.cli so the spawner can switch adapters."""
+    plan_file = _write_plan(
+        tmp_path,
+        {
+            "stages": [
+                {
+                    "name": "rgr",
+                    "steps": [
+                        {"title": "Red", "cli": "opencode"},
+                        {"title": "Green", "cli": "opencode"},
+                    ],
+                },
+                {
+                    "name": "review",
+                    "steps": [{"title": "Code review", "cli": "claude"}],
+                },
+            ]
+        },
+    )
+    tasks = load_plan_from_yaml(plan_file)
+    assert [t.cli for t in tasks] == ["opencode", "opencode", "claude"]
+
+
+def test_step_cli_empty_string_treated_as_none(tmp_path: Path) -> None:
+    """An empty `cli:` is silently dropped — same convention as model/effort."""
+    plan_file = _write_plan(
+        tmp_path,
+        {"stages": [{"name": "S", "steps": [{"title": "T", "cli": ""}]}]},
+    )
+    tasks = load_plan_from_yaml(plan_file)
+    assert tasks[0].cli is None
 
 
 def test_step_estimated_minutes(tmp_path: Path) -> None:

--- a/tests/unit/test_spawner.py
+++ b/tests/unit/test_spawner.py
@@ -494,6 +494,62 @@ class TestSpawnerWithRouter:
         assert session.model_config.model == "openai/gpt-5.4-mini"
         assert session.pid == 777
 
+    def test_per_step_cli_overrides_default_adapter(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
+        """Task.cli (per-step `cli:` from plan YAML) drives adapter selection,
+        winning over the spawner's default adapter when no role policy is set."""
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        default_adapter = mock_adapter_factory(pid=100)
+        default_adapter.name.return_value = "claude"
+
+        opencode_adapter = mock_adapter_factory(pid=555)
+        opencode_adapter.name.return_value = "opencode"
+
+        spawner = AgentSpawner(
+            default_adapter,
+            templates_dir,
+            tmp_path,
+            use_worktrees=False,
+        )
+
+        task = make_task(role="backend")
+        task.cli = "opencode"
+
+        with patch.object(spawner, "_get_adapter_by_name", return_value=opencode_adapter):
+            session = spawner.spawn_for_tasks([task])
+
+        assert session.provider == "opencode"
+        assert session.pid == 555
+
+    def test_per_step_cli_beats_role_policy_provider(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
+        """When both task.cli and role_model_policy.provider are set, the
+        per-step value wins — that's the whole point of the field."""
+        templates_dir = tmp_path / "templates" / "roles"
+        templates_dir.mkdir(parents=True)
+
+        default_adapter = mock_adapter_factory(pid=100)
+        default_adapter.name.return_value = "claude"
+
+        opencode_adapter = mock_adapter_factory(pid=601)
+        opencode_adapter.name.return_value = "opencode"
+
+        spawner = AgentSpawner(
+            default_adapter,
+            templates_dir,
+            tmp_path,
+            role_model_policy={"backend": {"provider": "codex"}},
+            use_worktrees=False,
+        )
+
+        task = make_task(role="backend")
+        task.cli = "opencode"
+
+        with patch.object(spawner, "_get_adapter_by_name", return_value=opencode_adapter):
+            session = spawner.spawn_for_tasks([task])
+
+        assert session.provider == "opencode"
+
     def test_spawn_rate_limiter_blocks_repeated_spawns(self, tmp_path: Path, make_task, mock_adapter_factory) -> None:
         adapter = mock_adapter_factory(pid=321)
         adapter.name.return_value = "claude"


### PR DESCRIPTION
Closes #964 (and #962 once shipped).

## What changed

A plan step can now declare a `cli:` field — opencode for one stage, claude for the next, no more splitting one workflow into multiple plan files.

```yaml
stages:
  - name: red-green-refactor
    steps:
      - { title: Red,      cli: opencode }
      - { title: Green,    cli: opencode }
      - { title: Refactor, cli: opencode }
  - name: review
    steps:
      - { title: Code review, cli: claude }
```

Precedence (highest wins): `task.cli` (per-step) → `role_model_policy.<role>.provider` → top-level `cli:` → default adapter.

## Plumbing

The blocker wasn't the spawner — it already cached adapters and could hot-swap (`_get_adapter_by_name`). The blocker was that the plan→server wire format silently dropped `cli` (it dropped `model` / `effort` too, which is a related existing gap I left as a follow-up).

End-to-end:

- `Task.cli: str | None` next to existing `model` / `effort` (`tasks/models.py`).
- `plan_loader._parse_step` reads `step["cli"]`.
- `planner._post_task_to_server` and `manager._post_task_to_server` forward `cli` over the wire.
- `TaskCreate` / `TaskResponse` / `TaskCreateRequest` Protocol / `task_to_response` / both `TaskStore` Task constructions all carry the field through.
- `spawner_core._spawn_for_tasks_internal` sets `preferred_provider = task.cli or role_policy.provider`. Router-skip rule for non-Claude adapters respects the per-step override (`_should_use_router` sees a synthesised role policy with `cli` injected).

## Tests

- `test_plan_loader.py`: parses `cli:` per step, empty string → `None`, default-none case asserts the new field.
- `test_spawner.py`: `task.cli` overrides the default adapter; `task.cli` beats `role_model_policy.provider` when both are set.

## Out of scope

Same gap exists for `model:` and `effort:` on plan steps (also dropped in `_post_task_to_server`). Trivial to fix the same way — left for a follow-up to keep this PR scoped to #964.

## Test plan
- [x] `uv run pytest tests/unit/test_plan_loader.py tests/unit/test_spawner.py tests/unit/test_task_store.py tests/unit/test_models.py -q` (150 passed)
- [x] `ruff check` + `ruff format --check` (clean)
- [ ] Full CI on this branch