### PR TITLE
fix(cluster): KeyUsage on test CA + explicit cipher allowlist

### DIFF
--- a/src/bernstein/core/protocols/cluster/cluster_tls.py
+++ b/src/bernstein/core/protocols/cluster/cluster_tls.py
@@ -34,6 +34,18 @@ VerifyMode = Literal["required", "optional", "disabled"]
 
 _VALID_MODES: tuple[VerifyMode, ...] = ("required", "optional", "disabled")
 
+# TLS 1.2 cipher allowlist — modern AEAD suites with forward secrecy only.
+# Drops PSK (we don't pre-share keys), pure-RSA key exchange (no PFS), and
+# every legacy weak family (NULL/EXPORT/RC4/DES/MD5/IDEA/SEED/RC2/aNULL).
+# OpenSSL's default cipher list on Linux ships PSK suites, so an explicit
+# allowlist is the simplest way to keep the surface auditable across
+# distros and Python builds (Py 3.12 ubuntu was failing the weak-suite
+# audit on the unconstrained default).
+# TLS 1.3 cipher selection is independent — its three default suites
+# (TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
+# TLS_AES_128_GCM_SHA256) are always permitted and use AEAD + PFS by design.
+_CIPHER_ALLOWLIST = "ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20"
+
 
 class TLSConfigError(ValueError):
     """Raised when a :class:`TLSConfig` is malformed or references missing files."""
@@ -119,6 +131,7 @@ def build_ssl_context(cfg: TLSConfig) -> ssl.SSLContext:
     # sentinel sorts numerically below TLSVersion.TLSv1_2 (771), so a
     # downstream `>= TLSv1_2` security assertion would silently fail.
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.set_ciphers(_CIPHER_ALLOWLIST)
     ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
 
     if cfg.verify_mode == "disabled":
@@ -162,12 +175,14 @@ def build_httpx_client_kwargs(cfg: TLSConfig | None) -> dict[str, Any]:
     if cfg.verify_mode == "disabled":
         ctx = ssl.create_default_context()
         ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+        ctx.set_ciphers(_CIPHER_ALLOWLIST)
         ctx.check_hostname = False
         ctx.verify_mode = ssl.CERT_NONE
         ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
         return {"verify": ctx}
     ctx = ssl.create_default_context(cafile=str(_resolve(cfg.ca_file)))
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.set_ciphers(_CIPHER_ALLOWLIST)
     ctx.load_cert_chain(certfile=str(_resolve(cfg.cert_file)), keyfile=str(_resolve(cfg.key_file)))
     return {"verify": ctx}
 

--- a/tests/unit/test_cluster_mtls_phase1.py
+++ b/tests/unit/test_cluster_mtls_phase1.py
@@ -61,6 +61,25 @@ def _build_ca(now: datetime.datetime, cn: str = "phase1-ca") -> tuple[x509.Certi
         .not_valid_before(now - datetime.timedelta(minutes=5))
         .not_valid_after(now + datetime.timedelta(days=1))
         .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        # OpenSSL 3.2+ (ships with Python 3.13) rejects CA certs that set
+        # `pathLen` in BasicConstraints without a matching `keyCertSign` bit
+        # in KeyUsage — error: "Path length given without key usage
+        # keyCertSign". RFC 5280 §4.2.1.9 actually requires KeyUsage on any
+        # cert that signs other certs; older OpenSSL was lenient.
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
         .add_extension(
             x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
             critical=False,


### PR DESCRIPTION
## Summary
Two regressions on **main** after PR #1063 merged. Both in `test_cluster_mtls_phase1.py` / `cluster_tls.py`, fixed in one branch.

### Failure 1 — Py 3.13 (ubuntu + macos)
\`\`\`
test_handshake_accepts_valid_client_cert
ssl.SSLCertVerificationError: Path length given without key usage keyCertSign
\`\`\`
OpenSSL 3.2+ (Py 3.13's bundled crypto) enforces RFC 5280 §4.2.1.9: a CA cert with \`pathLen\` in BasicConstraints **must** also carry \`KeyUsage\` with \`keyCertSign=True\`. Older OpenSSL was lenient. Fix: add a critical \`KeyUsage\` extension (\`key_cert_sign + crl_sign\`) to the test CA in \`_build_ca\`.

### Failure 2 — Py 3.12 (ubuntu)
\`\`\`
test_cipher_suites_exclude_known_weak
AssertionError: weak suites in default cipher list: ['RSA-PSK-...', 'DHE-PSK-...', ... 26 suites]
\`\`\`
\`ssl.create_default_context()\` on this Linux build inherits an OpenSSL cipher list that includes PSK families. Bernstein never pre-shares keys, so PSK is dead weight and an audit-fail. Fix: pin an explicit allowlist \`ECDHE+AESGCM:ECDHE+CHACHA20:DHE+AESGCM:DHE+CHACHA20\` in both \`build_ssl_context\` and \`build_httpx_client_kwargs\`. TLS 1.3 ciphers (always AEAD + PFS) unaffected.

## Test plan
- [x] \`uv run pytest tests/unit/test_cluster_mtls_phase1.py -x -q\` — 16/16 pass on Py 3.13
- [ ] CI green on ubuntu/macOS × Py 3.12/3.13 once it runs
- [ ] Unblocks 4 open PRs (#1061, #1062, #1064, #1065) once main is green