### PR TITLE
fix(tests): document agents-md in README + coverage allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Commands that eliminate the glue code most teams end up writing around their run
 | `bernstein connect <provider>` / `bernstein creds` | Stores and rotates API credentials in the OS keychain. Agents inherit scoped keys per-run. |
 | `bernstein autofix` | Daemon that monitors open Bernstein PRs; spawns a fixer agent when CI fails and pushes the repair automatically. |
 | `bernstein preview start` | Starts a sandboxed dev server for the current branch and prints a shareable public tunnel URL. |
+| `bernstein agents-md` | Generates a canonical [AAIF AGENTS.md](https://agents.md) for the repo and rewrites it into each CLI's native shape. `generate` (preview), `write` (single file), `sync` (canonical + Cursor `.cursor/rules/*.mdc` + Claude `CLAUDE.md` + Aider `CONVENTIONS.md` + Goose `.goosehints`), `verify` (CI gate), `diff` (shows drift between canonical IR and on-disk files). |
 
 ### Retrieval & caching: what's actually under the hood
 

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -174,6 +174,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "migrate",
         "routine",
         "wheelhouse",
+        # AAIF AGENTS.md generator (closes #1087)
+        "agents-md",
     }
 )
 


### PR DESCRIPTION
Fixes the post-merge CI regression on #1097: `test_readme_api_coverage::test_all_cli_commands_are_documented` failed on ubuntu-latest, macos-latest, and ubuntu-3.12 because the new `agents-md` Click group wasn't in DOCUMENTED_COMMANDS and wasn't in README.

Added a row to the **Operator commands** table covering all 5 subcommands (generate / write / sync / verify / diff) with the [agents.md](https://agents.md) link, and appended `agents-md` to DOCUMENTED_COMMANDS.

Verified locally: `uv run pytest tests/unit/test_readme_api_coverage.py` → 3 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)