### PR TITLE
chore(audit): close claims-vs-reality gaps from landing copy audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ---
 
-**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 39 more), runs the tests, and merges the code that actually passes. You come back to working code.
+**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 37 more), runs the tests, and merges the code that actually passes. You come back to working code.
 
 Forward-deployed engineering, on a swarm. Drop Bernstein into a client repo and you get a multi-agent crew with file-based state, per-agent credential scoping, and an HMAC-signed audit trail — running on whichever CLI agents the client already trusts.
 
@@ -82,7 +82,7 @@ Other install options: `pipx install bernstein`, `pip install bernstein`, `uv to
 
 Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap local models for boilerplate, heavier cloud models for architecture.
 
-42 CLI agent adapters: 41 third-party wrappers plus a generic wrapper for anything with `--prompt`.
+40 CLI agent adapters: 37 third-party wrappers, 2 leaf-node delegators (Composio, Ralphex), plus a generic wrapper for anything with `--prompt`.
 
 | Agent | Models | Install |
 |-------|--------|---------|
@@ -251,7 +251,7 @@ performs vector search.
 | Feature | Bernstein | CrewAI | AutoGen [^autogen] | LangGraph |
 |---------|-----------|--------|---------|-----------|
 | Orchestrator | Deterministic code | LLM-driven (+ code Flows) | LLM-driven | Graph + LLM |
-| Works with | Any CLI agent (37 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (40 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
 | Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Verification | Janitor + quality gates | Guardrails + Pydantic output | Termination conditions | Conditional edges |
@@ -276,7 +276,7 @@ The table above compares Bernstein against LLM-orchestration frameworks (they or
 | Shape | Python CLI + library + MCP server | Python CLI + tmux sessions + web UI | TypeScript CLI + local dashboard | Electron desktop app | Go CLI |
 | Primary language | Python | Python | TypeScript | TypeScript | Go |
 | Install | `pipx install bernstein` | `uv tool install cli-agent-orchestrator` | `npm install -g @aoagents/ao` | `.dmg` / `.msi` / `.AppImage` | `go install` / single binary |
-| Agent adapters | 42 | 5 (Kiro, Claude Code, Codex, Gemini, Kimi) | 3 (Claude Code, Codex, Aider) | 24 | 1 (Claude Code only) |
+| Agent adapters | 40 | 5 (Kiro, Claude Code, Codex, Gemini, Kimi) | 3 (Claude Code, Codex, Aider) | 24 | 1 (Claude Code only) |
 | Parallel multi-agent execution | Yes | Yes (tmux session per agent) | Yes | Yes | No (single sequential session) |
 | Git worktree per agent | Yes | No (planned, [#100](https://github.com/awslabs/cli-agent-orchestrator/issues/100)) | Yes | Yes | Optional `--worktree` flag |
 | MCP server mode (exposes self as MCP) | Yes (stdio + HTTP/SSE) | Yes (inter-agent comms) | No | No | No |

--- a/docs/compare/bernstein-vs-dorothy.md
+++ b/docs/compare/bernstein-vs-dorothy.md
@@ -21,7 +21,7 @@ The core difference: Dorothy gives you a visual control plane. Bernstein gives y
 | Feature | Bernstein | Dorothy |
 |---|---|---|
 | **Interface** | CLI + TUI + JSON status endpoint | Desktop app (Kanban, dashboard) |
-| **Agent coverage** | 42 CLI adapters | Claude Code, Codex, Gemini, local |
+| **Agent coverage** | 40 CLI adapters | Claude Code, Codex, Gemini, local |
 | **Scheduler** | Deterministic Python, no LLM | "Super Agent" (LLM) via MCP |
 | **Verification** | Janitor: tests, linter, file checks | None built-in |
 | **Parallel execution** | Yes — independent tasks run concurrently | Yes — up to ~10 agents |

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    42 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Droid, Crush, and more.
+    40 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Droid, Crush, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**

--- a/tests/unit/test_adapter_registry.py
+++ b/tests/unit/test_adapter_registry.py
@@ -67,3 +67,25 @@ def test_register_and_get_instance_adapter() -> None:
     register_adapter("instance_adapter", instance)
     result = get_adapter("instance_adapter")
     assert result is instance
+
+
+def test_user_facing_adapter_count_matches_public_copy() -> None:
+    """Lock the user-facing adapter count cited in README / landing copy.
+
+    Reality:
+      - ``_ADAPTERS`` holds 40 entries; ``mock`` is a test-only stub.
+      - ``generic`` is served by a special-case in ``get_adapter`` and not
+        present in the dict.
+
+    User-facing total = (entries excluding ``mock``) + 1 for ``generic`` = 40.
+    Of those: 2 leaf-node delegators (``composio``, ``ralphex``) + 1 generic
+    + 37 third-party wrappers.
+
+    If you add or remove an adapter, update README.md / docs/index.md /
+    landing copy together with this assertion so the public count stays
+    honest.
+    """
+    production = {name for name in _ADAPTERS if name != "mock"}
+    user_facing = production | {"generic"}
+    assert len(user_facing) == 40, sorted(user_facing)
+    assert {"composio", "ralphex"}.issubset(user_facing)


### PR DESCRIPTION
## Summary

Audit pass over the public surface (landing copy + README + docs) against
the actual implementation. The bernstein worktree side covers two gaps:

- **Adapter count was overstated.** README claimed `42 CLI agent adapters:
  41 third-party wrappers`. `_ADAPTERS` in `src/bernstein/adapters/registry.py`
  holds 40 entries; one (`mock`) is a test-only stub, so production = 39.
  Including the special-case `generic` adapter, the user-facing total is
  **40**: 37 third-party wrappers + 1 generic + 2 leaf-node delegators
  (Composio, Ralphex). Updated README, `docs/index.md`,
  `docs/compare/bernstein-vs-dorothy.md`.
- **Lock the count.** Added a regression assertion in
  `tests/unit/test_adapter_registry.py` so future adapter additions or
  removals trip the test and force a copy update.

The bernstein_landing repo got its own commit stream (no PR per repo
convention) for the matching landing-side fixes:

- `Prometheus :9464` pill -> `Prometheus /metrics` (scrape lives on the
  task server, port `8052`, not `9464`).
- Stats strip `31 adapters +1 generic +2 delegating` -> the honest
  `37 adapters +1 generic +2 delegating`.

No sandbox-related copy was touched (separate agent owns that surface).

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_registry.py -x -q` (10 passed)
- [x] `uv run ruff format` (no changes)
- [x] `uv run ruff check src/ tests/ scripts/` (clean)
- [x] `uv run lint-imports` (3 contracts kept)