### PR TITLE
feat(adapters): add Junie CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ---
 
-**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 39 more), runs the tests, and merges the code that actually passes. You come back to working code.
+**What is this?** You tell it what you want built. It splits the work across several AI coding agents (Claude Code, Codex, Gemini CLI, and 40 more), runs the tests, and merges the code that actually passes. You come back to working code.
 
 Forward-deployed engineering, on a swarm. Drop Bernstein into a client repo and you get a multi-agent crew with file-based state, per-agent credential scoping, and an HMAC-signed audit trail — running on whichever CLI agents the client already trusts.
 
@@ -256,7 +256,7 @@ performs vector search.
 | Feature | Bernstein | CrewAI | AutoGen [^autogen] | LangGraph |
 |---------|-----------|--------|---------|-----------|
 | Orchestrator | Deterministic code | LLM-driven (+ code Flows) | LLM-driven | Graph + LLM |
-| Works with | Any CLI agent (42 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (43 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
 | Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Verification | Janitor + quality gates | Guardrails + Pydantic output | Termination conditions | Conditional edges |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap l
 | [Continue](https://continue.dev) | Any OpenAI/Anthropic-compatible | `npm install -g @continuedev/cli` (binary: `cn`) |
 | [Goose](https://block.github.io/goose/) | Any provider Goose supports | See [Goose docs](https://block.github.io/goose/) |
 | [IaC](https://www.terraform.io/) (Terraform/Pulumi) | Any provider the base agent uses | Built-in |
+| [Junie](https://junie.jetbrains.com) | BYOK (Anthropic, OpenAI, Google, xAI, OpenRouter, Copilot) | `curl -fsSL https://junie.jetbrains.com/install.sh \| bash` |
 | [Kilo](https://kilo.dev) | Kilo-hosted | See [Kilo docs](https://kilo.dev) |
 | [Kiro](https://kiro.dev) | Kiro-hosted | See [Kiro docs](https://kiro.dev) |
 | [AWS Q Developer](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/command-line.html) | Amazon Q-managed (Claude-backed) | `brew install --cask amazon-q` then `q login` |

--- a/examples/plugins/reporter_plugin.py
+++ b/examples/plugins/reporter_plugin.py
@@ -65,7 +65,6 @@ class SlackReporter:
         self._summary.failed.append(f"{task_id} ({role}): {error[:100]}")
         self._post(
             f":x: Task *{task_id}* failed ({role})\n```{error[:300]}```",
-            
         )
 
     @hookimpl

--- a/src/bernstein/adapters/junie.py
+++ b/src/bernstein/adapters/junie.py
@@ -45,7 +45,7 @@ from bernstein.adapters.env_isolation import build_filtered_env
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from bernstein.core.tasks.models import ModelConfig
+    from bernstein.core.models import ModelConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/bernstein/adapters/junie.py
+++ b/src/bernstein/adapters/junie.py
@@ -1,0 +1,279 @@
+"""JetBrains Junie CLI adapter.
+
+`Junie <https://junie.jetbrains.com>`_ is JetBrains' LLM-agnostic AI
+coding agent. It ships as a single ``junie`` binary installed via::
+
+    curl -fsSL https://junie.jetbrains.com/install.sh | bash
+
+The installer drops the binary at ``$HOME/.local/bin/junie`` and the
+public README documents an interactive surface (``junie`` followed by
+natural-language prompts) plus slash commands such as
+``/install-github-action`` and ``/feedback``.
+
+For unattended Bernstein runs we use the documented headless surface
+``junie run --headless --model <id> --prompt-file <path>``: the prompt
+lives in a file under ``.sdd/runtime/`` so multi-line prompts and shell
+metacharacters round-trip cleanly, and ``--headless`` suppresses the
+interactive TUI so the process exits when the model finishes the
+response.  Junie is BYOK across providers (Anthropic, OpenAI, Google,
+xAI, OpenRouter, Copilot), so the adapter forwards whichever provider
+key the routed model needs and pins the network policy to the
+provider-specific endpoint.
+
+Last verified against https://junie.jetbrains.com/ and the upstream
+repository https://github.com/jetbrains-junie/junie on 2026-05-06.
+The CLI flag set is still in beta — if the public surface drifts,
+update :data:`_HEADLESS_FLAG` / :data:`_PROMPT_FILE_FLAG` here and the
+matching assertions in ``tests/unit/test_adapter_junie.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from typing import TYPE_CHECKING, Any
+
+from bernstein.adapters.base import (
+    DEFAULT_TIMEOUT_SECONDS,
+    CLIAdapter,
+    SpawnResult,
+    build_worker_cmd,
+)
+from bernstein.adapters.env_isolation import build_filtered_env
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.tasks.models import ModelConfig
+
+logger = logging.getLogger(__name__)
+
+# Headless / prompt-file flags from the JetBrains Junie CLI spec
+# (junie.jetbrains.com/, 2026-05-06).  Centralised so the test suite
+# pins a single source of truth and a CLI drift surfaces in one diff.
+_RUN_SUBCOMMAND = "run"
+_HEADLESS_FLAG = "--headless"
+_MODEL_FLAG = "--model"
+_PROMPT_FILE_FLAG = "--prompt-file"
+
+# Map ``JUNIE_PROVIDER`` env values (and falsy -> default route) to the
+# corresponding provider-key env var Junie expects in its subprocess.
+# Keys mirror the BYOK providers documented at junie.jetbrains.com.
+_PROVIDER_ENV_KEYS: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "xai": "XAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+    "copilot": "GH_COPILOT_TOKEN",
+    "mistral": "MISTRAL_API_KEY",
+}
+
+# Provider-host map for the network-policy allow-list. Falls back to
+# the empty tuple (no remote allow-listing) when the routed provider is
+# unknown — the policy then defers to the global default.
+_PROVIDER_ENDPOINTS: dict[str, tuple[tuple[str, int], ...]] = {
+    "anthropic": (("api.anthropic.com", 443),),
+    "openai": (("api.openai.com", 443),),
+    "google": (("generativelanguage.googleapis.com", 443),),
+    "gemini": (("generativelanguage.googleapis.com", 443),),
+    "xai": (("api.x.ai", 443),),
+    "openrouter": (("openrouter.ai", 443),),
+    "copilot": (("api.githubcopilot.com", 443),),
+    "mistral": (("api.mistral.ai", 443),),
+}
+
+# JetBrains Account / Junie API key — always forwarded so the binary
+# can resolve account-level entitlements regardless of routed provider.
+_JUNIE_ACCOUNT_KEY = "JUNIE_API_KEY"
+# Provider-routing override read directly by the binary.
+_JUNIE_PROVIDER_KEY = "JUNIE_PROVIDER"
+
+
+class JunieAdapter(CLIAdapter):
+    """Spawn and monitor JetBrains Junie CLI sessions.
+
+    Junie is BYOK and LLM-agnostic; the adapter's external-endpoint
+    declaration is populated dynamically from
+    ``model_config.provider`` (or ``JUNIE_PROVIDER`` as a fallback) so
+    Bernstein's network policy matches whichever upstream API the
+    routed model dials.
+
+    The adapter raises only at :meth:`spawn` time — importing this
+    module never touches the env, so missing credentials surface as a
+    runtime warning when an actual task is dispatched.
+    """
+
+    # External endpoints are computed per-spawn via :meth:`_resolve_provider`
+    # because Junie can route to any of the BYOK providers. Leave the
+    # class-level tuple empty so the base class skips the static check
+    # and the per-spawn enforcement is the only authority.
+    external_endpoints: tuple[tuple[str, int], ...] = ()
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        """Launch a one-shot Junie headless session.
+
+        Args:
+            prompt: Task prompt — written to a per-session file and
+                passed to Junie via ``--prompt-file``.
+            workdir: Working directory; Junie treats this as the
+                project root.
+            model_config: Bernstein model selection.  ``model`` is
+                forwarded via ``--model``; ``provider`` (when set on a
+                future ``ModelConfig`` revision) drives provider-
+                specific env routing — until then we fall back to
+                ``$JUNIE_PROVIDER``.
+            session_id: Unique session identifier used for log naming
+                and the bernstein-worker title.
+            mcp_config: Optional MCP server definitions (unused —
+                Junie has its own MCP wiring).
+            timeout_seconds: Process wall-clock timeout.
+            task_scope: Task scope hint (unused by Junie).
+            budget_multiplier: Retry budget multiplier (unused).
+            system_addendum: Protocol-critical instructions; Junie's
+                headless mode reads a single prompt file, so the
+                addendum is appended to the prompt body.
+
+        Returns:
+            SpawnResult describing the spawned process.
+
+        Raises:
+            RuntimeError: The ``junie`` binary is missing from PATH or
+                the OS denies execution.
+        """
+        provider = self._resolve_provider(model_config)
+        # Bind external endpoints for the network policy check based on
+        # the routed provider; class-level remains empty so this is the
+        # single source of truth.
+        self.external_endpoints = _PROVIDER_ENDPOINTS.get(provider, ())
+        self.enforce_network_policy()
+
+        runtime_dir = workdir / ".sdd" / "runtime"
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+        log_path = runtime_dir / f"{session_id}.log"
+        prompt_path = runtime_dir / f"{session_id}-prompt.txt"
+
+        # Junie's headless mode reads the prompt from a file. Multi-line
+        # prompts and shell metacharacters survive intact this way; we
+        # also append the system addendum because Junie has no separate
+        # system-prompt channel in the documented ``run --headless``
+        # surface.
+        full_prompt = f"{prompt}\n\n{system_addendum}".rstrip() if system_addendum else prompt
+        prompt_path.write_text(full_prompt, encoding="utf-8")
+
+        # Surface missing credentials as a warning rather than a hard
+        # error: Junie also supports OAuth login via JetBrains Account,
+        # so a fresh user could legitimately have no env-var keys set.
+        provider_key = _PROVIDER_ENV_KEYS.get(provider)
+        if not os.environ.get(_JUNIE_ACCOUNT_KEY) and not (provider_key and os.environ.get(provider_key)):
+            logger.warning(
+                "JunieAdapter: neither %s nor the routed provider key (%s) is set "
+                "and no JetBrains Account OAuth cache has been confirmed — "
+                "spawn may fail with an authentication error.",
+                _JUNIE_ACCOUNT_KEY,
+                provider_key or "<unknown provider>",
+            )
+
+        cmd: list[str] = [
+            "junie",
+            _RUN_SUBCOMMAND,
+            _HEADLESS_FLAG,
+        ]
+        # Only forward ``--model`` when a non-empty model is selected;
+        # Junie falls back to its account-default model otherwise. This
+        # matches the Devin adapter's defensive model-flag handling.
+        if model_config.model:
+            cmd.extend([_MODEL_FLAG, model_config.model])
+        cmd.extend([_PROMPT_FILE_FLAG, str(prompt_path)])
+
+        # Wrap with bernstein-worker for process visibility (bernstein ps).
+        pid_dir = runtime_dir / "pids"
+        wrapped_cmd = build_worker_cmd(
+            cmd,
+            role=session_id.rsplit("-", 1)[0],
+            session_id=session_id,
+            pid_dir=pid_dir,
+            workdir=workdir,
+            log_path=log_path,
+            model=model_config.model,
+        )
+
+        # Always forward JUNIE_API_KEY + JUNIE_PROVIDER plus the
+        # provider-specific key for the routed model.  Keep the list
+        # minimal so unrelated master credentials (e.g. an
+        # ``OPENAI_MASTER_KEY`` used by the orchestrator itself) cannot
+        # leak into the agent's environment.
+        extra_keys: list[str] = [_JUNIE_ACCOUNT_KEY, _JUNIE_PROVIDER_KEY]
+        if provider_key:
+            extra_keys.append(provider_key)
+        env = build_filtered_env(extra_keys)
+
+        with log_path.open("w") as log_file:
+            try:
+                proc = subprocess.Popen(
+                    wrapped_cmd,
+                    cwd=workdir,
+                    env=env,
+                    stdout=log_file,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,
+                )
+            except FileNotFoundError as exc:
+                msg = (
+                    "junie not found in PATH. "
+                    "Install: curl -fsSL https://junie.jetbrains.com/install.sh | bash "
+                    "(see https://junie.jetbrains.com/)"
+                )
+                raise RuntimeError(msg) from exc
+            except PermissionError as exc:
+                raise RuntimeError(f"Permission denied executing junie: {exc}") from exc
+
+        self._probe_fast_exit(proc, log_path, provider_name="junie")
+
+        result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
+        if timeout_seconds > 0:
+            result.timeout_timer = self._start_timeout_watchdog(proc.pid, timeout_seconds, session_id)
+        return result
+
+    def name(self) -> str:
+        """Return the registry / metadata adapter name."""
+        return "junie"
+
+    @staticmethod
+    def _resolve_provider(model_config: ModelConfig) -> str:
+        """Resolve the BYOK provider for env routing and policy.
+
+        Precedence:
+          1. ``model_config.provider`` if explicitly set on the task
+             (a future ``ModelConfig`` revision will surface this).
+          2. ``$JUNIE_PROVIDER`` env var (matches the binary's own
+             override mechanism).
+          3. Empty string when nothing is configured — caller falls
+             back to provider-agnostic env routing.
+
+        Returns:
+            Lower-cased provider slug (e.g. ``"anthropic"``).  May be
+            empty when no provider is configured.
+        """
+        provider_obj: Any = getattr(model_config, "provider", None)
+        if provider_obj is not None:
+            # Tolerate both StrEnum values and plain strings.
+            provider_value = getattr(provider_obj, "value", str(provider_obj))
+            if provider_value:
+                return str(provider_value).lower()
+        env_value = os.environ.get(_JUNIE_PROVIDER_KEY, "")
+        return env_value.lower()

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -33,6 +33,7 @@ from bernstein.adapters.goose import GooseAdapter
 from bernstein.adapters.gptme import GptmeAdapter
 from bernstein.adapters.hermes import HermesAdapter
 from bernstein.adapters.iac import IaCAdapter
+from bernstein.adapters.junie import JunieAdapter
 from bernstein.adapters.kilo import KiloAdapter
 from bernstein.adapters.kimi import KimiAdapter
 from bernstein.adapters.kiro import KiroAdapter
@@ -79,6 +80,7 @@ _ADAPTERS: dict[str, type[CLIAdapter] | CLIAdapter] = {
     "gptme": GptmeAdapter,
     "hermes": HermesAdapter,
     "iac": IaCAdapter,
+    "junie": JunieAdapter,
     "kilo": KiloAdapter,
     "kimi": KimiAdapter,
     "kiro": KiroAdapter,

--- a/src/bernstein/core/agents/adapter_autodetect.py
+++ b/src/bernstein/core/agents/adapter_autodetect.py
@@ -43,6 +43,7 @@ _KNOWN_BINARIES: dict[str, str] = {
     "cursor": "cursor",
     "cn": "continue",
     "goose": "goose",
+    "junie": "junie",
     "kilo": "kilo",
     "kiro-cli": "kiro",
     "ollama": "ollama",

--- a/tests/integration/acp/conformance/test_acp_vectors.py
+++ b/tests/integration/acp/conformance/test_acp_vectors.py
@@ -32,7 +32,9 @@ from bernstein.core.protocols.acp.transport import StdioAcpTransport
 FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "acp" / "conformance"
 
 
-def _wire_pipe(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
+def _wire_pipe(
+    loop: asyncio.AbstractEventLoop,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
     transport_reader = asyncio.StreamReader(loop=loop)
     capture_reader = asyncio.StreamReader(loop=loop)
     capture_protocol = asyncio.StreamReaderProtocol(capture_reader, loop=loop)
@@ -58,7 +60,11 @@ def _wire_pipe(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader, a
         def write_eof(self) -> None:
             self.close()
 
-    return transport_reader, asyncio.StreamWriter(_CaptureTransport(), capture_protocol, transport_reader, loop), capture_reader
+    return (
+        transport_reader,
+        asyncio.StreamWriter(_CaptureTransport(), capture_protocol, transport_reader, loop),
+        capture_reader,
+    )
 
 
 def _make_registry() -> ACPHandlerRegistry:
@@ -97,9 +103,7 @@ def _replay(fixture: Path) -> list[dict[str, Any]]:
     async def _run() -> list[dict[str, Any]]:
         loop = asyncio.get_running_loop()
         reader, writer, capture = _wire_pipe(loop)
-        transport = StdioAcpTransport(
-            registry=_make_registry(), reader=reader, writer=writer
-        )
+        transport = StdioAcpTransport(registry=_make_registry(), reader=reader, writer=writer)
         serve_task = asyncio.create_task(transport.serve_forever())
 
         responses: list[dict[str, Any]] = []

--- a/tests/integration/acp/test_audit_parity.py
+++ b/tests/integration/acp/test_audit_parity.py
@@ -87,24 +87,31 @@ def test_acp_and_cli_emit_identical_audit_payloads() -> None:
             )
             sid = result["sessionId"]
             await registry.dispatch(_ctx("setMode", 2), {"sessionId": sid, "mode": "auto"})
-            await registry.dispatch(
-                _ctx("cancel", 3), {"sessionId": sid, "reason": "user_done"}
-            )
+            await registry.dispatch(_ctx("cancel", 3), {"sessionId": sid, "reason": "user_done"})
             return sid
 
         sid = asyncio.run(_drive_acp())
 
         # Mimic the CLI surface invoking the same audit calls directly.
         cli_audit.log(
-            "acp.prompt", "acp_bridge", "session", sid,
+            "acp.prompt",
+            "acp_bridge",
+            "session",
+            sid,
             {"peer": "test", "cwd": "/work", "role": "backend", "mode": "manual"},
         )
         cli_audit.log(
-            "acp.set_mode", "acp_bridge", "session", sid,
+            "acp.set_mode",
+            "acp_bridge",
+            "session",
+            sid,
             {"peer": "test", "mode": "auto"},
         )
         cli_audit.log(
-            "acp.cancel", "acp_bridge", "session", sid,
+            "acp.cancel",
+            "acp_bridge",
+            "session",
+            sid,
             {"peer": "test", "reason": "user_done", "ok": True},
         )
 

--- a/tests/integration/acp/test_lifecycle.py
+++ b/tests/integration/acp/test_lifecycle.py
@@ -18,7 +18,9 @@ from bernstein.core.protocols.acp.session import ACPSessionStore
 from bernstein.core.protocols.acp.transport import StdioAcpTransport
 
 
-def _wire_pipe(loop: asyncio.AbstractEventLoop) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
+def _wire_pipe(
+    loop: asyncio.AbstractEventLoop,
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyncio.StreamReader]:
     """In-memory reader/writer pair (same shape as the unit-test helper)."""
     transport_reader = asyncio.StreamReader(loop=loop)
     capture_reader = asyncio.StreamReader(loop=loop)
@@ -216,9 +218,7 @@ def test_request_permission_round_trip_through_transport() -> None:
         )
         await asyncio.sleep(0.01)
         # Find the open waiter id from the notification just emitted.
-        rp_frame = next(
-            f for f in notifications if f.get("method") == "requestPermission"
-        )
+        rp_frame = next(f for f in notifications if f.get("method") == "requestPermission")
         prompt_id = rp_frame["params"]["promptId"]
         # Reply via the requestPermission handler.
         resp = await registry.dispatch(

--- a/tests/integration/fleet/test_aggregator_e2e.py
+++ b/tests/integration/fleet/test_aggregator_e2e.py
@@ -59,10 +59,7 @@ class _Handler(BaseHTTPRequestHandler):
                 self.wfile.write(b"event: heartbeat\ndata: {}\n\n")
                 self.wfile.flush()
                 for name, payload in list(self.__class__.sse_events):
-                    line = (
-                        f"event: {name}\n"
-                        f"data: {json.dumps(payload)}\n\n"
-                    ).encode()
+                    line = (f"event: {name}\ndata: {json.dumps(payload)}\n\n").encode()
                     self.wfile.write(line)
                     self.wfile.flush()
                 # Keep connection alive briefly for the client to consume.
@@ -115,9 +112,7 @@ async def test_aggregator_against_real_http_server(tmp_path: Path) -> None:
     _Handler.sse_events = [("task.created", {"task_id": "t1", "title": "demo"})]
     with _serve(_Handler) as port:
         project = _project(tmp_path, "alpha", port)
-        aggregator = FleetAggregator(
-            [project], poll_interval_s=0.1, backoff_min_s=0.05, backoff_max_s=0.1
-        )
+        aggregator = FleetAggregator([project], poll_interval_s=0.1, backoff_min_s=0.05, backoff_max_s=0.1)
         await aggregator.start()
         try:
             for _ in range(40):
@@ -203,9 +198,7 @@ async def test_web_app_projects_endpoint(tmp_path: Path) -> None:
     }
     with _serve(_Handler) as port:
         project = _project(tmp_path, "alpha", port)
-        aggregator = FleetAggregator(
-            [project], poll_interval_s=0.1, backoff_min_s=0.05, backoff_max_s=0.1
-        )
+        aggregator = FleetAggregator([project], poll_interval_s=0.1, backoff_min_s=0.05, backoff_max_s=0.1)
         await aggregator.start()
         try:
             # Allow the poll to run at least once.

--- a/tests/integration/preview/test_preview_lifecycle.py
+++ b/tests/integration/preview/test_preview_lifecycle.py
@@ -141,9 +141,7 @@ class _FakeSandbox:
 def test_full_lifecycle_with_real_socket(tmp_path: Path, local_server: _LocalServer) -> None:
     """Start → list → stop, with audit-chain verification at the end."""
     # Project file the discovery layer can pick up.
-    (tmp_path / "package.json").write_text(
-        json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8"
-    )
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8")
 
     # The fake dev server reports the port that the actual local socket
     # is bound to, so the TCP probe in PreviewManager.start succeeds.

--- a/tests/integration/protocols/mcp_catalog/test_catalog_integration.py
+++ b/tests/integration/protocols/mcp_catalog/test_catalog_integration.py
@@ -69,14 +69,10 @@ def isolated_audit_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return audit_dir
 
 
-def test_full_install_writes_managed_block_and_audit(
-    tmp_path: Path, isolated_audit_dir: Path
-) -> None:
+def test_full_install_writes_managed_block_and_audit(tmp_path: Path, isolated_audit_dir: Path) -> None:
     cache = tmp_path / "cache.json"
     user_config = tmp_path / "mcp.json"
-    user_config.write_text(
-        json.dumps({"mcpServers": {"manual": {"command": "x"}}})
-    )
+    user_config.write_text(json.dumps({"mcpServers": {"manual": {"command": "x"}}}))
 
     transport = _OneShotTransport(json.dumps(CATALOG_PAYLOAD).encode())
     fetcher = CatalogFetcher(
@@ -100,9 +96,7 @@ def test_full_install_writes_managed_block_and_audit(
     outcome = service.install("fs-readonly", skip_confirmation=True)
     assert outcome.installed is not None
     assert outcome.preview.exit_code == 0
-    assert any(
-        change.path == "install-marker.txt" for change in outcome.preview.diff
-    )
+    assert any(change.path == "install-marker.txt" for change in outcome.preview.diff)
 
     payload = json.loads(user_config.read_text())
     assert payload["mcpServers"]["manual"] == {"command": "x"}
@@ -113,12 +107,7 @@ def test_full_install_writes_managed_block_and_audit(
 
     audit_files = list(isolated_audit_dir.glob("*.jsonl"))
     assert audit_files, "expected at least one daily audit file"
-    audit_lines = [
-        json.loads(line)
-        for fp in audit_files
-        for line in fp.read_text().splitlines()
-        if line.strip()
-    ]
+    audit_lines = [json.loads(line) for fp in audit_files for line in fp.read_text().splitlines() if line.strip()]
     event_types = {entry["event_type"] for entry in audit_lines}
     assert "mcp_catalog.fetch" in event_types
     assert "mcp_catalog.install" in event_types

--- a/tests/unit/autofix/test_dispatcher.py
+++ b/tests/unit/autofix/test_dispatcher.py
@@ -178,14 +178,10 @@ def test_fourth_attempt_escalates_to_human(tmp_path: Path) -> None:
     log = LogExtraction(ok=True, body="config drift")
 
     for _ in range(MAX_ATTEMPTS_PER_PUSH):
-        rec = dispatcher.dispatch(
-            repo_config=cfg, pr=pr, run_id="r", log=log, session_id="sess123"
-        )
+        rec = dispatcher.dispatch(repo_config=cfg, pr=pr, run_id="r", log=log, session_id="sess123")
         assert rec.outcome == "success"
 
-    overflow = dispatcher.dispatch(
-        repo_config=cfg, pr=pr, run_id="r", log=log, session_id="sess123"
-    )
+    overflow = dispatcher.dispatch(repo_config=cfg, pr=pr, run_id="r", log=log, session_id="sess123")
     assert overflow.outcome == "needs_human"
     assert any(label == "needs-human" for _, _, label in actions.labels)
     # No dispatch on the overflow attempt.
@@ -200,9 +196,7 @@ def test_fourth_attempt_escalates_to_human(tmp_path: Path) -> None:
 def test_cost_cap_aborts_and_comments(tmp_path: Path) -> None:
     """Spend over the per-repo cap aborts the attempt cleanly."""
     actions = _Actions()
-    spy = _DispatchSpy(
-        result=DispatchResult(success=True, commit_sha="sha", cost_usd=10.0)
-    )
+    spy = _DispatchSpy(result=DispatchResult(success=True, commit_sha="sha", cost_usd=10.0))
     dispatcher = Dispatcher(
         audit=_audit(tmp_path),
         action_adapter=actions,
@@ -249,9 +243,7 @@ def test_audit_chain_is_intact_after_attempt(tmp_path: Path) -> None:
     dispatcher = Dispatcher(
         audit=audit,
         action_adapter=_Actions(),
-        dispatch_hook=_DispatchSpy(
-            result=DispatchResult(success=True, commit_sha="sha", cost_usd=0.5)
-        ),
+        dispatch_hook=_DispatchSpy(result=DispatchResult(success=True, commit_sha="sha", cost_usd=0.5)),
     )
     dispatcher.dispatch(
         repo_config=_repo_config(),
@@ -271,9 +263,7 @@ def test_attempt_id_links_open_and_close_events(tmp_path: Path) -> None:
     dispatcher = Dispatcher(
         audit=audit,
         action_adapter=_Actions(),
-        dispatch_hook=_DispatchSpy(
-            result=DispatchResult(success=True, commit_sha="sha", cost_usd=0.5)
-        ),
+        dispatch_hook=_DispatchSpy(result=DispatchResult(success=True, commit_sha="sha", cost_usd=0.5)),
     )
     dispatcher.dispatch(
         repo_config=_repo_config(),
@@ -285,11 +275,7 @@ def test_attempt_id_links_open_and_close_events(tmp_path: Path) -> None:
 
     log_files = sorted(audit_dir.glob("*.jsonl"))
     assert log_files, "audit log must exist"
-    events = [
-        json.loads(line)
-        for line in log_files[0].read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
+    events = [json.loads(line) for line in log_files[0].read_text(encoding="utf-8").splitlines() if line.strip()]
     assert len(events) == 2
     assert events[0]["event_type"] == "autofix.attempt.start"
     assert events[1]["event_type"] == "autofix.attempt.finish"

--- a/tests/unit/fleet/test_bulk.py
+++ b/tests/unit/fleet/test_bulk.py
@@ -28,7 +28,10 @@ def _project(tmp_path: Path, name: str) -> ProjectConfig:
 
 def test_evaluate_filter_basic(tmp_path: Path) -> None:
     snap = ProjectSnapshot(
-        name="alpha", state=ProjectState.ONLINE, agents=3, cost_usd=10.0,
+        name="alpha",
+        state=ProjectState.ONLINE,
+        agents=3,
+        cost_usd=10.0,
         pending_approvals=2,
     )
     assert evaluate_filter(snap, "cost>5")

--- a/tests/unit/fleet/test_prometheus_proxy.py
+++ b/tests/unit/fleet/test_prometheus_proxy.py
@@ -39,11 +39,7 @@ def test_merge_text_preserves_existing_labels() -> None:
 
 
 def test_merge_text_keeps_help_and_type_lines() -> None:
-    body = (
-        "# HELP bernstein_tasks_total Total tasks\n"
-        "# TYPE bernstein_tasks_total counter\n"
-        "bernstein_tasks_total 1\n"
-    )
+    body = "# HELP bernstein_tasks_total Total tasks\n# TYPE bernstein_tasks_total counter\nbernstein_tasks_total 1\n"
     rewritten = merge_text("alpha", body)
     assert "# HELP bernstein_tasks_total" in rewritten
     assert "# TYPE bernstein_tasks_total counter" in rewritten

--- a/tests/unit/preview/test_manager.py
+++ b/tests/unit/preview/test_manager.py
@@ -161,9 +161,7 @@ def test_parse_duration_rejects_invalid(spec: str) -> None:
 
 def test_start_persists_state_and_writes_audit_chain(tmp_path: Path) -> None:
     """Successful start emits 2 audit entries (start + link) and persists state."""
-    (tmp_path / "package.json").write_text(
-        json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8"
-    )
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8")
     runner = _FakeRunner(["VITE ready", "Local:   http://localhost:5173/"])
     audit = _audit_log(tmp_path)
     store = PreviewStore(path=tmp_path / "preview.json")
@@ -209,10 +207,7 @@ def test_start_persists_state_and_writes_audit_chain(tmp_path: Path) -> None:
     log_files = list((tmp_path / "audit").glob("*.jsonl"))
     assert log_files, "audit log should have produced at least one daily file"
     raw_lines = [
-        json.loads(line)
-        for f in log_files
-        for line in f.read_text(encoding="utf-8").splitlines()
-        if line.strip()
+        json.loads(line) for f in log_files for line in f.read_text(encoding="utf-8").splitlines() if line.strip()
     ]
     event_types = [r["event_type"] for r in raw_lines]
     assert "preview.start" in event_types
@@ -221,9 +216,7 @@ def test_start_persists_state_and_writes_audit_chain(tmp_path: Path) -> None:
 
 def test_stop_removes_record_and_audits(tmp_path: Path) -> None:
     """``stop`` tears the tunnel down, deletes state, audits ``preview.stop``."""
-    (tmp_path / "package.json").write_text(
-        json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8"
-    )
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8")
     runner = _FakeRunner(["http://localhost:1234"])
     tunnel = _FakeTunnel()
     audit = _audit_log(tmp_path)
@@ -262,9 +255,7 @@ def test_stop_removes_record_and_audits(tmp_path: Path) -> None:
 
 def test_tunnel_failure_rolls_back_dev_server(tmp_path: Path) -> None:
     """When the tunnel can't open, the dev server is terminated."""
-    (tmp_path / "package.json").write_text(
-        json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8"
-    )
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8")
     runner = _FakeRunner(["http://localhost:1234"])
     audit = _audit_log(tmp_path)
     store = PreviewStore(path=tmp_path / "preview.json")
@@ -293,9 +284,7 @@ def test_tunnel_failure_rolls_back_dev_server(tmp_path: Path) -> None:
 
 def test_port_probe_failure_rolls_back(tmp_path: Path) -> None:
     """A failing TCP probe also tears the dev server down."""
-    (tmp_path / "package.json").write_text(
-        json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8"
-    )
+    (tmp_path / "package.json").write_text(json.dumps({"scripts": {"dev": "vite"}}), encoding="utf-8")
     runner = _FakeRunner(["http://localhost:1234"])
     store = PreviewStore(path=tmp_path / "preview.json")
     audit = _audit_log(tmp_path)

--- a/tests/unit/protocols/acp/test_handlers.py
+++ b/tests/unit/protocols/acp/test_handlers.py
@@ -153,13 +153,9 @@ def test_set_mode_persists_on_session() -> None:
     registry = _build_registry(audit_log=audit)
 
     async def _run() -> None:
-        prompt_result = await registry.dispatch(
-            _ctx("prompt"), {"prompt": "do x", "cwd": "/w"}
-        )
+        prompt_result = await registry.dispatch(_ctx("prompt"), {"prompt": "do x", "cwd": "/w"})
         sid = prompt_result["sessionId"]
-        result = await registry.dispatch(
-            _ctx("setMode"), {"sessionId": sid, "mode": "auto"}
-        )
+        result = await registry.dispatch(_ctx("setMode"), {"sessionId": sid, "mode": "auto"})
         assert result["mode"] == "auto"
         session = await registry.sessions.get(sid)
         assert session is not None and session.mode == "auto"
@@ -173,9 +169,7 @@ def test_set_mode_unknown_session_raises() -> None:
 
     async def _run() -> None:
         with pytest.raises(ACPSchemaError) as exc:
-            await registry.dispatch(
-                _ctx("setMode"), {"sessionId": "missing", "mode": "auto"}
-            )
+            await registry.dispatch(_ctx("setMode"), {"sessionId": "missing", "mode": "auto"})
         assert exc.value.code == SESSION_NOT_FOUND
 
     asyncio.run(_run())
@@ -194,9 +188,7 @@ def test_cancel_walks_drain_pipeline() -> None:
     async def _run() -> None:
         prompt_result = await registry.dispatch(_ctx("prompt"), {"prompt": "do x"})
         sid = prompt_result["sessionId"]
-        result = await registry.dispatch(
-            _ctx("cancel"), {"sessionId": sid, "reason": "mid_tool_call"}
-        )
+        result = await registry.dispatch(_ctx("cancel"), {"sessionId": sid, "reason": "mid_tool_call"})
         assert result["cancelled"] is True
         assert canceller_calls == [(sid, "mid_tool_call")]
         # Audit chain captures the cancel event.
@@ -265,9 +257,7 @@ def test_default_permission_asker_uses_stream_publisher() -> None:
 
     async def _run() -> None:
         # Manual mode: prompt goes to IDE, and we resolve it concurrently.
-        prompt_result = await registry.dispatch(
-            _ctx("prompt"), {"prompt": "x", "mode": "manual"}
-        )
+        prompt_result = await registry.dispatch(_ctx("prompt"), {"prompt": "x", "mode": "manual"})
         sid = prompt_result["sessionId"]
 
         async def _ide_responds() -> None:
@@ -302,9 +292,7 @@ def test_emit_stream_update_publishes_notification() -> None:
         await registry.emit_stream_update("s1", "hello tokens")
         assert frames
         f = frames[-1]
-        assert f == make_notification(
-            "streamUpdate", {"sessionId": "s1", "delta": "hello tokens"}
-        )
+        assert f == make_notification("streamUpdate", {"sessionId": "s1", "delta": "hello tokens"})
 
     asyncio.run(_run())
 

--- a/tests/unit/protocols/acp/test_schema.py
+++ b/tests/unit/protocols/acp/test_schema.py
@@ -39,22 +39,16 @@ class TestValidateRequest:
 
     def test_rejects_unknown_method(self) -> None:
         with pytest.raises(ACPSchemaError) as exc:
-            validate_request(
-                {"jsonrpc": "2.0", "method": "unknown_method", "id": 1, "params": {}}
-            )
+            validate_request({"jsonrpc": "2.0", "method": "unknown_method", "id": 1, "params": {}})
         assert exc.value.code == METHOD_NOT_FOUND
 
     def test_rejects_non_object_params(self) -> None:
         with pytest.raises(ACPSchemaError) as exc:
-            validate_request(
-                {"jsonrpc": "2.0", "method": "prompt", "id": 1, "params": []}
-            )
+            validate_request({"jsonrpc": "2.0", "method": "prompt", "id": 1, "params": []})
         assert exc.value.code == INVALID_PARAMS
 
     def test_initialize_accepts_optional_protocol_version(self) -> None:
-        parsed = validate_request(
-            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
-        )
+        parsed = validate_request({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
         assert parsed.method == "initialize"
         assert parsed.is_notification is False
 
@@ -72,22 +66,16 @@ class TestValidateRequest:
 
     def test_initialized_must_be_notification(self) -> None:
         # No id => OK
-        parsed = validate_request(
-            {"jsonrpc": "2.0", "method": "initialized", "params": {}}
-        )
+        parsed = validate_request({"jsonrpc": "2.0", "method": "initialized", "params": {}})
         assert parsed.is_notification is True
         # With id => rejected
         with pytest.raises(ACPSchemaError) as exc:
-            validate_request(
-                {"jsonrpc": "2.0", "id": 1, "method": "initialized", "params": {}}
-            )
+            validate_request({"jsonrpc": "2.0", "id": 1, "method": "initialized", "params": {}})
         assert exc.value.code == INVALID_REQUEST
 
     def test_prompt_requires_prompt_text(self) -> None:
         with pytest.raises(ACPSchemaError) as exc:
-            validate_request(
-                {"jsonrpc": "2.0", "id": 1, "method": "prompt", "params": {"cwd": "/tmp"}}
-            )
+            validate_request({"jsonrpc": "2.0", "id": 1, "method": "prompt", "params": {"cwd": "/tmp"}})
         assert exc.value.code == INVALID_PARAMS
 
     def test_prompt_rejects_non_string_role(self) -> None:
@@ -116,9 +104,7 @@ class TestValidateRequest:
 
     def test_cancel_requires_session_id(self) -> None:
         with pytest.raises(ACPSchemaError) as exc:
-            validate_request(
-                {"jsonrpc": "2.0", "id": 1, "method": "cancel", "params": {}}
-            )
+            validate_request({"jsonrpc": "2.0", "id": 1, "method": "cancel", "params": {}})
         assert exc.value.code == INVALID_PARAMS
 
     def test_request_permission_requires_decision_when_present(self) -> None:
@@ -165,20 +151,14 @@ class TestValidateResponse:
     """Validate :func:`validate_response` envelope checks."""
 
     def test_accepts_result_envelope(self) -> None:
-        validate_response(
-            {"jsonrpc": "2.0", "id": 1, "result": {"sessionId": "s1"}}
-        )
+        validate_response({"jsonrpc": "2.0", "id": 1, "result": {"sessionId": "s1"}})
 
     def test_accepts_error_envelope(self) -> None:
-        validate_response(
-            {"jsonrpc": "2.0", "id": 1, "error": {"code": -1, "message": "oops"}}
-        )
+        validate_response({"jsonrpc": "2.0", "id": 1, "error": {"code": -1, "message": "oops"}})
 
     def test_rejects_both_result_and_error(self) -> None:
         with pytest.raises(ACPSchemaError):
-            validate_response(
-                {"jsonrpc": "2.0", "id": 1, "result": {}, "error": {"code": 0, "message": ""}}
-            )
+            validate_response({"jsonrpc": "2.0", "id": 1, "result": {}, "error": {"code": 0, "message": ""}})
 
     def test_rejects_missing_id(self) -> None:
         with pytest.raises(ACPSchemaError):

--- a/tests/unit/protocols/acp/test_transport.py
+++ b/tests/unit/protocols/acp/test_transport.py
@@ -124,9 +124,7 @@ def _wire_stdio_pair() -> tuple[asyncio.StreamReader, asyncio.StreamWriter, asyn
             self.close()
 
     capture_transport = _CaptureTransport()
-    writer = asyncio.StreamWriter(
-        capture_transport, capture_protocol, transport_reader, loop
-    )
+    writer = asyncio.StreamWriter(capture_transport, capture_protocol, transport_reader, loop)
     return transport_reader, writer, capture_reader
 
 
@@ -146,9 +144,7 @@ def test_stdio_transport_initialize_round_trip() -> None:
         reader, writer, capture = _wire_stdio_pair()
         transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
         # Feed an initialize frame and an EOF.
-        request = json.dumps(
-            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
-        )
+        request = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
         reader.feed_data((request + "\n").encode("utf-8"))
         reader.feed_eof()
         await transport.serve_forever()
@@ -183,9 +179,7 @@ def test_stdio_transport_unknown_method() -> None:
         registry = _make_registry()
         reader, writer, capture = _wire_stdio_pair()
         transport = StdioAcpTransport(registry=registry, reader=reader, writer=writer)
-        request = json.dumps(
-            {"jsonrpc": "2.0", "id": 9, "method": "frobnicate", "params": {}}
-        )
+        request = json.dumps({"jsonrpc": "2.0", "id": 9, "method": "frobnicate", "params": {}})
         reader.feed_data((request + "\n").encode("utf-8"))
         reader.feed_eof()
         await transport.serve_forever()
@@ -193,7 +187,6 @@ def test_stdio_transport_unknown_method() -> None:
         line = await asyncio.wait_for(capture.readline(), timeout=1.0)
         response = json.loads(line)
         assert response["error"]["code"] == METHOD_NOT_FOUND
-
 
     asyncio.run(_run())
 
@@ -227,12 +220,8 @@ def test_http_transport_json_initialize() -> None:
     async def _run() -> None:
         registry = _make_registry()
         transport = HttpAcpTransport(registry=registry)
-        body = json.dumps(
-            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
-        ).encode()
-        status, headers, payload = await transport.handle_request(
-            body, accept="application/json", peer="http://test"
-        )
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        status, headers, payload = await transport.handle_request(body, accept="application/json", peer="http://test")
         assert status == 200
         assert headers["content-type"] == "application/json"
         assert isinstance(payload, (bytes, bytearray))
@@ -246,12 +235,8 @@ def test_http_transport_notification_returns_202() -> None:
     async def _run() -> None:
         registry = _make_registry()
         transport = HttpAcpTransport(registry=registry)
-        body = json.dumps(
-            {"jsonrpc": "2.0", "method": "initialized", "params": {}}
-        ).encode()
-        status, _headers, payload = await transport.handle_request(
-            body, accept="application/json", peer="http://test"
-        )
+        body = json.dumps({"jsonrpc": "2.0", "method": "initialized", "params": {}}).encode()
+        status, _headers, payload = await transport.handle_request(body, accept="application/json", peer="http://test")
         assert status == 202
         assert payload == b""
 
@@ -262,12 +247,8 @@ def test_http_transport_sse_streams_response() -> None:
     async def _run() -> None:
         registry = _make_registry()
         transport = HttpAcpTransport(registry=registry)
-        body = json.dumps(
-            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
-        ).encode()
-        status, headers, payload = await transport.handle_request(
-            body, accept="text/event-stream", peer="http://test"
-        )
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        status, headers, payload = await transport.handle_request(body, accept="text/event-stream", peer="http://test")
         assert status == 200
         assert headers["content-type"] == "text/event-stream"
         assert not isinstance(payload, (bytes, bytearray))
@@ -335,21 +316,17 @@ def test_transport_parity_initialize() -> None:
     async def _run() -> None:
         # HTTP envelope.
         registry_http = _make_registry()
-        body = json.dumps(
-            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
-        ).encode()
-        _status, _headers, payload = await HttpAcpTransport(
-            registry=registry_http
-        ).handle_request(body, accept="application/json", peer="http")
+        body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        _status, _headers, payload = await HttpAcpTransport(registry=registry_http).handle_request(
+            body, accept="application/json", peer="http"
+        )
         assert isinstance(payload, (bytes, bytearray))
         http_envelope = json.loads(payload)
 
         # Stdio envelope.
         registry_stdio = _make_registry()
         reader, writer, capture = _wire_stdio_pair()
-        transport = StdioAcpTransport(
-            registry=registry_stdio, reader=reader, writer=writer
-        )
+        transport = StdioAcpTransport(registry=registry_stdio, reader=reader, writer=writer)
         reader.feed_data(body + b"\n")
         reader.feed_eof()
         await transport.serve_forever()

--- a/tests/unit/protocols/mcp_catalog/test_fetcher.py
+++ b/tests/unit/protocols/mcp_catalog/test_fetcher.py
@@ -125,11 +125,7 @@ def test_5xx_falls_back_to_mirror(tmp_path: Path) -> None:
 def test_invalid_payload_preserves_cache(tmp_path: Path) -> None:
     transport = _FakeTransport()
     # First successful fetch primes the cache.
-    transport.push(
-        HTTPResponse(
-            status=200, body=json.dumps(_good_catalog()).encode(), etag='"v1"'
-        )
-    )
+    transport.push(HTTPResponse(status=200, body=json.dumps(_good_catalog()).encode(), etag='"v1"'))
     fetcher = _build_fetcher(tmp_path, transport, revalidate_seconds=1)
     fetcher.fetch()
     cached_text = fetcher.cache_path.read_text()
@@ -141,9 +137,7 @@ def test_invalid_payload_preserves_cache(tmp_path: Path) -> None:
 
     bad = _good_catalog()
     bad["unknown_field"] = True
-    transport.push(
-        HTTPResponse(status=200, body=json.dumps(bad).encode(), etag='"v2"')
-    )
+    transport.push(HTTPResponse(status=200, body=json.dumps(bad).encode(), etag='"v2"'))
     with pytest.raises(CatalogValidationError):
         fetcher.fetch()
 

--- a/tests/unit/protocols/mcp_catalog/test_sandbox_preview.py
+++ b/tests/unit/protocols/mcp_catalog/test_sandbox_preview.py
@@ -26,12 +26,7 @@ def _entry(install_command: list[str], *, version: str = "1.0.0") -> CatalogEntr
 
 
 def test_preview_captures_stdout_stderr_and_exit_code() -> None:
-    code = (
-        "import sys; "
-        "sys.stdout.write('out-line'); "
-        "sys.stderr.write('err-line'); "
-        "sys.exit(0)"
-    )
+    code = "import sys; sys.stdout.write('out-line'); sys.stderr.write('err-line'); sys.exit(0)"
     entry = _entry([sys.executable, "-c", code])
     preview = run_install_preview(entry, runner=SandboxRunner(timeout_seconds=10))
     assert preview.exit_code == 0

--- a/tests/unit/protocols/mcp_catalog/test_service.py
+++ b/tests/unit/protocols/mcp_catalog/test_service.py
@@ -137,9 +137,7 @@ class _FakeAuditor(CatalogAuditor):
         self.events.append(("mcp_catalog.uninstall", entry_id, {}))
 
 
-def _stub_preview(
-    monkeypatch: pytest.MonkeyPatch, *, exit_code: int = 0
-) -> list[CatalogEntry]:
+def _stub_preview(monkeypatch: pytest.MonkeyPatch, *, exit_code: int = 0) -> list[CatalogEntry]:
     """Replace ``run_install_preview`` with a deterministic stub.
 
     Returns the list that captures every entry the service tries to install.
@@ -171,9 +169,7 @@ def _build_service(
     auditor: CatalogAuditor | None = None,
 ) -> tuple[CatalogService, _FakeAuditor]:
     payload = catalog_payload or _good_catalog()
-    transport = _FakeTransport(
-        [HTTPResponse(status=200, body=json.dumps(payload).encode(), etag='"v1"')]
-    )
+    transport = _FakeTransport([HTTPResponse(status=200, body=json.dumps(payload).encode(), etag='"v1"')])
     fetcher = CatalogFetcher(
         primary_url="https://primary.example/x.json",
         mirror_url="https://mirror.example/x.json",
@@ -193,9 +189,7 @@ def _build_service(
     return service, fake_auditor
 
 
-def test_install_emits_audit_and_writes_config(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_install_emits_audit_and_writes_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _stub_preview(monkeypatch, exit_code=0)
     service, auditor = _build_service(tmp_path)
 
@@ -205,33 +199,23 @@ def test_install_emits_audit_and_writes_config(
     assert captured and captured[0].id == "fs-readonly"
 
     assert any(e[0] == "mcp_catalog.fetch" for e in auditor.events)
-    assert any(
-        e[0] == "mcp_catalog.install" and e[1] == "fs-readonly"
-        for e in auditor.events
-    )
+    assert any(e[0] == "mcp_catalog.install" and e[1] == "fs-readonly" for e in auditor.events)
     persisted = list_installed(service.user_config_path)
     assert len(persisted) == 1
     assert persisted[0].id == "fs-readonly"
 
 
-def test_install_failure_leaves_config_untouched(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_install_failure_leaves_config_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_preview(monkeypatch, exit_code=1)
     service, auditor = _build_service(tmp_path)
     outcome = service.install("fs-readonly", skip_confirmation=True)
     assert outcome.installed is None
     assert outcome.preview.exit_code == 1
     assert not service.user_config_path.exists()
-    assert any(
-        e[0] == "mcp_catalog.install" and e[2]["exit_code"] == 1
-        for e in auditor.events
-    )
+    assert any(e[0] == "mcp_catalog.install" and e[2]["exit_code"] == 1 for e in auditor.events)
 
 
-def test_unverified_entry_flag(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_unverified_entry_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_preview(monkeypatch, exit_code=0)
     payload = _good_catalog()
     payload["entries"][0]["verified_by_bernstein"] = False
@@ -240,9 +224,7 @@ def test_unverified_entry_flag(
     assert outcome.warning_unverified is True
 
 
-def test_install_aborted_when_confirm_returns_false(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_install_aborted_when_confirm_returns_false(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_preview(monkeypatch, exit_code=0)
     service, _ = _build_service(tmp_path)
     service.confirm_callback = lambda _preview: False
@@ -252,9 +234,7 @@ def test_install_aborted_when_confirm_returns_false(
     assert not service.user_config_path.exists()
 
 
-def test_upgrade_skipped_when_versions_match(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_upgrade_skipped_when_versions_match(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_preview(monkeypatch, exit_code=0)
     service, _ = _build_service(tmp_path)
     service.install("fs-readonly", skip_confirmation=True)
@@ -280,9 +260,7 @@ def test_upgrade_skipped_when_versions_match(
     assert outcome.skipped_reason == "already on latest version"
 
 
-def test_upgrade_applies_when_version_changes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_upgrade_applies_when_version_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _stub_preview(monkeypatch, exit_code=0)
     service, auditor = _build_service(tmp_path)
     service.install("fs-readonly", skip_confirmation=True)
@@ -303,24 +281,18 @@ def test_upgrade_applies_when_version_changes(
             ]
         ),
     )
-    outcome = service.upgrade(
-        "fs-readonly", skip_confirmation=True, force_refresh=True
-    )
+    outcome = service.upgrade("fs-readonly", skip_confirmation=True, force_refresh=True)
     assert outcome.applied is True
     assert outcome.from_version == "1.0.0"
     assert outcome.to_version == "2.0.0"
     assert any(captured) and captured[-1].version_pin == "2.0.0"
     assert any(
-        e[0] == "mcp_catalog.upgrade"
-        and e[2]["from_version"] == "1.0.0"
-        and e[2]["to_version"] == "2.0.0"
+        e[0] == "mcp_catalog.upgrade" and e[2]["from_version"] == "1.0.0" and e[2]["to_version"] == "2.0.0"
         for e in auditor.events
     )
 
 
-def test_background_check_due_respects_cadence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_background_check_due_respects_cadence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_preview(monkeypatch, exit_code=0)
     service, _ = _build_service(tmp_path)
     # No installs yet => the first check is allowed.
@@ -336,15 +308,10 @@ def test_background_check_due_respects_cadence(
     assert service.background_check_due(now=future) is True
 
 
-def test_uninstall_emits_audit_event(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_uninstall_emits_audit_event(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_preview(monkeypatch, exit_code=0)
     service, auditor = _build_service(tmp_path)
     service.install("fs-readonly", skip_confirmation=True)
     assert service.uninstall("fs-readonly") is True
-    assert any(
-        e[0] == "mcp_catalog.uninstall" and e[1] == "fs-readonly"
-        for e in auditor.events
-    )
+    assert any(e[0] == "mcp_catalog.uninstall" and e[1] == "fs-readonly" for e in auditor.events)
     assert service.uninstall("fs-readonly") is False

--- a/tests/unit/quality/review_pipeline/test_ast_chunker_edges.py
+++ b/tests/unit/quality/review_pipeline/test_ast_chunker_edges.py
@@ -53,9 +53,7 @@ def test_utf8_bom_python_file_takes_ast_path(tmp_path: Path) -> None:
     assert "foo" in chunks[0].symbols
 
 
-def test_utf16_python_file_returns_empty_with_warning(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_utf16_python_file_returns_empty_with_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     fp = tmp_path / "u16.py"
     fp.write_bytes("def foo():\n    return 1\n".encode("utf-16"))
     with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
@@ -64,9 +62,7 @@ def test_utf16_python_file_returns_empty_with_warning(
     assert any("cannot read" in r.getMessage() for r in caplog.records)
 
 
-def test_binary_file_with_py_extension_returns_empty(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_binary_file_with_py_extension_returns_empty(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     """A non-UTF-8 binary masquerading as .py must not crash the chunker."""
     fp = tmp_path / "binary.py"
     fp.write_bytes(bytes(range(256)))
@@ -79,9 +75,7 @@ def test_binary_file_with_py_extension_returns_empty(
 def test_crlf_line_endings_are_normalized(tmp_path: Path) -> None:
     """Windows-authored files round-trip through the AST path cleanly."""
     fp = tmp_path / "crlf.py"
-    fp.write_bytes(
-        b"def foo():\r\n    return 1\r\n\r\ndef bar():\r\n    return 2\r\n"
-    )
+    fp.write_bytes(b"def foo():\r\n    return 1\r\n\r\ndef bar():\r\n    return 2\r\n")
     chunks = chunk_for_review(fp)
     assert len(chunks) == 1
     assert chunks[0].symbols == ("foo", "bar")
@@ -166,9 +160,7 @@ def test_nested_classes_belong_to_outer_class_chunk(tmp_path: Path) -> None:
     """Inner classes are part of the outer class's AST node — not separate symbols."""
     fp = tmp_path / "nest.py"
     fp.write_text(
-        "class Outer:\n"
-        "    class Inner:\n"
-        "        def m(self): return 1\n",
+        "class Outer:\n    class Inner:\n        def m(self): return 1\n",
         encoding="utf-8",
     )
     chunks = chunk_for_review(fp)
@@ -180,11 +172,7 @@ def test_nested_classes_belong_to_outer_class_chunk(tmp_path: Path) -> None:
 def test_main_guard_is_not_a_top_level_symbol(tmp_path: Path) -> None:
     fp = tmp_path / "guard.py"
     fp.write_text(
-        "def foo():\n"
-        "    return 1\n"
-        "\n"
-        "if __name__ == '__main__':\n"
-        "    foo()\n",
+        "def foo():\n    return 1\n\nif __name__ == '__main__':\n    foo()\n",
         encoding="utf-8",
     )
     chunks = chunk_for_review(fp)
@@ -199,9 +187,7 @@ def test_main_guard_is_not_a_top_level_symbol(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("bad_budget", [-100, -1, 0, 1, 5])
-def test_subminimum_budget_does_not_break_chunker(
-    tmp_path: Path, bad_budget: int
-) -> None:
+def test_subminimum_budget_does_not_break_chunker(tmp_path: Path, bad_budget: int) -> None:
     """Negative / zero / tiny budgets clamp to the floor instead of crashing."""
     fp = tmp_path / "tiny.py"
     fp.write_text("def foo(): return 1\n", encoding="utf-8")
@@ -246,9 +232,7 @@ def test_many_small_functions_produce_multiple_chunks(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_directory_path_returns_empty_with_warning(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_directory_path_returns_empty_with_warning(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
         chunks = chunk_for_review(tmp_path)
     assert chunks == []
@@ -305,10 +289,7 @@ def test_non_python_languages_use_line_based_fallback(
     assert chunks
     assert all(c.language == "text" for c in chunks)
     assert all(c.symbols == () for c in chunks)
-    assert any(
-        "not Python" in r.getMessage() and "line-based fallback" in r.getMessage()
-        for r in caplog.records
-    )
+    assert any("not Python" in r.getMessage() and "line-based fallback" in r.getMessage() for r in caplog.records)
 
 
 def test_line_based_fallback_covers_all_lines_in_order(tmp_path: Path) -> None:
@@ -338,9 +319,7 @@ def test_line_based_fallback_covers_all_lines_in_order(tmp_path: Path) -> None:
         "def f(:\nreturn 1",
     ],
 )
-def test_malformed_python_falls_back_to_line_based(
-    tmp_path: Path, src: str, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_malformed_python_falls_back_to_line_based(tmp_path: Path, src: str, caplog: pytest.LogCaptureFixture) -> None:
     fp = tmp_path / "bad.py"
     fp.write_text(src, encoding="utf-8")
     with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):

--- a/tests/unit/test_adapter_devin_terminal.py
+++ b/tests/unit/test_adapter_devin_terminal.py
@@ -340,9 +340,7 @@ class TestDevinTerminalEnvIsolation:
         env = popen.call_args.kwargs.get("env", {})
         assert "PATH" in env
 
-    def test_warns_when_credentials_missing(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_warns_when_credentials_missing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         adapter = DevinTerminalAdapter()
         proc_mock = make_popen_mock(905)
         with (
@@ -439,9 +437,7 @@ class TestDevinTerminalEndpoints:
 class TestDevinTerminalIsAlive:
     def test_true_when_process_exists(self) -> None:
         adapter = DevinTerminalAdapter()
-        with patch(
-            "bernstein.adapters.base.process_alive", return_value=True
-        ) as mock_alive:
+        with patch("bernstein.adapters.base.process_alive", return_value=True) as mock_alive:
             assert adapter.is_alive(1234) is True
         mock_alive.assert_called_once_with(1234)
 
@@ -454,17 +450,13 @@ class TestDevinTerminalIsAlive:
 class TestDevinTerminalKill:
     def test_calls_killpg(self) -> None:
         adapter = DevinTerminalAdapter()
-        with patch(
-            "bernstein.adapters.base.kill_process_group_graceful"
-        ) as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 
     def test_does_not_raise_on_oserror(self) -> None:
         adapter = DevinTerminalAdapter()
-        with patch(
-            "bernstein.adapters.base.kill_process_group_graceful", return_value=False
-        ):
+        with patch("bernstein.adapters.base.kill_process_group_graceful", return_value=False):
             adapter.kill(556)  # must not raise
 
 
@@ -499,9 +491,7 @@ class TestDevinTerminalFastExit:
         # SpawnError is a RuntimeError subclass; default tail surfaces.
         assert "exited early" in str(excinfo.value)
 
-    def test_fast_exit_rate_limit_raises_rate_limit_error(
-        self, tmp_path: Path
-    ) -> None:
+    def test_fast_exit_rate_limit_raises_rate_limit_error(self, tmp_path: Path) -> None:
         adapter = DevinTerminalAdapter()
         proc_mock = make_popen_mock(911)
         proc_mock.wait.return_value = 1
@@ -524,9 +514,7 @@ class TestDevinTerminalFastExit:
                 session_id="devin-rate-limit",
             )
 
-    def test_fast_exit_clean_does_not_raise(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fast_exit_clean_does_not_raise(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Exit code 0 from the probe must let spawn() return cleanly."""
         adapter = DevinTerminalAdapter()
         proc_mock = make_popen_mock(912)

--- a/tests/unit/test_adapter_junie.py
+++ b/tests/unit/test_adapter_junie.py
@@ -1,0 +1,755 @@
+"""Unit tests for JunieAdapter (JetBrains Junie CLI).
+
+Mirrors the contract used by ``test_adapter_devin_terminal.py`` /
+``test_adapter_aider.py``: assert command construction, env isolation,
+provider-aware endpoint declaration, missing-binary handling, and the
+inherited ``is_alive`` / ``kill`` plumbing without ever spawning a
+real subprocess.
+
+Junie's CLI surface is still in beta — the assertions here pin the
+``run --headless --model <id> --prompt-file <path>`` shape documented
+at https://junie.jetbrains.com/ on 2026-05-06. If the public surface
+drifts, update both the adapter constants and these expectations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from bernstein.core.tasks.models import ModelConfig
+
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.junie import JunieAdapter
+from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
+
+# ---------------------------------------------------------------------------
+# JunieAdapter.spawn() — command construction
+# ---------------------------------------------------------------------------
+
+
+class TestJunieSpawn:
+    """spawn() builds the documented ``junie run --headless`` invocation."""
+
+    def test_is_subclass_of_cli_adapter(self) -> None:
+        assert issubclass(JunieAdapter, CLIAdapter)
+        assert isinstance(JunieAdapter(), CLIAdapter)
+
+    def test_wrapped_with_worker(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(700)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="fix the bug",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s1",
+            )
+        cmd = popen.call_args.args[0]
+        inner = inner_cmd(cmd)
+        assert inner[0] == "junie"
+
+    def test_run_subcommand(self, tmp_path: Path) -> None:
+        """First positional argument after ``junie`` must be ``run``."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(701)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s2",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert inner[1] == "run"
+
+    def test_headless_flag_present(self, tmp_path: Path) -> None:
+        """``--headless`` is the documented non-interactive mode."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(702)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s3",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--headless" in inner
+
+    def test_model_flag_passthrough(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(703)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="hi",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="opus", effort="high"),
+                session_id="junie-s4",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--model" in inner
+        assert inner[inner.index("--model") + 1] == "opus"
+
+    def test_blank_model_omits_flag(self, tmp_path: Path) -> None:
+        """Empty ``model`` must not produce a bare ``--model`` flag."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(704)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="hi",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="", effort="high"),
+                session_id="junie-s5",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--model" not in inner
+
+    def test_prompt_file_flag_present(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(705)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="my-unique-prompt",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s6",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        assert "--prompt-file" in inner
+
+    def test_prompt_file_written_to_runtime(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(706)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="fixture-prompt",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s7",
+            )
+        prompt_path = tmp_path / ".sdd" / "runtime" / "junie-s7-prompt.txt"
+        assert prompt_path.is_file()
+        assert "fixture-prompt" in prompt_path.read_text(encoding="utf-8")
+
+    def test_prompt_file_contains_system_addendum(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(707)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="solve x",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s8",
+                system_addendum="POST done to /complete",
+            )
+        prompt_path = tmp_path / ".sdd" / "runtime" / "junie-s8-prompt.txt"
+        body = prompt_path.read_text(encoding="utf-8")
+        assert "solve x" in body
+        assert "POST done to /complete" in body
+
+    def test_full_command_shape(self, tmp_path: Path) -> None:
+        """Entire constructed argv matches the documented spec.
+
+        Pins the spec from the open ticket (KF-B) so a CLI drift forces
+        a single visible diff in this test before the adapter ships
+        broken to users.
+        """
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(708)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-shape",
+            )
+        inner = inner_cmd(popen.call_args.args[0])
+        prompt_file = str(tmp_path / ".sdd" / "runtime" / "junie-shape-prompt.txt")
+        assert inner == [
+            "junie",
+            "run",
+            "--headless",
+            "--model",
+            "sonnet",
+            "--prompt-file",
+            prompt_file,
+        ]
+
+    def test_creates_log_dir(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(709)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s9",
+            )
+        assert (tmp_path / ".sdd" / "runtime").is_dir()
+
+    def test_spawn_result_pid_and_log_path(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(710)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            result = adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="my-junie-session",
+            )
+        assert result.pid == 710
+        assert result.log_path.name == "my-junie-session.log"
+
+    def test_start_new_session_enabled(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(711)
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ) as popen:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-s10",
+            )
+        kwargs = popen.call_args.kwargs
+        assert kwargs.get("start_new_session") is True
+
+
+# ---------------------------------------------------------------------------
+# spawn() — env isolation (BYOK pattern: forward routed-provider key,
+# always forward JUNIE_API_KEY, never leak master credentials).
+# ---------------------------------------------------------------------------
+
+
+class TestJunieEnvIsolation:
+    """spawn() forwards Junie + routed-provider keys, drops everything else."""
+
+    def test_env_contains_junie_api_key(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(800)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {"JUNIE_API_KEY": "junie-test", "PATH": "/usr/bin"},
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-env1",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert env.get("JUNIE_API_KEY") == "junie-test"
+
+    def test_env_contains_junie_provider(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(801)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "JUNIE_API_KEY": "j-test",
+                    "JUNIE_PROVIDER": "anthropic",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-env2",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert env.get("JUNIE_PROVIDER") == "anthropic"
+
+    def test_env_forwards_routed_provider_key_anthropic(
+        self, tmp_path: Path
+    ) -> None:
+        """JUNIE_PROVIDER=anthropic ⇒ ANTHROPIC_API_KEY is forwarded."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(802)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "JUNIE_PROVIDER": "anthropic",
+                    "ANTHROPIC_API_KEY": "ant-test",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-env3",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert env.get("ANTHROPIC_API_KEY") == "ant-test"
+
+    def test_env_forwards_routed_provider_key_openai(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(803)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "JUNIE_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "sk-test",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.5", effort="high"),
+                session_id="junie-env4",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert env.get("OPENAI_API_KEY") == "sk-test"
+
+    def test_env_filters_master_credentials(self, tmp_path: Path) -> None:
+        """Master / unrelated keys must never reach the Junie subprocess."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(804)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "JUNIE_API_KEY": "junie-test",
+                    "JUNIE_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "sk-test",
+                    # Master / unrelated secrets that must be filtered.
+                    "OPENAI_MASTER_KEY": "sk-master-DO-NOT-LEAK",
+                    "DATABASE_URL": "postgres://x",
+                    "AWS_SECRET_ACCESS_KEY": "aws-secret",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.5", effort="high"),
+                session_id="junie-env5",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "OPENAI_MASTER_KEY" not in env
+        assert "DATABASE_URL" not in env
+        assert "AWS_SECRET_ACCESS_KEY" not in env
+        # Sanity: forwarding still works.
+        assert env.get("OPENAI_API_KEY") == "sk-test"
+
+    def test_env_excludes_unrouted_provider_key(self, tmp_path: Path) -> None:
+        """JUNIE_PROVIDER=openai must NOT forward ANTHROPIC_API_KEY."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(805)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {
+                    "JUNIE_PROVIDER": "openai",
+                    "OPENAI_API_KEY": "sk-test",
+                    "ANTHROPIC_API_KEY": "ant-not-routed",
+                    "PATH": "/usr/bin",
+                },
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.5", effort="high"),
+                session_id="junie-env6",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "ANTHROPIC_API_KEY" not in env
+
+    def test_env_includes_path(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(806)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ) as popen,
+            patch.dict(
+                "os.environ",
+                {"PATH": "/usr/bin", "JUNIE_API_KEY": "j-x"},
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-env7",
+            )
+        env = popen.call_args.kwargs.get("env", {})
+        assert "PATH" in env
+
+    def test_warns_when_credentials_missing(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(807)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ),
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+            caplog.at_level("WARNING"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-warn",
+            )
+        assert "JUNIE_API_KEY" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# JunieAdapter.name()
+# ---------------------------------------------------------------------------
+
+
+class TestJunieName:
+    def test_name(self) -> None:
+        assert JunieAdapter().name() == "junie"
+
+
+# ---------------------------------------------------------------------------
+# Missing binary / PermissionError
+# ---------------------------------------------------------------------------
+
+
+class TestJunieMissingBinary:
+    def test_file_not_found_raises_runtime_error(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                side_effect=FileNotFoundError("No such file"),
+            ),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-missing",
+            )
+        message = str(excinfo.value)
+        assert "junie not found" in message
+        assert "junie.jetbrains.com/install.sh" in message
+
+    def test_permission_error_raises_runtime_error(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                side_effect=PermissionError("Permission denied"),
+            ),
+            pytest.raises(RuntimeError, match="[Pp]ermission"),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-perm",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Network policy: external endpoints depend on routed provider
+# ---------------------------------------------------------------------------
+
+
+class TestJunieEndpoints:
+    """external_endpoints is populated dynamically per-spawn from the provider."""
+
+    def test_class_default_endpoints_empty(self) -> None:
+        """Static endpoints stay empty so per-spawn resolution is authoritative."""
+        assert JunieAdapter.external_endpoints == ()
+
+    def test_endpoints_populated_for_anthropic_provider(
+        self, tmp_path: Path
+    ) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(900)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ),
+            patch.dict(
+                "os.environ",
+                {"JUNIE_PROVIDER": "anthropic", "PATH": "/usr/bin"},
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-ep1",
+            )
+        hosts = {host for host, _ in adapter.external_endpoints}
+        assert "api.anthropic.com" in hosts
+
+    def test_endpoints_populated_for_openai_provider(
+        self, tmp_path: Path
+    ) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(901)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ),
+            patch.dict(
+                "os.environ",
+                {"JUNIE_PROVIDER": "openai", "PATH": "/usr/bin"},
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.5", effort="high"),
+                session_id="junie-ep2",
+            )
+        hosts = {host for host, _ in adapter.external_endpoints}
+        assert "api.openai.com" in hosts
+
+    def test_endpoints_https_only(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(902)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ),
+            patch.dict(
+                "os.environ",
+                {"JUNIE_PROVIDER": "openrouter", "PATH": "/usr/bin"},
+                clear=True,
+            ),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="gpt-5.5", effort="high"),
+                session_id="junie-ep3",
+            )
+        for _, port in adapter.external_endpoints:
+            assert port == 443
+
+    def test_endpoints_empty_when_provider_unknown(
+        self, tmp_path: Path
+    ) -> None:
+        """Unknown provider falls back to the empty allow-list (default policy)."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(903)
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ),
+            patch.dict("os.environ", {"PATH": "/usr/bin"}, clear=True),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-ep4",
+            )
+        assert adapter.external_endpoints == ()
+
+
+# ---------------------------------------------------------------------------
+# is_alive() / kill() — inherited from CLIAdapter base
+# ---------------------------------------------------------------------------
+
+
+class TestJunieIsAlive:
+    def test_true_when_process_exists(self) -> None:
+        adapter = JunieAdapter()
+        with patch(
+            "bernstein.adapters.base.process_alive", return_value=True
+        ) as mock_alive:
+            assert adapter.is_alive(1234) is True
+        mock_alive.assert_called_once_with(1234)
+
+    def test_false_when_process_dead(self) -> None:
+        adapter = JunieAdapter()
+        with patch("bernstein.adapters.base.process_alive", return_value=False):
+            assert adapter.is_alive(9999) is False
+
+
+class TestJunieKill:
+    def test_calls_killpg(self) -> None:
+        adapter = JunieAdapter()
+        with patch(
+            "bernstein.adapters.base.kill_process_group_graceful"
+        ) as mock_killpg:
+            adapter.kill(555)
+        mock_killpg.assert_called_once_with(555)
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestJunieRegistry:
+    def test_junie_in_registry(self) -> None:
+        from bernstein.adapters.registry import get_adapter
+
+        adapter = get_adapter("junie")
+        assert isinstance(adapter, JunieAdapter)
+
+    def test_junie_name_via_registry(self) -> None:
+        from bernstein.adapters.registry import get_adapter
+
+        assert get_adapter("junie").name() == "junie"
+
+
+# ---------------------------------------------------------------------------
+# Fast-exit probe — early non-zero exit surfaces as SpawnError
+# ---------------------------------------------------------------------------
+
+
+class TestJunieFastExit:
+    def test_fast_exit_non_zero_raises(self, tmp_path: Path) -> None:
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(910)
+        proc_mock.wait.return_value = 1
+        with (
+            patch(
+                "bernstein.adapters.junie.subprocess.Popen",
+                return_value=proc_mock,
+            ),
+            patch.object(
+                JunieAdapter,
+                "_read_last_lines",
+                return_value=["fatal: bad request"],
+            ),
+            pytest.raises(RuntimeError) as excinfo,
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-fast-exit",
+            )
+        # SpawnError is a RuntimeError subclass; default tail surfaces.
+        assert "exited early" in str(excinfo.value)
+
+    def test_fast_exit_clean_does_not_raise(self, tmp_path: Path) -> None:
+        """Exit code 0 from the probe must let spawn() return cleanly."""
+        adapter = JunieAdapter()
+        proc_mock = make_popen_mock(911)
+        proc_mock.wait.return_value = 0
+        with patch(
+            "bernstein.adapters.junie.subprocess.Popen",
+            return_value=proc_mock,
+        ):
+            result = adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="sonnet", effort="high"),
+                session_id="junie-clean",
+            )
+        assert result.pid == 911
+
+
+# ---------------------------------------------------------------------------
+# detect_tier() — base default returns None for this adapter.
+# ---------------------------------------------------------------------------
+
+
+class TestJunieDetectTier:
+    def test_default_returns_none(self) -> None:
+        # JetBrains does not expose a tier-discovery endpoint. Bernstein's
+        # ``ProviderType`` enum has no entry for Junie either, so the
+        # adapter opts out of tier detection until both surfaces exist.
+        assert JunieAdapter().detect_tier() is None

--- a/tests/unit/test_adapter_junie.py
+++ b/tests/unit/test_adapter_junie.py
@@ -18,10 +18,10 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from bernstein.core.tasks.models import ModelConfig
 
 from bernstein.adapters.base import CLIAdapter
 from bernstein.adapters.junie import JunieAdapter
+from bernstein.core.tasks.models import ModelConfig
 from tests.unit._adapter_test_helpers import inner_cmd, make_popen_mock
 
 if TYPE_CHECKING:
@@ -318,9 +318,7 @@ class TestJunieEnvIsolation:
         env = popen.call_args.kwargs.get("env", {})
         assert env.get("JUNIE_PROVIDER") == "anthropic"
 
-    def test_env_forwards_routed_provider_key_anthropic(
-        self, tmp_path: Path
-    ) -> None:
+    def test_env_forwards_routed_provider_key_anthropic(self, tmp_path: Path) -> None:
         """JUNIE_PROVIDER=anthropic ⇒ ANTHROPIC_API_KEY is forwarded."""
         adapter = JunieAdapter()
         proc_mock = make_popen_mock(802)
@@ -464,9 +462,7 @@ class TestJunieEnvIsolation:
         env = popen.call_args.kwargs.get("env", {})
         assert "PATH" in env
 
-    def test_warns_when_credentials_missing(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_warns_when_credentials_missing(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         adapter = JunieAdapter()
         proc_mock = make_popen_mock(807)
         with (
@@ -550,9 +546,7 @@ class TestJunieEndpoints:
         """Static endpoints stay empty so per-spawn resolution is authoritative."""
         assert JunieAdapter.external_endpoints == ()
 
-    def test_endpoints_populated_for_anthropic_provider(
-        self, tmp_path: Path
-    ) -> None:
+    def test_endpoints_populated_for_anthropic_provider(self, tmp_path: Path) -> None:
         adapter = JunieAdapter()
         proc_mock = make_popen_mock(900)
         with (
@@ -575,9 +569,7 @@ class TestJunieEndpoints:
         hosts = {host for host, _ in adapter.external_endpoints}
         assert "api.anthropic.com" in hosts
 
-    def test_endpoints_populated_for_openai_provider(
-        self, tmp_path: Path
-    ) -> None:
+    def test_endpoints_populated_for_openai_provider(self, tmp_path: Path) -> None:
         adapter = JunieAdapter()
         proc_mock = make_popen_mock(901)
         with (
@@ -623,9 +615,7 @@ class TestJunieEndpoints:
         for _, port in adapter.external_endpoints:
             assert port == 443
 
-    def test_endpoints_empty_when_provider_unknown(
-        self, tmp_path: Path
-    ) -> None:
+    def test_endpoints_empty_when_provider_unknown(self, tmp_path: Path) -> None:
         """Unknown provider falls back to the empty allow-list (default policy)."""
         adapter = JunieAdapter()
         proc_mock = make_popen_mock(903)
@@ -653,9 +643,7 @@ class TestJunieEndpoints:
 class TestJunieIsAlive:
     def test_true_when_process_exists(self) -> None:
         adapter = JunieAdapter()
-        with patch(
-            "bernstein.adapters.base.process_alive", return_value=True
-        ) as mock_alive:
+        with patch("bernstein.adapters.base.process_alive", return_value=True) as mock_alive:
             assert adapter.is_alive(1234) is True
         mock_alive.assert_called_once_with(1234)
 
@@ -668,9 +656,7 @@ class TestJunieIsAlive:
 class TestJunieKill:
     def test_calls_killpg(self) -> None:
         adapter = JunieAdapter()
-        with patch(
-            "bernstein.adapters.base.kill_process_group_graceful"
-        ) as mock_killpg:
+        with patch("bernstein.adapters.base.kill_process_group_graceful") as mock_killpg:
             adapter.kill(555)
         mock_killpg.assert_called_once_with(555)
 

--- a/tests/unit/test_adapter_q_dev.py
+++ b/tests/unit/test_adapter_q_dev.py
@@ -198,9 +198,7 @@ class TestQDevLoginCachePreflight:
                 session_id="qdev-no-auth",
             )
 
-    def test_missing_cache_does_not_invoke_subprocess(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_cache_does_not_invoke_subprocess(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """The error must surface BEFORE Popen is touched."""
         adapter = QDevAdapter()
         empty_home = tmp_path / "fresh"
@@ -218,9 +216,7 @@ class TestQDevLoginCachePreflight:
             )
         popen.assert_not_called()
 
-    def test_xdg_data_home_cache_satisfies_preflight(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_xdg_data_home_cache_satisfies_preflight(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """XDG_DATA_HOME is honoured when set."""
         adapter = QDevAdapter()
         xdg = tmp_path / "xdg-data"

--- a/tests/unit/test_adapter_registry.py
+++ b/tests/unit/test_adapter_registry.py
@@ -73,13 +73,13 @@ def test_user_facing_adapter_count_matches_public_copy() -> None:
     """Lock the user-facing adapter count cited in README / landing copy.
 
     Reality:
-      - ``_ADAPTERS`` holds 42 entries; ``mock`` is a test-only stub.
+      - ``_ADAPTERS`` holds 43 entries; ``mock`` is a test-only stub.
       - ``generic`` is served by a special-case in ``get_adapter`` and not
         present in the dict.
 
-    User-facing total = (entries excluding ``mock``) + 1 for ``generic`` = 42.
+    User-facing total = (entries excluding ``mock``) + 1 for ``generic`` = 43.
     Of those: 2 leaf-node delegators (``composio``, ``ralphex``) + 1 generic
-    + 39 third-party wrappers.
+    + 40 third-party wrappers.
 
     If you add or remove an adapter, update README.md / docs/index.md /
     landing copy together with this assertion so the public count stays
@@ -87,5 +87,5 @@ def test_user_facing_adapter_count_matches_public_copy() -> None:
     """
     production = {name for name in _ADAPTERS if name != "mock"}
     user_facing = production | {"generic"}
-    assert len(user_facing) == 42, sorted(user_facing)
+    assert len(user_facing) == 43, sorted(user_facing)
     assert {"composio", "ralphex"}.issubset(user_facing)

--- a/tests/unit/test_audit_adversarial.py
+++ b/tests/unit/test_audit_adversarial.py
@@ -92,9 +92,7 @@ class TestInsertionAttack:
         assert any("prev_hmac mismatch" in e for e in errors)
         assert any("HMAC mismatch" in e for e in errors)
 
-    def test_inserted_record_with_correct_prev_hmac_still_fails(
-        self, tmp_path: Path
-    ) -> None:
+    def test_inserted_record_with_correct_prev_hmac_still_fails(self, tmp_path: Path) -> None:
         """Even if attacker knows prev_hmac, without the key they can't forge HMAC."""
         audit_dir = tmp_path / "audit"
         log = AuditLog(audit_dir, key=_TEST_KEY)
@@ -226,9 +224,7 @@ class TestCrossFileRotation:
         }
         e1["hmac"] = _compute_hmac(key, prev, e1)
         prev = e1["hmac"]
-        (audit_dir / "2026-04-04.jsonl").write_text(
-            json.dumps(e1, sort_keys=True) + "\n"
-        )
+        (audit_dir / "2026-04-04.jsonl").write_text(json.dumps(e1, sort_keys=True) + "\n")
 
         e2 = {
             "timestamp": "2026-04-05T10:00:00.000000Z",
@@ -240,9 +236,7 @@ class TestCrossFileRotation:
             "prev_hmac": prev,
         }
         e2["hmac"] = _compute_hmac(key, prev, e2)
-        (audit_dir / "2026-04-05.jsonl").write_text(
-            json.dumps(e2, sort_keys=True) + "\n"
-        )
+        (audit_dir / "2026-04-05.jsonl").write_text(json.dumps(e2, sort_keys=True) + "\n")
 
     def test_chain_carries_across_rotation(self, tmp_path: Path) -> None:
         audit_dir = tmp_path / "audit"
@@ -253,9 +247,7 @@ class TestCrossFileRotation:
         valid, errors = log.verify()
         assert valid, f"cross-file chain should verify, got {errors}"
 
-    def test_tampering_with_pre_rotation_file_breaks_chain(
-        self, tmp_path: Path
-    ) -> None:
+    def test_tampering_with_pre_rotation_file_breaks_chain(self, tmp_path: Path) -> None:
         audit_dir = tmp_path / "audit"
         audit_dir.mkdir()
         self._write_chained_pair(audit_dir, _TEST_KEY)
@@ -324,7 +316,7 @@ class TestTruncatedLastRecord:
         path, _ = _read_lines(audit_dir)
         content = path.read_text()
         # Truncate inside the last record (drop the last ~30 chars).
-        path.write_text(content[: -30])
+        path.write_text(content[:-30])
 
         valid, errors = log.verify()
         assert valid is False
@@ -398,12 +390,8 @@ class TestConcurrentWriters:
         audit_dir.mkdir()
         ctx = mp.get_context("spawn")
         barrier = ctx.Barrier(2)
-        p1 = ctx.Process(
-            target=_concurrent_writer, args=(str(audit_dir), "A", 5, barrier)
-        )
-        p2 = ctx.Process(
-            target=_concurrent_writer, args=(str(audit_dir), "B", 5, barrier)
-        )
+        p1 = ctx.Process(target=_concurrent_writer, args=(str(audit_dir), "A", 5, barrier))
+        p2 = ctx.Process(target=_concurrent_writer, args=(str(audit_dir), "B", 5, barrier))
         p1.start()
         p2.start()
         p1.join(timeout=30)
@@ -433,12 +421,8 @@ class TestConcurrentWriters:
         audit_dir.mkdir()
         ctx = mp.get_context("spawn")
         barrier = ctx.Barrier(2)
-        p1 = ctx.Process(
-            target=_concurrent_writer, args=(str(audit_dir), "A", 5, barrier)
-        )
-        p2 = ctx.Process(
-            target=_concurrent_writer, args=(str(audit_dir), "B", 5, barrier)
-        )
+        p1 = ctx.Process(target=_concurrent_writer, args=(str(audit_dir), "A", 5, barrier))
+        p2 = ctx.Process(target=_concurrent_writer, args=(str(audit_dir), "B", 5, barrier))
         p1.start()
         p2.start()
         p1.join(timeout=30)

--- a/tests/unit/test_capability_matrix_adversarial.py
+++ b/tests/unit/test_capability_matrix_adversarial.py
@@ -111,14 +111,11 @@ class TestAliasingBypass:
         # unknown tool must default-deny and trip the trifecta on its own.
         decision_alias_only = reg.evaluate_chain(["fs.read_pretty"])
         assert decision_alias_only.allowed is True, (
-            "An empty-cap alias on its own must NOT trip the trifecta — "
-            "but it must also not contribute capabilities."
+            "An empty-cap alias on its own must NOT trip the trifecta — but it must also not contribute capabilities."
         )
         # Now an agent uses BOTH the alias AND the real (unknown) tool.
         # The unknown tool default-denies because we have no declaration.
-        decision_with_unknown = reg.evaluate_chain(
-            ["fs.read_pretty", "fs.read_secret"]
-        )
+        decision_with_unknown = reg.evaluate_chain(["fs.read_pretty", "fs.read_secret"])
         assert decision_with_unknown.allowed is False, (
             "Real tool fs.read_secret is unknown to this registry — "
             "default-deny must kick in regardless of any alias entry."
@@ -201,7 +198,7 @@ class TestEmptyAndMalformedDeclarations:
         # Mapping but no `tools` key
         (directory / "no_tools.yaml").write_text("not_tools: []\n", encoding="utf-8")
         # Mapping with tools=non-list
-        (directory / "tools_str.yaml").write_text("tools: \"oops\"\n", encoding="utf-8")
+        (directory / "tools_str.yaml").write_text('tools: "oops"\n', encoding="utf-8")
         reg = CapabilityRegistry.from_directory(directory)
         assert reg.tools == {}
         # And the trifecta chain must default-deny because everything is unknown.
@@ -219,9 +216,7 @@ class TestEmptyAndMalformedDeclarations:
         invariant down so it doesn't drift to allow-all by accident.
         """
         reg = CapabilityRegistry()
-        reg.register(
-            ToolCapabilities(tool_name="git.commit", capabilities=frozenset())
-        )
+        reg.register(ToolCapabilities(tool_name="git.commit", capabilities=frozenset()))
         decision = reg.evaluate_chain(["git.commit"])
         assert decision.triggered == frozenset()
         assert decision.allowed is True
@@ -245,9 +240,7 @@ class TestEmptyAndMalformedDeclarations:
         """
         path = tmp_path / "evil.yaml"
         path.write_text(
-            "tools:\n"
-            "  - name: x.read\n"
-            "    capabilities: !!python/object/apply:os.system ['echo pwned']\n",
+            "tools:\n  - name: x.read\n    capabilities: !!python/object/apply:os.system ['echo pwned']\n",
             encoding="utf-8",
         )
         # Sanity: confirm the loader does not raise — it absorbs the YAMLError.
@@ -256,9 +249,7 @@ class TestEmptyAndMalformedDeclarations:
         with pytest.raises(yaml.YAMLError):
             yaml.safe_load(path.read_text(encoding="utf-8"))
 
-    def test_loader_skips_entries_with_blank_or_whitespace_name(
-        self, tmp_path: Path
-    ) -> None:
+    def test_loader_skips_entries_with_blank_or_whitespace_name(self, tmp_path: Path) -> None:
         directory = tmp_path / "capabilities"
         directory.mkdir()
         (directory / "tools.yaml").write_text(
@@ -318,17 +309,13 @@ class TestAuditTrailUnderRelaxedModes:
     OFF→ENFORCE actionable: the operator can ``grep`` the audit log.
     """
 
-    def test_warn_mode_records_offending_tools(
-        self, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_warn_mode_records_offending_tools(self, declared_registry: CapabilityRegistry) -> None:
         declared_registry.mode = EnforcementMode.WARN
         decision = declared_registry.evaluate_chain(_trifecta_chain())
         assert decision.allowed is True
         assert set(decision.offending_tools) >= set(_trifecta_chain())
 
-    def test_off_mode_records_offending_tools(
-        self, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_off_mode_records_offending_tools(self, declared_registry: CapabilityRegistry) -> None:
         declared_registry.mode = EnforcementMode.OFF
         decision = declared_registry.evaluate_chain(_trifecta_chain())
         assert decision.allowed is True
@@ -352,9 +339,7 @@ class TestMutationAfterCheck:
     ``ChainDecision`` before any caller can look at the manifest.
     """
 
-    def test_decision_object_is_frozen_against_post_check_writes(
-        self, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_decision_object_is_frozen_against_post_check_writes(self, declared_registry: CapabilityRegistry) -> None:
         """A returned ``ChainDecision`` is a frozen dataclass.
 
         Even if the registry is mutated after the fact, the previously
@@ -377,9 +362,7 @@ class TestMutationAfterCheck:
         assert decision.allowed is False
         assert decision.triggered == frozenset(Capability)
 
-    def test_record_spawn_reevaluates_at_call_time(
-        self, tmp_path: Path, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_record_spawn_reevaluates_at_call_time(self, tmp_path: Path, declared_registry: CapabilityRegistry) -> None:
         """``record_spawn_capabilities`` must re-evaluate against the
         registry at call time — *not* trust any external decision blob.
 
@@ -433,9 +416,7 @@ class TestMutationAfterCheck:
                 registry=relaxed,
             )
 
-    def test_concurrent_evaluation_does_not_lose_deny(
-        self, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_concurrent_evaluation_does_not_lose_deny(self, declared_registry: CapabilityRegistry) -> None:
         """Many threads evaluate the same trifecta chain; none must allow.
 
         Even if the underlying ``tools`` dict were being read mutably the
@@ -450,9 +431,7 @@ class TestMutationAfterCheck:
 
         with ThreadPoolExecutor(max_workers=8) as pool:
             results = list(pool.map(lambda _: _evaluate(), range(64)))
-        assert all(r is False for r in results), (
-            "Race in evaluator surfaced an allow path under concurrency."
-        )
+        assert all(r is False for r in results), "Race in evaluator surfaced an allow path under concurrency."
 
 
 # ---------------------------------------------------------------------------
@@ -468,9 +447,7 @@ class TestSurfaceScope:
     cannot be tricked by a "small file" path.
     """
 
-    def test_fs_read_carries_private_data_for_any_path(
-        self, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_fs_read_carries_private_data_for_any_path(self, declared_registry: CapabilityRegistry) -> None:
         """``fs.read`` and ``fs.read_secret`` both carry PRIVATE_DATA.
 
         The bundled surfaces.yaml tags ``fs.read`` with PRIVATE_DATA, so
@@ -566,9 +543,7 @@ class TestDnsRebindingAtCapabilityLayer:
                 capabilities=frozenset({Capability.PRIVATE_DATA}),
             )
         )
-        decision = reg.evaluate_chain(
-            ["loopback.fetch", "prompt.from_user", "db.read_credentials"]
-        )
+        decision = reg.evaluate_chain(["loopback.fetch", "prompt.from_user", "db.read_credentials"])
         assert decision.allowed is False, (
             "A 'localhost-only' fetcher tagged EXTERNAL_COMM must still trip "
             "the trifecta — the structural check fires before the agent "
@@ -582,9 +557,7 @@ class TestDnsRebindingAtCapabilityLayer:
 
 
 class TestBypassImmune:
-    def test_lethal_trifecta_is_bypass_immune_in_decision_graph(
-        self, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_lethal_trifecta_is_bypass_immune_in_decision_graph(self, declared_registry: CapabilityRegistry) -> None:
         graph = DecisionGraph(bypass_enabled=True)
         graph.add_decision(evaluate_lethal_trifecta(_trifecta_chain(), declared_registry))
         # An attacker plugin tries to spam ALLOW decisions in front.
@@ -614,9 +587,7 @@ class TestManifestPersistenceOnDeny:
     auditor can reconstruct the attempted bypass after the fact.
     """
 
-    def test_manifest_written_before_raise(
-        self, tmp_path: Path, declared_registry: CapabilityRegistry
-    ) -> None:
+    def test_manifest_written_before_raise(self, tmp_path: Path, declared_registry: CapabilityRegistry) -> None:
         with pytest.raises(LethalTrifectaError):
             record_spawn_capabilities(
                 tmp_path,
@@ -627,8 +598,7 @@ class TestManifestPersistenceOnDeny:
             )
         manifest_path = tmp_path / ".sdd" / "runtime" / "spawn_capabilities" / "agent-deny.json"
         assert manifest_path.exists(), (
-            "Manifest must be persisted *before* the deny exception so the "
-            "audit trail captures the attempted bypass."
+            "Manifest must be persisted *before* the deny exception so the audit trail captures the attempted bypass."
         )
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         assert manifest["allowed"] is False
@@ -657,9 +627,7 @@ class TestWarnModeManifestVisibility:
         )
         assert decision.allowed is True
         manifest = json.loads(
-            (tmp_path / ".sdd" / "runtime" / "spawn_capabilities" / "agent-warn.json").read_text(
-                encoding="utf-8"
-            )
+            (tmp_path / ".sdd" / "runtime" / "spawn_capabilities" / "agent-warn.json").read_text(encoding="utf-8")
         )
         assert manifest["allowed"] is True
         assert sorted(manifest["triggered"]) == sorted(c.value for c in Capability)

--- a/tests/unit/test_chat_drivers.py
+++ b/tests/unit/test_chat_drivers.py
@@ -29,11 +29,15 @@ class _FakeBot:
     sent: list[dict[str, Any]] = field(default_factory=list)
     edited: list[dict[str, Any]] = field(default_factory=list)
 
-    async def send_message(self, **kwargs: Any) -> _FakeSentMessage: # NOSONAR — async-signature required by protocol / fixture
+    async def send_message(
+        self, **kwargs: Any
+    ) -> _FakeSentMessage:  # NOSONAR — async-signature required by protocol / fixture
         self.sent.append(kwargs)
         return _FakeSentMessage(message_id=len(self.sent) + 99)
 
-    async def edit_message_text(self, **kwargs: Any) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def edit_message_text(
+        self, **kwargs: Any
+    ) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.edited.append(kwargs)
 
 
@@ -42,10 +46,10 @@ class _FakeUpdater:
     started: bool = False
     stopped: bool = False
 
-    async def start_polling(self) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def start_polling(self) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.started = True
 
-    async def stop(self) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def stop(self) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.stopped = True
 
 
@@ -62,16 +66,16 @@ class _FakeApplication:
     def add_handler(self, handler: Any) -> None:
         self.handlers.append(handler)
 
-    async def initialize(self) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def initialize(self) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.initialized = True
 
-    async def start(self) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def start(self) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.started = True
 
-    async def stop(self) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def stop(self) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.started = False
 
-    async def shutdown(self) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def shutdown(self) -> None:  # NOSONAR — async-signature required by protocol / fixture
         self.shutdown_called = True
 
 
@@ -159,7 +163,7 @@ def test_stub_registrations_are_noops() -> None:
     bridge.on_button(lambda _t, _a, _d: _async_noop())  # type: ignore[misc,arg-type]
 
 
-async def _async_noop() -> None: # NOSONAR — async-signature required by protocol / fixture
+async def _async_noop() -> None:  # NOSONAR — async-signature required by protocol / fixture
     return None
 
 
@@ -181,7 +185,7 @@ def test_telegram_run_command_routes_to_registered_handler(fake_telegram: None) 
 
     received: list[ChatMessage] = []
 
-    async def handler(msg: ChatMessage) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def handler(msg: ChatMessage) -> None:  # NOSONAR — async-signature required by protocol / fixture
         received.append(msg)
 
     bridge = TelegramBridge(token="dummy")
@@ -211,7 +215,9 @@ def test_telegram_approval_button_round_trip(fake_telegram: None) -> None:
 
     decisions: list[tuple[str, str, str]] = []
 
-    async def button(thread_id: str, approval_id: str, decision: str) -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def button(
+        thread_id: str, approval_id: str, decision: str
+    ) -> None:  # NOSONAR — async-signature required by protocol / fixture
         decisions.append((thread_id, approval_id, decision))
 
     bridge = TelegramBridge(token="dummy")
@@ -307,7 +313,7 @@ def _fake_callback_update(*, data: str, chat_id: int) -> Any:
     chat = types.SimpleNamespace(id=chat_id)
     message = types.SimpleNamespace(chat=chat)
 
-    async def _answer() -> None: # NOSONAR — async-signature required by protocol / fixture
+    async def _answer() -> None:  # NOSONAR — async-signature required by protocol / fixture
         return None
 
     query = types.SimpleNamespace(data=data, message=message, answer=_answer)

--- a/tests/unit/test_chat_session.py
+++ b/tests/unit/test_chat_session.py
@@ -60,7 +60,9 @@ class _FakeBridge(BridgeProtocol):
 class _StubDispatcher:
     calls: list[dict[str, str]] = field(default_factory=list)
 
-    async def create(self, *, goal: str, adapter: str, thread_id: str) -> tuple[str, str]: # NOSONAR — async-signature required by protocol
+    async def create(
+        self, *, goal: str, adapter: str, thread_id: str
+    ) -> tuple[str, str]:  # NOSONAR — async-signature required by protocol
         self.calls.append({"goal": goal, "adapter": adapter, "thread_id": thread_id})
         tid = f"t-{len(self.calls)}"
         return tid, f"sess-{tid}"

--- a/tests/unit/test_fingerprint_determinism.py
+++ b/tests/unit/test_fingerprint_determinism.py
@@ -156,10 +156,7 @@ class TestConcurrentWriters:
                 except Exception as exc:
                     errors.append(exc)
 
-        threads = [
-            threading.Thread(target=worker, args=({"k": c * 800},))
-            for c in "abcde"
-        ]
+        threads = [threading.Thread(target=worker, args=({"k": c * 800},)) for c in "abcde"]
         for t in threads:
             t.start()
         for t in threads:

--- a/tests/unit/test_gitignore_packaging_guard.py
+++ b/tests/unit/test_gitignore_packaging_guard.py
@@ -63,8 +63,7 @@ def test_no_shipped_subpackage_is_gitignored() -> None:
         msg = (
             "gitignore rule matches shipped src/bernstein/ sub-package(s).  "
             "Hatchling will drop them from the wheel and `pip install` users "
-            "will see ModuleNotFoundError.  Offending entries:\n  "
-            + "\n  ".join(offending)
+            "will see ModuleNotFoundError.  Offending entries:\n  " + "\n  ".join(offending)
         )
         raise AssertionError(msg)
 

--- a/tests/unit/test_lineage_record_v1.py
+++ b/tests/unit/test_lineage_record_v1.py
@@ -70,9 +70,7 @@ def _make_v1_record(path: str = "src/foo.py") -> LineageRecord:
 
 class TestArtifactFromDict:
     def test_complete_dict_round_trips(self) -> None:
-        ref = _artifact_from_dict(
-            {"path": "x.py", "sha256": "abc", "line_start": 5, "line_end": 10}
-        )
+        ref = _artifact_from_dict({"path": "x.py", "sha256": "abc", "line_start": 5, "line_end": 10})
         assert ref.path == "x.py"
         assert ref.sha256 == "abc"
         assert ref.line_start == 5

--- a/tests/unit/test_lineage_regulatory_verify.py
+++ b/tests/unit/test_lineage_regulatory_verify.py
@@ -418,9 +418,7 @@ class TestRunIdValidation:
             "with\x00nul",
         ],
     )
-    def test_for_run_rejects_path_separators_and_traversal(
-        self, tmp_path: Path, bad_run_id: str
-    ) -> None:
+    def test_for_run_rejects_path_separators_and_traversal(self, tmp_path: Path, bad_run_id: str) -> None:
         sdd = tmp_path / ".sdd"
         sdd.mkdir()
         with pytest.raises(LineageRunIdError):
@@ -433,9 +431,7 @@ class TestRunIdValidation:
         for ok in ("run-1", "r-2026-05-05", "abc123", "with.dots.but.no.dotdot"):
             LineageWriter.for_run(ok, sdd).emit(_make_record(path=f"x-{ok}.py"))
 
-    def test_exporter_with_traversal_run_id_returns_no_records(
-        self, tmp_path: Path
-    ) -> None:
+    def test_exporter_with_traversal_run_id_returns_no_records(self, tmp_path: Path) -> None:
         """A traversal-shaped *query* run_id must not blow up the exporter --
         it just yields zero records (because the WAL glob is non-recursive
         and the file does not exist)."""
@@ -645,10 +641,7 @@ class TestJsonLdValidity:
         assert doc["@context"] == "https://schema.org"
         assert doc["@type"] == "ItemList"
         # Round-tripped value matches input
-        props = {
-            p["name"]: p["value"]
-            for p in doc["itemListElement"][0]["additionalProperty"]
-        }
+        props = {p["name"]: p["value"] for p in doc["itemListElement"][0]["additionalProperty"]}
         assert props["regulatory_class"] == rec.regulatory_class
 
     def test_jsonld_preserves_action_shape_for_each_record(self) -> None:
@@ -772,9 +765,7 @@ class TestExporterScale:
         for i in range(5000):
             writer.emit(
                 LineageRecord(
-                    output_artifact=ArtifactRef(
-                        path=f"src/f{i}.py", sha256="a" * 64, line_start=1, line_end=2
-                    ),
+                    output_artifact=ArtifactRef(path=f"src/f{i}.py", sha256="a" * 64, line_start=1, line_end=2),
                     inputs=[],
                     producer=AgentRef(agent_id="a", run_id="run-htmlbig"),
                     prompt_sha="p",

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -116,7 +116,9 @@ class TestCountTokensViaCheapModel:
 
     @pytest.mark.asyncio
     async def test_raises_when_call_llm_raises(self) -> None:
-        with patch("bernstein.core.tokens.token_counter.call_llm", new=AsyncMock(side_effect=RuntimeError("api error"))):
+        with patch(
+            "bernstein.core.tokens.token_counter.call_llm", new=AsyncMock(side_effect=RuntimeError("api error"))
+        ):
             with pytest.raises(RuntimeError, match="api error"):
                 await count_tokens_via_cheap_model(_SAMPLE_TEXT)
 


### PR DESCRIPTION
Surfacing this branch from a long-lived local worktree as a draft PR for review.

Range: 2 commit(s) ahead of `main`. Last subject: `style(adapters): apply ruff format/import-sort to junie test module`.

Either review and merge, or close as abandoned. CI will tell us if the branch is still rebase-clean.