### PR TITLE
feat(session): handoff between terminal and chat/dashboard

### DIFF
--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -65,6 +65,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "gateway_cmd": "bernstein.cli.commands.gateway_cmd",
     "gradients": "bernstein.cli.display.gradients",
     "graph_cmd": "bernstein.cli.commands.graph_cmd",
+    "handoff_cmd": "bernstein.cli.commands.handoff_cmd",
     "icons": "bernstein.cli.display.icons",
     "image_renderer": "bernstein.cli.display.image_renderer",
     "incident_cmd": "bernstein.cli.commands.incident_cmd",

--- a/src/bernstein/cli/commands/chat_cmd.py
+++ b/src/bernstein/cli/commands/chat_cmd.py
@@ -203,6 +203,8 @@ class ChatSession:
         self.bridge.on_command("reject", self._on_reject)
         self.bridge.on_command("switch", self._on_switch)
         self.bridge.on_command("stop", self._on_stop)
+        # op-005: cross-surface session handoff.
+        self.bridge.on_command("handoff", self._on_handoff)
         self.bridge.on_button(self._on_button)
 
     async def run_forever(self) -> None:
@@ -327,6 +329,85 @@ class ChatSession:
         )
         self.bindings.delete(self.bridge.platform, msg.thread_id)
         await self.bridge.send_message(msg.thread_id, "Stop requested. Session will wind down gracefully.")
+
+    async def _on_handoff(self, msg: ChatMessage) -> None:
+        """Handle ``/handoff [<token>]`` — emit or claim a resume token (op-005).
+
+        With no argument, freezes the current thread's binding and emits
+        a token. With a token argument, claims it and rebinds this
+        thread to the same session — the live stream will continue to
+        flow into the new thread without interrupting any in-flight
+        tool calls because the session id is preserved.
+        """
+        from bernstein.core.handoff import (
+            HandoffClaimError,
+            HandoffTokenStore,
+            HandoffUnknownTokenError,
+            StreamTailBuffer,
+        )
+
+        if not await self._gate(msg):
+            return
+
+        store = HandoffTokenStore(self.workdir)
+        if not msg.args:
+            binding = self.bindings.get(self.bridge.platform, msg.thread_id)
+            if binding is None or not binding.session_id:
+                await self.bridge.send_message(
+                    msg.thread_id,
+                    "No active session to hand off; start one with /run first.",
+                )
+                return
+            issued = store.issue(
+                session_id=binding.session_id,
+                task_id=binding.task_id,
+                source_surface="chat",
+                note=f"{self.bridge.platform}:{msg.thread_id}",
+            )
+            ttl_left = int(issued.expires_at - issued.issued_at)
+            await self.bridge.send_message(
+                msg.thread_id,
+                (
+                    f"Handoff token: `{issued.token}`\n"
+                    f"Valid for {ttl_left}s. Claim from another surface "
+                    f"with /handoff <token> or `bernstein handoff claim <token>`."
+                ),
+            )
+            return
+
+        token = msg.args[0].strip("`<> ")
+        try:
+            record = store.claim(token, claimed_by="chat")
+        except HandoffUnknownTokenError:
+            await self.bridge.send_message(msg.thread_id, "Unknown handoff token.")
+            return
+        except HandoffClaimError as exc:
+            await self.bridge.send_message(msg.thread_id, f"Could not claim token: {exc}")
+            return
+
+        # Rebind this thread to the same session_id so the live stream
+        # continues to flow without disrupting in-flight tool calls.
+        binding = self.bindings.get(self.bridge.platform, msg.thread_id)
+        if binding is None:
+            binding = Binding(
+                platform=self.bridge.platform,
+                thread_id=msg.thread_id,
+            )
+        binding.session_id = record.session_id
+        binding.task_id = record.task_id
+        self.bindings.put(binding)
+
+        tail = StreamTailBuffer(self.workdir, record.session_id).read(limit=20)
+        body_lines = [
+            f"Attached to session {record.session_id}"
+            + (f" / task {record.task_id}" if record.task_id else "")
+            + f" (from {record.source_surface}).",
+        ]
+        if tail:
+            body_lines.append(f"Recent stream tail ({len(tail)} line(s)):")
+            for entry in tail:
+                body_lines.append(f"  [{entry.surface}] {entry.text}")
+        await self.bridge.send_message(msg.thread_id, "\n".join(body_lines))
 
     async def _on_button(self, thread_id: str, approval_id: str, decision: str) -> None:
         """Persist an approve/reject decision to the security handshake dir."""

--- a/src/bernstein/cli/commands/handoff_cmd.py
+++ b/src/bernstein/cli/commands/handoff_cmd.py
@@ -1,0 +1,173 @@
+"""``bernstein handoff`` CLI group — pass a session between surfaces (op-005).
+
+A run started in the terminal can be continued from the web dashboard,
+a chat bridge, or another terminal session — and vice versa. The
+``handoff`` group is the operator-facing seam:
+
+* ``bernstein handoff emit --session <id>`` freezes the source surface
+  and prints a 5-minute resume token.
+* ``bernstein handoff claim <token>`` re-attaches the current terminal
+  to the same session, replaying the recent stream tail so the operator
+  does not see a blank pane while the live stream catches up.
+
+The same token works for the web dashboard (``GET /handoff/<token>``)
+and the chat bridges (``/handoff <token>`` slash command); both routes
+go through :mod:`bernstein.core.handoff` so the contract stays
+single-sourced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import click
+
+from bernstein.core.handoff import (
+    HandoffClaimError,
+    HandoffToken,
+    HandoffUnknownTokenError,
+    StreamTailBuffer,
+    claim_token,
+    emit_token,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.handoff.tokens import Surface
+
+__all__ = ["handoff_group"]
+
+_DEFAULT_WORKDIR = Path.cwd
+_SURFACE_CHOICES = ("terminal", "chat", "dashboard")
+_DEFAULT_TAIL_LINES = 50
+
+
+@click.group("handoff")
+def handoff_group() -> None:
+    """Move a live session between terminal, chat and dashboard."""
+
+
+@handoff_group.command("emit")
+@click.option(
+    "--session",
+    "session_id",
+    required=True,
+    help="Bernstein session id to hand off.",
+)
+@click.option(
+    "--task",
+    "task_id",
+    default="",
+    help="Active task id, if any.",
+)
+@click.option(
+    "--from",
+    "source_surface",
+    type=click.Choice(_SURFACE_CHOICES),
+    default="terminal",
+    show_default=True,
+    help="Surface that is freezing.",
+)
+@click.option(
+    "--note",
+    default="",
+    help="Free-form note carried alongside the token (e.g. chat thread id).",
+)
+def handoff_emit(
+    session_id: str,
+    task_id: str,
+    source_surface: str,
+    note: str,
+) -> None:
+    """Freeze SESSION and print a short-lived resume token (5 min TTL)."""
+    workdir = _DEFAULT_WORKDIR()
+    surface = cast("Surface", source_surface)
+    token = emit_token(
+        workdir,
+        session_id=session_id,
+        task_id=task_id,
+        source_surface=surface,
+        note=note,
+    )
+    click.echo(token.token)
+    click.echo(
+        f"  session={token.session_id}"
+        + (f" task={token.task_id}" if token.task_id else "")
+        + f" expires_in={int(token.expires_at - token.issued_at)}s",
+        err=True,
+    )
+
+
+@handoff_group.command("claim")
+@click.argument("token", required=True)
+@click.option(
+    "--as",
+    "claimed_by",
+    type=click.Choice(_SURFACE_CHOICES),
+    default="terminal",
+    show_default=True,
+    help="Destination surface claiming the token.",
+)
+@click.option(
+    "--tail-lines",
+    type=int,
+    default=_DEFAULT_TAIL_LINES,
+    show_default=True,
+    help="Number of recent stream lines to replay.",
+)
+def handoff_claim(token: str, claimed_by: str, tail_lines: int) -> None:
+    """Claim TOKEN, print session info, and replay the recent stream tail."""
+    workdir = _DEFAULT_WORKDIR()
+    surface = cast("Surface", claimed_by)
+    try:
+        record = claim_token(workdir, token, claimed_by=surface)
+    except HandoffUnknownTokenError as exc:
+        raise click.ClickException(f"unknown handoff token: {exc}") from exc
+    except HandoffClaimError as exc:
+        raise click.ClickException(f"could not claim handoff token: {exc}") from exc
+
+    _render_attach_banner(record)
+    _replay_tail(workdir, record.session_id, tail_lines)
+
+
+@handoff_group.command("status")
+def handoff_status() -> None:
+    """List live (non-expired) handoff tokens."""
+    from bernstein.core.handoff import HandoffTokenStore
+
+    workdir = _DEFAULT_WORKDIR()
+    store = HandoffTokenStore(workdir)
+    tokens = store.all()
+    if not tokens:
+        click.echo("handoff: no live tokens.")
+        return
+    for tok in tokens:
+        state = "claimed" if tok.claimed else "pending"
+        click.echo(
+            f"{tok.token[:12]}... session={tok.session_id} "
+            f"task={tok.task_id or '-'} from={tok.source_surface} "
+            f"state={state} ttl_left={int(tok.expires_at - tok.issued_at)}s"
+        )
+
+
+def _render_attach_banner(record: HandoffToken) -> None:
+    click.echo(
+        f"handoff: attached to session {record.session_id}"
+        + (f" / task {record.task_id}" if record.task_id else "")
+        + f" (from {record.source_surface})"
+    )
+    if record.note:
+        click.echo(f"handoff: note={record.note}")
+
+
+def _replay_tail(workdir: Path, session_id: str, tail_lines: int) -> None:
+    if tail_lines <= 0:
+        return
+    buffer = StreamTailBuffer(workdir, session_id)
+    entries = buffer.read(limit=tail_lines)
+    if not entries:
+        click.echo("handoff: no buffered tail to replay.")
+        return
+    click.echo(f"handoff: replaying last {len(entries)} line(s):")
+    for entry in entries:
+        click.echo(f"  [{entry.surface}] {entry.text}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -857,3 +857,8 @@ cli.add_command(wheelhouse_group, "wheelhouse")
 from bernstein.cli.commands.cluster_cmd import cluster_group  # noqa: E402
 
 cli.add_command(cluster_group, "cluster")
+
+# op-005: cross-surface session handoff (terminal <-> chat <-> dashboard).
+from bernstein.cli.commands.handoff_cmd import handoff_group  # noqa: E402
+
+cli.add_command(handoff_group, "handoff")

--- a/src/bernstein/core/handoff/__init__.py
+++ b/src/bernstein/core/handoff/__init__.py
@@ -1,0 +1,49 @@
+"""Session handoff between terminal and chat/dashboard surfaces (op-005).
+
+A run started in the terminal should be continuable from the web
+dashboard, a chat bridge, or another terminal session — and vice versa.
+The :func:`emit_token` call freezes the source surface and writes a
+short-lived (5 min) resume token; the destination calls
+:func:`claim_token` to re-attach to the same session_id without
+interrupting any in-flight tool calls.
+
+State lives in ``.sdd/runtime/handoff_tokens.json`` (atomic JSON map)
+plus a per-session ring buffer at ``.sdd/runtime/handoff_tail/``.
+
+Public API:
+
+* :class:`HandoffToken` — typed payload carrying session/task identity
+  and the ring-buffer pointer the destination uses to replay the stream
+  tail.
+* :class:`HandoffTokenStore` — file-backed token table (atomic read /
+  write, expiry sweep, single-claim semantics).
+* :class:`StreamTailBuffer` — bounded log ring buffer the source writes
+  into and the destination drains on claim.
+* :func:`emit_token` / :func:`claim_token` — high-level helpers used by
+  the CLI, the dashboard route, and the chat slash command.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.handoff.ring_buffer import StreamTailBuffer, TailEntry
+from bernstein.core.handoff.tokens import (
+    DEFAULT_TOKEN_TTL_S,
+    HandoffClaimError,
+    HandoffToken,
+    HandoffTokenStore,
+    HandoffUnknownTokenError,
+    claim_token,
+    emit_token,
+)
+
+__all__ = [
+    "DEFAULT_TOKEN_TTL_S",
+    "HandoffClaimError",
+    "HandoffToken",
+    "HandoffTokenStore",
+    "HandoffUnknownTokenError",
+    "StreamTailBuffer",
+    "TailEntry",
+    "claim_token",
+    "emit_token",
+]

--- a/src/bernstein/core/handoff/ring_buffer.py
+++ b/src/bernstein/core/handoff/ring_buffer.py
@@ -1,0 +1,206 @@
+"""Bounded log ring buffer used to replay the stream tail on handoff.
+
+When a surface (terminal, chat, dashboard) hands off, the destination
+needs to render the last few hundred lines of agent output so the
+operator does not see a blank pane while the live stream catches up.
+We keep that tail on disk per session so any surface can read it back
+without coordinating with the source process.
+
+Storage layout::
+
+    .sdd/runtime/handoff_tail/<session_id>.jsonl
+
+Each line is a JSON object with ``ts`` (epoch seconds), ``surface``
+(``terminal``/``chat``/``dashboard``), and ``text`` (the raw line that
+was streamed to the user). Writers call :meth:`StreamTailBuffer.append`
+which trims older lines once the file crosses
+``max_entries`` records — this keeps replay cheap and bounds the on-disk
+footprint regardless of run length.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+__all__ = [
+    "DEFAULT_MAX_ENTRIES",
+    "StreamTailBuffer",
+    "TailEntry",
+]
+
+DEFAULT_MAX_ENTRIES: Final[int] = 500
+_TAIL_DIR: Final[Path] = Path(".sdd") / "runtime" / "handoff_tail"
+
+
+@dataclass(slots=True, frozen=True)
+class TailEntry:
+    """One captured line of agent output preserved for replay.
+
+    Attributes:
+        ts: Epoch seconds when the line was emitted.
+        surface: Origin surface — ``"terminal"``, ``"chat"`` or
+            ``"dashboard"``.
+        text: Raw line as it was rendered to the operator. Trailing
+            newlines are stripped on append so the wire format stays
+            line-oriented.
+    """
+
+    ts: float
+    surface: str
+    text: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-compatible dict."""
+        return {"ts": self.ts, "surface": self.surface, "text": self.text}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> TailEntry:
+        """Deserialise from a JSON-parsed dict.
+
+        Unknown keys are ignored; missing fields fall back to safe
+        defaults so a single torn line does not break the replay.
+
+        Args:
+            data: Parsed JSON object.
+
+        Returns:
+            Populated :class:`TailEntry`.
+        """
+        ts_raw = data.get("ts", 0.0)
+        try:
+            ts = float(ts_raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            ts = 0.0
+        return cls(
+            ts=ts,
+            surface=str(data.get("surface", "")),
+            text=str(data.get("text", "")),
+        )
+
+
+class StreamTailBuffer:
+    """File-backed ring buffer for one session's recent stream output.
+
+    The buffer is intentionally simple — append-only JSONL with a hard
+    cap on the line count. We trim by rewriting the tail when the line
+    count would exceed ``max_entries``; this is O(N) on trim but the
+    cap keeps N small (default 500 lines).
+
+    The class is process-safe but not thread-safe; callers that share
+    a buffer between threads should serialise their own access.
+    """
+
+    def __init__(
+        self,
+        workdir: Path,
+        session_id: str,
+        *,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
+        """Create or open a buffer for ``session_id``.
+
+        Args:
+            workdir: Project root (the ``.sdd/`` parent).
+            session_id: Bernstein session whose tail we are recording.
+            max_entries: Hard cap on lines retained on disk.
+        """
+        if not session_id:
+            raise ValueError("session_id is required")
+        if max_entries <= 0:
+            raise ValueError("max_entries must be positive")
+        self._workdir = workdir
+        self._session_id = session_id
+        self._max_entries = max_entries
+        self._path = workdir / _TAIL_DIR / f"{session_id}.jsonl"
+
+    @property
+    def path(self) -> Path:
+        """Absolute path of the on-disk JSONL file."""
+        return self._path
+
+    def append(self, surface: str, text: str, *, ts: float | None = None) -> None:
+        """Record one line of streamed output.
+
+        Trims older lines once the on-disk count exceeds
+        ``max_entries`` so the file never grows unbounded.
+
+        Args:
+            surface: Origin surface (``"terminal"`` / ``"chat"`` /
+                ``"dashboard"``).
+            text: Raw stream line. A single trailing newline is stripped
+                so the JSONL stays well-formed.
+            ts: Optional explicit timestamp; defaults to ``time.time()``.
+        """
+        entry = TailEntry(
+            ts=ts if ts is not None else time.time(),
+            surface=surface,
+            text=text.rstrip("\n"),
+        )
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry.to_dict()) + "\n")
+        self._maybe_trim()
+
+    def read(self, *, limit: int | None = None) -> list[TailEntry]:
+        """Return the buffered tail in chronological order.
+
+        Args:
+            limit: If set, return only the last ``limit`` entries.
+
+        Returns:
+            Ordered list of :class:`TailEntry`. Empty when the buffer
+            file is missing or unreadable.
+        """
+        if not self._path.exists():
+            return []
+        entries: list[TailEntry] = []
+        try:
+            for line in self._path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(parsed, dict):
+                    continue
+                entries.append(TailEntry.from_dict(parsed))  # type: ignore[arg-type]
+        except OSError:
+            return []
+        if limit is not None and limit >= 0:
+            return entries[-limit:]
+        return entries
+
+    def clear(self) -> None:
+        """Delete the on-disk buffer (no-op if missing)."""
+        self._path.unlink(missing_ok=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _maybe_trim(self) -> None:
+        """Rewrite the file if it has grown past ``max_entries``."""
+        try:
+            line_count = sum(1 for _ in self._path.open("r", encoding="utf-8"))
+        except OSError:
+            return
+        if line_count <= self._max_entries:
+            return
+        # Read all, keep the suffix, rewrite atomically via .tmp.
+        try:
+            lines = self._path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return
+        keep = lines[-self._max_entries :]
+        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        try:
+            tmp.write_text("\n".join(keep) + ("\n" if keep else ""), encoding="utf-8")
+            tmp.replace(self._path)
+        except OSError:
+            tmp.unlink(missing_ok=True)

--- a/src/bernstein/core/handoff/tokens.py
+++ b/src/bernstein/core/handoff/tokens.py
@@ -1,0 +1,395 @@
+"""Short-lived resume tokens for cross-surface session handoff (op-005).
+
+A :class:`HandoffToken` is the single piece of state the source surface
+emits when it freezes; the destination presents it back to claim the
+session. Tokens live in ``.sdd/runtime/handoff_tokens.json`` so any
+surface (CLI, dashboard, chat bridge) can resolve them without IPC.
+
+Lifecycle:
+
+1. Source calls :func:`emit_token`. We mint a 32-character urlsafe id,
+   stamp ``issued_at``/``expires_at`` (TTL: 5 min), and persist the
+   record.
+2. Destination calls :func:`claim_token`. We look the id up, check it
+   is not expired or already-claimed, and return the
+   :class:`HandoffToken` so the caller can re-attach to the session.
+3. The token is **single-use** — claiming flips a flag and any future
+   claim raises :class:`HandoffClaimError`.
+4. Expired tokens are swept on every load; nothing else needs to run a
+   janitor.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Final, Literal, cast
+
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+__all__ = [
+    "DEFAULT_TOKEN_TTL_S",
+    "HandoffClaimError",
+    "HandoffToken",
+    "HandoffTokenStore",
+    "HandoffUnknownTokenError",
+    "Surface",
+    "claim_token",
+    "emit_token",
+]
+
+DEFAULT_TOKEN_TTL_S: Final[float] = 300.0  # 5 minutes per the ticket.
+_TOKENS_FILE: Final[Path] = Path(".sdd") / "runtime" / "handoff_tokens.json"
+_TOKEN_BYTES: Final[int] = 24  # ~32 urlsafe chars
+
+Surface = Literal["terminal", "chat", "dashboard"]
+_VALID_SURFACES: Final[tuple[str, ...]] = ("terminal", "chat", "dashboard")
+
+
+class HandoffUnknownTokenError(KeyError):
+    """Raised when the destination presents a token we never issued."""
+
+
+class HandoffClaimError(RuntimeError):
+    """Raised when a token cannot be claimed (expired or already used)."""
+
+
+@dataclass(slots=True)
+class HandoffToken:
+    """One pending or consumed cross-surface handoff record.
+
+    Attributes:
+        token: Opaque urlsafe id minted by :func:`emit_token`.
+        session_id: Bernstein session the destination should re-attach
+            to.
+        task_id: Active task id, if any. Empty string when the session
+            is between tasks.
+        source_surface: Surface that emitted the token
+            (``"terminal"`` / ``"chat"`` / ``"dashboard"``).
+        issued_at: Epoch seconds when the source froze.
+        expires_at: Epoch seconds after which the token is invalid.
+        claimed: ``True`` once a destination has consumed the token.
+        claimed_at: Epoch seconds when the claim happened, or ``None``.
+        claimed_by: Surface that claimed the token. Empty until claimed.
+        note: Free-form note the source can attach (e.g. the chat
+            thread id) so the destination can render context.
+    """
+
+    token: str
+    session_id: str
+    task_id: str = ""
+    source_surface: Surface = "terminal"
+    issued_at: float = field(default_factory=time.time)
+    expires_at: float = 0.0
+    claimed: bool = False
+    claimed_at: float | None = None
+    claimed_by: str = ""
+    note: str = ""
+
+    def is_expired(self, *, now: float | None = None) -> bool:
+        """Return True when the token is past its TTL.
+
+        Args:
+            now: Optional clock override (used in tests).
+        """
+        ts = now if now is not None else time.time()
+        return ts >= self.expires_at
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HandoffToken:
+        """Deserialise from a JSON-parsed dict.
+
+        Args:
+            data: Parsed JSON object.
+
+        Returns:
+            Populated :class:`HandoffToken`.
+
+        Raises:
+            KeyError: If ``token`` or ``session_id`` is absent.
+            ValueError: If numeric fields cannot be coerced.
+        """
+        surface_raw = str(data.get("source_surface", "terminal"))
+        if surface_raw not in _VALID_SURFACES:
+            surface_raw = "terminal"
+        claimed_at_raw = data.get("claimed_at")
+        return cls(
+            token=str(data["token"]),
+            session_id=str(data["session_id"]),
+            task_id=str(data.get("task_id", "")),
+            source_surface=cast("Surface", surface_raw),
+            issued_at=float(data.get("issued_at", 0.0)),
+            expires_at=float(data.get("expires_at", 0.0)),
+            claimed=bool(data.get("claimed", False)),
+            claimed_at=float(claimed_at_raw) if claimed_at_raw is not None else None,
+            claimed_by=str(data.get("claimed_by", "")),
+            note=str(data.get("note", "")),
+        )
+
+
+class HandoffTokenStore:
+    """File-backed registry of pending and consumed handoff tokens.
+
+    Persists to ``<workdir>/.sdd/runtime/handoff_tokens.json``. Each
+    public mutation goes through :func:`write_atomic_json` so concurrent
+    crashes never leave a torn JSON document.
+    """
+
+    def __init__(
+        self,
+        workdir: Path,
+        *,
+        ttl_s: float = DEFAULT_TOKEN_TTL_S,
+        clock: object | None = None,
+    ) -> None:
+        """Create a store rooted at *workdir*.
+
+        Args:
+            workdir: Project root (the ``.sdd/`` parent).
+            ttl_s: Token lifetime in seconds. Defaults to 5 minutes per
+                the ticket.
+            clock: Optional callable returning the current epoch
+                seconds; tests inject deterministic clocks here.
+        """
+        if ttl_s <= 0:
+            raise ValueError("ttl_s must be positive")
+        self._workdir = workdir
+        self._ttl_s = ttl_s
+        self._path = workdir / _TOKENS_FILE
+        self._lock = threading.Lock()
+        self._clock: Any = clock if callable(clock) else time.time
+
+    @property
+    def path(self) -> Path:
+        """Absolute path of the on-disk JSON registry."""
+        return self._path
+
+    @property
+    def ttl_s(self) -> float:
+        """Configured token TTL in seconds."""
+        return self._ttl_s
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+
+    def issue(
+        self,
+        *,
+        session_id: str,
+        task_id: str = "",
+        source_surface: Surface = "terminal",
+        note: str = "",
+    ) -> HandoffToken:
+        """Mint a new token bound to ``session_id``.
+
+        Args:
+            session_id: Bernstein session the destination should
+                attach to. Must be non-empty.
+            task_id: Active task id, if any.
+            source_surface: Surface emitting the token.
+            note: Free-form note (e.g. chat thread id).
+
+        Returns:
+            The freshly issued :class:`HandoffToken`.
+        """
+        if not session_id:
+            raise ValueError("session_id is required")
+        now = float(self._clock())
+        token = HandoffToken(
+            token=secrets.token_urlsafe(_TOKEN_BYTES),
+            session_id=session_id,
+            task_id=task_id,
+            source_surface=source_surface,
+            issued_at=now,
+            expires_at=now + self._ttl_s,
+            note=note,
+        )
+        with self._lock:
+            tokens = self._load_locked()
+            tokens[token.token] = token
+            self._save_locked(self._purge_expired(tokens, now=now))
+        return token
+
+    def claim(self, token: str, *, claimed_by: Surface) -> HandoffToken:
+        """Consume the token, returning its payload.
+
+        Args:
+            token: Opaque token string the destination presents.
+            claimed_by: Destination surface (recorded for audit).
+
+        Returns:
+            The :class:`HandoffToken` after marking it consumed.
+
+        Raises:
+            HandoffUnknownTokenError: When ``token`` was never issued.
+            HandoffClaimError: When the token has expired or has
+                already been claimed.
+        """
+        if not token:
+            raise HandoffUnknownTokenError("empty token")
+        now = float(self._clock())
+        with self._lock:
+            tokens = self._load_locked()
+            tokens = self._purge_expired(tokens, now=now)
+            existing = tokens.get(token)
+            if existing is None:
+                self._save_locked(tokens)
+                raise HandoffUnknownTokenError(token)
+            if existing.claimed:
+                raise HandoffClaimError(f"token already claimed by {existing.claimed_by!r}")
+            if existing.is_expired(now=now):
+                # Expiry sweep above should already have removed it,
+                # but double-check for clock skew safety.
+                tokens.pop(token, None)
+                self._save_locked(tokens)
+                raise HandoffClaimError("token expired")
+            existing.claimed = True
+            existing.claimed_at = now
+            existing.claimed_by = claimed_by
+            tokens[token] = existing
+            self._save_locked(tokens)
+            return existing
+
+    def get(self, token: str) -> HandoffToken | None:
+        """Return the stored record for ``token`` or ``None``.
+
+        Performs an expiry sweep but does **not** mutate the
+        ``claimed`` flag; this is a read-only inspection helper used by
+        tests and the dashboard route.
+        """
+        if not token:
+            return None
+        now = float(self._clock())
+        with self._lock:
+            tokens = self._load_locked()
+            tokens = self._purge_expired(tokens, now=now)
+            self._save_locked(tokens)
+            return tokens.get(token)
+
+    def all(self) -> list[HandoffToken]:
+        """Return every live (non-expired) token in issue order."""
+        now = float(self._clock())
+        with self._lock:
+            tokens = self._load_locked()
+            tokens = self._purge_expired(tokens, now=now)
+            self._save_locked(tokens)
+            return sorted(tokens.values(), key=lambda t: t.issued_at)
+
+    # ------------------------------------------------------------------
+    # I/O helpers (assume the lock is already held)
+    # ------------------------------------------------------------------
+
+    def _load_locked(self) -> dict[str, HandoffToken]:
+        if not self._path.exists():
+            return {}
+        try:
+            raw = json.loads(self._path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, HandoffToken] = {}
+        for key, value in cast("dict[str, Any]", raw).items():
+            if not isinstance(value, dict):
+                continue
+            try:
+                token = HandoffToken.from_dict(cast("dict[str, Any]", value))
+            except (KeyError, ValueError):
+                continue
+            out[str(key)] = token
+        return out
+
+    def _save_locked(self, tokens: dict[str, HandoffToken]) -> None:
+        payload = {key: tok.to_dict() for key, tok in tokens.items()}
+        write_atomic_json(self._path, payload)
+
+    def _purge_expired(
+        self,
+        tokens: dict[str, HandoffToken],
+        *,
+        now: float,
+    ) -> dict[str, HandoffToken]:
+        return {
+            tid: tok
+            for tid, tok in tokens.items()
+            # Keep claimed tokens around for ttl_s after issue so
+            # operators can still see "who claimed what" briefly.
+            if not tok.is_expired(now=now)
+        }
+
+
+# ---------------------------------------------------------------------------
+# High-level helpers used by the CLI / dashboard / chat surfaces.
+# ---------------------------------------------------------------------------
+
+
+def emit_token(
+    workdir: Path,
+    *,
+    session_id: str,
+    task_id: str = "",
+    source_surface: Surface = "terminal",
+    note: str = "",
+    ttl_s: float = DEFAULT_TOKEN_TTL_S,
+) -> HandoffToken:
+    """Mint a new handoff token for *session_id*.
+
+    Convenience wrapper around :class:`HandoffTokenStore`. Callers that
+    need to share a store instance (e.g. a long-running server) should
+    instantiate it directly.
+
+    Args:
+        workdir: Project root.
+        session_id: Bernstein session id to hand off.
+        task_id: Active task id, if any.
+        source_surface: Surface emitting the token.
+        note: Free-form note carried alongside the token.
+        ttl_s: Token lifetime in seconds.
+
+    Returns:
+        The freshly issued :class:`HandoffToken`.
+    """
+    store = HandoffTokenStore(workdir, ttl_s=ttl_s)
+    return store.issue(
+        session_id=session_id,
+        task_id=task_id,
+        source_surface=source_surface,
+        note=note,
+    )
+
+
+def claim_token(
+    workdir: Path,
+    token: str,
+    *,
+    claimed_by: Surface,
+    ttl_s: float = DEFAULT_TOKEN_TTL_S,
+) -> HandoffToken:
+    """Consume a token, returning its payload.
+
+    Args:
+        workdir: Project root.
+        token: Opaque token presented by the destination.
+        claimed_by: Surface claiming the token.
+        ttl_s: Token lifetime — used purely for expiry sweeping when the
+            store is constructed; the previously-recorded
+            ``expires_at`` is what gates the claim.
+
+    Returns:
+        The claimed :class:`HandoffToken`.
+
+    Raises:
+        HandoffUnknownTokenError: When the token was never issued.
+        HandoffClaimError: When the token is expired or already claimed.
+    """
+    store = HandoffTokenStore(workdir, ttl_s=ttl_s)
+    return store.claim(token, claimed_by=claimed_by)

--- a/src/bernstein/core/routes/handoff.py
+++ b/src/bernstein/core/routes/handoff.py
@@ -1,0 +1,122 @@
+"""Dashboard route for session handoff (op-005).
+
+The web dashboard exposes ``GET /handoff/<token>`` so a browser session
+can claim a token emitted from the terminal or a chat bridge. The
+endpoint:
+
+1. Resolves ``<token>`` against the on-disk
+   :class:`~bernstein.core.handoff.HandoffTokenStore`.
+2. Marks the token consumed (single-claim semantics).
+3. Returns the session/task identity plus the recent stream tail so the
+   browser can render the last N lines without waiting for the live
+   stream to catch up.
+
+Errors map to HTTP status codes:
+
+* ``404`` — token never issued.
+* ``410`` — token expired or already claimed.
+
+The route uses ``request.app.state.workdir`` when set (the test server
+sets this); otherwise it falls back to the directory containing the
+``.sdd/`` runtime path. Keeping the logic resolver-light here means the
+route stays trivial and the heavy lifting lives in the core module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+
+from bernstein.core.handoff import (
+    HandoffClaimError,
+    HandoffTokenStore,
+    HandoffUnknownTokenError,
+    StreamTailBuffer,
+)
+
+router = APIRouter()
+
+
+def _resolve_workdir(request: Request) -> Path:
+    """Locate the project root from app state.
+
+    The server sets ``app.state.workdir`` when it knows the project
+    root; otherwise we fall back to the parent of
+    ``app.state.runtime_dir`` (which lives at ``.sdd/runtime``).
+    """
+    workdir = getattr(request.app.state, "workdir", None)
+    if isinstance(workdir, Path):
+        return workdir
+    runtime_dir = getattr(request.app.state, "runtime_dir", None)
+    if isinstance(runtime_dir, Path):
+        # ``.sdd/runtime`` -> project root is two levels up.
+        return runtime_dir.parent.parent
+    return Path.cwd()
+
+
+@router.get("/handoff/{token}")
+def claim_handoff_token(token: str, request: Request) -> JSONResponse:
+    """Claim a handoff token and return the session identity + tail.
+
+    Args:
+        token: Opaque urlsafe token presented by the dashboard.
+        request: FastAPI request (used to resolve the workdir).
+
+    Returns:
+        JSON envelope with ``session_id``, ``task_id``,
+        ``source_surface``, ``claimed_at``, ``note`` and ``tail`` (a
+        list of recent stream entries).
+
+    Raises:
+        HTTPException: ``404`` for unknown tokens, ``410`` for expired
+        or already-claimed tokens.
+    """
+    workdir = _resolve_workdir(request)
+    store = HandoffTokenStore(workdir)
+    try:
+        record = store.claim(token, claimed_by="dashboard")
+    except HandoffUnknownTokenError as exc:
+        raise HTTPException(status_code=404, detail="unknown handoff token") from exc
+    except HandoffClaimError as exc:
+        raise HTTPException(status_code=410, detail=str(exc)) from exc
+
+    tail_limit = _tail_limit(request)
+    tail_entries = StreamTailBuffer(workdir, record.session_id).read(limit=tail_limit)
+
+    payload: dict[str, object] = {
+        "session_id": record.session_id,
+        "task_id": record.task_id,
+        "source_surface": record.source_surface,
+        "claimed_at": record.claimed_at,
+        "note": record.note,
+        "tail": [entry.to_dict() for entry in tail_entries],
+    }
+    return JSONResponse(payload)
+
+
+def _tail_limit(request: Request) -> int:
+    """Resolve the requested tail size from the ``tail`` query string.
+
+    Defaults to 50 lines and is hard-capped at 500 to mirror the
+    on-disk ring buffer cap.
+    """
+    raw = request.query_params.get("tail")
+    if raw is None:
+        return 50
+    try:
+        value = int(raw)
+    except ValueError:
+        return 50
+    return max(0, min(value, 500))
+
+
+__all__ = ["router"]
+
+
+# Helpful for tests that build a minimal app: re-export the workdir resolver.
+def resolve_workdir_for_request(request: Request) -> Path:
+    """Public alias of ``_resolve_workdir`` for test composition."""
+    return _resolve_workdir(cast("Request", request))

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1210,6 +1210,7 @@ def create_app(
     from bernstein.core.routes.graduation import router as graduation_router
     from bernstein.core.routes.grafana import router as grafana_router
     from bernstein.core.routes.graphql_api import router as graphql_router
+    from bernstein.core.routes.handoff import router as handoff_router
     from bernstein.core.routes.health import router as health_deps_router
     from bernstein.core.routes.hooks import router as hooks_router
     from bernstein.core.routes.identities import router as identities_router
@@ -1271,6 +1272,7 @@ def create_app(
         audit_log_router,
         graphql_router,
         graduation_router,
+        handoff_router,
         team_router,
         provider_latency_router,
         predictive_router,

--- a/tests/unit/test_handoff_chat.py
+++ b/tests/unit/test_handoff_chat.py
@@ -1,0 +1,155 @@
+"""Unit tests for the chat ``/handoff`` slash command (op-005)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from bernstein.cli.commands.chat_cmd import ChatSession, _TaskDispatcher
+from bernstein.core.chat import AllowList, Binding, BindingStore, PendingApproval
+from bernstein.core.chat.bridge import BridgeProtocol, ChatMessage
+from bernstein.core.handoff import HandoffTokenStore, StreamTailBuffer
+
+
+@dataclass(slots=True)
+class _FakeBridge(BridgeProtocol):
+    platform: str = "telegram"
+    sent: list[tuple[str, str]] = field(default_factory=list)
+    edits: list[tuple[str, str, str]] = field(default_factory=list)
+    cmd_handlers: dict[str, Any] = field(default_factory=dict)
+    button_handler: Any = None
+    approvals: list[PendingApproval] = field(default_factory=list)
+    next_message_id: int = 1
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+    async def send_message(self, thread_id: str, text: str) -> str:
+        self.sent.append((thread_id, text))
+        self.next_message_id += 1
+        return str(self.next_message_id)
+
+    async def edit_message(self, thread_id: str, message_id: str, text: str) -> None:
+        self.edits.append((thread_id, message_id, text))
+
+    async def push_approval(self, approval: PendingApproval) -> str:
+        self.approvals.append(approval)
+        self.next_message_id += 1
+        return str(self.next_message_id)
+
+    def on_command(self, name: str, handler: Any) -> None:
+        self.cmd_handlers[name] = handler
+
+    def on_button(self, handler: Any) -> None:
+        self.button_handler = handler
+
+
+def _make_session(tmp_path: Path) -> tuple[ChatSession, _FakeBridge]:
+    bridge = _FakeBridge()
+    session = ChatSession(
+        bridge=bridge,
+        bindings=BindingStore(tmp_path),
+        allow_list=AllowList(users={"7"}),
+        workdir=tmp_path,
+        dispatcher=_TaskDispatcher(workdir=tmp_path),
+    )
+    session.install_handlers()
+    return session, bridge
+
+
+def test_handoff_emit_writes_token(tmp_path: Path) -> None:
+    """``/handoff`` (no args) issues a token bound to the active session."""
+    session, bridge = _make_session(tmp_path)
+    session.bindings.put(
+        Binding(
+            platform="telegram",
+            thread_id="42",
+            session_id="sess-old",
+            task_id="t-old",
+            adapter="claude",
+            goal="Fix the bug",
+        ),
+    )
+
+    async def scenario() -> None:
+        await bridge.cmd_handlers["handoff"](
+            ChatMessage(thread_id="42", user_id="7", text="/handoff"),
+        )
+
+    asyncio.run(scenario())
+
+    tokens = HandoffTokenStore(tmp_path).all()
+    assert len(tokens) == 1
+    assert tokens[0].session_id == "sess-old"
+    assert tokens[0].source_surface == "chat"
+    # Bridge should have surfaced the token to the user.
+    assert any("Handoff token" in text for _, text in bridge.sent)
+
+
+def test_handoff_claim_rebinds_thread(tmp_path: Path) -> None:
+    """``/handoff <token>`` rebinds the chat thread to the issued session."""
+    # Pre-issue a token via the store, simulating another surface.
+    issued = HandoffTokenStore(tmp_path).issue(
+        session_id="sess-shared",
+        task_id="t-shared",
+        source_surface="terminal",
+    )
+    StreamTailBuffer(tmp_path, "sess-shared").append(surface="terminal", text="hello from terminal")
+
+    session, bridge = _make_session(tmp_path)
+
+    async def scenario() -> None:
+        await bridge.cmd_handlers["handoff"](
+            ChatMessage(
+                thread_id="42",
+                user_id="7",
+                text=f"/handoff {issued.token}",
+                args=[issued.token],
+            ),
+        )
+
+    asyncio.run(scenario())
+
+    binding = session.bindings.get("telegram", "42")
+    assert binding is not None
+    assert binding.session_id == "sess-shared"
+    assert binding.task_id == "t-shared"
+    # Tail line is replayed.
+    assert any("hello from terminal" in text for _, text in bridge.sent)
+
+
+def test_handoff_claim_unknown_token_replies_with_error(tmp_path: Path) -> None:
+    """An unknown token surfaces a friendly error rather than raising."""
+    _, bridge = _make_session(tmp_path)
+
+    async def scenario() -> None:
+        await bridge.cmd_handlers["handoff"](
+            ChatMessage(
+                thread_id="42",
+                user_id="7",
+                text="/handoff nope",
+                args=["nope"],
+            ),
+        )
+
+    asyncio.run(scenario())
+    assert any("Unknown handoff token" in text for _, text in bridge.sent)
+
+
+def test_handoff_emit_without_active_session_replies_with_error(tmp_path: Path) -> None:
+    """Emitting from a thread with no binding yields a guidance message."""
+    _, bridge = _make_session(tmp_path)
+
+    async def scenario() -> None:
+        await bridge.cmd_handlers["handoff"](
+            ChatMessage(thread_id="42", user_id="7", text="/handoff"),
+        )
+
+    asyncio.run(scenario())
+    assert any("No active session" in text for _, text in bridge.sent)
+    assert HandoffTokenStore(tmp_path).all() == []

--- a/tests/unit/test_handoff_cli.py
+++ b/tests/unit/test_handoff_cli.py
@@ -1,0 +1,78 @@
+"""Unit tests for the ``bernstein handoff`` CLI commands (op-005)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.handoff_cmd import handoff_group
+from bernstein.core.handoff import HandoffTokenStore, StreamTailBuffer
+
+
+@pytest.fixture
+def runner_in_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[CliRunner, Path]:
+    """Run CLI commands inside a temp workdir so .sdd state is isolated."""
+    monkeypatch.chdir(tmp_path)
+    return CliRunner(), tmp_path
+
+
+def test_emit_prints_token_and_persists(runner_in_tmp: tuple[CliRunner, Path]) -> None:
+    """``handoff emit`` prints a token and writes it to disk."""
+    runner, workdir = runner_in_tmp
+    result = runner.invoke(handoff_group, ["emit", "--session", "sess-1", "--task", "t-1"])
+    assert result.exit_code == 0, result.output
+    token = result.output.strip().splitlines()[0]
+    assert token, "expected a token on stdout"
+
+    stored = HandoffTokenStore(workdir).get(token)
+    assert stored is not None
+    assert stored.session_id == "sess-1"
+    assert stored.task_id == "t-1"
+    assert stored.source_surface == "terminal"
+
+
+def test_claim_round_trip(runner_in_tmp: tuple[CliRunner, Path]) -> None:
+    """``handoff claim`` consumes a token issued by ``emit``."""
+    runner, workdir = runner_in_tmp
+    issued = runner.invoke(handoff_group, ["emit", "--session", "sess-1"])
+    token = issued.output.strip().splitlines()[0]
+
+    # Pre-seed a tail line so the replay path is exercised.
+    StreamTailBuffer(workdir, "sess-1").append(surface="terminal", text="hello from terminal")
+
+    claimed = runner.invoke(handoff_group, ["claim", token, "--as", "terminal"])
+    assert claimed.exit_code == 0, claimed.output
+    assert "attached to session sess-1" in claimed.output
+    assert "[terminal] hello from terminal" in claimed.output
+
+
+def test_claim_unknown_token_errors(runner_in_tmp: tuple[CliRunner, Path]) -> None:
+    """``handoff claim`` exits non-zero on an unknown token."""
+    runner, _ = runner_in_tmp
+    result = runner.invoke(handoff_group, ["claim", "nope"])
+    assert result.exit_code != 0
+    assert "unknown handoff token" in (result.output + (result.stderr or "")).lower()
+
+
+def test_claim_already_claimed_errors(runner_in_tmp: tuple[CliRunner, Path]) -> None:
+    """A second claim returns a CLI error instead of crashing."""
+    runner, _ = runner_in_tmp
+    issued = runner.invoke(handoff_group, ["emit", "--session", "sess-1"])
+    token = issued.output.strip().splitlines()[0]
+    runner.invoke(handoff_group, ["claim", token])
+
+    second = runner.invoke(handoff_group, ["claim", token])
+    assert second.exit_code != 0
+    assert "could not claim handoff token" in (second.output + (second.stderr or "")).lower()
+
+
+def test_status_lists_pending_tokens(runner_in_tmp: tuple[CliRunner, Path]) -> None:
+    """``handoff status`` prints live tokens after ``emit``."""
+    runner, _ = runner_in_tmp
+    runner.invoke(handoff_group, ["emit", "--session", "sess-1"])
+    result = runner.invoke(handoff_group, ["status"])
+    assert result.exit_code == 0
+    assert "session=sess-1" in result.output
+    assert "state=pending" in result.output

--- a/tests/unit/test_handoff_route.py
+++ b/tests/unit/test_handoff_route.py
@@ -1,0 +1,71 @@
+"""Unit tests for the dashboard handoff route (op-005)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from bernstein.core.handoff import HandoffTokenStore, StreamTailBuffer
+from bernstein.core.routes.handoff import router
+
+
+def _make_app(workdir: Path) -> FastAPI:
+    app = FastAPI()
+    app.state.workdir = workdir
+    app.include_router(router)
+    return app
+
+
+def test_get_handoff_returns_payload(tmp_path: Path) -> None:
+    """A pending token is claimed and the recent tail comes back inline."""
+    issued = HandoffTokenStore(tmp_path).issue(
+        session_id="sess-1",
+        task_id="t-1",
+        source_surface="terminal",
+        note="thread:42",
+    )
+    StreamTailBuffer(tmp_path, "sess-1").append(surface="terminal", text="line one")
+    StreamTailBuffer(tmp_path, "sess-1").append(surface="terminal", text="line two")
+
+    client = TestClient(_make_app(tmp_path))
+    response = client.get(f"/handoff/{issued.token}")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["session_id"] == "sess-1"
+    assert body["task_id"] == "t-1"
+    assert body["source_surface"] == "terminal"
+    assert body["note"] == "thread:42"
+    assert [entry["text"] for entry in body["tail"]] == ["line one", "line two"]
+
+
+def test_get_handoff_unknown_token_404(tmp_path: Path) -> None:
+    """Unknown tokens return 404."""
+    client = TestClient(_make_app(tmp_path))
+    response = client.get("/handoff/never-issued")
+    assert response.status_code == 404
+
+
+def test_get_handoff_already_claimed_410(tmp_path: Path) -> None:
+    """A second claim attempt returns 410 Gone."""
+    issued = HandoffTokenStore(tmp_path).issue(session_id="sess-1")
+    HandoffTokenStore(tmp_path).claim(issued.token, claimed_by="terminal")
+
+    client = TestClient(_make_app(tmp_path))
+    response = client.get(f"/handoff/{issued.token}")
+    assert response.status_code == 410
+
+
+def test_tail_query_caps_replay(tmp_path: Path) -> None:
+    """The ``tail`` query parameter limits how many lines are returned."""
+    issued = HandoffTokenStore(tmp_path).issue(session_id="sess-1")
+    buf = StreamTailBuffer(tmp_path, "sess-1")
+    for i in range(5):
+        buf.append(surface="terminal", text=f"line {i}")
+
+    client = TestClient(_make_app(tmp_path))
+    response = client.get(f"/handoff/{issued.token}", params={"tail": 2})
+    assert response.status_code == 200
+    body = response.json()
+    assert [entry["text"] for entry in body["tail"]] == ["line 3", "line 4"]

--- a/tests/unit/test_handoff_tokens.py
+++ b/tests/unit/test_handoff_tokens.py
@@ -1,0 +1,186 @@
+"""Unit tests for the handoff token store (op-005).
+
+Coverage targets the ticket's three required scenarios:
+
+* token TTL — expired tokens cannot be claimed and are swept on load,
+* duplicate claim — a second claim raises ``HandoffClaimError``,
+* missing session / unknown token — ``HandoffUnknownTokenError``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.handoff import (
+    DEFAULT_TOKEN_TTL_S,
+    HandoffClaimError,
+    HandoffToken,
+    HandoffTokenStore,
+    HandoffUnknownTokenError,
+    StreamTailBuffer,
+    claim_token,
+    emit_token,
+)
+
+
+class _StubClock:
+    """Deterministic clock so we can drive TTL behaviour synchronously."""
+
+    def __init__(self, start: float = 1_000_000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _store(tmp_path: Path, *, ttl_s: float = DEFAULT_TOKEN_TTL_S) -> tuple[HandoffTokenStore, _StubClock]:
+    clock = _StubClock()
+    return HandoffTokenStore(tmp_path, ttl_s=ttl_s, clock=clock), clock
+
+
+def test_handoff_token_round_trip() -> None:
+    """``HandoffToken`` survives a JSON round trip without losing fields."""
+    token = HandoffToken(
+        token="abc",
+        session_id="sess-1",
+        task_id="t-1",
+        source_surface="terminal",
+        issued_at=1_000.0,
+        expires_at=1_300.0,
+        note="thread:42",
+    )
+    decoded = HandoffToken.from_dict(json.loads(json.dumps(token.to_dict())))
+    assert decoded == token
+
+
+def test_issue_persists_token_to_disk(tmp_path: Path) -> None:
+    """A freshly issued token is reachable via a second store instance."""
+    issued = emit_token(
+        tmp_path,
+        session_id="sess-1",
+        task_id="t-1",
+        source_surface="terminal",
+    )
+    other = HandoffTokenStore(tmp_path)
+    record = other.get(issued.token)
+    assert record is not None
+    assert record.session_id == "sess-1"
+    assert record.task_id == "t-1"
+    assert record.source_surface == "terminal"
+    assert not record.claimed
+
+
+def test_claim_marks_token_consumed(tmp_path: Path) -> None:
+    """The first claim returns the payload and flips ``claimed``."""
+    store, _ = _store(tmp_path)
+    issued = store.issue(session_id="sess-1", source_surface="terminal")
+
+    claimed = store.claim(issued.token, claimed_by="dashboard")
+    assert claimed.session_id == "sess-1"
+    assert claimed.claimed
+    assert claimed.claimed_by == "dashboard"
+    assert claimed.claimed_at is not None
+
+
+def test_duplicate_claim_raises(tmp_path: Path) -> None:
+    """Claiming an already-consumed token raises ``HandoffClaimError``."""
+    store, _ = _store(tmp_path)
+    issued = store.issue(session_id="sess-1")
+    store.claim(issued.token, claimed_by="dashboard")
+
+    with pytest.raises(HandoffClaimError):
+        store.claim(issued.token, claimed_by="terminal")
+
+
+def test_unknown_token_raises(tmp_path: Path) -> None:
+    """An unissued token raises ``HandoffUnknownTokenError``."""
+    store, _ = _store(tmp_path)
+    with pytest.raises(HandoffUnknownTokenError):
+        store.claim("nope-not-a-real-token", claimed_by="terminal")
+
+
+def test_empty_token_raises_unknown(tmp_path: Path) -> None:
+    """The empty string is treated as unknown, not as a claim error."""
+    store, _ = _store(tmp_path)
+    with pytest.raises(HandoffUnknownTokenError):
+        store.claim("", claimed_by="terminal")
+
+
+def test_expired_token_cannot_be_claimed(tmp_path: Path) -> None:
+    """A token past TTL is purged on load and surfaces as unknown."""
+    store, clock = _store(tmp_path, ttl_s=10.0)
+    issued = store.issue(session_id="sess-1")
+
+    clock.advance(11.0)  # past the 10s TTL
+
+    with pytest.raises(HandoffUnknownTokenError):
+        store.claim(issued.token, claimed_by="dashboard")
+    # Sweep should have removed the record from the JSON file too.
+    assert store.get(issued.token) is None
+
+
+def test_session_id_required(tmp_path: Path) -> None:
+    """Issuing without a session_id is rejected — protects against silent corruption."""
+    store, _ = _store(tmp_path)
+    with pytest.raises(ValueError):
+        store.issue(session_id="")
+
+
+def test_emit_and_claim_helpers_round_trip(tmp_path: Path) -> None:
+    """The high-level helpers used by the CLI compose correctly."""
+    issued = emit_token(
+        tmp_path,
+        session_id="sess-1",
+        task_id="t-1",
+        source_surface="terminal",
+        ttl_s=60.0,
+    )
+    claimed = claim_token(tmp_path, issued.token, claimed_by="dashboard", ttl_s=60.0)
+    assert claimed.session_id == "sess-1"
+    assert claimed.claimed_by == "dashboard"
+
+
+def test_all_returns_live_tokens_only(tmp_path: Path) -> None:
+    """``all()`` filters out expired tokens and orders by issue time."""
+    store, clock = _store(tmp_path, ttl_s=10.0)
+    first = store.issue(session_id="sess-1")
+    clock.advance(1.0)
+    second = store.issue(session_id="sess-2")
+
+    tokens = store.all()
+    assert [t.token for t in tokens] == [first.token, second.token]
+
+    clock.advance(15.0)  # both expire
+    assert store.all() == []
+
+
+def test_stream_tail_buffer_round_trip(tmp_path: Path) -> None:
+    """The ring buffer captures and replays lines in order."""
+    buffer = StreamTailBuffer(tmp_path, "sess-1", max_entries=4)
+    for i in range(6):
+        buffer.append(surface="terminal", text=f"line {i}", ts=1000.0 + i)
+    entries = buffer.read()
+    # Older lines are trimmed once we cross the cap.
+    assert [e.text for e in entries] == ["line 2", "line 3", "line 4", "line 5"]
+    assert all(e.surface == "terminal" for e in entries)
+
+
+def test_stream_tail_buffer_limit(tmp_path: Path) -> None:
+    """``read(limit=N)`` returns only the last N entries."""
+    buffer = StreamTailBuffer(tmp_path, "sess-1")
+    for i in range(5):
+        buffer.append(surface="chat", text=f"line {i}")
+    tail = buffer.read(limit=2)
+    assert [e.text for e in tail] == ["line 3", "line 4"]
+
+
+def test_stream_tail_buffer_session_id_required(tmp_path: Path) -> None:
+    """An empty session_id is rejected to avoid colliding tail files."""
+    with pytest.raises(ValueError):
+        StreamTailBuffer(tmp_path, "")


### PR DESCRIPTION
## Summary

Implements — session handoff between terminal, chat bridge, and web dashboard surfaces.

- New package `src/bernstein/core/handoff/` with:
 - `HandoffToken` dataclass + `HandoffTokenStore` (file-backed, atomic JSON, single-claim, 5 min TTL).
 - `StreamTailBuffer` ring buffer at `.sdd/runtime/handoff_tail/<session_id>.jsonl` for tail replay.
- `bernstein handoff emit --session <id> [--task <id>] [--from terminal|chat|dashboard]` mints a 5-minute token; `bernstein handoff claim <token>` re-attaches and replays the recent stream tail. `bernstein handoff status` lists live tokens.
- Dashboard route `GET /handoff/<token>` returns session/task identity and recent tail; 404for unknown, 410for expired/already-claimed.
- Chat slash command `/handoff [<token>]` — with no arg, emits a token bound to the active thread; with a token, rebinds the thread to the issued session_id so the live stream keeps flowing without disrupting in-flight tool calls.

## Acceptance criteria

- [x] `src/bernstein/core/handoff/` with `HandoffToken` dataclass + 5-min token store.
- [x] `bernstein handoff emit` on the source, `bernstein handoff claim <token>` on the destination.
- [x] Web dashboard route `/handoff/<token>` attaches the browser session.
- [x] Chat bridges gain a `/handoff <token>` command.
- [x] Stream tail replayed from the log ring buffer; in-flight tool calls keep running because the session_id is preserved across surfaces.
- [x] Unit tests: token TTL, duplicate claim, missing/unknown token.

## Test plan

- [x] `uv run pytest tests/unit/test_handoff_tokens.py tests/unit/test_handoff_cli.py tests/unit/test_handoff_route.py tests/unit/test_handoff_chat.py -x -q` — 26 passed
- [x] `uv run pytest tests/unit/test_session.py tests/unit/test_chat_session.py tests/unit/test_chat_bindings.py tests/unit/test_chat_drivers.py tests/unit/test_chat_permissions.py -x -q` — 62 passed (regression smoke)
- [x] `uv run ruff format --check` on touched files
- [x] `uv run ruff check src/ tests/ scripts/` — clean
- [x] `uv run lint-imports` — 3 contracts kept

## Notes

(chat bridges) and (interactive approvals) already shipped; this change only adds the new handoff surface and stays clear of their internals.