### PR TITLE
feat(protocols): tool-search lazy loading for large MCP catalogs

### DIFF
--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -285,6 +285,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "mcp_skill_registry": "bernstein.core.protocols.mcp.mcp_skill_registry",
     "mcp_task_filter": "bernstein.core.protocols.mcp.mcp_task_filter",
     "mcp_tool_normalization": "bernstein.core.protocols.mcp.mcp_tool_normalization",
+    "mcp_tool_search": "bernstein.core.protocols.mcp.mcp_tool_search",
     "mcp_transport": "bernstein.core.protocols.mcp.mcp_transport",
     "mcp_usage_analytics": "bernstein.core.protocols.mcp.mcp_usage_analytics",
     "mcp_version_compat": "bernstein.core.protocols.mcp.mcp_version_compat",

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -413,6 +413,26 @@ class CatalogDefaults:
 
 
 # ---------------------------------------------------------------------------
+# MCP tool-search lazy loading defaults
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MCPToolSearchDefaults:
+    """Lazy-loading thresholds for MCP tool descriptions in agent prompts.
+
+    When the combined size of every MCP tool's name + summary + JSON Schema
+    exceeds :attr:`threshold_tokens`, the prompt builder swaps the full
+    catalog for a ``tool_search`` meta-tool plus a compact name+summary
+    directory.  Full schemas are then fetched on demand by the agent.
+    """
+
+    enabled: bool = True
+    threshold_tokens: int = 6000
+    directory_budget_tokens: int = 1500
+
+
+# ---------------------------------------------------------------------------
 # Security defaults
 # ---------------------------------------------------------------------------
 
@@ -489,6 +509,7 @@ PHASE_PIPELINE = PhasePipelineDefaults()
 TRIGGER = TriggerDefaults()
 JANITOR = JanitorDefaults()
 CATALOG = CatalogDefaults()
+MCP_TOOL_SEARCH = MCPToolSearchDefaults()
 SECURITY = SecurityDefaults()
 ACTION_CACHE = ActionCacheDefaults()
 SCHEMA_RETRY = SchemaRetryDefaults()
@@ -496,6 +517,8 @@ SCHEMA_RETRY = SchemaRetryDefaults()
 # Module-level constant for direct import — preferred when only the
 # numeric cap is needed (no need to import the whole singleton).
 SCHEMA_RETRY_MAX_ATTEMPTS: int = SCHEMA_RETRY.max_attempts
+MCP_TOOL_SEARCH_ENABLED: bool = MCP_TOOL_SEARCH.enabled
+MCP_TOOL_SEARCH_THRESHOLD_TOKENS: int = MCP_TOOL_SEARCH.threshold_tokens
 
 
 # Mapping of section name (as used in bernstein.yaml ``tuning:`` blocks) to the
@@ -518,6 +541,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "trigger": "TRIGGER",
         "janitor": "JANITOR",
         "catalog": "CATALOG",
+        "mcp_tool_search": "MCP_TOOL_SEARCH",
         "security": "SECURITY",
         "action_cache": "ACTION_CACHE",
         "schema_retry": "SCHEMA_RETRY",
@@ -543,6 +567,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "TRIGGER": TriggerDefaults,
         "JANITOR": JanitorDefaults,
         "CATALOG": CatalogDefaults,
+        "MCP_TOOL_SEARCH": MCPToolSearchDefaults,
         "SECURITY": SecurityDefaults,
         "ACTION_CACHE": ActionCacheDefaults,
         "SCHEMA_RETRY": SchemaRetryDefaults,

--- a/src/bernstein/core/protocols/mcp/mcp_manager.py
+++ b/src/bernstein/core/protocols/mcp/mcp_manager.py
@@ -850,3 +850,61 @@ def handle_mcp_auth_error(server_name: str, error_code: int, error_message: str)
 def register_mcp_oauth_refresh(server_name: str, refresh_callback: Callable[[], str | None]) -> None:
     """Register OAuth refresh callback for an MCP server."""
     _oauth_refresh_handler.register_refresh_callback(server_name, refresh_callback)
+
+
+# ---------------------------------------------------------------------------
+# Tool-search lazy loading wire-in (tool-search-lazy-loading)
+# ---------------------------------------------------------------------------
+
+
+def build_tools_prompt_section(
+    tools: list[tuple[str, str, str, dict[str, Any]]],
+    *,
+    threshold_tokens: int | None = None,
+    directory_budget_tokens: int | None = None,
+    enabled: bool | None = None,
+) -> str:
+    """Render the MCP tools prompt section, lazy-loading when oversized.
+
+    Args:
+        tools: List of ``(server, tool_name, summary, schema)`` tuples
+            collected from live MCP sessions.
+        threshold_tokens: Catalog token cap before swapping to tool_search.
+            Defaults to :data:`MCP_TOOL_SEARCH_THRESHOLD_TOKENS`.
+        directory_budget_tokens: Cap for the compact directory after swap.
+        enabled: When ``False``, always return the inline catalog regardless
+            of size.  Defaults to :data:`MCP_TOOL_SEARCH_ENABLED`.
+
+    Returns:
+        Prompt-ready string.  Empty when ``tools`` is empty.
+    """
+    if not tools:
+        return ""
+
+    from bernstein.core.defaults import (
+        MCP_TOOL_SEARCH_ENABLED,
+        MCP_TOOL_SEARCH_THRESHOLD_TOKENS,
+    )
+    from bernstein.core.protocols.mcp.mcp_tool_search import (
+        ToolCatalog,
+        ToolEntry,
+        build_prompt_section,
+    )
+
+    use_lazy = enabled if enabled is not None else MCP_TOOL_SEARCH_ENABLED
+    threshold = threshold_tokens if threshold_tokens is not None else MCP_TOOL_SEARCH_THRESHOLD_TOKENS
+    budget = directory_budget_tokens if directory_budget_tokens is not None else 1500
+
+    catalog = ToolCatalog(
+        ToolEntry(name=name, summary=summary, server=server, schema=schema) for server, name, summary, schema in tools
+    )
+
+    if not use_lazy:
+        lines = ["MCP tools available:", *catalog.directory_lines()]
+        return "\n".join(lines)
+
+    return build_prompt_section(
+        catalog,
+        threshold_tokens=threshold,
+        directory_budget_tokens=budget,
+    )

--- a/src/bernstein/core/protocols/mcp/mcp_tool_search.py
+++ b/src/bernstein/core/protocols/mcp/mcp_tool_search.py
@@ -1,0 +1,370 @@
+"""MCP tool-search lazy loading.
+
+Keeps full MCP tool descriptions out of an agent's system prompt by
+exposing a single ``tool_search`` meta-tool plus a compact directory of
+tool names + one-line summaries.  Full JSON Schemas are only fetched on
+demand via :func:`expand_tools` once the agent has chosen what it needs.
+
+The pattern is the lazy-loading half of "tool search" from
+awesome-agentic-patterns: with 7+ MCP servers the full catalog can run
+to ~67k tokens — ruinous for short-lived agents whose whole reason for
+existing is fast spawn time.  When the catalog exceeds a configurable
+threshold we serve a directory + search affordance instead.
+
+Usage::
+
+    from bernstein.core.protocols.mcp.mcp_tool_search import (
+        ToolCatalog, ToolEntry, ToolSearchEngine, build_prompt_section,
+    )
+
+    catalog = ToolCatalog([ToolEntry(name="git_diff", ...), ...])
+    engine = ToolSearchEngine(catalog)
+    hits = engine.search("git diff", limit=5)
+    schemas = catalog.expand([h.name for h in hits])
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from bernstein.core.observability.prometheus import Counter as PromCounter
+from bernstein.core.observability.prometheus import registry
+
+logger = logging.getLogger(__name__)
+
+
+_AVG_CHARS_PER_TOKEN: float = 4.0
+_MAX_SUMMARY_CHARS: int = 120
+_BM25_K1: float = 1.5
+_BM25_B: float = 0.75
+_TOKEN_RE: re.Pattern[str] = re.compile(r"[A-Za-z0-9]+")
+
+
+mcp_tool_search_invocations_total: PromCounter = PromCounter(
+    "mcp_tool_search_invocations_total",
+    "Number of times the MCP tool_search meta-tool was invoked.",
+    labelnames=["mode"],
+    registry=registry,
+)
+
+
+@dataclass(frozen=True)
+class ToolEntry:
+    """A single MCP tool record kept by :class:`ToolCatalog`.
+
+    Attributes:
+        name: Fully-qualified tool name (e.g. ``"github.create_issue"``).
+        summary: One-line description used in the directory and for ranking.
+        server: Originating MCP server name.
+        schema: Full JSON Schema for the tool's input parameters.
+    """
+
+    name: str
+    summary: str
+    server: str
+    schema: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def directory_line(self) -> str:
+        """Return a compact one-line catalog entry for prompt injection."""
+        truncated = (
+            self.summary if len(self.summary) <= _MAX_SUMMARY_CHARS else self.summary[: _MAX_SUMMARY_CHARS - 1] + "…"
+        )
+        return f"- {self.name} ({self.server}): {truncated}"
+
+
+def _tokenize(text: str) -> list[str]:
+    return [t.lower() for t in _TOKEN_RE.findall(text)]
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap token-count estimate using a chars-per-token heuristic.
+
+    Avoids pulling in tiktoken — close enough for budget gating.
+    """
+    if not text:
+        return 0
+    return max(1, math.ceil(len(text) / _AVG_CHARS_PER_TOKEN))
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    """One ranked search result."""
+
+    name: str
+    server: str
+    summary: str
+    score: float
+
+
+class ToolCatalog:
+    """Indexed collection of :class:`ToolEntry` records.
+
+    Provides directory rendering, schema expansion, and the underlying
+    statistics consumed by :class:`ToolSearchEngine`.
+    """
+
+    def __init__(self, entries: Iterable[ToolEntry]) -> None:
+        self._entries: dict[str, ToolEntry] = {}
+        for entry in entries:
+            self._entries[entry.name] = entry
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __contains__(self, name: object) -> bool:
+        return isinstance(name, str) and name in self._entries
+
+    @property
+    def entries(self) -> list[ToolEntry]:
+        return list(self._entries.values())
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._entries)
+
+    def get(self, name: str) -> ToolEntry | None:
+        return self._entries.get(name)
+
+    def expand(self, names: Iterable[str]) -> dict[str, dict[str, Any]]:
+        """Return full JSON schemas for *names*.
+
+        Unknown names are silently skipped; callers can detect a miss by
+        comparing keys.
+        """
+        out: dict[str, dict[str, Any]] = {}
+        for name in names:
+            entry = self._entries.get(name)
+            if entry is None:
+                continue
+            out[entry.name] = {
+                "name": entry.name,
+                "server": entry.server,
+                "description": entry.summary,
+                "input_schema": dict(entry.schema),
+            }
+        return out
+
+    def directory_lines(self) -> list[str]:
+        return [entry.directory_line for entry in self._entries.values()]
+
+    def estimate_full_tokens(self) -> int:
+        """Estimate token cost of the full catalog with schemas inlined."""
+        total = 0
+        for entry in self._entries.values():
+            total += estimate_tokens(entry.name)
+            total += estimate_tokens(entry.summary)
+            total += estimate_tokens(_schema_blob(entry.schema))
+        return total
+
+    def estimate_directory_tokens(self) -> int:
+        """Estimate token cost of just the names + summaries directory."""
+        return sum(estimate_tokens(line) for line in self.directory_lines())
+
+
+def _schema_blob(schema: Mapping[str, Any]) -> str:
+    """Stringify a JSON Schema for token estimation purposes only."""
+    if not schema:
+        return ""
+    parts: list[str] = []
+    for key, value in schema.items():
+        parts.append(str(key))
+        if isinstance(value, Mapping):
+            parts.append(_schema_blob(value))
+        elif isinstance(value, list | tuple):
+            parts.extend(str(v) for v in value)
+        else:
+            parts.append(str(value))
+    return " ".join(parts)
+
+
+class ToolSearchEngine:
+    """BM25 ranker over tool name + summary text.
+
+    BM25 is plenty for v1 — names and summaries are short, the corpus is
+    small (low hundreds of tools at most), and we want zero extra
+    dependencies.  Vector embeddings are deferred per the ticket.
+    """
+
+    def __init__(self, catalog: ToolCatalog) -> None:
+        self._catalog = catalog
+        self._docs: dict[str, list[str]] = {}
+        self._df: Counter[str] = Counter()
+        self._avg_dl: float = 0.0
+        self._build_index()
+
+    def _build_index(self) -> None:
+        total_dl = 0
+        for entry in self._catalog.entries:
+            tokens = _tokenize(f"{entry.name} {entry.summary} {entry.server}")
+            self._docs[entry.name] = tokens
+            for term in set(tokens):
+                self._df[term] += 1
+            total_dl += len(tokens)
+        if self._docs:
+            self._avg_dl = total_dl / len(self._docs)
+
+    def _idf(self, term: str) -> float:
+        n = len(self._docs)
+        if n == 0:
+            return 0.0
+        df = self._df.get(term, 0)
+        return math.log(1 + (n - df + 0.5) / (df + 0.5))
+
+    def _bm25(self, query_terms: list[str], doc_terms: list[str]) -> float:
+        if not doc_terms:
+            return 0.0
+        dl = len(doc_terms)
+        tf = Counter(doc_terms)
+        score = 0.0
+        for term in query_terms:
+            f = tf.get(term, 0)
+            if f == 0:
+                continue
+            idf = self._idf(term)
+            denom = f + _BM25_K1 * (1 - _BM25_B + _BM25_B * dl / (self._avg_dl or 1.0))
+            score += idf * (f * (_BM25_K1 + 1)) / denom
+        return score
+
+    def search(self, query: str, *, limit: int = 10) -> list[SearchHit]:
+        """Return the top-*limit* tools ranked for *query*.
+
+        Falls back to a substring-match scan when BM25 produces no hits
+        (covers the case where the agent searches for an exact tool name
+        with no overlapping terms in summaries).
+        """
+        query_terms = _tokenize(query)
+        hits: list[SearchHit] = []
+        if query_terms:
+            for name, doc_terms in self._docs.items():
+                score = self._bm25(query_terms, doc_terms)
+                if score <= 0:
+                    continue
+                entry = self._catalog.get(name)
+                if entry is None:
+                    continue
+                hits.append(SearchHit(name=name, server=entry.server, summary=entry.summary, score=score))
+
+        if not hits:
+            needle = query.lower().strip()
+            if needle:
+                for entry in self._catalog.entries:
+                    if needle in entry.name.lower() or needle in entry.summary.lower():
+                        hits.append(
+                            SearchHit(
+                                name=entry.name,
+                                server=entry.server,
+                                summary=entry.summary,
+                                score=0.0,
+                            )
+                        )
+
+        hits.sort(key=lambda h: (-h.score, h.name))
+        return hits[:limit]
+
+
+def compact_descriptions(catalog: ToolCatalog, budget_tokens: int) -> list[str]:
+    """Pack as many directory lines as fit inside *budget_tokens*.
+
+    Returns the lines in catalog order; truncation is by line, not by
+    character, so partial entries never leak into the prompt.
+    """
+    if budget_tokens <= 0:
+        return []
+    selected: list[str] = []
+    spent = 0
+    for line in catalog.directory_lines():
+        cost = estimate_tokens(line)
+        if spent + cost > budget_tokens:
+            break
+        selected.append(line)
+        spent += cost
+    return selected
+
+
+def expand_tools(catalog: ToolCatalog, names: Iterable[str]) -> dict[str, dict[str, Any]]:
+    """Module-level shim around :meth:`ToolCatalog.expand`.
+
+    Records the invocation against the Prometheus counter so the lazy
+    path is observable.
+    """
+    name_list = list(names)
+    try:
+        mcp_tool_search_invocations_total.labels(mode="expand").inc()
+    except Exception:
+        logger.debug("Failed to record mcp_tool_search expand invocation", exc_info=True)
+    return catalog.expand(name_list)
+
+
+def search_tools(catalog: ToolCatalog, query: str, *, limit: int = 10) -> list[SearchHit]:
+    """Convenience search that also bumps the Prometheus invocation counter."""
+    try:
+        mcp_tool_search_invocations_total.labels(mode="search").inc()
+    except Exception:
+        logger.debug("Failed to record mcp_tool_search search invocation", exc_info=True)
+    return ToolSearchEngine(catalog).search(query, limit=limit)
+
+
+def should_use_tool_search(catalog: ToolCatalog, threshold_tokens: int) -> bool:
+    """Return True when the full catalog exceeds *threshold_tokens*."""
+    if threshold_tokens <= 0:
+        return False
+    return catalog.estimate_full_tokens() > threshold_tokens
+
+
+_META_TOOL_DESCRIPTION = (
+    "tool_search(query, limit=10): search the MCP tool directory by keyword. "
+    "Returns ranked tool names + summaries. "
+    "Call expand_tools(names=[...]) to fetch full JSON schemas before invoking."
+)
+
+
+def build_prompt_section(
+    catalog: ToolCatalog,
+    *,
+    threshold_tokens: int,
+    directory_budget_tokens: int = 1500,
+) -> str:
+    """Construct the MCP-tools prompt section.
+
+    When the full catalog fits inside *threshold_tokens* we return the
+    inline tool list (one line per tool, schemas not included).  When it
+    overflows we return the lazy section: a meta-tool description plus a
+    truncated directory bounded by *directory_budget_tokens*.
+    """
+    if not should_use_tool_search(catalog, threshold_tokens):
+        lines = ["MCP tools available:", *catalog.directory_lines()]
+        return "\n".join(lines)
+
+    directory = compact_descriptions(catalog, directory_budget_tokens)
+    sections = [
+        "MCP tool catalog is large; use the meta-tool below to load schemas on demand.",
+        _META_TOOL_DESCRIPTION,
+        "",
+        "Directory (names + 1-line summaries):",
+        *directory,
+    ]
+    if len(directory) < len(catalog):
+        sections.append(f"... ({len(catalog) - len(directory)} more tools, search to discover)")
+    return "\n".join(sections)
+
+
+__all__ = [
+    "SearchHit",
+    "ToolCatalog",
+    "ToolEntry",
+    "ToolSearchEngine",
+    "build_prompt_section",
+    "compact_descriptions",
+    "estimate_tokens",
+    "expand_tools",
+    "mcp_tool_search_invocations_total",
+    "search_tools",
+    "should_use_tool_search",
+]

--- a/tests/unit/test_mcp_tool_search.py
+++ b/tests/unit/test_mcp_tool_search.py
@@ -1,0 +1,253 @@
+"""Tests for MCP tool-search lazy loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.protocols.mcp.mcp_manager import build_tools_prompt_section
+from bernstein.core.protocols.mcp.mcp_tool_search import (
+    SearchHit,
+    ToolCatalog,
+    ToolEntry,
+    ToolSearchEngine,
+    build_prompt_section,
+    compact_descriptions,
+    estimate_tokens,
+    expand_tools,
+    search_tools,
+    should_use_tool_search,
+)
+
+
+def _entry(name: str, summary: str, server: str = "git", schema: dict[str, object] | None = None) -> ToolEntry:
+    return ToolEntry(name=name, summary=summary, server=server, schema=schema or {})
+
+
+@pytest.fixture()
+def small_catalog() -> ToolCatalog:
+    return ToolCatalog(
+        [
+            _entry("git_diff", "show working tree changes", schema={"path": "string"}),
+            _entry("git_commit", "create a commit from staged changes"),
+            _entry("github_create_issue", "open a new GitHub issue", server="github"),
+        ]
+    )
+
+
+@pytest.fixture()
+def large_catalog() -> ToolCatalog:
+    entries: list[ToolEntry] = []
+    for i in range(80):
+        entries.append(
+            _entry(
+                f"server{i}.tool_{i}",
+                "do something useful with the input parameters and return a structured response payload",
+                server=f"server{i}",
+                schema={"a": "string", "b": "number", "c": "boolean", "d": {"nested": "object"}},
+            )
+        )
+    return ToolCatalog(entries)
+
+
+class TestToolEntry:
+    def test_directory_line_truncates_long_summary(self) -> None:
+        entry = _entry("a.tool", "x" * 500)
+        line = entry.directory_line
+        assert "…" in line
+        assert len(line) < 500
+
+    def test_directory_line_short_summary_unchanged(self) -> None:
+        entry = _entry("a.tool", "short summary")
+        assert entry.directory_line == "- a.tool (git): short summary"
+
+
+class TestEstimateTokens:
+    def test_empty_string_zero(self) -> None:
+        assert estimate_tokens("") == 0
+
+    def test_short_string_at_least_one(self) -> None:
+        assert estimate_tokens("hi") >= 1
+
+    def test_scales_with_length(self) -> None:
+        short = estimate_tokens("a" * 4)
+        long = estimate_tokens("a" * 400)
+        assert long > short * 50
+
+
+class TestToolCatalog:
+    def test_len_and_contains(self, small_catalog: ToolCatalog) -> None:
+        assert len(small_catalog) == 3
+        assert "git_diff" in small_catalog
+        assert "missing" not in small_catalog
+
+    def test_expand_known_tools(self, small_catalog: ToolCatalog) -> None:
+        out = small_catalog.expand(["git_diff", "git_commit"])
+        assert set(out) == {"git_diff", "git_commit"}
+        assert out["git_diff"]["input_schema"] == {"path": "string"}
+        assert out["git_diff"]["server"] == "git"
+
+    def test_expand_unknown_silently_skipped(self, small_catalog: ToolCatalog) -> None:
+        out = small_catalog.expand(["git_diff", "nope"])
+        assert set(out) == {"git_diff"}
+
+    def test_full_tokens_grows_with_schema(self) -> None:
+        thin = ToolCatalog([_entry("a", "b")])
+        fat = ToolCatalog([_entry("a", "b", schema={f"k{i}": f"v{i}" for i in range(40)})])
+        assert fat.estimate_full_tokens() > thin.estimate_full_tokens()
+
+
+class TestSearchEngine:
+    def test_ranking_prefers_query_term_matches(self, small_catalog: ToolCatalog) -> None:
+        engine = ToolSearchEngine(small_catalog)
+        hits = engine.search("git diff")
+        assert hits, "expected at least one hit"
+        assert hits[0].name == "git_diff"
+
+    def test_substring_fallback(self, small_catalog: ToolCatalog) -> None:
+        engine = ToolSearchEngine(small_catalog)
+        hits = engine.search("github")
+        assert any(h.name == "github_create_issue" for h in hits)
+
+    def test_limit_respected(self) -> None:
+        catalog = ToolCatalog([_entry(f"git_t{i}", "git tool") for i in range(20)])
+        engine = ToolSearchEngine(catalog)
+        hits = engine.search("git", limit=5)
+        assert len(hits) == 5
+
+    def test_empty_query_returns_no_bm25_hits(self, small_catalog: ToolCatalog) -> None:
+        engine = ToolSearchEngine(small_catalog)
+        assert engine.search("") == []
+
+    def test_empty_catalog_returns_empty(self) -> None:
+        engine = ToolSearchEngine(ToolCatalog([]))
+        assert engine.search("anything") == []
+
+
+class TestCompactDescriptions:
+    def test_fits_within_budget(self, large_catalog: ToolCatalog) -> None:
+        lines = compact_descriptions(large_catalog, budget_tokens=200)
+        joined_tokens = sum(estimate_tokens(line) for line in lines)
+        assert joined_tokens <= 200
+        assert len(lines) < len(large_catalog)
+
+    def test_zero_budget_returns_empty(self, small_catalog: ToolCatalog) -> None:
+        assert compact_descriptions(small_catalog, budget_tokens=0) == []
+
+    def test_huge_budget_returns_all(self, small_catalog: ToolCatalog) -> None:
+        lines = compact_descriptions(small_catalog, budget_tokens=10_000)
+        assert len(lines) == len(small_catalog)
+
+
+class TestThreshold:
+    def test_small_catalog_below_threshold(self, small_catalog: ToolCatalog) -> None:
+        assert should_use_tool_search(small_catalog, threshold_tokens=6000) is False
+
+    def test_large_catalog_above_threshold(self, large_catalog: ToolCatalog) -> None:
+        assert should_use_tool_search(large_catalog, threshold_tokens=500) is True
+
+    def test_zero_threshold_disables(self, large_catalog: ToolCatalog) -> None:
+        assert should_use_tool_search(large_catalog, threshold_tokens=0) is False
+
+
+class TestExpandRoundTrip:
+    def test_search_then_expand(self, small_catalog: ToolCatalog) -> None:
+        hits = search_tools(small_catalog, "git", limit=10)
+        names = [h.name for h in hits]
+        assert names
+        schemas = expand_tools(small_catalog, names)
+        assert set(schemas) == set(names)
+        for name in names:
+            assert "input_schema" in schemas[name]
+
+    def test_expand_unknown_returns_empty(self, small_catalog: ToolCatalog) -> None:
+        assert expand_tools(small_catalog, ["does-not-exist"]) == {}
+
+
+class TestPromptSection:
+    def test_inline_when_below_threshold(self, small_catalog: ToolCatalog) -> None:
+        text = build_prompt_section(small_catalog, threshold_tokens=10_000)
+        assert "MCP tools available" in text
+        assert "tool_search" not in text
+
+    def test_lazy_when_above_threshold(self, large_catalog: ToolCatalog) -> None:
+        text = build_prompt_section(large_catalog, threshold_tokens=200, directory_budget_tokens=300)
+        assert "tool_search" in text
+        assert "expand_tools" in text
+        assert "more tools" in text
+
+
+class TestManagerWireIn:
+    def test_empty_tools_returns_empty(self) -> None:
+        assert build_tools_prompt_section([]) == ""
+
+    def test_small_catalog_inline(self) -> None:
+        tools = [("git", "git_diff", "show diff", {"path": "string"})]
+        out = build_tools_prompt_section(tools, threshold_tokens=10_000)
+        assert "MCP tools available" in out
+        assert "tool_search" not in out
+
+    def test_large_catalog_swaps_to_meta_tool(self) -> None:
+        tools = [
+            (
+                f"s{i}",
+                f"s{i}.tool_{i}",
+                "do work over inputs and produce structured output payload",
+                {"a": "string", "b": "object"},
+            )
+            for i in range(60)
+        ]
+        out = build_tools_prompt_section(tools, threshold_tokens=200, directory_budget_tokens=300)
+        assert "tool_search" in out
+        assert "expand_tools" in out
+
+    def test_disabled_forces_inline_even_when_large(self) -> None:
+        tools = [(f"s{i}", f"tool_{i}", "summary", {}) for i in range(60)]
+        out = build_tools_prompt_section(tools, threshold_tokens=10, enabled=False)
+        assert "tool_search" not in out
+        assert "MCP tools available" in out
+
+
+def _counter_value(counter: object, **labels: str) -> float:
+    """Read a labelled Prometheus counter via the public _value attribute.
+
+    Falls back to 0.0 when the prometheus_client stubs are in use.
+    """
+    try:
+        labelled = counter.labels(**labels)  # type: ignore[attr-defined]
+        return float(labelled._value.get())  # type: ignore[attr-defined]
+    except Exception:
+        return 0.0
+
+
+class TestMetricsCounter:
+    def test_search_invocation_increments_counter(self, small_catalog: ToolCatalog) -> None:
+        from bernstein.core.protocols.mcp.mcp_tool_search import (
+            mcp_tool_search_invocations_total,
+        )
+
+        before = _counter_value(mcp_tool_search_invocations_total, mode="search")
+        search_tools(small_catalog, "git")
+        after = _counter_value(mcp_tool_search_invocations_total, mode="search")
+        assert after >= before + 1
+
+    def test_expand_invocation_increments_counter(self, small_catalog: ToolCatalog) -> None:
+        from bernstein.core.protocols.mcp.mcp_tool_search import (
+            mcp_tool_search_invocations_total,
+        )
+
+        before = _counter_value(mcp_tool_search_invocations_total, mode="expand")
+        expand_tools(small_catalog, ["git_diff"])
+        after = _counter_value(mcp_tool_search_invocations_total, mode="expand")
+        assert after >= before + 1
+
+
+class TestSearchHitDataclass:
+    def test_search_hit_fields(self, small_catalog: ToolCatalog) -> None:
+        engine = ToolSearchEngine(small_catalog)
+        hits = engine.search("commit")
+        assert hits
+        hit = hits[0]
+        assert isinstance(hit, SearchHit)
+        assert hit.name
+        assert hit.server
+        assert hit.summary


### PR DESCRIPTION
## Summary
Implements `tool-search-lazy-loading` from `.sdd/backlog/open/2026-04-30-feat-tool-search-lazy-loading.md`.

When a fleet's combined MCP tool descriptions exceed `MCP_TOOL_SEARCH_THRESHOLD_TOKENS` (default 6000), agents now get a `tool_search` meta-tool plus a compact name+summary directory instead of the full catalog. Schemas load on demand via `expand_tools(names=...)`. With 7+ MCP servers a fleet can routinely hit 67k+ tokens of tool descriptions baked into every short-lived agent's system prompt; this pattern is the lazy-loading half of "tool search" from awesome-agentic-patterns.

## Changes
- New module `src/bernstein/core/protocols/mcp/mcp_tool_search.py`:
  - `ToolEntry`, `ToolCatalog`, `SearchHit` dataclasses
  - `ToolSearchEngine` — BM25 over name + summary + server, with substring fallback
  - `compact_descriptions(catalog, budget_tokens)` — token-budgeted directory
  - `expand_tools(names)` — round-trip from rank to full JSON Schema
  - `build_prompt_section(catalog, threshold_tokens=...)` — inline vs lazy
  - Prometheus counter `mcp_tool_search_invocations_total{mode}`
- `mcp_manager.build_tools_prompt_section(...)` — wire-in helper
- `defaults.MCPToolSearchDefaults` + module constants `MCP_TOOL_SEARCH_ENABLED`, `MCP_TOOL_SEARCH_THRESHOLD_TOKENS`
- `core.__init__._REDIRECT_MAP` — alias for back-compat imports
- 31 unit tests in `tests/unit/test_mcp_tool_search.py`

Out of scope per the ticket: full tool-call protocol replacement, cross-server dedupe, embedding-based search.

## Test plan
- [x] `uv run pytest tests/unit/test_mcp_tool_search.py -x -q` (31 passed)
- [x] Smoke: `tests/unit/test_mcp_manager.py`, `test_mcp_lazy_discovery.py`, `test_mcp_tool_normalization.py`, `test_defaults.py` (113 passed, 2 skipped)
- [x] `ruff format` + `ruff check` clean on all touched files