### PR TITLE
chore: bump to 1.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.1"
+version = "1.10.2"
 description = "Multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 28 more) — deterministic, declarative, zero vendor lock-in."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.10.1"
+version = "1.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Why
Auto-release on \`main\` failed at the \`Bump patch\` step (run [25493800238](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/25493800238)) because the workflow tried to push \`chore: auto-bump to v1.10.2\` directly to protected main and got GH006 (13 required status checks not met).

Root cause: pyproject still pinned to \`1.10.1\` while \`v1.10.1\` tag already exists, so the auto-release took the \`exists=true\` branch (push-to-main path) instead of the \`exists=false\` branch (tag+publish only).

## What
Moves \`pyproject.toml\` from \`1.10.1\` → \`1.10.2\` via a normal PR so the bump commit goes through the 13 required status checks like any other change. After merge, the auto-release workflow will see \`pyproject == 1.10.2\` and \`v1.10.2\` tag missing → take the no-push branch → tag, build, publish to PyPI/npm/GHCR + clean up the stale v1.10.2 release-drafter draft.

## What ships in 1.10.2
Two new adapters (JetBrains Junie, AWS Q Developer), Bernstein self-autofix CI workflow, and four operator-visible bug fixes (cluster mTLS on Py 3.13/OpenSSL 3.2, persistence memo cache determinism, airgap distribution hardening, Devin Terminal registry). See the auto-generated release notes after merge.

## Test plan
- [x] Lint clean (pre-push verified)
- [ ] CI passes the 13 required checks on this PR
- [ ] After merge, auto-release fires successfully and ships v1.10.2 to PyPI/npm/GHCR