### PR TITLE
fix(ci): unblock auto-release by triggering CI on pyproject.toml-only merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,13 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      # Auto-release version bumps (prevent CI → release → CI loop)
-      - "pyproject.toml"
+      # NOTE: pyproject.toml IS NOT ignored. Auto-release uses a PR-based
+      # bump flow (auto-release.yml → opens auto/bump-vX.Y.Z PR with
+      # auto-merge); the resulting squash-merge to main carries only a
+      # pyproject.toml diff and MUST trigger CI so the workflow_run
+      # listener in auto-release.yml can fire and tag + publish. The old
+      # CI→release→CI loop concern is already handled by the bot-author
+      # filter and the "tag exists?" check inside auto-release.yml.
       # Documentation & prose
       - "docs/**"
       - "*.md"


### PR DESCRIPTION
## Why v1.10.3 didn't release

`auto-release.yml` listens on `workflow_run: workflows: ["CI"]`. The PR-based bump flow merges `auto/bump-vX.Y.Z` PRs whose squash commit changes only `pyproject.toml`. The current `ci.yml` `paths-ignore` skips CI for those merges, so the `workflow_run` listener never fires and the version never tags. PR #1083's bump landed at 21:31 UTC May 7 and v1.10.3 has been wedged ever since (the release exists only as a Drafter `Draft`).

## Fix

Drop the `pyproject.toml` entry from `paths-ignore` in `ci.yml`. The CI→release→CI loop concern that originally motivated the entry is already handled by:

1. The bot-author short-circuit in `auto-release.yml` gate.
2. The `Check tag` step that skips re-bumping when the tag already exists.

Once this lands, the next bump-merge will fire CI normally, `auto-release.yml` will tag + publish.

## Recovery for the existing wedge

After this PR merges and CI passes, the next non-bump push to main will trigger a fresh `auto-release` run, which will see `pyproject.toml=1.10.3` with no `v1.10.3` tag and proceed to tag + publish.

I've also already re-run the failed CI on PR #1098's merge commit (sha `13ac00e8`) — that should green-light v1.10.3 directly without needing additional commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)