### PR TITLE
feat(adapters): orchestrate the orchestrators — composio + ralphex

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap l
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | Workers AI models | `bernstein cloud login` |
 | **Generic** | Any CLI with `--prompt` | Built-in |
 
+#### Orchestrator delegation (leaf-node)
+
+A separate, smaller class of adapters that wrap **other CLI orchestrators** as if they were single agents. Bernstein hands the wrapped tool a prompt or plan and only sees the final exit code — sub-agent costs and quality gates inside the wrapped orchestrator are not visible to Bernstein. Useful when you want to drop an existing workflow built on one of these tools into a step of a larger Bernstein plan.
+
+| Orchestrator | Wrapped as | Install |
+|--------------|------------|---------|
+| [Composio Agent Orchestrator](https://github.com/ComposioHQ/agent-orchestrator) (`@aoagents/ao`) | `composio` | `npm install -g @aoagents/ao` |
+| [umputun/ralphex](https://github.com/umputun/ralphex) | `ralphex` | `go install github.com/umputun/ralphex/cmd/ralphex@latest` |
+
 Any adapter also works as the **internal scheduler LLM**. Run the entire stack without any specific provider:
 
 ```yaml

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -593,6 +593,38 @@ Simulates agent behavior for unit and integration tests. Not for production use.
 
 ---
 
+## Orchestrator Delegation Adapters
+
+The 31 adapters above wrap **CLI coding agents** — tools that execute one task per invocation. The two below wrap **other CLI orchestrators** as if each were a single agent. Bernstein hands the wrapped tool a prompt or plan and only sees the final exit code and combined log; sub-agent costs and quality gates *inside* the wrapped orchestrator are not visible to Bernstein. This is leaf-node delegation, not deep meta-orchestration.
+
+Use these when you have an existing workflow built on Composio or ralphex and want to drop it into one step of a larger Bernstein plan, rather than re-implementing it natively.
+
+### composio (Composio Agent Orchestrator, `@aoagents/ao`)
+
+**Install:** `npm install -g @aoagents/ao`
+
+**Env vars:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GITHUB_TOKEN`, plus optional `COMPOSIO_API_KEY` / `AO_PROJECT_ID`. Composio inherits credentials from whichever underlying agent plugin (`codex`, `claude-code`, …) it's configured with — there is no dedicated key.
+
+**Invocation:** `ao spawn --prompt "<text>"` — the documented non-interactive entry point. The companion `ao start` is interactive (boots a tmux + dashboard) and is unsuitable for headless use. With no `ao start` running, `ao spawn` prints a benign warning that "AO is not running — lifecycle polling is inactive." The session still completes; the warning is expected for leaf-node delegation.
+
+**Best for:** Teams already running Composio's TypeScript orchestrator who want to keep that workflow as a step inside a Bernstein plan.
+
+---
+
+### ralphex (umputun/ralphex)
+
+**Install:** `go install github.com/umputun/ralphex/cmd/ralphex@latest`
+
+**Env vars:** `ANTHROPIC_API_KEY` (ralphex shells out to Claude Code internally), plus `CLAUDE_CONFIG_DIR` / `RALPHEX_CONFIG_DIR` if non-default.
+
+**Invocation:** Ralphex consumes a markdown plan file rather than a prompt string. The adapter materialises the Bernstein prompt into `.sdd/runtime/<session>-plan.md` with a minimal `### Task 1` checkbox block (the format ralphex requires) and runs `ralphex --no-color <plan-file>`. The `--plan "<text>"` flag exists in ralphex but invokes an interactive fzf picker, so it can't be used headlessly.
+
+**Caveats:** Ralphex must run from a git repo root and creates branches and commits on its own as part of its plan-walking flow. Bernstein already isolates agents in worktrees so this is safe, but operators should know.
+
+**Best for:** Teams using ralphex's single-pass plan walker over Claude Code who want to stitch it into a multi-step Bernstein plan without rewriting it.
+
+---
+
 ## Support Modules
 
 In addition to the 31 CLI agent adapters above, the adapter package includes

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -43,6 +43,13 @@ Bernstein orchestrates short-lived CLI coding agents around a central task serve
 | [Autohand](https://autohand.ai/code/) | `npm install -g autohand-cli` |
 | [Forge](https://forgecode.dev/docs/) | `curl -fsSL https://forgecode.dev/cli \| sh` |
 
+Two more adapters wrap **other CLI orchestrators** as if each were a single agent (leaf-node delegation — Bernstein only sees the wrapped tool's exit code, not its internal sub-agents):
+
+| Orchestrator | Install |
+|--------------|---------|
+| [Composio Agent Orchestrator](https://github.com/ComposioHQ/agent-orchestrator) | `npm install -g @aoagents/ao` |
+| [umputun/ralphex](https://github.com/umputun/ralphex) | `go install github.com/umputun/ralphex/cmd/ralphex@latest` |
+
 No agent yet? Run `bernstein demo` for a zero-config walkthrough.
 
 ---

--- a/src/bernstein/adapters/composio.py
+++ b/src/bernstein/adapters/composio.py
@@ -1,0 +1,122 @@
+"""Composio Agent Orchestrator (``ao``) CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class ComposioAdapter(CLIAdapter):
+    """Spawn and monitor Composio Agent Orchestrator (``ao``) sessions.
+
+    This adapter wraps Composio's ``@aoagents/ao`` as a single Bernstein
+    agent. The wrapped orchestrator runs its own internal multi-agent
+    workflow inside a tmux session — Bernstein only observes the final
+    exit code and the captured log output. This is leaf-node delegation,
+    not deep meta-orchestration: the cost, quality gates, and routing
+    decisions made by Composio's sub-agents are not visible to
+    Bernstein's accounting or policy layers.
+
+    The CLI is invoked as ``ao spawn --prompt <text>``. ``ao spawn``
+    is documented as the non-interactive entry point that spawns a
+    single agent session for a free-form prompt (without requiring a
+    GitHub issue). The companion ``ao start`` command is interactive
+    and launches the dashboard, so it is not used here.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Composio Agent Orchestrator session.
+
+        Args:
+            prompt: Free-form instructions delivered via ``--prompt``.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (retained for
+                interface compatibility; Composio routes to its own
+                configured sub-agent plugins internally).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused; Composio
+                manages its own plugin configuration via ``ao start``).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``ao`` binary is missing from PATH or
+                cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["ao", "spawn", "--prompt", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        # Composio inherits credentials from the underlying agent plugin
+        # (codex, claude-code, etc.), so we pass through the common keys.
+        env = build_filtered_env(
+            [
+                "COMPOSIO_API_KEY",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+                "GITHUB_TOKEN",
+                "GH_TOKEN",
+                "AO_PROJECT_ID",
+            ]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "ao not found in PATH. Install: npm install -g @aoagents/ao"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing ao: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Composio Agent Orchestrator"

--- a/src/bernstein/adapters/ralphex.py
+++ b/src/bernstein/adapters/ralphex.py
@@ -1,0 +1,135 @@
+"""Ralphex (umputun/ralphex) CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class RalphexAdapter(CLIAdapter):
+    """Spawn umputun/ralphex as a single Bernstein-managed agent.
+
+    Ralphex is itself a plan-walking orchestrator that runs Claude Code in
+    repeated short-lived sessions, executing a markdown task plan and
+    cycling through its own multi-phase code-review pipeline. Bernstein
+    treats one ralphex invocation as a single leaf agent: we hand it a
+    plan and observe only the final exit code and combined log output.
+    Bernstein does not (and cannot) see the individual Claude sessions
+    that ralphex spawns inside its own loop -- this is leaf-node
+    delegation, not deep meta-orchestration.
+
+    The CLI is non-interactive when given a positional plan-file
+    argument, so we materialize the prompt as a markdown plan in
+    ``.sdd/runtime/<session>-plan.md`` and invoke
+    ``ralphex --no-color <plan-file>``. Ralphex does not expose a
+    single-shot ``--goal``/``--prompt`` flag; ``--plan "<text>"`` exists
+    but uses an interactive fzf/picker dialogue and is unsuitable for
+    headless spawn. Auth flows entirely through Claude Code's normal
+    credential discovery (``~/.claude/`` or ``ANTHROPIC_API_KEY``); ralphex
+    itself takes no API key.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a ralphex session over a synthesized plan file.
+
+        Args:
+            prompt: Task description; written verbatim into a generated
+                markdown plan file that ralphex will consume.
+            workdir: Working directory for the agent process; must be a
+                git repository (ralphex requires this).
+            model_config: Model and effort configuration; mapped to
+                ralphex's ``--task-model model[:effort]`` flag.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused;
+                ralphex configures Claude Code internally).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions
+                (folded into the generated plan body).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``ralphex`` binary is missing from PATH
+                or cannot be executed.
+        """
+        runtime_dir = workdir / ".sdd" / "runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        log_path = runtime_dir / f"{session_id}.log"
+
+        plan_path = runtime_dir / f"{session_id}-plan.md"
+        plan_body = prompt if not system_addendum else f"{system_addendum}\n\n{prompt}"
+        plan_path.write_text(
+            f"# Plan: {session_id}\n\n"
+            "## Validation Commands\n\n"
+            "### Task 1: Execute requested work\n\n"
+            f"- [ ] {plan_body}\n",
+            encoding="utf-8",
+        )
+
+        cmd = ["ralphex", "--no-color"]
+        if model_config.model:
+            spec = model_config.model
+            if model_config.effort:
+                spec = f"{spec}:{model_config.effort}"
+            cmd.extend(["--task-model", spec])
+        cmd.append(str(plan_path))
+
+        pid_dir = runtime_dir / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["ANTHROPIC_API_KEY", "CLAUDE_CONFIG_DIR", "RALPHEX_CONFIG_DIR"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "ralphex not found in PATH. Install: go install github.com/umputun/ralphex/cmd/ralphex@latest"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing ralphex: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Ralphex"

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -18,6 +18,7 @@ from bernstein.adapters.cloudflare_agents import CloudflareAgentsAdapter
 from bernstein.adapters.codebuff import CodebuffAdapter
 from bernstein.adapters.codex import CodexAdapter
 from bernstein.adapters.cody import CodyAdapter
+from bernstein.adapters.composio import ComposioAdapter
 from bernstein.adapters.continue_dev import ContinueDevAdapter
 from bernstein.adapters.copilot import CopilotAdapter
 from bernstein.adapters.cursor import CursorAdapter
@@ -38,6 +39,7 @@ from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
 from bernstein.adapters.opencode import OpenCodeAdapter
 from bernstein.adapters.pi import PiAdapter
 from bernstein.adapters.qwen import QwenAdapter
+from bernstein.adapters.ralphex import RalphexAdapter
 from bernstein.adapters.rovo import RovoAdapter
 
 logger = logging.getLogger(__name__)
@@ -54,6 +56,7 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "codebuff": CodebuffAdapter,
     "codex": CodexAdapter,
     "cody": CodyAdapter,
+    "composio": ComposioAdapter,
     "continue": ContinueDevAdapter,
     "copilot": CopilotAdapter,
     "cursor": CursorAdapter,
@@ -73,6 +76,7 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "opencode": OpenCodeAdapter,
     "pi": PiAdapter,
     "qwen": QwenAdapter,
+    "ralphex": RalphexAdapter,
     "rovo": RovoAdapter,
 }
 

--- a/tests/unit/test_adapter_composio.py
+++ b/tests/unit/test_adapter_composio.py
@@ -1,0 +1,57 @@
+"""Unit tests for ComposioAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.composio import ComposioAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = ComposioAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.composio.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="composio-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:3] == ["ao", "spawn", "--prompt"]
+    assert inner[-1] == "fix the bug"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = ComposioAdapter()
+    with (
+        patch(
+            "bernstein.adapters.composio.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="ao not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="composio-missing",
+        )
+
+
+def test_name() -> None:
+    assert ComposioAdapter().name() == "Composio Agent Orchestrator"

--- a/tests/unit/test_adapter_ralphex.py
+++ b/tests/unit/test_adapter_ralphex.py
@@ -1,0 +1,59 @@
+"""Unit tests for RalphexAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.ralphex import RalphexAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = RalphexAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.ralphex.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="ralphex-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:2] == ["ralphex", "--no-color"]
+    assert "--task-model" in inner
+    assert "sonnet:high" in inner
+    assert inner[-1].endswith("ralphex-s1-plan.md")
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = RalphexAdapter()
+    with (
+        patch(
+            "bernstein.adapters.ralphex.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="ralphex not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="ralphex-missing",
+        )
+
+
+def test_name() -> None:
+    assert RalphexAdapter().name() == "Ralphex"


### PR DESCRIPTION
.

## What

Two new CLI adapters that wrap **other CLI orchestrators** as if each were a single Bernstein agent. The README has a comparison table where Bernstein sits next to Composio's \`@aoagents/ao\` and umputun/ralphex; this PR turns the joke around — Bernstein can now drive each of them as a leaf-node delegation step inside a larger plan.

- \`composio\` — wraps \`@aoagents/ao\`. Invoked as \`ao spawn --prompt "<text>"\` (their documented non-interactive entry point).
- \`ralphex\` — wraps umputun/ralphex. The CLI takes a markdown plan file rather than a prompt string, so the adapter materialises the Bernstein prompt into \`.sdd/runtime/<session>-plan.md\` with the minimal \`### Task 1\` checkbox block ralphex requires.

## Honest framing

This is **leaf-node delegation, not deep meta-orchestration.** Bernstein hands the wrapped tool a prompt and only sees the final exit code and combined log — sub-agent costs, quality gates, and routing decisions made *inside* the wrapped orchestrator are invisible. Class docstrings, the new README "Orchestrator delegation (leaf-node)" subsection, and the ADAPTER_GUIDE section all state this caveat explicitly so users don't expect cost/gate transparency through the wrapped flow. The headline "31 adapters" claim stays unchanged — composio and ralphex live in their own subsection, separate from the cooperating CLI-coding-agent adapters they delegate to.

## Why

- **Marketing.** "Bernstein orchestrates the orchestrators" is a clean line for HN / X / a release-note headline. Nobody else in the category has shipped this.
- **Real migration use case.** Users running ralphex or \`@aoagents/ao\` today can keep that workflow as one step inside a Bernstein plan instead of rewriting it natively.
- **Cheap.** Each adapter is ~120 LOC mirroring \`copilot.py\`, with three tests apiece using the existing \`_adapter_test_helpers.py\`.

## Files

- \`src/bernstein/adapters/composio.py\` (new, 122 LOC)
- \`src/bernstein/adapters/ralphex.py\` (new, 135 LOC)
- \`tests/unit/test_adapter_composio.py\` (new, 3 tests)
- \`tests/unit/test_adapter_ralphex.py\` (new, 3 tests)
- \`src/bernstein/adapters/registry.py\` — register \`"composio"\` / \`"ralphex"\`
- \`README.md\` — new "Orchestrator delegation (leaf-node)" subsection under the adapter table
- \`docs/adapters/ADAPTER_GUIDE.md\` — new "Orchestrator Delegation Adapters" section with full caveats per adapter
- \`docs/getting-started/GETTING_STARTED.md\` — small follow-up table after the main adapter list

## Test plan
- [x] \`uv run pytest tests/unit/test_adapter_composio.py tests/unit/test_adapter_ralphex.py tests/unit/test_adapter_copilot.py tests/unit/test_adapter_registry.py -q\` (44 passed)
- [x] \`ruff check\` + \`ruff format --check\` (clean)
- [x] Adapter registry exposes \`composio\` and \`ralphex\` (\`get_adapter("composio")\` returns \`ComposioAdapter\`)
- [ ] Full CI on this branch

## Out of scope

- emdash (Electron desktop, no CLI to wrap) intentionally excluded. The README's three-way comparison table keeps it as a competitor — we don't pretend to delegate to it.
- A third orchestrator adapter (\`claude-code-router\` was on the original ticket) — dropped to keep the joke tight: we only wrap the orchestrators we actually compare against.