### PR TITLE
test(adapters): cover CLM adapter edge cases

### DIFF
--- a/tests/unit/test_adapter_clm.py
+++ b/tests/unit/test_adapter_clm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import sys
 from pathlib import Path
@@ -24,8 +25,10 @@ from bernstein.adapters.clm import (
     ClmConfig,
     ClmConfigError,
     StreamingChunk,
+    StreamingLineagePayload,
     assemble_streaming_response,
     build_openai_tools_schema,
+    parse_tool_allowlist_env,
     redactable_clm_env_keys,
     tls_config_from_env,
 )
@@ -464,3 +467,497 @@ def test_redactable_env_keys_includes_token_and_paths() -> None:
     # configuration the audit trail needs to preserve for traceability.
     assert CLM_ENDPOINT_ENV not in keys
     assert CLM_MODEL_ENV not in keys
+
+
+# ---------------------------------------------------------------------------
+# Edge / failure-mode coverage (verify/clm-adapter-edges)
+# ---------------------------------------------------------------------------
+
+
+def test_clm_config_is_truly_frozen_no_late_mutation() -> None:
+    """ClmConfig is ``frozen=True`` — late mutation is impossible.
+
+    A late-binding mutation of the resolved config would let one spawn
+    leak a token / endpoint into a sibling spawn whose ClmConfig was
+    captured earlier.  The frozen dataclass guarantee is the load-bearing
+    invariant; this test pins it.
+    """
+    cfg = ClmConfig(
+        endpoint="https://clm.example/v1/",
+        token="scoped-jwt-aaa",
+        model="clm-7b-instruct",
+        request_timeout_seconds=60,
+        max_retries=2,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.token = "swap-me-into-another-customer"  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.endpoint = "https://attacker.example/v1/"  # type: ignore[misc]
+    # Sanity: the read after the failed mutation still returns the original.
+    assert cfg.token == "scoped-jwt-aaa"
+
+
+def test_streaming_chunk_and_payload_are_frozen() -> None:
+    """Streaming dataclasses are frozen so a lineage-write race can't rewrite them."""
+    chunk = StreamingChunk(content="x", finish_reason="stop")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        chunk.content = "y"  # type: ignore[misc]
+    payload = StreamingLineagePayload(content="x", tool_calls=(), finish_reason="stop", chunk_count=1)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        payload.content = "y"  # type: ignore[misc]
+
+
+def test_spawn_filters_broad_provider_master_keys(tmp_path: Path) -> None:
+    """No host master credential — Anthropic, OpenAI, Azure, AWS, GCP, GitHub — leaks to the subprocess.
+
+    The existing test pinned ``ANTHROPIC_API_KEY`` and ``OPENAI_API_KEY``;
+    sovereign-AI deployments routinely co-locate cloud credentials, so we
+    explicitly verify the wider blast radius is also clipped.  ``OPENAI_API_KEY``
+    is overwritten by the scoped CLM_TOKEN; the rest are dropped entirely.
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(730)
+    leaky_env = {
+        **_ENV_BUNDLE,
+        "ANTHROPIC_API_KEY": "master-anthropic",
+        "OPENAI_API_KEY": "master-openai",
+        "OPENAI_ORG_ID": "org-master-secret",
+        "OPENAI_PROJECT_ID": "proj-master-secret",
+        "AZURE_OPENAI_API_KEY": "azure-master",
+        "AZURE_OPENAI_ENDPOINT": "https://azure.master.example/",
+        "AWS_ACCESS_KEY_ID": "AKIA-master",
+        "AWS_SECRET_ACCESS_KEY": "secret-aws-master",
+        "AWS_SESSION_TOKEN": "session-aws-master",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/etc/master/gcp-key.json",
+        "GITHUB_TOKEN": "ghp_master_token",
+        "DATABASE_URL": "postgres://master:master@db/master",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", leaky_env, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-leak-broad",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    # Scoped token survives as the OpenAI bearer credential — never the master.
+    assert env["OPENAI_API_KEY"] == "scoped-jwt-customer-001"
+    # No other provider master keys made it through.
+    for forbidden_key in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_ORG_ID",
+        "OPENAI_PROJECT_ID",
+        "AZURE_OPENAI_API_KEY",
+        "AZURE_OPENAI_ENDPOINT",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GITHUB_TOKEN",
+        "DATABASE_URL",
+    ):
+        assert forbidden_key not in env, f"{forbidden_key} leaked into spawn env"
+    # Belt-and-braces: master *values* must not appear anywhere in the env.
+    serialized = json.dumps(env)
+    forbidden_values = [
+        "master-anthropic",
+        "master-openai",
+        "org-master-secret",
+        "proj-master-secret",
+        "azure-master",
+        "AKIA-master",
+        "secret-aws-master",
+        "session-aws-master",
+        "ghp_master_token",
+        "/etc/master/gcp-key.json",
+    ]
+    for value in forbidden_values:
+        assert value not in serialized, f"master credential value leaked: {value}"
+
+
+def test_spawn_propagates_openai_api_timeout_to_subprocess(tmp_path: Path) -> None:
+    """The configured request timeout reaches the OpenAI SDK via ``OPENAI_API_TIMEOUT``."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(740)
+    env_with_timeout = {
+        **_ENV_BUNDLE,
+        "CLM_REQUEST_TIMEOUT_SECONDS": "120",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_timeout, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-timeout",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert env.get("OPENAI_API_TIMEOUT") == "120"
+
+
+def test_clm_request_timeout_seconds_malformed_raises_typed_error() -> None:
+    """Non-integer CLM_REQUEST_TIMEOUT_SECONDS surfaces a typed ClmConfigError."""
+    bad_env = {**_ENV_BUNDLE, "CLM_REQUEST_TIMEOUT_SECONDS": "ten-seconds"}
+    with pytest.raises(ClmConfigError, match="CLM_REQUEST_TIMEOUT_SECONDS"):
+        ClmConfig.from_env(bad_env)
+
+
+def test_clm_max_retries_malformed_raises_typed_error() -> None:
+    """Non-integer CLM_MAX_RETRIES surfaces a typed ClmConfigError, not a silent default."""
+    bad_env = {**_ENV_BUNDLE, "CLM_MAX_RETRIES": "twice"}
+    with pytest.raises(ClmConfigError, match="CLM_MAX_RETRIES"):
+        ClmConfig.from_env(bad_env)
+
+
+def test_parse_tool_allowlist_env_handles_whitespace_and_empties() -> None:
+    """Allowlist parser strips whitespace, drops empty entries, preserves order."""
+    with patch.dict("os.environ", {"BERNSTEIN_TOOL_ALLOWLIST": " fs.read , , git.commit ,, "}, clear=True):
+        assert parse_tool_allowlist_env() == ["fs.read", "git.commit"]
+
+
+def test_parse_tool_allowlist_env_returns_none_when_unset() -> None:
+    """Unset / whitespace-only allowlist env returns ``None`` (not an empty list).
+
+    The distinction matters: ``None`` means "no caller scoped the spawn"
+    whereas ``[]`` would be an explicit empty allowlist.  Spawn defaults
+    to ``[]`` on ``None`` via ``parse_tool_allowlist_env() or []``.
+    """
+    with patch.dict("os.environ", {}, clear=True):
+        assert parse_tool_allowlist_env() is None
+    with patch.dict("os.environ", {"BERNSTEIN_TOOL_ALLOWLIST": "   "}, clear=True):
+        assert parse_tool_allowlist_env() is None
+
+
+def test_build_openai_tools_schema_empty_allowlist_returns_empty_list() -> None:
+    """An empty allowlist produces an empty schema list — never a wildcard."""
+    assert build_openai_tools_schema([]) == []
+
+
+def test_streaming_lineage_handles_empty_event_stream() -> None:
+    """An empty stream yields a payload with no content, no tool calls, finish_reason=None."""
+    payload = assemble_streaming_response(iter(()))
+    assert payload.content == ""
+    assert payload.tool_calls == ()
+    assert payload.finish_reason is None
+    assert payload.chunk_count == 0
+
+
+def test_streaming_lineage_finish_reason_is_last_non_none() -> None:
+    """When multiple chunks declare a finish_reason, the *last* non-None wins.
+
+    Some gateways emit a placeholder ``finish_reason`` mid-stream and then
+    overwrite it on the terminal chunk.  Lineage must record the terminal
+    state, not an intermediate one — otherwise the audit trail thinks the
+    response was truncated when it really wasn't (and vice versa).
+    """
+    events = [
+        StreamingChunk(content="a", finish_reason=None),
+        StreamingChunk(content="b", finish_reason="length"),
+        StreamingChunk(content="c", finish_reason=None),
+        StreamingChunk(content="d", finish_reason="stop"),
+    ]
+    payload = assemble_streaming_response(events)
+    assert payload.finish_reason == "stop"
+    assert payload.content == "abcd"
+
+
+def test_streaming_lineage_preserves_tool_call_order_across_chunks() -> None:
+    """Tool calls accumulate in the order they were emitted across chunks."""
+    events = [
+        StreamingChunk(tool_calls=({"id": "1", "name": "fs.read"},)),
+        StreamingChunk(content="thinking"),
+        StreamingChunk(tool_calls=({"id": "2", "name": "git.commit"},)),
+        StreamingChunk(tool_calls=({"id": "3", "name": "git.push"},)),
+        StreamingChunk(finish_reason="tool_calls"),
+    ]
+    payload = assemble_streaming_response(events)
+    assert [c["id"] for c in payload.tool_calls] == ["1", "2", "3"]
+
+
+def test_spawn_propagates_verify_mode_when_mtls_active(tmp_path: Path) -> None:
+    """``CLM_VERIFY_MODE`` reaches the subprocess so the launcher rebuilds the SSL ctx faithfully."""
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(750)
+
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    ca = tmp_path / "ca.crt"
+    for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+        _write_pem_stub(path, label)
+
+    env_with_mtls = {
+        **_ENV_BUNDLE,
+        CLM_CERT_FILE_ENV: str(cert),
+        CLM_KEY_FILE_ENV: str(key),
+        CLM_CA_FILE_ENV: str(ca),
+        CLM_VERIFY_MODE_ENV: "optional",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_mtls, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-mtls-verify",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert env[CLM_VERIFY_MODE_ENV] == "optional"
+
+
+def test_spawn_drops_verify_mode_when_mtls_off(tmp_path: Path) -> None:
+    """Without an mTLS triple, ``CLM_VERIFY_MODE`` is *not* allow-listed into the subprocess.
+
+    Forwarding it would imply mTLS is active downstream, which breaks the
+    "off by default" contract sovereign-AI customers depend on for staged
+    rollouts.
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(751)
+
+    env_with_orphan_verify = {
+        **_ENV_BUNDLE,
+        CLM_VERIFY_MODE_ENV: "required",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_orphan_verify, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-no-mtls-no-verify",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    assert CLM_VERIFY_MODE_ENV not in env
+
+
+def test_tls_config_from_env_disabled_mode_still_returns_config(tmp_path: Path) -> None:
+    """``verify_mode='disabled'`` is a valid (non-default) operator choice — config still returned."""
+    cert = tmp_path / "client.crt"
+    key = tmp_path / "client.key"
+    ca = tmp_path / "ca.crt"
+    for path, label in ((cert, "CERTIFICATE"), (key, "PRIVATE KEY"), (ca, "CERTIFICATE")):
+        _write_pem_stub(path, label)
+    cfg = tls_config_from_env(
+        {
+            CLM_CERT_FILE_ENV: str(cert),
+            CLM_KEY_FILE_ENV: str(key),
+            CLM_CA_FILE_ENV: str(ca),
+            CLM_VERIFY_MODE_ENV: "disabled",
+        }
+    )
+    assert cfg is not None
+    assert cfg.verify_mode == "disabled"
+
+
+def test_spawn_undeclared_tools_do_not_block_trifecta(tmp_path: Path) -> None:
+    """Undeclared tools (not in the capability registry) default-deny but don't fail spawn here.
+
+    Per the policy comment in ``_evaluate_lethal_trifecta``: undeclared
+    tools surface as warnings via the audit CLI; the spawn-time refusal
+    only fires when the *declared* subset unions the trifecta.  An
+    allowlist of pure noise must therefore complete the spawn (then a
+    downstream audit catches the unknowns).
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(760)
+    env_with_unknowns = {
+        **_ENV_BUNDLE,
+        "BERNSTEIN_TOOL_ALLOWLIST": "definitely.not.a.real.tool,still.fictional",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_unknowns, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-unknown-tools",
+        )
+    assert popen.called, "spawn should not abort on undeclared tools alone"
+
+
+def test_spawn_overrides_host_openai_api_base_with_clm_endpoint(tmp_path: Path) -> None:
+    """A pre-existing host ``OPENAI_API_BASE`` must be overridden by the CLM endpoint.
+
+    If an operator has the OpenAI cloud API base in their shell rc,
+    inheritance must not redirect the spawn to it — that would silently
+    bypass the customer-side gateway and ship prompts to OpenAI.
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(770)
+    env_with_host_base = {
+        **_ENV_BUNDLE,
+        "OPENAI_API_BASE": "https://api.openai.com/v1",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_host_base, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-base-override",
+        )
+    env = popen.call_args.kwargs.get("env", {})
+    assert env["OPENAI_API_BASE"] == "https://clm.internal.example/v1/"
+    # Belt-and-braces: the operator's cloud base must not appear anywhere.
+    assert "api.openai.com" not in json.dumps(env)
+
+
+def test_spawn_tools_schema_env_is_strict_json_with_documented_shape(tmp_path: Path) -> None:
+    """The serialized tools schema is well-formed JSON with the documented shape.
+
+    Lineage / audit replay must be able to round-trip this without
+    rebuilding the schema from a registry that may have drifted; the
+    contract therefore is "the env value parses, lists every requested
+    name, and never silently widens parameters".
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(780)
+    env_with_allowlist = {
+        **_ENV_BUNDLE,
+        "BERNSTEIN_TOOL_ALLOWLIST": "fs.read,git.commit,git.push",
+    }
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", env_with_allowlist, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-schema-shape",
+        )
+
+    env = popen.call_args.kwargs.get("env", {})
+    raw = env[CLM_TOOLS_SCHEMA_ENV]
+    schema = json.loads(raw)
+    assert isinstance(schema, list) and len(schema) == 3
+    for entry in schema:
+        assert entry["type"] == "function"
+        assert set(entry["function"].keys()) == {"name", "description", "parameters"}
+        assert entry["function"]["parameters"] == {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": True,
+        }
+    # Each entry's name must correspond to its allowlist entry, in order.
+    for name, entry in zip(["fs.read", "git.commit", "git.push"], schema, strict=True):
+        assert entry["function"]["name"] == name
+        assert name in entry["function"]["description"]
+
+
+def test_spawn_passes_clm_namespaced_extras_only(tmp_path: Path) -> None:
+    """``build_filtered_env`` is invoked with CLM_*-only extras — never operator master keys.
+
+    Asserts the contract from the inside: regardless of host env, the
+    ``extra_keys`` argument lists *only* CLM-namespaced keys, so a future
+    refactor that accidentally adds ``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY``
+    to extras would be caught here, not in production.
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(790)
+
+    captured: dict[str, object] = {}
+    from bernstein.adapters.env_isolation import build_filtered_env as real_build
+
+    def _spy(extra_keys: list[str], **kwargs: object) -> dict[str, str]:
+        captured["extra_keys"] = list(extra_keys)
+        return real_build(extra_keys, **kwargs)
+
+    with (
+        patch("bernstein.adapters.clm.build_filtered_env", side_effect=_spy),
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock),
+        patch.dict("os.environ", _ENV_BUNDLE, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+            session_id="clm-extras-shape",
+        )
+
+    extras = captured["extra_keys"]
+    assert isinstance(extras, list)
+    # Every extra key must start with CLM_ — no provider master snuck in.
+    for key in extras:
+        assert isinstance(key, str)
+        assert key.startswith("CLM_"), f"non-CLM key in extras: {key}"
+    # The minimum-viable trio (endpoint, token, model) is always there.
+    assert {CLM_ENDPOINT_ENV, CLM_TOKEN_ENV, CLM_MODEL_ENV} <= set(extras)
+
+
+def test_spawn_clm_endpoint_overrides_inherited_host_endpoint(tmp_path: Path) -> None:
+    """Late-binding: even if the host process inherits a stale ``CLM_ENDPOINT``, only the
+    *current* call's value is materialised in the spawn env.
+
+    Frozen-config invariant: each ``spawn()`` call rereads env, builds a
+    fresh frozen ClmConfig, and routes its endpoint into the subprocess.
+    A stale value from a previous spawn must not bleed into the next one.
+    """
+    adapter = ClmAdapter()
+    proc1 = make_popen_mock(800)
+    proc2 = make_popen_mock(801)
+
+    env_a = {**_ENV_BUNDLE, CLM_ENDPOINT_ENV: "https://customer-a.example/v1/"}
+    env_b = {**_ENV_BUNDLE, CLM_ENDPOINT_ENV: "https://customer-b.example/v1/"}
+
+    with patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc1) as popen:
+        with patch.dict("os.environ", env_a, clear=True):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+                session_id="clm-cust-a",
+            )
+        captured_a = popen.call_args.kwargs.get("env", {}).get("OPENAI_API_BASE")
+    with patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc2) as popen:
+        with patch.dict("os.environ", env_b, clear=True):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="clm-7b-instruct", effort="medium"),
+                session_id="clm-cust-b",
+            )
+        captured_b = popen.call_args.kwargs.get("env", {}).get("OPENAI_API_BASE")
+
+    assert captured_a == "https://customer-a.example/v1/"
+    assert captured_b == "https://customer-b.example/v1/"
+
+
+def test_spawn_uses_model_config_override_when_provided(tmp_path: Path) -> None:
+    """``model_config.model`` overrides the env-default ``CLM_MODEL`` per-spawn.
+
+    Routing per-task is core to the orchestrator; if the env wins over an
+    explicit override, the orchestrator can't pin different models for
+    different agents talking to the same gateway.
+    """
+    adapter = ClmAdapter()
+    proc_mock = make_popen_mock(810)
+    with (
+        patch("bernstein.adapters.clm.subprocess.Popen", return_value=proc_mock) as popen,
+        patch.dict("os.environ", _ENV_BUNDLE, clear=True),
+    ):
+        adapter.spawn(
+            prompt="hello",
+            workdir=tmp_path,
+            model_config=ModelConfig(model="clm-13b-coder", effort="high"),
+            session_id="clm-model-override",
+        )
+    inner = inner_cmd(popen.call_args.args[0])
+    assert inner[inner.index("--model") + 1] == "openai/clm-13b-coder"

--- a/tests/unit/test_clm_tls_launcher.py
+++ b/tests/unit/test_clm_tls_launcher.py
@@ -189,3 +189,249 @@ def test_run_aider_no_argv_returns_usage_error(capsys: pytest.CaptureFixture[str
     rc = clm_tls_launcher._run_aider([])
     assert rc == 2
     assert "no command supplied" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Edge / failure-mode coverage (verify/clm-adapter-edges)
+# ---------------------------------------------------------------------------
+
+
+def test_install_httpx_mtls_defaults_also_patches_async_client(
+    tmp_path: Path,
+    httpx_init_restored: object,
+) -> None:
+    """The ``AsyncClient`` patch is symmetric with the sync one.
+
+    The OpenAI SDK uses ``httpx.AsyncClient`` for its async paths; if
+    only ``httpx.Client`` were patched, async callers would skip the
+    customer cert and fall back to the system CA bundle — silent mTLS
+    bypass.  This pins the async monkey-patch.
+    """
+    pki = _make_pki(tmp_path)
+    cfg = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["cert"],
+        key_file=pki["key"],
+        verify_mode="required",
+    )
+    captured: dict[str, object] = {}
+    saved_init = httpx.AsyncClient.__init__
+
+    def _capture(self: httpx.AsyncClient, *args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("captured")
+
+    httpx.AsyncClient.__init__ = _capture  # type: ignore[method-assign]
+    try:
+        clm_tls_launcher.install_httpx_mtls_defaults(cfg)
+        with pytest.raises(RuntimeError, match="captured"):
+            httpx.AsyncClient()
+    finally:
+        httpx.AsyncClient.__init__ = saved_init  # type: ignore[method-assign]
+
+    import ssl
+
+    assert "verify" in captured
+    assert isinstance(captured["verify"], ssl.SSLContext)
+
+
+def test_install_httpx_mtls_defaults_async_client_honours_explicit_verify(
+    tmp_path: Path,
+    httpx_init_restored: object,
+) -> None:
+    """When the caller explicitly sets ``verify=`` on AsyncClient, the patch must not override."""
+    pki = _make_pki(tmp_path)
+    cfg = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["cert"],
+        key_file=pki["key"],
+        verify_mode="required",
+    )
+    captured: dict[str, object] = {}
+    saved_init = httpx.AsyncClient.__init__
+
+    def _capture(self: httpx.AsyncClient, *args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("captured")
+
+    httpx.AsyncClient.__init__ = _capture  # type: ignore[method-assign]
+    try:
+        clm_tls_launcher.install_httpx_mtls_defaults(cfg)
+        with pytest.raises(RuntimeError, match="captured"):
+            httpx.AsyncClient(verify=False)
+    finally:
+        httpx.AsyncClient.__init__ = saved_init  # type: ignore[method-assign]
+
+    assert captured["verify"] is False
+
+
+def test_install_httpx_mtls_defaults_required_mode_keeps_hostname_check(
+    tmp_path: Path,
+    httpx_init_restored: object,
+) -> None:
+    """In ``required`` mode the SSLContext must enforce hostname verification.
+
+    A frequent mTLS regression is silently disabling hostname checks in
+    pursuit of a "just make it work" patch — that turns full mTLS into
+    transport encryption only and lets a leaf cert be lifted onto a
+    different gateway DNS name.  This test pins ``check_hostname=True``
+    on the context the launcher injects.
+    """
+    pki = _make_pki(tmp_path)
+    cfg = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["cert"],
+        key_file=pki["key"],
+        verify_mode="required",
+    )
+    captured: dict[str, object] = {}
+    saved_init = httpx.Client.__init__
+
+    def _capture(self: httpx.Client, *args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("captured")
+
+    httpx.Client.__init__ = _capture  # type: ignore[method-assign]
+    try:
+        clm_tls_launcher.install_httpx_mtls_defaults(cfg)
+        with pytest.raises(RuntimeError, match="captured"):
+            httpx.Client()
+    finally:
+        httpx.Client.__init__ = saved_init  # type: ignore[method-assign]
+
+    import ssl
+
+    ctx = captured["verify"]
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.check_hostname is True
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_install_httpx_mtls_defaults_disabled_mode_drops_hostname_check(
+    tmp_path: Path,
+    httpx_init_restored: object,
+) -> None:
+    """In ``disabled`` mode hostname check is intentionally off (operator opt-in).
+
+    The launcher should respect the operator's chosen verify_mode; if
+    they requested ``disabled`` (e.g. for a staged rollout against a
+    self-signed gateway) the SSLContext must reflect that without the
+    launcher silently re-enabling it.
+    """
+    pki = _make_pki(tmp_path)
+    cfg = TLSConfig(
+        ca_file=pki["ca"],
+        cert_file=pki["cert"],
+        key_file=pki["key"],
+        verify_mode="disabled",
+    )
+    captured: dict[str, object] = {}
+    saved_init = httpx.Client.__init__
+
+    def _capture(self: httpx.Client, *args: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+        raise RuntimeError("captured")
+
+    httpx.Client.__init__ = _capture  # type: ignore[method-assign]
+    try:
+        clm_tls_launcher.install_httpx_mtls_defaults(cfg)
+        with pytest.raises(RuntimeError, match="captured"):
+            httpx.Client()
+    finally:
+        httpx.Client.__init__ = saved_init  # type: ignore[method-assign]
+
+    import ssl
+
+    ctx = captured["verify"]
+    assert isinstance(ctx, ssl.SSLContext)
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_NONE
+
+
+def test_run_aider_string_systemexit_code_returns_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A string SystemExit code (rare but documented in CPython) maps to rc=1.
+
+    ``runpy.run_module`` propagates whatever ``sys.exit(...)`` was called
+    with; CPython allows strings ("error message") which print to stderr
+    and exit with rc=1.  The launcher's exception handler must collapse
+    these to a non-zero integer rc rather than returning the string
+    upstream (where Popen would mishandle it).
+    """
+
+    def _fake_run_module(name: str, **kwargs: object) -> None:
+        raise SystemExit("custom-error-message")
+
+    monkeypatch.setattr(clm_tls_launcher.runpy, "run_module", _fake_run_module)
+    rc = clm_tls_launcher._run_aider(["aider", "--message", "x"])
+    assert rc == 1
+
+
+def test_run_aider_none_systemexit_code_returns_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sys.exit(None)`` (success) maps to rc=0."""
+
+    def _fake_run_module(name: str, **kwargs: object) -> None:
+        raise SystemExit(None)
+
+    monkeypatch.setattr(clm_tls_launcher.runpy, "run_module", _fake_run_module)
+    rc = clm_tls_launcher._run_aider(["aider"])
+    assert rc == 0
+
+
+def test_run_aider_int_systemexit_code_passed_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Aider's own non-zero exit code is forwarded verbatim."""
+
+    def _fake_run_module(name: str, **kwargs: object) -> None:
+        raise SystemExit(42)
+
+    monkeypatch.setattr(clm_tls_launcher.runpy, "run_module", _fake_run_module)
+    rc = clm_tls_launcher._run_aider(["aider", "--message", "x"])
+    assert rc == 42
+
+
+def test_main_with_no_tls_env_skips_monkey_patches(
+    monkeypatch: pytest.MonkeyPatch,
+    httpx_init_restored: object,
+) -> None:
+    """When mTLS env triple is absent, ``main`` does not install monkey-patches.
+
+    Bare-HTTPS spawns must not see the launcher's defaults injected,
+    otherwise non-mTLS deployments inherit a misconfigured SSLContext.
+    """
+    monkeypatch.delenv(CLM_CERT_FILE_ENV, raising=False)
+    monkeypatch.delenv(CLM_KEY_FILE_ENV, raising=False)
+    monkeypatch.delenv(CLM_CA_FILE_ENV, raising=False)
+
+    saved_client = httpx.Client.__init__
+    saved_async = httpx.AsyncClient.__init__
+
+    def _stub_run(_argv: list[str]) -> int:
+        return 0
+
+    monkeypatch.setattr(clm_tls_launcher, "_run_aider", _stub_run)
+    rc = clm_tls_launcher.main(["aider"])
+    assert rc == 0
+    # The init slots must be byte-identical to before main() ran.
+    assert httpx.Client.__init__ is saved_client
+    assert httpx.AsyncClient.__init__ is saved_async
+
+
+def test_resolve_tls_falls_back_to_required_for_bogus_verify_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Launcher-side: an invalid ``CLM_VERIFY_MODE`` defensively falls back to ``required``.
+
+    The launcher runs *after* the adapter has already validated the env
+    triple; reaching ``_resolve_tls_from_env`` with a bogus value would
+    indicate operator tampering or env corruption.  The defensive
+    behaviour is to refuse to silently relax to anything other than
+    ``required`` — fail-safe, not fail-open.
+    """
+    pki = _make_pki(tmp_path)
+    monkeypatch.setenv(CLM_CERT_FILE_ENV, str(pki["cert"]))
+    monkeypatch.setenv(CLM_KEY_FILE_ENV, str(pki["key"]))
+    monkeypatch.setenv(CLM_CA_FILE_ENV, str(pki["ca"]))
+    monkeypatch.setenv("CLM_VERIFY_MODE", "trust-me-bro")
+    cfg = clm_tls_launcher._resolve_tls_from_env()
+    assert cfg is not None
+    assert cfg.verify_mode == "required"


### PR DESCRIPTION
Surfacing this branch from a long-lived local worktree as a draft PR for review.

Range: 1 commit(s) ahead of `main`. Last subject: `test(adapters): cover CLM adapter edge cases — frozen config, broad master-key filter, mTLS hostname check`.

Either review and merge, or close as abandoned. CI will tell us if the branch is still rebase-clean.