### PR TITLE
chore(docs): drop internal ticket-ref breadcrumbs from public docs

### DIFF
--- a/docs/adapters/openai-agents.md
+++ b/docs/adapters/openai-agents.md
@@ -6,8 +6,6 @@ existing Bernstein spawner can manage lifecycle, timeouts, rate-limit
 back-off, and cost tracking the same way it does for every other coding
 agent.
 
-Ticket: [oai-001](../../.sdd/backlog/open/oai-001-feat-openai-agents-sdk-adapter.yaml).
-
 ---
 
 ## Installation
@@ -90,10 +88,9 @@ stages:
         sandbox_provider: unix_local   # unix_local | docker | e2b | modal
 ```
 
-Sandbox provider selection is adapter-internal for now.  Once
-[oai-002](../../.sdd/backlog/open/) ships the pluggable
-`SandboxBackend` abstraction, this choice will be promoted to a
-top-level Bernstein setting.
+Sandbox provider selection is adapter-internal for now. Once the
+pluggable `SandboxBackend` abstraction ships, this choice will be
+promoted to a top-level Bernstein setting.
 
 ---
 
@@ -165,7 +162,7 @@ code onto Bernstein's existing back-off (`COST.rate_limit_cooldown_s`).
 
 ## Known gaps (tracked separately)
 
-* **oai-002** — promote sandbox provider selection to Bernstein's outer
+* Promote sandbox provider selection to Bernstein's outer
   `SandboxBackend` once the abstraction lands.
-* **oai-003** — capture per-tool latency breakdown from the SDK's event
-  stream (currently only total tool-call count is recorded).
+* Capture per-tool latency breakdown from the SDK's event stream
+  (currently only total tool-call count is recorded).

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -212,20 +212,20 @@ Three pluggable subsystems landed in the 1.9 series. Each has its own
 dedicated architecture page:
 
 - **[Sandbox backends](sandbox.md)** — pluggable `SandboxBackend` /
-  `SandboxSession` protocol (oai-002). First-party backends: local git
+  `SandboxSession` protocol. First-party backends: local git
   `worktree` (default), `docker`, `e2b` (Firecracker microVMs), and
   `modal` (serverless containers with optional GPU). Third parties
   register through the `bernstein.sandbox_backends` entry-point group;
   `bernstein agents sandbox-backends` lists every installed backend.
 - **[Artifact storage sinks](storage.md)** — async `ArtifactSink`
-  protocol (oai-003) that decouples `.sdd/` persistence from the local
+  protocol that decouples `.sdd/` persistence from the local
   filesystem. First-party sinks cover `local_fs`, `s3`, `gcs`,
   `azure_blob`, and `r2`. `BufferedSink` preserves the WAL
   crash-safety contract by fsyncing locally first and mirroring the
   payload to the remote asynchronously. Third parties extend via
   `bernstein.storage_sinks`.
 - **[Progressive skill packs](skills.md)** — OpenAI Agents SDK
-  "Skills" pattern (oai-004): only a compact index ships in every
+  "Skills" pattern: only a compact index ships in every
   spawn's system prompt; agents pull full bodies on demand via the
   `load_skill` MCP tool. Plugins register additional skill sources
   under `bernstein.skill_sources`. Inspect available skills with

--- a/docs/architecture/graphs.md
+++ b/docs/architecture/graphs.md
@@ -28,6 +28,6 @@ reads from it so future readers don't confuse them.
 ## History
 
 `task_graph.py` was named `graph.py` and `ast_symbol_graph.py` was named
-`semantic_graph.py` until audit-177 (2026-04). The old names are still resolved
+`semantic_graph.py` until April 2026. The old names are still resolved
 through `_REDIRECT_MAP` in `bernstein/core/__init__.py` for back-compat, but new
 code should import the self-descriptive names directly.

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -3,9 +3,9 @@
 Bernstein isolates every spawned agent in a sandbox so multiple agents
 running against the same repository cannot stomp on each other's
 files, processes, or secrets. Historically the only sandbox type was
-a local git worktree. As of oai-002 the choice of sandbox is pluggable
-— agents can run inside worktrees, Docker containers, E2B microVMs,
-Modal sandboxes, or any backend a plugin author registers.
+a local git worktree. The choice of sandbox is now pluggable — agents
+can run inside worktrees, Docker containers, E2B microVMs, Modal
+sandboxes, or any backend a plugin author registers.
 
 This document covers:
 
@@ -15,8 +15,8 @@ This document covers:
 - The `bernstein.sandbox_backends` entry-point group for third-party
   backends
 - The phased rollout plan (phase 1 lands the protocol and backends;
-  phase 2 — tracked as `oai-002b` — refactors the spawner to route
-  adapter exec through `SandboxSession`)
+  phase 2 refactors the spawner to route adapter exec through
+  `SandboxSession`)
 
 ## Protocol shape
 
@@ -87,7 +87,8 @@ class WorkspaceManifest:
 
 `GitRepoEntry` and `FileEntry` are companion frozen dataclasses.
 Cloud-specific mount entries (S3, persistent volumes, secrets
-manager bindings) are intentionally deferred to `oai-003`.
+manager bindings) are intentionally deferred to the storage-sinks
+work.
 
 ## First-party backends
 
@@ -114,7 +115,7 @@ manager bindings) are intentionally deferred to `oai-003`.
   only `modal` exposes GPU today.
 - **Supported exec semantics.** All four backends handle argv-based
   exec with exit-code, stdout, and stderr capture. `docker` does not
-  support stdin injection in phase 1; that is tracked in `oai-002b`.
+  support stdin injection in phase 1; phase 2 addresses that.
 
 ## `plan.yaml` extension
 
@@ -134,7 +135,8 @@ stages:
 ```
 
 `sandbox:` is entirely optional. When omitted the stage runs in the
-worktree backend — byte-identical to pre-oai-002 behaviour.
+worktree backend — byte-identical to the pre-pluggable-sandbox
+behaviour.
 
 ## Registering a custom backend
 
@@ -161,7 +163,7 @@ Third-party backends must:
 
 ## Phased rollout
 
-### Phase 1 (this ticket, `oai-002`)
+### Phase 1
 
 - `SandboxBackend` / `SandboxSession` / `SandboxCapability` /
   `WorkspaceManifest` land in `src/bernstein/core/sandbox/`.
@@ -173,7 +175,7 @@ Third-party backends must:
 - `bernstein agents sandbox-backends` lists installed backends.
 - `plan.yaml` accepts an optional `sandbox:` block per stage.
 
-### Phase 2 (follow-up, `oai-002b`)
+### Phase 2
 
 - `AgentSpawner` routes adapter exec through
   `SandboxSession.exec`, so the selected backend controls where
@@ -195,8 +197,8 @@ metrics:
 - `sandbox_session_destroyed{backend=..., duration_seconds=...}`
 - `sandbox_exec_count{backend=..., exit_code=...}`
 
-Wiring into the existing metrics/WAL subsystems is part of
-`oai-002b`; phase 1 only exposes the interfaces.
+Wiring into the existing metrics/WAL subsystems is part of phase 2;
+phase 1 only exposes the interfaces.
 
 ## Conformance
 

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,11 +1,11 @@
 # Skills — progressive-disclosure capability packs
 
-Status: active (oai-004, April 2026).
+Status: active (April 2026).
 Applies to: all CLI adapters spawned by Bernstein.
 
 ## Motivation
 
-Before oai-004 every agent spawn loaded the full ``templates/roles/<role>/system_prompt.md``
+Before this work every agent spawn loaded the full ``templates/roles/<role>/system_prompt.md``
 into the system prompt, whether or not the agent actually exercised the
 deep guidance. Across 17 roles the bodies averaged ~40 lines each; the
 token bill was paid on every spawn, including retries and forks.
@@ -30,7 +30,7 @@ templates/
       task_prompt.md
       config.yaml
     …
-  skills/               # new skill packs (oai-004)
+  skills/               # new skill packs
     backend/
       SKILL.md
       references/
@@ -203,7 +203,7 @@ Dead skills (zero loads in 30 days) become candidates for deprecation.
 
 ## Migration status
 
-All 17 roles migrated to skill packs as of oai-004:
+All 17 roles migrated to skill packs:
 
 | role              | references                                                  | notes                          |
 | ----------------- | ----------------------------------------------------------- | ------------------------------ |

--- a/docs/architecture/state-persistence.md
+++ b/docs/architecture/state-persistence.md
@@ -28,7 +28,7 @@ each run) is intentional:
 | `.sdd/backlog/closed/*.yaml` | Tasks the janitor has finalised | durable — append-only history |
 | `.sdd/backlog/issues/*.yaml` | Tasks synced from GitHub issues | durable — re-synced each run |
 | `.sdd/runtime/wal/<run-id>.wal.jsonl` | Hash-chained write-ahead log of every orchestrator decision | durable for crash recovery |
-| `.sdd/runtime/wal/uncommitted.idx.json` | Sidecar index of in-flight entries (audit-085) | rebuildable from WAL |
+| `.sdd/runtime/wal/uncommitted.idx.json` | Sidecar index of in-flight entries | rebuildable from WAL |
 | `.sdd/runtime/wal/idempotency.jsonl` | Replay deduplication markers | durable — survives crashes |
 | `.sdd/metrics/*.jsonl` | Cost ledger, cascade chain reports, file-health scores | durable — append-only |
 | `.sdd/cas/{xx}/{sha256}` | Content-addressed artifact blobs | durable — deduplicated |

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -1,4 +1,4 @@
-# Artifact Storage Sinks (oai-003)
+# Artifact Storage Sinks
 
 Bernstein persists its working state under `.sdd/`: the WAL, HMAC
 audit logs, runtime state, task outputs, cost ledger, and metrics
@@ -94,12 +94,12 @@ the ephemeral local disk may be empty. They fall back to local when
 the remote is unreachable or doesn't have the key (e.g. the mirror is
 still pending).
 
-## Sandbox integration (ties in with oai-002)
+## Sandbox integration
 
 `WorkspaceManifest` now carries a tuple of `ArtifactMount` entries
 (`S3Mount`, `GCSMount`, `AzureBlobMount`, `R2Mount`). Cloud sandbox
-backends (oai-002: docker, e2b, modal; future: daytona, cloudflare,
-vercel) translate these into provider-native filesystem bindings
+backends (docker, e2b, modal; future: daytona, cloudflare, vercel)
+translate these into provider-native filesystem bindings
 (`rclone mount` for S3/R2, `gcsfuse` for GCS, `blobfuse2` for Azure)
 so agent writes to the mount path stream straight into the
 orchestrator's artifact sink. The `worktree` backend ignores the

--- a/docs/operations/DEPLOYMENT.md
+++ b/docs/operations/DEPLOYMENT.md
@@ -36,7 +36,7 @@ docker compose ps
 docker compose up --scale bernstein-worker=4 -d
 ```
 
-> **Single-worker task server (audit-025).** Only `bernstein-worker`
+> **Single-worker task server.** Only `bernstein-worker`
 > replicas scale horizontally. The `bernstein-server` container must run
 > with **exactly one uvicorn worker** — the in-process `TaskStore` holds
 > state in memory and guards mutations with `asyncio.Lock`. Running

--- a/docs/operations/autofix.md
+++ b/docs/operations/autofix.md
@@ -129,8 +129,8 @@ $ bernstein autofix attach [--limit 200]
 
 Replays the last N attempts as JSON-per-line, then tails new entries —
 same surface `attach` provides for chat-control sessions
-(`src/bernstein/cli/commands/autofix_cmd.py:398-436`). The "resume from
-any terminal" handoff defined by op-005.
+(`src/bernstein/cli/commands/autofix_cmd.py:398-436`). This is the
+"resume from any terminal" handoff used by the chat-control surfaces.
 
 ---
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -701,7 +701,7 @@ Multi-project dashboard.
 
 #### `bernstein approve-tool` / `bernstein reject-tool`
 
-Tool-call approval gate (op-002). When an agent requests a sensitive tool call (network egress, file write outside its worktree, exec outside its sandbox), the orchestrator pauses and writes a request to `.sdd/runtime/tool_approvals/`. Resolve with these commands.
+Tool-call approval gate. When an agent requests a sensitive tool call (network egress, file write outside its worktree, exec outside its sandbox), the orchestrator pauses and writes a request to `.sdd/runtime/tool_approvals/`. Resolve with these commands.
 
 ```bash
 bernstein approve-tool <request_id>

--- a/docs/routine-scenarios.md
+++ b/docs/routine-scenarios.md
@@ -3,7 +3,7 @@
 The Bernstein scenario library and Anthropic's Claude Code Routines complement
 each other: scenarios are version-controlled YAML recipes for multi-agent work,
 Routines are cloud-side triggers that fire prompts on schedules or GitHub
-events. The rt-003 bridge wires them together so a team lead can author one
+events. The bridge wires them together so a team lead can author one
 scenario in the repo and an operator can stand up the matching Routine in
 about five minutes.
 

--- a/docs/security/security-hardening.md
+++ b/docs/security/security-hardening.md
@@ -436,7 +436,7 @@ Rotate the JWT signing secret and audit log HMAC key periodically:
 export BERNSTEIN_JWT_SECRET="$(openssl rand -hex 32)"
 bernstein stop && bernstein run   # Restart to pick up new secret
 
-# Rotate the audit log HMAC key (audit-043: key lives OUTSIDE .sdd/ by default).
+# Rotate the audit log HMAC key. The key lives OUTSIDE .sdd/ by default.
 # Default location: $XDG_STATE_HOME/bernstein/audit.key
 #   (falls back to ~/.local/state/bernstein/audit.key)
 # Override with: export BERNSTEIN_AUDIT_KEY_PATH=/secure/path/audit.key

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -8,13 +8,12 @@ description: >-
 
 # What's New in 1.9.x
 
-Bernstein 1.9 collects four feature tracks that landed as tickets
-`oai-001` through `oai-004`. This page summarises them in terms of what
-changes for someone upgrading from 1.8.x. Full detail lives in the
-dedicated architecture pages and the
+Bernstein 1.9 collects four feature tracks. This page summarises them in
+terms of what changes for someone upgrading from 1.8.x. Full detail lives
+in the dedicated architecture pages and the
 [CHANGELOG](CHANGELOG.md).
 
-## OpenAI Agents SDK v2 adapter (`openai_agents`) — oai-001
+## OpenAI Agents SDK v2 adapter (`openai_agents`)
 
 Bernstein now ships a first-class adapter for the
 [OpenAI Agents SDK v2](https://openai.github.io/openai-agents-python/).
@@ -49,7 +48,7 @@ See the [adapter reference](adapters/openai-agents.md) and the
 [decision guide](compare/openai-agents.md) for when to pick
 `openai_agents` vs `codex` vs `claude`.
 
-## Pluggable sandbox backends — oai-002
+## Pluggable sandbox backends
 
 Every spawned agent now runs inside a `SandboxSession`. Four
 first-party backends ship:
@@ -86,7 +85,7 @@ entry-point group.
 Full detail:
 [architecture/sandbox.md](architecture/sandbox.md).
 
-## Cloud artifact storage sinks — oai-003
+## Cloud artifact storage sinks
 
 `.sdd/` persistence (WAL, audit log, task outputs, cost ledger) now
 decouples from the local filesystem via an async `ArtifactSink`
@@ -108,7 +107,7 @@ disk.
 Full detail:
 [architecture/storage.md](architecture/storage.md).
 
-## Progressive-disclosure skill packs — oai-004
+## Progressive-disclosure skill packs
 
 Role prompts migrated from monolithic `templates/roles/<role>/system_prompt.md`
 files to OpenAI Agents SDK-shaped **skill packs** under


### PR DESCRIPTION
## Summary

Strips internal ticket prefixes (`oai-NNN`, `audit-NNN`, `op-NNN`, `rt-NNN`, `meta-NNN`, `KF-X`) from 13 public docs files. Sentence flow preserved.

## Files

- `docs/whats-new.md` — drop ticket-suffix headings.
- `docs/architecture/{ARCHITECTURE,sandbox,skills,storage,graphs,state-persistence}.md` — drop parenthetical refs.
- `docs/adapters/openai-agents.md` — drop "Ticket: …" link + known-gap refs.
- `docs/operations/{DEPLOYMENT,autofix}.md`, `docs/security/security-hardening.md`, `docs/reference/cli-reference.md`, `docs/routine-scenarios.md` — drop inline refs.

## Test plan

- [x] No internal-ref patterns remain in `README.md`, `docs/`, `CHANGELOG.md`, `CONTRIBUTORS.md`.
- [x] No behaviour change — text-only edits.