### PR TITLE
docs(compare): Claude Squad, claude-flow, AgentsMesh + refreshed Crystal

### DIFF
--- a/docs/compare/README.md
+++ b/docs/compare/README.md
@@ -33,15 +33,15 @@ How Bernstein compares to other tools in the multi-agent coding space.
 
 |  | Bernstein | [Stoneforge](./bernstein-vs-stoneforge.md) | [Agent HQ](./bernstein-vs-github-agent-hq.md) | [Conductor](./bernstein-vs-conductor.md) | [Crystal](./bernstein-vs-crystal.md) | [Parallel Code](./bernstein-vs-parallel-code.md) | [Dorothy](./bernstein-vs-dorothy.md) | [Single agent](./bernstein-vs-single-agent.md) |
 |--|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **Parallel execution** | yes | yes | yes | yes | no | yes | yes | no |
-| **CLI agent support** | 31 adapters | no | Claude/Codex/Copilot | no | no | Claude/Codex/Gemini | Claude/Codex/Gemini/local | yes |
-| **Pluggable sandbox** | worktree/docker/e2b/modal | no | no | no | no | no | no | no |
-| **Result verification** | janitor (tests+lint) | provider-native | GitHub CI | none | LLM reviewer | manual | none | none |
+| **Parallel execution** | yes | yes | yes | yes | yes (worktrees) | yes | yes | no |
+| **CLI agent support** | 31 adapters | no | Claude/Codex/Copilot | no | Claude/Codex | Claude/Codex/Gemini | Claude/Codex/Gemini/local | yes |
+| **Pluggable sandbox** | worktree/docker/e2b/modal | no | no | no | worktree | no | no | no |
+| **Result verification** | janitor (tests+lint) | provider-native | GitHub CI | none | none | manual | none | none |
 | **Task planning from goal** | yes | no | yes | no | no | no | via Super Agent | no |
 | **Self-evolution** | yes | no | no | no | no | no | no | no |
 | **Model routing** | bandit | no | no | no | no | no | no | no |
-| **Headless / overnight** | yes | limited | GitHub Actions | yes | varies | no | app must run | no |
-| **IDE integration** | no | VS Code, JetBrains | GitHub UI | no | varies | desktop app | desktop app | no |
+| **Headless / overnight** | yes | limited | GitHub Actions | yes | no (Electron) | no | app must run | no |
+| **IDE integration** | no | VS Code, JetBrains | GitHub UI | no | no | desktop app | desktop app | no |
 | **Chat bridges (Telegram / Discord / Slack)** *(only Bernstein)* | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ~ | ✗ |
 | **SSH remote sandbox** *(only Bernstein)* | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | **Lifecycle hooks (pre/post task, merge, spawn)** *(only Bernstein)* | ✓ | ✗ | ~ | ✗ | ✗ | ✗ | ✗ | ✗ |
@@ -49,9 +49,26 @@ How Bernstein compares to other tools in the multi-agent coding space.
 | **Tunnel wrapper (4 providers, one CLI)** *(only Bernstein)* | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
 | **Interactive tool-call approval** *(only Bernstein)* | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ~ | ✗ |
 | **Daemon / service install (systemd / launchd)** *(only Bernstein)* | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| **Open source** | Apache 2.0 | Apache 2.0 | no | Apache 2.0 | varies | MIT | MIT | varies |
+| **Open source** | Apache 2.0 | Apache 2.0 | no | Apache 2.0 | MIT (deprecated 2026-02 → Nimbalyst) | MIT | MIT | varies |
 
-*Last verified: 2026-04-19. Stoneforge launched 2026-03-03. Paperclip (launched 2026-03-04) is covered on its [own page](./bernstein-vs-paperclip.md); it is an AI-company control plane, not a CLI orchestrator, and is not compared in this table.*
+*Last verified: 2026-04-29. Stoneforge launched 2026-03-03. Paperclip (launched 2026-03-04) is covered on its [own page](./bernstein-vs-paperclip.md); it is an AI-company control plane, not a CLI orchestrator, and is not compared in this table.*
+
+## Table C — Multi-session and swarm orchestrators
+
+A second wave of tools focuses on managing multiple sessions of a single coding agent (usually Claude Code) — tmux-based, Claude-Code-shaped, or workforce-style. Bernstein's wedge against this group is provider breadth (31 cooperating CLI adapters, not Claude-only) and a deterministic Python scheduler (no LLM-driven swarm coordination).
+
+|  | Bernstein | [Claude Squad](./bernstein-vs-claude-squad.md) | [claude-flow / Ruflo](./bernstein-vs-claude-flow.md) | [AgentsMesh](./bernstein-vs-agentsmesh.md) |
+|--|:---:|:---:|:---:|:---:|
+| **Primary scope** | provider-agnostic CLI orchestrator | tmux session manager | Claude Code plugin pack + swarm | self-hosted agent workforce platform |
+| **Built-in agent breadth** | 31 cooperating + 2 delegated | Claude Code (extra via `-p`) | Claude Code | Claude/Codex/Gemini/Aider/OpenCode |
+| **Scheduler** | deterministic Python | human picks per session | LLM-driven hooks + queen agent | service that dispatches AgentPods |
+| **Plan files (`depends_on`)** | yes (YAML stages/steps) | no | partial (SPARC) | no |
+| **Quality gates / janitor** | yes (tests + lint + types + files) | no | safety scans only (PII/CVE) | no |
+| **MCP server (first-class)** | yes | no | yes (built-in MCP server) | no |
+| **Headless / CI** | yes | no (needs tmux) | yes (npm CLI) | server-based |
+| **State** | files (`.sdd/`) | per-session worktrees | vector memory store + Claude state | PostgreSQL + Redis + MinIO |
+| **Cost tracking with budgets** | yes | no | no | partial |
+| **License** | Apache 2.0 | AGPL-3.0 | MIT | BSL-1.1 (→ GPL-2.0-or-later in 2030) |
 
 ---
 
@@ -75,10 +92,12 @@ Earlier drafts of this page cited larger deltas that were not reproducible at n=
 **Consider alternatives if:**
 - You need production workflow orchestration for non-coding workloads (→ Conductor)
 - You want deep IDE integration and are committed to one provider (→ Stoneforge)
-- You need iterative LLM review loops per task rather than external test verification (→ Crystal)
-- You want a desktop app to run a few agents side by side and resolve conflicts manually (→ Parallel Code)
+- You want a desktop app to run a few agents side by side and resolve conflicts manually (→ Parallel Code or Crystal/Nimbalyst)
 - You want an AI-company control plane with org charts, budgets, and governance on top of your agents (→ Paperclip)
 - You want a Kanban-style desktop dashboard to delegate work between a few agents (→ Dorothy)
+- You want a tmux-based multi-session manager for one Claude Code account (→ Claude Squad)
+- Your stack is Claude-Code-only and you want a swarm/SPARC layer on top (→ claude-flow / Ruflo)
+- You need a multi-tenant agent workforce platform with RBAC, SSO, and audit logs (→ AgentsMesh)
 - Your task is simple and well-scoped (→ single agent, no orchestration needed)
 
 ---
@@ -95,8 +114,13 @@ Earlier drafts of this page cited larger deltas that were not reproducible at n=
 - [Bernstein vs. Parallel Code](./bernstein-vs-parallel-code.md) — orchestrated parallel vs manual multi-terminal
 - [Bernstein vs. Stoneforge](./bernstein-vs-stoneforge.md) — provider-agnostic vs provider-integrated (Stoneforge launched March 3, 2026)
 - [Bernstein vs. GitHub Agent HQ](./bernstein-vs-github-agent-hq.md) — open-source alternative to GitHub's multi-agent system (Universe 2025)
-- [Bernstein vs. Crystal](./bernstein-vs-crystal.md) — external test verification vs LLM review loops
+- [Bernstein vs. Crystal](./bernstein-vs-crystal.md) — provider-agnostic CLI orchestrator vs Electron desktop app for Claude Code / Codex worktrees (Crystal deprecated Feb 2026)
 - [Bernstein vs. Conductor](./bernstein-vs-conductor.md) — workflow engine vs coding agent orchestrator (Netflix Conductor and forks)
+
+### Multi-session and swarm orchestrators
+- [Bernstein vs. Claude Squad](./bernstein-vs-claude-squad.md) — orchestrator with plan files and quality gates vs tmux session manager
+- [Bernstein vs. claude-flow](./bernstein-vs-claude-flow.md) — provider-agnostic deterministic scheduler vs Claude Code plugin pack with LLM-driven swarm coordination
+- [Bernstein vs. AgentsMesh](./bernstein-vs-agentsmesh.md) — single-process file-based orchestrator vs server-stack agent workforce platform
 
 ### Agent management overlays
 - [Bernstein vs. Paperclip](./bernstein-vs-paperclip.md) — engineering orchestrator vs AI-company control plane (Paperclip launched March 4, 2026)

--- a/docs/compare/bernstein-vs-agentsmesh.md
+++ b/docs/compare/bernstein-vs-agentsmesh.md
@@ -1,0 +1,143 @@
+# Bernstein vs. AgentsMesh
+
+> **tl;dr** — AgentsMesh is a self-hosted AI workforce platform: a multi-tenant web console, a Postgres-backed task board, and remote "AgentPods" running CLI agents in PTY sandboxes. It targets organizations giving every team member an AI agent squad. Bernstein is a single-process orchestrator that turns a goal into tasks, runs them in parallel through a deterministic Python scheduler, verifies output with a janitor, and merges working branches. They overlap on "run multiple CLI agents at once" and diverge on almost everything else.
+
+*Last verified: 2026-04-27. Based on `github.com/AgentsMesh/AgentsMesh` (1.8k stars, v0.29.0, repo created 2026-02-28) and agentsmesh.ai.*
+
+---
+
+## What each tool is
+
+**AgentsMesh** (1.8k stars, BSL-1.1 until 2030, Go backend + Next.js frontend) is a self-hosted "AI Agent Workforce Platform." A central control plane (PostgreSQL, Redis, MinIO) manages organizations, teams, and tickets. Self-hosted runners spawn "AgentPods" — long-lived PTY sandboxes that run a CLI agent (Claude Code, Codex CLI, Gemini CLI, Aider, OpenCode, or a custom terminal agent). Operators bind tickets to pods from a Kanban board, watch I/O stream through a WebSocket relay, and review the resulting MRs/PRs. The pitch is enterprise-shaped: multi-tenant org hierarchy with row-level isolation, SSO, RBAC, audit logs, air-gapped deployment, BYOK for API keys.
+
+**Bernstein** (Apache 2.0, Python 3.12+) is a CLI-native orchestrator for coding agents. It breaks a goal into tasks via a deterministic Python scheduler, spawns short-lived agents in isolated git worktrees, verifies their output (tests, lint, type checks, file presence), and merges the results. State lives in `.sdd/` files on disk, inspectable from the shell. It ships 31 cooperating CLI adapters plus 2 leaf-node delegation adapters, an MCP server, plan files with `depends_on` between stages, cost tracking with budget caps, and a `--evolve` mode for self-improvement runs.
+
+---
+
+## Feature comparison
+
+| Feature | Bernstein | AgentsMesh |
+|---|---|---|
+| **Primary focus** | Ship code from a CLI | Run an AI workforce from a web console |
+| **License** | Apache 2.0 | BSL-1.1 (GPL-2.0-or-later in 2030) |
+| **Language / runtime** | Python 3.12+ (hatchling) | Go backend + TypeScript/Next.js frontend |
+| **Install path** | `pip install bernstein` / `uv` | `curl ... \| sh`, deb/rpm, Docker |
+| **Required infrastructure** | None (single process) | PostgreSQL + Redis + MinIO + Relay cluster |
+| **CLI agent integrations** | 31 cooperating + 2 delegation adapters | 5 — Claude Code, Codex, Gemini, Aider, OpenCode (+ custom) |
+| **Orchestrator logic** | Deterministic Python scheduler | Manual ticket-to-pod binding, queue-based |
+| **LLM tokens for coordination** | Zero | Zero (no LLM "manager"; humans assign) |
+| **Agent lifetime** | Short-lived per task | Long-lived AgentPods |
+| **Sandbox model** | Git worktree per agent | PTY sandbox per pod |
+| **State storage** | `.sdd/` files on local disk | PostgreSQL + Redis + object storage |
+| **Plan files** | YAML with `stages` + `steps` + `depends_on` | Not documented |
+| **Quality gates** | Janitor: tests, lint, types, file checks | Not documented |
+| **Cost tracking** | Per-task tracking + global budget cap | BYOK; user-managed |
+| **MCP server** | First-class | Not documented |
+| **A2A protocol** | Yes | Not documented |
+| **Multi-tenant orgs / RBAC / SSO** | No | Yes — core feature |
+| **Web console** | Web dashboard + TUI (`bernstein live`) | Web console is the primary UI |
+| **Self-evolution** | `bernstein --evolve` | Not documented |
+| **Headless / CI** | Yes — runs in CI, over SSH, in containers | Web-console-first; CI integration not documented |
+| **Audit log** | HMAC-chained, file-based | Enterprise audit logs (mechanism not documented) |
+| **Per-step model/effort routing** | Yes (cascade router, `cli:` field per step in PR #965) | Pod is bound to one agent type |
+| **Cloud execution** | Cloudflare Workers adapter | Self-hosted by design |
+| **Multi-repo orchestration** | Yes | Per-pod git worktree, no documented multi-repo plan |
+
+---
+
+## Architecture comparison
+
+**AgentsMesh (workforce platform):**
+```
+Web console (Next.js)
+    │
+    ▼
+Control plane (Go, gRPC + mTLS)
+    │
+    ├── PostgreSQL  (org, team, tickets, pod lifecycle)
+    ├── Redis       (queues, presence)
+    └── MinIO       (artifacts)
+    │
+    ▼
+Relay cluster (WebSocket pub/sub for I/O)
+    │
+    ▼
+Self-hosted runner(s)
+    │
+    ├── AgentPod #1 — PTY sandbox running Claude Code
+    ├── AgentPod #2 — PTY sandbox running Codex
+    └── AgentPod #3 — PTY sandbox running Aider
+```
+
+The unit of work is a long-lived AgentPod. An operator (or a teammate via the Kanban board) binds a ticket to a pod, watches the terminal stream, and reviews the MR/PR the pod opens. Coordination is human-in-the-loop through a web UI.
+
+**Bernstein (CLI orchestrator):**
+```
+bernstein run plans/feature.yaml   (terminal, CI, SSH)
+    │
+    ▼
+Task server (local FastAPI, deterministic Python scheduler)
+    │
+    ├── Task A → claude  (worktree A) → janitor → merge
+    ├── Task B → codex   (worktree B) → janitor → merge
+    └── Task C → gemini  (worktree C) → janitor → merge
+
+State: .sdd/ files (backlog, runtime, metrics, config)
+```
+
+The unit of work is a short-lived task. Agents are spawned per task, verified by the janitor, and exited. Coordination is deterministic code reading and writing files on disk.
+
+---
+
+## When AgentsMesh is the right tool
+
+**You need a workforce control plane, not a CLI tool.** AgentsMesh's core value is the org-shaped layer above the agent: tenants, teams, RBAC, SSO, audit logs, ticket boards, MR/PR integration. If your problem is "give 40 engineers their own AI squad and see what each pod is doing in real time," AgentsMesh ships a working product for that. Bernstein doesn't try to.
+
+**You want long-lived interactive sandboxes.** AgentPods are persistent PTY sandboxes you can attach to from the browser. That maps to "park an agent on a problem, walk away, check on it." Bernstein agents are short-lived processes — once a task ships or fails, they're gone.
+
+**You're deploying enterprise-style.** Air-gapped install, mTLS between runner and control plane, row-level multi-tenancy, BYOK, SSO. These are first-class. Bernstein has none of them — it's a single-user CLI by default.
+
+**Moonshot-adjacent / actively developed.** v0.29.0 was published April 17, 2026; the repo has 56 releases since February 2026. Steady release cadence and a hosted SaaS at agentsmesh.ai.
+
+**Five-agent integration is enough.** If you only run Claude Code, Codex, Gemini, Aider, and OpenCode, AgentsMesh covers the common case out of the box.
+
+---
+
+## When Bernstein is the right tool
+
+**Adapter breadth.** 31 cooperating adapters plus 2 leaf-node delegation adapters (Composio, Ralphex shipping in PR #966) versus AgentsMesh's five built-ins. If you need Amp, Cursor, Cody, Continue, Goose, Kilo, Kiro, Qwen, Ollama, OpenCode, IaC, or a generic adapter alongside Claude/Codex/Gemini, Bernstein already wires them in. AgentsMesh's "custom terminal-based agent" hook covers this in principle but doesn't ship the integrations.
+
+**Deterministic scheduler with reproducible runs.** Bernstein's orchestrator is Python code, not a hosted service. Ticks, retries, fair scheduling, and cost decisions are all in-process and replayable from the WAL. Audit logs are HMAC-chained on disk. No relay cluster, no Postgres, no Redis.
+
+**File-based state inspectable from the shell.** `.sdd/backlog.json`, `.sdd/runtime/`, `.sdd/metrics/`, `.sdd/config/` — `cat`, `jq`, `grep`. No SQL queries to write to answer "what is task 47 doing." AgentsMesh keeps state in PostgreSQL behind the control plane.
+
+**Plan files with dependencies.** `templates/plan.yaml` describes multi-stage projects with `stages`, `steps`, `depends_on`, per-step `goal`, `role`, `priority`, `scope`, `complexity`, and the new per-step `cli:` field landing in PR #965. AgentsMesh's Kanban model is task-by-task; declarative dependency graphs are not documented.
+
+**MCP server first-class.** Bernstein exposes its task server as an MCP server, so other Claude Code / Codex agents can drive it directly. AgentsMesh's README does not mention MCP.
+
+**Quality gates before merge.** The janitor runs tests, lint, type checks, and file-existence checks before any agent's work is merged. AgentsMesh provides MR/PR integration but doesn't document automated pre-merge verification.
+
+**Headless and `--evolve`.** Runs in CI, over SSH, in a container. `bernstein --evolve` reads past run metrics and improves prompts and routing. AgentsMesh is web-console-first; headless and self-improvement loops aren't part of its surface.
+
+**Cost tracking with budgets.** Per-task cost tracking, anomaly detection, and global budget enforcement at the orchestrator. AgentsMesh's cost story is BYOK — you bring keys and absorb costs yourself.
+
+**Single-process install.** `pip install bernstein` and you're running. AgentsMesh requires PostgreSQL, Redis, MinIO, a relay cluster, and a runner before it does anything.
+
+---
+
+## How to evaluate which one you need
+
+Three questions usually settle it:
+
+1. **Is the unit of work a ticket assigned to a teammate's pod, or a task pulled by a scheduler?** First answer points at AgentsMesh. Second points at Bernstein.
+2. **Do you need multi-tenant org/RBAC/SSO from day one?** If yes, AgentsMesh ships it. Bernstein doesn't.
+3. **Is your usage shape "CI runs Bernstein on a goal, agents merge code, humans review the PR"?** That's Bernstein's primary loop. AgentsMesh works in this loop too but its architecture targets persistent attended pods.
+
+The tools could coexist. AgentsMesh could own the workforce layer (who has access to which pod, where logs live, what the audit trail says) while Bernstein runs inside a pod as the actual scheduler — turning a single AgentPod into a 31-adapter parallel orchestrator with a janitor and plan files. Nothing in either project prevents that.
+
+---
+
+## See also
+
+- [Bernstein vs. Paperclip](./bernstein-vs-paperclip.md)
+- [Full comparison index](./README.md)

--- a/docs/compare/bernstein-vs-claude-flow.md
+++ b/docs/compare/bernstein-vs-claude-flow.md
@@ -1,0 +1,140 @@
+# Bernstein vs. claude-flow
+
+> **tl;dr** — claude-flow (recently renamed Ruflo) is a Claude Code plugin pack: 20 plugins, an MCP server, and a swarm coordination layer that turns Claude Code into a multi-agent platform. It is Claude-Code-shaped end to end. Bernstein is provider-agnostic: a deterministic Python orchestrator that drives 31 different CLI agents (Claude, Codex, Gemini, Aider, Goose, Cursor, Qwen, Ollama, and more) in isolated git worktrees with file-based state. If your stack is Claude Code and you want a swarm/SPARC layer on top, claude-flow is the natural fit. If you want to mix providers, ship code through quality gates, and keep the scheduler out of an LLM, Bernstein is the right tool.
+
+*Last verified: 2026-04-27. Based on `github.com/ruvnet/claude-flow` (~34k stars, MIT, npm package `claude-flow` v3.6.9, latest release v3.5.80 on 2026-04-11). The project has been rebranded "Ruflo" inside the same repo.*
+
+---
+
+## What is claude-flow?
+
+**claude-flow / Ruflo** is a TypeScript/Node.js orchestration layer built specifically for Claude Code. It installs three ways: as a Claude Code plugin (`/plugin install ruflo-core@ruflo`), as an npm CLI (`npm install -g ruflo@latest`), or as an MCP server (`claude mcp add ruflo`). The shipped surface is a marketplace of ~20 plugins — `ruflo-core`, `ruflo-swarm`, `ruflo-autopilot`, `ruflo-intelligence`, `ruflo-agentdb`, `ruflo-aidefence`, `ruflo-jujutsu`, `ruflo-wasm`, `ruflo-rag-memory`, etc. — that drop skills, slash commands, agents, and MCP tools into Claude Code. Coordination happens through a "queen-led" topology with hierarchical/mesh/adaptive layouts, an HNSW vector memory store (AgentDB), and a hooks layer that auto-routes tasks. The project is active (1,400+ releases, latest v3.5.80 in April 2026) and licensed MIT.
+
+The README markets several headline numbers ("89% routing accuracy", "150x–12,500x faster search", "SONA self-learning patterns", Raft/Byzantine consensus). These are claims about the runtime; the codebase that implements them is a TypeScript monorepo under `v3/@claude-flow/*` plus optional ruvector / agentdb native bindings. Treat the claims as claims and the architecture as: Node.js process, MCP-server-shaped, Claude-Code-bound.
+
+## What is Bernstein?
+
+**Bernstein** (Apache 2.0, Python 3.12+) is a multi-agent orchestrator for CLI coding agents. It breaks a goal into tasks, spawns short-lived agents in isolated git worktrees, verifies each agent's output through a janitor (tests, lint, types, file checks), and merges the results. The orchestrator is deterministic Python — no LLM in the scheduling loop. It ships 31 cooperating CLI adapters (Claude Code, Codex, Cursor, Gemini, Aider, Amp, Goose, OpenCode, Qwen, Kilo, Kiro, Ollama, Continue, Cody, Cloudflare, IaC, Generic, …) plus 2 leaf-node delegation adapters (Composio, Ralphex). State lives in `.sdd/` files; agents are ~1–3 tasks each and exit. Cost tracking, budget caps, MCP server mode, multi-repo workspaces, Cloudflare Workers cloud execution, and HMAC-chained audit logs are all first-class.
+
+---
+
+## Feature comparison
+
+| Feature | Bernstein | claude-flow / Ruflo |
+|---|---|---|
+| **Primary focus** | Ship code across many CLI agents | Multi-agent swarm layer for Claude Code |
+| **License** | Apache 2.0 | MIT |
+| **Language / runtime** | Python 3.12+ | Node.js 20+ (TypeScript) |
+| **Install path** | `pipx install bernstein` / `uv tool install` | `npm i -g ruflo` / Claude Code plugin / MCP |
+| **Provider scope** | 31 CLI adapters + 2 leaf-node | Claude Code first-class; multi-provider routing via plugins |
+| **Orchestrator logic** | Deterministic Python scheduler | LLM + hooks + queen-led swarm coordination |
+| **Coordination cost** | Zero LLM tokens for scheduling | Coordination uses LLM calls (hooks, routing, consensus) |
+| **State storage** | File-based (`.sdd/`) | AgentDB (HNSW vector) + RVF + ReasoningBank |
+| **Git isolation** | Per-agent worktrees | Worktree isolation via `ruflo-swarm` plugin |
+| **Quality gates** | Janitor: tests, lint, types, file checks before merge | AIDefence: PII / prompt-injection / CVE scanning |
+| **Automated retries** | Yes — failure-aware retry with model escalation | Hooks/learning loop reattempts |
+| **Cost tracking** | Per-task, per-run, with budget caps | Not a primary surface |
+| **Plan files** | YAML stages + steps + `cli:` per step | SPARC / GOAP / workflow templates per plugin |
+| **MCP server** | First-class (`bernstein mcp`) | First-class (`@claude-flow/cli` MCP) |
+| **Headless / CI** | Yes — designed for unattended CI | Optimized for interactive Claude Code sessions |
+| **Multi-repo** | Yes — multi-repo workspaces | Single project per session |
+| **Cloud execution** | Cloudflare Workers adapter | Not shipped |
+| **Audit trail** | HMAC-chained `.sdd/audit.jsonl` | Activity logs |
+| **Self-evolution** | `bernstein --evolve` rewrites prompts/templates | SONA pattern learning, ReasoningBank trajectories |
+| **Headline claims** | Conservative — measured against tests | "89% routing accuracy", "150x–12,500x search", "100+ agents" |
+
+---
+
+## Architecture comparison
+
+**claude-flow / Ruflo (Claude-Code-native swarm layer):**
+```
+Claude Code session
+    │
+    ▼
+Ruflo MCP server + 27 hooks
+    │
+    ├── Router (intelligent task dispatch)
+    │
+    ▼
+Swarm coordinator (queen + topology)
+    │
+    ├── coder, tester, reviewer, architect, security, ...
+    │
+    ▼
+AgentDB (HNSW vector memory) + ReasoningBank
+    │
+    ▼
+LLM providers (Claude / GPT / Gemini / Cohere / Ollama)
+```
+
+The system lives inside Claude Code. Hooks intercept tasks, the router decides which agent handles them, the swarm coordinator runs the chosen topology, and shared state flows through a vector memory store. Coordination is LLM-driven and hook-driven.
+
+**Bernstein (provider-agnostic engineering orchestrator):**
+```
+bernstein -g "goal"   (terminal, CI, SSH, MCP)
+    │
+    ▼
+Task server (FastAPI, deterministic Python)
+    │
+    ├── Task A → claude   (worktree) → janitor → merge
+    ├── Task B → codex    (worktree) → janitor → merge
+    ├── Task C → gemini   (worktree) → janitor → merge
+    └── Task D → aider    (worktree) → janitor → merge
+
+State: .sdd/  (backlog, runtime, metrics, audit, config)
+```
+
+The orchestrator is ~800 lines of deterministic Python. Agents are short-lived processes — one per task — that read the codebase, make changes, and exit. The janitor runs tests/lint/types in the worktree before any merge. No LLM is consulted to decide what to do next.
+
+---
+
+## When claude-flow is the right tool
+
+**You are all-in on Claude Code.** The product is built around it. Plugins drop into `/plugin`, hooks integrate with Claude Code's task lifecycle, and the MCP server speaks that ecosystem fluently. If your team's daily driver is Claude Code and you want to extend it without leaving the session, claude-flow is the more native experience.
+
+**You want a swarm/SPARC methodology layer.** The queen-led hierarchy, mesh/adaptive topologies, and consensus mechanisms are an opinionated take on coordinating many specialized agents (coder, tester, reviewer, architect, security). If that conceptual model maps to how you want to organize work, the plugins are wired up to it.
+
+**You want vector-memory shared context between agents.** AgentDB / HNSW / ReasoningBank are designed for cross-session, cross-agent memory retrieval. Bernstein's file-based state is simpler and cheaper but doesn't index trajectories for semantic recall.
+
+**You want a plugin marketplace.** Twenty plugins covering RAG, browser automation, security audit, doc generation, GOAP planning, WASM sandboxing, etc. is a large pre-built surface to draw from inside Claude Code.
+
+---
+
+## When Bernstein is the right tool
+
+**You use more than one CLI agent.** 31 adapters vs. Claude-Code-as-the-host. If you actually run Codex, Gemini, Aider, Amp, Goose, Qwen, Kilo, Kiro, OpenCode, Cursor, or Ollama — not as bash shims but as first-class adapters with their own auth and cost models — Bernstein meets you where you are. claude-flow can route to other providers through plugins, but the orchestration substrate is Claude Code.
+
+**You want zero LLM tokens in the scheduler.** Bernstein's tick pipeline, task assignment, retries, and merge ordering are deterministic Python. claude-flow's coordination uses hooks + routers + a learning loop, all of which spend tokens to make decisions. Both approaches work; the cost and reproducibility profiles are different.
+
+**You want quality gates, not safety scanning.** Bernstein's janitor is engineering verification: did the tests pass, did the linter pass, did Pyright pass, do the expected files exist. claude-flow's AIDefence is security/safety scanning (PII, prompt injection, CVE). They solve different problems. Bernstein refuses to merge a branch with a failing test; claude-flow refuses to send a prompt with PII in it.
+
+**You run in CI / headless / SSH / cloud.** Bernstein is designed to run unattended: `bernstein run --plan plans/x.yaml`, return exit code, ship a branch. Cloudflare Workers execution is supported. claude-flow is optimized for interactive Claude Code sessions.
+
+**You want file-based reproducible state.** Everything Bernstein does lands in `.sdd/`: backlog, runtime, metrics, HMAC-chained audit log. You can diff two runs, replay a run, or hand `.sdd/` to a teammate. claude-flow's state lives in vector DBs and learning stores designed for retrieval, not byte-level reproducibility.
+
+**You want per-step model and provider selection.** Bernstein's plan YAML supports `cli:` per step (PR #965), so a plan can route the cheap step to Haiku-via-Claude, the heavy refactor to Codex, and the doc pass to Gemini. claude-flow leans on its router to decide.
+
+**You want multi-repo orchestration.** Bernstein workspaces span repos. claude-flow operates per project.
+
+**You want Apache 2.0.** If license matters to your org, Apache 2.0 vs. MIT is a real distinction (patent grant). Both are permissive; pick the one your legal team prefers.
+
+---
+
+## Stitching claude-flow into a Bernstein plan
+
+These are not mutually exclusive. claude-flow's strength is being Claude-Code-native; Bernstein's strength is provider-agnostic orchestration. A pragmatic combination:
+
+- Use Bernstein as the top-level scheduler. It owns the plan, the worktrees, the janitor gate, and the merge.
+- For Claude-Code-heavy steps, set `cli: claude` on the step and let Bernstein's Claude adapter spawn the agent. If you want claude-flow's swarm/skills inside that session, the Claude adapter will pick up `.claude/` plugins and MCP servers configured in the workspace.
+- Keep deterministic verification at the Bernstein layer (tests + lint + types in the worktree, not inside the swarm). The janitor's pass/fail is what gates the merge.
+- Keep cost tracking at the Bernstein layer. claude-flow doesn't surface per-step cost; Bernstein does.
+
+This keeps the scheduler deterministic and cheap, and lets claude-flow do what it does best inside the Claude Code steps that benefit from a swarm.
+
+---
+
+## See also
+
+- [Bernstein vs. Paperclip](./bernstein-vs-paperclip.md)
+- [Full comparison index](./README.md)

--- a/docs/compare/bernstein-vs-claude-squad.md
+++ b/docs/compare/bernstein-vs-claude-squad.md
@@ -1,0 +1,157 @@
+# Bernstein vs. Claude Squad
+
+> **tl;dr** — Claude Squad is a tmux-based TUI that lets a single developer juggle several Claude Code (or Codex / Aider / Gemini) sessions side-by-side, each in its own git worktree. Bernstein is a multi-agent orchestrator: a deterministic Python scheduler that decomposes a goal into tasks, hands them to one of 31+ CLI agents, runs quality gates, and merges the results. Claude Squad is a session manager. Bernstein is an orchestrator. If you want a richer interactive control panel for hand-driven parallel work, Claude Squad is solid. If you want a goal turned into shipped, verified code with no human in the inner loop, Bernstein is the right shape.
+
+*Last verified: 2026-04-27. Based on `github.com/smtg-ai/claude-squad` (~7.2k stars, AGPL-3.0, Go, last release v1.0.17, last commit 2026-03-28, project active).*
+
+---
+
+## What each tool is
+
+**Claude Squad** (AGPL-3.0, Go, installed as `cs`) is a terminal app for managing multiple AI coding sessions in parallel. It launches each agent inside its own tmux session and its own git worktree, then renders a TUI with a session list, a preview pane, and a diff tab. Default agent is `claude`, but `cs -p codex`, `cs -p aider ...`, `cs -p gemini`, and a config-file `profiles` array let you choose what runs in each session. Keybindings drive the workflow: `n` new session, `N` new with prompt, `↵` attach, `s` commit + push, `c` checkout-and-pause, `r` resume, `D` kill. Configuration lives in `~/.claude-squad/config.json`. Prerequisites are `tmux` and `gh`. There is no plan format, no cross-session scheduler, no automated verification — the human is the orchestrator, and the TUI is the control surface.
+
+**Bernstein** (Apache 2.0, Python 3.12+) is a multi-agent orchestrator. Given a goal or a YAML plan with stages and steps, it decomposes work into tasks, spawns short-lived agents in isolated worktrees, runs quality gates (tests, lint, types, file checks) via the janitor module, retries with model escalation on failure, and merges what passes. The orchestrator itself is deterministic Python — no LLM tokens spent on coordination. State is file-based under `.sdd/`. It ships 31 cooperating CLI agent adapters plus 2 leaf-node delegation adapters (Composio, Ralphex), an MCP server, a task server (FastAPI on `127.0.0.1:8052`), cost tracking with budget caps, and a per-step `cli:` field so a plan can switch CLIs between stages.
+
+---
+
+## Feature comparison
+
+| Feature | Bernstein | Claude Squad |
+|---|---|---|
+| **Primary focus** | Goal → tasks → verified merged code | Multiple agent sessions in one TUI |
+| **License** | Apache 2.0 | AGPL-3.0 |
+| **Language** | Python 3.12+ | Go |
+| **Install** | `pip install bernstein` (or `uv`) | `brew install claude-squad` / `install.sh` |
+| **Interface** | CLI + TUI + web dashboard + MCP | TUI (tmux-backed) |
+| **Orchestrator logic** | Deterministic Python scheduler | None — the human picks tasks |
+| **Plan format** | YAML stages + steps, `depends_on`, `complexity` | None |
+| **Agent adapters** | 31 cooperating + 2 delegation (Claude, Codex, Gemini, Aider, Amp, Goose, OpenCode, Cursor, Cody, Continue, Kilo, Kiro, Qwen, Ollama, generic, …) | Any agent, but as a launch command per session (`-p "claude"`, `-p "codex"`, `-p "aider …"`) |
+| **Per-stage agent switching** | Yes — `cli:` field per step (PR #965) | No — one program per session at creation time |
+| **Git worktree isolation** | Yes — per task | Yes — per session |
+| **Parallel execution model** | Scheduler dispatches N tasks across worktrees, ticks deterministically | tmux panes, human switches between them |
+| **Quality gates** | Janitor: tests, lint, types, file existence; blocks merge on fail | None — diffs shown in TUI for human review |
+| **Automated retry** | Yes — with model escalation on failure | No |
+| **Cross-agent messaging** | Bulletin board (`POST /bulletin`) | None |
+| **State storage** | `.sdd/` files (backlog, runtime, metrics, config) | `~/.claude-squad/` config + tmux session state |
+| **Cost tracking** | Per-task tokens + USD, budget caps, anomaly detection | None |
+| **MCP server** | First-class (`bernstein mcp serve`) | None |
+| **Headless / CI** | Yes — runs without TTY, no tmux dependency | No — requires interactive tmux + TTY |
+| **Multi-repo** | Yes — workspace orchestration across repos | One repo per `cs` invocation |
+| **Cloud execution** | Cloudflare Workers adapter | None |
+| **Self-evolution** | `bernstein --evolve` | No |
+| **Audit trail** | HMAC-chained file logs | None |
+| **Auto-PR with cost summary** | `bernstein pr` | `s` keybind: commit + push to GitHub via `gh` |
+| **Yolo / auto-accept** | Per-task policy + tool-call approval | `--autoyes` flag (experimental) |
+| **Prereqs** | Python 3.12+, git | tmux, `gh` |
+
+---
+
+## Architecture comparison
+
+**Claude Squad (tmux session manager):**
+```
+cs (TUI, Go)
+    │
+    ├── tmux session A → claude   (worktree A) ── human attaches via Enter
+    ├── tmux session B → codex    (worktree B) ── human attaches via Enter
+    └── tmux session C → aider    (worktree C) ── human attaches via Enter
+
+State: ~/.claude-squad/config.json + live tmux sessions
+Coordination: human keyboard input
+```
+
+The human decides what each session works on, attaches to inspect or re-prompt, and presses `s` to commit and push. There is no scheduler — sessions run independently, and the only cross-session structure is the list rendered in the TUI.
+
+**Bernstein (deterministic orchestrator):**
+```
+bernstein run plan.yaml   (terminal, CI, SSH, MCP)
+    │
+    ▼
+Task server (FastAPI 127.0.0.1:8052) + deterministic tick pipeline
+    │
+    ├── Task A → claude   (worktree A) → janitor (tests/lint/types) → merge
+    ├── Task B → codex    (worktree B) → janitor (tests/lint/types) → merge
+    └── Task C → gemini   (worktree C) → janitor (tests/lint/types) → retry → escalate model → merge
+
+State: .sdd/ files; cost: per-task tokens + USD with budget caps
+Coordination: deterministic Python (no LLM tokens spent on scheduling)
+```
+
+A plan defines stages and steps. The scheduler picks tasks, picks a model and effort per task, dispatches to the right adapter, runs quality gates on the result, retries failures, and merges what passes. The human sets the goal; the orchestrator runs the loop.
+
+---
+
+## The fundamental difference
+
+Claude Squad answers: *"How do I keep five Claude Code sessions in front of me without losing my mind?"*
+
+Bernstein answers: *"How do I turn a goal into shipped, tested code without sitting at the keyboard?"*
+
+Both use git worktrees for isolation. Both can run multiple agents at once. The difference is who drives. In Claude Squad, the human is the scheduler — picking which session to attend to, when to commit, when to abandon a branch. In Bernstein, the scheduler is deterministic Python code, and the human reads results.
+
+---
+
+## When Claude Squad is the right tool
+
+- **Single-developer interactive workflows.** You want to babysit a few agents, watch their output, prompt them mid-flight, and decide on the spot what to keep. The TUI is purpose-built for this.
+- **Lightweight, no-config, no-server.** No daemon, no API server, no plan files. Install, run `cs`, press `n`. Total config is one JSON file.
+- **You like tmux.** If your existing workflow lives in tmux and you want AI sessions as additional panes, Claude Squad fits naturally. The diff tab and preview pane are well-designed for terminal-native review.
+- **One repo at a time.** If your work is bounded by a single repository and a handful of parallel branches, the simplicity is a feature, not a limitation.
+- **You don't need automated verification.** You're going to read every diff anyway; the human eye is the quality gate.
+
+This is a real niche. For a developer who wants parallelism with full manual control, Claude Squad is a better fit than Bernstein — Bernstein's machinery (plan files, quality gates, task server, cost tracking) is overhead you don't need.
+
+---
+
+## When Bernstein is the right tool
+
+- **Provider breadth.** 31 cooperating adapters plus 2 leaf-node delegation adapters. You can mix Claude, Codex, Gemini, Aider, Amp, Kilo, Kiro, Qwen, Goose, OpenCode, Cody, Continue, and Ollama in the same run. Claude Squad treats every agent as a launch command — fine for one-at-a-time, but with no shared task model across them.
+- **Deterministic scheduling.** The orchestrator is Python code, not an LLM. No tokens spent deciding which agent gets which task. Reproducible runs, replayable from `.sdd/`.
+- **Quality gates before merge.** The janitor runs tests, lint, type checks, and file-existence assertions. Failures retry, optionally with model escalation. Claude Squad shows a diff and lets you decide.
+- **Plan files.** YAML with `stages`, `steps`, `depends_on`, `goal`, `role`, `priority`, `scope`, `complexity`. Encodes "build the API, then the migrations, then the tests" once and replays it deterministically. Claude Squad has no equivalent.
+- **Headless / CI execution.** Bernstein runs without a TTY, with no tmux dependency, in GitHub Actions or any CI runner. Claude Squad needs an interactive tmux session.
+- **MCP server first-class.** Other tools and Claude itself can drive Bernstein via MCP. Claude Squad has no MCP surface.
+- **Multi-repo orchestration.** One run can span multiple repositories. `cs` is one repo per invocation.
+- **Cost tracking with budgets.** Per-task token counts, per-task USD, anomaly detection, hard budget caps. Claude Squad doesn't track cost.
+- **Cross-agent communication.** The bulletin board lets agents post findings or blockers another task can read. Claude Squad sessions are siloed.
+- **Cloud execution.** Cloudflare Workers adapter for ephemeral remote execution.
+
+---
+
+## How to migrate from Claude Squad to Bernstein
+
+If you already use Claude Squad and want to try Bernstein for a specific run rather than as a wholesale replacement, the path is short.
+
+1. **Keep using `cs` for interactive work.** Bernstein doesn't replace the TUI loop; it replaces the goal-decomposition-and-verification loop. Run both.
+2. **Translate one repeated workflow into a plan file.** If you find yourself spinning up the same three sessions every Monday — "refactor the auth module, write the tests, update the docs" — that's a plan. Write it as `plans/auth-refactor.yaml` with three steps and a `depends_on`.
+   ```yaml
+   stages:
+     - name: refactor
+       steps:
+         - goal: "Refactor auth module to use the new session abstraction"
+           role: backend
+           cli: claude
+     - name: tests
+       depends_on: [refactor]
+       steps:
+         - goal: "Add unit tests for the refactored auth module"
+           role: qa
+           cli: codex
+     - name: docs
+       depends_on: [refactor]
+       steps:
+         - goal: "Update auth.md to reflect the new API"
+           role: docs
+   ```
+3. **Run it.** `bernstein run plans/auth-refactor.yaml`. Worktrees, quality gates, cost tracking, and merge happen without you attaching to any session.
+4. **Keep the human-driven sessions in `cs`.** When a task is exploratory and you want to drive it yourself, that's still Claude Squad's job.
+
+The two tools coexist cleanly because they answer different questions. `cs` is for "I want to drive five agents at once." `bernstein run` is for "I want this goal shipped while I do something else."
+
+---
+
+## See also
+
+- [Bernstein vs. Crystal](./bernstein-vs-crystal.md) — another tmux-adjacent multi-agent TUI
+- [Bernstein vs. Conductor](./bernstein-vs-conductor.md) — orchestrator comparison
+- [Full comparison index](./README.md)

--- a/docs/compare/bernstein-vs-crystal.md
+++ b/docs/compare/bernstein-vs-crystal.md
@@ -1,18 +1,42 @@
 # Bernstein vs. Crystal
 
-> **tl;dr** — Crystal uses iterative self-review loops: an agent writes code, a reviewer agent critiques it, the writer revises, repeat until quality gates pass. Bernstein uses external verification: the janitor runs tests and the linter, and trusts those results over agent self-assessment. Crystal is better when objective test suites are thin or absent. Bernstein is better when tests are the ground truth and you want fast, deterministic verification.
+> **tl;dr** — Crystal (stravu/crystal) is an Electron desktop app for running parallel Claude Code and Codex sessions in git worktrees, with a friendly visual UI for a single developer watching agents work. Bernstein is a CLI orchestrator with 31 cooperating agent adapters, a deterministic Python scheduler, file-based state, MCP server, plan files, cost budgets, and headless CI execution. They overlap on the worktree-isolation idea and diverge on almost everything else. As of February 2026 Crystal is deprecated in favor of its successor Nimbalyst; this comparison is kept here because it remains the most-cited "parallel agents in worktrees" reference.
 
-*Last verified: 2026-04-19.*
+*Last verified: 2026-04-27. Based on `github.com/stravu/crystal` (3.0k+ stars, MIT, last release 0.3.5 on 2026-02-26, deprecated in favor of `nimbalyst.com`).*
 
 ---
 
-## What each tool is
+## What is Crystal?
 
-**Crystal** is a multi-agent coding framework that wraps each coding task in a review loop. A writer agent produces output; a reviewer agent critiques it against a rubric; the writer revises; the cycle continues until the reviewer approves or a max-iteration limit is reached. The verification is agent-to-agent, internal to the system.
+Crystal is an Electron desktop application written in TypeScript (React 19 frontend, Node.js + better-sqlite3 backend, node-pty for process management). Its scope is narrow and intentional:
 
-**Bernstein** separates writing from verification entirely. A coding agent (Claude Code, Codex, Gemini CLI) produces output in an isolated git worktree. A deterministic janitor — not another LLM — runs `pytest`, `ruff`, and file existence checks. If any check fails, the task goes back to the queue. The agent's self-assessment is not trusted.
+- **Two agents.** Claude Code and OpenAI Codex, integrated via their SDKs and CLIs.
+- **Sessions in worktrees.** Each session creates a git worktree off a project's main branch and runs one (or, since 0.3.4, several) agents inside it.
+- **Local SQLite state.** Sessions, conversation messages, prompt history, panel configurations, execution diffs, and run-script logs all live in `~/.crystal/` SQLite tables.
+- **Per-session UI.** Output view, raw-message view, diff view, and an editor view. Multiple XTerm.js terminals per session, with 50,000-line scrollback and lazy initialization.
+- **Git operations.** Rebase / merge to main, squash, diff visualization, conflict surfacing.
+- **Notifications.** Desktop notifications, Web Audio sound cues on status change.
 
-The core difference: Crystal trusts agent judgment to improve quality through iteration. Bernstein trusts test results to define quality.
+What Crystal does not have: no CLI mode, no headless / CI execution, no MCP server, no plan files, no cost tracking with budgets, no support for any agent beyond Claude Code and Codex, no multi-machine coordination, no automated retries with model escalation, no quality gates beyond what the agent decides itself.
+
+Crystal is a desktop app for one developer running a few parallel agents and watching them in tabs. That is the entire product.
+
+**Project status (April 2026).** Crystal's final release was `0.3.5` on 2026-02-26. The repo is now a migration shim pointing at Nimbalyst (`nimbalyst.com`, `Nimbalyst/nimbalyst`). The historical Crystal architecture and feature set are still useful as a reference point because Nimbalyst's parallel-agents model inherits the same constraints (single machine, desktop-first, Claude Code + Codex focus).
+
+---
+
+## What is Bernstein?
+
+Bernstein (Apache 2.0, Python 3.12+, hatchling) is a CLI orchestrator for multi-agent coding workflows. The orchestrator is deterministic Python — no LLM tokens are spent on coordination. Agents are short-lived processes that pick up a task, execute it in an isolated worktree, and exit. State lives in `.sdd/` files (backlog, runtime, metrics, config), inspectable from the shell.
+
+- 31 cooperating CLI agent adapters (Claude Code, Codex, Cursor, Aider, Amp, Cody, Continue, Gemini CLI, Goose, Kilo, Kiro, Ollama, OpenCode, Qwen, plus a generic adapter), with two leaf-node delegation adapters (Composio, Ralphex) shipping in PR #966.
+- Per-step `cli:` field (PR #965) so a plan can pin a specific agent to a step.
+- Janitor module — quality gates for tests, lint, types, file checks. Failures go back into the queue; successful work merges.
+- MCP server first-class, exposing run / status / cost / approve / tasks tools.
+- YAML plan files with stages, dependencies, role assignments — repeatable workflows checked into the repo.
+- Cost tracking with budgets, anomaly detection, and per-agent budget enforcement.
+- Multi-repo orchestration; cloud execution via Cloudflare Workers; SSH remote sandbox.
+- Headless: runs in CI, over SSH, in a tmux session, in a daemon. No GUI required.
 
 ---
 
@@ -20,137 +44,132 @@ The core difference: Crystal trusts agent judgment to improve quality through it
 
 | Feature | Bernstein | Crystal |
 |---|---|---|
-| **Verification approach** | External: tests, linter, file checks | Internal: LLM reviewer agent |
-| **Reviewer type** | Deterministic (pytest, ruff) | LLM-based (another agent) |
-| **Review cost** | Near-zero (test runner is cheap) | Additional LLM API calls per review cycle |
-| **Task isolation** | Git worktree per agent, no shared context | Shared context within review cycle |
-| **Parallelism** | Yes — multiple tasks concurrently | Within-task review cycles are sequential |
-| **CLI agent support** | Yes — wraps installed CLI tools | SDK-based integration |
-| **Model routing** | Cost-aware bandit across providers | Configurable per role |
-| **Self-evolution** | Yes — `--evolve` mode | No |
-| **Headless operation** | Yes — `--headless` flag | Depends on deployment |
-| **Open source** | Apache 2.0 | Varies |
-| **Primary use case** | Parallel coding tasks with test verification | High-quality single-task output via review loops |
+| **Primary surface** | CLI + optional TUI / web dashboard | Electron desktop app |
+| **License** | Apache 2.0 | MIT |
+| **Language** | Python 3.12+ | TypeScript (React 19, Node, Electron) |
+| **Project status** | Active | Deprecated 2026-02-26 (replaced by Nimbalyst) |
+| **Orchestrator logic** | Deterministic Python scheduler | Per-session UI; no cross-session orchestration |
+| **Agent adapters** | 31 CLI adapters + 2 leaf delegators | 2 (Claude Code, Codex) |
+| **Per-step agent selection** | Yes — `cli:` field in plan steps (PR #965) | Per-session at creation; multi-agent per worktree as of 0.3.4 |
+| **Git worktree isolation** | Yes — per task | Yes — per session |
+| **Plan files (repeatable workflows)** | YAML stages + steps + `depends_on` | None |
+| **Headless / CI mode** | Yes | No — desktop only |
+| **MCP server** | First-class (`bernstein mcp`) | None |
+| **Cost tracking + budgets** | Yes — per-task cost, budget caps, anomaly detection | Token usage display only |
+| **Quality gates / verification** | Janitor: tests, lint, types, file checks | Run-scripts; agent self-judgment |
+| **Automated retry with model escalation** | Yes | No |
+| **State storage** | `.sdd/` files (inspectable from shell) | `~/.crystal/` SQLite |
+| **Multi-repo / multi-project** | Yes — multi-repo workspaces | Multiple projects, single machine |
+| **Multi-machine / cluster** | Yes — cluster mode + Cloudflare Workers | No |
+| **SSH remote sandbox** | `bernstein remote test/run/forget` | No |
+| **Chat bridges (Telegram / Discord / Slack)** | `bernstein chat serve --platform=...` | No |
+| **Tunnel wrapper (cloudflared / ngrok / bore / tailscale)** | `bernstein tunnel start/list/stop` | No |
+| **Daemon / service install** | `bernstein daemon install/start/stop/status` | n/a (desktop app) |
+| **Self-evolution** | `bernstein --evolve` | No |
+| **Audit trail** | HMAC-chained, file-based | SQLite tables, not signed |
 
 ---
 
 ## Architecture comparison
 
-**Crystal (internal review loop):**
-```
-Task
-    │
-    ▼
-Writer agent (LLM) ──→ code output
-    │
-    ▼
-Reviewer agent (LLM) ──→ critique + rubric check
-    │
-    ├── Approved → output
-    └── Rejected → writer agent (revised prompt with critique)
-         │
-         └── (loop, max N iterations)
-```
+**Crystal (desktop app, single machine):**
 
-The review cycle is internal: two LLMs in dialogue. The quality gate is "reviewer LLM approves," not "test suite passes." This can catch issues that tests don't cover (code readability, architectural consistency, edge case reasoning) but can also miss issues that tests would catch deterministically.
-
-**Bernstein (external verification):**
 ```
-Task
-    │
-    ▼
-Coding agent (Claude Code / Codex / Gemini CLI)
-    │
-    ▼
-Janitor (deterministic)
-    ├── pytest → pass/fail
-    ├── ruff → lint violations count
-    └── file existence checks → pass/fail
-    │
-    ├── All pass → commit + merge
-    └── Any fail → task back to queue (retry, or quarantine after N failures)
+~/.crystal/ SQLite
+        ▲
+        │
+Electron main process
+  ├── SessionManager
+  ├── WorktreeManager
+  ├── ClaudeCode / Codex SDK
+  ├── node-pty PTY processes
+  └── Bull task queue (in-memory)
+        │
+        ▼
+React renderer (Sidebar, Terminal panels, Diff view, Editor)
 ```
 
-The quality gate is objective: either the tests pass or they don't. No LLM reviewer is consulted. The janitor can't be fooled by confident-sounding but wrong reasoning.
+Everything runs inside one Electron process. Sessions are visible to one user on one machine. The "orchestration" is a queue of process invocations driven by user clicks in the sidebar.
+
+**Bernstein (CLI orchestrator, deterministic scheduler):**
+
+```
+bernstein -g "goal"  (terminal, CI, SSH, daemon)
+    │
+    ▼
+Task server (local FastAPI, deterministic Python tick pipeline)
+    │
+    ├── Task A → claude  (worktree A) → janitor → merge
+    ├── Task B → codex   (worktree B) → janitor → merge
+    ├── Task C → gemini  (worktree C) → janitor → merge
+    └── Task D → aider   (worktree D) → janitor → retry with stronger model
+                                 │
+                                 ▼
+                       Plan files (YAML), cost budget, audit log
+                       State: .sdd/ (file-based, inspectable via shell)
+```
+
+The orchestrator is a long-running process (or a one-shot CLI invocation) that schedules tasks across whatever agents are available, verifies their output through the janitor, and merges working branches.
 
 ---
 
-## The reviewer hallucination problem
+## When Crystal is the right tool
 
-Crystal's LLM reviewer can approve incorrect code if the reviewer hallucinates correctness. This is the same failure mode as asking "does this look right?" — if the reviewer doesn't actually run the code, it's making an educated guess.
+Crystal earned its niche, and the niche is real:
 
-Bernstein's janitor is not a language model. It runs `pytest` and reads exit codes. It cannot be convinced by an argument that the code is correct if the tests fail.
+- **Single developer, single machine, two agents.** If you're sitting at one Mac, you have Claude Code and Codex installed, and you want to run three or four parallel attempts at the same task and pick the best one — Crystal's UI is genuinely pleasant for that. Sidebar, tabs, diff view, run-script panel.
+- **Visual diff and merge workflow.** Watching a worktree's diff change in real time as the agent works, then clicking "merge to main," is a nicer experience in Crystal than scrolling through a terminal log.
+- **No CI requirement.** If your work is "explore three approaches to this prompt and keep the one I like," you don't need plan files, budgets, or headless execution. Crystal is lighter weight for that loop.
+- **You already use it.** Until Nimbalyst stabilizes, Crystal still works; it just won't get new features.
 
-This matters most for:
-
-- **Logic errors that look syntactically correct.** A reviewer LLM may not catch off-by-one errors, incorrect algorithm choices, or wrong API usage. Tests catch these.
-- **Integration failures.** Code that works in isolation but breaks when integrated. Tests that import and exercise the code catch these; a reviewing LLM reading the diff may not.
-- **Regressions.** Changes that break unrelated functionality. A regression test suite catches these automatically. A reviewer LLM doesn't know what previously worked.
-
-Crystal's review loop catches things tests don't cover — code organization, naming consistency, documentation quality, architectural alignment. For these concerns, LLM review adds value that deterministic checks can't provide.
+If your problem is "I want a desktop UI to run a few Claude Code or Codex sessions in worktrees and watch them in tabs," Crystal is the better fit. Bernstein is built for a different shape of problem.
 
 ---
 
-## Cost comparison
+## When Bernstein is the right tool
 
-Crystal's review loop adds API calls. For a 3-iteration loop with writer + reviewer:
+Bernstein's wedge is everything Crystal's scope deliberately excludes:
 
-| Review cycles | API calls | Approximate additional cost |
-|---|---:|---|
-| 1 (write only, no review) | 1 | $0 |
-| 2 (write + one review) | 2–3 | +$0.10–0.20 |
-| 3 (write + two reviews) | 4–5 | +$0.20–0.40 |
-| 4 (write + three reviews) | 6–7 | +$0.30–0.60 |
-
-Bernstein adds no extra LLM calls for verification — the janitor runs `pytest` and `ruff` and reads exit codes. Crystal's review loop adds one or more LLM calls per iteration. For a fair head-to-head on the same task mix, we are holding back quantitative claims until the Bernstein SWE-Bench Lite harness lands. See [`benchmarks/README.md`](../../benchmarks/README.md) for the current pilot (n=25, +8 pp, p=0.569).
-
-The cost premium for Crystal is task-type-dependent. For tasks with good test coverage, Bernstein's test-based verification is faster and cheaper while providing stronger guarantees. For tasks without test coverage, Crystal's review loop provides quality signal that Bernstein can't.
-
----
-
-## When test coverage changes the calculus
-
-| Scenario | Better choice |
-|---|---|
-| Good test suite (80%+ coverage) | Bernstein — external verification is definitive |
-| Thin test suite (< 40% coverage) | Crystal — LLM review catches what tests miss |
-| No tests at all | Crystal or manual review — janitor has nothing to check |
-| Tests exist but are slow (> 5 min) | Crystal may be faster despite extra API calls |
-| Legacy codebase with fragile tests | Crystal — LLM review can reason about intent |
-| New greenfield project with tests | Bernstein — tests are ground truth |
+- **Provider breadth.** 31 CLI adapters versus Crystal's two. Mix Claude Code, Codex, Gemini CLI, Aider, Amp, Goose, Cursor, OpenCode, Qwen, Kilo, Kiro, Ollama in the same run — first-class, not bash shims. If a vendor breaks or a model regresses, switch the `cli:` field on the affected steps.
+- **Headless / CI execution.** Crystal can't run in GitHub Actions. Bernstein can. `bernstein run plans/release.yaml` in a CI job spawns agents, runs the janitor, and exits with a status code.
+- **Plan files for repeatable workflows.** A YAML plan with stages, `depends_on` edges, and per-step `cli:` and `role:` fields turns "I implemented this with three agents last Tuesday" into a checked-in artifact that runs again identically.
+- **Deterministic Python scheduler.** No tokens spent on coordination. The scheduler is code, not an LLM. Failures in scheduling are bugs you can fix; LLM coordination drift is not a class of problem here.
+- **File-based state inspectable from the shell.** `.sdd/runtime/tasks.json`, `.sdd/metrics/`, `.sdd/config.yaml` — `cat`, `jq`, `grep`. No SQLite browser required, no Electron app needed to read your own state.
+- **MCP server first-class.** Bernstein exposes its run, status, cost, approve, tasks, create-subtask, and load-skill operations over MCP. Other agents can drive Bernstein. Crystal does not expose MCP.
+- **Janitor verification.** Tests, lint, types, file existence — checked before merge. A task that breaks the test suite goes back to the queue with retry-and-escalate. Crystal relies on the user's run-script and the agent's own judgment.
+- **Cost tracking with budgets.** Per-task cost, anomaly detection, hard budget cap that stops a runaway loop. Crystal displays token usage; it doesn't enforce a budget.
+- **Multi-repo orchestration.** A single run can touch several repositories; Crystal binds a session to one project at a time on one machine.
+- **Cluster + Cloudflare Workers + SSH remote sandbox.** Bernstein runs across machines. Crystal is local-only by design.
 
 ---
 
-## When to use Crystal instead
+## How to migrate from Crystal to Bernstein
 
-- **Your test coverage is low.** If tests cover only 30–40% of the codebase, Bernstein's janitor misses most quality issues. Crystal's review loop adds value where tests don't exist.
-- **Code quality is harder to define than correctness.** API design consistency, documentation completeness, architectural alignment — these require judgment that deterministic checks don't have.
-- **You're working in a domain where tests are hard to write.** ML model training, infrastructure code, database migrations — areas where test execution is expensive or impractical.
-- **You want the agent to self-correct before verification.** Crystal's iterative loop can catch obvious mistakes before they hit the test suite, reducing wasted CI time.
+If you've been using Crystal and want to keep the worktree-per-task model while gaining headless execution, more agents, and verification, the path is:
 
----
-
-## When to use Bernstein instead
-
-- **Your test suite is the ground truth.** Tests either pass or fail — agent consensus about correctness is irrelevant.
-- **You want parallel task execution.** Bernstein runs multiple independent tasks concurrently. Crystal's review cycles are sequential per task.
-- **You want faster verification.** Running `pytest` takes seconds. Three LLM review cycles takes minutes.
-- **You want deterministic quality gates.** A test suite gives the same result every time. LLM reviewers don't.
-- **You want cost transparency.** Bernstein logs per-task API costs. Crystal's review loop costs are harder to predict.
-- **You want model-agnostic CLI agent support.** Bernstein wraps Claude Code, Codex, Gemini CLI, and Qwen as installed tools. Crystal typically requires SDK-based integration.
+1. **Keep your projects where they are.** Bernstein operates on a normal git repo. No data migration. Nothing in `~/.crystal/` needs to move; you can run both in parallel during the transition.
+2. **Install Bernstein.** `pip install bernstein` (or `uv tool install bernstein`). State lives in `.sdd/` inside each repo.
+3. **Translate "sessions" into "tasks."** What Crystal called a session — one goal, one worktree — Bernstein calls a task. Run `bernstein run -g "your goal"` or `bernstein run plans/your-plan.yaml`.
+4. **Pick agents per step.** Where Crystal had a per-session model picker, Bernstein has a per-step `cli:` field. Pin Claude to architectural steps, Codex to refactors, Gemini to docs — whatever maps to your team's habits.
+5. **Add a janitor config.** A two-line `pytest` + `ruff check` block in your plan turns "the agent says it's done" into "the test suite says it's done."
+6. **Set a budget.** `bernstein config set cost.budget_usd 5` caps a single run. The orchestrator stops when it hits the cap.
+7. **Run it in CI.** Add a workflow step that runs `bernstein run plans/nightly-cleanup.yaml`. Crystal could not do this; Bernstein is built for it.
+8. **Drop the GUI if you don't miss it.** If you do miss it, `bernstein dashboard` and `bernstein live` (TUI) cover most of what Crystal's UI offered for monitoring runs in progress.
 
 ---
 
-## Combining both approaches
+## The honest summary
 
-Some teams use both: Bernstein for the primary coding loop (test-verified) and a Crystal-style LLM review as an additional gate before merge. This is the highest-confidence configuration: objective test verification plus qualitative LLM review.
+Crystal solved a specific problem well: give one developer a friendly desktop UI for running a couple of Claude Code and Codex sessions in parallel worktrees, with diff view and merge buttons. For that exact shape, it's a fine tool, and its UI is genuinely nicer than running raw `claude` and `codex` in side-by-side terminals.
 
-The Bernstein roadmap includes optional review agents as a post-janitor step — not replacing the test-based verification, but supplementing it for codebases where qualitative review matters.
+Bernstein solves a different problem: orchestrate many CLI agents across many tasks, verify their output with deterministic checks, track costs, run headless in CI, and do it across more than one provider and more than one machine. The scopes overlap on "git worktree per task" and diverge from there.
+
+Crystal is deprecated. Nimbalyst is its successor and inherits Crystal's desktop-first model. If your future is "single user, desktop, polished editor experience," Nimbalyst is where to look. If your future is "headless multi-agent automation with verification and budgets," Bernstein.
 
 ---
 
 ## See also
 
-- [Bernstein benchmark: multi-agent vs single-agent](../../benchmarks/README.md)
-- [Full comparison matrix](./README.md)
-- [Bernstein vs. single agent](./bernstein-vs-single-agent.md)
+- [Bernstein vs. Conductor](./bernstein-vs-conductor.md)
+- [Bernstein vs. Parallel Code](./bernstein-vs-parallel-code.md)
+- [Full comparison index](./README.md)


### PR DESCRIPTION
Three new comparison pages plus an honest refresh of the Crystal page.

## Why

Our top-55 CLI agents research surfaced four orchestrators that compete on the same multi-session / swarm shape but were missing from the comparison docs:

- **Claude Squad** (smtg-ai/claude-squad) — Go TUI tmux-based session manager. Active, AGPL-3.0.
- **claude-flow / Ruflo** (ruvnet/claude-flow) — Claude Code plugin pack with swarm hooks. Active, MIT.
- **AgentsMesh** (AgentsMesh/AgentsMesh) — self-hosted agent workforce platform. Active, BSL-1.1.
- **Crystal** (stravu/crystal) — the existing comparison page described a fictional "self-review-loop" tool with no source link; replaced with content matching the actual repo (Electron desktop app for Claude Code/Codex worktrees, deprecated Feb 2026 in favor of Nimbalyst).

## What changed

- Three new comparison docs at \`docs/compare/bernstein-vs-{claude-squad,claude-flow,agentsmesh}.md\`.
- \`docs/compare/bernstein-vs-crystal.md\` rewritten to match the real product.
- \`docs/compare/README.md\` gains a new **Table C — Multi-session and swarm orchestrators** (Bernstein vs Claude Squad / claude-flow / AgentsMesh), refreshes the Crystal row in Table B, and adds a "Multi-session and swarm orchestrators" section to the deep-link list.

## Tone

Factual. Each competitor gets real credit for its niche (Claude Squad for single-dev tmux workflows; claude-flow for Claude-Code-only swarms; AgentsMesh for multi-tenant RBAC/SSO/audit) before the gaps are listed. Bernstein's wedge lives in provider breadth, deterministic scheduling, file-based state, MCP server first-class, quality gates, and plan files — and it's stated as specifics, not adjectives.

## Test plan
- [x] Markdown renders cleanly (visual check)
- [x] Internal links to other compare docs resolve
- [ ] Full CI on this branch

## Out of scope
- Adapter implementation for these orchestrators is not in this PR. Two leaf-node delegation adapters (Composio, Ralphex) ship in #966; further additions would land in a follow-up via the ticket.