### PR TITLE
feat(a2a): real HTTP delegation + cross-process federation integration tests

### DIFF
--- a/.github/workflows/a2a-federation-e2e.yml
+++ b/.github/workflows/a2a-federation-e2e.yml
@@ -1,0 +1,60 @@
+name: a2a-federation-e2e
+
+# Cross-process A2A federation harness: spins up two FastAPI servers in
+# the same process (different ports) and exercises real HTTP delegation
+# with retry, peer-state machine, concurrency, and idempotent inbound
+# acceptance. Deliberately slower than the unit suite so it runs only on
+# PRs that touch the federation surface, plus a nightly schedule.
+#
+# Skipped on Windows in the test module itself because the asyncio +
+# uvicorn fixture combo wedges under ProactorEventLoop.
+
+on:
+  pull_request:
+    paths:
+      - "src/bernstein/core/protocols/a2a/**"
+      - "src/bernstein/core/routes/task_a2a.py"
+      - "src/bernstein/core/server/server_app.py"
+      - "tests/integration/test_a2a_federation_e2e.py"
+      - ".github/workflows/a2a-federation-e2e.yml"
+  schedule:
+    # 03:33 UTC nightly; offset from cluster-e2e (03:17) and CI-fix.
+    - cron: "33 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a2a-federation-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a2a-federation-e2e:
+    name: a2a-federation-e2e (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # Module-level pytest.skipif handles Windows; covering ubuntu and
+        # macOS here gives confidence on both POSIX targets.
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run A2A federation e2e suite
+        run: |
+          uv run pytest tests/integration/test_a2a_federation_e2e.py \
+            -x -q --tb=short

--- a/src/bernstein/core/protocols/a2a/a2a_federation.py
+++ b/src/bernstein/core/protocols/a2a/a2a_federation.py
@@ -4,29 +4,108 @@ Exchange tasks with external orchestrators via A2A protocol. Builds on
 the existing :mod:`bernstein.core.a2a` module to add:
 
 - Peer registry for known external orchestrators.
-- Outbound task delegation (send a task to an external peer).
+- Outbound task delegation (send a task to an external peer over HTTP).
 - Inbound task acceptance (receive and track federated tasks).
 - Status synchronisation between local and remote task states.
+
+Wire transport
+--------------
+``delegate_task_http`` performs a real HTTP POST to the peer's
+``/a2a/v0/tasks`` endpoint, with retry on 5xx and connection errors,
+and updates the local ledger transactionally:
+
+* on success → ``mark_sent`` is called and the peer's ``last_seen`` /
+  ``state`` are refreshed to ``ACTIVE``;
+* on final failure → the federated task is moved to ``FAILED`` and the
+  peer transitions to ``UNREACHABLE``; an :class:`A2ADelegationError`
+  is raised so the caller can react.
+
+The in-memory ledger is still authoritative for local state — HTTP is
+only the wire transport. Synchronous :meth:`delegate_task` is preserved
+for bookkeeping-only use cases (tests, dry runs, planning) and remains
+the path used by all 25 existing unit tests.
 
 Usage::
 
     from bernstein.core.protocols.a2a_federation import A2AFederation
 
-    fed = A2AFederation(local_handler=handler)
+    fed = A2AFederation(local_endpoint="http://orchestrator:8052")
     fed.register_peer("design-team", "http://design.local:8052")
-    task = fed.delegate_task("design-team", "Create wireframes for login page")
+    task = await fed.delegate_task_http(
+        "design-team",
+        "Create wireframes for login page",
+    )
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from bernstein.core.protocols.a2a.a2a import AgentCard
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults & constants
+# ---------------------------------------------------------------------------
+
+# Path on the peer where federated tasks are POSTed.
+A2A_TASKS_PATH = "/a2a/v0/tasks"
+
+# Default httpx timeouts: 10s connect / 30s read.
+DEFAULT_CONNECT_TIMEOUT = 10.0
+DEFAULT_READ_TIMEOUT = 30.0
+
+# Retry policy for delegate_task_http.
+DEFAULT_MAX_RETRIES = 3
+DEFAULT_BACKOFF_BASE = 0.25  # seconds — 0.25, 0.5, 1.0 by default
+
+
+class A2ADelegationError(RuntimeError):
+    """Raised when a task delegation fails after all retries.
+
+    Attributes:
+        peer_name: Peer that the delegation targeted.
+        attempts: Number of attempts made (including the first).
+        last_error: The last underlying error (httpx exception, status code).
+    """
+
+    def __init__(
+        self,
+        peer_name: str,
+        attempts: int,
+        last_error: str,
+    ) -> None:
+        super().__init__(f"A2A delegation to peer '{peer_name}' failed after {attempts} attempts: {last_error}")
+        self.peer_name = peer_name
+        self.attempts = attempts
+        self.last_error = last_error
+
+
+class A2ATaskRejectedError(RuntimeError):
+    """Raised when the peer accepts the request but rejects the task body.
+
+    Distinct from :class:`A2ADelegationError`: rejection means the peer is
+    reachable and authoritative — there is nothing to retry. The local
+    ledger reflects ``REJECTED`` for the task and the peer remains
+    ``ACTIVE``.
+    """
+
+    def __init__(self, peer_name: str, status_code: int, detail: str) -> None:
+        super().__init__(f"Peer '{peer_name}' rejected task (HTTP {status_code}): {detail}")
+        self.peer_name = peer_name
+        self.status_code = status_code
+        self.detail = detail
 
 
 class PeerState(StrEnum):
@@ -139,6 +218,9 @@ class A2AFederation:
         self._peers: dict[str, FederationPeer] = {}
         self._tasks: dict[str, FederatedTask] = {}
         self._by_peer: dict[str, list[str]] = {}
+        # Per-peer asyncio lock keeps ledger writes serialised within the
+        # same peer while still allowing cross-peer concurrency.
+        self._peer_locks: dict[str, asyncio.Lock] = {}
 
     def register_peer(
         self,
@@ -196,11 +278,11 @@ class A2AFederation:
         message: str,
         role: str = "backend",
     ) -> FederatedTask | None:
-        """Delegate a task to an external peer.
+        """Create a pending outbound delegation entry in the local ledger.
 
-        Creates a FederatedTask in PENDING state. The actual HTTP send
-        is handled by :meth:`mark_sent` after the caller performs the
-        network request.
+        This is the synchronous bookkeeping primitive: it records intent
+        but performs no I/O. For the wire-level path (HTTP POST + retry +
+        peer-state lifecycle), use :meth:`delegate_task_http`.
 
         Args:
             peer_name: Name of the target peer.
@@ -208,8 +290,8 @@ class A2AFederation:
             role: Role hint for routing.
 
         Returns:
-            The created FederatedTask, or None if the peer is unknown
-            or deregistered.
+            The created FederatedTask, or ``None`` if the peer is unknown
+            or has been deregistered.
         """
         peer = self._peers.get(peer_name)
         if peer is None or peer.state == PeerState.DEREGISTERED:
@@ -229,6 +311,239 @@ class A2AFederation:
         logger.info("Delegated task '%s' to peer '%s'", task.id, peer_name)
         return task
 
+    async def delegate_task_http(
+        self,
+        peer_name: str,
+        message: str,
+        role: str = "backend",
+        *,
+        sender_card: AgentCard | dict[str, Any] | None = None,
+        client: httpx.AsyncClient | None = None,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        backoff_base: float = DEFAULT_BACKOFF_BASE,
+        connect_timeout: float = DEFAULT_CONNECT_TIMEOUT,
+        read_timeout: float = DEFAULT_READ_TIMEOUT,
+    ) -> FederatedTask:
+        """Delegate a task to a peer over HTTP, with retries and ledger updates.
+
+        Performs a POST to ``{peer.endpoint}/a2a/v0/tasks`` carrying the
+        sender Agent Card and task body. On success the local ledger is
+        updated via :meth:`mark_sent` and the peer is refreshed to
+        ``ACTIVE``. On final failure the peer is marked ``UNREACHABLE``
+        and :class:`A2ADelegationError` is raised. If the peer responds
+        with a non-retryable 4xx (anything other than 408/425/429), the
+        task is moved to ``REJECTED`` and :class:`A2ATaskRejectedError`
+        is raised without further retries.
+
+        Args:
+            peer_name: Name of the target peer (must be registered).
+            message: Task description.
+            role: Role hint for routing.
+            sender_card: Optional :class:`AgentCard` describing this
+                orchestrator. Falls back to a minimal card derived from
+                ``local_endpoint``.
+            client: Optional preconfigured ``httpx.AsyncClient`` (test
+                injection or shared connection pooling). When omitted a
+                client is created and closed within the call.
+            max_retries: Total attempts on transient errors (5xx,
+                connect/read errors). Default 3.
+            backoff_base: Exponential backoff base in seconds. Sleep on
+                attempt ``n`` is ``backoff_base * 2**(n-1)``.
+            connect_timeout: HTTP connect timeout per attempt.
+            read_timeout: HTTP read timeout per attempt.
+
+        Returns:
+            The updated FederatedTask in ``SENT`` state.
+
+        Raises:
+            A2ADelegationError: All retries exhausted; peer marked UNREACHABLE.
+            A2ATaskRejectedError: Peer responded with a non-retriable 4xx.
+            ValueError: Peer is unknown or has been deregistered.
+        """
+        peer = self._peers.get(peer_name)
+        if peer is None or peer.state == PeerState.DEREGISTERED:
+            raise ValueError(f"Cannot delegate to peer '{peer_name}': not registered or deregistered")
+
+        task = self.delegate_task(peer_name, message, role)
+        if task is None:  # pragma: no cover — guarded above
+            raise ValueError(f"Failed to allocate ledger entry for peer '{peer_name}'")
+
+        # Lock here so concurrent in-flight delegations to the same peer
+        # don't interleave UNREACHABLE/ACTIVE writes; cross-peer
+        # delegations remain concurrent.
+        lock = self._peer_locks.setdefault(peer_name, asyncio.Lock())
+        async with lock:
+            try:
+                remote_task_id = await self._post_with_retries(
+                    peer=peer,
+                    task=task,
+                    sender_card=sender_card,
+                    client=client,
+                    max_retries=max_retries,
+                    backoff_base=backoff_base,
+                    connect_timeout=connect_timeout,
+                    read_timeout=read_timeout,
+                )
+            except A2ATaskRejectedError:
+                # Peer reached us; ledger reflects rejection but peer remains ACTIVE.
+                task.status = FederatedTaskStatus.REJECTED
+                task.updated_at = time.time()
+                raise
+            except A2ADelegationError:
+                # Final failure: mark task FAILED and peer UNREACHABLE.
+                task.status = FederatedTaskStatus.FAILED
+                task.updated_at = time.time()
+                peer.state = PeerState.UNREACHABLE
+                raise
+            except BaseException:
+                # Bug fix: anything unexpected (asyncio.CancelledError,
+                # programming errors) used to leave the ledger entry in
+                # PENDING forever. Mark FAILED and re-raise so the caller
+                # has a clean ledger view to recover from.
+                task.status = FederatedTaskStatus.FAILED
+                task.updated_at = time.time()
+                raise
+
+            # Success path.
+            self.mark_sent(task.id, remote_task_id)
+            peer.state = PeerState.ACTIVE
+            peer.last_seen = time.time()
+            return task
+
+    async def _post_with_retries(
+        self,
+        *,
+        peer: FederationPeer,
+        task: FederatedTask,
+        sender_card: AgentCard | dict[str, Any] | None,
+        client: httpx.AsyncClient | None,
+        max_retries: int,
+        backoff_base: float,
+        connect_timeout: float,
+        read_timeout: float,
+    ) -> str:
+        """POST the task to the peer with retry-on-5xx/connect-error.
+
+        Returns:
+            The ``remote_task_id`` assigned by the peer.
+
+        Raises:
+            A2ATaskRejectedError: 4xx (non-retryable).
+            A2ADelegationError: All retries exhausted.
+        """
+        url = f"{peer.endpoint}{A2A_TASKS_PATH}"
+        payload = self._build_payload(
+            task=task,
+            sender_card=sender_card,
+            local_endpoint=self._local_endpoint,
+        )
+
+        owns_client = client is None
+        timeout = httpx.Timeout(read_timeout, connect=connect_timeout)
+        ac = client or httpx.AsyncClient(timeout=timeout)
+        attempts = 0
+        last_error = "unknown error"
+        try:
+            for attempt in range(1, max_retries + 1):
+                attempts = attempt
+                try:
+                    response = await ac.post(url, json=payload, timeout=timeout)
+                except (httpx.ConnectError, httpx.ConnectTimeout, httpx.ReadTimeout) as exc:
+                    last_error = f"{type(exc).__name__}: {exc}"
+                    logger.warning(
+                        "A2A delegate attempt %d/%d to '%s' failed: %s",
+                        attempt,
+                        max_retries,
+                        peer.name,
+                        last_error,
+                    )
+                    if attempt < max_retries:
+                        await asyncio.sleep(backoff_base * (2 ** (attempt - 1)))
+                        continue
+                    break
+                except httpx.HTTPError as exc:
+                    last_error = f"{type(exc).__name__}: {exc}"
+                    logger.warning(
+                        "A2A delegate attempt %d/%d to '%s' transport error: %s",
+                        attempt,
+                        max_retries,
+                        peer.name,
+                        last_error,
+                    )
+                    if attempt < max_retries:
+                        await asyncio.sleep(backoff_base * (2 ** (attempt - 1)))
+                        continue
+                    break
+
+                status = response.status_code
+                if 200 <= status < 300:
+                    return self._extract_remote_id(response, fallback=task.id)
+                if status >= 500 or status in (408, 425, 429):
+                    last_error = f"HTTP {status}: {response.text[:120]}"
+                    logger.warning(
+                        "A2A delegate attempt %d/%d to '%s' transient %d",
+                        attempt,
+                        max_retries,
+                        peer.name,
+                        status,
+                    )
+                    if attempt < max_retries:
+                        await asyncio.sleep(backoff_base * (2 ** (attempt - 1)))
+                        continue
+                    break
+                # Non-retryable client error.
+                detail = response.text[:200]
+                raise A2ATaskRejectedError(peer.name, status, detail)
+        finally:
+            if owns_client:
+                await ac.aclose()
+
+        raise A2ADelegationError(peer.name, attempts, last_error)
+
+    @staticmethod
+    def _build_payload(
+        *,
+        task: FederatedTask,
+        sender_card: AgentCard | dict[str, Any] | None,
+        local_endpoint: str,
+    ) -> dict[str, Any]:
+        """Compose the wire payload for ``POST /a2a/v0/tasks``."""
+        if sender_card is None:
+            card_dict: dict[str, Any] = {
+                "name": "bernstein-orchestrator",
+                "description": "Bernstein A2A federation peer",
+                "endpoint": local_endpoint,
+                "provider": "bernstein",
+                "protocol_version": "0.1",
+                "capabilities": [],
+            }
+        elif isinstance(sender_card, dict):
+            card_dict = dict(sender_card)
+        else:
+            card_dict = sender_card.to_dict()
+        return {
+            "sender": card_dict,
+            "task": {
+                "id": task.id,
+                "message": task.message,
+                "role": task.role,
+            },
+        }
+
+    @staticmethod
+    def _extract_remote_id(response: httpx.Response, *, fallback: str) -> str:
+        """Pull the remote task id out of a 2xx response body, with fallback."""
+        try:
+            data = response.json()
+        except (ValueError, httpx.DecodingError):
+            return fallback
+        if isinstance(data, dict):
+            for key in ("remote_task_id", "task_id", "id"):
+                value = data.get(key)
+                if isinstance(value, str) and value:
+                    return value
+        return fallback
+
     def accept_inbound_task(
         self,
         peer_name: str,
@@ -236,7 +551,15 @@ class A2AFederation:
         message: str,
         role: str = "backend",
     ) -> FederatedTask:
-        """Accept an inbound task from an external peer.
+        """Accept an inbound task from an external peer (idempotent).
+
+        Bug fix: when the caller retries (e.g. after a transient 5xx that
+        slipped through the receiver before the response was sent), the
+        same ``(peer_name, remote_task_id)`` arrives twice. The previous
+        implementation appended a duplicate entry to the ledger every
+        time, which broke any "tasks-by-peer" or "delegated-task-count"
+        invariant the orchestrator relied on. Look up the existing entry
+        first and return it untouched if found.
 
         Args:
             peer_name: Name of the sending peer.
@@ -245,8 +568,24 @@ class A2AFederation:
             role: Role hint.
 
         Returns:
-            The created inbound FederatedTask.
+            The accepted FederatedTask (newly created or existing one).
         """
+        # Idempotent path — return the existing entry on duplicate posts.
+        if remote_task_id:
+            for existing_id in self._by_peer.get(peer_name, ()):
+                existing = self._tasks.get(existing_id)
+                if (
+                    existing is not None
+                    and existing.direction == "inbound"
+                    and existing.remote_task_id == remote_task_id
+                ):
+                    # Refresh peer heartbeat even on duplicate.
+                    peer = self._peers.get(peer_name)
+                    if peer is not None and peer.state != PeerState.DEREGISTERED:
+                        peer.last_seen = time.time()
+                        peer.state = PeerState.ACTIVE
+                    return existing
+
         task = FederatedTask(
             id=uuid.uuid4().hex[:12],
             peer_name=peer_name,
@@ -258,6 +597,11 @@ class A2AFederation:
         )
         self._tasks[task.id] = task
         self._by_peer.setdefault(peer_name, []).append(task.id)
+        # Refresh peer last_seen so inbound traffic counts as a heartbeat.
+        peer = self._peers.get(peer_name)
+        if peer is not None and peer.state != PeerState.DEREGISTERED:
+            peer.last_seen = time.time()
+            peer.state = PeerState.ACTIVE
         logger.info("Accepted inbound task '%s' from peer '%s'", task.id, peer_name)
         return task
 

--- a/src/bernstein/core/routes/task_a2a.py
+++ b/src/bernstein/core/routes/task_a2a.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException, Request
 
+from bernstein.core.a2a import AgentCard
 from bernstein.core.difficulty_estimator import estimate_difficulty, minutes_for_level
 from bernstein.core.server import (
     A2AAgentCardResponse,
@@ -26,6 +27,7 @@ from bernstein.core.tenanting import request_tenant_id
 
 if TYPE_CHECKING:
     from bernstein.core.a2a import A2AHandler
+    from bernstein.core.a2a_federation import A2AFederation
 
 router = APIRouter()
 
@@ -40,6 +42,10 @@ def _get_sse_bus(request: Request) -> SSEBus:
 
 def _get_a2a_handler(request: Request) -> A2AHandler:
     return request.app.state.a2a_handler  # type: ignore[no-any-return]
+
+
+def _get_a2a_federation(request: Request) -> A2AFederation:
+    return request.app.state.a2a_federation  # type: ignore[no-any-return]
 
 
 def _require_task_access(task: object, request: Request) -> None:
@@ -179,3 +185,86 @@ def a2a_add_artifact(a2a_task_id: str, body: A2AArtifactRequest, request: Reques
         data=artifact.data,
         created_at=artifact.created_at,
     )
+
+
+@router.post(
+    "/a2a/v0/tasks",
+    status_code=202,
+    responses={
+        400: {"description": "Invalid sender Agent Card or task body"},
+        409: {"description": "Task rejected (validation, capacity, etc.)"},
+    },
+)
+async def a2a_v0_accept_task(request: Request) -> dict[str, Any]:
+    """Accept a federated task delegated from a peer orchestrator.
+
+    Wire format::
+
+        {
+          "sender": { ...AgentCard... },
+          "task":   { "id": "...", "message": "...", "role": "..." }
+        }
+
+    Returns 202 with the local federated-task id and the remote task id
+    that was offered. Validation errors return HTTP 409 so that the
+    caller's retry policy treats them as terminal (the peer is reachable
+    and authoritative, no point retrying with the same body).
+    """
+    a2a_federation = _get_a2a_federation(request)
+
+    try:
+        body = await request.json()
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON body: {exc}") from None
+
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Body must be a JSON object")
+
+    sender_raw = body.get("sender")
+    task_raw = body.get("task")
+
+    if not isinstance(sender_raw, dict) or not sender_raw:
+        raise HTTPException(status_code=400, detail="Missing or invalid 'sender' Agent Card")
+    if not isinstance(task_raw, dict) or not task_raw:
+        raise HTTPException(status_code=400, detail="Missing or invalid 'task' body")
+
+    # Validate the sender Agent Card upfront so malformed peers are
+    # rejected at the boundary rather than silently logged.
+    try:
+        AgentCard.validate(sender_raw)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid sender card: {exc}") from None
+
+    sender_name = str(sender_raw.get("name") or "")
+    remote_task_id = str(task_raw.get("id") or "")
+    message = task_raw.get("message")
+    role = str(task_raw.get("role") or "backend")
+
+    if not remote_task_id:
+        raise HTTPException(status_code=409, detail="Missing 'task.id'")
+    if not isinstance(message, str) or not message.strip():
+        raise HTTPException(status_code=409, detail="Missing or empty 'task.message'")
+
+    # Auto-register inbound peer so the federation ledger has an ACTIVE
+    # entry to refresh; explicit register_peer remains available for
+    # callers that want to seed peers up-front with custom capabilities.
+    if a2a_federation.get_peer(sender_name) is None and sender_name:
+        endpoint = str(sender_raw.get("endpoint") or "")
+        a2a_federation.register_peer(
+            sender_name,
+            endpoint,
+            capabilities=list(sender_raw.get("capabilities") or []),
+        )
+
+    federated = a2a_federation.accept_inbound_task(
+        peer_name=sender_name,
+        remote_task_id=remote_task_id,
+        message=message,
+        role=role,
+    )
+    return {
+        "id": federated.id,
+        "remote_task_id": federated.remote_task_id,
+        "status": federated.status.value,
+        "peer_name": federated.peer_name,
+    }

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import FastAPI
 
 from bernstein.core.a2a import A2AHandler
+from bernstein.core.a2a_federation import A2AFederation
 from bernstein.core.acp import ACPHandler
 from bernstein.core.auth_rate_limiter import RequestRateLimitMiddleware
 from bernstein.core.bulletin import BulletinBoard, DirectChannel, MessageBoard
@@ -1138,6 +1139,7 @@ def create_app(
     message_board = MessageBoard()
     direct_channel = DirectChannel()
     a2a_handler = A2AHandler(server_url="http://localhost:8052")
+    a2a_federation = A2AFederation(local_endpoint="http://localhost:8052")
     acp_handler = ACPHandler(server_url="http://localhost:8052")
 
     application.state.store = store  # type: ignore[attr-defined]
@@ -1145,6 +1147,7 @@ def create_app(
     application.state.message_board = message_board  # type: ignore[attr-defined]
     application.state.direct_channel = direct_channel  # type: ignore[attr-defined]
     application.state.a2a_handler = a2a_handler  # type: ignore[attr-defined]
+    application.state.a2a_federation = a2a_federation  # type: ignore[attr-defined]
     application.state.acp_handler = acp_handler  # type: ignore[attr-defined]
     application.state.node_registry = node_registry  # type: ignore[attr-defined]
     application.state.cluster_authenticator = cluster_authenticator  # type: ignore[attr-defined]

--- a/tests/integration/test_a2a_federation_e2e.py
+++ b/tests/integration/test_a2a_federation_e2e.py
@@ -1,0 +1,514 @@
+"""Cross-process A2A federation end-to-end tests.
+
+Spins up two FastAPI servers on different ports — peer A (caller) and peer B
+(callee) — and exercises the real HTTP path between them:
+
+* happy-path delegation roundtrip with ledger consistency on both sides;
+* peer state machine: ACTIVE → UNREACHABLE on connect failures, refresh on
+  inbound traffic;
+* retry/backoff on transient 5xx;
+* terminal failure (port closed) → UNREACHABLE after retries exhausted;
+* peer-side validation rejection (4xx) → ledger reflects REJECTED, peer
+  remains ACTIVE;
+* concurrent delegations from peer A → peer B all land, ledger consistent;
+* invalid sender Agent Card → 400 at the boundary, no inbound bookkeeping;
+* dedicated client injection — no httpx connection warnings on shutdown.
+
+Skipped on Windows: the asyncio + uvicorn fixture combo is fragile under
+the Windows ProactorEventLoop and the cluster-e2e/clm-fake-nim tests use
+the same skip rationale.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+import sys
+import threading
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import httpx
+import pytest
+import uvicorn
+from bernstein.core.a2a import AgentCard
+from bernstein.core.a2a_federation import (
+    A2A_TASKS_PATH,
+    A2ADelegationError,
+    A2AFederation,
+    A2ATaskRejectedError,
+    FederatedTaskStatus,
+    PeerState,
+)
+from fastapi import FastAPI
+
+from bernstein.core.server import create_app
+
+# Skip the whole module on Windows — uvicorn lifespan + asyncio fixtures
+# wedge under ProactorEventLoop in CI. Same rationale as the cluster-e2e
+# and clm-fake-nim integration suites that share this scaffolding.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="uvicorn + asyncio + httpx fixtures fragile on Windows CI runners",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — port allocation and uvicorn lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    """Return a port that is currently free on 127.0.0.1."""
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _PeerServer:
+    """A FastAPI application running uvicorn in a background thread.
+
+    Used as one side of the A2A federation — the test drives delegation
+    from a separate ``A2AFederation`` instance that POSTs into this
+    server's ``/a2a/v0/tasks`` endpoint over real HTTP.
+    """
+
+    def __init__(self, app: FastAPI, port: int) -> None:
+        self.app = app
+        self.port = port
+        self.endpoint = f"http://127.0.0.1:{port}"
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self, *, timeout: float = 5.0) -> None:
+        """Start uvicorn in a daemon thread, block until ``server.started``."""
+        config = uvicorn.Config(
+            self.app,
+            host="127.0.0.1",
+            port=self.port,
+            log_level="error",
+            lifespan="off",
+        )
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True, name=f"peer-{self.port}")
+        thread.start()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and not server.started:
+            time.sleep(0.02)
+        if not server.started:
+            server.should_exit = True
+            thread.join(timeout=2)
+            raise RuntimeError(f"peer server on port {self.port} did not start within {timeout}s")
+        self._server = server
+        self._thread = thread
+
+    def stop(self) -> None:
+        """Signal uvicorn to exit and join the background thread."""
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+
+def _build_peer_app(jsonl_path: Path) -> FastAPI:
+    """Build a Bernstein FastAPI app rooted at ``jsonl_path``."""
+    return create_app(jsonl_path=jsonl_path)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — peer A (caller) and peer B (callee), each in its own server
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def peer_a(tmp_path: Path) -> Generator[_PeerServer, None, None]:
+    """Caller-side peer: server-app rooted at tmp_path/a/tasks.jsonl."""
+    root = tmp_path / "a"
+    root.mkdir()
+    app = _build_peer_app(root / "tasks.jsonl")
+    server = _PeerServer(app, _free_port())
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def peer_b(tmp_path: Path) -> Generator[_PeerServer, None, None]:
+    """Callee-side peer: server-app rooted at tmp_path/b/tasks.jsonl."""
+    root = tmp_path / "b"
+    root.mkdir()
+    app = _build_peer_app(root / "tasks.jsonl")
+    server = _PeerServer(app, _free_port())
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture
+def caller_card() -> AgentCard:
+    """The Agent Card used by peer A to identify itself in delegations."""
+    return AgentCard(
+        name="peer-a",
+        description="Test caller orchestrator",
+        capabilities=["task_orchestration"],
+        endpoint="http://127.0.0.1:0",
+        provider="bernstein-test",
+    )
+
+
+@pytest.fixture
+def caller_federation(peer_b: _PeerServer) -> A2AFederation:
+    """Caller-side ``A2AFederation`` pre-registered with peer B."""
+    fed = A2AFederation(local_endpoint="http://127.0.0.1:0")
+    fed.register_peer("peer-b", peer_b.endpoint)
+    return fed
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path — real HTTP roundtrip, ledger consistent on both sides
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_task_http_roundtrip(
+    peer_a: _PeerServer,
+    peer_b: _PeerServer,
+    caller_federation: A2AFederation,
+    caller_card: AgentCard,
+) -> None:
+    """End-to-end: peer A delegates → peer B accepts → both ledgers updated."""
+    task = await caller_federation.delegate_task_http(
+        "peer-b",
+        "Render header SVG",
+        sender_card=caller_card,
+    )
+
+    # Caller-side ledger.
+    assert task.status == FederatedTaskStatus.SENT
+    assert task.peer_name == "peer-b"
+    assert task.remote_task_id  # non-empty
+    peer = caller_federation.get_peer("peer-b")
+    assert peer is not None
+    assert peer.state == PeerState.ACTIVE
+
+    # Callee-side ledger — pulled from the real FastAPI app state.
+    callee_fed: A2AFederation = peer_b.app.state.a2a_federation  # type: ignore[attr-defined]
+    inbound = callee_fed.list_tasks(direction="inbound")
+    assert len(inbound) == 1
+    assert inbound[0].status == FederatedTaskStatus.ACCEPTED
+    assert inbound[0].remote_task_id == task.id
+    assert inbound[0].peer_name == "peer-a"
+
+
+# ---------------------------------------------------------------------------
+# 2. Retry on transient 5xx, eventual success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_retries_on_5xx_then_succeeds(
+    peer_b: _PeerServer,
+    caller_federation: A2AFederation,
+    caller_card: AgentCard,
+) -> None:
+    """Peer B returns 503 once, then 202 — retry path delivers."""
+    # Patch the route to fail the first call, succeed afterwards.
+    state = {"calls": 0}
+
+    fed_b: A2AFederation = peer_b.app.state.a2a_federation  # type: ignore[attr-defined]
+    real_accept = fed_b.accept_inbound_task
+
+    def flaky_accept(*args: object, **kwargs: object) -> object:
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise RuntimeError("first attempt blows up")
+        return real_accept(*args, **kwargs)  # type: ignore[arg-type]
+
+    fed_b.accept_inbound_task = flaky_accept  # type: ignore[method-assign]
+
+    try:
+        task = await caller_federation.delegate_task_http(
+            "peer-b",
+            "Retried task",
+            sender_card=caller_card,
+            backoff_base=0.01,
+        )
+    finally:
+        fed_b.accept_inbound_task = real_accept  # type: ignore[method-assign]
+
+    assert task.status == FederatedTaskStatus.SENT
+    assert state["calls"] >= 2
+    inbound = fed_b.list_tasks(direction="inbound")
+    assert len(inbound) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. All retries exhausted — peer marked UNREACHABLE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_unreachable_marks_peer(
+    caller_card: AgentCard,
+) -> None:
+    """Port closed before delegation → A2ADelegationError + peer UNREACHABLE."""
+    fed = A2AFederation(local_endpoint="http://127.0.0.1:0")
+    closed_port = _free_port()
+    fed.register_peer("dead-peer", f"http://127.0.0.1:{closed_port}")
+
+    with pytest.raises(A2ADelegationError) as exc_info:
+        await fed.delegate_task_http(
+            "dead-peer",
+            "doomed",
+            sender_card=caller_card,
+            max_retries=2,
+            backoff_base=0.01,
+            connect_timeout=0.5,
+            read_timeout=1.0,
+        )
+
+    assert exc_info.value.peer_name == "dead-peer"
+    assert exc_info.value.attempts == 2
+
+    peer = fed.get_peer("dead-peer")
+    assert peer is not None
+    assert peer.state == PeerState.UNREACHABLE
+
+    # Outbound ledger entry is FAILED, not stuck in PENDING/SENT.
+    outbound = fed.list_tasks(direction="outbound")
+    assert len(outbound) == 1
+    assert outbound[0].status == FederatedTaskStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# 4. Peer rejects validation — REJECTED, peer stays ACTIVE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delegate_rejected_keeps_peer_active(
+    peer_b: _PeerServer,
+    caller_federation: A2AFederation,
+    caller_card: AgentCard,
+) -> None:
+    """Peer rejects body (4xx) → ledger REJECTED, peer remains ACTIVE."""
+    # Empty message triggers the 409 validation branch on the receiver.
+    with pytest.raises(A2ATaskRejectedError) as exc_info:
+        await caller_federation.delegate_task_http(
+            "peer-b",
+            "   ",  # whitespace-only message → server returns 409
+            sender_card=caller_card,
+            max_retries=3,
+            backoff_base=0.01,
+        )
+    assert exc_info.value.peer_name == "peer-b"
+    assert exc_info.value.status_code == 409
+
+    peer = caller_federation.get_peer("peer-b")
+    assert peer is not None
+    assert peer.state == PeerState.ACTIVE  # rejected ≠ unreachable
+
+    outbound = caller_federation.list_tasks(direction="outbound")
+    assert len(outbound) == 1
+    assert outbound[0].status == FederatedTaskStatus.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# 5. Invalid sender card — peer rejects with 400, no ledger entry on B
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_sender_card_rejected_at_boundary(
+    peer_b: _PeerServer,
+) -> None:
+    """Posting a malformed sender card returns 400; B's ledger stays empty."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{peer_b.endpoint}{A2A_TASKS_PATH}",
+            json={
+                "sender": {"description": "missing name"},  # name is required
+                "task": {"id": "t1", "message": "Hi"},
+            },
+        )
+    assert response.status_code == 400
+
+    fed_b: A2AFederation = peer_b.app.state.a2a_federation  # type: ignore[attr-defined]
+    assert fed_b.list_tasks() == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Concurrent delegations from one caller to one callee — ledger consistent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_delegations_consistent_ledger(
+    peer_b: _PeerServer,
+    caller_federation: A2AFederation,
+    caller_card: AgentCard,
+) -> None:
+    """Five parallel delegations all land; both ledgers see five tasks."""
+    n = 5
+
+    async def one_call(idx: int) -> str:
+        task = await caller_federation.delegate_task_http(
+            "peer-b",
+            f"concurrent-task-{idx}",
+            sender_card=caller_card,
+        )
+        return task.id
+
+    ids = await asyncio.gather(*(one_call(i) for i in range(n)))
+    assert len(set(ids)) == n  # all task ids unique
+
+    outbound = caller_federation.list_tasks(direction="outbound")
+    assert len(outbound) == n
+    assert all(t.status == FederatedTaskStatus.SENT for t in outbound)
+
+    fed_b: A2AFederation = peer_b.app.state.a2a_federation  # type: ignore[attr-defined]
+    inbound = fed_b.list_tasks(direction="inbound")
+    assert len(inbound) == n
+
+    peer = caller_federation.get_peer("peer-b")
+    assert peer is not None
+    assert peer.task_count == n
+    assert peer.state == PeerState.ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# 7. Reusable httpx client — no un-closed connection warnings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_external_httpx_client_reused_no_leak(
+    peer_b: _PeerServer,
+    caller_federation: A2AFederation,
+    caller_card: AgentCard,
+) -> None:
+    """Caller-supplied AsyncClient is reused across attempts and not closed."""
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for i in range(3):
+            task = await caller_federation.delegate_task_http(
+                "peer-b",
+                f"reuse-{i}",
+                sender_card=caller_card,
+                client=client,
+            )
+            assert task.status == FederatedTaskStatus.SENT
+        # The caller still owns the client at this point: subsequent
+        # call must succeed without ClientHasBeenClosed errors.
+        await client.get(f"{peer_b.endpoint}/a2a/agent-card")
+
+
+# ---------------------------------------------------------------------------
+# 8. Bidirectional delegation — A→B then B→A round-trips both ledgers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bidirectional_delegation_two_servers(
+    peer_a: _PeerServer,
+    peer_b: _PeerServer,
+    caller_card: AgentCard,
+) -> None:
+    """A delegates to B, then B delegates to A — both directions land."""
+    # Caller-side feds for each peer's outbound calls.
+    fed_a_out = A2AFederation(local_endpoint=peer_a.endpoint)
+    fed_a_out.register_peer("peer-b", peer_b.endpoint)
+
+    fed_b_out = A2AFederation(local_endpoint=peer_b.endpoint)
+    fed_b_out.register_peer("peer-a", peer_a.endpoint)
+
+    card_b = AgentCard(
+        name="peer-b",
+        description="Test B",
+        endpoint=peer_b.endpoint,
+        provider="bernstein-test",
+    )
+
+    # A → B
+    task_ab = await fed_a_out.delegate_task_http("peer-b", "do thing in B", sender_card=caller_card)
+    # B → A
+    task_ba = await fed_b_out.delegate_task_http("peer-a", "do thing in A", sender_card=card_b)
+
+    assert task_ab.status == FederatedTaskStatus.SENT
+    assert task_ba.status == FederatedTaskStatus.SENT
+
+    fed_a_in: A2AFederation = peer_a.app.state.a2a_federation  # type: ignore[attr-defined]
+    fed_b_in: A2AFederation = peer_b.app.state.a2a_federation  # type: ignore[attr-defined]
+    assert len(fed_a_in.list_tasks(direction="inbound")) == 1
+    assert len(fed_b_in.list_tasks(direction="inbound")) == 1
+
+
+# ---------------------------------------------------------------------------
+# 9. Inbound idempotency — duplicate POSTs from a retry don't double-book
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbound_idempotent_on_duplicate_remote_task_id(
+    peer_b: _PeerServer,
+) -> None:
+    """Bug fix: same ``(peer_name, remote_task_id)`` posted twice → one entry.
+
+    Models the retry case: the receiver accepted the first POST but the
+    202 reply got lost on the wire, so the caller retries; the receiver
+    must dedupe rather than insert a second inbound row.
+    """
+    payload = {
+        "sender": {
+            "name": "duplicate-peer",
+            "description": "Test caller",
+            "endpoint": "http://example.invalid",
+            "provider": "bernstein-test",
+            "capabilities": [],
+        },
+        "task": {"id": "remote-stable-1", "message": "hello", "role": "backend"},
+    }
+    async with httpx.AsyncClient() as client:
+        first = await client.post(f"{peer_b.endpoint}{A2A_TASKS_PATH}", json=payload)
+        second = await client.post(f"{peer_b.endpoint}{A2A_TASKS_PATH}", json=payload)
+    assert first.status_code == 202
+    assert second.status_code == 202
+    # Same local-id returned both times — proves the idempotent path.
+    assert first.json()["id"] == second.json()["id"]
+    fed_b: A2AFederation = peer_b.app.state.a2a_federation  # type: ignore[attr-defined]
+    inbound = fed_b.list_tasks(direction="inbound", peer_name="duplicate-peer")
+    assert len(inbound) == 1
+
+
+# ---------------------------------------------------------------------------
+# 10. Recovery — UNREACHABLE peer comes back, next delegate flips to ACTIVE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unreachable_peer_recovers_to_active_on_success(
+    peer_b: _PeerServer,
+    caller_federation: A2AFederation,
+    caller_card: AgentCard,
+) -> None:
+    """First delegation marks UNREACHABLE; a working call must reset to ACTIVE."""
+    # Manually flip the peer to UNREACHABLE without touching the endpoint.
+    peer = caller_federation.get_peer("peer-b")
+    assert peer is not None
+    peer.state = PeerState.UNREACHABLE
+
+    # Real peer B is reachable, so the next delegation succeeds and the
+    # ledger must transition the peer back to ACTIVE — proves the state
+    # machine isn't stuck in UNREACHABLE forever.
+    task = await caller_federation.delegate_task_http(
+        "peer-b",
+        "recovery",
+        sender_card=caller_card,
+    )
+    assert task.status == FederatedTaskStatus.SENT
+    assert peer.state == PeerState.ACTIVE


### PR DESCRIPTION
## What's wired

`A2AFederation.delegate_task_http(peer_name, message, role, *, sender_card, ...)` now performs a real `httpx.AsyncClient` POST to `{peer.endpoint}/a2a/v0/tasks` and updates the local ledger transactionally:

- success -> `mark_sent` + `peer.state=ACTIVE` + `last_seen` refreshed
- peer 4xx (non-408/425/429) -> task `REJECTED`, peer stays `ACTIVE` (raises `A2ATaskRejectedError`)
- retries exhausted on 5xx / connect errors -> task `FAILED`, peer `UNREACHABLE` (raises `A2ADelegationError`)

Retry policy: max 3 attempts (configurable), exponential backoff `0.25 * 2^(n-1)` seconds, default 10s connect / 30s read timeouts. Per-peer `asyncio.Lock` prevents concurrent delegations to the same peer from interleaving state writes.

New `POST /a2a/v0/tasks` route on the receiver:
- validates the sender `AgentCard` at the boundary (400 on malformed cards)
- validates task body (409 on missing `task.id` / empty `task.message`)
- auto-registers unknown inbound peers
- runs `accept_inbound_task`, returns 202 with the local federated-task id

`A2AFederation` is registered on the FastAPI app state alongside the existing `A2AHandler`. The synchronous `delegate_task()` is preserved for bookkeeping use cases so all 25 existing unit tests continue to pass unchanged.

## Bugs found (exposed by the real HTTP path)

1. **Non-idempotent inbound** — `accept_inbound_task` used to insert a second row when the same `(peer_name, remote_task_id)` arrived twice (the canonical retry case where the receiver accepted but the 202 reply got lost). Now returns the existing entry and refreshes the peer heartbeat.
2. **Stuck PENDING on cancellation** — an unexpected exception (e.g. `asyncio.CancelledError` during a retry sleep) used to leave the outbound ledger entry in `PENDING` forever. Added a `BaseException` safety net that flips status to `FAILED` before re-raising.
3. **Same-peer concurrency race** — multiple in-flight delegations to the same peer could interleave `UNREACHABLE`/`ACTIVE` writes; per-peer lock prevents this while keeping cross-peer delegations concurrent.

## Tests added

`tests/integration/test_a2a_federation_e2e.py` — 10 cases, two real uvicorn servers on random ports:
- happy-path roundtrip with both ledgers asserted
- retry on 5xx then succeeds (monkey-patched receiver, real HTTP)
- port-closed -> `A2ADelegationError` + peer `UNREACHABLE`
- peer 4xx rejection -> `REJECTED`, peer stays `ACTIVE`
- invalid sender Agent Card rejected at boundary (400, no inbound row)
- 5 concurrent delegations land, ledger consistent
- caller-supplied `AsyncClient` reused across calls, no leak
- bidirectional A<->B delegation with two real servers
- inbound idempotency on duplicate `(peer_name, remote_task_id)`
- `UNREACHABLE -> ACTIVE` recovery on next successful delegation

`.github/workflows/a2a-federation-e2e.yml` runs the suite on ubuntu-latest and macos-latest for any PR touching `a2a/`, `task_a2a`, `server_app.py`, the test, or the workflow itself, plus a 03:33 UTC nightly. Module-level `pytest.skipif` covers Windows (asyncio + uvicorn fixtures fragile under ProactorEventLoop).

## Test plan

- [x] `uv run pytest tests/unit/test_a2a*.py -x` -> 57 passed
- [x] `uv run pytest tests/integration/test_a2a_federation_e2e.py -x` -> 10 passed
- [x] `uv run ruff check ...` clean on changed files
- [x] `uv run ruff format ...` clean on changed files
- [x] `uv run lint-imports` -> 3 contracts kept, 0 broken
- [x] `actionlint .github/workflows/a2a-federation-e2e.yml` clean
- [ ] CI green (this PR triggers both `ci.yml` and the new `a2a-federation-e2e.yml`)

## Out of scope

Signed Agent Cards (#1095, JWS over JCS, RFC-8707) are intentionally **not** part of this work — separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)