### PR TITLE
docs: align retrieval/embeddings claims with reality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ All notable project changes are tracked here (code + docs).
   - R2 Workspace Sync (`bridges/r2_sync.py`) — content-addressed delta file sync via Cloudflare R2
   - Workers AI Provider (`core/routing/cloudflare_ai.py`) — free-tier LLM models (Llama 3.1, Mistral, Gemma, Qwen) for planning
   - D1 Analytics Client (`core/cost/d1_analytics.py`) — usage metering, billing tiers (free/pro/team/enterprise), quota enforcement
-  - Vectorize Semantic Cache (`core/memory/vectorize_cache.py`) — embedding-based LLM response caching
   - MCP Remote Transport (`mcp/remote_transport.py`) — streamable HTTP transport for remote MCP server access
   - Cloud CLI (`cli/commands/cloud_cmd.py`) — `bernstein cloud` subcommands: login, logout, run, status, runs, cost, deploy
   - Cloudflare Agents Adapter (`adapters/cloudflare_agents.py`) — spawn agents via `npx wrangler dev`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ You are working on Bernstein, a multi-agent orchestration system for CLI coding 
   - `knowledge/` — knowledge graph, codebase impact analysis
   - `plugins_core/` — pluggy-based plugin system
   - `routes/` — HTTP route handlers
-  - `memory/` — persistent memory stores (SQLite + vector cache)
+  - `memory/` — persistent memory stores (SQLite-backed, no vector index)
   - `trigger_sources/` — external trigger integrations
   - `grpc_gen/` — generated gRPC stubs
   - Back-compat: `from bernstein.core.<old> import X` works via a `sys.meta_path` finder in `core/__init__.py` (`_CoreRedirectFinder`, `_REDIRECT_MAP`). The finder covers legacy names like `orchestrator.py`, `spawner.py`, `task_lifecycle.py`, etc. Top-level `.py` files outside sub-packages: `defaults.py`, `credential_scoping.py`, `streaming_merge.py`. WARNING: new aliases MUST be added to `_REDIRECT_MAP` in `src/bernstein/core/__init__.py`; creating physical shim files will shadow the finder.

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ Bernstein can run agents on Cloudflare Workers instead of locally. The `bernstei
 - **R2 workspace sync**. Local worktree state syncs to R2 object storage so cloud agents see the same files.
 - **Workers AI** (experimental). Use Cloudflare-hosted models as the LLM provider, no external API keys required.
 - **D1 analytics**. Task metrics and cost data stored in D1 for querying.
-- **Vectorize**. Semantic cache backed by Cloudflare's vector database.
 - **Browser rendering**. Headless Chrome on Workers for agents that need to inspect web output.
 - **MCP remote transport**. Expose or consume MCP servers over Cloudflare's network.
 
@@ -220,6 +219,24 @@ Commands that eliminate the glue code most teams end up writing around their run
 | `bernstein connect <provider>` / `bernstein creds` | Stores and rotates API credentials in the OS keychain. Agents inherit scoped keys per-run. |
 | `bernstein autofix` | Daemon that monitors open Bernstein PRs; spawns a fixer agent when CI fails and pushes the repair automatically. |
 | `bernstein preview start` | Starts a sandboxed dev server for the current branch and prints a shareable public tunnel URL. |
+
+### Retrieval & caching: what's actually under the hood
+
+Bernstein deliberately uses **no neural embeddings, no vector databases, and no
+external embedding APIs**. There are two retrieval/caching layers, both
+keyword/lexical:
+
+- **Codebase RAG** (`core/knowledge/rag.py`) — SQLite FTS5 with BM25 ranking
+  and AST-aware chunking for Python files. Built incrementally on file mtime;
+  used to enrich agent task context within token budgets.
+- **Semantic cache** (`core/knowledge/semantic_cache.py`) — despite the name,
+  fuzzy matching is done with TF (term-frequency) cosine similarity over word
+  counts, not learned embeddings. It deduplicates near-identical LLM planning
+  and agent-output requests so we don't re-spawn agents for the same goal.
+
+If you need real semantic retrieval (vector DB, neural embeddings), wire it
+yourself via the retrieval role/skill in `templates/`; nothing in core
+performs vector search.
 
 ## How it compares
 

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.9.2"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The repo has no neural embeddings, no vector database, and no external embedding APIs (verified: zero imports of `sentence-transformers`, OpenAI/Voyage/Cohere embeddings, chromadb/qdrant/pinecone/faiss/pgvector; nothing in `pyproject.toml`). Several docs implied otherwise and were confusing readers.

What's actually under the hood:
- `core/knowledge/rag.py` — SQLite FTS5 + BM25 with AST-aware chunking. Real, active, integrated into bootstrap and task-context enrichment.
- `core/knowledge/semantic_cache.py` — actively used (5 importers), but the "semantic" similarity is TF (term-frequency) cosine over `Counter` word counts, not learned embeddings.
- `core/embedding_scorer.py` — removed earlier, dead code.
- `core/memory/vectorize_cache.py` — never existed, despite being listed in CHANGELOG 1.7.0.

Cloudflare-section audit: 7/8 features in the README Cloudflare list are real, substantive implementations (200-800 LOC each). Only **Vectorize** was vapor — handled here.

## Changes

- `CLAUDE.md:35` — "(SQLite + vector cache)" → "(SQLite-backed, no vector index)" — `core/memory/` only contains `sqlite_store.py`.
- `README.md:161` — removed "Vectorize" bullet from Cloudflare features (no backing implementation).
- `README.md` — added a new **"Retrieval & caching: what's actually under the hood"** section that names the two real layers and explicitly states "no neural embeddings, no vector databases, no external embedding APIs".
- `CHANGELOG.md:16` — removed the `Vectorize Semantic Cache (core/memory/vectorize_cache.py)` line; that file was never shipped in 1.7.0.
- `uv.lock` — synced with `v1.9.4` version bump (separate chore commit).

## Test plan

- [ ] CI passes (this is a docs-only change — no source code touched, only `*.md` and `uv.lock`)
- [ ] `grep -n "vector cache\|vectorize_cache\|Vectorize" CLAUDE.md README.md CHANGELOG.md` returns nothing
- [ ] README renders with the new "Retrieval & caching" section between Capabilities and "How it compares"

https://claude.ai/code/session_01WtpVhNwAeggM5GD3CDrjcZ