### PR TITLE
feat(adapters): add AWS Q Developer CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ---
 
-**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 38 more), runs the tests, and merges the code that actually passes. You come back to working code.
+**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 39 more), runs the tests, and merges the code that actually passes. You come back to working code.
 
 Forward-deployed engineering, on a swarm. Drop Bernstein into a client repo and you get a multi-agent crew with file-based state, per-agent credential scoping, and an HMAC-signed audit trail — running on whichever CLI agents the client already trusts.
 
@@ -83,7 +83,7 @@ Other install options: `pipx install bernstein`, `pip install bernstein`, `uv to
 
 Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap local models for boilerplate, heavier cloud models for architecture.
 
-41 CLI agent adapters: 38 third-party wrappers, 2 leaf-node delegators (Composio, Ralphex), plus a generic wrapper for anything with `--prompt`.
+42 CLI agent adapters: 39 third-party wrappers, 2 leaf-node delegators (Composio, Ralphex), plus a generic wrapper for anything with `--prompt`.
 
 | Agent | Models | Install |
 |-------|--------|---------|
@@ -103,6 +103,7 @@ Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap l
 | [IaC](https://www.terraform.io/) (Terraform/Pulumi) | Any provider the base agent uses | Built-in |
 | [Kilo](https://kilo.dev) | Kilo-hosted | See [Kilo docs](https://kilo.dev) |
 | [Kiro](https://kiro.dev) | Kiro-hosted | See [Kiro docs](https://kiro.dev) |
+| [AWS Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html) | Amazon Q-managed (Claude-backed) | `brew install --cask amazon-q` then `q login` |
 | [Ollama](https://ollama.ai) + Aider | Local models (offline) | `brew install ollama` |
 | [OpenCode](https://opencode.ai) | Any provider OpenCode supports | See [OpenCode docs](https://opencode.ai) |
 | [Qwen](https://github.com/QwenLM/qwen-code) | Qwen Code models | `npm install -g @qwen-code/qwen-code` |
@@ -254,7 +255,7 @@ performs vector search.
 | Feature | Bernstein | CrewAI | AutoGen [^autogen] | LangGraph |
 |---------|-----------|--------|---------|-----------|
 | Orchestrator | Deterministic code | LLM-driven (+ code Flows) | LLM-driven | Graph + LLM |
-| Works with | Any CLI agent (41 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (42 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
 | Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Verification | Janitor + quality gates | Guardrails + Pydantic output | Termination conditions | Conditional edges |
@@ -279,7 +280,7 @@ The table above compares Bernstein against LLM-orchestration frameworks (they or
 | Shape | Python CLI + library + MCP server | Python CLI + tmux sessions + web UI | TypeScript CLI + local dashboard | Electron desktop app | Go CLI |
 | Primary language | Python | Python | TypeScript | TypeScript | Go |
 | Install | `pipx install bernstein` | `uv tool install cli-agent-orchestrator` | `npm install -g @aoagents/ao` | `.dmg` / `.msi` / `.AppImage` | `go install` / single binary |
-| Agent adapters | 41 | 5 (Kiro, Claude Code, Codex, Gemini, Kimi) | 3 (Claude Code, Codex, Aider) | 24 | 1 (Claude Code only) |
+| Agent adapters | 42 | 5 (Kiro, Claude Code, Codex, Gemini, Kimi) | 3 (Claude Code, Codex, Aider) | 24 | 1 (Claude Code only) |
 | Parallel multi-agent execution | Yes | Yes (tmux session per agent) | Yes | Yes | No (single sequential session) |
 | Git worktree per agent | Yes | No (planned, [#100](https://github.com/awslabs/cli-agent-orchestrator/issues/100)) | Yes | Yes | Optional `--worktree` flag |
 | MCP server mode (exposes self as MCP) | Yes (stdio + HTTP/SSE) | Yes (inter-agent comms) | No | No | No |

--- a/docs/compare/bernstein-vs-dorothy.md
+++ b/docs/compare/bernstein-vs-dorothy.md
@@ -21,7 +21,7 @@ The core difference: Dorothy gives you a visual control plane. Bernstein gives y
 | Feature | Bernstein | Dorothy |
 |---|---|---|
 | **Interface** | CLI + TUI + JSON status endpoint | Desktop app (Kanban, dashboard) |
-| **Agent coverage** | 40 CLI adapters | Claude Code, Codex, Gemini, local |
+| **Agent coverage** | 42 CLI adapters | Claude Code, Codex, Gemini, local |
 | **Scheduler** | Deterministic Python, no LLM | "Super Agent" (LLM) via MCP |
 | **Verification** | Janitor: tests, linter, file checks | None built-in |
 | **Parallel execution** | Yes — independent tasks run concurrently | Yes — up to ~10 agents |

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: Bernstein — Open-Source Multi-Agent Orchestration Platform
 description: >-
   Bernstein is the open-source multi-agent orchestrator for AI coding agents.
   Run Claude Code, Codex, Gemini CLI, and the OpenAI Agents SDK in parallel.
-  Deterministic scheduling, 41 adapters, pluggable sandbox backends,
+  Deterministic scheduling, 42 adapters, pluggable sandbox backends,
   cloud artifact storage, progressive skills, zero vendor lock-in.
 tags:
   - orchestration
@@ -74,7 +74,7 @@ bernstein -g "Add JWT auth with refresh tokens, tests, and API docs"
 
     ---
 
-    41 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, Droid, Crush, and more.
+    42 CLI adapters: Claude Code, Codex, OpenAI Agents SDK v2, Gemini, Cursor, Aider, Cloudflare Agents, GitHub Copilot, Devin Terminal, CLM gateway, AWS Q Developer, and more.
     Mix cheap local models with cloud models in the same run.
 
 - :material-source-branch:{ .lg .middle } **Git worktree isolation**
@@ -99,7 +99,7 @@ Bernstein is built for the forward-deployed engineering pattern:
 parachute onto a client repo and stand up an AI engineering crew in
 minutes. State lives in `.sdd/` — no server to provision. Per-agent
 credential scoping keeps your keys out of the client's environment.
-The 41-adapter spread means the swarm runs on whichever CLI agent
+The 42-adapter spread means the swarm runs on whichever CLI agent
 the client already trusts (Claude Code, Codex, Gemini CLI, Aider,
 and more). Every step is an HMAC-signed audit record, replayable
 for client compliance review.

--- a/src/bernstein/adapters/q_dev.py
+++ b/src/bernstein/adapters/q_dev.py
@@ -1,0 +1,264 @@
+"""AWS Q Developer CLI adapter (binary: ``q``).
+
+Amazon Q Developer ships a single-binary CLI installed via Homebrew
+(``brew install --cask amazon-q``), the AppImage on Linux, or the AWS-hosted
+``.deb``/``.rpm`` packages.  Headless invocation matches the documented
+non-interactive shape::
+
+    q chat --no-interactive --trust-all-tools "<prompt>"
+
+The agent reads its bearer token from the on-disk login cache that
+``q login`` writes — there is no ``Q_API_KEY`` style env var.  The cache
+location is platform-dependent (XDG-anchored on Linux/macOS,
+``%LOCALAPPDATA%`` on Windows) and Bernstein refuses to spawn when no
+plausible cache directory is present, surfacing a clear "run ``q login``"
+message rather than letting the CLI dump an authentication stack-trace
+into the agent log.
+
+Authentication backends supported by the upstream binary:
+
+* AWS Builder ID (free, personal account).
+* IAM Identity Center (enterprise SSO).
+
+Important risk: when the spawn env carries an IAM Identity Center session,
+``q``'s tool calls execute with **the user's IAM Identity Center role**.
+Routing infra-touching tasks (Terraform plans, AWS resource mutations)
+through this adapter therefore inherits that role's permissions —
+operators should scope the role narrowly or route those tasks via a
+dedicated ``IaCAdapter`` instead.
+
+Project status (2026-05-06): the upstream
+`aws/amazon-q-developer-cli <https://github.com/aws/amazon-q-developer-cli>`_
+repo declares the project deprecated and rebranded as **Kiro CLI**
+(``kiro-cli``, see :mod:`bernstein.adapters.kiro`).  The legacy ``q``
+binary continues to ship for existing installs and the documented
+``--no-interactive --trust-all-tools`` surface is unchanged; this adapter
+targets that legacy surface on purpose so users on the original Builder ID
+flow keep working without forcing a Kiro migration.
+
+Last verified against:
+* https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html
+* https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line-chat.html
+* https://github.com/aws/amazon-q-developer-cli (issues #1951, #1995)
+
+verified on 2026-05-06.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import (
+    DEFAULT_TIMEOUT_SECONDS,
+    CLIAdapter,
+    SpawnError,
+    SpawnResult,
+    build_worker_cmd,
+)
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from bernstein.core.models import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+
+# Documented non-interactive flags. ``--no-interactive`` disables the TTY
+# prompt and ``--trust-all-tools`` short-circuits per-tool confirmations,
+# both required for unattended runs (issue #1951 in the upstream repo
+# describes how missing either flag deadlocks the CLI on stdin).
+_NON_INTERACTIVE_FLAG = "--no-interactive"
+_TRUST_ALL_TOOLS_FLAG = "--trust-all-tools"
+
+
+class QDevAdapter(CLIAdapter):
+    """Spawn and monitor AWS Q Developer (``q``) CLI sessions.
+
+    The adapter intentionally surfaces a hard error when no Q login cache
+    is present: ``q chat`` would otherwise emit a multi-line OAuth flow
+    into the log file and block waiting for a browser handshake that no
+    headless agent can complete.  Operators should run ``q login`` once
+    on the host before pointing Bernstein at this adapter.
+
+    Permissions are bound to the underlying AWS Builder ID / IAM Identity
+    Center principal — see the module docstring for the role-scoping
+    caveat.
+    """
+
+    # AWS Q dials home through the regional ``*.amazonaws.com`` plane and
+    # the developer-tooling control plane on ``*.aws.dev``.  The wildcards
+    # are honoured by ``policy.check`` when the active network policy
+    # allows host-pattern entries.
+    external_endpoints = (
+        ("*.amazonaws.com", 443),
+        ("*.aws.dev", 443),
+    )
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a one-shot ``q chat`` session.
+
+        Args:
+            prompt: Task prompt — passed as the trailing positional after
+                the documented ``--no-interactive --trust-all-tools``
+                flags.
+            workdir: Working directory; ``q`` treats it as the project
+                root.
+            model_config: Bernstein model selection.  ``q`` exposes model
+                routing via Amazon Q-side configuration rather than a
+                per-invocation flag, so the requested model is logged for
+                observability but not forwarded.
+            session_id: Unique session identifier used for log naming and
+                the bernstein-worker process title.
+            mcp_config: Optional MCP server definitions (unused — Q
+                manages MCP via its own ``q mcp`` subcommand).
+            timeout_seconds: Process wall-clock timeout.
+            task_scope: Task scope hint (unused).
+            budget_multiplier: Retry budget multiplier (unused).
+            system_addendum: Protocol-critical instructions; ``q`` accepts
+                a single positional prompt so the addendum is appended
+                inline.
+
+        Returns:
+            SpawnResult describing the spawned process.
+
+        Raises:
+            SpawnError: No ``q login`` cache was found on the host.
+            RuntimeError: The ``q`` binary is missing from PATH or the OS
+                denies execution.
+        """
+        self.enforce_network_policy()
+        log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Fail fast when no Q login cache is present — q would otherwise
+        # block on an OAuth browser flow that no unattended agent can
+        # complete.  This must happen *before* subprocess.Popen so the
+        # error never gets buried inside the agent log.
+        if not _has_q_login_cache():
+            raise SpawnError(
+                "AWS Q Developer login cache not found. "
+                "Run `q login` once on this host before spawning the q_dev adapter "
+                "(token persists in ~/.local/share/amazon-q/ on Linux/macOS or "
+                "%LOCALAPPDATA%\\amazon-q\\ on Windows).",
+            )
+
+        # ``q`` accepts a single positional prompt; graft the addendum on
+        # so completion / heartbeat instructions still reach the agent
+        # regardless of system_addendum being empty.
+        full_prompt = f"{prompt}\n\n{system_addendum}".rstrip() if system_addendum else prompt
+
+        if model_config.model and model_config.model.lower() != "auto":
+            logger.info(
+                "QDevAdapter: requested model %s for session %s; AWS Q exposes model "
+                "selection via account-side configuration, not a per-run flag",
+                model_config.model,
+                session_id,
+            )
+        if mcp_config:
+            logger.debug("QDevAdapter ignoring runtime MCP config injection for session %s", session_id)
+
+        cmd: list[str] = [
+            "q",
+            "chat",
+            _NON_INTERACTIVE_FLAG,
+            _TRUST_ALL_TOOLS_FLAG,
+            full_prompt,
+        ]
+
+        # Wrap with bernstein-worker for process visibility (bernstein ps).
+        pid_dir = workdir / ".sdd" / "runtime" / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        # Q reads its bearer token from the on-disk login cache, NOT from
+        # AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY style env vars.  We
+        # forward AWS_PROFILE / AWS_REGION so users with multiple
+        # Identity Center sessions can pin one without leaking root
+        # credentials, but never the long-lived access keys.
+        env = build_filtered_env(["AWS_PROFILE", "AWS_REGION", "AWS_DEFAULT_REGION"])
+
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "q not found in PATH. Install AWS Q Developer CLI: "
+                    "`brew install --cask amazon-q` (macOS) or see "
+                    "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing q: {exc}") from exc
+
+        self._probe_fast_exit(proc, log_path, provider_name="q_dev")
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the registry slug used by the orchestrator and configs."""
+        return "q_dev"
+
+
+def _has_q_login_cache() -> bool:
+    """Return True when a plausible ``q login`` cache directory exists.
+
+    We don't validate token freshness here — that's q's job at runtime.
+    The check is purely "did anyone log in on this host at least once?"
+    so we can fail with a clean error message instead of letting q
+    deadlock on the OAuth handshake.
+
+    Linux/macOS look at ``$XDG_DATA_HOME/amazon-q`` (falling back to
+    ``~/.local/share/amazon-q``); Windows looks at
+    ``%LOCALAPPDATA%\\amazon-q``.  Either layout counts as logged-in.
+    """
+    candidates: list[Path] = []
+    home = Path.home()
+
+    if platform.system() == "Windows":
+        local_appdata = os.environ.get("LOCALAPPDATA")
+        if local_appdata:
+            candidates.append(Path(local_appdata) / "amazon-q")
+        candidates.append(home / "AppData" / "Local" / "amazon-q")
+    else:
+        xdg_data = os.environ.get("XDG_DATA_HOME")
+        if xdg_data:
+            candidates.append(Path(xdg_data) / "amazon-q")
+        candidates.append(home / ".local" / "share" / "amazon-q")
+        # macOS users sometimes end up with the legacy ~/.amazon-q layout.
+        candidates.append(home / ".amazon-q")
+
+    return any(p.exists() for p in candidates)

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -46,6 +46,7 @@ from bernstein.adapters.opencode import OpenCodeAdapter
 from bernstein.adapters.openhands import OpenHandsAdapter
 from bernstein.adapters.pi import PiAdapter
 from bernstein.adapters.plandex import PlandexAdapter
+from bernstein.adapters.q_dev import QDevAdapter
 from bernstein.adapters.qwen import QwenAdapter
 from bernstein.adapters.ralphex import RalphexAdapter
 from bernstein.adapters.rovo import RovoAdapter
@@ -91,6 +92,7 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "openhands": OpenHandsAdapter,
     "pi": PiAdapter,
     "plandex": PlandexAdapter,
+    "q_dev": QDevAdapter,
     "qwen": QwenAdapter,
     "ralphex": RalphexAdapter,
     "rovo": RovoAdapter,

--- a/tests/unit/test_adapter_contract.py
+++ b/tests/unit/test_adapter_contract.py
@@ -67,8 +67,13 @@ def _discover_registered_names() -> list[str]:
       are set; the contract test mocks Popen but can't satisfy the runtime
       config requirement.  Covered by ``test_adapter_clm.py`` and the
       integration suite under ``tests/integration/adapters/``.
+    - ``q_dev`` — spawn() raises SpawnError unless a ``q login`` cache
+      exists on disk; CI runners don't have one and the contract test
+      mocks Popen but can't fake an authenticated AWS Builder ID
+      session.  Covered by ``test_adapter_q_dev.py`` which monkeypatches
+      ``Path.home`` to stand up a fake cache directory.
     """
-    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic", "iac", "clm"})
+    return sorted(n for n in _ADAPTERS if n not in {"mock", "generic", "iac", "clm", "q_dev"})
 
 
 def _make_factory(name: str) -> Any:

--- a/tests/unit/test_adapter_q_dev.py
+++ b/tests/unit/test_adapter_q_dev.py
@@ -1,0 +1,418 @@
+"""Unit tests for ``QDevAdapter`` (AWS Q Developer CLI).
+
+Mirrors the contract used by ``test_adapter_kiro.py`` /
+``test_adapter_devin_terminal.py``: assert command construction, env
+isolation, login-cache pre-flight, and the inherited ``is_alive`` /
+``kill`` plumbing without ever spawning a real subprocess.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import CLIAdapter, SpawnError
+from bernstein.adapters.q_dev import QDevAdapter
+from bernstein.adapters.registry import get_adapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+@pytest.fixture
+def fake_q_login(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Stand up a fake ``q login`` cache so spawn() doesn't reject the run.
+
+    Points ``Path.home`` at a temporary directory and creates the
+    ``~/.local/share/amazon-q`` directory inside it; clears the XDG and
+    Windows env hints so the cache lookup deterministically lands on
+    that path.
+    """
+    home = tmp_path / "home"
+    (home / ".local" / "share" / "amazon-q").mkdir(parents=True)
+    monkeypatch.setattr("bernstein.adapters.q_dev.Path.home", lambda: home)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.delenv("LOCALAPPDATA", raising=False)
+    return home
+
+
+# ---------------------------------------------------------------------------
+# QDevAdapter — registry / contract surface
+# ---------------------------------------------------------------------------
+
+
+class TestQDevRegistry:
+    """Adapter is reachable through the public registry as ``q_dev``."""
+
+    def test_registered_under_q_dev_slug(self) -> None:
+        adapter = get_adapter("q_dev")
+        assert isinstance(adapter, QDevAdapter)
+
+    def test_subclasses_cli_adapter(self) -> None:
+        assert issubclass(QDevAdapter, CLIAdapter)
+        assert isinstance(QDevAdapter(), CLIAdapter)
+
+    def test_name_returns_q_dev(self) -> None:
+        assert QDevAdapter().name() == "q_dev"
+
+
+# ---------------------------------------------------------------------------
+# QDevAdapter.spawn() — command construction
+# ---------------------------------------------------------------------------
+
+
+class TestQDevSpawnCommand:
+    """spawn() builds the documented ``q chat`` non-interactive invocation."""
+
+    def test_wrapped_with_worker(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(900)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-s1",
+            )
+        cmd = popen.call_args.args[0]
+        assert cmd[0] == sys.executable
+        assert cmd[1:3] == ["-m", "bernstein.core.orchestration.worker"]
+        inner = inner_cmd(cmd)
+        assert inner[0] == "q"
+        assert inner[1] == "chat"
+
+    def test_canonical_command_line(self, tmp_path: Path, fake_q_login: Path) -> None:
+        """Lock the documented ``q chat --no-interactive --trust-all-tools <prompt>`` shape."""
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(901)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-s2",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert inner == ["q", "chat", "--no-interactive", "--trust-all-tools", "fix the bug"]
+
+    def test_prompt_appended_last(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(902)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="my-unique-prompt",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-s3",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert inner[-1] == "my-unique-prompt"
+
+    def test_system_addendum_grafted_onto_prompt(self, tmp_path: Path, fake_q_login: Path) -> None:
+        """``q`` accepts a single positional — addendum must reach the agent."""
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(903)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="primary task",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-s4",
+                system_addendum="HEARTBEAT every 30s",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "primary task" in inner[-1]
+        assert "HEARTBEAT every 30s" in inner[-1]
+
+    def test_creates_log_dir(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(904)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-s5",
+            )
+        assert (tmp_path / ".sdd" / "runtime").is_dir()
+
+    def test_log_path_uses_session_id(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(905)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock):
+            result = adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="my-q-session",
+            )
+        assert result.log_path.name == "my-q-session.log"
+
+    def test_start_new_session_enabled(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(906)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-s6",
+            )
+        kwargs = popen.call_args.kwargs
+        assert kwargs.get("start_new_session") is True
+
+
+# ---------------------------------------------------------------------------
+# QDevAdapter.spawn() — login cache pre-flight
+# ---------------------------------------------------------------------------
+
+
+class TestQDevLoginCachePreflight:
+    """spawn() refuses to run when no ``q login`` cache exists.
+
+    Letting the spawn through would cause q to deadlock on its OAuth
+    browser handshake, with the failure buried inside the agent log.
+    """
+
+    def test_missing_cache_raises_spawn_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        adapter = QDevAdapter()
+        empty_home = tmp_path / "fresh"
+        empty_home.mkdir()
+        monkeypatch.setattr("bernstein.adapters.q_dev.Path.home", lambda: empty_home)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+
+        with pytest.raises(SpawnError, match="q login"):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-no-auth",
+            )
+
+    def test_missing_cache_does_not_invoke_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The error must surface BEFORE Popen is touched."""
+        adapter = QDevAdapter()
+        empty_home = tmp_path / "fresh"
+        empty_home.mkdir()
+        monkeypatch.setattr("bernstein.adapters.q_dev.Path.home", lambda: empty_home)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.delenv("LOCALAPPDATA", raising=False)
+
+        with patch("bernstein.adapters.q_dev.subprocess.Popen") as popen, pytest.raises(SpawnError):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-no-auth-no-popen",
+            )
+        popen.assert_not_called()
+
+    def test_xdg_data_home_cache_satisfies_preflight(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """XDG_DATA_HOME is honoured when set."""
+        adapter = QDevAdapter()
+        xdg = tmp_path / "xdg-data"
+        (xdg / "amazon-q").mkdir(parents=True)
+        monkeypatch.setenv("XDG_DATA_HOME", str(xdg))
+        monkeypatch.setattr("bernstein.adapters.q_dev.Path.home", lambda: tmp_path / "elsewhere")
+
+        proc_mock = make_popen_mock(950)
+        with patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock):
+            # Should not raise — XDG cache is enough.
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-xdg",
+            )
+
+
+# ---------------------------------------------------------------------------
+# QDevAdapter.spawn() — env isolation
+# ---------------------------------------------------------------------------
+
+
+class TestQDevEnvIsolation:
+    """spawn() exposes ONLY profile/region hints to the spawned q process.
+
+    Q reads its bearer token from the on-disk login cache, so long-lived
+    AWS access keys must NEVER be propagated.
+    """
+
+    def test_aws_access_keys_stripped(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(910)
+        with (
+            patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "AWS_ACCESS_KEY_ID": "AKIATESTKEY",
+                    "AWS_SECRET_ACCESS_KEY": "supersecret",
+                    "AWS_SESSION_TOKEN": "longlivedtoken",
+                    "AWS_PROFILE": "dev",
+                    "AWS_REGION": "us-east-1",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-env1",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "AWS_ACCESS_KEY_ID" not in env
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        assert "AWS_SESSION_TOKEN" not in env
+        # Profile/region hints DO pass through — they're metadata, not
+        # authentication material.
+        assert env.get("AWS_PROFILE") == "dev"
+        assert env.get("AWS_REGION") == "us-east-1"
+
+    def test_unrelated_secrets_excluded(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(911)
+        with (
+            patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "ANTHROPIC_API_KEY": "ant-secret",
+                    "OPENAI_API_KEY": "sk-test",
+                    "DATABASE_URL": "postgres://x",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-env2",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert "DATABASE_URL" not in env
+
+    def test_path_propagated(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        proc_mock = make_popen_mock(912)
+        with (
+            patch("bernstein.adapters.q_dev.subprocess.Popen", return_value=proc_mock) as popen,
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-env3",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "PATH" in env
+
+
+# ---------------------------------------------------------------------------
+# QDevAdapter — external endpoint declaration
+# ---------------------------------------------------------------------------
+
+
+class TestQDevExternalEndpoints:
+    """Adapter must declare its AWS-side endpoints for the network policy."""
+
+    def test_amazonaws_endpoint_declared(self) -> None:
+        endpoints = {host for host, _port in QDevAdapter.external_endpoints}
+        assert "*.amazonaws.com" in endpoints
+
+    def test_aws_dev_endpoint_declared(self) -> None:
+        endpoints = {host for host, _port in QDevAdapter.external_endpoints}
+        assert "*.aws.dev" in endpoints
+
+    def test_endpoints_use_https_port(self) -> None:
+        ports = {port for _host, port in QDevAdapter.external_endpoints}
+        assert ports == {443}
+
+
+# ---------------------------------------------------------------------------
+# QDevAdapter — missing binary / PermissionError
+# ---------------------------------------------------------------------------
+
+
+class TestQDevSpawnMissingBinary:
+    def test_file_not_found_raises_runtime_error(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        with (
+            patch(
+                "bernstein.adapters.q_dev.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError, match="not found in PATH"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-missing",
+            )
+
+    def test_permission_error_raises_runtime_error(self, tmp_path: Path, fake_q_login: Path) -> None:
+        adapter = QDevAdapter()
+        with (
+            patch(
+                "bernstein.adapters.q_dev.subprocess.Popen",
+                side_effect=PermissionError("Permission denied"),
+            ),
+            pytest.raises(RuntimeError, match="[Pp]ermission"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="auto", effort="high"),
+                session_id="qdev-perm",
+            )
+
+
+# ---------------------------------------------------------------------------
+# is_alive() and kill() — inherited from CLIAdapter base
+# ---------------------------------------------------------------------------
+
+
+class TestQDevIsAlive:
+    def test_true_when_process_exists(self) -> None:
+        adapter = QDevAdapter()
+        with patch("bernstein.adapters.base.process_alive", return_value=True):
+            assert adapter.is_alive(1234) is True
+
+    def test_false_when_dead(self) -> None:
+        adapter = QDevAdapter()
+        with patch("bernstein.adapters.base.process_alive", return_value=False):
+            assert adapter.is_alive(9999) is False
+
+
+class TestQDevKill:
+    def test_calls_kill_process_group_graceful(self) -> None:
+        adapter = QDevAdapter()
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_kill:
+            adapter.kill(555)
+        mock_kill.assert_called_once_with(555)
+
+    def test_does_not_raise_on_dead_process(self) -> None:
+        adapter = QDevAdapter()
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
+            adapter.kill(556)  # must not raise

--- a/tests/unit/test_adapter_registry.py
+++ b/tests/unit/test_adapter_registry.py
@@ -73,13 +73,13 @@ def test_user_facing_adapter_count_matches_public_copy() -> None:
     """Lock the user-facing adapter count cited in README / landing copy.
 
     Reality:
-      - ``_ADAPTERS`` holds 41 entries; ``mock`` is a test-only stub.
+      - ``_ADAPTERS`` holds 42 entries; ``mock`` is a test-only stub.
       - ``generic`` is served by a special-case in ``get_adapter`` and not
         present in the dict.
 
-    User-facing total = (entries excluding ``mock``) + 1 for ``generic`` = 41.
+    User-facing total = (entries excluding ``mock``) + 1 for ``generic`` = 42.
     Of those: 2 leaf-node delegators (``composio``, ``ralphex``) + 1 generic
-    + 38 third-party wrappers.
+    + 39 third-party wrappers.
 
     If you add or remove an adapter, update README.md / docs/index.md /
     landing copy together with this assertion so the public count stays
@@ -87,5 +87,5 @@ def test_user_facing_adapter_count_matches_public_copy() -> None:
     """
     production = {name for name in _ADAPTERS if name != "mock"}
     user_facing = production | {"generic"}
-    assert len(user_facing) == 41, sorted(user_facing)
+    assert len(user_facing) == 42, sorted(user_facing)
     assert {"composio", "ralphex"}.issubset(user_facing)


### PR DESCRIPTION
## Summary

Implements `.sdd/backlog/open/2026-05-06-new-agent-adapters-sap-joule-and-others.md`: a Bernstein adapter for the AWS Q Developer CLI (`q` binary) registered under the `q_dev` slug.

- Wraps the documented `q chat --no-interactive --trust-all-tools <prompt>` non-interactive surface (verified against [`docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html`](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html) and the [`aws/amazon-q-developer-cli`](https://github.com/aws/amazon-q-developer-cli) issues #1951 / #1995 on 2026-05-06).
- **Pre-flight cache check.** Spawn refuses (`SpawnError`) when no `q login` cache exists (`~/.local/share/amazon-q/` on Linux/macOS, `%LOCALAPPDATA%\amazon-q\` on Windows, `XDG_DATA_HOME/amazon-q` honoured). Without this q would deadlock on its OAuth browser handshake with the failure buried inside the agent log.
- **Aggressive env filtering.** Long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` are stripped from the spawn env — q reads its bearer from the on-disk cache only. Profile/region hints (`AWS_PROFILE`, `AWS_REGION`, `AWS_DEFAULT_REGION`) pass through.
- **External endpoints declared:** `*.amazonaws.com:443`, `*.aws.dev:443`.
- **IAM Identity Center role-scoping risk** documented in the module docstring: q's tool calls execute with the user's Identity Center role, so infra-touching tasks should be scoped narrowly or routed via `IaCAdapter` instead.

Bumps user-facing adapter count 41 → 42 (lock-stepped with the registry count assertion in `tests/unit/test_adapter_registry.py`). The Junie adapter is on a sibling branch and will bump 42 → 43 when it lands; this PR only accounts for the +1 from `q_dev`.

## Notes for reviewer

- Project status caveat: AWS upstream rebranded the project as Kiro CLI in 2026 (existing `kiro` adapter covers that). The legacy `q` binary continues to ship for existing installs and the `--no-interactive --trust-all-tools` surface is unchanged, so this adapter targets the legacy surface on purpose — Builder ID users on the original CLI keep working without forcing a Kiro migration.
- Defaults entry: not added. Vendor-locked adapters (Kiro, Cursor, Copilot, Amp, Cody, …) have no entries in `defaults.py`; q follows that pattern. The `free_adapters` tuple stays unchanged because q is not free-tier.
- Contract test exclusion: `q_dev` joins `iac` / `clm` in the spawn-pre-flight exclusion list because the contract suite mocks `subprocess.Popen` but cannot fake an authenticated AWS Builder ID session. `test_adapter_q_dev.py` exercises spawn end-to-end with a fake cache directory.

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_q_dev.py tests/unit/test_adapter_registry.py -x -q` (35 passed)
- [x] `uv run pytest tests/unit/test_adapter_contract.py -x -q` (510 passed across all registered adapters)
- [x] `uv run pytest tests/unit/test_adapter_conformance.py -x -q` (41 passed)
- [ ] CI runs full adapter suite on PR
- [ ] Manual smoke: install AWS Q CLI on a host with `q login` completed, run a one-shot `bernstein` task with `cli: q_dev` in `bernstein.yaml`

## Coordination

There is a parallel `feat/adapter-junie` branch. Both touch `src/bernstein/adapters/registry.py` (new entry) and `tests/unit/test_adapter_registry.py` (count assertion). Conflicts are expected — please rebase the second-merging branch onto the first. **Do not auto-merge this PR**; the orchestrator will sequence merges manually.