### PR TITLE
fix(tests): unbreak main-CI flakes blocking auto-release

### DIFF
--- a/tests/golden/cli_snapshots/task_response.json
+++ b/tests/golden/cli_snapshots/task_response.json
@@ -4,6 +4,7 @@
   "batch_eligible": false,
   "cell_id": null,
   "claimed_at": null,
+  "cli": null,
   "completion_signals": [],
   "complexity": "medium",
   "created_at": 1700000000.0,

--- a/tests/unit/test_idle_agent_recycling.py
+++ b/tests/unit/test_idle_agent_recycling.py
@@ -283,8 +283,13 @@ def test_heartbeat_idle_threshold_lower_in_evolve_mode(tmp_path: Path) -> None:
     session = _make_session(["T-evolve-1"])
     orch._agents["s-ev-01"] = session
 
-    # Heartbeat is 65s stale — above evolve threshold (60s) but below normal (90s)
-    stale_ts = time.time() - (_IDLE_HEARTBEAT_THRESHOLD_EVOLVE_S + 5)
+    # Heartbeat must exceed the evolve threshold *plus* the liveness-extension
+    # window. Same reason as test_shutdown_sent_on_heartbeat_idle (b5da11a6):
+    # PID 12345 is system-occupied on Ubuntu CI runners, so _is_process_alive
+    # returns True and the agent stays inside the 600s liveness extension —
+    # the recycle path only fires when the heartbeat is stale enough to
+    # exceed *both* gates.
+    stale_ts = time.time() - (_IDLE_HEARTBEAT_THRESHOLD_EVOLVE_S + _IDLE_LIVENESS_EXTENSION_S + 5)
     orch._signal_mgr.read_heartbeat.return_value = AgentHeartbeat(timestamp=stale_ts)
 
     tasks_snapshot = {

--- a/tests/unit/test_quality_metrics.py
+++ b/tests/unit/test_quality_metrics.py
@@ -509,11 +509,18 @@ def test_quality_endpoint_with_iso8601_timestamps(tmp_path: Path) -> None:
     metrics_dir = tmp_path / ".sdd" / "metrics"
     metrics_dir.mkdir(parents=True)
 
-    # Write gate records with ISO 8601 string timestamps (as found in production)
+    # Write gate records with ISO 8601 string timestamps (as found in production).
+    # Use recent timestamps so the /quality endpoint's 30-day window doesn't
+    # filter them out depending on when the test happens to run.
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    iso_now = now.isoformat()
+    iso_recent = now.replace(microsecond=now.microsecond - 1 if now.microsecond else 0).isoformat()
     gates_file = metrics_dir / "quality_gates.jsonl"
     gate_records = [
-        {"timestamp": "2026-03-29T19:48:43.812896+00:00", "task_id": "t1", "gate": "lint", "result": "pass"},
-        {"timestamp": "2026-03-29T19:50:41.230744+00:00", "task_id": "t2", "gate": "lint", "result": "blocked"},
+        {"timestamp": iso_now, "task_id": "t1", "gate": "lint", "result": "pass"},
+        {"timestamp": iso_recent, "task_id": "t2", "gate": "lint", "result": "blocked"},
     ]
     gates_file.write_text("\n".join(json.dumps(r) for r in gate_records))
 

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Three pre-existing tests have been failing main CI today, blocking auto-release. All three fixes are mechanical and isolated to test files; no production code touched.

## What's broken

- **\`test_quality_endpoint_with_iso8601_timestamps\`** — hardcoded \`2026-03-29\` timestamps in the test data are now 31 days old, just past the 30-day window the \`/quality\` endpoint applies. Records get filtered out → empty \`gate_stats\` → \`KeyError 'lint'\`.
- **\`test_heartbeat_idle_threshold_lower_in_evolve_mode\`** — same root cause as \`test_shutdown_sent_on_heartbeat_idle\` already fixed in b5da11a6: PID 12345 is system-occupied on Ubuntu CI runners, \`_is_process_alive\` returns True, agent stays inside the 600s liveness-extension window, and a 65s-stale heartbeat isn't enough to trigger the recycle path.
- **\`test_task_response_shape\`** — golden snapshot \`tests/golden/cli_snapshots/task_response.json\` went stale after #968 added the \`cli\` field to the \`Task\` model. Snapshot now includes \`"cli": null\` between \`claimed_at\` and \`completion_signals\` (alphabetical position).

## Fixes

1. iso8601 test: switched the test data to \`datetime.now(UTC).isoformat()\` so the records always sit inside the 30-day window regardless of when the test runs.
2. Evolve-mode heartbeat test: now uses \`_IDLE_HEARTBEAT_THRESHOLD_EVOLVE_S + _IDLE_LIVENESS_EXTENSION_S + 5\` for the stale heartbeat — matches the sibling test's pattern from b5da11a6.
3. Snapshot: added \`"cli": null\` to mirror the new \`Task.cli\` field shipped in #968.

## Test plan
- [x] \`uv run pytest tests/unit/test_quality_metrics.py tests/unit/test_idle_agent_recycling.py tests/unit/test_cli_snapshots.py -q\` (all pass)
- [x] \`ruff check\` clean
- [ ] Full CI on this branch