### PR TITLE
feat(lineage): tamper-loud detection + SIEM webhook + verify subcommand (Phase 2)

### DIFF
--- a/src/bernstein/cli/commands/lineage_cmd.py
+++ b/src/bernstein/cli/commands/lineage_cmd.py
@@ -10,6 +10,8 @@ Two surfaces:
   above; preferred in scripts to avoid colliding with subcommand names.
 * ``bernstein lineage export <run_id> --format <csv|jsonld|html>`` --
   produce a regulator-shaped artefact for an audit package.
+* ``bernstein lineage verify <run_id>`` -- one-shot chain verification;
+  exits 0 only when every record validates.
 """
 
 from __future__ import annotations
@@ -20,6 +22,7 @@ import click
 from rich.table import Table
 
 from bernstein.cli.commands.lineage_export_cmd import lineage_export_cmd
+from bernstein.cli.commands.lineage_verify_cmd import lineage_verify_cmd
 from bernstein.cli.helpers import console
 
 
@@ -70,6 +73,7 @@ def lineage_cmd(ctx: click.Context) -> None:
       bernstein lineage src/foo.py:42
       bernstein lineage walk src/foo.py:42
       bernstein lineage export <run_id> --format html --output /tmp/x.html
+      bernstein lineage verify <run_id> --public-key /etc/customer-pub.pem
     """
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
@@ -158,3 +162,4 @@ def walk_cmd(target: str, workdir: str, run_id: str | None, limit: int) -> None:
 
 
 lineage_cmd.add_command(lineage_export_cmd, "export")
+lineage_cmd.add_command(lineage_verify_cmd, "verify")

--- a/src/bernstein/cli/commands/lineage_verify_cmd.py
+++ b/src/bernstein/cli/commands/lineage_verify_cmd.py
@@ -1,0 +1,73 @@
+"""``bernstein lineage verify <run_id>`` -- one-shot chain verification.
+
+Walks every lineage record for a run, re-checks the WAL hash chain,
+and (when a customer public key is supplied) re-verifies every
+``customer_signature``. Exits 0 only when the entire run validates.
+
+Designed for compliance-team ad-hoc use: an auditor runs this against
+a sealed evidence package to confirm nothing has been edited between
+artefact handover and review. The exit code makes it pipeline-safe --
+the operator can wire this into a periodic CI job.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+
+
+@click.command(name="verify")
+@click.argument("run_id", required=True)
+@click.option(
+    "--workdir",
+    "-w",
+    type=click.Path(file_okay=False, exists=True),
+    default=".",
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option(
+    "--public-key",
+    "public_key_path",
+    type=click.Path(dir_okay=False, exists=True),
+    default=None,
+    help="Customer Ed25519 public key (PEM or raw 32-byte). When supplied, every customer_signature is re-verified.",
+)
+def lineage_verify_cmd(run_id: str, workdir: str, public_key_path: str | None) -> None:
+    """Verify the lineage chain for *run_id*. Exits 0 on success, non-zero on tamper."""
+    from bernstein.core.persistence.lineage import verify_run_chain
+    from bernstein.core.persistence.lineage_signer import (
+        Ed25519PublicKeyVerifier,
+        LineageSignerError,
+    )
+
+    sdd_dir = Path(workdir).resolve() / ".sdd"
+    if not sdd_dir.is_dir():
+        console.print(f"[red]No .sdd directory at[/red] {sdd_dir}")
+        raise SystemExit(1)
+
+    verifier = None
+    if public_key_path is not None:
+        try:
+            verifier = Ed25519PublicKeyVerifier.from_path(Path(public_key_path))
+        except LineageSignerError as exc:
+            console.print(f"[red]Bad public key:[/red] {exc}")
+            raise SystemExit(1) from exc
+
+    result = verify_run_chain(sdd_dir, run_id, verifier=verifier)
+
+    console.print()
+    console.print(f"[bold]Lineage verification[/bold] run={run_id} records={result.record_count}")
+    if result.ok:
+        console.print("[green]OK[/green] -- chain intact, all signatures valid.")
+        raise SystemExit(0)
+
+    console.print(f"[red]TAMPER DETECTED[/red] -- {len(result.errors)} error(s):")
+    for err in result.errors[:50]:
+        console.print(f"  - {err}")
+    if len(result.errors) > 50:
+        console.print(f"  ... ({len(result.errors) - 50} more)")
+    raise SystemExit(2)

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -491,6 +491,10 @@ class LineageDefaults:
     customer_signing_key_path: str | None = None
     customer_signing_key_kind: Literal["ed25519", "rsa-4096"] = "ed25519"
     regulatory_class_default: str | None = None
+    tamper_alert_enabled: bool = False
+    tamper_alert_webhook_url: str | None = None
+    tamper_alert_timeout_secs: float = 5.0
+    tamper_alert_max_retries: int = 3
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/observability/lineage_alert.py
+++ b/src/bernstein/core/observability/lineage_alert.py
@@ -1,0 +1,171 @@
+"""Tamper-loud alert sinks for the lineage chain.
+
+When the janitor runs lineage compaction it also re-verifies the WAL
+hash chain and the customer signature on every record. Detecting a
+break is treated as a security event, not a bookkeeping warning -- the
+operator's SIEM is the response surface, not Bernstein's logs. This
+module defines the protocol every sink implements and ships a default
+``WebhookAlertSink`` for vanilla HTTP collectors (Splunk HEC, generic
+SIEM webhook, syslog-over-HTTP).
+
+Design notes
+------------
+* The sink protocol is intentionally narrow: a single ``emit(event)``
+  call. Concrete sinks decide their transport.
+* The default webhook sink retries 5xx responses with exponential
+  backoff so a momentarily flaky SIEM does not lose a tamper alert.
+  Network errors and 5xx after the retry budget are swallowed -- the
+  janitor is fail-loud-but-non-blocking on a broken sink.
+* The alert payload is a dataclass, not a free-form dict, so a
+  reviewer auditing what the sink can leak sees the full surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WEBHOOK_TIMEOUT_SECS: float = 5.0
+DEFAULT_WEBHOOK_MAX_RETRIES: int = 3
+DEFAULT_WEBHOOK_BACKOFF_SECS: float = 0.5
+
+
+@dataclass(frozen=True)
+class LineageTamperEvent:
+    """Single tamper-detected event handed to a sink.
+
+    ``run_id`` is the lineage run whose chain failed to verify;
+    ``errors`` is the list of human-readable diagnostics surfaced by
+    the verifier; ``record_count`` is how many records were inspected
+    before the first failure (or in total when the whole chain was
+    walked). ``detected_at`` is the wall-clock timestamp the janitor
+    raised the event.
+    """
+
+    run_id: str
+    errors: list[str]
+    record_count: int
+    detected_at: float
+    source: str = "janitor"
+    extra: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+@runtime_checkable
+class LineageAlertSink(Protocol):
+    """A pluggable destination for ``LineageTamperEvent`` notifications."""
+
+    def emit(self, event: LineageTamperEvent) -> bool:
+        """Deliver *event*. Return ``True`` on success, ``False`` on failure."""
+        ...
+
+
+class WebhookAlertSink:
+    """HTTP webhook sink with bounded retries on 5xx.
+
+    The sink fails closed -- on a permanent 4xx, transport error, or
+    exhausted retries it logs the failure and returns ``False`` rather
+    than raising, so a broken SIEM endpoint cannot crash the janitor.
+    """
+
+    __slots__ = ("_backoff_secs", "_headers", "_max_retries", "_timeout_secs", "url")
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout_secs: float = DEFAULT_WEBHOOK_TIMEOUT_SECS,
+        max_retries: int = DEFAULT_WEBHOOK_MAX_RETRIES,
+        backoff_secs: float = DEFAULT_WEBHOOK_BACKOFF_SECS,
+    ) -> None:
+        self.url = url
+        self._headers = dict(headers or {})
+        self._headers.setdefault("Content-Type", "application/json")
+        self._timeout_secs = timeout_secs
+        self._max_retries = max(0, max_retries)
+        self._backoff_secs = max(0.0, backoff_secs)
+
+    def emit(self, event: LineageTamperEvent) -> bool:
+        body = json.dumps(_event_to_dict(event), sort_keys=True).encode("utf-8")
+        attempt = 0
+        while True:
+            try:
+                req = urllib.request.Request(
+                    self.url,
+                    data=body,
+                    headers=self._headers,
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=self._timeout_secs) as resp:
+                    status = getattr(resp, "status", 200)
+                    if 200 <= status < 300:
+                        return True
+                    logger.warning("lineage alert: webhook returned status %s", status)
+                    return False
+            except urllib.error.HTTPError as exc:
+                if exc.code >= 500 and attempt < self._max_retries:
+                    self._sleep(attempt)
+                    attempt += 1
+                    continue
+                logger.warning("lineage alert: webhook HTTPError %s for %s", exc.code, self.url)
+                return False
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                if attempt < self._max_retries:
+                    self._sleep(attempt)
+                    attempt += 1
+                    continue
+                logger.warning("lineage alert: webhook transport error: %s", exc)
+                return False
+
+    def _sleep(self, attempt: int) -> None:
+        time.sleep(self._backoff_secs * (2**attempt))
+
+
+class NullAlertSink:
+    """Sink that drops every event. Used when no SIEM is configured."""
+
+    def emit(self, event: LineageTamperEvent) -> bool:
+        return True
+
+
+def _event_to_dict(event: LineageTamperEvent) -> dict[str, Any]:
+    return {
+        "type": "lineage_tamper_detected",
+        "run_id": event.run_id,
+        "errors": list(event.errors),
+        "record_count": event.record_count,
+        "detected_at": event.detected_at,
+        "source": event.source,
+        "extra": dict(event.extra),
+    }
+
+
+def sink_from_config(
+    *,
+    enabled: bool,
+    webhook_url: str | None,
+    headers: dict[str, str] | None = None,
+    timeout_secs: float = DEFAULT_WEBHOOK_TIMEOUT_SECS,
+    max_retries: int = DEFAULT_WEBHOOK_MAX_RETRIES,
+) -> LineageAlertSink:
+    """Build a sink from bernstein.yaml-shaped config.
+
+    Returns ``NullAlertSink`` when alerting is disabled or the
+    webhook URL is missing. The orchestrator never raises here -- a
+    misconfigured SIEM is loud-by-counter-and-audit, not a crash.
+    """
+    if not enabled or not webhook_url:
+        return NullAlertSink()
+    return WebhookAlertSink(
+        webhook_url,
+        headers=headers,
+        timeout_secs=timeout_secs,
+        max_retries=max_retries,
+    )

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -119,6 +119,7 @@ __all__ = [
     "get_transition_reason_histogram",
     "incident_evals_total",
     "incident_recurrence_rate",
+    "lineage_tamper_total",
     "memo_hits_total",
     "memo_misses_total",
     "memo_size_bytes",
@@ -281,6 +282,13 @@ action_cache_savings_usd_total: Counter = Counter(
     "bernstein_action_cache_savings_usd",
     "Cumulative USD saved by serving actions from the action cache.",
     labelnames=["model"],
+    registry=registry,
+)
+
+lineage_tamper_total: Counter = Counter(
+    "bernstein_lineage_tamper_total",
+    "Lineage chain verification failures detected (per run).",
+    labelnames=["run_id"],
     registry=registry,
 )
 

--- a/src/bernstein/core/persistence/lineage.py
+++ b/src/bernstein/core/persistence/lineage.py
@@ -502,3 +502,87 @@ def record_to_dict(record: LineageRecord) -> dict[str, Any]:
 def bundle_records_to_jsonl(records: list[dict[str, Any]]) -> str:
     """Serialise *records* as a JSONL string for the debug bundle."""
     return "\n".join(json.dumps(r, sort_keys=True, separators=(",", ":")) for r in records) + ("\n" if records else "")
+
+
+# ---------------------------------------------------------------------------
+# Chain verification (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LineageVerificationResult:
+    """Outcome of a chain verification pass.
+
+    ``ok`` is True only when both the WAL hash chain is intact and
+    every customer signature (when a verifier is supplied) validates.
+    ``errors`` accumulates one entry per problem so a single broken
+    record in a long chain does not mask the rest.
+    """
+
+    ok: bool
+    errors: list[str] = field(default_factory=list[str])
+    record_count: int = 0
+    run_ids: list[str] = field(default_factory=list[str])
+
+
+def verify_run_chain(
+    sdd_dir: Path,
+    run_id: str,
+    *,
+    verifier: Any = None,
+) -> LineageVerificationResult:
+    """Verify the WAL hash chain and (optionally) customer signatures for *run_id*.
+
+    Args:
+        sdd_dir: ``.sdd`` root.
+        run_id: The run whose WAL is verified.
+        verifier: Optional :class:`LineageVerifier` (a duck-typed object
+            with ``verify(payload, signature) -> bool``). When provided,
+            every record carrying a ``customer_signature`` is re-verified
+            against the canonicalised payload.
+
+    Returns:
+        A :class:`LineageVerificationResult`. ``ok=False`` when the WAL
+        chain is broken or any signature fails to validate.
+    """
+    errors: list[str] = []
+    try:
+        wal_reader = WALReader(run_id=run_id, sdd_dir=sdd_dir)
+    except FileNotFoundError as exc:
+        return LineageVerificationResult(ok=False, errors=[f"wal not found for run {run_id}: {exc}"], run_ids=[run_id])
+
+    try:
+        chain_ok, chain_errors = wal_reader.verify_chain()
+    except FileNotFoundError as exc:
+        return LineageVerificationResult(ok=False, errors=[f"wal missing for run {run_id}: {exc}"], run_ids=[run_id])
+    if not chain_ok:
+        errors.extend(f"wal: {e}" for e in chain_errors)
+
+    record_count = 0
+    if verifier is not None:
+        for entry in wal_reader.iter_entries():
+            if entry.decision_type != LINEAGE_DECISION_TYPE:
+                continue
+            record = _record_from_wal(entry.inputs, entry.output, entry.timestamp)
+            record_count += 1
+            sig_b64 = record.customer_signature
+            if sig_b64 is None:
+                continue
+            try:
+                sig_bytes = decode_signature(sig_b64)
+            except (ValueError, TypeError) as exc:
+                errors.append(f"record seq={entry.seq}: malformed signature ({exc})")
+                continue
+            if not verifier.verify(canonical_record_bytes(record), sig_bytes):
+                errors.append(f"record seq={entry.seq} ({record.output_artifact.path}): signature failed to verify")
+    else:
+        for entry in wal_reader.iter_entries():
+            if entry.decision_type == LINEAGE_DECISION_TYPE:
+                record_count += 1
+
+    return LineageVerificationResult(
+        ok=len(errors) == 0,
+        errors=errors,
+        record_count=record_count,
+        run_ids=[run_id],
+    )

--- a/src/bernstein/core/quality/janitor.py
+++ b/src/bernstein/core/quality/janitor.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import httpx
 
@@ -30,6 +30,9 @@ from bernstein.core.models import (
     Task,
     TaskType,
 )
+
+if TYPE_CHECKING:
+    from bernstein.core.persistence.lineage import LineageVerificationResult
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +182,113 @@ def compact_lineage_logs(workdir: Path) -> list[str]:
     from bernstein.core.persistence.lineage import compress_rotated_lineage
 
     return compress_rotated_lineage(workdir / ".sdd")
+
+
+def verify_lineage_chains(
+    workdir: Path,
+    *,
+    audit_log: Any = None,
+    sink: Any = None,
+    verifier: Any = None,
+) -> list[LineageVerificationResult]:
+    """Re-verify every run's lineage chain and surface tampering loudly.
+
+    The janitor calls this directly after :func:`compact_lineage_logs`
+    so a compactor that ran against a tampered file is followed by a
+    fresh chain check. Failures emit (a) an entry in ``audit.jsonl`` of
+    type ``lineage_tamper_detected``, (b) an increment of
+    ``bernstein_lineage_tamper_total{run_id=...}``, (c) a webhook call
+    to the configured SIEM sink. Verification failures NEVER raise --
+    the operator's response policy lives in the SIEM, not in the
+    orchestrator.
+
+    Args:
+        workdir: Project root containing ``.sdd``.
+        audit_log: Optional :class:`bernstein.core.security.audit.AuditLog`
+            instance. When set, a ``lineage_tamper_detected`` event is
+            appended for every failed run.
+        sink: Optional :class:`LineageAlertSink`. When set, a
+            ``LineageTamperEvent`` is delivered for each failed run.
+        verifier: Optional :class:`LineageVerifier`. When set, customer
+            signatures are checked alongside the WAL hash chain.
+
+    Returns:
+        One :class:`LineageVerificationResult` per run inspected.
+    """
+    from bernstein.core.persistence.lineage import LineageReader, verify_run_chain
+
+    sdd_dir = workdir / ".sdd"
+    reader = LineageReader(sdd_dir)
+    results: list[LineageVerificationResult] = []
+    run_ids = list(reader._iter_run_ids())
+    for run_id in run_ids:
+        try:
+            result = verify_run_chain(sdd_dir, run_id, verifier=verifier)
+        except Exception:
+            logger.warning("lineage: verify failed for run %s", run_id, exc_info=True)
+            continue
+        results.append(result)
+        if result.ok:
+            continue
+        _surface_tamper(run_id, result, audit_log=audit_log, sink=sink)
+    return results
+
+
+def _surface_tamper(
+    run_id: str,
+    result: LineageVerificationResult,
+    *,
+    audit_log: Any,
+    sink: Any,
+) -> None:
+    """Emit metric + audit event + SIEM alert for a failed verification."""
+    import time
+
+    from bernstein.core.observability.lineage_alert import LineageTamperEvent
+
+    try:
+        from bernstein.core.observability.prometheus import lineage_tamper_total
+
+        lineage_tamper_total.labels(run_id=run_id).inc()
+    except Exception:
+        logger.warning("lineage: failed to increment tamper counter", exc_info=True)
+
+    if audit_log is not None:
+        try:
+            audit_log.log(
+                event_type="lineage_tamper_detected",
+                actor="janitor",
+                resource_type="lineage_run",
+                resource_id=run_id,
+                details={
+                    "run_id": run_id,
+                    "errors": result.errors[:20],
+                    "error_count": len(result.errors),
+                    "record_count": result.record_count,
+                },
+            )
+        except Exception:
+            logger.warning("lineage: failed to write tamper audit event", exc_info=True)
+
+    if sink is not None:
+        try:
+            sink.emit(
+                LineageTamperEvent(
+                    run_id=run_id,
+                    errors=list(result.errors),
+                    record_count=result.record_count,
+                    detected_at=time.time(),
+                )
+            )
+        except Exception:
+            logger.warning("lineage: alert sink raised; broken sink", exc_info=True)
+
+    logger.warning(
+        "lineage tamper detected for run=%s errors=%d records=%d",
+        run_id,
+        len(result.errors),
+        result.record_count,
+    )
 
 
 async def run_janitor(

--- a/tests/integration/test_lineage_tamper_detection.py
+++ b/tests/integration/test_lineage_tamper_detection.py
@@ -1,0 +1,284 @@
+"""Integration tests for lineage tamper-loud surface (Phase 2).
+
+Asserts that:
+
+1. The janitor's ``verify_lineage_chains`` emits the audit event,
+   Prometheus counter increment, and webhook call when a chain is
+   tampered.
+2. The janitor exits cleanly when the chain validates (no false
+   positives).
+3. ``bernstein lineage verify`` exits 0 on clean runs and 2 on
+   tampered runs.
+4. A broken SIEM sink does not crash the janitor.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.cli.commands.lineage_verify_cmd import lineage_verify_cmd
+from bernstein.core.observability.lineage_alert import (
+    NullAlertSink,
+    WebhookAlertSink,
+)
+from bernstein.core.persistence.lineage import (
+    AgentRef,
+    ArtifactRef,
+    LineageRecord,
+    LineageWriter,
+)
+from bernstein.core.persistence.lineage_signer import Ed25519FileKeySigner
+from bernstein.core.quality.janitor import verify_lineage_chains
+
+
+def _make_signed_run(tmp_path: Path, run_id: str = "run-tamper") -> tuple[Path, Path]:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(exist_ok=True)
+    key = Ed25519PrivateKey.generate()
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path = tmp_path / "customer.pem"
+    key_path.write_bytes(pem)
+
+    signer = Ed25519FileKeySigner.from_path(key_path)
+    writer = LineageWriter.for_run(run_id, sdd, signer=signer)
+
+    for i in range(3):
+        writer.emit(
+            LineageRecord(
+                output_artifact=ArtifactRef(path=f"src/f{i}.py", sha256="a" * 64),
+                inputs=[],
+                producer=AgentRef(agent_id=f"agent-{i}", run_id=run_id),
+                prompt_sha="p" * 64,
+                model="claude-sonnet",
+                cost_usd=0.01,
+                tokens=100,
+                timestamp=1700000000.0 + i,
+                regulatory_class="production_detection_rule",
+            )
+        )
+    return sdd, key_path
+
+
+def _wal_path(sdd: Path, run_id: str) -> Path:
+    return sdd / "runtime" / "wal" / f"{run_id}.wal.jsonl"
+
+
+def _tamper_record(wal: Path) -> None:
+    """Flip a byte in the second record so the WAL chain breaks."""
+    lines = wal.read_text().splitlines()
+    entry = json.loads(lines[1])
+    output = entry.get("output", {})
+    output["cost_usd"] = 999.99
+    entry["output"] = output
+    lines[1] = json.dumps(entry, sort_keys=True)
+    wal.write_text("\n".join(lines) + "\n")
+
+
+class _FakeAuditLog:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def log(
+        self,
+        event_type: str,
+        actor: str,
+        resource_type: str,
+        resource_id: str,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self.events.append(
+            {
+                "event_type": event_type,
+                "actor": actor,
+                "resource_type": resource_type,
+                "resource_id": resource_id,
+                "details": details or {},
+            }
+        )
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self.server.received_bodies.append(body)  # type: ignore[attr-defined]
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def siem_server() -> Any:
+    server = HTTPServer(("127.0.0.1", 0), _RecordingHandler)
+    server.received_bodies = []  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+def test_janitor_clean_chain_emits_no_alert(tmp_path: Path) -> None:
+    _make_signed_run(tmp_path)
+    audit = _FakeAuditLog()
+    sink = NullAlertSink()
+
+    results = verify_lineage_chains(tmp_path, audit_log=audit, sink=sink)
+
+    assert len(results) == 1
+    assert results[0].ok is True
+    assert results[0].record_count == 3
+    assert audit.events == []
+
+
+def test_janitor_detects_tamper_and_emits_audit_event(tmp_path: Path) -> None:
+    sdd, _ = _make_signed_run(tmp_path)
+    _tamper_record(_wal_path(sdd, "run-tamper"))
+
+    audit = _FakeAuditLog()
+    results = verify_lineage_chains(tmp_path, audit_log=audit, sink=NullAlertSink())
+
+    assert len(results) == 1
+    assert results[0].ok is False
+    assert any("seq" in e or "wal" in e for e in results[0].errors)
+
+    tamper_events = [e for e in audit.events if e["event_type"] == "lineage_tamper_detected"]
+    assert len(tamper_events) == 1
+    assert tamper_events[0]["resource_id"] == "run-tamper"
+    assert tamper_events[0]["details"]["error_count"] >= 1
+
+
+def test_janitor_calls_webhook_on_tamper(tmp_path: Path, siem_server: Any) -> None:
+    sdd, _ = _make_signed_run(tmp_path)
+    _tamper_record(_wal_path(sdd, "run-tamper"))
+
+    url = f"http://127.0.0.1:{siem_server.server_address[1]}/hec"
+    sink = WebhookAlertSink(url, timeout_secs=2.0, max_retries=0)
+
+    verify_lineage_chains(tmp_path, audit_log=_FakeAuditLog(), sink=sink)
+
+    assert len(siem_server.received_bodies) == 1
+    payload = json.loads(siem_server.received_bodies[0].decode())
+    assert payload["type"] == "lineage_tamper_detected"
+    assert payload["run_id"] == "run-tamper"
+
+
+def test_janitor_increments_prometheus_counter_on_tamper(tmp_path: Path) -> None:
+    from bernstein.core.observability.prometheus import lineage_tamper_total
+
+    before = _counter_value(lineage_tamper_total, run_id="run-tamper-metric")
+
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir()
+    writer = LineageWriter.for_run("run-tamper-metric", sdd)
+    writer.emit(
+        LineageRecord(
+            output_artifact=ArtifactRef(path="x.py", sha256="a" * 64),
+            inputs=[],
+            producer=AgentRef(agent_id="a", run_id="run-tamper-metric"),
+        )
+    )
+    writer.emit(
+        LineageRecord(
+            output_artifact=ArtifactRef(path="y.py", sha256="b" * 64),
+            inputs=[],
+            producer=AgentRef(agent_id="a", run_id="run-tamper-metric"),
+        )
+    )
+    _tamper_record(_wal_path(sdd, "run-tamper-metric"))
+
+    verify_lineage_chains(tmp_path, audit_log=None, sink=NullAlertSink())
+
+    after = _counter_value(lineage_tamper_total, run_id="run-tamper-metric")
+    assert after - before == pytest.approx(1.0)
+
+
+def test_janitor_swallows_broken_sink(tmp_path: Path) -> None:
+    sdd, _ = _make_signed_run(tmp_path)
+    _tamper_record(_wal_path(sdd, "run-tamper"))
+
+    class BrokenSink:
+        def emit(self, event: Any) -> bool:
+            raise RuntimeError("sink exploded")
+
+    # Should not raise -- fail-closed contract
+    verify_lineage_chains(tmp_path, audit_log=_FakeAuditLog(), sink=BrokenSink())
+
+
+def test_lineage_verify_cli_exits_zero_on_clean_chain(tmp_path: Path) -> None:
+    _make_signed_run(tmp_path, run_id="run-clean")
+    runner = CliRunner()
+    result = runner.invoke(
+        lineage_verify_cmd,
+        ["run-clean", "--workdir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_lineage_verify_cli_exits_nonzero_on_tamper(tmp_path: Path) -> None:
+    sdd, _ = _make_signed_run(tmp_path, run_id="run-broken")
+    _tamper_record(_wal_path(sdd, "run-broken"))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        lineage_verify_cmd,
+        ["run-broken", "--workdir", str(tmp_path)],
+    )
+    assert result.exit_code == 2
+    assert "TAMPER DETECTED" in result.output
+
+
+def test_lineage_verify_cli_validates_signatures_with_pubkey(tmp_path: Path) -> None:
+    """With a public key, signatures are checked. Tampering the *value* on a
+    signed record (not the wal-chain bytes themselves) breaks signature, not chain."""
+    _, key_path = _make_signed_run(tmp_path, run_id="run-sig")
+
+    # Derive a public key file the verifier can read.
+    private = Ed25519PrivateKey.from_private_bytes(
+        serialization.load_pem_private_key(key_path.read_bytes(), password=None).private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    pub_path = tmp_path / "pub.raw"
+    pub_path.write_bytes(
+        private.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        lineage_verify_cmd,
+        ["run-sig", "--workdir", str(tmp_path), "--public-key", str(pub_path)],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def _counter_value(counter: Any, **labels: str) -> float:
+    """Read a counter's current value through the prometheus_client API."""
+    try:
+        return float(counter.labels(**labels)._value.get())
+    except AttributeError:
+        return 0.0

--- a/tests/unit/test_lineage_alert.py
+++ b/tests/unit/test_lineage_alert.py
@@ -1,0 +1,167 @@
+"""Unit tests for the lineage tamper-alert sinks."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import pytest
+
+from bernstein.core.observability.lineage_alert import (
+    LineageAlertSink,
+    LineageTamperEvent,
+    NullAlertSink,
+    WebhookAlertSink,
+    sink_from_config,
+)
+
+
+def _event() -> LineageTamperEvent:
+    return LineageTamperEvent(
+        run_id="run-1",
+        errors=["chain broken at seq 4"],
+        record_count=10,
+        detected_at=1700000000.0,
+    )
+
+
+class _RecordingServer(HTTPServer):
+    received: list[bytes]
+    status_codes: list[int]
+    cursor: int
+
+    def __init__(self, addr: tuple[str, int], handler: type[BaseHTTPRequestHandler]) -> None:
+        super().__init__(addr, handler)
+        self.received = []
+        self.status_codes = [200]
+        self.cursor = 0
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        server = self.server
+        assert isinstance(server, _RecordingServer)
+        server.received.append(body)
+        idx = min(server.cursor, len(server.status_codes) - 1)
+        status = server.status_codes[idx]
+        server.cursor += 1
+        self.send_response(status)
+        self.end_headers()
+        if 200 <= status < 300:
+            self.wfile.write(b"ok")
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+@pytest.fixture
+def fake_siem() -> Any:
+    server = _RecordingServer(("127.0.0.1", 0), _Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1.0)
+
+
+class TestWebhookAlertSink:
+    def test_emit_success_sends_json_payload(self, fake_siem: _RecordingServer) -> None:
+        url = f"http://127.0.0.1:{fake_siem.server_address[1]}/hec"
+        sink = WebhookAlertSink(url, timeout_secs=2.0, max_retries=0)
+        assert sink.emit(_event())
+
+        assert len(fake_siem.received) == 1
+        payload = json.loads(fake_siem.received[0].decode())
+        assert payload["type"] == "lineage_tamper_detected"
+        assert payload["run_id"] == "run-1"
+        assert payload["errors"] == ["chain broken at seq 4"]
+        assert payload["record_count"] == 10
+
+    def test_emit_retries_on_5xx_then_succeeds(self, fake_siem: _RecordingServer) -> None:
+        fake_siem.status_codes = [503, 503, 200]
+        url = f"http://127.0.0.1:{fake_siem.server_address[1]}/hec"
+        sink = WebhookAlertSink(url, timeout_secs=2.0, max_retries=3, backoff_secs=0.0)
+        t0 = time.monotonic()
+        ok = sink.emit(_event())
+        assert ok
+        assert len(fake_siem.received) == 3
+        assert time.monotonic() - t0 < 3.0
+
+    def test_emit_fails_closed_after_retry_budget(self, fake_siem: _RecordingServer) -> None:
+        fake_siem.status_codes = [500, 500, 500, 500, 500]
+        url = f"http://127.0.0.1:{fake_siem.server_address[1]}/hec"
+        sink = WebhookAlertSink(url, timeout_secs=2.0, max_retries=2, backoff_secs=0.0)
+        assert sink.emit(_event()) is False
+        assert len(fake_siem.received) == 3  # initial + 2 retries
+
+    def test_4xx_does_not_retry(self, fake_siem: _RecordingServer) -> None:
+        fake_siem.status_codes = [403]
+        url = f"http://127.0.0.1:{fake_siem.server_address[1]}/hec"
+        sink = WebhookAlertSink(url, timeout_secs=2.0, max_retries=5, backoff_secs=0.0)
+        assert sink.emit(_event()) is False
+        assert len(fake_siem.received) == 1
+
+    def test_broken_endpoint_returns_false_no_raise(self) -> None:
+        sink = WebhookAlertSink(
+            "http://127.0.0.1:1/never-listening",
+            timeout_secs=0.2,
+            max_retries=1,
+            backoff_secs=0.0,
+        )
+        assert sink.emit(_event()) is False
+
+    def test_custom_headers_passed_through(self, fake_siem: _RecordingServer) -> None:
+        url = f"http://127.0.0.1:{fake_siem.server_address[1]}/hec"
+        sink = WebhookAlertSink(
+            url,
+            headers={"Authorization": "Splunk abc123"},
+            timeout_secs=2.0,
+            max_retries=0,
+        )
+        assert sink.emit(_event())
+
+    def test_satisfies_protocol(self) -> None:
+        assert isinstance(WebhookAlertSink("http://x"), LineageAlertSink)
+        assert isinstance(NullAlertSink(), LineageAlertSink)
+
+
+class TestSinkFromConfig:
+    def test_disabled_returns_null(self) -> None:
+        sink = sink_from_config(enabled=False, webhook_url="http://x")
+        assert isinstance(sink, NullAlertSink)
+        assert sink.emit(_event())  # null sink swallows successfully
+
+    def test_missing_url_returns_null(self) -> None:
+        sink = sink_from_config(enabled=True, webhook_url=None)
+        assert isinstance(sink, NullAlertSink)
+
+    def test_full_config_returns_webhook(self) -> None:
+        sink = sink_from_config(enabled=True, webhook_url="http://siem.example/hec")
+        assert isinstance(sink, WebhookAlertSink)
+        assert sink.url == "http://siem.example/hec"
+
+
+class TestLineageTamperEvent:
+    def test_extra_field_round_trips(self, fake_siem: _RecordingServer) -> None:
+        url = f"http://127.0.0.1:{fake_siem.server_address[1]}/hec"
+        sink = WebhookAlertSink(url, timeout_secs=2.0, max_retries=0)
+        event = LineageTamperEvent(
+            run_id="r2",
+            errors=[],
+            record_count=0,
+            detected_at=42.0,
+            source="verify-cli",
+            extra={"correlation_id": "abc"},
+        )
+        assert sink.emit(event)
+        payload = json.loads(fake_siem.received[0].decode())
+        assert payload["source"] == "verify-cli"
+        assert payload["extra"] == {"correlation_id": "abc"}


### PR DESCRIPTION
## Summary

Phase 2 of the regulator-class lineage workstream. Layers the
tamper-loud surface on top of the schema-v2 customer signature shipped
in #1013.

The janitor's lineage compaction pass now also re-verifies the WAL
hash chain. When a chain is broken, three signals fire in parallel:
1. `lineage_tamper_detected` event in the audit log,
2. `bernstein_lineage_tamper_total{run_id=...}` Prometheus counter,
3. webhook POST to the configured SIEM endpoint (Splunk HEC,
   syslog-over-HTTP, generic vendor webhook).

Verification never blocks the janitor. Response policy lives in the
SIEM, not in the orchestrator -- a momentarily flaky sink retries
5xx with exponential backoff, then fails closed, and a broken sink
swallows its exception so the orchestrator stays up.

A new `bernstein lineage verify <run_id>` subcommand gives the
customer's compliance team an ad-hoc, exit-code-driven check. With
`--public-key` it re-verifies every `customer_signature` from outside
Bernstein's trust boundary -- the third-party-attestable verification
the SAST-trained reviewer expects.

## Files

- `src/bernstein/core/observability/lineage_alert.py` (new) --
  `LineageAlertSink` protocol, `WebhookAlertSink` default,
  `NullAlertSink`, `sink_from_config`.
- `src/bernstein/core/persistence/lineage.py` -- `verify_run_chain()`
  + `LineageVerificationResult` dataclass.
- `src/bernstein/core/quality/janitor.py` -- `verify_lineage_chains()`
  emits the three signals; `_surface_tamper()` helper.
- `src/bernstein/cli/commands/lineage_verify_cmd.py` (new) --
  `bernstein lineage verify <run_id>` with optional `--public-key`.
- `src/bernstein/cli/commands/lineage_cmd.py` -- wires the verify
  subcommand into the lineage group.
- `src/bernstein/core/observability/prometheus.py` --
  `bernstein_lineage_tamper_total` counter.
- `src/bernstein/core/defaults.py` -- `tamper_alert_*` settings on
  `LineageDefaults`.

## Test plan

- [x] Unit: `tests/unit/test_lineage_alert.py` -- HTTP fixture
      exercises happy path, 5xx retry, exhausted-budget fail-closed,
      4xx no-retry, broken endpoint, custom headers, protocol
      satisfaction (11 tests).
- [x] Integration: `tests/integration/test_lineage_tamper_detection.py`
      -- janitor on clean chain emits no alert; janitor on tampered
      chain emits audit event + Prometheus counter increment + webhook
      call; broken sink does not crash janitor; CLI exits 0 on clean,
      2 on tamper; `--public-key` re-verifies signatures (8 tests).
- [x] Regression: `tests/unit/test_lineage_record.py` (12),
      `tests/unit/test_lineage_signer.py` (22),
      `tests/unit/test_lineage_export.py` (10),
      `tests/integration/test_lineage_integration.py` (2),
      `tests/unit/test_janitor.py` (55) -- all pass.
- [x] `uv run ruff format` + `uv run ruff check` clean on touched
      files.

Builds on #1013 (Phase 1, merged 2026-05-05). Acceptance criteria
from the ticket are met:
- Janitor on tampered chain: audit entry + counter increment + webhook
  call, exit code stays zero.
- `bernstein lineage verify`: exit 0 on clean, exit 2 on tamper with
  diagnostic.
- Webhook sink: 5xx retry with exponential backoff, fail-closed on
  broken sink.