### PR TITLE
docs(readme): add use-case workflows page

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,19 @@ The table above compares Bernstein against LLM-orchestration frameworks (they or
 
 Bernstein's wedge in this category: **Python-native, MCP-server-first, widest adapter coverage, true multi-agent parallelism, deterministic scheduler with no LLM in the coordination loop**. If you want AWS-aligned tmux-session isolation with a hierarchical LLM supervisor, AWS Labs' `cao` is a closer fit; if your stack is TypeScript and you want a product with a dashboard, Composio's `@aoagents/ao` is a better fit; if you want a polished desktop ADE, emdash is; if you only use Claude Code and want a single Go binary that walks a plan top-to-bottom, ralphex is. If you want a primitive that imports into Python, exposes itself over MCP to any client, runs many agents in parallel, and covers the full agent breadth (including Qwen, Goose, Ollama, OpenAI Agents SDK, Cloudflare Agents, and more) — Bernstein.
 
+## What people use it for
+
+These are real workflow patterns from Bernstein's own docs, examples, and project surface — not invented customer quotes.
+
+- **Parallel test generation** — fan out across untested modules with `bernstein -g "Generate unit tests for untested modules in src/" --max-agents 5`.
+- **CI failure repair** — watch open PRs and dispatch scoped fixers with `bernstein autofix start --repo your-org/your-repo --foreground`.
+- **PR review follow-up** — turn review comments into tracked fix tasks with `bernstein review-responder start --repo your-org/your-repo --foreground`.
+- **Codebase modernization** — run wide refactors like `bernstein -g "Migrate callback-based modules in src/ to async/await and update tests" --max-agents 8`.
+- **Ticket-to-run workflows** — import GitHub, Jira, or Linear work directly with `bernstein from-ticket https://github.com/your-org/your-repo/issues/123 --run`.
+- **API-change safety checks** — catch downstream breakage before merge with `bernstein dep-impact --base main`.
+
+See [Who Uses Bernstein](docs/use-cases.md) for the longer version with command examples and notes on when each workflow fits.
+
 [^autogen]: AutoGen is in maintenance mode; successor is Microsoft Agent Framework 1.0.
 
 ## Monitoring

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,69 @@
+# Who Uses Bernstein
+
+These are honest workflow patterns pulled from Bernstein's own docs and CLI surface. No invented companies, no fake testimonials — just the jobs teams reach for when they want orchestration, isolation, and verification in one tool.
+
+## Common workflows
+
+### Parallel test generation with AI agents
+
+When a codebase has dozens of untested modules, the bottleneck is usually coordination, not test-writing itself. Bernstein lets you fan out the work across isolated worktrees so multiple agents can add coverage at the same time without stepping on each other.
+
+```bash
+bernstein -g "Generate unit tests for untested modules in src/" --max-agents 5
+```
+
+Good fit when you want broad coverage quickly, but still need janitor verification before anything lands.
+
+### CI failure repair that opens a follow-up fix
+
+Some teams use Bernstein as the repair loop after review has already happened. The autofix daemon watches open PRs, classifies failing checks, and dispatches a scoped fix run when CI turns red.
+
+```bash
+bernstein autofix start --repo your-org/your-repo --foreground
+```
+
+Good fit when the painful part is not finding failures, but paying the context-switch tax every time lint, typing, or a focused test failure breaks a PR. See [operations/autofix.md](operations/autofix.md).
+
+### PR review follow-up from inline comments
+
+Review comments are often small, mechanical, and easy to lose between pushes. Bernstein's review-responder daemon turns those comments into tracked work so the author can keep moving while the system handles the obvious follow-up.
+
+```bash
+bernstein review-responder start --repo your-org/your-repo --foreground
+```
+
+Good fit when your team already does human review but wants the "please rename this / add a guard / update the test" loop to close faster. See [operations/review-responder.md](operations/review-responder.md).
+
+### Large-scale codebase modernization
+
+The classic migration problem is repetitive but still risky: move callbacks to async/await, add types, rename an API surface, or update a framework pattern everywhere. Bernstein helps by splitting the migration into parallel worktrees, then running verification gates before merge.
+
+```bash
+bernstein -g "Migrate callback-based modules in src/ to async/await and update tests" --max-agents 8
+```
+
+Good fit when the change is spread across many files and the main risk is merge conflict churn or uneven follow-through.
+
+### Ticket-to-run execution from GitHub, Jira, or Linear
+
+A lot of teams do not want another planning system; they want their existing tickets to become executable work. Bernstein can import a ticket URL, infer scope, and immediately turn it into a run.
+
+```bash
+bernstein from-ticket https://github.com/your-org/your-repo/issues/123 --run
+```
+
+Good fit when you want issue trackers to stay as the source of truth instead of copying requirements into a separate agent tool.
+
+### API-change safety checks before merge
+
+Breaking a function signature is easy; finding every downstream caller is the annoying part. `dep-impact` compares your branch against a base ref and reports affected call sites before the change merges.
+
+```bash
+bernstein dep-impact --base main
+```
+
+Good fit when you are doing refactors in shared libraries or internal platforms and want a fast, concrete answer to "what else does this break?"
+
+## Submit your workflow
+
+If you use Bernstein for something real, open a PR and add it here. The bar is simple: describe the workflow honestly, include a command that actually exists, and say what worked or where it was rough.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Tutorial: getting-started/quickstart-tutorial.md
       - Install on Linux: getting-started/install-linux.md
       - Configuration: operations/CONFIG.md
+      - Use cases: use-cases.md
   - Concepts:
       - Architecture: architecture/ARCHITECTURE.md
       - Why deterministic: architecture/WHY_DETERMINISTIC.md


### PR DESCRIPTION
## What

Add a real-workflows "What people use it for" section to the README and a new `docs/use-cases.md` page.

## Why

Closes #762.

The repo already has a broad feature surface, but the README did not have an honest "who uses this / what is it good for" section. This adds use-case framing without inventing companies or testimonials.

## How

- add `docs/use-cases.md` with six workflow patterns and copy-paste commands that exist today
- add a short README section after the comparison tables linking to the new page
- register the page in `mkdocs.yml` so it appears in the docs nav
- keep the framing explicit: these are patterns from Bernstein's docs/CLI surface, not customer quotes

## Checklist

- [ ] `uv run ruff check src/` passes
- [ ] `uv run pyright src/` passes
- [ ] `uv run python scripts/run_tests.py -x` passes
- [ ] New code has type hints
- [x] Docs updated if needed

## Verification

- [x] `uv run python -m bernstein --help`
- [x] `uv run python -m bernstein autofix start --help`
- [x] `uv run python -m bernstein review-responder start --help`
- [x] `uv run python -m bernstein from-ticket --help`
- [x] `uv run python -m bernstein dep-impact --help`
- [x] README/docs/nav link presence check via `uv run python`
- [ ] `uvx --with mkdocs-material --with mkdocs-minify-plugin mkdocs build --strict` (currently fails on pre-existing docs warnings elsewhere in the repo, plus missing `mkdocs-material[imaging]` extras for the social plugin)
