### PR TITLE
ci(codeql): drop paths filter on pull_request to unblock docs/CI-only PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,13 +8,15 @@ on:
       - "tests/**"
       - "scripts/**"
       - "pyproject.toml"
+  # No `paths:` filter on pull_request: branch protection on `main` lists
+  # `CodeQL` and `CodeQL (python)` as required status checks. If this
+  # workflow is path-filtered out of a PR (e.g. docs-only or workflow-only
+  # change), the required checks never appear and the PR sits BLOCKED
+  # indefinitely. Running CodeQL on every PR costs 2-3 min of CI but
+  # eliminates the deadlock; analysis is cheap when no Python source has
+  # changed because CodeQL re-uses its cached database.
   pull_request:
     branches: [main]
-    paths:
-      - "src/**"
-      - "tests/**"
-      - "scripts/**"
-      - "pyproject.toml"
   schedule:
     - cron: "0 4 * * 1"  # Weekly Monday 4 AM UTC
 


### PR DESCRIPTION
## Summary
Branch protection on `main` requires `CodeQL` and `CodeQL (python)` to pass before merge. The previous `paths:` filter on the `pull_request` trigger meant any PR not touching `src|tests|scripts|pyproject.toml` (docs PRs, workflow-file fixes, README translations) never triggered CodeQL → the required checks never appeared → the PR sat BLOCKED forever.
Just hit this on:
- #1080 (the `auto-release.yml` push-protection fix itself)
- #1081 (README anti-LLM-tells cleanup)
Both had to be admin-merged.
## Why this fix and not a shim workflow
A shim workflow with the same name + job-name pattern can satisfy `CodeQL (python)` (job-name match), but the `CodeQL` check (no language qualifier) is posted by GitHub's CodeQL service after SARIF upload — a shim cannot fake that without uploading SARIF.
So: just always run CodeQL on PRs. Cost is 2-3 min CI per PR; CodeQL caches its analysis database, so the overhead on docs-only PRs is small. The `push:` trigger keeps its path filter — main-branch analysis still only re-runs when relevant files change.
## Test plan
- [ ] CI green (CodeQL itself runs on this PR)
- [ ] Future docs-only / workflow-only PRs no longer sit BLOCKED indefinitely