### PR TITLE
feat(spawner): route adapter exec through SandboxSession

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -41,6 +41,12 @@ from bernstein.core.agents.spawner_merge import (
     update_trace_outcome as _update_trace_outcome,
 )
 from bernstein.core.agents.spawner_prompt_cache import mark_cacheable_prefix
+from bernstein.core.agents.spawner_sandbox_session import (
+    SandboxExecHandle,
+    cancel_session_exec,
+    submit_session_exec,
+    write_prompt_to_session,
+)
 from bernstein.core.agents.spawner_warm_pool import _select_batch_config, _should_use_router
 from bernstein.core.agents.spawner_worktree import (
     cleanup_worktree as _cleanup_worktree,
@@ -67,7 +73,11 @@ from bernstein.core.models import (
     TransitionReason,
 )
 from bernstein.core.orchestrator import ShutdownInProgress
-from bernstein.core.prometheus import agent_spawn_duration
+from bernstein.core.prometheus import (
+    agent_spawn_duration,
+    sandbox_exec_count_total,
+    sandbox_session_created_total,
+)
 from bernstein.core.router import ProviderHealthStatus, RouterError, TierAwareRouter
 from bernstein.core.sandbox import DockerSandbox, spawn_in_sandbox
 from bernstein.core.team_state import TeamStateStore
@@ -885,11 +895,20 @@ class AgentSpawner:
         self._runtime_bridge = runtime_bridge
         self._sandbox = sandbox if sandbox is not None and sandbox.enabled else None
         self._sandbox_managers: dict[str, ContainerManager] = {}
-        # oai-002 phase 1: optional SandboxBackend-issued session. Stored
-        # for orchestration visibility only — the spawner still routes
-        # exec through the worktree path in phase 1. Phase 2 (oai-002b)
-        # routes adapter exec through this session.
+        # oai-002 phase 1: optional SandboxBackend-issued session.
+        # Phase 2 (oai-002b) routes adapter exec through the session
+        # via :mod:`spawner_sandbox_session` when the backend is not
+        # the local worktree. Worktree-backed sessions still go through
+        # the existing direct-subprocess path so the worker wrapper,
+        # process-group bookkeeping, and timeout watchdog stay intact.
         self._sandbox_session: SandboxSession | None = sandbox_session
+        if sandbox_session is not None:
+            sandbox_session_created_total.labels(backend=getattr(sandbox_session, "backend_name", "unknown")).inc()
+        # session_id -> SandboxExecHandle for agents whose exec went
+        # through SandboxSession.exec.  Consulted by check_alive / kill
+        # so the orchestrator's lifecycle paths keep working without a
+        # local subprocess PID.
+        self._sandbox_exec_handles: dict[str, SandboxExecHandle] = {}
         # Container isolation
         self._container_mgr: ContainerManager | None = None
         if container_config is not None:
@@ -1873,6 +1892,25 @@ class AgentSpawner:
                                 mcp_config=effective_mcp,
                             )
                             result = SpawnResult(pid=fake_pid, log_path=actual_log_path)
+                        elif (
+                            self._sandbox_session is not None
+                            and getattr(self._sandbox_session, "backend_name", "worktree") != "worktree"
+                        ):
+                            # oai-002 phase 2: route exec through the
+                            # attached SandboxSession (Docker, E2B,
+                            # Modal, plugin).  The local-worktree
+                            # backend is intentionally excluded so the
+                            # existing direct-subprocess path keeps
+                            # worker-wrapper / PID semantics intact.
+                            result = self._spawn_via_sandbox_session(
+                                session_id=session_id,
+                                prompt=prompt,
+                                spawn_cwd=spawn_cwd,
+                                model_config=model_config,
+                                mcp_config=effective_mcp,
+                                session=session,
+                                adapter=target_adapter,
+                            )
                         elif self._sandbox is not None:
                             result = self._spawn_in_sandbox(
                                 session_id=session_id,
@@ -2399,6 +2437,105 @@ class AgentSpawner:
         session.isolation = IsolationMode.CONTAINER.value
         return SpawnResult(pid=handle.pid or 0, log_path=log_path)
 
+    def _spawn_via_sandbox_session(
+        self,
+        *,
+        session_id: str,
+        prompt: str,
+        spawn_cwd: Path,
+        model_config: ModelConfig,
+        mcp_config: dict[str, Any] | None,
+        session: AgentSession,
+        adapter: CLIAdapter,
+    ) -> SpawnResult:
+        """Route adapter exec through the attached :class:`SandboxSession`.
+
+        Phase 2 of ``oai-002``. When the spawner has been wired with a
+        non-worktree :class:`SandboxBackend` (Docker, E2B, Modal,
+        custom plugin), the adapter command is run via
+        :meth:`SandboxSession.exec` and the prompt is injected via
+        :meth:`SandboxSession.write` instead of mutating the host
+        worktree directly. The local-worktree backend is intentionally
+        excluded: keeping it on the legacy direct-subprocess path
+        preserves the worker-wrapper, process-group, and timeout-watchdog
+        bookkeeping that production tooling depends on, and matches the
+        ticket's "byte-identical behaviour for worktree-only configs"
+        acceptance criterion.
+
+        Args:
+            session_id: Agent session identifier.
+            prompt: Rendered system prompt.
+            spawn_cwd: Worktree path on the host. Reserved for log
+                output and for adapters that still read host paths.
+            model_config: Model and effort configuration.
+            mcp_config: Optional MCP configuration.
+            session: Mutable session record updated with isolation
+                metadata.
+            adapter: The adapter selected for this spawn attempt.
+
+        Returns:
+            A :class:`SpawnResult`. ``pid`` is ``0`` because the
+            command lives inside the backend; liveness is tracked via
+            the :class:`SandboxExecHandle` stored in
+            ``_sandbox_exec_handles``.
+        """
+        assert self._sandbox_session is not None
+        sbx_session = self._sandbox_session
+
+        log_dir = spawn_cwd / ".sdd" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / f"{session_id}.log"
+
+        # 1) Inject the prompt through the session's file primitive.
+        write_prompt_to_session(
+            session=sbx_session,
+            prompt=prompt,
+            session_id=session_id,
+        )
+
+        # 2) Build the command using the existing container-shaped
+        #    helper.  It reads the prompt from a relative path inside
+        #    the workspace, which is exactly what session.exec needs.
+        prompt_file = spawn_cwd / ".sdd" / "runtime" / "prompts" / f"{session_id}.md"
+        cmd = self._adapter_cmd_for_container(
+            prompt_file=prompt_file,
+            model_config=model_config,
+            session_id=session_id,
+            mcp_config=mcp_config,
+            adapter=adapter,
+        )
+
+        # 3) Submit the exec on a dedicated thread; the future drives
+        #    liveness checks via SandboxSession-aware paths.
+        handle = submit_session_exec(
+            session=sbx_session,
+            cmd=cmd,
+            session_id=session_id,
+            log_path=log_path,
+        )
+        self._sandbox_exec_handles[session_id] = handle
+
+        # When the future resolves we increment the per-exit-code
+        # counter so operators can see how often agents inside a given
+        # backend exit cleanly.
+        def _record_exit(_h: SandboxExecHandle = handle) -> None:
+            try:
+                if _h.future.cancelled():
+                    code = "cancelled"
+                elif _h.future.exception() is not None:
+                    code = "error"
+                else:
+                    code = str(_h.future.result().exit_code)
+            except Exception:  # pragma: no cover — defensive
+                code = "error"
+            sandbox_exec_count_total.labels(backend=_h.backend_name, exit_code=code).inc()
+
+        handle.future.add_done_callback(lambda _f: _record_exit())
+
+        session.isolation = IsolationMode.CONTAINER.value
+        session.runtime_backend = handle.backend_name
+        return SpawnResult(pid=0, log_path=log_path)
+
     def _adapter_cmd_for_container(
         self,
         *,
@@ -2491,6 +2628,30 @@ class AgentSpawner:
             return False
         return True
 
+    def _check_alive_sandbox_session(self, session: AgentSession) -> bool | None:
+        """Liveness for agents whose exec runs via :meth:`SandboxSession.exec`.
+
+        Returns ``None`` when the session was not routed through a
+        sandbox session (so the next checker in the chain runs).
+        """
+        handle = self._sandbox_exec_handles.get(session.id)
+        if handle is None:
+            return None
+        if not handle.future.done():
+            return True
+        if handle.future.cancelled():
+            session.exit_code = -1
+            return False
+        exc = handle.future.exception()
+        if exc is not None:
+            session.exit_code = -1
+            return False
+        try:
+            session.exit_code = handle.future.result().exit_code
+        except Exception:  # pragma: no cover — already inspected above
+            session.exit_code = -1
+        return False
+
     def _check_alive_in_process(self, session: AgentSession) -> bool | None:
         """Check liveness via InProcessAgent. Returns None if not applicable."""
         if self._in_process is None:
@@ -2514,7 +2675,12 @@ class AgentSpawner:
         if session.runtime_backend == "openclaw":
             return self._check_alive_openclaw(session)
 
-        for checker in (self._check_alive_container, self._check_alive_process, self._check_alive_in_process):
+        for checker in (
+            self._check_alive_sandbox_session,
+            self._check_alive_container,
+            self._check_alive_process,
+            self._check_alive_in_process,
+        ):
             result = checker(session)
             if result is not None:
                 return result
@@ -2547,6 +2713,18 @@ class AgentSpawner:
 
     def _kill_local(self, session: AgentSession) -> None:
         """Kill a locally-running agent (container, in-process, or PID)."""
+        # Sandbox-session-routed agents have no local PID; cancel the
+        # future on its owning loop instead.
+        sbx_handle = self._sandbox_exec_handles.get(session.id)
+        if sbx_handle is not None:
+            cancel_session_exec(sbx_handle)
+            self._sandbox_exec_handles.pop(session.id, None)
+            self._transition_to_dead(
+                session,
+                "kill requested",
+                "sandbox session exec cancellation requested by orchestrator",
+            )
+            return
         container_mgr = self._container_manager_for_session(session.id)
         if session.container_id and container_mgr is not None:
             handle = container_mgr.get_handle(session.id)

--- a/src/bernstein/core/agents/spawner_sandbox_session.py
+++ b/src/bernstein/core/agents/spawner_sandbox_session.py
@@ -1,0 +1,266 @@
+"""Spawner glue that routes adapter exec through a :class:`SandboxSession`.
+
+Phase 2 of ``oai-002`` (ticket ``oai-002b``). Phase 1 shipped the
+:class:`~bernstein.core.sandbox.backend.SandboxBackend` protocol and
+the optional ``sandbox_session`` parameter on :class:`AgentSpawner`,
+but adapter subprocess launches still went straight to the host
+worktree. This module owns the *routing seam* — the bit that, when a
+session is attached, performs:
+
+1. Prompt injection via :meth:`SandboxSession.write` so the agent
+   command can read the prompt file from inside whatever workspace
+   the backend has provisioned.
+2. Adapter command execution via :meth:`SandboxSession.exec` running on
+   a dedicated background thread (the spawner is sync; the session
+   protocol is async).
+3. Liveness tracking so :meth:`AgentSpawner.check_alive` and
+   :meth:`AgentSpawner.kill` keep working without subprocess PIDs.
+
+The worktree-direct path is preserved unchanged when no session is
+attached — existing users see byte-identical behaviour. The 35 adapters
+themselves are not refactored in this phase; they continue to expose
+:meth:`CLIAdapter.spawn`, which we still call as a fallback when the
+selected sandbox is the local-worktree backend (``backend_name ==
+"worktree"``) so the worker-wrapper / process-group bookkeeping that
+production tooling relies on stays intact. Cloud / container backends
+take the new ``session.exec`` path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import time
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from bernstein.core.sandbox.backend import ExecResult, SandboxSession
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SandboxExecHandle:
+    """Bookkeeping for an adapter command running inside a session.
+
+    Attributes:
+        session_id: Owning agent session identifier.
+        backend_name: Name of the sandbox backend running the command
+            (used for label cardinality on Prometheus metrics).
+        future: :class:`~concurrent.futures.Future` resolving to the
+            :class:`~bernstein.core.sandbox.backend.ExecResult` once the
+            command exits. The orchestrator polls
+            :meth:`Future.done` for liveness.
+        log_path: Local path where the command's stdout/stderr is
+            mirrored once the future resolves. Pre-allocated so other
+            modules can wire it as the agent log path before the
+            command finishes.
+        loop: Event loop running the underlying ``session.exec`` task.
+            Owned by :func:`_run_session_loop`; used to schedule
+            cancellation requests via :meth:`AgentSpawner.kill`.
+        task: The asyncio task wrapping the ``session.exec`` call.
+            ``None`` until the loop has scheduled it; consult
+            :attr:`future` for the canonical lifecycle signal.
+        started_at: ``time.monotonic()`` snapshot when scheduling
+            began. Used to surface duration metrics on completion.
+    """
+
+    session_id: str
+    backend_name: str
+    future: Future[ExecResult]
+    log_path: Path
+    loop: asyncio.AbstractEventLoop
+    task: asyncio.Task[ExecResult] | None = None
+    started_at: float = field(default_factory=time.monotonic)
+
+
+def _run_session_loop(
+    *,
+    coro_factory: Callable[[], object],
+    handle: SandboxExecHandle,
+) -> None:
+    """Run the per-handle event loop on its dedicated thread.
+
+    The spawner is synchronous; :meth:`SandboxSession.exec` is async.
+    Spinning up one tiny event loop per session keeps the seam local —
+    we don't need a global ``asyncio.run`` in the hot spawn path, and
+    cancellation stays scoped to the agent that asked for it.
+
+    Args:
+        coro_factory: Zero-arg callable that returns the awaitable to
+            run (we accept a factory rather than the coroutine itself
+            so the loop owns coroutine creation and Pyright stops
+            warning about cross-thread coroutine reuse).
+        handle: Bookkeeping record updated with the running task once
+            scheduled.
+    """
+    loop = handle.loop
+    asyncio.set_event_loop(loop)
+    try:
+        coro = coro_factory()
+        task: asyncio.Task[ExecResult] = loop.create_task(coro)  # type: ignore[arg-type]
+        handle.task = task
+        try:
+            result = loop.run_until_complete(task)
+        except asyncio.CancelledError:
+            handle.future.cancel()
+            return
+        except BaseException as exc:
+            handle.future.set_exception(exc)
+            return
+        handle.future.set_result(result)
+    finally:
+        try:
+            loop.close()
+        except Exception:  # pragma: no cover — defensive
+            logger.debug("loop close raised", exc_info=True)
+
+
+def submit_session_exec(
+    *,
+    session: SandboxSession,
+    cmd: list[str],
+    session_id: str,
+    log_path: Path,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+    timeout: int | None = None,
+) -> SandboxExecHandle:
+    """Run *cmd* through ``session.exec`` on a dedicated background thread.
+
+    The returned :class:`SandboxExecHandle` carries the future that
+    resolves to the :class:`~bernstein.core.sandbox.backend.ExecResult`
+    plus enough bookkeeping for liveness checks and cancellation.
+
+    Args:
+        session: The :class:`SandboxSession` produced by
+            :meth:`SandboxBackend.create`.
+        cmd: Argv list. Must be non-empty. Backends do not pipe through
+            a shell — wrap commands manually when shell semantics are
+            needed.
+        session_id: Owning agent session ID used for log/error context.
+        log_path: Path the spawner has reserved for this agent's log.
+            Mirrored stdout/stderr is written here once the command
+            completes (best effort — failures are logged at debug
+            level).
+        cwd: Optional working directory inside the sandbox. ``None``
+            uses :attr:`SandboxSession.workdir`.
+        env: Optional extra environment merged on top of the backend's
+            base environment.
+        timeout: Wall-clock timeout in seconds; ``None`` lets the
+            backend pick its default.
+
+    Returns:
+        A :class:`SandboxExecHandle` whose :attr:`SandboxExecHandle.future`
+        resolves once the command exits.
+    """
+    if not cmd:
+        raise ValueError("cmd must be a non-empty argv list")
+
+    fut: Future[ExecResult] = Future()
+    loop = asyncio.new_event_loop()
+    handle = SandboxExecHandle(
+        session_id=session_id,
+        backend_name=getattr(session, "backend_name", "unknown"),
+        future=fut,
+        log_path=log_path,
+        loop=loop,
+    )
+
+    def _factory() -> object:
+        return session.exec(cmd, cwd=cwd, env=env, timeout=timeout)
+
+    thread = threading.Thread(
+        target=_run_session_loop,
+        kwargs={"coro_factory": _factory, "handle": handle},
+        name=f"sandbox-exec-{session_id}",
+        daemon=True,
+    )
+    thread.start()
+
+    # Mirror logs once the future resolves so consumers can tail
+    # log_path even though session.exec captures bytes in memory.
+    def _persist_log(f: Future[ExecResult]) -> None:
+        if f.cancelled() or f.exception() is not None:
+            return
+        result = f.result()
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("ab") as fh:
+                fh.write(result.stdout)
+                if result.stderr:
+                    fh.write(b"\n--- stderr ---\n")
+                    fh.write(result.stderr)
+        except OSError as exc:  # pragma: no cover — best effort
+            logger.debug("Could not mirror sandbox exec log to %s: %s", log_path, exc)
+
+    fut.add_done_callback(_persist_log)
+    return handle
+
+
+def cancel_session_exec(handle: SandboxExecHandle) -> None:
+    """Best-effort cancellation of a running sandbox exec.
+
+    Schedules cancellation of the underlying asyncio task on the
+    handle's owning loop. Idempotent — safe to call after the future
+    already resolved.
+
+    Args:
+        handle: The handle returned by :func:`submit_session_exec`.
+    """
+    if handle.future.done():
+        return
+    task = handle.task
+    if task is None:
+        # Loop hasn't scheduled the task yet; mark the future cancelled.
+        handle.future.cancel()
+        return
+    handle.loop.call_soon_threadsafe(task.cancel)
+
+
+def write_prompt_to_session(
+    *,
+    session: SandboxSession,
+    prompt: str,
+    session_id: str,
+) -> str:
+    """Persist *prompt* to the sandbox via :meth:`SandboxSession.write`.
+
+    Returns the path the adapter command should read inside the
+    sandbox. Centralised so the spawner and any future plug-in points
+    use the same convention as :func:`AgentSpawner._spawn_in_container`
+    (``.sdd/runtime/prompts/<session_id>.md`` relative to ``workdir``).
+
+    Args:
+        session: The active sandbox session.
+        prompt: The rendered agent prompt.
+        session_id: Agent session ID, used as the file basename.
+
+    Returns:
+        The relative path inside the sandbox where the prompt was
+        written. Adapters can read it via ``$WORKDIR/<rel_path>`` or
+        treat it as relative to :attr:`SandboxSession.workdir`.
+    """
+    rel_path = f".sdd/runtime/prompts/{session_id}.md"
+    payload = prompt.encode("utf-8")
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(session.write(rel_path, payload))
+    finally:
+        loop.close()
+    return rel_path
+
+
+__all__ = [
+    "SandboxExecHandle",
+    "cancel_session_exec",
+    "submit_session_exec",
+    "write_prompt_to_session",
+]

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -131,6 +131,10 @@ __all__ = [
     "merge_duration",
     "record_transition_reason",
     "registry",
+    "sandbox_exec_count_total",
+    "sandbox_session_created_total",
+    "sandbox_session_destroyed_total",
+    "sandbox_session_duration_seconds",
     "set_prometheus_enabled",
     "task_duration_seconds",
     "task_queue_depth",
@@ -294,6 +298,42 @@ lineage_tamper_total: Counter = Counter(
     "bernstein_lineage_tamper_total",
     "Lineage chain verification failures detected (per run).",
     labelnames=["run_id"],
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Sandbox session metrics (oai-002 phase 2).  Labelled by backend so the
+# orchestrator and operators can see which isolation primitive is in use
+# and how often agents bounce off it.  Cardinality is bounded by the
+# fixed set of registered backends (worktree, docker, e2b, modal, ...).
+# ---------------------------------------------------------------------------
+
+sandbox_session_created_total: Counter = Counter(
+    "bernstein_sandbox_session_created_total",
+    "Sandbox sessions created via SandboxBackend.create, by backend.",
+    labelnames=["backend"],
+    registry=registry,
+)
+
+sandbox_session_destroyed_total: Counter = Counter(
+    "bernstein_sandbox_session_destroyed_total",
+    "Sandbox sessions destroyed via SandboxBackend.destroy, by backend.",
+    labelnames=["backend"],
+    registry=registry,
+)
+
+sandbox_session_duration_seconds: Histogram = Histogram(
+    "bernstein_sandbox_session_duration_seconds",
+    "End-to-end session lifetime in seconds, by backend.",
+    buckets=(1, 5, 30, 60, 300, 1800, 3600, 7200),
+    labelnames=["backend"],
+    registry=registry,
+)
+
+sandbox_exec_count_total: Counter = Counter(
+    "bernstein_sandbox_exec_count_total",
+    "Commands executed via SandboxSession.exec, by backend and exit code.",
+    labelnames=["backend", "exit_code"],
     registry=registry,
 )
 

--- a/tests/unit/test_spawner_sandbox_session.py
+++ b/tests/unit/test_spawner_sandbox_session.py
@@ -1,0 +1,202 @@
+"""Unit tests for AgentSpawner sandbox-session routing (oai-002 phase 2)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+from bernstein.core.models import AgentSession, ModelConfig
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.sandbox.backend import ExecResult, SandboxSession
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class _FakeAdapter(CLIAdapter):
+    """Minimal adapter that records direct-spawn calls."""
+
+    def __init__(self, adapter_name: str = "claude") -> None:
+        super().__init__()
+        self._name = adapter_name
+        self.spawn_calls: list[tuple[str, Path]] = []
+
+    def name(self) -> str:
+        return self._name
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, object] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        del model_config, session_id, mcp_config, timeout_seconds
+        del task_scope, budget_multiplier, system_addendum
+        self.spawn_calls.append((prompt, workdir))
+        return SpawnResult(pid=99, log_path=workdir / ".sdd" / "logs" / "direct.log")
+
+    def is_alive(self, pid: int) -> bool:  # pragma: no cover - not used
+        return pid == 99
+
+    def kill(self, pid: int) -> None:  # pragma: no cover - not used
+        del pid
+
+
+class _FakeSession(SandboxSession):
+    """In-memory :class:`SandboxSession` for spawner-routing tests."""
+
+    def __init__(self, *, backend_name: str, root: Path) -> None:
+        self.backend_name = backend_name
+        self.session_id = "fake-sess"
+        self.workdir = str(root)
+        self._root = root
+        self._exec_calls: list[list[str]] = []
+        self._exec_blocker: asyncio.Event | None = None
+        self.exit_code = 0
+
+    @property
+    def exec_calls(self) -> list[list[str]]:
+        return self._exec_calls
+
+    async def read(self, path: str) -> bytes:
+        return (self._root / path).read_bytes()
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        del mode
+        target = self._root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        del cwd, env, timeout, stdin
+        self._exec_calls.append(list(cmd))
+        if self._exec_blocker is not None:
+            await self._exec_blocker.wait()
+        return ExecResult(
+            exit_code=self.exit_code,
+            stdout=b"hello",
+            stderr=b"",
+            duration_seconds=0.01,
+        )
+
+    async def ls(self, path: str) -> list[str]:
+        target = self._root / path
+        return sorted(p.name for p in target.iterdir())
+
+    async def snapshot(self) -> str:
+        raise NotImplementedError
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def _build_spawner(tmp_path: Path, *, session: SandboxSession | None) -> tuple[AgentSpawner, _FakeAdapter]:
+    adapter = _FakeAdapter("claude")
+    with patch("bernstein.core.agents.spawner_core.get_registry", return_value=MagicMock()):
+        spawner = AgentSpawner(
+            adapter=adapter,
+            templates_dir=tmp_path,
+            workdir=tmp_path,
+            use_worktrees=False,
+            sandbox_session=session,
+        )
+    return spawner, adapter
+
+
+def test_spawn_via_sandbox_session_routes_through_session(tmp_path: Path) -> None:
+    """A non-worktree session causes exec/file ops to run via the session."""
+    session_obj = _FakeSession(backend_name="docker", root=tmp_path)
+    spawner, adapter = _build_spawner(tmp_path, session=session_obj)
+    agent_session = AgentSession(id="S-7", role="backend")
+
+    result = spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-7",
+        prompt="solve it",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=adapter,
+    )
+
+    # Wait for the background thread's future to resolve.
+    handle = spawner._sandbox_exec_handles["S-7"]  # pyright: ignore[reportPrivateUsage]
+    handle.future.result(timeout=5.0)
+
+    assert result.pid == 0
+    assert agent_session.isolation == "container"
+    assert agent_session.runtime_backend == "docker"
+    assert adapter.spawn_calls == []
+    # Prompt was written to the session-managed workdir.
+    prompt_path = tmp_path / ".sdd" / "runtime" / "prompts" / "S-7.md"
+    assert prompt_path.read_bytes() == b"solve it"
+    # Adapter command was executed via session.exec at least once.
+    assert session_obj.exec_calls, "session.exec was never invoked"
+
+
+def test_worktree_session_does_not_trigger_routing(tmp_path: Path) -> None:
+    """Worktree-backed sessions intentionally stay on the legacy path."""
+    session_obj = _FakeSession(backend_name="worktree", root=tmp_path)
+    spawner, _ = _build_spawner(tmp_path, session=session_obj)
+
+    # Re-implement the dispatcher's gate inline so the test asserts the
+    # exact predicate used in :meth:`AgentSpawner.spawn_for_tasks`.
+    routes_through_session = (
+        spawner.sandbox_session is not None
+        and getattr(spawner.sandbox_session, "backend_name", "worktree") != "worktree"
+    )
+    assert routes_through_session is False
+    # The session is still exposed for visibility, just not used for exec.
+    assert spawner.sandbox_session is session_obj
+
+
+def test_sandbox_session_check_alive_and_kill(tmp_path: Path) -> None:
+    """Liveness and kill paths cooperate with the in-flight session future."""
+    session_obj = _FakeSession(backend_name="docker", root=tmp_path)
+    # Block exec until kill triggers cancellation, so the "still alive"
+    # branch of _check_alive_sandbox_session is observable.
+    block_loop = asyncio.new_event_loop()
+    try:
+        session_obj._exec_blocker = asyncio.Event()  # pyright: ignore[reportPrivateUsage]
+    finally:
+        block_loop.close()
+
+    spawner, _ = _build_spawner(tmp_path, session=session_obj)
+    agent_session = AgentSession(id="S-9", role="backend")
+
+    spawner._spawn_via_sandbox_session(  # pyright: ignore[reportPrivateUsage]
+        session_id="S-9",
+        prompt="busy",
+        spawn_cwd=tmp_path,
+        model_config=ModelConfig("sonnet", "high"),
+        mcp_config=None,
+        session=agent_session,
+        adapter=_FakeAdapter("claude"),
+    )
+
+    # Liveness should report True while the future has not resolved.
+    assert spawner._check_alive_sandbox_session(agent_session) is True  # pyright: ignore[reportPrivateUsage]
+
+    # Kill cancels the future and clears the handle.
+    spawner._kill_local(agent_session)  # pyright: ignore[reportPrivateUsage]
+    assert "S-9" not in spawner._sandbox_exec_handles  # pyright: ignore[reportPrivateUsage]
+    assert agent_session.status == "dead"


### PR DESCRIPTION
## Summary

Phase 1 shipped the `SandboxBackend` protocol and an
optional `sandbox_session` parameter on `AgentSpawner` that was kept
purely informational. Phase 2 wires the session into the actual spawn
path so non-worktree backends (Docker / E2B / Modal / plugin) drive
adapter exec via `SandboxSession.exec` and prompt injection via
`SandboxSession.write`.

- New `spawner_sandbox_session.py` owns the seam: a per-handle asyncio
 loop runs `session.exec` on a daemon thread, the resulting `Future`
 drives liveness checks, and cancellation propagates through the
 loop so `AgentSpawner.kill` keeps working without a local PID.
- `AgentSpawner._spawn_via_sandbox_session` writes the prompt via
 `session.write`, builds the adapter argv with the existing
 `_adapter_cmd_for_container` helper, submits the exec, and tracks
 the handle in `_sandbox_exec_handles` for the liveness/kill paths.
- The spawn dispatcher only routes through the session when the
 backend is not the local worktree, preserving the byte-identical
 behaviour the ticket requires for worktree-only configurations.
- Prometheus metrics: `sandbox_session_created_total`,
 `sandbox_session_destroyed_total`, `sandbox_session_duration_seconds`,
 and `sandbox_exec_count_total` -- all labelled by backend.

## Deferred (named so reviewers do not flag as gaps)

- **Per-adapter refactor** (ticket point 2): all 35 adapters keep
 exposing `CLIAdapter.spawn` unchanged. The new path uses the
 existing `_adapter_cmd_for_container` helper, so adapters benefit
 immediately when running inside Docker / cloud backends without a
 signature break. A follow-up ticket can introduce a typed
 `build_command` mixin once we have a second consumer.
- **Orchestrator plan.yaml wiring** (point 3): plan loader does not
 yet read a `sandbox:` block per stage. The session is wired
 externally for now (preview manager, CLI). Adding a backend
 resolver to the plan loader is a clean follow-up.
- **Cross-backend conformance smoke** (point 5): unit-level
 fakes cover the routing contract; the Docker / E2B / Modal CI
 smoke matrix is gated on credentials and stays in the conformance
 package.

## Test plan

- [x] `uv run pytest tests/unit/test_spawner_sandbox_session.py tests/unit/test_spawner.py tests/unit/test_spawner_sandbox.py tests/unit/test_sandbox.py tests/unit/sandbox/ -x -q` (118 passed, 1 skipped)
- [x] `uv run pytest tests/unit/test_orchestrator.py -x -q` (206 passed)
- [x] `uv run ruff format` + `uv run ruff check src/ tests/ scripts/`
- [x] `uv run lint-imports` (3 contracts kept)