### PR TITLE
feat(quality): abstracted code review pipeline

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -497,6 +497,10 @@ SCHEMA_RETRY = SchemaRetryDefaults()
 # numeric cap is needed (no need to import the whole singleton).
 SCHEMA_RETRY_MAX_ATTEMPTS: int = SCHEMA_RETRY.max_attempts
 
+# Abstract-diff PR review augmentation (abstracted-code-review).
+ABSTRACT_DIFF_ENABLED: bool = True
+ABSTRACT_DIFF_MAX_FILES: int = 50
+
 
 # Mapping of section name (as used in bernstein.yaml ``tuning:`` blocks) to the
 # module-level attribute that stores the singleton.  We rebind the attribute

--- a/src/bernstein/core/quality/review_pipeline/abstract_diff.py
+++ b/src/bernstein/core/quality/review_pipeline/abstract_diff.py
@@ -1,0 +1,522 @@
+"""Intent-summary + pseudocode abstraction over raw PR diffs.
+
+Reviewing AI-generated diffs line-by-line is the bottleneck once
+``bernstein run`` is shipping multiple PRs per hour. This module turns a
+unified diff plus a task description into a per-file intent summary
+(1-3 bullets) and a pseudocode block for changed Python functions, so
+reviewers see *what* changed at the behavioural level with drill-down
+to the raw diff via a collapsible GitHub ``<details>`` block.
+
+Pattern source: ``nibzard/awesome-agentic-patterns`` —
+``abstracted-code-representation-for-review``.
+
+Public API:
+
+* :class:`IntentSummary` — per-file abstracted view.
+* :class:`TaskContext` — minimal task metadata fed to the summariser.
+* :func:`summarize_diff` — async, calls the cheap-tier LLM per file.
+* :func:`pseudo_for_function` — AST-walked pseudocode for a single
+  Python function.
+* :func:`render_pr_body` — markdown wrapper used by ``pr_gen``.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import contextlib
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import cast
+
+from bernstein.core.defaults import ABSTRACT_DIFF_ENABLED, ABSTRACT_DIFF_MAX_FILES
+from bernstein.core.llm import call_llm
+from bernstein.core.quality.cross_model_verifier import (
+    _MAX_TOKENS,
+    _PROVIDER,
+    select_reviewer_model,
+)
+
+logger = logging.getLogger(__name__)
+
+
+LLMCaller = Callable[..., Awaitable[str]]
+
+
+_PSEUDOCODE_INDENT: str = "    "
+_MAX_BULLETS_PER_FILE: int = 3
+_MAX_DIFF_CHARS_PER_FILE: int = 3_000
+_OPUS_MARKER: str = "opus"
+
+
+_SUMMARY_PROMPT_TEMPLATE: str = """\
+You are summarising a single file's diff for a human reviewer.
+Give a *behavioural* summary — what the change accomplishes — not a
+line-by-line restatement.
+
+## Task
+**Title:** {title}
+**Description:**
+{description}
+
+## File: {path}
+
+```diff
+{diff}
+```
+
+Return ONLY a JSON object with these fields:
+{{
+  "bullets": ["1-3 short bullets, each one sentence"],
+  "confidence": 0.0
+}}
+
+Bullets describe the *intent* (e.g. "switches sort to quicksort for
+N>32"), never raw line counts. ``confidence`` is between 0 and 1.
+No markdown fences. No prose around the JSON.
+"""
+
+
+@dataclass(frozen=True)
+class TaskContext:
+    """Minimal task metadata threaded into the summary prompt.
+
+    Attributes:
+        title: Short subject line.
+        description: Longer goal / acceptance criteria.
+        writer_model: Model that authored the diff. Used only to pick a
+            *different* reviewer via the cascade router.
+    """
+
+    title: str
+    description: str = ""
+    writer_model: str = ""
+
+
+@dataclass(frozen=True)
+class IntentSummary:
+    """Abstracted view of a single file's diff.
+
+    Attributes:
+        path: Repo-relative file path the summary describes.
+        bullet_points: 1-3 sentence bullets describing the intent. Empty
+            when the LLM call failed or returned unparseable output.
+        pseudocode_blocks: Pseudocode for changed Python functions
+            (one block per function), AST-walked from the post-diff
+            source text. Empty for non-Python files.
+        raw_diff_link: GitHub anchor / URL pointing at the raw diff for
+            drill-down. May be empty when no link is available.
+        confidence: Reviewer-reported confidence in ``[0, 1]``. ``0``
+            when the call failed or no number was returned.
+    """
+
+    path: str
+    bullet_points: tuple[str, ...] = ()
+    pseudocode_blocks: tuple[str, ...] = ()
+    raw_diff_link: str = ""
+    confidence: float = 0.0
+
+
+@dataclass(frozen=True)
+class _FileDiff:
+    path: str
+    body: str
+    post_image: str = ""
+    pseudocode: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _split_unified_diff(diff: str) -> list[_FileDiff]:
+    """Split a unified diff into per-file blocks.
+
+    Only ``diff --git`` headers are recognised — that is what ``git diff``
+    emits. The post-image (post-change source) is reconstructed from
+    ``+`` lines so :func:`pseudo_for_function` can run against syntactically
+    valid Python where possible.
+    """
+    if not diff.strip():
+        return []
+
+    files: list[_FileDiff] = []
+    current_path: str | None = None
+    current_lines: list[str] = []
+    post_lines: list[str] = []
+
+    def _flush() -> None:
+        if current_path is None:
+            return
+        body = "\n".join(current_lines)
+        post = "\n".join(post_lines)
+        files.append(_FileDiff(path=current_path, body=body, post_image=post))
+
+    for raw_line in diff.splitlines():
+        if raw_line.startswith("diff --git "):
+            _flush()
+            current_path = _extract_path(raw_line)
+            current_lines = [raw_line]
+            post_lines = []
+            continue
+        if current_path is None:
+            continue
+        current_lines.append(raw_line)
+        if (raw_line.startswith("+") and not raw_line.startswith("+++")) or raw_line.startswith(" "):
+            post_lines.append(raw_line[1:])
+
+    _flush()
+    return files
+
+
+def _extract_path(header: str) -> str:
+    """Pull the b-side path from a ``diff --git a/x b/x`` header."""
+    parts = header.split()
+    for token in parts:
+        if token.startswith("b/"):
+            return token[2:]
+    return parts[-1] if parts else "unknown"
+
+
+def pseudo_for_function(func_src: str) -> str:
+    """Return a pseudocode rendering of a Python function.
+
+    Walks the AST and emits one statement per significant node — control
+    flow keywords, returns, assignments, and calls — collapsing bodies to
+    pseudocode. Non-functions and unparseable input return an empty
+    string so callers can skip them silently.
+
+    Args:
+        func_src: Source text of a single function definition.
+    """
+    src = func_src.strip()
+    if not src:
+        return ""
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return ""
+
+    if not tree.body or not isinstance(tree.body[0], (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return ""
+    func = tree.body[0]
+    args = ", ".join(a.arg for a in func.args.args)
+    header = f"function {func.name}({args}):"
+    body = _render_block(func.body, depth=1)
+    return header + "\n" + body if body else header + "\n" + _PSEUDOCODE_INDENT + "pass"
+
+
+def _render_block(stmts: list[ast.stmt], *, depth: int) -> str:
+    pad = _PSEUDOCODE_INDENT * depth
+    out: list[str] = []
+    for node in stmts:
+        rendered = _render_stmt(node, depth=depth)
+        if rendered:
+            out.append(pad + rendered)
+    return "\n".join(out)
+
+
+def _render_stmt(node: ast.stmt, *, depth: int) -> str:
+    if isinstance(node, ast.If):
+        cond = _safe_unparse(node.test)
+        then = _render_block(node.body, depth=depth + 1)
+        out = f"if {cond}:"
+        if then:
+            out += "\n" + then
+        if node.orelse:
+            else_block = _render_block(node.orelse, depth=depth + 1)
+            out += "\n" + _PSEUDOCODE_INDENT * depth + "else:"
+            if else_block:
+                out += "\n" + else_block
+        return out
+    if isinstance(node, (ast.For, ast.AsyncFor)):
+        target = _safe_unparse(node.target)
+        it = _safe_unparse(node.iter)
+        body = _render_block(node.body, depth=depth + 1)
+        return f"for {target} in {it}:" + ("\n" + body if body else "")
+    if isinstance(node, ast.While):
+        cond = _safe_unparse(node.test)
+        body = _render_block(node.body, depth=depth + 1)
+        return f"while {cond}:" + ("\n" + body if body else "")
+    if isinstance(node, ast.Try):
+        body = _render_block(node.body, depth=depth + 1)
+        return "try:" + ("\n" + body if body else "")
+    if isinstance(node, ast.Return):
+        return f"return {_safe_unparse(node.value)}" if node.value is not None else "return"
+    if isinstance(node, (ast.Raise,)):
+        return f"raise {_safe_unparse(node.exc)}" if node.exc is not None else "raise"
+    if isinstance(node, ast.Assign):
+        targets = ", ".join(_safe_unparse(t) for t in node.targets)
+        return f"{targets} = {_safe_unparse(node.value)}"
+    if isinstance(node, ast.AugAssign):
+        return f"{_safe_unparse(node.target)} {type(node.op).__name__.lower()}= {_safe_unparse(node.value)}"
+    if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+        return f"call {_safe_unparse(node.value)}"
+    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        return f"define inner function {node.name}"
+    if isinstance(node, ast.ClassDef):
+        return f"define class {node.name}"
+    return ""
+
+
+def _safe_unparse(node: ast.AST | None) -> str:
+    if node is None:
+        return ""
+    try:
+        return ast.unparse(node)
+    except (AttributeError, ValueError):
+        return type(node).__name__
+
+
+def _extract_post_functions(post_image: str) -> tuple[str, ...]:
+    """AST-walk the post-image and return pseudocode for each function."""
+    if not post_image.strip():
+        return ()
+    try:
+        tree = ast.parse(post_image)
+    except SyntaxError:
+        return ()
+    blocks: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            try:
+                src = ast.unparse(node)
+            except (AttributeError, ValueError):
+                continue
+            pseudo = pseudo_for_function(src)
+            if pseudo:
+                blocks.append(pseudo)
+    return tuple(blocks)
+
+
+def _disallow_opus(model: str) -> str:
+    if _OPUS_MARKER in model.lower():
+        logger.info("abstract_diff: opus tier disallowed (%s) — falling back to gemini-flash", model)
+        return "google/gemini-flash-1.5"
+    return model
+
+
+def _build_summary_prompt(file: _FileDiff, ctx: TaskContext) -> str:
+    body = file.body
+    if len(body) > _MAX_DIFF_CHARS_PER_FILE:
+        body = body[:_MAX_DIFF_CHARS_PER_FILE] + "\n... (truncated)"
+    return _SUMMARY_PROMPT_TEMPLATE.format(
+        title=ctx.title,
+        description=ctx.description[:1500],
+        path=file.path,
+        diff=body,
+    )
+
+
+def _parse_summary(raw: str) -> tuple[tuple[str, ...], float]:
+    text = raw.strip()
+    if text.startswith("```"):
+        text = "\n".join(line for line in text.splitlines() if not line.strip().startswith("```")).strip()
+    data: dict[str, object] = {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}") + 1
+        if start >= 0 and end > start:
+            with contextlib.suppress(json.JSONDecodeError):
+                data = json.loads(text[start:end])
+    if not data:
+        return (), 0.0
+    bullets_raw: object = data.get("bullets", [])
+    bullets: list[str] = []
+    if isinstance(bullets_raw, list):
+        bullets = [str(item).strip() for item in cast("list[object]", bullets_raw) if str(item).strip()]
+    bullets = bullets[:_MAX_BULLETS_PER_FILE]
+    conf_raw: object = data.get("confidence", 0.0)
+    try:
+        confidence = float(cast("float | str | int", conf_raw))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    return tuple(bullets), max(0.0, min(1.0, confidence))
+
+
+async def _summarize_one(
+    file: _FileDiff,
+    ctx: TaskContext,
+    *,
+    model: str,
+    llm_caller: LLMCaller,
+    provider: str,
+    max_tokens: int,
+    raw_diff_link: str,
+) -> IntentSummary:
+    prompt = _build_summary_prompt(file, ctx)
+    try:
+        raw = await llm_caller(
+            prompt=prompt,
+            model=model,
+            provider=provider,
+            max_tokens=max_tokens,
+            temperature=0.0,
+        )
+    except (TimeoutError, RuntimeError, OSError) as exc:
+        logger.warning("abstract_diff: summary call failed for %s: %s", file.path, exc)
+        return IntentSummary(
+            path=file.path,
+            pseudocode_blocks=file.pseudocode,
+            raw_diff_link=raw_diff_link,
+        )
+    bullets, confidence = _parse_summary(raw)
+    return IntentSummary(
+        path=file.path,
+        bullet_points=bullets,
+        pseudocode_blocks=file.pseudocode,
+        raw_diff_link=raw_diff_link,
+        confidence=confidence,
+    )
+
+
+async def summarize_diff(
+    diff: str,
+    task_context: TaskContext,
+    *,
+    llm_caller: LLMCaller | None = None,
+    provider: str = _PROVIDER,
+    max_tokens: int = _MAX_TOKENS,
+    raw_diff_link: str = "",
+    enabled: bool | None = None,
+    max_files: int | None = None,
+) -> list[IntentSummary]:
+    """Produce a per-file :class:`IntentSummary` list for *diff*.
+
+    Uses the cheap-tier reviewer chosen by
+    :func:`bernstein.core.quality.cross_model_verifier.select_reviewer_model`
+    against ``task_context.writer_model``; the opus tier is explicitly
+    disallowed (the abstraction layer is meant to be cheap).
+
+    On diffs with more than :data:`ABSTRACT_DIFF_MAX_FILES` files the
+    abstraction *degrades gracefully*: a single top-level summary is
+    returned with empty bullets so the PR body still renders without
+    spending N x cheap-LLM calls.
+
+    Args:
+        diff: Unified diff text (``git diff`` output).
+        task_context: Title / description / writer model. Threaded into
+            the summary prompt so the reviewer sees *intent*.
+        llm_caller: Override for tests.  Defaults to ``call_llm``.
+        provider: LLM provider key.
+        max_tokens: Per-file response cap.
+        raw_diff_link: Optional GitHub anchor URL to embed in each
+            summary's ``raw_diff_link``.
+        enabled: Override the :data:`ABSTRACT_DIFF_ENABLED` toggle.
+        max_files: Override the :data:`ABSTRACT_DIFF_MAX_FILES` cap.
+
+    Returns:
+        One :class:`IntentSummary` per changed file, in diff order. An
+        empty list when the feature is disabled or the diff is empty.
+    """
+    is_enabled = ABSTRACT_DIFF_ENABLED if enabled is None else enabled
+    if not is_enabled:
+        return []
+    cap = ABSTRACT_DIFF_MAX_FILES if max_files is None else max_files
+
+    files_raw = _split_unified_diff(diff)
+    if not files_raw:
+        return []
+
+    files: list[_FileDiff] = []
+    for f in files_raw:
+        pseudo = _extract_post_functions(f.post_image) if f.path.endswith(".py") else ()
+        files.append(_FileDiff(path=f.path, body=f.body, post_image=f.post_image, pseudocode=pseudo))
+
+    if len(files) > cap:
+        logger.info(
+            "abstract_diff: %d files exceeds cap %d — emitting top-level summary only",
+            len(files),
+            cap,
+        )
+        bullet = f"{len(files)} files changed — exceeds abstract-diff cap of {cap}; see raw diff for per-file detail."
+        return [
+            IntentSummary(
+                path="<aggregate>",
+                bullet_points=(bullet,),
+                raw_diff_link=raw_diff_link,
+            )
+        ]
+
+    caller = llm_caller or call_llm
+    model = _disallow_opus(select_reviewer_model(task_context.writer_model or "claude"))
+
+    results = await asyncio.gather(
+        *[
+            _summarize_one(
+                f,
+                task_context,
+                model=model,
+                llm_caller=caller,
+                provider=provider,
+                max_tokens=max_tokens,
+                raw_diff_link=raw_diff_link,
+            )
+            for f in files
+        ]
+    )
+    return list(results)
+
+
+def render_pr_body(summaries: list[IntentSummary], *, raw_diff: str | None = None) -> str:
+    """Render an "Intent" markdown section for a PR body.
+
+    Each file gets a heading, its bullets, optional pseudocode, and a
+    collapsible ``<details>`` containing the file's raw diff slice. When
+    ``raw_diff`` is supplied, a single bottom-of-body details block holds
+    the full raw diff for absolute drill-down.
+
+    Args:
+        summaries: Output of :func:`summarize_diff`.
+        raw_diff: Optional full unified diff to embed at the bottom.
+    """
+    if not summaries:
+        return ""
+
+    lines: list[str] = ["## Intent", ""]
+    file_diffs: dict[str, str] = {f.path: f.body for f in _split_unified_diff(raw_diff or "")}
+
+    for s in summaries:
+        lines.append(f"### `{s.path}`")
+        if s.bullet_points:
+            lines.extend(f"- {b}" for b in s.bullet_points)
+        else:
+            lines.append("- _(no behavioural summary available)_")
+        if s.confidence:
+            lines.append("")
+            lines.append(f"_confidence: {s.confidence:.2f}_")
+        if s.pseudocode_blocks:
+            lines.append("")
+            lines.append("<details><summary>Pseudocode</summary>")
+            lines.append("")
+            for block in s.pseudocode_blocks:
+                lines.append("```text")
+                lines.append(block)
+                lines.append("```")
+            lines.append("")
+            lines.append("</details>")
+        slice_diff = file_diffs.get(s.path, "")
+        if slice_diff:
+            lines.append("")
+            lines.append("<details><summary>Raw diff</summary>")
+            lines.append("")
+            lines.append("```diff")
+            lines.append(slice_diff)
+            lines.append("```")
+            lines.append("")
+            lines.append("</details>")
+        elif s.raw_diff_link:
+            lines.append("")
+            lines.append(f"[Raw diff]({s.raw_diff_link})")
+        lines.append("")
+
+    if raw_diff and len(summaries) > 1:
+        lines.append("<details><summary>Full raw diff</summary>")
+        lines.append("")
+        lines.append("```diff")
+        lines.append(raw_diff)
+        lines.append("```")
+        lines.append("")
+        lines.append("</details>")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/bernstein/core/review_responder/pr_gen.py
+++ b/src/bernstein/core/review_responder/pr_gen.py
@@ -1,0 +1,82 @@
+"""PR-body assembly for bernstein-authored pull requests.
+
+Wires the abstract-diff layer (intent summaries + pseudocode) into the
+markdown body posted on PR creation. The raw description supplied by
+the spawning task is preserved at the top; the abstracted "Intent"
+section follows, with collapsible ``<details>`` blocks that hold the
+raw diff for drill-down.
+
+This module is intentionally thin — the heavy lifting lives in
+``bernstein.core.quality.review_pipeline.abstract_diff``. The split is
+about layering: the responder owns *what shows up on the PR*, the
+review pipeline owns *how the abstraction is computed*.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from bernstein.core.quality.review_pipeline.abstract_diff import (
+    IntentSummary,
+    TaskContext,
+    render_pr_body,
+    summarize_diff,
+)
+
+logger = logging.getLogger(__name__)
+
+
+LLMCaller = Callable[..., Awaitable[str]]
+
+
+async def build_pr_body(
+    *,
+    description: str,
+    diff: str,
+    task_context: TaskContext,
+    raw_diff_link: str = "",
+    llm_caller: LLMCaller | None = None,
+    enabled: bool | None = None,
+    max_files: int | None = None,
+) -> str:
+    """Compose the markdown body for a PR opened by Bernstein.
+
+    Calls :func:`summarize_diff` to produce per-file intent bullets and
+    pseudocode, then concatenates the supplied ``description`` with the
+    rendered "Intent" section.  Falls back to ``description`` alone when
+    the abstraction layer is disabled or returns an empty result.
+
+    Args:
+        description: Free-form PR description (carried over from the
+            spawning task).  Always rendered first.
+        diff: Unified diff of the PR changes.  Truncation is handled by
+            the summariser.
+        task_context: Title / writer-model context for the summariser.
+        raw_diff_link: GitHub URL for the raw diff; embedded as a
+            drill-down link per file when no inline diff is present.
+        llm_caller: Optional override for tests.
+        enabled: Override the global ``ABSTRACT_DIFF_ENABLED`` toggle.
+        max_files: Override the global ``ABSTRACT_DIFF_MAX_FILES`` cap.
+    """
+    summaries = await summarize_diff(
+        diff,
+        task_context,
+        llm_caller=llm_caller,
+        raw_diff_link=raw_diff_link,
+        enabled=enabled,
+        max_files=max_files,
+    )
+    body = description.rstrip()
+    intent = render_pr_body(summaries, raw_diff=diff)
+    if not intent:
+        return body + ("\n" if body and not body.endswith("\n") else "")
+    sep = "\n\n" if body else ""
+    return f"{body}{sep}{intent}"
+
+
+__all__ = [
+    "IntentSummary",
+    "TaskContext",
+    "build_pr_body",
+]

--- a/tests/unit/test_abstract_diff.py
+++ b/tests/unit/test_abstract_diff.py
@@ -1,0 +1,268 @@
+"""Tests for the intent-summary + pseudocode abstraction layer."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Awaitable
+from typing import Any
+
+import pytest
+
+from bernstein.core.quality.review_pipeline.abstract_diff import (
+    IntentSummary,
+    TaskContext,
+    pseudo_for_function,
+    render_pr_body,
+    summarize_diff,
+)
+from bernstein.core.review_responder.pr_gen import build_pr_body
+
+_TWO_FILE_DIFF = """\
+diff --git a/src/foo.py b/src/foo.py
+--- a/src/foo.py
++++ b/src/foo.py
+@@ -1,3 +1,7 @@
+-def slow(xs):
+-    return sorted(xs)
++def slow(xs):
++    if len(xs) > 32:
++        return quicksort(xs)
++    return sorted(xs)
+diff --git a/src/bar.py b/src/bar.py
+--- a/src/bar.py
++++ b/src/bar.py
+@@ -1,1 +1,2 @@
++import os
+ x = 1
+"""
+
+
+def _stub_llm(result_by_path: dict[str, dict[str, Any]]) -> Any:
+    """Return an async LLM stub that picks responses by file path in the prompt."""
+    calls: list[dict[str, Any]] = []
+
+    async def caller(*, prompt: str, model: str, **_: Any) -> str:
+        calls.append({"prompt": prompt, "model": model})
+        for path, payload in result_by_path.items():
+            if path in prompt:
+                return json.dumps(payload)
+        return json.dumps({"bullets": ["fallback"], "confidence": 0.5})
+
+    caller.calls = calls  # type: ignore[attr-defined]
+    return caller
+
+
+def _run(awaitable: Awaitable[Any]) -> Any:
+    return asyncio.run(awaitable)
+
+
+def test_summarize_diff_returns_one_summary_per_file() -> None:
+    stub = _stub_llm(
+        {
+            "src/foo.py": {"bullets": ["adds quicksort branch for large lists"], "confidence": 0.9},
+            "src/bar.py": {"bullets": ["imports os"], "confidence": 0.7},
+        }
+    )
+    summaries = _run(
+        summarize_diff(
+            _TWO_FILE_DIFF,
+            TaskContext(title="Speed up sort", description="prefer quicksort", writer_model="claude"),
+            llm_caller=stub,
+        )
+    )
+    assert [s.path for s in summaries] == ["src/foo.py", "src/bar.py"]
+    assert summaries[0].bullet_points == ("adds quicksort branch for large lists",)
+    assert summaries[0].confidence == pytest.approx(0.9)
+    assert summaries[1].bullet_points == ("imports os",)
+
+
+def test_summarize_diff_disabled_returns_empty() -> None:
+    summaries = _run(
+        summarize_diff(
+            _TWO_FILE_DIFF,
+            TaskContext(title="x"),
+            llm_caller=_stub_llm({}),
+            enabled=False,
+        )
+    )
+    assert summaries == []
+
+
+def test_summarize_diff_empty_diff_returns_empty() -> None:
+    summaries = _run(summarize_diff("", TaskContext(title="x"), llm_caller=_stub_llm({})))
+    assert summaries == []
+
+
+def test_summarize_diff_caps_bullets_at_three() -> None:
+    stub = _stub_llm(
+        {
+            "src/foo.py": {
+                "bullets": ["a", "b", "c", "d", "e"],
+                "confidence": 0.5,
+            },
+            "src/bar.py": {"bullets": [], "confidence": 0.0},
+        }
+    )
+    summaries = _run(summarize_diff(_TWO_FILE_DIFF, TaskContext(title="x"), llm_caller=stub))
+    assert len(summaries[0].bullet_points) == 3
+
+
+def test_summarize_diff_handles_unparseable_llm_output() -> None:
+    async def junk(*, prompt: str, model: str, **_: Any) -> str:
+        return "not json at all"
+
+    summaries = _run(summarize_diff(_TWO_FILE_DIFF, TaskContext(title="x"), llm_caller=junk))
+    assert all(s.bullet_points == () for s in summaries)
+    assert all(s.confidence == 0.0 for s in summaries)
+
+
+def test_summarize_diff_handles_llm_exception() -> None:
+    async def boom(*, prompt: str, model: str, **_: Any) -> str:
+        raise RuntimeError("rate-limited")
+
+    summaries = _run(summarize_diff(_TWO_FILE_DIFF, TaskContext(title="x"), llm_caller=boom))
+    assert len(summaries) == 2
+    for s in summaries:
+        assert s.bullet_points == ()
+        assert s.confidence == 0.0
+
+
+def test_summarize_diff_degrades_when_too_many_files() -> None:
+    big = "\n".join(
+        f"diff --git a/f{i}.py b/f{i}.py\n--- a/f{i}.py\n+++ b/f{i}.py\n@@ -1 +1 @@\n-x\n+y\n" for i in range(60)
+    )
+    stub = _stub_llm({})
+    summaries = _run(summarize_diff(big, TaskContext(title="huge"), llm_caller=stub, max_files=50))
+    assert len(summaries) == 1
+    assert summaries[0].path == "<aggregate>"
+    assert "exceeds abstract-diff cap" in summaries[0].bullet_points[0]
+    assert stub.calls == []  # no per-file calls — graceful degradation
+
+
+def test_summarize_diff_disallows_opus_tier() -> None:
+    stub = _stub_llm({"src/foo.py": {"bullets": ["x"]}, "src/bar.py": {"bullets": ["y"]}})
+    _ = _run(
+        summarize_diff(
+            _TWO_FILE_DIFF,
+            TaskContext(title="t", writer_model="opus"),
+            llm_caller=stub,
+        )
+    )
+    for call in stub.calls:
+        assert "opus" not in call["model"].lower()
+
+
+def test_pseudo_for_function_renders_control_flow() -> None:
+    src = """\
+def slow(xs):
+    if len(xs) > 32:
+        return quicksort(xs)
+    total = 0
+    for x in xs:
+        total = total + x
+    return sorted(xs)
+"""
+    pseudo = pseudo_for_function(src)
+    assert pseudo.startswith("function slow(xs):")
+    assert "if len(xs) > 32:" in pseudo
+    assert "return quicksort(xs)" in pseudo
+    assert "for x in xs:" in pseudo
+    assert "return sorted(xs)" in pseudo
+
+
+def test_pseudo_for_function_empty_input() -> None:
+    assert pseudo_for_function("") == ""
+    assert pseudo_for_function("not a function") == ""
+    assert pseudo_for_function("def broken(:") == ""
+
+
+def test_pseudo_for_function_pass_body() -> None:
+    pseudo = pseudo_for_function("def empty(): ...")
+    assert pseudo.startswith("function empty():")
+
+
+def test_render_pr_body_includes_intent_and_details() -> None:
+    summaries = [
+        IntentSummary(
+            path="src/foo.py",
+            bullet_points=("switches to quicksort",),
+            pseudocode_blocks=("function slow(xs):\n    return sorted(xs)",),
+            confidence=0.8,
+        ),
+        IntentSummary(
+            path="src/bar.py",
+            bullet_points=("imports os",),
+            confidence=0.6,
+        ),
+    ]
+    body = render_pr_body(summaries, raw_diff=_TWO_FILE_DIFF)
+    assert "## Intent" in body
+    assert "### `src/foo.py`" in body
+    assert "- switches to quicksort" in body
+    assert "<details><summary>Pseudocode</summary>" in body
+    assert "<details><summary>Raw diff</summary>" in body
+    assert "<details><summary>Full raw diff</summary>" in body
+    assert "_confidence: 0.80_" in body
+
+
+def test_render_pr_body_empty_summaries_returns_empty_string() -> None:
+    assert render_pr_body([]) == ""
+
+
+def test_render_pr_body_falls_back_to_link_when_no_raw_diff() -> None:
+    body = render_pr_body([IntentSummary(path="src/x.py", bullet_points=("a",), raw_diff_link="https://gh/diff")])
+    assert "[Raw diff](https://gh/diff)" in body
+    assert "<details><summary>Raw diff>" not in body
+
+
+def test_build_pr_body_concatenates_description_and_intent() -> None:
+    stub = _stub_llm(
+        {
+            "src/foo.py": {"bullets": ["adds quicksort"], "confidence": 0.9},
+            "src/bar.py": {"bullets": ["imports os"], "confidence": 0.4},
+        }
+    )
+    body = _run(
+        build_pr_body(
+            description="Closes #123 — speed up sort.",
+            diff=_TWO_FILE_DIFF,
+            task_context=TaskContext(title="Speed up sort", writer_model="claude"),
+            llm_caller=stub,
+        )
+    )
+    assert body.startswith("Closes #123 — speed up sort.")
+    assert "## Intent" in body
+    assert "- adds quicksort" in body
+
+
+def test_build_pr_body_disabled_returns_description_only() -> None:
+    body = _run(
+        build_pr_body(
+            description="Closes #1.",
+            diff=_TWO_FILE_DIFF,
+            task_context=TaskContext(title="x"),
+            llm_caller=_stub_llm({}),
+            enabled=False,
+        )
+    )
+    assert "## Intent" not in body
+    assert body.rstrip() == "Closes #1."
+
+
+def test_build_pr_body_large_diff_degrades_gracefully() -> None:
+    big = "\n".join(
+        f"diff --git a/f{i}.py b/f{i}.py\n--- a/f{i}.py\n+++ b/f{i}.py\n@@ -1 +1 @@\n-x\n+y\n" for i in range(100)
+    )
+    stub = _stub_llm({})
+    body = _run(
+        build_pr_body(
+            description="Big change",
+            diff=big,
+            task_context=TaskContext(title="huge"),
+            llm_caller=stub,
+            max_files=50,
+        )
+    )
+    assert "exceeds abstract-diff cap" in body
+    assert stub.calls == []


### PR DESCRIPTION
Implements ticket [`2026-04-30-feat-abstracted-code-review`](.sdd/backlog/open/2026-04-30-feat-abstracted-code-review.md): an intent-summary + pseudocode abstraction layer that turns raw PR diffs into behavioural review notes with drill-down to the underlying code.

## Summary

- `core/quality/review_pipeline/abstract_diff.py` — splits unified diffs per file, calls the cheap-tier reviewer chosen by `select_reviewer_model` (opus tier explicitly disallowed), AST-walks the post-image to render Python pseudocode, and renders a markdown "Intent" section with collapsible `<details>` raw-diff blocks.
- `core/review_responder/pr_gen.py` — thin async `build_pr_body` that concatenates the spawning task description with the abstracted intent section.
- `core/defaults.py` — `ABSTRACT_DIFF_ENABLED = True`, `ABSTRACT_DIFF_MAX_FILES = 50`.
- Graceful degradation: diffs over the file cap return a single top-level summary with no per-file LLM calls.
- LLM and OS errors fall through to empty-bullet summaries (transient outages do not block PR creation).

## Test plan

- [x] `uv run pytest tests/unit/test_abstract_diff.py -x -q` — 17 tests, mocked LLM, covers summary generation, pseudocode extraction, PR body rendering, large-diff truncation, opus-tier guard, exception handling.
- [x] `uv run pytest tests/unit/quality/review_pipeline/ -x -q` — 35 existing tests still pass (no regressions on `ast_chunker` shipped in #993).
- [x] `uv run ruff format` + `ruff check` clean on touched files.

## What's not in scope (per ticket)

- No formal verification of pseudocode equivalence (confidence scoring + drill-down only).
- No control-flow / data-flow diagrams.
- The existing rubric-based review verdict is unchanged; this augments PR bodies, not the merge gate.