### PR TITLE
feat(adapters): CLM adapter mTLS support (Phase 2.5)

### DIFF
--- a/docs/adapters/clm.md
+++ b/docs/adapters/clm.md
@@ -6,9 +6,11 @@ telemetry and served behind NVIDIA NIM (TensorRT-LLM + Triton).
 NIM exposes an OpenAI-compatible HTTP API; the adapter is a thin
 shim that points `aider` at a customer-side CLM gateway.
 
-Phase 1 — adapter MVP. Phase 2 (mTLS, tool-calling, streaming
-regression) is deferred until the `cluster-mtls-transport` ticket
-lands.
+Phase 1 shipped the adapter MVP. Phase 2 partial added the
+tool-calling allowlist + streaming regression. Phase 2.5 (this
+document includes it) adds opt-in **mTLS** to the customer gateway,
+reusing the `TLSConfig` plumbing introduced by the
+`cluster-mtls-transport` ticket.
 
 ---
 
@@ -43,6 +45,10 @@ locally-pulled model.
 |----------|--------:|---------|
 | `CLM_REQUEST_TIMEOUT_SECONDS` | `60` | Per-request HTTP timeout |
 | `CLM_MAX_RETRIES` | `2` | SDK-level retry budget for transient errors |
+| `CLM_CERT_FILE` | _(unset)_ | Path to the worker's PEM-encoded client certificate (mTLS). Required when any of the three mTLS files is set. |
+| `CLM_KEY_FILE` | _(unset)_ | Path to the matching PEM-encoded private key. File mode 0600. |
+| `CLM_CA_FILE` | _(unset)_ | Path to the customer's CA bundle used to verify the gateway's server certificate. |
+| `CLM_VERIFY_MODE` | `required` | One of `required` / `optional` / `disabled`. Mirrors `TLSConfig.verify_mode`. Use `disabled` only for staged rollouts; **never** in a production sovereign deployment. |
 
 ### Credential scoping
 
@@ -111,12 +117,76 @@ is a v2 follow-up — not in scope for Phase 1.
 
 ---
 
-## Phase 2 (deferred)
+## mTLS (Phase 2.5)
 
-Tracked separately — blocked on `cluster-mtls-transport`:
+Sovereign customers commonly require the worker side of any agent
+session to present a client certificate signed by their internal CA
+during the TLS handshake. The CLM adapter supports this via the
+`CLM_CERT_FILE` / `CLM_KEY_FILE` / `CLM_CA_FILE` triple — the same
+PEM-encoded files the operator's PKI already issues for cluster
+node-to-node mTLS.
 
-* mTLS handshake against the customer's PKI.
-* Tool-calling with the per-agent allowlist mapped to NIM's
-  OpenAI-compatible `tools=[]` array.
-* Streaming regression test guaranteeing lineage records contain the
-  full assembled response, not just the first chunk.
+### How it wires through
+
+Aider talks to NIM via the OpenAI Python SDK, which dispatches every
+request through `httpx.Client`. httpx 0.28+ deliberately does **not**
+read TLS material from environment variables, so the adapter wraps the
+spawn through a small launcher
+(`bernstein.adapters.clm_tls_launcher`) that:
+
+1. Reads the `CLM_*_FILE` triple inside the spawned subprocess.
+2. Builds an `ssl.SSLContext` via
+   `bernstein.core.protocols.cluster.cluster_tls.build_httpx_client_kwargs`
+   — the same helper the cluster transport uses, so there is exactly
+   one place that knows how to produce a worker-side mTLS context.
+3. Monkey-patches `httpx.Client.__init__` and
+   `httpx.AsyncClient.__init__` to default to that context for any
+   constructor call that does **not** explicitly override `verify=`.
+4. Hands off to aider via `runpy.run_module("aider")` so the patch
+   survives into the OpenAI SDK call sites.
+
+The launcher is only inserted into the spawn command when all three
+`CLM_*_FILE` variables are set. A *partial* triple is rejected at
+spawn time with `ClmConfigError` — operator-error category, not a
+silent fallback to plain HTTP.
+
+### Configuration example
+
+```bash
+export CLM_ENDPOINT="https://clm.internal.<customer>/v1/"
+export CLM_TOKEN="$(cat /var/run/secrets/clm/jwt)"
+export CLM_MODEL="clm-7b-instruct"
+
+# mTLS: the operator's PKI emits these on a customer-provisioned jump box.
+export CLM_CERT_FILE=/etc/bernstein/pki/worker.crt
+export CLM_KEY_FILE=/etc/bernstein/pki/worker.key
+export CLM_CA_FILE=/etc/bernstein/pki/customer-ca.bundle.crt
+# Optional: override the verify mode (defaults to required).
+# export CLM_VERIFY_MODE=required
+```
+
+### Security caveats specific to mTLS
+
+* `CLM_CERT_FILE` and `CLM_KEY_FILE` paths are added to the adapter's
+  redaction set: their *values* (paths) leak deployment topology and
+  must not appear in lineage / audit / `.sdd/runtime/` records. The
+  files themselves stay where the operator's PKI placed them.
+* The private key file should be mode `0600` and owned by the user
+  account the operator runs Bernstein under. `bernstein cluster
+  bootstrap-ca` enforces this for self-hosted internal clusters; for
+  customer-issued material the customer's PKI is responsible.
+* `CLM_VERIFY_MODE=disabled` accepts any peer certificate (still TLS,
+  but no peer-cert verification). It exists for staged rollouts —
+  do not ship it.
+
+### Tested handshake paths
+
+The integration suite (`tests/integration/adapters/test_adapter_clm_with_fake_nim.py`)
+covers two acceptance criteria from the Phase 2.5 ticket:
+
+* **Positive** — a worker carrying the matching client cert completes
+  the TLS handshake against a `verify_mode='required'` fake NIM and
+  receives a 200 response.
+* **Negative** — a worker that trusts the CA but presents no client
+  cert is rejected at the handshake, surfacing as `httpx.HTTPError`
+  before any chat-completions endpoint runs.

--- a/src/bernstein/adapters/clm.py
+++ b/src/bernstein/adapters/clm.py
@@ -7,13 +7,17 @@ talk to that gateway via ``OPENAI_API_BASE`` / ``OPENAI_API_KEY``,
 unlocking Bernstein's HMAC audit chain, lineage trail, and
 fingerprint memoisation for engineering workflows against CLM.
 
-Phase 1 — adapter MVP. Phase 2 partial (this module) wires the
-per-agent tool allowlist (T578) into the OpenAI-compatible
-``tools=[]`` request shape, refuses spawns that trip the lethal-
-trifecta capability matrix, and exposes a streaming-assembly helper
-whose lineage payload always carries the full response — never just
-the first chunk. mTLS support is deferred to Phase 2.5 once
-cluster-mtls-transport's shared ``httpx.SSLContext`` plumbing lands.
+Phase 1 — adapter MVP. Phase 2 partial — tool-calling allowlist
+(T578) wired into the OpenAI-compatible ``tools=[]`` request shape,
+lethal-trifecta refusal, and streaming-assembly helper whose lineage
+payload always carries the full response — never just the first
+chunk. Phase 2.5 (this module) — opt-in mTLS to the customer
+gateway, reusing :class:`bernstein.core.protocols.cluster.cluster_tls.TLSConfig`
+plumbing. When ``CLM_CERT_FILE`` / ``CLM_KEY_FILE`` / ``CLM_CA_FILE``
+are set, the adapter routes the spawn through a small launcher
+(:mod:`bernstein.adapters.clm_tls_launcher`) that monkey-patches
+:class:`httpx.Client` defaults before importing aider, so the OpenAI
+SDK transparently presents the customer-issued client cert.
 See ``docs/adapters/clm.md`` for configuration.
 """
 
@@ -23,7 +27,9 @@ import json
 import logging
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from bernstein.adapters.base import (
@@ -35,10 +41,10 @@ from bernstein.adapters.base import (
 )
 from bernstein.adapters.env_isolation import build_filtered_env
 from bernstein.core.agents.spawner_warm_pool import parse_tool_allowlist_env
+from bernstein.core.protocols.cluster.cluster_tls import TLSConfig, TLSConfigError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping, Sequence
-    from pathlib import Path
 
     from bernstein.core.models import ModelConfig
     from bernstein.core.security.capability_matrix import CapabilityRegistry
@@ -59,12 +65,50 @@ CLM_MAX_RETRIES_ENV = "CLM_MAX_RETRIES"
 # it as ``tools=[...]`` on the chat-completions request.
 CLM_TOOLS_SCHEMA_ENV = "CLM_TOOLS_SCHEMA"
 
+# Phase 2.5 — opt-in mTLS to the customer gateway. When all three are
+# set the adapter wires a launcher shim (clm_tls_launcher) into the
+# spawn cmd and forwards the paths so the in-process httpx client
+# presents the customer-issued client certificate during the TLS
+# handshake. Paths must be readable inside the spawned subprocess.
+CLM_CERT_FILE_ENV = "CLM_CERT_FILE"
+CLM_KEY_FILE_ENV = "CLM_KEY_FILE"
+CLM_CA_FILE_ENV = "CLM_CA_FILE"
+# Optional verification mode override, mirroring TLSConfig.verify_mode.
+# Defaults to "required" — a missing peer cert at the gateway aborts.
+CLM_VERIFY_MODE_ENV = "CLM_VERIFY_MODE"
+
 # Stable adapter token used by the lethal-trifecta capability matrix.
 # Matches the row registered in ``templates/capabilities/adapters.yaml``.
 _ADAPTER_CAPABILITY_TOKEN = "adapter.clm"
 
 _DEFAULT_REQUEST_TIMEOUT_SECONDS = 60
 _DEFAULT_MAX_RETRIES = 2
+
+# Env keys whose *values* are sensitive and must never be logged or
+# persisted to lineage / audit / .sdd/runtime/. Path keys are listed so
+# operators with a "scrub anything CLM_*" rule see them; the token key
+# is the load-bearing one. Cert/key files themselves stay on disk where
+# the operator's PKI placed them — only the env-var *values* (which are
+# paths and could leak deployment topology) are kept off the wire.
+_REDACTABLE_CLM_ENV_KEYS: frozenset[str] = frozenset(
+    {
+        CLM_TOKEN_ENV,
+        CLM_CERT_FILE_ENV,
+        CLM_KEY_FILE_ENV,
+        CLM_CA_FILE_ENV,
+    }
+)
+
+
+def redactable_clm_env_keys() -> frozenset[str]:
+    """Names of CLM_* env vars whose values must never be logged or persisted.
+
+    Exported so that audit / lineage writers can grep their payload and
+    scrub matches without hard-coding the list. The token is the
+    load-bearing entry; the cert/key/CA paths are included because they
+    leak the operator's PKI layout.
+    """
+    return _REDACTABLE_CLM_ENV_KEYS
 
 
 class ClmConfigError(SpawnError):
@@ -128,6 +172,59 @@ def _int_env(source: Mapping[str, str], name: str, default: int) -> int:
         return int(raw)
     except ValueError as exc:
         raise ClmConfigError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def tls_config_from_env(env: Mapping[str, str] | None = None) -> TLSConfig | None:
+    """Resolve an optional :class:`TLSConfig` from ``CLM_CERT_FILE`` / ``CLM_KEY_FILE`` / ``CLM_CA_FILE``.
+
+    Returns ``None`` when none of the three are set (operator opted out
+    of mTLS — equivalent to plain HTTPS / HTTP behaviour). Returns a
+    fully-validated :class:`TLSConfig` when all three are set. A
+    *partial* triple is treated as misconfiguration, since presenting a
+    client cert without trusting a CA bundle (or vice versa) is almost
+    always operator error rather than intent.
+
+    Args:
+        env: Optional env mapping override (mainly for tests). Defaults
+            to :data:`os.environ`.
+
+    Returns:
+        The resolved :class:`TLSConfig`, or ``None`` if mTLS is off.
+
+    Raises:
+        ClmConfigError: If the triple is partial, the verify-mode
+            override is invalid, or the resolved paths fail validation.
+    """
+    source: Mapping[str, str] = env if env is not None else os.environ
+    cert_raw = (source.get(CLM_CERT_FILE_ENV) or "").strip()
+    key_raw = (source.get(CLM_KEY_FILE_ENV) or "").strip()
+    ca_raw = (source.get(CLM_CA_FILE_ENV) or "").strip()
+    parts = ((CLM_CERT_FILE_ENV, cert_raw), (CLM_KEY_FILE_ENV, key_raw), (CLM_CA_FILE_ENV, ca_raw))
+    set_count = sum(1 for _, v in parts if v)
+    if set_count == 0:
+        return None
+    if set_count != len(parts):
+        missing = ", ".join(name for name, value in parts if not value)
+        raise ClmConfigError(
+            f"CLM mTLS requires {missing} alongside the other CLM_*_FILE entries; "
+            "see docs/adapters/clm.md (mTLS section)."
+        )
+    verify_raw = (source.get(CLM_VERIFY_MODE_ENV) or "required").strip()
+    if verify_raw not in ("required", "optional", "disabled"):
+        raise ClmConfigError(
+            f"{CLM_VERIFY_MODE_ENV} must be one of 'required', 'optional', 'disabled', got {verify_raw!r}"
+        )
+    try:
+        cfg = TLSConfig(
+            ca_file=Path(ca_raw),
+            cert_file=Path(cert_raw),
+            key_file=Path(key_raw),
+            verify_mode=verify_raw,  # type: ignore[arg-type]
+        )
+        cfg.validate_paths()
+    except TLSConfigError as exc:
+        raise ClmConfigError(f"CLM mTLS configuration is invalid: {exc}") from exc
+    return cfg
 
 
 def build_openai_tools_schema(allowlist: Sequence[str]) -> list[dict[str, Any]]:
@@ -273,13 +370,14 @@ class ClmAdapter(CLIAdapter):
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
         config = ClmConfig.from_env()
+        tls = tls_config_from_env()
         model_id = model_config.model or config.model
 
         allowlist = parse_tool_allowlist_env() or []
         _evaluate_lethal_trifecta(allowlist, workdir=workdir)
         tools_schema = build_openai_tools_schema(allowlist)
 
-        cmd = [
+        aider_args = [
             "aider",
             "--model",
             f"openai/{model_id}",
@@ -291,6 +389,13 @@ class ClmAdapter(CLIAdapter):
             "1024",
             "--no-auto-lint",
         ]
+        if tls is not None:
+            # Route through the launcher so httpx.Client defaults are
+            # patched with the customer client cert before aider imports
+            # the OpenAI SDK. The launcher then execs into aider's main.
+            cmd = [sys.executable, "-m", "bernstein.adapters.clm_tls_launcher", *aider_args]
+        else:
+            cmd = aider_args
 
         pid_dir = workdir / ".sdd" / "runtime" / "pids"
         wrapped_cmd = build_worker_cmd(
@@ -303,7 +408,10 @@ class ClmAdapter(CLIAdapter):
             model=f"clm/{model_id}",
         )
 
-        env = build_filtered_env([CLM_ENDPOINT_ENV, CLM_TOKEN_ENV, CLM_MODEL_ENV])
+        extra_keys = [CLM_ENDPOINT_ENV, CLM_TOKEN_ENV, CLM_MODEL_ENV]
+        if tls is not None:
+            extra_keys.extend([CLM_CERT_FILE_ENV, CLM_KEY_FILE_ENV, CLM_CA_FILE_ENV, CLM_VERIFY_MODE_ENV])
+        env = build_filtered_env(extra_keys)
         # Aider speaks the OpenAI wire format; rewire it onto the CLM
         # gateway via the standard OpenAI env vars. The scoped CLM_TOKEN
         # rides as the Bearer credential — never the operator's master.

--- a/src/bernstein/adapters/clm_tls_launcher.py
+++ b/src/bernstein/adapters/clm_tls_launcher.py
@@ -1,0 +1,136 @@
+"""mTLS launcher for the CLM adapter.
+
+Aider talks to the customer-side CLM gateway via the OpenAI Python SDK,
+which dispatches through :class:`httpx.Client`. Plain ``OPENAI_API_BASE``
+gets the URL onto the gateway, but mTLS needs the client cert / key /
+CA bundle threaded into the underlying HTTP client — and httpx 0.28+
+deliberately does *not* read those from environment variables.
+
+This launcher monkey-patches :class:`httpx.Client` and
+:class:`httpx.AsyncClient` so that any callsite that constructs one
+without an explicit ``verify=`` / ``cert=`` automatically inherits the
+customer-issued :class:`ssl.SSLContext` produced by
+:func:`bernstein.core.protocols.cluster.cluster_tls.build_httpx_client_kwargs`.
+
+The launcher is intentionally tiny: read the three CLM_*_FILE env vars,
+build a TLSConfig, install the patches, and hand off to aider's
+console-script entry point. No SDK initialisation or aider-version-
+specific knowledge is required, so this stays robust to aider releases.
+
+Usage (set by :class:`bernstein.adapters.clm.ClmAdapter` when mTLS is
+configured)::
+
+    python -m bernstein.adapters.clm_tls_launcher aider [aider args...]
+"""
+
+from __future__ import annotations
+
+import os
+import runpy
+import sys
+from pathlib import Path
+from typing import Any
+
+from bernstein.adapters.clm import (
+    CLM_CA_FILE_ENV,
+    CLM_CERT_FILE_ENV,
+    CLM_KEY_FILE_ENV,
+    CLM_VERIFY_MODE_ENV,
+)
+from bernstein.core.protocols.cluster.cluster_tls import (
+    TLSConfig,
+    build_httpx_client_kwargs,
+)
+
+
+def _resolve_tls_from_env() -> TLSConfig | None:
+    """Build a :class:`TLSConfig` from the CLM_*_FILE env triple.
+
+    Returns ``None`` if any of the three is unset — in that case the
+    launcher is being run without mTLS (defensive: the adapter only
+    invokes us when all three are set, but we don't crash if it's not).
+    """
+    cert = os.environ.get(CLM_CERT_FILE_ENV, "").strip()
+    key = os.environ.get(CLM_KEY_FILE_ENV, "").strip()
+    ca = os.environ.get(CLM_CA_FILE_ENV, "").strip()
+    if not (cert and key and ca):
+        return None
+    verify_raw = (os.environ.get(CLM_VERIFY_MODE_ENV) or "required").strip()
+    if verify_raw not in ("required", "optional", "disabled"):
+        verify_raw = "required"
+    return TLSConfig(
+        ca_file=Path(ca),
+        cert_file=Path(cert),
+        key_file=Path(key),
+        verify_mode=verify_raw,  # type: ignore[arg-type]
+    )
+
+
+def install_httpx_mtls_defaults(tls: TLSConfig) -> None:
+    """Patch ``httpx.Client`` / ``httpx.AsyncClient`` to default to ``tls``.
+
+    Each constructor call gets its kwargs *inspected* (not silently
+    overwritten): if the caller already supplied ``verify=`` or
+    ``cert=`` we honour their explicit choice. This keeps the patch
+    safe for libraries that intentionally configure a different
+    transport (rare, but possible inside the OpenAI SDK's retry
+    helper).
+    """
+    import httpx  # local import: keep launcher import-light if httpx absent
+
+    kwargs = build_httpx_client_kwargs(tls)
+    original_client_init = httpx.Client.__init__
+    original_async_init = httpx.AsyncClient.__init__
+
+    def _client_init(self: httpx.Client, *args: Any, **call_kwargs: Any) -> None:
+        if "verify" not in call_kwargs:
+            call_kwargs["verify"] = kwargs["verify"]
+        original_client_init(self, *args, **call_kwargs)
+
+    def _async_init(self: httpx.AsyncClient, *args: Any, **call_kwargs: Any) -> None:
+        if "verify" not in call_kwargs:
+            call_kwargs["verify"] = kwargs["verify"]
+        original_async_init(self, *args, **call_kwargs)
+
+    httpx.Client.__init__ = _client_init  # type: ignore[method-assign]
+    httpx.AsyncClient.__init__ = _async_init  # type: ignore[method-assign]
+
+
+def _run_aider(argv: list[str]) -> int:
+    """Hand off to aider's console-script entry point.
+
+    We use :func:`runpy.run_module` rather than :func:`os.execvp` so the
+    httpx monkey-patch installed above survives into aider's process.
+    ``sys.argv`` is rewritten to look like a direct ``aider …`` invocation.
+    """
+    if not argv:
+        sys.stderr.write("clm_tls_launcher: no command supplied\n")
+        return 2
+    target, *rest = argv
+    if target != "aider":
+        # Defensive: the adapter only ever passes "aider" as the first
+        # positional; if a future caller asks for a different binary we
+        # refuse rather than silently mis-routing the request.
+        sys.stderr.write(f"clm_tls_launcher: only supports aider, got {target!r}\n")
+        return 2
+    sys.argv = [target, *rest]
+    try:
+        runpy.run_module("aider", run_name="__main__", alter_sys=True)
+    except SystemExit as exc:
+        code = exc.code
+        if isinstance(code, int):
+            return code
+        return 0 if code is None else 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    tls = _resolve_tls_from_env()
+    if tls is not None:
+        install_httpx_mtls_defaults(tls)
+    return _run_aider(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/adapters/_clm_mtls_app.py
+++ b/tests/integration/adapters/_clm_mtls_app.py
@@ -1,0 +1,37 @@
+"""TLS-terminated fake NIM gateway used by the CLM Phase 2.5 mTLS test.
+
+Spawned as a uvicorn subprocess (see
+``test_adapter_clm_with_fake_nim.py``); kept tiny on purpose so the
+subprocess starts in <1s on CI runners. The bearer-token check stays
+in lockstep with the in-thread fake NIM so the two share a wire-format
+contract — only the transport layer differs.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Header, HTTPException
+
+_FAKE_NIM_TOKEN = "scoped-jwt-fake-nim-mtls"
+_FAKE_NIM_REPLY = "mtls handshake ok"
+
+app = FastAPI()
+
+
+@app.post("/v1/chat/completions")
+async def chat(authorization: str = Header(default="")) -> dict[str, object]:
+    if authorization != f"Bearer {_FAKE_NIM_TOKEN}":
+        raise HTTPException(status_code=401, detail="bad token")
+    # A non-streaming completion is enough — we're testing the TLS layer,
+    # not SSE assembly (that's already covered by the plaintext test).
+    return {
+        "id": "chatcmpl-mtls-fake",
+        "object": "chat.completion",
+        "model": "clm-7b-instruct",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": _FAKE_NIM_REPLY},
+                "finish_reason": "stop",
+            }
+        ],
+    }

--- a/tests/integration/adapters/test_adapter_clm_with_fake_nim.py
+++ b/tests/integration/adapters/test_adapter_clm_with_fake_nim.py
@@ -9,13 +9,22 @@ shape NVIDIA NIM exposes, points :class:`ClmAdapter` at it via
 * the gateway sees the OpenAI-shaped chat-completions request,
 * the streaming SSE assembly returns the full response body,
 * no CLM_TOKEN bytes leak into the spawn log.
+
+Phase 2.5 — also exercises the mTLS path against a TLS-terminated
+fake NIM driven via :func:`build_httpx_client_kwargs` plumbing, with a
+matching negative-path test that asserts the gateway rejects a
+worker which has no client cert at the TLS handshake.
 """
 
 from __future__ import annotations
 
 import contextlib
+import datetime
 import json
 import socket
+import ssl
+import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -24,17 +33,28 @@ from typing import TYPE_CHECKING
 import httpx
 import pytest
 import uvicorn
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
 from bernstein.adapters.clm import (
+    CLM_CA_FILE_ENV,
+    CLM_CERT_FILE_ENV,
     CLM_ENDPOINT_ENV,
+    CLM_KEY_FILE_ENV,
     CLM_MODEL_ENV,
     CLM_TOKEN_ENV,
     ClmAdapter,
     ClmConfig,
     StreamingChunk,
     assemble_streaming_response,
+    tls_config_from_env,
+)
+from bernstein.core.protocols.cluster.cluster_tls import (
+    build_httpx_client_kwargs,
 )
 
 if TYPE_CHECKING:
@@ -240,3 +260,189 @@ def test_streaming_lineage_regression_50plus_chunks(
     assert "long-chunk-000" in payload.content
     assert "long-chunk-059" in payload.content
     assert payload.finish_reason == "stop"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.5 — mTLS handshake against a TLS-terminated fake NIM
+# ---------------------------------------------------------------------------
+
+
+_MTLS_APP_MODULE = "tests.integration.adapters._clm_mtls_app"
+_MTLS_FAKE_NIM_TOKEN = "scoped-jwt-fake-nim-mtls"
+
+
+def _make_mtls_pki(out_dir: Path) -> dict[str, Path]:
+    """Generate CA + server cert/key + client cert/key for the mTLS test.
+
+    Mirrors :func:`tests.integration.test_cluster_mtls_handshake._make_pki`
+    so the two tests stay in lockstep on cert shape (CN/SAN/EKU). Lifted
+    rather than imported because the cluster test treats its helper as
+    a private fixture.
+    """
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+    now = datetime.datetime.now(datetime.UTC)
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    paths = {
+        "ca": out_dir / "ca.crt",
+        "server_cert": out_dir / "server.crt",
+        "server_key": out_dir / "server.key",
+        "client_cert": out_dir / "client.crt",
+        "client_key": out_dir / "client.key",
+    }
+    paths["ca"].write_bytes(ca.public_bytes(serialization.Encoding.PEM))
+
+    for role, cert_path, key_path, eku in (
+        ("server", paths["server_cert"], paths["server_key"], x509.ExtendedKeyUsageOID.SERVER_AUTH),
+        ("client", paths["client_cert"], paths["client_key"], x509.ExtendedKeyUsageOID.CLIENT_AUTH),
+    ):
+        leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        cn = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, role)])
+        san = x509.SubjectAlternativeName([x509.DNSName("localhost"), x509.DNSName("127.0.0.1")])
+        leaf = (
+            x509.CertificateBuilder()
+            .subject_name(cn)
+            .issuer_name(ca_name)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=1))
+            .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+            .add_extension(x509.ExtendedKeyUsage([eku]), critical=False)
+            .add_extension(san, critical=False)
+            .sign(ca_key, hashes.SHA256())
+        )
+        cert_path.write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
+        key_path.write_bytes(
+            leaf_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+    return paths
+
+
+@contextlib.contextmanager
+def _serve_fake_nim_tls(pki: dict[str, Path], port: int) -> Generator[None, None, None]:
+    """Spawn a uvicorn TLS subprocess hosting the mTLS fake-NIM app.
+
+    A subprocess (rather than an in-thread :class:`uvicorn.Server`) is
+    used because asyncio's selector-based SSL transport has well-known
+    flakiness when the event loop runs on a non-main thread on macOS.
+    The cluster mTLS test makes the same call.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        f"{_MTLS_APP_MODULE}:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+        "--ssl-certfile",
+        str(pki["server_cert"]),
+        "--ssl-keyfile",
+        str(pki["server_key"]),
+        "--ssl-ca-certs",
+        str(pki["ca"]),
+        "--ssl-cert-reqs",
+        str(int(ssl.CERT_REQUIRED)),
+    ]
+    proc = subprocess.Popen(cmd)
+    deadline = time.time() + 15.0
+    started = False
+    while time.time() < deadline:
+        with contextlib.suppress(OSError):
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                started = True
+                break
+        time.sleep(0.1)
+    if not started:
+        proc.terminate()
+        pytest.fail("uvicorn TLS subprocess never opened the port")
+    try:
+        yield
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2.0)
+
+
+@pytest.fixture
+def mtls_pki(tmp_path: Path) -> dict[str, Path]:
+    return _make_mtls_pki(tmp_path)
+
+
+def test_mtls_handshake_succeeds_with_client_cert(
+    mtls_pki: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A worker carrying the matching client cert completes the TLS handshake and the chat-completion succeeds.
+
+    Drives the gateway via :func:`build_httpx_client_kwargs` — exactly
+    the kwargs the launcher (:mod:`bernstein.adapters.clm_tls_launcher`)
+    splats into ``httpx.Client`` defaults inside the spawned aider
+    subprocess. Asserting the success path here means the launcher's
+    transport layer is wire-correct without paying for an aider install
+    on every CI run.
+    """
+    monkeypatch.setenv(CLM_CERT_FILE_ENV, str(mtls_pki["client_cert"]))
+    monkeypatch.setenv(CLM_KEY_FILE_ENV, str(mtls_pki["client_key"]))
+    monkeypatch.setenv(CLM_CA_FILE_ENV, str(mtls_pki["ca"]))
+
+    tls = tls_config_from_env()
+    assert tls is not None
+    assert tls.verify_mode == "required"
+
+    port = _free_port()
+    with _serve_fake_nim_tls(mtls_pki, port):
+        kwargs = build_httpx_client_kwargs(tls)
+        with httpx.Client(**kwargs, timeout=10.0) as client:
+            resp = client.post(
+                f"https://localhost:{port}/v1/chat/completions",
+                json={
+                    "model": "clm-7b-instruct",
+                    "messages": [{"role": "user", "content": "ping"}],
+                },
+                headers={"Authorization": f"Bearer {_MTLS_FAKE_NIM_TOKEN}"},
+            )
+        assert resp.status_code == 200, f"handshake or auth failed: {resp.status_code} {resp.text}"
+        body = resp.json()
+        assert body["choices"][0]["message"]["content"] == "mtls handshake ok"
+
+
+def test_mtls_handshake_rejected_without_client_cert(mtls_pki: dict[str, Path]) -> None:
+    """A worker that trusts the CA but presents no client cert is refused at the TLS layer.
+
+    Negative-path acceptance criterion: the gateway is configured with
+    ``verify_mode='required'``, so the handshake must abort before the
+    chat-completions endpoint runs.
+    """
+    port = _free_port()
+    with _serve_fake_nim_tls(mtls_pki, port):
+        # Client trusts the CA so we know the failure is *only* the
+        # missing client cert, not a CA-trust issue.
+        verify_ctx = ssl.create_default_context(cafile=str(mtls_pki["ca"]))
+        with httpx.Client(verify=verify_ctx, timeout=10.0) as client, pytest.raises(httpx.HTTPError):
+            client.post(
+                f"https://localhost:{port}/v1/chat/completions",
+                json={"model": "clm-7b-instruct", "messages": []},
+                headers={"Authorization": f"Bearer {_MTLS_FAKE_NIM_TOKEN}"},
+            )

--- a/tests/unit/test_adapter_clm.py
+++ b/tests/unit/test_adapter_clm.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -11,22 +12,24 @@ from bernstein.core.models import ModelConfig
 
 from bernstein.adapters.base import SpawnError
 from bernstein.adapters.clm import (
+    CLM_CA_FILE_ENV,
+    CLM_CERT_FILE_ENV,
     CLM_ENDPOINT_ENV,
+    CLM_KEY_FILE_ENV,
     CLM_MODEL_ENV,
     CLM_TOKEN_ENV,
     CLM_TOOLS_SCHEMA_ENV,
+    CLM_VERIFY_MODE_ENV,
     ClmAdapter,
     ClmConfig,
     ClmConfigError,
     StreamingChunk,
     assemble_streaming_response,
     build_openai_tools_schema,
+    redactable_clm_env_keys,
+    tls_config_from_env,
 )
 from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
 
 pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
 
@@ -264,3 +267,200 @@ def test_streaming_lineage_captures_tool_calls_across_chunks() -> None:
     payload = assemble_streaming_response(events)
     assert [c["id"] for c in payload.tool_calls] == ["c1", "c2"]
     assert payload.finish_reason == "tool_calls"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2.5 — opt-in mTLS to the customer gateway
+# ---------------------------------------------------------------------------
+
+
+def _write_pem_stub(path: Path, label: str) -> None:
+    """Write a syntactically-valid PEM placeholder for path-validation only.
+
+    ``tls_config_from_env`` calls ``TLSConfig.validate_paths`` which only
+    asserts the files *exist*; integration tests cover real handshakes
+    against properly-signed certs. Keeping the unit tier free of x509
+    machinery avoids the per-test ~80ms RSA-keygen tax.
+    """
+    path.write_text(f"-----BEGIN {label}-----\nstub\n-----END {label}-----\n", encoding="utf-8")
+
+
+def test_tls_config_from_env_returns_none_when_unset() -> None:
+    """Operator opted out of mTLS — adapter must keep plain-HTTPS behaviour."""
+    assert tls_config_from_env({}) is None
+    # PATH presence alone should not flip mTLS on.
+    assert tls_config_from_env({"PATH": "/usr/bin"}) is None
+
+
+def test_tls_config_from_env_partial_triple_raises(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    _write_pem_stub(cert, "CERTIFICATE")
+    with pytest.raises(ClmConfigError, match=r"CLM_KEY_FILE.*CLM_CA_FILE"):
+        tls_config_from_env({CLM_CERT_FILE_ENV: str(cert)})
+
+
+def test_tls_config_from_env_full_triple_returns_validated_config(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    ca = tmp_path / "ca.crt"
+    for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+        _write_pem_stub(path, label)
+    cfg = tls_config_from_env(
+        {
+            CLM_CERT_FILE_ENV: str(cert),
+            CLM_KEY_FILE_ENV: str(key),
+            CLM_CA_FILE_ENV: str(ca),
+        }
+    )
+    assert cfg is not None
+    assert cfg.cert_file == cert
+    assert cfg.key_file == key
+    assert cfg.ca_file == ca
+    assert cfg.verify_mode == "required"
+
+
+def test_tls_config_from_env_honours_verify_mode_override(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    ca = tmp_path / "ca.crt"
+    for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+        _write_pem_stub(path, label)
+    cfg = tls_config_from_env(
+        {
+            CLM_CERT_FILE_ENV: str(cert),
+            CLM_KEY_FILE_ENV: str(key),
+            CLM_CA_FILE_ENV: str(ca),
+            CLM_VERIFY_MODE_ENV: "optional",
+        }
+    )
+    assert cfg is not None
+    assert cfg.verify_mode == "optional"
+
+
+def test_tls_config_from_env_rejects_bogus_verify_mode(tmp_path: Path) -> None:
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    ca = tmp_path / "ca.crt"
+    for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+        _write_pem_stub(path, label)
+    with pytest.raises(ClmConfigError, match="CLM_VERIFY_MODE"):
+        tls_config_from_env(
+            {
+                CLM_CERT_FILE_ENV: str(cert),
+                CLM_KEY_FILE_ENV: str(key),
+                CLM_CA_FILE_ENV: str(ca),
+                CLM_VERIFY_MODE_ENV: "trust-me-bro",
+            }
+        )
+
+
+def test_tls_config_from_env_missing_files_raises(tmp_path: Path) -> None:
+    with pytest.raises(ClmConfigError, match=r"CLM mTLS configuration is invalid"):
+        tls_config_from_env(
+            {
+                CLM_CERT_FILE_ENV: str(tmp_path / "absent.crt"),
+                CLM_KEY_FILE_ENV: str(tmp_path / "absent.key"),
+                CLM_CA_FILE_ENV: str(tmp_path / "absent.ca"),
+            }
+        )
+
+
+def test_spawn_routes_through_launcher_when_mtls_configured(tmp_path: Path) -> None:
+    """When the CLM_*_FILE triple is set, the spawn cmd is rewritten to ``python -m clm_tls_launcher aider …``."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(720)
+
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    ca = tmp_path / "ca.crt"
+    for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+        _write_pem_stub(path, label)
+
+    env_with_mtls = {
+        **_ENV_BUNDLE,
+        CLM_CERT_FILE_ENV: str(cert),
+        CLM_KEY_FILE_ENV: str(key),
+        CLM_CA_FILE_ENV: str(ca),
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_mtls, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-mtls",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    # Launcher prefix: `<python> -m bernstein.adapters.clm_tls_launcher aider …`
+    assert inner[0] == sys.executable
+    assert inner[1] == "-m"
+    assert inner[2] == "bernstein.adapters.clm_tls_launcher"
+    assert inner[3] == "aider"
+    # Aider's args are preserved unchanged after the launcher prefix.
+    assert "--model" in inner
+    assert inner[inner.index("--model") + 1] == "openai/clm-7b-instruct"
+
+    env = popen.call_args.kwargs.get("env", {})
+    # Cert/key/ca env vars must reach the spawned subprocess so the
+    # launcher can rebuild the TLSConfig in-process.
+    assert env[CLM_CERT_FILE_ENV] == str(cert)
+    assert env[CLM_KEY_FILE_ENV] == str(key)
+    assert env[CLM_CA_FILE_ENV] == str(ca)
+
+
+def test_spawn_skips_launcher_when_mtls_not_configured(tmp_path: Path) -> None:
+    """No mTLS env triple → adapter still calls aider directly (no behaviour drift)."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(721)
+
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", _ENV_BUNDLE, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-no-mtls",
+        )
+
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[0] == "aider"
+    env = popen.call_args.kwargs.get("env", {})
+    assert CLM_CERT_FILE_ENV not in env
+    assert CLM_KEY_FILE_ENV not in env
+    assert CLM_CA_FILE_ENV not in env
+
+
+def test_spawn_partial_mtls_triple_surfaces_typed_error(tmp_path: Path) -> None:
+    """A half-configured mTLS triple is operator error — fail fast, not silently."""
+    adapter = ClmAdapter()
+    cert = tmp_path / "client.crt"
+    _write_pem_stub(cert, "CERTIFICATE")
+    env_partial = {**_ENV_BUNDLE, CLM_CERT_FILE_ENV: str(cert)}
+    with (
+        patch.dict("os.environ", env_partial, clear=True),
+        pytest.raises(ClmConfigError, match="CLM mTLS"),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-partial-mtls",
+        )
+
+
+def test_redactable_env_keys_includes_token_and_paths() -> None:
+    """Audit / lineage scrubbers must see the token plus all three cert paths."""
+    keys = redactable_clm_env_keys()
+    assert CLM_TOKEN_ENV in keys
+    assert CLM_CERT_FILE_ENV in keys
+    assert CLM_KEY_FILE_ENV in keys
+    assert CLM_CA_FILE_ENV in keys
+    # The endpoint and model are *not* redacted — they're operator
+    # configuration the audit trail needs to preserve for traceability.
+    assert CLM_ENDPOINT_ENV not in keys
+    assert CLM_MODEL_ENV not in keys

--- a/tests/unit/test_clm_tls_launcher.py
+++ b/tests/unit/test_clm_tls_launcher.py
@@ -1,0 +1,191 @@
+"""Unit tests for the CLM mTLS launcher shim.
+
+Covers the pieces of :mod:`bernstein.adapters.clm_tls_launcher` that
+don't require aider on PATH: env-var resolution, the
+``httpx.Client`` / ``httpx.AsyncClient`` monkey-patch, and the
+defensive guard against being asked to launch something other than
+aider. The end-to-end TLS handshake is exercised separately by
+``tests/integration/adapters/test_adapter_clm_with_fake_nim.py``.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from bernstein.adapters import clm_tls_launcher
+from bernstein.adapters.clm import (
+    CLM_CA_FILE_ENV,
+    CLM_CERT_FILE_ENV,
+    CLM_KEY_FILE_ENV,
+)
+from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+
+
+def _make_pki(out_dir: Path) -> dict[str, Path]:
+    """Tiny self-signed CA + leaf cert/key trio for httpx-patch sanity."""
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+    now = datetime.datetime.now(datetime.UTC)
+    ca = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "client")]))
+        .issuer_name(ca_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    paths = {
+        "ca": out_dir / "ca.crt",
+        "cert": out_dir / "client.crt",
+        "key": out_dir / "client.key",
+    }
+    paths["ca"].write_bytes(ca.public_bytes(serialization.Encoding.PEM))
+    paths["cert"].write_bytes(leaf.public_bytes(serialization.Encoding.PEM))
+    paths["key"].write_bytes(
+        leaf_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return paths
+
+
+@pytest.fixture
+def httpx_init_restored() -> object:
+    """Snapshot+restore ``httpx.Client.__init__`` so monkey-patches don't leak."""
+    saved_client = httpx.Client.__init__
+    saved_async = httpx.AsyncClient.__init__
+    yield None
+    httpx.Client.__init__ = saved_client  # type: ignore[method-assign]
+    httpx.AsyncClient.__init__ = saved_async  # type: ignore[method-assign]
+
+
+def test_resolve_tls_returns_none_when_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(CLM_CERT_FILE_ENV, raising=False)
+    monkeypatch.delenv(CLM_KEY_FILE_ENV, raising=False)
+    monkeypatch.delenv(CLM_CA_FILE_ENV, raising=False)
+    assert clm_tls_launcher._resolve_tls_from_env() is None
+
+
+def test_resolve_tls_builds_config_from_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pki = _make_pki(tmp_path)
+    monkeypatch.setenv(CLM_CERT_FILE_ENV, str(pki["cert"]))
+    monkeypatch.setenv(CLM_KEY_FILE_ENV, str(pki["key"]))
+    monkeypatch.setenv(CLM_CA_FILE_ENV, str(pki["ca"]))
+    cfg = clm_tls_launcher._resolve_tls_from_env()
+    assert cfg is not None
+    assert cfg.verify_mode == "required"
+    assert cfg.ca_file == pki["ca"]
+
+
+def test_install_httpx_mtls_defaults_injects_verify_kwarg(
+    tmp_path: Path,
+    httpx_init_restored: object,
+) -> None:
+    """A bare ``httpx.Client()`` after the patch picks up the SSLContext."""
+    pki = _make_pki(tmp_path)
+    cfg = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["cert"],
+        key_file=pki["key"],
+        verify_mode="required",
+    )
+    captured: dict[str, object] = {}
+    saved_init = httpx.Client.__init__
+
+    def _capture(self: httpx.Client, *args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        # Don't actually open sockets — abort here once we've recorded
+        # what the patched __init__ chose to forward.
+        raise RuntimeError("captured")
+
+    httpx.Client.__init__ = _capture  # type: ignore[method-assign]
+    try:
+        clm_tls_launcher.install_httpx_mtls_defaults(cfg)
+        with pytest.raises(RuntimeError, match="captured"):
+            httpx.Client()
+    finally:
+        httpx.Client.__init__ = saved_init  # type: ignore[method-assign]
+
+    # The patch must have inserted ``verify=`` because we didn't supply
+    # one ourselves. It's an SSLContext (not a path / bool), per the
+    # cluster_tls implementation note pinned by PR #1019.
+    assert "verify" in captured
+    import ssl
+
+    assert isinstance(captured["verify"], ssl.SSLContext)
+
+
+def test_install_httpx_mtls_defaults_honours_explicit_verify(
+    tmp_path: Path,
+    httpx_init_restored: object,
+) -> None:
+    """If the caller already passed ``verify=`` we keep their choice — no silent override."""
+    pki = _make_pki(tmp_path)
+    cfg = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["cert"],
+        key_file=pki["key"],
+        verify_mode="required",
+    )
+    captured: dict[str, object] = {}
+    saved_init = httpx.Client.__init__
+
+    def _capture(self: httpx.Client, *args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("captured")
+
+    httpx.Client.__init__ = _capture  # type: ignore[method-assign]
+    try:
+        clm_tls_launcher.install_httpx_mtls_defaults(cfg)
+        with pytest.raises(RuntimeError, match="captured"):
+            httpx.Client(verify=False)
+    finally:
+        httpx.Client.__init__ = saved_init  # type: ignore[method-assign]
+
+    assert captured["verify"] is False
+
+
+def test_run_aider_refuses_non_aider_target(capsys: pytest.CaptureFixture[str]) -> None:
+    """Defensive guard: launcher only ever fronts aider; refuse anything else."""
+    rc = clm_tls_launcher._run_aider(["sh", "-c", "rm -rf /"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "only supports aider" in err
+
+
+def test_run_aider_no_argv_returns_usage_error(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = clm_tls_launcher._run_aider([])
+    assert rc == 2
+    assert "no command supplied" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Closes the CLM adapter story. Phase 1 shipped in #1012, Phase 2 partial (tool-calling + streaming regression) in #1016, and the cluster-mtls-transport dependency in #1019. This PR delivers the deferred Phase 2.5 mTLS support so the adapter can dial a TLS-terminated customer-side CLM gateway with a customer-issued client certificate.

## How it wires through

Aider talks to the gateway via the OpenAI Python SDK, which dispatches every request through ``httpx.Client``. httpx 0.28+ deliberately does **not** read TLS material from environment variables, so passing the cert/key/CA paths through the adapter env (option 1 in the ticket) does not in fact wire through to the OpenAI SDK transport.

I went with **option 2** — the launcher shim. ``bernstein.adapters.clm_tls_launcher``:

1. Reads ``CLM_CERT_FILE`` / ``CLM_KEY_FILE`` / ``CLM_CA_FILE`` inside the spawned subprocess.
2. Builds an ``ssl.SSLContext`` via ``build_httpx_client_kwargs`` from the cluster-mtls-transport plumbing — single source of truth for worker-side mTLS context.
3. Monkey-patches ``httpx.Client.__init__`` and ``httpx.AsyncClient.__init__`` to default to that context (only when the caller did not pass an explicit ``verify=`` of their own).
4. Hands off to aider via ``runpy.run_module`` so the patch survives into the SDK call sites.

The launcher is only inserted into the spawn cmd when all three CLM_*_FILE env vars are set. A partial triple is rejected at spawn time with ``ClmConfigError`` — operator-error category, not a silent fallback to plain HTTP.

## What changed

- ``src/bernstein/adapters/clm.py``: ``CLM_CERT_FILE`` / ``CLM_KEY_FILE`` / ``CLM_CA_FILE`` / ``CLM_VERIFY_MODE`` env constants, ``tls_config_from_env()`` resolver, launcher injection in ``spawn()``, ``redactable_clm_env_keys()`` helper.
- ``src/bernstein/adapters/clm_tls_launcher.py``: new launcher shim.
- ``docs/adapters/clm.md``: mTLS configuration block + security caveats + launcher rationale.
- Unit tests:
  - ``tests/unit/test_adapter_clm.py`` — env triple resolution, launcher cmd injection, partial-triple rejection, redaction-key set.
  - ``tests/unit/test_clm_tls_launcher.py`` — env resolution, ``httpx.Client`` patch behaviour, defensive guard.
- Integration tests (``tests/integration/adapters/test_adapter_clm_with_fake_nim.py``):
  - **Positive path** — TLS-terminated fake NIM (uvicorn subprocess + self-signed CA), worker carrying matching client cert completes handshake, chat-completion returns 200.
  - **Negative path** — worker that trusts the CA but presents no client cert is rejected at the TLS handshake (``httpx.HTTPError``), per the Phase 2.5 acceptance criterion.

## Acceptance criteria from the ticket

- [x] Adapter accepts ``tls=TLSConfig(...)`` configuration (via env triple) and forwards it to the spawned subprocess.
- [x] Integration test: 2-process setup with self-signed CA, adapter drives the subprocess, handshake succeeds end-to-end against a TLS-terminated fake NIM.
- [x] Worker without a client cert is rejected at the TLS handshake (negative-path integration test).
- [x] No regression in existing CLM adapter tests (#1012 + #1016) — all 22 prior unit + 2 prior integration tests still pass.
- [x] Doc page updated; security caveats called out.

## Test plan

- [x] ``uv run pytest tests/unit/test_adapter_clm.py tests/unit/test_clm_tls_launcher.py tests/integration/adapters/test_adapter_clm_with_fake_nim.py -x -q`` — 32 passed.
- [x] ``uv run ruff format`` + ``uv run ruff check`` clean on all touched files.
- [x] ``uv run pyright`` produces the same 6 pre-existing errors as ``main`` — no net new type issues.

## Related work

- #1012 — CLM adapter Phase 1 (MVP).
- #1016 — CLM adapter Phase 2 partial (tool-calling + streaming regression).
- #1019 — cluster-mtls-transport (dependency for the shared ``TLSConfig`` plumbing reused here).

## Out of scope

- Per-request client cert rotation — one cert per spawn, lifecycle managed by the operator's PKI.
- Custom certificate validation logic beyond ``ssl.SSLContext`` — we trust the standard library.
- New TLS infrastructure — reuses the cluster-mtls-transport primitives.

**Do not merge.** Tagged for review per the ticket's PR-only deliverable.