### PR TITLE
feat(adapters): +6 CLI agent adapters (OpenHands, Open Interpreter, gptme, Plandex, AIChat, Letta Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ---
 
-**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 28 more), runs the tests, and merges the code that actually passes. You come back to working code.
+**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 34 more), runs the tests, and merges the code that actually passes. You come back to working code.
 
 ### Install and run
 
@@ -72,7 +72,7 @@ Other install options: `pipx install bernstein`, `pip install bernstein`, `uv to
 
 Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap local models for boilerplate, heavier cloud models for architecture.
 
-31 CLI agent adapters: 30 third-party wrappers plus a generic wrapper for anything with `--prompt`.
+37 CLI agent adapters: 36 third-party wrappers plus a generic wrapper for anything with `--prompt`.
 
 | Agent | Models | Install |
 |-------|--------|---------|
@@ -94,6 +94,12 @@ Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap l
 | [OpenCode](https://opencode.ai) | Any provider OpenCode supports | See [OpenCode docs](https://opencode.ai) |
 | [Qwen](https://github.com/QwenLM/qwen-code) | Qwen Code models | `npm install -g @qwen-code/qwen-code` |
 | [Cloudflare Agents](https://developers.cloudflare.com/agents/) | Workers AI models | `bernstein cloud login` |
+| [OpenHands](https://github.com/OpenHands/OpenHands) | Any LiteLLM-supported (Anthropic, OpenAI, ...) | `uv tool install openhands --python 3.12` |
+| [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter) | Any (LiteLLM-backed) | `pip install open-interpreter` |
+| [gptme](https://github.com/gptme/gptme) | Anthropic, OpenAI, OpenRouter | `pipx install gptme` |
+| [Plandex](https://github.com/plandex-ai/plandex) | Plandex Cloud or self-hosted models | `curl -sL https://plandex.ai/install.sh \| bash` |
+| [AIChat](https://github.com/sigoden/aichat) | OpenAI, Anthropic, OpenRouter, Groq, Gemini | `cargo install aichat` |
+| [Letta Code](https://github.com/letta-ai/letta-code) | Letta-routed (Anthropic, OpenAI) | `npm install -g @letta-ai/letta-code` |
 | **Generic** | Any CLI with `--prompt` | Built-in |
 
 Any adapter also works as the **internal scheduler LLM**. Run the entire stack without any specific provider:
@@ -209,7 +215,7 @@ Commands that eliminate the glue code most teams end up writing around their run
 | Feature | Bernstein | CrewAI | AutoGen [^autogen] | LangGraph |
 |---------|-----------|--------|---------|-----------|
 | Orchestrator | Deterministic code | LLM-driven (+ code Flows) | LLM-driven | Graph + LLM |
-| Works with | Any CLI agent (31 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (37 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
 | Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Verification | Janitor + quality gates | Guardrails + Pydantic output | Termination conditions | Conditional edges |

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -1,6 +1,6 @@
 # Adapter Selection Guide
 
-Bernstein ships 31 CLI agent adapters in `src/bernstein/adapters/` (30 named
+Bernstein ships 37 CLI agent adapters in `src/bernstein/adapters/` (36 named
 third-party wrappers plus a `generic` catch-all), along with support modules
 (caching, conformance testing, environment isolation, plugin SDK, etc.).
 
@@ -587,6 +587,82 @@ Runs OpenAI Codex inside Cloudflare sandboxes for isolated, scalable execution.
 
 ---
 
+### openhands (OpenHands)
+
+**Install:** `uv tool install openhands --python 3.12` (Python 3.12+ required).
+
+**Env vars:** `LLM_API_KEY`, `LLM_MODEL`, `LLM_BASE_URL` (OpenHands-native), plus `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (LiteLLM provider keys).
+
+**Invocation:** `openhands --headless --override-with-envs -t '<task>'`. The `--override-with-envs` flag is mandatory — without it OpenHands ignores env vars and reads persisted config from `~/.openhands/agent_settings.json`.
+
+**Best for:** Teams who want OpenHands' autonomous multi-step loop (plan + edit + execute) as a single Bernstein agent. Bernstein wraps the whole loop and only sees the final exit code; OpenHands' own sub-agent steps are not visible to Bernstein's accounting.
+
+---
+
+### open_interpreter (Open Interpreter)
+
+**Install:** `pip install open-interpreter`
+
+**Env vars:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` (Open Interpreter uses LiteLLM).
+
+**Invocation:** `interpreter -y --model <model> '<prompt>'`. The `-y` (auto-run) flag is mandatory — without it the subprocess hangs forever on the per-code-block confirmation prompt.
+
+**Best for:** Tasks that benefit from Open Interpreter's local code-execution loop. Bernstein's worktree isolation handles the host-level sandbox concern.
+
+---
+
+### gptme
+
+**Install:** `pipx install gptme`
+
+**Env vars:** `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENROUTER_API_KEY`.
+
+**Invocation:** `gptme -n -m <model> '<prompt>'`. The `-n` (`--non-interactive`) flag implies `--no-confirm` and exits when the prompt is complete.
+
+**Best for:** Lightweight terminal coding sessions. gptme is a general-purpose agent (code + shell + browser tools); Bernstein invokes it for coding tasks and leaves the browser tooling unused.
+
+---
+
+### plandex (Plandex)
+
+**Install:** `curl -sL https://plandex.ai/install.sh | bash`
+
+**Env vars:** `PLANDEX_API_KEY`, `PLANDEX_ENV`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`.
+
+**Invocation:** `plandex tell '<prompt>' --apply --auto-exec --skip-menu --stop`. The full flag combo is required to bypass Plandex's interactive REPL — `--auto-exec` skips per-command approval, `--apply` applies pending changes, `--skip-menu` avoids the post-response menu, `--stop` exits after one response.
+
+**Server requirement:** Plandex uses a client-server architecture. The CLI must reach Plandex Cloud or a self-hosted server (default `http://localhost:8099`). When no server is reachable, `plandex` exits early with a connection error and Bernstein surfaces it via the standard early-exit fast-fail path.
+
+**Best for:** Teams on Plandex's plan-first workflow who want Bernstein to drive the full plan-and-execute loop as one agent.
+
+---
+
+### aichat
+
+**Install:** `cargo install aichat` (or `brew install aichat`).
+
+**Env vars:** `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `GROQ_API_KEY`, `GEMINI_API_KEY`.
+
+**Invocation:** `aichat -m <model> -- '<prompt>'`. Prompt is positional; `--` terminates flags so prompts beginning with `-` are not misparsed.
+
+**Best for:** Lightweight tasks where a thin LLM CLI (no built-in repo navigation) is enough. AIChat does not replace coding-specific agents; use it for cost-sensitive simple tasks or as a fallback provider.
+
+---
+
+### letta_code (Letta Code)
+
+**Install:** `npm install -g @letta-ai/letta-code`
+
+**Env vars:** `LETTA_API_KEY`, `LETTA_BASE_URL`, plus `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` for the underlying model.
+
+**Invocation:** `letta --yolo -p '<prompt>'`. The `-p` flag is the documented one-off prompt mode; `--yolo` bypasses most permission prompts.
+
+**Caveats:** Letta Code's signature feature is cross-task memory via Letta Cloud. **Bernstein wraps Letta as a leaf-node one-shot agent** — Bernstein does not coordinate Letta's memory across tasks. Cross-task memory still works in Letta's own backend; it's just opaque to Bernstein's accounting and routing.
+
+**Best for:** Teams running Letta Cloud who want one-shot Letta sessions inside a larger Bernstein plan.
+
+---
+
 ### mock (Testing only)
 
 Simulates agent behavior for unit and integration tests. Not for production use.
@@ -595,7 +671,7 @@ Simulates agent behavior for unit and integration tests. Not for production use.
 
 ## Support Modules
 
-In addition to the 31 CLI agent adapters above, the adapter package includes
+In addition to the 37 CLI agent adapters above, the adapter package includes
 support modules that provide cross-cutting infrastructure:
 
 | Module | Purpose |

--- a/docs/adapters/compatibility.md
+++ b/docs/adapters/compatibility.md
@@ -10,7 +10,7 @@ Last updated: 2026-04-19
 
 - Python: project targets Python 3.12+.
 - Task server/API: FastAPI-based local or remote server operation.
-- CLI adapters: 31 CLI agent adapters (30 third-party + generic) in `src/bernstein/adapters/`, including the OpenAI Agents SDK v2 adapter (`openai_agents`).
+- CLI adapters: 37 CLI agent adapters (36 third-party + generic) in `src/bernstein/adapters/`, including the OpenAI Agents SDK v2 adapter (`openai_agents`).
 
 ### Supported CLI agent adapters
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -7,7 +7,7 @@ Bernstein orchestrates short-lived CLI coding agents around a central task serve
 ## Prerequisites
 
 - **Python 3.12+** (macOS, Linux, Windows)
-- **At least one CLI coding agent** installed and authenticated. Bernstein supports 31 adapters out of the box:
+- **At least one CLI coding agent** installed and authenticated. Bernstein supports 37 adapters out of the box:
 
 | Agent | Install |
 |-------|---------|
@@ -42,6 +42,12 @@ Bernstein orchestrates short-lived CLI coding agents around a central task serve
 | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) | `curl -LsSf https://mistral.ai/vibe/install.sh \| bash` |
 | [Autohand](https://autohand.ai/code/) | `npm install -g autohand-cli` |
 | [Forge](https://forgecode.dev/docs/) | `curl -fsSL https://forgecode.dev/cli \| sh` |
+| [OpenHands](https://github.com/OpenHands/OpenHands) | `uv tool install openhands --python 3.12` |
+| [Open Interpreter](https://github.com/OpenInterpreter/open-interpreter) | `pip install open-interpreter` |
+| [gptme](https://github.com/gptme/gptme) | `pipx install gptme` |
+| [Plandex](https://github.com/plandex-ai/plandex) | `curl -sL https://plandex.ai/install.sh \| bash` |
+| [AIChat](https://github.com/sigoden/aichat) | `cargo install aichat` |
+| [Letta Code](https://github.com/letta-ai/letta-code) | `npm install -g @letta-ai/letta-code` |
 
 No agent yet? Run `bernstein demo` for a zero-config walkthrough.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
     "featureList": [
       "Multi-agent parallel orchestration",
       "Deterministic Python scheduling — zero LLM tokens on coordination",
-      "31 CLI agent adapters (Claude Code, Codex, Gemini CLI, Cursor, Aider, GitHub Copilot, Droid, Crush, and more)",
+      "37 CLI agent adapters (Claude Code, Codex, Gemini CLI, Cursor, Aider, GitHub Copilot, Droid, Crush, and more)",
       "Git worktree isolation per agent",
       "Janitor verification system (tests, lint, types, PII scan)",
       "Cross-model code review",

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: Bernstein — Open-Source Multi-Agent Orchestration Platform
 description: >-
   Bernstein is the open-source multi-agent orchestrator for AI coding agents.
   Run Claude Code, Codex, Gemini CLI, and the OpenAI Agents SDK in parallel.
-  Deterministic scheduling, 31 adapters, pluggable sandbox backends,
+  Deterministic scheduling, 37 adapters, pluggable sandbox backends,
   cloud artifact storage, progressive skills, zero vendor lock-in.
 tags:
   - orchestration
@@ -73,7 +73,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    31 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Droid, Crush, and more.
+    37 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Droid, Crush, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Bernstein
 
 > Bernstein is an open-source multi-agent orchestration platform for AI coding agents.
-> Deterministic scheduling, 31 CLI adapters, pluggable sandbox backends, cloud artifact
+> Deterministic scheduling, 37 CLI adapters, pluggable sandbox backends, cloud artifact
 > storage sinks, progressive-disclosure skill packs, zero vendor lock-in. Apache 2.0 licensed.
 
 ## Core Documentation

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -15,7 +15,7 @@
     "name": "Bernstein",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Linux, macOS, Windows",
-    "description": "Open-source multi-agent orchestration platform for AI coding agents. Deterministic scheduling, 31 CLI adapters, pluggable sandbox backends, cloud artifact storage, zero vendor lock-in.",
+    "description": "Open-source multi-agent orchestration platform for AI coding agents. Deterministic scheduling, 37 CLI adapters, pluggable sandbox backends, cloud artifact storage, zero vendor lock-in.",
     "url": "https://bernstein.readthedocs.io/",
     "downloadUrl": "https://pypi.org/project/bernstein/",
     "codeRepository": "https://github.com/chernistry/bernstein",

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -77,7 +77,7 @@ Legend:
 
 | Capability | Runtime status | Docs status | Notes |
 |---|---|---|---|
-| Agent catalog/discovery | Shipped | Full | `bernstein agents sync/list/discover/match/showcase` (31 CLI agent adapters) |
+| Agent catalog/discovery | Shipped | Full | `bernstein agents sync/list/discover/match/showcase` (37 CLI agent adapters) |
 | GitHub App and CI fix flows | Shipped | Full | `bernstein ci fix <url>`, `github setup` |
 | Trigger sources (`github`, `slack`, `file_watch`, `webhook`) | Partial | Brief | Source adapters exist; authoring docs need detail |
 | Plugin hooks (pluggy) | Shipped | Full | SDK docs in CONTRIBUTING.md |

--- a/src/bernstein/adapters/aichat.py
+++ b/src/bernstein/adapters/aichat.py
@@ -1,0 +1,119 @@
+"""AIChat CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class AIChatAdapter(CLIAdapter):
+    """Spawn and monitor AIChat (https://github.com/sigoden/aichat) sessions.
+
+    The CLI is invoked as ``aichat -m <model> -- <prompt>`` where ``-m``
+    selects the underlying LLM (e.g. ``openai:gpt-4o``, ``claude:...``)
+    and the prompt is passed as a positional argument; aichat exits after
+    emitting the response.
+
+    AIChat is a thinner LLM CLI than coding-specific agents like Aider or
+    Claude Code: it does not have built-in repo navigation, multi-file
+    editing, or autonomous tool loops. It does support user-defined
+    function/tool calling (``-f``) and has ``-c/--code`` (output code only)
+    and ``-e/--execute`` (translate prompt to a shell command) modes.
+    Bernstein wraps plain chat mode for tasks where a lightweight,
+    one-shot model invocation suffices (e.g. quick rewrites, summaries,
+    classification) and richer agentic behavior is not required.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch an AIChat session.
+
+        Args:
+            prompt: The prompt passed positionally after ``--``.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration; ``model`` is
+                forwarded to aichat via ``-m`` (e.g. ``openai:gpt-4o``).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused; aichat
+                has its own function/tool registry).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by aichat).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused;
+                aichat has no system-prompt flag for one-shot mode).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``aichat`` binary is missing from PATH
+                or cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["aichat", "-m", model_config.model, "--", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            [
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+                "OPENROUTER_API_KEY",
+                "GROQ_API_KEY",
+                "GEMINI_API_KEY",
+            ]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "aichat not found in PATH. Install: cargo install aichat (or `brew install aichat`)"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing aichat: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "AIChat"

--- a/src/bernstein/adapters/gptme.py
+++ b/src/bernstein/adapters/gptme.py
@@ -1,0 +1,118 @@
+"""gptme CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+# Map Bernstein short model names to gptme model identifiers.
+# gptme accepts provider-prefixed names (e.g. "anthropic/claude-sonnet-4-6",
+# "openai/gpt-5.4"). Unknown names pass through unchanged.
+_MODEL_MAP: dict[str, str] = {
+    "opus": "anthropic/claude-opus-4-7",
+    "opus-4-6": "anthropic/claude-opus-4-6",
+    "sonnet": "anthropic/claude-sonnet-4-6",
+    "haiku": "anthropic/claude-haiku-4-5-20251001",
+    "gpt-5.4": "openai/gpt-5.4",
+    "gpt-5.4-mini": "openai/gpt-5.4-mini",
+}
+
+
+class GptmeAdapter(CLIAdapter):
+    """Spawn and monitor gptme CLI sessions.
+
+    The CLI is invoked as ``gptme -n -m <model> <prompt>`` where ``-n`` runs
+    non-interactively (implies ``--no-confirm`` and exits when the prompt is
+    complete) and ``-m`` selects the model.
+
+    gptme is a general-purpose terminal agent with code, shell, and browser
+    tools. Bernstein invokes it for coding tasks; the browser tooling is left
+    available but unused by the orchestrator's coding workflow.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a gptme CLI session.
+
+        Args:
+            prompt: The initial prompt passed as a positional argument.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration; ``model`` is mapped
+                to a provider-prefixed gptme model id.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by gptme).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``gptme`` binary is missing from PATH or
+                cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        model_id = _MODEL_MAP.get(model_config.model, model_config.model)
+
+        cmd = ["gptme", "-n", "-m", model_id, prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_id,
+        )
+
+        env = build_filtered_env(["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "gptme not found in PATH. Install: pipx install gptme"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing gptme: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "gptme"

--- a/src/bernstein/adapters/letta_code.py
+++ b/src/bernstein/adapters/letta_code.py
@@ -1,0 +1,124 @@
+"""Letta Code CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class LettaCodeAdapter(CLIAdapter):
+    """Spawn and monitor Letta Code CLI sessions.
+
+    The CLI is invoked as ``letta --yolo -p <prompt>`` where ``-p`` runs
+    a one-off prompt in headless mode (per
+    ``docs.letta.com/letta-code/quickstart`` and ``cli-reference``) and
+    ``--yolo`` bypasses most permission prompts so the agent does not
+    block waiting on TTY input. The binary ships as ``letta`` from the
+    npm package ``@letta-ai/letta-code``; if the documented headless
+    flag changes upstream, ``-p`` is the only contract Letta currently
+    publishes for non-interactive runs.
+
+    Letta Code's defining feature is *cross-task memory* persisted via
+    Letta Cloud (``LETTA_API_KEY``) -- the agent maintains long-lived
+    state across separate invocations. Bernstein wraps Letta Code as a
+    leaf-node, one-shot agent: each task spawns a fresh ``letta -p``
+    process and exits when the prompt completes. Bernstein does not
+    coordinate Letta's cross-task memory, agent IDs, or memory blocks;
+    that machinery still operates in Letta's own backend, but it is
+    opaque to Bernstein's orchestrator. If you want Bernstein-level
+    state to survive across tasks, use Bernstein's ``.sdd/`` files,
+    not Letta's memory.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Letta Code CLI session.
+
+        Args:
+            prompt: The headless prompt supplied via ``-p``.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (retained for
+                interface compatibility; Letta Code resolves the model
+                via ``/connect`` config or ``--model``, not via the
+                Bernstein scope mapping).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by Letta Code).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``letta`` binary is missing from PATH
+                or cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["letta", "--yolo", "-p", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            [
+                "LETTA_API_KEY",
+                "LETTA_BASE_URL",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+            ]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "letta not found in PATH. Install: npm install -g @letta-ai/letta-code"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing letta: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Letta Code"

--- a/src/bernstein/adapters/open_interpreter.py
+++ b/src/bernstein/adapters/open_interpreter.py
@@ -1,0 +1,112 @@
+"""Open Interpreter CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class OpenInterpreterAdapter(CLIAdapter):
+    """Spawn and monitor Open Interpreter CLI sessions.
+
+    The CLI is invoked as ``interpreter -y --model <model> "<prompt>"``.
+    Open Interpreter takes the prompt as a positional argument (joined from
+    ``sys.argv[1:]`` when the first token does not start with ``-``).
+
+    The ``-y`` flag (long form ``--auto_run``) is mandatory for headless
+    operation: without it, the interpreter pauses and asks the user to
+    confirm every code execution, so the spawned subprocess hangs forever
+    waiting on stdin. With ``-y`` the agent auto-approves its own code
+    execution and runs to completion.
+
+    Open Interpreter executes shell commands and arbitrary code on the
+    host machine, which is the whole point of the tool. Bernstein already
+    runs each spawned agent inside its own git worktree, so filesystem
+    isolation is handled at the orchestrator layer; the adapter does not
+    add a sandbox of its own.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch an Open Interpreter CLI session.
+
+        Args:
+            prompt: The initial prompt supplied as a positional argument.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration. ``model`` is
+                forwarded via ``--model`` so LiteLLM (which Open Interpreter
+                uses internally) can resolve the provider.
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``interpreter`` binary is missing from
+                PATH or cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["interpreter", "-y", "--model", model_config.model, prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(["OPENAI_API_KEY", "ANTHROPIC_API_KEY"])
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "interpreter not found in PATH. Install: pip install open-interpreter"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing interpreter: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Open Interpreter"

--- a/src/bernstein/adapters/openhands.py
+++ b/src/bernstein/adapters/openhands.py
@@ -1,0 +1,115 @@
+"""OpenHands CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class OpenHandsAdapter(CLIAdapter):
+    """Spawn and monitor OpenHands CLI sessions.
+
+    The CLI is invoked as ``openhands --headless --override-with-envs -t
+    '<task>'`` where ``--headless`` runs without the interactive TUI,
+    ``--override-with-envs`` opts the CLI into honouring ``LLM_API_KEY`` /
+    ``LLM_MODEL`` / ``LLM_BASE_URL`` environment variables (otherwise it
+    reads ``~/.openhands/agent_settings.json``), and ``-t`` supplies the
+    task text. OpenHands is itself a multi-step autonomous agent that
+    plans, edits, and runs commands inside the working directory; Bernstein
+    wraps it as a single short-lived agent and only observes the final exit
+    code via the standard worker watchdog. Persisted settings still live
+    under ``~/.openhands/`` regardless of the env override.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch an OpenHands CLI session in headless mode.
+
+        Args:
+            prompt: The task text supplied via ``-t``.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (retained for
+                interface compatibility; OpenHands resolves the model from
+                ``LLM_MODEL`` or its persisted ``agent_settings.json``).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by OpenHands).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``openhands`` binary is missing from PATH
+                or cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = ["openhands", "--headless", "--override-with-envs", "-t", prompt]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            [
+                "LLM_API_KEY",
+                "LLM_MODEL",
+                "LLM_BASE_URL",
+                "ANTHROPIC_API_KEY",
+                "OPENAI_API_KEY",
+            ],
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "openhands not found in PATH. Install: uv tool install openhands --python 3.12"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing openhands: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "OpenHands"

--- a/src/bernstein/adapters/plandex.py
+++ b/src/bernstein/adapters/plandex.py
@@ -1,0 +1,142 @@
+"""Plandex CLI adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+
+class PlandexAdapter(CLIAdapter):
+    """Spawn and monitor Plandex CLI sessions.
+
+    The CLI is invoked as
+    ``plandex tell <prompt> --apply --auto-exec --skip-menu --stop`` where:
+
+    * ``tell`` is the non-interactive entry point (the default ``plandex``
+      invocation drops into a REPL).
+    * ``--apply``/``-a`` auto-applies pending changes to the working tree
+      and confirms context updates.
+    * ``--auto-exec`` auto-executes any shell commands the plan requests,
+      bypassing the per-command approval prompt.
+    * ``--skip-menu`` skips the interactive "what next?" menu Plandex shows
+      after each response.
+    * ``--stop``/``-s`` halts after a single response so the subprocess
+      exits instead of waiting for follow-up turns.
+
+    Without these flags Plandex will block forever on its interactive
+    approval gates and the spawned process will never complete.
+
+    Plandex is plan-first: it builds an internal plan, then executes it
+    incrementally with build/apply phases.  Bernstein wraps the entire
+    plan-and-execute loop as a single short-lived agent.
+
+    Note: Plandex uses a client-server architecture.  The CLI connects to
+    Plandex Cloud or a self-hosted server (default ``http://localhost:8099``,
+    started via ``./start_local.sh``).  When no server is reachable the
+    spawned ``plandex`` process exits with a connection error; that surface
+    is handled by the standard early-exit path rather than via a pre-flight
+    probe in this adapter.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a Plandex CLI session.
+
+        Args:
+            prompt: The task prompt passed as a positional argument to
+                ``plandex tell``.
+            workdir: Working directory for the agent process.
+            model_config: Model and effort configuration (retained for
+                interface compatibility; Plandex selects models via its
+                own ``set-model`` configuration and provider env vars).
+            session_id: Unique session identifier.
+            mcp_config: Optional MCP server definitions (unused).
+            timeout_seconds: Process timeout in seconds.
+            task_scope: Task scope hint (unused by Plandex).
+            budget_multiplier: Multiplier on scope budget (unused).
+            system_addendum: Protocol-critical system instructions (unused;
+                Plandex does not expose a system-prompt channel).
+
+        Returns:
+            SpawnResult with the spawned PID and log path.
+
+        Raises:
+            RuntimeError: If the ``plandex`` binary is missing from PATH
+                or cannot be executed.
+        """
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "plandex",
+            "tell",
+            prompt,
+            "--apply",
+            "--auto-exec",
+            "--skip-menu",
+            "--stop",
+        ]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        env = build_filtered_env(
+            [
+                "PLANDEX_API_KEY",
+                "PLANDEX_ENV",
+                "OPENAI_API_KEY",
+                "ANTHROPIC_API_KEY",
+                "OPENROUTER_API_KEY",
+            ]
+        )
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = "plandex not found in PATH. Install: curl -sL https://plandex.ai/install.sh | bash"
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing plandex: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the human-readable adapter name."""
+        return "Plandex"

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 from importlib.metadata import entry_points
 
+from bernstein.adapters.aichat import AIChatAdapter
 from bernstein.adapters.aider import AiderAdapter
 from bernstein.adapters.amp import AmpAdapter
 from bernstein.adapters.auggie import AuggieAdapter
@@ -26,23 +27,29 @@ from bernstein.adapters.forge import ForgeAdapter
 from bernstein.adapters.gemini import GeminiAdapter
 from bernstein.adapters.generic import GenericAdapter
 from bernstein.adapters.goose import GooseAdapter
+from bernstein.adapters.gptme import GptmeAdapter
 from bernstein.adapters.hermes import HermesAdapter
 from bernstein.adapters.iac import IaCAdapter
 from bernstein.adapters.kilo import KiloAdapter
 from bernstein.adapters.kimi import KimiAdapter
 from bernstein.adapters.kiro import KiroAdapter
+from bernstein.adapters.letta_code import LettaCodeAdapter
 from bernstein.adapters.mistral import MistralAdapter
 from bernstein.adapters.mock import MockAgentAdapter
 from bernstein.adapters.ollama import OllamaAdapter
+from bernstein.adapters.open_interpreter import OpenInterpreterAdapter
 from bernstein.adapters.openai_agents import OpenAIAgentsAdapter
 from bernstein.adapters.opencode import OpenCodeAdapter
+from bernstein.adapters.openhands import OpenHandsAdapter
 from bernstein.adapters.pi import PiAdapter
+from bernstein.adapters.plandex import PlandexAdapter
 from bernstein.adapters.qwen import QwenAdapter
 from bernstein.adapters.rovo import RovoAdapter
 
 logger = logging.getLogger(__name__)
 
 _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
+    "aichat": AIChatAdapter,
     "aider": AiderAdapter,
     "amp": AmpAdapter,
     "auggie": AuggieAdapter,
@@ -61,17 +68,22 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "forge": ForgeAdapter,
     "gemini": GeminiAdapter,
     "goose": GooseAdapter,
+    "gptme": GptmeAdapter,
     "hermes": HermesAdapter,
     "iac": IaCAdapter,
     "kilo": KiloAdapter,
     "kimi": KimiAdapter,
     "kiro": KiroAdapter,
+    "letta_code": LettaCodeAdapter,
     "mistral": MistralAdapter,
     "mock": MockAgentAdapter,
     "ollama": OllamaAdapter,
+    "open_interpreter": OpenInterpreterAdapter,
     "openai_agents": OpenAIAgentsAdapter,
     "opencode": OpenCodeAdapter,
+    "openhands": OpenHandsAdapter,
     "pi": PiAdapter,
+    "plandex": PlandexAdapter,
     "qwen": QwenAdapter,
     "rovo": RovoAdapter,
 }

--- a/tests/unit/test_adapter_aichat.py
+++ b/tests/unit/test_adapter_aichat.py
@@ -1,0 +1,58 @@
+"""Unit tests for AIChatAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.aichat import AIChatAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = AIChatAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.aichat.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="summarize this",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="openai:gpt-4o", effort="high"),
+            session_id="aichat-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:3] == ["aichat", "-m", "openai:gpt-4o"]
+    assert inner[-2] == "--"
+    assert inner[-1] == "summarize this"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = AIChatAdapter()
+    with (
+        patch(
+            "bernstein.adapters.aichat.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="aichat not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="openai:gpt-4o", effort="high"),
+            session_id="aichat-missing",
+        )
+
+
+def test_name() -> None:
+    assert AIChatAdapter().name() == "AIChat"

--- a/tests/unit/test_adapter_gptme.py
+++ b/tests/unit/test_adapter_gptme.py
@@ -1,0 +1,57 @@
+"""Unit tests for GptmeAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.gptme import GptmeAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = GptmeAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.gptme.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="gptme-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:4] == ["gptme", "-n", "-m", "anthropic/claude-sonnet-4-6"]
+    assert inner[-1] == "fix the bug"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = GptmeAdapter()
+    with (
+        patch(
+            "bernstein.adapters.gptme.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="gptme not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="gptme-missing",
+        )
+
+
+def test_name() -> None:
+    assert GptmeAdapter().name() == "gptme"

--- a/tests/unit/test_adapter_letta_code.py
+++ b/tests/unit/test_adapter_letta_code.py
@@ -1,0 +1,57 @@
+"""Unit tests for LettaCodeAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.letta_code import LettaCodeAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = LettaCodeAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.letta_code.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="letta-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:3] == ["letta", "--yolo", "-p"]
+    assert inner[-1] == "fix the bug"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = LettaCodeAdapter()
+    with (
+        patch(
+            "bernstein.adapters.letta_code.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="letta not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="letta-missing",
+        )
+
+
+def test_name() -> None:
+    assert LettaCodeAdapter().name() == "Letta Code"

--- a/tests/unit/test_adapter_open_interpreter.py
+++ b/tests/unit/test_adapter_open_interpreter.py
@@ -1,0 +1,65 @@
+"""Unit tests for OpenInterpreterAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.open_interpreter import OpenInterpreterAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = OpenInterpreterAdapter()
+    proc_mock = make_popen_mock(801)
+
+    with patch(
+        "bernstein.adapters.open_interpreter.subprocess.Popen",
+        return_value=proc_mock,
+    ) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-4o", effort="high"),
+            session_id="oi-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[0] == "interpreter"
+    # The -y / --auto_run flag is mandatory; without it the process hangs
+    # on every code-execution confirmation. This assertion is the
+    # make-or-break check for this adapter.
+    assert "-y" in inner
+    assert inner[inner.index("--model") + 1] == "gpt-4o"
+    assert inner[-1] == "fix the bug"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = OpenInterpreterAdapter()
+    with (
+        patch(
+            "bernstein.adapters.open_interpreter.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="interpreter not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="gpt-4o", effort="high"),
+            session_id="oi-missing",
+        )
+
+
+def test_name() -> None:
+    assert OpenInterpreterAdapter().name() == "Open Interpreter"

--- a/tests/unit/test_adapter_openhands.py
+++ b/tests/unit/test_adapter_openhands.py
@@ -1,0 +1,57 @@
+"""Unit tests for OpenHandsAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.openhands import OpenHandsAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = OpenHandsAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.openhands.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="fix the bug",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="openhands-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:4] == ["openhands", "--headless", "--override-with-envs", "-t"]
+    assert inner[-1] == "fix the bug"
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = OpenHandsAdapter()
+    with (
+        patch(
+            "bernstein.adapters.openhands.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="openhands not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="openhands-missing",
+        )
+
+
+def test_name() -> None:
+    assert OpenHandsAdapter().name() == "OpenHands"

--- a/tests/unit/test_adapter_plandex.py
+++ b/tests/unit/test_adapter_plandex.py
@@ -1,0 +1,60 @@
+"""Unit tests for PlandexAdapter."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.plandex import PlandexAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+def test_spawn_builds_run_command(tmp_path: Path) -> None:
+    adapter = PlandexAdapter()
+    proc_mock = make_popen_mock(900)
+
+    with patch("bernstein.adapters.plandex.subprocess.Popen", return_value=proc_mock) as popen:
+        adapter.spawn(
+            prompt="refactor module",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="plandex-s1",
+        )
+
+    cmd = popen.call_args.args[0]
+    inner = inner_cmd(cmd)
+    assert inner[:3] == ["plandex", "tell", "refactor module"]
+    assert "--apply" in inner
+    assert "--auto-exec" in inner
+    assert "--skip-menu" in inner
+    assert "--stop" in inner
+
+
+def test_spawn_translates_missing_cli(tmp_path: Path) -> None:
+    adapter = PlandexAdapter()
+    with (
+        patch(
+            "bernstein.adapters.plandex.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="plandex not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="sonnet", effort="high"),
+            session_id="plandex-missing",
+        )
+
+
+def test_name() -> None:
+    assert PlandexAdapter().name() == "Plandex"


### PR DESCRIPTION
Six new CLI agent adapters from the top-55 research file. Bumps the cooperating-CLI-agent count from 31 to 37.

## What's new

| Adapter | Tool | Invocation | Notes |
|---------|------|------------|-------|
| \`openhands\` | OpenHands | \`openhands --headless --override-with-envs -t '<task>'\` | \`--override-with-envs\` mandatory or env vars are ignored |
| \`open_interpreter\` | Open Interpreter | \`interpreter -y --model <m> '<prompt>'\` | \`-y\` mandatory or hangs on per-block confirmation |
| \`gptme\` | gptme | \`gptme -n -m <model> '<prompt>'\` | \`-n\` implies \`--no-confirm\` and exits when done |
| \`plandex\` | Plandex | \`plandex tell '<prompt>' --apply --auto-exec --skip-menu --stop\` | Requires reachable Plandex server (Cloud or self-hosted) |
| \`aichat\` | AIChat | \`aichat -m <model> -- '<prompt>'\` | Positional prompt; \`--\` terminates flag parsing |
| \`letta_code\` | Letta Code | \`letta --yolo -p '<prompt>'\` | Leaf-node delegation; cross-task memory opaque to Bernstein |

Each adapter is ~80–150 LOC mirroring \`copilot.py\`, with three tests apiece (spawn shape, missing CLI, name) using the shared \`_adapter_test_helpers.py\`.

## Backlog tickets closed

- agent-001 (OpenHands) ✓
- agent-002 (Open Interpreter) ✓
- agent-003 (gptme) ✓
- agent-004 (Plandex) ✓
- agent-005 (AIChat) ✓
- agent-007 (Letta Code) ✓

## Backlog tickets dismissed

- **agent-006 / groq-code-cli** — TUI-only, no headless mode (~43 upstream commits, "blueprint not a product"). Will revisit if upstream ships a headless flag.
- **agent-008 / gpt-engineer** — archived upstream 2026-04-22; project README points users at gptengineer.app or Aider (which we already wrap).

## Doc updates

- \`README.md\` adapter table + count
- \`docs/getting-started/GETTING_STARTED.md\` install table + count
- \`docs/adapters/ADAPTER_GUIDE.md\` dedicated subsections per adapter
- Various count claims (\`docs/index.md\`, \`docs/llms.txt\`, etc.) bumped 31 → 37
- Compare-doc count bumps intentionally left to PR #967 (the comparisons branch); they'll rebase cleanly when one lands first

## Test plan
- [x] \`uv run pytest tests/unit/test_adapter_{aichat,gptme,letta_code,open_interpreter,openhands,plandex,registry,copilot}.py -q\` (30 passed)
- [x] \`ruff check\` + \`ruff format --check\` clean
- [x] Registry passes manual smoke (\`get_adapter("openhands")\` → \`OpenHandsAdapter\`); 37 adapters total
- [ ] Full CI on this branch

## Out of scope

- Tier detection / rate-limit probing for the new adapters (we follow the minor-adapter pattern of returning the base-class defaults).
- MCP config support — none of these tools speak MCP yet to my knowledge; \`mcp_config\` is accepted and ignored, same as most minor adapters.
- Landing-page count updates (\`bernstein.run\`) — separate, follow-up after this lands and a release ships.