### PR TITLE
ci(auto-release): bind release job to pypi environment for green deploy markers

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -89,6 +89,14 @@ jobs:
     if: needs.gate.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Binding to the "pypi" environment makes every successful publish
+    # create a green deployment marker (visible in the repo sidebar
+    # Deployments view). Without this, recent v1.10.x publishes succeed
+    # but the sidebar still shows whatever the last environment-bound
+    # run left behind — which was a stale failure from April 26.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bernstein/
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Why

The repo sidebar's **Deployments** view shows a red x on the `pypi` environment. Cause: the last environment-bound run was a failed Auto-release from 2026-04-26 — the `Generate App token` step 404'd because the GitHub App had no installation on this repo. That step has since been removed and publishes go through `secrets.GITHUB_TOKEN`, but the release job never declared an `environment:` block. So all subsequent successful v1.10.x publishes register on PyPI but don't update the deployment marker.

## What

Bind the `release` job in `.github/workflows/auto-release.yml` to environment `pypi` with URL `https://pypi.org/p/bernstein/`. Every successful publish from this point forward creates a green deployment record visible in the repo sidebar.

## Companion cleanup

The stale failed deployment record (id `4491031809`) was deleted via the GitHub Deployments API. This PR prevents the same kind of stale-record-blocking-the-view from recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)