### PR TITLE
docs: add enterprise evaluation guide and checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![License](https://img.shields.io/github/license/sipyourdrink-ltd/bernstein)](LICENSE)
 [![MseeP.ai](https://img.shields.io/badge/MseeP.ai-verified-2496ed)](https://mseep.ai/app/chernistry-bernstein)
 
-[Website](https://bernstein.run) &middot; [Documentation](https://bernstein.readthedocs.io/) &middot; [Install](docs/getting-started/install.md) &middot; [First run](docs/getting-started/first-run.md) &middot; [Glossary](docs/reference/GLOSSARY.md) &middot; [Limitations](docs/reference/KNOWN_LIMITATIONS.md)
+[Website](https://bernstein.run) &middot; [Documentation](https://bernstein.readthedocs.io/) &middot; [Install](docs/getting-started/install.md) &middot; [First run](docs/getting-started/first-run.md) &middot; [Enterprise evaluation](docs/ENTERPRISE.md) &middot; [Glossary](docs/reference/GLOSSARY.md) &middot; [Limitations](docs/reference/KNOWN_LIMITATIONS.md)
 
 <sub>As featured in</sub><br>
 <a href="https://codetrendy.com/listing/bernstein" target="_blank" rel="noopener noreferrer"><img src="https://codetrendy.com/api/badge/bernstein?theme=brand" alt="Bernstein - Listed on CodeTrendy" height="104" /></a>

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,0 +1,274 @@
+# Enterprise evaluation guide
+
+Audience: senior engineers, security reviewers, and platform teams evaluating Bernstein for production use.
+
+This page is the short path through Bernstein's enterprise surface. It does not try to replace the deeper docs; it tells you what to verify, where the trust boundaries are, and what the real limitations are.
+
+## Executive summary
+
+Bernstein is a local-first orchestration layer for CLI coding agents. In the default deployment model:
+
+- orchestration state lives on disk under `.sdd/`
+- agents run as separate local processes, usually in isolated git worktrees
+- the API surface is local unless you explicitly expose it
+- audit events are written to an HMAC-chained append-only log
+- outbound network traffic depends on which adapters, model providers, and cloud features you enable
+
+There is no separate enterprise edition. Auth, RBAC, audit logging, compliance tooling, model policy, and identity controls ship in-tree.
+
+## 1. Security model
+
+Bernstein has two security planes:
+
+### Human plane
+
+Operators authenticate through local auth, OIDC, or SAML and are authorized through RBAC.
+
+Read next:
+- [Security & identity](operations/security-and-identity.md)
+- [Secrets & credentials](operations/secrets.md)
+
+What to verify:
+- who can log in
+- which routes each role can access
+- whether auth is mandatory in your deployment
+- where JWTs and session state are stored
+
+### Agent plane
+
+Each spawned agent can be treated as its own identity, with task-scoped permissions and audit history.
+
+What to verify:
+- whether agents can only mutate the tasks they were issued for
+- how credentials are scoped into child processes
+- whether your policy engine requires human approval for sensitive paths
+
+### Isolation model
+
+By default, Bernstein isolates agents by:
+
+- separate processes
+- separate git worktrees
+- per-agent task ownership
+- optional credential scoping
+
+Important limitation: **git worktrees are not a security sandbox**. Agents can still execute arbitrary code with the privileges of the runtime unless you add a stronger sandbox backend or OS/container isolation.
+
+For stronger isolation, evaluate:
+- [Sandbox backends](architecture/sandbox.md)
+- [Environment isolation](operations/env-isolation.md)
+- [Deployment guide](operations/deployment-guide.md)
+
+## 2. What leaves the machine
+
+The safe answer is: **it depends on what you enable**.
+
+### Default local orchestration
+
+By default, Bernstein does not require a Bernstein-hosted control plane. Local orchestration state, task metadata, logs, and audit data stay on the machine under `.sdd/`.
+
+### Typical outbound traffic
+
+Outbound network traffic usually comes from one of these sources:
+
+- the LLM provider used by your adapter (Anthropic, OpenAI, Google, etc.)
+- package/install/update workflows you chose to run
+- optional cloud features, webhooks, preview tunnels, cluster mode, or remote storage
+
+### Local-only / air-gapped path
+
+If you run only local models and local storage, Bernstein can operate without third-party model APIs. That is the deployment to validate for air-gapped or tightly regulated environments.
+
+Read next:
+- [Model policy](operations/MODEL_POLICY.md)
+- [Compliance](operations/compliance.md)
+- [Deployment guide](operations/deployment-guide.md)
+
+## 3. Compliance considerations
+
+Bernstein ships compliance tooling, but your deployment posture still depends on your model/provider choices and runtime environment.
+
+### SOC 2 / ISO 27001 / PCI-DSS / NIST 800-53
+
+Bernstein includes:
+- policy evaluation
+- evidence generation
+- audit logging
+- compliance-as-code surfaces
+
+Read next:
+- [Compliance](operations/compliance.md)
+- `bernstein compliance check`
+- `bernstein compliance assess`
+
+### HIPAA / PHI
+
+Bernstein has PHI detection and HIPAA-oriented controls, but HIPAA suitability still depends on the provider and contract boundary you choose.
+
+Verify:
+- which model provider sees PHI-bearing prompts, if any
+- whether you have a BAA where required
+- whether local-only or approved-provider mode is enforced
+
+### Data residency
+
+Bernstein's local state can remain local. Data residency risk usually comes from the model provider, remote artifact sink, or cloud deployment you enable.
+
+Use [Model policy](operations/MODEL_POLICY.md) and deployment-level network controls to constrain this.
+
+## 4. Network requirements
+
+### Default local CLI mode
+
+- inbound: none required
+- localhost: Bernstein may expose local services for orchestration and dashboard flows
+- outbound: only what your configured adapters/providers/features require
+
+### Self-hosted shared server
+
+- inbound: only the API/UI endpoints you intentionally expose
+- outbound: model providers, optional storage sinks, optional identity providers
+
+### Air-gapped / local-model mode
+
+- inbound: none beyond your internal network policy
+- outbound: none to external model providers if you use local models only
+
+### Cloud / distributed mode
+
+If you enable Cloudflare, cluster mode, preview tunnels, webhooks, or remote storage, re-do the network review. Those features are explicitly outside the minimal local-only trust boundary.
+
+## 5. Cost controls
+
+Bernstein has native cost-control primitives:
+
+- per-run budgets
+- token and policy limits
+- model routing policy
+- anomaly detection / burn-rate controls
+- cost reporting
+
+Read next:
+- [Cost optimization](operations/cost-optimization.md)
+- [Model policy](operations/MODEL_POLICY.md)
+- `bernstein cost`
+
+What to verify:
+- hard budget caps actually stop runs
+- cheap models are used for cheap work
+- expensive models are reserved for high-value steps
+- alerting and audit surfaces satisfy your approval workflow
+
+## 6. Audit trail and forensics
+
+Bernstein keeps a file-based audit trail designed for reconstruction and tamper evidence.
+
+Expect to inspect:
+- `.sdd/` runtime state
+- task lifecycle records
+- per-agent identity history
+- HMAC-chained audit logs
+
+Read next:
+- [Security & identity](operations/security-and-identity.md)
+- `security/AUDIT.md`
+- [Disaster recovery](operations/disaster-recovery.md)
+
+What to verify:
+- you can reconstruct who started a run
+- you can reconstruct which agent touched which task
+- audit retention matches policy
+- HMAC key handling is externalized appropriately for your environment
+
+## 7. Deployment patterns
+
+### Developer laptop
+
+Best when:
+- a single engineer owns the workflow
+- local provider/API key use is acceptable
+- you want the smallest operational footprint
+
+### CI / ephemeral runner
+
+Best when:
+- every run should be reproducible
+- credentials are short-lived and centrally managed
+- artifact retention and logs are already part of CI
+
+### Shared internal server
+
+Best when:
+- multiple operators need one controlled Bernstein instance
+- you want SSO, RBAC, centralized audit, and stronger policy enforcement
+
+### Air-gapped / local-model deployment
+
+Best when:
+- code cannot be sent to third-party providers
+- you can accept local-model quality/performance tradeoffs
+
+## 8. Honest limitations
+
+These are the bits a security team should hear plainly:
+
+- Bernstein orchestrates tools that can execute arbitrary code. If you need strong containment, you must provide it.
+- Git worktree isolation is operational isolation, not a security boundary.
+- "No external traffic" is only true for the deployment you actually configure. Cloud features, remote storage, webhooks, and hosted model providers change the answer.
+- Compliance tooling helps produce evidence; it does not make an unsafe deployment safe by itself.
+- Provider risk is real. Model policy reduces it, but cannot change a provider's underlying trust model.
+
+## 9. Evaluation checklist
+
+Use this as a practical sign-off sheet.
+
+### Identity and access
+
+- [ ] Verified which auth mode is enabled (OIDC, SAML, or local)
+- [ ] Confirmed auth is not disabled in production
+- [ ] Reviewed RBAC roles and route permissions
+- [ ] Tested agent identity scoping and revocation
+
+### Data flow
+
+- [ ] Mapped all outbound destinations for the chosen deployment
+- [ ] Confirmed which model/provider can receive source code
+- [ ] Confirmed whether any remote artifact sink or cloud feature is enabled
+- [ ] Validated data residency requirements against provider reality
+
+### Isolation and execution
+
+- [ ] Tested agent isolation at the process/worktree level
+- [ ] Decided whether stronger sandboxing is required
+- [ ] Verified secret scoping into child agents
+- [ ] Reviewed policy engine rules for sensitive paths/commands
+
+### Audit and recovery
+
+- [ ] Inspected `.sdd/` layout and retention plan
+- [ ] Reviewed HMAC audit-chain handling
+- [ ] Reconstructed a sample run from logs and task state
+- [ ] Tested stop/restart / crash-recovery behavior
+
+### Cost and governance
+
+- [ ] Confirmed budget caps work
+- [ ] Confirmed model routing policy matches approved providers
+- [ ] Reviewed anomaly/cost reporting surfaces
+- [ ] Validated approval workflow for high-risk tasks
+
+### Compliance
+
+- [ ] Ran `bernstein compliance check` for the required framework(s)
+- [ ] Generated an evidence package where applicable
+- [ ] Reviewed HIPAA / PHI posture if regulated data is in scope
+- [ ] Documented remaining gaps and compensating controls
+
+## Recommended evaluation flow
+
+1. Start with [Security & identity](operations/security-and-identity.md).
+2. Review [Compliance](operations/compliance.md) and [Model policy](operations/MODEL_POLICY.md).
+3. Decide whether default worktree isolation is sufficient.
+4. Run a small pilot on a non-sensitive repo.
+5. Validate audit reconstruction, cost limits, and restart behavior.
+6. Only then move to sensitive code or shared-server deployment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,7 @@ nav:
       - Cluster observability: observability/cluster.md
       - Cluster e2e harness: testing/cluster-e2e-harness.md
       - Fleet (multi-project): operations/fleet.md
+      - Enterprise evaluation: ENTERPRISE.md
       - Security & identity: operations/security-and-identity.md
       - Capability matrix: security/capability-matrix.md
       - Secrets & creds: operations/secrets.md


### PR DESCRIPTION
## What

Add a dedicated `docs/ENTERPRISE.md` guide for enterprise evaluations and link it from the README + MkDocs nav.

## Why

Closes #270.

The repo already has deep docs for security, compliance, model policy, and deployment, but there was no single evaluation page a security or platform team could use as the entry point.

## How

- added `docs/ENTERPRISE.md` as a practical evaluation guide covering trust boundaries, data flow, network review, compliance posture, cost controls, audit/recovery, deployment patterns, and a concrete sign-off checklist
- kept the document honest about the main limitation: worktree isolation is operational isolation, not a hard security sandbox
- linked the guide from the README hero links and the MkDocs Operations nav so it is discoverable in both GitHub and published docs
- validated the new local markdown links and ran `uv run pytest tests/unit/test_readme_api_coverage.py -x -q`

## Checklist

- [ ] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [ ] New code has type hints
- [x] Docs updated if needed
