### PR TITLE
feat(adapters): CLM adapter tool-calling + streaming regression (Phase 2 partial)

### DIFF
--- a/src/bernstein/adapters/clm.py
+++ b/src/bernstein/adapters/clm.py
@@ -7,13 +7,19 @@ talk to that gateway via ``OPENAI_API_BASE`` / ``OPENAI_API_KEY``,
 unlocking Bernstein's HMAC audit chain, lineage trail, and
 fingerprint memoisation for engineering workflows against CLM.
 
-Phase 1 — adapter MVP. Phase 2 (mTLS, tool-calling, streaming
-regression) is deferred until the cluster-mtls-transport ticket
-lands. See ``docs/adapters/clm.md`` for configuration.
+Phase 1 — adapter MVP. Phase 2 partial (this module) wires the
+per-agent tool allowlist (T578) into the OpenAI-compatible
+``tools=[]`` request shape, refuses spawns that trip the lethal-
+trifecta capability matrix, and exposes a streaming-assembly helper
+whose lineage payload always carries the full response — never just
+the first chunk. mTLS support is deferred to Phase 2.5 once
+cluster-mtls-transport's shared ``httpx.SSLContext`` plumbing lands.
+See ``docs/adapters/clm.md`` for configuration.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess
@@ -28,12 +34,14 @@ from bernstein.adapters.base import (
     build_worker_cmd,
 )
 from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.core.agents.spawner_warm_pool import parse_tool_allowlist_env
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping, Sequence
     from pathlib import Path
 
     from bernstein.core.models import ModelConfig
+    from bernstein.core.security.capability_matrix import CapabilityRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +52,16 @@ CLM_TOKEN_ENV = "CLM_TOKEN"
 CLM_MODEL_ENV = "CLM_MODEL"
 CLM_TIMEOUT_ENV = "CLM_REQUEST_TIMEOUT_SECONDS"
 CLM_MAX_RETRIES_ENV = "CLM_MAX_RETRIES"
+
+# Forwarded into the spawned subprocess as the JSON-encoded OpenAI tools
+# array (one entry per allow-listed tool). A downstream wrapper (or an
+# in-process HTTP client when we move off aider) reads this and embeds
+# it as ``tools=[...]`` on the chat-completions request.
+CLM_TOOLS_SCHEMA_ENV = "CLM_TOOLS_SCHEMA"
+
+# Stable adapter token used by the lethal-trifecta capability matrix.
+# Matches the row registered in ``templates/capabilities/adapters.yaml``.
+_ADAPTER_CAPABILITY_TOKEN = "adapter.clm"
 
 _DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
 _DEFAULT_MAX_RETRIES = 2
@@ -112,6 +130,122 @@ def _int_env(source: Mapping[str, str], name: str, default: int) -> int:
         raise ClmConfigError(f"{name} must be an integer, got {raw!r}") from exc
 
 
+def build_openai_tools_schema(allowlist: Sequence[str]) -> list[dict[str, Any]]:
+    """Translate a Bernstein tool allowlist into the OpenAI ``tools=[]`` shape.
+
+    NIM exposes the OpenAI-compatible tools API; the per-spawn allowlist
+    (``BERNSTEIN_TOOL_ALLOWLIST``) caps which tools the model is allowed
+    to call. The schemas are intentionally minimal — tool descriptions
+    and JSON-Schema parameter shapes are owned by the catalog, not the
+    adapter; we forward only the names so the catalog stays the single
+    source of truth and the adapter cannot accidentally widen them.
+    """
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_name,
+                "description": f"Bernstein scoped tool: {tool_name}",
+                "parameters": {"type": "object", "properties": {}, "additionalProperties": True},
+            },
+        }
+        for tool_name in allowlist
+    ]
+
+
+@dataclass(frozen=True)
+class StreamingChunk:
+    """One assistant streaming event emitted by the gateway."""
+
+    content: str = ""
+    tool_calls: tuple[dict[str, Any], ...] = ()
+    finish_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class StreamingLineagePayload:
+    """Streaming response state captured for the lineage record.
+
+    The contract this dataclass defends, asserted by the regression
+    test, is that lineage records carry the *full* assembled response
+    even when streaming is on — never just the first chunk.
+
+    Attributes:
+        content: Full assistant message body, joined from every chunk.
+        tool_calls: Every assistant tool call seen across the stream.
+        finish_reason: Final ``finish_reason`` reported by the gateway.
+        chunk_count: Total number of chunks observed (for drift signal).
+    """
+
+    content: str
+    tool_calls: tuple[dict[str, Any], ...]
+    finish_reason: str | None
+    chunk_count: int
+
+
+def assemble_streaming_response(events: Iterable[StreamingChunk]) -> StreamingLineagePayload:
+    """Fold a streaming event sequence into the full response payload.
+
+    Done in adapter code (not delegated to the SDK) because the lineage
+    contract requires the full body, and SDK iterators have historically
+    been the source of "first-chunk-only" lineage bugs — see the Phase 2
+    streaming regression test.
+    """
+    content_parts: list[str] = []
+    tool_calls: list[dict[str, Any]] = []
+    finish_reason: str | None = None
+    count = 0
+    for event in events:
+        count += 1
+        if event.content:
+            content_parts.append(event.content)
+        if event.tool_calls:
+            tool_calls.extend(event.tool_calls)
+        if event.finish_reason is not None:
+            finish_reason = event.finish_reason
+    return StreamingLineagePayload(
+        content="".join(content_parts),
+        tool_calls=tuple(tool_calls),
+        finish_reason=finish_reason,
+        chunk_count=count,
+    )
+
+
+def _evaluate_lethal_trifecta(
+    allowlist: Sequence[str],
+    *,
+    workdir: Path | None = None,
+    registry: CapabilityRegistry | None = None,
+) -> None:
+    """Refuse spawns whose adapter-token + tool chain unions all three capabilities.
+
+    The matrix already considers ``adapter.clm`` as carrying
+    ``private_data + external_comm`` (it dials a customer gateway with
+    operator-shared prompts). Adding any tool tagged ``untrusted_input``
+    therefore unions the full trifecta. Enforcement runs *before* the
+    CLM call is made, per the Phase 2 acceptance criterion.
+
+    Only the *declared* subset of the chain is evaluated — undeclared
+    tools default-deny in the matrix but should not block a spawn here
+    (the spawner_core path surfaces them as warnings via the audit CLI),
+    matching the policy already used in :mod:`spawner_core`.
+    """
+    from bernstein.core.security.capability_matrix import (
+        CapabilityRegistry,
+        LethalTrifectaError,
+    )
+
+    reg = registry if registry is not None else CapabilityRegistry.load_default(workdir=workdir)
+    chain = [_ADAPTER_CAPABILITY_TOKEN, *allowlist]
+    declared = [t for t in chain if t in reg.tools]
+    if not declared:
+        return
+    decision = reg.evaluate_chain(declared)
+    if not decision.allowed:
+        err = LethalTrifectaError(decision)
+        raise SpawnError(f"lethal trifecta: {decision.reason}") from err
+
+
 class ClmAdapter(CLIAdapter):
     """Spawn ``aider`` against a CLM (NIM) OpenAI-compatible gateway.
 
@@ -140,6 +274,10 @@ class ClmAdapter(CLIAdapter):
 
         config = ClmConfig.from_env()
         model_id = model_config.model or config.model
+
+        allowlist = parse_tool_allowlist_env() or []
+        _evaluate_lethal_trifecta(allowlist, workdir=workdir)
+        tools_schema = build_openai_tools_schema(allowlist)
 
         cmd = [
             "aider",
@@ -172,6 +310,8 @@ class ClmAdapter(CLIAdapter):
         env["OPENAI_API_BASE"] = config.endpoint
         env["OPENAI_API_KEY"] = config.token
         env["OPENAI_API_TIMEOUT"] = str(config.request_timeout_seconds)
+        if tools_schema:
+            env[CLM_TOOLS_SCHEMA_ENV] = json.dumps(tools_schema, separators=(",", ":"))
 
         with log_path.open("w") as log_file:
             try:

--- a/templates/capabilities/adapters.yaml
+++ b/templates/capabilities/adapters.yaml
@@ -13,6 +13,8 @@ tools:
     capabilities: [private_data, untrusted_input, external_comm]
   - name: adapter.claude
     capabilities: [private_data, untrusted_input, external_comm]
+  - name: adapter.clm
+    capabilities: [private_data, external_comm]
   - name: adapter.cloudflare_agents
     capabilities: [private_data, untrusted_input, external_comm]
   - name: adapter.codex

--- a/tests/integration/adapters/test_adapter_clm_with_fake_nim.py
+++ b/tests/integration/adapters/test_adapter_clm_with_fake_nim.py
@@ -33,6 +33,8 @@ from bernstein.adapters.clm import (
     CLM_TOKEN_ENV,
     ClmAdapter,
     ClmConfig,
+    StreamingChunk,
+    assemble_streaming_response,
 )
 
 if TYPE_CHECKING:
@@ -50,6 +52,9 @@ def _free_port() -> int:
         return int(s.getsockname()[1])
 
 
+_LONG_STREAM_CHUNKS: tuple[str, ...] = tuple(f"long-chunk-{i:03d} " for i in range(60))
+
+
 def _build_fake_nim_app(received: list[dict[str, object]]) -> FastAPI:
     app = FastAPI()
 
@@ -60,15 +65,29 @@ def _build_fake_nim_app(received: list[dict[str, object]]) -> FastAPI:
         body = await request.json()
         received.append({"auth": authorization, "body": body})
 
+        # Distinguish the short canonical reply from the regression-test
+        # stream by inspecting a marker in the request body. Keeps both
+        # tests behind one fake-NIM fixture instead of two.
+        is_long = bool(body.get("stream")) and "long-stream" in json.dumps(body.get("messages", []))
+        chunks: tuple[str, ...] = _LONG_STREAM_CHUNKS if is_long else tuple(_FAKE_NIM_REPLY.split())
+        suffix = "" if is_long else " "
+
         async def sse() -> Generator[bytes, None, None]:  # type: ignore[misc]
-            for chunk in _FAKE_NIM_REPLY.split():
+            for chunk in chunks:
                 payload = {
                     "id": "chatcmpl-fake",
                     "object": "chat.completion.chunk",
                     "model": _FAKE_NIM_MODEL,
-                    "choices": [{"index": 0, "delta": {"content": chunk + " "}, "finish_reason": None}],
+                    "choices": [{"index": 0, "delta": {"content": chunk + suffix}, "finish_reason": None}],
                 }
                 yield f"data: {json.dumps(payload)}\n\n".encode()
+            done = {
+                "id": "chatcmpl-fake",
+                "object": "chat.completion.chunk",
+                "model": _FAKE_NIM_MODEL,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            }
+            yield f"data: {json.dumps(done)}\n\n".encode()
             yield b"data: [DONE]\n\n"
 
         return StreamingResponse(sse(), media_type="text/event-stream")
@@ -163,3 +182,61 @@ def test_adapter_handshake_and_streaming_assembly(
 
     # Sanity: instantiated adapter reports the expected name.
     assert ClmAdapter().name() == "clm"
+
+
+def test_streaming_lineage_regression_50plus_chunks(
+    fake_nim: tuple[str, list[dict[str, object]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Phase 2 regression: a 50+ chunk stream must produce a single lineage payload carrying the *full* assembled body.
+
+    Historically, lineage writers consuming streaming SDK iterators
+    captured only the first chunk's delta. The contract this test
+    pins down: ``assemble_streaming_response`` joins every chunk and
+    its lineage payload contains every part of the body, in order.
+    """
+    endpoint, _ = fake_nim
+    monkeypatch.setenv(CLM_ENDPOINT_ENV, endpoint)
+    monkeypatch.setenv(CLM_TOKEN_ENV, _FAKE_NIM_TOKEN)
+    monkeypatch.setenv(CLM_MODEL_ENV, _FAKE_NIM_MODEL)
+
+    config = ClmConfig.from_env()
+
+    with httpx.Client(base_url=endpoint, timeout=10.0) as client:
+        request_body = {
+            "model": config.model,
+            "messages": [{"role": "user", "content": "long-stream please"}],
+            "stream": True,
+        }
+        events: list[StreamingChunk] = []
+        with client.stream(
+            "POST",
+            "chat/completions",
+            json=request_body,
+            headers={"Authorization": f"Bearer {config.token}"},
+        ) as stream:
+            for raw in stream.iter_lines():
+                if not raw or not raw.startswith("data:"):
+                    continue
+                data = raw[len("data:") :].strip()
+                if data == "[DONE]":
+                    break
+                event = json.loads(data)
+                choice = event["choices"][0]
+                delta = choice["delta"]
+                events.append(
+                    StreamingChunk(
+                        content=delta.get("content", "") or "",
+                        finish_reason=choice.get("finish_reason"),
+                    )
+                )
+
+    payload = assemble_streaming_response(events)
+    expected = "".join(_LONG_STREAM_CHUNKS)
+
+    assert payload.chunk_count >= 50, f"expected 50+ chunks, got {payload.chunk_count}"
+    assert payload.content == expected
+    assert payload.content != events[0].content
+    assert "long-chunk-000" in payload.content
+    assert "long-chunk-059" in payload.content
+    assert payload.finish_reason == "stop"

--- a/tests/unit/test_adapter_clm.py
+++ b/tests/unit/test_adapter_clm.py
@@ -9,13 +9,18 @@ from unittest.mock import patch
 import pytest
 from bernstein.core.models import ModelConfig
 
+from bernstein.adapters.base import SpawnError
 from bernstein.adapters.clm import (
     CLM_ENDPOINT_ENV,
     CLM_MODEL_ENV,
     CLM_TOKEN_ENV,
+    CLM_TOOLS_SCHEMA_ENV,
     ClmAdapter,
     ClmConfig,
     ClmConfigError,
+    StreamingChunk,
+    assemble_streaming_response,
+    build_openai_tools_schema,
 )
 from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
 
@@ -141,3 +146,121 @@ def test_config_from_env_parses_optional_overrides() -> None:
     assert cfg.endpoint == "https://clm.internal.example/v1/"
     assert cfg.request_timeout_seconds == 120
     assert cfg.max_retries == 5
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 partial — tool-calling allowlist + lethal-trifecta enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_build_openai_tools_schema_emits_function_entries() -> None:
+    schema = build_openai_tools_schema(["fs.read", "git.commit"])
+    assert [entry["type"] for entry in schema] == ["function", "function"]
+    names = [entry["function"]["name"] for entry in schema]
+    assert names == ["fs.read", "git.commit"]
+    for entry in schema:
+        assert entry["function"]["parameters"]["type"] == "object"
+
+
+def test_spawn_forwards_tool_allowlist_as_openai_tools_array(tmp_path: Path) -> None:
+    """The per-spawn allowlist (T578) materialises as OpenAI ``tools=[]`` schema in the env."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(710)
+    env_with_allowlist = {
+        **_ENV_BUNDLE,
+        "BERNSTEIN_TOOL_ALLOWLIST": "fs.read,git.commit",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_allowlist, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-tools",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert CLM_TOOLS_SCHEMA_ENV in env
+    schema = json.loads(env[CLM_TOOLS_SCHEMA_ENV])
+    assert [entry["function"]["name"] for entry in schema] == ["fs.read", "git.commit"]
+
+
+def test_spawn_omits_tools_schema_env_when_no_allowlist(tmp_path: Path) -> None:
+    """No allowlist → no ``tools=[]`` env, so the gateway sees the unconstrained default."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(711)
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", _ENV_BUNDLE, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-no-tools",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert CLM_TOOLS_SCHEMA_ENV not in env
+
+
+def test_spawn_refuses_lethal_trifecta_chain(tmp_path: Path) -> None:
+    """An allowlist that unions ``private_data + untrusted_input + external_comm`` is denied before the CLM call."""
+    adapter = ClmAdapter()
+    env_with_lethal_chain = {
+        **_ENV_BUNDLE,
+        # adapter.clm carries [private_data, external_comm]; web.fetch
+        # adds [untrusted_input, external_comm] → full trifecta → deny.
+        "BERNSTEIN_TOOL_ALLOWLIST": "web.fetch",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen") as popen,
+        patch.dict("os.environ", env_with_lethal_chain, clear=True),
+        pytest.raises(SpawnError, match="lethal trifecta"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-trifecta",
+        )
+    assert not popen.called, "trifecta refusal must run BEFORE the gateway call"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 partial — streaming verification regression
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_lineage_carries_full_response_not_first_chunk() -> None:
+    """Lineage payload assembles every chunk's content, never just the first.
+
+    This is the regression test the ticket calls out by name:
+    streaming bugs historically captured only ``events[0].content`` for
+    lineage. We feed 50+ chunks and assert the full body is preserved.
+    """
+    body = [f"chunk-{i}-payload " for i in range(50)]
+    events = [StreamingChunk(content=part) for part in body]
+    events.append(StreamingChunk(finish_reason="stop"))
+
+    payload = assemble_streaming_response(events)
+
+    assert payload.content == "".join(body)
+    assert payload.chunk_count == len(events)
+    assert payload.finish_reason == "stop"
+    assert payload.content != events[0].content
+    assert "chunk-49-payload" in payload.content
+
+
+def test_streaming_lineage_captures_tool_calls_across_chunks() -> None:
+    events = [
+        StreamingChunk(content="thinking..."),
+        StreamingChunk(tool_calls=({"id": "c1", "name": "fs.read"},)),
+        StreamingChunk(tool_calls=({"id": "c2", "name": "git.commit"},)),
+        StreamingChunk(finish_reason="tool_calls"),
+    ]
+    payload = assemble_streaming_response(events)
+    assert [c["id"] for c in payload.tool_calls] == ["c1", "c2"]
+    assert payload.finish_reason == "tool_calls"


### PR DESCRIPTION
## Summary

Phase 2 partial for the CLM (Cyber Language Model) sovereign-LLM adapter. Builds on Phase 1 (merged in #1012). Two pieces land here; mTLS is deferred to Phase 2.5.

- **Tool-calling**: `ClmAdapter.spawn()` reads the per-agent allowlist via `parse_tool_allowlist_env()` (T578), translates it into the OpenAI-compatible `tools=[]` schema, and forwards it to the spawned subprocess via the `CLM_TOOLS_SCHEMA` env var. Before the call is made, the lethal-trifecta capability matrix is consulted on the chain `[adapter.clm, *allowlist]`; spawns whose union covers all three capabilities are refused with `SpawnError`. Adds `adapter.clm` to `templates/capabilities/adapters.yaml` with `[private_data, external_comm]` — any allow-listed tool tagged `untrusted_input` therefore unions the full trifecta and is denied.
- **Streaming regression**: new `StreamingChunk` / `StreamingLineagePayload` dataclasses plus `assemble_streaming_response()` helper. The explicit regression test (the one the ticket calls out by name) drives 60+ chunks through the fake NIM and asserts the lineage payload carries the full assembled body — not just `events[0].content`.

## Deferred — Phase 2.5

mTLS support for the adapter is **not** in this PR. It needs the shared `httpx.SSLContext` plumbing being added by the open `cluster-mtls-transport` ticket. Once that merges, a small follow-up wires mTLS through the same channel and adds the self-signed-CA handshake test from the Phase 2 acceptance criteria.

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_clm.py tests/integration/adapters/test_adapter_clm_with_fake_nim.py -x -q` — 14 passed
- [x] `uv run ruff format` + `uv run ruff check` clean on touched files
- [x] No CLM_TOKEN bytes leak into env / log assertions still pass
- [x] Pre-existing Phase 1 tests still green (no regression in adapter handshake or streaming assembly fixture)

## Files

- `src/bernstein/adapters/clm.py` — allowlist hook, lethal-trifecta gate, streaming-assembly helpers (~150 LOC added)
- `templates/capabilities/adapters.yaml` — register `adapter.clm`
- `tests/unit/test_adapter_clm.py` — 7 new tests covering tools schema, allowlist forwarding, trifecta refusal, full-body streaming assembly
- `tests/integration/adapters/test_adapter_clm_with_fake_nim.py` — 60-chunk streaming regression test