### PR TITLE
style: ruff format claude adapter (post #1070 merge)

### DIFF
--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -63,6 +63,7 @@ def _task_budgets_opt_in() -> bool:
     raw = os.environ.get(_TASK_BUDGETS_OPT_IN_ENV, "")
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
+
 # Map short model names to Claude Code CLI model IDs.
 # Last verified against upstream @anthropic-ai/claude-code 2.1.x on 2026-05-05.
 # Opus 4.7 is GA at the same price as 4.6 (Anthropic news, 2026-04-16); Sonnet


### PR DESCRIPTION
PR #1070 merged with one whitespace tick on `src/bernstein/adapters/claude.py` that `ruff format --check` rejected. This applies the formatter; one-line diff.