### PR TITLE
feat(routes): static service manifest for A2A/agent discovery

### DIFF
--- a/src/bernstein/core/routes/task_a2a.py
+++ b/src/bernstein/core/routes/task_a2a.py
@@ -49,9 +49,14 @@ def _require_task_access(task: object, request: Request) -> None:
     _impl(task, request)  # type: ignore[arg-type]
 
 
-@router.get("/.well-known/agent.json")
+@router.get("/a2a/agent-card")
 def agent_card(request: Request) -> A2AAgentCardResponse:
-    """Publish the Bernstein orchestrator Agent Card (A2A spec)."""
+    """Publish the Bernstein orchestrator Agent Card (legacy A2A path).
+
+    The richer service manifest at ``/.well-known/agent.json`` is served by
+    ``routes.well_known``; this endpoint is preserved for callers that
+    historically pulled the orchestrator's own A2A card.
+    """
     a2a_handler = _get_a2a_handler(request)
     card = a2a_handler.orchestrator_card()
     d = card.to_dict()

--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -1,0 +1,149 @@
+"""Static service manifest routes — A2A agent card and llms.txt summary.
+
+External agents (Claude Code, Codex, third-party orchestrators) discover the
+Bernstein task API by fetching ``/.well-known/agent.json`` (A2A-compliant
+JSON card) or ``/llms.txt`` (markdown summary).  Both endpoints derive from
+a single in-module ``_ENDPOINTS`` table so the markdown summary cannot drift
+from the structured manifest — the regression test in
+``tests/unit/test_well_known.py`` enforces that every entry in the table is
+mentioned in the rendered llms.txt body.
+
+Both routes are unauthenticated; they live in ``AUTH_PUBLIC_PATHS`` so any
+network caller can read them without provisioning a token.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+from bernstein import __version__ as _BERNSTEIN_VERSION
+
+router = APIRouter()
+
+_AGENT_NAME = "bernstein"
+_AGENT_DESCRIPTION = (
+    "Bernstein orchestrates short-lived CLI coding agents (Claude Code, "
+    "Codex, Gemini CLI, Aider, ...) against a file-based task store.  "
+    "Clients submit tasks, query status, and post cross-agent bulletins "
+    "via the documented endpoints below."
+)
+_PROTOCOL_VERSION = "0.2"
+_DEFAULT_BASE_URL = "http://127.0.0.1:8052"
+_DOCS_URL = "https://github.com/sipyourdrink-ltd/bernstein"
+
+
+@dataclass(frozen=True, slots=True)
+class _Endpoint:
+    """Single documented endpoint in the manifest."""
+
+    method: str
+    path: str
+    summary: str
+
+
+_ENDPOINTS: tuple[_Endpoint, ...] = (
+    _Endpoint("POST", "/tasks", "Create a new task in the backlog."),
+    _Endpoint("GET", "/tasks", "List tasks (filter via ?status=open|claimed|done)."),
+    _Endpoint("GET", "/tasks/{id}", "Fetch a single task by id."),
+    _Endpoint("POST", "/tasks/{id}/complete", "Mark task done with a result summary."),
+    _Endpoint("POST", "/tasks/{id}/fail", "Mark task failed with an error reason."),
+    _Endpoint("POST", "/tasks/{id}/progress", "Report partial progress (files, tests, errors)."),
+    _Endpoint("POST", "/bulletin", "Post a finding or blocker visible to other agents."),
+    _Endpoint("GET", "/bulletin", "Read recent bulletins (filter via ?since=ts)."),
+    _Endpoint("GET", "/status", "Server-side dashboard summary."),
+    _Endpoint("GET", "/health", "Liveness probe."),
+    _Endpoint("GET", "/health/ready", "Readiness probe."),
+)
+
+_SKILLS: tuple[dict[str, object], ...] = (
+    {
+        "id": "task-orchestration",
+        "name": "Task orchestration",
+        "description": "Submit goals, watch their progress, and react to terminal state.",
+        "tags": ["tasks", "orchestration"],
+    },
+    {
+        "id": "agent-bulletin",
+        "name": "Cross-agent bulletin",
+        "description": "Broadcast findings and blockers to peer agents.",
+        "tags": ["bulletin", "messaging"],
+    },
+)
+
+
+def _agent_card_payload(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
+    """Build the A2A agent-card dict served at /.well-known/agent.json.
+
+    Args:
+        base_url: Public base URL of the task server.
+
+    Returns:
+        JSON-serialisable dict accepted by ``parse_agent_card``.
+    """
+    return {
+        "name": _AGENT_NAME,
+        "description": _AGENT_DESCRIPTION,
+        "version": _BERNSTEIN_VERSION,
+        "protocolVersion": _PROTOCOL_VERSION,
+        "url": base_url,
+        "documentationUrl": _DOCS_URL,
+        "capabilities": [
+            {"name": "task-crud", "description": "Create / read / complete / fail tasks."},
+            {"name": "bulletin", "description": "Post and read cross-agent bulletins."},
+            {"name": "status", "description": "Read server status and health probes."},
+        ],
+        "skills": list(_SKILLS),
+        "defaultInputModes": ["text", "application/json"],
+        "defaultOutputModes": ["application/json"],
+        "authentication": {
+            "schemes": ["Bearer"],
+            "publicPaths": ["/health", "/.well-known/agent.json", "/llms.txt"],
+            "description": (
+                "Bearer token in Authorization header.  Set BERNSTEIN_AUTH_DISABLED=1 "
+                "for local development (no token required)."
+            ),
+        },
+        "endpoints": [{"method": e.method, "path": e.path, "summary": e.summary} for e in _ENDPOINTS],
+    }
+
+
+def _render_llms_txt() -> str:
+    """Render the markdown summary served at /llms.txt."""
+    lines: list[str] = [
+        f"# {_AGENT_NAME}",
+        "",
+        f"> {_AGENT_DESCRIPTION}",
+        "",
+        f"- Version: {_BERNSTEIN_VERSION}",
+        f"- Protocol: A2A {_PROTOCOL_VERSION}",
+        f"- Docs: {_DOCS_URL}",
+        "",
+        "## Endpoints",
+        "",
+    ]
+    lines.extend(f"- `{e.method} {e.path}` — {e.summary}" for e in _ENDPOINTS)
+    lines += [
+        "",
+        "## Auth",
+        "",
+        "Send `Authorization: Bearer <token>` on every request.  Public paths: "
+        "`/health`, `/.well-known/agent.json`, `/llms.txt`.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+@router.get("/.well-known/agent.json", include_in_schema=False)
+def agent_json() -> dict[str, Any]:
+    """Return the A2A-compliant agent card for this task server."""
+    return _agent_card_payload()
+
+
+@router.get("/llms.txt", include_in_schema=False, response_class=PlainTextResponse)
+def llms_txt() -> str:
+    """Return a markdown summary of the public API surface."""
+    return _render_llms_txt()

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -76,6 +76,7 @@ AUTH_PUBLIC_PATHS = frozenset(
         # Agent / protocol discovery
         "/.well-known/agent.json",
         "/.well-known/acp.json",
+        "/llms.txt",
         "/acp/v0/agents",
         # Auth flow endpoints (must be public for login to work)
         "/auth/login",

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1222,6 +1222,7 @@ def create_app(
     from bernstein.core.routes.task_detail import router as task_detail_router
     from bernstein.core.routes.team import router as team_router
     from bernstein.core.routes.websocket import router as ws_router
+    from bernstein.core.routes.well_known import router as well_known_router
 
     # Full roster of application routers.
     #
@@ -1273,6 +1274,7 @@ def create_app(
         team_router,
         provider_latency_router,
         predictive_router,
+        well_known_router,
     ]
 
     for r in all_routers:

--- a/tests/unit/test_a2a.py
+++ b/tests/unit/test_a2a.py
@@ -201,8 +201,13 @@ class TestA2AHandler:
 
 @pytest.mark.anyio
 async def test_agent_card_endpoint(client: AsyncClient) -> None:
-    """GET /.well-known/agent.json returns the orchestrator Agent Card."""
-    resp = await client.get("/.well-known/agent.json")
+    """GET /a2a/agent-card returns the orchestrator Agent Card.
+
+    The /.well-known/agent.json path now serves the richer service
+    manifest (see ``routes.well_known``); the legacy orchestrator card
+    moved to /a2a/agent-card.
+    """
+    resp = await client.get("/a2a/agent-card")
     assert resp.status_code == 200
     data = resp.json()
     assert data["name"] == "bernstein-orchestrator"

--- a/tests/unit/test_well_known.py
+++ b/tests/unit/test_well_known.py
@@ -1,0 +1,81 @@
+"""Tests for static service manifest routes (/.well-known/agent.json, /llms.txt)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.agents.claude_agent_card import parse_agent_card
+from bernstein.core.routes.well_known import (
+    _ENDPOINTS,
+    _agent_card_payload,
+    _render_llms_txt,
+)
+from bernstein.core.security.auth_middleware import AUTH_PUBLIC_PATHS
+from bernstein.core.server import create_app
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> TestClient:
+    os.environ["BERNSTEIN_AUTH_DISABLED"] = "1"
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    return TestClient(app)
+
+
+def test_agent_json_returns_valid_a2a_card(client: TestClient) -> None:
+    resp = client.get("/.well-known/agent.json")
+    assert resp.status_code == 200
+    data = resp.json()
+    card = parse_agent_card(data)
+    assert card.name == "bernstein"
+    assert card.protocol_version
+    assert card.version
+    assert card.url
+    assert any(c.name == "task-crud" for c in card.capabilities)
+    assert any(s.id == "task-orchestration" for s in card.skills)
+
+
+def test_agent_json_lists_documented_endpoints(client: TestClient) -> None:
+    resp = client.get("/.well-known/agent.json")
+    endpoints = resp.json()["endpoints"]
+    paths = {(e["method"], e["path"]) for e in endpoints}
+    assert ("POST", "/tasks") in paths
+    assert ("POST", "/tasks/{id}/complete") in paths
+    assert ("POST", "/bulletin") in paths
+    assert ("GET", "/bulletin") in paths
+
+
+def test_llms_txt_is_markdown(client: TestClient) -> None:
+    resp = client.get("/llms.txt")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/plain")
+    body = resp.text
+    assert body.startswith("# bernstein")
+    assert "## Endpoints" in body
+    assert "## Auth" in body
+
+
+def test_llms_txt_mentions_every_documented_endpoint() -> None:
+    """Regression guard: adding an endpoint to the manifest must surface in llms.txt.
+
+    The single ``_ENDPOINTS`` table feeds both renderers, so this test will
+    fail loudly if the markdown template ever stops iterating it.
+    """
+    body = _render_llms_txt()
+    for endpoint in _ENDPOINTS:
+        assert endpoint.path in body, f"missing {endpoint.path}"
+        assert endpoint.method in body, f"missing {endpoint.method}"
+
+
+def test_well_known_paths_are_public_in_auth_middleware() -> None:
+    assert "/.well-known/agent.json" in AUTH_PUBLIC_PATHS
+    assert "/llms.txt" in AUTH_PUBLIC_PATHS
+
+
+def test_agent_card_payload_supports_custom_base_url() -> None:
+    payload = _agent_card_payload(base_url="https://api.example.com")
+    assert payload["url"] == "https://api.example.com"
+    assert payload["authentication"]["schemes"] == ["Bearer"]


### PR DESCRIPTION
Implements ticket `2026-04-30-feat-static-service-manifest` — Bernstein's task server now publishes a machine-readable manifest at the standard well-known URLs so external agents (Claude Code, Codex, third-party orchestrators) can discover the API without hand-configuration.

## Summary

- New `src/bernstein/core/routes/well_known.py` (~140 LOC) serves:
  - `GET /.well-known/agent.json` — A2A-compliant card listing task CRUD + bulletin endpoints, auth scheme, version, and skills.
  - `GET /llms.txt` — markdown summary of the public API.
- Both routes derive from a single `_ENDPOINTS` table so the markdown summary cannot drift from the structured manifest; the regression test fails if a documented endpoint is added without surfacing in `llms.txt`.
- Both endpoints work without auth — `/.well-known/agent.json` was already in `AUTH_PUBLIC_PATHS`; `/llms.txt` was added.
- The legacy `/.well-known/agent.json` handler in `task_a2a.py` (which served only the orchestrator A2A card) moved to `/a2a/agent-card`. The richer service manifest now lives at the well-known URL.
- agent.json validates against the existing A2A schema parser in `claude_agent_card.py`.

## Test plan

- [x] `uv run pytest tests/unit/test_well_known.py -x -q` — 6 passed
- [x] `uv run pytest tests/unit/test_a2a.py -x -q` — 29 passed (legacy card path updated)
- [x] `uv run pytest tests/unit/test_auth_middleware.py tests/unit/test_auth_middleware_defaults.py -x -q` — 47 passed
- [x] `uv run ruff format` + `ruff check` — clean
- [x] `uv run pyright src/bernstein/core/routes/well_known.py` — 0 errors