### PR TITLE
chore: auto-bump to v1.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.2"
+version = "1.10.3"
 description = "Multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 28 more) — deterministic, declarative, zero vendor lock-in."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Automated patch bump from v1.10.2 → v1.10.3. Original auto-release run failed at PR creation because the org-level 'GitHub Actions create PRs' toggle was off; the bump commit landed on the branch but no PR. Opening manually so the next auto-release run on main tags + publishes v1.10.3.

Repo-level toggle has now been flipped (`can_approve_pull_request_reviews=true`); future bumps will self-PR.