### PR TITLE
feat(routing): agent mode profiles

### DIFF
--- a/src/bernstein/core/agents/spawner_prompt.py
+++ b/src/bernstein/core/agents/spawner_prompt.py
@@ -1,0 +1,165 @@
+"""Apply :class:`ModeProfile` to spawn-time prompts and tool allowlists.
+
+This module is the integration glue between the routing-layer mode profiles
+(:mod:`bernstein.core.routing.mode_profile`) and the agent spawner. It:
+- Resolves the profile for a (model_id, task) pair.
+- Loads YAML-defined profiles from ``templates/mode_profiles/`` once.
+- Returns the prompt+tools+turn-budget bundle the spawner should hand to the
+  CLI adapter.
+- Records a Prometheus counter labelled by ``mode_profile``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein import _BUNDLED_TEMPLATES_DIR  # type: ignore[reportPrivateUsage]
+from bernstein.core.defaults import MODE_PROFILES_ENABLED
+from bernstein.core.observability.prometheus import agent_spawns_by_mode_total
+from bernstein.core.routing.mode_profile import (
+    AppliedMode,
+    ModeProfile,
+    apply_mode,
+    install_loaded_profiles,
+    load_profiles_from_dir,
+    select_mode,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+_LOAD_LOCK = threading.Lock()
+_LOADED = False
+
+
+def _profiles_dir(workdir: Path | None) -> Path:
+    """Return the first existing profile directory in priority order."""
+    candidates: list[Path] = []
+    if workdir is not None:
+        candidates.append(workdir / "templates" / "mode_profiles")
+    candidates.append(_BUNDLED_TEMPLATES_DIR / "mode_profiles")
+    for path in candidates:
+        if path.is_dir():
+            return path
+    return candidates[-1]
+
+
+def ensure_profiles_loaded(workdir: Path | None = None, *, force: bool = False) -> None:
+    """Load YAML-defined profiles once (idempotent, thread-safe)."""
+    global _LOADED
+    if _LOADED and not force:
+        return
+    with _LOAD_LOCK:
+        if _LOADED and not force:
+            return
+        path = _profiles_dir(workdir)
+        loaded = load_profiles_from_dir(path)
+        if loaded:
+            install_loaded_profiles(loaded)
+            logger.info("Loaded %d mode profiles from %s", len(loaded), path)
+        _LOADED = True
+
+
+@dataclass(frozen=True)
+class SpawnModeBundle:
+    """Outcome of applying a mode profile at spawn time.
+
+    Attributes:
+        profile: The :class:`ModeProfile` that was applied.
+        prompt: System prompt with the profile preamble prepended.
+        tools: Tool list filtered through the profile's allowlist.
+        max_turns: Per-spawn turn budget from the profile.
+        temperature: Sampling temperature target from the profile.
+    """
+
+    profile: ModeProfile
+    prompt: str
+    tools: list[str]
+    max_turns: int
+    temperature: float
+
+
+def apply_mode_to_spawn(
+    *,
+    model_id: str,
+    prompt: str,
+    tools: list[str] | None = None,
+    task: Task | None = None,
+    workdir: Path | None = None,
+) -> SpawnModeBundle:
+    """Resolve and apply the mode profile for a spawn.
+
+    When :data:`MODE_PROFILES_ENABLED` is ``False`` the call is a no-op: the
+    prompt and tool list are returned unchanged with the ``smart`` profile
+    selected for accounting purposes.
+
+    Args:
+        model_id: Selected model identifier.
+        prompt: Base system prompt before mode preamble.
+        tools: Tool names available to the agent (allowlist input).
+        task: Optional task; ``task.metadata['mode']`` overrides the default.
+        workdir: Project root used to locate ``templates/mode_profiles/``.
+
+    Returns:
+        A :class:`SpawnModeBundle` ready to hand to the adapter.
+    """
+    available = list(tools or [])
+    if not MODE_PROFILES_ENABLED:
+        from bernstein.core.routing.mode_profile import MODE_REGISTRY
+
+        smart = MODE_REGISTRY.get("smart")
+        if smart is None:
+            raise RuntimeError("smart profile missing from MODE_REGISTRY")
+        return SpawnModeBundle(
+            profile=smart,
+            prompt=prompt,
+            tools=available,
+            max_turns=smart.max_turns,
+            temperature=smart.temperature,
+        )
+
+    ensure_profiles_loaded(workdir)
+
+    profile = select_mode(model_id, task)
+    applied: AppliedMode = apply_mode(profile, prompt=prompt, tools=available)
+
+    try:
+        agent_spawns_by_mode_total.labels(mode_profile=profile.name).inc()
+    except Exception as exc:
+        logger.debug("Failed to record mode_profile metric: %s", exc)
+
+    return SpawnModeBundle(
+        profile=applied.profile,
+        prompt=applied.prompt,
+        tools=applied.tools,
+        max_turns=profile.max_turns,
+        temperature=profile.temperature,
+    )
+
+
+def resolve_profile(model_id: str, task: Task | None = None) -> ModeProfile:
+    """Return the mode profile that would be applied for *model_id* and *task*."""
+    return select_mode(model_id, task)
+
+
+def reset_profile_cache() -> None:
+    """Reset the one-shot YAML load flag (test helper)."""
+    global _LOADED
+    with _LOAD_LOCK:
+        _LOADED = False
+
+
+__all__ = [
+    "SpawnModeBundle",
+    "apply_mode_to_spawn",
+    "ensure_profiles_loaded",
+    "reset_profile_cache",
+    "resolve_profile",
+]

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -552,6 +552,11 @@ MCP_TOOL_SEARCH_THRESHOLD_TOKENS: int = MCP_TOOL_SEARCH.threshold_tokens
 ABSTRACT_DIFF_ENABLED: bool = True
 ABSTRACT_DIFF_MAX_FILES: int = 50
 
+# Per-model agent mode profiles (smart/deep/fast).  When ``False`` the
+# spawner skips preamble injection and tool filtering — useful as a kill
+# switch while the feature is rolled out.
+MODE_PROFILES_ENABLED: bool = True
+
 
 # Mapping of section name (as used in bernstein.yaml ``tuning:`` blocks) to the
 # module-level attribute that stores the singleton.  We rebind the attribute

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -109,6 +109,7 @@ __all__ = [
     "action_cache_hits_total",
     "action_cache_savings_usd_total",
     "agent_spawn_duration",
+    "agent_spawns_by_mode_total",
     "agent_transition_reasons_total",
     "agents_active",
     "cluster_admission_failures_total",
@@ -191,6 +192,13 @@ agent_spawn_duration: Histogram = Histogram(
     "Time taken to spawn an agent subprocess.",
     buckets=(1, 2, 5, 10, 20, 30),
     labelnames=["adapter"],
+    registry=registry,
+)
+
+agent_spawns_by_mode_total: Counter = Counter(
+    "bernstein_agent_spawns_by_mode_total",
+    "Total agent spawns partitioned by applied mode profile.",
+    labelnames=["mode_profile"],
     registry=registry,
 )
 

--- a/src/bernstein/core/routing/mode_profile.py
+++ b/src/bernstein/core/routing/mode_profile.py
@@ -1,0 +1,293 @@
+"""Per-model agent mode profiles (system prompt + tool subset + turn budget).
+
+Bernstein chooses a model via the bandit/cascade routers based purely on
+cost/quality signals. Once a model is selected, the *mode profile* layered
+on top tailors the agent's interaction style to that model's personality:
+- ``smart`` — Claude-family models, rapid feedback, broad tool surface.
+- ``deep`` — GPT-5.2-class models, long autonomous research, narrow tools.
+- ``fast`` — small/fast models, terse output, minimal tool surface.
+
+Profiles are loaded from ``templates/mode_profiles/<name>.yaml`` at startup
+when present and fall back to the in-code defaults below otherwise. The
+mapping ``model_id -> default mode`` is deterministic; per-task overrides
+are honoured via ``Task.metadata['mode']`` (e.g. ``mode=fast``).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ModeProfile:
+    """Mode-specific configuration applied after model selection.
+
+    Attributes:
+        name: Profile identifier (``smart``, ``deep``, ``fast``).
+        system_prompt_preamble: Text prepended to the agent's system prompt.
+        tool_subset: Allowlist of tool names; empty tuple means "all tools".
+        temperature: Sampling temperature target for the adapter.
+        max_turns: Upper bound on conversation turns for this profile.
+        expected_runtime_minutes: Wall-clock budget hint for callers.
+    """
+
+    name: str
+    system_prompt_preamble: str
+    tool_subset: tuple[str, ...] = ()
+    temperature: float = 0.2
+    max_turns: int = 40
+    expected_runtime_minutes: int = 15
+
+    def filter_tools(self, available: list[str]) -> list[str]:
+        """Return *available* tools intersected with this profile's allowlist."""
+        if not self.tool_subset:
+            return list(available)
+        allowed = set(self.tool_subset)
+        return [t for t in available if t in allowed]
+
+    def apply_preamble(self, prompt: str) -> str:
+        """Prepend the profile preamble to *prompt* with a blank-line separator."""
+        if not self.system_prompt_preamble:
+            return prompt
+        return f"{self.system_prompt_preamble.rstrip()}\n\n{prompt}"
+
+
+_SMART_DEFAULT = ModeProfile(
+    name="smart",
+    system_prompt_preamble=(
+        "## Mode: smart (rapid feedback)\n"
+        "You operate in interactive smart mode. Make small, verifiable steps; "
+        "report progress often; ask for clarification when blocked rather than "
+        "guessing. Prefer concise responses and iterate quickly with the user."
+    ),
+    tool_subset=(),
+    temperature=0.2,
+    max_turns=40,
+    expected_runtime_minutes=15,
+)
+
+_DEEP_DEFAULT = ModeProfile(
+    name="deep",
+    system_prompt_preamble=(
+        "## Mode: deep (long autonomous research)\n"
+        "You operate in deep autonomous mode. Plan thoroughly before acting, "
+        "minimise external chatter, and only surface findings when you have a "
+        "complete answer. Use tools sparingly and prefer reasoning."
+    ),
+    tool_subset=("Read", "Grep", "Glob", "Bash"),
+    temperature=0.3,
+    max_turns=120,
+    expected_runtime_minutes=60,
+)
+
+_FAST_DEFAULT = ModeProfile(
+    name="fast",
+    system_prompt_preamble=(
+        "## Mode: fast (terse, minimal tool use)\n"
+        "You operate in fast mode. Produce the shortest correct answer. "
+        "Avoid exploratory tool calls; prefer a single well-targeted action."
+    ),
+    tool_subset=("Read", "Edit"),
+    temperature=0.0,
+    max_turns=15,
+    expected_runtime_minutes=5,
+)
+
+
+MODE_REGISTRY: dict[str, ModeProfile] = {
+    "smart": _SMART_DEFAULT,
+    "deep": _DEEP_DEFAULT,
+    "fast": _FAST_DEFAULT,
+}
+
+
+_MODEL_FAMILY_TO_MODE: dict[str, str] = {
+    "claude": "smart",
+    "opus": "smart",
+    "sonnet": "smart",
+    "haiku": "fast",
+    "gpt-5": "deep",
+    "gpt-5.1": "deep",
+    "gpt-5.2": "deep",
+    "o1": "deep",
+    "o3": "deep",
+    "gemini": "smart",
+    "qwen": "fast",
+    "ollama": "fast",
+}
+
+
+def _classify_model_family(model_id: str) -> str:
+    """Return the family key that maps a model id to its default mode."""
+    lower = model_id.lower().strip()
+    if not lower:
+        return "claude"
+    for prefix in (
+        "gpt-5.2",
+        "gpt-5.1",
+        "gpt-5",
+        "opus",
+        "sonnet",
+        "haiku",
+        "claude",
+        "gemini",
+        "qwen",
+        "ollama",
+        "o3",
+        "o1",
+    ):
+        if prefix in lower:
+            return prefix
+    return "claude"
+
+
+def select_mode(
+    model_id: str,
+    task: Any | None = None,
+    registry: dict[str, ModeProfile] | None = None,
+) -> ModeProfile:
+    """Pick the mode profile for *task* running on *model_id*.
+
+    Resolution order:
+    1. Explicit override via ``task.metadata['mode']`` (when present and known).
+    2. Model-family default from :data:`_MODEL_FAMILY_TO_MODE`.
+    3. ``smart`` as a final fallback.
+
+    Args:
+        model_id: Selected model identifier (e.g. ``"claude-sonnet-4-6"``).
+        task: Optional task carrying a ``metadata`` dict; ``metadata['mode']``
+            forces a specific profile when its value matches a registry key.
+        registry: Override registry (defaults to :data:`MODE_REGISTRY`).
+
+    Returns:
+        A :class:`ModeProfile` from the registry. Always non-``None``.
+    """
+    table = registry if registry is not None else MODE_REGISTRY
+
+    if task is not None:
+        metadata = getattr(task, "metadata", None)
+        if isinstance(metadata, dict):
+            override = metadata.get("mode")
+            if isinstance(override, str) and override in table:
+                return table[override]
+
+    family = _classify_model_family(model_id)
+    mode_name = _MODEL_FAMILY_TO_MODE.get(family, "smart")
+    return table.get(mode_name, table.get("smart", _SMART_DEFAULT))
+
+
+def _coerce_profile(name: str, raw: dict[str, Any]) -> ModeProfile | None:
+    """Build a :class:`ModeProfile` from a YAML-decoded dict; return ``None`` on bad input."""
+    try:
+        tool_subset_raw = raw.get("tool_subset", []) or []
+        if not isinstance(tool_subset_raw, list):
+            raise TypeError(f"tool_subset must be a list, got {type(tool_subset_raw).__name__}")
+        return ModeProfile(
+            name=str(raw.get("name", name)),
+            system_prompt_preamble=str(raw.get("system_prompt_preamble", "")),
+            tool_subset=tuple(str(t) for t in tool_subset_raw),
+            temperature=float(raw.get("temperature", 0.2)),
+            max_turns=int(raw.get("max_turns", 40)),
+            expected_runtime_minutes=int(raw.get("expected_runtime_minutes", 15)),
+        )
+    except (TypeError, ValueError) as exc:
+        logger.warning("Invalid mode profile %r: %s", name, exc)
+        return None
+
+
+def load_profiles_from_dir(path: Path) -> dict[str, ModeProfile]:
+    """Load mode profiles from ``<path>/*.yaml``; missing dir returns ``{}``.
+
+    Each YAML file's stem becomes the profile name unless overridden by a
+    ``name:`` key inside the document. Malformed files are skipped with a
+    warning rather than crashing startup.
+    """
+    if not path.is_dir():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        logger.warning("PyYAML not installed; skipping mode profile load from %s", path)
+        return {}
+
+    loaded: dict[str, ModeProfile] = {}
+    for yaml_file in sorted(path.glob("*.yaml")):
+        try:
+            raw = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError) as exc:
+            logger.warning("Failed to read mode profile %s: %s", yaml_file, exc)
+            continue
+        if not isinstance(raw, dict):
+            logger.warning("Mode profile %s does not contain a mapping; skipped", yaml_file)
+            continue
+        profile = _coerce_profile(yaml_file.stem, raw)
+        if profile is not None:
+            loaded[profile.name] = profile
+    return loaded
+
+
+def install_loaded_profiles(loaded: dict[str, ModeProfile]) -> None:
+    """Merge *loaded* profiles into the module-level :data:`MODE_REGISTRY`.
+
+    YAML-defined profiles override the in-code defaults of the same name.
+    Unknown names are added so callers can register new modes from disk.
+    """
+    for name, profile in loaded.items():
+        MODE_REGISTRY[name] = profile
+
+
+@dataclass(frozen=True)
+class AppliedMode:
+    """Result of applying a profile to a spawn-time prompt and tool list.
+
+    Attributes:
+        profile: The mode profile that was applied.
+        prompt: System prompt with the profile preamble prepended.
+        tools: Tool list filtered through the profile's allowlist.
+    """
+
+    profile: ModeProfile
+    prompt: str
+    tools: list[str] = field(default_factory=list[str])
+
+
+def apply_mode(
+    profile: ModeProfile,
+    *,
+    prompt: str,
+    tools: list[str] | None = None,
+) -> AppliedMode:
+    """Return an :class:`AppliedMode` carrying the prompt+tools after profile."""
+    available = list(tools or [])
+    return AppliedMode(
+        profile=profile,
+        prompt=profile.apply_preamble(prompt),
+        tools=profile.filter_tools(available),
+    )
+
+
+def replace_profile(name: str, **changes: Any) -> ModeProfile:
+    """Replace fields on the registry entry *name* and return the new instance."""
+    current = MODE_REGISTRY[name]
+    updated = replace(current, **changes)
+    MODE_REGISTRY[name] = updated
+    return updated
+
+
+__all__ = [
+    "MODE_REGISTRY",
+    "AppliedMode",
+    "ModeProfile",
+    "apply_mode",
+    "install_loaded_profiles",
+    "load_profiles_from_dir",
+    "replace_profile",
+    "select_mode",
+]

--- a/templates/mode_profiles/deep.yaml
+++ b/templates/mode_profiles/deep.yaml
@@ -1,0 +1,14 @@
+name: deep
+system_prompt_preamble: |
+  ## Mode: deep (long autonomous research)
+  You operate in deep autonomous mode. Plan thoroughly before acting,
+  minimise external chatter, and only surface findings when you have a
+  complete answer. Use tools sparingly and prefer reasoning.
+tool_subset:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+temperature: 0.3
+max_turns: 120
+expected_runtime_minutes: 60

--- a/templates/mode_profiles/fast.yaml
+++ b/templates/mode_profiles/fast.yaml
@@ -1,0 +1,11 @@
+name: fast
+system_prompt_preamble: |
+  ## Mode: fast (terse, minimal tool use)
+  You operate in fast mode. Produce the shortest correct answer.
+  Avoid exploratory tool calls; prefer a single well-targeted action.
+tool_subset:
+  - Read
+  - Edit
+temperature: 0.0
+max_turns: 15
+expected_runtime_minutes: 5

--- a/templates/mode_profiles/smart.yaml
+++ b/templates/mode_profiles/smart.yaml
@@ -1,0 +1,10 @@
+name: smart
+system_prompt_preamble: |
+  ## Mode: smart (rapid feedback)
+  You operate in interactive smart mode. Make small, verifiable steps;
+  report progress often; ask for clarification when blocked rather than
+  guessing. Prefer concise responses and iterate quickly with the user.
+tool_subset: []
+temperature: 0.2
+max_turns: 40
+expected_runtime_minutes: 15

--- a/tests/unit/test_mode_profile.py
+++ b/tests/unit/test_mode_profile.py
@@ -1,0 +1,265 @@
+"""Tests for per-model agent mode profiles (smart/deep/fast)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.routing.mode_profile import (
+    MODE_REGISTRY,
+    ModeProfile,
+    apply_mode,
+    install_loaded_profiles,
+    load_profiles_from_dir,
+    select_mode,
+)
+
+
+@dataclass
+class _FakeTask:
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+class TestSelectMode:
+    def test_claude_defaults_to_smart(self) -> None:
+        profile = select_mode("claude-sonnet-4-6")
+        assert profile.name == "smart"
+
+    def test_opus_defaults_to_smart(self) -> None:
+        assert select_mode("claude-opus-4-7").name == "smart"
+
+    def test_haiku_defaults_to_fast(self) -> None:
+        assert select_mode("claude-haiku-4").name == "fast"
+
+    def test_gpt5_defaults_to_deep(self) -> None:
+        profile = select_mode("gpt-5.2-pro")
+        assert profile.name == "deep"
+
+    def test_gpt5_has_longer_max_turns_than_smart(self) -> None:
+        deep = select_mode("gpt-5.2")
+        smart = select_mode("claude-sonnet-4-6")
+        assert deep.max_turns > smart.max_turns
+
+    def test_o3_defaults_to_deep(self) -> None:
+        assert select_mode("o3-mini").name == "deep"
+
+    def test_unknown_model_falls_back_to_smart(self) -> None:
+        assert select_mode("unknown-model-xyz").name == "smart"
+
+    def test_empty_model_id_falls_back_to_smart(self) -> None:
+        assert select_mode("").name == "smart"
+
+    def test_metadata_mode_overrides_default(self) -> None:
+        task = _FakeTask(metadata={"mode": "fast"})
+        profile = select_mode("claude-sonnet-4-6", task)
+        assert profile.name == "fast"
+
+    def test_metadata_mode_overrides_gpt5_default(self) -> None:
+        task = _FakeTask(metadata={"mode": "smart"})
+        assert select_mode("gpt-5.2-pro", task).name == "smart"
+
+    def test_unknown_metadata_mode_falls_back_to_default(self) -> None:
+        task = _FakeTask(metadata={"mode": "warp-speed"})
+        assert select_mode("claude-sonnet-4-6", task).name == "smart"
+
+    def test_task_without_metadata_attribute_is_safe(self) -> None:
+        class _Bare: ...
+
+        assert select_mode("claude-sonnet-4-6", _Bare()).name == "smart"
+
+
+class TestModeProfileBehaviour:
+    def test_filter_tools_with_empty_subset_returns_all(self) -> None:
+        profile = ModeProfile(name="x", system_prompt_preamble="", tool_subset=())
+        assert profile.filter_tools(["A", "B", "C"]) == ["A", "B", "C"]
+
+    def test_filter_tools_intersects_with_subset(self) -> None:
+        profile = ModeProfile(
+            name="x",
+            system_prompt_preamble="",
+            tool_subset=("Read", "Edit"),
+        )
+        filtered = profile.filter_tools(["Read", "Bash", "Edit", "Write"])
+        assert filtered == ["Read", "Edit"]
+
+    def test_filter_tools_drops_disallowed(self) -> None:
+        profile = ModeProfile(name="x", system_prompt_preamble="", tool_subset=("Read",))
+        assert profile.filter_tools(["Bash", "Write"]) == []
+
+    def test_apply_preamble_prepends_with_blank_line(self) -> None:
+        profile = ModeProfile(name="x", system_prompt_preamble="HEADER", tool_subset=())
+        result = profile.apply_preamble("body text")
+        assert result.startswith("HEADER\n\n")
+        assert result.endswith("body text")
+
+    def test_apply_preamble_empty_returns_prompt_unchanged(self) -> None:
+        profile = ModeProfile(name="x", system_prompt_preamble="", tool_subset=())
+        assert profile.apply_preamble("body") == "body"
+
+
+class TestApplyMode:
+    def test_apply_mode_filters_tools_and_injects_preamble(self) -> None:
+        profile = ModeProfile(
+            name="fast",
+            system_prompt_preamble="MODE: fast",
+            tool_subset=("Read",),
+            max_turns=10,
+        )
+        applied = apply_mode(profile, prompt="do the thing", tools=["Read", "Bash"])
+        assert applied.profile is profile
+        assert applied.tools == ["Read"]
+        assert applied.prompt.startswith("MODE: fast")
+        assert "do the thing" in applied.prompt
+
+    def test_apply_mode_with_no_tools(self) -> None:
+        profile = MODE_REGISTRY["smart"]
+        applied = apply_mode(profile, prompt="hello", tools=None)
+        assert applied.tools == []
+
+
+class TestRegistryDefaults:
+    def test_smart_deep_fast_present(self) -> None:
+        assert {"smart", "deep", "fast"}.issubset(MODE_REGISTRY)
+
+    def test_deep_has_narrower_tool_subset_than_smart(self) -> None:
+        smart = MODE_REGISTRY["smart"]
+        deep = MODE_REGISTRY["deep"]
+        # smart accepts everything (empty allowlist), deep restricts.
+        assert smart.tool_subset == ()
+        assert len(deep.tool_subset) > 0
+
+    def test_fast_has_lowest_turn_budget(self) -> None:
+        budgets = {n: MODE_REGISTRY[n].max_turns for n in ("smart", "deep", "fast")}
+        assert budgets["fast"] < budgets["smart"] < budgets["deep"]
+
+
+class TestYamlLoading:
+    def test_load_profiles_from_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert load_profiles_from_dir(tmp_path / "does_not_exist") == {}
+
+    def test_load_profiles_from_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "custom.yaml").write_text(
+            "name: custom\n"
+            "system_prompt_preamble: 'CUSTOM PREAMBLE'\n"
+            "tool_subset: [Read]\n"
+            "temperature: 0.5\n"
+            "max_turns: 25\n"
+            "expected_runtime_minutes: 8\n",
+            encoding="utf-8",
+        )
+        loaded = load_profiles_from_dir(tmp_path)
+        assert "custom" in loaded
+        custom = loaded["custom"]
+        assert custom.system_prompt_preamble == "CUSTOM PREAMBLE"
+        assert custom.tool_subset == ("Read",)
+        assert custom.max_turns == 25
+
+    def test_install_loaded_profiles_overrides_defaults(self, tmp_path: Path) -> None:
+        original = MODE_REGISTRY["fast"]
+        try:
+            (tmp_path / "fast.yaml").write_text(
+                "name: fast\n"
+                "system_prompt_preamble: 'OVERRIDDEN'\n"
+                "tool_subset: []\n"
+                "temperature: 0.0\n"
+                "max_turns: 99\n"
+                "expected_runtime_minutes: 1\n",
+                encoding="utf-8",
+            )
+            loaded = load_profiles_from_dir(tmp_path)
+            install_loaded_profiles(loaded)
+            assert MODE_REGISTRY["fast"].max_turns == 99
+            assert MODE_REGISTRY["fast"].system_prompt_preamble == "OVERRIDDEN"
+        finally:
+            MODE_REGISTRY["fast"] = original
+
+    def test_malformed_yaml_is_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.yaml").write_text("just a string", encoding="utf-8")
+        (tmp_path / "good.yaml").write_text(
+            "name: good\nsystem_prompt_preamble: ''\ntool_subset: []\n",
+            encoding="utf-8",
+        )
+        loaded = load_profiles_from_dir(tmp_path)
+        assert "bad" not in loaded
+        assert "good" in loaded
+
+
+class TestSpawnerPromptIntegration:
+    def test_apply_mode_to_spawn_claude_yields_smart(self) -> None:
+        from bernstein.core.agents.spawner_prompt import apply_mode_to_spawn
+
+        bundle = apply_mode_to_spawn(
+            model_id="claude-sonnet-4-6",
+            prompt="base prompt",
+            tools=["Read", "Bash", "Edit"],
+        )
+        assert bundle.profile.name == "smart"
+        assert "base prompt" in bundle.prompt
+        # smart has no tool subset → all tools pass.
+        assert set(bundle.tools) == {"Read", "Bash", "Edit"}
+
+    def test_apply_mode_to_spawn_gpt5_yields_deep_and_filters_tools(self) -> None:
+        from bernstein.core.agents.spawner_prompt import apply_mode_to_spawn
+
+        bundle = apply_mode_to_spawn(
+            model_id="gpt-5.2",
+            prompt="base prompt",
+            tools=["Read", "Edit", "Bash", "WebFetch"],
+        )
+        assert bundle.profile.name == "deep"
+        # deep allowlist excludes Edit and WebFetch.
+        assert "Edit" not in bundle.tools
+        assert "WebFetch" not in bundle.tools
+        assert "Read" in bundle.tools
+        assert bundle.max_turns == bundle.profile.max_turns
+        assert bundle.max_turns > 40
+
+    def test_apply_mode_to_spawn_metadata_override(self) -> None:
+        from bernstein.core.agents.spawner_prompt import apply_mode_to_spawn
+
+        task = _FakeTask(metadata={"mode": "fast"})
+        bundle = apply_mode_to_spawn(
+            model_id="claude-sonnet-4-6",
+            prompt="base prompt",
+            tools=["Read", "Bash", "Edit"],
+            task=task,  # type: ignore[arg-type]
+        )
+        assert bundle.profile.name == "fast"
+        assert "Bash" not in bundle.tools
+
+    def test_apply_mode_to_spawn_preamble_is_prepended(self) -> None:
+        from bernstein.core.agents.spawner_prompt import apply_mode_to_spawn
+
+        bundle = apply_mode_to_spawn(
+            model_id="claude-sonnet-4-6",
+            prompt="<<BODY>>",
+            tools=[],
+        )
+        assert "<<BODY>>" in bundle.prompt
+        assert bundle.prompt.index("Mode:") < bundle.prompt.index("<<BODY>>")
+
+    def test_apply_mode_to_spawn_disabled_is_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.core.agents import spawner_prompt as sp
+
+        monkeypatch.setattr(sp, "MODE_PROFILES_ENABLED", False)
+        bundle = sp.apply_mode_to_spawn(
+            model_id="gpt-5.2",
+            prompt="base prompt",
+            tools=["Read", "Edit", "WebFetch"],
+        )
+        assert bundle.prompt == "base prompt"
+        assert bundle.tools == ["Read", "Edit", "WebFetch"]
+
+
+class TestBundledYamlProfiles:
+    def test_bundled_profiles_exist_and_load(self) -> None:
+        from bernstein import _BUNDLED_TEMPLATES_DIR  # type: ignore[reportPrivateUsage]
+
+        path = _BUNDLED_TEMPLATES_DIR / "mode_profiles"
+        if not path.is_dir():
+            pytest.skip("Bundled mode_profiles dir missing in this build layout")
+        loaded = load_profiles_from_dir(path)
+        assert {"smart", "deep", "fast"}.issubset(loaded)


### PR DESCRIPTION
Implements ticket [.sdd/backlog/open/2026-04-30-feat-agent-modes-by-personality.md](https://github.com/sipyourdrink-ltd/bernstein/blob/main/.sdd/backlog/open/2026-04-30-feat-agent-modes-by-personality.md).

## Summary

Per-model agent mode profiles (smart/deep/fast) layered on top of model selection. Each profile carries a system-prompt preamble, tool allowlist, turn budget, temperature target, and runtime hint, so different model personalities (rapid-feedback Claude vs long-running GPT-5.2 vs small/fast) get tailored interaction modes.

- `src/bernstein/core/routing/mode_profile.py` — `ModeProfile` dataclass, `MODE_REGISTRY`, deterministic `select_mode(model_id, task)` with model-family mapping and `task.metadata['mode']` override, plus a YAML loader.
- `src/bernstein/core/agents/spawner_prompt.py` — `apply_mode_to_spawn()` resolves and applies the profile, returning the prompt+tools+turn-budget bundle. Honours `defaults.MODE_PROFILES_ENABLED`. Records a Prometheus counter.
- `templates/mode_profiles/{smart,deep,fast}.yaml` — declarative profile definitions loaded at startup with bundled-templates fallback.
- `src/bernstein/core/defaults.py` — `MODE_PROFILES_ENABLED = True` kill switch.
- `src/bernstein/core/observability/prometheus.py` — new `bernstein_agent_spawns_by_mode_total` counter labelled `mode_profile`.
- `tests/unit/test_mode_profile.py` — 32 unit tests.

## Acceptance criteria

- [x] Spawning a Claude agent applies `smart` profile by default.
- [x] Spawning a GPT-5.2 agent applies `deep` profile (longer `max_turns`, narrower `tool_subset`).
- [x] Per-task tag `mode=fast` (via `Task.metadata['mode']`) overrides the model default.
- [x] Profiles loaded from `templates/mode_profiles/*.yaml` at startup (idempotent, thread-safe).
- [x] Prometheus label `mode_profile` added to spawn metrics (new counter, no breaking change to existing histogram).

## Test plan

- [x] `uv run pytest tests/unit/test_mode_profile.py -x -q` — 32 passed
- [x] `uv run pytest tests/unit/test_defaults.py tests/unit/test_prometheus.py tests/unit/test_spawn_prompt.py -x -q` — 38 passed
- [x] `uv run pytest tests/unit/test_model_routing.py tests/unit/test_route_decision.py tests/unit/test_model_recommender.py tests/unit/test_capability_router.py -x -q` — 130 passed
- [x] `uv run ruff format` and `uv run ruff check` — clean
- [ ] CI green

## Out of scope

- Wiring `apply_mode_to_spawn()` into `spawner_core.py` (this PR adds the abstraction; integration is a follow-up so changes can land in isolation).
- Per-task UI customization, dynamic mid-session mode switching, replacing the existing model router.