### PR TITLE
feat(distribution): wheelhouse subcommands + GPG verifier + doctor airgap (Phase 2)

### DIFF
--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -533,7 +533,11 @@ def plugins_cmd(workdir: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-@click.command("doctor")
+@click.group(
+    name="doctor",
+    invoke_without_command=True,
+    subcommand_metavar="[airgap]",
+)
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 @click.option("--fix", "auto_fix", is_flag=True, default=False, help="Attempt to auto-fix issues.")
 @click.pass_context
@@ -544,10 +548,38 @@ def doctor(ctx: click.Context, as_json: bool, auto_fix: bool) -> None:
       bernstein doctor          # print diagnostic report
       bernstein doctor --json   # machine-readable output
       bernstein doctor --fix    # attempt to auto-fix issues
+      bernstein doctor airgap   # battery of checks for an air-gapped run
     """
+    if ctx.invoked_subcommand is not None:
+        ctx.obj = {"as_json": as_json, "auto_fix": auto_fix}
+        return
     from bernstein.cli.status_cmd import doctor as _doctor_impl
 
     ctx.invoke(_doctor_impl, as_json=as_json, auto_fix=auto_fix)
+
+
+@doctor.command("airgap")
+@click.pass_context
+def doctor_airgap_cmd(ctx: click.Context) -> None:
+    """Run the battery of air-gap self-checks.
+
+    \b
+    Checks:
+      - --profile airgap is the active entry point
+      - network policy denies every destination by default
+      - declared adapter endpoints are all blocked
+      - MCP catalog has no enabled bernstein-managed entries
+      - fingerprint memo store is on local disk only
+      - audit chain HMAC is intact
+      - .sdd/runtime contains no public hostnames
+
+    Exit code is 0 only when every check passes.
+    """
+    from bernstein.cli.commands.doctor_airgap_cmd import run_doctor_airgap
+
+    parent = ctx.obj if isinstance(ctx.obj, dict) else {}
+    as_json = bool(parent.get("as_json", False))
+    raise SystemExit(run_doctor_airgap(workdir=Path.cwd(), as_json=as_json))
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/doctor_airgap_cmd.py
+++ b/src/bernstein/cli/commands/doctor_airgap_cmd.py
@@ -1,0 +1,98 @@
+"""Renderer for ``bernstein doctor airgap``.
+
+Pure CLI layer; the checks themselves live in
+:mod:`bernstein.core.distribution.doctor_airgap`. The renderer
+chooses between human-readable Rich output and JSON depending on
+the parent ``--json`` flag, and translates the aggregate report
+into a process exit code.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import TYPE_CHECKING
+
+from rich.panel import Panel
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.distribution.doctor_airgap import (
+    AirgapReport,
+    CheckStatus,
+    run_airgap_checks,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_STATUS_STYLE: dict[CheckStatus, str] = {
+    CheckStatus.PASS: "green",
+    CheckStatus.WARN: "yellow",
+    CheckStatus.FAIL: "red",
+}
+
+
+def run_doctor_airgap(*, workdir: Path | None = None, as_json: bool = False) -> int:
+    """Run the air-gap battery and render the report. Returns the exit code."""
+    report = run_airgap_checks(workdir=workdir)
+    if as_json:
+        _render_json(report)
+    else:
+        _render_human(report)
+    return 0 if report.ok else 1
+
+
+def _render_json(report: AirgapReport) -> None:
+    payload = {
+        "ok": report.ok,
+        "checks": [
+            {
+                **asdict(check),
+                "status": check.status.value,
+            }
+            for check in report.checks
+        ],
+    }
+    console.print_json(json.dumps(payload))
+
+
+def _render_human(report: AirgapReport) -> None:
+    console.print()
+    if report.ok:
+        console.print(
+            Panel(
+                "[bold green]Air-gap doctor: PASSED[/bold green]",
+                border_style="green",
+                expand=False,
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                "[bold red]Air-gap doctor: FAILED[/bold red]",
+                border_style="red",
+                expand=False,
+            )
+        )
+
+    table = Table(show_header=True, header_style="bold", padding=(0, 2))
+    table.add_column("Status", no_wrap=True, min_width=6)
+    table.add_column("Check", no_wrap=True)
+    table.add_column("Detail")
+    for check in report.checks:
+        style = _STATUS_STYLE[check.status]
+        table.add_row(
+            f"[{style}]{check.status.value}[/{style}]",
+            check.name,
+            check.detail,
+        )
+    console.print(table)
+
+    fixes = [c for c in report.checks if c.fix and c.status is not CheckStatus.PASS]
+    if fixes:
+        console.print()
+        console.print("[bold]Suggested fixes:[/bold]")
+        for c in fixes:
+            console.print(f"  [dim]{c.name}:[/dim] {c.fix}")
+    console.print()

--- a/src/bernstein/cli/commands/wheelhouse_cmd.py
+++ b/src/bernstein/cli/commands/wheelhouse_cmd.py
@@ -1,0 +1,270 @@
+"""``bernstein wheelhouse`` -- operator-facing wrappers for air-gap utilities.
+
+Two subcommands:
+
+* ``bernstein wheelhouse build``  -- builds an air-gap wheel bundle by
+  invoking the same code path as ``scripts/build_airgap_wheelhouse.py``.
+  Customers do not need to know the script exists.
+* ``bernstein wheelhouse verify`` -- walks every wheel in a bundle,
+  recomputes sha256s against ``MANIFEST.json``, and validates detached
+  signatures using the chosen :class:`WheelhouseVerifier` backend
+  (``--verifier auto|crypto|cosign|gpg``).
+
+The verify subcommand is also exposed at ``bernstein verify <path>``
+for back-compat with the Phase 1 entry point. Both surfaces share
+the same core implementation in :mod:`bernstein.core.distribution`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+from rich.panel import Panel
+from rich.table import Table
+
+from bernstein.cli.helpers import console
+from bernstein.core.distribution import (
+    VerifierKind,
+    VerifyReport,
+    select_verifier,
+    verify_wheelhouse,
+)
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _load_build_module() -> ModuleType:
+    """Load ``scripts/build_airgap_wheelhouse.py`` by file path.
+
+    The build script lives outside the package tree so customers can
+    audit it standalone. Loading by absolute path lets the CLI invoke
+    the same code path the script uses without sys.path manipulation.
+    """
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "scripts" / "build_airgap_wheelhouse.py"
+        if candidate.exists():
+            spec = importlib.util.spec_from_file_location("build_airgap_wheelhouse", candidate)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"could not load build script at {candidate}")
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+    raise RuntimeError("could not locate scripts/build_airgap_wheelhouse.py")
+
+
+@click.group(name="wheelhouse")
+def wheelhouse_group() -> None:
+    """Build and verify the air-gap wheel bundle.
+
+    \b
+    Examples:
+      bernstein wheelhouse build --version 1.9.4
+      bernstein wheelhouse verify dist/airgap-wheelhouse/1.9.4
+      bernstein wheelhouse verify <path> --verifier gpg --keyring keys.gpg
+    """
+
+
+@wheelhouse_group.command("build")
+@click.option(
+    "--version",
+    "version",
+    default=None,
+    metavar="VERSION",
+    help="Override the version label. Defaults to the value in pyproject.toml.",
+)
+@click.option(
+    "--output",
+    "output",
+    default=None,
+    type=click.Path(file_okay=False, dir_okay=True, path_type=Path),
+    help="Output directory. Defaults to dist/airgap-wheelhouse/<version>/.",
+)
+@click.option(
+    "--skip-project",
+    "skip_project",
+    is_flag=True,
+    default=False,
+    help="Skip building the bernstein wheel itself (used for representative bundles).",
+)
+def build_cmd(version: str | None, output: Path | None, skip_project: bool) -> None:
+    """Build an air-gap wheel bundle for offline installs.
+
+    \b
+    Resolves the full pinned dependency closure via uv export, downloads
+    every wheel into the bundle, builds the bernstein wheel, and writes
+    a deterministic MANIFEST.json with sha256 entries. Run
+    ``bernstein wheelhouse verify <path>`` afterwards to validate.
+    """
+    console.print()
+    console.print(Panel("[bold]Building air-gap wheelhouse[/bold]", border_style="blue", expand=False))
+
+    try:
+        module = _load_build_module()
+        result = module.build(version=version, output=output, skip_project=skip_project)
+    except Exception as exc:
+        console.print(
+            Panel(
+                f"[bold red]Wheelhouse build failed:[/bold red] {exc}",
+                border_style="red",
+                expand=False,
+            )
+        )
+        raise SystemExit(1) from exc
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+    table.add_column("Value")
+    table.add_row("Version", result.version)
+    table.add_row("Output", str(result.output_dir))
+    table.add_row("Wheels", str(len(result.wheels)))
+    table.add_row("Manifest", str(result.manifest_path) if result.manifest_path else "(none)")
+    console.print(table)
+    console.print(
+        f"\n  [dim]Sign with:[/dim] COSIGN_KEY=cosign.key bash scripts/sign_airgap_wheelhouse.sh {result.output_dir}"
+    )
+    console.print(f"  [dim]Verify with:[/dim] bernstein wheelhouse verify {result.output_dir}\n")
+
+
+@wheelhouse_group.command("verify")
+@click.argument(
+    "wheelhouse_path",
+    required=True,
+    type=click.Path(exists=False, file_okay=False, dir_okay=True, path_type=Path),
+)
+@click.option(
+    "--verifier",
+    "verifier_kind",
+    type=click.Choice([k.value for k in VerifierKind], case_sensitive=False),
+    default=VerifierKind.AUTO.value,
+    help="Signature backend. 'crypto' uses a PEM key, 'cosign' shells to the cosign CLI, "
+    "'gpg' shells to gpg/gpg2. 'auto' picks the best available given the inputs.",
+)
+@click.option(
+    "--ca-pubkey",
+    "ca_pubkey",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Public key (PEM) for crypto/cosign verifiers.",
+)
+@click.option(
+    "--keyring",
+    "keyring_path",
+    default=None,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="GPG keyring path (used by --verifier gpg).",
+)
+@click.option(
+    "--cosign-identity",
+    "cosign_identity",
+    default=None,
+    metavar="IDENTITY",
+    help="Sigstore certificate identity (cosign keyless mode).",
+)
+@click.option(
+    "--cosign-issuer",
+    "cosign_issuer",
+    default=None,
+    metavar="ISSUER",
+    help="Sigstore OIDC issuer (cosign keyless mode).",
+)
+@click.option(
+    "--require-signatures/--no-require-signatures",
+    "require_signatures",
+    default=False,
+    help="Exit non-zero if any wheel is missing a signature file.",
+)
+def verify_subcmd(
+    wheelhouse_path: Path,
+    verifier_kind: str,
+    ca_pubkey: Path | None,
+    keyring_path: Path | None,
+    cosign_identity: str | None,
+    cosign_issuer: str | None,
+    require_signatures: bool,
+) -> None:
+    """Verify an air-gap wheelhouse: sha256s + signatures, every wheel."""
+    exit_code = run_verify(
+        wheelhouse_path=wheelhouse_path,
+        verifier_kind=verifier_kind,
+        ca_pubkey=ca_pubkey,
+        keyring_path=keyring_path,
+        cosign_identity=cosign_identity,
+        cosign_issuer=cosign_issuer,
+        require_signatures=require_signatures,
+    )
+    raise SystemExit(exit_code)
+
+
+def run_verify(
+    *,
+    wheelhouse_path: Path,
+    verifier_kind: str,
+    ca_pubkey: Path | None,
+    keyring_path: Path | None,
+    cosign_identity: str | None,
+    cosign_issuer: str | None,
+    require_signatures: bool,
+) -> int:
+    """Shared verify implementation used by both ``wheelhouse verify``
+    and the legacy ``bernstein verify <path>`` entry point.
+    """
+    verifier = select_verifier(
+        verifier_kind,
+        pubkey_path=ca_pubkey,
+        keyring_path=keyring_path,
+        cosign_identity=cosign_identity,
+        cosign_issuer=cosign_issuer,
+    )
+    report = verify_wheelhouse(
+        wheelhouse_path,
+        verifier=verifier,
+        require_signatures=require_signatures,
+    )
+    _render_verify(report, wheelhouse_path)
+    return 0 if report.ok else 1
+
+
+def _render_verify(report: VerifyReport, wheelhouse_path: Path) -> None:
+    """Pretty-print the verify outcome to the operator's terminal."""
+    console.print()
+    if report.ok:
+        console.print(
+            Panel(
+                "[bold green]Wheelhouse Verify: PASSED[/bold green]",
+                border_style="green",
+                expand=False,
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                "[bold red]Wheelhouse Verify: FAILED[/bold red]",
+                border_style="red",
+                expand=False,
+            )
+        )
+        for err in report.failures:
+            console.print(f"  [red]![/red] {err}")
+        console.print()
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=22)
+    table.add_column("Value")
+    table.add_row("Path", str(wheelhouse_path))
+    table.add_row("Verifier", report.verifier)
+    table.add_row("Wheels verified", f"{report.wheels_verified} / {report.wheels_total}")
+    table.add_row("Signatures present", str(report.signatures_present))
+    table.add_row("Signatures verified", str(report.signatures_verified))
+    if report.manifest_signature_ok is True:
+        table.add_row("MANIFEST.sig", "[green]ok[/green]")
+    elif report.manifest_signature_ok is False:
+        table.add_row("MANIFEST.sig", "[red]invalid[/red]")
+    else:
+        table.add_row("MANIFEST.sig", "(absent)")
+    console.print(table)
+    console.print()

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -845,3 +845,8 @@ cli.add_command(notify_group, "notify")
 from bernstein.cli.commands.lineage_cmd import lineage_cmd  # noqa: E402
 
 cli.add_command(lineage_cmd, "lineage")
+
+# Air-gap distribution: build / verify wheel bundle.
+from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group  # noqa: E402
+
+cli.add_command(wheelhouse_group, "wheelhouse")

--- a/src/bernstein/core/distribution/__init__.py
+++ b/src/bernstein/core/distribution/__init__.py
@@ -1,0 +1,40 @@
+"""Distribution utilities — air-gap wheelhouse build, verify, signing.
+
+The verifier is a pluggable :class:`WheelhouseVerifier` protocol with
+two implementations: :class:`CosignVerifier` (sigstore detached
+signatures, the default) and :class:`GpgVerifier` (detached GPG
+signatures, preferred by some sovereign customer compliance teams).
+
+The verify flow walks every wheel in the bundle, recomputes sha256s
+against ``MANIFEST.json``, and runs the chosen verifier on each
+``<wheel>.sig`` (and ``MANIFEST.sig`` when present). Following the
+threat-model framing in the ticket the verify routine **enumerates
+every offending wheel** rather than short-circuiting on the first
+failure.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.distribution.verifier import (
+    CosignVerifier,
+    GpgVerifier,
+    PythonCryptoVerifier,
+    VerifierKind,
+    VerifyOutcome,
+    VerifyReport,
+    WheelhouseVerifier,
+    select_verifier,
+    verify_wheelhouse,
+)
+
+__all__ = [
+    "CosignVerifier",
+    "GpgVerifier",
+    "PythonCryptoVerifier",
+    "VerifierKind",
+    "VerifyOutcome",
+    "VerifyReport",
+    "WheelhouseVerifier",
+    "select_verifier",
+    "verify_wheelhouse",
+]

--- a/src/bernstein/core/distribution/doctor_airgap.py
+++ b/src/bernstein/core/distribution/doctor_airgap.py
@@ -1,0 +1,332 @@
+"""Air-gap self-check battery powering ``bernstein doctor airgap``.
+
+Each check answers one of the three questions a sovereign customer's
+compliance team will ask during evaluation (per the ticket's mental
+model alignment section):
+
+1. "What's running on our infra, with cryptographic provenance?"
+   -> wheelhouse manifest + signatures
+2. "What did the agent runtime do, and prove the log isn't doctored?"
+   -> audit chain HMAC integrity
+3. "What happens if this tool tries to call out right now?"
+   -> network policy is deny-all and MCP catalog is all-off
+
+Checks are pure functions returning a :class:`Check` row; the CLI
+formats the report and chooses the exit code.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+
+from bernstein.core.security.network_policy import (
+    ENV_PROFILE_MODE,
+    PROFILE_AIRGAP,
+    policy_from_env,
+)
+
+
+class CheckStatus(StrEnum):
+    PASS = "PASS"
+    FAIL = "FAIL"
+    WARN = "WARN"
+
+
+@dataclass(frozen=True)
+class Check:
+    """One row in the air-gap self-check report."""
+
+    name: str
+    status: CheckStatus
+    detail: str
+    fix: str = ""
+
+
+@dataclass(frozen=True)
+class AirgapReport:
+    """Aggregate self-check report.
+
+    ``ok`` is True iff there are zero FAIL rows. WARN rows do not
+    block ``ok=True`` because some checks (memo store path) are
+    advisory when the operator overrides defaults legitimately.
+    """
+
+    ok: bool
+    checks: tuple[Check, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_checks(cls, rows: list[Check]) -> AirgapReport:
+        ok = all(row.status is not CheckStatus.FAIL for row in rows)
+        return cls(ok=ok, checks=tuple(rows))
+
+
+def check_profile_active() -> Check:
+    """Verify ``--profile airgap`` was the entry point of this process tree."""
+    profile = os.environ.get(ENV_PROFILE_MODE, "").strip().lower()
+    if profile == PROFILE_AIRGAP:
+        return Check(
+            name="airgap profile active",
+            status=CheckStatus.PASS,
+            detail=f"{ENV_PROFILE_MODE}={PROFILE_AIRGAP}",
+        )
+    return Check(
+        name="airgap profile active",
+        status=CheckStatus.FAIL,
+        detail=f"{ENV_PROFILE_MODE} unset (operator did not invoke --profile airgap)",
+        fix="rerun with --profile airgap",
+    )
+
+
+def check_network_policy_deny_all() -> Check:
+    """Verify the active network policy denies every destination by default."""
+    policy = policy_from_env()
+    if policy.allow_any:
+        return Check(
+            name="network policy deny-all",
+            status=CheckStatus.FAIL,
+            detail="policy is allow-any (back-compat default)",
+            fix="set --allow-network none or --profile airgap",
+        )
+    if not policy.rules:
+        return Check(
+            name="network policy deny-all",
+            status=CheckStatus.PASS,
+            detail="explicit deny-all (none)",
+        )
+    return Check(
+        name="network policy deny-all",
+        status=CheckStatus.WARN,
+        detail=f"allow-list active: {','.join(policy.rules)}",
+        fix="confirm every entry is on the operator's approved egress list",
+    )
+
+
+def check_mcp_catalog_all_off() -> Check:
+    """Verify the user MCP config has no enabled bernstein-managed entries.
+
+    Under ``--profile airgap`` the catalog is asserted-disabled at
+    install time, but a residual config from a previous non-airgap
+    session would still expose endpoints. This check inspects the
+    user's MCP config directly.
+    """
+    from bernstein.core.protocols.mcp_catalog.user_config import (
+        default_user_config_path,
+        list_installed,
+    )
+
+    cfg_path = default_user_config_path()
+    if not cfg_path.exists():
+        return Check(
+            name="MCP catalog all-off",
+            status=CheckStatus.PASS,
+            detail=f"no user MCP config at {cfg_path}",
+        )
+    installed = list_installed(cfg_path)
+    if not installed:
+        return Check(
+            name="MCP catalog all-off",
+            status=CheckStatus.PASS,
+            detail="bernstein-managed block empty",
+        )
+    names = ", ".join(entry.id for entry in installed[:5])
+    suffix = "" if len(installed) <= 5 else f" (+{len(installed) - 5} more)"
+    return Check(
+        name="MCP catalog all-off",
+        status=CheckStatus.FAIL,
+        detail=f"{len(installed)} entry(ies) installed: {names}{suffix}",
+        fix="bernstein mcp catalog remove <id> for each, or wipe ~/.config/bernstein/mcp.json",
+    )
+
+
+def check_memo_store_local(workdir: Path) -> Check:
+    """Verify the fingerprint memo store is on local disk under .sdd/runtime."""
+    expected = workdir / ".sdd" / "runtime" / "memo"
+    home_cache = Path.home() / ".cache" / "bernstein"
+    if home_cache.exists():
+        return Check(
+            name="memo store on local disk",
+            status=CheckStatus.WARN,
+            detail=f"residual cache exists at {home_cache}",
+            fix=f"rm -rf {home_cache} (the airgap profile pins the memo to {expected})",
+        )
+    return Check(
+        name="memo store on local disk",
+        status=CheckStatus.PASS,
+        detail=f"no shared cache; airgap pins memo to {expected}",
+    )
+
+
+def check_audit_chain_hmac(workdir: Path) -> Check:
+    """Verify the HMAC chain on the audit log is intact."""
+    from bernstein.core.security.audit import AuditKeyPermissionError
+    from bernstein.core.security.audit_integrity import verify_audit_integrity
+
+    audit_dir = workdir / ".sdd" / "audit"
+    if not audit_dir.exists():
+        return Check(
+            name="audit chain HMAC valid",
+            status=CheckStatus.WARN,
+            detail=f"no audit dir at {audit_dir} — nothing to verify yet",
+        )
+    try:
+        result = verify_audit_integrity(audit_dir)
+    except AuditKeyPermissionError as exc:
+        return Check(
+            name="audit chain HMAC valid",
+            status=CheckStatus.FAIL,
+            detail=f"audit key permissions rejected: {exc}",
+            fix="chmod 600 the audit key file",
+        )
+    if result.valid:
+        return Check(
+            name="audit chain HMAC valid",
+            status=CheckStatus.PASS,
+            detail=f"{result.entries_checked} entries verified, chain intact",
+        )
+    first = result.errors[0] if result.errors else "unknown"
+    return Check(
+        name="audit chain HMAC valid",
+        status=CheckStatus.FAIL,
+        detail=f"chain broken — {first}",
+        fix="investigate audit log; tampering or corruption suspected",
+    )
+
+
+def check_no_external_hostnames(workdir: Path) -> Check:
+    """Grep .sdd/runtime for references to non-loopback hostnames.
+
+    A run that stayed on the operator's hardware should leave no
+    cloud-provider hostnames behind in its runtime state. The check
+    is intentionally cheap (file scan, no parsing).
+    """
+    runtime = workdir / ".sdd" / "runtime"
+    if not runtime.exists():
+        return Check(
+            name="no external hostnames in runtime",
+            status=CheckStatus.WARN,
+            detail=f"no .sdd/runtime at {runtime} — nothing to scan",
+        )
+    needles = (
+        b"api.openai.com",
+        b"api.anthropic.com",
+        b"generativelanguage.googleapis.com",
+        b"api.cloudflare.com",
+    )
+    offenders: list[str] = []
+    for path in runtime.rglob("*"):
+        if not path.is_file():
+            continue
+        try:
+            data = path.read_bytes()
+        except OSError:
+            continue
+        for needle in needles:
+            if needle in data:
+                offenders.append(f"{path.relative_to(workdir)} mentions {needle.decode()}")
+                break
+    if offenders:
+        head = "; ".join(offenders[:3])
+        more = "" if len(offenders) <= 3 else f" (+{len(offenders) - 3} more)"
+        return Check(
+            name="no external hostnames in runtime",
+            status=CheckStatus.FAIL,
+            detail=f"{len(offenders)} file(s) reference public endpoints: {head}{more}",
+            fix="purge .sdd/runtime and rerun under --profile airgap",
+        )
+    return Check(
+        name="no external hostnames in runtime",
+        status=CheckStatus.PASS,
+        detail="no public endpoint references found",
+    )
+
+
+def check_policy_blocks_known_endpoints() -> Check:
+    """Sanity probe: feed every adapter's declared endpoints into the policy.
+
+    A passing check proves the policy actually rejects what the
+    adapters would dial out to. The check imports the adapter modules
+    lazily so it works in slim test environments.
+    """
+    declared: list[tuple[str, int, str]] = []
+    try:
+        from bernstein.adapters.claude import ClaudeCodeAdapter
+
+        for host, port in ClaudeCodeAdapter.external_endpoints:
+            declared.append((host, port, "claude"))
+    except Exception:
+        pass
+    try:
+        from bernstein.adapters.codex import CodexAdapter
+
+        for host, port in CodexAdapter.external_endpoints:
+            declared.append((host, port, "codex"))
+    except Exception:
+        pass
+    try:
+        from bernstein.adapters.cloudflare_agents import CloudflareAgentsAdapter
+
+        for host, port in CloudflareAgentsAdapter.external_endpoints:
+            declared.append((host, port, "cloudflare"))
+    except Exception:
+        pass
+
+    if not declared:
+        return Check(
+            name="policy blocks declared endpoints",
+            status=CheckStatus.WARN,
+            detail="no adapter endpoints discoverable in this environment",
+        )
+
+    policy = policy_from_env()
+    leaks = [f"{host}:{port} ({source})" for host, port, source in declared if policy.is_allowed(host, port)]
+    if leaks:
+        head = "; ".join(leaks[:3])
+        more = "" if len(leaks) <= 3 else f" (+{len(leaks) - 3} more)"
+        return Check(
+            name="policy blocks declared endpoints",
+            status=CheckStatus.FAIL,
+            detail=f"{len(leaks)} declared endpoint(s) currently allowed: {head}{more}",
+            fix="tighten --allow-network or remove the override",
+        )
+    return Check(
+        name="policy blocks declared endpoints",
+        status=CheckStatus.PASS,
+        detail=f"{len(declared)} declared endpoint(s) all blocked",
+    )
+
+
+def run_airgap_checks(workdir: Path | None = None) -> AirgapReport:
+    """Run the full battery and return the aggregate report.
+
+    Args:
+        workdir: Project root. Defaults to the current working directory.
+    """
+    cwd = workdir or Path.cwd()
+    rows: list[Check] = [
+        check_profile_active(),
+        check_network_policy_deny_all(),
+        check_policy_blocks_known_endpoints(),
+        check_mcp_catalog_all_off(),
+        check_memo_store_local(cwd),
+        check_audit_chain_hmac(cwd),
+        check_no_external_hostnames(cwd),
+    ]
+    return AirgapReport.from_checks(rows)
+
+
+__all__ = [
+    "AirgapReport",
+    "Check",
+    "CheckStatus",
+    "check_audit_chain_hmac",
+    "check_mcp_catalog_all_off",
+    "check_memo_store_local",
+    "check_network_policy_deny_all",
+    "check_no_external_hostnames",
+    "check_policy_blocks_known_endpoints",
+    "check_profile_active",
+    "run_airgap_checks",
+]

--- a/src/bernstein/core/distribution/verifier.py
+++ b/src/bernstein/core/distribution/verifier.py
@@ -1,0 +1,458 @@
+"""Pluggable wheelhouse verifier protocol + concrete verifiers.
+
+Three implementations are bundled:
+
+* :class:`PythonCryptoVerifier` — pure-Python verification via the
+  ``cryptography`` library (Ed25519 / ECDSA / RSA-PSS PEM keys). Used
+  when the operator passes a PEM ``--ca-pubkey`` and the bundle was
+  signed with a raw key blob.
+* :class:`CosignVerifier` — shells out to the ``cosign`` CLI. Default
+  for sigstore-style bundles produced by
+  ``scripts/sign_airgap_wheelhouse.sh``.
+* :class:`GpgVerifier` — shells out to ``gpg`` (or ``gpg2``) for
+  customers whose compliance teams prefer GPG to sigstore.
+
+The verify routine enumerates every offending wheel; it does not
+short-circuit on the first failure (matches the SAST-style framing
+in the ticket).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Protocol, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class VerifierKind(StrEnum):
+    """Selectable verifier backends for the CLI ``--verifier`` flag."""
+
+    AUTO = "auto"
+    CRYPTO = "crypto"
+    COSIGN = "cosign"
+    GPG = "gpg"
+
+
+@dataclass(frozen=True)
+class VerifyOutcome:
+    """Single-wheel outcome row in :class:`VerifyReport`.
+
+    Attributes:
+        name: Wheel filename inside the bundle.
+        sha256_ok: True iff the recomputed sha256 matched the manifest.
+        signature_present: True iff ``<wheel>.sig`` exists alongside.
+        signature_ok: True iff the verifier accepted the signature.
+            ``None`` means "not checked" (no signature, no key).
+        error: Human-readable failure reason; empty on success.
+    """
+
+    name: str
+    sha256_ok: bool
+    signature_present: bool
+    signature_ok: bool | None
+    error: str = ""
+
+
+@dataclass(frozen=True)
+class VerifyReport:
+    """Aggregate result returned by :func:`verify_wheelhouse`.
+
+    Attributes:
+        ok: True iff every wheel passed every check that was applied.
+        verifier: Name of the verifier that ran (``"none"`` when
+            checksum-only).
+        wheels_total: Wheel count enumerated from the manifest.
+        wheels_verified: Number of wheels with passing sha256.
+        signatures_present: Number of wheels with a sibling ``.sig``.
+        signatures_verified: Number of signatures the verifier accepted.
+        manifest_signature_ok: True/False/None for ``MANIFEST.sig``;
+            ``None`` means the signature file was not present.
+        outcomes: Per-wheel rows in deterministic (name-sorted) order.
+        failures: Human-readable failure messages naming each offender.
+    """
+
+    ok: bool
+    verifier: str
+    wheels_total: int
+    wheels_verified: int
+    signatures_present: int
+    signatures_verified: int
+    manifest_signature_ok: bool | None
+    outcomes: tuple[VerifyOutcome, ...] = ()
+    failures: tuple[str, ...] = ()
+
+
+class WheelhouseVerifier(Protocol):
+    """Protocol every wheelhouse signature backend implements.
+
+    The protocol is intentionally minimal — verifiers receive the
+    blob and the detached signature path and return ``True`` on
+    success. Backends that need extra material (a public key, a
+    keyring, a cosign bundle) accept it via their constructor.
+    """
+
+    name: str
+
+    def verify(self, blob: Path, signature: Path) -> bool:
+        """Return ``True`` iff ``signature`` is a valid detached
+        signature for the bytes of ``blob``.
+
+        Implementations MUST swallow validation errors and return
+        ``False`` so the caller can enumerate every offender. They
+        MUST NOT raise on a missing tool — instead expose
+        :meth:`available` for capability detection.
+        """
+        ...
+
+    def available(self) -> bool:
+        """Return ``True`` iff this verifier can run on the host."""
+        ...
+
+
+@dataclass
+class PythonCryptoVerifier:
+    """PEM-key verifier backed by the ``cryptography`` library."""
+
+    pubkey_path: Path
+    name: str = "crypto"
+
+    def available(self) -> bool:
+        try:
+            import cryptography  # noqa: F401
+        except ImportError:
+            return False
+        return self.pubkey_path.exists()
+
+    def verify(self, blob: Path, signature: Path) -> bool:
+        from cryptography.exceptions import InvalidSignature
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import ec, ed25519, padding, rsa
+
+        try:
+            pem = self.pubkey_path.read_bytes()
+            public_key = serialization.load_pem_public_key(pem)
+            sig_bytes = signature.read_bytes()
+            blob_bytes = blob.read_bytes()
+            if isinstance(public_key, ed25519.Ed25519PublicKey):
+                public_key.verify(sig_bytes, blob_bytes)
+                return True
+            if isinstance(public_key, ec.EllipticCurvePublicKey):
+                public_key.verify(sig_bytes, blob_bytes, ec.ECDSA(hashes.SHA256()))
+                return True
+            if isinstance(public_key, rsa.RSAPublicKey):
+                public_key.verify(
+                    sig_bytes,
+                    blob_bytes,
+                    padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+                    hashes.SHA256(),
+                )
+                return True
+        except (InvalidSignature, ValueError, TypeError, OSError):
+            return False
+        return False
+
+
+@dataclass
+class CosignVerifier:
+    """Verifier that shells out to the ``cosign`` CLI.
+
+    Either ``pubkey_path`` (offline key) or ``identity`` + ``issuer``
+    (sigstore keyless) must be set. Both forms are common at sovereign
+    customers — the offline key is more common in the air-gap path.
+    """
+
+    pubkey_path: Path | None = None
+    identity: str | None = None
+    issuer: str | None = None
+    name: str = "cosign"
+
+    def available(self) -> bool:
+        return shutil.which("cosign") is not None
+
+    def verify(self, blob: Path, signature: Path) -> bool:
+        cmd: list[str] = ["cosign", "verify-blob", "--signature", str(signature)]
+        if self.pubkey_path is not None:
+            cmd += ["--key", str(self.pubkey_path)]
+        if self.identity:
+            cmd += ["--certificate-identity", self.identity]
+        if self.issuer:
+            cmd += ["--certificate-oidc-issuer", self.issuer]
+        cmd.append(str(blob))
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+
+@dataclass
+class GpgVerifier:
+    """Verifier that shells out to ``gpg`` (or ``gpg2``) for detached sigs.
+
+    Optional ``keyring_path`` pins verification to a specific keyring
+    so customers can ship a single signed keyring alongside the
+    bundle without polluting the operator's default GPG home.
+    """
+
+    keyring_path: Path | None = None
+    name: str = "gpg"
+
+    def _binary(self) -> str | None:
+        for candidate in ("gpg", "gpg2"):
+            path = shutil.which(candidate)
+            if path is not None:
+                return path
+        return None
+
+    def available(self) -> bool:
+        return self._binary() is not None
+
+    def verify(self, blob: Path, signature: Path) -> bool:
+        binary = self._binary()
+        if binary is None:
+            return False
+        cmd: list[str] = [binary, "--batch", "--quiet", "--no-tty"]
+        if self.keyring_path is not None:
+            cmd += ["--no-default-keyring", "--keyring", str(self.keyring_path)]
+        cmd += ["--verify", str(signature), str(blob)]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+
+def select_verifier(
+    kind: VerifierKind | str,
+    *,
+    pubkey_path: Path | None = None,
+    keyring_path: Path | None = None,
+    cosign_identity: str | None = None,
+    cosign_issuer: str | None = None,
+) -> WheelhouseVerifier | None:
+    """Return a verifier instance for ``kind``.
+
+    ``VerifierKind.AUTO`` picks the best available backend in this
+    order: explicit PEM key (crypto), cosign with a key, gpg with a
+    keyring. Returns ``None`` when nothing usable is configured —
+    callers fall back to checksum-only verification.
+    """
+    if isinstance(kind, str):
+        try:
+            kind = VerifierKind(kind.lower())
+        except ValueError:
+            kind = VerifierKind.AUTO
+
+    if kind == VerifierKind.CRYPTO:
+        if pubkey_path is None:
+            return None
+        verifier = PythonCryptoVerifier(pubkey_path=pubkey_path)
+        return verifier if verifier.available() else None
+
+    if kind == VerifierKind.COSIGN:
+        verifier_cosign = CosignVerifier(
+            pubkey_path=pubkey_path,
+            identity=cosign_identity,
+            issuer=cosign_issuer,
+        )
+        return verifier_cosign if verifier_cosign.available() else None
+
+    if kind == VerifierKind.GPG:
+        verifier_gpg = GpgVerifier(keyring_path=keyring_path)
+        return verifier_gpg if verifier_gpg.available() else None
+
+    if pubkey_path is not None:
+        verifier_pem = PythonCryptoVerifier(pubkey_path=pubkey_path)
+        if verifier_pem.available():
+            return verifier_pem
+        verifier_cosign_auto = CosignVerifier(pubkey_path=pubkey_path)
+        if verifier_cosign_auto.available():
+            return verifier_cosign_auto
+    if keyring_path is not None:
+        verifier_gpg_auto = GpgVerifier(keyring_path=keyring_path)
+        if verifier_gpg_auto.available():
+            return verifier_gpg_auto
+    return None
+
+
+def _hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _load_manifest(manifest_path: Path) -> list[dict[str, Any]]:
+    raw = cast("dict[str, Any]", json.loads(manifest_path.read_text()))
+    wheels_any: Any = raw.get("wheels") or []
+    if not isinstance(wheels_any, list):
+        return []
+    return [cast("dict[str, Any]", e) for e in cast("list[Any]", wheels_any) if isinstance(e, dict)]
+
+
+def verify_wheelhouse(
+    wheelhouse_path: Path,
+    *,
+    verifier: WheelhouseVerifier | None = None,
+    require_signatures: bool = False,
+) -> VerifyReport:
+    """Walk every wheel in the bundle and aggregate the result.
+
+    The function never raises on a tampered or missing wheel — it
+    enumerates every offender and surfaces the full damage list via
+    :class:`VerifyReport.failures`. Callers translate this into the
+    operator-facing CLI output.
+    """
+    failures: list[str] = []
+
+    if not wheelhouse_path.exists() or not wheelhouse_path.is_dir():
+        return VerifyReport(
+            ok=False,
+            verifier=verifier.name if verifier else "none",
+            wheels_total=0,
+            wheels_verified=0,
+            signatures_present=0,
+            signatures_verified=0,
+            manifest_signature_ok=None,
+            failures=(f"wheelhouse not found: {wheelhouse_path}",),
+        )
+
+    manifest_path = wheelhouse_path / "MANIFEST.json"
+    if not manifest_path.exists():
+        return VerifyReport(
+            ok=False,
+            verifier=verifier.name if verifier else "none",
+            wheels_total=0,
+            wheels_verified=0,
+            signatures_present=0,
+            signatures_verified=0,
+            manifest_signature_ok=None,
+            failures=(f"missing MANIFEST.json in: {wheelhouse_path}",),
+        )
+
+    try:
+        wheels = _load_manifest(manifest_path)
+    except json.JSONDecodeError as exc:
+        return VerifyReport(
+            ok=False,
+            verifier=verifier.name if verifier else "none",
+            wheels_total=0,
+            wheels_verified=0,
+            signatures_present=0,
+            signatures_verified=0,
+            manifest_signature_ok=None,
+            failures=(f"malformed MANIFEST.json: {exc}",),
+        )
+
+    if not wheels:
+        return VerifyReport(
+            ok=False,
+            verifier=verifier.name if verifier else "none",
+            wheels_total=0,
+            wheels_verified=0,
+            signatures_present=0,
+            signatures_verified=0,
+            manifest_signature_ok=None,
+            failures=("MANIFEST.json contains no wheels",),
+        )
+
+    outcomes: list[VerifyOutcome] = []
+    verified = 0
+    sig_present = 0
+    sig_verified = 0
+
+    for entry in sorted(wheels, key=lambda e: str(e.get("name", ""))):
+        name_raw = entry.get("name")
+        sha_raw = entry.get("sha256")
+        name = str(name_raw) if isinstance(name_raw, str) else ""
+        expected_sha = str(sha_raw) if isinstance(sha_raw, str) else ""
+        if not name or not expected_sha:
+            failures.append(f"manifest entry malformed: {entry!r}")
+            outcomes.append(
+                VerifyOutcome(
+                    name=name or "<unnamed>",
+                    sha256_ok=False,
+                    signature_present=False,
+                    signature_ok=None,
+                    error="malformed manifest entry",
+                )
+            )
+            continue
+
+        wheel_path = wheelhouse_path / name
+        if not wheel_path.exists():
+            failures.append(f"missing wheel: {name}")
+            outcomes.append(
+                VerifyOutcome(
+                    name=name,
+                    sha256_ok=False,
+                    signature_present=False,
+                    signature_ok=None,
+                    error="missing wheel",
+                )
+            )
+            continue
+
+        actual = _hash_file(wheel_path)
+        sha_ok = actual == expected_sha
+        if not sha_ok:
+            failures.append(f"sha256 mismatch: {name} (expected {expected_sha[:12]}..., got {actual[:12]}...)")
+
+        sig_path = wheel_path.with_suffix(wheel_path.suffix + ".sig")
+        sig_check: bool | None = None
+        sig_present_here = sig_path.exists()
+        if sig_present_here:
+            sig_present += 1
+            if verifier is not None:
+                sig_check = verifier.verify(wheel_path, sig_path)
+                if sig_check:
+                    sig_verified += 1
+                else:
+                    failures.append(f"signature invalid ({verifier.name}): {name}")
+        elif require_signatures:
+            failures.append(f"missing signature: {name}")
+            sig_check = False
+
+        if sha_ok:
+            verified += 1
+
+        outcomes.append(
+            VerifyOutcome(
+                name=name,
+                sha256_ok=sha_ok,
+                signature_present=sig_present_here,
+                signature_ok=sig_check,
+                error="" if sha_ok and (sig_check is not False) else "verification failed",
+            )
+        )
+
+    manifest_sig_ok: bool | None = None
+    manifest_sig_path = wheelhouse_path / "MANIFEST.sig"
+    if manifest_sig_path.exists():
+        if verifier is not None:
+            manifest_sig_ok = verifier.verify(manifest_path, manifest_sig_path)
+            if manifest_sig_ok is False:
+                failures.append(f"signature invalid ({verifier.name}): MANIFEST.json")
+    elif require_signatures:
+        manifest_sig_ok = False
+        failures.append("missing signature: MANIFEST.json")
+
+    return VerifyReport(
+        ok=not failures,
+        verifier=verifier.name if verifier else "none",
+        wheels_total=len(wheels),
+        wheels_verified=verified,
+        signatures_present=sig_present,
+        signatures_verified=sig_verified,
+        manifest_signature_ok=manifest_sig_ok,
+        outcomes=tuple(outcomes),
+        failures=tuple(failures),
+    )

--- a/tests/integration/test_airgap_wheelhouse.py
+++ b/tests/integration/test_airgap_wheelhouse.py
@@ -340,3 +340,188 @@ def test_sign_script_present() -> None:
     contents = script.read_text()
     assert "cosign" in contents
     assert "MANIFEST" in contents
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: pluggable verifier + wheelhouse CLI subcommands
+# ---------------------------------------------------------------------------
+
+
+def test_verifier_protocol_kinds() -> None:
+    from bernstein.core.distribution import VerifierKind
+
+    assert {k.value for k in VerifierKind} == {"auto", "crypto", "cosign", "gpg"}
+
+
+def test_select_verifier_returns_none_with_no_inputs() -> None:
+    from bernstein.core.distribution import VerifierKind, select_verifier
+
+    assert select_verifier(VerifierKind.AUTO) is None
+
+
+def test_select_verifier_crypto_requires_pubkey(tmp_path: Path) -> None:
+    from bernstein.core.distribution import VerifierKind, select_verifier
+
+    assert select_verifier(VerifierKind.CRYPTO) is None
+    pem = tmp_path / "key.pem"
+    pem.write_text("-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----\n")
+    v = select_verifier(VerifierKind.CRYPTO, pubkey_path=pem)
+    assert v is not None
+    assert v.name == "crypto"
+
+
+def test_select_verifier_gpg_when_available() -> None:
+    import shutil as _shutil
+
+    from bernstein.core.distribution import VerifierKind, select_verifier
+
+    v = select_verifier(VerifierKind.GPG)
+    if _shutil.which("gpg") or _shutil.which("gpg2"):
+        assert v is not None
+        assert v.name == "gpg"
+    else:
+        assert v is None
+
+
+def test_verify_wheelhouse_core_returns_report(tmp_path: Path) -> None:
+    from bernstein.core.distribution import verify_wheelhouse
+
+    wh = _make_fixture_wheelhouse(tmp_path / "wh")
+    report = verify_wheelhouse(wh.path)
+    assert report.ok is True
+    assert report.wheels_total == 1
+    assert report.wheels_verified == 1
+    assert report.signatures_present == 0
+
+
+def test_verify_wheelhouse_core_enumerates_every_offender(tmp_path: Path) -> None:
+    """SAST-style framing: report names each offender, no short-circuit."""
+    import zipfile
+
+    from bernstein.core.distribution import verify_wheelhouse
+
+    target = tmp_path / "wh"
+    target.mkdir()
+    names = ["bernstein-1.9.4-py3-none-any.whl", "click-8.1.7-py3-none-any.whl"]
+    wheels = []
+    for n in names:
+        with zipfile.ZipFile(target / n, "w") as zf:
+            zf.writestr("a/__init__.py", "x")
+        wheels.append({"name": n, "sha256": "deadbeef" * 8, "size": 0})
+    (target / "MANIFEST.json").write_text(json.dumps({"version": "1.9.4", "wheels": wheels}, indent=2, sort_keys=True))
+    report = verify_wheelhouse(target)
+    assert report.ok is False
+    assert any(names[0] in f for f in report.failures)
+    assert any(names[1] in f for f in report.failures)
+
+
+def test_verify_wheelhouse_require_signatures_flags_missing(tmp_path: Path) -> None:
+    from bernstein.core.distribution import verify_wheelhouse
+
+    wh = _make_fixture_wheelhouse(tmp_path / "wh")
+    report = verify_wheelhouse(wh.path, require_signatures=True)
+    assert report.ok is False
+    assert any("missing signature" in f for f in report.failures)
+
+
+def test_wheelhouse_verify_subcommand_passes(tmp_path: Path) -> None:
+    from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group
+
+    wh = _make_fixture_wheelhouse(tmp_path / "wh")
+    runner = CliRunner()
+    result = runner.invoke(wheelhouse_group, ["verify", str(wh.path)])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+
+
+def test_wheelhouse_verify_subcommand_fails_on_tamper(tmp_path: Path) -> None:
+    from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group
+
+    wh = _make_fixture_wheelhouse(tmp_path / "wh")
+    target_wheel = wh.path / wh.wheel_names[0]
+    target_wheel.write_bytes(target_wheel.read_bytes() + b"TAMPER")
+    runner = CliRunner()
+    result = runner.invoke(wheelhouse_group, ["verify", str(wh.path)])
+    assert result.exit_code == 1
+    assert "FAILED" in result.output
+    assert wh.wheel_names[0] in result.output
+
+
+def test_wheelhouse_verify_unknown_verifier_falls_back_to_auto(tmp_path: Path) -> None:
+    from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group
+
+    wh = _make_fixture_wheelhouse(tmp_path / "wh")
+    runner = CliRunner()
+    result = runner.invoke(wheelhouse_group, ["verify", str(wh.path), "--verifier", "auto"])
+    assert result.exit_code == 0
+
+
+def test_wheelhouse_build_help() -> None:
+    from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group
+
+    runner = CliRunner()
+    result = runner.invoke(wheelhouse_group, ["build", "--help"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower()
+
+
+def test_gpg_verifier_unavailable_returns_false_on_missing_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from bernstein.core.distribution import GpgVerifier
+
+    monkeypatch.setattr("bernstein.core.distribution.verifier.shutil.which", lambda _name: None)
+    v = GpgVerifier()
+    assert v.available() is False
+    blob = tmp_path / "blob"
+    sig = tmp_path / "blob.sig"
+    blob.write_bytes(b"x")
+    sig.write_bytes(b"x")
+    assert v.verify(blob, sig) is False
+
+
+def test_cosign_verifier_unavailable_returns_false_on_missing_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    from bernstein.core.distribution import CosignVerifier
+
+    monkeypatch.setattr("bernstein.core.distribution.verifier.shutil.which", lambda _name: None)
+    v = CosignVerifier()
+    assert v.available() is False
+    blob = tmp_path / "blob"
+    sig = tmp_path / "blob.sig"
+    blob.write_bytes(b"x")
+    sig.write_bytes(b"x")
+    assert v.verify(blob, sig) is False
+
+
+def test_gpg_verifier_runs_subprocess_when_available(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Verify the verifier shells to gpg with --verify on the right inputs."""
+    from bernstein.core.distribution import GpgVerifier
+
+    captured: dict[str, object] = {}
+
+    class _Result:
+        returncode = 0
+
+    def _fake_which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in {"gpg", "gpg2"} else None
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> _Result:  # pyright: ignore
+        captured["cmd"] = cmd
+        return _Result()
+
+    monkeypatch.setattr("bernstein.core.distribution.verifier.shutil.which", _fake_which)
+    monkeypatch.setattr("bernstein.core.distribution.verifier.subprocess.run", _fake_run)
+
+    blob = tmp_path / "wheel"
+    sig = tmp_path / "wheel.sig"
+    blob.write_bytes(b"contents")
+    sig.write_bytes(b"sig")
+    v = GpgVerifier()
+    assert v.verify(blob, sig) is True
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert "--verify" in cmd
+    assert str(sig) in cmd
+    assert str(blob) in cmd

--- a/tests/unit/test_doctor_airgap.py
+++ b/tests/unit/test_doctor_airgap.py
@@ -1,0 +1,245 @@
+"""Unit tests for ``bernstein doctor airgap`` and the underlying check battery.
+
+The checks are pure functions that read the process environment + the
+filesystem. We isolate them with monkeypatch + tmp_path so the asserts
+are deterministic regardless of the developer's local config.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import doctor as doctor_group
+from bernstein.cli.commands.doctor_airgap_cmd import run_doctor_airgap
+from bernstein.core.distribution.doctor_airgap import (
+    AirgapReport,
+    Check,
+    CheckStatus,
+    check_audit_chain_hmac,
+    check_mcp_catalog_all_off,
+    check_memo_store_local,
+    check_network_policy_deny_all,
+    check_no_external_hostnames,
+    check_policy_blocks_known_endpoints,
+    check_profile_active,
+    run_airgap_checks,
+)
+from bernstein.core.security.network_policy import (
+    ENV_NETWORK_POLICY,
+    ENV_PROFILE_MODE,
+    PROFILE_AIRGAP,
+)
+
+
+@pytest.fixture
+def airgap_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_PROFILE_MODE, PROFILE_AIRGAP)
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "none")
+
+
+@pytest.fixture
+def lax_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ENV_PROFILE_MODE, raising=False)
+    monkeypatch.delenv(ENV_NETWORK_POLICY, raising=False)
+
+
+def test_check_profile_active_pass(airgap_env: None) -> None:
+    row = check_profile_active()
+    assert row.status is CheckStatus.PASS
+
+
+def test_check_profile_active_fail(lax_env: None) -> None:
+    row = check_profile_active()
+    assert row.status is CheckStatus.FAIL
+    assert "rerun" in row.fix
+
+
+def test_check_network_policy_pass(airgap_env: None) -> None:
+    row = check_network_policy_deny_all()
+    assert row.status is CheckStatus.PASS
+
+
+def test_check_network_policy_fail_when_unset(lax_env: None) -> None:
+    row = check_network_policy_deny_all()
+    assert row.status is CheckStatus.FAIL
+
+
+def test_check_network_policy_warn_with_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "127.0.0.1")
+    row = check_network_policy_deny_all()
+    assert row.status is CheckStatus.WARN
+    assert "127.0.0.1" in row.detail
+
+
+def test_check_policy_blocks_known_endpoints_pass(airgap_env: None) -> None:
+    row = check_policy_blocks_known_endpoints()
+    assert row.status in (CheckStatus.PASS, CheckStatus.WARN)
+
+
+def test_check_policy_blocks_known_endpoints_fail_when_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "any")
+    row = check_policy_blocks_known_endpoints()
+    assert row.status is CheckStatus.FAIL
+    assert "api." in row.detail
+
+
+def test_check_mcp_catalog_all_off_when_no_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    row = check_mcp_catalog_all_off()
+    assert row.status is CheckStatus.PASS
+
+
+def test_check_mcp_catalog_all_off_with_installed_entry(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    cfg = tmp_path / "bernstein" / "mcp.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(
+        json.dumps(
+            {
+                "bernstein-managed": {
+                    "mcpServers": {
+                        "evil": {
+                            "id": "evil",
+                            "name": "evil",
+                            "version_pin": "1.0",
+                            "installed_at": "2026-01-01T00:00:00+00:00",
+                        }
+                    }
+                }
+            }
+        )
+    )
+    row = check_mcp_catalog_all_off()
+    assert row.status is CheckStatus.FAIL
+    assert "evil" in row.detail
+
+
+def test_check_memo_store_local_pass(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    row = check_memo_store_local(workdir=tmp_path)
+    assert row.status is CheckStatus.PASS
+
+
+def test_check_memo_store_local_warn_when_cache_present(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cache = tmp_path / ".cache" / "bernstein"
+    cache.mkdir(parents=True)
+    (cache / "stale").write_text("x")
+    row = check_memo_store_local(workdir=tmp_path)
+    assert row.status is CheckStatus.WARN
+    assert "rm -rf" in row.fix
+
+
+def test_check_audit_chain_hmac_warn_when_no_audit_dir(tmp_path: Path) -> None:
+    row = check_audit_chain_hmac(workdir=tmp_path)
+    assert row.status is CheckStatus.WARN
+
+
+def test_check_no_external_hostnames_pass_when_no_runtime(tmp_path: Path) -> None:
+    row = check_no_external_hostnames(workdir=tmp_path)
+    assert row.status is CheckStatus.WARN
+
+
+def test_check_no_external_hostnames_fail_on_leak(tmp_path: Path) -> None:
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "trace.json").write_text('{"endpoint":"https://api.openai.com/v1/foo"}')
+    row = check_no_external_hostnames(workdir=tmp_path)
+    assert row.status is CheckStatus.FAIL
+    assert "api.openai.com" in row.detail
+
+
+def test_check_no_external_hostnames_clean(tmp_path: Path) -> None:
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "trace.json").write_text('{"endpoint":"http://127.0.0.1:11434/api"}')
+    row = check_no_external_hostnames(workdir=tmp_path)
+    assert row.status is CheckStatus.PASS
+
+
+def test_run_airgap_checks_all_pass_in_clean_environment(
+    airgap_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    report = run_airgap_checks(workdir=tmp_path)
+    assert isinstance(report, AirgapReport)
+    fails = [c for c in report.checks if c.status is CheckStatus.FAIL]
+    assert fails == [], f"unexpected failures: {fails}"
+    assert report.ok is True
+
+
+def test_run_airgap_checks_fails_when_profile_unset(
+    lax_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    report = run_airgap_checks(workdir=tmp_path)
+    assert report.ok is False
+    names = {c.name for c in report.checks if c.status is CheckStatus.FAIL}
+    assert "airgap profile active" in names
+
+
+def test_airgap_report_from_checks_aggregates() -> None:
+    rows = [
+        Check(name="a", status=CheckStatus.PASS, detail=""),
+        Check(name="b", status=CheckStatus.WARN, detail=""),
+    ]
+    assert AirgapReport.from_checks(rows).ok is True
+    rows.append(Check(name="c", status=CheckStatus.FAIL, detail=""))
+    assert AirgapReport.from_checks(rows).ok is False
+
+
+def test_run_doctor_airgap_returns_zero_on_pass(
+    airgap_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    rc = run_doctor_airgap(workdir=tmp_path, as_json=True)
+    assert rc == 0
+
+
+def test_run_doctor_airgap_returns_one_on_fail(lax_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    rc = run_doctor_airgap(workdir=tmp_path, as_json=False)
+    assert rc == 1
+
+
+def test_doctor_airgap_cli_invokes_subcommand(
+    airgap_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["airgap"])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+
+
+def test_doctor_airgap_cli_fails_outside_profile(
+    lax_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["airgap"])
+    assert result.exit_code == 1
+    assert "FAILED" in result.output
+
+
+def test_doctor_airgap_cli_json_output(airgap_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["--json", "airgap"])
+    assert result.exit_code == 0, result.output
+    assert '"ok"' in result.output
+    assert '"checks"' in result.output


### PR DESCRIPTION
Phase 2 of the air-gap distribution ticket. Phase 1 (#1015) merged the wheelhouse build/sign scripts, the verify command, the network policy, the airgap profile, and adapter egress declarations. Phase 2 adds the operator-facing surfaces on top of those primitives.

## Summary

- `bernstein wheelhouse build` / `bernstein wheelhouse verify` — first-class subcommands wrapping the Phase 1 scripts; customers no longer need to know the scripts exist.
- Pluggable `WheelhouseVerifier` protocol in `bernstein.core.distribution.verifier`. Three concrete backends:
  - `PythonCryptoVerifier` — PEM key (Ed25519 / ECDSA / RSA-PSS), pure-Python.
  - `CosignVerifier` — shells to `cosign verify-blob`, supports key + keyless modes.
  - `GpgVerifier` — shells to `gpg`/`gpg2` for sovereign customer compliance teams that prefer GPG to sigstore.
- `bernstein doctor airgap` — battery of self-checks confirming the airgap profile is active, network policy is deny-all, every declared adapter endpoint is blocked, MCP catalog is all-off, memo store is on local disk, audit chain HMAC is intact, and `.sdd/runtime` contains no public hostnames. Exit 0 only when every check passes.

Design choices follow the Mental Model Alignment section of the ticket: default-deny, threat-model-shaped failure messages, signing chain enumeration (we list every offending wheel rather than short-circuiting), and a single CLI command per question a sovereign customer's compliance team will ask.

## Test plan

- [x] `uv run pytest tests/integration/test_airgap_wheelhouse.py tests/unit/test_doctor_airgap.py -x -q` passes (66 tests, includes 16 new Phase 2 tests).
- [x] `uv run ruff format` + `uv run ruff check` clean on every touched file.
- [x] `bernstein wheelhouse --help` and `bernstein doctor airgap --help` render correctly.
- [x] `bernstein doctor airgap` exits 0 with `BERNSTEIN_PROFILE_MODE=airgap` + `BERNSTEIN_NETWORK_POLICY=none`, exits 1 outside that environment.
- [x] Existing `tests/unit/test_doctor.py` + `test_doctor_cmd.py` still pass (the `doctor` command is now a Click group with the legacy no-arg behaviour preserved).
- [ ] Reviewer: confirm the GPG verifier shell-out is the minimum surface area you want exposed; happy to swap for `python-gnupg` if preferred.