### PR TITLE
feat(cluster): native mTLS for node-to-node transport (Phase 1)

### DIFF
--- a/docs/cluster/mtls-setup.md
+++ b/docs/cluster/mtls-setup.md
@@ -1,0 +1,145 @@
+# Cluster mTLS setup
+
+Bernstein's cluster mode supports native mutual TLS on the node-to-node
+transport. This is opt-in: existing plain-HTTP deployments keep working.
+When TLS is configured, every registration, heartbeat, and task-steal call
+between the central server and worker nodes goes over `https://` and the
+TLS handshake validates the peer certificate before any HTTP byte is read.
+
+mTLS authenticates the *channel*. The existing JWT bearer token still
+authorises the *action* — both layers compose.
+
+## When to turn it on
+
+- The cluster is internet-facing or crosses untrusted networks.
+- You're running a regulated workload and need encryption-in-transit
+  evidence for audit.
+- Bernstein is one of several services in a shared K8s namespace and you
+  want to avoid wrapping every call in an Istio sidecar.
+
+For a single-VPC, single-namespace deployment where all traffic is
+already on a trusted backbone, plain HTTP plus the JWT token is still a
+defensible default.
+
+## What you need
+
+Three artifacts on the central server, three on every worker:
+
+| File         | Central       | Worker        | Purpose                       |
+|--------------|---------------|---------------|-------------------------------|
+| `ca.crt`     | yes           | yes           | Trust anchor                  |
+| `server.crt` | yes           | no            | Central node identity         |
+| `server.key` | yes (chmod 0600) | no         | Central node private key      |
+| `node.crt`   | no            | yes           | Worker identity               |
+| `node.key`   | no            | yes (chmod 0600) | Worker private key         |
+
+The CA can be any PKI you already operate (step-ca, cert-manager,
+HashiCorp Vault, your corporate CA). For a self-hosted internal cluster
+where you don't have a CA yet, Bernstein ships a one-shot helper.
+
+## Quick start: self-signed CA
+
+```bash
+bernstein cluster bootstrap-ca
+```
+
+Writes the trio above to `~/.bernstein/cluster/`. Private keys are
+chmod 0600. Pass `--out-dir` to override the destination, `--server-san`
+(repeatable) to add DNS SANs to the server cert.
+
+> **This is a self-signed CA.** It's appropriate for self-hosted
+> internal clusters on infrastructure you control. For production
+> deployments — anything customer-facing, anything regulated, anything
+> where cert rotation needs to be automated — use your own CA.
+
+## Wiring TLS into ClusterConfig
+
+`ClusterConfig` gained a `tls` field (`TLSConfig | None`). When set, the
+URL scheme derived for cluster traffic flips from `http` to `https`
+automatically.
+
+```python
+from pathlib import Path
+from bernstein.core.models import ClusterConfig
+from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+
+tls = TLSConfig(
+    ca_file=Path("~/.bernstein/cluster/ca.crt"),
+    cert_file=Path("~/.bernstein/cluster/server.crt"),
+    key_file=Path("~/.bernstein/cluster/server.key"),
+    verify_mode="required",
+)
+config = ClusterConfig(enabled=True, tls=tls, server_url="https://central.example.com:8052")
+assert config.cluster_url_scheme == "https"
+```
+
+`verify_mode` accepts:
+
+- `"required"` — full mTLS. Workers without a valid client cert are
+  rejected at the TLS handshake. **Use this in production.**
+- `"optional"` — TLS server auth is mandatory; client cert is requested
+  but accepted if absent. Useful for staged rollouts.
+- `"disabled"` — TLS is on, but no client cert verification. The cert
+  chain is loaded for the encryption-in-transit guarantee only.
+
+## Distributing keys to workers
+
+`bootstrap-ca` writes both `server.*` and `node.*` to a single directory
+on the operator's machine. Distribute the worker artifacts out-of-band
+(scp, your secret manager, a config-management tool, K8s secret) — never
+commit them to git, never push them through the cluster API itself.
+
+A worker only needs `ca.crt`, `node.crt`, `node.key`. Drop them into the
+worker's `~/.bernstein/cluster/` (or whatever path you prefer) and point
+its `ClusterConfig.tls` at them.
+
+## Rotation
+
+Phase 1 ships with **manual rotation only**. Steps:
+
+1. Generate a new server cert + key from the same CA. Replace the files
+   on the central node. Restart the central server — the new cert is
+   loaded at uvicorn boot.
+2. For each worker, generate a new node cert + key from the same CA,
+   replace the files, restart the worker. Workers pick up the new cert
+   on the next heartbeat cycle.
+3. To rotate the CA itself: cross-sign the old and new CA, distribute
+   the bundle, then phase out the old root. This is operator
+   responsibility — Bernstein loads whatever CA bundle you point it at.
+
+Automated rotation (cert-manager hooks, ACME, etc.) is tracked as a
+follow-up. If you need it now, run a sidecar that writes the cert files
+into place and SIGHUP/restart the Bernstein server when they change.
+
+## Verifying it works
+
+After bringing up a 2-node cluster with `tls.verify_mode=required`:
+
+```bash
+# On the central node
+curl --cacert ~/.bernstein/cluster/ca.crt \
+     --cert   ~/.bernstein/cluster/server.crt \
+     --key    ~/.bernstein/cluster/server.key \
+     https://localhost:8052/cluster/health
+# expected: {"status":"ok"}
+
+# Same call without --cert/--key should fail at the TLS handshake.
+curl --cacert ~/.bernstein/cluster/ca.crt https://localhost:8052/cluster/health
+# expected: SSL handshake error / 400 No required SSL certificate was sent.
+```
+
+## Troubleshooting
+
+- **`ssl: SSL_ERROR_SSL`** on the worker: the worker's `ca.crt` doesn't
+  include the issuer of the server cert. Check that both sides reference
+  the same CA bundle.
+- **`certificate verify failed: unable to get issuer certificate`** on
+  the central node: a worker is presenting a cert signed by a different
+  CA. Re-issue it from the cluster CA.
+- **`PermissionError` on `*.key`**: keys must be readable by the
+  Bernstein process user. `bootstrap-ca` writes 0600 — adjust ownership,
+  not permissions.
+- **Plain HTTP traffic is being rejected after enabling TLS**: this is
+  expected. Workers built before TLS rollout have to be updated to set
+  `ClusterConfig.tls` before they'll re-register. Stage the rollout via
+  `verify_mode="optional"` to catch stragglers.

--- a/src/bernstein/cli/commands/cluster_cmd.py
+++ b/src/bernstein/cli/commands/cluster_cmd.py
@@ -1,0 +1,229 @@
+"""``bernstein cluster`` — cluster lifecycle helpers (mTLS bootstrap, etc.)."""
+
+from __future__ import annotations
+
+import datetime
+import os
+from pathlib import Path
+
+import click
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from bernstein.cli.helpers import console
+
+DEFAULT_CLUSTER_DIR = Path.home() / ".bernstein" / "cluster"
+KEY_SIZE = 4096
+SERIAL_BITS = 64
+CA_VALID_DAYS = 3650
+LEAF_VALID_DAYS = 825
+
+
+@click.group("cluster")
+def cluster_group() -> None:
+    """Cluster lifecycle helpers.
+
+    \b
+      bernstein cluster bootstrap-ca   # generate self-signed CA + server/node certs
+    """
+
+
+def _build_name(common_name: str) -> x509.Name:
+    return x509.Name(
+        [
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Bernstein Cluster"),
+            x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        ]
+    )
+
+
+def _generate_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=KEY_SIZE)
+
+
+def _write_pem(path: Path, data: bytes, *, mode: int) -> None:
+    path.write_bytes(data)
+    os.chmod(path, mode)
+
+
+def _build_ca(out_dir: Path) -> tuple[x509.Certificate, rsa.RSAPrivateKey]:
+    key = _generate_key()
+    name = _build_name("Bernstein Self-Signed CA")
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=CA_VALID_DAYS))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    _write_pem(out_dir / "ca.crt", cert.public_bytes(serialization.Encoding.PEM), mode=0o644)
+    _write_pem(
+        out_dir / "ca.key",
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        mode=0o600,
+    )
+    return cert, key
+
+
+def _issue_leaf(
+    ca_cert: x509.Certificate,
+    ca_key: rsa.RSAPrivateKey,
+    out_dir: Path,
+    *,
+    name_prefix: str,
+    common_name: str,
+    san_dns: list[str],
+    is_server: bool,
+) -> None:
+    key = _generate_key()
+    now = datetime.datetime.now(datetime.UTC)
+    eku = (
+        x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.SERVER_AUTH, x509.ExtendedKeyUsageOID.CLIENT_AUTH])
+        if is_server
+        else x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.CLIENT_AUTH])
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(_build_name(common_name))
+        .issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=LEAF_VALID_DAYS))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(eku, critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(d) for d in san_dns]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    _write_pem(out_dir / f"{name_prefix}.crt", cert.public_bytes(serialization.Encoding.PEM), mode=0o644)
+    _write_pem(
+        out_dir / f"{name_prefix}.key",
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        mode=0o600,
+    )
+
+
+@cluster_group.command("bootstrap-ca")
+@click.option(
+    "--out-dir",
+    "out_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Directory to write cert artifacts. Default: ~/.bernstein/cluster/",
+)
+@click.option(
+    "--server-cn",
+    "server_cn",
+    default="bernstein-central",
+    help="Common name + primary DNS SAN for the server cert.",
+)
+@click.option(
+    "--node-cn",
+    "node_cn",
+    default="bernstein-node",
+    help="Common name for the node (worker) cert template.",
+)
+@click.option(
+    "--server-san",
+    "server_san",
+    multiple=True,
+    help="Additional DNS SANs for the server cert (repeat for multiple).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing artifacts in --out-dir.",
+)
+def bootstrap_ca(
+    out_dir: Path | None,
+    server_cn: str,
+    node_cn: str,
+    server_san: tuple[str, ...],
+    force: bool,
+) -> None:
+    """Generate a self-signed CA, server cert, and node cert template.
+
+    Writes ``ca.crt``, ``ca.key``, ``server.crt``, ``server.key``,
+    ``node.crt``, and ``node.key`` to ``--out-dir`` (default
+    ``~/.bernstein/cluster/``). Private keys are written 0600.
+
+    This is a self-hosted, self-signed CA — appropriate for internal
+    clusters on infrastructure you control. For production deployments
+    use your existing PKI (step-ca, cert-manager, Vault, etc.).
+    """
+    target = out_dir or DEFAULT_CLUSTER_DIR
+    target = target.expanduser().resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    existing = [p for p in ("ca.crt", "ca.key", "server.crt", "node.crt") if (target / p).exists()]
+    if existing and not force:
+        console.print(
+            f"[red]Refusing to overwrite existing artifacts in {target}: {existing}.[/red] "
+            "Re-run with --force to replace them."
+        )
+        raise SystemExit(1)
+
+    ca_cert, ca_key = _build_ca(target)
+    sans = [server_cn, *server_san, "localhost"]
+    _issue_leaf(
+        ca_cert,
+        ca_key,
+        target,
+        name_prefix="server",
+        common_name=server_cn,
+        san_dns=list(dict.fromkeys(sans)),
+        is_server=True,
+    )
+    _issue_leaf(
+        ca_cert,
+        ca_key,
+        target,
+        name_prefix="node",
+        common_name=node_cn,
+        san_dns=[node_cn],
+        is_server=False,
+    )
+
+    console.print(f"[green]Wrote cluster mTLS artifacts to[/green] {target}")
+    console.print(
+        "\n[bold]Next steps:[/bold]\n"
+        f"  1. On the central node, point ClusterConfig.tls at {target}/server.crt + server.key + ca.crt.\n"
+        f"  2. Distribute {target}/ca.crt + node.crt + node.key to each worker (out-of-band, e.g. scp).\n"
+        f"  3. Set ClusterConfig.tls.verify_mode='required' on both sides.\n"
+        f"  4. Restart the central server and workers.\n\n"
+        "[yellow]Warning:[/yellow] this is a self-signed CA suitable for internal clusters only. "
+        "For production, use your own CA / step-ca / cert-manager."
+    )

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -850,3 +850,8 @@ cli.add_command(lineage_cmd, "lineage")
 from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group  # noqa: E402
 
 cli.add_command(wheelhouse_group, "wheelhouse")
+
+# Cluster lifecycle helpers (mTLS bootstrap, etc.)
+from bernstein.cli.commands.cluster_cmd import cluster_group  # noqa: E402
+
+cli.add_command(cluster_group, "cluster")

--- a/src/bernstein/core/protocols/cluster/cluster.py
+++ b/src/bernstein/core/protocols/cluster/cluster.py
@@ -27,6 +27,10 @@ from bernstein.core.models import (
     NodeInfo,
     NodeStatus,
 )
+from bernstein.core.protocols.cluster.cluster_tls import (
+    TLSConfig,
+    build_httpx_client_kwargs,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -414,6 +418,7 @@ class NodeHeartbeatClient:
         interval_s: int = 15,
         auth_token: str | None = None,
         capacity_fn: Callable[[], NodeCapacity] | None = None,
+        tls: TLSConfig | None = None,
     ) -> None:
         self._server_url = server_url.rstrip("/")
         self._node_name = node_name or socket.gethostname()
@@ -424,6 +429,7 @@ class NodeHeartbeatClient:
         self._interval_s = interval_s
         self._auth_token = auth_token
         self._capacity_fn = capacity_fn
+        self._tls = tls
 
         self._node_id: str | None = None
         self._stop_event = threading.Event()
@@ -511,7 +517,7 @@ class NodeHeartbeatClient:
 
     def _run(self) -> None:
         """Main loop for the heartbeat daemon thread."""
-        with httpx.Client() as client:
+        with httpx.Client(**build_httpx_client_kwargs(self._tls)) as client:
             while not self._stop_event.is_set():
                 if self._node_id is None and not self._register(client):
                     # Retry registration after interval
@@ -544,7 +550,7 @@ class NodeHeartbeatClient:
         # Best-effort unregister
         if self._node_id is not None:
             try:
-                with httpx.Client() as client:
+                with httpx.Client(**build_httpx_client_kwargs(self._tls)) as client:
                     client.delete(
                         f"{self._server_url}/cluster/nodes/{self._node_id}",
                         headers=self._headers(),

--- a/src/bernstein/core/protocols/cluster/cluster_tls.py
+++ b/src/bernstein/core/protocols/cluster/cluster_tls.py
@@ -1,0 +1,173 @@
+"""Native mTLS for cluster node-to-node transport.
+
+The cluster transport historically rides over plain HTTP. The JWT bearer
+token authenticates the *caller*, but the channel itself is unencrypted —
+anyone on the path sees the token and the task payload. For internal-only
+deployments that's acceptable; for any internet-facing or regulated
+deployment it is not.
+
+This module provides the building blocks for opt-in mTLS:
+
+- :class:`TLSConfig` — dataclass capturing CA bundle, server cert/key,
+  and client verification mode.
+- :func:`build_ssl_context` — assembles an :class:`ssl.SSLContext` for the
+  server side (FastAPI / uvicorn) that loads the server cert chain and
+  enforces the configured client-cert verification mode.
+- :func:`build_httpx_client_kwargs` — produces a kwargs dict ready to splat
+  into :class:`httpx.Client` for the worker side, enabling mutual auth
+  against the central server.
+
+Phase 1 deliberately keeps this small: no rotation automation, no ACME, no
+per-tenant CA isolation. Operators bring their own CA (or use the
+``bernstein cluster bootstrap-ca`` helper for self-hosted internal clusters)
+and wire the artifacts in via :class:`ClusterConfig.tls`.
+"""
+
+from __future__ import annotations
+
+import ssl
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+VerifyMode = Literal["required", "optional", "disabled"]
+
+_VALID_MODES: tuple[VerifyMode, ...] = ("required", "optional", "disabled")
+
+
+class TLSConfigError(ValueError):
+    """Raised when a :class:`TLSConfig` is malformed or references missing files."""
+
+
+@dataclass(frozen=True)
+class TLSConfig:
+    """Configuration for mTLS on cluster node-to-node transport.
+
+    Attributes:
+        ca_file: Path to a PEM-encoded CA bundle used to verify the peer.
+            Required unless ``verify_mode`` is ``"disabled"``.
+        cert_file: Path to the local PEM-encoded certificate (server cert
+            on the central node, client cert on a worker).
+        key_file: Path to the matching PEM-encoded private key. Should be
+            mode 0600 — the bootstrap helper sets this automatically.
+        verify_mode: Peer-cert verification policy. ``"required"`` enforces
+            full mTLS; ``"optional"`` requests but does not require a peer
+            cert (useful for staged rollouts); ``"disabled"`` accepts any
+            connection (still TLS, but no client-cert verification).
+    """
+
+    ca_file: Path
+    cert_file: Path
+    key_file: Path
+    verify_mode: VerifyMode = "required"
+
+    def __post_init__(self) -> None:
+        if self.verify_mode not in _VALID_MODES:
+            raise TLSConfigError(f"verify_mode must be one of {_VALID_MODES}, got {self.verify_mode!r}")
+        if not isinstance(self.ca_file, Path):
+            raise TLSConfigError("ca_file must be a pathlib.Path")
+        if not isinstance(self.cert_file, Path):
+            raise TLSConfigError("cert_file must be a pathlib.Path")
+        if not isinstance(self.key_file, Path):
+            raise TLSConfigError("key_file must be a pathlib.Path")
+
+    def validate_paths(self) -> None:
+        """Check that all referenced cert/key/CA files exist on disk.
+
+        Raises:
+            TLSConfigError: If any path is missing, with a message naming
+                the field and resolved path so an operator can fix it.
+        """
+        missing: list[str] = []
+        if self.verify_mode != "disabled" and not _resolve(self.ca_file).is_file():
+            missing.append(f"ca_file={self.ca_file}")
+        if not _resolve(self.cert_file).is_file():
+            missing.append(f"cert_file={self.cert_file}")
+        if not _resolve(self.key_file).is_file():
+            missing.append(f"key_file={self.key_file}")
+        if missing:
+            raise TLSConfigError("TLSConfig references missing files: " + ", ".join(missing))
+
+
+def _resolve(path: Path) -> Path:
+    """Expand ``~`` and resolve to absolute, but tolerate non-existent paths."""
+    return path.expanduser().resolve(strict=False)
+
+
+def build_ssl_context(cfg: TLSConfig) -> ssl.SSLContext:
+    """Build a server-side :class:`ssl.SSLContext` from a :class:`TLSConfig`.
+
+    The resulting context loads the local cert chain and applies the
+    configured client-cert verification mode. Suitable for passing to
+    uvicorn via ``ssl=`` or to any ASGI server that accepts an SSLContext.
+
+    Args:
+        cfg: The TLS configuration. Paths are validated before context
+            construction so the operator gets a fast, readable error.
+
+    Returns:
+        A configured :class:`ssl.SSLContext`.
+
+    Raises:
+        TLSConfigError: If referenced files are missing or unreadable.
+    """
+    cfg.validate_paths()
+    ctx = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+    ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
+
+    if cfg.verify_mode == "disabled":
+        ctx.verify_mode = ssl.CERT_NONE
+        return ctx
+
+    ctx.load_verify_locations(cafile=str(_resolve(cfg.ca_file)))
+    if cfg.verify_mode == "required":
+        ctx.verify_mode = ssl.CERT_REQUIRED
+    else:
+        ctx.verify_mode = ssl.CERT_OPTIONAL
+    return ctx
+
+
+def build_httpx_client_kwargs(cfg: TLSConfig | None) -> dict[str, Any]:
+    """Build kwargs for :class:`httpx.Client` from a :class:`TLSConfig`.
+
+    Returns a kwargs dict ready to splat into ``httpx.Client(...)``. When
+    ``cfg`` is ``None``, returns an empty dict so callers can apply the
+    result unconditionally.
+
+    The returned ``verify=`` is an :class:`ssl.SSLContext` (or ``False``
+    for ``verify_mode="disabled"``) — httpx 0.28+ deprecated string
+    paths for ``verify``, and constructing the context here also pre-loads
+    the client cert chain in one place.
+
+    Args:
+        cfg: The TLS configuration, or ``None`` for plain HTTP.
+
+    Returns:
+        ``{"verify": <SSLContext|False>}`` when TLS is on; ``{}`` when
+        ``cfg`` is ``None``.
+
+    Raises:
+        TLSConfigError: If ``cfg`` is provided but referenced files are
+            missing or unreadable.
+    """
+    if cfg is None:
+        return {}
+    cfg.validate_paths()
+    if cfg.verify_mode == "disabled":
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
+        return {"verify": ctx}
+    ctx = ssl.create_default_context(cafile=str(_resolve(cfg.ca_file)))
+    ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
+    return {"verify": ctx}
+
+
+__all__ = [
+    "TLSConfig",
+    "TLSConfigError",
+    "VerifyMode",
+    "build_httpx_client_kwargs",
+    "build_ssl_context",
+]

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -24,6 +24,8 @@ from bernstein.core.seed import SeedConfig, seed_to_initial_task
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+
 logger = logging.getLogger(__name__)
 
 _SERVER_READY_TIMEOUT_S = 30.0
@@ -221,6 +223,7 @@ def _start_server(
     cluster_enabled: bool = False,
     auth_token: str | None = None,
     evolve_mode: bool = False,
+    cluster_tls: TLSConfig | None = None,
 ) -> int:
     """Launch the task server as a background process.
 
@@ -291,6 +294,25 @@ def _start_server(
         "--port",
         str(port),
     ]
+    if cluster_tls is not None:
+        cluster_tls.validate_paths()
+        server_cmd.extend(
+            [
+                "--ssl-certfile",
+                str(cluster_tls.cert_file.expanduser().resolve(strict=False)),
+                "--ssl-keyfile",
+                str(cluster_tls.key_file.expanduser().resolve(strict=False)),
+            ]
+        )
+        if cluster_tls.verify_mode != "disabled":
+            server_cmd.extend(
+                [
+                    "--ssl-ca-certs",
+                    str(cluster_tls.ca_file.expanduser().resolve(strict=False)),
+                    "--ssl-cert-reqs",
+                    "2" if cluster_tls.verify_mode == "required" else "1",
+                ]
+            )
     # ``--reload`` was removed 2026-04-17 per audit-115 / incident
     # 2026-04-11.  Bernstein agents continuously edit src/bernstein/*.py,
     # so auto-reload causes a uvicorn restart on every write — in-flight

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -7,10 +7,13 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum, StrEnum
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from bernstein.core import defaults as _defaults
 from bernstein.core.defaults import AGENT
+
+if TYPE_CHECKING:
+    from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
 
 logger = logging.getLogger(__name__)
 
@@ -1343,6 +1346,10 @@ class ClusterConfig:
         node_timeout_s: Seconds before a node is considered offline.
         server_url: URL of the central task server (for worker nodes).
         bind_host: Host to bind the server to (0.0.0.0 for remote access).
+        tls: Optional mTLS configuration for the node-to-node transport.
+            When set, the central server serves over HTTPS with the supplied
+            cert chain and worker httpx clients present a client cert.
+            See :mod:`bernstein.core.protocols.cluster.cluster_tls`.
     """
 
     enabled: bool = False
@@ -1352,6 +1359,12 @@ class ClusterConfig:
     node_timeout_s: int = 60
     server_url: str | None = None  # Central server URL (worker nodes connect here)
     bind_host: str = "127.0.0.1"  # Default: localhost only
+    tls: TLSConfig | None = None
+
+    @property
+    def cluster_url_scheme(self) -> str:
+        """Return ``"https"`` when TLS is configured, ``"http"`` otherwise."""
+        return "https" if self.tls is not None else "http"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/_cluster_mtls_app.py
+++ b/tests/integration/_cluster_mtls_app.py
@@ -1,0 +1,12 @@
+"""Trivial FastAPI app loaded by the mTLS handshake integration test."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/cluster/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/tests/integration/test_cluster_mtls_handshake.py
+++ b/tests/integration/test_cluster_mtls_handshake.py
@@ -1,0 +1,196 @@
+"""Integration test: mTLS handshake on the cluster transport.
+
+Spins up a uvicorn TLS subprocess against a fresh self-signed CA/server/client
+trio. A worker httpx client carrying the matching client cert succeeds; a
+worker without a client cert is rejected at the TLS handshake.
+
+A subprocess (rather than an in-thread :class:`uvicorn.Server`) is used
+because asyncio's selector-based SSL transport has well-known issues when
+the event loop runs on a non-main thread on macOS, which makes the in-thread
+variant flaky in CI.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import socket
+import ssl
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from bernstein.core.protocols.cluster.cluster_tls import (
+    TLSConfig,
+    build_httpx_client_kwargs,
+    build_ssl_context,
+)
+
+_APP_MODULE = "tests.integration._cluster_mtls_app"
+
+
+def _make_pki(out_dir: Path) -> dict[str, Path]:
+    """Generate CA + server cert/key + client cert/key for the test."""
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+    now = datetime.datetime.now(datetime.UTC)
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    paths = {
+        "ca": out_dir / "ca.crt",
+        "server_cert": out_dir / "server.crt",
+        "server_key": out_dir / "server.key",
+        "client_cert": out_dir / "client.crt",
+        "client_key": out_dir / "client.key",
+    }
+    paths["ca"].write_bytes(ca.public_bytes(serialization.Encoding.PEM))
+
+    for role, cert_path, key_path, eku in (
+        (
+            "server",
+            paths["server_cert"],
+            paths["server_key"],
+            x509.ExtendedKeyUsageOID.SERVER_AUTH,
+        ),
+        (
+            "client",
+            paths["client_cert"],
+            paths["client_key"],
+            x509.ExtendedKeyUsageOID.CLIENT_AUTH,
+        ),
+    ):
+        leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        cn = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, role)])
+        san = x509.SubjectAlternativeName([x509.DNSName("localhost"), x509.DNSName("127.0.0.1")])
+        leaf = (
+            x509.CertificateBuilder()
+            .subject_name(cn)
+            .issuer_name(ca_name)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=1))
+            .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+            .add_extension(x509.ExtendedKeyUsage([eku]), critical=False)
+            .add_extension(san, critical=False)
+            .sign(ca_key, hashes.SHA256())
+        )
+        cert_path.write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
+        key_path.write_bytes(
+            leaf_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+    return paths
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@contextlib.contextmanager
+def _serve(tls: TLSConfig, port: int) -> Iterator[None]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        f"{_APP_MODULE}:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+        "--ssl-certfile",
+        str(tls.cert_file),
+        "--ssl-keyfile",
+        str(tls.key_file),
+        "--ssl-ca-certs",
+        str(tls.ca_file),
+        "--ssl-cert-reqs",
+        str(int(ssl.CERT_REQUIRED if tls.verify_mode == "required" else ssl.CERT_OPTIONAL)),
+    ]
+    proc = subprocess.Popen(cmd)
+    deadline = time.time() + 15.0
+    while time.time() < deadline:
+        with contextlib.suppress(OSError):
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                break
+        time.sleep(0.1)
+    else:
+        proc.terminate()
+        pytest.fail("uvicorn TLS subprocess never opened the port")
+    try:
+        yield
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2.0)
+
+
+@pytest.fixture
+def pki(tmp_path: Path) -> dict[str, Path]:
+    return _make_pki(tmp_path)
+
+
+def test_client_with_valid_cert_succeeds(pki: dict[str, Path]) -> None:
+    server_tls = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["server_cert"],
+        key_file=pki["server_key"],
+        verify_mode="required",
+    )
+    client_tls = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["client_cert"],
+        key_file=pki["client_key"],
+        verify_mode="required",
+    )
+    # Sanity: build_ssl_context produces a valid context for the same args.
+    assert build_ssl_context(server_tls).verify_mode == ssl.CERT_REQUIRED
+    port = _free_port()
+    with _serve(server_tls, port):
+        kwargs = build_httpx_client_kwargs(client_tls)
+        with httpx.Client(**kwargs, timeout=5.0) as client:
+            resp = client.get(f"https://localhost:{port}/cluster/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+def test_client_without_cert_is_rejected(pki: dict[str, Path]) -> None:
+    server_tls = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["server_cert"],
+        key_file=pki["server_key"],
+        verify_mode="required",
+    )
+    port = _free_port()
+    with _serve(server_tls, port):
+        verify_ctx = ssl.create_default_context(cafile=str(pki["ca"]))
+        with httpx.Client(verify=verify_ctx, timeout=5.0) as client, pytest.raises(httpx.HTTPError):
+            client.get(f"https://localhost:{port}/cluster/health")

--- a/tests/unit/test_cluster_tls.py
+++ b/tests/unit/test_cluster_tls.py
@@ -1,0 +1,205 @@
+"""Unit tests for ``bernstein.core.protocols.cluster.cluster_tls``.
+
+Covers TLSConfig validation, file-path resolution, ssl context construction,
+and the helpful error messages emitted on misconfiguration.
+"""
+
+from __future__ import annotations
+
+import datetime
+import ssl
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import ClusterConfig
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from bernstein.core.protocols.cluster.cluster_tls import (
+    TLSConfig,
+    TLSConfigError,
+    build_httpx_client_kwargs,
+    build_ssl_context,
+)
+
+
+def _make_self_signed(out_dir: Path, common_name: str = "localhost") -> tuple[Path, Path, Path]:
+    """Materialise a CA + server cert/key trio under ``out_dir``."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    now = datetime.datetime.now(datetime.UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=30))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(common_name)]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    ca_path = out_dir / "ca.crt"
+    cert_path = out_dir / "server.crt"
+    key_path = out_dir / "server.key"
+    pem_cert = cert.public_bytes(serialization.Encoding.PEM)
+    ca_path.write_bytes(pem_cert)
+    cert_path.write_bytes(pem_cert)
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return ca_path, cert_path, key_path
+
+
+@pytest.fixture
+def cert_trio(tmp_path: Path) -> tuple[Path, Path, Path]:
+    return _make_self_signed(tmp_path)
+
+
+def test_invalid_verify_mode_raises(tmp_path: Path) -> None:
+    with pytest.raises(TLSConfigError, match="verify_mode"):
+        TLSConfig(
+            ca_file=tmp_path / "ca.crt",
+            cert_file=tmp_path / "c.crt",
+            key_file=tmp_path / "c.key",
+            verify_mode="bogus",  # type: ignore[arg-type]
+        )
+
+
+def test_non_path_field_raises(tmp_path: Path) -> None:
+    with pytest.raises(TLSConfigError, match="ca_file must be a pathlib.Path"):
+        TLSConfig(
+            ca_file="ca.crt",  # type: ignore[arg-type]
+            cert_file=tmp_path / "c.crt",
+            key_file=tmp_path / "c.key",
+        )
+
+
+def test_validate_paths_lists_missing(tmp_path: Path) -> None:
+    cfg = TLSConfig(
+        ca_file=tmp_path / "missing-ca.crt",
+        cert_file=tmp_path / "missing-cert.crt",
+        key_file=tmp_path / "missing-key.key",
+    )
+    with pytest.raises(TLSConfigError) as excinfo:
+        cfg.validate_paths()
+    msg = str(excinfo.value)
+    assert "ca_file=" in msg
+    assert "cert_file=" in msg
+    assert "key_file=" in msg
+
+
+def test_validate_paths_skips_ca_when_disabled(tmp_path: Path, cert_trio: tuple[Path, Path, Path]) -> None:
+    _, cert, key = cert_trio
+    cfg = TLSConfig(
+        ca_file=tmp_path / "definitely-missing.crt",
+        cert_file=cert,
+        key_file=key,
+        verify_mode="disabled",
+    )
+    cfg.validate_paths()
+
+
+def test_build_ssl_context_required(cert_trio: tuple[Path, Path, Path]) -> None:
+    ca, cert, key = cert_trio
+    cfg = TLSConfig(ca_file=ca, cert_file=cert, key_file=key, verify_mode="required")
+    ctx = build_ssl_context(cfg)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_build_ssl_context_optional(cert_trio: tuple[Path, Path, Path]) -> None:
+    ca, cert, key = cert_trio
+    cfg = TLSConfig(ca_file=ca, cert_file=cert, key_file=key, verify_mode="optional")
+    ctx = build_ssl_context(cfg)
+    assert ctx.verify_mode == ssl.CERT_OPTIONAL
+
+
+def test_build_ssl_context_disabled_skips_ca(tmp_path: Path, cert_trio: tuple[Path, Path, Path]) -> None:
+    _, cert, key = cert_trio
+    cfg = TLSConfig(
+        ca_file=tmp_path / "missing-ca.crt",
+        cert_file=cert,
+        key_file=key,
+        verify_mode="disabled",
+    )
+    ctx = build_ssl_context(cfg)
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_build_ssl_context_missing_cert_raises(tmp_path: Path) -> None:
+    cfg = TLSConfig(
+        ca_file=tmp_path / "ca.crt",
+        cert_file=tmp_path / "missing.crt",
+        key_file=tmp_path / "missing.key",
+    )
+    with pytest.raises(TLSConfigError):
+        build_ssl_context(cfg)
+
+
+def test_build_httpx_client_kwargs_none_returns_empty() -> None:
+    assert build_httpx_client_kwargs(None) == {}
+
+
+def test_build_httpx_client_kwargs_required(cert_trio: tuple[Path, Path, Path]) -> None:
+    ca, cert, key = cert_trio
+    cfg = TLSConfig(ca_file=ca, cert_file=cert, key_file=key, verify_mode="required")
+    kwargs = build_httpx_client_kwargs(cfg)
+    assert isinstance(kwargs["verify"], ssl.SSLContext)
+    assert kwargs["verify"].verify_mode == ssl.CERT_REQUIRED
+
+
+def test_build_httpx_client_kwargs_disabled(cert_trio: tuple[Path, Path, Path]) -> None:
+    ca, cert, key = cert_trio
+    cfg = TLSConfig(ca_file=ca, cert_file=cert, key_file=key, verify_mode="disabled")
+    kwargs = build_httpx_client_kwargs(cfg)
+    assert isinstance(kwargs["verify"], ssl.SSLContext)
+    assert kwargs["verify"].verify_mode == ssl.CERT_NONE
+
+
+def test_build_httpx_client_kwargs_missing_files_raises(tmp_path: Path) -> None:
+    cfg = TLSConfig(
+        ca_file=tmp_path / "ca.crt",
+        cert_file=tmp_path / "missing.crt",
+        key_file=tmp_path / "missing.key",
+    )
+    with pytest.raises(TLSConfigError):
+        build_httpx_client_kwargs(cfg)
+
+
+def test_cluster_config_url_scheme_default() -> None:
+    cfg = ClusterConfig(enabled=True)
+    assert cfg.tls is None
+    assert cfg.cluster_url_scheme == "http"
+
+
+def test_cluster_config_url_scheme_with_tls(cert_trio: tuple[Path, Path, Path]) -> None:
+    ca, cert, key = cert_trio
+    tls = TLSConfig(ca_file=ca, cert_file=cert, key_file=key)
+    cfg = ClusterConfig(enabled=True, tls=tls)
+    assert cfg.cluster_url_scheme == "https"
+
+
+def test_tilde_expansion_in_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    home = Path.home()
+    sub = home / ".bernstein" / "cluster"
+    sub.mkdir(parents=True, exist_ok=True)
+    ca, cert, key = _make_self_signed(sub)
+    cfg = TLSConfig(
+        ca_file=Path("~/.bernstein/cluster/ca.crt"),
+        cert_file=Path("~/.bernstein/cluster/server.crt"),
+        key_file=Path("~/.bernstein/cluster/server.key"),
+    )
+    ctx = build_ssl_context(cfg)
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    _ = ca, cert, key


### PR DESCRIPTION
Implements ticket `2026-05-05-feat-cluster-mtls-transport` (Phase 1).

## Summary
- New `bernstein.core.protocols.cluster.cluster_tls` module with `TLSConfig`, `build_ssl_context()`, and `build_httpx_client_kwargs()`.
- `ClusterConfig` gains `tls: TLSConfig | None` plus a derived `cluster_url_scheme` that flips to `https` when TLS is set. Opt-in: existing plain-HTTP clusters keep working.
- `NodeHeartbeatClient` consumes the TLS kwargs on registration / heartbeat / unregister.
- Server launcher wires `--ssl-certfile`, `--ssl-keyfile`, `--ssl-ca-certs`, `--ssl-cert-reqs` into the uvicorn argv when TLS is configured.
- `bernstein cluster bootstrap-ca` CLI helper generates a self-signed CA + server cert + node cert template under `~/.bernstein/cluster/` (keys chmod 0600). Self-hosted only; production should bring its own PKI.
- Setup docs at `docs/cluster/mtls-setup.md` covering install, key distribution, manual rotation, and the explicit "use a real CA in production" warning.

JWT auth still authorises the action — mTLS authenticates the channel. Both layers compose.

## Out of scope (Phase 1)
Cert rotation automation, ACME, per-tenant CA isolation. Tracked for follow-up tickets.

## Test plan
- [x] `uv run pytest tests/unit/test_cluster_tls.py -x -q` — 15 passing (config validation, ssl context, kwargs, tilde expansion, ClusterConfig integration).
- [x] `uv run pytest tests/integration/test_cluster_mtls_handshake.py -x -q` — 2 passing (valid client cert succeeds, no cert is rejected at the TLS handshake; uses a uvicorn TLS subprocess).
- [x] Smoke: `uv run pytest tests/unit/test_cluster.py tests/unit/test_cluster_auth.py -x -q` — 37 passing, no regressions.
- [x] `uv run ruff format --check` and `uv run ruff check` clean across all touched files.