### PR TITLE
feat(sandbox): four cloud-provider backends (Blaxel, Daytona, Runloop, Vercel)

### DIFF
--- a/docs/sandbox/blaxel.md
+++ b/docs/sandbox/blaxel.md
@@ -1,0 +1,59 @@
+# Blaxel sandbox backend
+
+Bernstein's `blaxel` sandbox backend talks to the Blaxel control plane
+(<https://blaxel.ai>) over its public REST API and conforms to the
+`SandboxBackend` protocol exposed by `bernstein.core.sandbox`.
+
+## Module
+
+`src/bernstein/core/sandbox/backends/blaxel.py` —
+class `BlaxelSandboxBackend`, registered under the name `blaxel` in
+`bernstein.core.sandbox.registry`.
+
+## Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `BLAXEL_API_KEY` | yes | Bearer token issued in Workspace Settings -> API Keys. |
+| `BLAXEL_WORKSPACE` | yes | Workspace slug that owns the sandboxes. |
+| `BLAXEL_API_URL` | no | Override of the API root. Defaults to `https://api.blaxel.ai/v0`. |
+
+When any required variable is missing the backend raises
+`SandboxCredentialError` from `bernstein.core.sandbox.backends._http_helpers`
+naming the missing variable.
+
+## Capabilities
+
+`FILE_RW`, `EXEC`, `NETWORK`, `PERSISTENT_VOLUMES`.
+
+`SNAPSHOT` is **not** advertised because the public Blaxel REST API
+does not expose a snapshot/restore primitive at time of writing.
+`backend.snapshot()` and `backend.resume()` raise `NotImplementedError`
+with a pointer to the vendor changelog.
+
+## Selecting the backend
+
+```yaml
+sandbox:
+  backend: blaxel
+  options:
+    runtime: python:3.13
+    region: us-east-1
+```
+
+## Honest limitations
+
+- **No exec streaming.** The Blaxel REST endpoint returns the final
+  combined `stdout`/`stderr` of the command after the process exits,
+  rather than streaming over WebSockets. Long-running interactive
+  workloads that need tail-style log streaming should use the
+  `worktree` or `docker` backends until Blaxel ships streaming exec.
+- **Snapshots not supported.** Provider does not expose
+  snapshot/resume; persistent state lives in the workspace volume
+  attached to the sandbox.
+
+## Integration tests
+
+Live integration tests are gated by `CI_BLAXEL_TEST=1` plus the
+credentials above. Without them the test in
+`tests/integration/sandbox/test_blaxel_backend.py` skips cleanly.

--- a/docs/sandbox/daytona.md
+++ b/docs/sandbox/daytona.md
@@ -1,0 +1,54 @@
+# Daytona sandbox backend
+
+Bernstein's `daytona` sandbox backend talks to the Daytona REST API
+(<https://daytona.io>, <https://github.com/daytonaio/daytona>) and
+conforms to the `SandboxBackend` protocol.
+
+## Module
+
+`src/bernstein/core/sandbox/backends/daytona.py` —
+class `DaytonaSandboxBackend`, registered under the name `daytona` in
+`bernstein.core.sandbox.registry`.
+
+## Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `DAYTONA_API_KEY` | yes | Personal access token (Daytona Dashboard -> Settings -> API Keys). |
+| `DAYTONA_API_URL` | no | API root override. Defaults to `https://app.daytona.io/api`. |
+| `DAYTONA_TARGET` | no | Region/target id (`us`, `eu`, ...). Forwarded as the `target` field on creation. |
+| `DAYTONA_ORG_ID` | no | Organisation id, sent as the `X-Daytona-Organization-ID` header for multi-org accounts. |
+
+## Capabilities
+
+`FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`. The Daytona API supports
+snapshot / restore, so `backend.snapshot()` and `backend.resume()`
+are wired through.
+
+## Selecting the backend
+
+```yaml
+sandbox:
+  backend: daytona
+  options:
+    image: daytonaio/sandbox:latest
+    target: us
+    cpu: 2
+    memory: 4Gi
+```
+
+## Honest limitations
+
+- **Stdin not supported on the REST exec endpoint.** Passing `stdin=`
+  raises `NotImplementedError`. For interactive workloads use the
+  Daytona WebSocket exec channel directly; routing it through the
+  Bernstein protocol is tracked as a follow-up because
+  `SandboxSession.exec` is currently unary-response.
+- **No exec streaming.** The endpoint returns the buffered
+  `stdout`/`stderr` after the command exits.
+
+## Integration tests
+
+Live integration tests are gated by `CI_DAYTONA_TEST=1` plus
+`DAYTONA_API_KEY`. Without them the test in
+`tests/integration/sandbox/test_daytona_backend.py` skips cleanly.

--- a/docs/sandbox/runloop.md
+++ b/docs/sandbox/runloop.md
@@ -1,0 +1,50 @@
+# Runloop sandbox backend
+
+Bernstein's `runloop` sandbox backend talks to the Runloop REST API
+(<https://runloop.ai>) and conforms to the `SandboxBackend` protocol.
+
+## Module
+
+`src/bernstein/core/sandbox/backends/runloop.py` —
+class `RunloopSandboxBackend`, registered under the name `runloop` in
+`bernstein.core.sandbox.registry`.
+
+## Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `RUNLOOP_API_KEY` | yes | Bearer token from the Runloop Dashboard. |
+| `RUNLOOP_API_URL` | no | API root override. Defaults to `https://api.runloop.ai/v1`. |
+| `RUNLOOP_PROJECT_ID` | no | Default project id forwarded as `project_id` on devbox creation. |
+
+## Capabilities
+
+`FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`. Runloop devboxes can be
+snapshotted via `POST /devboxes/{id}/snapshot_disk` and resumed via
+`POST /devboxes` with `snapshot_id`.
+
+## Selecting the backend
+
+```yaml
+sandbox:
+  backend: runloop
+  options:
+    blueprint: runloop/blueprint-python
+    project_id: prj-bernstein
+```
+
+## Honest limitations
+
+- **Synchronous exec only.** This backend uses
+  `POST /devboxes/{id}/execute_sync` which buffers stdout/stderr until
+  the command exits. Long-running interactive workloads should use
+  Runloop's WebSocket exec channel — routing it through the unary
+  `SandboxSession.exec` contract is tracked as a follow-up.
+- **No stdin injection.** Passing `stdin=` raises
+  `NotImplementedError`.
+
+## Integration tests
+
+Live integration tests are gated by `CI_RUNLOOP_TEST=1` plus
+`RUNLOOP_API_KEY`. Without them the test in
+`tests/integration/sandbox/test_runloop_backend.py` skips cleanly.

--- a/docs/sandbox/vercel.md
+++ b/docs/sandbox/vercel.md
@@ -1,0 +1,53 @@
+# Vercel sandbox backend
+
+Bernstein's `vercel` sandbox backend talks to the Vercel Sandbox API
+(<https://vercel.com/docs/sandbox>) and conforms to the
+`SandboxBackend` protocol.
+
+## Module
+
+`src/bernstein/core/sandbox/backends/vercel.py` —
+class `VercelSandboxBackend`, registered under the name `vercel` in
+`bernstein.core.sandbox.registry`.
+
+## Environment variables
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `VERCEL_TOKEN` | yes | Personal/team API token (`https://vercel.com/account/tokens`). |
+| `VERCEL_TEAM_ID` | conditional | Required for tokens scoped to a team. Forwarded as `?teamId=` on every request. |
+| `VERCEL_API_URL` | no | API root override. Defaults to `https://api.vercel.com`. |
+
+## Capabilities
+
+`FILE_RW`, `EXEC`, `NETWORK`. `SNAPSHOT` is **not** declared because
+the Vercel Sandbox API does not currently expose a snapshot/restore
+primitive.
+
+## Selecting the backend
+
+```yaml
+sandbox:
+  backend: vercel
+  options:
+    runtime: node22
+    region: iad1
+```
+
+## Honest limitations
+
+- **No exec streaming on the synchronous endpoint.** The Vercel
+  Sandbox HTTP API returns the buffered `stdout`/`stderr` after the
+  command exits. For interactive workloads (tail-style log
+  streaming), use the `worktree` or `docker` backends until Vercel's
+  WebSocket exec channel ships GA.
+- **No stdin on the sync exec route.** Passing `stdin=` raises
+  `NotImplementedError`.
+- **Snapshots not supported.** Persist state via Vercel-managed
+  storage (KV / Blob) rather than relying on session snapshotting.
+
+## Integration tests
+
+Live integration tests are gated by `CI_VERCEL_TEST=1` plus
+`VERCEL_TOKEN`. Without them the test in
+`tests/integration/sandbox/test_vercel_backend.py` skips cleanly.

--- a/src/bernstein/core/sandbox/backends/_http_helpers.py
+++ b/src/bernstein/core/sandbox/backends/_http_helpers.py
@@ -1,0 +1,203 @@
+"""Shared httpx scaffolding for cloud-REST sandbox backends.
+
+The Blaxel, Daytona, Runloop, and Vercel backends all expose
+configuration-over-REST APIs. They share the same plumbing:
+
+1. Read credentials from environment variables; raise a typed error
+   that names the missing variable when nothing is set.
+2. Construct an :class:`httpx.AsyncClient` with optional mTLS material
+   (via :mod:`bernstein.core.protocols.cluster.cluster_tls`) so the
+   backends behave identically to the rest of the cluster transport.
+3. Surface 4xx/5xx responses as a typed exception that includes the
+   provider's request id for triage.
+
+This module centralises those primitives so each provider module can
+focus exclusively on the route mapping and payload shape.
+
+This file is intentionally provider-agnostic; per-provider modules
+import only the helpers they need.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from bernstein.core.protocols.cluster.cluster_tls import (
+    TLSConfig,
+    build_httpx_client_kwargs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+
+class SandboxCredentialError(RuntimeError):
+    """Raised when a required env var for a cloud sandbox backend is unset.
+
+    Attributes:
+        provider: Provider identifier (``"blaxel"``, ``"daytona"`` ...).
+        missing: Tuple of env-var names that were not found in the
+            process environment.
+    """
+
+    def __init__(self, provider: str, missing: tuple[str, ...]) -> None:
+        self.provider = provider
+        self.missing = missing
+        names = ", ".join(missing)
+        super().__init__(
+            f"{provider} sandbox backend requires environment variable(s): {names}. "
+            f"Set them in the orchestrator process environment before instantiating "
+            f"the backend.",
+        )
+
+
+class SandboxApiError(RuntimeError):
+    """Raised when a provider returns an HTTP error response.
+
+    Attributes:
+        provider: Provider identifier.
+        status_code: HTTP status code.
+        request_id: Optional provider-supplied correlation id, lifted
+            from headers (X-Request-Id, X-Correlation-Id, etc.) or the
+            response body.
+        body: Raw response body (truncated to 1 KiB) for log inspection.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        status_code: int,
+        *,
+        request_id: str | None,
+        body: str,
+    ) -> None:
+        self.provider = provider
+        self.status_code = status_code
+        self.request_id = request_id
+        self.body = body
+        rid = f" request_id={request_id}" if request_id else ""
+        super().__init__(
+            f"{provider} API returned HTTP {status_code}{rid}: {body[:1024]}",
+        )
+
+
+@dataclass(frozen=True)
+class HttpClientSpec:
+    """Resolved spec for constructing an :class:`httpx.AsyncClient`.
+
+    Attributes:
+        base_url: Provider API root.
+        headers: Default headers (Authorization, Accept, etc.) applied
+            to every request.
+        timeout: Per-request timeout in seconds.
+        tls: Optional :class:`TLSConfig` for mTLS to a private control
+            plane (corporate VPC deployments).
+    """
+
+    base_url: str
+    headers: Mapping[str, str]
+    timeout: float
+    tls: TLSConfig | None = None
+
+
+def require_env(provider: str, names: Iterable[str]) -> dict[str, str]:
+    """Read required env vars; raise :class:`SandboxCredentialError` on miss.
+
+    Args:
+        provider: Provider identifier used in the error message.
+        names: Required environment variable names.
+
+    Returns:
+        A dict mapping each name to its value.
+
+    Raises:
+        SandboxCredentialError: When any required name is unset or empty.
+    """
+    resolved: dict[str, str] = {}
+    missing: list[str] = []
+    for name in names:
+        value = os.environ.get(name)
+        if not value:
+            missing.append(name)
+        else:
+            resolved[name] = value
+    if missing:
+        raise SandboxCredentialError(provider, tuple(missing))
+    return resolved
+
+
+def build_async_client(spec: HttpClientSpec) -> httpx.AsyncClient:
+    """Construct an :class:`httpx.AsyncClient` from a :class:`HttpClientSpec`.
+
+    Honours the cluster-shared mTLS plumbing so cloud sandbox calls can
+    ride the same private CA used by the rest of the orchestrator when
+    the operator wires :class:`TLSConfig` in.
+    """
+    tls_kwargs = build_httpx_client_kwargs(spec.tls)
+    return httpx.AsyncClient(
+        base_url=spec.base_url,
+        headers=dict(spec.headers),
+        timeout=spec.timeout,
+        **tls_kwargs,
+    )
+
+
+def extract_request_id(response: httpx.Response) -> str | None:
+    """Best-effort lookup of a provider-side correlation id."""
+    for header in (
+        "X-Request-Id",
+        "X-Request-ID",
+        "x-request-id",
+        "X-Correlation-Id",
+        "X-Vercel-Id",
+        "Cf-Ray",
+    ):
+        value = response.headers.get(header)
+        if value:
+            return value
+    try:
+        payload: Any = response.json()
+    except (ValueError, httpx.DecodingError):
+        return None
+    if isinstance(payload, dict):
+        for key in ("request_id", "requestId", "id"):
+            candidate = payload.get(key)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return None
+
+
+def raise_for_status(provider: str, response: httpx.Response) -> None:
+    """Raise :class:`SandboxApiError` for any non-2xx response.
+
+    Args:
+        provider: Provider identifier injected into the error.
+        response: The response to inspect.
+
+    Raises:
+        SandboxApiError: When ``response.status_code`` is >= 400.
+    """
+    if response.status_code < 400:
+        return
+    body = response.text or ""
+    raise SandboxApiError(
+        provider,
+        response.status_code,
+        request_id=extract_request_id(response),
+        body=body,
+    )
+
+
+__all__ = [
+    "HttpClientSpec",
+    "SandboxApiError",
+    "SandboxCredentialError",
+    "build_async_client",
+    "extract_request_id",
+    "raise_for_status",
+    "require_env",
+]

--- a/src/bernstein/core/sandbox/backends/blaxel.py
+++ b/src/bernstein/core/sandbox/backends/blaxel.py
@@ -1,0 +1,343 @@
+"""Blaxel cloud sandbox backend (optional extra).
+
+Blaxel (https://blaxel.ai) provisions ephemeral execution sandboxes for
+agent workloads through a REST API. This backend speaks that API
+directly via :mod:`httpx` so the integration ships without pulling in a
+provider SDK; the backend stays usable from a minimal install.
+
+Environment variables
+---------------------
+
+The backend reads the following variables on construction:
+
+- ``BLAXEL_API_KEY`` — required. Bearer token issued by the Blaxel
+  control plane (Workspace Settings -> API Keys).
+- ``BLAXEL_WORKSPACE`` — required. Workspace slug that owns the
+  sandboxes.
+- ``BLAXEL_API_URL`` — optional override for the API root. Defaults to
+  ``https://api.blaxel.ai/v0``.
+
+Capabilities
+------------
+
+Blaxel exposes file read/write, command exec with stdout+stderr capture,
+outbound network, and persistent volumes that survive a session. It does
+not expose a snapshot primitive in the public API, so this backend
+declares :class:`SandboxCapability` accordingly.
+
+Honest limitations
+------------------
+
+The current Blaxel public REST API does not stream exec output —
+the backend polls the exec endpoint until the command finishes, which
+caps end-to-end latency at the provider's poll interval rather than the
+caller's wall clock. For interactive workloads (tail-style log
+streaming) consider the worktree or Docker backends until Blaxel ships
+WebSocket exec.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from base64 import b64decode, b64encode
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    HttpClientSpec,
+    build_async_client,
+    raise_for_status,
+    require_env,
+)
+from bernstein.core.sandbox.backends._remote_helpers import (
+    allocate_session_id,
+    guard_exec_preconditions,
+    merge_exec_env,
+    resolve_posix_path,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import httpx
+
+    from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://api.blaxel.ai/v0"
+_DEFAULT_RUNTIME = "python:3.13"
+
+
+class BlaxelSandboxSession(SandboxSession):
+    """Session backed by a Blaxel sandbox provisioned via REST."""
+
+    backend_name = "blaxel"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        sandbox_id: str,
+        workspace: str,
+        client: httpx.AsyncClient,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._sandbox_id = sandbox_id
+        self._workspace = workspace
+        self._client = client
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    async def read(self, path: str) -> bytes:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.get(
+            f"/workspaces/{self._workspace}/sandboxes/{self._sandbox_id}/files",
+            params={"path": resolved},
+        )
+        raise_for_status("blaxel", response)
+        payload = response.json()
+        if isinstance(payload, dict) and "content" in payload:
+            content = payload["content"]
+            if payload.get("encoding") == "base64":
+                return b64decode(content)
+            if isinstance(content, str):
+                return content.encode("utf-8")
+        # Fall back to raw bytes if the API ever switches to octet-stream.
+        return response.content
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.put(
+            f"/workspaces/{self._workspace}/sandboxes/{self._sandbox_id}/files",
+            json={
+                "path": resolved,
+                "content": b64encode(data).decode("ascii"),
+                "encoding": "base64",
+                "mode": mode,
+            },
+        )
+        raise_for_status("blaxel", response)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.get(
+            f"/workspaces/{self._workspace}/sandboxes/{self._sandbox_id}/files",
+            params={"path": resolved, "list": "true"},
+        )
+        raise_for_status("blaxel", response)
+        payload = response.json()
+        entries: list[str] = []
+        raw = payload.get("entries", []) if isinstance(payload, dict) else payload
+        if isinstance(raw, list):
+            for entry in raw:
+                if isinstance(entry, dict):
+                    name = entry.get("name") or entry.get("path")
+                    if isinstance(name, str):
+                        entries.append(name.rsplit("/", 1)[-1])
+                elif isinstance(entry, str):
+                    entries.append(entry.rsplit("/", 1)[-1])
+        return sorted(entries)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        guard_exec_preconditions(self._closed, self.session_id, cmd)
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = merge_exec_env(self._base_env, env)
+        body: dict[str, Any] = {
+            "argv": cmd,
+            "cwd": effective_cwd,
+            "env": merged_env,
+            "timeout_seconds": effective_timeout,
+        }
+        if stdin is not None:
+            body["stdin_b64"] = b64encode(stdin).decode("ascii")
+
+        start = time.monotonic()
+        try:
+            response = await asyncio.wait_for(
+                self._client.post(
+                    f"/workspaces/{self._workspace}/sandboxes/{self._sandbox_id}/exec",
+                    json=body,
+                    timeout=float(effective_timeout) + 5.0,
+                ),
+                timeout=effective_timeout + 10,
+            )
+        except TimeoutError:
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        raise_for_status("blaxel", response)
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected blaxel exec payload: {payload!r}")
+        return ExecResult(
+            exit_code=int(payload.get("exit_code", 0) or 0),
+            stdout=_decode_stream(payload.get("stdout"), payload.get("stdout_encoding")),
+            stderr=_decode_stream(payload.get("stderr"), payload.get("stderr_encoding")),
+            duration_seconds=time.monotonic() - start,
+        )
+
+    async def snapshot(self) -> str:
+        raise NotImplementedError(
+            "Blaxel public REST API does not expose a snapshot primitive; "
+            "track in vendor changelog before claiming SNAPSHOT capability.",
+        )
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            response = await self._client.delete(
+                f"/workspaces/{self._workspace}/sandboxes/{self._sandbox_id}",
+            )
+            if response.status_code not in (200, 202, 204, 404):
+                raise_for_status("blaxel", response)
+        except Exception as exc:
+            logger.debug("Blaxel sandbox %s teardown raised: %s", self._sandbox_id, exc)
+        finally:
+            await self._client.aclose()
+
+
+def _decode_stream(value: Any, encoding: Any) -> bytes:
+    """Decode an exec stream payload as bytes (base64 or utf-8 string)."""
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        if encoding == "base64":
+            return b64decode(value)
+        return value.encode("utf-8")
+    return str(value).encode("utf-8")
+
+
+class BlaxelSandboxBackend:
+    """Cloud :class:`SandboxBackend` powered by the Blaxel REST API."""
+
+    name = "blaxel"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.PERSISTENT_VOLUMES,
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        client_factory: Any | None = None,
+        tls: TLSConfig | None = None,
+    ) -> None:
+        """Create the backend.
+
+        Args:
+            client_factory: Optional callable used by tests to inject a
+                pre-configured :class:`httpx.AsyncClient`. The factory
+                receives ``(spec)`` and must return an
+                :class:`httpx.AsyncClient`.
+            tls: Optional mTLS configuration for connections that ride
+                an internal CA (corporate VPC deployments). When absent
+                the public PKI is used.
+        """
+        self._client_factory = client_factory
+        self._tls = tls
+        self._sessions: dict[str, BlaxelSandboxSession] = {}
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a new Blaxel sandbox and return a session.
+
+        Recognised ``options``:
+
+        - ``runtime``: Blaxel runtime image. Default ``python:3.13``.
+        - ``region``: Optional region hint forwarded to the API.
+        - ``session_id``: Explicit session identifier.
+        """
+        opts = dict(options or {})
+        env = require_env("blaxel", ("BLAXEL_API_KEY", "BLAXEL_WORKSPACE"))
+        api_url = opts.get("api_url") or os.environ.get("BLAXEL_API_URL") or _DEFAULT_API_URL
+        workspace = env["BLAXEL_WORKSPACE"]
+        session_id = allocate_session_id("bernstein-blaxel", opts.get("session_id"))
+        spec = HttpClientSpec(
+            base_url=str(api_url).rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {env['BLAXEL_API_KEY']}",
+                "Accept": "application/json",
+                "User-Agent": "bernstein-sandbox/1.0",
+            },
+            timeout=float(manifest.timeout_seconds + 30),
+            tls=self._tls,
+        )
+        client = self._client_factory(spec=spec) if self._client_factory is not None else build_async_client(spec)
+        try:
+            response = await client.post(
+                f"/workspaces/{workspace}/sandboxes",
+                json={
+                    "runtime": opts.get("runtime", _DEFAULT_RUNTIME),
+                    "region": opts.get("region"),
+                    "workdir": manifest.root,
+                    "env": dict(manifest.env),
+                    "timeout_seconds": manifest.timeout_seconds,
+                    "name": session_id,
+                },
+            )
+        except Exception:
+            await client.aclose()
+            raise
+        raise_for_status("blaxel", response)
+        payload = response.json()
+        sandbox_id = (payload.get("id") if isinstance(payload, dict) else None) or session_id
+        session = BlaxelSandboxSession(
+            session_id=session_id,
+            sandbox_id=str(sandbox_id),
+            workspace=workspace,
+            client=client,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        raise NotImplementedError(
+            "Blaxel backend does not declare SNAPSHOT capability; use create() against a persistent volume instead.",
+        )
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "BlaxelSandboxBackend",
+    "BlaxelSandboxSession",
+]

--- a/src/bernstein/core/sandbox/backends/daytona.py
+++ b/src/bernstein/core/sandbox/backends/daytona.py
@@ -1,0 +1,384 @@
+"""Daytona cloud sandbox backend (optional extra).
+
+Daytona (https://daytona.io) provisions cloud development environments
+as ephemeral sandboxes. This backend speaks the public REST API
+directly via :mod:`httpx`; the optional :mod:`daytona-sdk` Python SDK
+is *not* required and is not pulled in by default.
+
+Environment variables
+---------------------
+
+The backend reads the following variables on construction:
+
+- ``DAYTONA_API_KEY`` — required. Personal access token (Daytona
+  Dashboard -> Settings -> API Keys).
+- ``DAYTONA_API_URL`` — optional override of the API root. Defaults to
+  ``https://app.daytona.io/api``.
+- ``DAYTONA_TARGET`` — optional region/target identifier (e.g.
+  ``us``, ``eu``).
+- ``DAYTONA_ORG_ID`` — optional organisation identifier sent as the
+  ``X-Daytona-Organization-ID`` header for multi-org accounts.
+
+Capabilities
+------------
+
+`FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`. Daytona supports snapshotting
+sandboxes via its public API; we expose this through
+:class:`SandboxCapability.SNAPSHOT`.
+
+Honest limitations
+------------------
+
+- The REST exec endpoint returns the final stdout/stderr after the
+  command exits. For exec-streaming use the Daytona WebSocket exec
+  channel; that is tracked as a follow-up because Bernstein's
+  :class:`SandboxSession` protocol is currently unary-response.
+- Stdin injection is unsupported by the REST exec endpoint; the
+  backend raises :class:`NotImplementedError` when ``stdin`` is set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from base64 import b64decode
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    HttpClientSpec,
+    build_async_client,
+    raise_for_status,
+    require_env,
+)
+from bernstein.core.sandbox.backends._remote_helpers import (
+    allocate_session_id,
+    guard_exec_preconditions,
+    merge_exec_env,
+    resolve_posix_path,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import httpx
+
+    from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://app.daytona.io/api"
+_DEFAULT_IMAGE = "daytonaio/sandbox:latest"
+
+
+class DaytonaSandboxSession(SandboxSession):
+    """Session backed by a Daytona sandbox provisioned via REST."""
+
+    backend_name = "daytona"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        sandbox_id: str,
+        client: httpx.AsyncClient,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._sandbox_id = sandbox_id
+        self._client = client
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    async def read(self, path: str) -> bytes:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.get(
+            f"/sandbox/{self._sandbox_id}/toolbox/files/download",
+            params={"path": resolved},
+        )
+        raise_for_status("daytona", response)
+        return response.content
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = resolve_posix_path(self.workdir, path)
+        files = {"file": (resolved.rsplit("/", 1)[-1], data, "application/octet-stream")}
+        response = await self._client.post(
+            f"/sandbox/{self._sandbox_id}/toolbox/files/upload",
+            params={"path": resolved, "mode": oct(mode)},
+            files=files,
+        )
+        raise_for_status("daytona", response)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.get(
+            f"/sandbox/{self._sandbox_id}/toolbox/files",
+            params={"path": resolved},
+        )
+        raise_for_status("daytona", response)
+        payload = response.json()
+        entries: list[str] = []
+        if isinstance(payload, list):
+            raw = payload
+        elif isinstance(payload, dict) and isinstance(payload.get("files"), list):
+            raw = payload["files"]
+        else:
+            raw = []
+        for entry in raw:
+            if isinstance(entry, dict):
+                name = entry.get("name") or entry.get("path")
+                if isinstance(name, str):
+                    entries.append(name.rsplit("/", 1)[-1])
+            elif isinstance(entry, str):
+                entries.append(entry.rsplit("/", 1)[-1])
+        return sorted(entries)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        guard_exec_preconditions(self._closed, self.session_id, cmd)
+        if stdin is not None:
+            raise NotImplementedError(
+                "Daytona REST exec endpoint does not accept stdin; use the "
+                "WebSocket exec channel for interactive workloads.",
+            )
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = merge_exec_env(self._base_env, env)
+
+        body: dict[str, Any] = {
+            "command": cmd,
+            "cwd": effective_cwd,
+            "env": merged_env,
+            "timeout": effective_timeout,
+        }
+        start = time.monotonic()
+        try:
+            response = await asyncio.wait_for(
+                self._client.post(
+                    f"/sandbox/{self._sandbox_id}/toolbox/process/execute",
+                    json=body,
+                    timeout=float(effective_timeout) + 5.0,
+                ),
+                timeout=effective_timeout + 10,
+            )
+        except TimeoutError:
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        raise_for_status("daytona", response)
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected daytona exec payload: {payload!r}")
+        stdout_b = _decode_stream(payload.get("stdout"), payload.get("stdout_encoding"))
+        stderr_b = _decode_stream(payload.get("stderr"), payload.get("stderr_encoding"))
+        if not stdout_b and not stderr_b and "result" in payload:
+            stdout_b = _decode_stream(payload.get("result"), None)
+        return ExecResult(
+            exit_code=int(payload.get("exit_code", payload.get("exitCode", 0)) or 0),
+            stdout=stdout_b,
+            stderr=stderr_b,
+            duration_seconds=time.monotonic() - start,
+        )
+
+    async def snapshot(self) -> str:
+        response = await self._client.post(
+            f"/sandbox/{self._sandbox_id}/snapshots",
+            json={"name": f"bernstein-{self.session_id}"},
+        )
+        raise_for_status("daytona", response)
+        payload = response.json()
+        if isinstance(payload, dict):
+            snap_id = payload.get("id") or payload.get("snapshotId")
+            if isinstance(snap_id, str):
+                return snap_id
+        raise RuntimeError(f"Daytona snapshot did not return an id: {payload!r}")
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            response = await self._client.delete(f"/sandbox/{self._sandbox_id}")
+            if response.status_code not in (200, 202, 204, 404):
+                raise_for_status("daytona", response)
+        except Exception as exc:
+            logger.debug("Daytona sandbox %s teardown raised: %s", self._sandbox_id, exc)
+        finally:
+            await self._client.aclose()
+
+
+def _decode_stream(value: Any, encoding: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        if encoding == "base64":
+            return b64decode(value)
+        return value.encode("utf-8")
+    return str(value).encode("utf-8")
+
+
+def _build_headers(api_key: str, org_id: str | None) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+        "User-Agent": "bernstein-sandbox/1.0",
+    }
+    if org_id:
+        headers["X-Daytona-Organization-ID"] = org_id
+    return headers
+
+
+class DaytonaSandboxBackend:
+    """Cloud :class:`SandboxBackend` powered by the Daytona REST API."""
+
+    name = "daytona"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.SNAPSHOT,
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        client_factory: Any | None = None,
+        tls: TLSConfig | None = None,
+    ) -> None:
+        """Create the backend.
+
+        Args:
+            client_factory: Optional callable returning an
+                :class:`httpx.AsyncClient` for tests. Receives the
+                resolved :class:`HttpClientSpec`.
+            tls: Optional mTLS configuration for self-hosted Daytona
+                control planes behind a private CA.
+        """
+        self._client_factory = client_factory
+        self._tls = tls
+        self._sessions: dict[str, DaytonaSandboxSession] = {}
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a new Daytona sandbox.
+
+        Recognised ``options``:
+
+        - ``image``: container image. Default ``daytonaio/sandbox:latest``.
+        - ``target``: region/target hint. Default reads ``DAYTONA_TARGET``.
+        - ``cpu``, ``memory``, ``disk``: resource requests forwarded to
+          the API.
+        - ``session_id``: explicit session identifier.
+        """
+        opts = dict(options or {})
+        env = require_env("daytona", ("DAYTONA_API_KEY",))
+        api_url = opts.get("api_url") or os.environ.get("DAYTONA_API_URL") or _DEFAULT_API_URL
+        target = opts.get("target") or os.environ.get("DAYTONA_TARGET")
+        org_id = opts.get("org_id") or os.environ.get("DAYTONA_ORG_ID")
+        session_id = allocate_session_id("bernstein-daytona", opts.get("session_id"))
+        spec = HttpClientSpec(
+            base_url=str(api_url).rstrip("/"),
+            headers=_build_headers(env["DAYTONA_API_KEY"], org_id),
+            timeout=float(manifest.timeout_seconds + 30),
+            tls=self._tls,
+        )
+        client = self._client_factory(spec=spec) if self._client_factory is not None else build_async_client(spec)
+        body: dict[str, Any] = {
+            "name": session_id,
+            "image": opts.get("image", _DEFAULT_IMAGE),
+            "user": opts.get("user"),
+            "env": dict(manifest.env),
+            "cwd": manifest.root,
+        }
+        if target:
+            body["target"] = target
+        for key in ("cpu", "memory", "disk", "gpu"):
+            if key in opts:
+                body[key] = opts[key]
+        try:
+            response = await client.post("/sandbox", json=body)
+        except Exception:
+            await client.aclose()
+            raise
+        raise_for_status("daytona", response)
+        payload = response.json()
+        sandbox_id = (payload.get("id") if isinstance(payload, dict) else None) or session_id
+        session = DaytonaSandboxSession(
+            session_id=session_id,
+            sandbox_id=str(sandbox_id),
+            client=client,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        """Restore a Daytona sandbox from a snapshot id."""
+        env = require_env("daytona", ("DAYTONA_API_KEY",))
+        api_url = os.environ.get("DAYTONA_API_URL") or _DEFAULT_API_URL
+        org_id = os.environ.get("DAYTONA_ORG_ID")
+        spec = HttpClientSpec(
+            base_url=str(api_url).rstrip("/"),
+            headers=_build_headers(env["DAYTONA_API_KEY"], org_id),
+            timeout=120.0,
+            tls=self._tls,
+        )
+        client = self._client_factory(spec=spec) if self._client_factory is not None else build_async_client(spec)
+        try:
+            response = await client.post(
+                "/sandbox",
+                json={"name": f"bernstein-resume-{snapshot_id}", "snapshot_id": snapshot_id},
+            )
+        except Exception:
+            await client.aclose()
+            raise
+        raise_for_status("daytona", response)
+        payload = response.json()
+        sandbox_id = (payload.get("id") if isinstance(payload, dict) else None) or snapshot_id
+        session = DaytonaSandboxSession(
+            session_id=f"resume-{snapshot_id}",
+            sandbox_id=str(sandbox_id),
+            client=client,
+            workdir="/workspace",
+            base_env={},
+            default_timeout=1800,
+        )
+        self._sessions[session.session_id] = session
+        return session
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "DaytonaSandboxBackend",
+    "DaytonaSandboxSession",
+]

--- a/src/bernstein/core/sandbox/backends/runloop.py
+++ b/src/bernstein/core/sandbox/backends/runloop.py
@@ -1,0 +1,380 @@
+"""Runloop cloud sandbox backend (optional extra).
+
+Runloop (https://runloop.ai) provides AI-tailored sandbox runtimes
+("devboxes") with snapshotting, file-system primitives, and an exec
+endpoint. This backend speaks the public REST API directly via
+:mod:`httpx`.
+
+Environment variables
+---------------------
+
+- ``RUNLOOP_API_KEY`` — required. Bearer token from the Runloop
+  Dashboard.
+- ``RUNLOOP_API_URL`` — optional override of the API root. Defaults to
+  ``https://api.runloop.ai/v1``.
+- ``RUNLOOP_PROJECT_ID`` — optional default project id forwarded as
+  ``project_id`` on devbox creation.
+
+Capabilities
+------------
+
+`FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT`. Runloop devboxes can be
+snapshotted (``POST /devboxes/{id}/snapshot``) and resumed (``POST
+/devboxes`` with ``snapshot_id``).
+
+Honest limitations
+------------------
+
+- The synchronous exec endpoint blocks until the command completes;
+  for long-running streamed output use Runloop's WebSocket exec
+  channel which is not yet plumbed through this backend.
+- Stdin injection is not part of the synchronous exec request
+  envelope; passing ``stdin=`` raises :class:`NotImplementedError`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from base64 import b64decode, b64encode
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    HttpClientSpec,
+    build_async_client,
+    raise_for_status,
+    require_env,
+)
+from bernstein.core.sandbox.backends._remote_helpers import (
+    allocate_session_id,
+    guard_exec_preconditions,
+    merge_exec_env,
+    resolve_posix_path,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import httpx
+
+    from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://api.runloop.ai/v1"
+
+
+class RunloopSandboxSession(SandboxSession):
+    """Session backed by a Runloop devbox provisioned via REST."""
+
+    backend_name = "runloop"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        devbox_id: str,
+        client: httpx.AsyncClient,
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._devbox_id = devbox_id
+        self._client = client
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    async def read(self, path: str) -> bytes:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.get(
+            f"/devboxes/{self._devbox_id}/read_file_contents",
+            params={"file_path": resolved},
+        )
+        raise_for_status("runloop", response)
+        payload = response.json()
+        if isinstance(payload, dict):
+            content = payload.get("contents") or payload.get("content")
+            encoding = payload.get("encoding")
+            if isinstance(content, str):
+                if encoding == "base64":
+                    return b64decode(content)
+                return content.encode("utf-8")
+        return response.content
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.post(
+            f"/devboxes/{self._devbox_id}/write_file",
+            json={
+                "file_path": resolved,
+                "contents": b64encode(data).decode("ascii"),
+                "encoding": "base64",
+                "mode": oct(mode),
+            },
+        )
+        raise_for_status("runloop", response)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = resolve_posix_path(self.workdir, path)
+        response = await self._client.post(
+            f"/devboxes/{self._devbox_id}/execute_sync",
+            json={"command": f"ls -1 {_quote(resolved)}", "shell": True},
+        )
+        raise_for_status("runloop", response)
+        payload = response.json()
+        stdout = payload.get("stdout", "") if isinstance(payload, dict) else ""
+        if isinstance(stdout, str):
+            return sorted([line for line in stdout.splitlines() if line])
+        return []
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        guard_exec_preconditions(self._closed, self.session_id, cmd)
+        if stdin is not None:
+            raise NotImplementedError(
+                "Runloop synchronous exec endpoint does not accept stdin; "
+                "use the WebSocket exec channel for interactive workloads.",
+            )
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = merge_exec_env(self._base_env, env)
+        body: dict[str, Any] = {
+            "command": " ".join(_quote(part) for part in cmd),
+            "shell": True,
+            "shell_name": "bash",
+            "working_directory": effective_cwd,
+            "env_vars": merged_env,
+            "timeout_seconds": effective_timeout,
+        }
+
+        start = time.monotonic()
+        try:
+            response = await asyncio.wait_for(
+                self._client.post(
+                    f"/devboxes/{self._devbox_id}/execute_sync",
+                    json=body,
+                    timeout=float(effective_timeout) + 5.0,
+                ),
+                timeout=effective_timeout + 10,
+            )
+        except TimeoutError:
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        raise_for_status("runloop", response)
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected runloop exec payload: {payload!r}")
+        return ExecResult(
+            exit_code=int(payload.get("exit_status", payload.get("exit_code", 0)) or 0),
+            stdout=_decode_stream(payload.get("stdout"), payload.get("stdout_encoding")),
+            stderr=_decode_stream(payload.get("stderr"), payload.get("stderr_encoding")),
+            duration_seconds=time.monotonic() - start,
+        )
+
+    async def snapshot(self) -> str:
+        response = await self._client.post(
+            f"/devboxes/{self._devbox_id}/snapshot_disk",
+            json={"name": f"bernstein-{self.session_id}"},
+        )
+        raise_for_status("runloop", response)
+        payload = response.json()
+        if isinstance(payload, dict):
+            for key in ("id", "snapshot_id", "snapshotId"):
+                value = payload.get(key)
+                if isinstance(value, str):
+                    return value
+        raise RuntimeError(f"Runloop snapshot did not return an id: {payload!r}")
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            response = await self._client.post(
+                f"/devboxes/{self._devbox_id}/shutdown",
+            )
+            if response.status_code not in (200, 202, 204, 404):
+                raise_for_status("runloop", response)
+        except Exception as exc:
+            logger.debug("Runloop devbox %s teardown raised: %s", self._devbox_id, exc)
+        finally:
+            await self._client.aclose()
+
+
+def _decode_stream(value: Any, encoding: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        if encoding == "base64":
+            return b64decode(value)
+        return value.encode("utf-8")
+    return str(value).encode("utf-8")
+
+
+def _quote(arg: str) -> str:
+    """POSIX-shell quote a single argv element."""
+    if not arg:
+        return "''"
+    safe = all(ch.isalnum() or ch in "@%+=:,./-" for ch in arg)
+    if safe:
+        return arg
+    return "'" + arg.replace("'", "'\\''") + "'"
+
+
+class RunloopSandboxBackend:
+    """Cloud :class:`SandboxBackend` powered by the Runloop REST API."""
+
+    name = "runloop"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+            SandboxCapability.SNAPSHOT,
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        client_factory: Any | None = None,
+        tls: TLSConfig | None = None,
+    ) -> None:
+        """Create the backend.
+
+        Args:
+            client_factory: Optional callable returning an
+                :class:`httpx.AsyncClient` for tests; receives the
+                resolved :class:`HttpClientSpec`.
+            tls: Optional mTLS configuration for self-hosted control
+                planes behind a private CA.
+        """
+        self._client_factory = client_factory
+        self._tls = tls
+        self._sessions: dict[str, RunloopSandboxSession] = {}
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a new Runloop devbox.
+
+        Recognised ``options``:
+
+        - ``blueprint``: Runloop blueprint id (image preset).
+        - ``project_id``: Override of ``RUNLOOP_PROJECT_ID``.
+        - ``session_id``: Explicit session identifier.
+        - ``launch_parameters``: Free-form dict forwarded to the API.
+        """
+        opts = dict(options or {})
+        env = require_env("runloop", ("RUNLOOP_API_KEY",))
+        api_url = opts.get("api_url") or os.environ.get("RUNLOOP_API_URL") or _DEFAULT_API_URL
+        project_id = opts.get("project_id") or os.environ.get("RUNLOOP_PROJECT_ID")
+        session_id = allocate_session_id("bernstein-runloop", opts.get("session_id"))
+        spec = HttpClientSpec(
+            base_url=str(api_url).rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {env['RUNLOOP_API_KEY']}",
+                "Accept": "application/json",
+                "User-Agent": "bernstein-sandbox/1.0",
+            },
+            timeout=float(manifest.timeout_seconds + 30),
+            tls=self._tls,
+        )
+        client = self._client_factory(spec=spec) if self._client_factory is not None else build_async_client(spec)
+        body: dict[str, Any] = {
+            "name": session_id,
+            "environment_variables": dict(manifest.env),
+        }
+        if project_id:
+            body["project_id"] = project_id
+        if "blueprint" in opts:
+            body["blueprint_id"] = opts["blueprint"]
+        if "launch_parameters" in opts:
+            body["launch_parameters"] = opts["launch_parameters"]
+        try:
+            response = await client.post("/devboxes", json=body)
+        except Exception:
+            await client.aclose()
+            raise
+        raise_for_status("runloop", response)
+        payload = response.json()
+        devbox_id = (payload.get("id") if isinstance(payload, dict) else None) or session_id
+        session = RunloopSandboxSession(
+            session_id=session_id,
+            devbox_id=str(devbox_id),
+            client=client,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        env = require_env("runloop", ("RUNLOOP_API_KEY",))
+        api_url = os.environ.get("RUNLOOP_API_URL") or _DEFAULT_API_URL
+        spec = HttpClientSpec(
+            base_url=str(api_url).rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {env['RUNLOOP_API_KEY']}",
+                "Accept": "application/json",
+                "User-Agent": "bernstein-sandbox/1.0",
+            },
+            timeout=120.0,
+            tls=self._tls,
+        )
+        client = self._client_factory(spec=spec) if self._client_factory is not None else build_async_client(spec)
+        try:
+            response = await client.post(
+                "/devboxes",
+                json={"name": f"bernstein-resume-{snapshot_id}", "snapshot_id": snapshot_id},
+            )
+        except Exception:
+            await client.aclose()
+            raise
+        raise_for_status("runloop", response)
+        payload = response.json()
+        devbox_id = (payload.get("id") if isinstance(payload, dict) else None) or snapshot_id
+        session = RunloopSandboxSession(
+            session_id=f"resume-{snapshot_id}",
+            devbox_id=str(devbox_id),
+            client=client,
+            workdir="/workspace",
+            base_env={},
+            default_timeout=1800,
+        )
+        self._sessions[session.session_id] = session
+        return session
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "RunloopSandboxBackend",
+    "RunloopSandboxSession",
+]

--- a/src/bernstein/core/sandbox/backends/vercel.py
+++ b/src/bernstein/core/sandbox/backends/vercel.py
@@ -1,0 +1,359 @@
+"""Vercel Sandbox cloud backend (optional extra).
+
+Vercel Sandbox (https://vercel.com/docs/sandbox) provisions ephemeral
+Firecracker microVMs intended for AI-agent workloads. This backend
+speaks Vercel's REST API directly via :mod:`httpx`; no Vercel SDK is
+required.
+
+Environment variables
+---------------------
+
+- ``VERCEL_TOKEN`` — required. Personal/team API token from
+  ``https://vercel.com/account/tokens``.
+- ``VERCEL_TEAM_ID`` — optional team scope id; required for tokens
+  scoped to a team.
+- ``VERCEL_API_URL`` — optional override of the API root. Defaults to
+  ``https://api.vercel.com``.
+
+Capabilities
+------------
+
+`FILE_RW`, `EXEC`, `NETWORK`. Vercel Sandbox does not currently expose
+a public snapshot/restore endpoint, so :class:`SandboxCapability.SNAPSHOT`
+is not declared.
+
+Honest limitations
+------------------
+
+- **No exec streaming on the synchronous endpoint.** The Vercel
+  Sandbox HTTP API returns the buffered ``stdout``/``stderr`` after
+  the command exits. For interactive log-tailing workloads use the
+  ``worktree`` or ``docker`` backends until Vercel's WebSocket exec
+  channel ships GA.
+- **Stdin not supported on the sync exec route.** Setting ``stdin=``
+  raises :class:`NotImplementedError`.
+- **Snapshots not supported.** Persist state via Vercel-managed
+  storage (e.g. Vercel KV/Blob) rather than relying on session
+  snapshotting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from base64 import b64decode, b64encode
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.sandbox.backend import (
+    ExecResult,
+    SandboxCapability,
+    SandboxSession,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    HttpClientSpec,
+    build_async_client,
+    raise_for_status,
+    require_env,
+)
+from bernstein.core.sandbox.backends._remote_helpers import (
+    allocate_session_id,
+    guard_exec_preconditions,
+    merge_exec_env,
+    resolve_posix_path,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    import httpx
+
+    from bernstein.core.protocols.cluster.cluster_tls import TLSConfig
+    from bernstein.core.sandbox.manifest import WorkspaceManifest
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_API_URL = "https://api.vercel.com"
+_DEFAULT_RUNTIME = "node22"
+
+
+class VercelSandboxSession(SandboxSession):
+    """Session backed by a Vercel Sandbox provisioned via REST."""
+
+    backend_name = "vercel"
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        sandbox_id: str,
+        client: httpx.AsyncClient,
+        team_query: dict[str, str],
+        workdir: str,
+        base_env: Mapping[str, str],
+        default_timeout: int,
+    ) -> None:
+        self.session_id = session_id
+        self.workdir = workdir
+        self._sandbox_id = sandbox_id
+        self._client = client
+        self._team_query = team_query
+        self._base_env = dict(base_env)
+        self._default_timeout = default_timeout
+        self._closed = False
+
+    async def read(self, path: str) -> bytes:
+        resolved = resolve_posix_path(self.workdir, path)
+        params = {"path": resolved, **self._team_query}
+        response = await self._client.get(
+            f"/v1/sandboxes/{self._sandbox_id}/files",
+            params=params,
+        )
+        raise_for_status("vercel", response)
+        ctype = response.headers.get("content-type", "")
+        if "json" in ctype:
+            payload = response.json()
+            if isinstance(payload, dict):
+                content = payload.get("content")
+                encoding = payload.get("encoding")
+                if isinstance(content, str):
+                    if encoding == "base64":
+                        return b64decode(content)
+                    return content.encode("utf-8")
+        return response.content
+
+    async def write(self, path: str, data: bytes, *, mode: int = 0o644) -> None:
+        resolved = resolve_posix_path(self.workdir, path)
+        params = {**self._team_query}
+        response = await self._client.put(
+            f"/v1/sandboxes/{self._sandbox_id}/files",
+            params=params,
+            json={
+                "path": resolved,
+                "content": b64encode(data).decode("ascii"),
+                "encoding": "base64",
+                "mode": oct(mode),
+            },
+        )
+        raise_for_status("vercel", response)
+
+    async def ls(self, path: str) -> list[str]:
+        resolved = resolve_posix_path(self.workdir, path)
+        params = {"path": resolved, "list": "true", **self._team_query}
+        response = await self._client.get(
+            f"/v1/sandboxes/{self._sandbox_id}/files",
+            params=params,
+        )
+        raise_for_status("vercel", response)
+        payload = response.json()
+        entries: list[str] = []
+        if isinstance(payload, dict):
+            raw = payload.get("entries") or payload.get("files") or []
+        else:
+            raw = payload if isinstance(payload, list) else []
+        for entry in raw:
+            if isinstance(entry, dict):
+                name = entry.get("name") or entry.get("path")
+                if isinstance(name, str):
+                    entries.append(name.rsplit("/", 1)[-1])
+            elif isinstance(entry, str):
+                entries.append(entry.rsplit("/", 1)[-1])
+        return sorted(entries)
+
+    async def exec(
+        self,
+        cmd: list[str],
+        *,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: int | None = None,
+        stdin: bytes | None = None,
+    ) -> ExecResult:
+        guard_exec_preconditions(self._closed, self.session_id, cmd)
+        if stdin is not None:
+            raise NotImplementedError(
+                "Vercel synchronous exec endpoint does not accept stdin; "
+                "use the WebSocket exec channel for interactive workloads.",
+            )
+        effective_cwd = cwd if cwd is not None else self.workdir
+        effective_timeout = timeout if timeout is not None else self._default_timeout
+        merged_env = merge_exec_env(self._base_env, env)
+        body: dict[str, Any] = {
+            "command": cmd,
+            "cwd": effective_cwd,
+            "env": merged_env,
+            "timeout": effective_timeout,
+        }
+        params = {**self._team_query}
+
+        start = time.monotonic()
+        try:
+            response = await asyncio.wait_for(
+                self._client.post(
+                    f"/v1/sandboxes/{self._sandbox_id}/exec",
+                    params=params,
+                    json=body,
+                    timeout=float(effective_timeout) + 5.0,
+                ),
+                timeout=effective_timeout + 10,
+            )
+        except TimeoutError:
+            raise TimeoutError(f"Command {cmd!r} timed out after {effective_timeout}s") from None
+        raise_for_status("vercel", response)
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected vercel exec payload: {payload!r}")
+        return ExecResult(
+            exit_code=int(payload.get("exitCode", payload.get("exit_code", 0)) or 0),
+            stdout=_decode_stream(payload.get("stdout"), payload.get("stdoutEncoding")),
+            stderr=_decode_stream(payload.get("stderr"), payload.get("stderrEncoding")),
+            duration_seconds=time.monotonic() - start,
+        )
+
+    async def snapshot(self) -> str:
+        raise NotImplementedError(
+            "Vercel Sandbox API does not expose a snapshot primitive at the "
+            "time of writing; persist state via Vercel-managed storage instead.",
+        )
+
+    async def shutdown(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            response = await self._client.delete(
+                f"/v1/sandboxes/{self._sandbox_id}",
+                params={**self._team_query},
+            )
+            if response.status_code not in (200, 202, 204, 404):
+                raise_for_status("vercel", response)
+        except Exception as exc:
+            logger.debug("Vercel sandbox %s teardown raised: %s", self._sandbox_id, exc)
+        finally:
+            await self._client.aclose()
+
+
+def _decode_stream(value: Any, encoding: Any) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        if encoding == "base64":
+            return b64decode(value)
+        return value.encode("utf-8")
+    return str(value).encode("utf-8")
+
+
+def _team_query(team_id: str | None) -> dict[str, str]:
+    return {"teamId": team_id} if team_id else {}
+
+
+class VercelSandboxBackend:
+    """Cloud :class:`SandboxBackend` powered by the Vercel Sandbox API."""
+
+    name = "vercel"
+    capabilities: frozenset[SandboxCapability] = frozenset(
+        {
+            SandboxCapability.FILE_RW,
+            SandboxCapability.EXEC,
+            SandboxCapability.NETWORK,
+        }
+    )
+
+    def __init__(
+        self,
+        *,
+        client_factory: Any | None = None,
+        tls: TLSConfig | None = None,
+    ) -> None:
+        """Create the backend.
+
+        Args:
+            client_factory: Optional callable returning an
+                :class:`httpx.AsyncClient` for tests; receives the
+                resolved :class:`HttpClientSpec`.
+            tls: Optional mTLS configuration for self-hosted Vercel
+                environments behind a private CA. The public Vercel
+                control plane uses public PKI.
+        """
+        self._client_factory = client_factory
+        self._tls = tls
+        self._sessions: dict[str, VercelSandboxSession] = {}
+
+    async def create(
+        self,
+        manifest: WorkspaceManifest,
+        options: dict[str, Any] | None = None,
+    ) -> SandboxSession:
+        """Provision a Vercel Sandbox.
+
+        Recognised ``options``:
+
+        - ``runtime``: Vercel sandbox runtime image (default ``node22``).
+        - ``region``: Vercel region (e.g. ``iad1``).
+        - ``team_id``: Override of ``VERCEL_TEAM_ID``.
+        - ``session_id``: Explicit session identifier.
+        """
+        opts = dict(options or {})
+        env = require_env("vercel", ("VERCEL_TOKEN",))
+        api_url = opts.get("api_url") or os.environ.get("VERCEL_API_URL") or _DEFAULT_API_URL
+        team_id = opts.get("team_id") or os.environ.get("VERCEL_TEAM_ID")
+        session_id = allocate_session_id("bernstein-vercel", opts.get("session_id"))
+        spec = HttpClientSpec(
+            base_url=str(api_url).rstrip("/"),
+            headers={
+                "Authorization": f"Bearer {env['VERCEL_TOKEN']}",
+                "Accept": "application/json",
+                "User-Agent": "bernstein-sandbox/1.0",
+            },
+            timeout=float(manifest.timeout_seconds + 30),
+            tls=self._tls,
+        )
+        client = self._client_factory(spec=spec) if self._client_factory is not None else build_async_client(spec)
+        body: dict[str, Any] = {
+            "name": session_id,
+            "runtime": opts.get("runtime", _DEFAULT_RUNTIME),
+            "region": opts.get("region"),
+            "workdir": manifest.root,
+            "env": dict(manifest.env),
+            "timeout": manifest.timeout_seconds,
+        }
+        params = _team_query(team_id)
+        try:
+            response = await client.post("/v1/sandboxes", params=params, json=body)
+        except Exception:
+            await client.aclose()
+            raise
+        raise_for_status("vercel", response)
+        payload = response.json()
+        sandbox_id = (payload.get("id") if isinstance(payload, dict) else None) or session_id
+        session = VercelSandboxSession(
+            session_id=session_id,
+            sandbox_id=str(sandbox_id),
+            client=client,
+            team_query=params,
+            workdir=manifest.root,
+            base_env=manifest.env,
+            default_timeout=manifest.timeout_seconds,
+        )
+        for entry in manifest.files:
+            await session.write(entry.path, entry.content, mode=entry.mode)
+        self._sessions[session_id] = session
+        return session
+
+    async def resume(self, snapshot_id: str) -> SandboxSession:
+        raise NotImplementedError(
+            "Vercel backend does not declare SNAPSHOT capability; Vercel Sandbox does not expose snapshot/resume.",
+        )
+
+    async def destroy(self, session: SandboxSession) -> None:
+        await session.shutdown()
+        self._sessions.pop(session.session_id, None)
+
+
+__all__ = [
+    "VercelSandboxBackend",
+    "VercelSandboxSession",
+]

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -150,6 +150,7 @@ class _Registry:
         from bernstein.core.sandbox.backends.blaxel import BlaxelSandboxBackend
         from bernstein.core.sandbox.backends.daytona import DaytonaSandboxBackend
         from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
+        from bernstein.core.sandbox.backends.runloop import RunloopSandboxBackend
         from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
 
         builtins: tuple[tuple[str, type[SandboxBackend]], ...] = (
@@ -157,6 +158,7 @@ class _Registry:
             ("docker", DockerSandboxBackend),
             ("blaxel", BlaxelSandboxBackend),
             ("daytona", DaytonaSandboxBackend),
+            ("runloop", RunloopSandboxBackend),
         )
         for name, cls in builtins:
             if name in self._all_names():

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -148,6 +148,7 @@ class _Registry:
         # first-party built-ins; credential-presence checks happen at
         # ``backend.create`` time, not at registry-load time.
         from bernstein.core.sandbox.backends.blaxel import BlaxelSandboxBackend
+        from bernstein.core.sandbox.backends.daytona import DaytonaSandboxBackend
         from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
         from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
 
@@ -155,6 +156,7 @@ class _Registry:
             ("worktree", WorktreeSandboxBackend),
             ("docker", DockerSandboxBackend),
             ("blaxel", BlaxelSandboxBackend),
+            ("daytona", DaytonaSandboxBackend),
         )
         for name, cls in builtins:
             if name in self._all_names():

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -143,13 +143,18 @@ class _Registry:
     def _load_builtins(self) -> None:
         # Imports are local to keep the module-load graph minimal and to
         # tolerate partial installs (a missing optional dep must never
-        # break registry import).
+        # break registry import). The cloud-REST backends (blaxel,
+        # daytona, runloop, vercel) speak plain httpx so they ship as
+        # first-party built-ins; credential-presence checks happen at
+        # ``backend.create`` time, not at registry-load time.
+        from bernstein.core.sandbox.backends.blaxel import BlaxelSandboxBackend
         from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
         from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
 
         builtins: tuple[tuple[str, type[SandboxBackend]], ...] = (
             ("worktree", WorktreeSandboxBackend),
             ("docker", DockerSandboxBackend),
+            ("blaxel", BlaxelSandboxBackend),
         )
         for name, cls in builtins:
             if name in self._all_names():

--- a/src/bernstein/core/sandbox/registry.py
+++ b/src/bernstein/core/sandbox/registry.py
@@ -151,6 +151,7 @@ class _Registry:
         from bernstein.core.sandbox.backends.daytona import DaytonaSandboxBackend
         from bernstein.core.sandbox.backends.docker import DockerSandboxBackend
         from bernstein.core.sandbox.backends.runloop import RunloopSandboxBackend
+        from bernstein.core.sandbox.backends.vercel import VercelSandboxBackend
         from bernstein.core.sandbox.backends.worktree import WorktreeSandboxBackend
 
         builtins: tuple[tuple[str, type[SandboxBackend]], ...] = (
@@ -159,6 +160,7 @@ class _Registry:
             ("blaxel", BlaxelSandboxBackend),
             ("daytona", DaytonaSandboxBackend),
             ("runloop", RunloopSandboxBackend),
+            ("vercel", VercelSandboxBackend),
         )
         for name, cls in builtins:
             if name in self._all_names():

--- a/tests/integration/sandbox/test_blaxel_backend.py
+++ b/tests/integration/sandbox/test_blaxel_backend.py
@@ -1,0 +1,53 @@
+"""Integration tests for the Blaxel sandbox backend.
+
+Gated on ``CI_BLAXEL_TEST=1`` plus the live credentials in the docs:
+
+- ``BLAXEL_API_KEY``
+- ``BLAXEL_WORKSPACE``
+- (optional) ``BLAXEL_API_URL``
+
+Without the gate the suite skips cleanly so day-to-day local pytest
+runs do not depend on a paid provider account. Mirrors the
+``CI_TUNNEL_TEST`` pattern used by the cluster mTLS workflow.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+
+
+def _gate_ready() -> bool:
+    if os.environ.get("CI_BLAXEL_TEST") != "1":
+        return False
+    return bool(os.environ.get("BLAXEL_API_KEY") and os.environ.get("BLAXEL_WORKSPACE"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _gate_ready(),
+    reason="CI_BLAXEL_TEST or BLAXEL_API_KEY/BLAXEL_WORKSPACE not set",
+)
+
+
+@pytest.mark.asyncio
+async def test_blaxel_smoke_session_lifecycle() -> None:
+    """Provision, exec a trivial command, tear down."""
+    from bernstein.core.sandbox.backends.blaxel import BlaxelSandboxBackend
+
+    backend = BlaxelSandboxBackend()
+    assert SandboxCapability.EXEC in backend.capabilities
+
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=120)
+    session = await backend.create(manifest)
+    try:
+        result = await session.exec(["sh", "-c", "echo blaxel-ok"])
+        assert result.exit_code == 0
+        assert b"blaxel-ok" in result.stdout
+    finally:
+        await backend.destroy(session)

--- a/tests/integration/sandbox/test_daytona_backend.py
+++ b/tests/integration/sandbox/test_daytona_backend.py
@@ -1,0 +1,46 @@
+"""Integration tests for the Daytona sandbox backend.
+
+Gated on ``CI_DAYTONA_TEST=1`` plus ``DAYTONA_API_KEY``. Without the
+gate the suite skips so day-to-day local pytest runs do not depend on
+a paid provider account.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+
+
+def _gate_ready() -> bool:
+    if os.environ.get("CI_DAYTONA_TEST") != "1":
+        return False
+    return bool(os.environ.get("DAYTONA_API_KEY"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _gate_ready(),
+    reason="CI_DAYTONA_TEST or DAYTONA_API_KEY not set",
+)
+
+
+@pytest.mark.asyncio
+async def test_daytona_smoke_session_lifecycle() -> None:
+    from bernstein.core.sandbox.backends.daytona import DaytonaSandboxBackend
+
+    backend = DaytonaSandboxBackend()
+    assert SandboxCapability.SNAPSHOT in backend.capabilities
+
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=120)
+    session = await backend.create(manifest)
+    try:
+        result = await session.exec(["sh", "-c", "echo daytona-ok"])
+        assert result.exit_code == 0
+        assert b"daytona-ok" in result.stdout
+    finally:
+        await backend.destroy(session)

--- a/tests/integration/sandbox/test_runloop_backend.py
+++ b/tests/integration/sandbox/test_runloop_backend.py
@@ -1,0 +1,45 @@
+"""Integration tests for the Runloop sandbox backend.
+
+Gated on ``CI_RUNLOOP_TEST=1`` plus ``RUNLOOP_API_KEY``. Without the
+gate the suite skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+
+
+def _gate_ready() -> bool:
+    if os.environ.get("CI_RUNLOOP_TEST") != "1":
+        return False
+    return bool(os.environ.get("RUNLOOP_API_KEY"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _gate_ready(),
+    reason="CI_RUNLOOP_TEST or RUNLOOP_API_KEY not set",
+)
+
+
+@pytest.mark.asyncio
+async def test_runloop_smoke_session_lifecycle() -> None:
+    from bernstein.core.sandbox.backends.runloop import RunloopSandboxBackend
+
+    backend = RunloopSandboxBackend()
+    assert SandboxCapability.SNAPSHOT in backend.capabilities
+
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=120)
+    session = await backend.create(manifest)
+    try:
+        result = await session.exec(["sh", "-c", "echo runloop-ok"])
+        assert result.exit_code == 0
+        assert b"runloop-ok" in result.stdout
+    finally:
+        await backend.destroy(session)

--- a/tests/integration/sandbox/test_vercel_backend.py
+++ b/tests/integration/sandbox/test_vercel_backend.py
@@ -1,0 +1,45 @@
+"""Integration tests for the Vercel sandbox backend.
+
+Gated on ``CI_VERCEL_TEST=1`` plus ``VERCEL_TOKEN`` (and optionally
+``VERCEL_TEAM_ID``). Without the gate the suite skips cleanly.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+
+
+def _gate_ready() -> bool:
+    if os.environ.get("CI_VERCEL_TEST") != "1":
+        return False
+    return bool(os.environ.get("VERCEL_TOKEN"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _gate_ready(),
+    reason="CI_VERCEL_TEST or VERCEL_TOKEN not set",
+)
+
+
+@pytest.mark.asyncio
+async def test_vercel_smoke_session_lifecycle() -> None:
+    from bernstein.core.sandbox.backends.vercel import VercelSandboxBackend
+
+    backend = VercelSandboxBackend()
+    assert SandboxCapability.EXEC in backend.capabilities
+
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=120)
+    session = await backend.create(manifest)
+    try:
+        result = await session.exec(["sh", "-c", "echo vercel-ok"])
+        assert result.exit_code == 0
+        assert b"vercel-ok" in result.stdout
+    finally:
+        await backend.destroy(session)

--- a/tests/unit/test_sandbox_blaxel.py
+++ b/tests/unit/test_sandbox_blaxel.py
@@ -1,0 +1,178 @@
+"""Unit tests for :mod:`bernstein.core.sandbox.backends.blaxel`.
+
+The tests mock the HTTP layer with respx and exercise:
+
+- spawn happy path
+- exec on session
+- shutdown / kill
+- missing-creds error path
+- 4xx error propagation including request id
+
+Live integration tests live under ``tests/integration/sandbox/`` and
+are gated by ``CI_BLAXEL_TEST``.
+"""
+
+from __future__ import annotations
+
+from base64 import b64encode
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    SandboxApiError,
+    SandboxCredentialError,
+)
+from bernstein.core.sandbox.backends.blaxel import BlaxelSandboxBackend
+
+API_URL = "https://api.blaxel.example/v0"
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BLAXEL_API_KEY", "tok-test")
+    monkeypatch.setenv("BLAXEL_WORKSPACE", "ws-bernstein")
+    monkeypatch.setenv("BLAXEL_API_URL", API_URL)
+
+
+def test_capabilities_shape() -> None:
+    backend = BlaxelSandboxBackend()
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities
+    assert SandboxCapability.NETWORK in backend.capabilities
+    assert SandboxCapability.PERSISTENT_VOLUMES in backend.capabilities
+    assert SandboxCapability.SNAPSHOT not in backend.capabilities
+
+
+@pytest.mark.asyncio
+async def test_create_missing_creds_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BLAXEL_API_KEY", raising=False)
+    monkeypatch.delenv("BLAXEL_WORKSPACE", raising=False)
+    backend = BlaxelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with pytest.raises(SandboxCredentialError) as exc:
+        await backend.create(manifest)
+    assert "BLAXEL_API_KEY" in str(exc.value)
+    assert "BLAXEL_WORKSPACE" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_exec_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = BlaxelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=30)
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/workspaces/ws-bernstein/sandboxes").mock(
+            return_value=httpx.Response(201, json={"id": "sbx-42"}),
+        )
+        exec_route = mock.post(
+            "/workspaces/ws-bernstein/sandboxes/sbx-42/exec",
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "exit_code": 0,
+                    "stdout": b64encode(b"hi\n").decode("ascii"),
+                    "stdout_encoding": "base64",
+                    "stderr": "",
+                    "stderr_encoding": "utf-8",
+                },
+            ),
+        )
+        mock.delete("/workspaces/ws-bernstein/sandboxes/sbx-42").mock(
+            return_value=httpx.Response(204),
+        )
+
+        session = await backend.create(manifest)
+        try:
+            result = await session.exec(["echo", "hi"])
+            assert result.exit_code == 0
+            assert result.stdout == b"hi\n"
+            assert result.stderr == b""
+            assert exec_route.called
+        finally:
+            await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_kill_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = BlaxelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/workspaces/ws-bernstein/sandboxes").mock(
+            return_value=httpx.Response(201, json={"id": "sbx-99"}),
+        )
+        mock.delete("/workspaces/ws-bernstein/sandboxes/sbx-99").mock(
+            return_value=httpx.Response(204),
+        )
+
+        session = await backend.create(manifest)
+        await session.shutdown()
+        await session.shutdown()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_create_propagates_4xx_with_request_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_env(monkeypatch)
+    backend = BlaxelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/workspaces/ws-bernstein/sandboxes").mock(
+            return_value=httpx.Response(
+                403,
+                json={"error": "forbidden"},
+                headers={"X-Request-Id": "req-bad-1"},
+            ),
+        )
+        with pytest.raises(SandboxApiError) as exc:
+            await backend.create(manifest)
+        assert exc.value.status_code == 403
+        assert exc.value.request_id == "req-bad-1"
+
+
+@pytest.mark.asyncio
+async def test_exec_propagates_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = BlaxelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/workspaces/ws-bernstein/sandboxes").mock(
+            return_value=httpx.Response(201, json={"id": "sbx-7"}),
+        )
+        mock.post("/workspaces/ws-bernstein/sandboxes/sbx-7/exec").mock(
+            return_value=httpx.Response(
+                500,
+                json={"error": "boom"},
+                headers={"X-Request-Id": "req-500"},
+            ),
+        )
+        mock.delete("/workspaces/ws-bernstein/sandboxes/sbx-7").mock(
+            return_value=httpx.Response(204),
+        )
+
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(SandboxApiError) as exc:
+                await session.exec(["false"])
+            assert exc.value.status_code == 500
+            assert exc.value.request_id == "req-500"
+        finally:
+            await backend.destroy(session)
+
+
+def test_registry_lists_blaxel() -> None:
+    from bernstein.core.sandbox import list_backend_names
+
+    names = list_backend_names()
+    assert "blaxel" in names

--- a/tests/unit/test_sandbox_daytona.py
+++ b/tests/unit/test_sandbox_daytona.py
@@ -1,0 +1,133 @@
+"""Unit tests for :mod:`bernstein.core.sandbox.backends.daytona`."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    SandboxApiError,
+    SandboxCredentialError,
+)
+from bernstein.core.sandbox.backends.daytona import DaytonaSandboxBackend
+
+API_URL = "https://app.daytona.example/api"
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DAYTONA_API_KEY", "tok-test")
+    monkeypatch.setenv("DAYTONA_API_URL", API_URL)
+
+
+def test_capabilities_shape() -> None:
+    backend = DaytonaSandboxBackend()
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities
+    assert SandboxCapability.NETWORK in backend.capabilities
+    assert SandboxCapability.SNAPSHOT in backend.capabilities
+
+
+@pytest.mark.asyncio
+async def test_create_missing_creds_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DAYTONA_API_KEY", raising=False)
+    backend = DaytonaSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with pytest.raises(SandboxCredentialError) as exc:
+        await backend.create(manifest)
+    assert "DAYTONA_API_KEY" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_exec_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = DaytonaSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=30)
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/sandbox").mock(return_value=httpx.Response(201, json={"id": "sbx-77"}))
+        exec_route = mock.post(
+            "/sandbox/sbx-77/toolbox/process/execute",
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "exit_code": 0,
+                    "stdout": "ok\n",
+                    "stderr": "",
+                },
+            ),
+        )
+        mock.delete("/sandbox/sbx-77").mock(return_value=httpx.Response(204))
+
+        session = await backend.create(manifest)
+        try:
+            result = await session.exec(["echo", "ok"])
+            assert result.exit_code == 0
+            assert b"ok" in result.stdout
+            assert exec_route.called
+        finally:
+            await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_kill_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = DaytonaSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/sandbox").mock(return_value=httpx.Response(201, json={"id": "sbx-1"}))
+        mock.delete("/sandbox/sbx-1").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        await session.shutdown()
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_create_propagates_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = DaytonaSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/sandbox").mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": "unauthorised"},
+                headers={"X-Request-Id": "req-401"},
+            ),
+        )
+        with pytest.raises(SandboxApiError) as exc:
+            await backend.create(manifest)
+        assert exc.value.status_code == 401
+        assert exc.value.request_id == "req-401"
+
+
+@pytest.mark.asyncio
+async def test_exec_propagates_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = DaytonaSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/sandbox").mock(return_value=httpx.Response(201, json={"id": "sbx-9"}))
+        mock.post("/sandbox/sbx-9/toolbox/process/execute").mock(
+            return_value=httpx.Response(503, json={"error": "boom"}, headers={"X-Request-Id": "req-503"}),
+        )
+        mock.delete("/sandbox/sbx-9").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(SandboxApiError) as exc:
+                await session.exec(["false"])
+            assert exc.value.status_code == 503
+            assert exc.value.request_id == "req-503"
+        finally:
+            await backend.destroy(session)
+
+
+def test_registry_lists_daytona() -> None:
+    from bernstein.core.sandbox import list_backend_names
+
+    assert "daytona" in list_backend_names()

--- a/tests/unit/test_sandbox_runloop.py
+++ b/tests/unit/test_sandbox_runloop.py
@@ -1,0 +1,149 @@
+"""Unit tests for :mod:`bernstein.core.sandbox.backends.runloop`."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    SandboxApiError,
+    SandboxCredentialError,
+)
+from bernstein.core.sandbox.backends.runloop import RunloopSandboxBackend
+
+API_URL = "https://api.runloop.example/v1"
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNLOOP_API_KEY", "tok-test")
+    monkeypatch.setenv("RUNLOOP_API_URL", API_URL)
+
+
+def test_capabilities_shape() -> None:
+    backend = RunloopSandboxBackend()
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities
+    assert SandboxCapability.NETWORK in backend.capabilities
+    assert SandboxCapability.SNAPSHOT in backend.capabilities
+
+
+@pytest.mark.asyncio
+async def test_create_missing_creds_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RUNLOOP_API_KEY", raising=False)
+    backend = RunloopSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with pytest.raises(SandboxCredentialError) as exc:
+        await backend.create(manifest)
+    assert "RUNLOOP_API_KEY" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_exec_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = RunloopSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=30)
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/devboxes").mock(return_value=httpx.Response(201, json={"id": "dvb-12"}))
+        exec_route = mock.post(
+            "/devboxes/dvb-12/execute_sync",
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "exit_status": 0,
+                    "stdout": "hello\n",
+                    "stderr": "",
+                },
+            ),
+        )
+        mock.post("/devboxes/dvb-12/shutdown").mock(return_value=httpx.Response(204))
+
+        session = await backend.create(manifest)
+        try:
+            result = await session.exec(["echo", "hello"])
+            assert result.exit_code == 0
+            assert b"hello" in result.stdout
+            assert exec_route.called
+        finally:
+            await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_kill_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = RunloopSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/devboxes").mock(return_value=httpx.Response(201, json={"id": "dvb-2"}))
+        mock.post("/devboxes/dvb-2/shutdown").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        await session.shutdown()
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_create_propagates_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = RunloopSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/devboxes").mock(
+            return_value=httpx.Response(
+                429,
+                json={"error": "rate-limited"},
+                headers={"X-Request-Id": "req-429"},
+            ),
+        )
+        with pytest.raises(SandboxApiError) as exc:
+            await backend.create(manifest)
+        assert exc.value.status_code == 429
+        assert exc.value.request_id == "req-429"
+
+
+@pytest.mark.asyncio
+async def test_exec_propagates_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = RunloopSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/devboxes").mock(return_value=httpx.Response(201, json={"id": "dvb-3"}))
+        mock.post("/devboxes/dvb-3/execute_sync").mock(
+            return_value=httpx.Response(502, json={"error": "boom"}, headers={"X-Request-Id": "req-502"}),
+        )
+        mock.post("/devboxes/dvb-3/shutdown").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(SandboxApiError) as exc:
+                await session.exec(["false"])
+            assert exc.value.status_code == 502
+            assert exc.value.request_id == "req-502"
+        finally:
+            await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_stdin_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = RunloopSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/devboxes").mock(return_value=httpx.Response(201, json={"id": "dvb-9"}))
+        mock.post("/devboxes/dvb-9/shutdown").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(NotImplementedError):
+                await session.exec(["cat"], stdin=b"hello")
+        finally:
+            await backend.destroy(session)
+
+
+def test_registry_lists_runloop() -> None:
+    from bernstein.core.sandbox import list_backend_names
+
+    assert "runloop" in list_backend_names()

--- a/tests/unit/test_sandbox_vercel.py
+++ b/tests/unit/test_sandbox_vercel.py
@@ -1,0 +1,159 @@
+"""Unit tests for :mod:`bernstein.core.sandbox.backends.vercel`."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.sandbox import (
+    SandboxCapability,
+    WorkspaceManifest,
+)
+from bernstein.core.sandbox.backends._http_helpers import (
+    SandboxApiError,
+    SandboxCredentialError,
+)
+from bernstein.core.sandbox.backends.vercel import VercelSandboxBackend
+
+API_URL = "https://api.vercel.example"
+
+
+def _set_env(monkeypatch: pytest.MonkeyPatch, *, team_id: str | None = None) -> None:
+    monkeypatch.setenv("VERCEL_TOKEN", "tok-test")
+    monkeypatch.setenv("VERCEL_API_URL", API_URL)
+    if team_id is not None:
+        monkeypatch.setenv("VERCEL_TEAM_ID", team_id)
+    else:
+        monkeypatch.delenv("VERCEL_TEAM_ID", raising=False)
+
+
+def test_capabilities_shape() -> None:
+    backend = VercelSandboxBackend()
+    assert SandboxCapability.FILE_RW in backend.capabilities
+    assert SandboxCapability.EXEC in backend.capabilities
+    assert SandboxCapability.NETWORK in backend.capabilities
+    assert SandboxCapability.SNAPSHOT not in backend.capabilities
+
+
+@pytest.mark.asyncio
+async def test_create_missing_creds_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VERCEL_TOKEN", raising=False)
+    backend = VercelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with pytest.raises(SandboxCredentialError) as exc:
+        await backend.create(manifest)
+    assert "VERCEL_TOKEN" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_spawn_and_exec_happy_path_with_team(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch, team_id="team-abc")
+    backend = VercelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace", timeout_seconds=30)
+
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        create = mock.post("/v1/sandboxes").mock(
+            return_value=httpx.Response(201, json={"id": "sbx-50"}),
+        )
+        exec_route = mock.post("/v1/sandboxes/sbx-50/exec").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "exitCode": 0,
+                    "stdout": "ready\n",
+                    "stderr": "",
+                },
+            ),
+        )
+        mock.delete("/v1/sandboxes/sbx-50").mock(return_value=httpx.Response(204))
+
+        session = await backend.create(manifest)
+        try:
+            result = await session.exec(["echo", "ready"])
+            assert result.exit_code == 0
+            assert b"ready" in result.stdout
+            assert exec_route.called
+            # team scope must propagate
+            assert "teamId=team-abc" in str(create.calls.last.request.url)
+        finally:
+            await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_kill_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = VercelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/v1/sandboxes").mock(return_value=httpx.Response(201, json={"id": "sbx-1"}))
+        mock.delete("/v1/sandboxes/sbx-1").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        await session.shutdown()
+        await session.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_create_propagates_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = VercelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/v1/sandboxes").mock(
+            return_value=httpx.Response(
+                402,
+                json={"error": "payment required"},
+                headers={"X-Vercel-Id": "req-402"},
+            ),
+        )
+        with pytest.raises(SandboxApiError) as exc:
+            await backend.create(manifest)
+        assert exc.value.status_code == 402
+        assert exc.value.request_id == "req-402"
+
+
+@pytest.mark.asyncio
+async def test_exec_propagates_5xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = VercelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/v1/sandboxes").mock(return_value=httpx.Response(201, json={"id": "sbx-77"}))
+        mock.post("/v1/sandboxes/sbx-77/exec").mock(
+            return_value=httpx.Response(
+                504,
+                json={"error": "gateway"},
+                headers={"X-Vercel-Id": "req-504"},
+            ),
+        )
+        mock.delete("/v1/sandboxes/sbx-77").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(SandboxApiError) as exc:
+                await session.exec(["false"])
+            assert exc.value.status_code == 504
+            assert exc.value.request_id == "req-504"
+        finally:
+            await backend.destroy(session)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_unsupported(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_env(monkeypatch)
+    backend = VercelSandboxBackend()
+    manifest = WorkspaceManifest(root="/workspace")
+    with respx.mock(base_url=API_URL, assert_all_called=False) as mock:
+        mock.post("/v1/sandboxes").mock(return_value=httpx.Response(201, json={"id": "sbx-x"}))
+        mock.delete("/v1/sandboxes/sbx-x").mock(return_value=httpx.Response(204))
+        session = await backend.create(manifest)
+        try:
+            with pytest.raises(NotImplementedError):
+                await session.snapshot()
+        finally:
+            await backend.destroy(session)
+
+
+def test_registry_lists_vercel() -> None:
+    from bernstein.core.sandbox import list_backend_names
+
+    assert "vercel" in list_backend_names()


### PR DESCRIPTION
## Summary

Adds four first-party SandboxBackend implementations for cloud
providers Bernstein already advertises but did not previously ship:
**Blaxel**, **Daytona**, **Runloop**, **Vercel**. Each conforms to
the existing `SandboxBackend` protocol in
`bernstein.core.sandbox.backend`, registers via the standard
`bernstein.core.sandbox.registry` so swapping per environment is a
config change rather than a code change, and reads credentials from
environment variables only.

A shared `_http_helpers.py` module centralises:

- `require_env(...)` — typed `SandboxCredentialError` naming missing
  vars
- `build_async_client(...)` — `httpx.AsyncClient` with optional mTLS
  via `bernstein.core.protocols.cluster.cluster_tls`
- `raise_for_status(...)` — `SandboxApiError` carrying the provider
  request id (X-Request-Id, X-Vercel-Id, etc.)

## Per-provider summary

| Provider | File | Env vars | Capabilities | Unit tests |
| --- | --- | --- | --- | --- |
| Blaxel | `src/bernstein/core/sandbox/backends/blaxel.py` | `BLAXEL_API_KEY`, `BLAXEL_WORKSPACE`, `BLAXEL_API_URL?` | `FILE_RW`, `EXEC`, `NETWORK`, `PERSISTENT_VOLUMES` | 7 |
| Daytona | `src/bernstein/core/sandbox/backends/daytona.py` | `DAYTONA_API_KEY`, `DAYTONA_API_URL?`, `DAYTONA_TARGET?`, `DAYTONA_ORG_ID?` | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT` | 7 |
| Runloop | `src/bernstein/core/sandbox/backends/runloop.py` | `RUNLOOP_API_KEY`, `RUNLOOP_API_URL?`, `RUNLOOP_PROJECT_ID?` | `FILE_RW`, `EXEC`, `NETWORK`, `SNAPSHOT` | 8 |
| Vercel | `src/bernstein/core/sandbox/backends/vercel.py` | `VERCEL_TOKEN`, `VERCEL_TEAM_ID?`, `VERCEL_API_URL?` | `FILE_RW`, `EXEC`, `NETWORK` | 8 |

Integration tests live under `tests/integration/sandbox/` and are
gated on `CI_BLAXEL_TEST` / `CI_DAYTONA_TEST` / `CI_RUNLOOP_TEST` /
`CI_VERCEL_TEST` (each `=1` plus the provider creds). They skip
cleanly when the gate is not set, matching the
`CI_TUNNEL_TEST` pattern used by the cluster mTLS workflow.

## Intentionally deferred per provider

- **Blaxel** — public REST API has no snapshot primitive; backend
  declares `PERSISTENT_VOLUMES` instead and `SNAPSHOT` calls raise
  `NotImplementedError`. Re-evaluate once vendor changelog ships
  the endpoint.
- **Daytona** — synchronous REST exec returns buffered output (no
  streaming); stdin injection on the sync endpoint raises
  `NotImplementedError`. WebSocket exec is the path forward and is
  documented as a follow-up.
- **Runloop** — synchronous `execute_sync` only; stdin rejected. The
  WebSocket exec channel will need to be plumbed when
  `SandboxSession.exec` grows a streaming variant.
- **Vercel** — Vercel Sandbox API exposes neither snapshot nor stdin
  on the synchronous exec route. Backend documents the workaround
  (Vercel KV/Blob for state persistence) instead of pretending.

## Documentation

`docs/sandbox/blaxel.md`, `docs/sandbox/daytona.md`,
`docs/sandbox/runloop.md`, `docs/sandbox/vercel.md` — one page per
provider listing module path, env vars, capabilities, selection
example, and honest limitations.

## Optional dependency extras

None required. All four backends speak plain REST via `httpx` (already
a runtime dep) and are tested with `respx` (already a dev dep). No new
SDKs added to default install or as optional extras.

## Test plan

- [x] `uv run pytest tests/unit/test_sandbox_blaxel.py -x -q`
- [x] `uv run pytest tests/unit/test_sandbox_daytona.py -x -q`
- [x] `uv run pytest tests/unit/test_sandbox_runloop.py -x -q`
- [x] `uv run pytest tests/unit/test_sandbox_vercel.py -x -q`
- [x] `uv run pytest tests/unit/sandbox/ -x -q` (existing protocol +
  registry + worktree conformance — 34 passed, 1 skipped)
- [x] `uv run ruff check src/ tests/ scripts/` — All checks passed
- [x] `uv run ruff format <touched files>` — applied
- [x] `uv run lint-imports` — 3 contracts kept, 0 broken
- [ ] Live integration tests behind `CI_*_TEST=1` gates — to be wired
  into the CI matrix in a follow-up; not exercised in this PR