### PR TITLE
fix(release): silence npm-publish failures so deployment status stays clean

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -199,6 +199,14 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
+      # The npm publish is intentionally fire-and-forget. After the
+      # repo transfer to sipyourdrink-ltd, NPM_TOKEN does not have
+      # permission to publish bernstein-orchestrator (the package is
+      # owned by alexchernysh on npm). Until a fresh token with
+      # publish rights is provisioned and stored as NPM_TOKEN, we
+      # absorb the failure here so it does not poison the release
+      # job's deployment status. PyPI / GitHub Release / GHCR are
+      # unaffected — they ran in earlier steps.
       - name: Publish npm wrapper
         continue-on-error: true
         env:
@@ -206,7 +214,9 @@ jobs:
         run: |
           cd packaging/npm
           npm version "${{ steps.final.outputs.version }}" --no-git-tag-version
-          npm publish --access public
+          if ! npm publish --access public; then
+            echo "::warning::npm publish failed for v${{ steps.final.outputs.version }} — continuing release. Likely cause: NPM_TOKEN needs to be re-issued with publish rights for bernstein-orchestrator. PyPI/GHCR/GitHub Release already succeeded in earlier steps."
+          fi
 
       # --- Docker / OCI ---
       - name: Log in to GitHub Container Registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,14 +199,25 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
           cd packaging/npm
           npm version "$VERSION" --no-git-tag-version --allow-same-version
+      # Absorb npm-publish failures so they don't fail the tag-triggered
+      # publish workflow (matching the behaviour in auto-release.yml).
+      # NPM_TOKEN currently lacks publish rights for bernstein-orchestrator
+      # after the sipyourdrink-ltd repo transfer; until a fresh token is
+      # provisioned, the npm wrapper stays at its last successful version
+      # while PyPI / GHCR / GitHub Release continue shipping.
       - name: Publish to npm
-        run: cd packaging/npm && npm publish --access public
+        continue-on-error: true
         env:
           # packaging/npm/.npmrc uses ${NPM_TOKEN} for interpolation, so
           # both variables must be set. NODE_AUTH_TOKEN is kept for
           # compatibility with actions/setup-node's default config.
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packaging/npm
+          if ! npm publish --access public; then
+            echo "::warning::npm publish failed — continuing release. Likely cause: NPM_TOKEN needs to be re-issued with publish rights for bernstein-orchestrator."
+          fi
 
   # COPR RPM rebuild — triggers a new build from the updated PyPI release.
   trigger-copr:


### PR DESCRIPTION
## Why

After the repo transfer to \`sipyourdrink-ltd\`, \`NPM_TOKEN\` lost publish rights for the \`bernstein-orchestrator\` package (the package is owned by \`alexchernysh\` on npm). Every release since v1.9.0 has marked the GitHub Deployment status as **failure** even though:

- PyPI shipped 1.9.0 and 1.9.1 ✓
- GHCR (\`ghcr.io/sipyourdrink-ltd/bernstein\`) tagged \`latest\` + \`1.9.0\` + \`1.9.1\` ✓
- GitHub Releases created v1.9.0 and v1.9.1 ✓
- npm wrapper stuck at 1.8.15 ✗

The npm step already had \`continue-on-error: true\`, but the bash \`npm publish\` exits non-zero, which emits \`##[error]Process completed with exit code 1.\` — and the deployment-status updater picks that up and marks the deployment red.

The deployments page at https://github.com/sipyourdrink-ltd/bernstein/deployments/pypi shows red Xs as a result, even though PyPI is fine.

## Fix

Wrap the \`npm publish\` call so it emits a \`::warning::\` and returns 0 on failure. The deployment status now reflects only the parts of the release that actually shipped. The warning makes the npm gap visible without making it look like a release-wide failure.

Applied to both:
- \`.github/workflows/auto-release.yml\` (the patch-bump path that fires on CI completion).
- \`.github/workflows/publish.yml\` (the tag-triggered manual-release path).

## Out of scope

Actually fixing the NPM_TOKEN — that requires a fresh npm token with publish rights for \`bernstein-orchestrator\`, stored in the GitHub repo as the \`NPM_TOKEN\` secret. Once provisioned this guard becomes redundant but harmless. The warning message tells whoever sees it what to do.

## Test plan
- [x] Workflow YAML lints cleanly
- [ ] Full CI (workflow-only changes; only the workflow-lint job is meaningful)
- [ ] Verify next release after merge marks the PyPI deployment as success