### PR TITLE
fix(persistence): replay determinism + concurrency safety for memo cache

### DIFF
--- a/src/bernstein/core/persistence/fingerprint.py
+++ b/src/bernstein/core/persistence/fingerprint.py
@@ -30,9 +30,11 @@ import hashlib
 import inspect
 import json
 import logging
+import os
 import pickle
 import textwrap
 import threading
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -50,15 +52,39 @@ _AST_CACHE_LOCK = threading.Lock()
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+def _canonicalize(value: Any) -> Any:
+    """Recursively normalise *value* into a JSON-friendly, order-stable form.
+
+    Sets and frozensets are sorted (by ``repr`` of their members, which
+    is total even for mixed-type members) so two processes with
+    different ``PYTHONHASHSEED`` produce identical bytes.  Without this,
+    ``json.dumps({"a","b"}, default=repr)`` round-trips through
+    ``repr(set)`` whose member order is hash-randomised — yielding a
+    different cache key per process and silently breaking action-cache
+    hits in CI.  Dicts recurse so nested sets are also canonicalised.
+    """
+    if isinstance(value, dict):
+        return {str(k): _canonicalize(v) for k, v in sorted(value.items(), key=lambda kv: repr(kv[0]))}
+    if isinstance(value, (set, frozenset)):
+        return ["__set__", sorted((_canonicalize(v) for v in value), key=repr)]
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize(v) for v in value]
+    return value
+
+
 def _canonical_arg_repr(value: Any) -> bytes:
     """Return a stable byte representation of an argument value.
 
-    Tries JSON first (deterministic, sort_keys); falls back to pickle
-    with a fixed protocol for objects JSON cannot encode.  Keeps the
-    contract: equal logical inputs produce equal bytes.
+    Canonicalises sets/frozensets and nested containers before JSON
+    encoding so member order is fixed across processes (Python's hash
+    randomisation otherwise yields different bytes per
+    ``PYTHONHASHSEED``).  Falls back to pickle for objects JSON cannot
+    encode; the fall-back path is reached only by exotic types (custom
+    classes, file objects, etc.) that callers should not normally pass
+    through a memoised function anyway.
     """
     try:
-        return json.dumps(value, sort_keys=True, default=repr).encode("utf-8")
+        return json.dumps(_canonicalize(value), sort_keys=True, default=repr).encode("utf-8")
     except (TypeError, ValueError):
         try:
             return pickle.dumps(value, protocol=5)
@@ -143,7 +169,13 @@ class MemoStore:
         return self._root / hexd[:2] / f"{hexd[2:]}.bin"
 
     def get(self, digest: bytes) -> Any | None:
-        """Return cached value for *digest* or ``None`` on miss."""
+        """Return cached value for *digest* or ``None`` on miss.
+
+        Corrupt entries (truncated, partial-write, wrong protocol) are
+        unlinked before returning ``None`` so the next ``put`` can
+        replace them; otherwise a one-time corruption would force an
+        infinite stream of misses on a hot key.
+        """
         path = self._path_for(digest)
         if not path.exists():
             with self._lock:
@@ -152,8 +184,11 @@ class MemoStore:
         try:
             data = path.read_bytes()
             value = pickle.loads(data)
-        except (OSError, pickle.UnpicklingError, EOFError) as exc:
+        except (OSError, pickle.UnpicklingError, EOFError, ValueError) as exc:
             logger.debug("memo: failed to load %s: %s", path, exc)
+            # Self-heal: drop the bad entry so the next put repopulates it.
+            with contextlib.suppress(OSError):
+                path.unlink()
             with self._lock:
                 self._misses += 1
             return None
@@ -165,7 +200,16 @@ class MemoStore:
         return value
 
     def put(self, digest: bytes, value: Any) -> None:
-        """Persist *value* under *digest*; evict if size cap exceeded."""
+        """Persist *value* under *digest*; evict if size cap exceeded.
+
+        Concurrent writers targeting the same digest are tolerated by
+        giving each writer a unique temp filename
+        (``<name>.<pid>.<rand>.tmp``) and using ``os.replace`` for the
+        atomic rename onto the final path.  Without per-writer temp
+        paths two threads sharing one ``MemoStore`` instance race: the
+        first ``replace`` unlinks the temp, the second writer's
+        subsequent ``replace`` then sees ``FileNotFoundError``.
+        """
         path = self._path_for(digest)
         path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -173,9 +217,17 @@ class MemoStore:
         except (pickle.PicklingError, TypeError) as exc:
             logger.debug("memo: cannot pickle value for %s: %s", digest.hex()[:12], exc)
             return
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_bytes(payload)
-        tmp.replace(path)
+        tmp = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        try:
+            tmp.write_bytes(payload)
+            os.replace(tmp, path)
+        except OSError as exc:
+            # Best-effort cleanup; another concurrent writer may have already
+            # claimed the slot which is fine — content is content-addressed.
+            logger.debug("memo: put failed for %s: %s", digest.hex()[:12], exc)
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            return
         self._maybe_evict()
 
     def _iter_entries(self) -> list[tuple[Path, int, float]]:

--- a/src/bernstein/core/persistence/lineage.py
+++ b/src/bernstein/core/persistence/lineage.py
@@ -133,9 +133,20 @@ def _artifact_to_dict(ref: ArtifactRef) -> dict[str, Any]:
 
 
 def _artifact_from_dict(data: dict[str, Any]) -> ArtifactRef:
+    """Reconstruct an :class:`ArtifactRef` from its serialised dict form.
+
+    Tolerates missing or malformed v1 fields by defaulting ``path`` and
+    ``sha256`` to empty strings: the reader contract guarantees that a
+    truncated or partially-written WAL entry yields an ``ArtifactRef("", "")``
+    rather than crashing the entire iterator.  Empty-path records are
+    still useful in the bundle export and signature-verification paths
+    because they keep producer/prompt metadata intact.
+    """
+    if not isinstance(data, dict):
+        return ArtifactRef(path="", sha256="")
     return ArtifactRef(
-        path=str(data["path"]),
-        sha256=str(data["sha256"]),
+        path=str(data.get("path", "")),
+        sha256=str(data.get("sha256", "")),
         byte_start=data.get("byte_start"),
         byte_end=data.get("byte_end"),
         line_start=data.get("line_start"),

--- a/tests/unit/test_fingerprint_determinism.py
+++ b/tests/unit/test_fingerprint_determinism.py
@@ -1,0 +1,317 @@
+"""Replay-determinism and concurrency tests for fingerprint memoization.
+
+These complement :mod:`tests.unit.test_fingerprint` by covering the
+failure modes the lineage-trail audit surfaced:
+
+* sets/frozensets must hash to the same digest across processes
+  (``PYTHONHASHSEED`` randomises ``set`` member order; without sorting,
+  two CI runs on the same input get different cache keys);
+* concurrent ``put`` on the same digest must not raise — the original
+  implementation reused one fixed ``.tmp`` filename so the second
+  ``replace`` fired ``FileNotFoundError``;
+* corrupt cache files must self-heal so a single torn write does not
+  trap a hot key in an infinite-miss loop;
+* same input must yield byte-identical pickle payloads on disk
+  (replay determinism).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.persistence.fingerprint import (
+    MemoStore,
+    _canonicalize,
+    fingerprint,
+)
+
+# ---------------------------------------------------------------------------
+# Cross-process determinism
+# ---------------------------------------------------------------------------
+
+
+_CROSS_PROCESS_SCRIPT = """
+import json, sys
+sys.path.insert(0, {src!r})
+from bernstein.core.persistence.fingerprint import fingerprint
+
+def f(s):
+    return len(s)
+
+print(fingerprint(f, {payload}).hex())
+"""
+
+
+def _run_under_seed(seed: str, payload: str) -> str:
+    """Execute a tiny script with PYTHONHASHSEED=*seed* and return its hex digest."""
+    src = str(Path(__file__).resolve().parents[2] / "src")
+    script = _CROSS_PROCESS_SCRIPT.format(src=src, payload=payload)
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = seed
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return proc.stdout.strip()
+
+
+class TestCrossProcessDeterminism:
+    def test_set_arg_hashes_identically_across_hash_seeds(self) -> None:
+        seeds = ["1", "2", "42", "9999"]
+        digests = [_run_under_seed(s, "{'a','b','c','d','e','f','g','h'}") for s in seeds]
+        assert len(set(digests)) == 1, f"set fingerprints diverged across seeds: {digests}"
+
+    def test_frozenset_arg_hashes_identically_across_hash_seeds(self) -> None:
+        seeds = ["1", "7", "99"]
+        digests = [_run_under_seed(s, "frozenset(['a','b','c','d','e'])") for s in seeds]
+        assert len(set(digests)) == 1, f"frozenset fingerprints diverged: {digests}"
+
+    def test_dict_with_nested_set_value_hashes_identically(self) -> None:
+        seeds = ["1", "2", "100"]
+        digests = [_run_under_seed(s, "{'k': {'a','b','c','d'}, 'n': 1}") for s in seeds]
+        assert len(set(digests)) == 1, f"nested-set fingerprints diverged: {digests}"
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalize:
+    def test_set_becomes_sorted_marker_list(self) -> None:
+        out = _canonicalize({"c", "a", "b"})
+        assert out[0] == "__set__"
+        assert out[1] == sorted(["c", "a", "b"], key=repr)
+
+    def test_frozenset_becomes_sorted_marker_list(self) -> None:
+        out = _canonicalize(frozenset({1, 2, 3}))
+        assert out[0] == "__set__"
+        assert out[1] == [1, 2, 3]
+
+    def test_nested_dicts_recurse(self) -> None:
+        result = _canonicalize({"outer": {"inner": {1, 2, 3}}})
+        assert result["outer"]["inner"] == ["__set__", [1, 2, 3]]
+
+    def test_scalars_pass_through(self) -> None:
+        assert _canonicalize(5) == 5
+        assert _canonicalize("hi") == "hi"
+        assert _canonicalize(None) is None
+        assert _canonicalize(3.14) == 3.14
+
+
+# ---------------------------------------------------------------------------
+# Replay determinism
+# ---------------------------------------------------------------------------
+
+
+def _replay_target(x: int, y: int) -> dict[str, int]:
+    return {"sum": x + y, "product": x * y}
+
+
+class TestReplayDeterminism:
+    def test_same_input_yields_same_digest(self) -> None:
+        d1 = fingerprint(_replay_target, 3, 4)
+        d2 = fingerprint(_replay_target, 3, 4)
+        assert d1 == d2
+
+    def test_pickle_payload_is_byte_identical_for_equal_values(self, tmp_path: Path) -> None:
+        store_a = MemoStore(root=tmp_path / "a", max_mb=1)
+        store_b = MemoStore(root=tmp_path / "b", max_mb=1)
+        digest = fingerprint(_replay_target, 1, 2)
+        value = _replay_target(1, 2)
+        store_a.put(digest, value)
+        store_b.put(digest, value)
+
+        # Both stores hold the entry under the *same* relative path
+        rel_a = store_a._path_for(digest).relative_to(store_a.root)
+        rel_b = store_b._path_for(digest).relative_to(store_b.root)
+        assert rel_a == rel_b
+        assert (store_a.root / rel_a).read_bytes() == (store_b.root / rel_b).read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writers
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentWriters:
+    def test_concurrent_put_same_digest_does_not_raise(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=4)
+        digest = b"\xaa" * 32
+        errors: list[BaseException] = []
+
+        def worker(payload: dict[str, str]) -> None:
+            for _ in range(50):
+                try:
+                    store.put(digest, payload)
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=({"k": c * 800},))
+            for c in "abcde"
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # Some writer's payload must be persisted intact.
+        final = store.get(digest)
+        assert final is not None
+        assert "k" in final
+        assert len(final["k"]) == 800
+
+    def test_concurrent_put_distinct_digests_no_corruption(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=4)
+        errors: list[BaseException] = []
+
+        def worker(prefix: int) -> None:
+            for i in range(40):
+                d = bytes([prefix]) * 32
+                try:
+                    store.put(d, {"prefix": prefix, "i": i})
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(p,)) for p in range(1, 9)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # All 8 distinct digests must be readable.
+        for prefix in range(1, 9):
+            d = bytes([prefix]) * 32
+            v = store.get(d)
+            assert v is not None
+            assert v["prefix"] == prefix
+
+
+# ---------------------------------------------------------------------------
+# Corrupt-file self-heal
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptFileSelfHeal:
+    def test_corrupt_pickle_is_unlinked_on_get(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        digest = b"\x42" * 32
+        store.put(digest, {"x": 1})
+
+        path = store._path_for(digest)
+        path.write_bytes(b"this is not pickle")
+
+        assert store.get(digest) is None
+        assert not path.exists(), "corrupt file should be unlinked so put() can re-populate"
+
+    def test_repopulate_after_corruption_works(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        digest = b"\x42" * 32
+        store.put(digest, {"x": 1})
+        store._path_for(digest).write_bytes(b"junk")
+
+        # First get observes corruption and self-heals.
+        assert store.get(digest) is None
+        # Subsequent put + get round-trips cleanly.
+        store.put(digest, {"x": 2})
+        assert store.get(digest) == {"x": 2}
+
+    def test_truncated_file_treated_as_miss(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        digest = b"\x77" * 32
+        store.put(digest, {"big": "x" * 500})
+        # Truncate to a fragment so pickle.loads raises EOFError.
+        store._path_for(digest).write_bytes(b"\x80\x05")
+
+        assert store.get(digest) is None
+        assert store.stats().misses >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tmp-file path uniqueness
+# ---------------------------------------------------------------------------
+
+
+class TestTmpFileSafety:
+    def test_no_lingering_tmp_files_after_successful_put(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        for i in range(20):
+            store.put(bytes([i]) * 32, {"i": i})
+
+        # No .tmp files should remain when puts succeed.
+        leftovers = list((tmp_path / "memo").rglob("*.tmp"))
+        assert leftovers == [], f"leftover tmp files: {leftovers}"
+
+    def test_total_bytes_excludes_partial_tmp_files(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        digest = b"\x33" * 32
+        store.put(digest, {"a": 1})
+
+        # Drop a stray .tmp file alongside the entry.  total_bytes() counts
+        # only ``.bin`` files so the fake tmp must not inflate the total.
+        path = store._path_for(digest)
+        stray = path.with_name(path.name + ".stale.tmp")
+        stray.write_bytes(b"x" * 10_000)
+
+        assert store.total_bytes() == path.stat().st_size
+
+
+# ---------------------------------------------------------------------------
+# Path traversal
+# ---------------------------------------------------------------------------
+
+
+class TestPathTraversalSafety:
+    def test_digest_hex_only_alphanumeric(self, tmp_path: Path) -> None:
+        # digest.hex() is alphanumeric by construction; any byte sequence
+        # therefore cannot escape the cache root via "../".
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        weird_digest = bytes(range(32))  # arbitrary bytes
+        path = store._path_for(weird_digest)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # ``relative_to`` will raise if path escaped the root.
+        path.relative_to(store.root)
+
+
+# ---------------------------------------------------------------------------
+# Eviction stability with concurrent writers
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionUnderConcurrency:
+    def test_size_cap_holds_under_concurrent_writers(self, tmp_path: Path) -> None:
+        store = MemoStore(root=tmp_path / "memo", max_mb=1)
+        store._max_bytes = 32 * 1024  # 32 KiB
+
+        def worker(prefix: int) -> None:
+            payload = b"x" * 256
+            for i in range(100):
+                d = (prefix.to_bytes(2, "big") + i.to_bytes(2, "big")) + b"\x00" * 28
+                store.put(d, payload)
+
+        threads = [threading.Thread(target=worker, args=(p,)) for p in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # 400 writers x 256B = 100 KiB attempted vs 32 KiB cap.
+        # Eviction is best-effort under contention so allow a 4x slack
+        # (every writer can race past the eviction step once).
+        assert store.total_bytes() <= store._max_bytes * 4
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-q"])

--- a/tests/unit/test_lineage_record_v1.py
+++ b/tests/unit/test_lineage_record_v1.py
@@ -1,0 +1,281 @@
+"""Schema-v1 robustness tests for the per-artifact lineage trail.
+
+These complement :mod:`tests.unit.test_lineage_record` by covering the
+v1-specific failure modes the audit surfaced:
+
+* a torn write that leaves ``output_artifact`` missing must NOT crash
+  the iterator — a long chain with one bad row should still walk the
+  remaining records;
+* malformed artifact dicts must degrade to an empty :class:`ArtifactRef`,
+  not a ``KeyError``;
+* lookups against a chain that mixes v1 and v2 records must still
+  honour the v1 path/line filter.
+
+We deliberately avoid the schema-v2 fields (``regulatory_class``,
+``customer_signature``) here — those live in the regulatory-lineage
+verification suite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.persistence.lineage import (
+    LINEAGE_DECISION_TYPE,
+    SCHEMA_VERSION_V1,
+    AgentRef,
+    ArtifactRef,
+    LineageReader,
+    LineageRecord,
+    LineageWriter,
+    _artifact_from_dict,
+    _record_from_wal,
+)
+from bernstein.core.persistence.wal import WALReader, WALWriter
+
+
+def _sdd(tmp_path: Path) -> Path:
+    sdd = tmp_path / ".sdd"
+    sdd.mkdir(parents=True, exist_ok=True)
+    return sdd
+
+
+def _make_v1_record(path: str = "src/foo.py") -> LineageRecord:
+    return LineageRecord(
+        output_artifact=ArtifactRef(
+            path=path,
+            sha256="a" * 64,
+            line_start=1,
+            line_end=10,
+        ),
+        inputs=[ArtifactRef(path="src/bar.py", sha256="b" * 64)],
+        producer=AgentRef(agent_id="agent-1", run_id="run-1"),
+        prompt_sha="c" * 64,
+        model="claude-sonnet",
+        cost_usd=0.01,
+        tokens=1000,
+        timestamp=1700000000.0,
+        # Explicitly v1 — leave regulatory_class / customer_signature unset.
+        schema_version=SCHEMA_VERSION_V1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _artifact_from_dict resilience
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactFromDict:
+    def test_complete_dict_round_trips(self) -> None:
+        ref = _artifact_from_dict(
+            {"path": "x.py", "sha256": "abc", "line_start": 5, "line_end": 10}
+        )
+        assert ref.path == "x.py"
+        assert ref.sha256 == "abc"
+        assert ref.line_start == 5
+        assert ref.line_end == 10
+
+    def test_missing_path_yields_empty(self) -> None:
+        ref = _artifact_from_dict({"sha256": "abc"})
+        assert ref.path == ""
+        assert ref.sha256 == "abc"
+
+    def test_missing_sha_yields_empty(self) -> None:
+        ref = _artifact_from_dict({"path": "x.py"})
+        assert ref.path == "x.py"
+        assert ref.sha256 == ""
+
+    def test_completely_empty_dict_yields_empty_ref(self) -> None:
+        ref = _artifact_from_dict({})
+        assert ref.path == ""
+        assert ref.sha256 == ""
+        assert ref.line_start is None
+        assert ref.line_end is None
+
+    def test_non_dict_input_returns_empty_ref(self) -> None:
+        # Defensive: a corrupt WAL row could yield a list or scalar.
+        assert _artifact_from_dict([]).path == ""  # type: ignore[arg-type]
+        assert _artifact_from_dict("oops").sha256 == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _record_from_wal resilience
+# ---------------------------------------------------------------------------
+
+
+class TestRecordFromWalResilience:
+    def test_v1_record_with_missing_output_artifact_does_not_crash(self) -> None:
+        # Pre-fix: this raised KeyError('path').
+        record = _record_from_wal({"inputs": []}, {}, ts=1.0)
+        assert record.output_artifact.path == ""
+        assert record.schema_version == SCHEMA_VERSION_V1
+
+    def test_v1_record_with_partial_output_artifact(self) -> None:
+        record = _record_from_wal(
+            {"inputs": [], "producer": {"agent_id": "a", "run_id": "r"}},
+            {"output_artifact": {"sha256": "deadbeef"}, "cost_usd": 0.5},
+            ts=1700000000.0,
+        )
+        assert record.output_artifact.path == ""
+        assert record.output_artifact.sha256 == "deadbeef"
+        assert record.cost_usd == 0.5
+        assert record.producer.agent_id == "a"
+
+    def test_inputs_with_partial_artifact_dicts_do_not_crash(self) -> None:
+        record = _record_from_wal(
+            {
+                "inputs": [
+                    {"path": "src/a.py", "sha256": "aa"},
+                    {},  # totally empty
+                    {"sha256": "bb"},  # missing path
+                ],
+                "producer": {"agent_id": "a", "run_id": "r"},
+            },
+            {"output_artifact": {"path": "src/o.py", "sha256": "oo"}},
+            ts=1.0,
+        )
+        assert len(record.inputs) == 3
+        assert record.inputs[1].path == ""
+        assert record.inputs[2].path == ""
+        assert record.inputs[2].sha256 == "bb"
+
+
+# ---------------------------------------------------------------------------
+# LineageReader against a WAL with one bad row mixed into a long chain
+# ---------------------------------------------------------------------------
+
+
+class TestReaderToleratesBadRows:
+    def test_iter_records_skips_torn_row_keeps_walking(self, tmp_path: Path) -> None:
+        sdd = _sdd(tmp_path)
+        # Append two clean records, then forge a third entry directly to
+        # the WAL with a missing ``output_artifact`` payload, then a clean
+        # fourth one.
+        wal_writer = WALWriter(run_id="run-1", sdd_dir=sdd)
+        lineage = LineageWriter(wal_writer)
+
+        lineage.emit(_make_v1_record(path="src/a.py"))
+        lineage.emit(_make_v1_record(path="src/b.py"))
+
+        # Forged "torn" record: ``output_artifact`` field absent in output.
+        wal_writer.append(
+            decision_type=LINEAGE_DECISION_TYPE,
+            inputs={"inputs": [], "producer": {"agent_id": "agent-2", "run_id": "run-1"}},
+            output={"cost_usd": 0.0, "tokens": 0},  # no output_artifact!
+            actor="agent-2",
+        )
+
+        lineage.emit(_make_v1_record(path="src/c.py"))
+
+        reader = LineageReader(sdd)
+        all_records = list(reader.iter_records(run_id="run-1"))
+        # Pre-fix the torn row would crash before yielding c.py.
+        paths = [r.output_artifact.path for r in all_records]
+        assert paths == ["src/a.py", "src/b.py", "", "src/c.py"]
+
+    def test_lookup_path_filter_ignores_torn_rows(self, tmp_path: Path) -> None:
+        sdd = _sdd(tmp_path)
+        wal_writer = WALWriter(run_id="run-2", sdd_dir=sdd)
+        lineage = LineageWriter(wal_writer)
+        lineage.emit(_make_v1_record(path="src/x.py"))
+        # Torn row: empty output dict.
+        wal_writer.append(
+            decision_type=LINEAGE_DECISION_TYPE,
+            inputs={"inputs": []},
+            output={},
+            actor="agent-2",
+        )
+        lineage.emit(_make_v1_record(path="src/y.py"))
+
+        reader = LineageReader(sdd)
+        x_rows = reader.lookup("src/x.py")
+        y_rows = reader.lookup("src/y.py")
+        assert len(x_rows) == 1
+        assert len(y_rows) == 1
+        # The torn row gets ArtifactRef(path="") and so doesn't match x/y.
+        assert x_rows[0].output_artifact.path == "src/x.py"
+
+
+# ---------------------------------------------------------------------------
+# v1 round-trip via WAL preserves byte-for-byte serialization shape
+# ---------------------------------------------------------------------------
+
+
+class TestV1OnDiskShape:
+    def test_v1_record_serialised_with_optional_fields_omitted(self, tmp_path: Path) -> None:
+        sdd = _sdd(tmp_path)
+        writer = LineageWriter.for_run("run-3", sdd)
+        # Emit a record marked v1 — optional v2 fields stay None.
+        writer.emit(_make_v1_record())
+
+        wal_path = sdd / "runtime" / "wal" / "run-3.wal.jsonl"
+        line = wal_path.read_text().splitlines()[0]
+        data = json.loads(line)
+        output = data["output"]
+        # Optional v2 fields must not bloat v1 records on disk.
+        assert "regulatory_class" not in output
+        assert "customer_signature" not in output
+
+    def test_v1_record_replay_yields_identical_output_dict(self, tmp_path: Path) -> None:
+        """Two writes of the same v1 record yield identical serialised lines.
+
+        This is the crux of replay determinism for the lineage trail:
+        identical inputs must produce identical bytes on disk so a
+        downstream verifier can compare two runs directly.
+        """
+        sdd_a = _sdd(tmp_path / "a")
+        sdd_b = _sdd(tmp_path / "b")
+        rec = _make_v1_record(path="src/det.py")
+
+        LineageWriter.for_run("run-x", sdd_a).emit(rec)
+        LineageWriter.for_run("run-x", sdd_b).emit(rec)
+
+        line_a = (sdd_a / "runtime" / "wal" / "run-x.wal.jsonl").read_text().splitlines()[0]
+        line_b = (sdd_b / "runtime" / "wal" / "run-x.wal.jsonl").read_text().splitlines()[0]
+        # Strip the timestamp field which is set by the WAL writer to
+        # ``time.time()`` — the rest of the payload must match exactly.
+        d_a = json.loads(line_a)
+        d_b = json.loads(line_b)
+        for d in (d_a, d_b):
+            d.pop("timestamp", None)
+            d.pop("entry_hash", None)
+            d.pop("prev_hash", None)
+            d["output"].pop("timestamp", None)
+        assert d_a == d_b
+
+
+# ---------------------------------------------------------------------------
+# Reader + writer round-trip with malformed input fields
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndResilience:
+    def test_chain_verification_passes_with_torn_row(self, tmp_path: Path) -> None:
+        """The WAL hash chain remains intact even when one row is torn.
+
+        ``output_artifact`` may be missing from the payload, but the WAL
+        hashing happens over the *whole* JSON line — so the chain stays
+        verifiable. Only the lineage decoder needs to tolerate the gap.
+        """
+        sdd = _sdd(tmp_path)
+        wal_writer = WALWriter(run_id="run-c", sdd_dir=sdd)
+        lineage = LineageWriter(wal_writer)
+        lineage.emit(_make_v1_record(path="src/z.py"))
+        wal_writer.append(
+            decision_type=LINEAGE_DECISION_TYPE,
+            inputs={"inputs": []},
+            output={},
+            actor="agent",
+        )
+        lineage.emit(_make_v1_record(path="src/zz.py"))
+
+        reader = WALReader(run_id="run-c", sdd_dir=sdd)
+        ok, errors = reader.verify_chain()
+        assert ok, errors
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-q"])

--- a/tests/unit/test_memo_store_concurrency.py
+++ b/tests/unit/test_memo_store_concurrency.py
@@ -1,0 +1,180 @@
+"""Concurrency and determinism tests for MemoStore + ActionCache.
+
+These complement :mod:`tests.unit.test_action_cache` by covering the
+failure modes the audit surfaced on the action-cache layer:
+
+* concurrent writers through ``ActionCache.record`` must not crash;
+* recording the same action twice must produce a stable cache state
+  (the second write is a no-op because content is content-addressed);
+* a torn cache file must self-heal so a hot key does not stay stuck
+  in an infinite-miss loop.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.persistence.action_cache import (
+    ActionCache,
+    TokenCounts,
+    derive_key,
+)
+from bernstein.core.persistence.fingerprint import MemoStore
+
+
+def _make_cache(tmp_path: Path) -> ActionCache:
+    store = MemoStore(root=tmp_path / "ac", max_mb=1)
+    return ActionCache(store, mode="hybrid", run_id="run-test")
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writers
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentRecord:
+    def test_concurrent_record_same_key_does_not_raise(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        errors: list[BaseException] = []
+
+        def worker(out: str) -> None:
+            for _ in range(50):
+                try:
+                    cache.record(
+                        model_id="opus",
+                        prompt="hello",
+                        output_text=out,
+                        tokens=TokenCounts(prompt_tokens=2),
+                        cost_usd=0.001,
+                    )
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(c * 200,)) for c in "abcde"]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        rec = cache.lookup(model_id="opus", prompt="hello")
+        assert rec is not None
+        assert rec.output_text  # some writer's payload survived
+
+    def test_concurrent_record_distinct_keys_all_persisted(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        errors: list[BaseException] = []
+
+        def worker(prefix: int) -> None:
+            for i in range(20):
+                try:
+                    cache.record(
+                        model_id="opus",
+                        prompt=f"prompt-{prefix}-{i}",
+                        output_text=f"out-{prefix}-{i}",
+                    )
+                except Exception as exc:
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(p,)) for p in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        # Every recorded action must round-trip.
+        for prefix in range(6):
+            for i in range(20):
+                rec = cache.lookup(model_id="opus", prompt=f"prompt-{prefix}-{i}")
+                assert rec is not None
+                assert rec.output_text == f"out-{prefix}-{i}"
+
+
+# ---------------------------------------------------------------------------
+# Replay determinism
+# ---------------------------------------------------------------------------
+
+
+class TestReplayDeterminism:
+    def test_derive_key_is_byte_stable(self) -> None:
+        a = derive_key(model_id="opus", prompt="hello", tool_name="bash", tool_args={"cmd": "ls"})
+        b = derive_key(model_id="opus", prompt="hello", tool_name="bash", tool_args={"cmd": "ls"})
+        assert a == b
+        assert isinstance(a, bytes)
+        assert len(a) == 32
+
+    def test_replay_same_inputs_yields_byte_identical_payload_on_disk(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store_a = MemoStore(root=tmp_path / "a", max_mb=1)
+        store_b = MemoStore(root=tmp_path / "b", max_mb=1)
+        cache_a = ActionCache(store_a, mode="record", run_id="r")
+        cache_b = ActionCache(store_b, mode="record", run_id="r")
+        # Identical record() invocation on two stores.
+        cache_a.record(model_id="opus", prompt="p", output_text="hello", cost_usd=0.0)
+        cache_b.record(model_id="opus", prompt="p", output_text="hello", cost_usd=0.0)
+
+        digest = derive_key(model_id="opus", prompt="p")
+        # The two on-disk pickles can differ because ``ActionRecord.timestamp``
+        # is set to ``time.time()`` per call; after stripping it the *records*
+        # must compare equal.
+        assert store_a._path_for(digest).name == store_b._path_for(digest).name
+        rec_a = cache_a.lookup(model_id="opus", prompt="p")
+        rec_b = cache_b.lookup(model_id="opus", prompt="p")
+        assert rec_a is not None
+        assert rec_b is not None
+        # Compare every field except the timestamp.
+        for field in ("model_id", "prompt", "output_text", "cost_usd", "run_id", "version"):
+            assert getattr(rec_a, field) == getattr(rec_b, field)
+
+
+# ---------------------------------------------------------------------------
+# Corrupt cache file self-heal at the action-cache layer
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptActionRecord:
+    def test_corrupt_cache_file_treated_as_miss(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        cache.record(model_id="opus", prompt="hi", output_text="ok")
+
+        # Corrupt the file on disk.
+        digest = derive_key(model_id="opus", prompt="hi")
+        path = cache.store._path_for(digest)
+        path.write_bytes(b"definitely_not_pickle")
+
+        assert cache.lookup(model_id="opus", prompt="hi") is None
+
+        # After self-heal, a fresh record() repopulates cleanly.
+        cache.record(model_id="opus", prompt="hi", output_text="re-recorded")
+        rec = cache.lookup(model_id="opus", prompt="hi")
+        assert rec is not None
+        assert rec.output_text == "re-recorded"
+
+
+# ---------------------------------------------------------------------------
+# No tmp leakage
+# ---------------------------------------------------------------------------
+
+
+class TestNoTmpLeakage:
+    def test_record_does_not_leave_tmp_files(self, tmp_path: Path) -> None:
+        cache = _make_cache(tmp_path)
+        for i in range(20):
+            cache.record(
+                model_id="opus",
+                prompt=f"p-{i}",
+                output_text=f"o-{i}",
+            )
+        leftovers: list[Any] = list((tmp_path / "ac").rglob("*.tmp"))
+        assert leftovers == [], f"tmp files leaked: {leftovers}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-q"])


### PR DESCRIPTION
Surfacing this branch from a long-lived local worktree as a draft PR for review.

Range: 1 commit(s) ahead of `main`. Last subject: `fix(persistence): replay determinism + concurrency safety for memo cache`.

Either review and merge, or close as abandoned. CI will tell us if the branch is still rebase-clean.