### PR TITLE
feat(cost): add run savings summary

### DIFF
--- a/src/bernstein/cli/display/summary_card.py
+++ b/src/bernstein/cli/display/summary_card.py
@@ -29,12 +29,28 @@ class RunSummaryData:
     wall_clock_seconds: float
     total_cost_usd: float
     quality_score: float | None  # 0.0-1.0, None if no verification data
+    sequential_time_seconds: float | None = None
+    cost_per_task_usd: float = 0.0
+    routing_savings_usd: float = 0.0
     timestamp: float = field(default_factory=time.time)
 
     @property
     def estimated_time_saved_seconds(self) -> float:
-        """2x total wall-clock time as estimated manual dev time savings."""
-        return self.wall_clock_seconds * 2.0
+        """Return time saved versus sequential execution.
+
+        Falls back to the historical 2x wall-clock heuristic when no
+        sequential estimate is available.
+        """
+        if self.sequential_time_seconds is None:
+            return self.wall_clock_seconds * 2.0
+        return max(self.sequential_time_seconds - self.wall_clock_seconds, 0.0)
+
+    @property
+    def time_saved_pct(self) -> float:
+        """Return percentage of time saved versus sequential execution."""
+        if not self.sequential_time_seconds or self.sequential_time_seconds <= 0:
+            return 0.0
+        return self.estimated_time_saved_seconds / self.sequential_time_seconds
 
     def to_dict(self) -> dict[str, object]:
         """Serialise to a plain dict suitable for JSON output."""
@@ -104,8 +120,17 @@ def build_summary_card(data: RunSummaryData) -> Table:
 
     table.add_row("Total time", _fmt_duration(data.wall_clock_seconds))
 
+    if data.sequential_time_seconds is not None:
+        table.add_row("Sequential estimate", _fmt_duration(data.sequential_time_seconds))
+        pct = round(data.time_saved_pct * 100)
+        table.add_row("Time saved", f"[green]{_fmt_duration(data.estimated_time_saved_seconds)} ({pct}%)[/green]")
+
     if data.total_cost_usd > 0:
         table.add_row("Total cost", f"[green]${data.total_cost_usd:.4f}[/green]")
+        if data.tasks_completed > 0:
+            table.add_row("Cost per task", f"[dim]${data.cost_per_task_usd:.4f}[/dim]")
+        if data.routing_savings_usd > 0:
+            table.add_row("Model routing savings", f"[green]${data.routing_savings_usd:.4f}[/green]")
 
     table.add_row(
         "Est. time saved",

--- a/src/bernstein/core/cost/savings_calculator.py
+++ b/src/bernstein/core/cost/savings_calculator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from bernstein.core.cost.cost import compute_savings_vs_opus
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from bernstein.core.observability.metric_collector import TaskMetrics
+
+
+@dataclass(frozen=True)
+class SavingsReport:
+    """Derived end-of-run savings metrics for the summary card."""
+
+    sequential_time_seconds: float
+    parallel_time_seconds: float
+    time_saved_seconds: float
+    time_saved_pct: float
+    total_cost_usd: float
+    cost_per_task_usd: float
+    routing_savings_usd: float
+
+
+def calculate_savings(
+    task_metrics: Iterable[TaskMetrics],
+    *,
+    wall_clock_seconds: float,
+    total_cost_usd: float,
+    completed_tasks: int,
+) -> SavingsReport:
+    """Calculate time/cost savings for a finished run.
+
+    Sequential time is the sum of completed task durations.
+    Parallel time is the actual wall clock for the run.
+    Routing savings compares actual model spend with an all-Opus baseline.
+    """
+
+    completed = [m for m in task_metrics if m.end_time is not None]
+    sequential_time_seconds = sum(max(float(m.end_time or 0.0) - float(m.start_time), 0.0) for m in completed)
+    parallel_time_seconds = max(float(wall_clock_seconds), 0.0)
+    if sequential_time_seconds <= 0.0:
+        sequential_time_seconds = parallel_time_seconds
+    time_saved_seconds = max(sequential_time_seconds - parallel_time_seconds, 0.0)
+    time_saved_pct = (time_saved_seconds / sequential_time_seconds) if sequential_time_seconds > 0 else 0.0
+    cost_per_task_usd = (total_cost_usd / completed_tasks) if completed_tasks > 0 else 0.0
+    routing_savings_usd = compute_savings_vs_opus(
+        [
+            {
+                "cost_usd": m.cost_usd,
+                "tokens_prompt": m.tokens_prompt,
+                "tokens_completion": m.tokens_completion,
+                "model": m.model,
+            }
+            for m in completed
+        ]
+    )
+    return SavingsReport(
+        sequential_time_seconds=sequential_time_seconds,
+        parallel_time_seconds=parallel_time_seconds,
+        time_saved_seconds=time_saved_seconds,
+        time_saved_pct=time_saved_pct,
+        total_cost_usd=total_cost_usd,
+        cost_per_task_usd=cost_per_task_usd,
+        routing_savings_usd=routing_savings_usd,
+    )

--- a/src/bernstein/core/orchestration/orchestrator_summary.py
+++ b/src/bernstein/core/orchestration/orchestrator_summary.py
@@ -12,6 +12,7 @@ import os
 import time
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.cost.savings_calculator import calculate_savings
 from bernstein.core.metrics import get_collector
 from bernstein.core.retrospective import generate_retrospective
 
@@ -19,6 +20,17 @@ if TYPE_CHECKING:
     from bernstein.core.models import Task
 
 logger = logging.getLogger(__name__)
+
+
+def _format_duration(seconds: float) -> str:
+    total_seconds = max(int(seconds), 0)
+    hours, rem = divmod(total_seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
 
 
 def generate_run_summary(
@@ -44,6 +56,12 @@ def generate_run_summary(
     collector = get_collector(orch._workdir / ".sdd" / "metrics")
     total_cost = collector.get_total_cost()
     files_modified: int = sum(getattr(m, "files_modified", 0) for m in collector.task_metrics.values())
+    savings = calculate_savings(
+        collector.task_metrics.values(),
+        wall_clock_seconds=wall_clock_s,
+        total_cost_usd=total_cost,
+        completed_tasks=total_completed,
+    )
 
     task_lines: list[str] = []
     for task in sorted(done_tasks, key=lambda t: t.title):
@@ -51,14 +69,7 @@ def generate_run_summary(
     for task in sorted(failed_tasks, key=lambda t: t.title):
         task_lines.append(f"- [ ] {task.title} *(failed)*")
 
-    hours, rem = divmod(int(wall_clock_s), 3600)
-    minutes, seconds = divmod(rem, 60)
-    if hours:
-        duration_str = f"{hours}h {minutes}m {seconds}s"
-    elif minutes:
-        duration_str = f"{minutes}m {seconds}s"
-    else:
-        duration_str = f"{seconds}s"
+    duration_str = _format_duration(wall_clock_s)
 
     lines = [
         "# Run Summary",
@@ -67,7 +78,11 @@ def generate_run_summary(
         f"**Total failed:** {total_failed}",
         f"**Files modified:** {files_modified}",
         f"**Estimated cost:** ${total_cost:.4f}",
+        f"**Cost per task:** ${savings.cost_per_task_usd:.4f}",
         f"**Wall-clock duration:** {duration_str}",
+        f"**Sequential estimate:** {_format_duration(savings.sequential_time_seconds)}",
+        f"**Time saved:** {_format_duration(savings.time_saved_seconds)} ({savings.time_saved_pct:.0%})",
+        f"**Model routing savings:** ${savings.routing_savings_usd:.4f}",
         "",
         "## Tasks",
         "",
@@ -144,6 +159,13 @@ def emit_summary_card(
     if verified:
         quality_score = sum(1 for m in verified if m.janitor_passed) / len(verified)
 
+    savings = calculate_savings(
+        task_metrics.values(),
+        wall_clock_seconds=wall_clock_s,
+        total_cost_usd=total_cost,
+        completed_tasks=len(done_tasks),
+    )
+
     summary_data = RunSummaryData(
         run_id=orch._run_id,
         tasks_completed=len(done_tasks),
@@ -152,6 +174,9 @@ def emit_summary_card(
         wall_clock_seconds=wall_clock_s,
         total_cost_usd=total_cost,
         quality_score=quality_score,
+        sequential_time_seconds=savings.sequential_time_seconds,
+        cost_per_task_usd=savings.cost_per_task_usd,
+        routing_savings_usd=savings.routing_savings_usd,
     )
 
     sdd_dir = orch._workdir / ".sdd"

--- a/tests/unit/test_savings_calculator.py
+++ b/tests/unit/test_savings_calculator.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from bernstein.core.cost.savings_calculator import calculate_savings
+from bernstein.core.observability.metric_collector import TaskMetrics
+
+
+def _task(
+    task_id: str,
+    *,
+    start: float,
+    end: float,
+    model: str = "sonnet",
+    cost_usd: float = 1.0,
+    tokens_prompt: int = 1000,
+    tokens_completion: int = 1000,
+) -> TaskMetrics:
+    tm = TaskMetrics(
+        task_id=task_id,
+        role="backend",
+        model=model,
+        provider="anthropic",
+        start_time=start,
+    )
+    tm.end_time = end
+    tm.cost_usd = cost_usd
+    tm.tokens_prompt = tokens_prompt
+    tm.tokens_completion = tokens_completion
+    return tm
+
+
+def test_calculate_savings_uses_sum_of_task_durations() -> None:
+    report = calculate_savings(
+        [
+            _task(
+                "t1", start=0.0, end=60.0, model="haiku", cost_usd=0.02, tokens_prompt=10000, tokens_completion=10000
+            ),
+            _task(
+                "t2", start=10.0, end=100.0, model="sonnet", cost_usd=0.08, tokens_prompt=10000, tokens_completion=10000
+            ),
+        ],
+        wall_clock_seconds=100.0,
+        total_cost_usd=0.1,
+        completed_tasks=2,
+    )
+
+    assert report.sequential_time_seconds == 150.0
+    assert report.parallel_time_seconds == 100.0
+    assert report.time_saved_seconds == 50.0
+    assert report.time_saved_pct == 50.0 / 150.0
+    assert report.cost_per_task_usd == 0.05
+    assert report.routing_savings_usd > 0.0
+
+
+def test_calculate_savings_handles_empty_metrics() -> None:
+    report = calculate_savings(
+        [],
+        wall_clock_seconds=42.0,
+        total_cost_usd=0.0,
+        completed_tasks=0,
+    )
+
+    assert report.sequential_time_seconds == 42.0
+    assert report.time_saved_seconds == 0.0
+    assert report.time_saved_pct == 0.0
+    assert report.cost_per_task_usd == 0.0
+    assert report.routing_savings_usd == 0.0

--- a/tests/unit/test_summary_card.py
+++ b/tests/unit/test_summary_card.py
@@ -43,7 +43,7 @@ def test_fmt_duration_hours() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_estimated_time_saved_is_double() -> None:
+def test_estimated_time_saved_is_double_without_sequential_estimate() -> None:
     data = RunSummaryData(
         run_id="x",
         tasks_completed=3,
@@ -54,6 +54,21 @@ def test_estimated_time_saved_is_double() -> None:
         quality_score=None,
     )
     assert data.estimated_time_saved_seconds == pytest.approx(600.0)
+
+
+def test_estimated_time_saved_uses_sequential_estimate() -> None:
+    data = RunSummaryData(
+        run_id="x",
+        tasks_completed=3,
+        tasks_total=3,
+        tasks_failed=0,
+        wall_clock_seconds=300.0,
+        total_cost_usd=0.0,
+        quality_score=None,
+        sequential_time_seconds=900.0,
+    )
+    assert data.estimated_time_saved_seconds == pytest.approx(600.0)
+    assert data.time_saved_pct == pytest.approx(600.0 / 900.0)
 
 
 def test_to_dict_includes_estimated_time_saved() -> None:
@@ -113,6 +128,29 @@ def test_card_no_failed_row_when_zero_failures() -> None:
     table = build_summary_card(data)
     rendered = _render(table)
     assert "Tasks failed" not in rendered
+
+
+def test_card_shows_savings_rows_when_available() -> None:
+    data = RunSummaryData(
+        run_id="r3a",
+        tasks_completed=5,
+        tasks_total=5,
+        tasks_failed=0,
+        wall_clock_seconds=30.0,
+        total_cost_usd=0.5,
+        quality_score=0.75,
+        sequential_time_seconds=90.0,
+        cost_per_task_usd=0.1,
+        routing_savings_usd=1.25,
+    )
+    table = build_summary_card(data)
+    rendered = _render(table)
+    assert "Sequential estimate" in rendered
+    assert "1m 30s" in rendered
+    assert "Time saved" in rendered
+    assert "1m 0s (67%)" in rendered
+    assert "Cost per task" in rendered
+    assert "Model routing savings" in rendered
 
 
 def test_card_quality_score_present_when_provided() -> None:


### PR DESCRIPTION
## What
- add a dedicated savings calculator for end-of-run summaries
- show sequential estimate, time saved, cost per task, and model routing savings in the summary card
- persist the same savings metrics in `.sdd/runtime/summary.md` and cover them with unit tests

Closes #750.

## Why
- the run summary already existed, but its "time saved" number was just a fixed heuristic
- issue #750 asked for a real parallel-vs-sequential comparison plus cost savings users can screenshot and share

## How
- compute sequential time from completed task durations and compare it against actual wall clock time
- reuse the existing all-Opus baseline logic to estimate routing savings
- thread the derived savings data into `RunSummaryData` so the card renderer and JSON output stay in sync

## Checklist
- [x] `uv run ruff check src/bernstein/core/cost/savings_calculator.py src/bernstein/core/orchestration/orchestrator_summary.py src/bernstein/cli/display/summary_card.py tests/unit/test_savings_calculator.py tests/unit/test_summary_card.py` passes
- [ ] `uv run pyright src/` passes
- [x] `uv run pytest tests/unit/test_savings_calculator.py tests/unit/test_summary_card.py -x -q` passes
- [x] New code has type hints
- [ ] Docs updated if needed
