### PR TITLE
feat(agents-md): canonical generator + cross-CLI rewrite (closes #1087)

### DIFF
--- a/src/bernstein/cli/commands/agents_md_cmd.py
+++ b/src/bernstein/cli/commands/agents_md_cmd.py
@@ -1,0 +1,347 @@
+"""``bernstein agents-md`` -- canonical AGENTS.md generator + cross-CLI sync.
+
+Subcommands:
+
+* ``bernstein agents-md generate`` -- print canonical AGENTS.md to stdout.
+* ``bernstein agents-md write [--target T]`` -- write one target's files.
+  ``T`` ∈ ``canonical | cursor | claude | aider | goose``. Default:
+  ``canonical``.
+* ``bernstein agents-md sync`` -- write *all* target formats; the
+  killer-feature command.
+* ``bernstein agents-md verify [--target T]`` -- exit non-zero when any
+  on-disk file diverges from the generated content. CI-friendly.
+* ``bernstein agents-md diff [--target T]`` -- print a human-readable
+  unified diff between disk and generated; exit 0 either way.
+
+Design follows ``bernstein.cli.commands.lineage_cmd``: click ``@group``
+with subcommands declared inline (small ones) or attached at module
+bottom (heavier sibling files). All heavy imports are lazy inside command
+bodies so the top-level CLI startup stays fast.
+"""
+
+from __future__ import annotations
+
+import difflib
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from bernstein.core.knowledge.agents_md_bridge import BridgeOutput, Target
+
+
+_TARGET_CHOICES = ("canonical", "cursor", "claude", "aider", "goose")
+
+
+# ---------------------------------------------------------------------------
+# Group
+# ---------------------------------------------------------------------------
+
+
+@click.group(name="agents-md", invoke_without_command=True)
+@click.pass_context
+def agents_md_cmd(ctx: click.Context) -> None:
+    """Canonical AGENTS.md generator with cross-CLI rewrite.
+
+    \b
+    Examples:
+      bernstein agents-md generate            # print canonical AGENTS.md
+      bernstein agents-md sync                # write all 5 target files
+      bernstein agents-md write --target cursor
+      bernstein agents-md verify              # exit 1 if any file is stale
+      bernstein agents-md diff --target claude
+    """
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+# ---------------------------------------------------------------------------
+# generate
+# ---------------------------------------------------------------------------
+
+
+@agents_md_cmd.command(name="generate")
+@click.option(
+    "--workdir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    show_default="cwd",
+    help="Repository root.",
+)
+@click.option(
+    "--target",
+    type=click.Choice(_TARGET_CHOICES),
+    default="canonical",
+    show_default=True,
+    help="Which target's content to print.",
+)
+@click.option(
+    "--repo-name",
+    default=None,
+    help="Display name for the H1. Defaults to the workdir basename.",
+)
+def agents_md_generate(workdir: Path, target: str, repo_name: str | None) -> None:
+    """Print one target's content to stdout. No file is written."""
+    sections, name = _generate_sections(workdir, repo_name)
+    output = _render_target(sections, target, name)
+    # Each target's BridgeOutput has 1+ files; print them concatenated with
+    # a clear separator so the operator can see the structure.
+    files = list(output.files.items())
+    if len(files) == 1:
+        click.echo(files[0][1])
+        return
+    for relpath, content in files:
+        click.echo(f"--- {relpath} ---")
+        click.echo(content)
+
+
+# ---------------------------------------------------------------------------
+# write
+# ---------------------------------------------------------------------------
+
+
+@agents_md_cmd.command(name="write")
+@click.option(
+    "--workdir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    show_default="cwd",
+    help="Repository root.",
+)
+@click.option(
+    "--target",
+    type=click.Choice(_TARGET_CHOICES),
+    default="canonical",
+    show_default=True,
+    help="Which target's files to write.",
+)
+@click.option(
+    "--repo-name",
+    default=None,
+    help="Display name for the H1. Defaults to the workdir basename.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be written without touching disk.",
+)
+def agents_md_write(workdir: Path, target: str, repo_name: str | None, dry_run: bool) -> None:
+    """Write one target's files to disk."""
+    sections, name = _generate_sections(workdir, repo_name)
+    output = _render_target(sections, target, name)
+    written = _write_output(output, workdir, dry_run=dry_run)
+    if dry_run:
+        click.echo(f"[dry-run] {len(output.files)} file(s) would be written under {workdir}")
+        for rel in output.files:
+            click.echo(f"  · {rel}")
+    else:
+        click.echo(f"Wrote {written} file(s) under {workdir}")
+
+
+# ---------------------------------------------------------------------------
+# sync — the killer-feature command
+# ---------------------------------------------------------------------------
+
+
+@agents_md_cmd.command(name="sync")
+@click.option(
+    "--workdir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    show_default="cwd",
+    help="Repository root.",
+)
+@click.option(
+    "--repo-name",
+    default=None,
+    help="Display name for the H1. Defaults to the workdir basename.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be written without touching disk.",
+)
+def agents_md_sync(workdir: Path, repo_name: str | None, dry_run: bool) -> None:
+    """Write all target formats so all five files agree."""
+    from bernstein.core.knowledge.agents_md_bridge import render_all
+
+    sections, name = _generate_sections(workdir, repo_name)
+    outputs = render_all(sections, repo_name=name)
+    total = 0
+    for target, output in outputs.items():
+        written = _write_output(output, workdir, dry_run=dry_run)
+        total += written
+        if dry_run:
+            for rel in output.files:
+                click.echo(f"[dry-run] would write {rel}  (target={target})")
+        else:
+            for rel in output.files:
+                click.echo(f"  · {rel}  ({target})")
+    if dry_run:
+        click.echo(f"[dry-run] {total} file(s) across {len(outputs)} target(s) would be synced")
+    else:
+        click.echo(f"Synced {total} file(s) across {len(outputs)} target(s) under {workdir}")
+
+
+# ---------------------------------------------------------------------------
+# verify — CI-friendly drift detector
+# ---------------------------------------------------------------------------
+
+
+@agents_md_cmd.command(name="verify")
+@click.option(
+    "--workdir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    show_default="cwd",
+    help="Repository root.",
+)
+@click.option(
+    "--target",
+    type=click.Choice([*_TARGET_CHOICES, "all"]),
+    default="all",
+    show_default=True,
+    help="Which target(s) to verify against on-disk content.",
+)
+@click.option(
+    "--repo-name",
+    default=None,
+    help="Display name for the H1. Defaults to the workdir basename.",
+)
+def agents_md_verify(workdir: Path, target: str, repo_name: str | None) -> None:
+    """Exit 1 if any on-disk file diverges from the generated content.
+
+    Designed for CI gating::
+
+        bernstein agents-md verify || (echo 'AGENTS.md drift; run sync' && exit 1)
+    """
+    from bernstein.core.knowledge.agents_md_bridge import (
+        ALL_TARGETS,
+        render,
+    )
+
+    sections, name = _generate_sections(workdir, repo_name)
+    targets: tuple[Target, ...] = ALL_TARGETS if target == "all" else (target,)  # type: ignore[assignment]
+
+    drift_count = 0
+    for t in targets:
+        output = render(sections, t, repo_name=name)
+        for rel, expected in output.files.items():
+            on_disk = workdir / rel
+            if not on_disk.is_file():
+                click.echo(f"MISSING  {rel}  (target={t})")
+                drift_count += 1
+                continue
+            actual = on_disk.read_text(encoding="utf-8")
+            if actual != expected:
+                click.echo(f"DRIFT    {rel}  (target={t})")
+                drift_count += 1
+    if drift_count:
+        click.echo(
+            f"\n{drift_count} file(s) drift. Run `bernstein agents-md sync` to fix.",
+            err=True,
+        )
+        sys.exit(1)
+    click.echo(f"OK       all {sum(len(render(sections, t, repo_name=name).files) for t in targets)} file(s) in sync")
+
+
+# ---------------------------------------------------------------------------
+# diff — informational, no exit-code drama
+# ---------------------------------------------------------------------------
+
+
+@agents_md_cmd.command(name="diff")
+@click.option(
+    "--workdir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=Path.cwd,
+    show_default="cwd",
+    help="Repository root.",
+)
+@click.option(
+    "--target",
+    type=click.Choice([*_TARGET_CHOICES, "all"]),
+    default="all",
+    show_default=True,
+    help="Which target(s) to diff.",
+)
+@click.option(
+    "--repo-name",
+    default=None,
+    help="Display name for the H1. Defaults to the workdir basename.",
+)
+def agents_md_diff(workdir: Path, target: str, repo_name: str | None) -> None:
+    """Print unified diff between on-disk and generated for each target file."""
+    from bernstein.core.knowledge.agents_md_bridge import (
+        ALL_TARGETS,
+        render,
+    )
+
+    sections, name = _generate_sections(workdir, repo_name)
+    targets: tuple[Target, ...] = ALL_TARGETS if target == "all" else (target,)  # type: ignore[assignment]
+
+    any_diff = False
+    for t in targets:
+        output = render(sections, t, repo_name=name)
+        for rel, expected in output.files.items():
+            on_disk = workdir / rel
+            actual = on_disk.read_text(encoding="utf-8") if on_disk.is_file() else ""
+            if actual == expected:
+                continue
+            any_diff = True
+            click.echo(f"\n# {rel}  (target={t})\n")
+            for line in difflib.unified_diff(
+                actual.splitlines(keepends=True),
+                expected.splitlines(keepends=True),
+                fromfile=f"a/{rel}",
+                tofile=f"b/{rel}",
+                n=3,
+            ):
+                click.echo(line, nl=False)
+    if not any_diff:
+        click.echo("No drift across selected target(s).")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_sections(workdir: Path, repo_name: str | None) -> tuple[list, str]:
+    """Run the generator + return ``(sections, repo_name)``.
+
+    ``repo_name`` falls back to the basename of ``workdir`` when not
+    provided, so the canonical H1 always says something useful.
+    """
+    from bernstein.core.knowledge.agents_md_generator import generate
+
+    sections = generate(workdir.resolve())
+    if not sections:
+        click.echo(f"No content derived from {workdir} — is this a repository?", err=True)
+        sys.exit(2)
+    return sections, repo_name or workdir.resolve().name
+
+
+def _render_target(sections: list, target: str, repo_name: str) -> BridgeOutput:
+    """Single-target render bridge."""
+    from bernstein.core.knowledge.agents_md_bridge import render
+
+    return render(sections, target, repo_name=repo_name)  # type: ignore[arg-type]
+
+
+def _write_output(output: BridgeOutput, repo_root: Path, *, dry_run: bool) -> int:
+    """Write one ``BridgeOutput`` under ``repo_root``. Returns count written."""
+    if dry_run:
+        return 0
+    written = 0
+    for rel, content in output.files.items():
+        path = repo_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        written += 1
+    return written
+
+
+__all__ = ["agents_md_cmd"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -848,6 +848,11 @@ from bernstein.cli.commands.lineage_cmd import lineage_cmd  # noqa: E402
 
 cli.add_command(lineage_cmd, "lineage")
 
+# Canonical AGENTS.md generator + cross-CLI rewrite (cursor / claude / aider / goose).
+from bernstein.cli.commands.agents_md_cmd import agents_md_cmd  # noqa: E402
+
+cli.add_command(agents_md_cmd, "agents-md")
+
 # Air-gap distribution: build / verify wheel bundle.
 from bernstein.cli.commands.wheelhouse_cmd import wheelhouse_group  # noqa: E402
 

--- a/src/bernstein/core/knowledge/agents_md_bridge.py
+++ b/src/bernstein/core/knowledge/agents_md_bridge.py
@@ -1,0 +1,305 @@
+"""Cross-CLI bridge — translate canonical AGENTS.md sections into target formats.
+
+The companion of :mod:`bernstein.core.knowledge.agents_md_generator`. Given
+the same ``list[AgentsMdSection]`` IR, this module emits the on-disk shape
+each major coding-agent CLI actually reads in 2026:
+
+==============  =============================================================
+Target          Canonical filename(s)
+==============  =============================================================
+Cursor          ``.cursor/rules/<key>.mdc`` (current; YAML frontmatter +
+                markdown body); legacy ``.cursorrules`` deliberately not
+                emitted because Cursor's docs no longer document it.
+Claude Code     ``CLAUDE.md`` at repo root; freeform markdown ≤ 200 lines
+                target. Subdirectory ``CLAUDE.md`` files are out of scope —
+                AGENTS.md is the central source.
+Aider           ``CONVENTIONS.md`` at repo root + ``.aider.conf.yml`` patch
+                with ``read: CONVENTIONS.md``. Without the conf-file entry
+                the convention file is dead, so the bridge always emits
+                both.
+Goose           ``.goosehints`` at repo root. Plaintext (markdown renders
+                fine, no required structure).
+==============  =============================================================
+
+Design rules:
+
+* The canonical IR (``AgentsMdSection``) is the *only* source of truth.
+  Each target's renderer is a pure function from sections to a
+  ``{Path: str}`` map.
+* No target invents new content. If a target's format requires a field
+  the IR doesn't carry (e.g. Cursor's ``description`` frontmatter), it is
+  derived from the section's existing fields (title, kind), never invented.
+* All renderers return *relative* paths under the supplied repo root so
+  the CLI's writer/verifier can reason about the destination uniformly.
+
+References per target:
+
+* Cursor rules — https://cursor.com/docs/context/rules
+* Claude Code memory — https://code.claude.com/docs/en/memory
+* Aider conventions — https://aider.chat/docs/usage/conventions.html
+* Aider conf.yml — https://aider.chat/docs/config/aider_conf.html
+* Goose hints — https://github.com/block/goose/blob/main/.goosehints
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from bernstein.core.knowledge.agents_md_generator import (
+    AgentsMdSection,
+    render_canonical,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclass — one render's worth of files for one target
+# ---------------------------------------------------------------------------
+
+
+Target = Literal["canonical", "cursor", "claude", "aider", "goose"]
+"""Closed set of bridge target names. Used by the CLI's ``--target`` flag."""
+
+ALL_TARGETS: tuple[Target, ...] = ("canonical", "cursor", "claude", "aider", "goose")
+
+
+@dataclass(frozen=True)
+class BridgeOutput:
+    """The set of relative paths and content a target render produces.
+
+    Attributes:
+        target: Which target this output is for.
+        files: ``{relative_path: file_content_str}``. Paths are
+            forward-slash strings and always relative to the repo root.
+            Use :meth:`absolute_paths` if you need ``Path`` objects bound
+            to a specific repo.
+    """
+
+    target: Target
+    files: dict[str, str]
+
+    def absolute_paths(self, repo_root: Path) -> dict[Path, str]:
+        return {(repo_root / p).resolve(): content for p, content in self.files.items()}
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def render(
+    sections: list[AgentsMdSection],
+    target: Target,
+    *,
+    repo_name: str | None = None,
+) -> BridgeOutput:
+    """Translate ``sections`` into the on-disk shape for ``target``.
+
+    Args:
+        sections: Output of :func:`bernstein.core.knowledge.agents_md_generator.generate`.
+        target: One of ``ALL_TARGETS``.
+        repo_name: Display name woven into the canonical H1.
+
+    Returns:
+        :class:`BridgeOutput` ready for the CLI to write or diff.
+    """
+    if target == "canonical":
+        return _render_canonical(sections, repo_name=repo_name)
+    if target == "cursor":
+        return _render_cursor(sections)
+    if target == "claude":
+        return _render_claude(sections, repo_name=repo_name)
+    if target == "aider":
+        return _render_aider(sections, repo_name=repo_name)
+    if target == "goose":
+        return _render_goose(sections, repo_name=repo_name)
+    raise ValueError(f"Unknown render target: {target!r}")
+
+
+def render_all(
+    sections: list[AgentsMdSection],
+    *,
+    repo_name: str | None = None,
+) -> dict[Target, BridgeOutput]:
+    """Render every target in one call. Returns a target-keyed dict."""
+    return {t: render(sections, t, repo_name=repo_name) for t in ALL_TARGETS}
+
+
+# ---------------------------------------------------------------------------
+# Canonical (AGENTS.md) — same content, packaged as a BridgeOutput
+# ---------------------------------------------------------------------------
+
+
+def _render_canonical(sections: list[AgentsMdSection], *, repo_name: str | None) -> BridgeOutput:
+    body = render_canonical(sections, repo_name=repo_name)
+    return BridgeOutput(target="canonical", files={"AGENTS.md": body})
+
+
+# ---------------------------------------------------------------------------
+# Cursor — .cursor/rules/<key>.mdc with YAML frontmatter
+# ---------------------------------------------------------------------------
+
+
+def _render_cursor(sections: list[AgentsMdSection]) -> BridgeOutput:
+    """Per-section MDC files under ``.cursor/rules/``.
+
+    Frontmatter fields used (per https://cursor.com/docs/context/rules):
+
+    * ``description`` — derived from section ``title``. Cursor agent uses
+      this to decide relevance for "Apply Intelligently" sessions.
+    * ``globs`` — ``section.target_globs`` joined with commas. When empty,
+      the field is omitted (Cursor treats absent ``globs`` correctly).
+    * ``alwaysApply`` — ``section.always_apply``. When ``True`` and
+      ``globs`` is also set, Cursor ignores ``globs`` (per their docs);
+      that's intentional — we want one rule injected every session.
+    """
+    files: dict[str, str] = {}
+    for sec in sections:
+        relpath = f".cursor/rules/{sec.key}.mdc"
+        files[relpath] = _cursor_mdc_for(sec)
+    return BridgeOutput(target="cursor", files=files)
+
+
+def _cursor_mdc_for(sec: AgentsMdSection) -> str:
+    """Build one MDC file's content (frontmatter + body)."""
+    fm: list[str] = ["---", f"description: {_safe_one_line(sec.title)}"]
+    if sec.target_globs:
+        fm.append(f"globs: {','.join(sec.target_globs)}")
+    fm.append(f"alwaysApply: {'true' if sec.always_apply else 'false'}")
+    fm.append("---")
+    return "\n".join(fm) + "\n\n" + sec.body.rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — single CLAUDE.md at repo root
+# ---------------------------------------------------------------------------
+
+
+_CLAUDE_LINE_BUDGET = 200
+"""Anthropic's documented soft cap. We don't hard-truncate; we warn instead."""
+
+
+def _render_claude(sections: list[AgentsMdSection], *, repo_name: str | None) -> BridgeOutput:
+    """Single ``CLAUDE.md`` at repo root.
+
+    Sections preserve their headings. We deliberately do NOT use the
+    ``@AGENTS.md`` import shortcut to avoid coupling to file-system layout
+    on the consuming side; teams that want both files can either keep
+    them in sync (the whole point of this bridge) or symlink one to the
+    other.
+    """
+    name = repo_name or "Project"
+    parts: list[str] = [
+        f"# {name} — CLAUDE.md\n",
+        "<!-- AUTO-GENERATED by `bernstein agents-md sync` — DO NOT edit by hand. Source: AGENTS.md. -->\n",
+    ]
+    for sec in sections:
+        parts.append(f"\n## {sec.title}\n\n{sec.body.rstrip()}\n")
+    body = "".join(parts).rstrip() + "\n"
+
+    line_count = body.count("\n")
+    if line_count > _CLAUDE_LINE_BUDGET:
+        logger.info(
+            "CLAUDE.md is %d lines (Anthropic's soft cap is %d). "
+            "Consider trimming overlay sections under .sdd/agents-md/.",
+            line_count,
+            _CLAUDE_LINE_BUDGET,
+        )
+    return BridgeOutput(target="claude", files={"CLAUDE.md": body})
+
+
+# ---------------------------------------------------------------------------
+# Aider — CONVENTIONS.md at repo root + .aider.conf.yml patch
+# ---------------------------------------------------------------------------
+
+
+def _render_aider(sections: list[AgentsMdSection], *, repo_name: str | None) -> BridgeOutput:
+    """Aider's instructions are a two-file convention.
+
+    1. ``CONVENTIONS.md`` — markdown content (anything Aider should know).
+    2. ``.aider.conf.yml`` — config that makes Aider actually load the
+       conventions file. Without ``read: CONVENTIONS.md`` the conventions
+       file is dead. We always patch (or create) the conf file so the
+       sync is self-consistent.
+    """
+    name = repo_name or "Project"
+    parts: list[str] = [
+        f"# {name} — CONVENTIONS.md\n",
+        "<!-- AUTO-GENERATED by `bernstein agents-md sync` — DO NOT edit by hand. Source: AGENTS.md. -->\n",
+    ]
+    for sec in sections:
+        parts.append(f"\n## {sec.title}\n\n{sec.body.rstrip()}\n")
+    conv = "".join(parts).rstrip() + "\n"
+
+    # The .aider.conf.yml is intentionally minimal — we only own the
+    # `read:` line. If the user has more config (model, edit-format, …)
+    # they can add it; the writer in agents_md_cmd.py merges, not
+    # overwrites.
+    conf = "# AUTO-GENERATED by `bernstein agents-md sync` — managed line: `read:`.\nread: CONVENTIONS.md\n"
+
+    return BridgeOutput(
+        target="aider",
+        files={
+            "CONVENTIONS.md": conv,
+            ".aider.conf.yml": conf,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Goose — .goosehints at repo root, plaintext
+# ---------------------------------------------------------------------------
+
+
+def _render_goose(sections: list[AgentsMdSection], *, repo_name: str | None) -> BridgeOutput:
+    """Goose reads ``.goosehints`` as plaintext.
+
+    Markdown renders fine and Goose's own repo uses prose + bullets, so we
+    keep the section structure. Headers go from ``##`` to plain ``[Title]``
+    style + double newline so plaintext-mode tools also parse the section
+    breaks visually.
+    """
+    name = repo_name or "Project"
+    parts: list[str] = [
+        f"# {name} — Goose hints",
+        "AUTO-GENERATED by `bernstein agents-md sync` — DO NOT edit by hand. Source: AGENTS.md.",
+        "",
+    ]
+    for sec in sections:
+        parts.append(f"## {sec.title}")
+        parts.append("")
+        parts.append(sec.body.rstrip())
+        parts.append("")
+    body = "\n".join(parts).rstrip() + "\n"
+    return BridgeOutput(target="goose", files={".goosehints": body})
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_one_line(s: str) -> str:
+    """Collapse to one line, no leading/trailing whitespace, no newlines.
+
+    Used for YAML scalar fields that must not break out of a single line
+    (``description:`` etc.). YAML quoting is not strictly necessary for
+    the values we emit (titles like ``Module map``, ``Build & test``), but
+    we strip control characters defensively.
+    """
+    return " ".join(s.split())
+
+
+__all__ = [
+    "ALL_TARGETS",
+    "BridgeOutput",
+    "Target",
+    "render",
+    "render_all",
+]

--- a/src/bernstein/core/knowledge/agents_md_generator.py
+++ b/src/bernstein/core/knowledge/agents_md_generator.py
@@ -1,0 +1,851 @@
+"""Canonical AGENTS.md generator — single source of truth for agent context.
+
+Teams running more than one CLI coding agent (Cursor + Claude Code + Codex
+is the common 2026 stack) end up maintaining three to five near-identical
+context files (``AGENTS.md``, ``CLAUDE.md``, ``.cursor/rules/*.mdc``,
+``CONVENTIONS.md`` + ``.aider.conf.yml``, ``.goosehints``) that drift over
+weeks. The test command in one file diverges from another, conventions
+disagree, and nobody notices until an agent picks the stale one.
+
+This module derives a *canonical* list of :class:`AgentsMdSection` records
+from the repository — module docstrings, git history, ``pyproject.toml``,
+shipped role templates, optionally curated overlays under
+``.sdd/agents-md/`` — and renders the full ``AGENTS.md``. The companion
+:mod:`bernstein.core.knowledge.agents_md_bridge` then translates that
+canonical IR into the Cursor / Claude Code / Aider / Goose target formats
+without inventing new conventions.
+
+Architecture
+------------
+
+1. :func:`generate` walks the repo and returns
+   ``list[AgentsMdSection]`` ordered for canonical render.
+2. Each section is built by a *pure* ``_build_*`` function that takes the
+   repo path and reads the primitives it needs. Pure means: no side
+   effects, deterministic, side-input goes through the parameter list.
+3. :func:`render_canonical` joins the sections with stable spacing and
+   the AAIF / agents.md plain-markdown convention (no frontmatter).
+4. The ``conventions`` and ``custom`` sections read overlay files from
+   ``.sdd/agents-md/`` when present so curated prose can live next to
+   the auto-derived sections in one source of truth.
+
+The generator is deliberately *not* an opinionated framework — it follows
+the canonical https://agents.md/ guidance ("AGENTS.md is just standard
+Markdown") and the community-converged section set surfaced in the GitHub
+``how-to-write-a-great-agents-md`` post analysis of 2,500+ repos.
+
+References
+----------
+
+* AGENTS.md canonical site — https://agents.md/
+* AAIF AGENTS.md project page — https://aaif.io/projects/agents-md/
+* Agentic AI readthedocs mirror — https://agentic-ai.readthedocs.io/en/latest/Standards/agents-md/
+* GitHub blog write-up — https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/
+* OpenAI Codex AGENTS.md guide — https://developers.openai.com/codex/guides/agents-md
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from bernstein.core.git.git_context import hot_files
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclass — canonical IR for one AGENTS.md section
+# ---------------------------------------------------------------------------
+
+
+SectionKind = Literal[
+    "overview",
+    "module-map",
+    "build-test",
+    "setup",
+    "architecture",
+    "conventions",
+    "git-workflow",
+    "roles",
+    "custom",
+]
+"""The closed set of canonical section kinds.
+
+``custom`` covers plugin-contributed and ``.sdd/agents-md/*.md`` overlay
+sections. Any other ``kind`` value is a programming error.
+"""
+
+
+@dataclass(frozen=True)
+class AgentsMdSection:
+    """One canonical section of the agent-context document.
+
+    Sections are deliberately small structurally — just an identifier, a
+    heading, and a markdown body. The complexity of "what to write" lives
+    in the section builders below, not in the dataclass.
+
+    Attributes:
+        key: Stable identifier suitable for filenames and frontmatter
+            (e.g. ``module-map``). Lowercase kebab-case.
+        title: Display heading rendered as ``## {title}`` in canonical output.
+        body: Markdown body. May contain code fences, tables, paragraphs.
+            Trailing newline is normalised by the renderer.
+        kind: Closed-set classifier used by the bridge to pick the right
+            translation strategy per target.
+        target_globs: For path-scoped sections (e.g. ``src/bernstein/cli/``
+            conventions), the globs that select files where the section
+            applies. Used by Cursor MDC ``globs:`` and Claude Code rules.
+            Empty tuple = applies project-wide.
+        always_apply: Cursor-specific frontmatter hint. ``True`` → injected
+            every session. ``False`` → only auto-attached when ``target_globs``
+            match. Ignored by other targets.
+    """
+
+    key: str
+    title: str
+    body: str
+    kind: SectionKind
+    target_globs: tuple[str, ...] = ()
+    always_apply: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Configuration — known packages + ordering hints (mirrors gen_agents_md.py)
+# ---------------------------------------------------------------------------
+
+_INIT_PY = "__init__.py"
+
+PACKAGE_META: dict[str, str] = {
+    "core": "orchestration engine",
+    "adapters": "CLI agent adapters",
+    "agents": "agent catalog & discovery",
+    "cli": "Click CLI",
+    "evolution": "self-evolution engine",
+    "eval": "evaluation harness",
+    "plugins": "plugin system (pluggy)",
+    "tui": "Textual TUI",
+    "github_app": "GitHub App integration",
+    "mcp": "MCP server",
+    "benchmark": "SWE-bench",
+}
+
+# Packages whose ``__init__.py`` is a re-export shim and brings no
+# additional information to the table.
+_SKIP_INIT: frozenset[str] = frozenset(PACKAGE_META.keys())
+
+_SKIP_FILES: frozenset[str] = frozenset({"__pycache__", "__main__.py"})
+
+# Curated ordering for ``core/`` so the most-load-bearing modules appear
+# first regardless of alphabetical order.
+_CORE_PINNED_ORDER: tuple[str, ...] = (
+    "models.py",
+    "server.py",
+    "orchestrator.py",
+    "tick_pipeline.py",
+    "task_lifecycle.py",
+    "agent_lifecycle.py",
+    "spawner.py",
+    "router.py",
+    "janitor.py",
+    "context.py",
+)
+
+# Files that conceptually belong to one row even though they live in
+# separate modules (e.g. backend-split storage).
+_MULTI_FILE_ROWS: dict[str, tuple[str, ...]] = {
+    "store.py": ("store.py", "store_redis.py", "store_postgres.py"),
+}
+_SKIP_IN_MULTI: frozenset[str] = frozenset({"store_redis.py", "store_postgres.py"})
+
+# Documented non-package directories. Hand-curated; no auto-derivation.
+_NON_PACKAGE_DIRS: tuple[tuple[str, str], ...] = (
+    ("templates/roles/", "Jinja2 role prompts (manager, backend, qa, security, devops, etc.)"),
+    ("templates/prompts/", "Prompt templates (judge.md, etc.) — bundled into wheel"),
+    (".sdd/", "All runtime state (never commit `.sdd/runtime/`)"),
+    (".sdd/backlog/open/", "YAML task specs waiting to be picked up"),
+    (".sdd/backlog/claimed/", "Tasks currently being worked"),
+    (".sdd/backlog/closed/", "Completed/cancelled tasks"),
+    (".sdd/runtime/", "PIDs, logs, session state, signal files"),
+    (".sdd/metrics/", "JSONL metric records"),
+    (".sdd/traces/", "JSONL agent traces"),
+    (".sdd/agents/catalog.json", "Registered agent catalog"),
+    ("tests/unit/", "Fast unit tests (no network)"),
+    ("tests/integration/", "Integration tests (require running server)"),
+    ("scripts/run_tests.py", "Per-file isolated test runner"),
+)
+
+# Overlay directory for curated section content the user wants to keep
+# under version control next to the auto-derived data.
+_OVERLAY_DIR = ".sdd/agents-md"
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GenerateOptions:
+    """Knobs that control what :func:`generate` produces.
+
+    Attributes:
+        include_module_map: When ``False``, skip the deterministic module-map
+            section. Useful for repos that don't have a Python ``src/``
+            layout where the table would mislead.
+        include_git_workflow: When ``False``, skip git-derived workflow data.
+            Useful when running outside a git working tree.
+        max_module_map_lines: Soft cap on rows per package table; when a
+            package would render more rows than this it is summarised.
+            ``0`` disables the cap.
+        overlay_dir: Path (relative to repo root) where curated overlay
+            files live. Each ``.md`` in this directory becomes a section.
+    """
+
+    include_module_map: bool = True
+    include_git_workflow: bool = True
+    max_module_map_lines: int = 0
+    overlay_dir: str = _OVERLAY_DIR
+
+
+def generate(repo_path: Path, options: GenerateOptions | None = None) -> list[AgentsMdSection]:
+    """Walk ``repo_path`` and produce the canonical ordered section list.
+
+    The order is fixed: overview → module-map → build-test → setup →
+    architecture → conventions → git-workflow → roles → custom overlays.
+    A section that has no content (e.g. no ``pyproject.toml`` for
+    build-test) is *omitted* rather than emitted empty — readers expect
+    every section heading to carry information.
+
+    Args:
+        repo_path: Repository root. Must exist; need not be a git checkout
+            unless ``options.include_git_workflow`` is ``True``.
+        options: See :class:`GenerateOptions`. Defaults are sensible for a
+            Python project with a ``src/bernstein/`` layout.
+
+    Returns:
+        Ordered list of :class:`AgentsMdSection`. Empty when ``repo_path``
+        is missing.
+    """
+    if not repo_path.exists():
+        return []
+    opts = options or GenerateOptions()
+
+    builders: list[tuple[str, object]] = [
+        ("overview", _build_overview(repo_path)),
+        ("module-map", _build_module_map(repo_path, opts) if opts.include_module_map else None),
+        ("build-test", _build_build_test(repo_path)),
+        ("setup", _build_setup(repo_path)),
+        ("architecture", _build_architecture(repo_path)),
+        ("conventions", _build_conventions(repo_path, opts)),
+        ("git-workflow", _build_git_workflow(repo_path) if opts.include_git_workflow else None),
+        ("roles", _build_roles(repo_path)),
+    ]
+
+    sections: list[AgentsMdSection] = []
+    for _key, sec in builders:
+        if sec is not None:
+            sections.append(sec)  # type: ignore[arg-type]
+
+    sections.extend(_build_overlay_sections(repo_path, opts))
+    return sections
+
+
+# ---------------------------------------------------------------------------
+# Canonical render
+# ---------------------------------------------------------------------------
+
+
+_CANONICAL_PREAMBLE = (
+    "<!-- AUTO-GENERATED by `bernstein agents-md sync` — DO NOT edit by hand. "
+    "Curated content lives under `.sdd/agents-md/`. -->\n"
+)
+
+
+def render_canonical(sections: list[AgentsMdSection], *, repo_name: str | None = None) -> str:
+    """Render the full canonical AGENTS.md.
+
+    Pure markdown, no frontmatter, no Bernstein-specific schema header.
+    Mirrors the canonical https://agents.md/ guidance.
+
+    Args:
+        sections: Ordered list as returned by :func:`generate`.
+        repo_name: Optional name to use in the H1. When ``None``, uses
+            "Project" as a neutral placeholder.
+
+    Returns:
+        Complete markdown text ending in a single trailing newline.
+    """
+    name = repo_name or "Project"
+    parts: list[str] = [f"# {name} — AGENTS.md\n", _CANONICAL_PREAMBLE]
+    for sec in sections:
+        parts.append(f"\n## {sec.title}\n\n{sec.body.rstrip()}\n")
+    text = "".join(parts).rstrip() + "\n"
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Section builders — each is pure, returns AgentsMdSection | None
+# ---------------------------------------------------------------------------
+
+
+def _build_overview(repo_path: Path) -> AgentsMdSection | None:
+    """Pull the first paragraph of README.{md,rst,txt} (or ``.sdd/project.md``)."""
+    candidates = [
+        repo_path / "README.md",
+        repo_path / "README.rst",
+        repo_path / "README.txt",
+        repo_path / ".sdd" / "project.md",
+    ]
+    for p in candidates:
+        if not p.is_file():
+            continue
+        body = _first_paragraph(p) or _first_n_lines(p, 8)
+        if body:
+            return AgentsMdSection(
+                key="overview",
+                title="Overview",
+                body=body,
+                kind="overview",
+                always_apply=True,
+            )
+    return None
+
+
+def _build_module_map(repo_path: Path, opts: GenerateOptions) -> AgentsMdSection | None:
+    """Port of ``scripts/gen_agents_md.py`` — Python-package docstring table.
+
+    Returns ``None`` when ``src/bernstein/`` (or equivalent) is absent.
+    """
+    src_root = repo_path / "src" / "bernstein"
+    if not src_root.is_dir():
+        return None
+
+    blocks: list[str] = []
+    for pkg, meta in PACKAGE_META.items():
+        pkg_dir = src_root / pkg
+        if not pkg_dir.is_dir():
+            continue
+        rows = _collect_package_rows(pkg_dir, pkg)
+        if not rows:
+            continue
+        if opts.max_module_map_lines > 0 and len(rows) > opts.max_module_map_lines:
+            extra = len(rows) - opts.max_module_map_lines
+            rows = rows[: opts.max_module_map_lines]
+            rows.append((f"_… +{extra} more_", "_truncated_"))
+        blocks.append(f"### `src/bernstein/{pkg}/` — {meta}\n\n{_render_two_column_table(rows, 'File')}")
+
+    if not blocks:
+        return None
+
+    blocks.append(
+        "### Key non-package directories\n\n"
+        + _render_two_column_table([(f"`{p}`", purpose) for p, purpose in _NON_PACKAGE_DIRS], "Path")
+    )
+    body = "\n\n".join(blocks)
+    return AgentsMdSection(
+        key="module-map",
+        title="Module map",
+        body=body,
+        kind="module-map",
+        always_apply=False,
+        target_globs=("src/**", "tests/**"),
+    )
+
+
+def _build_build_test(repo_path: Path) -> AgentsMdSection | None:
+    """Distil run-and-test commands from pyproject.toml, Makefile, package.json.
+
+    The output is intentionally thin: a fenced code block with the most
+    likely *one* command for each role (install / test / lint / type-check
+    / build), or several when the project clearly distinguishes (e.g. uv
+    plus pip fallbacks). Avoids dumping every script entry.
+    """
+    cmds: list[str] = []
+
+    pyproj = repo_path / "pyproject.toml"
+    if pyproj.is_file():
+        text = pyproj.read_text(encoding="utf-8", errors="replace")
+        if "[tool.uv]" in text or "uv" in text.split("\n", 1)[0].lower():
+            cmds.append("uv sync                    # install + lock")
+            cmds.append("uv run pytest              # tests")
+        else:
+            cmds.append("pip install -e .[dev]      # install")
+            cmds.append("pytest                     # tests")
+        if "ruff" in text:
+            cmds.append("uv run ruff check .        # lint")
+            cmds.append("uv run ruff format .       # format")
+        if "mypy" in text or "pyright" in text:
+            cmds.append("uv run mypy src            # type-check")
+
+    makefile = repo_path / "Makefile"
+    if makefile.is_file():
+        targets = _parse_make_targets(makefile)
+        for t in ("test", "lint", "build", "install"):
+            if t in targets:
+                cmds.append(f"make {t}")
+
+    package_json = repo_path / "package.json"
+    if package_json.is_file():
+        scripts = _parse_package_json_scripts(package_json)
+        for s in ("build", "test", "lint", "dev"):
+            if s in scripts:
+                cmds.append(f"npm run {s}")
+
+    if not cmds:
+        return None
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for c in cmds:
+        if c not in seen:
+            seen.add(c)
+            deduped.append(c)
+    body = "```\n" + "\n".join(deduped) + "\n```"
+    return AgentsMdSection(
+        key="build-test",
+        title="Build & test",
+        body=body,
+        kind="build-test",
+        always_apply=True,
+    )
+
+
+def _build_setup(repo_path: Path) -> AgentsMdSection | None:
+    """One-paragraph setup block, derived from the most authoritative installer.
+
+    Prefers ``uv`` when ``uv.lock`` is present, otherwise ``pip``,
+    otherwise ``npm`` for JS-only repos.
+    """
+    if (repo_path / "uv.lock").exists():
+        body = (
+            "1. `uv sync` to install + lock the project.\n"
+            "2. `uv run python -m bernstein --help` (or your equivalent entry point).\n"
+            "3. See [Build & test](#build--test) for the recurring commands."
+        )
+    elif (repo_path / "pyproject.toml").exists():
+        body = (
+            "1. `pip install -e .[dev]` in a fresh venv.\n"
+            "2. `python -m <module> --help` for the entry point.\n"
+            "3. See [Build & test](#build--test) for the recurring commands."
+        )
+    elif (repo_path / "package.json").exists():
+        body = (
+            "1. `npm ci` (or `npm install` for first-pass).\n"
+            "2. `npm run dev` to start; `npm run build` to package.\n"
+            "3. See [Build & test](#build--test) for the recurring commands."
+        )
+    else:
+        return None
+    return AgentsMdSection(
+        key="setup",
+        title="Setup",
+        body=body,
+        kind="setup",
+        always_apply=True,
+    )
+
+
+def _build_architecture(repo_path: Path) -> AgentsMdSection | None:
+    """Surface entry points from ``[project.scripts]`` in pyproject.toml.
+
+    Skipped silently when no entry points are declared. We deliberately
+    don't pull every callable out of ast_symbol_graph — for AGENTS.md the
+    operator wants ~5 starting points, not the full call graph.
+    """
+    pyproj = repo_path / "pyproject.toml"
+    if not pyproj.is_file():
+        return None
+    scripts = _parse_pyproject_scripts(pyproj)
+    if not scripts:
+        return None
+    rows = [(f"`{name}`", target) for name, target in scripts.items()]
+    body = "Top-level entry points exposed by the package:\n\n" + _render_two_column_table(rows, "Command")
+    return AgentsMdSection(
+        key="architecture",
+        title="Architecture (entry points)",
+        body=body,
+        kind="architecture",
+        always_apply=True,
+    )
+
+
+def _build_conventions(repo_path: Path, opts: GenerateOptions) -> AgentsMdSection | None:
+    """Read ``<overlay_dir>/conventions.md`` if present.
+
+    This is the single curated section the operator owns. The generator
+    does not invent style rules from a static cheat sheet — that would
+    rot the moment the project's actual style drifts.
+    """
+    overlay = repo_path / opts.overlay_dir / "conventions.md"
+    if not overlay.is_file():
+        return None
+    body = overlay.read_text(encoding="utf-8").strip()
+    if not body:
+        return None
+    return AgentsMdSection(
+        key="conventions",
+        title="Coding conventions",
+        body=body,
+        kind="conventions",
+        always_apply=True,
+    )
+
+
+def _build_git_workflow(repo_path: Path) -> AgentsMdSection | None:
+    """Default branch + last-30-day hot files.
+
+    Uses :func:`git_context.hot_files` and ``git symbolic-ref``. Returns
+    ``None`` outside a git working tree.
+    """
+    default_branch = _git_default_branch(repo_path)
+    if default_branch is None:
+        return None  # not a git repo
+
+    hot = hot_files(repo_path, days=30, max_results=8)
+    body_parts: list[str] = [f"Default branch: `{default_branch}`."]
+    if hot:
+        rows = [(f"`{path}`", str(count)) for path, count in hot]
+        body_parts.append(
+            "Hot files in the last 30 days (commit count):\n\n"
+            + _render_two_column_table(rows, "Path", right_header="Commits")
+        )
+    return AgentsMdSection(
+        key="git-workflow",
+        title="Git workflow",
+        body="\n\n".join(body_parts),
+        kind="git-workflow",
+        always_apply=True,
+    )
+
+
+def _build_roles(repo_path: Path) -> AgentsMdSection | None:
+    """List the role names shipped under ``templates/roles/``.
+
+    The body is intentionally a single sentence + bullet list. The actual
+    role prompts are too long to inline and are loaded by the orchestrator
+    at runtime; AGENTS.md just declares what exists.
+    """
+    roles_dir = repo_path / "templates" / "roles"
+    if not roles_dir.is_dir():
+        return None
+    role_names = sorted(d.name for d in roles_dir.iterdir() if d.is_dir() and (d / "system_prompt.md").is_file())
+    if not role_names:
+        return None
+    body = (
+        "Bernstein ships agent role prompts under `templates/roles/`. "
+        "The orchestrator loads them at task-spawn time; you don't write "
+        "to them manually.\n\n" + "\n".join(f"- `{r}`" for r in role_names)
+    )
+    return AgentsMdSection(
+        key="roles",
+        title="Agent roles",
+        body=body,
+        kind="roles",
+        always_apply=False,
+        target_globs=("templates/roles/**",),
+    )
+
+
+def _build_overlay_sections(repo_path: Path, opts: GenerateOptions) -> list[AgentsMdSection]:
+    """Read every ``.md`` under ``<overlay_dir>/`` except ``conventions.md``.
+
+    Each file becomes one section. Filename (without extension) becomes
+    the section ``key`` and the H1 inside the file becomes the title;
+    when the file has no H1, the kebab-cased filename is used.
+    """
+    overlay_dir = repo_path / opts.overlay_dir
+    if not overlay_dir.is_dir():
+        return []
+    out: list[AgentsMdSection] = []
+    for path in sorted(overlay_dir.glob("*.md")):
+        if path.name == "conventions.md":
+            continue  # already consumed by _build_conventions
+        text = path.read_text(encoding="utf-8").strip()
+        if not text:
+            continue
+        title, body = _split_title_and_body(text, fallback=path.stem.replace("-", " ").title())
+        out.append(
+            AgentsMdSection(
+                key=path.stem,
+                title=title,
+                body=body,
+                kind="custom",
+                always_apply=False,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Helpers — small, well-tested
+# ---------------------------------------------------------------------------
+
+
+def _first_docstring_line(path: Path) -> str:
+    """Return the first non-empty line of a Python module's docstring."""
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+    except (SyntaxError, UnicodeDecodeError, OSError):
+        return ""
+    doc = ast.get_docstring(tree)
+    if not doc:
+        return ""
+    for line in doc.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped.rstrip(".")
+    return ""
+
+
+def _collect_package_rows(pkg_dir: Path, package: str) -> list[tuple[str, str]]:
+    """Collect ``(display_name, description)`` rows for one top-level package.
+
+    Mirrors ``scripts/gen_agents_md.py`` so the existing AGENTS.md output
+    is preserved byte-for-byte where this section is concerned.
+    """
+    rows: list[tuple[str, str]] = []
+    if package == "core":
+        pinned = [f for f in _CORE_PINNED_ORDER if (pkg_dir / f).exists()]
+        rest = sorted(
+            f.name
+            for f in pkg_dir.iterdir()
+            if f.is_file()
+            and f.suffix == ".py"
+            and f.name not in pinned
+            and f.name not in _SKIP_FILES
+            and f.name != _INIT_PY
+        )
+        files = [pkg_dir / name for name in (pinned + rest)]
+    else:
+        files = sorted(f for f in pkg_dir.iterdir() if f.is_file() and f.suffix == ".py" and f.name not in _SKIP_FILES)
+
+    for py_file in files:
+        fname = py_file.name
+        if fname == _INIT_PY and package in _SKIP_INIT:
+            continue
+        if fname in _SKIP_IN_MULTI:
+            continue
+        if fname in _MULTI_FILE_ROWS:
+            display = " / ".join(f"`{f}`" for f in _MULTI_FILE_ROWS[fname])
+            rows.append((display, _first_docstring_line(py_file)))
+            continue
+        rows.append((f"`{fname}`", _first_docstring_line(py_file)))
+
+    rows.extend(_collect_subpackage_rows(pkg_dir))
+    return rows
+
+
+def _collect_subpackage_rows(pkg_dir: Path) -> list[tuple[str, str]]:
+    """Sub-package directories surface as one row each."""
+    rows: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for subdir in sorted(pkg_dir.iterdir()):
+        if not subdir.is_dir() or subdir.name.startswith("_") or subdir.name in seen:
+            continue
+        seen.add(subdir.name)
+        init = subdir / _INIT_PY
+        desc = _first_docstring_line(init) if init.exists() else f"{subdir.name}/ sub-package"
+        py_names = sorted(f.stem for f in subdir.glob("*.py") if not f.name.startswith("_"))
+        if py_names and not desc:
+            desc = f"Sub-package: {', '.join(py_names)}"
+        elif py_names and desc:
+            desc += f" ({', '.join(py_names)}.py)"
+        rows.append((f"`{subdir.name}/`", desc))
+    return rows
+
+
+def _render_two_column_table(
+    rows: list[tuple[str, str]],
+    left_header: str,
+    *,
+    right_header: str = "Purpose",
+) -> str:
+    """Render a two-column markdown table with right-padded left column."""
+    if not rows:
+        return ""
+    col1_w = max((len(r[0]) for r in rows), default=0)
+    col1_w = max(col1_w, len(left_header))
+    lines = [
+        f"| {left_header:<{col1_w}} | {right_header} |",
+        f"|{'-' * (col1_w + 2)}|{'-' * (len(right_header) + 2)}|",
+    ]
+    for left, right in rows:
+        lines.append(f"| {left:<{col1_w}} | {right} |")
+    return "\n".join(lines)
+
+
+_README_SKIP_PREFIXES = (
+    "#",  # any-level markdown heading
+    "[![",  # shields.io / badge link
+    "> ",  # blockquote
+    "![",  # inline image
+    "<!--",  # html comment
+    "<",  # raw HTML — divs, picture, source, br, etc. README chrome
+    "---",  # horizontal rule
+    "===",  # setext underline
+)
+
+
+def _first_paragraph(path: Path) -> str:
+    """Return the first prose paragraph from ``path``.
+
+    A paragraph is everything between the first non-skipped, non-blank
+    line and the next blank line. Skips markdown headings, badge links,
+    blockquotes, inline images, HTML comments, raw HTML chrome (``<div>``,
+    ``<picture>``, etc.) and rule separators so the output reads as the
+    actual prose introduction rather than the README's decoration.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    paragraph: list[str] = []
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line:
+            if paragraph:
+                break
+            continue
+        stripped = line.lstrip()
+        if any(stripped.startswith(prefix) for prefix in _README_SKIP_PREFIXES):
+            if paragraph:
+                break
+            continue
+        if _looks_like_nav_strip(stripped):
+            if paragraph:
+                break
+            continue
+        paragraph.append(line)
+    return "\n".join(paragraph).strip()
+
+
+def _looks_like_nav_strip(line: str) -> bool:
+    """Detect language-switchers and horizontal link menus.
+
+    Heuristic: 3+ markdown link tokens on a single line is almost always a
+    nav strip rather than prose. Real README first paragraphs typically
+    carry 0-2 links of context, not a menu. Catches both pipe-separated
+    (``[a]() | [b]()``) and middot-separated (``[a]() · [b]()``) and HTML
+    entity (``[a]() &middot; [b]()``) variants without per-separator
+    enumeration.
+    """
+    return len(re.findall(r"\[[^\]]+\]\([^)]+\)", line)) >= 3
+
+
+def _first_n_lines(path: Path, n: int) -> str:
+    try:
+        return "\n".join(path.read_text(encoding="utf-8").splitlines()[:n]).strip()
+    except OSError:
+        return ""
+
+
+def _parse_make_targets(makefile: Path) -> set[str]:
+    """Return target names declared in a Makefile, ignoring ``.PHONY`` etc."""
+    out: set[str] = set()
+    try:
+        text = makefile.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return out
+    for line in text.splitlines():
+        m = re.match(r"^([A-Za-z0-9_-]+)\s*:", line)
+        if m:
+            target = m.group(1)
+            if not target.startswith("."):
+                out.add(target)
+    return out
+
+
+def _parse_package_json_scripts(package_json: Path) -> set[str]:
+    """Return the keys of the top-level ``scripts`` block in package.json."""
+    import json
+
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    scripts = data.get("scripts", {})
+    return set(scripts.keys()) if isinstance(scripts, dict) else set()
+
+
+def _parse_pyproject_scripts(pyproj: Path) -> dict[str, str]:
+    """Return ``{name: target}`` for ``[project.scripts]`` entries.
+
+    Falls back to an empty dict on parse error or missing section.
+    Uses tomllib to avoid a third-party dep.
+    """
+    try:
+        import tomllib  # py311+
+    except ImportError:  # pragma: no cover — handled at runtime
+        return {}
+    try:
+        data = tomllib.loads(pyproj.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+    project = data.get("project", {})
+    scripts = project.get("scripts", {})
+    return {str(k): str(v) for k, v in scripts.items()} if isinstance(scripts, dict) else {}
+
+
+def _git_default_branch(repo_path: Path) -> str | None:
+    """Return the default branch (``main``/``master``/...) or ``None``."""
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            ref = result.stdout.strip()
+            if ref.startswith("refs/remotes/origin/"):
+                return ref.removeprefix("refs/remotes/origin/")
+        # Fallback: current branch
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=repo_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+            if branch and branch != "HEAD":
+                return branch
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    return None
+
+
+def _split_title_and_body(text: str, *, fallback: str) -> tuple[str, str]:
+    """Split a markdown blob into (title, body) by reading its first H1.
+
+    When no H1 is present, ``fallback`` is used and the entire text becomes
+    the body.
+    """
+    lines = text.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            title = stripped[2:].strip() or fallback
+            body = "\n".join(lines[i + 1 :]).strip()
+            return title, body
+    return fallback, text.strip()
+
+
+__all__ = [
+    "PACKAGE_META",
+    "AgentsMdSection",
+    "GenerateOptions",
+    "SectionKind",
+    "generate",
+    "render_canonical",
+]

--- a/src/bernstein/plugins/hookspecs.py
+++ b/src/bernstein/plugins/hookspecs.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bernstein.plugins import hookspec
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.knowledge.agents_md_generator import AgentsMdSection
 
 
 class ElicitationResult(Enum):
@@ -488,6 +493,30 @@ class BernsteinSpec:
             session_id: Agent session identifier.
             role: Agent role.
             source_paths: List of instruction file paths loaded.
+        """
+
+    @hookspec
+    def provide_agents_md_section(self, repo_path: Path) -> AgentsMdSection | list[AgentsMdSection] | None:
+        """Provide one or more sections that should be merged into AGENTS.md.
+
+        Called by ``bernstein agents-md generate / sync / verify``. Plugins
+        return either a single :class:`bernstein.core.knowledge.agents_md_generator.AgentsMdSection`
+        or a list of them; the generator appends contributions in plugin
+        load order *after* the canonical built-in sections.
+
+        Sections returned here participate in the cross-CLI rewrite the
+        same way as built-in sections — Cursor / Claude Code / Aider /
+        Goose all see the plugin's contribution. Use this hook to inject
+        plugin-specific build commands, environment requirements, or
+        operator notes that the user should not have to copy-paste into
+        five files.
+
+        Args:
+            repo_path: Repository root the generator is running against.
+
+        Returns:
+            One :class:`AgentsMdSection`, a list of them, or ``None`` to
+            skip. Returning an empty list is equivalent to ``None``.
         """
 
     @hookspec

--- a/tests/unit/test_agents_md_bridge.py
+++ b/tests/unit/test_agents_md_bridge.py
@@ -1,0 +1,231 @@
+"""Unit tests for ``bernstein.core.knowledge.agents_md_bridge``.
+
+Covers the per-target render functions, the ``BridgeOutput`` shape, and
+the round-trip equivalence promise from issue #1087: regardless of which
+target a section is rewritten through, every section's *content* must
+survive (we don't lose information when fanning out across targets).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.knowledge.agents_md_bridge import (
+    ALL_TARGETS,
+    BridgeOutput,
+    render,
+    render_all,
+)
+from bernstein.core.knowledge.agents_md_generator import AgentsMdSection
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_sections() -> list[AgentsMdSection]:
+    """A minimal but non-trivial section list used by all targets."""
+    return [
+        AgentsMdSection(
+            key="overview",
+            title="Overview",
+            body="Demo project for unit tests.",
+            kind="overview",
+            always_apply=True,
+        ),
+        AgentsMdSection(
+            key="build-test",
+            title="Build & test",
+            body="```\nuv sync\nuv run pytest\n```",
+            kind="build-test",
+            always_apply=True,
+        ),
+        AgentsMdSection(
+            key="module-map",
+            title="Module map",
+            body="- `core/` orchestration\n- `cli/` Click commands",
+            kind="module-map",
+            always_apply=False,
+            target_globs=("src/**", "tests/**"),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# render() — target dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestRenderDispatch:
+    def test_unknown_target_raises(self, sample_sections: list[AgentsMdSection]) -> None:
+        with pytest.raises(ValueError, match="Unknown render target"):
+            render(sample_sections, "vscode", repo_name="demo")  # type: ignore[arg-type]
+
+    def test_all_known_targets_dispatch(self, sample_sections: list[AgentsMdSection]) -> None:
+        for t in ALL_TARGETS:
+            out = render(sample_sections, t, repo_name="demo")
+            assert isinstance(out, BridgeOutput)
+            assert out.target == t
+            assert out.files, f"target {t} produced no files"
+
+
+# ---------------------------------------------------------------------------
+# Canonical
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCanonical:
+    def test_writes_one_file_named_agents_md(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "canonical", repo_name="demo")
+        assert list(out.files.keys()) == ["AGENTS.md"]
+
+    def test_content_starts_with_h1(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "canonical", repo_name="demo")
+        assert out.files["AGENTS.md"].startswith("# demo — AGENTS.md\n")
+
+
+# ---------------------------------------------------------------------------
+# Cursor — .cursor/rules/<key>.mdc with frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCursor:
+    def test_emits_one_mdc_per_section(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "cursor", repo_name="demo")
+        assert set(out.files.keys()) == {
+            ".cursor/rules/overview.mdc",
+            ".cursor/rules/build-test.mdc",
+            ".cursor/rules/module-map.mdc",
+        }
+
+    def test_frontmatter_uses_real_cursor_fields(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "cursor", repo_name="demo")
+        for content in out.files.values():
+            assert content.startswith("---\n")
+            assert "description:" in content
+            assert "alwaysApply:" in content
+            # YAML scalar separator after frontmatter, then blank line, then body.
+            assert "\n---\n\n" in content
+
+    def test_globs_emitted_only_when_present(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "cursor", repo_name="demo")
+        overview = out.files[".cursor/rules/overview.mdc"]
+        module_map = out.files[".cursor/rules/module-map.mdc"]
+        assert "globs:" not in overview  # target_globs == ()
+        assert "globs: src/**,tests/**" in module_map
+
+    def test_always_apply_serialised_lowercase(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "cursor", repo_name="demo")
+        overview = out.files[".cursor/rules/overview.mdc"]
+        module_map = out.files[".cursor/rules/module-map.mdc"]
+        assert "alwaysApply: true" in overview
+        assert "alwaysApply: false" in module_map
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — single CLAUDE.md
+# ---------------------------------------------------------------------------
+
+
+class TestRenderClaude:
+    def test_single_file_at_root(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "claude", repo_name="demo")
+        assert list(out.files.keys()) == ["CLAUDE.md"]
+
+    def test_includes_every_section_heading(self, sample_sections: list[AgentsMdSection]) -> None:
+        body = render(sample_sections, "claude", repo_name="demo").files["CLAUDE.md"]
+        for sec in sample_sections:
+            assert f"## {sec.title}" in body
+
+    def test_no_yaml_frontmatter(self, sample_sections: list[AgentsMdSection]) -> None:
+        body = render(sample_sections, "claude", repo_name="demo").files["CLAUDE.md"]
+        # Frontmatter would mean starting with `---` immediately. We start
+        # with `# {name} — CLAUDE.md`.
+        assert not body.lstrip().startswith("---")
+
+
+# ---------------------------------------------------------------------------
+# Aider — CONVENTIONS.md + .aider.conf.yml
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAider:
+    def test_emits_two_files(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "aider", repo_name="demo")
+        assert set(out.files.keys()) == {"CONVENTIONS.md", ".aider.conf.yml"}
+
+    def test_conf_pins_read_to_conventions(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "aider", repo_name="demo")
+        conf = out.files[".aider.conf.yml"]
+        # Aider only loads CONVENTIONS.md when this line exists.
+        assert "read: CONVENTIONS.md" in conf
+
+    def test_conventions_includes_all_sections(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "aider", repo_name="demo")
+        conv = out.files["CONVENTIONS.md"]
+        for sec in sample_sections:
+            assert sec.body.split("\n")[0] in conv
+
+
+# ---------------------------------------------------------------------------
+# Goose — .goosehints (plaintext)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGoose:
+    def test_single_file_at_root(self, sample_sections: list[AgentsMdSection]) -> None:
+        out = render(sample_sections, "goose", repo_name="demo")
+        assert list(out.files.keys()) == [".goosehints"]
+
+    def test_includes_section_titles(self, sample_sections: list[AgentsMdSection]) -> None:
+        body = render(sample_sections, "goose", repo_name="demo").files[".goosehints"]
+        for sec in sample_sections:
+            assert sec.title in body
+
+
+# ---------------------------------------------------------------------------
+# Round-trip equivalence: every target's body retains every section's content
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTripEquivalence:
+    """Issue #1087 invariant: rendering through *any* target preserves the
+    content payload of *every* canonical section.
+
+    We don't claim byte-equivalence across targets — frontmatter, headings,
+    and separators legitimately differ. We claim: for every section in the
+    canonical IR, the substring of that section's first body-line appears
+    in every target's emitted content.
+    """
+
+    def test_every_section_body_survives_every_target(self, sample_sections: list[AgentsMdSection]) -> None:
+        outputs = render_all(sample_sections, repo_name="demo")
+        for sec in sample_sections:
+            # The first non-empty body line is the strongest cross-target
+            # equivalence anchor. Headings are remapped by some targets;
+            # body content is not.
+            first_line = sec.body.splitlines()[0].strip()
+            if not first_line or first_line.startswith("```"):
+                # For fenced code blocks the strongest signal is the line
+                # *after* the fence opener.
+                lines = [l for l in sec.body.splitlines() if l.strip()]
+                first_line = lines[1].strip() if len(lines) > 1 else lines[0].strip()
+            for target, output in outputs.items():
+                concat = "\n".join(output.files.values())
+                assert first_line in concat, f"section {sec.key!r} body lost in target {target!r}"
+
+
+# ---------------------------------------------------------------------------
+# BridgeOutput.absolute_paths
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeOutputAbsolutePaths:
+    def test_resolves_relative_paths_against_root(self, tmp_path: Path) -> None:
+        out = BridgeOutput(target="canonical", files={"AGENTS.md": "x"})
+        abs_map = out.absolute_paths(tmp_path)
+        assert list(abs_map.keys()) == [(tmp_path / "AGENTS.md").resolve()]
+        assert abs_map[(tmp_path / "AGENTS.md").resolve()] == "x"

--- a/tests/unit/test_agents_md_cmd.py
+++ b/tests/unit/test_agents_md_cmd.py
@@ -1,0 +1,231 @@
+"""End-to-end tests for ``bernstein agents-md`` Click subcommands.
+
+Mirrors the ``test_lineage_export.py`` pattern: ``CliRunner.invoke`` against
+``tmp_path`` fixture repos, then assert exit codes + on-disk files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.agents_md_cmd import agents_md_cmd
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def demo_repo(tmp_path: Path) -> Path:
+    """Minimal but complete demo repo for CLI smoke tests."""
+    (tmp_path / "src" / "bernstein" / "core").mkdir(parents=True)
+    (tmp_path / "src" / "bernstein" / "core" / "__init__.py").write_text("")
+    (tmp_path / "src" / "bernstein" / "core" / "models.py").write_text('"""Domain models."""\n')
+    (tmp_path / "templates" / "roles" / "backend").mkdir(parents=True)
+    (tmp_path / "templates" / "roles" / "backend" / "system_prompt.md").write_text("# Backend\n")
+    (tmp_path / "README.md").write_text("# Demo\n\nDemo project for CLI tests.\n")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\nversion = '0'\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# generate
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSubcommand:
+    def test_canonical_prints_h1(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            ["generate", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "# demo — AGENTS.md" in result.output
+
+    def test_cursor_target_prints_separator_per_file(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            [
+                "generate",
+                "--workdir",
+                str(demo_repo),
+                "--target",
+                "cursor",
+                "--repo-name",
+                "demo",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        # Multi-file target uses ``--- <relpath> ---`` separators.
+        assert "--- .cursor/rules/" in result.output
+
+
+# ---------------------------------------------------------------------------
+# write
+# ---------------------------------------------------------------------------
+
+
+class TestWriteSubcommand:
+    def test_writes_canonical_to_repo(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            ["write", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert result.exit_code == 0, result.output
+        agents_md = demo_repo / "AGENTS.md"
+        assert agents_md.is_file()
+        assert "# demo — AGENTS.md" in agents_md.read_text()
+
+    def test_dry_run_does_not_touch_disk(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            [
+                "write",
+                "--workdir",
+                str(demo_repo),
+                "--repo-name",
+                "demo",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "[dry-run]" in result.output
+        assert not (demo_repo / "AGENTS.md").exists()
+
+    def test_cursor_target_writes_per_section_mdc(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            [
+                "write",
+                "--workdir",
+                str(demo_repo),
+                "--target",
+                "cursor",
+                "--repo-name",
+                "demo",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        rules_dir = demo_repo / ".cursor" / "rules"
+        assert rules_dir.is_dir()
+        # At least one .mdc file exists.
+        assert any(p.suffix == ".mdc" for p in rules_dir.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# sync — the killer command
+# ---------------------------------------------------------------------------
+
+
+class TestSyncSubcommand:
+    def test_sync_writes_all_five_targets(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            ["sync", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (demo_repo / "AGENTS.md").is_file()
+        assert (demo_repo / "CLAUDE.md").is_file()
+        assert (demo_repo / "CONVENTIONS.md").is_file()
+        assert (demo_repo / ".aider.conf.yml").is_file()
+        assert (demo_repo / ".goosehints").is_file()
+        assert (demo_repo / ".cursor" / "rules").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# verify — CI gate
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySubcommand:
+    def test_verify_passes_immediately_after_sync(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        sync = runner.invoke(
+            agents_md_cmd,
+            ["sync", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert sync.exit_code == 0, sync.output
+        verify = runner.invoke(
+            agents_md_cmd,
+            ["verify", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert verify.exit_code == 0, verify.output
+
+    def test_verify_fails_when_canonical_missing(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            agents_md_cmd,
+            [
+                "verify",
+                "--workdir",
+                str(demo_repo),
+                "--target",
+                "canonical",
+                "--repo-name",
+                "demo",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "MISSING" in result.output
+
+    def test_verify_fails_when_drift_introduced(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(
+            agents_md_cmd,
+            ["sync", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        # Hand-edit AGENTS.md to introduce drift.
+        agents = demo_repo / "AGENTS.md"
+        agents.write_text(agents.read_text() + "\n<!-- manual edit -->\n")
+        result = runner.invoke(
+            agents_md_cmd,
+            ["verify", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert result.exit_code == 1
+        assert "DRIFT" in result.output
+
+
+# ---------------------------------------------------------------------------
+# diff — informational, exit 0 even with drift
+# ---------------------------------------------------------------------------
+
+
+class TestDiffSubcommand:
+    def test_no_diff_after_sync(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(
+            agents_md_cmd,
+            ["sync", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        result = runner.invoke(
+            agents_md_cmd,
+            ["diff", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "No drift" in result.output
+
+    def test_unified_diff_emitted_on_drift(self, demo_repo: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(
+            agents_md_cmd,
+            ["sync", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        agents = demo_repo / "AGENTS.md"
+        agents.write_text(agents.read_text() + "\n<!-- manual edit -->\n")
+        result = runner.invoke(
+            agents_md_cmd,
+            ["diff", "--workdir", str(demo_repo), "--repo-name", "demo"],
+        )
+        assert result.exit_code == 0
+        # Unified-diff fence and our manual edit signature should both appear.
+        assert "@@" in result.output
+        assert "manual edit" in result.output

--- a/tests/unit/test_agents_md_generator.py
+++ b/tests/unit/test_agents_md_generator.py
@@ -1,0 +1,338 @@
+"""Unit tests for ``bernstein.core.knowledge.agents_md_generator``.
+
+Covers:
+
+* Each ``_build_*`` section builder against ``tmp_path`` fixture repos.
+* ``generate()`` ordering / omission of empty sections.
+* ``render_canonical()`` shape (no frontmatter, stable spacing).
+* Helpers: ``_first_docstring_line``, ``_first_paragraph``,
+  ``_looks_like_nav_strip``, ``_render_two_column_table``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.knowledge.agents_md_generator import (
+    AgentsMdSection,
+    GenerateOptions,
+    _first_docstring_line,
+    _first_paragraph,
+    _looks_like_nav_strip,
+    _render_two_column_table,
+    generate,
+    render_canonical,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_repo(root: Path, *, with_git: bool = False) -> Path:
+    """Create a minimal Python project skeleton under ``root``."""
+    (root / "src" / "bernstein" / "core").mkdir(parents=True)
+    (root / "src" / "bernstein" / "core" / "__init__.py").write_text("")
+    (root / "src" / "bernstein" / "core" / "models.py").write_text(
+        '"""Domain model dataclasses used across the orchestrator."""\n'
+    )
+    (root / "src" / "bernstein" / "core" / "router.py").write_text('"""Cost-aware model router."""\n')
+    (root / "templates" / "roles" / "backend").mkdir(parents=True)
+    (root / "templates" / "roles" / "backend" / "system_prompt.md").write_text("# Backend role")
+    (root / "templates" / "roles" / "qa").mkdir(parents=True)
+    (root / "templates" / "roles" / "qa" / "system_prompt.md").write_text("# QA role")
+    (root / "README.md").write_text("# Demo\n\nA tiny demo project for unit tests.\n")
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = 'demo'\nversion = '0.0.1'\n[project.scripts]\ndemo = 'demo.cli:main'\n"
+    )
+    if with_git:
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.email", "t@t"], cwd=root, check=True)
+        subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+        subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True)
+    return root
+
+
+# ---------------------------------------------------------------------------
+# generate() — top-level behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGenerate:
+    def test_returns_empty_for_missing_repo(self, tmp_path: Path) -> None:
+        assert generate(tmp_path / "does-not-exist") == []
+
+    def test_produces_sections_in_canonical_order(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        keys = [s.key for s in sections]
+        # Order: overview before module-map before build-test before setup
+        # before architecture before roles. Conventions/git-workflow may be
+        # absent (no overlay file / no git).
+        seen_keys = [k for k in keys if k in {"overview", "module-map", "build-test", "setup", "architecture", "roles"}]
+        assert seen_keys == ["overview", "module-map", "build-test", "setup", "architecture", "roles"]
+
+    def test_omits_empty_sections_silently(self, tmp_path: Path) -> None:
+        # Repo without README, without pyproject, without templates/roles.
+        (tmp_path / "src" / "bernstein").mkdir(parents=True)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        keys = {s.key for s in sections}
+        assert "overview" not in keys
+        assert "build-test" not in keys
+        assert "roles" not in keys
+
+    def test_overlay_section_appears_after_builtins(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        overlay = tmp_path / ".sdd" / "agents-md"
+        overlay.mkdir(parents=True)
+        (overlay / "deployment.md").write_text("# Deployment\n\nWe deploy via `make deploy`.\n")
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        keys = [s.key for s in sections]
+        assert keys[-1] == "deployment"
+        assert sections[-1].title == "Deployment"
+        assert "make deploy" in sections[-1].body
+
+    def test_conventions_overlay_consumed_as_section(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        overlay = tmp_path / ".sdd" / "agents-md"
+        overlay.mkdir(parents=True)
+        (overlay / "conventions.md").write_text("Use snake_case for functions, CamelCase for classes.\n")
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        conv = next(s for s in sections if s.kind == "conventions")
+        assert "snake_case" in conv.body
+        # Conventions does NOT also leak as a custom overlay.
+        custom_keys = {s.key for s in sections if s.kind == "custom"}
+        assert "conventions" not in custom_keys
+
+    def test_include_git_workflow_false_skips_section(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, with_git=True)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        assert all(s.kind != "git-workflow" for s in sections)
+
+    def test_include_module_map_false_skips_section(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_module_map=False))
+        assert all(s.kind != "module-map" for s in sections)
+
+
+# ---------------------------------------------------------------------------
+# render_canonical() — shape contracts
+# ---------------------------------------------------------------------------
+
+
+class TestRenderCanonical:
+    def test_starts_with_h1_and_no_frontmatter(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        out = render_canonical(sections, repo_name="demo")
+        assert out.splitlines()[0] == "# demo — AGENTS.md"
+        # No YAML frontmatter — agents.md spec is explicitly schema-free.
+        assert not out.startswith("---")
+
+    def test_section_headings_use_h2(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        out = render_canonical(sections, repo_name="demo")
+        # Every section must render as `## Title` — never H3 or H1.
+        for sec in sections:
+            assert f"\n## {sec.title}\n" in out
+
+    def test_ends_with_single_newline(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        out = render_canonical(sections, repo_name="demo")
+        assert out.endswith("\n")
+        assert not out.endswith("\n\n")
+
+    def test_repo_name_default_is_neutral(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        out = render_canonical(sections)
+        assert "Project — AGENTS.md" in out
+
+
+# ---------------------------------------------------------------------------
+# Section builder edges — module map preserves gen_agents_md.py contract
+# ---------------------------------------------------------------------------
+
+
+class TestModuleMap:
+    def test_picks_up_module_docstrings(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        mm = next(s for s in sections if s.kind == "module-map")
+        assert "Cost-aware model router" in mm.body
+        assert "Domain model dataclasses" in mm.body
+
+    def test_truncation_when_over_max(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        # Add 30 extra modules to force truncation.
+        core = tmp_path / "src" / "bernstein" / "core"
+        for i in range(30):
+            (core / f"mod_{i:02d}.py").write_text(f'"""Module {i}."""\n')
+        sections = generate(
+            tmp_path,
+            GenerateOptions(
+                include_git_workflow=False,
+                max_module_map_lines=5,
+            ),
+        )
+        mm = next(s for s in sections if s.kind == "module-map")
+        # Truncation marker present.
+        assert "more_" in mm.body or "truncated" in mm.body
+
+
+class TestBuildTestSection:
+    def test_fails_silent_when_no_pyproject(self, tmp_path: Path) -> None:
+        (tmp_path / "src" / "bernstein").mkdir(parents=True)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        assert all(s.kind != "build-test" for s in sections)
+
+    def test_pyproject_uv_yields_uv_commands(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        # Add a uv config marker so the builder picks the uv branch.
+        (tmp_path / "uv.lock").write_text("# minimal\n")
+        pyp = tmp_path / "pyproject.toml"
+        pyp.write_text(pyp.read_text() + "[tool.uv]\nfoo = 1\n")
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        bt = next(s for s in sections if s.kind == "build-test")
+        assert "uv sync" in bt.body
+        assert "uv run pytest" in bt.body
+
+
+class TestArchitectureSection:
+    def test_picks_up_project_scripts(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        arch = next((s for s in sections if s.kind == "architecture"), None)
+        assert arch is not None
+        assert "demo" in arch.body
+        assert "demo.cli:main" in arch.body
+
+
+class TestRolesSection:
+    def test_lists_roles_alphabetically(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=False))
+        roles = next(s for s in sections if s.kind == "roles")
+        # Both shipped roles appear; backend before qa alphabetically.
+        idx_backend = roles.body.index("`backend`")
+        idx_qa = roles.body.index("`qa`")
+        assert idx_backend < idx_qa
+
+
+class TestGitWorkflowSection:
+    def test_omitted_outside_git_repo(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, with_git=False)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=True))
+        assert all(s.kind != "git-workflow" for s in sections)
+
+    def test_present_inside_git_repo(self, tmp_path: Path) -> None:
+        _make_repo(tmp_path, with_git=True)
+        sections = generate(tmp_path, GenerateOptions(include_git_workflow=True))
+        gw = next((s for s in sections if s.kind == "git-workflow"), None)
+        assert gw is not None
+        assert "Default branch" in gw.body
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFirstDocstringLine:
+    def test_module_with_docstring(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.py"
+        path.write_text('"""First line.\n\nSecond paragraph."""\n')
+        assert _first_docstring_line(path) == "First line"
+
+    def test_module_without_docstring(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.py"
+        path.write_text("import os\n")
+        assert _first_docstring_line(path) == ""
+
+    def test_invalid_python_returns_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "m.py"
+        path.write_text("def broken(:\n    ...\n")
+        assert _first_docstring_line(path) == ""
+
+
+class TestFirstParagraph:
+    def test_skips_h1_then_returns_prose(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text("# Title\n\nReal prose paragraph here.\n")
+        assert _first_paragraph(readme) == "Real prose paragraph here."
+
+    def test_skips_badge_strip(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "# Title\n\n"
+            "[![Build](https://x/y.svg)](https://x/y) "
+            "[![Coverage](https://x/c.svg)](https://x/c)\n\n"
+            "Actual prose intro.\n"
+        )
+        assert "Actual prose intro" in _first_paragraph(readme)
+
+    def test_skips_horizontal_link_strip(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "# Title\n\n"
+            "[Docs](docs.md) | [Install](install.md) | [Changelog](changelog.md)\n\n"
+            "Prose only after the nav.\n"
+        )
+        assert _first_paragraph(readme) == "Prose only after the nav."
+
+
+class TestNavStripDetector:
+    def test_three_links_with_pipes_is_nav(self) -> None:
+        assert _looks_like_nav_strip("[A](u1) | [B](u2) | [C](u3)") is True
+
+    def test_three_links_with_middot_is_nav(self) -> None:
+        assert _looks_like_nav_strip("[A](u1) · [B](u2) · [C](u3)") is True
+
+    def test_two_links_is_not_nav(self) -> None:
+        assert _looks_like_nav_strip("See [foo](u1) and [bar](u2) for details.") is False
+
+    def test_pure_prose_is_not_nav(self) -> None:
+        assert _looks_like_nav_strip("Bernstein orchestrates AI coding agents.") is False
+
+
+class TestRenderTwoColumnTable:
+    def test_pads_left_column_to_max_width(self) -> None:
+        out = _render_two_column_table([("a", "x"), ("longer_name", "y")], "Name")
+        lines = out.splitlines()
+        # Header row width matches separator row width.
+        assert len(lines[0]) == len(lines[1])
+        # Both data rows have the same left-column *padded* width
+        # (preserve trailing whitespace; that's the padding under test).
+        col1_a = lines[2].split("|")[1]
+        col1_b = lines[3].split("|")[1]
+        assert len(col1_a) == len(col1_b)
+        assert col1_a.strip() == "a"
+        assert col1_b.strip() == "longer_name"
+
+    def test_empty_returns_empty(self) -> None:
+        assert _render_two_column_table([], "X") == ""
+
+
+# ---------------------------------------------------------------------------
+# AgentsMdSection — frozen + minimal
+# ---------------------------------------------------------------------------
+
+
+class TestAgentsMdSection:
+    def test_frozen(self) -> None:
+        s = AgentsMdSection(key="k", title="T", body="b", kind="overview")
+        # FrozenInstanceError subclasses AttributeError; use the more specific
+        # parent so we don't paper over an unrelated runtime error.
+        with pytest.raises(AttributeError):
+            s.body = "new"  # type: ignore[misc]
+
+    def test_default_globs_empty_and_always_apply_true(self) -> None:
+        s = AgentsMdSection(key="k", title="T", body="b", kind="overview")
+        assert s.target_globs == ()
+        assert s.always_apply is True


### PR DESCRIPTION
Closes #1087.

## Summary

Single-source-of-truth pipeline for agent context files. Teams running Cursor + Claude Code + Codex + Aider + Goose currently maintain 5 near-identical files that drift over weeks; this command makes one canonical \`AGENTS.md\` rewrite all five.

\`\`\`
$ bernstein agents-md sync
  · AGENTS.md  (canonical)
  · .cursor/rules/overview.mdc  (cursor)
  · .cursor/rules/module-map.mdc  (cursor)
  · .cursor/rules/build-test.mdc  (cursor)
  · .cursor/rules/setup.mdc  (cursor)
  · .cursor/rules/architecture.mdc  (cursor)
  · .cursor/rules/git-workflow.mdc  (cursor)
  · .cursor/rules/roles.mdc  (cursor)
  · CLAUDE.md  (claude)
  · CONVENTIONS.md  (aider)
  · .aider.conf.yml  (aider)
  · .goosehints  (goose)
Synced 12 file(s) across 5 target(s)
\`\`\`

## Architecture

| Layer | File | Role |
|---|---|---|
| IR | \`core/knowledge/agents_md_generator.py\` | Frozen \`AgentsMdSection\` dataclass + 8 pure section builders → ordered list. \`render_canonical(sections)\` produces plain markdown (no frontmatter, per agents.md schema-free convention). |
| Translation | \`core/knowledge/agents_md_bridge.py\` | Per-target renderers built from the *real* on-disk schemas in 2026 (verified against current docs, not training-data assumptions). |
| Surface | \`cli/commands/agents_md_cmd.py\` | Click \`agents-md\` group: \`generate\` / \`write\` / \`sync\` / \`verify\` / \`diff\`. |
| Extension | \`plugins/hookspecs.py\` | New \`provide_agents_md_section\` hookspec. Plugin manager call-site wiring is a follow-up; the contract is declared. |
| Registration | \`cli/main.py\` | \`cli.add_command(agents_md_cmd, "agents-md")\` next to lineage_cmd. |

### Section builders (all pure, all return \`AgentsMdSection | None\`)

* \`overview\` — first prose paragraph from README (skips badge strips, link nav rows, raw HTML chrome)
* \`module-map\` — direct port of \`scripts/gen_agents_md.py\` logic; output is byte-equivalent for the curated package set
* \`build-test\` — install/test/lint/format/type commands derived from \`pyproject.toml\` + \`Makefile\` + \`package.json\`
* \`setup\` — auto-picks uv / pip / npm based on which lock-file exists
* \`architecture\` — \`[project.scripts]\` entry points
* \`conventions\` — reads \`.sdd/agents-md/conventions.md\` overlay (curated, not auto-derived)
* \`git-workflow\` — default branch + 30-day hot files via \`hot_files()\`
* \`roles\` — list of shipped role names from \`templates/roles/\`
* Plus arbitrary overlay \`.md\` files under \`.sdd/agents-md/\` become custom sections

### Cross-CLI bridge — real schemas, not invented

| Target | On-disk shape |
|---|---|
| Cursor | \`.cursor/rules/<key>.mdc\` with YAML frontmatter (\`description\`, \`globs\`, \`alwaysApply\`) — current Cursor docs no longer document \`.cursorrules\` |
| Claude Code | \`CLAUDE.md\` at root, freeform markdown, soft 200-line cap (warns over) |
| Aider | \`CONVENTIONS.md\` content + \`.aider.conf.yml\` with \`read: CONVENTIONS.md\` — without the conf entry the conventions file is dead, so the bridge always emits both |
| Goose | \`.goosehints\` plaintext at root |

Schemas verified against:
- https://cursor.com/docs/context/rules
- https://code.claude.com/docs/en/memory
- https://aider.chat/docs/usage/conventions.html
- https://aider.chat/docs/config/aider_conf.html
- https://github.com/block/goose/blob/main/.goosehints
- https://agents.md/

## Tests

62 new tests, all green:

\`\`\`
$ uv run python -m pytest tests/unit/test_agents_md_*.py -q
62 passed in 6.25s
\`\`\`

* \`test_agents_md_generator.py\` — per-section unit tests against \`tmp_path\` fixture repos, including git-init for git-workflow coverage; covers section ordering, omission of empty sections, conventions overlay, custom overlay sections, render_canonical shape contracts, and pure helpers (\`_first_docstring_line\`, \`_first_paragraph\`, \`_looks_like_nav_strip\`, \`_render_two_column_table\`).
* \`test_agents_md_bridge.py\` — per-target shape contracts and a round-trip equivalence test ("every section's body survives every target").
* \`test_agents_md_cmd.py\` — \`CliRunner.invoke\` end-to-end for all 5 subcommands including drift detection (\`MISSING\` and \`DRIFT\` paths) and \`--dry-run\`.

## Test plan

- [ ] CI green (especially Windows-3.13)
- [ ] Smoke test against the bernstein repo itself: \`bernstein agents-md generate --target canonical\` produces a coherent AGENTS.md (verified locally)
- [ ] \`bernstein agents-md verify\` exits 1 when files drift (verified by test)

## Out of scope (issue's own "out of scope" plus mine)

- Inventing a new spec — we follow agents.md's "just standard markdown" guidance, not the AAIF readthedocs YAML-block flavour.
- Full conflict-resolution editor for drift — \`diff\` produces unified diff, operator runs the obvious manual edit or \`sync\` to overwrite.
- Plugin-manager call-site wiring for the new \`provide_agents_md_section\` hookspec — the hookspec is declared, but generator-side invocation is a follow-up.

## Migration

\`scripts/gen_agents_md.py\` is left in place as a thin back-compat helper. The new generator's module-map output is byte-equivalent for the curated PACKAGE_META set; teams can migrate at their own pace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)