### PR TITLE
feat(tasks): schema validation with retry and error accumulation

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -454,6 +454,23 @@ class ActionCacheDefaults:
 
 
 # ---------------------------------------------------------------------------
+# Schema-validation retry defaults (schema-validation-retry)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SchemaRetryDefaults:
+    """Bounds for the structured-output validation-retry helper.
+
+    Used by :mod:`bernstein.core.tasks.schema_retry` to cap the number
+    of times an agent is asked to fix its own malformed JSON / schema
+    failure before the call site gives up.
+    """
+
+    max_attempts: int = 3  # industry-standard 2-3 attempts; see Self-Refine ICLR 2024
+
+
+# ---------------------------------------------------------------------------
 # Singletons (rebindable via override()/reset())
 # ---------------------------------------------------------------------------
 
@@ -474,6 +491,11 @@ JANITOR = JanitorDefaults()
 CATALOG = CatalogDefaults()
 SECURITY = SecurityDefaults()
 ACTION_CACHE = ActionCacheDefaults()
+SCHEMA_RETRY = SchemaRetryDefaults()
+
+# Module-level constant for direct import — preferred when only the
+# numeric cap is needed (no need to import the whole singleton).
+SCHEMA_RETRY_MAX_ATTEMPTS: int = SCHEMA_RETRY.max_attempts
 
 
 # Mapping of section name (as used in bernstein.yaml ``tuning:`` blocks) to the
@@ -498,6 +520,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "catalog": "CATALOG",
         "security": "SECURITY",
         "action_cache": "ACTION_CACHE",
+        "schema_retry": "SCHEMA_RETRY",
     }
 )
 
@@ -522,6 +545,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "CATALOG": CatalogDefaults,
         "SECURITY": SecurityDefaults,
         "ACTION_CACHE": ActionCacheDefaults,
+        "SCHEMA_RETRY": SchemaRetryDefaults,
     }
 )
 

--- a/src/bernstein/core/orchestration/manager_parsing.py
+++ b/src/bernstein/core/orchestration/manager_parsing.py
@@ -26,6 +26,11 @@ from bernstein.core.orchestration.manager_models import (
     QueueCorrection,
     QueueReviewResult,
 )
+from bernstein.core.tasks.schema_retry import (
+    AskAgain,
+    SchemaRetryContext,
+    validate_with_retry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -100,17 +105,12 @@ def parse_queue_review_response(raw: str) -> QueueReviewResult:
     )
 
 
-def parse_tasks_response(raw: str) -> list[dict[str, Any]]:
-    """Parse the LLM planning response into raw task dicts.
+def _decode_tasks_payload(raw: str) -> list[dict[str, Any]]:
+    """Pure validator: cleans and decodes a JSON-array tasks payload.
 
-    Args:
-        raw: Raw LLM response (should be a JSON array of task objects).
-
-    Returns:
-        List of parsed task dictionaries.
-
-    Raises:
-        ValueError: If the response is not valid JSON or not a list.
+    Used as the ``validate`` argument to :func:`validate_with_retry`
+    and as the implementation of :func:`parse_tasks_response` for the
+    one-shot path.
     """
     cleaned = _extract_json(raw)
     try:
@@ -121,6 +121,47 @@ def parse_tasks_response(raw: str) -> list[dict[str, Any]]:
     if not isinstance(parsed, list):
         raise ValueError(f"Expected a JSON array, got {type(parsed).__name__}")
     return cast("list[dict[str, Any]]", parsed)
+
+
+def parse_tasks_response(
+    raw: str,
+    *,
+    ctx: SchemaRetryContext | None = None,
+    ask_again: AskAgain | None = None,
+    base_prompt: str = "",
+) -> list[dict[str, Any]]:
+    """Parse the LLM planning response into raw task dicts.
+
+    When ``ctx`` and ``ask_again`` are supplied, malformed payloads are
+    retried via :func:`validate_with_retry`; the validation error is
+    fed back into the next attempt's prompt.  Without them, the call
+    behaves as before (one-shot, raises ``ValueError`` on first failure).
+
+    Args:
+        raw: Raw LLM response (should be a JSON array of task objects).
+        ctx: Optional retry context for cross-step error accumulation.
+        ask_again: Optional spawner used to re-prompt the agent on failure.
+        base_prompt: Optional prompt body appended after the error preamble.
+
+    Returns:
+        List of parsed task dictionaries.
+
+    Raises:
+        ValueError: If the response is not valid JSON or not a list and
+            no retry path is configured.
+        SchemaRetryExhausted: If the retry path is configured and all
+            attempts fail.
+    """
+    if ctx is not None and ask_again is not None:
+        return validate_with_retry(
+            initial_response=raw,
+            validate=_decode_tasks_payload,
+            ctx=ctx,
+            ask_again=ask_again,
+            step_id="manager.plan",
+            base_prompt=base_prompt,
+        )
+    return _decode_tasks_payload(raw)
 
 
 def _parse_completion_signal(raw: dict[str, str]) -> CompletionSignal:

--- a/src/bernstein/core/protocols/mcp/mcp_tool_normalization.py
+++ b/src/bernstein/core/protocols/mcp/mcp_tool_normalization.py
@@ -20,10 +20,17 @@ Usage::
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, cast
+
+from bernstein.core.tasks.schema_retry import (
+    AskAgain,
+    SchemaRetryContext,
+    validate_with_retry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -441,3 +448,58 @@ class ToolNormalizer:
             }
             for entry in self._by_original.values()
         ]
+
+
+# ---------------------------------------------------------------------------
+# Tool-result decoding with schema-validation retry
+# ---------------------------------------------------------------------------
+
+
+def _decode_tool_result(raw: str) -> dict[str, Any]:
+    """Decode a JSON-object MCP tool result.
+
+    Raises:
+        ValueError: If the payload is not valid JSON or not an object.
+    """
+    try:
+        parsed: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Tool result is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Expected a JSON object, got {type(parsed).__name__}")
+    return cast("dict[str, Any]", parsed)
+
+
+def decode_tool_result_with_retry(
+    raw: str,
+    *,
+    ctx: SchemaRetryContext,
+    ask_again: AskAgain,
+    base_prompt: str = "",
+) -> dict[str, Any]:
+    """Decode an MCP tool result, retrying with error feedback on failure.
+
+    Thin wrapper around :func:`validate_with_retry` that decodes a
+    JSON-object tool response.  See the schema_retry module for the
+    full semantics.
+
+    Args:
+        raw: Raw text returned by the MCP tool.
+        ctx: Retry context (accumulates errors across calls).
+        ask_again: Callable that re-invokes the tool with a new prompt.
+        base_prompt: Optional prompt body appended after the error preamble.
+
+    Returns:
+        Parsed JSON object.
+
+    Raises:
+        SchemaRetryExhausted: If all attempts fail.
+    """
+    return validate_with_retry(
+        initial_response=raw,
+        validate=_decode_tool_result,
+        ctx=ctx,
+        ask_again=ask_again,
+        step_id="mcp.tool_result",
+        base_prompt=base_prompt,
+    )

--- a/src/bernstein/core/tasks/schema_retry.py
+++ b/src/bernstein/core/tasks/schema_retry.py
@@ -1,0 +1,273 @@
+"""Schema-validation retry with cross-step error accumulation.
+
+A small, dependency-light helper that lets call sites which parse
+structured output from spawned agents (manager planning JSON, MCP tool
+results, planner-output decoder, etc.) retry the agent up to N times,
+feeding the **specific validation error** back into the next prompt.
+Errors accumulate across steps so the agent can see "you keep mis-typing
+field X".
+
+The retry loop itself is the repair mechanism — there is no LLM-based
+schema repair here.  The pattern is documented as Self-Refine
+(ICLR 2024) and is reported to improve structured-output quality by
+15-45%.
+
+Usage::
+
+    from bernstein.core.tasks.schema_retry import (
+        SchemaRetryContext,
+        validate_with_retry,
+    )
+
+    ctx = SchemaRetryContext(step_id="manager.plan")
+
+    def ask_again(prompt: str) -> str:
+        return spawn_one_shot(prompt)
+
+    payload = validate_with_retry(
+        initial_response=raw_text,
+        validate=lambda s: parse_tasks_response(s),
+        ctx=ctx,
+        ask_again=ask_again,
+    )
+
+``validate`` is any callable that either returns a parsed value or
+raises :class:`ValueError` (or any subclass) describing the failure.
+On exhaustion :class:`SchemaRetryExhausted` is raised with the full
+error trail attached.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from bernstein.core.defaults import SCHEMA_RETRY
+
+logger = logging.getLogger(__name__)
+
+
+AskAgain = Callable[[str], str]
+"""Pluggable callable: takes a prompt with accumulated errors, returns raw text."""
+
+type Validator[T] = Callable[[str], T]
+"""Validator callable: parses raw text and raises ``ValueError`` on schema failure."""
+
+
+@dataclass(frozen=True)
+class SchemaRetryAttempt:
+    """One attempt in the retry loop.
+
+    Attributes:
+        step_id: Logical step that produced this attempt (e.g. ``"manager.plan"``).
+        attempt: 1-indexed attempt number within the step.
+        error: Validation error message (empty for successful attempts).
+        raw_response: Raw response that was validated.
+    """
+
+    step_id: str
+    attempt: int
+    error: str
+    raw_response: str
+
+
+@dataclass
+class SchemaRetryContext:
+    """Accumulates validation failures across one or more steps.
+
+    Pass the same context to multiple :func:`validate_with_retry` calls
+    in the same workflow to give the agent visibility into failures it
+    made during *earlier* steps as well as the current one.
+
+    Attributes:
+        step_id: Default step id used when none is supplied to ``record``.
+        attempts: Ordered list of all attempts recorded so far.
+    """
+
+    step_id: str = "default"
+    attempts: list[SchemaRetryAttempt] = field(default_factory=list[SchemaRetryAttempt])
+
+    def record(self, *, error: str, raw_response: str, step_id: str | None = None) -> None:
+        """Record one failed attempt.
+
+        Args:
+            error: Validation error message.
+            raw_response: The raw text that failed validation.
+            step_id: Override the default step id for this attempt.
+        """
+        sid = step_id if step_id is not None else self.step_id
+        next_attempt = sum(1 for a in self.attempts if a.step_id == sid) + 1
+        self.attempts.append(
+            SchemaRetryAttempt(
+                step_id=sid,
+                attempt=next_attempt,
+                error=error,
+                raw_response=raw_response,
+            )
+        )
+
+    def errors_for(self, step_id: str) -> list[SchemaRetryAttempt]:
+        """Return attempts recorded for a specific step."""
+        return [a for a in self.attempts if a.step_id == step_id]
+
+
+class SchemaRetryExhausted(Exception):
+    """Raised when ``max_attempts`` validation attempts have all failed.
+
+    Attributes:
+        ctx: The retry context, with the full attempt trail.
+        last_error: The final validation error message.
+    """
+
+    def __init__(self, ctx: SchemaRetryContext, last_error: str) -> None:
+        self.ctx = ctx
+        self.last_error = last_error
+        super().__init__(f"Schema validation failed after {len(ctx.attempts)} attempt(s); last error: {last_error}")
+
+
+def format_errors_for_prompt(ctx: SchemaRetryContext) -> str:
+    """Render the accumulated errors as a prompt preamble.
+
+    The preamble is empty when no errors have been recorded yet so it
+    can be unconditionally prepended.
+
+    Args:
+        ctx: The retry context.
+
+    Returns:
+        A multi-line string ready to prepend to the next prompt, or an
+        empty string when there are no errors yet.
+    """
+    if not ctx.attempts:
+        return ""
+    lines = ["Your previous response(s) failed validation. Fix these errors:"]
+    for att in ctx.attempts:
+        lines.append(f"  - [{att.step_id} attempt {att.attempt}] {att.error}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def validate_with_retry[T](
+    initial_response: str,
+    validate: Validator[T],
+    ctx: SchemaRetryContext,
+    *,
+    ask_again: AskAgain,
+    max_attempts: int | None = None,
+    step_id: str | None = None,
+    base_prompt: str = "",
+) -> T:
+    """Validate ``initial_response`` and retry on failure with error feedback.
+
+    The first attempt uses ``initial_response`` directly.  On
+    :class:`ValueError`, the error is recorded, and a new prompt
+    (``base_prompt`` plus :func:`format_errors_for_prompt`) is fed to
+    ``ask_again``; its return value is the next attempt.  After
+    ``max_attempts`` failures, :class:`SchemaRetryExhausted` is raised.
+
+    Args:
+        initial_response: Raw text from the first agent call.
+        validate: Callable that parses the response or raises ``ValueError``.
+        ctx: Context that accumulates errors across calls.
+        ask_again: Pluggable spawner — receives a prompt, returns raw text.
+        max_attempts: Override the configured default.
+        step_id: Override ``ctx.step_id`` for attempts recorded by this call.
+        base_prompt: Optional prompt body appended after the error preamble.
+
+    Returns:
+        Whatever ``validate`` returns on success.
+
+    Raises:
+        SchemaRetryExhausted: If all attempts fail validation.
+    """
+    attempts_cap = max_attempts if max_attempts is not None else SCHEMA_RETRY.max_attempts
+    if attempts_cap < 1:
+        raise ValueError(f"max_attempts must be >= 1, got {attempts_cap}")
+
+    sid = step_id if step_id is not None else ctx.step_id
+    response = initial_response
+    last_error = ""
+
+    for attempt_num in range(1, attempts_cap + 1):
+        try:
+            result = validate(response)
+        except ValueError as exc:
+            last_error = str(exc)
+            ctx.record(error=last_error, raw_response=response, step_id=sid)
+            _record_metric("retry" if attempt_num < attempts_cap else "exhausted")
+            if attempt_num >= attempts_cap:
+                logger.warning(
+                    "Schema validation exhausted for step=%s after %d attempts; last error: %s",
+                    sid,
+                    attempt_num,
+                    last_error,
+                )
+                raise SchemaRetryExhausted(ctx, last_error) from exc
+            preamble = format_errors_for_prompt(ctx)
+            next_prompt = preamble + base_prompt if base_prompt else preamble
+            logger.info(
+                "Schema validation failed for step=%s attempt=%d; retrying. Error: %s",
+                sid,
+                attempt_num,
+                last_error,
+            )
+            response = ask_again(next_prompt)
+            continue
+        else:
+            _record_metric("success" if attempt_num == 1 else "recovered")
+            return result
+
+    # Unreachable: the loop either returns or raises.
+    raise SchemaRetryExhausted(ctx, last_error)
+
+
+def _record_metric(outcome: str) -> None:
+    """Increment the schema_retry_attempts_total Prometheus counter.
+
+    The counter is created lazily so the module stays importable even
+    when ``prometheus_client`` is not installed (Windows / minimal
+    installs).  Failures are swallowed — metrics must never break the
+    retry loop.
+    """
+    counter: Any = _get_counter()
+    if counter is None:
+        return
+    try:
+        counter.labels(outcome=outcome).inc()
+    except Exception:  # pragma: no cover
+        # Metrics must never break the retry loop.
+        logger.debug("schema_retry_attempts_total increment failed", exc_info=True)
+
+
+_counter_singleton: Any = None
+_counter_init_failed = False
+
+
+def _get_counter() -> Any:
+    """Lazy-init the Prometheus counter on the shared registry.
+
+    Returns ``None`` if ``prometheus_client`` is unavailable or the
+    metric could not be registered.
+    """
+    global _counter_singleton, _counter_init_failed
+    if _counter_singleton is not None:
+        return _counter_singleton
+    if _counter_init_failed:
+        return None
+    try:
+        from prometheus_client import Counter
+
+        from bernstein.core.observability.prometheus import registry as _shared_registry
+
+        _counter_singleton = Counter(
+            "schema_retry_attempts_total",
+            "Schema-validation retry attempts by terminal outcome.",
+            labelnames=["outcome"],
+            registry=_shared_registry,  # type: ignore[arg-type]  # stub or real registry
+        )
+    except Exception:
+        _counter_init_failed = True
+        return None
+    return _counter_singleton

--- a/tests/unit/test_schema_retry.py
+++ b/tests/unit/test_schema_retry.py
@@ -1,0 +1,216 @@
+"""Unit tests for the schema-validation retry helper."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from bernstein.core.orchestration.manager_parsing import parse_tasks_response
+from bernstein.core.tasks.schema_retry import (
+    SchemaRetryContext,
+    SchemaRetryExhausted,
+    format_errors_for_prompt,
+    validate_with_retry,
+)
+
+
+def _ok_validator(raw: str) -> dict[str, Any]:
+    parsed: Any = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Expected object, got {type(parsed).__name__}")
+    return parsed  # type: ignore[no-any-return]
+
+
+def test_succeeds_on_first_attempt() -> None:
+    ctx = SchemaRetryContext(step_id="t")
+    calls: list[str] = []
+
+    def ask(prompt: str) -> str:
+        calls.append(prompt)
+        return ""
+
+    result = validate_with_retry(
+        initial_response='{"ok": true}',
+        validate=_ok_validator,
+        ctx=ctx,
+        ask_again=ask,
+    )
+
+    assert result == {"ok": True}
+    assert ctx.attempts == []
+    assert calls == []
+
+
+def test_recovers_on_second_attempt_with_error_feedback() -> None:
+    ctx = SchemaRetryContext(step_id="t")
+    seen_prompts: list[str] = []
+
+    def ask(prompt: str) -> str:
+        seen_prompts.append(prompt)
+        return '{"recovered": 1}'
+
+    result = validate_with_retry(
+        initial_response="not json",
+        validate=_ok_validator,
+        ctx=ctx,
+        ask_again=ask,
+    )
+
+    assert result == {"recovered": 1}
+    assert len(ctx.attempts) == 1
+    assert ctx.attempts[0].attempt == 1
+    assert "not json" in ctx.attempts[0].raw_response
+    assert seen_prompts, "ask_again should have been called once"
+    assert "previously" in seen_prompts[0].lower() or "fix" in seen_prompts[0].lower()
+
+
+def test_terminal_failure_raises_with_full_trail() -> None:
+    ctx = SchemaRetryContext(step_id="t")
+
+    def ask(_prompt: str) -> str:
+        return "still not json"
+
+    with pytest.raises(SchemaRetryExhausted) as excinfo:
+        validate_with_retry(
+            initial_response="bad",
+            validate=_ok_validator,
+            ctx=ctx,
+            ask_again=ask,
+            max_attempts=3,
+        )
+
+    assert len(ctx.attempts) == 3
+    assert all(a.error for a in ctx.attempts)
+    assert excinfo.value.last_error
+    assert "3 attempt" in str(excinfo.value)
+
+
+def test_error_accumulation_across_steps() -> None:
+    ctx = SchemaRetryContext(step_id="default")
+
+    def ask_a(_prompt: str) -> str:
+        return '{"a": 1}'
+
+    # Step 1 — fail then recover.
+    validate_with_retry(
+        initial_response="bad-a",
+        validate=_ok_validator,
+        ctx=ctx,
+        ask_again=ask_a,
+        step_id="step.a",
+    )
+
+    # Step 2 — capture the prompt to confirm step.a's error is included.
+    captured: list[str] = []
+
+    def ask_b(prompt: str) -> str:
+        captured.append(prompt)
+        return '{"b": 2}'
+
+    validate_with_retry(
+        initial_response="bad-b",
+        validate=_ok_validator,
+        ctx=ctx,
+        ask_again=ask_b,
+        step_id="step.b",
+    )
+
+    assert any(a.step_id == "step.a" for a in ctx.attempts)
+    assert any(a.step_id == "step.b" for a in ctx.attempts)
+    assert "step.a" in captured[0]
+    assert "step.b" in captured[0]
+
+
+def test_format_errors_empty_when_no_attempts() -> None:
+    ctx = SchemaRetryContext()
+    assert format_errors_for_prompt(ctx) == ""
+
+
+def test_format_errors_includes_step_and_attempt() -> None:
+    ctx = SchemaRetryContext(step_id="foo")
+    ctx.record(error="missing field 'title'", raw_response="{}")
+    rendered = format_errors_for_prompt(ctx)
+
+    assert "foo" in rendered
+    assert "attempt 1" in rendered
+    assert "missing field 'title'" in rendered
+
+
+def test_max_attempts_must_be_positive() -> None:
+    ctx = SchemaRetryContext()
+    with pytest.raises(ValueError, match="max_attempts"):
+        validate_with_retry(
+            initial_response="x",
+            validate=_ok_validator,
+            ctx=ctx,
+            ask_again=lambda _p: "x",
+            max_attempts=0,
+        )
+
+
+def test_manager_parsing_retries_malformed_then_valid() -> None:
+    valid_payload = json.dumps([{"title": "do thing", "role": "backend"}])
+    ctx = SchemaRetryContext(step_id="manager.plan")
+
+    def ask(_prompt: str) -> str:
+        return valid_payload
+
+    result = parse_tasks_response("```json\nnot really json\n```", ctx=ctx, ask_again=ask)
+
+    assert result == [{"title": "do thing", "role": "backend"}]
+    assert len(ctx.attempts) == 1
+    assert ctx.attempts[0].step_id == "manager.plan"
+
+
+def test_manager_parsing_one_shot_path_unchanged() -> None:
+    valid_payload = json.dumps([{"title": "do thing"}])
+    assert parse_tasks_response(valid_payload) == [{"title": "do thing"}]
+
+    with pytest.raises(ValueError, match="not valid JSON"):
+        parse_tasks_response("definitely not json")
+
+
+def test_record_metric_does_not_break_when_prometheus_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.tasks import schema_retry as sr
+
+    monkeypatch.setattr(sr, "_counter_singleton", None)
+    monkeypatch.setattr(sr, "_counter_init_failed", True)
+
+    ctx = SchemaRetryContext()
+    result = validate_with_retry(
+        initial_response='{"ok": 1}',
+        validate=_ok_validator,
+        ctx=ctx,
+        ask_again=lambda _p: "",
+    )
+    assert result == {"ok": 1}
+
+
+def test_prometheus_counter_increments_on_outcomes() -> None:
+    """If prometheus_client is installed, the counter is created and labelled."""
+    pytest.importorskip("prometheus_client")
+    from bernstein.core.tasks import schema_retry as sr
+
+    counter = sr._get_counter()
+    assert counter is not None
+
+    # Successful first-attempt path.
+    ctx = SchemaRetryContext()
+    validate_with_retry(
+        initial_response='{"ok": 1}',
+        validate=_ok_validator,
+        ctx=ctx,
+        ask_again=lambda _p: "",
+    )
+
+    # Exhausted path.
+    with pytest.raises(SchemaRetryExhausted):
+        validate_with_retry(
+            initial_response="bad",
+            validate=_ok_validator,
+            ctx=SchemaRetryContext(),
+            ask_again=lambda _p: "still bad",
+            max_attempts=2,
+        )


### PR DESCRIPTION
## Summary

Implements `.sdd/backlog/open/2026-04-30-feat-schema-validation-retry.md`.

- New `bernstein.core.tasks.schema_retry` module: `SchemaRetryContext`, `validate_with_retry`, `format_errors_for_prompt`, `SchemaRetryExhausted`. The retry loop feeds the specific validation error back into the next prompt and accumulates errors across steps so the agent can see failures it made in earlier stages.
- `manager_parsing.parse_tasks_response` now accepts optional `ctx` / `ask_again` to drive the retry path; the one-shot path is unchanged.
- `mcp_tool_normalization.decode_tool_result_with_retry` provides the same wrap for JSON-object MCP tool responses.
- Adds `SCHEMA_RETRY_MAX_ATTEMPTS = 3` and a `SchemaRetryDefaults` dataclass to `core.defaults` (rebindable via `tuning.schema_retry`).
- Lazy-init `schema_retry_attempts_total{outcome=}` Prometheus counter on the shared registry; metrics failures never break the retry loop.

## Test plan

- [x] `validate_with_retry` succeeds on attempt 1 when payload is valid
- [x] Recovers on attempt 2 with the prior error visible in the next prompt
- [x] After `max_attempts` failures, `SchemaRetryExhausted` is raised with the full attempt trail
- [x] Error accumulation across two distinct `step_id`s shows both errors in the next prompt
- [x] `manager_parsing` regression test: malformed-then-valid payload via the retry path
- [x] `manager_parsing` one-shot path remains unchanged
- [x] `_record_metric` is a no-op when prometheus_client is absent
- [x] `uv run pytest tests/unit/test_schema_retry.py -x -q` -> 11 passed
- [x] `uv run ruff format --check` and `uv run ruff check` clean on touched files
- [x] `uv run pyright src/bernstein/core/tasks/schema_retry.py` -> 0 errors