### PR TITLE
feat(quality): AST-aware chunking for reviewer reads

### DIFF
--- a/src/bernstein/core/quality/review_pipeline/__init__.py
+++ b/src/bernstein/core/quality/review_pipeline/__init__.py
@@ -17,6 +17,10 @@ Public API:
 
 from __future__ import annotations
 
+from bernstein.core.quality.review_pipeline.ast_chunker import (
+    ReviewChunk,
+    chunk_for_review,
+)
 from bernstein.core.quality.review_pipeline.runner import (
     DiffSource,
     diff_from_pr,
@@ -57,12 +61,14 @@ __all__ = [
     "EffortLevel",
     "FinalVerdict",
     "PipelineVerdict",
+    "ReviewChunk",
     "ReviewPipeline",
     "ReviewPipelineError",
     "StageSpec",
     "StageVerdict",
     "aggregate_pipeline",
     "aggregate_stage",
+    "chunk_for_review",
     "diff_from_pr",
     "diff_from_task",
     "load_pipeline",

--- a/src/bernstein/core/quality/review_pipeline/ast_chunker.py
+++ b/src/bernstein/core/quality/review_pipeline/ast_chunker.py
@@ -1,0 +1,244 @@
+"""AST-aware chunking for the reviewer pipeline.
+
+When the reviewer agent inspects a file larger than its read budget, naive
+line-based windowing slices through function bodies and drops imports.
+This module groups source files into review-sized chunks that respect
+top-level Python AST boundaries: a function or class is never split.
+
+For non-Python files (or Python that fails to parse), we fall back to
+line-based windowing and emit a single warning so operators can see what
+degraded.
+
+Public API:
+
+* :class:`ReviewChunk`
+* :func:`chunk_for_review`
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CHARS_PER_TOKEN: int = 4
+_DEFAULT_LINES_PER_FALLBACK_CHUNK: int = 200
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough char-based token estimate; matches the prompt-cache optimizer."""
+    return max(1, len(text) // _CHARS_PER_TOKEN)
+
+
+@dataclass(frozen=True)
+class ReviewChunk:
+    """A reviewer-ready slice of source.
+
+    Attributes:
+        path: Relative or absolute path of the source file.
+        start_line: 1-indexed first line of the chunk.
+        end_line: 1-indexed last line of the chunk (inclusive).
+        symbols: Top-level symbol names included (functions, classes).
+        text: Source text of the chunk, ending in a newline.
+        header: Human-readable summary of which symbols are inside.
+        language: ``"python"`` for AST-driven chunks, ``"text"`` otherwise.
+    """
+
+    path: str
+    start_line: int
+    end_line: int
+    symbols: tuple[str, ...]
+    text: str
+    header: str
+    language: str = "python"
+
+    def estimated_tokens(self) -> int:
+        """Cheap token estimate for budget accounting."""
+        return _estimate_tokens(self.text)
+
+
+@dataclass
+class _Unit:
+    """An indivisible top-level slice — a function, class, or run of statements."""
+
+    start_line: int
+    end_line: int
+    text: str
+    symbols: list[str] = field(default_factory=list[str])
+
+
+def _node_symbol(node: ast.stmt) -> str | None:
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return node.name
+    return None
+
+
+def _slice_lines(source_lines: list[str], start: int, end: int) -> str:
+    """Return inclusive 1-indexed line range as text with trailing newline."""
+    snippet = "\n".join(source_lines[start - 1 : end])
+    return snippet if snippet.endswith("\n") else snippet + "\n"
+
+
+def _build_units(source: str, tree: ast.Module) -> list[_Unit]:
+    """Collapse the AST into atomic top-level units, preserving file order."""
+    lines = source.split("\n")
+    if not tree.body:
+        whole = source if source.endswith("\n") else source + "\n"
+        return [_Unit(start_line=1, end_line=max(1, len(lines)), text=whole)]
+
+    units: list[_Unit] = []
+    cursor = 1
+    for node in tree.body:
+        node_start = node.lineno
+        node_end = node.end_lineno or node.lineno
+        if node_start > cursor:
+            units.append(
+                _Unit(
+                    start_line=cursor,
+                    end_line=node_start - 1,
+                    text=_slice_lines(lines, cursor, node_start - 1),
+                )
+            )
+        sym = _node_symbol(node)
+        units.append(
+            _Unit(
+                start_line=node_start,
+                end_line=node_end,
+                text=_slice_lines(lines, node_start, node_end),
+                symbols=[sym] if sym else [],
+            )
+        )
+        cursor = node_end + 1
+
+    total = len(lines)
+    if cursor <= total:
+        trailing = _slice_lines(lines, cursor, total)
+        if trailing.strip():
+            units.append(_Unit(start_line=cursor, end_line=total, text=trailing))
+    return units
+
+
+def _format_header(path: str, symbols: list[str], start: int, end: int) -> str:
+    sym_part = ", ".join(symbols) if symbols else "(no top-level symbols)"
+    return f"# {path} L{start}-{end} — symbols: {sym_part}"
+
+
+def _pack_units(units: list[_Unit], path: str, budget_tokens: int) -> list[ReviewChunk]:
+    chunks: list[ReviewChunk] = []
+    cur_text: list[str] = []
+    cur_symbols: list[str] = []
+    cur_start: int | None = None
+    cur_end: int | None = None
+    cur_tokens = 0
+
+    def flush() -> None:
+        nonlocal cur_text, cur_symbols, cur_start, cur_end, cur_tokens
+        if cur_start is None or cur_end is None or not cur_text:
+            return
+        body = "".join(cur_text)
+        header = _format_header(path, cur_symbols, cur_start, cur_end)
+        chunks.append(
+            ReviewChunk(
+                path=path,
+                start_line=cur_start,
+                end_line=cur_end,
+                symbols=tuple(cur_symbols),
+                text=body,
+                header=header,
+            )
+        )
+        cur_text = []
+        cur_symbols = []
+        cur_start = None
+        cur_end = None
+        cur_tokens = 0
+
+    for unit in units:
+        u_tokens = _estimate_tokens(unit.text)
+        # A single unit larger than budget is emitted whole — never split a function.
+        if cur_tokens and cur_tokens + u_tokens > budget_tokens:
+            flush()
+        if cur_start is None:
+            cur_start = unit.start_line
+        cur_end = unit.end_line
+        cur_text.append(unit.text)
+        cur_symbols.extend(unit.symbols)
+        cur_tokens += u_tokens
+
+    flush()
+    return chunks
+
+
+def _line_based_chunks(path: str, source: str, budget_tokens: int) -> list[ReviewChunk]:
+    """Fallback windowing for non-Python or unparseable input."""
+    lines = source.split("\n")
+    total = len(lines)
+    if total == 0:
+        return []
+    target_lines = max(1, min(_DEFAULT_LINES_PER_FALLBACK_CHUNK, budget_tokens * _CHARS_PER_TOKEN // 80))
+    chunks: list[ReviewChunk] = []
+    start = 1
+    while start <= total:
+        end = min(total, start + target_lines - 1)
+        text = _slice_lines(lines, start, end)
+        chunks.append(
+            ReviewChunk(
+                path=path,
+                start_line=start,
+                end_line=end,
+                symbols=(),
+                text=text,
+                header=f"# {path} L{start}-{end} — line-based fallback",
+                language="text",
+            )
+        )
+        start = end + 1
+    return chunks
+
+
+def chunk_for_review(path: str | Path, budget_tokens: int = 4000) -> list[ReviewChunk]:
+    """Split *path* into reviewer-friendly chunks under *budget_tokens* each.
+
+    Python files are split on top-level AST boundaries — functions, classes,
+    and statement runs stay intact. Other languages (or Python that fails
+    to parse) fall back to line-based windowing with a warning.
+
+    Args:
+        path: File to chunk. Relative paths are accepted; the same string
+            is preserved on the returned :class:`ReviewChunk`.
+        budget_tokens: Soft per-chunk token budget. Single AST units larger
+            than the budget are still emitted whole.
+
+    Returns:
+        A list of :class:`ReviewChunk` in source order. Empty when the file
+        is missing, unreadable, or empty.
+    """
+    p = Path(path)
+    path_str = str(path)
+    try:
+        source = p.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("ast_chunker: cannot read %s (%s) — emitting no chunks", path_str, exc)
+        return []
+    if not source:
+        return []
+
+    if p.suffix != ".py":
+        logger.info("ast_chunker: %s is not Python — using line-based fallback", path_str)
+        return _line_based_chunks(path_str, source, budget_tokens)
+
+    try:
+        tree = ast.parse(source, filename=path_str)
+    except SyntaxError as exc:
+        logger.warning(
+            "ast_chunker: %s failed to parse (%s) — falling back to line-based chunking",
+            path_str,
+            exc,
+        )
+        return _line_based_chunks(path_str, source, budget_tokens)
+
+    units = _build_units(source, tree)
+    return _pack_units(units, path_str, budget_tokens)

--- a/tests/unit/quality/review_pipeline/test_ast_chunker.py
+++ b/tests/unit/quality/review_pipeline/test_ast_chunker.py
@@ -1,0 +1,175 @@
+"""Tests for the AST-aware reviewer chunker.
+
+Critical contract: on a 5000-line Python fixture, no emitted chunk may
+split a top-level function or class. Each chunk must AST-parse cleanly.
+"""
+
+from __future__ import annotations
+
+import ast
+import itertools
+import logging
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.quality.review_pipeline import (
+    ReviewChunk,
+    chunk_for_review,
+)
+from bernstein.core.quality.review_pipeline.ast_chunker import (
+    _CHARS_PER_TOKEN,
+)
+
+
+def _synthesize_python_file(path: Path, target_lines: int = 5000) -> int:
+    """Write a deterministic Python module of roughly *target_lines* lines."""
+    lines: list[str] = [
+        '"""Synthetic fixture for AST chunker tests."""',
+        "",
+        "from __future__ import annotations",
+        "",
+        "import math",
+        "import os",
+        "",
+        "MODULE_CONST = 42",
+        "",
+    ]
+    func_idx = 0
+    cls_idx = 0
+    while len(lines) < target_lines:
+        if func_idx % 5 == 4:
+            cls_idx += 1
+            lines.append(f"class Widget{cls_idx}:")
+            lines.append(f'    """Widget number {cls_idx}."""')
+            lines.append("")
+            for m in range(3):
+                lines.append(f"    def method_{m}(self, x: int) -> int:")
+                lines.append(f'        """Method {m} of widget {cls_idx}."""')
+                lines.append("        total = 0")
+                for k in range(8):
+                    lines.append(f"        total += x * {k} + {m}")
+                lines.append("        return total")
+                lines.append("")
+        else:
+            lines.append(f"def helper_{func_idx}(x: int, y: int = 1) -> int:")
+            lines.append(f'    """Helper function {func_idx}."""')
+            lines.append("    acc = x + y")
+            for k in range(6):
+                lines.append(f"    acc += {k} * x - y")
+            lines.append("    return acc")
+            lines.append("")
+        func_idx += 1
+
+    text = "\n".join(lines) + "\n"
+    path.write_text(text, encoding="utf-8")
+    return text.count("\n")
+
+
+@pytest.fixture
+def big_python_file(tmp_path: Path) -> Path:
+    fp = tmp_path / "big_module.py"
+    actual_lines = _synthesize_python_file(fp, target_lines=5000)
+    assert actual_lines >= 5000
+    return fp
+
+
+def _assert_no_split_definitions(chunks: list[ReviewChunk]) -> None:
+    """Each chunk must parse as valid Python (no half-functions inside)."""
+    for ch in chunks:
+        assert ch.language == "python", f"unexpected language for {ch.path}"
+        try:
+            tree = ast.parse(ch.text)
+        except SyntaxError as exc:  # pragma: no cover - failure path
+            pytest.fail(f"chunk L{ch.start_line}-{ch.end_line} failed to parse: {exc}\n{ch.text[:300]}")
+        for node in tree.body:
+            assert node.end_lineno is not None
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                # The node body must be non-empty when the def line is in range.
+                assert node.body, f"empty body for {node.name} in chunk L{ch.start_line}-{ch.end_line}"
+
+
+def test_5000_line_fixture_never_splits_definitions(big_python_file: Path) -> None:
+    chunks = chunk_for_review(big_python_file, budget_tokens=2000)
+    assert len(chunks) > 1, "fixture should produce multiple chunks at this budget"
+    _assert_no_split_definitions(chunks)
+
+
+def test_chunks_cover_full_file_in_order(big_python_file: Path) -> None:
+    chunks = chunk_for_review(big_python_file, budget_tokens=2000)
+    source = big_python_file.read_text(encoding="utf-8")
+    total_lines = source.count("\n")
+
+    assert chunks[0].start_line == 1
+    # Last chunk may stop one line short — we deliberately drop trailing
+    # whitespace-only runs that have no AST node.
+    assert chunks[-1].end_line >= total_lines - 1
+    for prev, nxt in itertools.pairwise(chunks):
+        assert nxt.start_line == prev.end_line + 1
+        assert prev.end_line >= prev.start_line
+
+
+def test_each_chunk_under_budget_when_units_fit(tmp_path: Path) -> None:
+    fp = tmp_path / "small.py"
+    _synthesize_python_file(fp, target_lines=400)
+    budget = 1500
+    chunks = chunk_for_review(fp, budget_tokens=budget)
+    for ch in chunks[:-1]:
+        assert ch.estimated_tokens() <= budget * 1.5
+
+
+def test_oversized_function_emitted_whole(tmp_path: Path) -> None:
+    """A function larger than the budget must still be one intact chunk."""
+    fp = tmp_path / "huge_fn.py"
+    body = "\n".join(f"    x += {i}" for i in range(400))
+    src = f"def huge():\n    x = 0\n{body}\n    return x\n"
+    fp.write_text(src, encoding="utf-8")
+
+    chunks = chunk_for_review(fp, budget_tokens=10)
+    assert len(chunks) == 1
+    parsed = ast.parse(chunks[0].text)
+    assert isinstance(parsed.body[0], ast.FunctionDef)
+    assert parsed.body[0].name == "huge"
+
+
+def test_header_lists_top_level_symbols(tmp_path: Path) -> None:
+    fp = tmp_path / "two.py"
+    fp.write_text("def alpha():\n    return 1\n\ndef beta():\n    return 2\n", encoding="utf-8")
+    chunks = chunk_for_review(fp, budget_tokens=10_000)
+    assert len(chunks) == 1
+    assert "alpha" in chunks[0].header
+    assert "beta" in chunks[0].header
+    assert chunks[0].symbols == ("alpha", "beta")
+
+
+def test_non_python_falls_back_to_line_based(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    fp = tmp_path / "notes.md"
+    fp.write_text("\n".join(f"line {i}" for i in range(600)) + "\n", encoding="utf-8")
+    with caplog.at_level(logging.INFO, logger="bernstein.core.quality.review_pipeline.ast_chunker"):
+        chunks = chunk_for_review(fp, budget_tokens=200)
+    assert chunks, "should still produce some chunks"
+    assert all(c.language == "text" for c in chunks)
+    assert any("line-based fallback" in r.getMessage() for r in caplog.records)
+
+
+def test_unparseable_python_falls_back_with_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    fp = tmp_path / "broken.py"
+    fp.write_text("def oops(:\n    pass\n", encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.quality.review_pipeline.ast_chunker"):
+        chunks = chunk_for_review(fp, budget_tokens=200)
+    assert chunks
+    assert all(c.language == "text" for c in chunks)
+    assert any("falling back to line-based" in r.getMessage() for r in caplog.records)
+
+
+def test_missing_file_returns_empty(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    fp = tmp_path / "does_not_exist.py"
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.quality.review_pipeline.ast_chunker"):
+        chunks = chunk_for_review(fp)
+    assert chunks == []
+    assert any("cannot read" in r.getMessage() for r in caplog.records)
+
+
+def test_chars_per_token_constant_matches_optimizer() -> None:
+    # Sanity: keep this aligned with the prompt-cache optimizer's heuristic.
+    assert _CHARS_PER_TOKEN == 4


### PR DESCRIPTION
## Summary

AST-aware chunking for reviewer reads of large Python files. Reviewer never sees a function or class split mid-body. Falls back to line-based windowing for non-Python with an `INFO` log.

## Changes

- New `src/bernstein/core/quality/review_pipeline/ast_chunker.py` (~140 SLOC, stdlib-only)
- `chunk_for_review(path, budget_tokens) -> list[ReviewChunk]`
- Walks `tree.body` top-level nodes, greedily packs under budget; oversized single units are emitted whole rather than truncated
- Re-exports `ReviewChunk`, `chunk_for_review` from `review_pipeline/__init__.py`

## Test plan

- [x] 9 new tests pass — including the critical correctness test that AST-parses every emitted chunk on a synthesised 5000-line module
- [x] 35 existing review_pipeline unit + 4 integration tests pass — no regression
- [x] Ruff clean
- [ ] CI green

Source: `.sdd/backlog/open/2026-05-05-feat-ast-aware-chunking-for-reviewer.md`