### PR TITLE
feat(security): tool capability matrix and lethal-trifecta orchestration check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,9 @@ packages = ["src/bernstein"]
 # bernstein.core.quality.review_pipeline at runtime when users omit a
 # pipeline path.
 "templates/review" = "bernstein/_default_templates/review"
+# Lethal-trifecta capability matrix declarations.  Bundled so the
+# default-deny check can find tags right after pip install.
+"templates/capabilities" = "bernstein/_default_templates/capabilities"
 # ascii_logo.md now lives in-package at src/bernstein/_default_templates/ —
 # no force-include needed. The dev-repo copy at docs/assets/ascii_logo.md is
 # the display fallback read by cli/display/splash_v2.py when running from a

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -303,6 +303,82 @@ def export_cmd(period: str, fmt: str, output: str | None, workdir: str) -> None:
     console.print()
 
 
+@audit_group.command("capabilities")
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    help="Project root (used to load templates/capabilities/).",
+)
+def capabilities_cmd(workdir: str) -> None:
+    """Print the lethal-trifecta capability matrix and any violations.
+
+    Loads tool capability declarations from
+    ``<workdir>/templates/capabilities/`` (falling back to the bundled
+    defaults), prints the matrix, and scans recorded spawn manifests
+    under ``.sdd/runtime/spawn_capabilities/`` for any chain that trips
+    all three capabilities.  Exits non-zero when a violation is found.
+    """
+    import json as _json
+
+    from bernstein.core.security.capability_matrix import (
+        Capability,
+        CapabilityRegistry,
+        EnforcementMode,
+        find_violating_chains,
+    )
+
+    root = Path(workdir).resolve()
+    registry = CapabilityRegistry.load_default(workdir=root, mode=EnforcementMode.ENFORCE)
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Tool", style="bold")
+    table.add_column("Source", style="dim")
+    for cap in Capability:
+        table.add_column(cap.value, justify="center")
+
+    for name in sorted(registry.tools):
+        entry = registry.tools[name]
+        row: list[str] = [name, entry.source]
+        for cap in Capability:
+            row.append("[green]Y[/green]" if cap in entry.capabilities else "[dim]-[/dim]")
+        table.add_row(*row)
+
+    console.print()
+    console.print(Panel("[bold]Tool Capability Matrix[/bold]", border_style="cyan", expand=False))
+    console.print(table)
+    console.print(f"\n[dim]{len(registry.tools)} tool(s) declared[/dim]\n")
+
+    runtime_dir = root / ".sdd" / "runtime" / "spawn_capabilities"
+    chains: list[list[str]] = []
+    if runtime_dir.is_dir():
+        for path in sorted(runtime_dir.glob("*.json")):
+            try:
+                manifest = _json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, _json.JSONDecodeError):
+                continue
+            tools = manifest.get("tools", [])
+            if isinstance(tools, list):
+                chains.append([str(t) for t in tools])
+
+    violations = find_violating_chains(registry, chains)
+    if not violations:
+        console.print("[green]No lethal-trifecta violations in recorded spawns.[/green]\n")
+        return
+
+    console.print(
+        Panel(
+            f"[bold red]{len(violations)} lethal-trifecta violation(s)[/bold red]",
+            border_style="red",
+            expand=False,
+        )
+    )
+    for decision in violations:
+        console.print(f"  [red]![/red] {decision.reason} — tools=[bold]{list(decision.offending_tools)}[/bold]")
+    console.print()
+    raise SystemExit(1)
+
+
 @audit_group.command("query")
 @click.option("--event-type", default=None, help="Filter by event type.")
 @click.option("--actor", default=None, help="Filter by actor.")

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -85,6 +85,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "bulletin": "bernstein.core.communication.bulletin",
     "cache_token_tracker": "bernstein.core.tokens.cache_token_tracker",
     "canary_mode": "bernstein.core.orchestration.canary_mode",
+    "capability_matrix": "bernstein.core.security.capability_matrix",
     "capability_router": "bernstein.core.routing.capability_router",
     "capacity_wake": "bernstein.core.orchestration.capacity_wake",
     "cascade": "bernstein.core.routing.cascade",

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1144,6 +1144,89 @@ class AgentSpawner:
         """Merge the agent's worktree branch with conflict detection."""
         return merge_worktree_branch(session_id, self._workdir, repo_root=repo_root)
 
+    def _enforce_lethal_trifecta(
+        self,
+        session_id: str,
+        role: str,
+        catalog_agent: CatalogAgent | None,
+    ) -> None:
+        """Refuse spawns whose configured tool chain trips the full trifecta.
+
+        Records a capability manifest under
+        ``.sdd/runtime/spawn_capabilities/`` and raises :class:`SpawnError`
+        when enforcement is on.  Warn / off modes only persist the
+        manifest.
+
+        The adapter envelope is recorded for traceability but the
+        evaluation only considers the catalog-declared tool list — the
+        adapter alone is fine-grained-scoped via the worker tool
+        allowlist (T578) at runtime.  Once an operator opts into a
+        specific tool combination that unions the trifecta, the spawn is
+        refused.
+        """
+        import json
+        from datetime import UTC, datetime
+
+        from bernstein.core.defaults import SECURITY
+        from bernstein.core.security.capability_matrix import (
+            CapabilityRegistry,
+            EnforcementMode,
+            LethalTrifectaError,
+        )
+
+        try:
+            mode = EnforcementMode(SECURITY.lethal_trifecta_enforcement)
+        except ValueError:
+            mode = EnforcementMode.ENFORCE
+        registry = CapabilityRegistry.load_default(workdir=self._workdir, mode=mode)
+
+        adapter_token = f"adapter.{self._adapter.name()}"
+        catalog_tools = list(catalog_agent.tools) if catalog_agent is not None else []
+        chain: list[str] = [adapter_token, *catalog_tools]
+
+        # Spawn-time enforcement only refuses chains where the trifecta is
+        # reached via *declared* tool tags — undeclared catalog tools
+        # default to all-three at the registry level (so the audit CLI
+        # surfaces them as warnings) but a single undeclared tool should
+        # not block a spawn.  Once any operator-declared chain unions all
+        # three, we deny.
+        declared_only = [t for t in catalog_tools if t in registry.tools]
+        decision = registry.evaluate_chain(declared_only)
+
+        runtime_dir = self._workdir / ".sdd" / "runtime" / "spawn_capabilities"
+        try:
+            runtime_dir.mkdir(parents=True, exist_ok=True)
+            manifest = {
+                "agent_id": session_id,
+                "role": role,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "tools": chain,
+                "evaluated": catalog_tools,
+                "triggered": sorted(c.value for c in decision.triggered),
+                "allowed": decision.allowed,
+                "reason": decision.reason,
+                "mode": decision.mode.value,
+                "unknown_tools": list(decision.unknown_tools),
+                "offending_tools": list(decision.offending_tools),
+            }
+            (runtime_dir / f"{session_id}.json").write_text(
+                json.dumps(manifest, indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning("Could not persist capability manifest for %s: %s", session_id, exc)
+
+        if not decision.allowed:
+            err = LethalTrifectaError(decision)
+            logger.error(
+                "Refusing spawn %s (role=%s): %s — chain=%s",
+                session_id,
+                role,
+                decision.reason,
+                chain,
+            )
+            raise SpawnError(f"lethal trifecta: {decision.reason}") from err
+
     def _reap_openclaw(self, session: AgentSession) -> None:
         """Sync logs from the remote bridge for an OpenClaw session."""
         reap_openclaw(session, self._runtime_bridge, self._run_bridge_call)
@@ -1467,6 +1550,11 @@ class AgentSpawner:
 
         # Build session ID early so we can inject it into the prompt for signal checks
         session_id = f"{role}-{uuid.uuid4().hex[:8]}"
+
+        # Lethal-trifecta structural check (orchestration-time).  See
+        # bernstein.core.security.capability_matrix.  The adapter envelope
+        # plus any catalog-declared tools form the chain we evaluate.
+        self._enforce_lethal_trifecta(session_id, role, catalog_agent)
 
         # Build catalog system prompt, appending tool preferences when present
         catalog_system_prompt: str | None = None

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -35,7 +35,7 @@ import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal
 
 # ---------------------------------------------------------------------------
 # Orchestrator defaults
@@ -389,6 +389,21 @@ class CatalogDefaults:
 
 
 # ---------------------------------------------------------------------------
+# Security defaults
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SecurityDefaults:
+    """Structural security knobs (orchestration-time, not LLM-driven)."""
+
+    # Lethal-trifecta enforcement: "enforce" denies any agent spawn whose
+    # tool chain unions PRIVATE_DATA + UNTRUSTED_INPUT + EXTERNAL_COMM.
+    # "warn" logs the violation; "off" disables the check entirely.
+    lethal_trifecta_enforcement: Literal["enforce", "warn", "off"] = "enforce"
+
+
+# ---------------------------------------------------------------------------
 # Singletons (rebindable via override()/reset())
 # ---------------------------------------------------------------------------
 
@@ -406,6 +421,7 @@ PLAN = PlanDefaults()
 TRIGGER = TriggerDefaults()
 JANITOR = JanitorDefaults()
 CATALOG = CatalogDefaults()
+SECURITY = SecurityDefaults()
 
 
 # Mapping of section name (as used in bernstein.yaml ``tuning:`` blocks) to the
@@ -427,6 +443,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "trigger": "TRIGGER",
         "janitor": "JANITOR",
         "catalog": "CATALOG",
+        "security": "SECURITY",
     }
 )
 
@@ -448,6 +465,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "TRIGGER": TriggerDefaults,
         "JANITOR": JanitorDefaults,
         "CATALOG": CatalogDefaults,
+        "SECURITY": SecurityDefaults,
     }
 )
 

--- a/src/bernstein/core/security/capability_matrix.py
+++ b/src/bernstein/core/security/capability_matrix.py
@@ -1,0 +1,393 @@
+"""Lethal-trifecta capability matrix for tool/MCP/adapter calls.
+
+Implements Simon Willison's "lethal trifecta" structural rule: every tool
+is tagged with which of the three capabilities it carries
+(``PRIVATE_DATA``, ``UNTRUSTED_INPUT``, ``EXTERNAL_COMM``); whenever the
+union of capabilities along a single execution path covers all three, the
+chain is denied.
+
+This is a structural orchestration-time check — not a guardrail prompt —
+so it cannot be bypassed by injection attempts in untrusted content.
+
+Usage::
+
+    from bernstein.core.security.capability_matrix import (
+        Capability,
+        CapabilityRegistry,
+        EnforcementMode,
+    )
+
+    registry = CapabilityRegistry.load_default()
+    decision = registry.evaluate_chain(
+        ["fs.read_secret", "github.fetch_issue", "github.post_comment"]
+    )
+    if not decision.allowed:
+        raise PermissionError(decision.reason)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Literal, cast
+
+import yaml
+
+from bernstein import _BUNDLED_TEMPLATES_DIR  # type: ignore[reportPrivateUsage]
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class Capability(StrEnum):
+    """Lethal-trifecta capability axes.
+
+    A tool may carry zero or more of these tags.  When all three are
+    carried by the *union* of tools on an execution path, the path is
+    refused.
+    """
+
+    PRIVATE_DATA = "private_data"
+    UNTRUSTED_INPUT = "untrusted_input"
+    EXTERNAL_COMM = "external_comm"
+
+
+CapabilitySource = Literal["declared", "inferred", "default"]
+
+
+class EnforcementMode(StrEnum):
+    """Lethal-trifecta enforcement levels."""
+
+    ENFORCE = "enforce"
+    WARN = "warn"
+    OFF = "off"
+
+
+_ALL_CAPABILITIES: frozenset[Capability] = frozenset(Capability)
+
+
+@dataclass(frozen=True)
+class ToolCapabilities:
+    """Capability tags attached to a single tool name.
+
+    Attributes:
+        tool_name: Stable identifier (MCP tool, adapter command, hook).
+        capabilities: Capability axes the tool carries.
+        source: Where the tags came from — declared YAML, inferred from
+            heuristics, or defaulted because the tool was unknown.
+    """
+
+    tool_name: str
+    capabilities: frozenset[Capability]
+    source: CapabilitySource = "declared"
+
+
+@dataclass(frozen=True)
+class ChainDecision:
+    """Result of evaluating a tool chain against the capability matrix.
+
+    Attributes:
+        allowed: True when the chain is permitted under the active mode.
+        reason: Human-readable explanation (constant for stable audit).
+        triggered: The set of capabilities present along the chain.
+        offending_tools: Tools that contributed each triggering capability.
+        unknown_tools: Tools missing declarations (treated as high-risk).
+        mode: The enforcement mode used for this evaluation.
+    """
+
+    allowed: bool
+    reason: str
+    triggered: frozenset[Capability] = frozenset()
+    offending_tools: tuple[str, ...] = ()
+    unknown_tools: tuple[str, ...] = ()
+    mode: EnforcementMode = EnforcementMode.ENFORCE
+
+
+@dataclass
+class CapabilityRegistry:
+    """In-memory map of tool name → :class:`ToolCapabilities`.
+
+    Unknown tools are treated as carrying *all three* capabilities — the
+    safest default, since the orchestrator cannot prove otherwise.
+    """
+
+    tools: dict[str, ToolCapabilities] = field(default_factory=dict[str, ToolCapabilities])
+    mode: EnforcementMode = EnforcementMode.ENFORCE
+
+    DEFAULT_REASON: str = "lethal trifecta"
+    UNKNOWN_REASON: str = "lethal trifecta (unknown tool defaults to all capabilities)"
+
+    def register(self, entry: ToolCapabilities) -> None:
+        """Register a capability declaration, replacing any prior entry."""
+        self.tools[entry.tool_name] = entry
+
+    def lookup(self, tool_name: str) -> ToolCapabilities:
+        """Return the entry for *tool_name*; default-deny when unknown.
+
+        Missing tools yield a synthetic ``ToolCapabilities`` carrying all
+        three capabilities with ``source="default"`` so callers can
+        distinguish declared from defaulted entries.
+        """
+        existing = self.tools.get(tool_name)
+        if existing is not None:
+            return existing
+        return ToolCapabilities(
+            tool_name=tool_name,
+            capabilities=_ALL_CAPABILITIES,
+            source="default",
+        )
+
+    def evaluate_chain(self, tools: Sequence[str]) -> ChainDecision:
+        """Evaluate a tool chain for the lethal trifecta.
+
+        Args:
+            tools: Tools that will run on a single execution path.
+
+        Returns:
+            A :class:`ChainDecision`.  In ``OFF`` mode the chain is always
+            allowed (the audit trail still records the triggered set).
+            In ``WARN`` mode the chain is allowed but the reason carries
+            the warning so the caller can log it.
+        """
+        triggered: set[Capability] = set()
+        offending: dict[Capability, list[str]] = {cap: [] for cap in Capability}
+        unknown: list[str] = []
+
+        for tool in tools:
+            entry = self.lookup(tool)
+            if entry.source == "default":
+                unknown.append(tool)
+            for cap in entry.capabilities:
+                triggered.add(cap)
+                offending[cap].append(tool)
+
+        triggered_frozen = frozenset(triggered)
+        full_trifecta = triggered_frozen >= _ALL_CAPABILITIES
+
+        if not full_trifecta:
+            return ChainDecision(
+                allowed=True,
+                reason="capability chain ok",
+                triggered=triggered_frozen,
+                unknown_tools=tuple(unknown),
+                mode=self.mode,
+            )
+
+        offending_tools = tuple(sorted({tool for tools_list in offending.values() for tool in tools_list}))
+        reason = self.UNKNOWN_REASON if unknown else self.DEFAULT_REASON
+
+        if self.mode is EnforcementMode.OFF:
+            return ChainDecision(
+                allowed=True,
+                reason=f"{reason} (enforcement off)",
+                triggered=triggered_frozen,
+                offending_tools=offending_tools,
+                unknown_tools=tuple(unknown),
+                mode=self.mode,
+            )
+        if self.mode is EnforcementMode.WARN:
+            return ChainDecision(
+                allowed=True,
+                reason=f"{reason} (warn-only)",
+                triggered=triggered_frozen,
+                offending_tools=offending_tools,
+                unknown_tools=tuple(unknown),
+                mode=self.mode,
+            )
+        return ChainDecision(
+            allowed=False,
+            reason=reason,
+            triggered=triggered_frozen,
+            offending_tools=offending_tools,
+            unknown_tools=tuple(unknown),
+            mode=self.mode,
+        )
+
+    @classmethod
+    def from_directory(
+        cls,
+        directory: Path,
+        *,
+        mode: EnforcementMode = EnforcementMode.ENFORCE,
+    ) -> CapabilityRegistry:
+        """Load all ``*.yaml`` declarations under *directory* recursively."""
+        registry = cls(mode=mode)
+        if not directory.is_dir():
+            return registry
+        files = sorted(directory.rglob("*.yaml")) + sorted(directory.rglob("*.yml"))
+        for path in files:
+            for entry in _load_yaml_file(path):
+                registry.register(entry)
+        return registry
+
+    @classmethod
+    def load_default(
+        cls,
+        *,
+        workdir: Path | None = None,
+        mode: EnforcementMode = EnforcementMode.ENFORCE,
+    ) -> CapabilityRegistry:
+        """Load capability declarations from the workdir or bundled templates.
+
+        Resolution order:
+            1. ``<workdir>/templates/capabilities/`` if present.
+            2. Bundled ``_default_templates/capabilities/``.
+        """
+        if workdir is not None:
+            local = workdir / "templates" / "capabilities"
+            if local.is_dir():
+                return cls.from_directory(local, mode=mode)
+        bundled = _BUNDLED_TEMPLATES_DIR / "capabilities"
+        return cls.from_directory(bundled, mode=mode)
+
+
+def _coerce_capabilities(values: Iterable[object]) -> frozenset[Capability]:
+    """Coerce raw YAML strings into a :class:`Capability` frozenset.
+
+    Unknown tokens are dropped with a warning rather than crashing the
+    registry loader; the surrounding default-deny semantics still keep
+    the path safe.
+    """
+    out: set[Capability] = set()
+    for raw in values:
+        token = str(raw).strip().lower()
+        try:
+            out.add(Capability(token))
+        except ValueError:
+            logger.warning("Unknown capability token %r — ignoring", token)
+    return frozenset(out)
+
+
+def _load_yaml_file(path: Path) -> list[ToolCapabilities]:
+    """Parse a capabilities YAML file into :class:`ToolCapabilities` rows."""
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        logger.warning("Failed to read capabilities file %s: %s", path, exc)
+        return []
+    except yaml.YAMLError as exc:
+        logger.warning("Failed to parse capabilities file %s: %s", path, exc)
+        return []
+    if not isinstance(raw, dict):
+        return []
+
+    mapping = cast("dict[str, object]", raw)
+    items = mapping.get("tools", [])
+    if not isinstance(items, list):
+        return []
+
+    out: list[ToolCapabilities] = []
+    for item in cast("list[object]", items):
+        if not isinstance(item, dict):
+            continue
+        entry = cast("dict[str, object]", item)
+        name_raw = entry.get("name")
+        if not isinstance(name_raw, str) or not name_raw.strip():
+            continue
+        caps_raw = entry.get("capabilities", [])
+        if not isinstance(caps_raw, list):
+            continue
+        source_raw = entry.get("source", "declared")
+        source: CapabilitySource = "declared"
+        if source_raw in ("declared", "inferred", "default"):
+            source = cast(CapabilitySource, source_raw)
+        out.append(
+            ToolCapabilities(
+                tool_name=name_raw.strip(),
+                capabilities=_coerce_capabilities(cast("list[object]", caps_raw)),
+                source=source,
+            )
+        )
+    return out
+
+
+def find_violating_chains(
+    registry: CapabilityRegistry,
+    chains: Sequence[Sequence[str]],
+) -> list[ChainDecision]:
+    """Return decisions for chains that trigger the lethal trifecta.
+
+    Helper used by the ``bernstein audit capabilities`` CLI to scan agent
+    configs.  Only chains where the full trifecta is reached are returned.
+    """
+    out: list[ChainDecision] = []
+    for chain in chains:
+        decision = registry.evaluate_chain(chain)
+        if decision.triggered >= _ALL_CAPABILITIES:
+            out.append(decision)
+    return out
+
+
+class LethalTrifectaError(PermissionError):
+    """Raised when a spawn would chain the full lethal trifecta."""
+
+    def __init__(self, decision: ChainDecision) -> None:
+        super().__init__(decision.reason)
+        self.decision = decision
+
+
+def record_spawn_capabilities(
+    workdir: Path,
+    agent_id: str,
+    role: str,
+    tools: Sequence[str],
+    *,
+    registry: CapabilityRegistry | None = None,
+) -> ChainDecision:
+    """Record the capability set for a spawned agent and enforce the rule.
+
+    Persists a small JSON manifest under
+    ``.sdd/runtime/spawn_capabilities/<agent_id>.json`` so the
+    ``bernstein audit capabilities`` CLI can replay spawns and so the
+    HMAC audit chain can attest to the structural decision.
+
+    Args:
+        workdir: Project root.  The capability registry is loaded from
+            ``<workdir>/templates/capabilities/`` if present.
+        agent_id: Stable identifier for the spawn record.
+        role: Agent role name (recorded for inspection).
+        tools: Tool chain the agent will be permitted to invoke.
+        registry: Optional pre-loaded registry (tests / repeated spawns).
+
+    Returns:
+        The :class:`ChainDecision` produced by the registry.
+
+    Raises:
+        LethalTrifectaError: When enforcement is on and the chain trips
+            all three capabilities.
+    """
+    import json
+    from datetime import UTC, datetime
+
+    reg = registry if registry is not None else CapabilityRegistry.load_default(workdir=workdir)
+    decision = reg.evaluate_chain(tools)
+
+    runtime_dir = workdir / ".sdd" / "runtime" / "spawn_capabilities"
+    try:
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "agent_id": agent_id,
+            "role": role,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "tools": list(tools),
+            "triggered": sorted(c.value for c in decision.triggered),
+            "allowed": decision.allowed,
+            "reason": decision.reason,
+            "mode": decision.mode.value,
+            "unknown_tools": list(decision.unknown_tools),
+            "offending_tools": list(decision.offending_tools),
+        }
+        (runtime_dir / f"{agent_id}.json").write_text(
+            json.dumps(manifest, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as exc:
+        logger.warning("Could not persist capability manifest for %s: %s", agent_id, exc)
+
+    if not decision.allowed:
+        raise LethalTrifectaError(decision)
+    return decision

--- a/src/bernstein/core/security/policy_engine.py
+++ b/src/bernstein/core/security/policy_engine.py
@@ -17,7 +17,10 @@ from typing import TYPE_CHECKING, Any, Literal, cast
 import yaml
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from bernstein.core.models import Task
+    from bernstein.core.security.capability_matrix import CapabilityRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +97,40 @@ class DecisionGraph:
             return d
 
         return PermissionDecision(DecisionType.ALLOW, "All checks passed or bypassed")
+
+
+def evaluate_lethal_trifecta(
+    tools: Sequence[str],
+    registry: CapabilityRegistry,
+) -> PermissionDecision:
+    """Evaluate a tool chain against the lethal-trifecta registry.
+
+    Produces a :class:`DecisionType.IMMUNE` denial (``bypass_immune=True``)
+    when the union of capabilities along the chain covers the full
+    trifecta and enforcement is on; otherwise an ALLOW.  Designed to be
+    fed into a :class:`DecisionGraph` ahead of plugin-level layers so
+    that plugins cannot override the structural rule.
+
+    Args:
+        tools: Tool identifiers as recorded in the registry.
+        registry: The capability registry (carries the enforcement mode).
+
+    Returns:
+        A :class:`PermissionDecision`.  IMMUNE+bypass_immune when denied,
+        ALLOW otherwise (warn-mode chains are ALLOW with a hint reason).
+    """
+    decision = registry.evaluate_chain(tools)
+    if decision.allowed:
+        return PermissionDecision(
+            type=DecisionType.ALLOW,
+            reason=decision.reason,
+        )
+    detail = f"{decision.reason}: tools={list(decision.offending_tools)}"
+    return PermissionDecision(
+        type=DecisionType.IMMUNE,
+        reason=detail,
+        bypass_immune=True,
+    )
 
 
 _REGEX_RULE_RE = re.compile(r"^(?P<field>[a-z_]+)[ \t]*(?P<operator>!~|=~)[ \t]*/(?P<pattern>.+)/$")

--- a/templates/capabilities/adapters.yaml
+++ b/templates/capabilities/adapters.yaml
@@ -1,0 +1,43 @@
+# Lethal-trifecta capability tags for Bernstein CLI agent adapters.
+#
+# Adapters launch a generic CLI coding agent (Claude Code, Codex, etc.).
+# Once a CLI agent is running it can read repository files, fetch URLs,
+# and call git/gh — so every adapter is tagged with all three capabilities
+# unless an operator scopes it via per-agent credential scoping or the
+# tool allowlist.  Treat the adapter row as the *outer* envelope; the
+# inner tool calls are tagged separately in mcp_tools.yaml / surfaces.yaml.
+tools:
+  - name: adapter.aider
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.amp
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.claude
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.cloudflare_agents
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.codex
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.cody
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.continue_dev
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.cursor
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.gemini
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.generic
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.goose
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.iac
+    capabilities: [private_data, external_comm]
+  - name: adapter.kilo
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.kiro
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.ollama
+    capabilities: [private_data, untrusted_input]
+  - name: adapter.opencode
+    capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.qwen
+    capabilities: [private_data, untrusted_input, external_comm]

--- a/templates/capabilities/mcp_tools.yaml
+++ b/templates/capabilities/mcp_tools.yaml
@@ -1,0 +1,23 @@
+# Built-in Bernstein MCP server tools (src/bernstein/mcp/server.py).
+# These talk to the local task server only — no external comm and no
+# untrusted input.  bernstein_run *can* spawn agents that touch private
+# data, so it is tagged accordingly.
+tools:
+  - name: mcp.bernstein_health
+    capabilities: []
+  - name: mcp.bernstein_run
+    capabilities: [private_data]
+  - name: mcp.bernstein_status
+    capabilities: [private_data]
+  - name: mcp.bernstein_tasks
+    capabilities: [private_data]
+  - name: mcp.bernstein_cost
+    capabilities: [private_data]
+  - name: mcp.bernstein_stop
+    capabilities: []
+  - name: mcp.bernstein_approve
+    capabilities: []
+  - name: mcp.bernstein_create_subtask
+    capabilities: [private_data]
+  - name: mcp.load_skill
+    capabilities: [private_data]

--- a/templates/capabilities/surfaces.yaml
+++ b/templates/capabilities/surfaces.yaml
@@ -1,0 +1,45 @@
+# Generic tool surfaces invoked by CLI agents.  Names follow the
+# convention <surface>.<verb> so capability lookups remain stable even
+# when adapters wrap them under different display names.
+tools:
+  # --- File I/O ----------------------------------------------------------
+  - name: fs.read
+    capabilities: [private_data]
+  - name: fs.read_secret
+    capabilities: [private_data]
+  - name: fs.write
+    capabilities: []
+  - name: fs.delete
+    capabilities: []
+
+  # --- Web / network fetch (untrusted by definition) ---------------------
+  - name: web.fetch
+    capabilities: [untrusted_input, external_comm]
+  - name: web.search
+    capabilities: [untrusted_input, external_comm]
+
+  # --- GitHub adapter / `gh` CLI -----------------------------------------
+  - name: github.fetch_issue
+    capabilities: [untrusted_input, external_comm]
+  - name: github.fetch_pr
+    capabilities: [untrusted_input, external_comm]
+  - name: github.fetch_comment
+    capabilities: [untrusted_input, external_comm]
+  - name: github.post_comment
+    capabilities: [external_comm]
+  - name: github.post_pr
+    capabilities: [external_comm]
+  - name: github.post_issue
+    capabilities: [external_comm]
+
+  # --- Git ---------------------------------------------------------------
+  - name: git.read
+    capabilities: [private_data]
+  - name: git.commit
+    capabilities: []
+  - name: git.push
+    capabilities: [external_comm]
+
+  # --- Shell / process exec ----------------------------------------------
+  - name: shell.exec
+    capabilities: [private_data, external_comm]

--- a/tests/unit/test_capability_matrix.py
+++ b/tests/unit/test_capability_matrix.py
@@ -1,0 +1,243 @@
+"""Unit tests for the lethal-trifecta capability matrix.
+
+Covers the registry, chain evaluator, default-deny semantics, the YAML
+loader, and the spawn-time recording helper.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.capability_matrix import (
+    Capability,
+    CapabilityRegistry,
+    EnforcementMode,
+    LethalTrifectaError,
+    ToolCapabilities,
+    find_violating_chains,
+    record_spawn_capabilities,
+)
+
+
+@pytest.fixture()
+def registry() -> CapabilityRegistry:
+    reg = CapabilityRegistry()
+    reg.register(
+        ToolCapabilities(
+            tool_name="fs.read_secret",
+            capabilities=frozenset({Capability.PRIVATE_DATA}),
+        )
+    )
+    reg.register(
+        ToolCapabilities(
+            tool_name="github.fetch_issue",
+            capabilities=frozenset({Capability.UNTRUSTED_INPUT, Capability.EXTERNAL_COMM}),
+        )
+    )
+    reg.register(
+        ToolCapabilities(
+            tool_name="github.post_comment",
+            capabilities=frozenset({Capability.EXTERNAL_COMM}),
+        )
+    )
+    reg.register(
+        ToolCapabilities(
+            tool_name="git.commit",
+            capabilities=frozenset(),
+        )
+    )
+    return reg
+
+
+class TestEvaluateChain:
+    def test_empty_chain_is_allowed(self, registry: CapabilityRegistry) -> None:
+        decision = registry.evaluate_chain([])
+        assert decision.allowed is True
+        assert decision.triggered == frozenset()
+
+    def test_two_capabilities_is_allowed(self, registry: CapabilityRegistry) -> None:
+        decision = registry.evaluate_chain(["fs.read_secret", "git.commit"])
+        assert decision.allowed is True
+        assert Capability.PRIVATE_DATA in decision.triggered
+        assert Capability.UNTRUSTED_INPUT not in decision.triggered
+
+    def test_full_trifecta_is_denied_in_enforce_mode(self, registry: CapabilityRegistry) -> None:
+        decision = registry.evaluate_chain(["fs.read_secret", "github.fetch_issue", "github.post_comment"])
+        assert decision.allowed is False
+        assert decision.reason == CapabilityRegistry.DEFAULT_REASON
+        assert decision.triggered == frozenset(Capability)
+        assert "fs.read_secret" in decision.offending_tools
+        assert "github.fetch_issue" in decision.offending_tools
+
+    def test_warn_mode_allows_but_marks_reason(self, registry: CapabilityRegistry) -> None:
+        registry.mode = EnforcementMode.WARN
+        decision = registry.evaluate_chain(["fs.read_secret", "github.fetch_issue", "github.post_comment"])
+        assert decision.allowed is True
+        assert "warn-only" in decision.reason
+        assert decision.triggered == frozenset(Capability)
+
+    def test_off_mode_disables_check(self, registry: CapabilityRegistry) -> None:
+        registry.mode = EnforcementMode.OFF
+        decision = registry.evaluate_chain(["fs.read_secret", "github.fetch_issue", "github.post_comment"])
+        assert decision.allowed is True
+        assert "enforcement off" in decision.reason
+
+
+class TestUnknownTools:
+    def test_unknown_tool_defaults_to_all_capabilities(self) -> None:
+        reg = CapabilityRegistry()
+        decision = reg.evaluate_chain(["mystery.tool"])
+        assert decision.allowed is False
+        assert decision.unknown_tools == ("mystery.tool",)
+        assert decision.triggered == frozenset(Capability)
+        assert "unknown tool" in decision.reason
+
+    def test_unknown_tool_in_warn_mode_still_flags(self) -> None:
+        reg = CapabilityRegistry(mode=EnforcementMode.WARN)
+        decision = reg.evaluate_chain(["mystery.tool"])
+        assert decision.allowed is True
+        assert "unknown tool" in decision.reason
+        assert decision.unknown_tools == ("mystery.tool",)
+
+    def test_partial_unknown_with_declared_tools(self, registry: CapabilityRegistry) -> None:
+        decision = registry.evaluate_chain(["fs.read_secret", "mystery.tool"])
+        assert decision.allowed is False
+        assert "mystery.tool" in decision.unknown_tools
+        assert decision.triggered == frozenset(Capability)
+
+
+class TestYAMLLoader:
+    def test_loads_valid_yaml(self, tmp_path: Path) -> None:
+        directory = tmp_path / "capabilities"
+        directory.mkdir()
+        (directory / "tools.yaml").write_text(
+            "tools:\n"
+            "  - name: x.read\n"
+            "    capabilities: [private_data]\n"
+            "  - name: x.fetch\n"
+            "    capabilities: [untrusted_input, external_comm]\n",
+            encoding="utf-8",
+        )
+        reg = CapabilityRegistry.from_directory(directory)
+        assert "x.read" in reg.tools
+        assert reg.tools["x.read"].capabilities == frozenset({Capability.PRIVATE_DATA})
+        assert reg.tools["x.fetch"].capabilities == frozenset({Capability.UNTRUSTED_INPUT, Capability.EXTERNAL_COMM})
+
+    def test_unknown_tokens_are_dropped_safely(self, tmp_path: Path) -> None:
+        directory = tmp_path / "capabilities"
+        directory.mkdir()
+        (directory / "tools.yaml").write_text(
+            "tools:\n  - name: y.weird\n    capabilities: [private_data, nonsense]\n",
+            encoding="utf-8",
+        )
+        reg = CapabilityRegistry.from_directory(directory)
+        assert reg.tools["y.weird"].capabilities == frozenset({Capability.PRIVATE_DATA})
+
+    def test_missing_directory_returns_empty_registry(self, tmp_path: Path) -> None:
+        reg = CapabilityRegistry.from_directory(tmp_path / "missing")
+        assert reg.tools == {}
+
+
+class TestRecordSpawn:
+    def test_records_manifest_for_allowed_chain(self, tmp_path: Path, registry: CapabilityRegistry) -> None:
+        decision = record_spawn_capabilities(
+            tmp_path,
+            "agent-1",
+            "backend",
+            ["fs.read_secret", "git.commit"],
+            registry=registry,
+        )
+        assert decision.allowed is True
+        manifest_path = tmp_path / ".sdd" / "runtime" / "spawn_capabilities" / "agent-1.json"
+        assert manifest_path.exists()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["allowed"] is True
+        assert manifest["agent_id"] == "agent-1"
+        assert manifest["role"] == "backend"
+
+    def test_raises_lethal_trifecta_for_full_chain(self, tmp_path: Path, registry: CapabilityRegistry) -> None:
+        with pytest.raises(LethalTrifectaError) as excinfo:
+            record_spawn_capabilities(
+                tmp_path,
+                "agent-2",
+                "backend",
+                ["fs.read_secret", "github.fetch_issue", "github.post_comment"],
+                registry=registry,
+            )
+        assert "lethal trifecta" in str(excinfo.value)
+        manifest_path = tmp_path / ".sdd" / "runtime" / "spawn_capabilities" / "agent-2.json"
+        assert manifest_path.exists()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["allowed"] is False
+        assert manifest["reason"] == CapabilityRegistry.DEFAULT_REASON
+
+
+class TestFindViolatingChains:
+    def test_returns_only_violating_chains(self, registry: CapabilityRegistry) -> None:
+        chains: list[list[str]] = [
+            ["fs.read_secret", "git.commit"],
+            ["fs.read_secret", "github.fetch_issue", "github.post_comment"],
+        ]
+        violations = find_violating_chains(registry, chains)
+        assert len(violations) == 1
+        assert violations[0].triggered == frozenset(Capability)
+
+
+class TestSpawnTimeRefusal:
+    """Sanity check that a declared trifecta chain is denied at spawn time."""
+
+    def test_full_trifecta_via_declared_tools_is_denied(self, tmp_path: Path, registry: CapabilityRegistry) -> None:
+        with pytest.raises(LethalTrifectaError):
+            record_spawn_capabilities(
+                tmp_path,
+                "agent-x",
+                "backend",
+                ["fs.read_secret", "github.fetch_issue", "github.post_comment"],
+                registry=registry,
+            )
+
+
+class TestBundledTemplates:
+    """Sanity-check that the bundled YAML files load cleanly."""
+
+    def test_default_registry_covers_all_adapters(self) -> None:
+        reg = CapabilityRegistry.load_default()
+        adapters = [
+            "aider",
+            "amp",
+            "claude",
+            "cloudflare_agents",
+            "codex",
+            "cody",
+            "continue_dev",
+            "cursor",
+            "gemini",
+            "generic",
+            "goose",
+            "iac",
+            "kilo",
+            "kiro",
+            "ollama",
+            "opencode",
+            "qwen",
+        ]
+        for name in adapters:
+            assert f"adapter.{name}" in reg.tools, f"adapter.{name} missing from bundled YAML"
+
+    def test_default_registry_covers_built_in_mcp_tools(self) -> None:
+        reg = CapabilityRegistry.load_default()
+        for tool in (
+            "mcp.bernstein_health",
+            "mcp.bernstein_run",
+            "mcp.bernstein_status",
+            "mcp.bernstein_tasks",
+            "mcp.bernstein_cost",
+            "mcp.bernstein_stop",
+            "mcp.bernstein_approve",
+            "mcp.bernstein_create_subtask",
+            "mcp.load_skill",
+        ):
+            assert tool in reg.tools, f"{tool} missing from bundled YAML"

--- a/tests/unit/test_policy_engine_trifecta.py
+++ b/tests/unit/test_policy_engine_trifecta.py
@@ -1,0 +1,98 @@
+"""Integration tests: lethal-trifecta evaluator inside the policy stack.
+
+These verify that ``evaluate_lethal_trifecta`` produces a bypass-immune
+IMMUNE decision so plugins running with ``bypass_enabled=True`` cannot
+override the structural rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.security.capability_matrix import (
+    Capability,
+    CapabilityRegistry,
+    EnforcementMode,
+    ToolCapabilities,
+)
+from bernstein.core.security.policy_engine import (
+    DecisionGraph,
+    DecisionType,
+    PermissionDecision,
+    evaluate_lethal_trifecta,
+)
+
+
+@pytest.fixture()
+def trifecta_registry() -> CapabilityRegistry:
+    reg = CapabilityRegistry()
+    reg.register(
+        ToolCapabilities(
+            tool_name="fs.read_secret",
+            capabilities=frozenset({Capability.PRIVATE_DATA}),
+        )
+    )
+    reg.register(
+        ToolCapabilities(
+            tool_name="github.fetch_issue",
+            capabilities=frozenset({Capability.UNTRUSTED_INPUT, Capability.EXTERNAL_COMM}),
+        )
+    )
+    reg.register(
+        ToolCapabilities(
+            tool_name="github.post_comment",
+            capabilities=frozenset({Capability.EXTERNAL_COMM}),
+        )
+    )
+    return reg
+
+
+class TestEvaluateLethalTrifecta:
+    def test_safe_chain_returns_allow(self, trifecta_registry: CapabilityRegistry) -> None:
+        decision = evaluate_lethal_trifecta(["fs.read_secret"], trifecta_registry)
+        assert decision.type == DecisionType.ALLOW
+
+    def test_full_trifecta_returns_immune_with_bypass_immune(self, trifecta_registry: CapabilityRegistry) -> None:
+        decision = evaluate_lethal_trifecta(
+            ["fs.read_secret", "github.fetch_issue", "github.post_comment"],
+            trifecta_registry,
+        )
+        assert decision.type == DecisionType.IMMUNE
+        assert decision.bypass_immune is True
+        assert "lethal trifecta" in decision.reason
+
+    def test_warn_mode_returns_allow(self, trifecta_registry: CapabilityRegistry) -> None:
+        trifecta_registry.mode = EnforcementMode.WARN
+        decision = evaluate_lethal_trifecta(
+            ["fs.read_secret", "github.fetch_issue", "github.post_comment"],
+            trifecta_registry,
+        )
+        assert decision.type == DecisionType.ALLOW
+
+
+class TestDecisionGraphIntegration:
+    def test_immune_layer_blocks_even_with_bypass_enabled(self, trifecta_registry: CapabilityRegistry) -> None:
+        graph = DecisionGraph(bypass_enabled=True)
+        graph.add_decision(
+            evaluate_lethal_trifecta(
+                ["fs.read_secret", "github.fetch_issue", "github.post_comment"],
+                trifecta_registry,
+            )
+        )
+        graph.add_decision(PermissionDecision(DecisionType.ALLOW, "plugin allowed"))
+        final = graph.evaluate()
+        assert final.type == DecisionType.IMMUNE
+        assert "lethal trifecta" in final.reason
+
+    def test_safe_chain_yields_allow_through_graph(self, trifecta_registry: CapabilityRegistry) -> None:
+        graph = DecisionGraph(bypass_enabled=False)
+        graph.add_decision(evaluate_lethal_trifecta(["fs.read_secret"], trifecta_registry))
+        final = graph.evaluate()
+        assert final.type == DecisionType.ALLOW
+
+    def test_unknown_tool_default_deny_stays_immune_with_bypass(self, trifecta_registry: CapabilityRegistry) -> None:
+        graph = DecisionGraph(bypass_enabled=True)
+        graph.add_decision(evaluate_lethal_trifecta(["mystery.tool"], trifecta_registry))
+        final = graph.evaluate()
+        assert final.type == DecisionType.IMMUNE
+        assert final.bypass_immune is True


### PR DESCRIPTION
Implements ticket [`2026-04-30-feat-lethal-trifecta-capability-matrix`](.sdd/backlog/open/2026-04-30-feat-lethal-trifecta-capability-matrix.md).

## Summary

- New `bernstein.core.security.capability_matrix` module: `Capability` enum (`PRIVATE_DATA`, `UNTRUSTED_INPUT`, `EXTERNAL_COMM`), `ToolCapabilities`, `CapabilityRegistry`, `ChainDecision`, `EnforcementMode`, `LethalTrifectaError`, plus a YAML loader and a `record_spawn_capabilities` helper.
- Bundled tags under `templates/capabilities/` covering all 17 adapters, the built-in Bernstein MCP tools, and common file/web/git/github surfaces. Default-deny: unknown tools inherit all three capabilities.
- New `evaluate_lethal_trifecta()` in `policy_engine.py` produces a bypass-immune `DecisionType.IMMUNE` decision so plugins running with `bypass_enabled=True` cannot override the structural rule.
- Spawner wires the check into `_spawn_for_tasks_internal`: the configured catalog tool list is evaluated against the registry, a manifest is persisted under `.sdd/runtime/spawn_capabilities/<agent>.json`, and trifecta-tripping spawns raise `SpawnError`. Adapter envelopes alone do not deny — fine-grained scoping happens via the existing T578 worker tool allowlist.
- New CLI: `bernstein audit capabilities` prints the matrix and exits non-zero if a recorded spawn manifest unions all three capabilities.
- New `SECURITY` defaults singleton with `lethal_trifecta_enforcement: enforce | warn | off` (default `enforce`), tunable via `tuning.security:` in `bernstein.yaml`.

## Test plan

- [x] `uv run pytest tests/unit/test_capability_matrix.py -x -q` — 17 passed
- [x] `uv run pytest tests/unit/test_policy_engine_trifecta.py -x -q` — 6 passed
- [x] `uv run pytest tests/unit/test_policy_engine.py tests/unit/test_spawner.py tests/unit/test_defaults.py -x -q` — 93 passed (no regressions)
- [x] `uv run ruff format --check` and `uv run ruff check` clean on all touched files
- [x] `bernstein audit capabilities` prints 42-tool matrix; exits 1 when a synthetic violating spawn manifest is present