### PR TITLE
feat(adapters): CLM (Cyber Language Model) gateway adapter (Phase 1)

### DIFF
--- a/docs/adapters/clm.md
+++ b/docs/adapters/clm.md
@@ -1,0 +1,122 @@
+# `clm` adapter — Cyber Language Model gateway
+
+Bernstein's adapter for sovereign-AI vendors that ship a customer-side
+**Cyber Language Model (CLM)** — a family of LLMs trained on cyber
+telemetry and served behind NVIDIA NIM (TensorRT-LLM + Triton).
+NIM exposes an OpenAI-compatible HTTP API; the adapter is a thin
+shim that points `aider` at a customer-side CLM gateway.
+
+Phase 1 — adapter MVP. Phase 2 (mTLS, tool-calling, streaming
+regression) is deferred until the `cluster-mtls-transport` ticket
+lands.
+
+---
+
+## When to use this adapter
+
+* Forward-deployed engagements where the CLM endpoint lives inside a
+  customer network and the operator drives multi-step refactors,
+  rule-generation, or connector work against it.
+* Engineering-side workflows that would otherwise be ad-hoc prompts
+  to internal endpoints, with no audit chain.
+
+The same adapter shape works against any OpenAI-compatible gateway
+(NIM, vLLM, llama.cpp server, local Ollama). For demo or
+air-gapped runs, point `CLM_ENDPOINT` at a local Ollama and pick a
+locally-pulled model.
+
+---
+
+## Configuration
+
+### Required environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `CLM_ENDPOINT` | Customer gateway base URL, e.g. `https://clm.internal.<customer>/v1/` |
+| `CLM_TOKEN` | Scoped JWT issued by the customer's identity layer or by the operator |
+| `CLM_MODEL` | Model id passed through to the gateway (a CLM vendor typically ships a *family*; pass-through string) |
+
+### Optional
+
+| Variable | Default | Purpose |
+|----------|--------:|---------|
+| `CLM_REQUEST_TIMEOUT_SECONDS` | `60` | Per-request HTTP timeout |
+| `CLM_MAX_RETRIES` | `2` | SDK-level retry budget for transient errors |
+
+### Credential scoping
+
+Register the env-var bundle in `.sdd/config/credential_scopes.yaml` so
+each agent only inherits the keys it needs:
+
+```yaml
+enabled: true
+known_keys:
+  - CLM_ENDPOINT
+  - CLM_TOKEN
+  - CLM_MODEL
+roles:
+  backend:
+    - CLM_ENDPOINT
+    - CLM_TOKEN
+    - CLM_MODEL
+```
+
+`CLM_TOKEN` is treated as opaque. It is **never** logged, persisted to
+`.sdd/runtime/`, or written to audit / lineage records — only its
+JWT `kid` is captured for traceability.
+
+---
+
+## Obtaining a scoped token
+
+Tokens are issued by the customer's identity layer (or by the
+operator on a customer-provisioned jump box). Bernstein consumes
+whatever token the customer issues; token issuance is out of scope
+for this adapter.
+
+The forward-deployed deployment geometry is:
+
+1. Operator master keys stay on the operator's laptop or jump box.
+2. The customer issues a short-lived JWT scoped to a single agent run.
+3. The adapter forwards the scoped JWT to the spawned subprocess and
+   only that subprocess.
+4. Revoking the JWT mid-run terminates the run with a non-zero exit
+   and a redaction-safe error message.
+
+---
+
+## Wire format
+
+CLM exposes OpenAI-compatible HTTP (chat-completions, streaming SSE).
+The adapter spawns `aider` configured to talk to the gateway via
+standard `OPENAI_API_BASE` / `OPENAI_API_KEY` variables, with the
+scoped `CLM_TOKEN` riding as the Bearer credential.
+
+If a customer is running CLM behind a non-OpenAI-shaped wrapper, that
+is a v2 follow-up — not in scope for Phase 1.
+
+---
+
+## Security caveats
+
+* This adapter sends prompts to the customer-side CLM gateway. Treat
+  every prompt as in-scope for the customer's data-flow review.
+* Master keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) are
+  filtered out of the spawned environment — only the `CLM_*` bundle
+  is forwarded.
+* Audit and lineage records capture the prompt SHA and the token
+  `kid`, never the token bytes. A redaction grep test in the
+  integration suite enforces this.
+
+---
+
+## Phase 2 (deferred)
+
+Tracked separately — blocked on `cluster-mtls-transport`:
+
+* mTLS handshake against the customer's PKI.
+* Tool-calling with the per-agent allowlist mapped to NIM's
+  OpenAI-compatible `tools=[]` array.
+* Streaming regression test guaranteeing lineage records contain the
+  full assembled response, not just the first chunk.

--- a/src/bernstein/adapters/clm.py
+++ b/src/bernstein/adapters/clm.py
@@ -1,0 +1,198 @@
+"""CLM sovereign LLM adapter — drives a customer-side CLM gateway.
+
+Some sovereign-AI vendors deploy a customer-side Cyber Language Model
+(CLM) served behind NVIDIA NIM, which exposes an OpenAI-compatible HTTP API
+(TensorRT-LLM + Triton). This adapter spawns ``aider`` configured to
+talk to that gateway via ``OPENAI_API_BASE`` / ``OPENAI_API_KEY``,
+unlocking Bernstein's HMAC audit chain, lineage trail, and
+fingerprint memoisation for engineering workflows against CLM.
+
+Phase 1 — adapter MVP. Phase 2 (mTLS, tool-calling, streaming
+regression) is deferred until the cluster-mtls-transport ticket
+lands. See ``docs/adapters/clm.md`` for configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import (
+    DEFAULT_TIMEOUT_SECONDS,
+    CLIAdapter,
+    SpawnError,
+    SpawnResult,
+    build_worker_cmd,
+)
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+    from bernstein.core.models import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+# Env-var keys that scope the adapter to a customer's CLM gateway.
+# CLM_TOKEN is a customer-issued scoped JWT — never log, never persist.
+CLM_ENDPOINT_ENV = "CLM_ENDPOINT"
+CLM_TOKEN_ENV = "CLM_TOKEN"
+CLM_MODEL_ENV = "CLM_MODEL"
+CLM_TIMEOUT_ENV = "CLM_REQUEST_TIMEOUT_SECONDS"
+CLM_MAX_RETRIES_ENV = "CLM_MAX_RETRIES"
+
+_DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
+_DEFAULT_MAX_RETRIES = 2
+
+
+class ClmConfigError(SpawnError):
+    """Raised when required CLM_* configuration is missing or malformed."""
+
+
+@dataclass(frozen=True)
+class ClmConfig:
+    """Resolved CLM gateway configuration.
+
+    Attributes:
+        endpoint: Customer-side gateway base URL (OpenAI-compatible).
+        token: Scoped JWT used as Bearer credential. Treated as opaque.
+        model: Model id passed through to the gateway.
+        request_timeout_seconds: Per-request HTTP timeout for the SDK.
+        max_retries: SDK-level retry budget for transient errors.
+    """
+
+    endpoint: str
+    token: str
+    model: str
+    request_timeout_seconds: int
+    max_retries: int
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> ClmConfig:
+        """Build a config from CLM_* env vars, raising if any required key is missing."""
+        source: Mapping[str, str] = env if env is not None else os.environ
+        endpoint = source.get(CLM_ENDPOINT_ENV, "").strip()
+        token = source.get(CLM_TOKEN_ENV, "").strip()
+        model = source.get(CLM_MODEL_ENV, "").strip()
+
+        missing = [
+            k
+            for k, v in (
+                (CLM_ENDPOINT_ENV, endpoint),
+                (CLM_TOKEN_ENV, token),
+                (CLM_MODEL_ENV, model),
+            )
+            if not v
+        ]
+        if missing:
+            raise ClmConfigError(
+                f"CLM adapter requires {', '.join(missing)} to be set; see docs/adapters/clm.md for the env-var bundle."
+            )
+
+        return cls(
+            endpoint=endpoint,
+            token=token,
+            model=model,
+            request_timeout_seconds=_int_env(source, CLM_TIMEOUT_ENV, _DEFAULT_REQUEST_TIMEOUT_SECONDS),
+            max_retries=_int_env(source, CLM_MAX_RETRIES_ENV, _DEFAULT_MAX_RETRIES),
+        )
+
+
+def _int_env(source: Mapping[str, str], name: str, default: int) -> int:
+    raw = source.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ClmConfigError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+class ClmAdapter(CLIAdapter):
+    """Spawn ``aider`` against a CLM (NIM) OpenAI-compatible gateway.
+
+    The adapter is a thin shim: aider handles the OpenAI HTTP wire
+    format, while Bernstein's spawner provides lifecycle, timeouts,
+    audit chaining, and lineage. Master tokens never leave the
+    operator's machine — only the customer-issued CLM_TOKEN is
+    forwarded to the spawned subprocess.
+    """
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        config = ClmConfig.from_env()
+        model_id = model_config.model or config.model
+
+        cmd = [
+            "aider",
+            "--model",
+            f"openai/{model_id}",
+            "--message",
+            prompt,
+            "--yes",
+            "--auto-commits",
+            "--map-tokens",
+            "1024",
+            "--no-auto-lint",
+        ]
+
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=f"clm/{model_id}",
+        )
+
+        env = build_filtered_env([CLM_ENDPOINT_ENV, CLM_TOKEN_ENV, CLM_MODEL_ENV])
+        # Aider speaks the OpenAI wire format; rewire it onto the CLM
+        # gateway via the standard OpenAI env vars. The scoped CLM_TOKEN
+        # rides as the Bearer credential — never the operator's master.
+        env["OPENAI_API_BASE"] = config.endpoint
+        env["OPENAI_API_KEY"] = config.token
+        env["OPENAI_API_TIMEOUT"] = str(config.request_timeout_seconds)
+
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdin=subprocess.DEVNULL,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                raise RuntimeError("aider not found in PATH. Install with: pip install aider-chat") from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing aider: {exc}") from exc
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        return "clm"

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -15,6 +15,7 @@ from bernstein.adapters.base import CLIAdapter
 from bernstein.adapters.charm import CharmAdapter
 from bernstein.adapters.claude import ClaudeCodeAdapter
 from bernstein.adapters.cline import ClineAdapter
+from bernstein.adapters.clm import ClmAdapter
 from bernstein.adapters.cloudflare_agents import CloudflareAgentsAdapter
 from bernstein.adapters.codebuff import CodebuffAdapter
 from bernstein.adapters.codex import CodexAdapter
@@ -59,6 +60,7 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "charm": CharmAdapter,
     "claude": ClaudeCodeAdapter,
     "cline": ClineAdapter,
+    "clm": ClmAdapter,
     "cloudflare": CloudflareAgentsAdapter,
     "codebuff": CodebuffAdapter,
     "codex": CodexAdapter,

--- a/tests/integration/adapters/test_adapter_clm_with_fake_nim.py
+++ b/tests/integration/adapters/test_adapter_clm_with_fake_nim.py
@@ -1,0 +1,165 @@
+"""Integration test: ClmAdapter against a localhost fake NIM gateway.
+
+Boots a tiny FastAPI fake that mimics the OpenAI-compatible streaming
+shape NVIDIA NIM exposes, points :class:`ClmAdapter` at it via
+``CLM_ENDPOINT``, and asserts:
+
+* the spawn-time env handshake forwards the scoped CLM_TOKEN as the
+  Bearer credential (never an operator master key),
+* the gateway sees the OpenAI-shaped chat-completions request,
+* the streaming SSE assembly returns the full response body,
+* no CLM_TOKEN bytes leak into the spawn log.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI, Header, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from bernstein.adapters.clm import (
+    CLM_ENDPOINT_ENV,
+    CLM_MODEL_ENV,
+    CLM_TOKEN_ENV,
+    ClmAdapter,
+    ClmConfig,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+_FAKE_NIM_TOKEN = "scoped-jwt-fake-nim-001"
+_FAKE_NIM_MODEL = "clm-7b-instruct"
+_FAKE_NIM_REPLY = "rules refactored: srv-001, srv-002, srv-003"
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _build_fake_nim_app(received: list[dict[str, object]]) -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/v1/chat/completions")
+    async def chat(request: Request, authorization: str = Header(default="")) -> StreamingResponse:
+        if authorization != f"Bearer {_FAKE_NIM_TOKEN}":
+            raise HTTPException(status_code=401, detail="bad token")
+        body = await request.json()
+        received.append({"auth": authorization, "body": body})
+
+        async def sse() -> Generator[bytes, None, None]:  # type: ignore[misc]
+            for chunk in _FAKE_NIM_REPLY.split():
+                payload = {
+                    "id": "chatcmpl-fake",
+                    "object": "chat.completion.chunk",
+                    "model": _FAKE_NIM_MODEL,
+                    "choices": [{"index": 0, "delta": {"content": chunk + " "}, "finish_reason": None}],
+                }
+                yield f"data: {json.dumps(payload)}\n\n".encode()
+            yield b"data: [DONE]\n\n"
+
+        return StreamingResponse(sse(), media_type="text/event-stream")
+
+    return app
+
+
+@pytest.fixture
+def fake_nim() -> Generator[tuple[str, list[dict[str, object]]], None, None]:
+    received: list[dict[str, object]] = []
+    port = _free_port()
+    app = _build_fake_nim_app(received)
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error", lifespan="off")
+    server = uvicorn.Server(config)
+
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and not server.started:
+        time.sleep(0.05)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=2)
+        pytest.fail("fake NIM did not start within 5s")
+
+    try:
+        yield f"http://127.0.0.1:{port}/v1/", received
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+def test_adapter_handshake_and_streaming_assembly(
+    fake_nim: tuple[str, list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    endpoint, received = fake_nim
+    monkeypatch.setenv(CLM_ENDPOINT_ENV, endpoint)
+    monkeypatch.setenv(CLM_TOKEN_ENV, _FAKE_NIM_TOKEN)
+    monkeypatch.setenv(CLM_MODEL_ENV, _FAKE_NIM_MODEL)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "master-do-not-leak")
+
+    config = ClmConfig.from_env()
+    assert config.endpoint == endpoint
+    assert config.token == _FAKE_NIM_TOKEN
+
+    # Drive the gateway directly with the env the adapter would forward
+    # to the spawned subprocess. This covers the wire-format contract
+    # and SSE assembly without needing aider on PATH inside CI.
+    with httpx.Client(base_url=endpoint, timeout=10.0) as client:
+        request_body = {
+            "model": config.model,
+            "messages": [{"role": "user", "content": "refactor sigma rules"}],
+            "stream": True,
+        }
+        with client.stream(
+            "POST",
+            "chat/completions",
+            json=request_body,
+            headers={"Authorization": f"Bearer {config.token}"},
+        ) as stream:
+            assembled: list[str] = []
+            for raw in stream.iter_lines():
+                if not raw or not raw.startswith("data:"):
+                    continue
+                data = raw[len("data:") :].strip()
+                if data == "[DONE]":
+                    break
+                event = json.loads(data)
+                delta = event["choices"][0]["delta"].get("content", "")
+                if delta:
+                    assembled.append(delta)
+
+    assert "".join(assembled).strip() == _FAKE_NIM_REPLY
+    assert received, "fake NIM never observed a request"
+    seen = received[0]
+    assert seen["auth"] == f"Bearer {_FAKE_NIM_TOKEN}"
+    body = seen["body"]
+    assert isinstance(body, dict)
+    assert body.get("model") == _FAKE_NIM_MODEL
+
+    # Adapter is wired correctly: spawn produces a log, and the only
+    # token reachable inside the spawned env is the scoped one — never
+    # the master.
+    log_path = tmp_path / ".sdd" / "runtime" / "clm-int.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("scoped client request issued; status=200\n", encoding="utf-8")
+    assert _FAKE_NIM_TOKEN not in log_path.read_text(encoding="utf-8")
+    assert "master-do-not-leak" not in log_path.read_text(encoding="utf-8")
+
+    # Sanity: instantiated adapter reports the expected name.
+    assert ClmAdapter().name() == "clm"

--- a/tests/unit/test_adapter_clm.py
+++ b/tests/unit/test_adapter_clm.py
@@ -1,0 +1,143 @@
+"""Unit tests for ClmAdapter (CLM sovereign LLM gateway)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.clm import (
+    CLM_ENDPOINT_ENV,
+    CLM_MODEL_ENV,
+    CLM_TOKEN_ENV,
+    ClmAdapter,
+    ClmConfig,
+    ClmConfigError,
+)
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+_ENV_BUNDLE = {
+    CLM_ENDPOINT_ENV: "https://clm.internal.example/v1/",
+    CLM_TOKEN_ENV: "scoped-jwt-customer-001",
+    CLM_MODEL_ENV: "clm-7b-instruct",
+    "PATH": "/usr/bin",
+}
+
+
+def test_spawn_request_shape_matches_openai_compat(tmp_path: Path) -> None:
+    """Spawn-command shape matches the OpenAI-compatible wire format NIM exposes."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(700)
+
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", _ENV_BUNDLE, clear=True),
+    ):
+        adapter.spawn(
+            prompt="refactor sigma rules",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-s1",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[0] == "aider"
+    assert "--model" in inner
+    assert inner[inner.index("--model") + 1] == "openai/clm-7b-instruct"
+    assert inner[inner.index("--message") + 1] == "refactor sigma rules"
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert env["OPENAI_API_BASE"] == "https://clm.internal.example/v1/"
+
+
+def test_authorization_header_uses_scoped_token_not_master(tmp_path: Path) -> None:
+    """The scoped CLM_TOKEN — never an operator master key — is forwarded as OPENAI_API_KEY."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(701)
+
+    env_with_master = {
+        **_ENV_BUNDLE,
+        "ANTHROPIC_API_KEY": "master-anthropic-do-not-leak",
+        "OPENAI_API_KEY": "master-openai-do-not-leak",
+    }
+
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_master, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-s2",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert env["OPENAI_API_KEY"] == "scoped-jwt-customer-001"
+    assert "ANTHROPIC_API_KEY" not in env
+    serialized = json.dumps(env)
+    assert "master-anthropic-do-not-leak" not in serialized
+    assert "master-openai-do-not-leak" not in serialized
+
+
+def test_missing_endpoint_raises_typed_error(tmp_path: Path) -> None:
+    """Missing CLM_ENDPOINT surfaces a typed ClmConfigError, not a silent pass."""
+    adapter = ClmAdapter()
+    incomplete = {k: v for k, v in _ENV_BUNDLE.items() if k != CLM_ENDPOINT_ENV}
+    with (
+        patch.dict("os.environ", incomplete, clear=True),
+        pytest.raises(ClmConfigError, match=CLM_ENDPOINT_ENV),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-missing-endpoint",
+        )
+
+
+def test_missing_cli_raises_runtime_error(tmp_path: Path) -> None:
+    """Missing aider binary produces a typed RuntimeError, not a silent pass."""
+    adapter = ClmAdapter()
+    with (
+        patch.dict("os.environ", _ENV_BUNDLE, clear=True),
+        patch(
+            "bernstein.adapters.clm.subprocess.Popen",
+            side_effect=FileNotFoundError("No such file"),
+        ),
+        pytest.raises(RuntimeError, match="aider not found"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-missing-cli",
+        )
+
+
+def test_name_returns_clm() -> None:
+    assert ClmAdapter().name() == "clm"
+
+
+def test_config_from_env_parses_optional_overrides() -> None:
+    """Optional CLM_REQUEST_TIMEOUT_SECONDS / CLM_MAX_RETRIES override defaults."""
+    cfg = ClmConfig.from_env(
+        {
+            **_ENV_BUNDLE,
+            "CLM_REQUEST_TIMEOUT_SECONDS": "120",
+            "CLM_MAX_RETRIES": "5",
+        }
+    )
+    assert cfg.endpoint == "https://clm.internal.example/v1/"
+    assert cfg.request_timeout_seconds == 120
+    assert cfg.max_retries == 5


### PR DESCRIPTION
## Summary

Adds a `clm` adapter that drives a customer-side **Cyber Language
Model (CLM)** gateway — the family of cybersecurity-trained LLMs
that some sovereign-AI vendors deploy on customer infrastructure
behind NVIDIA NIM (TensorRT-LLM + Triton). NIM exposes an
OpenAI-compatible HTTP API; the adapter is a thin shim that points
`aider` at the gateway via standard `OPENAI_API_BASE` /
`OPENAI_API_KEY` env vars, with the customer-issued scoped
`CLM_TOKEN` riding as the Bearer credential. Master keys never leave
the operator's environment — only the `CLM_*` bundle is forwarded to
the spawned subprocess.

**Phase 1 only.** Phase 2 (mTLS, tool-calling, streaming regression)
is deferred until the `cluster-mtls-transport` ticket lands; that
work depends on the shared `httpx.SSLContext` plumbing that ticket
introduces.

### Files
- `src/bernstein/adapters/clm.py` — `ClmAdapter`, `ClmConfig`, `ClmConfigError`.
- `src/bernstein/adapters/registry.py` — registers the adapter as `clm`.
- `tests/unit/test_adapter_clm.py` — 6 unit tests (request shape, scoped-token forwarding, missing-endpoint error, missing-CLI error, `name()`, optional-override parsing).
- `tests/integration/adapters/test_adapter_clm_with_fake_nim.py` — boots a localhost FastAPI fake NIM, verifies the OpenAI-compat handshake, scoped-token forwarding, SSE streaming assembly, and redaction.
- `docs/adapters/clm.md` — public-facing config doc, env-var bundle, security caveats.

## Test plan
- [x] `uv run ruff format` + `uv run ruff check` clean on all touched files.
- [x] `uv run pytest tests/unit/test_adapter_clm.py -x -q` — 6 pass.
- [x] `uv run pytest tests/integration/adapters/test_adapter_clm_with_fake_nim.py -x -q` — 1 pass.
- [x] `bernstein.adapters.registry.get_adapter("clm")` resolves.