### PR TITLE
feat(routines): routine-scenario bridge with auto-provisioning

### DIFF
--- a/docs/routine-scenarios.md
+++ b/docs/routine-scenarios.md
@@ -1,0 +1,88 @@
+# Routine <-> Scenario Bridge
+
+The Bernstein scenario library and Anthropic's Claude Code Routines complement
+each other: scenarios are version-controlled YAML recipes for multi-agent work,
+Routines are cloud-side triggers that fire prompts on schedules or GitHub
+events. The rt-003 bridge wires them together so a team lead can author one
+scenario in the repo and an operator can stand up the matching Routine in
+about five minutes.
+
+## Two directions
+
+### Direction A — Scenario to Routine (export)
+
+`bernstein routine export <scenario-id> --repo owner/name --output ./out` writes:
+
+```
+out/
+  prompt.md          paste into the Routine prompt field
+  mcp-config.json    add as an MCP connector
+  env.json           env vars the Routine session needs
+  setup-guide.md     step-by-step instructions
+  triggers.md        recommended trigger configurations
+```
+
+The prompt instructs the Routine session to call `bernstein_scenario`,
+poll status, and summarise outcomes (including PR comments when a GitHub
+trigger supplied a pull request number).
+
+`bernstein routine provision` is an interactive wrapper around the same
+flow that also registers the trigger id once the operator pastes it back.
+
+### Direction B — Routine to Scenario (invoke)
+
+The MCP server exposes three tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `bernstein_scenarios()` | List scenarios known to the local library. |
+| `bernstein_scenario(scenario_id, context, pr_number, branch)` | Spawn one task per scenario template. |
+| `bernstein_scenario_status(orchestration_id)` | Aggregate status of a running scenario. |
+
+Each spawned task carries `metadata.scenario_id` and
+`metadata.orchestration_id` so the status tool can group them.
+
+## Provisioning flow
+
+```
+team lead          bernstein           Anthropic Routines
+---------          ---------           -----------------
+defines    ---->   exports    ---->   trigger fires on
+scenario           prompt +           GitHub event
+.yaml              mcp config         ----v-----------
+                                          calls
+                                          bernstein_scenario()
+                                          ----v-----------
+bernstein orchestrates parallel
+multi-agent work in worktrees
+```
+
+Scenarios live in `templates/scenarios/`. The repo currently ships eight
+ready-to-use templates covering:
+
+- comprehensive PR review
+- security-focused PR review
+- nightly maintenance
+- deploy verification
+- issue decomposition
+- docs sync
+- dependency audit
+- test coverage boost
+
+## Auto-provisioning
+
+Trigger ids resolved through `bernstein routine register --scenario <id>
+--trigger-id <tid> --repo owner/name` are persisted under
+`.sdd/routines/registry.json`. When the Routine webhook arrives at the
+Bernstein server with the matching trigger id, the bridge looks up the
+binding and invokes the scenario without operator intervention.
+
+`bernstein routine bindings` lists all registered bindings.
+
+## See also
+
+- `src/bernstein/core/planning/scenario_library.py` — scenario data model.
+- `src/bernstein/core/planning/routine_provisioner.py` — Direction A export.
+- `src/bernstein/core/planning/routine_bridge.py` — bidirectional bridge.
+- `src/bernstein/mcp/routine_tools.py` — MCP tool registration.
+- `src/bernstein/cli/commands/routine_cmd.py` — CLI surface.

--- a/src/bernstein/cli/commands/routine_cmd.py
+++ b/src/bernstein/cli/commands/routine_cmd.py
@@ -1,0 +1,235 @@
+"""``bernstein routine ...`` CLI commands (rt-003).
+
+Subcommands:
+  scenarios   List scenarios available in the library.
+  export      Export a scenario as a Routine config bundle.
+  provision   Interactive wizard that exports a scenario and registers a
+              binding once the operator pastes the trigger id.
+  register    Register an existing trigger id against a scenario.
+  bindings    List known trigger -> scenario bindings.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from bernstein.core.planning.routine_bridge import RoutineBridge
+
+# Default scenarios directory shipped with the package.
+_DEFAULT_SCENARIOS_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent / "templates" / "scenarios"
+
+
+def _resolve_state_dir(workdir: Path) -> Path:
+    return workdir / ".sdd" / "routines"
+
+
+def _make_bridge(scenarios_dir: Path | None, workdir: Path) -> RoutineBridge:
+    return RoutineBridge.from_paths(
+        scenarios_dir=scenarios_dir or _DEFAULT_SCENARIOS_DIR,
+        state_dir=_resolve_state_dir(workdir),
+    )
+
+
+@click.group("routine")
+def routine_group() -> None:
+    """Manage Claude Code Routine <-> Bernstein scenario integration."""
+
+
+@routine_group.command("scenarios")
+@click.option(
+    "--scenarios-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the bundled scenarios directory.",
+)
+def routine_scenarios(scenarios_dir: Path | None) -> None:
+    """List all scenarios in the library."""
+    from rich.console import Console
+    from rich.table import Table
+
+    bridge = _make_bridge(scenarios_dir, Path.cwd())
+    console = Console()
+    scenarios = bridge.provisioner.list_scenarios()
+    if not scenarios:
+        console.print("[yellow]No scenarios found.[/yellow]")
+        return
+    table = Table(title="Bernstein scenarios", show_lines=True)
+    table.add_column("id", style="bold cyan")
+    table.add_column("name")
+    table.add_column("tasks", justify="right")
+    table.add_column("tags", style="dim")
+    for s in sorted(scenarios, key=lambda r: r.scenario_id):
+        table.add_row(s.scenario_id, s.name, str(len(s.tasks)), ", ".join(s.tags))
+    console.print(table)
+
+
+@routine_group.command("export")
+@click.argument("scenario_id")
+@click.option("--repo", required=True, help="Target repo (owner/name).")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path("routine-config"),
+    show_default=True,
+    help="Directory to write the Routine config bundle into.",
+)
+@click.option(
+    "--scenarios-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the bundled scenarios directory.",
+)
+@click.option(
+    "--bernstein-url",
+    default="http://127.0.0.1:8052",
+    show_default=True,
+    help="Bernstein task server URL embedded in the prompt and MCP config.",
+)
+def routine_export(
+    scenario_id: str,
+    repo: str,
+    output: Path,
+    scenarios_dir: Path | None,
+    bernstein_url: str,
+) -> None:
+    """Export SCENARIO_ID as a Routine config bundle."""
+    from rich.console import Console
+
+    console = Console()
+    bridge = RoutineBridge.from_paths(
+        scenarios_dir=scenarios_dir or _DEFAULT_SCENARIOS_DIR,
+        state_dir=_resolve_state_dir(Path.cwd()),
+        bernstein_url=bernstein_url,
+    )
+    try:
+        export, files = bridge.provision(scenario_id, repo, output)
+    except KeyError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+    console.print(f"[green]Exported {scenario_id} -> {output}[/green]")
+    console.print(f"  name: {export.name}")
+    console.print(f"  triggers: {len(export.recommended_triggers)} recommendation(s)")
+    for path in files:
+        console.print(f"  wrote: {path}")
+
+
+@routine_group.command("provision")
+@click.option(
+    "--scenarios-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the bundled scenarios directory.",
+)
+@click.option(
+    "--bernstein-url",
+    default="http://127.0.0.1:8052",
+    show_default=True,
+)
+def routine_provision(scenarios_dir: Path | None, bernstein_url: str) -> None:
+    """Interactive wizard: pick a scenario, export it, then register a binding."""
+    from rich.console import Console
+
+    console = Console()
+    bridge = RoutineBridge.from_paths(
+        scenarios_dir=scenarios_dir or _DEFAULT_SCENARIOS_DIR,
+        state_dir=_resolve_state_dir(Path.cwd()),
+        bernstein_url=bernstein_url,
+    )
+    scenarios = sorted(bridge.provisioner.list_scenarios(), key=lambda r: r.scenario_id)
+    if not scenarios:
+        console.print("[red]No scenarios found.[/red]")
+        raise SystemExit(1)
+
+    console.print("[bold]Available scenarios:[/bold]")
+    for idx, s in enumerate(scenarios, start=1):
+        console.print(f"  {idx}. [cyan]{s.scenario_id}[/cyan] — {s.name}")
+    raw_choice = click.prompt("Pick a scenario", type=str)
+    try:
+        choice_idx = int(raw_choice)
+        scenario = scenarios[choice_idx - 1]
+    except (ValueError, IndexError):
+        scenario = next((s for s in scenarios if s.scenario_id == raw_choice), None)
+        if scenario is None:
+            console.print(f"[red]Unknown scenario: {raw_choice}[/red]")
+            raise SystemExit(1) from None
+
+    repo = click.prompt("Target repo (owner/name)", type=str)
+    out_dir_raw = click.prompt("Output directory", default="routine-config", type=str)
+    out_dir = Path(out_dir_raw)
+
+    _export, files = bridge.provision(scenario.scenario_id, repo, out_dir)
+    console.print(f"[green]Exported {scenario.scenario_id} -> {out_dir}[/green]")
+    for path in files:
+        console.print(f"  wrote: {path}")
+
+    console.print()
+    console.print("[bold]Next steps:[/bold]")
+    console.print("  1. Open https://claude.ai/code/routines")
+    console.print("  2. Create a new Routine using the artefacts above")
+    console.print("  3. Copy the trigger id from the Routine UI")
+
+    if click.confirm("Register the trigger id now?", default=True):
+        trigger_id = click.prompt("Trigger id", type=str)
+        binding = bridge.register_binding(trigger_id, scenario.scenario_id, repo)
+        console.print(f"[green]Registered {binding.trigger_id} -> {binding.scenario_id}[/green]")
+    else:
+        console.print(
+            f"[dim]Run `bernstein routine register --scenario {scenario.scenario_id} --trigger-id <id>` later.[/dim]"
+        )
+
+
+@routine_group.command("register")
+@click.option("--scenario", "scenario_id", required=True)
+@click.option("--trigger-id", "trigger_id", required=True)
+@click.option("--repo", required=True)
+@click.option(
+    "--scenarios-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+)
+def routine_register(
+    scenario_id: str,
+    trigger_id: str,
+    repo: str,
+    scenarios_dir: Path | None,
+) -> None:
+    """Register an existing Routine trigger id against a scenario."""
+    from rich.console import Console
+
+    console = Console()
+    bridge = _make_bridge(scenarios_dir, Path.cwd())
+    try:
+        binding = bridge.register_binding(trigger_id, scenario_id, repo)
+    except KeyError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+    console.print(f"[green]Registered {binding.trigger_id} -> {binding.scenario_id} for {binding.repo}[/green]")
+
+
+@routine_group.command("bindings")
+@click.option(
+    "--scenarios-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+)
+def routine_bindings(scenarios_dir: Path | None) -> None:
+    """List known Routine trigger -> scenario bindings."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console()
+    bridge = _make_bridge(scenarios_dir, Path.cwd())
+    bindings = bridge.list_bindings()
+    if not bindings:
+        console.print("[yellow]No bindings registered.[/yellow]")
+        return
+    table = Table(title="Routine bindings", show_lines=True)
+    table.add_column("trigger_id", style="bold cyan")
+    table.add_column("scenario_id", style="green")
+    table.add_column("repo")
+    for b in bindings:
+        table.add_row(b.trigger_id, b.scenario_id, b.repo)
+    console.print(table)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -853,6 +853,11 @@ from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group  # noqa: E402
 
 cli.add_command(wheelhouse_group, "wheelhouse")
 
+# rt-003: Claude Code Routine <-> scenario bridge.
+from bernstein.cli.commands.routine_cmd import routine_group  # noqa: E402
+
+cli.add_command(routine_group, "routine")
+
 # Cluster lifecycle helpers (mTLS bootstrap, etc.)
 from bernstein.cli.commands.cluster_cmd import cluster_group  # noqa: E402
 

--- a/src/bernstein/core/planning/routine_bridge.py
+++ b/src/bernstein/core/planning/routine_bridge.py
@@ -1,0 +1,477 @@
+"""Bidirectional Routine <-> Scenario bridge with auto-provisioning.
+
+This module wires the existing scenario library into both ends of the rt-003
+flow:
+
+* **Direction A (export):** :func:`provision_scenario` builds a
+  :class:`RoutineExport` and writes it to disk so an operator can stand up a
+  Claude Code Routine in minutes.
+* **Direction B (invoke):** :func:`build_task_payloads` turns a scenario into
+  a list of task payloads suitable for ``POST /tasks``, and
+  :func:`spawn_scenario_tasks` fires those payloads at the Bernstein task
+  server when called from the MCP layer or the CLI.
+
+The bridge also keeps a small JSON registry under
+``.sdd/routines/registry.json`` that maps Routine trigger ids to scenario
+ids — so a webhook arriving with ``X-Trigger-Id: <id>`` resolves to a known
+scenario without operator hand-holding.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, cast
+
+from bernstein.core.planning.routine_provisioner import (
+    RoutineExport,
+    RoutineProvisioner,
+)
+from bernstein.core.planning.scenario_library import (
+    ScenarioRecipe,
+    load_scenario_library,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.planning.scenario_library import ScenarioLibrary
+
+logger = logging.getLogger(__name__)
+
+
+# Mapping from scenario-template scope/complexity strings to the values the
+# Bernstein task server accepts on POST /tasks. The scenario library already
+# normalises into {small, medium, large} / {low, medium, high}, so this keeps
+# things 1:1 except for legacy values that still appear in YAML templates.
+_SCOPE_NORMALISE: dict[str, str] = {
+    "small": "small",
+    "medium": "medium",
+    "large": "large",
+}
+_COMPLEXITY_NORMALISE: dict[str, str] = {
+    "low": "low",
+    "simple": "low",
+    "medium": "medium",
+    "moderate": "medium",
+    "high": "high",
+    "complex": "high",
+}
+
+
+@dataclass(frozen=True)
+class ScenarioTaskPayload:
+    """A single task payload to be POSTed at ``/tasks`` by the bridge.
+
+    Attributes:
+        title: Human-readable task title.
+        description: Full task description body, including any context the
+            Routine injected (PR number, branch, etc.).
+        role: Specialist role.
+        priority: 1=critical, 2=normal, 3=nice-to-have.
+        scope: ``small`` | ``medium`` | ``large``.
+        complexity: ``low`` | ``medium`` | ``high``.
+        scenario_id: Source scenario, propagated for traceability.
+        orchestration_id: Shared id grouping all tasks of one scenario run.
+    """
+
+    title: str
+    description: str
+    role: str
+    priority: int
+    scope: str
+    complexity: str
+    scenario_id: str
+    orchestration_id: str
+
+    def as_server_payload(self) -> dict[str, Any]:
+        """Return a dict suitable for ``POST /tasks``."""
+        return {
+            "title": self.title,
+            "description": self.description,
+            "role": self.role,
+            "priority": self.priority,
+            "scope": self.scope,
+            "complexity": self.complexity,
+            "metadata": {
+                "scenario_id": self.scenario_id,
+                "orchestration_id": self.orchestration_id,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class ScenarioInvocation:
+    """Result of invoking a scenario as a set of tasks.
+
+    Attributes:
+        orchestration_id: Identifier shared by every task spawned from this
+            scenario invocation.
+        scenario_id: Source scenario.
+        task_count: Number of tasks that were (or would be) spawned.
+        estimated_minutes: Rough total wall-clock estimate.
+        task_ids: Server-assigned task ids, populated by
+            :func:`spawn_scenario_tasks`. Empty when called in dry-run mode.
+    """
+
+    orchestration_id: str
+    scenario_id: str
+    task_count: int
+    estimated_minutes: int
+    task_ids: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RoutineBinding:
+    """Mapping between a Routine trigger id and a Bernstein scenario.
+
+    Attributes:
+        trigger_id: Routine trigger identifier (assigned by claude.ai).
+        scenario_id: Scenario the trigger should invoke.
+        repo: Target repository in ``owner/name`` form.
+        registered_at: Unix timestamp.
+    """
+
+    trigger_id: str
+    scenario_id: str
+    repo: str
+    registered_at: float
+
+
+def _build_context_block(context: str, pr_number: int | None, branch: str | None) -> str:
+    """Format Routine-supplied trigger context as a markdown block."""
+    if not context and pr_number is None and not branch:
+        return ""
+    parts = ["", "## Trigger context"]
+    if pr_number is not None:
+        parts.append(f"- PR number: #{pr_number}")
+    if branch:
+        parts.append(f"- Branch: `{branch}`")
+    if context:
+        parts.append(f"- Note: {context}")
+    return "\n".join(parts) + "\n"
+
+
+def build_task_payloads(
+    scenario: ScenarioRecipe,
+    *,
+    context: str = "",
+    pr_number: int | None = None,
+    branch: str | None = None,
+    orchestration_id: str | None = None,
+) -> list[ScenarioTaskPayload]:
+    """Decompose a scenario into one task payload per scenario task template.
+
+    Args:
+        scenario: Source scenario.
+        context: Free-form context the trigger supplied.
+        pr_number: Optional PR number to inject into descriptions.
+        branch: Optional branch to inject into descriptions.
+        orchestration_id: Reuse an id (for retries). Generated when omitted.
+
+    Returns:
+        A list of payloads — one per scenario task template, in scenario
+        order. Empty when the scenario has no tasks.
+    """
+    orch_id = orchestration_id or f"scn-{uuid.uuid4().hex[:12]}"
+    context_block = _build_context_block(context, pr_number, branch)
+    out: list[ScenarioTaskPayload] = []
+    for tpl in scenario.tasks:
+        description = (tpl.description or tpl.title) + context_block
+        out.append(
+            ScenarioTaskPayload(
+                title=tpl.title[:120],
+                description=description,
+                role=tpl.role or "backend",
+                priority=int(tpl.priority),
+                scope=_SCOPE_NORMALISE.get(tpl.scope.lower(), "medium"),
+                complexity=_COMPLEXITY_NORMALISE.get(tpl.complexity.lower(), "medium"),
+                scenario_id=scenario.scenario_id,
+                orchestration_id=orch_id,
+            )
+        )
+    return out
+
+
+def estimate_minutes(scenario: ScenarioRecipe) -> int:
+    """Conservative wall-clock estimate for a full scenario run.
+
+    Heuristic: scope and complexity each contribute base minutes, summed
+    across tasks; parallel execution divides the total by the number of
+    distinct roles (capped at four).
+
+    Args:
+        scenario: Source scenario.
+
+    Returns:
+        Estimate in minutes (minimum of 5 when the scenario has any task).
+    """
+    if not scenario.tasks:
+        return 0
+    scope_min = {"small": 10, "medium": 25, "large": 60}
+    complexity_min = {"low": 5, "medium": 15, "high": 35}
+    total = 0
+    for t in scenario.tasks:
+        total += scope_min.get(t.scope, 25) + complexity_min.get(t.complexity, 15)
+    distinct_roles = len({t.role for t in scenario.tasks}) or 1
+    parallel_factor = min(distinct_roles, 4)
+    return max(5, total // parallel_factor)
+
+
+@dataclass
+class RoutineBridge:
+    """Bidirectional bridge with auto-provisioning.
+
+    The bridge owns:
+
+    * a :class:`ScenarioLibrary` (loaded from disk),
+    * a :class:`RoutineProvisioner` (Direction A — export configs),
+    * a Routine binding registry persisted under ``state_dir``.
+
+    Attributes:
+        library: Loaded scenario library.
+        provisioner: Provisioner reused for exports.
+        state_dir: Directory holding ``registry.json`` (typically
+            ``.sdd/routines``).
+    """
+
+    library: ScenarioLibrary
+    provisioner: RoutineProvisioner
+    state_dir: Path
+
+    @classmethod
+    def from_paths(
+        cls,
+        scenarios_dir: Path,
+        state_dir: Path,
+        *,
+        bernstein_url: str = "http://127.0.0.1:8052",
+    ) -> RoutineBridge:
+        """Construct a bridge by loading a scenario library from disk.
+
+        Args:
+            scenarios_dir: Directory of scenario YAML files.
+            state_dir: Directory for the binding registry. Created on demand.
+            bernstein_url: Default Bernstein task server URL.
+
+        Returns:
+            A configured :class:`RoutineBridge`.
+        """
+        library = load_scenario_library(scenarios_dir)
+        provisioner = RoutineProvisioner(library=library, bernstein_url=bernstein_url)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        return cls(library=library, provisioner=provisioner, state_dir=state_dir)
+
+    # ------------------------------------------------------------------ A
+    # Direction A: scenario -> Routine config
+    # ------------------------------------------------------------------
+
+    def provision(
+        self,
+        scenario_id: str,
+        repo: str,
+        out_dir: Path,
+    ) -> tuple[RoutineExport, list[Path]]:
+        """Generate and persist a Routine configuration for a scenario.
+
+        Args:
+            scenario_id: Source scenario id.
+            repo: Target repository (``owner/name``).
+            out_dir: Directory to write the artefacts into.
+
+        Returns:
+            ``(export, written_paths)``.
+        """
+        export = self.provisioner.export_scenario_as_routine(scenario_id, repo)
+        files = self.provisioner.write_export(export, out_dir)
+        return export, files
+
+    # ------------------------------------------------------------------ B
+    # Direction B: scenario -> task spawn
+    # ------------------------------------------------------------------
+
+    def invoke_scenario(
+        self,
+        scenario_id: str,
+        *,
+        context: str = "",
+        pr_number: int | None = None,
+        branch: str | None = None,
+    ) -> tuple[ScenarioInvocation, list[ScenarioTaskPayload]]:
+        """Decompose a scenario into task payloads (no HTTP call).
+
+        Args:
+            scenario_id: Source scenario id.
+            context: Free-form trigger context.
+            pr_number: PR number to inject when the trigger came from GitHub.
+            branch: Branch override.
+
+        Returns:
+            ``(invocation, payloads)``. ``invocation.task_ids`` is empty —
+            populate it via :func:`spawn_scenario_tasks` once tasks are POSTed.
+
+        Raises:
+            KeyError: If the scenario is unknown.
+        """
+        recipe = self.library.get(scenario_id)
+        if recipe is None:
+            msg = f"Unknown scenario: {scenario_id}"
+            raise KeyError(msg)
+        payloads = build_task_payloads(
+            recipe,
+            context=context,
+            pr_number=pr_number,
+            branch=branch,
+        )
+        invocation = ScenarioInvocation(
+            orchestration_id=payloads[0].orchestration_id if payloads else "scn-empty",
+            scenario_id=recipe.scenario_id,
+            task_count=len(payloads),
+            estimated_minutes=estimate_minutes(recipe),
+        )
+        return invocation, payloads
+
+    # ------------------------------------------------------------------
+    # Routine binding registry
+    # ------------------------------------------------------------------
+
+    @property
+    def registry_path(self) -> Path:
+        """Path to the JSON registry mapping trigger ids to scenarios."""
+        return self.state_dir / "registry.json"
+
+    def _load_registry(self) -> dict[str, dict[str, Any]]:
+        path = self.registry_path
+        if not path.exists():
+            return {}
+        try:
+            data: object = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning("Could not read routine registry %s: %s", path, exc)
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        data_dict = cast("dict[Any, Any]", data)
+        out: dict[str, dict[str, Any]] = {}
+        for k, v in data_dict.items():
+            if isinstance(v, dict):
+                v_dict = cast("dict[str, Any]", v)
+                out[str(k)] = dict(v_dict)
+        return out
+
+    def _save_registry(self, data: dict[str, dict[str, Any]]) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.registry_path.write_text(
+            json.dumps(data, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def register_binding(
+        self,
+        trigger_id: str,
+        scenario_id: str,
+        repo: str,
+    ) -> RoutineBinding:
+        """Persist a mapping between a Routine trigger id and a scenario.
+
+        Args:
+            trigger_id: Routine trigger identifier from claude.ai.
+            scenario_id: Scenario the trigger should invoke.
+            repo: Target repository in ``owner/name`` form.
+
+        Returns:
+            The persisted :class:`RoutineBinding`.
+
+        Raises:
+            KeyError: If ``scenario_id`` is unknown.
+        """
+        if self.library.get(scenario_id) is None:
+            msg = f"Unknown scenario: {scenario_id}"
+            raise KeyError(msg)
+        binding = RoutineBinding(
+            trigger_id=trigger_id,
+            scenario_id=scenario_id,
+            repo=repo,
+            registered_at=time.time(),
+        )
+        registry = self._load_registry()
+        registry[trigger_id] = {
+            "scenario_id": binding.scenario_id,
+            "repo": binding.repo,
+            "registered_at": binding.registered_at,
+        }
+        self._save_registry(registry)
+        return binding
+
+    def lookup_binding(self, trigger_id: str) -> RoutineBinding | None:
+        """Return the binding for ``trigger_id`` or ``None`` if missing."""
+        entry = self._load_registry().get(trigger_id)
+        if entry is None:
+            return None
+        scenario_id = str(entry.get("scenario_id", ""))
+        if not scenario_id:
+            return None
+        return RoutineBinding(
+            trigger_id=trigger_id,
+            scenario_id=scenario_id,
+            repo=str(entry.get("repo", "")),
+            registered_at=float(entry.get("registered_at", 0.0)),
+        )
+
+    def list_bindings(self) -> list[RoutineBinding]:
+        """Return all known bindings, sorted by registration time."""
+        out: list[RoutineBinding] = []
+        for trig_id, entry in self._load_registry().items():
+            scenario_id = str(entry.get("scenario_id", ""))
+            if not scenario_id:
+                continue
+            out.append(
+                RoutineBinding(
+                    trigger_id=trig_id,
+                    scenario_id=scenario_id,
+                    repo=str(entry.get("repo", "")),
+                    registered_at=float(entry.get("registered_at", 0.0)),
+                )
+            )
+        out.sort(key=lambda b: b.registered_at)
+        return out
+
+
+def spawn_scenario_tasks(
+    payloads: list[ScenarioTaskPayload],
+    *,
+    poster: object,
+) -> list[str]:
+    """POST each payload at the Bernstein task server.
+
+    Args:
+        payloads: Task payloads produced by :func:`build_task_payloads`.
+        poster: Callable with signature ``(path: str, body: dict) -> dict``
+            (typically ``bernstein.cli.helpers.server_post``). Passed by
+            dependency injection so the bridge stays decoupled from HTTP.
+
+    Returns:
+        The list of server-assigned task ids, in payload order. Tasks the
+        server rejects are skipped (a warning is logged).
+    """
+    if not callable(poster):
+        msg = "poster must be callable"
+        raise TypeError(msg)
+    task_ids: list[str] = []
+    for payload in payloads:
+        try:
+            result = poster("/tasks", payload.as_server_payload())  # type: ignore[misc]
+        except Exception:
+            logger.exception("Failed to POST scenario task %s", payload.title)
+            continue
+        if not isinstance(result, dict):
+            logger.warning("Unexpected /tasks response for %s: %r", payload.title, result)
+            continue
+        result_dict = cast("dict[str, Any]", result)
+        task_id = str(result_dict.get("id", "")).strip()
+        if task_id:
+            task_ids.append(task_id)
+    return task_ids

--- a/src/bernstein/core/planning/routine_provisioner.py
+++ b/src/bernstein/core/planning/routine_provisioner.py
@@ -1,0 +1,370 @@
+"""Direction A: export Bernstein scenarios as Claude Code Routine configs.
+
+A Routine = prompt + repos + environment + connectors + triggers, configured
+through ``claude.ai/code/routines``. There is no programmatic creation API
+(research preview), so this module produces everything an operator needs to
+paste into the Routine UI:
+
+* a prompt body that instructs the Routine to drive Bernstein orchestration,
+* an MCP connector config pointing at the local or remote Bernstein server,
+* a setup guide that walks through the manual steps,
+* a list of recommended trigger types derived from scenario tags.
+
+This is one half of rt-003. Direction B (Routine -> Bernstein scenario lookup)
+lives in :mod:`bernstein.mcp.routine_tools` and the new
+:class:`RoutineBridge` in :mod:`bernstein.core.planning.routine_bridge`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.planning.scenario_library import (
+        ScenarioLibrary,
+        ScenarioRecipe,
+        ScenarioTaskTemplate,
+    )
+
+
+@dataclass(frozen=True)
+class TriggerRecommendation:
+    """A single trigger configuration suggestion for a Routine.
+
+    Attributes:
+        type: One of ``"github"``, ``"schedule"``, ``"api"``.
+        event: Event name when ``type == "github"``
+            (e.g. ``"pull_request.opened"``).
+        cadence: Cadence string when ``type == "schedule"``
+            (e.g. ``"daily"``, ``"hourly"``).
+        reason: Short human-readable justification for the suggestion.
+    """
+
+    type: str
+    reason: str
+    event: str = ""
+    cadence: str = ""
+
+
+@dataclass(frozen=True)
+class RoutineExport:
+    """All artefacts needed to provision a Routine from a scenario.
+
+    Attributes:
+        scenario_id: Source scenario identifier.
+        name: Suggested Routine name (``"Bernstein: <scenario name>"``).
+        prompt: Markdown prompt to paste into the Routine prompt field.
+        recommended_triggers: Trigger configurations the operator should set.
+        mcp_config: JSON blob to register as an MCP connector.
+        environment_vars: Environment variables the Routine session needs
+            (e.g. ``BERNSTEIN_AUTH_TOKEN``).
+        setup_instructions: Step-by-step markdown guide.
+    """
+
+    scenario_id: str
+    name: str
+    prompt: str
+    recommended_triggers: tuple[TriggerRecommendation, ...]
+    mcp_config: dict[str, object]
+    environment_vars: dict[str, str]
+    setup_instructions: str
+
+
+# Tag groups to map scenario tags onto trigger recommendations.
+_REVIEW_TAGS = frozenset({"review", "ci", "pr"})
+_MAINTENANCE_TAGS = frozenset({"maintenance", "cleanup", "schedule", "nightly"})
+_DEPLOY_TAGS = frozenset({"deploy", "verify", "verification"})
+
+
+def recommend_triggers(scenario: ScenarioRecipe) -> tuple[TriggerRecommendation, ...]:
+    """Suggest Routine triggers based on a scenario's tags.
+
+    Args:
+        scenario: Scenario to inspect.
+
+    Returns:
+        A tuple of trigger recommendations, possibly empty. Each recommendation
+        is independent — operators can pick one or several.
+    """
+    tags = {t.lower() for t in scenario.tags}
+    out: list[TriggerRecommendation] = []
+    if tags & _REVIEW_TAGS:
+        out.append(
+            TriggerRecommendation(
+                type="github",
+                event="pull_request.opened",
+                reason="Review and CI scenarios should run on every new PR",
+            )
+        )
+    if tags & _MAINTENANCE_TAGS:
+        out.append(
+            TriggerRecommendation(
+                type="schedule",
+                cadence="daily",
+                reason="Maintenance scenarios run best on a nightly schedule",
+            )
+        )
+    if tags & _DEPLOY_TAGS:
+        out.append(
+            TriggerRecommendation(
+                type="api",
+                reason="Deploy verification should be triggered by the CD pipeline",
+            )
+        )
+    if not out:
+        # Fall back to a manual API trigger so the operator always has at
+        # least one option to attach.
+        out.append(
+            TriggerRecommendation(
+                type="api",
+                reason="No tags matched a known pattern; use manual API trigger",
+            )
+        )
+    return tuple(out)
+
+
+def _format_task_list(tasks: tuple[ScenarioTaskTemplate, ...]) -> str:
+    """Render a markdown bullet list of scenario tasks."""
+    lines: list[str] = []
+    for idx, t in enumerate(tasks, start=1):
+        suffix = f" — {t.description}" if t.description else ""
+        lines.append(f"{idx}. **{t.title}** (role: `{t.role}`, priority: {t.priority}){suffix}")
+    return "\n".join(lines)
+
+
+def build_routine_prompt(scenario: ScenarioRecipe, bernstein_url: str) -> str:
+    """Produce the markdown prompt body the Routine session will execute.
+
+    The prompt instructs the Routine to:
+
+    1. Connect to the Bernstein MCP server at ``bernstein_url``.
+    2. Call ``bernstein_scenario`` with this scenario's id (and PR/branch
+       context if it was triggered by a GitHub event).
+    3. Poll ``bernstein_scenario_status`` until completion.
+    4. Summarise the outcome (and post a PR comment when applicable).
+
+    Args:
+        scenario: Source scenario.
+        bernstein_url: Bernstein task server URL the MCP connector points at.
+
+    Returns:
+        Markdown prompt body suitable for pasting into the Routine UI.
+    """
+    task_list = _format_task_list(scenario.tasks)
+    return (
+        "You are a Bernstein orchestration relay.\n"
+        "When triggered, you drive a multi-agent Bernstein run end to end.\n"
+        "\n"
+        "## Steps\n"
+        "1. Call the Bernstein MCP tool `bernstein_scenario` with:\n"
+        f"   - scenario_id: `{scenario.scenario_id}`\n"
+        "   - context: short summary of the trigger event\n"
+        "   - pr_number / branch: from the trigger payload when present\n"
+        "2. Poll `bernstein_scenario_status(orchestration_id)` every 30s.\n"
+        "3. When all tasks finish, summarise outcomes:\n"
+        "   - per-task status (passed / failed)\n"
+        "   - quality gate failures, if any\n"
+        "   - if triggered by a PR, post a review comment with findings\n"
+        "\n"
+        f"## Scenario: {scenario.name}\n"
+        f"{scenario.description}\n"
+        "\n"
+        f"## Tasks Bernstein will spawn ({len(scenario.tasks)})\n"
+        f"{task_list}\n"
+        "\n"
+        "## Expected behaviour\n"
+        f"- Bernstein decomposes this into {len(scenario.tasks)} parallel tasks.\n"
+        "- Each task runs in an isolated git worktree.\n"
+        "- Quality gates verify output before merge.\n"
+        "- A failing task auto-retries with an escalated model.\n"
+        "\n"
+        "## MCP connector\n"
+        f"The Bernstein MCP server should be registered with base URL `{bernstein_url}`.\n"
+    )
+
+
+def build_mcp_config(bernstein_url: str) -> dict[str, object]:
+    """Return the MCP connector config to register inside the Routine.
+
+    Args:
+        bernstein_url: Bernstein task server URL.
+
+    Returns:
+        A JSON-serialisable dict describing the MCP server connection.
+    """
+    return {
+        "name": "bernstein",
+        "command": "bernstein",
+        "args": ["mcp"],
+        "transport": "stdio",
+        "env": {
+            "BERNSTEIN_SERVER_URL": bernstein_url,
+        },
+    }
+
+
+def build_env_vars(scenario: ScenarioRecipe) -> dict[str, str]:
+    """Return the environment variables the Routine session should declare.
+
+    Args:
+        scenario: Source scenario (used for tag-conditional defaults).
+
+    Returns:
+        Mapping of env var name to documentation/default string. Operators
+        replace empty values with real secrets when configuring the Routine.
+    """
+    env: dict[str, str] = {
+        "BERNSTEIN_AUTH_TOKEN": "",
+        "BERNSTEIN_SERVER_URL": "http://127.0.0.1:8052",
+    }
+    if "github" in scenario.tags or any("review" in t for t in scenario.tags):
+        env["GITHUB_TOKEN"] = ""
+    return env
+
+
+def build_setup_guide(scenario: ScenarioRecipe, repo: str) -> str:
+    """Produce a markdown setup guide for the operator.
+
+    Args:
+        scenario: Source scenario.
+        repo: Target repository in ``owner/name`` form.
+
+    Returns:
+        Markdown walk-through of the manual provisioning steps.
+    """
+    triggers = recommend_triggers(scenario)
+    trigger_lines = "\n".join(
+        f"- **{r.type}**"
+        + (f" (`{r.event}`)" if r.event else "")
+        + (f" cadence `{r.cadence}`" if r.cadence else "")
+        + f": {r.reason}"
+        for r in triggers
+    )
+    return (
+        f"# Provision Routine: {scenario.name}\n"
+        "\n"
+        "## 1. Open the Routine UI\n"
+        "Visit https://claude.ai/code/routines and click **New Routine**.\n"
+        "\n"
+        "## 2. Paste the prompt\n"
+        "Copy `prompt.md` (in this directory) into the Routine prompt field.\n"
+        "\n"
+        "## 3. Attach the repository\n"
+        f"Add `{repo}` as the working repository.\n"
+        "\n"
+        "## 4. Register the MCP connector\n"
+        "Paste the contents of `mcp-config.json` into the Routine's connectors\n"
+        "section. The Routine will spawn a `bernstein mcp` stdio process to\n"
+        "talk to the Bernstein task server.\n"
+        "\n"
+        "## 5. Set environment variables\n"
+        "Configure the variables listed in `env.json`. `BERNSTEIN_AUTH_TOKEN`\n"
+        "is required when the task server has auth enabled; `GITHUB_TOKEN` is\n"
+        "required for review or comment-posting scenarios.\n"
+        "\n"
+        "## 6. Configure a trigger\n"
+        f"{trigger_lines}\n"
+        "\n"
+        "## 7. Save the Routine and copy the trigger id\n"
+        "Run `bernstein routine register --scenario "
+        f"{scenario.scenario_id} --trigger-id <id>` so Bernstein can correlate\n"
+        "incoming webhooks with this scenario.\n"
+    )
+
+
+@dataclass
+class RoutineProvisioner:
+    """Generate ready-to-use Routine configs from Bernstein scenarios.
+
+    Attributes:
+        library: Scenario library to look scenarios up in.
+        bernstein_url: Default base URL of the Bernstein task server. Used
+            both inside the prompt and inside the MCP connector config.
+    """
+
+    library: ScenarioLibrary
+    bernstein_url: str = "http://127.0.0.1:8052"
+
+    def list_scenarios(self) -> list[ScenarioRecipe]:
+        """Return all scenarios known to this provisioner."""
+        return list(self.library.scenarios.values())
+
+    def export_scenario_as_routine(
+        self,
+        scenario_id: str,
+        repo: str,
+        bernstein_url: str | None = None,
+    ) -> RoutineExport:
+        """Build a :class:`RoutineExport` for ``scenario_id``.
+
+        Args:
+            scenario_id: Identifier of the scenario to export.
+            repo: Target repository in ``owner/name`` form.
+            bernstein_url: Override the default Bernstein server URL.
+
+        Returns:
+            The export bundle.
+
+        Raises:
+            KeyError: If ``scenario_id`` is not in the library.
+        """
+        recipe = self.library.get(scenario_id)
+        if recipe is None:
+            msg = f"Unknown scenario: {scenario_id}"
+            raise KeyError(msg)
+        url = bernstein_url or self.bernstein_url
+        return RoutineExport(
+            scenario_id=recipe.scenario_id,
+            name=f"Bernstein: {recipe.name}",
+            prompt=build_routine_prompt(recipe, url),
+            recommended_triggers=recommend_triggers(recipe),
+            mcp_config=build_mcp_config(url),
+            environment_vars=build_env_vars(recipe),
+            setup_instructions=build_setup_guide(recipe, repo),
+        )
+
+    def write_export(self, export: RoutineExport, out_dir: Path) -> list[Path]:
+        """Write all artefacts of ``export`` to ``out_dir``.
+
+        Args:
+            export: Bundle produced by :meth:`export_scenario_as_routine`.
+            out_dir: Target directory. Created if missing.
+
+        Returns:
+            The list of files written, in deterministic order.
+        """
+        out_dir.mkdir(parents=True, exist_ok=True)
+        triggers_md = _format_triggers_markdown(export.recommended_triggers)
+
+        files: list[tuple[Path, str]] = [
+            (out_dir / "prompt.md", export.prompt),
+            (out_dir / "mcp-config.json", json.dumps(export.mcp_config, indent=2) + "\n"),
+            (out_dir / "env.json", json.dumps(export.environment_vars, indent=2) + "\n"),
+            (out_dir / "setup-guide.md", export.setup_instructions),
+            (out_dir / "triggers.md", triggers_md),
+        ]
+        for path, content in files:
+            path.write_text(content, encoding="utf-8")
+        return [p for p, _ in files]
+
+
+def _format_triggers_markdown(triggers: tuple[TriggerRecommendation, ...]) -> str:
+    """Render the ``triggers.md`` artefact."""
+    if not triggers:
+        return "# Recommended Triggers\n\nNo automatic recommendations.\n"
+    lines = ["# Recommended Triggers", ""]
+    for r in triggers:
+        header = f"## {r.type}"
+        if r.event:
+            header += f" — `{r.event}`"
+        if r.cadence:
+            header += f" — cadence `{r.cadence}`"
+        lines.append(header)
+        lines.append("")
+        lines.append(r.reason)
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/bernstein/mcp/routine_tools.py
+++ b/src/bernstein/mcp/routine_tools.py
@@ -1,16 +1,45 @@
-"""MCP tools for Claude Code Routine integration."""
+"""MCP tools for the rt-003 Routine <-> Scenario bridge.
+
+This module exposes two flavours of helpers:
+
+* **Pure list/detail helpers** (``list_scenarios``, ``get_scenario_detail``)
+  used by tests and the CLI.
+* **MCP tool registration** (:func:`register_scenario_tools`) which wires
+  ``bernstein_scenario``, ``bernstein_scenarios``, and
+  ``bernstein_scenario_status`` onto a FastMCP server.
+
+The MCP tools delegate to the Bernstein task server over HTTP — they do not
+run orchestration in-process — keeping the MCP layer thin and stateless.
+"""
 
 from __future__ import annotations
 
+import json
+import logging
+import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
+import httpx
+
+from bernstein.core.planning.routine_bridge import build_task_payloads, estimate_minutes
 from bernstein.core.planning.scenario_library import (
     load_scenario_library,
 )
 
-# Default scenario directory
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+# Default scenario directory shipped with the package.
 _SCENARIOS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "templates" / "scenarios"
+
+# HTTP timeout for the task-server calls these tools make (seconds).
+_HTTP_TIMEOUT = 5.0
+
+# Env var holding the bearer token; mirrors mcp.server convention.
+_AUTH_TOKEN_ENV = "BERNSTEIN_AUTH_TOKEN"
 
 
 def list_scenarios(scenarios_dir: Path | None = None) -> list[dict[str, Any]]:
@@ -63,3 +92,216 @@ def get_scenario_detail(scenario_id: str, scenarios_dir: Path | None = None) -> 
             for t in recipe.tasks
         ],
     }
+
+
+def _auth_headers() -> dict[str, str]:
+    tok = os.environ.get(_AUTH_TOKEN_ENV, "")
+    return {"Authorization": f"Bearer {tok}"} if tok else {}
+
+
+async def invoke_scenario_via_server(
+    scenario_id: str,
+    *,
+    server_url: str,
+    context: str = "",
+    pr_number: int | None = None,
+    branch: str | None = None,
+    scenarios_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Spawn one task per scenario template by POSTing at ``server_url``.
+
+    Args:
+        scenario_id: Source scenario id.
+        server_url: Bernstein task server base URL.
+        context: Free-form trigger context appended to each task description.
+        pr_number: Optional PR number injected into descriptions.
+        branch: Optional branch override.
+        scenarios_dir: Override the bundled scenarios directory.
+
+    Returns:
+        A dict with ``orchestration_id``, ``scenario_id``, ``task_count``,
+        ``estimated_minutes``, and ``task_ids``. On failure to POST, returns
+        a dict with an ``error`` key.
+    """
+    library = load_scenario_library(scenarios_dir or _SCENARIOS_DIR)
+    recipe = library.get(scenario_id)
+    if recipe is None:
+        return {"error": f"Unknown scenario: {scenario_id}"}
+
+    payloads = build_task_payloads(
+        recipe,
+        context=context,
+        pr_number=pr_number,
+        branch=branch,
+    )
+    if not payloads:
+        return {"error": f"Scenario {scenario_id} has no tasks"}
+
+    orchestration_id = payloads[0].orchestration_id
+    task_ids: list[str] = []
+    headers = _auth_headers()
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        for payload in payloads:
+            try:
+                resp = await client.post(
+                    f"{server_url}/tasks",
+                    json=payload.as_server_payload(),
+                    headers=headers,
+                )
+                resp.raise_for_status()
+                data: object = resp.json()
+            except Exception as exc:
+                logger.warning("scenario task POST failed: %s", exc)
+                continue
+            if isinstance(data, dict):
+                data_dict = cast("dict[str, Any]", data)
+                raw_id = data_dict.get("id", "")
+                tid = str(raw_id).strip() if raw_id else ""
+            else:
+                tid = ""
+            if tid:
+                task_ids.append(tid)
+
+    return {
+        "orchestration_id": orchestration_id,
+        "scenario_id": recipe.scenario_id,
+        "task_count": len(payloads),
+        "estimated_minutes": estimate_minutes(recipe),
+        "task_ids": task_ids,
+    }
+
+
+async def fetch_scenario_status(
+    orchestration_id: str,
+    *,
+    server_url: str,
+) -> dict[str, Any]:
+    """Aggregate the status of all tasks belonging to an orchestration.
+
+    Args:
+        orchestration_id: Identifier shared by every task of one scenario run
+            (set in ``metadata.orchestration_id`` at spawn time).
+        server_url: Bernstein task server base URL.
+
+    Returns:
+        A dict with per-status counts and the matched task list (truncated
+        to a sensible size).
+    """
+    headers = _auth_headers()
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(f"{server_url}/tasks", headers=headers)
+            resp.raise_for_status()
+            tasks_raw: object = resp.json()
+    except Exception as exc:
+        return {"error": str(exc)}
+    if not isinstance(tasks_raw, list):
+        return {"error": "Unexpected /tasks response"}
+
+    matched: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    tasks_list = cast("list[Any]", tasks_raw)
+    for raw_obj in tasks_list:
+        if not isinstance(raw_obj, dict):
+            continue
+        raw = cast("dict[str, Any]", raw_obj)
+        meta_obj: object = raw.get("metadata") or {}
+        meta: dict[str, Any] = cast("dict[str, Any]", meta_obj) if isinstance(meta_obj, dict) else {}
+        orch = meta.get("orchestration_id")
+        if orch != orchestration_id:
+            continue
+        status = str(raw.get("status", "unknown"))
+        counts[status] = counts.get(status, 0) + 1
+        matched.append(
+            {
+                "id": raw.get("id"),
+                "title": raw.get("title"),
+                "role": raw.get("role"),
+                "status": status,
+                "result_summary": raw.get("result_summary"),
+            }
+        )
+    return {
+        "orchestration_id": orchestration_id,
+        "task_count": len(matched),
+        "status_counts": counts,
+        "tasks": matched[:50],
+    }
+
+
+def _error_response(exc: Exception) -> str:
+    logger.warning("scenario MCP tool error: %s", exc)
+    return json.dumps({"error": str(exc)})
+
+
+def register_scenario_tools(mcp: FastMCP[None], server_url: str) -> None:
+    """Register the ``bernstein_scenario(s|_status)`` MCP tools.
+
+    Args:
+        mcp: FastMCP instance to attach tools to.
+        server_url: Bernstein task server base URL the tools will hit.
+    """
+
+    @mcp.tool()
+    async def bernstein_scenarios() -> str:  # pyright: ignore[reportUnusedFunction]
+        """List all Bernstein scenarios known to the local library.
+
+        Returns:
+            JSON array of scenario summaries (id, name, description, tags,
+            task_count, roles).
+        """
+        try:
+            return json.dumps(list_scenarios(), indent=2)
+        except Exception as exc:
+            return _error_response(exc)
+
+    @mcp.tool()
+    async def bernstein_scenario(  # pyright: ignore[reportUnusedFunction]
+        scenario_id: str,
+        context: str = "",
+        pr_number: int | None = None,
+        branch: str | None = None,
+    ) -> str:
+        """Invoke a Bernstein scenario by id, spawning one task per template.
+
+        Args:
+            scenario_id: Identifier from the scenario library
+                (e.g. ``"pr-review-comprehensive"``).
+            context: Free-form context (the trigger event summary, for
+                example) appended to each task's description.
+            pr_number: PR number to inject when triggered by GitHub.
+            branch: Branch override.
+
+        Returns:
+            JSON with ``orchestration_id``, ``scenario_id``, ``task_count``,
+            ``estimated_minutes`` and ``task_ids``.
+        """
+        try:
+            result = await invoke_scenario_via_server(
+                scenario_id,
+                server_url=server_url,
+                context=context,
+                pr_number=pr_number,
+                branch=branch,
+            )
+            return json.dumps(result, indent=2)
+        except Exception as exc:
+            return _error_response(exc)
+
+    @mcp.tool()
+    async def bernstein_scenario_status(  # pyright: ignore[reportUnusedFunction]
+        orchestration_id: str,
+    ) -> str:
+        """Aggregate the status of all tasks of a running scenario.
+
+        Args:
+            orchestration_id: Value returned by ``bernstein_scenario``.
+
+        Returns:
+            JSON with status counts and per-task details.
+        """
+        try:
+            result = await fetch_scenario_status(orchestration_id, server_url=server_url)
+            return json.dumps(result, indent=2)
+        except Exception as exc:
+            return _error_response(exc)

--- a/src/bernstein/mcp/server.py
+++ b/src/bernstein/mcp/server.py
@@ -398,6 +398,10 @@ def create_mcp_server(
     _register_query_tools(mcp, server_url)
     _register_action_tools(mcp, server_url)
     _register_skill_tools(mcp)
+    # rt-003: scenario <-> Routine bridge tools.
+    from bernstein.mcp.routine_tools import register_scenario_tools
+
+    register_scenario_tools(mcp, server_url)
     return mcp
 
 

--- a/templates/scenarios/dependency-audit.yaml
+++ b/templates/scenarios/dependency-audit.yaml
@@ -1,0 +1,30 @@
+id: dependency-audit
+name: Dependency Audit
+description: Full security audit of the dependency tree with upgrade recommendations
+tags: [security, maintenance, schedule, dependencies]
+version: "1.0"
+tasks:
+  - title: Inventory direct and transitive dependencies
+    description: Produce a snapshot of direct and transitive dependencies with versions and license info
+    role: security
+    priority: 1
+    scope: small
+    complexity: low
+  - title: Scan for known vulnerabilities
+    description: Cross-reference dependency versions with CVE feeds, flag any high or critical severity issues
+    role: security
+    priority: 0
+    scope: medium
+    complexity: medium
+  - title: Recommend upgrades
+    description: Group safe patch upgrades, breaking-change upgrades, and risky upgrades with migration notes
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+  - title: Open issues for unresolved findings
+    description: For each unresolved CVE or stuck upgrade, file a tracked issue with reproduction context
+    role: devops
+    priority: 2
+    scope: small
+    complexity: low

--- a/templates/scenarios/docs-sync.yaml
+++ b/templates/scenarios/docs-sync.yaml
@@ -1,0 +1,24 @@
+id: docs-sync
+name: Docs Sync
+description: Detect and fix drift between code, public APIs, and documentation
+tags: [docs, maintenance, schedule, quality]
+version: "1.0"
+tasks:
+  - title: Detect docs drift
+    description: Compare public API surface against README and docs/ for missing, stale, or contradictory entries
+    role: docs
+    priority: 0
+    scope: medium
+    complexity: medium
+  - title: Update API reference
+    description: Regenerate API reference for changed signatures and remove references to deleted symbols
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+  - title: Refresh quickstart and examples
+    description: Verify quickstart commands still work, fix broken example snippets and outdated screenshots
+    role: docs
+    priority: 2
+    scope: small
+    complexity: low

--- a/templates/scenarios/issue-decomposition.yaml
+++ b/templates/scenarios/issue-decomposition.yaml
@@ -1,0 +1,30 @@
+id: issue-decomposition
+name: Issue Decomposition
+description: Break a GitHub issue into actionable implementation tasks with acceptance criteria
+tags: [planning, github, decomposition, issues]
+version: "1.0"
+tasks:
+  - title: Analyze issue scope and constraints
+    description: Read the issue, related discussions, and linked code paths; identify scope boundaries and external dependencies
+    role: architect
+    priority: 0
+    scope: medium
+    complexity: medium
+  - title: Design implementation approach
+    description: Propose a concrete approach with module boundaries, data structures, and migration steps
+    role: architect
+    priority: 0
+    scope: medium
+    complexity: high
+  - title: Generate task breakdown
+    description: Emit a list of small, parallelizable subtasks each with role, priority, scope, and acceptance criteria
+    role: manager
+    priority: 1
+    scope: small
+    complexity: medium
+  - title: Risk and rollback notes
+    description: Document risks, monitoring hooks, and a rollback plan for the proposed changes
+    role: backend
+    priority: 2
+    scope: small
+    complexity: medium

--- a/templates/scenarios/pr-review-security-focused.yaml
+++ b/templates/scenarios/pr-review-security-focused.yaml
@@ -1,0 +1,30 @@
+id: pr-review-security-focused
+name: Security-Focused PR Review
+description: Security-first PR review with SAST scanning, auth flow analysis, and dependency audit
+tags: [review, security, ci, github, sast]
+version: "1.0"
+tasks:
+  - title: SAST scan of changed files
+    description: Run static application security testing on modified files, flag injection, XSS, path traversal, and unsafe deserialization patterns
+    role: security
+    priority: 0
+    scope: medium
+    complexity: high
+  - title: Auth and authz flow review
+    description: Analyze authentication and authorization changes, verify principle of least privilege, check for privilege escalation paths
+    role: security
+    priority: 0
+    scope: medium
+    complexity: high
+  - title: Dependency vulnerability audit
+    description: Audit added or upgraded dependencies for known CVEs, license issues, and supply-chain risks
+    role: security
+    priority: 1
+    scope: small
+    complexity: medium
+  - title: Secrets and PII scan
+    description: Scan diff for hard-coded secrets, API keys, tokens, and PII leakage in logs or responses
+    role: security
+    priority: 0
+    scope: small
+    complexity: medium

--- a/templates/scenarios/test-coverage-boost.yaml
+++ b/templates/scenarios/test-coverage-boost.yaml
@@ -1,0 +1,24 @@
+id: test-coverage-boost
+name: Test Coverage Boost
+description: Find untested code paths and generate targeted unit tests
+tags: [qa, coverage, maintenance, tests]
+version: "1.0"
+tasks:
+  - title: Identify uncovered code
+    description: Run coverage and produce a ranked list of public functions and branches without tests
+    role: qa
+    priority: 0
+    scope: medium
+    complexity: medium
+  - title: Generate unit tests for high-value gaps
+    description: Write focused unit tests for the highest-priority uncovered code paths, including edge cases and error handling
+    role: qa
+    priority: 1
+    scope: medium
+    complexity: medium
+  - title: Verify new tests are deterministic
+    description: Run the new tests in isolation and in random order, confirm they pass deterministically and finish under the smoke threshold
+    role: qa
+    priority: 1
+    scope: small
+    complexity: low

--- a/tests/unit/test_routine_bridge.py
+++ b/tests/unit/test_routine_bridge.py
@@ -1,0 +1,267 @@
+"""Unit tests for the bidirectional Routine bridge (rt-003)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.planning.routine_bridge import (
+    RoutineBridge,
+    build_task_payloads,
+    estimate_minutes,
+    spawn_scenario_tasks,
+)
+from bernstein.core.planning.scenario_library import (
+    ScenarioLibrary,
+    ScenarioRecipe,
+    ScenarioTaskTemplate,
+)
+
+
+def _recipe(
+    *,
+    scenario_id: str = "demo",
+    n_tasks: int = 3,
+    tags: tuple[str, ...] = ("review",),
+) -> ScenarioRecipe:
+    tasks = tuple(
+        ScenarioTaskTemplate(
+            title=f"T{i}",
+            description=f"d{i}",
+            role="backend" if i == 0 else "qa",
+            priority=1 + (i % 3),
+            scope="medium",
+            complexity="medium",
+        )
+        for i in range(n_tasks)
+    )
+    return ScenarioRecipe(
+        scenario_id=scenario_id,
+        name="Demo",
+        description="desc",
+        tags=tags,
+        tasks=tasks,
+    )
+
+
+def _make_bridge(tmp_path: Path, *, scenarios: dict[str, ScenarioRecipe] | None = None) -> RoutineBridge:
+    library = ScenarioLibrary(scenarios=scenarios or {})
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    from bernstein.core.planning.routine_provisioner import RoutineProvisioner
+
+    return RoutineBridge(
+        library=library,
+        provisioner=RoutineProvisioner(library=library),
+        state_dir=state_dir,
+    )
+
+
+class TestBuildTaskPayloads:
+    def test_one_payload_per_task_template(self) -> None:
+        recipe = _recipe(n_tasks=4)
+        payloads = build_task_payloads(recipe)
+        assert len(payloads) == 4
+
+    def test_payload_carries_scenario_id(self) -> None:
+        recipe = _recipe(scenario_id="abc")
+        payloads = build_task_payloads(recipe)
+        assert all(p.scenario_id == "abc" for p in payloads)
+
+    def test_all_payloads_share_orchestration_id(self) -> None:
+        recipe = _recipe(n_tasks=3)
+        payloads = build_task_payloads(recipe)
+        orch_ids = {p.orchestration_id for p in payloads}
+        assert len(orch_ids) == 1
+
+    def test_explicit_orchestration_id_is_preserved(self) -> None:
+        recipe = _recipe(n_tasks=2)
+        payloads = build_task_payloads(recipe, orchestration_id="my-orch-1")
+        assert all(p.orchestration_id == "my-orch-1" for p in payloads)
+
+    def test_pr_number_injected_into_description(self) -> None:
+        recipe = _recipe(n_tasks=1)
+        payloads = build_task_payloads(recipe, pr_number=42, branch="feat/foo")
+        assert "#42" in payloads[0].description
+        assert "feat/foo" in payloads[0].description
+
+    def test_no_context_means_clean_description(self) -> None:
+        recipe = _recipe(n_tasks=1)
+        payloads = build_task_payloads(recipe)
+        assert "Trigger context" not in payloads[0].description
+
+    def test_complexity_legacy_values_normalised(self) -> None:
+        recipe = ScenarioRecipe(
+            scenario_id="x",
+            name="x",
+            description="",
+            tags=(),
+            tasks=(
+                ScenarioTaskTemplate(
+                    title="t",
+                    description="",
+                    role="qa",
+                    priority=1,
+                    scope="medium",
+                    complexity="medium",
+                ),
+            ),
+        )
+        payloads = build_task_payloads(recipe)
+        # ScenarioTaskTemplate normalises 'simple'/'moderate'/'complex' on parse,
+        # so post-load the values are already low/medium/high. Confirm the
+        # bridge passes them through unchanged.
+        assert payloads[0].complexity in {"low", "medium", "high"}
+
+    def test_as_server_payload_has_metadata(self) -> None:
+        recipe = _recipe(n_tasks=1)
+        payloads = build_task_payloads(recipe)
+        body = payloads[0].as_server_payload()
+        assert body["metadata"]["scenario_id"] == "demo"
+        assert "orchestration_id" in body["metadata"]
+
+
+class TestEstimateMinutes:
+    def test_empty_scenario_is_zero(self) -> None:
+        recipe = ScenarioRecipe(scenario_id="x", name="x", description="", tags=(), tasks=())
+        assert estimate_minutes(recipe) == 0
+
+    def test_minimum_is_five(self) -> None:
+        recipe = _recipe(n_tasks=1)
+        assert estimate_minutes(recipe) >= 5
+
+    def test_more_distinct_roles_lowers_estimate(self) -> None:
+        single_role = ScenarioRecipe(
+            scenario_id="s",
+            name="s",
+            description="",
+            tags=(),
+            tasks=tuple(
+                ScenarioTaskTemplate(
+                    title=f"t{i}",
+                    description="",
+                    role="backend",
+                    priority=1,
+                    scope="medium",
+                    complexity="medium",
+                )
+                for i in range(4)
+            ),
+        )
+        many_roles = ScenarioRecipe(
+            scenario_id="m",
+            name="m",
+            description="",
+            tags=(),
+            tasks=tuple(
+                ScenarioTaskTemplate(
+                    title=f"t{i}",
+                    description="",
+                    role=f"role_{i}",
+                    priority=1,
+                    scope="medium",
+                    complexity="medium",
+                )
+                for i in range(4)
+            ),
+        )
+        assert estimate_minutes(many_roles) < estimate_minutes(single_role)
+
+
+class TestRoutineBridgeInvoke:
+    def test_invoke_unknown_raises(self, tmp_path: Path) -> None:
+        bridge = _make_bridge(tmp_path)
+        with pytest.raises(KeyError):
+            bridge.invoke_scenario("nope")
+
+    def test_invoke_returns_payloads_and_invocation(self, tmp_path: Path) -> None:
+        recipe = _recipe(n_tasks=2)
+        bridge = _make_bridge(tmp_path, scenarios={recipe.scenario_id: recipe})
+        invocation, payloads = bridge.invoke_scenario(recipe.scenario_id, pr_number=7)
+        assert invocation.task_count == 2
+        assert invocation.estimated_minutes > 0
+        assert len(payloads) == 2
+        assert all("#7" in p.description for p in payloads)
+
+
+class TestRoutineBridgeRegistry:
+    def test_register_unknown_raises(self, tmp_path: Path) -> None:
+        bridge = _make_bridge(tmp_path)
+        with pytest.raises(KeyError):
+            bridge.register_binding("trig-1", "missing", "o/r")
+
+    def test_register_persists_to_disk(self, tmp_path: Path) -> None:
+        recipe = _recipe()
+        bridge = _make_bridge(tmp_path, scenarios={recipe.scenario_id: recipe})
+        binding = bridge.register_binding("trig-1", recipe.scenario_id, "o/r")
+        assert binding.trigger_id == "trig-1"
+        assert bridge.registry_path.exists()
+        data: dict[str, Any] = json.loads(bridge.registry_path.read_text())
+        assert "trig-1" in data
+        assert data["trig-1"]["scenario_id"] == recipe.scenario_id
+
+    def test_lookup_returns_binding(self, tmp_path: Path) -> None:
+        recipe = _recipe()
+        bridge = _make_bridge(tmp_path, scenarios={recipe.scenario_id: recipe})
+        bridge.register_binding("trig-1", recipe.scenario_id, "o/r")
+        found = bridge.lookup_binding("trig-1")
+        assert found is not None
+        assert found.scenario_id == recipe.scenario_id
+
+    def test_lookup_missing_returns_none(self, tmp_path: Path) -> None:
+        bridge = _make_bridge(tmp_path)
+        assert bridge.lookup_binding("ghost") is None
+
+    def test_list_bindings_orders_by_time(self, tmp_path: Path) -> None:
+        recipe = _recipe()
+        bridge = _make_bridge(tmp_path, scenarios={recipe.scenario_id: recipe})
+        bridge.register_binding("a", recipe.scenario_id, "o/r")
+        bridge.register_binding("b", recipe.scenario_id, "o/r")
+        listing = bridge.list_bindings()
+        assert [b.trigger_id for b in listing] == ["a", "b"]
+
+
+class TestSpawnScenarioTasks:
+    def test_spawn_calls_poster_per_payload(self, tmp_path: Path) -> None:
+        recipe = _recipe(n_tasks=3)
+        payloads = build_task_payloads(recipe)
+        calls: list[tuple[str, dict[str, Any]]] = []
+
+        def fake_poster(path: str, body: dict[str, Any]) -> dict[str, Any]:
+            calls.append((path, body))
+            return {"id": f"task-{len(calls)}"}
+
+        ids = spawn_scenario_tasks(payloads, poster=fake_poster)
+        assert ids == ["task-1", "task-2", "task-3"]
+        assert all(p == "/tasks" for p, _ in calls)
+
+    def test_spawn_skips_failed_posts(self, tmp_path: Path) -> None:
+        recipe = _recipe(n_tasks=2)
+        payloads = build_task_payloads(recipe)
+
+        def flaky_poster(path: str, body: dict[str, Any]) -> dict[str, Any]:
+            if "T0" in body.get("title", ""):
+                raise RuntimeError("boom")
+            return {"id": "ok"}
+
+        ids = spawn_scenario_tasks(payloads, poster=flaky_poster)
+        assert ids == ["ok"]
+
+    def test_spawn_rejects_non_callable(self) -> None:
+        with pytest.raises(TypeError):
+            spawn_scenario_tasks([], poster=42)  # type: ignore[arg-type]
+
+
+class TestRoutineBridgeProvision:
+    def test_provision_writes_artefacts(self, tmp_path: Path) -> None:
+        recipe = _recipe()
+        bridge = _make_bridge(tmp_path, scenarios={recipe.scenario_id: recipe})
+        out_dir = tmp_path / "exported"
+        export, files = bridge.provision(recipe.scenario_id, "owner/repo", out_dir)
+        assert export.scenario_id == recipe.scenario_id
+        assert (out_dir / "prompt.md").exists()
+        assert (out_dir / "mcp-config.json").exists()
+        assert len(files) == 5

--- a/tests/unit/test_routine_provisioner.py
+++ b/tests/unit/test_routine_provisioner.py
@@ -1,0 +1,207 @@
+"""Unit tests for the Direction A Routine provisioner (rt-003)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.planning.routine_provisioner import (
+    RoutineProvisioner,
+    build_env_vars,
+    build_mcp_config,
+    build_routine_prompt,
+    recommend_triggers,
+)
+from bernstein.core.planning.scenario_library import (
+    ScenarioLibrary,
+    ScenarioRecipe,
+    ScenarioTaskTemplate,
+    load_scenario_library,
+)
+
+# Use the actual templates/scenarios directory shipped with the repo.
+_SCENARIOS_DIR = Path(__file__).resolve().parent.parent.parent / "templates" / "scenarios"
+
+
+def _sample_recipe(
+    *,
+    scenario_id: str = "demo",
+    name: str = "Demo",
+    tags: tuple[str, ...] = ("review", "ci"),
+    n_tasks: int = 2,
+) -> ScenarioRecipe:
+    tasks = tuple(
+        ScenarioTaskTemplate(
+            title=f"Task {i}",
+            description=f"Do thing {i}",
+            role="backend" if i % 2 == 0 else "qa",
+            priority=1,
+            scope="medium",
+            complexity="medium",
+        )
+        for i in range(n_tasks)
+    )
+    return ScenarioRecipe(
+        scenario_id=scenario_id,
+        name=name,
+        description="A test scenario",
+        tags=tags,
+        tasks=tasks,
+    )
+
+
+class TestRecommendTriggers:
+    def test_review_tag_yields_github_trigger(self) -> None:
+        recs = recommend_triggers(_sample_recipe(tags=("review",)))
+        assert any(r.type == "github" and r.event == "pull_request.opened" for r in recs)
+
+    def test_maintenance_tag_yields_schedule(self) -> None:
+        recs = recommend_triggers(_sample_recipe(tags=("maintenance",)))
+        assert any(r.type == "schedule" and r.cadence == "daily" for r in recs)
+
+    def test_deploy_tag_yields_api(self) -> None:
+        recs = recommend_triggers(_sample_recipe(tags=("deploy",)))
+        assert any(r.type == "api" for r in recs)
+
+    def test_no_known_tags_falls_back_to_api(self) -> None:
+        recs = recommend_triggers(_sample_recipe(tags=("misc",)))
+        assert len(recs) == 1
+        assert recs[0].type == "api"
+
+    def test_multiple_categories_emit_multiple_recs(self) -> None:
+        recs = recommend_triggers(_sample_recipe(tags=("review", "deploy", "maintenance")))
+        types = {r.type for r in recs}
+        assert {"github", "schedule", "api"}.issubset(types)
+
+
+class TestBuildRoutinePrompt:
+    def test_prompt_contains_scenario_id(self) -> None:
+        recipe = _sample_recipe(scenario_id="pr-review")
+        prompt = build_routine_prompt(recipe, "http://x:8052")
+        assert "pr-review" in prompt
+        assert "bernstein_scenario" in prompt
+
+    def test_prompt_contains_url(self) -> None:
+        recipe = _sample_recipe()
+        prompt = build_routine_prompt(recipe, "http://example.test:9000")
+        assert "http://example.test:9000" in prompt
+
+    def test_prompt_lists_tasks(self) -> None:
+        recipe = _sample_recipe(n_tasks=3)
+        prompt = build_routine_prompt(recipe, "http://x:8052")
+        for i in range(3):
+            assert f"Task {i}" in prompt
+
+
+class TestBuildMcpConfig:
+    def test_mcp_config_has_required_fields(self) -> None:
+        cfg = build_mcp_config("http://example:8052")
+        assert cfg["name"] == "bernstein"
+        assert cfg["transport"] == "stdio"
+        assert cfg["command"] == "bernstein"
+        env = cfg["env"]
+        assert isinstance(env, dict)
+        assert env["BERNSTEIN_SERVER_URL"] == "http://example:8052"
+
+    def test_mcp_config_serialises(self) -> None:
+        cfg = build_mcp_config("http://x:8052")
+        # Round-trip via JSON to confirm it is JSON-serialisable.
+        round_tripped = json.loads(json.dumps(cfg))
+        assert round_tripped == cfg
+
+
+class TestBuildEnvVars:
+    def test_default_keys_always_present(self) -> None:
+        env = build_env_vars(_sample_recipe(tags=("misc",)))
+        assert "BERNSTEIN_AUTH_TOKEN" in env
+        assert "BERNSTEIN_SERVER_URL" in env
+
+    def test_review_scenarios_request_github_token(self) -> None:
+        env = build_env_vars(_sample_recipe(tags=("review",)))
+        assert "GITHUB_TOKEN" in env
+
+    def test_non_github_scenarios_skip_github_token(self) -> None:
+        env = build_env_vars(_sample_recipe(tags=("misc",)))
+        assert "GITHUB_TOKEN" not in env
+
+
+class TestRoutineProvisioner:
+    def _provisioner(self) -> RoutineProvisioner:
+        recipe = _sample_recipe(scenario_id="t-1")
+        library = ScenarioLibrary(scenarios={recipe.scenario_id: recipe})
+        return RoutineProvisioner(library=library)
+
+    def test_export_unknown_scenario_raises(self) -> None:
+        prov = self._provisioner()
+        try:
+            prov.export_scenario_as_routine("nope", repo="o/r")
+        except KeyError as exc:
+            assert "nope" in str(exc)
+        else:
+            msg = "expected KeyError"
+            raise AssertionError(msg)
+
+    def test_export_returns_complete_bundle(self) -> None:
+        prov = self._provisioner()
+        export = prov.export_scenario_as_routine("t-1", repo="owner/repo")
+        assert export.scenario_id == "t-1"
+        assert export.name.startswith("Bernstein:")
+        assert "owner/repo" in export.setup_instructions
+        assert export.recommended_triggers
+        assert export.mcp_config["name"] == "bernstein"
+
+    def test_export_url_override(self) -> None:
+        prov = self._provisioner()
+        export = prov.export_scenario_as_routine(
+            "t-1",
+            repo="o/r",
+            bernstein_url="http://other:1111",
+        )
+        assert "http://other:1111" in export.prompt
+        env = export.mcp_config["env"]
+        assert isinstance(env, dict)
+        assert env["BERNSTEIN_SERVER_URL"] == "http://other:1111"
+
+    def test_write_export_creates_files(self, tmp_path: Path) -> None:
+        prov = self._provisioner()
+        export = prov.export_scenario_as_routine("t-1", repo="o/r")
+        files = prov.write_export(export, tmp_path / "out")
+        names = sorted(p.name for p in files)
+        assert names == [
+            "env.json",
+            "mcp-config.json",
+            "prompt.md",
+            "setup-guide.md",
+            "triggers.md",
+        ]
+        for path in files:
+            assert path.exists()
+            assert path.stat().st_size > 0
+
+    def test_list_scenarios_uses_library(self) -> None:
+        prov = self._provisioner()
+        listed = prov.list_scenarios()
+        assert len(listed) == 1
+        assert listed[0].scenario_id == "t-1"
+
+
+class TestBundledTemplatesParse:
+    """All scenario templates shipped under templates/scenarios/ must parse."""
+
+    def test_at_least_eight_templates(self) -> None:
+        library = load_scenario_library(_SCENARIOS_DIR)
+        assert len(library.scenarios) >= 8
+
+    def test_each_template_has_tasks(self) -> None:
+        library = load_scenario_library(_SCENARIOS_DIR)
+        for sid, recipe in library.scenarios.items():
+            assert recipe.tasks, f"scenario {sid} has no tasks"
+
+    def test_each_template_exports_cleanly(self) -> None:
+        library = load_scenario_library(_SCENARIOS_DIR)
+        prov = RoutineProvisioner(library=library)
+        for sid in library.scenarios:
+            export = prov.export_scenario_as_routine(sid, repo="o/r")
+            assert export.prompt
+            assert export.setup_instructions
+            assert export.recommended_triggers


### PR DESCRIPTION
Builds on the Routine trigger source and Routine offload adapter.

## Summary

Bidirectional bridge between the Bernstein scenario library and Claude Code Routines, plus a small auto-provisioning registry so a Routine webhook can resolve to a scenario without operator hand-holding.

- **Direction A — export** (`src/bernstein/core/planning/routine_provisioner.py`): turn a `ScenarioRecipe` into a five-file Routine config bundle (`prompt.md`, `mcp-config.json`, `env.json`, `setup-guide.md`, `triggers.md`). Trigger recommendations are derived from scenario tags (review/ci/pr -> GitHub, maintenance/cleanup/schedule -> schedule, deploy/verify -> API; otherwise manual API).
- **Direction B — invoke** (`src/bernstein/core/planning/routine_bridge.py` + `src/bernstein/mcp/routine_tools.py`): three new MCP tools — `bernstein_scenario`, `bernstein_scenarios`, `bernstein_scenario_status` — registered through `register_scenario_tools` on the FastMCP server. Each scenario invocation spawns one `POST /tasks` per template, tagged with shared `scenario_id` / `orchestration_id` metadata so the status tool can group tasks.
- **Auto-provisioning** (`RoutineBridge.register_binding` / `lookup_binding`): trigger ids are persisted under `.sdd/routines/registry.json`. `bernstein routine register --scenario <id> --trigger-id <tid>` writes a binding; the lookup helper is the hook the existing webhook normaliser will use to resolve incoming Routine events to a scenario.
- **CLI**: `bernstein routine scenarios | export | provision | register | bindings` (`src/bernstein/cli/commands/routine_cmd.py`, wired into `cli/main.py`).
- **Templates**: five new scenario templates (`pr-review-security-focused`, `issue-decomposition`, `docs-sync`, `dependency-audit`, `test-coverage-boost`) for a total of eight bundled scenarios.
- **Docs**: `docs/routine-scenarios.md` with the enterprise self-service flow and a diagram.

## Test plan

- [x] `uv run pytest tests/unit/test_routine_*.py tests/unit/test_scenario_*.py tests/unit/test_claude_routine_adapter.py -x -q` — 119 passed, 5 skipped.
- [x] `uv run ruff format` (8 files) and `uv run ruff check src/ tests/ scripts/` clean.
- [x] `uv run pyright` clean on the four new/modified modules under strict mode.
- [x] `uv run lint-imports` — three architecture contracts kept.
- [x] `uv run bernstein routine scenarios` lists all eight templates end to end.

## Notes for reviewers

- The bridge stays decoupled from HTTP via dependency injection (`spawn_scenario_tasks(poster=...)`), so unit tests cover both happy and flaky-poster paths without needing a live server.
- `recommend_triggers` always emits at least one suggestion (manual API fallback) so an operator never has to guess.
- The MCP layer reuses the existing `BERNSTEIN_AUTH_TOKEN` env-var convention from `bernstein.mcp.server`; no new auth surface is introduced.