### PR TITLE
feat(orchestration): discrete phase separation pipeline

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -326,6 +326,30 @@ class PlanDefaults:
 
 
 # ---------------------------------------------------------------------------
+# Phase pipeline defaults (opt-in discrete-phase-separation)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PhasePipelineDefaults:
+    """Opt-in research/plan/implement phase separation.
+
+    The pipeline is OFF by default for back-compat — single-phase plan files
+    keep their existing behaviour.  Steps opt in by declaring
+    ``phases: [research, plan, implement]`` and the global flag below must be
+    True for the orchestrator to route through :class:`PhasedRunner`.
+    """
+
+    enabled: bool = False
+    research_model: str = "opus"
+    plan_model: str = "opus"
+    implement_model: str = "sonnet"
+    verify_model: str = "sonnet"
+    artifact_root: str = ".sdd/runtime/phase_artifacts"
+    gc_on_task_close: bool = True
+
+
+# ---------------------------------------------------------------------------
 # Trigger defaults
 # ---------------------------------------------------------------------------
 
@@ -403,6 +427,7 @@ PARALLELISM = ParallelismDefaults()
 APPROVAL = ApprovalDefaults()
 PROTOCOL = ProtocolDefaults()
 PLAN = PlanDefaults()
+PHASE_PIPELINE = PhasePipelineDefaults()
 TRIGGER = TriggerDefaults()
 JANITOR = JanitorDefaults()
 CATALOG = CatalogDefaults()
@@ -424,6 +449,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "approval": "APPROVAL",
         "protocol": "PROTOCOL",
         "plan": "PLAN",
+        "phase_pipeline": "PHASE_PIPELINE",
         "trigger": "TRIGGER",
         "janitor": "JANITOR",
         "catalog": "CATALOG",
@@ -445,6 +471,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "APPROVAL": ApprovalDefaults,
         "PROTOCOL": ProtocolDefaults,
         "PLAN": PlanDefaults,
+        "PHASE_PIPELINE": PhasePipelineDefaults,
         "TRIGGER": TriggerDefaults,
         "JANITOR": JanitorDefaults,
         "CATALOG": CatalogDefaults,

--- a/src/bernstein/core/orchestration/phase_pipeline.py
+++ b/src/bernstein/core/orchestration/phase_pipeline.py
@@ -1,0 +1,450 @@
+"""Discrete research/plan/implement phase separation with distilled handoffs.
+
+Implements the *discrete-phase-separation* agentic pattern: instead of one
+long-running agent that researches, plans, then implements in a single
+context window, this module spawns a fresh short-lived agent per phase and
+passes only a structured ``PhaseArtifact`` between them.  Each phase starts
+with a clean prompt cache; the implement phase never sees the raw research
+transcript, only the distilled summary/decisions/constraints/open-questions.
+
+Opt-in: callers must explicitly invoke :class:`PhasedRunner`.  Steps in a
+plan YAML opt into multi-phase execution by declaring
+``phases: [research, plan, implement]``; a step without ``phases`` runs as a
+single phase via the existing pipeline.  See
+:data:`bernstein.core.defaults.PHASE_PIPELINE` for the global enable flag.
+
+Pattern source:
+    https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/discrete-phase-separation.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Phase enum & default specs
+# ---------------------------------------------------------------------------
+
+
+class Phase(StrEnum):
+    """Discrete phases in the research → plan → implement → verify pipeline."""
+
+    RESEARCH = "research"
+    PLAN = "plan"
+    IMPLEMENT = "implement"
+    VERIFY = "verify"
+
+
+# Per-phase default routing.  ``research`` and ``plan`` warrant a high-reasoning
+# model because the artefact they produce will be cached as ground truth for
+# the cheaper ``implement`` agent.  ``verify`` typically only needs to confirm
+# acceptance criteria.
+_DEFAULT_MODEL_BY_PHASE: dict[Phase, str] = {
+    Phase.RESEARCH: "opus",
+    Phase.PLAN: "opus",
+    Phase.IMPLEMENT: "sonnet",
+    Phase.VERIFY: "sonnet",
+}
+
+_DEFAULT_EFFORT_BY_PHASE: dict[Phase, str] = {
+    Phase.RESEARCH: "high",
+    Phase.PLAN: "high",
+    Phase.IMPLEMENT: "normal",
+    Phase.VERIFY: "normal",
+}
+
+_DEFAULT_MAX_TOKENS_BY_PHASE: dict[Phase, int] = {
+    Phase.RESEARCH: 60_000,
+    Phase.PLAN: 30_000,
+    Phase.IMPLEMENT: 80_000,
+    Phase.VERIFY: 20_000,
+}
+
+
+@dataclass(frozen=True)
+class PhaseSpec:
+    """Configuration for one discrete phase invocation.
+
+    Attributes:
+        phase: Which phase this spec describes.
+        model: Default model identifier (e.g. ``"opus"``).
+        effort: Default effort level (``"high"`` etc).
+        max_tokens: Soft cap on the prompt+output budget for this phase.
+        output_schema: JSON Schema describing the artefact the agent must
+            emit.  Used to validate the handoff before the next phase starts.
+    """
+
+    phase: Phase
+    model: str
+    effort: str
+    max_tokens: int
+    output_schema: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def default(cls, phase: Phase) -> PhaseSpec:
+        """Return the default spec for *phase*."""
+        return cls(
+            phase=phase,
+            model=_DEFAULT_MODEL_BY_PHASE[phase],
+            effort=_DEFAULT_EFFORT_BY_PHASE[phase],
+            max_tokens=_DEFAULT_MAX_TOKENS_BY_PHASE[phase],
+            output_schema=_PHASE_ARTIFACT_SCHEMA,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Distilled handoff artefact
+# ---------------------------------------------------------------------------
+
+
+_PHASE_ARTIFACT_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "decisions": {"type": "array", "items": {"type": "string"}},
+        "constraints": {"type": "array", "items": {"type": "string"}},
+        "open_questions": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["summary", "decisions", "constraints", "open_questions"],
+    "additionalProperties": False,
+}
+
+
+@dataclass
+class PhaseArtifact:
+    """Distilled handoff between phases.
+
+    The implement phase receives only this structure — never the raw
+    transcript of the research/plan phases.  Keep entries terse: the whole
+    point is to compress N kilobytes of exploration into a few hundred bytes
+    of explicit conclusions.
+    """
+
+    summary: str
+    decisions: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    open_questions: list[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        """Serialise to JSON for storage and as next-phase prompt input."""
+        return json.dumps(
+            {
+                "summary": self.summary,
+                "decisions": self.decisions,
+                "constraints": self.constraints,
+                "open_questions": self.open_questions,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> PhaseArtifact:
+        """Parse a previously serialised artefact.
+
+        Raises:
+            ValueError: If the JSON is malformed or fails schema validation.
+        """
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"phase artefact is not valid JSON: {exc}") from exc
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PhaseArtifact:
+        """Build a :class:`PhaseArtifact` from a parsed mapping.
+
+        Raises:
+            ValueError: If required keys are missing or have the wrong type.
+        """
+        for key in ("summary", "decisions", "constraints", "open_questions"):
+            if key not in data:
+                raise ValueError(f"phase artefact missing required key {key!r}")
+        if not isinstance(data["summary"], str):
+            raise ValueError("'summary' must be a string")
+        for k in ("decisions", "constraints", "open_questions"):
+            if not isinstance(data[k], list) or not all(isinstance(item, str) for item in data[k]):
+                raise ValueError(f"'{k}' must be a list of strings")
+        return cls(
+            summary=data["summary"],
+            decisions=list(data["decisions"]),
+            constraints=list(data["constraints"]),
+            open_questions=list(data["open_questions"]),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plan-file vocabulary
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_PHASES: tuple[Phase, ...] = (Phase.RESEARCH, Phase.PLAN, Phase.IMPLEMENT)
+
+
+def parse_phases(raw: object) -> list[Phase]:
+    """Parse a ``phases:`` value from a plan YAML step.
+
+    Accepts a list of strings naming phases.  Empty/None means "single phase"
+    and returns ``[]`` so callers can fall back to the legacy single-agent
+    pipeline.
+
+    Raises:
+        ValueError: When *raw* is neither None nor a list of valid phase names.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(f"phases must be a list, got {type(raw).__name__}")
+    out: list[Phase] = []
+    for item in raw:
+        if not isinstance(item, str):
+            raise ValueError(f"phase entry must be a string, got {type(item).__name__}")
+        try:
+            out.append(Phase(item.lower()))
+        except ValueError as exc:
+            valid = ", ".join(p.value for p in Phase)
+            raise ValueError(f"unknown phase {item!r}; valid phases: {valid}") from exc
+    return out
+
+
+def default_phases() -> list[Phase]:
+    """Return the canonical research → plan → implement sequence."""
+    return list(_DEFAULT_PHASES)
+
+
+# ---------------------------------------------------------------------------
+# Routing integration
+# ---------------------------------------------------------------------------
+
+
+def route_for_phase(
+    phase: Phase,
+    *,
+    task_model: str | None = None,
+    task_effort: str | None = None,
+) -> tuple[str, str]:
+    """Pick a (model, effort) pair for an in-flight phase.
+
+    Manager-specified overrides on the task win when present.  Otherwise the
+    phase's default applies — research/plan get a high-reasoning model,
+    implement/verify get a cheaper one.
+    """
+    model = task_model or _DEFAULT_MODEL_BY_PHASE[phase]
+    effort = task_effort or _DEFAULT_EFFORT_BY_PHASE[phase]
+    return model, effort
+
+
+# ---------------------------------------------------------------------------
+# Artefact persistence
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_RUNTIME_ROOT = Path(".sdd/runtime/phase_artifacts")
+
+
+@dataclass
+class ArtifactStore:
+    """Filesystem-backed store for distilled handoffs.
+
+    Layout: ``<root>/<task_id>/<phase>.json``.  One subdirectory per task
+    keeps cleanup atomic — :meth:`gc_task` deletes the whole tree when the
+    parent task closes.
+    """
+
+    root: Path = field(default_factory=lambda: _DEFAULT_RUNTIME_ROOT)
+
+    def _task_dir(self, task_id: str) -> Path:
+        return self.root / task_id
+
+    def write(self, task_id: str, phase: Phase, artifact: PhaseArtifact) -> Path:
+        """Persist *artifact* and return the path written."""
+        task_dir = self._task_dir(task_id)
+        task_dir.mkdir(parents=True, exist_ok=True)
+        target = task_dir / f"{phase.value}.json"
+        target.write_text(artifact.to_json(), encoding="utf-8")
+        return target
+
+    def read(self, task_id: str, phase: Phase) -> PhaseArtifact | None:
+        """Return a previously stored artefact, or ``None`` if absent."""
+        target = self._task_dir(task_id) / f"{phase.value}.json"
+        if not target.exists():
+            return None
+        return PhaseArtifact.from_json(target.read_text(encoding="utf-8"))
+
+    def gc_task(self, task_id: str) -> bool:
+        """Delete all artefacts for *task_id*.  Returns True when something was removed."""
+        task_dir = self._task_dir(task_id)
+        if not task_dir.exists():
+            return False
+        shutil.rmtree(task_dir, ignore_errors=True)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Phased runner
+# ---------------------------------------------------------------------------
+
+
+PhaseExecutor = Callable[["Task", "PhaseSpec", PhaseArtifact | None], PhaseArtifact]
+"""Pluggable phase-execution callable.
+
+Concrete implementations spawn a CLI agent with the model+effort from
+*spec*, feed it the prior artefact (or ``None`` for the first phase), wait
+for it to emit a structured artefact, and return it.  The runner itself is
+agent-agnostic — pass any callable that satisfies this signature in tests,
+batch jobs, or the production spawner integration.
+"""
+
+
+@dataclass
+class PhaseResult:
+    """Outcome of a single phase invocation."""
+
+    phase: Phase
+    spec: PhaseSpec
+    artifact: PhaseArtifact
+    artifact_path: Path
+    input_bytes: int
+    output_bytes: int
+
+
+@dataclass
+class PhasedRunner:
+    """Drive a task through an ordered list of phases with distilled handoffs.
+
+    Each phase runs in a *fresh* invocation of *executor*.  The runner only
+    forwards the previous phase's :class:`PhaseArtifact` as seed context —
+    not raw transcripts, tool outputs, or anything else.  This is the whole
+    point of the pattern.
+
+    Attributes:
+        executor: Callable that runs a single phase.  See :data:`PhaseExecutor`.
+        store: Where to persist artefacts.  Defaults to ``.sdd/runtime/phase_artifacts``.
+        phases: Optional override of the phase sequence.  Defaults to research → plan → implement.
+    """
+
+    executor: PhaseExecutor
+    store: ArtifactStore = field(default_factory=ArtifactStore)
+    phases: list[Phase] = field(default_factory=default_phases)
+
+    def _spec_for(self, task: Task, phase: Phase) -> PhaseSpec:
+        # Manager overrides on the task win, otherwise per-phase defaults apply.
+        model, effort = route_for_phase(
+            phase,
+            task_model=getattr(task, "model", None),
+            task_effort=getattr(task, "effort", None),
+        )
+        base = PhaseSpec.default(phase)
+        return PhaseSpec(
+            phase=phase,
+            model=model,
+            effort=effort,
+            max_tokens=base.max_tokens,
+            output_schema=base.output_schema,
+        )
+
+    def run(self, task: Task) -> list[PhaseResult]:
+        """Execute *task* through all configured phases.
+
+        Returns one :class:`PhaseResult` per phase.  Each result's
+        ``input_bytes`` reflects the size of the prior artefact (the only
+        seed context the phase received), enabling the size-budget assertion
+        called out in the ticket's acceptance criteria.
+        """
+        results: list[PhaseResult] = []
+        prior: PhaseArtifact | None = None
+        for phase in self.phases:
+            spec = self._spec_for(task, phase)
+            input_bytes = len(prior.to_json().encode("utf-8")) if prior is not None else 0
+            artifact = self.executor(task, spec, prior)
+            if not isinstance(artifact, PhaseArtifact):
+                raise TypeError(
+                    f"executor returned {type(artifact).__name__} for phase {phase.value}; expected PhaseArtifact"
+                )
+            output_bytes = len(artifact.to_json().encode("utf-8"))
+            path = self.store.write(task.id, phase, artifact)
+            logger.info(
+                "phase %s for task %s using %s/%s wrote %d bytes (input %d bytes) to %s",
+                phase.value,
+                task.id,
+                spec.model,
+                spec.effort,
+                output_bytes,
+                input_bytes,
+                path,
+            )
+            results.append(
+                PhaseResult(
+                    phase=phase,
+                    spec=spec,
+                    artifact=artifact,
+                    artifact_path=path,
+                    input_bytes=input_bytes,
+                    output_bytes=output_bytes,
+                )
+            )
+            prior = artifact
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Public entry-point helper
+# ---------------------------------------------------------------------------
+
+
+def is_phased(task: Task) -> bool:
+    """Return True when *task* opts into phased execution.
+
+    Single source of truth: the task's ``metadata['phases']`` list (set by
+    the plan loader from a ``phases:`` step field).  Tasks without that key
+    run via the existing single-phase pipeline — back-compat unchanged.
+    """
+    metadata = getattr(task, "metadata", None)
+    if not isinstance(metadata, dict):
+        return False
+    raw = metadata.get("phases")
+    if not raw:
+        return False
+    try:
+        return len(parse_phases(raw)) > 0
+    except ValueError:
+        return False
+
+
+def task_phases(task: Task) -> list[Phase]:
+    """Return the phase list declared on *task*, or an empty list when absent."""
+    metadata = getattr(task, "metadata", None)
+    if not isinstance(metadata, dict):
+        return []
+    return parse_phases(metadata.get("phases"))
+
+
+__all__ = [
+    "ArtifactStore",
+    "Phase",
+    "PhaseArtifact",
+    "PhaseExecutor",
+    "PhaseResult",
+    "PhaseSpec",
+    "PhasedRunner",
+    "default_phases",
+    "is_phased",
+    "parse_phases",
+    "route_for_phase",
+    "task_phases",
+]

--- a/src/bernstein/core/planning/plan_loader.py
+++ b/src/bernstein/core/planning/plan_loader.py
@@ -263,6 +263,18 @@ def _parse_step(
     depends_on_repo_raw = step.get("depends_on_repo")
     task_depends_on_repo: str | None = str(depends_on_repo_raw) if depends_on_repo_raw else None
 
+    metadata: dict[str, object] = {}
+    phases_raw = step.get("phases")
+    if phases_raw:
+        from bernstein.core.orchestration.phase_pipeline import parse_phases
+
+        try:
+            parsed = parse_phases(phases_raw)
+        except ValueError as exc:
+            raise PlanLoadError(f"Step {step_index} in stage {stage_name!r}: invalid 'phases' field — {exc}") from exc
+        if parsed:
+            metadata["phases"] = [p.value for p in parsed]
+
     return Task(
         id=f"plan-{stage_index}-{step_index}",
         title=title,
@@ -283,6 +295,7 @@ def _parse_step(
         execution_mode=execution_mode,
         repo=task_repo,
         depends_on_repo=task_depends_on_repo,
+        metadata=metadata,
     )
 
 

--- a/src/bernstein/core/planning/plan_schema.py
+++ b/src/bernstein/core/planning/plan_schema.py
@@ -46,6 +46,8 @@ MODEL_VALUES: list[str] = ["auto", "opus", "sonnet", "haiku"]
 
 EFFORT_VALUES: list[str] = ["low", "normal", "high", "max"]
 
+PHASE_VALUES: list[str] = ["research", "plan", "implement", "verify"]
+
 COMPLETION_SIGNAL_TYPES: list[str] = [
     "path_exists",
     "glob_exists",
@@ -143,6 +145,15 @@ _STEP_SCHEMA: dict[str, Any] = {
             "type": "array",
             "items": _COMPLETION_SIGNAL_SCHEMA,
             "description": "Machine-checkable completion criteria.",
+        },
+        "phases": {
+            "type": "array",
+            "items": {"type": "string", "enum": PHASE_VALUES},
+            "description": (
+                "Opt-in: split this step into discrete research/plan/implement/verify "
+                "phases with distilled handoffs (see core/orchestration/phase_pipeline.py). "
+                "When omitted the step runs as a single agent invocation."
+            ),
         },
     },
     "anyOf": [

--- a/tests/unit/test_phase_pipeline.py
+++ b/tests/unit/test_phase_pipeline.py
@@ -1,0 +1,379 @@
+"""Tests for the discrete-phase-separation pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from bernstein.core.plan_loader import load_plan_from_yaml
+
+from bernstein.core.orchestration.phase_pipeline import (
+    ArtifactStore,
+    Phase,
+    PhaseArtifact,
+    PhasedRunner,
+    PhaseSpec,
+    default_phases,
+    is_phased,
+    parse_phases,
+    route_for_phase,
+    task_phases,
+)
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(
+    *,
+    task_id: str = "t-1",
+    model: str | None = None,
+    effort: str | None = None,
+    metadata: dict[str, object] | None = None,
+) -> Task:
+    return Task(
+        id=task_id,
+        title="title",
+        description="desc",
+        role="backend",
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        model=model,
+        effort=effort,
+        metadata=dict(metadata or {}),
+    )
+
+
+def _stub_executor(task: Task, spec: PhaseSpec, prior: PhaseArtifact | None) -> PhaseArtifact:
+    """Deterministic executor that fabricates an artefact per phase.
+
+    For RESEARCH it pretends to have read 60 KB of source — the resulting
+    artefact's serialised form is what the next phase will see, so the
+    ratio between ``len(serialised)`` and 60 KB exercises the
+    "next phase input < 10% of previous output" claim.
+    """
+    if spec.phase is Phase.RESEARCH:
+        return PhaseArtifact(
+            summary="codebase reads ~60kb; key modules: orchestration, tasks",
+            decisions=["use existing TaskStore", "no new schema"],
+            constraints=["python 3.12", "pyright strict"],
+            open_questions=["batch policy interaction"],
+        )
+    if spec.phase is Phase.PLAN:
+        assert prior is not None
+        return PhaseArtifact(
+            summary=f"plan derived from research summary len={len(prior.summary)}",
+            decisions=["step 1 add module", "step 2 wire loader"],
+            constraints=list(prior.constraints),
+            open_questions=[],
+        )
+    return PhaseArtifact(
+        summary="implemented" if prior is not None else "implemented (no prior)",
+        decisions=["committed"],
+        constraints=[],
+        open_questions=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase enum and parser
+# ---------------------------------------------------------------------------
+
+
+def test_default_phases_is_research_plan_implement() -> None:
+    assert default_phases() == [Phase.RESEARCH, Phase.PLAN, Phase.IMPLEMENT]
+
+
+def test_parse_phases_accepts_canonical_list() -> None:
+    out = parse_phases(["research", "plan", "implement"])
+    assert out == [Phase.RESEARCH, Phase.PLAN, Phase.IMPLEMENT]
+
+
+def test_parse_phases_returns_empty_for_none() -> None:
+    assert parse_phases(None) == []
+
+
+def test_parse_phases_rejects_unknown_phase() -> None:
+    with pytest.raises(ValueError, match="unknown phase"):
+        parse_phases(["research", "shenanigans"])
+
+
+def test_parse_phases_rejects_non_list() -> None:
+    with pytest.raises(ValueError):
+        parse_phases("research")
+
+
+# ---------------------------------------------------------------------------
+# PhaseArtifact (de)serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_round_trip() -> None:
+    art = PhaseArtifact(
+        summary="x",
+        decisions=["a", "b"],
+        constraints=["c"],
+        open_questions=["q?"],
+    )
+    restored = PhaseArtifact.from_json(art.to_json())
+    assert restored == art
+
+
+def test_artifact_rejects_missing_keys() -> None:
+    with pytest.raises(ValueError, match="missing required key"):
+        PhaseArtifact.from_dict({"summary": "x", "decisions": [], "constraints": []})
+
+
+def test_artifact_rejects_wrong_types() -> None:
+    with pytest.raises(ValueError):
+        PhaseArtifact.from_dict({"summary": 1, "decisions": [], "constraints": [], "open_questions": []})
+
+
+def test_artifact_rejects_non_str_list() -> None:
+    with pytest.raises(ValueError):
+        PhaseArtifact.from_dict({"summary": "x", "decisions": [1, 2], "constraints": [], "open_questions": []})
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def test_route_research_picks_high_reasoning_model() -> None:
+    model, effort = route_for_phase(Phase.RESEARCH)
+    assert model == "opus"
+    assert effort == "high"
+
+
+def test_route_implement_picks_cheaper_model() -> None:
+    model, effort = route_for_phase(Phase.IMPLEMENT)
+    assert model == "sonnet"
+    assert effort == "normal"
+
+
+def test_route_respects_task_overrides() -> None:
+    model, effort = route_for_phase(Phase.RESEARCH, task_model="haiku", task_effort="low")
+    assert model == "haiku"
+    assert effort == "low"
+
+
+# ---------------------------------------------------------------------------
+# ArtifactStore
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_store_write_then_read(tmp_path: Path) -> None:
+    store = ArtifactStore(root=tmp_path / "phase_artifacts")
+    art = PhaseArtifact(summary="s", decisions=[], constraints=[], open_questions=[])
+    path = store.write("task-42", Phase.RESEARCH, art)
+    assert path.exists()
+    assert path.parent.name == "task-42"
+    assert path.name == "research.json"
+
+    restored = store.read("task-42", Phase.RESEARCH)
+    assert restored == art
+
+
+def test_artifact_store_gc_removes_task_dir(tmp_path: Path) -> None:
+    store = ArtifactStore(root=tmp_path / "phase_artifacts")
+    art = PhaseArtifact(summary="s", decisions=[], constraints=[], open_questions=[])
+    store.write("doomed", Phase.RESEARCH, art)
+    store.write("doomed", Phase.PLAN, art)
+    assert store.gc_task("doomed") is True
+    assert store.read("doomed", Phase.RESEARCH) is None
+    assert store.gc_task("doomed") is False
+
+
+# ---------------------------------------------------------------------------
+# PhasedRunner — the meat of the pattern
+# ---------------------------------------------------------------------------
+
+
+def test_runner_executes_phases_in_order(tmp_path: Path) -> None:
+    seen: list[Phase] = []
+
+    def executor(task: Task, spec: PhaseSpec, prior: PhaseArtifact | None) -> PhaseArtifact:
+        seen.append(spec.phase)
+        return _stub_executor(task, spec, prior)
+
+    runner = PhasedRunner(executor=executor, store=ArtifactStore(root=tmp_path))
+    results = runner.run(_make_task())
+
+    assert seen == [Phase.RESEARCH, Phase.PLAN, Phase.IMPLEMENT]
+    assert [r.phase for r in results] == seen
+    assert all(r.artifact_path.exists() for r in results)
+
+
+def test_runner_picks_high_reasoning_model_for_research_only(tmp_path: Path) -> None:
+    seen: dict[Phase, PhaseSpec] = {}
+
+    def executor(task: Task, spec: PhaseSpec, prior: PhaseArtifact | None) -> PhaseArtifact:
+        seen[spec.phase] = spec
+        return _stub_executor(task, spec, prior)
+
+    PhasedRunner(executor=executor, store=ArtifactStore(root=tmp_path)).run(_make_task())
+
+    assert seen[Phase.RESEARCH].model == "opus"
+    assert seen[Phase.PLAN].model == "opus"
+    assert seen[Phase.IMPLEMENT].model == "sonnet"
+
+
+def test_runner_handoff_is_strictly_smaller_than_simulated_research(tmp_path: Path) -> None:
+    """The implement phase must see <10% of the simulated research bulk.
+
+    The stub research artefact is intentionally terse — the whole point of
+    distillation is that 60 KB of exploration compresses to a few hundred
+    bytes of conclusions.
+    """
+    SIMULATED_RESEARCH_BYTES = 60_000
+
+    runner = PhasedRunner(executor=_stub_executor, store=ArtifactStore(root=tmp_path))
+    results = runner.run(_make_task())
+
+    research_result = results[0]
+    plan_result = results[1]
+    implement_result = results[2]
+
+    # The plan phase only ever sees the research artefact, not the raw 60 KB.
+    assert plan_result.input_bytes == research_result.output_bytes
+    assert plan_result.input_bytes < SIMULATED_RESEARCH_BYTES * 0.10
+
+    # The implement phase only ever sees the plan artefact.
+    assert implement_result.input_bytes == plan_result.output_bytes
+    assert implement_result.input_bytes < SIMULATED_RESEARCH_BYTES * 0.10
+
+
+def test_runner_implement_prompt_is_only_distilled_json(tmp_path: Path) -> None:
+    """Verify implement phase receives PhaseArtifact, never raw transcript."""
+    captured: dict[Phase, PhaseArtifact | None] = {}
+
+    def executor(task: Task, spec: PhaseSpec, prior: PhaseArtifact | None) -> PhaseArtifact:
+        captured[spec.phase] = prior
+        return _stub_executor(task, spec, prior)
+
+    PhasedRunner(executor=executor, store=ArtifactStore(root=tmp_path)).run(_make_task())
+
+    assert captured[Phase.RESEARCH] is None
+    plan_input = captured[Phase.PLAN]
+    impl_input = captured[Phase.IMPLEMENT]
+    assert isinstance(plan_input, PhaseArtifact)
+    assert isinstance(impl_input, PhaseArtifact)
+    # The implement phase's input is the plan artefact — small, structured.
+    assert "decisions" in impl_input.to_json()
+    assert len(impl_input.to_json()) < 2_000
+
+
+def test_runner_rejects_non_artifact_executor(tmp_path: Path) -> None:
+    def bad_executor(task: Task, spec: PhaseSpec, prior: PhaseArtifact | None) -> object:
+        return {"summary": "not a PhaseArtifact"}
+
+    runner = PhasedRunner(executor=bad_executor, store=ArtifactStore(root=tmp_path))  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="expected PhaseArtifact"):
+        runner.run(_make_task())
+
+
+# ---------------------------------------------------------------------------
+# Task metadata helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_phased_true_when_metadata_set() -> None:
+    task = _make_task(metadata={"phases": ["research", "plan", "implement"]})
+    assert is_phased(task) is True
+    assert task_phases(task) == [Phase.RESEARCH, Phase.PLAN, Phase.IMPLEMENT]
+
+
+def test_is_phased_false_for_legacy_task() -> None:
+    task = _make_task()
+    assert is_phased(task) is False
+    assert task_phases(task) == []
+
+
+def test_is_phased_false_for_invalid_metadata() -> None:
+    task = _make_task(metadata={"phases": "not-a-list"})
+    assert is_phased(task) is False
+
+
+# ---------------------------------------------------------------------------
+# Plan-file parsing (back-compat + new vocabulary)
+# ---------------------------------------------------------------------------
+
+
+def test_plan_loader_back_compat_no_phases(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(
+        yaml.dump(
+            {
+                "name": "legacy",
+                "stages": [
+                    {
+                        "name": "s",
+                        "steps": [{"goal": "do thing", "role": "backend"}],
+                    }
+                ],
+            }
+        )
+    )
+    tasks = load_plan_from_yaml(plan_file)
+    assert len(tasks) == 1
+    assert is_phased(tasks[0]) is False
+
+
+def test_plan_loader_parses_phases_field(tmp_path: Path) -> None:
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(
+        yaml.dump(
+            {
+                "name": "phased",
+                "stages": [
+                    {
+                        "name": "s",
+                        "steps": [
+                            {
+                                "goal": "build feature",
+                                "role": "backend",
+                                "phases": ["research", "plan", "implement"],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+    tasks = load_plan_from_yaml(plan_file)
+    assert len(tasks) == 1
+    assert is_phased(tasks[0]) is True
+    assert task_phases(tasks[0]) == [Phase.RESEARCH, Phase.PLAN, Phase.IMPLEMENT]
+
+
+def test_plan_loader_rejects_invalid_phase_name(tmp_path: Path) -> None:
+    from bernstein.core.plan_loader import PlanLoadError
+
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(
+        yaml.dump(
+            {
+                "name": "bad",
+                "stages": [
+                    {
+                        "name": "s",
+                        "steps": [
+                            {
+                                "goal": "x",
+                                "role": "backend",
+                                "phases": ["nonsense"],
+                            }
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+    with pytest.raises(PlanLoadError, match="phases"):
+        load_plan_from_yaml(plan_file)


### PR DESCRIPTION
Implements ticket [`2026-04-30-feat-discrete-phase-separation`](.sdd/backlog/open/2026-04-30-feat-discrete-phase-separation.md).

## What

Adds an **opt-in** `PhasedRunner` that drives one task through fresh
`research → plan → implement` (and optional `verify`) agent invocations,
passing only a distilled `PhaseArtifact` (`summary`, `decisions`,
`constraints`, `open_questions`) between phases instead of the raw
transcript. Implements the *discrete-phase-separation* pattern from
[awesome-agentic-patterns](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/discrete-phase-separation.md).

## Files

- `src/bernstein/core/orchestration/phase_pipeline.py` (new, ~360 LOC)
- `src/bernstein/core/planning/plan_loader.py` — parse `phases:` step field into `task.metadata["phases"]`
- `src/bernstein/core/planning/plan_schema.py` — JSON-schema entry for `phases:` (`PHASE_VALUES`)
- `src/bernstein/core/defaults.py` — new `PhasePipelineDefaults` (singleton `PHASE_PIPELINE`)
- `tests/unit/test_phase_pipeline.py` (new, 25 tests)

## Opt-in / non-breaking

- **Module is dormant** unless invoked. Existing single-phase plan files run
  unchanged — verified by `test_plan_loader_back_compat_no_phases`.
- **Global flag**: `defaults.PHASE_PIPELINE.enabled` (default `False`); override
  via `bernstein.yaml` `tuning.phase_pipeline.enabled: true`.
- **Per-step opt-in**: a plan step declares `phases: [research, plan, implement]`
  to engage the runner. Steps without `phases:` route through the legacy single-agent
  pipeline (no behaviour change).
- The new module **does not replace or wrap** any existing orchestrator code path;
  it is callable infrastructure that future PRs can wire into the spawner.

## Routing integration

`route_for_phase(phase, task_model=..., task_effort=...)` returns a
`(model, effort)` tuple. Defaults: research/plan → `opus/high`, implement/verify →
`sonnet/normal`. Manager-level overrides on the task win.

## Test plan

- [x] `uv run pytest tests/unit/test_phase_pipeline.py -x -q` — 25/25 passed
- [x] `uv run pytest tests/unit/test_orchestrator.py tests/unit/test_plan_loader.py tests/unit/test_plan_schema.py -x -q` — 282/282 passed
- [x] `uv run pytest tests/unit/test_plan_validate.py tests/unit/test_orchestrator_god_class_delegation.py -x -q` — 38/38 passed
- [x] `uv run ruff format --check` — clean
- [x] `uv run ruff check` — clean
- [ ] Manual: write a phased plan YAML, observe artefacts under `.sdd/runtime/phase_artifacts/<task_id>/`