### PR TITLE
feat(roles): add adversary-reviewer role

### DIFF
--- a/src/bernstein/cli/commands/plan_validate_cmd.py
+++ b/src/bernstein/cli/commands/plan_validate_cmd.py
@@ -14,6 +14,7 @@ from bernstein.core.plan_loader import PlanLoadError, load_plan
 # Known roles from templates/roles/
 _KNOWN_ROLES: frozenset[str] = frozenset(
     {
+        "adversary",
         "manager",
         "backend",
         "frontend",

--- a/src/bernstein/core/planning/plan_schema.py
+++ b/src/bernstein/core/planning/plan_schema.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 KNOWN_ROLES: list[str] = [
+    "adversary",
     "analyst",
     "architect",
     "backend",

--- a/templates/roles/adversary/config.yaml
+++ b/templates/roles/adversary/config.yaml
@@ -1,0 +1,3 @@
+default_model: opus
+default_effort: max
+max_tasks_per_session: 1

--- a/templates/roles/adversary/system_prompt.md
+++ b/templates/roles/adversary/system_prompt.md
@@ -1,0 +1,79 @@
+# You are the Adversary Reviewer
+
+Your job is to find reasons the attached diff should NOT merge. You do
+NOT approve changes; you produce structured findings that a downstream
+gate uses to block or allow the merge. A single `critical` finding
+blocks the merge.
+
+This is a deterministic gate — you run as the *last* pass before the
+Steward merges a worker's worktree.
+
+## Your specialization
+- ASI-class (Agentic Systems Initiative) failure modes (asi01..asi10)
+- Race conditions, TOCTOU bugs, ordering issues in async code
+- Off-by-one errors and boundary conditions
+- Missing edge-case tests (empty input, None, large input, unicode)
+- License/IP issues (vendored code without attribution, copy-pasted snippets)
+- Hidden state leaks across short-lived agents
+- Silent failures, swallowed exceptions, missing error propagation
+- Untested error paths and unverified assumptions
+
+## Project conventions (Bernstein)
+- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Use dataclasses or TypedDict, never raw dict soup
+- Ruff for linting and formatting: `uv run ruff check src/`
+- Google-style docstrings only where non-obvious
+- Async for IO-bound operations, sync for CPU-bound
+- Test runner: `uv run python scripts/run_tests.py -x` (NEVER `uv run pytest tests/` directly)
+- Single test file: `uv run pytest tests/unit/test_foo.py -x -q`
+
+## Methodology
+1. Read the diff in full. Do NOT skim.
+2. Read the surrounding context for each touched file (full function body,
+   the caller, the test file).
+3. For each suspicion, construct a falsification test: a concrete test
+   that, if it passes, closes the finding. If you cannot construct one,
+   the finding is too vague — drop it or downgrade it to `info`.
+4. Classify each finding by severity:
+   - `critical` — would cause data loss, security breach, work loss,
+     incorrect billing, or a regression in a documented behaviour. A
+     single `critical` finding blocks the merge.
+   - `warning` — would cause a flaky test, a missed edge case, or a
+     subtle correctness issue under uncommon conditions.
+   - `info` — design concern, style nit, or future-work hint.
+5. Be specific. Cite `path:line` evidence for every finding. No vague
+   findings like "this looks risky".
+
+## Output format (JSON)
+
+You MUST output a single JSON object on stdout with this shape:
+
+```json
+{
+  "findings": [
+    {
+      "severity": "info|warning|critical",
+      "category": "race|off_by_one|edge_case|license|asi01..asi10|silent_failure|hidden_state|...",
+      "evidence": ["path/to/file.py:42", "path/to/test.py:88"],
+      "rationale": "Concrete reason this is wrong; cite the failure scenario.",
+      "falsification_test": "If this test passes, the finding is closed: <test description>"
+    }
+  ]
+}
+```
+
+Empty `findings: []` is a valid output and means "no objections, merge".
+
+## Rules
+- You produce findings only. You do NOT modify source files.
+- Owned files in the task may include `*.json` or `*.md` for the report
+  output; never edit `src/` from the adversary role.
+- Do not approve. Approval is the Steward's job, based on your findings
+  + the rest of the gate.
+- If the diff is too large to review in one pass (>2000 LOC), report
+  one finding with severity `warning` and category `scope_too_large`.
+- If you cannot parse the diff (binary blob, generated code), report
+  one finding with severity `info` and category `unreviewable`.
+
+## Current task
+{{TASK_DESCRIPTION}}

--- a/templates/roles/adversary/task_prompt.md
+++ b/templates/roles/adversary/task_prompt.md
@@ -1,0 +1,61 @@
+# Task: {{TASK_TITLE}}
+
+## Description
+{{TASK_DESCRIPTION}}
+
+{{#IF FILES}}
+## Files to work with
+{{FILES}}
+{{/IF}}
+
+{{#IF CONTEXT}}
+## Context
+{{CONTEXT}}
+{{/IF}}
+
+## Instructions
+1. Run `git diff` against the base branch to see the change you are reviewing.
+   Do NOT skim; read every hunk.
+2. For each touched file, read the surrounding context (full function,
+   caller, and matching test file).
+3. Build a list of suspicions. For each one, construct a falsification
+   test: a concrete test that, if it passes, closes the finding.
+4. Drop any suspicion you cannot turn into a falsification test, or
+   downgrade it to `info`.
+5. Classify each finding's severity:
+   - `critical` — blocks the merge (data loss, security, work loss,
+     billing error, or a regression of documented behaviour).
+   - `warning` — flaky test, missed edge case, subtle correctness bug.
+   - `info` — design concern, style nit, future-work hint.
+6. Output a single JSON object on stdout with the schema documented in
+   your system prompt.
+7. Do NOT modify source files. You produce findings only.
+
+## If stuck or blocked
+- If a curl to the task server fails, retry up to 3 times with 2-second delays
+- If you cannot determine the failure mode but suspect a problem, use
+  `info` severity, not `critical`.
+- If the diff is unreviewable (binary, generated, > 2000 LOC), follow
+  the rules in your system prompt.
+- If you cannot complete the review, mark the task as failed:
+  ```bash
+  curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \
+    -H "Content-Type: application/json" \
+    -d '{"reason": "<describe what went wrong and what you tried>"}'
+  ```
+
+## Bulletin board
+Post critical findings immediately so the Steward can react before
+the timeout:
+```bash
+curl -s -X POST http://127.0.0.1:8052/bulletin \
+  -H "Content-Type: application/json" \
+  -d '{"agent_id": "{{AGENT_ID}}", "type": "blocker", "content": "<critical finding summary + evidence>"}'
+```
+
+## Done signal
+```bash
+curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete \
+  -H "Content-Type: application/json" \
+  -d '{"result_summary": "{{TASK_TITLE}}: <N critical, M warning, K info>"}'
+```

--- a/tests/unit/test_adversary_role.py
+++ b/tests/unit/test_adversary_role.py
@@ -1,0 +1,146 @@
+"""Tests for the adversary reviewer role template and registry wiring.
+
+Covers:
+    * The role's templates/roles/adversary/ directory exists with the
+      three expected files (system_prompt.md, task_prompt.md, config.yaml).
+    * The role appears in the canonical KNOWN_ROLES registry and the
+      plan_validate fallback set.
+    * The role is discoverable by the role-resolver legacy path.
+    * The system prompt enforces the structured-finding contract used
+      by the downstream merge gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bernstein.cli.commands.plan_validate_cmd import _KNOWN_ROLES
+from bernstein.core.planning.plan_schema import KNOWN_ROLES
+from bernstein.core.planning.role_resolver import (
+    invalidate_cache,
+    resolve_role_prompt,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ADVERSARY_DIR = _REPO_ROOT / "templates" / "roles" / "adversary"
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolver_cache() -> None:
+    """Reset the role-resolver cache between tests."""
+    invalidate_cache()
+
+
+# ---------------------------------------------------------------------------
+# Filesystem layout
+# ---------------------------------------------------------------------------
+
+
+class TestAdversaryRoleFilesExist:
+    """The role lives under templates/roles/adversary/ with the standard files."""
+
+    def test_role_directory_exists(self) -> None:
+        assert _ADVERSARY_DIR.is_dir(), (
+            f"Expected {_ADVERSARY_DIR} to exist as a directory"
+        )
+
+    def test_system_prompt_exists_and_non_empty(self) -> None:
+        system_prompt = _ADVERSARY_DIR / "system_prompt.md"
+        assert system_prompt.is_file()
+        assert len(system_prompt.read_text(encoding="utf-8")) > 200
+
+    def test_task_prompt_exists_and_non_empty(self) -> None:
+        task_prompt = _ADVERSARY_DIR / "task_prompt.md"
+        assert task_prompt.is_file()
+        assert len(task_prompt.read_text(encoding="utf-8")) > 200
+
+    def test_config_yaml_exists_and_parses(self) -> None:
+        config = _ADVERSARY_DIR / "config.yaml"
+        assert config.is_file()
+        parsed = yaml.safe_load(config.read_text(encoding="utf-8"))
+        assert isinstance(parsed, dict)
+        assert "default_model" in parsed
+        assert "default_effort" in parsed
+        assert "max_tasks_per_session" in parsed
+        # Adversary runs as the last gate before merge — keep its
+        # session short so it cannot drift onto unrelated tickets.
+        assert parsed["max_tasks_per_session"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAdversaryInRegistries:
+    """The adversary role appears in every place the orchestrator consults."""
+
+    def test_in_canonical_known_roles(self) -> None:
+        assert "adversary" in KNOWN_ROLES
+
+    def test_in_plan_validate_fallback(self) -> None:
+        assert "adversary" in _KNOWN_ROLES
+
+    def test_known_roles_remain_sorted(self) -> None:
+        # The canonical list is alphabetically sorted; if a future edit
+        # breaks this we want to know.
+        assert sorted(KNOWN_ROLES) == KNOWN_ROLES
+
+
+# ---------------------------------------------------------------------------
+# Role-resolver discovery (legacy path)
+# ---------------------------------------------------------------------------
+
+
+class TestAdversaryDiscoverable:
+    """The role-resolver finds the adversary template via the legacy path."""
+
+    def test_resolver_finds_legacy_template(self) -> None:
+        roles_dir = _REPO_ROOT / "templates" / "roles"
+        resolved = resolve_role_prompt(
+            "adversary",
+            templates_dir=roles_dir,
+            include_plugins=False,
+        )
+        # No skill pack exists for adversary; fall back to the legacy
+        # template.
+        assert resolved.source in {"skill", "legacy"}
+        assert resolved.body  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# Output-format contract
+# ---------------------------------------------------------------------------
+
+
+class TestAdversaryPromptContract:
+    """The system prompt must pin the JSON output shape used by the gate."""
+
+    def test_system_prompt_documents_severity_levels(self) -> None:
+        body = (_ADVERSARY_DIR / "system_prompt.md").read_text(encoding="utf-8")
+        for severity in ("info", "warning", "critical"):
+            assert severity in body, f"system prompt missing severity: {severity}"
+
+    def test_system_prompt_pins_falsification_test_field(self) -> None:
+        body = (_ADVERSARY_DIR / "system_prompt.md").read_text(encoding="utf-8")
+        # The merge gate reads `falsification_test` to know how to close
+        # findings; the prompt must spell it out.
+        assert "falsification_test" in body
+
+    def test_system_prompt_pins_findings_array(self) -> None:
+        body = (_ADVERSARY_DIR / "system_prompt.md").read_text(encoding="utf-8")
+        assert '"findings"' in body or "findings" in body
+
+    def test_system_prompt_forbids_modifying_source(self) -> None:
+        body = (_ADVERSARY_DIR / "system_prompt.md").read_text(encoding="utf-8")
+        # The role is read-only; it must say so explicitly.
+        lowered = body.lower()
+        assert "do not modify" in lowered or "do not approve" in lowered
+
+    def test_task_prompt_has_task_description_placeholder(self) -> None:
+        body = (_ADVERSARY_DIR / "task_prompt.md").read_text(encoding="utf-8")
+        assert "{{TASK_DESCRIPTION}}" in body
+        assert "{{TASK_TITLE}}" in body


### PR DESCRIPTION
## Summary

Adds a first-class `adversary` role under `templates/roles/adversary/`. The adversary reviewer runs as a deterministic gate before the Steward merges a worker's worktree: it tries to break the change rather than approve it, producing structured findings tagged with severity, category, evidence (`path:line`), rationale, and a falsification test that, if it passes, closes the finding.

This is the role-template + registry slice. Spawn rule, dataclass, merge gate, `--adversary-fix` CLI, and metrics are out of scope and live in a follow-up.

## What the role does

The adversary outputs JSON with the schema downstream gates consume:

```json
{
  "findings": [
    {
      "severity": "info|warning|critical",
      "category": "race|off_by_one|edge_case|license|asi01..asi10|...",
      "evidence": ["path/to/file.py:42"],
      "rationale": "Concrete reason this is wrong; cite the failure scenario.",
      "falsification_test": "If this test passes, the finding is closed: <test description>"
    }
  ]
}
```

A single `critical` finding is intended to block the merge. Empty findings means "no objections".

## Failure modes the role is shaped to catch

- Race conditions and TOCTOU bugs in async code
- Off-by-one errors and boundary conditions
- Missing edge-case tests (empty input, `None`, large input, unicode)
- Silent failures, swallowed exceptions, missing error propagation
- License/IP issues (vendored code without attribution, copy-pasted snippets)
- ASI-class (Agentic Systems Initiative) failure modes (`asi01..asi10`)
- Hidden state leaks across short-lived agents

The role is read-only — it produces findings only and never modifies source files.

## Wiring

- `templates/roles/adversary/system_prompt.md` — system prompt with the JSON contract, severity levels, methodology, and read-only rule
- `templates/roles/adversary/task_prompt.md` — per-task wrapper with the standard placeholders
- `templates/roles/adversary/config.yaml` — `default_model: opus`, `default_effort: max`, `max_tasks_per_session: 1` (short session keeps it on-task)
- Registered in the canonical `KNOWN_ROLES` (`src/bernstein/core/planning/plan_schema.py`) so plan YAMLs can declare adversary steps
- Registered in the `plan validate` fallback set so it is not flagged unknown

## Tests added

`tests/unit/test_adversary_role.py` — 13 tests covering:

- Role directory + three template files exist and are non-empty; `config.yaml` parses
- Registry membership in both `KNOWN_ROLES` and the `plan validate` fallback
- `KNOWN_ROLES` remains alphabetically sorted
- Role-resolver legacy path discovers the new template
- System prompt pins the output contract: severity levels (`info|warning|critical`), `falsification_test` field, `findings` array, read-only rule
- Task prompt has `{{TASK_TITLE}}` and `{{TASK_DESCRIPTION}}` placeholders

## Test plan

- [x] `uv run pytest tests/unit/test_adversary_role.py -x -q` — 13 passed
- [x] `uv run pytest tests/unit/test_plan_schema.py -x -q` — 41 passed (registry change does not break enum tests)
- [x] `uv run pytest tests/unit/test_plan_validate.py -x -q` — 9 passed
- [x] `uv run pytest tests/unit/test_role_classifier.py tests/unit/skills/test_role_resolver.py tests/unit/test_data_generators.py -x -q` — 51 passed
- [x] `uv run ruff check src tests` — all checks passed