### PR TITLE
fix(routing): tighten rework-ledger file mode to 0o600

### DIFF
--- a/src/bernstein/core/routing/rework_ledger.py
+++ b/src/bernstein/core/routing/rework_ledger.py
@@ -143,7 +143,11 @@ class ReworkLedger:
             payload = (json.dumps(asdict(sample), separators=(",", ":")) + "\n").encode("utf-8")
             # O_APPEND guarantees the seek-then-write is atomic at the
             # kernel level for sub-PIPE_BUF writes — no interleaving.
-            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+            # 0o600: rework telemetry contains (model, effort, phase, outcome)
+            # records that the cascade router replays. Reader and writer are
+            # the same operator user; world-read is unnecessary and would
+            # leak routing decisions to other users on shared hosts.
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
             try:
                 with self._lock:
                     os.write(fd, payload)


### PR DESCRIPTION
## Summary

Closes CodeQL alert #123 (\`py/overly-permissive-file\`) on \`src/bernstein/core/routing/rework_ledger.py:146\`. The ledger's \`os.open()\` was using \`0o644\`, making each shard world-readable.

The rework ledger holds \`(model, effort, phase, outcome)\` JSONL telemetry that the cascade router replays for promotion decisions. Reader and writer are the same operator user — world-read is unnecessary and would leak routing decisions to other users on shared hosts.

## Tests

\`\`\`
$ uv run python -m pytest tests/unit/ -k rework_ledger -q
14 passed, 22567 deselected in 16.05s
\`\`\`

The mode change is transparent to file API; no behavioural change beyond permission bits.

## Companion: alert #122 (\`cluster_cmd.py:48\`) — dismissed

Same rule, but \`_write_pem\` is the shared writer for both **public certs** (lines 80, 126) using \`0o644\` and **private keys** (lines 88, 134) using \`0o600\`. Public X.509 certs are intentionally world-readable — that's the deployment convention and matches \`/etc/ssl/certs/*\`. Private keys are correctly locked. Dismissed via API as false positive with explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)