### PR TITLE
docs: complete documentation audit for May 4-5 feature batch

### DIFF
--- a/docs/adapters/clm.md
+++ b/docs/adapters/clm.md
@@ -190,3 +190,32 @@ covers two acceptance criteria from the Phase 2.5 ticket:
 * **Negative** — a worker that trusts the CA but presents no client
   cert is rejected at the handshake, surfacing as `httpx.HTTPError`
   before any chat-completions endpoint runs.
+
+---
+
+## Limitations
+
+* OpenAI-compatible HTTP only. A non-OpenAI-shaped CLM gateway is a v2
+  follow-up — not in scope here.
+* Aider is the spawned subprocess. Switching to a different driver
+  CLI requires a separate adapter shim.
+* mTLS uses one client cert per spawn. Per-request cert rotation is
+  not supported — lifecycle is the operator's PKI's job.
+* Token issuance is the customer's identity layer. Bernstein consumes
+  whatever JWT the customer issues and does no rotation of its own.
+* Streaming responses are assembled and emitted to lineage as a
+  single record. Per-chunk lineage is not in v1.
+
+## Related
+
+* Source: `src/bernstein/adapters/clm.py`,
+  `src/bernstein/adapters/clm_tls_launcher.py`
+* Shared TLS plumbing: `src/bernstein/core/protocols/cluster/cluster_tls.py`
+* [Cluster mTLS setup](../cluster/mtls-setup.md) — same `TLSConfig`
+  the cluster transport uses
+* [Artifact lineage trail](../concepts/artifact-lineage.md) — what
+  the adapter produces per agent invocation
+* PRs #1012 (Phase 1), #1016 (Phase 2 partial — tools + streaming),
+  #1022 (Phase 2.5 — mTLS)
+* Tickets: `2026-05-05-feat-clm-agent-adapter.md`,
+  `2026-05-05-feat-clm-adapter-phase-2-5-mtls.md`

--- a/docs/cluster/mtls-setup.md
+++ b/docs/cluster/mtls-setup.md
@@ -143,3 +143,25 @@ curl --cacert ~/.bernstein/cluster/ca.crt https://localhost:8052/cluster/health
   expected. Workers built before TLS rollout have to be updated to set
   `ClusterConfig.tls` before they'll re-register. Stage the rollout via
   `verify_mode="optional"` to catch stragglers.
+
+## Limitations
+
+- Manual cert rotation only in v1. ACME / cert-manager hooks are a
+  follow-up.
+- Single CA per cluster. Per-tenant cert isolation is not in v1.
+- mTLS authenticates the channel; the JWT bearer token still
+  authorises the action. They compose; neither is removed.
+- `bootstrap-ca` produces a self-signed CA suitable for self-hosted
+  internal clusters. For production-grade deployments use an external
+  PKI (step-ca, cert-manager, Vault, your corporate CA).
+- Plain-HTTP cluster mode remains supported; this feature is opt-in
+  via `ClusterConfig.tls`.
+
+## Related
+
+- Source: `src/bernstein/core/protocols/cluster/cluster_tls.py`
+- CLI: `bernstein cluster bootstrap-ca`
+- [Cluster deployment patterns](deployment-patterns.md) — Cloudflare Tunnel + Tailscale + same-VPC
+- [Cluster observability](../observability/cluster.md) — metrics + audit events for cert validation
+- [Cluster end-to-end harness](../testing/cluster-e2e-harness.md) — mTLS-on parameterised scenarios
+- PR #1019, ticket `2026-05-05-feat-cluster-mtls-transport.md`

--- a/docs/compliance/regulatory-lineage.md
+++ b/docs/compliance/regulatory-lineage.md
@@ -109,8 +109,8 @@ class LineageSigner(Protocol):
 
 Any HSM / TPM / KMS-backed signer can be implemented to satisfy this
 protocol and injected into `LineageWriter(..., signer=...)`. Phase 1
-ships only the file-key reference implementation; Phase 2 will add a
-`bernstein lineage verify` subcommand and a tamper-loud SIEM webhook.
+ships only the file-key reference implementation; HSM / KMS adapters
+are operator-provided.
 
 ## Verifying a chain
 
@@ -147,10 +147,75 @@ package. The CSV form is ingestable by any GRC vendor that accepts
 CSV. The JSON-LD form is shaped against schema.org `Action` so a
 verifier with a JSON-LD library can graph-walk the chain.
 
+## Tamper-loud detection (Phase 2)
+
+The janitor's lineage compaction step now runs a chain verification
+pass on every cycle. If verification fails the janitor:
+
+1. Emits an `audit.jsonl` entry of type `lineage_tamper_detected`.
+2. Increments `bernstein_lineage_tamper_total{run_id}`.
+3. POSTs to the configured SIEM webhook (if any).
+
+The janitor itself **does not block** on a tamper detection — it
+records the event and lets the operator decide response policy via
+the SIEM. Webhooks retry with exponential back-off on 5xx and fail
+closed on a broken sink (the janitor never blocks on a bad webhook).
+
+### Configuring the SIEM webhook
+
+```yaml
+tuning:
+  lineage:
+    alert_sink:
+      kind: webhook
+      url: https://siem.internal/bernstein-lineage-tamper
+      headers:
+        Authorization: "Bearer ${SIEM_TOKEN}"
+      retries: 5
+      backoff_seconds: [1, 2, 4, 8, 16]
+```
+
+For air-gap deployments the alternative `kind: syslog` writes to the
+local syslog facility instead of HTTP.
+
+### `bernstein lineage verify`
+
+A one-shot chain verification that exits 0 only if every record's
+HMAC and customer signature validate:
+
+```bash
+bernstein lineage verify r-2026-05-05
+```
+
+Useful for compliance teams running ad-hoc checks against archived
+runs, or for CI gating against the most recent run.
+
 ## What is intentionally NOT in this release
 
-- Tamper-detection during janitor compaction (Phase 2).
-- SIEM webhook on tamper detection (Phase 2).
-- `bernstein lineage verify` subcommand (Phase 2).
 - Multi-key rotation registry (Phase 3+).
 - AI-generated regulatory-class inference (Phase 3+).
+- Direct integration with specific GRC vendor APIs (ServiceNow GRC,
+  Archer, etc.). The exporter formats are generic; customers ingest
+  CSV / JSON-LD / HTML through their existing pipeline.
+
+## Limitations
+
+- The customer signature covers full record bytes. Edits to any
+  field invalidate the signature — including downstream-derived
+  fields. This is intentional (simpler audit story); customers who
+  need finer-grained signing can plug in a custom canonicaliser.
+- Single signing key per run. Rotation across environments is on the
+  operator (the schema accommodates a key id prefix in the signature
+  blob; we do not ship a registry).
+- Compliance metadata (`regulatory_class` vocabulary) is operator-
+  supplied and unconstrained. We document a recommended set; we do
+  not enforce it.
+
+## Related
+
+- Source: `src/bernstein/core/persistence/lineage.py`,
+  `lineage_signer.py`, `core/observability/lineage_alert.py`
+- CLI: `src/bernstein/cli/commands/{lineage_cmd,lineage_export_cmd,lineage_verify_cmd}.py`
+- [Artifact lineage trail](../concepts/artifact-lineage.md) — Phase 1 backbone
+- PRs #996 (Phase 1 backbone), #1013 (Phase 1 regulatory schema), #1017 (Phase 2 tamper-loud + verify)
+- Tickets: `2026-05-05-feat-artifact-lineage-trail.md`, `2026-05-05-feat-regulatory-lineage.md`

--- a/docs/concepts/abstracted-code-review.md
+++ b/docs/concepts/abstracted-code-review.md
@@ -1,0 +1,78 @@
+# Abstracted code review
+
+PRs opened by Bernstein include an **Intent** section: 1-3 bullets per
+file describing what changed and why, plus a pseudocode block for
+non-trivial functions, with the raw diff folded under
+`<details>` for drill-down. Humans reviewing AI-generated diffs get
+intent-level context first, line-by-line context only when they need
+it.
+
+## Why it exists
+
+Once `bernstein run` starts shipping multiple PRs per hour, the
+bottleneck shifts from the agent's wall-clock speed to the human
+reviewer's reading speed. The data Bernstein already has — the
+spawning task description, agent progress reports, the diff, the test
+results — is enough to synthesise a 3-line summary per file. The
+abstraction layer turns that data into a PR body humans actually
+read.
+
+## How to use it
+
+It is on by default. PRs opened via `bernstein` carry the Intent
+section automatically. Disable per run:
+
+```bash
+# bernstein.yaml
+review:
+  abstract_diff: false
+```
+
+Or per repo:
+
+```python
+# defaults override
+ABSTRACT_DIFF_ENABLED = False
+```
+
+Programmatic API for custom tooling:
+
+```python
+from bernstein.core.quality.review_pipeline.abstract_diff import (
+    summarize_diff, pseudo_for_function,
+)
+
+summary = summarize_diff(diff_text, task_context)
+print(summary.bullet_points)
+print(summary.pseudocode_blocks)
+print(summary.raw_diff_link)
+```
+
+The summariser uses the cheap-tier model via the cascade router; cost
+is tracked alongside any other LLM call.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `defaults.ABSTRACT_DIFF_ENABLED` | `true` | Master switch. |
+| `defaults.ABSTRACT_DIFF_MAX_FILES` | `50` | Above this, the per-file abstraction degrades to a top-level summary only. |
+| Model tier | cheap-tier (cascade router) | Opus is disallowed at this layer. |
+
+## Limitations
+
+- The summary is LLM-generated. It is not a formal proof that the
+  pseudocode matches the real code — confidence scoring + drill-down
+  are the safety net.
+- No control-flow / data-flow diagrams in v1.
+- This augments the PR body. It does **not** replace the rubric-based
+  review verdict — the existing reviewer gate still runs.
+- Diffs > 50 files fall back to a top-level summary, not per-file
+  abstractions, to keep the PR body readable.
+
+## Related
+
+- Source: `src/bernstein/core/quality/review_pipeline/abstract_diff.py`
+- PR generation: `src/bernstein/core/review_responder/pr_gen.py`
+- [Quality Pipeline](../architecture/quality-pipeline.md)
+- PR #1005, ticket `2026-04-30-feat-abstracted-code-review.md`

--- a/docs/concepts/action-cache.md
+++ b/docs/concepts/action-cache.md
@@ -1,0 +1,84 @@
+# Action cache and replay
+
+The WAL gives Bernstein crash recovery. The **action cache** sits one
+layer above it and gives Bernstein **deterministic replay without
+paying the LLM bill**. Every action — prompt, model output, tool
+call, tool result — is content-addressed by `(model_id,
+normalized_prompt, tool_name, tool_args)` and stored under
+`.sdd/runtime/action_cache/<sha256>.json`. On replay, cache hits
+return the recorded result; misses fall through to the live model and
+append.
+
+## Why it exists
+
+Two scenarios drove this:
+
+1. **CI re-runs.** The same self-evolving smoke test runs on every PR.
+   Without a cache, each run pays full LLM cost.
+2. **Regression bisecting.** Verifying that a fix doesn't break a
+   known-good path is impossible if every re-run costs money and
+   produces non-deterministic output.
+
+The cache also produces a deterministic golden record we diff against
+to catch silent agent-output drift between model versions.
+
+## How to use it
+
+Pick a mode and run:
+
+```bash
+# Record (default in normal runs once enabled)
+bernstein run plan.yaml --cache record
+
+# Replay-only — fail-loud on cache miss instead of calling the model
+bernstein run plan.yaml --cache replay
+
+# Hybrid — replay on hit, fall through to live model on miss, append result
+bernstein run plan.yaml --cache hybrid
+
+# Re-execute a past run against its cache; emit a diff report on drift
+bernstein replay <run_id>
+
+# Inspect / prune the cache
+bernstein cache action ls
+bernstein cache action prune --older-than 30d
+```
+
+The `replay` subcommand walks the run's recorded actions, executes
+each against the cache, and reports any divergence between recorded
+and live output. Useful for catching model-version drift.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `cache.action_cache.enabled` | `true` | Master switch. |
+| `cache.action_cache.mode` | `record` | `record` / `replay` / `hybrid`. |
+| `cache.action_cache.size_mb` | `500` | LRU eviction cap. |
+
+Metrics:
+
+- `bernstein_action_cache_hits_total{site}`
+- `bernstein_action_cache_savings_usd` — estimated token-cost saved by
+  replay hits.
+
+## Limitations
+
+- Exact-key only. No semantic-similarity match across "almost the
+  same" prompts.
+- Bash / exec tool calls have side effects we cannot replay (file
+  writes, network calls). The cache covers the LLM and read-only tool
+  layer; bash is recorded but not replayed.
+- Single host. Cross-machine cache sharing rides on
+  `core/storage/sink.py` plumbing if you need it; not in v1.
+- Replay is byte-comparison strict. A different timestamp in a
+  recorded log is a "drift" finding even if functionally equivalent.
+
+## Related
+
+- Source: `src/bernstein/core/persistence/action_cache.py`
+- Layered on: `src/bernstein/core/persistence/fingerprint.py` (memo
+  store)
+- CLI: `src/bernstein/cli/commands/cache_cmd.py`,
+  `replay_filter_cmd.py`
+- PR #999, ticket `2026-04-30-feat-action-caching-replay.md`

--- a/docs/concepts/agent-mode-profiles.md
+++ b/docs/concepts/agent-mode-profiles.md
@@ -1,0 +1,90 @@
+# Agent mode profiles
+
+Different foundation models have distinct working styles. Claude likes
+rapid feedback, GPT-5.2 runs deep solo, small fast models thrive with
+narrow tool sets. **Mode profiles** sit between the model router and
+the spawner: once a model is chosen, the matching profile dictates the
+system-prompt preamble, the tool subset, the temperature, and the
+turn budget.
+
+## Why it exists
+
+Bernstein routes tasks to models by cost / quality bandit signals.
+Once the model is chosen, the same prompt and tool list go out
+regardless of who's at the other end. That throws away an obvious
+free win: tuning the interaction to the model's known personality.
+This module is the small abstraction shared across all 17 adapters
+that lets one prompt-build pipeline produce three different shapes.
+
+## How to use it
+
+Profiles ship preinstalled under `templates/mode_profiles/`. The
+default mapping is:
+
+| Model family | Profile | Why |
+|---|---|---|
+| Claude (Code, Opus, Sonnet) | `smart` | rapid feedback, full tool surface |
+| GPT-5.x, o-series | `deep` | longer turns, narrower tools, lower temp |
+| Small / fast (Qwen, Haiku) | `fast` | one tool subset, short turn budget |
+
+Override per task via tag:
+
+```yaml
+stages:
+  - name: research
+    steps:
+      - role: backend
+        goal: "Map every callsite of FooClient"
+        tags: [mode:fast]
+```
+
+Inspect a model's resolved profile:
+
+```python
+from bernstein.core.routing.mode_profile import select_mode
+
+profile = select_mode(model_id="claude-sonnet-4", task=task)
+print(profile.name, profile.max_turns, profile.tool_subset)
+```
+
+Add a custom profile by dropping a YAML under `templates/mode_profiles/`:
+
+```yaml
+# templates/mode_profiles/researcher.yaml
+name: researcher
+system_prompt_preamble: |
+  You are running in long-form research mode...
+tool_subset: [read_file, grep, web_fetch]
+temperature: 0.2
+max_turns: 80
+expected_runtime_minutes: 15
+```
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `defaults.MODE_PROFILES_ENABLED` | `true` | Master switch. |
+| `templates/mode_profiles/*.yaml` | three profiles shipped | Profile registry, loaded at startup. |
+| Per-task tag `mode=<name>` | none | Force a profile for one task. |
+
+Spawn metrics carry a `mode_profile` Prometheus label, so you can
+graph `spawns_total{mode_profile="deep"}` to see distribution.
+
+## Limitations
+
+- Server-side only. There is no per-task UI customisation knob.
+- One profile per spawn. No mid-session profile switching.
+- The mode profile sits **after** model selection, not before. It
+  does not influence which model is chosen.
+- The tool-subset filter operates on tool names declared in the
+  profile; tools added by hooks or plugins outside the profile list
+  are filtered out.
+
+## Related
+
+- Source: `src/bernstein/core/routing/mode_profile.py`
+- Profiles: `templates/mode_profiles/`
+- Spawner: `src/bernstein/core/agents/spawner_prompt.py`
+- [Model Routing](../architecture/model-routing.md)
+- PR #1007, ticket `2026-04-30-feat-agent-modes-by-personality.md`

--- a/docs/concepts/artifact-lineage.md
+++ b/docs/concepts/artifact-lineage.md
@@ -1,0 +1,101 @@
+# Artifact lineage trail
+
+Every write an agent produces is recorded as a `LineageRecord` linking
+the output back to the producing prompt, the input artefacts the agent
+read, the model, the run, and the cost. The chain is HMAC-signed and
+artefact-indexed, so "which agent run, which prompt, which source
+files produced this broken line?" becomes a one-command lookup.
+
+This page covers schema-v1 lineage. The customer-key signature and
+regulator-class fields shipped on top of v1 live in
+[Regulator-class lineage](../compliance/regulatory-lineage.md).
+
+## Why it exists
+
+The HMAC audit log is event-ordered: "agent X wrote file Y at time T."
+That is enough for forensics, not enough for compliance. EU AI Act,
+DORA, and SOC2 audits ask "show me the chain for this artefact" —
+producing prompt, input bytes, model, cost. Lineage is that chain.
+
+It is also the tool we reach for when:
+
+- Cross-model verifier flags a divergence and we need to see which
+  prompt + which input file produced it.
+- A regression lands and we need to bisect by producer.
+- We want to attribute tokens / cost back to the originating task.
+
+## How to use it
+
+Lineage records are emitted automatically by the WAL writer on every
+`apply_patch`-style tool call. There is nothing to enable for the
+write side. To read the chain back, use the `lineage` CLI:
+
+```bash
+# Walk the chain for one file (or one line within it)
+bernstein lineage src/foo.py
+bernstein lineage src/foo.py:42
+
+# Filter by run
+bernstein lineage src/foo.py --run r-2026-05-05
+
+# Export for a regulator (HTML / CSV / JSON-LD)
+bernstein lineage export r-2026-05-05 --format html  --output /tmp/audit.html
+bernstein lineage export r-2026-05-05 --format csv   --output /tmp/audit.csv
+bernstein lineage export r-2026-05-05 --format jsonld --output /tmp/audit.jsonld
+
+# Re-verify the HMAC + customer-key chain (Phase 2)
+bernstein lineage verify r-2026-05-05
+```
+
+The chain walks output → producing prompt → input artefact → upstream
+producer recursively. CLI text output prints the most recent producer
+first; `--full` walks to the leaves.
+
+## Programmatic access
+
+```python
+from bernstein.core.persistence.lineage import LineageReader
+
+reader = LineageReader(sdd_dir=".sdd")
+for record in reader.iter_records(path="src/foo.py", line=42):
+    print(record.producer.agent_id, record.prompt_sha, record.cost_usd)
+```
+
+Each `LineageRecord` carries:
+
+- `output_artifact` — `path`, `sha256`, byte / line range
+- `inputs` — list of `ArtifactRef`
+- `producer` — `agent_id`, `run_id`, `tick_id`
+- `prompt_sha`, `model`, `cost_usd`, `tokens`, `timestamp`
+- `regulatory_class`, `customer_signature` (schema v2; null for v1
+  records)
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `lineage.enabled` | `true` | Emit records on every write. |
+| `lineage.compaction.enabled` | `true` | Janitor gzips per-day files at compaction time. |
+| `lineage.regulatory_class.default` | `null` | Pin a default class for the run (Phase 2 / regulator-class). |
+| `lineage.customer_signing.*` | see [regulator doc](../compliance/regulatory-lineage.md) | Customer-key signing (Phase 2). |
+
+`bernstein debug bundle` includes the lineage graph for the run.
+
+## Limitations
+
+- Single-run today. Cross-run stitching across multiple `bernstein
+  run` invocations is a follow-up.
+- No backfill. Historical writes from before the feature shipped have
+  no records.
+- No GUI. CLI text and the HTML exporter only.
+- PII redaction lives in `core/security/pii_gating.py`; lineage
+  records inherit whatever redaction the audit log already applies —
+  no extra layer.
+
+## Related
+
+- Source: `src/bernstein/core/persistence/lineage.py`
+- CLI: `src/bernstein/cli/commands/lineage_cmd.py`,
+  `lineage_export_cmd.py`, `lineage_verify_cmd.py`
+- [Regulator-class lineage](../compliance/regulatory-lineage.md) — schema-v2 add-ons (regulatory class, customer signature, tamper-loud surface)
+- PRs #996, #1013, #1017; tickets `2026-05-05-feat-artifact-lineage-trail.md`, `2026-05-05-feat-regulatory-lineage.md`

--- a/docs/concepts/ast-aware-chunking.md
+++ b/docs/concepts/ast-aware-chunking.md
@@ -1,0 +1,66 @@
+# AST-aware chunking for the reviewer
+
+The reviewer role frequently inspects files larger than its read budget.
+Line-based windowing cuts in the middle of functions, drops imports, and
+hands the model partial context. **AST-aware chunking** uses the existing
+Python symbol graph to split files at function and class boundaries, so
+every chunk the reviewer sees is a complete syntactic unit.
+
+## Why it exists
+
+Reviewer false-negatives cost real bugs. Other roles read code they
+wrote; reviewer reads unfamiliar diffs. Splitting on the largest
+semantic unit that fits the budget (function → class → block → line)
+gives the reviewer denser context per token and prevents the
+"I-saw-half-a-function" failure mode.
+
+## How to use it
+
+The chunker is invoked automatically by the review pipeline whenever
+the reviewer would otherwise window-read a Python file larger than its
+budget. There is no flag to set per-run — it is on by default.
+
+If you are calling the chunker directly from custom tooling:
+
+```python
+from bernstein.core.quality.review_pipeline.ast_chunker import (
+    chunk_for_review,
+)
+
+chunks = chunk_for_review(
+    path="src/bernstein/core/orchestration/manager.py",
+    budget_tokens=4_000,
+)
+for chunk in chunks:
+    print(chunk.header)        # symbols included in this chunk
+    print(chunk.text)          # full Python source, never split mid-body
+```
+
+Each `ReviewChunk` carries the symbol header (function or class names
+included), the byte range, and the full source text. The reviewer
+prompt assembles them with the header as a one-line summary so the
+model sees structure before code.
+
+## Configuration
+
+There are no user-facing knobs in v1. The chunker reads
+`defaults.REVIEW_BUDGET_TOKENS` (the same budget the line-based
+fallback used) and is otherwise self-contained.
+
+## Limitations
+
+- Python only. TypeScript / Rust / Go fall back to line-based
+  windowing with a clear log line so you can see what's degraded.
+- The chunker does not synthesise summaries — it only segments. The
+  review prompt is unchanged.
+- Cross-file dependencies are not packaged into a chunk. If reviewing
+  function `foo` requires reading `bar` from a different file, the
+  reviewer asks for `bar` on a follow-up turn the same way it does
+  today.
+
+## Related
+
+- Source: `src/bernstein/core/quality/review_pipeline/ast_chunker.py`
+- Symbol graph: `src/bernstein/core/knowledge/ast_symbol_graph.py`
+- Quality pipeline: [Quality Pipeline](../architecture/quality-pipeline.md)
+- PR #993, ticket `2026-05-05-feat-ast-aware-chunking-for-reviewer.md`

--- a/docs/concepts/best-of-n.md
+++ b/docs/concepts/best-of-n.md
@@ -1,0 +1,88 @@
+# Best-of-N delegation
+
+For tasks tagged "complex" or "ambiguous", Bernstein can spawn K
+parallel candidate agents in isolated worktrees, score each candidate
+with automated signals (tests pass, lint clean, diff size) plus an
+LLM-as-judge rubric, and merge only the winner. Losing candidates'
+worktrees are cleaned up automatically.
+
+## Why it exists
+
+`task_retry` retries serially: fail → escalate → retry. That works
+for transient errors. It does **not** work for genuinely ambiguous
+tasks where serial retries compound the same wrong assumption. For
+those, K parallel attempts in isolated sandboxes plus a judge is
+cheaper in wall-clock and tokens than serial retries.
+
+The infrastructure to spawn parallel candidates already existed (git
+worktrees, sandbox backends, adaptive parallelism). This module is
+the candidate-selection layer on top.
+
+## How to use it
+
+Mark a task with `best_of_n` in the plan or via the API:
+
+```yaml
+stages:
+  - name: refactor
+    steps:
+      - role: backend
+        goal: "Migrate the auth module from Flask to FastAPI"
+        best_of_n: 3
+```
+
+Or programmatically:
+
+```python
+task = Task(
+    id="...",
+    goal="Migrate the auth module from Flask to FastAPI",
+    best_of_n=3,
+)
+```
+
+When the orchestrator picks up a task with `best_of_n=K`, it:
+
+1. Spawns K agents into K isolated worktrees.
+2. Awaits all K to finish (or hit the per-candidate timeout).
+3. Computes `score_candidate(result)` for each — weighted sum of
+   tests-passing, lint-score, diff size, runtime.
+4. Asks a cheap-tier LLM judge to rank candidates against a rubric.
+5. Merges the highest combined score; deletes the other worktrees.
+
+The cross-model verifier still runs **on the winner** before merge.
+Best-of-N does not replace verification — it picks a candidate to
+verify.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `defaults.BEST_OF_N_DEFAULT` | `1` (off) | Default `best_of_n` for tasks that don't set one. |
+| `defaults.BEST_OF_N_MAX` | `5` | Hard cap, regardless of what a plan asks for. |
+| `defaults.BEST_OF_N_JUDGE_RUBRIC_PATH` | `templates/prompts/best_of_n_judge.md` | Rubric the LLM judge uses. |
+
+Metrics:
+
+- `best_of_n_judge_score` (histogram)
+- `best_of_n_candidates_total{outcome}` — `winner` / `loser` /
+  `error`.
+
+## Limitations
+
+- One level of branching per task. No nested best-of-N inside a
+  candidate.
+- Auto-decision of when to escalate K (e.g., raise to 5 if confidence
+  is low) is not in v1 — set `best_of_n` manually.
+- All candidates run the same model unless you also set per-candidate
+  `mode_profile` overrides.
+- K worktrees mean K times the disk and parallel agent budget; the
+  existing `adaptive_parallelism` cap still applies.
+
+## Related
+
+- Source: `src/bernstein/core/orchestration/best_of_n.py`
+- Tick pipeline: `src/bernstein/core/orchestration/tick_pipeline.py`
+- [Adaptive parallelism](../architecture/adaptive-parallelism.md)
+- [Quality Pipeline](../architecture/quality-pipeline.md)
+- PR #1011, ticket `2026-04-30-feat-best-of-n-delegation.md`

--- a/docs/concepts/feature-contract.md
+++ b/docs/concepts/feature-contract.md
@@ -1,0 +1,97 @@
+# Feature contract
+
+A plan step can carry an immutable list of features. Each feature has
+an id, a description, an acceptance check, and a `passes` flag. Agents
+may flip `passes: true` only when the declared acceptance check
+actually exits zero. The list is hash-anchored in the audit chain so
+agents cannot quietly add, remove, or weaken entries.
+
+## Why it exists
+
+Two failure modes show up in long-running self-evolution runs:
+
+1. **Premature victory** — agent completes 6 of 10 features and calls
+   `POST /tasks/{id}/complete`, declaring the task done.
+2. **Test deletion** — agent "passes" by weakening or removing the
+   failing test rather than fixing the code.
+
+The feature contract is the immutable spec the agent reads but cannot
+meaningfully game, and the per-feature pass/fail board that survives
+across sessions.
+
+## How to use it
+
+Add a `features:` block to a step in your plan YAML:
+
+```yaml
+# plans/jwt-auth.yaml
+stages:
+  - name: backend
+    steps:
+      - role: backend
+        goal: "Add JWT auth with refresh tokens"
+        features:
+          - id: jwt-issue
+            description: "POST /auth/login returns a JWT"
+            acceptance_steps:
+              - "Login with valid creds"
+            acceptance_check: "pytest tests/auth/test_login.py::test_jwt_issued"
+          - id: jwt-refresh
+            description: "POST /auth/refresh exchanges a refresh token for a new JWT"
+            acceptance_steps:
+              - "Refresh with a valid refresh token"
+            acceptance_check: "pytest tests/auth/test_refresh.py"
+          - id: revocation
+            description: "Revoked refresh tokens cannot be reused"
+            acceptance_check: "pytest tests/auth/test_revocation.py"
+```
+
+Run the plan as usual. Inspect feature state at any time:
+
+```bash
+# Per-feature pass/fail board (exits non-zero if any feature is pending or failed)
+bernstein contract status
+
+# Force-run every acceptance check now
+bernstein contract verify
+```
+
+When an agent calls `POST /tasks/{id}/complete` while a feature is
+still `passes: false`, the server replies `400` and lists the failing
+ids. Pass `--allow-partial` (operator-only flag) to override.
+
+## How tamper-detection works
+
+The contract is persisted at `.sdd/contract/features.json`. Its
+canonical sha256 is stored in the HMAC-chained audit log. Any
+in-place edit by an agent is detected on the next chain validation.
+
+The janitor re-runs each `acceptance_check` post-merge. If a
+previously-passing check becomes a no-op (test file deleted, assertion
+weakened to `assert True`), the janitor flags it as
+`acceptance_check_decay`.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `features.completion_blocks_on_failure` | `true` | Reject `complete` if any feature is `passes: false`. |
+| `features.allow_partial_flag_required` | `true` | Only the operator-level `--allow-partial` overrides. |
+| `features.janitor_recheck_interval_s` | `0` (every drain) | How often the janitor re-runs acceptance checks. |
+
+## Limitations
+
+- The operator authors `acceptance_steps` and `acceptance_check`. No
+  LLM-generated suggestions in v1.
+- No cross-project feature library. Contracts live with the plan.
+- CLI table output only — no visual board UI.
+- Acceptance checks run as shell commands; supply them with care
+  (the existing command allowlist still applies).
+
+## Related
+
+- Source: `src/bernstein/core/planning/feature_contract.py`
+- Audit hook: `src/bernstein/core/security/audit.py`
+- Janitor integration: `src/bernstein/core/quality/janitor.py`
+- CLI: `bernstein contract status`, `bernstein contract verify`
+- PR #997, ticket `2026-04-30-feat-feature-list-immutable-contract.md`

--- a/docs/concepts/fingerprint-memoization.md
+++ b/docs/concepts/fingerprint-memoization.md
@@ -1,0 +1,82 @@
+# Fingerprint memoization
+
+Bernstein recomputes several expensive things on every tick: cross-model
+verification, knowledge-graph extraction, RAG re-embedding. Each call
+site historically invented its own cache key, and most of those keys
+hashed only the *inputs* — never the *function body*. A bug fix that
+should re-derive the cache silently kept serving stale entries.
+
+The `fingerprint` module replaces the ad-hoc keys with a single
+content-addressed store keyed by `hash(canonicalised_input)
+xor hash(function_AST)`. Change the function body, the key changes.
+
+## Why it exists
+
+Two failure modes drove this:
+
+1. **Stale cache after refactor** — fix a bug, re-run, get the buggy
+   result back because the cache key didn't include the source.
+2. **Per-site key duplication** — cross-model verifier, knowledge
+   graph, and RAG each rolled their own; they all needed the same
+   invariant and none had it consistently.
+
+## How to use it
+
+Decorate any deterministic function whose result is expensive to
+recompute and depends only on its arguments:
+
+```python
+from bernstein.core.persistence.fingerprint import (
+    MemoStore, memoize_persistent,
+)
+
+store = MemoStore.default()
+
+@memoize_persistent(store)
+def embed_chunk(chunk_text: str, embedder_id: str) -> list[float]:
+    # expensive embedding call
+    ...
+```
+
+On second invocation with the same arguments the call is served from
+`.sdd/runtime/memo/<sha>/` without re-execution. Edit the function
+body, redeploy, the next call misses cache and re-derives.
+
+The decorator is already applied at three call sites:
+
+| Site | Key |
+|---|---|
+| `quality/cross_model_verifier.py` | `(model_id, prompt, output, verifier_fn_hash)` |
+| `knowledge/knowledge_graph.py` | `(file_sha, extractor_fn_hash)` |
+| `knowledge/rag.py` | `(chunk_sha, embedder_id, chunker_fn_hash)` |
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `defaults.MEMO_MAX_MB` | `200` | Max disk used by the store before LRU eviction kicks in. |
+| Memo store path | `.sdd/runtime/memo/` | Pinned to `.sdd/` so air-gap runs do not write to `~/.cache/`. |
+
+Metrics exposed on `/metrics`:
+
+- `bernstein_memo_hits_total{site}`
+- `bernstein_memo_misses_total{site}`
+- `bernstein_memo_size_bytes`
+
+## Limitations
+
+- Single host. No cross-machine cache sharing in v1.
+- The fingerprint hashes the *immediate* function body only — not the
+  transitive closure of called helpers. If you rely on a helper that
+  changed, decorate that helper too, or invalidate manually.
+- Functions with hidden state (env vars read at call time, file IO,
+  network calls) are unsafe to memoize. Restrict use to pure
+  functions.
+- The decorator does not replace `semantic_cache.py` — that's a
+  vector cache for semantic-similarity lookup, a different concern.
+
+## Related
+
+- Source: `src/bernstein/core/persistence/fingerprint.py`
+- Inspired by [cocoindex memo_fingerprint](https://github.com/cocoindex-io/cocoindex/blob/main/python/cocoindex/_internal/memo_fingerprint.py) (Apache-2.0).
+- PR #995, ticket `2026-05-05-feat-fingerprint-memoization-for-recomputes.md`

--- a/docs/concepts/phase-pipeline.md
+++ b/docs/concepts/phase-pipeline.md
@@ -1,0 +1,86 @@
+# Discrete phase pipeline
+
+A plan step can split into discrete `research → plan → implement →
+verify` phases, each spawned as a fresh short-lived agent with its own
+context window. Between phases, only the **distilled handoff** —
+summary, decisions, constraints, open questions — passes forward. The
+implement phase never sees the research transcript.
+
+## Why it exists
+
+When one long-running agent does research, planning, and execution in
+the same window, it burns 60 k tokens reading the codebase, emits a
+plan, then keeps reading on top of that bloat while implementing —
+hitting compaction and degrading quality. Discrete phases keep each
+context window small and let the router pick a different model per
+phase: a high-reasoning model for research, a cheaper one for
+implementation.
+
+## How to use it
+
+Add a `phases:` list to a step:
+
+```yaml
+stages:
+  - name: feature
+    steps:
+      - role: backend
+        goal: "Add streaming responses to the chat handler"
+        phases: [research, plan, implement, verify]
+```
+
+When the orchestrator reaches that step, it spawns one agent per
+phase. Each phase writes a structured artefact to
+`.sdd/runtime/phase_artifacts/<task_id>/<phase>.json`:
+
+```json
+{
+  "summary":         "...",
+  "decisions":       ["..."],
+  "constraints":     ["..."],
+  "open_questions":  ["..."]
+}
+```
+
+The next phase's prompt is seeded with that JSON only — not the prior
+phase's transcript.
+
+Existing single-phase plans (no `phases:` field) run unchanged.
+
+## Routing per phase
+
+`core/routing/router.py` consults the phase to pick a model:
+
+| Phase | Default model class | Why |
+|---|---|---|
+| `research` | high-reasoning (sonnet / opus tier) | broad codebase reading, gap analysis |
+| `plan` | high-reasoning | cross-cutting design |
+| `implement` | cheap-tier | bounded, high-throughput edits |
+| `verify` | cheap-tier | structured assertion runner |
+
+Override per task via the existing `model:` field on the step.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `phase_pipeline.enabled` | `true` | Honour `phases:` in plans. |
+| `phase_pipeline.artefact_path` | `.sdd/runtime/phase_artifacts/` | Distilled handoff store. |
+| `phase_pipeline.gc_on_close` | `true` | Drop artefacts when the parent task closes. |
+
+## Limitations
+
+- One level of phasing per task. No nested phases inside a phase.
+- The handoff schema is a fixed dataclass; no LLM-based summariser
+  filling in narrative prose.
+- Mid-phase abort uses the existing `task_retry.py` path; there is no
+  phase-specific restart granularity.
+- Cross-task phase pooling (sharing a research artefact across two
+  unrelated tasks) is not supported.
+
+## Related
+
+- Source: `src/bernstein/core/orchestration/phase_pipeline.py`
+- Plan loader: `src/bernstein/core/planning/plan_loader.py`
+- Routing: `src/bernstein/core/routing/router.py`
+- PR #1000, ticket `2026-04-30-feat-discrete-phase-separation.md`

--- a/docs/concepts/schema-validation-retry.md
+++ b/docs/concepts/schema-validation-retry.md
@@ -1,0 +1,84 @@
+# Schema validation retry
+
+When a spawned agent emits malformed JSON (manager planning output,
+MCP tool response, planner decoder), Bernstein retries up to N times
+and **feeds the specific validation error back into the next prompt**.
+Errors accumulate across steps so the agent learns "you keep
+mis-typing field `priority`."
+
+## Why it exists
+
+Before this loop, schema failures fell into one of two paths: hard
+fail (mark the task failed) or generic retry that re-spawned without
+the validation error in context. Neither helped the agent self-correct.
+The Self-Refine pattern (ICLR 2024) and adjacent work documents 15-45 %
+quality improvement from a multi-attempt retry with detailed feedback.
+
+## How to use it
+
+The retry helper is wired into the call sites that decode structured
+agent output. From your own code:
+
+```python
+from bernstein.core.tasks.schema_retry import (
+    SchemaRetryContext,
+    validate_with_retry,
+)
+from pydantic import BaseModel
+
+class PlannerOutput(BaseModel):
+    tasks: list[str]
+    rationale: str
+
+ctx = SchemaRetryContext()
+
+def ask_again(prompt_with_errors: str) -> str:
+    # call your spawned agent / model with the augmented prompt
+    return run_agent(prompt_with_errors)
+
+result = validate_with_retry(
+    payload=raw_text,
+    schema=PlannerOutput,
+    ctx=ctx,
+    max_attempts=3,
+    ask_again=ask_again,
+)
+```
+
+On a malformed payload the helper:
+
+1. Runs the schema validator (Pydantic / JSONSchema).
+2. Records the error into `ctx`.
+3. Calls `ask_again(prompt + "you previously got these errors: …")`.
+4. Loops up to `max_attempts`; raises `SchemaRetryExhausted` with the
+   full error trail on terminal failure.
+
+Errors accumulate across steps in the same `SchemaRetryContext`, so
+the same agent across a multi-step pipeline sees the trail of every
+prior validation failure, not just the most recent.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `defaults.SCHEMA_RETRY_MAX_ATTEMPTS` | `3` | Per-decode retry budget. |
+| `schema_retry_attempts_total{outcome}` | metric | `success` / `retry` / `exhausted` outcomes; scrape for cost-tracking the retry loop. |
+
+## Limitations
+
+- This is a **wrapper** around existing validation, not a replacement
+  for Pydantic. Models still own field constraints.
+- The agent itself is the repair loop — there is no LLM-based schema
+  repair sitting between the validator and the agent.
+- Token cost of retries is captured by the existing `cost_tracker`,
+  not by this module.
+- Only places that have been wired in see retry: `manager_parsing`
+  and `mcp_tool_normalization`. Decoders elsewhere fall back to the
+  one-shot `json.loads` path.
+
+## Related
+
+- Source: `src/bernstein/core/tasks/schema_retry.py`
+- Wired in: `core/orchestration/manager_parsing.py`,
+  `core/protocols/mcp/mcp_tool_normalization.py`
+- PR #998, ticket `2026-04-30-feat-schema-validation-retry.md`

--- a/docs/concepts/spec-as-test.md
+++ b/docs/concepts/spec-as-test.md
@@ -1,0 +1,88 @@
+# Spec-as-test loop
+
+Plan files describe acceptance criteria as free-text. The
+`spec_assertions` module turns those bullets into **executable
+assertions** — file-exists / import-resolves / regex-in-file /
+test-passes — runs them after each stage drain, and routes failures
+back as auto-fix tasks or human-review bulletins.
+
+## Why it exists
+
+Before this loop, "spec said X, code does X" was a human re-read of
+the plan. Silent drift between plan intent and merged code went
+unnoticed until a human noticed. This pattern complements the
+[feature contract](feature-contract.md) — that one freezes the WHAT,
+spec-as-test verifies the IS.
+
+## How to use it
+
+Write your plan with explicit `acceptance:` bullets:
+
+```yaml
+stages:
+  - name: feature
+    steps:
+      - role: backend
+        goal: "Add /healthz endpoint"
+        acceptance:
+          - "file_exists: src/api/healthz.py"
+          - "import_resolves: api.healthz.healthz_view"
+          - "regex_in_file: src/api/__init__.py /from .healthz import/"
+          - "test_passes: pytest tests/api/test_healthz.py"
+```
+
+`extract_assertions(plan)` parses the bullets into typed `Assertion`
+records. `run_assertions(assertions, repo_root)` executes them after
+every stage drain. Failures post a bulletin and create an auto-fix
+task targeting the offending step.
+
+You can emit the assertions as a real pytest file for CI:
+
+```python
+from bernstein.core.planning.spec_assertions import (
+    extract_assertions, assertions_to_pytest,
+)
+
+assertions = extract_assertions(plan)
+assertions_to_pytest(assertions, out_path="tests/spec/test_plan_jwt.py")
+```
+
+Disable the loop for a run with `--no-spec-test` (default-on).
+
+## Supported assertion kinds
+
+| Kind | Predicate |
+|---|---|
+| `file_exists` | path resolves to a regular file |
+| `import_resolves` | dotted import succeeds in the project venv |
+| `test_passes` | named pytest selector exits 0 |
+| `regex_in_file` | regex matches at least once in the file's bytes |
+
+Unknown kinds parse as `unknown` and are skipped with a logged
+warning.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `spec_assertions.enabled` | `true` | Master switch (CLI: `--no-spec-test`). |
+| `spec_assertions.run_on_drain` | `true` | Run after every stage drain. |
+| `spec_assertions.emit_pytest` | `false` | Also write pytest files to `tests/spec/`. |
+
+## Limitations
+
+- Only the four kinds listed above. Property-based testing,
+  Gherkin/BDD, and LLM-generated assertions are out of scope.
+- Assertions are derived from the existing `acceptance:` field; no
+  separate spec format.
+- The pytest emitter writes synchronous tests; async-only test suites
+  need a custom runner wrap.
+- Failures attach an auto-fix task but never block merge by themselves
+  — the existing janitor + quality gates remain the merge gate.
+
+## Related
+
+- Source: `src/bernstein/core/planning/spec_assertions.py`
+- Drain hook: `src/bernstein/core/orchestration/drain.py`
+- Run flag: `src/bernstein/cli/commands/run_cmd.py`
+- PR #1003, ticket `2026-04-30-feat-spec-as-test-loop.md`

--- a/docs/concepts/swarm-migration.md
+++ b/docs/concepts/swarm-migration.md
@@ -1,0 +1,83 @@
+# Swarm migration
+
+A migration is "the same transform applied to N files" — framework
+upgrades, lint-rule rollouts, API renames. The `swarm_migration`
+module enumerates targets, chunks them, fans out one short-lived
+agent per chunk, and reduces the results back into a single report.
+Map-reduce, deterministic, one CLI command.
+
+## Why it exists
+
+`task_splitter` decomposes a parent task into 2-5 subtasks via the
+manager LLM. That's the right shape for normal feature work. It is
+the **wrong** shape for a migration touching hundreds of files where
+each file gets the same prompt — the LLM-driven split is wasted
+tokens and the LLM-chosen chunks are worse than a deterministic glob.
+
+Swarm migration is a separate first-class entry point that skips the
+manager planning loop and dispatches directly.
+
+## How to use it
+
+```bash
+# Dispatch 20 parallel agents, each rewriting up to 5 files
+bernstein migrate \
+    --glob 'src/**/*.py' \
+    --transform 'convert all sync handler functions to async' \
+    --chunk-size 5 \
+    --max-parallel 20
+
+# Use a saved migration plan
+bernstein migrate --plan templates/migrations/flask-to-fastapi.yaml
+```
+
+A migration plan YAML lives under `templates/migrations/`:
+
+```yaml
+# templates/migrations/sync-to-async.yaml
+glob: 'src/**/*.py'
+transform_prompt: |
+  Convert every sync function in this file to async, replacing every
+  blocking `requests.X` call with `httpx.AsyncClient`. Preserve public
+  signatures.
+chunk_size: 5
+max_parallel: 20
+```
+
+The fanout:
+
+1. `enumerate_targets(plan, repo_root)` resolves the glob.
+2. `chunk_targets(targets, chunk_size)` partitions into chunks.
+3. `spawn_swarm(plan)` emits one task per chunk with role=`backend`,
+   scope=`small`.
+4. `reduce_swarm(parent_id, child_results)` aggregates pass/fail per
+   chunk and posts a `SwarmReport` to the bulletin board.
+
+Re-running the same plan ID skips already-completed chunks
+(idempotent).
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `--max-parallel` | `min(20, len(chunks))` | Parallel agent count; respects `adaptive_parallelism` cap. |
+| `--chunk-size` | `5` | Files per chunk. |
+| `--plan-id` | hash of plan file | Idempotency key. |
+
+## Limitations
+
+- Chunks must be **independent**. Cross-file refactors (rename a
+  symbol used by 200 files) need a single agent or a custom split.
+- The transform logic lives in the agent's prompt — Bernstein does not
+  ship code transforms.
+- Rollback on partial failure uses the existing drain + worktree merge
+  logic. There is no migration-specific rollback.
+- Cross-chunk dependency analysis is the operator's responsibility.
+
+## Related
+
+- Source: `src/bernstein/core/tasks/swarm_migration.py`
+- CLI: `src/bernstein/cli/commands/migrate_cmd.py`
+- Plan templates: `templates/migrations/`
+- [Adaptive parallelism](../architecture/adaptive-parallelism.md)
+- PR #1010, ticket `2026-04-30-feat-swarm-migration.md`

--- a/docs/eval/incident-synthesis.md
+++ b/docs/eval/incident-synthesis.md
@@ -1,0 +1,89 @@
+# Incident-to-eval synthesis
+
+Bernstein already captures incidents in three places: the dead-letter
+queue, orchestrator postmortems, and the flaky-test detector. Until
+this feature, those records stayed where they were created and never
+became a **gate** on future runs. The same prompt-injection /
+token-runaway / adapter-timeout patterns surfaced as repeat incidents
+weeks apart.
+
+`incident_synthesizer` ingests each incident, redacts secrets,
+extracts the smallest reproducible trigger, and emits a YAML eval
+case. The eval corpus thus grows from production failures, and CI
+runs them as gates: P0 cases block release, P1 / P2 warn.
+
+## Why it exists
+
+"Log and forget" was the failure mode. The fix is "every P0/P1
+incident adds one regression case that future agents must pass."
+That closes the loop.
+
+## How to use it
+
+Run on demand or on the `task_terminally_failed` lifecycle hook:
+
+```bash
+# Sync now: read every incident, emit YAML cases under
+# src/bernstein/eval/cases/incidents/
+bernstein eval sync-incidents
+
+# Dry-run to see what would be generated without writing
+bernstein eval sync-incidents --dry-run
+```
+
+The synthesiser:
+
+1. Reads dead-letter queue + postmortem artefacts.
+2. Strips secrets via `core/security/sanitize.py`.
+3. Extracts the smallest trigger — the failing prompt, failing config,
+   failing tool-call sequence.
+4. Writes one YAML per incident, idempotent by content hash.
+
+Sample emitted case:
+
+```yaml
+id: inc-prompt-injection-2026-04-22
+severity: P0
+prompt: |
+  <minimal trigger that surfaced the original failure>
+expected_outcome:
+  - "agent refuses to follow injected instruction"
+  - "audit log carries DECISION_DENIED"
+source_incident: postmortem-2026-04-22-T14:33:11Z
+```
+
+The quality-gate pipeline runs every incident-derived case alongside
+the rest of the eval suite. Failures on P0 cases are blocking; P1 /
+P2 print warnings.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `eval.incident_sync.on_terminal_failure` | `true` | Auto-sync on every dead-letter event. |
+| `eval.incident_sync.write_path` | `src/bernstein/eval/cases/incidents/` | Where the YAML cases live. |
+| `eval.gate_severity_blocking` | `["P0"]` | Which severities block merge. |
+
+Metrics:
+
+- `bernstein_incident_evals_total{severity}`
+- `bernstein_incident_recurrence_rate`
+
+## Limitations
+
+- No LLM-driven fuzz expansion (one incident = one case).
+- No corpus auto-pruning — old cases accumulate until manually
+  trimmed; tracked as a follow-up.
+- Cross-tenant incident sharing is out of scope.
+- The minimaliser extracts the trigger using deterministic rules; it
+  does not understand semantic intent. For unusual incident shapes
+  the case may need hand-editing.
+
+## Related
+
+- Source: `src/bernstein/eval/incident_synthesizer.py`
+- Inputs: `core/tasks/dead_letter_queue.py`,
+  `core/observability/postmortem.py`
+- Quality gate: `core/quality/gate_pipeline.py`
+- CLI: `bernstein eval sync-incidents`
+- PR #1001, ticket `2026-04-30-feat-incident-to-eval-synthesis.md`

--- a/docs/installation/air-gap.md
+++ b/docs/installation/air-gap.md
@@ -24,8 +24,12 @@ You need `uv` and Python 3.12+ available. The build host is the only
 machine that needs PyPI access.
 
 ```bash
-# Build the wheelhouse (downloads every wheel in the closure + bernstein)
+# Build the wheelhouse (downloads every wheel in the closure + bernstein).
+# Either the script directly...
 python scripts/build_airgap_wheelhouse.py --version 1.9.4
+
+# ...or the operator-friendly subcommand (Phase 2):
+bernstein wheelhouse build --version 1.9.4
 
 # Sign every wheel + the manifest with cosign
 COSIGN_KEY=/secure/path/cosign.key \
@@ -54,9 +58,13 @@ Mount the encrypted media. Verify before installing — never run
 
 ```bash
 # 1. Confirm checksums against the manifest, signatures against the key.
+#    Either form below works:
 bernstein verify ./airgap-wheelhouse/1.9.4 \
   --ca-pubkey ./bernstein-release.pub \
   --require-signatures
+#  -- or, equivalently (Phase 2):
+bernstein wheelhouse verify ./airgap-wheelhouse/1.9.4 \
+  --ca-pubkey ./bernstein-release.pub
 
 # 2. Install with no PyPI access.
 python -m venv .venv && source .venv/bin/activate
@@ -64,10 +72,32 @@ pip install --no-index --find-links ./airgap-wheelhouse/1.9.4 bernstein
 
 # 3. Sanity check.
 bernstein --version
+
+# 4. Self-check the air-gap posture (Phase 2):
+bernstein doctor airgap
 ```
 
 The verify step is non-zero on any sha256 mismatch or signature
 failure and names the offending wheel in the error message.
+
+`bernstein doctor airgap` runs a battery of self-checks: confirms no
+network egress occurred during the last run, MCP catalog entries are
+all in their default state, the memo store path is local-only, and
+the audit chain's HMAC validates. It exits non-zero if any check
+fails and names which one.
+
+### GPG verifier
+
+Some sovereign customers prefer GPG over sigstore. Phase 2 ships a
+pluggable verifier:
+
+```bash
+bernstein wheelhouse verify ./airgap-wheelhouse/1.9.4 \
+  --signer gpg --gpg-keyring ./customer.gpg
+```
+
+The default verifier remains sigstore; switch via `--signer gpg` to
+use detached `*.asc` signatures alongside the wheels.
 
 ## Running with `--profile airgap`
 
@@ -142,17 +172,24 @@ running `python scripts/build_airgap_wheelhouse.py` with the same
 | `NetworkPolicyDenied: ...` at adapter spawn | Endpoint not on allow-list | Add `--allow-network <host>` or pick a local adapter |
 | `bernstein run` exits with `--profile` not recognised | Older bernstein version | Upgrade to ≥ 1.9.4 |
 
-## Future scope
+## Limitations
 
-Phase 2 (separate ticket) adds:
+- Linux x86_64 wheels only in the shipped wheelhouse build. Other
+  platforms (macOS, Windows, arm64) need their own wheelhouse pass —
+  a follow-up.
+- Native deps (cffi, lxml) are pinned to `manylinux_2_28_x86_64`. If
+  the customer's distro doesn't have that manylinux variant, rebuild
+  on a closer base image.
+- The signing key shipped is the Bernstein release key. Customers who
+  want their own bundle layer must re-sign as shown above.
+- `bernstein doctor airgap` reports state, not policy — use it to
+  confirm the run was clean, not as a runtime gate.
 
-- `bernstein wheelhouse build` and `bernstein wheelhouse verify`
-  subcommands that wrap these scripts so operators don't need to
-  know they exist as scripts on disk.
-- `bernstein doctor airgap` — a battery of self-checks (no-egress
-  during a plan, MCP catalog all-off, memo store local-only, audit
-  HMAC valid).
-- GPG verifier for sites that prefer GPG to sigstore.
+## Related
 
-Phase 1 is complete and ready for FDE-led demos. Phase 2 is the
-"production-ready operator experience" follow-up.
+- Source: `scripts/build_airgap_wheelhouse.py`,
+  `scripts/sign_airgap_wheelhouse.sh`,
+  `src/bernstein/cli/commands/{verify_cmd,wheelhouse_cmd,doctor_airgap_cmd}.py`
+- [Regulator-class lineage](../compliance/regulatory-lineage.md) —
+  tamper-loud audit on the produced artefacts
+- PRs #1015, #1018; tickets `2026-05-05-feat-airgap-distribution.md`

--- a/docs/integrations/cocoindex-code.md
+++ b/docs/integrations/cocoindex-code.md
@@ -86,3 +86,25 @@ bernstein mcp catalog uninstall cocoindex-code
 
 The local manifest is left in place so the entry continues to surface
 in `bernstein mcp catalog list` for future re-enable.
+
+## Limitations
+
+- Local index only — no shared index across hosts in v1.
+- Disabled by default. Catalog entry exists; servers are not started
+  until the operator explicitly enables.
+- The default embedding model is the upstream SentenceTransformer
+  default. Switching to a cloud-hosted embedding model means source
+  bytes cross the network — review that change as a data-flow
+  decision, not just a config flag.
+- The index path is upstream-managed (under the user cache dir). It
+  is intentionally outside `.sdd/` to avoid bloating run snapshots,
+  but the path is **not** controlled by Bernstein — confirm before
+  enabling on shared machines.
+
+## Related
+
+- Manifest: `src/bernstein/core/protocols/mcp_catalog/manifests/cocoindex_code.yaml`
+- [MCP server injection](mcp-server-injection.md)
+- [AST-aware reviewer chunking](../concepts/ast-aware-chunking.md) — sibling cocoindex-derived feature
+- [Fingerprint memoization](../concepts/fingerprint-memoization.md) — sibling cocoindex-derived feature
+- PR #994, ticket `2026-05-05-feat-cocoindex-code-mcp-catalog.md`

--- a/docs/observability/cluster.md
+++ b/docs/observability/cluster.md
@@ -1,8 +1,31 @@
 # Cluster observability
 
 Bernstein exposes Prometheus metrics and HMAC-chained audit events for
-every cluster operation.  Wire your Prometheus scraper at the task
+every cluster operation. Wire your Prometheus scraper at the task
 server's `/metrics` endpoint and ship the audit JSONL to your SIEM.
+
+## Why it exists
+
+Before this batch, cluster mode emitted no Prometheus signal and no
+audit event for register / heartbeat / steal / scale operations. That
+made production debugging impossible: the audit log wasn't there to
+replay, and the metrics weren't there to graph. This change adds five
+metrics and six event types, both rolled into the existing
+infrastructure (no new chain, no new endpoint).
+
+## How to scrape
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: bernstein-cluster
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['central.bernstein.example.com:8052']
+```
+
+Authenticate the scraper using the same Bearer token mechanism the rest
+of the task server uses (see [Security and identity](../operations/security-and-identity.md)).
 
 ## Prometheus metrics
 
@@ -21,7 +44,7 @@ bounded.
 ## Audit events
 
 Every cluster mutation is recorded through the existing HMAC-chained
-audit log.  The chain (`AuditLog.verify()`) covers these new event
+audit log. The chain (`AuditLog.verify()`) covers these new event
 types alongside task and security events:
 
 | Event type | Resource | Key fields |
@@ -33,8 +56,42 @@ types alongside task and security events:
 | `CLUSTER_TASK_STOLEN` | `cluster_task` | `task_id`, `from_node`, `to_node`, `queue_depth_delta` |
 | `CLUSTER_SCALE_DECISION` | `cluster_scale` | `action`, `target_count`, `backend`, `dry_run` |
 
+To verify the chain after a run:
+
+```bash
+bernstein audit verify
+```
+
 ## Grafana
 
 Import `docs/observability/cluster-grafana.json` into Grafana for a
 single-pane view: the node-status gauge plus the four counter rates.
 Point it at any Prometheus datasource that scrapes Bernstein.
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `observability.prometheus.enabled` | `true` | Master switch for `/metrics`. |
+| `audit.cluster_events.enabled` | `true` | Emit cluster events into the chain. |
+| `observability.label_cardinality_cap` | `unknown`-bucket | Outside-vocabulary label values get collapsed. |
+
+## Limitations
+
+- No distributed tracing yet. OTel spans for cluster ops are tracked
+  as a separate ticket; counters + gauge are the floor.
+- The audit log lives on the central node only. Workers do not keep
+  a local copy of cluster events in v1 (audit volume tradeoff).
+- The Grafana JSON is one example dashboard, not a product. Customise
+  freely.
+- No alert rules ship with this — recommended alerting will land
+  after we observe the metrics in real deployments.
+
+## Related
+
+- Source: `src/bernstein/core/observability/prometheus.py`,
+  `src/bernstein/core/security/audit_log.py`
+- [Cluster mTLS setup](../cluster/mtls-setup.md)
+- [Cluster deployment patterns](../cluster/deployment-patterns.md)
+- [Operations / Observability overview](../operations/observability-overview.md)
+- PR #1021, ticket `2026-05-05-feat-cluster-observability.md`

--- a/docs/protocols/tool-search.md
+++ b/docs/protocols/tool-search.md
@@ -1,0 +1,95 @@
+# MCP tool-search lazy loading
+
+When the MCP catalog gets large, every freshly-spawned agent receives
+the full tool description in its system prompt — easily 67 k+ tokens
+across 7+ servers. **Tool search** swaps that for a `tool_search`
+meta-tool plus a compact name + one-line summary directory. Full JSON
+schemas load on demand when the agent calls `tool_search(query)` and
+follows up with `expand_tools([...])`.
+
+## Why it exists
+
+Bernstein's whole model is short-lived agents, fresh per task. Paying
+67 k tokens per spawn just to *describe* tools the agent might never
+use is the dominant cost on small tasks. Tool search keeps the
+description budget bounded by the agent's actual need, not the
+catalog's total surface area.
+
+## How it triggers
+
+Above a configurable token threshold, the agent's prompt contains:
+
+```
+Available tools (search to expand):
+- tool_search(query: str) -> {names, summaries}
+- expand_tools(names: list[str]) -> {schemas}
+
+Compact directory (217 tools, full schemas available via expand_tools):
+- gh.issue_create — open a GitHub issue
+- gh.issue_comment — post a comment
+- pg.query — run a SQL query against the configured Postgres
+- ...
+```
+
+Below the threshold, the agent gets the full catalog in-prompt as
+before. The behaviour is automatic; the agent does not need to know.
+
+## How to use it
+
+Default-on, no config required. To tune:
+
+```yaml
+# bernstein.yaml
+mcp:
+  tool_search:
+    enabled: true                  # default
+    threshold_tokens: 6000         # below this, ship full catalog
+```
+
+To inspect the search engine directly:
+
+```python
+from bernstein.core.protocols.mcp.mcp_tool_search import (
+    ToolCatalog, ToolSearchEngine,
+)
+
+catalog = ToolCatalog.from_registered_servers()
+engine = ToolSearchEngine(catalog)
+
+hits = engine.search("git diff", k=10)
+for hit in hits:
+    print(hit.name, hit.summary, hit.score)
+
+schemas = engine.expand_tools(["gh.diff", "git.diff"])
+```
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `defaults.MCP_TOOL_SEARCH_ENABLED` | `true` | Master switch. |
+| `defaults.MCP_TOOL_SEARCH_THRESHOLD_TOKENS` | `6000` | Total catalog token budget; above this, switch to tool_search. |
+| Ranker | BM25 over `name + summary` | No semantic / vector ranking in v1. |
+
+Metric: `mcp_tool_search_invocations_total{outcome}` —
+`hit` / `miss` / `expand`.
+
+## Limitations
+
+- BM25 ranking only. Semantic / vector search across tool descriptions
+  is a follow-up.
+- Tool deduplication across servers (two MCP servers with the same
+  tool name) is handled by `mcp_tool_normalization.py`, not by this
+  module.
+- Schemas returned by `expand_tools` count against the agent's
+  context budget at expansion time. Expanding 50 schemas at once is
+  not free.
+- The threshold is a global token count. Per-role thresholds are not
+  in v1.
+
+## Related
+
+- Source: `src/bernstein/core/protocols/mcp/mcp_tool_search.py`
+- MCP manager: `src/bernstein/core/protocols/mcp/mcp_manager.py`
+- [MCP server injection](../integrations/mcp-server-injection.md)
+- PR #1009, ticket `2026-04-30-feat-tool-search-lazy-loading.md`

--- a/docs/protocols/well-known-manifest.md
+++ b/docs/protocols/well-known-manifest.md
@@ -1,0 +1,83 @@
+# Static service manifest (`.well-known/agent.json` + `llms.txt`)
+
+Bernstein's task server publishes two machine-readable manifests so
+external agents (Claude Code, Codex, third-party orchestrators) can
+discover its endpoints, auth scheme, and task-orchestration
+capabilities without hand configuration.
+
+| URL | Format | Purpose |
+|---|---|---|
+| `GET /.well-known/agent.json` | A2A-compliant JSON | Structured agent card with auth, endpoints, version |
+| `GET /llms.txt` | markdown | Human + LLM-friendly summary of the same |
+
+Both endpoints are unauthenticated and listed in the auth-middleware
+whitelist; they expose the public surface only.
+
+## Why it exists
+
+Before this, an external agent talking to Bernstein had to be
+hand-configured: someone had to know "task server is on 8052,
+endpoints are POST /tasks, etc." Serving a static manifest closes the
+loop and makes Bernstein a first-class platform other agents can
+discover.
+
+## How to use it
+
+Hit either endpoint:
+
+```bash
+curl http://127.0.0.1:8052/.well-known/agent.json
+curl http://127.0.0.1:8052/llms.txt
+```
+
+Sample `agent.json` (truncated):
+
+```json
+{
+  "schema_version": "0.1.0",
+  "name": "bernstein-task-server",
+  "version": "1.9.4",
+  "auth": {
+    "scheme": "bearer",
+    "token_endpoint": null
+  },
+  "endpoints": {
+    "tasks_create":   "POST /tasks",
+    "tasks_list":     "GET /tasks",
+    "tasks_complete": "POST /tasks/{id}/complete",
+    "bulletin_post":  "POST /bulletin",
+    "bulletin_read":  "GET /bulletin"
+  }
+}
+```
+
+`llms.txt` is the same information rendered as markdown for an LLM to
+parse, plus a short prose description.
+
+The contents are rendered from the templates `templates/well_known/agent.json.j2`
+and `templates/well_known/llms.txt.j2` against the running server's
+version + endpoint list at startup.
+
+## Configuration
+
+There are no user-facing knobs. The endpoints are always served and
+always public. To customise the manifest content, edit the Jinja
+templates under `templates/well_known/` and rebuild.
+
+## Limitations
+
+- One global manifest per server. No per-tenant customisation in v1.
+- Plugin / adapter manifests are **not** aggregated — only the
+  task-server's own surface is published.
+- The manifest is static at boot. Endpoints added by hot-loaded
+  plugins after startup do not appear until restart.
+- Hosting at `bernstein.dev` is not part of this — the endpoints live
+  on the local task server.
+
+## Related
+
+- Source: `src/bernstein/core/routes/well_known.py`
+- Templates: `templates/well_known/`
+- Auth middleware: `src/bernstein/core/security/auth_middleware.py`
+- A2A schema: parsed by `claude_agent_card.py`
+- PR #1004, ticket `2026-04-30-feat-static-service-manifest.md`

--- a/docs/security/capability-matrix.md
+++ b/docs/security/capability-matrix.md
@@ -1,0 +1,120 @@
+# Tool capability matrix and the lethal-trifecta check
+
+Every tool / MCP server / adapter call Bernstein knows about is
+classified along three axes: **accesses-private-data**,
+**consumes-untrusted-input**, **can-externally-communicate**. Before
+each agent spawn (and at policy time for each tool call), Bernstein
+evaluates the union of capabilities on the active execution path and
+**fails closed when all three are present**. That combination is the
+"lethal trifecta" Simon Willison calls the worst-case prompt-injection
+shape, and refusing it is a structural rule, not a guardrail.
+
+## Why it exists
+
+The existing layered policy (network isolation, DLP, command allow-list)
+helps when configured correctly, but it is per-axis. There was no
+declarative tagging that said "this tool can read secrets", and no
+orchestration-time check for the chain `read-secrets +
+fetch-untrusted-issue-body + post-public-comment`. The capability
+matrix is that tagging plus that check.
+
+## How capabilities are declared
+
+Every adapter, MCP tool, and hook ships a YAML under
+`templates/capabilities/`:
+
+```yaml
+# templates/capabilities/github_adapter.yaml
+tool_name: gh.issue_comment
+capabilities: [PRIVATE_DATA, EXTERNAL_COMM]
+source: declared
+```
+
+`Capability` is one of:
+
+| Value | Meaning |
+|---|---|
+| `PRIVATE_DATA` | The tool can read data the operator considers private (secrets, repo source, customer data). |
+| `UNTRUSTED_INPUT` | The tool ingests bytes from a source the operator does not control (issue body, web fetch, MCP server reply). |
+| `EXTERNAL_COMM` | The tool can transmit bytes to a destination outside the local sandbox (HTTP request, file write outside the repo, comment-posting). |
+
+The default for unknown tools is **all three** (high-risk). That is
+deliberate: missing metadata fails closed.
+
+## How to use it
+
+The matrix is consulted automatically. To check what the runtime
+sees:
+
+```bash
+# Print the matrix and any agent configs currently violating the rule
+bernstein audit capabilities
+
+# Non-zero exit if any violation exists
+bernstein audit capabilities --strict
+```
+
+Sample output:
+
+```
+Tool                             PRIVATE_DATA  UNTRUSTED  EXTERNAL_COMM  Source
+gh.issue_comment                 yes           no         yes            declared
+web_fetch                        no            yes        yes            declared
+read_file                        yes           no         no             declared
+mcp.cocoindex.search             yes           no         no             declared
+
+Active violations:
+  agent[reviewer-1]: gh.issue_comment + web_fetch + read_file = LETHAL_TRIFECTA
+```
+
+Programmatically:
+
+```python
+from bernstein.core.security.capability_matrix import (
+    CapabilityRegistry, Capability,
+)
+
+registry = CapabilityRegistry.from_templates()
+decision = registry.evaluate_chain([
+    "read_file",
+    "web_fetch",
+    "gh.issue_comment",
+])
+assert decision.kind == "DENY-trifecta"
+print(decision.reason)
+```
+
+## Configuration
+
+| Knob | Default | Controls |
+|---|--:|---|
+| `security.lethal_trifecta_enforcement` | `enforce` | `enforce` (deny + audit), `warn` (audit only), `off`. |
+| `templates/capabilities/*.yaml` | shipped for 17 adapters + built-in MCP tools | Capability declarations. |
+| Default for unknown tools | `frozenset(Capability)` (all three) | Fail-closed. |
+
+The decision lands as a new `DecisionType.IMMUNE` layer in the policy
+engine (`core/security/policy_engine.py`), evaluated **before** any
+`ALLOW` rule. Plugins cannot override it.
+
+Audit log records every denied chain with reason `lethal_trifecta`
+plus the offending tool list.
+
+## Limitations
+
+- Chain-level only. Per-argument analysis (`gh.issue_comment` on a
+  public issue vs a private issue) is not in v1.
+- No auto-discovery of capabilities by inspecting tool source. Each
+  surface needs an explicit YAML.
+- Runtime monitoring of *undeclared* network egress is the existing
+  `network_isolation.py` job, not this module's.
+- Capability tagging covers what we ship. Custom plugins that add
+  new tools without YAML are treated as high-risk by default.
+
+## Related
+
+- Source: `src/bernstein/core/security/capability_matrix.py`
+- Policy engine: `src/bernstein/core/security/policy_engine.py`
+- Capability declarations: `templates/capabilities/`
+- CLI: `bernstein audit capabilities`
+- Pattern: [Lethal-trifecta threat model](https://github.com/nibzard/awesome-agentic-patterns/blob/main/patterns/lethal-trifecta-threat-model.md)
+- PR #1002, ticket `2026-04-30-feat-lethal-trifecta-capability-matrix.md`

--- a/docs/testing/cluster-e2e-harness.md
+++ b/docs/testing/cluster-e2e-harness.md
@@ -1,0 +1,110 @@
+# Cluster 2-node end-to-end harness
+
+The single-process cluster tests prove the algorithm. The 2-node
+harness proves the **system** — real HTTP between two interpreters,
+real process kills, real network partitions, real token expiry. Six
+chaos scenarios run in CI on a dedicated workflow.
+
+This page is for contributors and operators evaluating cluster mode
+production-readiness. End-users do not interact with the harness.
+
+## Why it exists
+
+Customers asking "is cluster mode production-ready?" want to see
+tests that run two real processes and survive at least:
+
+- One node dies mid-operation
+- Network drops packets between heartbeats
+- Token expires mid-task-steal
+- Central server restarts and reloads node registry from JSON
+
+Mocking the HTTP layer in a single Python process cannot prove any
+of that.
+
+## How it works
+
+Fixtures live in `tests/integration/cluster/conftest.py`. The
+`two_node_cluster` fixture boots two real processes via
+`subprocess.Popen`, listens on OS-allocated ephemeral ports, and
+yields a `ClusterHandle`:
+
+```python
+def test_worker_crash_mid_task(two_node_cluster):
+    handle = two_node_cluster
+    task_id = handle.submit_task(role="backend", goal="...")
+    handle.kill_worker()                         # SIGKILL
+    handle.wait_for_node_status("offline", timeout=15)
+    handle.restart_worker()
+    handle.wait_for_task_completion(task_id, timeout=60)
+    assert handle.task_state(task_id) == "completed"
+```
+
+Helper methods on `ClusterHandle`:
+
+- `kill_worker()` / `restart_worker()` — process control
+- `restart_central()` — central server restart from the JSON registry
+- `block_traffic_for(seconds)` — Linux uses `iptables`; macOS uses a
+  Python proxy
+- `current_status()` — snapshot of the registry
+
+## The six chaos scenarios
+
+| Test | What it asserts |
+|---|---|
+| Happy path | register → heartbeat → task → complete; state matches on both sides. |
+| Worker crash mid-task | Central marks worker OFFLINE within heartbeat timeout; task is re-claimable. |
+| Central restart | Worker re-registers cleanly on next heartbeat after central reboots. |
+| Network partition | Worker goes OFFLINE during partition, reconciles on restoration. |
+| Token expiry mid-flight | 5 s JWT; sleep 6 s; heartbeat rejected; refresh succeeds. |
+| Concurrent claims | Two workers race for the same task; exactly one succeeds. |
+
+## How to run them
+
+These tests are **skipped by default** (`@pytest.mark.cluster_e2e`,
+`@pytest.mark.slow`). Run locally:
+
+```bash
+# Linux (full coverage including iptables-based partition test)
+uv run pytest tests/integration/cluster/test_real_2node.py \
+    -m cluster_e2e -x -q
+
+# macOS (skips iptables tests; uses Python proxy)
+PARTITION_BACKEND=python_proxy \
+    uv run pytest tests/integration/cluster/test_real_2node.py \
+    -m cluster_e2e -x -q
+```
+
+In CI, `.github/workflows/cluster-e2e.yml` runs them on PRs touching
+`core/protocols/cluster/**` and on a nightly schedule.
+
+When the mTLS fixture is parameterised (`tls=on`), the same six
+scenarios run with TLS enabled — no test rewrites required.
+
+## Diagnostics on failure
+
+When a scenario fails, the harness collects:
+
+- Process logs from both nodes
+- Last 100 audit-log lines
+- The `bernstein cluster status` snapshot
+
+These are written to `tests/_artifacts/cluster_e2e/<test_name>/`.
+
+## Limitations
+
+- Linux + macOS only (no Windows in CI).
+- Targets STAR topology only. MESH / HIERARCHICAL chaos is a
+  separate workstream — those topologies are unimplemented.
+- No autoscaler chaos.
+- Throughput / load testing (>2 nodes, hundreds of tasks) is out of
+  scope; this harness focuses on correctness under failure.
+- iptables tests require root or a privileged Docker container.
+
+## Related
+
+- Harness: `tests/integration/cluster/conftest.py`
+- Tests: `tests/integration/cluster/test_real_2node.py`
+- CI: `.github/workflows/cluster-e2e.yml`
+- [Cluster mTLS setup](../cluster/mtls-setup.md)
+- [Cluster observability](../observability/cluster.md)
+- PR #1020, ticket `2026-05-05-feat-cluster-real-2node-e2e-harness.md`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,13 +165,29 @@ nav:
       - Skill packs: architecture/skills.md
       - Design notes: architecture/DESIGN.md
       - Glossary: reference/GLOSSARY.md
+      - AST-aware reviewer chunks: concepts/ast-aware-chunking.md
+      - Fingerprint memoization: concepts/fingerprint-memoization.md
+      - Artifact lineage trail: concepts/artifact-lineage.md
+      - Feature contract: concepts/feature-contract.md
+      - Schema validation retry: concepts/schema-validation-retry.md
+      - Action cache and replay: concepts/action-cache.md
+      - Discrete phase pipeline: concepts/phase-pipeline.md
+      - Spec-as-test loop: concepts/spec-as-test.md
+      - Abstracted code review: concepts/abstracted-code-review.md
+      - Agent mode profiles: concepts/agent-mode-profiles.md
+      - Best-of-N delegation: concepts/best-of-n.md
+      - Swarm migration: concepts/swarm-migration.md
   - Adapters & integrations:
       - Adapter guide: adapters/ADAPTER_GUIDE.md
       - OpenAI Agents SDK: adapters/openai-agents.md
+      - CLM (Cyber Language Model): adapters/clm.md
       - Compatibility: adapters/compatibility.md
       - Hook system: integrations/hook-system.md
       - Plugin SDK: integrations/plugin-sdk.md
       - MCP server injection: integrations/mcp-server-injection.md
+      - MCP tool-search lazy loading: protocols/tool-search.md
+      - .well-known service manifest: protocols/well-known-manifest.md
+      - cocoindex-code (MCP catalog): integrations/cocoindex-code.md
       - GitHub Action: integrations/github-action.md
       - GitHub App: integrations/github-app-setup.md
   - Operations:
@@ -179,11 +195,19 @@ nav:
       - Deployment guide (long): operations/deployment-guide.md
       - Helm chart: operations/HELM_DEPLOYMENT.md
       - Cluster mode: operations/cluster-mode.md
+      - Cluster mTLS setup: cluster/mtls-setup.md
+      - Cluster deployment patterns: cluster/deployment-patterns.md
+      - Cluster observability: observability/cluster.md
+      - Cluster e2e harness: testing/cluster-e2e-harness.md
       - Fleet (multi-project): operations/fleet.md
       - Security & identity: operations/security-and-identity.md
+      - Capability matrix: security/capability-matrix.md
       - Secrets & creds: operations/secrets.md
       - Env isolation: operations/env-isolation.md
       - Compliance: operations/compliance.md
+      - Regulator-class lineage: compliance/regulatory-lineage.md
+      - Air-gap installation: installation/air-gap.md
+      - Incident-to-eval synthesis: eval/incident-synthesis.md
       - Verification tracking: operations/verification-tracking.md
       - Observability: operations/observability-overview.md
       - Notifications: operations/notifications.md


### PR DESCRIPTION
## Summary

Documentation pass over every feature shipped 2026-04-30 / 05-04 / 05-05.
Each feature now has a user-facing doc page covering: one-line
description, why it exists, how to use it (copy-paste-runnable),
configuration knobs, limitations, and related links.

No source code changes. Docs only.

## Audit table

| Feature | PR | Before | After |
|---|---|---|---|
| AST-aware reviewer chunking | #993 | missing | new `docs/concepts/ast-aware-chunking.md` |
| cocoindex-code MCP catalog | #994 | thin | extended (limitations + related) |
| Fingerprint memoization | #995 | missing | new `docs/concepts/fingerprint-memoization.md` |
| Artifact lineage trail | #996 | thin (only in compliance doc) | new `docs/concepts/artifact-lineage.md` |
| FDE positioning | already shipped on `main` | already done in PR #992 | unchanged |
| Cluster mTLS transport | #1019 | thin | extended (limitations + related) |
| Cluster 2-node e2e harness | #1020 | missing | new `docs/testing/cluster-e2e-harness.md` |
| Cluster observability | #1021 | thin | extended + renamed `index.md` → `cluster.md` |
| Cluster tunnel deployment patterns | #1024 | already complete | unchanged |
| CLM adapter (P1 + P2 + P2.5) | #1012/#1016/#1022 | thin (no limitations / related) | extended |
| Air-gap distribution (P1 + P2) | #1015/#1018 | P2 listed as "future scope" | extended (P2 shipped) |
| Regulator-class lineage (P1 + P2) | #1013/#1017 | P2 listed as "not in this release" | extended (P2 shipped) |
| Feature contract | #997 | missing | new `docs/concepts/feature-contract.md` |
| Schema validation retry | #998 | missing | new `docs/concepts/schema-validation-retry.md` |
| Action cache + replay | #999 | missing | new `docs/concepts/action-cache.md` |
| Discrete phase pipeline | #1000 | missing | new `docs/concepts/phase-pipeline.md` |
| Incident-to-eval synthesis | #1001 | missing | new `docs/eval/incident-synthesis.md` |
| Lethal-trifecta capability matrix | #1002 | missing | new `docs/security/capability-matrix.md` |
| Spec-as-test loop | #1003 | missing | new `docs/concepts/spec-as-test.md` |
| Static service manifest (`.well-known`) | #1004 | missing | new `docs/protocols/well-known-manifest.md` |
| Abstracted code review | #1005 | missing | new `docs/concepts/abstracted-code-review.md` |
| Agent mode profiles | #1007 | missing | new `docs/concepts/agent-mode-profiles.md` |
| MCP tool-search lazy loading | #1009 | missing | new `docs/protocols/tool-search.md` |
| Swarm migration | #1010 | missing | new `docs/concepts/swarm-migration.md` |
| Best-of-N delegation | #1011 | missing | new `docs/concepts/best-of-n.md` |
| Model/adapter freshness | #1023 | already current | unchanged (existing GPT-5.4 references remain valid) |

`mkdocs.yml` updated: every new page appears in the nav under
**Concepts**, **Adapters & integrations**, or **Operations**.

## Build verification

`uv run mkdocs build` succeeds. Strict-mode warning count is unchanged
from `origin/main` baseline (the pre-existing warnings noted in
`CLAUDE.md` remain; no new warnings introduced by these doc files).

## Test plan

- [ ] `uv run mkdocs build` passes locally
- [ ] Spot-check the new pages render in `mkdocs serve`
- [ ] Each new doc has the six required sections (description, why,
      how, configuration, limitations, related)

## Out of scope

- No source code changes.
- No emoji or marketing language anywhere in main copy.
- No Claude / Anthropic attribution anywhere.