### PR TITLE
feat(cluster): tunnel deployment patterns (Cloudflare Tunnel + Tailscale)

### DIFF
--- a/.github/workflows/cluster-tunnel-e2e.yml
+++ b/.github/workflows/cluster-tunnel-e2e.yml
@@ -1,0 +1,98 @@
+name: cluster-tunnel-e2e
+
+# Bring up Bernstein central + a cloudflared sidecar via docker compose
+# and assert a worker can register / heartbeat through the public
+# tunnel hostname.
+#
+# This workflow makes real outbound calls to Cloudflare's edge and
+# requires:
+#   * secrets.CF_TUNNEL_TOKEN     — token for the test tunnel
+#   * secrets.CF_TUNNEL_HOSTNAME  — public hostname mapped to the tunnel
+#
+# Both are scoped to a throwaway tunnel used only for CI.
+#
+# It is opt-in:
+#   * Default: NOT triggered on regular PRs (the test guards itself
+#     with CI_TUNNEL_TEST=1 and skips when the secrets are missing).
+#   * Nightly: scheduled cron run.
+#   * On-demand: workflow_dispatch.
+
+on:
+  schedule:
+    # 04:23 UTC nightly. Offset from cluster-e2e (03:17) and other
+    # nightly maintenance jobs so they don't compete for the same
+    # GitHub-hosted runner pool.
+    - cron: "23 4 * * *"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to test"
+        required: false
+        default: "main"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cluster-tunnel-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cluster-tunnel-e2e:
+    name: cluster-tunnel-e2e (linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    # Only run on the upstream repo so PRs from forks don't try to
+    # use the secrets (and silently skip).
+    if: github.repository == 'sipyourdrink-ltd/bernstein'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Verify docker compose available
+        run: docker compose version
+
+      - name: Run cluster tunnel smoke test
+        env:
+          CI_TUNNEL_TEST: "1"
+          CF_TUNNEL_TOKEN:    ${{ secrets.CF_TUNNEL_TOKEN }}
+          CF_TUNNEL_HOSTNAME: ${{ secrets.CF_TUNNEL_HOSTNAME }}
+          BERNSTEIN_RUN_CLUSTER_E2E: "1"
+        run: |
+          uv run pytest tests/integration/cluster/test_cluster_tunnel_smoke.py \
+            -m cluster_e2e -x -q --tb=short
+
+      - name: Collect docker compose logs
+        if: always()
+        run: |
+          docker ps -a > /tmp/docker-ps.txt 2>&1 || true
+          docker compose -f examples/cluster/cloudflared/docker-compose.yml \
+            logs --no-color > /tmp/compose-final.log 2>&1 || true
+          docker compose -f examples/cluster/cloudflared/docker-compose.yml \
+            down -v --remove-orphans > /tmp/compose-down.log 2>&1 || true
+
+      - name: Upload diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-tunnel-e2e-logs
+          path: |
+            /tmp/docker-ps.txt
+            /tmp/compose-final.log
+            /tmp/compose-down.log
+            /tmp/pytest-*/**/compose.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/docs/cluster/deployment-patterns.md
+++ b/docs/cluster/deployment-patterns.md
@@ -1,0 +1,311 @@
+# Cluster deployment patterns
+
+Bernstein's cluster mode is a STAR topology: one central server, N workers.
+The central server runs the orchestrator, the API, and the task store.
+Workers register, heartbeat, and pull tasks for the roles they advertise.
+
+This page describes three deployment patterns for getting workers to reach
+the central server across whatever network shape your environment imposes.
+Pick one based on where the workers live relative to the central node.
+
+| Pattern              | When to use                                                  | Complexity |
+|----------------------|--------------------------------------------------------------|------------|
+| Same-VPC mTLS        | Central + workers on the same trusted network                | Low        |
+| Cloudflare Tunnel    | Workers on the public internet, central behind a NAT/firewall | Medium     |
+| Tailscale overlay    | Workers on contractor laptops or a different cloud account    | Medium     |
+
+> Tunnels and mTLS stack. The tunnel protects the network path; mTLS
+> (see [`mtls-setup.md`](./mtls-setup.md)) authenticates the application.
+> A regulated production deployment usually wants both.
+
+---
+
+## Pattern 1 — Same-VPC mTLS
+
+Both the central server and the workers run inside one trusted network
+(office VPC, single AWS VPC, single GKE namespace). No NAT to traverse.
+Authenticity comes from mTLS at the transport layer plus the cluster JWT
+at the application layer.
+
+This is the simple case and is fully covered in
+[`mtls-setup.md`](./mtls-setup.md). A condensed checklist:
+
+```bash
+# On the central server
+bernstein cluster bootstrap-ca \
+    --out-dir ~/.bernstein/cluster \
+    --server-san central.internal
+
+bernstein cluster server \
+    --bind 0.0.0.0:8052 \
+    --tls-ca   ~/.bernstein/cluster/ca.crt \
+    --tls-cert ~/.bernstein/cluster/server.crt \
+    --tls-key  ~/.bernstein/cluster/server.key \
+    --tls-verify required
+```
+
+```bash
+# On each worker
+# (ca.crt + node.crt + node.key copied out-of-band into ~/.bernstein/cluster/)
+bernstein cluster worker \
+    --server https://central.internal:8052 \
+    --tls-ca   ~/.bernstein/cluster/ca.crt \
+    --tls-cert ~/.bernstein/cluster/node.crt \
+    --tls-key  ~/.bernstein/cluster/node.key \
+    --role backend
+```
+
+That's it. No tunnel, no overlay. The network is trusted; mTLS makes it
+auditable.
+
+---
+
+## Pattern 2 — Cloudflare Tunnel
+
+The central server runs in your office or a private VPC, and you do not
+control (or do not want to touch) the firewall it sits behind. Workers run
+on the public internet — contractor laptops, a separate cloud account, a
+build runner. A `cloudflared` sidecar opens an outbound connection from
+the central server to Cloudflare's edge, and workers reach the central
+server via a public hostname under your Cloudflare zone.
+
+```
++------------------+                                +------------------+
+|  Worker laptop   |                                |  Office VPC      |
+|  bernstein       |  HTTPS  +--------------+       |  +----------+    |
+|  cluster worker  +-------->| Cloudflare   |<------+--+ central  |    |
+|  --server https://         |  edge        |  out  |  | server   |    |
+|  central.example.com       +--------------+  bound|  +----------+    |
++------------------+                                |       ^          |
+                                                    |       | local    |
+                                                    |  +----+------+   |
+                                                    |  | cloudflared|  |
+                                                    |  | sidecar    |  |
+                                                    |  +-----------+   |
+                                                    +------------------+
+```
+
+### What you need
+
+1. A Cloudflare account with a zone (`example.com`).
+2. A tunnel created in the Zero Trust dashboard (or via `cloudflared
+   tunnel create bernstein-central`). Copy the tunnel token.
+3. A public hostname routed to the tunnel — e.g.
+   `central.bernstein.example.com` → `http://bernstein-central:8052`.
+4. (Recommended) A Cloudflare Access policy on that hostname so only
+   identified workers/users can reach it. Service tokens work well for
+   headless workers.
+
+### Files
+
+A complete copy-paste-runnable example lives at
+[`examples/cluster/cloudflared/`](../../examples/cluster/cloudflared/):
+
+- `config.yml` — `cloudflared` ingress config
+- `Dockerfile` — sidecar image (pinned `cloudflare/cloudflared:latest`)
+- `docker-compose.yml` — central + sidecar wired together
+
+### Bring it up
+
+```bash
+# On the host running the central server
+export CF_TUNNEL_TOKEN="eyJhIjoi..."        # from Cloudflare dashboard
+export BERNSTEIN_CLUSTER_AUTH_SECRET="$(openssl rand -hex 32)"
+cd examples/cluster/cloudflared
+docker compose up -d
+
+# Verify the tunnel is healthy
+curl -fsS https://central.bernstein.example.com/health
+# {"status":"ok"}
+```
+
+### Worker config
+
+Workers don't need to know anything about Cloudflare — they point at the
+public hostname like any HTTPS server.
+
+```bash
+# On the worker (laptop, separate cloud, build runner)
+bernstein cluster worker \
+    --server https://central.bernstein.example.com \
+    --role backend \
+    --auth-secret "$BERNSTEIN_CLUSTER_AUTH_SECRET"
+```
+
+If you put Cloudflare Access in front of the hostname, set:
+
+```bash
+export CF_ACCESS_CLIENT_ID="<service-token-id>"
+export CF_ACCESS_CLIENT_SECRET="<service-token-secret>"
+```
+
+…and add them to the worker's HTTP headers via your environment's standard
+mechanism (Bernstein passes through `CF-Access-*` headers as-is).
+
+### Customer scenario — contractor laptop
+
+> **Scenario:** You have three contractors building a feature against
+> your internal Bernstein. They are not on the corporate VPN, you are not
+> giving them VPN access, you don't want to expose port 8052 to the
+> internet, and you do want a per-contractor identity you can revoke.
+
+End-to-end:
+
+1. **Operator (central side).** Stand up the central server behind
+   `cloudflared` using the compose file in
+   `examples/cluster/cloudflared/`. Create a Cloudflare Access policy
+   on `central.bernstein.example.com` that requires a service token.
+2. **Operator (per contractor).** In the Cloudflare dashboard, mint one
+   Access service token per contractor; revoke it when they leave.
+3. **Contractor.** Install Bernstein, set the two `CF_ACCESS_*` env vars
+   for their service token, run `bernstein cluster worker --server
+   https://central.bernstein.example.com --role backend`. They never
+   touch your VPN.
+4. **Verify.** On the central node, `bernstein cluster status` lists the
+   contractor's worker as `ONLINE`. Revoking the service token in
+   Cloudflare immediately blocks them at the edge — Bernstein doesn't
+   need to know.
+
+For a regulated workload, layer mTLS underneath the tunnel so the
+encryption is end-to-end and the application can verify the worker's
+identity independently of Cloudflare.
+
+---
+
+## Pattern 3 — Tailscale overlay
+
+Both the central server and the workers join the same tailnet and
+address each other on private MagicDNS hostnames. Tailscale handles NAT
+traversal and identity; Bernstein sees a flat, private network.
+
+This is the right shape when:
+
+- Workers are on contractor laptops *and* you don't want to manage
+  Cloudflare zones.
+- You already use Tailscale for other internal services.
+- You want identity-on-the-network — the tailnet ACL decides who can
+  even reach Bernstein, before Bernstein evaluates a JWT.
+
+```
++----------------+         tailnet        +----------------+
+|   Worker       |    100.64.x.x          |  Central       |
+|   (laptop)     |<---------------------->|  server        |
+|   tailscaled   |                        |  tailscaled    |
++----------------+                        +----------------+
+       ^                                          ^
+       |  identity: contractor@example.com        |  identity: bernstein-central
+       +------------------------------------------+
+                   (Tailscale ACL)
+```
+
+### What you need
+
+1. A Tailscale account (or Headscale, ZeroTier — same shape).
+2. A tagged auth key for the central server (`tag:bernstein-central`)
+   and one for workers (`tag:bernstein-worker`). Reusable, ephemeral
+   keys are fine.
+3. An ACL that allows `tag:bernstein-worker` to talk to
+   `tag:bernstein-central` on TCP/8052 — see
+   [`examples/cluster/tailscale/tailscale.json`](../../examples/cluster/tailscale/tailscale.json).
+
+### Files
+
+A complete copy-paste-runnable example lives at
+[`examples/cluster/tailscale/`](../../examples/cluster/tailscale/):
+
+- `tailscale.json` — tailnet ACL granting only worker→central on 8052
+- `docker-compose.yml` — central + tailscaled sidecar
+- `bernstein.yaml` — sample config showing the tailnet hostname
+
+### Bring it up
+
+```bash
+# Central node
+export TS_AUTHKEY="tskey-auth-..."          # tag:bernstein-central
+export BERNSTEIN_CLUSTER_AUTH_SECRET="$(openssl rand -hex 32)"
+cd examples/cluster/tailscale
+docker compose up -d
+
+# Tailscale will publish the central server as
+#   bernstein-central.tailXXXXX.ts.net
+# (MagicDNS) once it's up. Verify:
+tailscale status | grep bernstein-central
+```
+
+### Worker config
+
+```bash
+# On the worker
+sudo tailscale up --authkey="$TS_AUTHKEY_WORKER" --advertise-tags=tag:bernstein-worker
+
+bernstein cluster worker \
+    --server http://bernstein-central.tailXXXXX.ts.net:8052 \
+    --role backend \
+    --auth-secret "$BERNSTEIN_CLUSTER_AUTH_SECRET"
+```
+
+The traffic stays inside the tailnet; the URL is `http://` because the
+encryption is handled by WireGuard at the network layer. If you also
+want application-layer mTLS for audit purposes, follow
+[`mtls-setup.md`](./mtls-setup.md) on top of this — they compose.
+
+### ACL shape
+
+The shipped ACL is intentionally minimal:
+
+```jsonc
+{
+  "tagOwners": {
+    "tag:bernstein-central": ["autogroup:admin"],
+    "tag:bernstein-worker":  ["autogroup:admin"]
+  },
+  "acls": [
+    { "action": "accept",
+      "src":    ["tag:bernstein-worker"],
+      "dst":    ["tag:bernstein-central:8052"] }
+  ]
+}
+```
+
+Workers cannot reach each other on the tailnet — Bernstein's STAR
+topology routes everything through the central server, so peer-to-peer
+reachability would just be attack surface.
+
+---
+
+## Picking a pattern
+
+```
+Workers and central on the same trusted network?
+  yes -> Pattern 1 (Same-VPC mTLS)
+  no  -> Do you already use Cloudflare for ingress?
+           yes -> Pattern 2 (Cloudflare Tunnel)
+           no  -> Pattern 3 (Tailscale overlay)
+```
+
+All three patterns work with the existing `bernstein cluster worker
+--server <url>` flag. Customers don't write Bernstein-specific
+networking code; they pick the tunnel/overlay that fits their
+operations and point the worker at the resulting hostname.
+
+## What's not covered here
+
+- **Peer-to-peer worker traffic.** The STAR topology routes through the
+  central server. Workers don't talk to each other.
+- **ZeroTier / WireGuard / Headscale.** Same shape as Tailscale; adapt
+  the example accordingly. We'll ship first-class samples when a
+  customer asks.
+- **Automated cert rotation.** See the rotation section of
+  `mtls-setup.md` — manual today, ACME/cert-manager hooks tracked as a
+  follow-up.
+- **In-cluster service mesh.** If you're already running Istio/Linkerd,
+  Bernstein's plain HTTP works fine behind the mesh; you don't need
+  any of the patterns above.
+
+## Related
+
+- [`mtls-setup.md`](./mtls-setup.md) — application-layer mutual TLS
+- [`examples/cluster/cloudflared/`](../../examples/cluster/cloudflared/)
+- [`examples/cluster/tailscale/`](../../examples/cluster/tailscale/)
+- [`tests/integration/cluster/test_cluster_tunnel_smoke.py`](../../tests/integration/cluster/test_cluster_tunnel_smoke.py)
+  — CI smoke test for Pattern 2

--- a/examples/cluster/cloudflared/Dockerfile
+++ b/examples/cluster/cloudflared/Dockerfile
@@ -1,0 +1,28 @@
+# cloudflared sidecar for the Bernstein central server.
+#
+# Pinned to a specific tag rather than `latest` so reproducing a
+# deployment doesn't depend on whatever Cloudflare promoted last.
+# Bump the tag deliberately when you want a newer version.
+FROM cloudflare/cloudflared:2025.1.0
+
+# The image's default entrypoint is cloudflared itself, so we only need
+# to provide arguments. We support two run modes:
+#   1. Token mode (recommended for fresh tunnels): pass `TUNNEL_TOKEN`
+#      via env. cloudflared looks it up automatically; no config file
+#      is required.
+#   2. Config-file mode: mount `config.yml` + `creds.json` into
+#      /etc/cloudflared/ and run `tunnel run`.
+#
+# docker-compose.yml drives mode (1) by default. Mode (2) is documented
+# in docs/cluster/deployment-patterns.md.
+
+USER nonroot
+WORKDIR /etc/cloudflared
+
+# Healthcheck: cloudflared exposes a metrics server when started with
+# `--metrics`. We probe it to confirm the tunnel daemon is alive.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD ["cloudflared", "--version"]
+
+ENTRYPOINT ["cloudflared"]
+CMD ["tunnel", "--no-autoupdate", "--metrics", "0.0.0.0:2000", "run"]

--- a/examples/cluster/cloudflared/config.yml
+++ b/examples/cluster/cloudflared/config.yml
@@ -1,0 +1,39 @@
+# cloudflared sidecar config for the Bernstein central server.
+#
+# The tunnel terminates at the Cloudflare edge; cloudflared opens an
+# outbound connection so no inbound port has to be exposed on the host
+# running the central server.
+#
+# Usage:
+#   - Create the tunnel in the Cloudflare Zero Trust dashboard (or via
+#     `cloudflared tunnel create bernstein-central`).
+#   - Set the tunnel UUID below or override it through the
+#     `TUNNEL_ID` env var in docker-compose.yml.
+#   - Map a public hostname (`central.bernstein.example.com`) to this
+#     tunnel via the dashboard's Public Hostnames page; the same
+#     mapping is repeated under `ingress:` so cloudflared can do
+#     local routing if it ever runs without the edge config.
+#
+# All values are placeholders — replace `example.com` and the UUID
+# with your own.
+
+tunnel: 00000000-0000-0000-0000-000000000000
+credentials-file: /etc/cloudflared/creds.json
+
+# Optional but recommended: TLS to origin even though it's localhost.
+# Cloudflare terminates the public TLS; this keeps the inner hop
+# encrypted as well.
+originRequest:
+  connectTimeout: 10s
+  tlsTimeout:     10s
+  keepAliveConnections: 16
+  keepAliveTimeout:     90s
+  noTLSVerify: false
+
+ingress:
+  - hostname: central.bernstein.example.com
+    service: http://bernstein-central:8052
+    originRequest:
+      httpHostHeader: central.bernstein.example.com
+  # Catch-all: required by cloudflared. Anything else gets a 404.
+  - service: http_status:404

--- a/examples/cluster/cloudflared/docker-compose.yml
+++ b/examples/cluster/cloudflared/docker-compose.yml
@@ -1,0 +1,65 @@
+# Bernstein central server + cloudflared sidecar.
+#
+# Brings up two containers on a private Docker network:
+#   * bernstein-central — the cluster central server (no public ports)
+#   * bernstein-cloudflared — the tunnel sidecar
+#
+# The central server is NOT published on the host; only cloudflared can
+# reach it on the internal network. The public ingress is the
+# Cloudflare hostname configured in the Zero Trust dashboard.
+#
+# Required environment:
+#   CF_TUNNEL_TOKEN              — token from `cloudflared tunnel token`
+#   BERNSTEIN_CLUSTER_AUTH_SECRET — shared HMAC secret for cluster JWTs
+#
+# Optional:
+#   BERNSTEIN_IMAGE              — pin a Bernstein image tag (default: latest)
+
+services:
+  bernstein-central:
+    image: ${BERNSTEIN_IMAGE:-ghcr.io/sipyourdrink-ltd/bernstein:latest}
+    container_name: bernstein-central
+    restart: unless-stopped
+    environment:
+      BERNSTEIN_CLUSTER_ENABLED: "1"
+      BERNSTEIN_CLUSTER_AUTH_SECRET: ${BERNSTEIN_CLUSTER_AUTH_SECRET:?required}
+      BERNSTEIN_BIND_HOST: "0.0.0.0"
+      BERNSTEIN_BIND_PORT: "8052"
+    command:
+      - "bernstein"
+      - "cluster"
+      - "server"
+      - "--bind"
+      - "0.0.0.0:8052"
+    volumes:
+      - bernstein-state:/var/lib/bernstein
+    networks:
+      - bernstein-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8052/health || exit 1"]
+      interval: 10s
+      timeout:  3s
+      retries:  6
+
+  bernstein-cloudflared:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: bernstein-cloudflared
+    restart: unless-stopped
+    environment:
+      TUNNEL_TOKEN: ${CF_TUNNEL_TOKEN:?required}
+    depends_on:
+      bernstein-central:
+        condition: service_healthy
+    networks:
+      - bernstein-net
+    # cloudflared talks outbound to Cloudflare's edge, so it does not
+    # need any inbound published ports.
+
+networks:
+  bernstein-net:
+    driver: bridge
+
+volumes:
+  bernstein-state:

--- a/examples/cluster/tailscale/bernstein.yaml
+++ b/examples/cluster/tailscale/bernstein.yaml
@@ -1,0 +1,40 @@
+# Sample Bernstein worker config for a Tailscale-overlay deployment.
+#
+# Drop this on the worker host as `~/.bernstein/bernstein.yaml`. The
+# only Bernstein-specific bit is the cluster `server_url` pointing at
+# the central node's MagicDNS hostname; everything else is identical
+# to a same-VPC worker.
+#
+# Bring it up with:
+#
+#   sudo tailscale up --authkey="$TS_AUTHKEY_WORKER" \
+#       --advertise-tags=tag:bernstein-worker
+#
+#   bernstein cluster worker \
+#       --config ~/.bernstein/bernstein.yaml \
+#       --role backend
+
+cluster:
+  enabled: true
+  # Replace `tailXXXXX` with your tailnet's MagicDNS suffix
+  # (`tailscale status --json | jq -r .MagicDNSSuffix`).
+  server_url: http://bernstein-central.tailXXXXX.ts.net:8052
+  # Shared HMAC secret with the central server. Provide it via env
+  # (`BERNSTEIN_CLUSTER_AUTH_SECRET`) rather than committing it.
+  auth_secret_env: BERNSTEIN_CLUSTER_AUTH_SECRET
+  heartbeat_interval_s: 5
+  node_timeout_s: 30
+  # The traffic is encrypted by WireGuard at the network layer, so
+  # plain HTTP is fine here. Layer mTLS on top if you need
+  # application-level identity for audit (see docs/cluster/mtls-setup.md).
+  tls: null
+
+worker:
+  role: backend
+  capacity:
+    max_agents: 4
+    gpu_available: false
+    supported_models: ["sonnet"]
+  labels:
+    deployment: tailscale-overlay
+    region: contractor-laptop

--- a/examples/cluster/tailscale/docker-compose.yml
+++ b/examples/cluster/tailscale/docker-compose.yml
@@ -1,0 +1,66 @@
+# Bernstein central server + tailscaled sidecar.
+#
+# Both containers share the same network namespace via
+# `network_mode: service:tailscale`. The tailscale container holds the
+# WireGuard interface; the bernstein-central container binds 8052
+# inside that namespace, so workers on the tailnet reach it via the
+# MagicDNS hostname `bernstein-central.tailXXXXX.ts.net:8052`.
+#
+# Required environment:
+#   TS_AUTHKEY                    — Tailscale auth key tagged
+#                                   `tag:bernstein-central`
+#   BERNSTEIN_CLUSTER_AUTH_SECRET — shared HMAC secret for cluster JWTs
+#
+# Optional:
+#   BERNSTEIN_IMAGE — pin a Bernstein image tag (default: latest)
+
+services:
+  tailscale:
+    image: tailscale/tailscale:stable
+    container_name: bernstein-tailscale
+    restart: unless-stopped
+    hostname: bernstein-central
+    environment:
+      TS_AUTHKEY:    ${TS_AUTHKEY:?required}
+      TS_HOSTNAME:   bernstein-central
+      TS_EXTRA_ARGS: --advertise-tags=tag:bernstein-central --accept-dns=true
+      TS_STATE_DIR:  /var/lib/tailscale
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - net_admin
+      - sys_module
+
+  bernstein-central:
+    image: ${BERNSTEIN_IMAGE:-ghcr.io/sipyourdrink-ltd/bernstein:latest}
+    container_name: bernstein-central
+    restart: unless-stopped
+    # Share the tailscale container's network namespace so we bind
+    # 8052 onto the WireGuard interface without exposing it on the
+    # host.
+    network_mode: service:tailscale
+    depends_on:
+      - tailscale
+    environment:
+      BERNSTEIN_CLUSTER_ENABLED: "1"
+      BERNSTEIN_CLUSTER_AUTH_SECRET: ${BERNSTEIN_CLUSTER_AUTH_SECRET:?required}
+      BERNSTEIN_BIND_HOST: "0.0.0.0"
+      BERNSTEIN_BIND_PORT: "8052"
+    command:
+      - "bernstein"
+      - "cluster"
+      - "server"
+      - "--bind"
+      - "0.0.0.0:8052"
+    volumes:
+      - bernstein-state:/var/lib/bernstein
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:8052/health || exit 1"]
+      interval: 10s
+      timeout:  3s
+      retries:  6
+
+volumes:
+  tailscale-state:
+  bernstein-state:

--- a/examples/cluster/tailscale/tailscale.json
+++ b/examples/cluster/tailscale/tailscale.json
@@ -1,0 +1,49 @@
+// Tailnet ACL for Bernstein cluster.
+//
+// Two tags:
+//   tag:bernstein-central — the central server
+//   tag:bernstein-worker  — every worker
+//
+// Workers can reach the central server on TCP/8052 only. Workers
+// cannot reach each other; the central server cannot initiate
+// connections back to workers (Bernstein's STAR topology routes
+// everything through the central node — peer-to-peer reachability
+// would just be attack surface).
+//
+// Drop this into the "Access controls" page of your tailnet (or
+// `tailscale acl set`).
+
+{
+  "tagOwners": {
+    "tag:bernstein-central": ["autogroup:admin"],
+    "tag:bernstein-worker":  ["autogroup:admin"]
+  },
+
+  "acls": [
+    {
+      "action": "accept",
+      "src":    ["tag:bernstein-worker"],
+      "dst":    ["tag:bernstein-central:8052"]
+    }
+  ],
+
+  "ssh": [
+    // Operators (admins) can SSH into the central node for
+    // troubleshooting. Workers cannot.
+    {
+      "action": "accept",
+      "src":    ["autogroup:admin"],
+      "dst":    ["tag:bernstein-central"],
+      "users":  ["autogroup:nonroot", "root"]
+    }
+  ],
+
+  "tests": [
+    {
+      "src":    "tag:bernstein-worker",
+      "accept": ["tag:bernstein-central:8052"],
+      "deny":   ["tag:bernstein-worker:8052",
+                 "tag:bernstein-central:22"]
+    }
+  ]
+}

--- a/tests/integration/cluster/test_cluster_tunnel_smoke.py
+++ b/tests/integration/cluster/test_cluster_tunnel_smoke.py
@@ -1,0 +1,226 @@
+"""Smoke test: Bernstein cluster reachable through a tunnel sidecar.
+
+This test brings up a 2-container compose:
+
+  * ``bernstein-central``     — the cluster central server
+  * ``bernstein-cloudflared`` — a ``cloudflared`` sidecar terminating
+    the public tunnel hostname
+
+…and asserts that a Bernstein worker, configured with the public
+tunnel URL, can register and heartbeat through the tunnel.
+
+It is **opt-in**:
+
+  * Skipped by default in PR runs.
+  * The CI nightly schedule runs it via the ``cluster-tunnel-e2e.yml``
+    workflow, which sets ``CI_TUNNEL_TEST=1``.
+  * Requires a Cloudflare tunnel token in ``CF_TUNNEL_TOKEN`` and the
+    public hostname in ``CF_TUNNEL_HOSTNAME``.
+
+The test is intentionally minimal: tunnel up → register → heartbeat →
+deregister. Anything more invasive belongs in ``test_real_2node.py``,
+which already exercises crash recovery, partitions, and token expiry
+on the local loopback path.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import shutil
+import subprocess
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+
+from bernstein.core.security.jwt_tokens import JWTManager, JWTPayload
+
+# --------------------------------------------------------------------------- #
+# Opt-in gate
+# --------------------------------------------------------------------------- #
+
+_TUNNEL_TEST_ENABLED = os.environ.get("CI_TUNNEL_TEST", "").lower() in ("1", "true", "yes")
+_CF_TOKEN = os.environ.get("CF_TUNNEL_TOKEN", "")
+_CF_HOSTNAME = os.environ.get("CF_TUNNEL_HOSTNAME", "")
+
+pytestmark = [
+    pytest.mark.cluster_e2e,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not _TUNNEL_TEST_ENABLED,
+        reason="cluster tunnel smoke test is opt-in: set CI_TUNNEL_TEST=1",
+    ),
+    pytest.mark.skipif(
+        not _CF_TOKEN or not _CF_HOSTNAME,
+        reason="CF_TUNNEL_TOKEN and CF_TUNNEL_HOSTNAME must be set (GitHub secrets in CI)",
+    ),
+    pytest.mark.skipif(
+        shutil.which("docker") is None,
+        reason="docker CLI is required to bring the compose stack up",
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPOSE_FILE = REPO_ROOT / "examples" / "cluster" / "cloudflared" / "docker-compose.yml"
+TUNNEL_READY_TIMEOUT_S = 120.0
+TUNNEL_READY_POLL_S = 2.0
+HEARTBEAT_OBSERVATION_WINDOW_S = 15.0
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _compose(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Run ``docker compose`` against the example compose file."""
+    cmd = ["docker", "compose", "-f", str(COMPOSE_FILE), *args]
+    return subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+    )
+
+
+def _wait_tunnel_ready(public_url: str, timeout_s: float = TUNNEL_READY_TIMEOUT_S) -> bool:
+    """Poll the public tunnel hostname until ``/health`` returns 200."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(f"{public_url}/health", timeout=5.0)
+            if resp.status_code == 200:
+                return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(TUNNEL_READY_POLL_S)
+    return False
+
+
+def _mint_token(secret: str, node_id: str, scopes: list[str]) -> str:
+    """Mint a cluster JWT signed with ``secret`` for ``node_id``."""
+    mgr = JWTManager(secret=secret, expiry_hours=1)
+    now = time.time()
+    payload = JWTPayload(
+        session_id=f"node-{node_id}",
+        user_id=node_id,
+        issued_at=now,
+        expires_at=now + 3600.0,
+        scopes=scopes,
+    )
+    return mgr._encode(payload)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture: bring the compose stack up + down
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def tunnel_stack(tmp_path: Path) -> Iterator[dict[str, str]]:
+    """Bring up cloudflared + central, yield connection info, tear down."""
+    cluster_secret = secrets.token_urlsafe(32)
+    public_url = f"https://{_CF_HOSTNAME}"
+
+    env = {
+        "CF_TUNNEL_TOKEN": _CF_TOKEN,
+        "BERNSTEIN_CLUSTER_AUTH_SECRET": cluster_secret,
+    }
+
+    up = _compose("up", "-d", "--build", env=env)
+    if up.returncode != 0:
+        pytest.fail(f"docker compose up failed:\nstdout:\n{up.stdout}\nstderr:\n{up.stderr}")
+
+    try:
+        if not _wait_tunnel_ready(public_url):
+            logs = _compose("logs", "--no-color", env=env).stdout
+            log_path = tmp_path / "compose.log"
+            log_path.write_text(logs, encoding="utf-8")
+            pytest.fail(
+                f"Tunnel did not become reachable at {public_url} within "
+                f"{TUNNEL_READY_TIMEOUT_S:.0f}s. Logs at {log_path}."
+            )
+        yield {
+            "public_url": public_url,
+            "cluster_secret": cluster_secret,
+        }
+    finally:
+        # Always capture logs on the way down so CI can publish them
+        # as an artifact; keep the operation best-effort.
+        logs_proc = _compose("logs", "--no-color", env=env)
+        log_path = tmp_path / "compose.log"
+        log_path.write_text(logs_proc.stdout or "", encoding="utf-8")
+        _compose("down", "-v", "--remove-orphans", env=env)
+
+
+# --------------------------------------------------------------------------- #
+# Test
+# --------------------------------------------------------------------------- #
+
+
+def test_worker_registers_and_heartbeats_via_tunnel(tunnel_stack: dict[str, str]) -> None:
+    """A worker reaching the central via Cloudflare Tunnel registers + heartbeats."""
+    public_url = tunnel_stack["public_url"]
+    secret = tunnel_stack["cluster_secret"]
+
+    register_token = _mint_token(secret, "smoke-worker", ["node:register"])
+    register_payload = {
+        "name": "smoke-worker",
+        "url": "",
+        "capacity": {
+            "max_agents": 1,
+            "available_slots": 1,
+            "active_agents": 0,
+            "gpu_available": False,
+            "supported_models": ["sonnet"],
+        },
+        "labels": {"deployment": "tunnel-smoke"},
+        "cell_ids": [],
+    }
+
+    with httpx.Client(timeout=10.0) as cli:
+        # ---- registration ------------------------------------------------ #
+        register = cli.post(
+            f"{public_url}/cluster/nodes",
+            json=register_payload,
+            headers={"Authorization": f"Bearer {register_token}"},
+        )
+        assert register.status_code == 201, f"register failed: {register.status_code} {register.text}"
+        node_id = register.json()["id"]
+        assert isinstance(node_id, str) and node_id, "central did not return a node id"
+
+        # ---- heartbeat loop --------------------------------------------- #
+        # Five heartbeats over ~15s. We don't try to assert reaper
+        # behaviour here — that's covered by the loopback suite. We
+        # just want to confirm the tunnel carries POSTs, not just GETs.
+        hb_token = _mint_token(secret, node_id, ["node:heartbeat"])
+        deadline = time.monotonic() + HEARTBEAT_OBSERVATION_WINDOW_S
+        ok_count = 0
+        while time.monotonic() < deadline and ok_count < 5:
+            hb = cli.post(
+                f"{public_url}/cluster/nodes/{node_id}/heartbeat",
+                json={"capacity": register_payload["capacity"]},
+                headers={"Authorization": f"Bearer {hb_token}"},
+            )
+            assert hb.status_code in (200, 204), f"heartbeat failed: {hb.status_code} {hb.text}"
+            ok_count += 1
+            time.sleep(2.0)
+
+        assert ok_count >= 3, f"only {ok_count} heartbeats succeeded through the tunnel"
+
+        # ---- deregister -------------------------------------------------- #
+        admin_token = _mint_token(secret, "smoke-admin", ["node:admin"])
+        deregister = cli.delete(
+            f"{public_url}/cluster/nodes/{node_id}",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        # Some builds return 200, others 204 — accept either.
+        assert deregister.status_code in (200, 204), f"deregister failed: {deregister.status_code} {deregister.text}"


### PR DESCRIPTION
## Summary

Implements `.sdd/backlog/open/2026-05-05-feat-cluster-tunnel-deployment-patterns.md`.

Documents and ships working samples for three cluster deployment shapes so customers can run workers behind NAT or on contractor laptops without inventing Bernstein-specific networking:

1. **Same-VPC mTLS** — direct, links to existing `mtls-setup.md`.
2. **Cloudflare Tunnel** — central server behind a `cloudflared` sidecar; workers reach it via a public tunnel hostname; optional Cloudflare Access policy for per-worker identity.
3. **Tailscale overlay** — both nodes on a tailnet, Bernstein addresses each other on MagicDNS hostnames; tailnet ACL restricts traffic to worker -> central:8052 only.

Each pattern in the doc has copy-paste-runnable config, env vars, and exact commands. The contractor-laptop scenario from the ticket is covered end-to-end. The doc explicitly notes that tunnels and mTLS stack rather than compete.

## What landed

- `docs/cluster/deployment-patterns.md` — three named patterns + decision tree.
- `examples/cluster/cloudflared/{config.yml,Dockerfile,docker-compose.yml}` — runnable cloudflared sidecar wired to a Bernstein central container on a private Docker network (no host port published).
- `examples/cluster/tailscale/{tailscale.json,docker-compose.yml,bernstein.yaml}` — tailnet ACL, central + tailscaled compose using `network_mode: service:tailscale`, sample worker `bernstein.yaml`.
- `tests/integration/cluster/test_cluster_tunnel_smoke.py` — one smoke test: 2-container compose (central + cloudflared) + a worker process that registers, heartbeats, deregisters via the public hostname.
- `.github/workflows/cluster-tunnel-e2e.yml` — nightly cron + workflow_dispatch; sets `CI_TUNNEL_TEST=1`, expects `secrets.CF_TUNNEL_TOKEN` and `secrets.CF_TUNNEL_HOSTNAME`; uploads compose logs on failure.

## Smoke-test status

- Skipped by default on PR runs (gated on `CI_TUNNEL_TEST=1` + presence of secrets + docker CLI).
- Locally collects + skips cleanly in <0.2s with no env: `1 skipped`.
- Will run nightly at 04:23 UTC and on workflow_dispatch from upstream.
- Uses placeholders for `CF_TUNNEL_TOKEN` / `CF_TUNNEL_HOSTNAME` — real values must be added as repo secrets before the first nightly run.

## Test plan

- [x] `uv run ruff format` (touched files clean).
- [x] `uv run ruff check tests/integration/cluster/test_cluster_tunnel_smoke.py` — passes.
- [x] `uv run lint-imports` — 3 contracts kept, 0 broken.
- [x] `uv run pytest tests/integration/cluster/test_cluster_tunnel_smoke.py` — `1 skipped` without env (expected).
- [x] All new YAML / JSONC parses (`yaml.safe_load`, `json.loads` after stripping `//` comments).
- [ ] Nightly cluster-tunnel-e2e workflow run (requires CF secrets to be configured by ops; this PR cannot verify that path itself).

## What's NOT in this PR

- No Bernstein-specific tunnel implementation; we point the existing `--server` flag at the tunnel/tailnet hostname.
- No Cloudflare Access policy automation from inside Bernstein.
- No ZeroTier / WireGuard samples (Tailscale covers the same shape; add others when a customer asks).
- No `bernstein cluster doctor` reachability subcommand — flagged in the ticket as a follow-up.