### PR TITLE
feat(tasks): swarm migration with deterministic map-reduce

### DIFF
--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -78,6 +78,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "mcp_cmd": "bernstein.cli.commands.mcp_cmd",
     "memory_cmd": "bernstein.cli.commands.memory_cmd",
     "merge_cmd": "bernstein.cli.commands.merge_cmd",
+    "migrate_cmd": "bernstein.cli.commands.migrate_cmd",
     "plan_diff": "bernstein.cli.plan.plan_diff",
     "plan_display": "bernstein.cli.plan.plan_display",
     "plan_explain": "bernstein.cli.plan.plan_explain",

--- a/src/bernstein/cli/commands/migrate_cmd.py
+++ b/src/bernstein/cli/commands/migrate_cmd.py
@@ -1,0 +1,159 @@
+"""``bernstein migrate`` — fan out a deterministic file-level migration.
+
+Wraps :mod:`bernstein.core.tasks.swarm_migration` so an operator can
+kick off a swarm without writing Python.  Tasks are created via the
+running task server (``POST /tasks``); when the server is offline the
+command exits non-zero with a clear message.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import click
+
+from bernstein.cli.helpers import SERVER_URL, console, server_post
+from bernstein.core.tasks.swarm_migration import (
+    MigrationPlan,
+    chunk_targets,
+    effective_max_parallel,
+    enumerate_targets,
+    spawn_swarm,
+)
+
+_DRY_RUN_PREVIEW_LIMIT = 10
+
+
+class _ServerTaskStore:
+    """Adapter that bridges :class:`spawn_swarm` to ``POST /tasks``."""
+
+    def create_sync(self, body: dict[str, Any]) -> str:
+        resp = server_post("/tasks", body)
+        if resp is None:
+            raise click.ClickException(f"Task server at {SERVER_URL} is unreachable; start `bernstein run` first.")
+        task_id = resp.get("id")
+        if not isinstance(task_id, str):
+            raise click.ClickException(f"Task server returned no task id: {resp!r}")
+        return task_id
+
+
+def _slugify(value: str) -> str:
+    safe = "".join(c if c.isalnum() or c in {"-", "_"} else "-" for c in value.strip().lower())
+    return safe.strip("-") or "swarm"
+
+
+def _print_plan_summary(
+    plan: MigrationPlan,
+    targets: list[Path],
+    chunks: list[list[Path]],
+    cap: int,
+) -> None:
+    console.print(f"[bold]Migration plan:[/bold] {plan.id}")
+    console.print(f"  glob:           {plan.glob}")
+    console.print(f"  files:          {len(targets)}")
+    console.print(f"  chunks:         {len(chunks)} (chunk_size={plan.chunk_size})")
+    console.print(f"  max_parallel:   {cap} (configured {plan.max_parallel})")
+    console.print(f"  role:           {plan.role}")
+
+
+def _print_dry_run_preview(targets: list[Path], chunks: list[list[Path]]) -> None:
+    console.print("\n[bold]Targets (preview):[/bold]")
+    for p in targets[:_DRY_RUN_PREVIEW_LIMIT]:
+        console.print(f"  - {p}")
+    if len(targets) > _DRY_RUN_PREVIEW_LIMIT:
+        console.print(f"  ... and {len(targets) - _DRY_RUN_PREVIEW_LIMIT} more")
+    console.print("\n[bold]First chunk:[/bold]")
+    if chunks:
+        for p in chunks[0]:
+            console.print(f"  - {p}")
+
+
+@click.command("migrate")
+@click.option("--glob", "glob_pattern", required=True, help="Repo-relative glob, e.g. 'src/**/*.py'.")
+@click.option("--transform", "transform_prompt", required=True, help="Instruction passed to each subagent.")
+@click.option("--id", "plan_id", default=None, help="Stable plan id used for idempotent re-runs.")
+@click.option("--chunk-size", type=int, default=5, show_default=True, help="Files per subagent.")
+@click.option("--max-parallel", type=int, default=20, show_default=True, help="Concurrent subagent cap.")
+@click.option("--role", default="backend", show_default=True, help="Role for spawned tasks.")
+@click.option(
+    "--exclude",
+    "excludes",
+    multiple=True,
+    help="Repo-relative glob to exclude (may be repeated).",
+)
+@click.option(
+    "--repo-root",
+    type=click.Path(file_okay=False, exists=True, path_type=Path),
+    default=Path.cwd(),
+    show_default="cwd",
+    help="Repository root used to resolve --glob.",
+)
+@click.option("--dry-run", is_flag=True, help="Show enumerated chunks without spawning tasks.")
+@click.option("--json-output", "json_output", is_flag=True, help="Emit machine-readable JSON instead of rich text.")
+def migrate_cmd(
+    glob_pattern: str,
+    transform_prompt: str,
+    plan_id: str | None,
+    chunk_size: int,
+    max_parallel: int,
+    role: str,
+    excludes: tuple[str, ...],
+    repo_root: Path,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    """Spawn one task per chunk for a deterministic migration."""
+    resolved_id = plan_id or _slugify(transform_prompt)[:48]
+    plan = MigrationPlan(
+        id=resolved_id,
+        glob=glob_pattern,
+        transform_prompt=transform_prompt,
+        chunk_size=chunk_size,
+        max_parallel=max_parallel,
+        role=role,
+        excludes=excludes,
+    )
+    repo_root = repo_root.resolve()
+    targets = enumerate_targets(plan, repo_root)
+    chunks = chunk_targets(targets, plan.chunk_size)
+    cap = effective_max_parallel(plan, len(chunks))
+
+    if not targets:
+        msg = f"No files matched glob {glob_pattern!r} under {repo_root}"
+        if json_output:
+            console.print(json.dumps({"plan_id": plan.id, "spawned": [], "warning": msg}))
+        else:
+            console.print(f"[yellow]{msg}[/yellow]")
+        return
+
+    if dry_run:
+        if json_output:
+            console.print(
+                json.dumps(
+                    {
+                        "plan": asdict(plan),
+                        "files": [str(p) for p in targets],
+                        "chunks": [[str(p) for p in c] for c in chunks],
+                        "effective_max_parallel": cap,
+                    },
+                    indent=2,
+                )
+            )
+            return
+        _print_plan_summary(plan, targets, chunks, cap)
+        _print_dry_run_preview(targets, chunks)
+        console.print("\n[dim]Dry run — no tasks spawned.[/dim]")
+        return
+
+    store = _ServerTaskStore()
+    spawned = spawn_swarm(plan, store, repo_root)
+    if json_output:
+        console.print(json.dumps({"plan_id": plan.id, "spawned": spawned, "chunks": len(chunks)}))
+        return
+    _print_plan_summary(plan, targets, chunks, cap)
+    console.print(f"\n[green]Spawned {len(spawned)} task(s).[/green]")
+    for tid in spawned:
+        console.print(f"  - {tid}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -82,6 +82,7 @@ from bernstein.cli.man_page import man_pages_cmd
 from bernstein.cli.manifest_cmd import manifest_group
 from bernstein.cli.memory_cmd import memory_group
 from bernstein.cli.merge_cmd import merge_cmd
+from bernstein.cli.migrate_cmd import migrate_cmd
 from bernstein.cli.plan_archive_cmd import plan_ls, plan_show
 from bernstein.cli.plan_generate_cmd import plan_generate
 from bernstein.cli.plan_validate_cmd import validate_plan
@@ -798,6 +799,7 @@ cli.add_command(undo_cmd, "undo")
 cli.add_command(worker, "worker")
 cli.add_command(diff_cmd, "diff")
 cli.add_command(merge_cmd, "merge")
+cli.add_command(migrate_cmd, "migrate")
 cli.add_command(changelog_cmd, "changelog")
 cli.add_command(run_changelog_cmd, "run-changelog")
 cli.add_command(dr_group, "dr")

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -502,6 +502,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "store_factory": "bernstein.core.persistence.store_factory",
     "store_postgres": "bernstein.core.persistence.store_postgres",
     "store_redis": "bernstein.core.persistence.store_redis",
+    "swarm_migration": "bernstein.core.tasks.swarm_migration",
     "sync": "bernstein.core.persistence.sync",
     # synthesis: removed in audit-169 — dead code, no production importers.
     "task_claim": "bernstein.core.tasks.task_claim",

--- a/src/bernstein/core/tasks/swarm_migration.py
+++ b/src/bernstein/core/tasks/swarm_migration.py
@@ -1,0 +1,369 @@
+"""Swarm migration: deterministic file-level fanout for high-cardinality changes.
+
+Framework migrations, lint-rule rollouts, and API renames want
+deterministic, file-level fanout with many subagents in parallel rather
+than the manager-LLM 2-5 split implemented by
+:mod:`bernstein.core.tasks.task_splitter`.
+
+The flow is:
+
+    plan = MigrationPlan(glob="src/**/*.py", transform_prompt="...", ...)
+    targets = enumerate_targets(plan, repo_root)
+    chunks = chunk_targets(targets, plan.chunk_size)
+    task_ids = spawn_swarm(plan, store, repo_root)            # one task per chunk
+    # ... agents execute, then orchestrator collects per-task results ...
+    report = reduce_swarm(plan_id, child_results)             # pass/fail aggregate
+
+Idempotency is provided via a checkpoint file under
+``<repo_root>/.sdd/runtime/swarm/{plan_id}.json`` — re-running with the
+same ``plan.id`` skips chunks whose hash already appears in the
+checkpoint's ``completed_chunks`` set.
+
+The actual code-transformation logic is delegated to spawned agents
+exactly like any other task; this module only owns enumeration,
+chunking, fanout, and reduction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CHUNK_SIZE = 5
+_DEFAULT_MAX_PARALLEL = 20
+_HARD_PARALLEL_CEILING = 20
+
+_SWARM_TAG = "[swarm-migration]"
+
+
+class _SwarmTaskStore(Protocol):
+    """Minimal task-store surface used by :func:`spawn_swarm`.
+
+    Designed so the production :class:`bernstein.core.tasks.task_store.TaskStore`
+    and lightweight in-memory test doubles satisfy the same contract
+    without dragging the full async server into unit tests.
+    """
+
+    def create_sync(self, body: dict[str, Any]) -> str:
+        """Create a task and return its server-assigned id."""
+        ...
+
+
+@dataclass(frozen=True)
+class MigrationPlan:
+    """Description of one swarm-migration run.
+
+    Attributes:
+        id: Stable identifier used for checkpointing and idempotency.
+        glob: Repo-relative glob pattern enumerating migration targets
+            (e.g. ``"src/**/*.py"``).
+        transform_prompt: Free-text instruction for the spawned agents,
+            describing the code transformation to apply.
+        chunk_size: Number of files handed to a single subagent.
+        max_parallel: Upper bound on concurrent swarm tasks.  The actual
+            cap is the minimum of this value, the chunk count, and
+            ``_HARD_PARALLEL_CEILING``.
+        role: Role assigned to spawned tasks.
+        title_prefix: Human-readable prefix for spawned task titles.
+        excludes: Optional repo-relative glob patterns to exclude after
+            primary enumeration (e.g. ``("**/__pycache__/**",)``).
+    """
+
+    id: str
+    glob: str
+    transform_prompt: str
+    chunk_size: int = _DEFAULT_CHUNK_SIZE
+    max_parallel: int = _DEFAULT_MAX_PARALLEL
+    role: str = "backend"
+    title_prefix: str = "swarm-migrate"
+    excludes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.chunk_size < 1:
+            raise ValueError(f"chunk_size must be >= 1, got {self.chunk_size}")
+        if self.max_parallel < 1:
+            raise ValueError(f"max_parallel must be >= 1, got {self.max_parallel}")
+        if not self.id.strip():
+            raise ValueError("plan id must be non-empty")
+        if not self.glob.strip():
+            raise ValueError("glob must be non-empty")
+
+
+@dataclass(frozen=True)
+class SwarmChunkResult:
+    """Outcome reported for a single swarm chunk."""
+
+    task_id: str
+    chunk_hash: str
+    files: tuple[str, ...]
+    passed: bool
+    summary: str = ""
+
+
+@dataclass(frozen=True)
+class SwarmReport:
+    """Aggregated report posted to the bulletin board after reduction."""
+
+    plan_id: str
+    total_chunks: int
+    passed_chunks: int
+    failed_chunks: int
+    skipped_chunks: int
+    failed_files: tuple[str, ...]
+    timestamp: float = field(default_factory=time.time)
+
+    def to_bulletin_content(self) -> str:
+        """Render a one-line bulletin summary."""
+        return (
+            f"{_SWARM_TAG} plan={self.plan_id} "
+            f"chunks={self.passed_chunks}/{self.total_chunks} "
+            f"failed={self.failed_chunks} skipped={self.skipped_chunks}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict (frozen dataclasses ship via asdict)."""
+        return asdict(self)
+
+
+def enumerate_targets(plan: MigrationPlan, repo_root: Path) -> list[Path]:
+    """Resolve ``plan.glob`` against ``repo_root`` and return matching files.
+
+    Hidden directories (anything whose name starts with ``.``) are
+    skipped to avoid descending into ``.git`` / ``.sdd`` / venvs by
+    accident.  Symlinks are not followed for the same reason.
+    Results are sorted for deterministic chunking.
+    """
+    if not repo_root.exists():
+        raise FileNotFoundError(f"repo_root does not exist: {repo_root}")
+
+    matched = {p.resolve() for p in repo_root.glob(plan.glob) if p.is_file()}
+    excluded: set[Path] = set()
+    for pattern in plan.excludes:
+        excluded.update(p.resolve() for p in repo_root.glob(pattern) if p.is_file())
+
+    def _is_hidden(p: Path) -> bool:
+        try:
+            rel_parts = p.relative_to(repo_root.resolve()).parts
+        except ValueError:
+            return False
+        return any(part.startswith(".") for part in rel_parts)
+
+    final = [p for p in sorted(matched - excluded) if not _is_hidden(p)]
+    logger.info(
+        "swarm_migration: enumerated %d target(s) for plan=%s glob=%s",
+        len(final),
+        plan.id,
+        plan.glob,
+    )
+    return final
+
+
+def chunk_targets(targets: list[Path], chunk_size: int) -> list[list[Path]]:
+    """Split *targets* into fixed-size chunks, preserving order."""
+    if chunk_size < 1:
+        raise ValueError(f"chunk_size must be >= 1, got {chunk_size}")
+    return [targets[i : i + chunk_size] for i in range(0, len(targets), chunk_size)]
+
+
+def _chunk_hash(plan_id: str, files: list[Path]) -> str:
+    """Stable chunk hash derived from plan id and the chunk's file paths."""
+    h = hashlib.sha256()
+    h.update(plan_id.encode("utf-8"))
+    h.update(b"\x00")
+    for f in files:
+        h.update(str(f).encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()[:16]
+
+
+def _checkpoint_path(repo_root: Path, plan_id: str) -> Path:
+    safe_id = plan_id.replace("/", "_").replace(" ", "_")
+    return repo_root / ".sdd" / "runtime" / "swarm" / f"{safe_id}.json"
+
+
+def _load_checkpoint(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"completed_chunks": [], "task_ids": {}}
+    try:
+        loaded: Any = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(loaded, dict):
+            raise TypeError("checkpoint root must be an object")
+        loaded.setdefault("completed_chunks", [])
+        loaded.setdefault("task_ids", {})
+        return loaded
+    except (OSError, ValueError, TypeError):
+        logger.warning("swarm_migration: corrupt checkpoint at %s; ignoring", path)
+        return {"completed_chunks": [], "task_ids": {}}
+
+
+def _write_checkpoint(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def effective_max_parallel(plan: MigrationPlan, chunk_count: int, adaptive_cap: int | None = None) -> int:
+    """Compute the effective concurrent-spawn cap for a swarm.
+
+    The cap is ``min(plan.max_parallel, chunk_count, _HARD_PARALLEL_CEILING)``
+    intersected with the adaptive-parallelism cap when supplied.
+    """
+    cap = min(plan.max_parallel, max(chunk_count, 1), _HARD_PARALLEL_CEILING)
+    if adaptive_cap is not None and adaptive_cap > 0:
+        cap = min(cap, adaptive_cap)
+    return max(cap, 1)
+
+
+def _build_task_body(
+    plan: MigrationPlan,
+    chunk: list[Path],
+    chunk_hash: str,
+    repo_root: Path,
+    chunk_index: int,
+    total_chunks: int,
+) -> dict[str, Any]:
+    rel_files = [str(p.relative_to(repo_root.resolve())) for p in chunk]
+    description = (
+        f"{_SWARM_TAG} plan={plan.id} chunk={chunk_index + 1}/{total_chunks} hash={chunk_hash}\n\n"
+        f"Apply the following transformation to each file in the chunk:\n\n"
+        f"{plan.transform_prompt}\n\n"
+        f"Files:\n" + "\n".join(f"- {p}" for p in rel_files)
+    )
+    return {
+        "title": f"{plan.title_prefix}: {plan.id} [{chunk_index + 1}/{total_chunks}]",
+        "description": description,
+        "role": plan.role,
+        "priority": 2,
+        "scope": "small",
+        "complexity": "medium",
+        "owned_files": rel_files,
+        "metadata": {
+            "swarm_plan_id": plan.id,
+            "swarm_chunk_hash": chunk_hash,
+            "swarm_chunk_index": chunk_index,
+            "swarm_total_chunks": total_chunks,
+        },
+    }
+
+
+def spawn_swarm(
+    plan: MigrationPlan,
+    store: _SwarmTaskStore,
+    repo_root: Path,
+    *,
+    adaptive_cap: int | None = None,
+) -> list[str]:
+    """Enumerate, chunk, and fan out one task per chunk.
+
+    Idempotent: chunks whose hash is recorded as completed in the plan's
+    checkpoint are skipped, and previously-spawned task ids are returned
+    unchanged.
+
+    Args:
+        plan: Migration plan describing the glob and transform.
+        store: Anything satisfying :class:`_SwarmTaskStore` (production
+            store or test double).
+        repo_root: Repo root used to resolve ``plan.glob`` and the
+            checkpoint location under ``.sdd/runtime/swarm/``.
+        adaptive_cap: Optional cap injected by the caller (typically
+            :class:`bernstein.core.orchestration.adaptive_parallelism.AdaptiveParallelism`).
+            A non-positive value is treated as "no cap".
+
+    Returns:
+        List of task ids that exist for the plan after this call —
+        previously-recorded ids first (in chunk order), then any newly
+        spawned ones.
+    """
+    targets = enumerate_targets(plan, repo_root)
+    chunks = chunk_targets(targets, plan.chunk_size)
+    cap = effective_max_parallel(plan, len(chunks), adaptive_cap)
+    logger.info(
+        "swarm_migration: plan=%s chunks=%d effective_max_parallel=%d",
+        plan.id,
+        len(chunks),
+        cap,
+    )
+
+    cp_path = _checkpoint_path(repo_root, plan.id)
+    checkpoint = _load_checkpoint(cp_path)
+    completed: set[str] = set(checkpoint["completed_chunks"])
+    known: dict[str, str] = dict(checkpoint["task_ids"])
+
+    ordered_ids: list[str] = []
+    for idx, chunk in enumerate(chunks):
+        chunk_hash = _chunk_hash(plan.id, chunk)
+        if chunk_hash in completed and chunk_hash in known:
+            ordered_ids.append(known[chunk_hash])
+            continue
+        if chunk_hash in known:
+            ordered_ids.append(known[chunk_hash])
+            continue
+        body = _build_task_body(plan, chunk, chunk_hash, repo_root, idx, len(chunks))
+        task_id = store.create_sync(body)
+        known[chunk_hash] = task_id
+        ordered_ids.append(task_id)
+
+    checkpoint["task_ids"] = known
+    checkpoint["completed_chunks"] = sorted(completed)
+    checkpoint["plan_id"] = plan.id
+    checkpoint["chunk_count"] = len(chunks)
+    checkpoint["effective_max_parallel"] = cap
+    checkpoint["updated_at"] = time.time()
+    _write_checkpoint(cp_path, checkpoint)
+    return ordered_ids
+
+
+def mark_chunk_complete(plan_id: str, chunk_hash: str, repo_root: Path) -> None:
+    """Record *chunk_hash* as completed for *plan_id*.
+
+    Called by the orchestrator (or tests) after a swarm task finishes
+    successfully so a re-run of the same plan skips the chunk.
+    """
+    cp_path = _checkpoint_path(repo_root, plan_id)
+    checkpoint = _load_checkpoint(cp_path)
+    completed: set[str] = set(checkpoint["completed_chunks"])
+    completed.add(chunk_hash)
+    checkpoint["completed_chunks"] = sorted(completed)
+    checkpoint["plan_id"] = plan_id
+    checkpoint["updated_at"] = time.time()
+    _write_checkpoint(cp_path, checkpoint)
+
+
+def reduce_swarm(plan_id: str, child_results: list[SwarmChunkResult]) -> SwarmReport:
+    """Aggregate per-chunk outcomes into a single :class:`SwarmReport`.
+
+    Failed files are collected from every non-passing chunk so the
+    operator can re-target them with a follow-up plan.
+    """
+    total = len(child_results)
+    passed = sum(1 for r in child_results if r.passed)
+    failed_files: list[str] = []
+    for r in child_results:
+        if not r.passed:
+            failed_files.extend(r.files)
+    report = SwarmReport(
+        plan_id=plan_id,
+        total_chunks=total,
+        passed_chunks=passed,
+        failed_chunks=total - passed,
+        skipped_chunks=0,
+        failed_files=tuple(failed_files),
+    )
+    logger.info(
+        "swarm_migration: plan=%s reduced %d/%d chunks passed (%d failed files)",
+        plan_id,
+        report.passed_chunks,
+        report.total_chunks,
+        len(report.failed_files),
+    )
+    return report

--- a/templates/migrations/pytest_asyncio.yaml
+++ b/templates/migrations/pytest_asyncio.yaml
@@ -1,0 +1,25 @@
+# Example swarm-migration plan: switch unittest-style async tests to pytest-asyncio.
+#
+# Use with:
+#   bernstein migrate \
+#     --id pytest-asyncio-rollout \
+#     --glob "tests/**/test_*.py" \
+#     --transform "$(cat templates/migrations/pytest_asyncio.yaml)" \
+#     --chunk-size 5 \
+#     --max-parallel 10
+#
+# The YAML body itself is consumed as the free-text transform prompt — the
+# top-level keys are informational only and ignored by `bernstein migrate`.
+id: pytest-asyncio-rollout
+description: |
+  Convert unittest.IsolatedAsyncioTestCase test classes to plain
+  pytest-asyncio coroutine functions.
+transform: |
+  For each file in the chunk:
+
+  1. Replace `class FooTest(unittest.IsolatedAsyncioTestCase):` with module-level
+     `async def test_foo()` definitions.
+  2. Add the `@pytest.mark.asyncio` decorator to every coroutine test.
+  3. Promote `setUp` / `tearDown` to fixtures defined in the same file.
+  4. Drop the `unittest` import once nothing else uses it.
+  5. Run `uv run pytest <file> -x -q` and confirm green before completing.

--- a/templates/migrations/sync_to_async.yaml
+++ b/templates/migrations/sync_to_async.yaml
@@ -1,0 +1,16 @@
+# Example swarm-migration plan: convert blocking helpers to async/await.
+id: sync-to-async-rollout
+description: |
+  Convert IO-bound helper modules from blocking sync to async/await.
+transform: |
+  For each file in the chunk:
+
+  1. Identify functions that perform network or filesystem IO and convert them
+     to `async def`. Update return types accordingly.
+  2. Replace `requests.<verb>` and `urllib.request` calls with `httpx.AsyncClient`.
+  3. Replace `open(...)` for large reads/writes with `aiofiles` where it improves
+     responsiveness (do NOT change tiny config reads).
+  4. Update every caller within the same file; cross-file callers remain on the
+     original list and will be migrated by a follow-up plan.
+  5. Run `uv run ruff check <file>` and the file's own test (if any) before
+     completing.

--- a/tests/unit/test_swarm_migration.py
+++ b/tests/unit/test_swarm_migration.py
@@ -1,0 +1,160 @@
+"""Unit tests for the swarm-migration map-reduce helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.swarm_migration import (
+    MigrationPlan,
+    SwarmChunkResult,
+    chunk_targets,
+    effective_max_parallel,
+    enumerate_targets,
+    mark_chunk_complete,
+    reduce_swarm,
+    spawn_swarm,
+)
+
+
+class _RecordingStore:
+    def __init__(self) -> None:
+        self.bodies: list[dict[str, Any]] = []
+        self._counter = 0
+
+    def create_sync(self, body: dict[str, Any]) -> str:
+        self._counter += 1
+        self.bodies.append(body)
+        return f"task-{self._counter:03d}"
+
+
+def _make_repo(tmp_path: Path, files: list[str]) -> Path:
+    for rel in files:
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# placeholder\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_migration_plan_validates_inputs() -> None:
+    with pytest.raises(ValueError, match="chunk_size"):
+        MigrationPlan(id="x", glob="*.py", transform_prompt="t", chunk_size=0)
+    with pytest.raises(ValueError, match="max_parallel"):
+        MigrationPlan(id="x", glob="*.py", transform_prompt="t", max_parallel=0)
+    with pytest.raises(ValueError, match="plan id"):
+        MigrationPlan(id="   ", glob="*.py", transform_prompt="t")
+    with pytest.raises(ValueError, match="glob"):
+        MigrationPlan(id="x", glob="", transform_prompt="t")
+
+
+def test_enumerate_targets_filters_hidden_and_excludes(tmp_path: Path) -> None:
+    repo = _make_repo(
+        tmp_path,
+        [
+            "src/a.py",
+            "src/b.py",
+            "src/sub/c.py",
+            "src/skip_me.py",
+            ".sdd/runtime/state.py",
+            ".git/hooks/pre-commit.py",
+        ],
+    )
+    plan = MigrationPlan(
+        id="t",
+        glob="src/**/*.py",
+        transform_prompt="convert",
+        excludes=("src/skip_me.py",),
+    )
+    targets = enumerate_targets(plan, repo)
+    rels = sorted(p.relative_to(repo).as_posix() for p in targets)
+    assert rels == ["src/a.py", "src/b.py", "src/sub/c.py"]
+
+
+def test_chunk_targets_preserves_order_and_size() -> None:
+    paths = [Path(f"f{i}.py") for i in range(7)]
+    chunks = chunk_targets(paths, chunk_size=3)
+    assert [len(c) for c in chunks] == [3, 3, 1]
+    assert chunks[0][0] == Path("f0.py")
+    assert chunks[2][0] == Path("f6.py")
+    with pytest.raises(ValueError):
+        chunk_targets(paths, chunk_size=0)
+
+
+def test_effective_max_parallel_caps_correctly() -> None:
+    plan = MigrationPlan(id="t", glob="*.py", transform_prompt="t", max_parallel=50)
+    assert effective_max_parallel(plan, chunk_count=3) == 3
+    assert effective_max_parallel(plan, chunk_count=100) == 20  # hard ceiling
+    assert effective_max_parallel(plan, chunk_count=10, adaptive_cap=4) == 4
+    assert effective_max_parallel(plan, chunk_count=10, adaptive_cap=0) == 10
+    assert effective_max_parallel(plan, chunk_count=0) == 1  # never zero
+
+
+def test_spawn_swarm_emits_one_task_per_chunk(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, [f"src/m{i}.py" for i in range(7)])
+    plan = MigrationPlan(id="big", glob="src/*.py", transform_prompt="convert", chunk_size=3)
+    store = _RecordingStore()
+
+    ids = spawn_swarm(plan, store, repo)
+
+    assert len(ids) == 3
+    assert len(store.bodies) == 3
+    first = store.bodies[0]
+    assert first["role"] == "backend"
+    assert first["scope"] == "small"
+    assert first["metadata"]["swarm_plan_id"] == "big"
+    assert first["metadata"]["swarm_chunk_index"] == 0
+    assert first["metadata"]["swarm_total_chunks"] == 3
+    assert len(first["owned_files"]) == 3
+
+    cp_path = repo / ".sdd" / "runtime" / "swarm" / "big.json"
+    assert cp_path.exists()
+    cp = json.loads(cp_path.read_text())
+    assert cp["chunk_count"] == 3
+    assert len(cp["task_ids"]) == 3
+
+
+def test_spawn_swarm_idempotent_skips_completed_chunks(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, [f"src/m{i}.py" for i in range(6)])
+    plan = MigrationPlan(id="dedup", glob="src/*.py", transform_prompt="convert", chunk_size=3)
+    store = _RecordingStore()
+
+    first_ids = spawn_swarm(plan, store, repo)
+    assert len(first_ids) == 2
+
+    # mark all chunks complete; a second run must spawn nothing new.
+    cp_path = repo / ".sdd" / "runtime" / "swarm" / "dedup.json"
+    cp = json.loads(cp_path.read_text())
+    for chunk_hash in cp["task_ids"]:
+        mark_chunk_complete(plan.id, chunk_hash, repo)
+
+    second_store = _RecordingStore()
+    second_ids = spawn_swarm(plan, second_store, repo)
+    assert second_ids == first_ids
+    assert second_store.bodies == []
+
+
+def test_reduce_swarm_aggregates_pass_fail() -> None:
+    results = [
+        SwarmChunkResult(task_id="t1", chunk_hash="h1", files=("a.py", "b.py"), passed=True),
+        SwarmChunkResult(task_id="t2", chunk_hash="h2", files=("c.py", "d.py"), passed=False, summary="syntax"),
+        SwarmChunkResult(task_id="t3", chunk_hash="h3", files=("e.py",), passed=True),
+    ]
+    report = reduce_swarm("plan-x", results)
+    assert report.plan_id == "plan-x"
+    assert report.total_chunks == 3
+    assert report.passed_chunks == 2
+    assert report.failed_chunks == 1
+    assert report.failed_files == ("c.py", "d.py")
+    bulletin = report.to_bulletin_content()
+    assert "plan=plan-x" in bulletin
+    assert "chunks=2/3" in bulletin
+
+
+def test_reduce_swarm_handles_empty_input() -> None:
+    report = reduce_swarm("empty", [])
+    assert report.total_chunks == 0
+    assert report.passed_chunks == 0
+    assert report.failed_files == ()


### PR DESCRIPTION
Implements `.sdd/backlog/open/2026-04-30-feat-swarm-migration.md`.

## Summary

- New `core/tasks/swarm_migration.py`: `MigrationPlan`, `enumerate_targets`, `chunk_targets`, `spawn_swarm` (idempotent), `reduce_swarm` -> `SwarmReport`. Uses a JSON checkpoint at `.sdd/runtime/swarm/{plan_id}.json` so re-runs skip already-completed chunks.
- New CLI: `bernstein migrate --glob 'src/**/*.py' --transform '...'` with `--dry-run`, `--json-output`, `--exclude`, `--id`, `--chunk-size`, `--max-parallel`, `--role`, `--repo-root`. Spawning goes through `POST /tasks` on the running task server; offline server -> clear non-zero exit.
- `effective_max_parallel` enforces `min(plan.max_parallel, chunk_count, 20)` with optional `adaptive_cap` so the swarm slots in under the existing `AdaptiveParallelism` ceiling.
- Two example plan YAMLs under `templates/migrations/` (pytest-asyncio rollout, sync->async rewrite).
- Redirect-map entries added in `bernstein.core.__init__` and `bernstein.cli.__init__`.

## Acceptance criteria

- [x] `bernstein migrate --glob ... --transform ...` enumerates files, chunks, and spawns N tasks.
- [x] Default `max_parallel = min(20, len(chunks))`; adaptive cap honoured via `adaptive_cap` parameter.
- [x] Reducer produces a `SwarmReport` with a `to_bulletin_content()` ready for `POST /bulletin`.
- [x] Idempotent: re-running with the same plan id skips chunks already in the checkpoint's `completed_chunks` set.
- [x] Unit tests cover enumeration (hidden / excludes), chunking (size + order), parallel cap, spawn count, idempotent re-run, and reduction.

## Test plan

- [x] `uv run pytest tests/unit/test_swarm_migration.py -x -q` (8 passed)
- [x] `uv run pytest tests/unit/test_task_splitter.py tests/unit/test_schema_retry.py -x -q` (existing tasks tests, 23 passed)
- [x] `uv run ruff format` + `ruff check` on touched files
- [x] `uv run bernstein migrate --help` renders the expected option list.