### PR TITLE
feat(orchestration): best-of-n delegation with judge scoring

### DIFF
--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -350,6 +350,33 @@ class PhasePipelineDefaults:
 
 
 # ---------------------------------------------------------------------------
+# Best-of-N delegation defaults (opt-in recursive-best-of-N pattern)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BestOfNDefaults:
+    """Opt-in best-of-N candidate fan-out.
+
+    OFF by default for back-compat — single-agent task assignment is
+    unchanged.  Tasks opt in by setting ``Task.best_of_n=K``; callers
+    must also flip ``BEST_OF_N.enabled`` (typically via the
+    ``best_of_n`` section of ``bernstein.yaml``) for the orchestrator to
+    actually fan out.
+    """
+
+    enabled: bool = False
+    default_candidates: int = 1
+    max_candidates: int = 5
+    judge_enabled: bool = True
+    judge_model: str = "haiku"
+    score_weight_tests: float = 0.5
+    score_weight_lint: float = 0.2
+    score_weight_judge: float = 0.2
+    score_weight_runtime: float = 0.1
+
+
+# ---------------------------------------------------------------------------
 # Trigger defaults
 # ---------------------------------------------------------------------------
 
@@ -533,6 +560,7 @@ APPROVAL = ApprovalDefaults()
 PROTOCOL = ProtocolDefaults()
 PLAN = PlanDefaults()
 PHASE_PIPELINE = PhasePipelineDefaults()
+BEST_OF_N = BestOfNDefaults()
 TRIGGER = TriggerDefaults()
 JANITOR = JanitorDefaults()
 CATALOG = CatalogDefaults()
@@ -570,6 +598,7 @@ _SECTION_TO_ATTR: Mapping[str, str] = MappingProxyType(
         "protocol": "PROTOCOL",
         "plan": "PLAN",
         "phase_pipeline": "PHASE_PIPELINE",
+        "best_of_n": "BEST_OF_N",
         "trigger": "TRIGGER",
         "janitor": "JANITOR",
         "catalog": "CATALOG",
@@ -597,6 +626,7 @@ _ATTR_TO_FACTORY: Mapping[str, type[Any]] = MappingProxyType(
         "PROTOCOL": ProtocolDefaults,
         "PLAN": PlanDefaults,
         "PHASE_PIPELINE": PhasePipelineDefaults,
+        "BEST_OF_N": BestOfNDefaults,
         "TRIGGER": TriggerDefaults,
         "JANITOR": JanitorDefaults,
         "CATALOG": CatalogDefaults,

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -111,6 +111,8 @@ __all__ = [
     "agent_spawn_duration",
     "agent_transition_reasons_total",
     "agents_active",
+    "best_of_n_candidates_total",
+    "best_of_n_judge_score",
     "cluster_admission_failures_total",
     "cluster_heartbeats_total",
     "cluster_nodes_total",
@@ -294,6 +296,21 @@ lineage_tamper_total: Counter = Counter(
     "bernstein_lineage_tamper_total",
     "Lineage chain verification failures detected (per run).",
     labelnames=["run_id"],
+    registry=registry,
+)
+
+best_of_n_candidates_total: Counter = Counter(
+    "bernstein_best_of_n_candidates_total",
+    "Best-of-N candidate workers by outcome (winner/loser).",
+    labelnames=["outcome", "role"],
+    registry=registry,
+)
+
+best_of_n_judge_score: Histogram = Histogram(
+    "bernstein_best_of_n_judge_score",
+    "LLM-as-judge rubric score per best-of-N candidate (0.0-1.0).",
+    buckets=(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+    labelnames=["role"],
     registry=registry,
 )
 

--- a/src/bernstein/core/orchestration/best_of_n.py
+++ b/src/bernstein/core/orchestration/best_of_n.py
@@ -1,0 +1,460 @@
+"""Recursive best-of-N delegation: spawn K candidates and pick the winner.
+
+Implements the *recursive-best-of-N-delegation* agentic pattern.  For tasks
+flagged with ``best_of_n=K`` (K in [2, 5]) the orchestrator spawns K
+candidate workers in isolated worktrees, scores each candidate with
+automated signals (tests passing, lint clean, runtime), optionally asks a
+cheap-tier LLM judge for a rubric score, blends the two into a final
+score, and keeps only the winner's diff.  Losing candidates' worktrees are
+reclaimed.
+
+Opt-in: callers must explicitly invoke :class:`BestOfNRunner`.  Tasks
+opt in by setting ``Task.best_of_n=K``; tasks without that field run as a
+single agent via the existing pipeline.  See
+:data:`bernstein.core.defaults.BEST_OF_N` for the global enable flag.
+
+Coexistence with :mod:`bernstein.core.orchestration.phase_pipeline`:
+both patterns are independent — a task can be phased *or* fan-out, not
+both at once (the runner only inspects ``best_of_n``).
+
+Pattern source:
+    https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/recursive-best-of-n-delegation.md
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core import defaults as _defaults
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CandidateResult:
+    """Outcome of one parallel candidate worker.
+
+    Attributes:
+        task_id: Server-assigned identifier for the candidate subtask.
+        diff: Unified-diff text produced by the candidate, or empty when
+            the candidate failed to make changes.
+        tests_passing: Whether the post-implementation test run was green.
+        lint_score: 0.0-1.0; 1.0 means zero lint findings.
+        runtime_s: Wall-clock seconds the candidate took.
+        judge_score: Optional 0.0-1.0 LLM-as-judge rubric score.  ``None``
+            means the judge was not invoked (e.g. judge disabled or the
+            candidate produced an empty diff).
+        worktree_path: Filesystem path to the candidate's isolated
+            worktree, used by :func:`reclaim_losers` for cleanup.
+    """
+
+    task_id: str
+    diff: str = ""
+    tests_passing: bool = False
+    lint_score: float = 0.0
+    runtime_s: float = 0.0
+    judge_score: float | None = None
+    worktree_path: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Scoring weights
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    """Weights used by :func:`score_candidate` and :func:`select_best`.
+
+    The defaults are tuned so that a candidate with passing tests
+    outranks a faster candidate that left tests broken, while a clean
+    diff still tips a near-tie towards the simpler change.
+    """
+
+    tests: float = 0.5
+    lint: float = 0.2
+    judge: float = 0.2
+    runtime: float = 0.1
+
+
+_DEFAULT_WEIGHTS = ScoreWeights()
+
+
+def score_candidate(result: CandidateResult, weights: ScoreWeights = _DEFAULT_WEIGHTS) -> float:
+    """Compute a 0.0-1.0 automated score for *result*.
+
+    Combines tests-passing, lint score, runtime (normalised so faster is
+    better), and the judge score when available.  When the judge has not
+    been invoked the judge weight is redistributed proportionally across
+    the remaining components — a candidate with no judge score is not
+    penalised.
+    """
+    tests_signal = 1.0 if result.tests_passing else 0.0
+    lint_signal = max(0.0, min(1.0, result.lint_score))
+    runtime_signal = _runtime_signal(result.runtime_s)
+
+    if result.judge_score is None:
+        denom = weights.tests + weights.lint + weights.runtime
+        if denom <= 0.0:
+            return 0.0
+        return (weights.tests * tests_signal + weights.lint * lint_signal + weights.runtime * runtime_signal) / denom
+
+    judge_signal = max(0.0, min(1.0, result.judge_score))
+    denom = weights.tests + weights.lint + weights.runtime + weights.judge
+    if denom <= 0.0:
+        return 0.0
+    return (
+        weights.tests * tests_signal
+        + weights.lint * lint_signal
+        + weights.runtime * runtime_signal
+        + weights.judge * judge_signal
+    ) / denom
+
+
+def _runtime_signal(seconds: float) -> float:
+    """Normalise runtime so faster candidates score higher.
+
+    Maps 0s → 1.0 and decays linearly to 0.0 at 30 minutes.  Above the
+    cap the signal is clamped at 0.0 — a 31-minute candidate is no worse
+    than a 30-minute one for ranking purposes.
+    """
+    if seconds <= 0.0:
+        return 1.0
+    cap = 1800.0
+    if seconds >= cap:
+        return 0.0
+    return 1.0 - (seconds / cap)
+
+
+# ---------------------------------------------------------------------------
+# Pluggable callbacks
+# ---------------------------------------------------------------------------
+
+
+CandidateSpawner = Callable[["Task", int], list[str]]
+"""Spawn *n* isolated candidate subtasks for a parent task.
+
+Concrete implementations create ``n`` worktrees, register subtasks with
+the task store, and return the new task IDs.  The runner is
+agent-agnostic — pass any callable matching this signature.  A typical
+production wiring delegates to :func:`bernstein.core.orchestration.spawner`.
+"""
+
+
+CandidateAwaiter = Callable[[list[str]], list[CandidateResult]]
+"""Block until all listed subtasks complete, then collect their results."""
+
+
+JudgeCallback = Callable[[list[CandidateResult], str], list[CandidateResult]]
+"""Score candidates with an LLM judge against *rubric*.
+
+Implementations call the cheap-tier LLM via the cascade router, parse a
+0.0-1.0 score per candidate, and return new :class:`CandidateResult`
+records with ``judge_score`` populated.  Order must match the input.
+"""
+
+
+WorktreeReclaimer = Callable[[CandidateResult], None]
+"""Tear down a losing candidate's worktree."""
+
+
+# ---------------------------------------------------------------------------
+# Default rubric
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_RUBRIC = (
+    "Score the candidate diff from 0.0 to 1.0 on a single line.\n"
+    "Criteria: correctness vs. the task description, scope discipline\n"
+    "(no out-of-scope edits), and code quality (readability, idiomatic\n"
+    "use of project patterns).  Return only the float."
+)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def clamp_n(requested: int) -> int:
+    """Clamp *requested* into the configured ``[1, BEST_OF_N.max_candidates]`` range.
+
+    A value of 1 (or below) collapses best-of-N back to the legacy
+    single-agent path, which is the safe default when callers receive
+    untrusted input.
+    """
+    cfg = _defaults.BEST_OF_N
+    if requested <= 1:
+        return 1
+    return min(requested, cfg.max_candidates)
+
+
+def select_best(
+    candidates: list[CandidateResult],
+    weights: ScoreWeights = _DEFAULT_WEIGHTS,
+) -> CandidateResult:
+    """Pick the candidate with the highest blended score.
+
+    Ties are broken by ``tests_passing`` (passing wins), then by faster
+    runtime, finally by ``task_id`` for determinism.
+
+    Raises:
+        ValueError: When *candidates* is empty.
+    """
+    if not candidates:
+        raise ValueError("select_best requires at least one candidate")
+    return max(
+        candidates,
+        key=lambda c: (
+            score_candidate(c, weights),
+            c.tests_passing,
+            -c.runtime_s,
+            c.task_id,
+        ),
+    )
+
+
+def judge_candidates(
+    candidates: list[CandidateResult],
+    rubric: str,
+    *,
+    judge: JudgeCallback | None,
+) -> list[CandidateResult]:
+    """Run *judge* on *candidates* and return updated records.
+
+    Returns the input unchanged when *judge* is ``None`` or
+    :data:`bernstein.core.defaults.BEST_OF_N` has the judge disabled.
+    Empty-diff candidates short-circuit to ``judge_score=0.0`` without
+    spending a judge call.
+    """
+    if judge is None or not _defaults.BEST_OF_N.judge_enabled:
+        return list(candidates)
+    if not candidates:
+        return []
+    judgeable = [c for c in candidates if c.diff]
+    if not judgeable:
+        return [
+            CandidateResult(
+                task_id=c.task_id,
+                diff=c.diff,
+                tests_passing=c.tests_passing,
+                lint_score=c.lint_score,
+                runtime_s=c.runtime_s,
+                judge_score=0.0,
+                worktree_path=c.worktree_path,
+            )
+            for c in candidates
+        ]
+    scored = judge(judgeable, rubric)
+    by_id = {r.task_id: r for r in scored}
+    out: list[CandidateResult] = []
+    for c in candidates:
+        if c.task_id in by_id:
+            out.append(by_id[c.task_id])
+        else:
+            out.append(
+                CandidateResult(
+                    task_id=c.task_id,
+                    diff=c.diff,
+                    tests_passing=c.tests_passing,
+                    lint_score=c.lint_score,
+                    runtime_s=c.runtime_s,
+                    judge_score=0.0,
+                    worktree_path=c.worktree_path,
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BestOfNOutcome:
+    """Aggregated result of one best-of-N round.
+
+    Attributes:
+        winner: Highest-scoring candidate.
+        losers: All other candidates, in original order.
+        candidates: The full list (winner + losers) for telemetry/debug.
+        n_requested: K originally requested by the caller.
+        n_actual: Number of candidates that returned (may be < K if some
+            crashed and the spawner reported failures).
+    """
+
+    winner: CandidateResult
+    losers: list[CandidateResult]
+    candidates: list[CandidateResult]
+    n_requested: int
+    n_actual: int
+
+
+@dataclass
+class BestOfNRunner:
+    """Drive a task through K parallel candidates and pick the winner.
+
+    Attributes:
+        spawner: Spawn ``n`` candidate subtasks; returns their task IDs.
+        awaiter: Block until candidates finish; returns
+            :class:`CandidateResult` records.
+        judge: Optional LLM-as-judge callback.  ``None`` disables judging.
+        reclaimer: Optional worktree teardown callback for losing
+            candidates.  ``None`` skips cleanup (useful in tests).
+        weights: Score-blending weights.
+        rubric: Judge prompt; defaults to a project-agnostic diff rubric.
+    """
+
+    spawner: CandidateSpawner
+    awaiter: CandidateAwaiter
+    judge: JudgeCallback | None = None
+    reclaimer: WorktreeReclaimer | None = None
+    weights: ScoreWeights = field(default_factory=ScoreWeights)
+    rubric: str = _DEFAULT_RUBRIC
+
+    def run(self, parent: Task, n: int) -> BestOfNOutcome:
+        """Execute *parent* through ``n`` parallel candidates.
+
+        Raises:
+            ValueError: When the spawner / awaiter return inconsistent IDs.
+            RuntimeError: When zero candidates produce a result.
+        """
+        clamped = clamp_n(n)
+        ids = list(self.spawner(parent, clamped))
+        if len(ids) != clamped:
+            raise ValueError(f"spawner returned {len(ids)} ids for n={clamped}; expected exactly {clamped}")
+        raw = self.awaiter(ids)
+        if not raw:
+            raise RuntimeError(f"best-of-N for task {parent.id} produced zero candidate results")
+        scored = judge_candidates(raw, self.rubric, judge=self.judge)
+        winner = select_best(scored, self.weights)
+        losers = [c for c in scored if c.task_id != winner.task_id]
+        if self.reclaimer is not None:
+            for loser in losers:
+                try:
+                    self.reclaimer(loser)
+                except Exception:  # pragma: no cover - reclaim must never fail the round
+                    logger.exception(
+                        "best-of-N reclaim failed for candidate %s (worktree %s)",
+                        loser.task_id,
+                        loser.worktree_path,
+                    )
+        _record_metrics(parent, winner, losers)
+        logger.info(
+            "best-of-N for task %s: winner=%s score=%.3f losers=%d",
+            parent.id,
+            winner.task_id,
+            score_candidate(winner, self.weights),
+            len(losers),
+        )
+        return BestOfNOutcome(
+            winner=winner,
+            losers=losers,
+            candidates=list(scored),
+            n_requested=clamped,
+            n_actual=len(scored),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task opt-in helpers
+# ---------------------------------------------------------------------------
+
+
+def is_best_of_n(task: Task) -> bool:
+    """Return True when *task* opts into best-of-N execution.
+
+    Honours both the task-level ``best_of_n`` field and the global
+    :data:`bernstein.core.defaults.BEST_OF_N.enabled` flag.  Either being
+    falsy keeps the task on the legacy single-agent path.
+    """
+    if not _defaults.BEST_OF_N.enabled:
+        return False
+    n = getattr(task, "best_of_n", None)
+    if n is None:
+        return False
+    try:
+        return int(n) > 1
+    except (TypeError, ValueError):
+        return False
+
+
+def task_n(task: Task) -> int:
+    """Return the candidate count requested on *task*, clamped to bounds.
+
+    Returns 1 when the task is not opted in — callers can treat that as
+    "single agent, skip best-of-N".
+    """
+    if not is_best_of_n(task):
+        return 1
+    raw = getattr(task, "best_of_n", None)
+    try:
+        return clamp_n(int(raw or 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+def _record_metrics(parent: Task, winner: CandidateResult, losers: list[CandidateResult]) -> None:
+    """Emit Prometheus telemetry for one best-of-N round.
+
+    Imported lazily so the module remains usable in test environments
+    where the Prometheus client is not installed.
+    """
+    try:
+        from bernstein.core.observability import prometheus as _p
+    except Exception:  # pragma: no cover - metrics are advisory
+        return
+    counter = getattr(_p, "best_of_n_candidates_total", None)
+    histogram = getattr(_p, "best_of_n_judge_score", None)
+    role = getattr(parent, "role", "") or ""
+    if counter is not None:
+        try:
+            counter.labels(outcome="winner", role=role).inc()
+            for _ in losers:
+                counter.labels(outcome="loser", role=role).inc()
+        except Exception:  # pragma: no cover
+            logger.debug("best-of-N counter emit failed", exc_info=True)
+    if histogram is not None:
+        for cand in (winner, *losers):
+            score = cand.judge_score
+            if score is None:
+                continue
+            try:
+                histogram.labels(role=role).observe(score)
+            except Exception:  # pragma: no cover
+                logger.debug("best-of-N histogram emit failed", exc_info=True)
+
+
+__all__ = [
+    "BestOfNOutcome",
+    "BestOfNRunner",
+    "CandidateAwaiter",
+    "CandidateResult",
+    "CandidateSpawner",
+    "JudgeCallback",
+    "ScoreWeights",
+    "WorktreeReclaimer",
+    "clamp_n",
+    "is_best_of_n",
+    "judge_candidates",
+    "score_candidate",
+    "select_best",
+    "task_n",
+]

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -18,6 +18,7 @@ from typing_extensions import TypedDict
 from bernstein.core.backlog_parser import parse_backlog_text
 from bernstein.core.context_collapse import staged_context_collapse
 from bernstein.core.models import Task, TaskType
+from bernstein.core.orchestration.best_of_n import is_best_of_n, task_n
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -821,3 +822,22 @@ def collapse_prompt_sections(
         )
 
     return result.sections, result
+
+
+def partition_best_of_n(tasks: list[Task]) -> tuple[list[Task], list[tuple[Task, int]]]:
+    """Split *tasks* into ``(single_agent, fan_out)`` lists.
+
+    The fan-out list pairs each opted-in task with its clamped K so the
+    caller can hand them to a :class:`bernstein.core.orchestration.best_of_n.BestOfNRunner`
+    instead of the legacy single-agent path.  When the global flag is
+    off, every task lands in ``single_agent`` and the fan-out list is
+    empty — the legacy assignment loop is unaffected.
+    """
+    single: list[Task] = []
+    fan_out: list[tuple[Task, int]] = []
+    for task in tasks:
+        if is_best_of_n(task):
+            fan_out.append((task, task_n(task)))
+        else:
+            single.append(task)
+    return single, fan_out

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -296,6 +296,9 @@ class Task:
     subtask_wait_started_at: float | None = None  # Epoch when task entered WAITING_FOR_SUBTASKS
     parent_context: str | None = None  # Parent agent's context summary (key decisions, files explored) for subtasks
     requires: list[str] = field(default_factory=list[str])  # Capability-based addressing: e.g. ["python", "testing"]
+    best_of_n: int | None = (
+        None  # Opt-in best-of-N candidate fan-out (K in [2, BEST_OF_N.max_candidates]); None/<=1 = single agent
+    )
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> Task:
@@ -387,6 +390,7 @@ class Task:
             subtask_wait_started_at=raw.get("subtask_wait_started_at"),
             parent_context=raw.get("parent_context"),
             requires=list(raw.get("requires", [])),
+            best_of_n=(lambda v: None if v is None else int(v))(raw.get("best_of_n")),
         )
 
 

--- a/tests/unit/test_best_of_n.py
+++ b/tests/unit/test_best_of_n.py
@@ -1,0 +1,356 @@
+"""Tests for the recursive best-of-N delegation pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from bernstein.core import defaults as _defaults
+from bernstein.core.orchestration.best_of_n import (
+    BestOfNRunner,
+    CandidateResult,
+    ScoreWeights,
+    clamp_n,
+    is_best_of_n,
+    judge_candidates,
+    score_candidate,
+    select_best,
+    task_n,
+)
+from bernstein.core.orchestration.tick_pipeline import partition_best_of_n
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(*, task_id: str = "parent-1", best_of_n: int | None = None) -> Task:
+    return Task(
+        id=task_id,
+        title="title",
+        description="desc",
+        role="backend",
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        best_of_n=best_of_n,
+    )
+
+
+def _candidate(
+    task_id: str,
+    *,
+    diff: str = "diff",
+    tests: bool = True,
+    lint: float = 1.0,
+    runtime: float = 60.0,
+    judge: float | None = None,
+    worktree: str = "",
+) -> CandidateResult:
+    return CandidateResult(
+        task_id=task_id,
+        diff=diff,
+        tests_passing=tests,
+        lint_score=lint,
+        runtime_s=runtime,
+        judge_score=judge,
+        worktree_path=worktree,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_best_of_n_defaults() -> Generator[None, None, None]:
+    _defaults.reset()
+    _defaults.override("best_of_n", {"enabled": True})
+    yield
+    _defaults.reset()
+
+
+# ---------------------------------------------------------------------------
+# Defaults & opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_default_flag_is_off_when_reset() -> None:
+    _defaults.reset()
+    assert _defaults.BEST_OF_N.enabled is False
+    assert _defaults.BEST_OF_N.max_candidates == 5
+    task = _make_task(best_of_n=3)
+    assert is_best_of_n(task) is False
+
+
+def test_clamp_n_collapses_low_values() -> None:
+    assert clamp_n(0) == 1
+    assert clamp_n(1) == 1
+    assert clamp_n(3) == 3
+    assert clamp_n(10) == _defaults.BEST_OF_N.max_candidates
+
+
+def test_task_n_zero_for_legacy_task() -> None:
+    assert task_n(_make_task()) == 1
+
+
+def test_task_n_clamped_when_too_large() -> None:
+    big = _make_task(best_of_n=99)
+    assert task_n(big) == _defaults.BEST_OF_N.max_candidates
+
+
+def test_is_best_of_n_requires_global_flag() -> None:
+    _defaults.override("best_of_n", {"enabled": False})
+    assert is_best_of_n(_make_task(best_of_n=3)) is False
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def test_score_candidate_perfect_signals_no_judge() -> None:
+    cand = _candidate("a", tests=True, lint=1.0, runtime=0.0, judge=None)
+    assert score_candidate(cand) == pytest.approx(1.0)
+
+
+def test_score_candidate_failing_tests_dominates() -> None:
+    passing = _candidate("p", tests=True, lint=0.0, runtime=1800.0)
+    failing = _candidate("f", tests=False, lint=1.0, runtime=0.0)
+    assert score_candidate(passing) > score_candidate(failing)
+
+
+def test_score_candidate_judge_redistribution() -> None:
+    cand = _candidate("c", tests=True, lint=1.0, runtime=0.0, judge=None)
+    cand_with_judge = _candidate("c", tests=True, lint=1.0, runtime=0.0, judge=1.0)
+    assert score_candidate(cand) == pytest.approx(score_candidate(cand_with_judge))
+
+
+def test_score_candidate_runtime_decays_linearly() -> None:
+    fast = _candidate("f", runtime=0.0, tests=True, lint=1.0)
+    slow = _candidate("s", runtime=1800.0, tests=True, lint=1.0)
+    assert score_candidate(fast) > score_candidate(slow)
+
+
+def test_score_clamps_invalid_lint_score() -> None:
+    cand = _candidate("c", lint=2.0, tests=True, runtime=0.0)
+    assert score_candidate(cand) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Winner selection
+# ---------------------------------------------------------------------------
+
+
+def test_select_best_picks_highest_score() -> None:
+    losers = _candidate("loser", tests=False, lint=0.5, runtime=120.0)
+    winner = _candidate("winner", tests=True, lint=1.0, runtime=30.0, judge=0.9)
+    assert select_best([losers, winner]).task_id == "winner"
+
+
+def test_select_best_breaks_ties_via_passing_then_runtime() -> None:
+    a = _candidate("a", tests=True, lint=1.0, runtime=30.0, judge=0.5)
+    b = _candidate("b", tests=True, lint=1.0, runtime=10.0, judge=0.5)
+    assert select_best([a, b]).task_id == "b"
+
+
+def test_select_best_empty_raises() -> None:
+    with pytest.raises(ValueError):
+        select_best([])
+
+
+# ---------------------------------------------------------------------------
+# Judge integration
+# ---------------------------------------------------------------------------
+
+
+def test_judge_candidates_returns_input_when_callback_none() -> None:
+    cands = [_candidate("a"), _candidate("b")]
+    out = judge_candidates(cands, "rubric", judge=None)
+    assert out == cands
+
+
+def test_judge_candidates_invokes_callback_only_for_non_empty_diffs() -> None:
+    seen: list[list[CandidateResult]] = []
+
+    def judge(cands: list[CandidateResult], rubric: str) -> list[CandidateResult]:
+        seen.append(cands)
+        return [
+            CandidateResult(
+                task_id=c.task_id,
+                diff=c.diff,
+                tests_passing=c.tests_passing,
+                lint_score=c.lint_score,
+                runtime_s=c.runtime_s,
+                judge_score=0.7,
+            )
+            for c in cands
+        ]
+
+    cands = [_candidate("good", diff="patch"), _candidate("empty", diff="")]
+    out = judge_candidates(cands, "rubric", judge=judge)
+    assert seen == [[cands[0]]]
+    by_id = {c.task_id: c for c in out}
+    assert by_id["good"].judge_score == pytest.approx(0.7)
+    assert by_id["empty"].judge_score == pytest.approx(0.0)
+
+
+def test_judge_candidates_disabled_via_defaults() -> None:
+    _defaults.override("best_of_n", {"enabled": True, "judge_enabled": False})
+
+    def judge(_cands: list[CandidateResult], _rubric: str) -> list[CandidateResult]:
+        raise AssertionError("judge must not be invoked when flag is off")
+
+    cands = [_candidate("a")]
+    assert judge_candidates(cands, "rubric", judge=judge) == cands
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def test_runner_spawns_clamped_n_and_picks_winner() -> None:
+    spawned: list[tuple[str, int]] = []
+
+    def spawner(parent: Task, n: int) -> list[str]:
+        spawned.append((parent.id, n))
+        return [f"{parent.id}-c{i}" for i in range(n)]
+
+    def awaiter(ids: list[str]) -> list[CandidateResult]:
+        return [
+            _candidate(ids[0], tests=True, lint=1.0, runtime=10.0, diff="patch", worktree="/tmp/c0"),
+            _candidate(ids[1], tests=False, lint=0.5, runtime=120.0, diff="", worktree="/tmp/c1"),
+            _candidate(ids[2], tests=True, lint=0.7, runtime=200.0, diff="patch", worktree="/tmp/c2"),
+        ]
+
+    reclaimed: list[CandidateResult] = []
+
+    def reclaimer(loser: CandidateResult) -> None:
+        reclaimed.append(loser)
+
+    runner = BestOfNRunner(spawner=spawner, awaiter=awaiter, reclaimer=reclaimer)
+    outcome = runner.run(_make_task(), n=3)
+
+    assert spawned == [("parent-1", 3)]
+    assert outcome.winner.task_id.endswith("-c0")
+    assert outcome.n_requested == 3
+    assert outcome.n_actual == 3
+    assert {r.task_id for r in reclaimed} == {
+        outcome.candidates[1].task_id,
+        outcome.candidates[2].task_id,
+    }
+
+
+def test_runner_invokes_judge_callback_when_provided() -> None:
+    def spawner(_p: Task, n: int) -> list[str]:
+        return [f"c{i}" for i in range(n)]
+
+    def awaiter(ids: list[str]) -> list[CandidateResult]:
+        return [_candidate(i, tests=True, lint=1.0, diff="patch") for i in ids]
+
+    invoked: dict[str, int] = {"count": 0}
+
+    def judge(cands: list[CandidateResult], _rubric: str) -> list[CandidateResult]:
+        invoked["count"] += 1
+        return [
+            CandidateResult(
+                task_id=c.task_id,
+                diff=c.diff,
+                tests_passing=c.tests_passing,
+                lint_score=c.lint_score,
+                runtime_s=c.runtime_s,
+                judge_score=1.0 if c.task_id == "c1" else 0.1,
+            )
+            for c in cands
+        ]
+
+    runner = BestOfNRunner(spawner=spawner, awaiter=awaiter, judge=judge)
+    outcome = runner.run(_make_task(), n=2)
+    assert invoked["count"] == 1
+    assert outcome.winner.task_id == "c1"
+    assert outcome.winner.judge_score == pytest.approx(1.0)
+
+
+def test_runner_rejects_inconsistent_spawner_count() -> None:
+    def spawner(_p: Task, _n: int) -> list[str]:
+        return ["only-one"]
+
+    def awaiter(_ids: list[str]) -> list[CandidateResult]:
+        return []
+
+    runner = BestOfNRunner(spawner=spawner, awaiter=awaiter)
+    with pytest.raises(ValueError, match="expected exactly"):
+        runner.run(_make_task(), n=3)
+
+
+def test_runner_zero_results_raises() -> None:
+    def spawner(_p: Task, n: int) -> list[str]:
+        return [f"c{i}" for i in range(n)]
+
+    def awaiter(_ids: list[str]) -> list[CandidateResult]:
+        return []
+
+    runner = BestOfNRunner(spawner=spawner, awaiter=awaiter)
+    with pytest.raises(RuntimeError, match="zero candidate"):
+        runner.run(_make_task(), n=2)
+
+
+def test_runner_clamps_oversized_n() -> None:
+    seen_n: list[int] = []
+
+    def spawner(_p: Task, n: int) -> list[str]:
+        seen_n.append(n)
+        return [f"c{i}" for i in range(n)]
+
+    def awaiter(ids: list[str]) -> list[CandidateResult]:
+        return [_candidate(i, tests=True, diff="x") for i in ids]
+
+    runner = BestOfNRunner(spawner=spawner, awaiter=awaiter)
+    runner.run(_make_task(), n=99)
+    assert seen_n == [_defaults.BEST_OF_N.max_candidates]
+
+
+def test_runner_skips_reclaim_when_callback_none() -> None:
+    def spawner(_p: Task, n: int) -> list[str]:
+        return [f"c{i}" for i in range(n)]
+
+    def awaiter(ids: list[str]) -> list[CandidateResult]:
+        return [_candidate(i, tests=True, diff="x") for i in ids]
+
+    runner = BestOfNRunner(spawner=spawner, awaiter=awaiter, reclaimer=None)
+    outcome = runner.run(_make_task(), n=2)
+    assert len(outcome.losers) == 1
+
+
+# ---------------------------------------------------------------------------
+# tick_pipeline routing helper
+# ---------------------------------------------------------------------------
+
+
+def test_partition_best_of_n_separates_opted_in_tasks() -> None:
+    legacy = _make_task(task_id="legacy")
+    fan_out = _make_task(task_id="fan", best_of_n=3)
+    single, parallel = partition_best_of_n([legacy, fan_out])
+    assert [t.id for t in single] == ["legacy"]
+    assert [(t.id, n) for t, n in parallel] == [("fan", 3)]
+
+
+def test_partition_best_of_n_respects_global_flag() -> None:
+    _defaults.override("best_of_n", {"enabled": False})
+    fan_out = _make_task(task_id="fan", best_of_n=3)
+    single, parallel = partition_best_of_n([fan_out])
+    assert [t.id for t in single] == ["fan"]
+    assert parallel == []
+
+
+# ---------------------------------------------------------------------------
+# Custom weights
+# ---------------------------------------------------------------------------
+
+
+def test_custom_weights_can_invert_priority() -> None:
+    runtime_first = ScoreWeights(tests=0.0, lint=0.0, judge=0.0, runtime=1.0)
+    fast_failing = _candidate("fast", tests=False, lint=0.0, runtime=0.0)
+    slow_passing = _candidate("slow", tests=True, lint=1.0, runtime=1800.0)
+    assert select_best([fast_failing, slow_passing], runtime_first).task_id == "fast"


### PR DESCRIPTION
Implements `.sdd/backlog/open/2026-04-30-feat-best-of-n-delegation.md`.

## Summary
- New module `src/bernstein/core/orchestration/best_of_n.py` exposing `BestOfNRunner`, `CandidateResult`, `score_candidate`, `select_best`, and `judge_candidates`. Spawn K parallel candidates, blend tests/lint/runtime/judge signals, keep the winner, reclaim losing worktrees.
- Coexists with `phase_pipeline.py` (PR #1000) — both patterns are independent; the runner only inspects `Task.best_of_n`.
- Opt-in via the new `BEST_OF_N` defaults section (`enabled=False` by default; `max_candidates=5`, configurable score weights and judge model). Tasks opt in by setting `Task.best_of_n=K`.
- `tick_pipeline.partition_best_of_n()` splits a backlog into legacy single-agent and fan-out tracks; legacy assignment is untouched.
- Prometheus `bernstein_best_of_n_candidates_total{outcome,role}` counter and `bernstein_best_of_n_judge_score{role}` histogram.

## Opt-in flag
`BEST_OF_N.enabled` (section `best_of_n` in `bernstein.yaml` `tuning:`). Default OFF.

## Test plan
- [x] `uv run pytest tests/unit/test_best_of_n.py -x -q` — 25 passed.
- [x] `uv run pytest tests/unit/test_orchestrator.py -x -q` (regression smoke) — 206 passed.
- [x] `uv run pytest tests/unit/test_phase_pipeline.py -x -q` (coexistence check) — 25 passed.
- [x] `uv run ruff format` + `ruff check` clean on touched files.

## Out of scope (deferred)
- Recursive nesting of best-of-N inside a candidate.
- Auto-escalation of K based on uncertainty (manual flag for v1).
- Replacing the cross-model verifier (best-of-N runs before verification; verifier still runs on the winner).