### PR TITLE
docs: expand air-gap user guide and surface it from entry pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Other install options: `pipx install bernstein`, `pip install bernstein`, `uv to
 - Forward-deployed engineering — drop the swarm onto a client repo when you arrive, take it with you when you leave.
 - Self-evolving projects — point Bernstein at its own repo and let it execute the backlog (this codebase is one).
 - CI fleets — run a swarm of agents in parallel on PRs, with per-agent credential scoping and signed audit trail.
+- Air-gapped / regulated deployment — install from a signed wheelhouse, run with `--profile airgap` to deny outbound by default, allow-list specific destinations as needed. See [Air-gap installation](docs/installation/air-gap.md).
 
 ## Supported agents
 

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -79,7 +79,10 @@ Outbound network traffic usually comes from one of these sources:
 
 If you run only local models and local storage, Bernstein can operate without third-party model APIs. That is the deployment to validate for air-gapped or tightly regulated environments.
 
+Bernstein ships first-class plumbing for this case: a pinned-dependency wheelhouse, signed `MANIFEST.json` plus per-wheel detached signatures, a `bernstein verify <wheelhouse>` checksum/signature pass (cosign or GPG), a `--profile airgap` runtime that flips the egress default to deny-all, a `--allow-network HOST|CIDR|none|any` per-destination override, and a `bernstein doctor airgap` self-check that confirms the perimeter before the first run.
+
 Read next:
+- [Air-gap installation](installation/air-gap.md) — wheelhouse build, signed verification, `--profile airgap`, and adapter network endpoint audit
 - [Model policy](operations/MODEL_POLICY.md)
 - [Compliance](operations/compliance.md)
 - [Deployment guide](operations/deployment-guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,6 +117,7 @@ for client compliance review.
 | :material-state-machine: [Lifecycle FSM](architecture/LIFECYCLE.md) | Task and agent state machines with transition tables |
 | :material-text-box-check: [What's New](whats-new.md) | Summary of recent releases (1.8 → 1.9) |
 | :material-history: [Changelog](CHANGELOG.md) | Full release history |
+| :material-shield-lock: [Air-gap installation](installation/air-gap.md) | Wheelhouse build, signed verification, `--profile airgap`, deny-all egress |
 
 ## Links
 

--- a/docs/installation/air-gap.md
+++ b/docs/installation/air-gap.md
@@ -6,6 +6,21 @@ egress policy. This guide is for forward-deployed engineers (FDEs)
 delivering Bernstein to sovereign customers, and for operators
 maintaining an air-gap environment.
 
+## When to reach for this
+
+Use this path when:
+
+- the host has no PyPI egress (regulated, sovereign, or simply offline)
+- compliance asks for cryptographic provenance on every dependency
+- adapters and MCP transports must fail closed on outbound packets
+  unless an operator explicitly opens a destination
+- the deployment must be auditable end-to-end without relying on a
+  hosted control plane
+
+The default Bernstein install on a developer laptop is fine without
+any of this. The air-gap path adds three things on top of the same
+binary: a wheelhouse, a signed manifest, and a runtime profile.
+
 There are three pieces:
 
 1. A **wheelhouse** — every wheel in Bernstein's pinned dependency
@@ -26,21 +41,21 @@ machine that needs PyPI access.
 ```bash
 # Build the wheelhouse (downloads every wheel in the closure + bernstein).
 # Either the script directly...
-python scripts/build_airgap_wheelhouse.py --version 1.9.4
+python scripts/build_airgap_wheelhouse.py --version 1.10.0
 
-# ...or the operator-friendly subcommand (Phase 2):
-bernstein wheelhouse build --version 1.9.4
+# ...or the operator-friendly subcommand:
+bernstein wheelhouse build --version 1.10.0
 
 # Sign every wheel + the manifest with cosign
 COSIGN_KEY=/secure/path/cosign.key \
-  bash scripts/sign_airgap_wheelhouse.sh dist/airgap-wheelhouse/1.9.4
+  bash scripts/sign_airgap_wheelhouse.sh dist/airgap-wheelhouse/1.10.0
 ```
 
-Result: `dist/airgap-wheelhouse/1.9.4/` containing
+Result: `dist/airgap-wheelhouse/1.10.0/` containing
 
 ```
-bernstein-1.9.4-py3-none-any.whl
-bernstein-1.9.4-py3-none-any.whl.sig
+bernstein-1.10.0-py3-none-any.whl
+bernstein-1.10.0-py3-none-any.whl.sig
 fastapi-0.115.x-py3-none-any.whl
 fastapi-0.115.x-py3-none-any.whl.sig
 ... (all transitive dependencies + their sigs) ...
@@ -59,45 +74,66 @@ Mount the encrypted media. Verify before installing — never run
 ```bash
 # 1. Confirm checksums against the manifest, signatures against the key.
 #    Either form below works:
-bernstein verify ./airgap-wheelhouse/1.9.4 \
+bernstein verify ./airgap-wheelhouse/1.10.0 \
   --ca-pubkey ./bernstein-release.pub \
   --require-signatures
-#  -- or, equivalently (Phase 2):
-bernstein wheelhouse verify ./airgap-wheelhouse/1.9.4 \
+#  -- or, equivalently:
+bernstein wheelhouse verify ./airgap-wheelhouse/1.10.0 \
   --ca-pubkey ./bernstein-release.pub
 
 # 2. Install with no PyPI access.
 python -m venv .venv && source .venv/bin/activate
-pip install --no-index --find-links ./airgap-wheelhouse/1.9.4 bernstein
+pip install --no-index --find-links ./airgap-wheelhouse/1.10.0 bernstein
 
 # 3. Sanity check.
 bernstein --version
 
-# 4. Self-check the air-gap posture (Phase 2):
+# 4. Self-check the air-gap posture.
 bernstein doctor airgap
 ```
 
 The verify step is non-zero on any sha256 mismatch or signature
 failure and names the offending wheel in the error message.
 
-`bernstein doctor airgap` runs a battery of self-checks: confirms no
-network egress occurred during the last run, MCP catalog entries are
-all in their default state, the memo store path is local-only, and
-the audit chain's HMAC validates. It exits non-zero if any check
-fails and names which one.
+`bernstein doctor airgap` runs a battery of self-checks against the
+current shell, exits 0 only when every row passes, and is the
+intended pre-flight before any first run. The checks are:
+
+| Check | What it asserts |
+| --- | --- |
+| `airgap profile active` | `BERNSTEIN_PROFILE_MODE=airgap` is set on this process |
+| `network policy deny-all` | The active policy is `none` or an explicit allow-list, not `any` |
+| `policy blocks declared endpoints` | Every adapter's `external_endpoints` is currently rejected |
+| `MCP catalog all-off` | The user MCP config has no enabled bernstein-managed entries |
+| `memo store on local disk` | No residual cache at `~/.cache/bernstein/`; memo pinned to `.sdd/runtime/memo/` |
+| `audit chain HMAC valid` | Every entry under `.sdd/audit/` chains correctly |
+| `no external hostnames in runtime` | No public LLM endpoint references in `.sdd/runtime/` |
+
+```bash
+bernstein doctor airgap          # human-readable
+bernstein doctor airgap --json   # machine-readable for compliance evidence
+```
+
+`WARN` rows do not fail the run (e.g. legitimately operator-overridden
+allow-list entries); only `FAIL` rows force the non-zero exit. The
+JSON form is suitable as evidence in an air-gap pilot's evaluation
+package.
 
 ### GPG verifier
 
-Some sovereign customers prefer GPG over sigstore. Phase 2 ships a
-pluggable verifier:
+Some sovereign customers prefer GPG over sigstore. The verifier is
+pluggable — pick a backend at verify time:
 
 ```bash
-bernstein wheelhouse verify ./airgap-wheelhouse/1.9.4 \
-  --signer gpg --gpg-keyring ./customer.gpg
+bernstein wheelhouse verify ./airgap-wheelhouse/1.10.0 \
+  --verifier gpg --keyring ./customer.gpg
 ```
 
-The default verifier remains sigstore; switch via `--signer gpg` to
-use detached `*.asc` signatures alongside the wheels.
+The default backend is `auto`, which picks pure-Python crypto when
+`--ca-pubkey` is supplied (Ed25519, ECDSA P-256, or RSA-PSS), falls
+back to cosign with the same key, then to GPG when `--keyring` is.
+Switch explicitly with `--verifier crypto|cosign|gpg` when both a
+PEM key and a GPG keyring are on disk and you need to pin the path.
 
 ## Running with `--profile airgap`
 
@@ -139,6 +175,57 @@ Repeat `--allow-network` for each rule:
 Default outside `--profile airgap` is `any`, so existing scripts
 keep working unmodified.
 
+## Adapter network endpoints
+
+Each adapter that dials a SaaS endpoint declares it on the class as
+`external_endpoints: tuple[tuple[str, int], ...]`. The base
+`CLIAdapter.enforce_network_policy()` consults the active policy on
+spawn and raises `NetworkPolicyDenied` before the child process
+starts. That is how `--profile airgap` keeps Claude Code, Codex,
+Gemini, Cloudflare Agents, Devin Terminal, AWS Q Developer, and the
+other cloud-backed adapters from leaving the perimeter without an
+explicit allow-list entry.
+
+Audit which adapters dial out by grepping the source:
+
+```bash
+grep -nE "external_endpoints\s*=" src/bernstein/adapters/*.py
+```
+
+Representative entries today:
+
+| Adapter | Source file | Declared endpoints |
+| --- | --- | --- |
+| Claude Code | `src/bernstein/adapters/claude.py` | `api.anthropic.com:443` |
+| Codex CLI | `src/bernstein/adapters/codex.py` | `api.openai.com:443` |
+| Gemini CLI | `src/bernstein/adapters/gemini.py` | `generativelanguage.googleapis.com:443` |
+| Cloudflare Agents | `src/bernstein/adapters/cloudflare_agents.py` | `api.cloudflare.com:443` |
+| Devin Terminal | `src/bernstein/adapters/devin_terminal.py` | `api.devin.ai:443`, `cli.devin.ai:443` |
+| AWS Q Developer | `src/bernstein/adapters/q_dev.py` | `*.amazonaws.com:443`, `*.aws.dev:443` |
+| Junie | `src/bernstein/adapters/junie.py` | depends on configured BYOK provider |
+
+Adapters that do not declare `external_endpoints` (Aider against a
+local Ollama, the IaC Terraform/Pulumi wrapper, the generic adapter,
+etc.) are pure local subprocesses — the network gate is a no-op for
+them. The OpenAI Agents SDK and any HTTP path inside the orchestrator
+itself flow through `bernstein.core.security.network_policy` and
+honour the same policy as the adapters.
+
+To enable one adapter under `--profile airgap`, allow-list its
+endpoint(s):
+
+```bash
+# Anthropic only — every other adapter still fails closed.
+bernstein run --profile airgap \
+  --allow-network api.anthropic.com:443 \
+  --goal "Tighten the alert-rule selection clause"
+```
+
+`bernstein doctor airgap` includes a check (`policy blocks declared
+endpoints`) that walks every adapter's declared destinations through
+the active policy and reports anything that would be allowed today,
+so the operator can confirm the perimeter before the first run.
+
 ## Re-signing on the customer side
 
 A customer who does not trust the upstream signing key (or wants
@@ -146,10 +233,10 @@ to layer their own audit) re-signs the wheelhouse with their own key:
 
 ```bash
 COSIGN_KEY=/secure/customer-key.key \
-  bash scripts/sign_airgap_wheelhouse.sh ./airgap-wheelhouse/1.9.4
+  bash scripts/sign_airgap_wheelhouse.sh ./airgap-wheelhouse/1.10.0
 
 # Bernstein verify accepts an alternative public key:
-bernstein verify ./airgap-wheelhouse/1.9.4 --ca-pubkey ./customer.pub
+bernstein verify ./airgap-wheelhouse/1.10.0 --ca-pubkey ./customer.pub
 ```
 
 The detached signature scheme means we never bury keys inside the
@@ -170,7 +257,7 @@ running `python scripts/build_airgap_wheelhouse.py` with the same
 | `pip install` resolves to PyPI anyway | Forgot `--no-index` | Always pass `--no-index --find-links <dir>` |
 | `bernstein verify` reports `missing signature` | The directory was copied without `.sig` files | Copy the entire wheelhouse, including signatures |
 | `NetworkPolicyDenied: ...` at adapter spawn | Endpoint not on allow-list | Add `--allow-network <host>` or pick a local adapter |
-| `bernstein run` exits with `--profile` not recognised | Older bernstein version | Upgrade to ≥ 1.9.4 |
+| `bernstein run` exits with `--profile` not recognised | Older bernstein version | Upgrade to ≥ 1.10.0 |
 
 ## Limitations
 
@@ -189,7 +276,12 @@ running `python scripts/build_airgap_wheelhouse.py` with the same
 
 - Source: `scripts/build_airgap_wheelhouse.py`,
   `scripts/sign_airgap_wheelhouse.sh`,
-  `src/bernstein/cli/commands/{verify_cmd,wheelhouse_cmd,doctor_airgap_cmd}.py`
+  `src/bernstein/cli/commands/{verify_cmd,wheelhouse_cmd,doctor_airgap_cmd}.py`,
+  `src/bernstein/core/security/network_policy.py`,
+  `src/bernstein/core/distribution/{verifier,doctor_airgap}.py`
+- [Enterprise evaluation](../ENTERPRISE.md) — what to verify before a
+  pilot, including the local-only / air-gapped path
 - [Regulator-class lineage](../compliance/regulatory-lineage.md) —
   tamper-loud audit on the produced artefacts
-- PRs #1015, #1018; tickets `2026-05-05-feat-airgap-distribution.md`
+- [Capability matrix](../security/capability-matrix.md) — how the
+  network gate composes with the other security primitives


### PR DESCRIPTION
## Summary

The v1.10.0 air-gap surface (wheelhouse builder, `bernstein verify`, `--profile airgap`, `--allow-network`, `bernstein doctor airgap`, adapter `external_endpoints`) shipped largely undocumented for end users. `docs/installation/air-gap.md` existed but was missing the adapter-endpoints audit section, did not surface from any entry page, and carried two stale claims.

This PR closes those gaps.

## Gaps closed

- **Surfacing.** Air-gap installation now appears in the `docs/index.md` quick-links table, the `docs/ENTERPRISE.md` "Local-only / air-gapped path" subsection, and the README "Use cases" list. An enterprise evaluator no longer has to find the page through nav drilldown alone.
- **Adapter network endpoints.** New section walks the `external_endpoints` declarations in `src/bernstein/adapters/` (Claude, Codex, Gemini, Cloudflare Agents, Devin Terminal, AWS Q Developer, Junie), explains how `CLIAdapter.enforce_network_policy()` consumes them on spawn, gives an audit grep, and shows how to allow-list a single adapter.
- **`bernstein doctor airgap` checks.** New table enumerating each row the doctor emits (profile-active, deny-all, declared-endpoints-blocked, MCP-catalog-off, memo-store-local, audit-chain-HMAC, no-external-hostnames-in-runtime), so a compliance reviewer can map output to evidence.
- **"When to reach for this" framing** so a reader can self-disqualify before reading the rest of the page.

## Stale-claim corrections

- GPG verifier flag: `--verifier gpg --keyring <path>` (not `--signer gpg --gpg-keyring <path>` as the previous page suggested) — verified against `src/bernstein/cli/commands/wheelhouse_cmd.py`.
- `--profile airgap` version floor: `>= 1.10.0` (the CHANGELOG entry shipping `--profile airgap`, not the prior `>= 1.9.4` placeholder).
- Removed leftover `(Phase 2)` rollout markers — every command described is registered Click code today.

## Verified claims

- `--profile airgap` exists and accepts only `airgap` as a value (`run_bootstrap.py:740`).
- `--allow-network HOST|CIDR|HOST:PORT|none|any` syntax matches `network_policy.py` parser behaviour, including the `--profile airgap` + `--allow-network any` rejection at parse time.
- Adapter endpoints listed are the literal `external_endpoints` tuples currently in tree.
- Doctor checks listed match `src/bernstein/core/distribution/doctor_airgap.py` `run_airgap_checks()`.
- AUTO verifier ordering (crypto then cosign with same key, then GPG with keyring) matches `core/distribution/verifier.py:select_verifier`.

## Test plan

- [x] `uv run mkdocs build` — succeeds; no new warnings introduced by these edits.
- [x] All cross-links resolve (`docs/installation/air-gap.md` from index, ENTERPRISE, README; sibling links to ENTERPRISE, regulatory-lineage, capability-matrix from the page itself).