### PR TITLE
feat(security): JWS+JCS Ed25519 signer for AgentIdentityCard (toward #1095)

### DIFF
--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -1,0 +1,249 @@
+"""Sign and verify ``AgentIdentityCard`` instances for A2A v1.0 federation.
+
+The current ``AgentIdentityCard.card_hash`` is a SHA-256 over the JSON body —
+useful as an internal HMAC anchor but not a *signature*. Third-party A2A
+verifiers won't accept a hash, so any Bernstein agent that wants to federate
+with another A2A-speaking system has to fall back to bespoke trust.
+
+This module wraps the existing card body in a detached **JSON Web Signature**
+(RFC 7515 compact form) over the JCS-canonicalized (RFC 8785) bytes, signed
+with **Ed25519** (RFC 8037 / EdDSA). The card body is left untouched, so the
+existing ``card_hash`` stays stable through the transition — verifiers that
+understand A2A v1.0 read the JWS, while internal code keeps using the body.
+
+Tracks `kcolbchain/switchboard#25`-style A2A spec work and bernstein
+`#1095`. Future work (deferred to a follow-up PR):
+
+- ``/.well-known/agent.json`` HTTP route.
+- JWKS endpoint at ``/.well-known/agent.json/keys``.
+- Adding A2A v1.0 fields (``protocol_version``, ``supported_interfaces``,
+  ``security_schemes``, ``signatures``) to ``AgentIdentityCard`` itself.
+- RFC 8707 Resource Indicators in ``auth_middleware``.
+
+The Ed25519 primitives reuse the same ``cryptography`` package already used
+by ``sigstore_attestation`` and the HIPAA AES-GCM helpers.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from .agent_identity import AgentIdentityCard
+
+__all__ = [
+    "AgentCardSignature",
+    "canonicalize_jcs",
+    "generate_ed25519_keypair",
+    "sign_agent_card",
+    "verify_agent_card",
+]
+
+
+# ---------------------------------------------------------------------------
+# JCS (RFC 8785) canonicalization
+# ---------------------------------------------------------------------------
+
+
+def canonicalize_jcs(value: Any) -> bytes:
+    """Return the RFC 8785 canonical JSON encoding of ``value`` as UTF-8 bytes.
+
+    Implements the spec's deterministic encoding rules sufficient for the
+    AgentIdentityCard surface (strings, ints, floats from ``time.time()``,
+    booleans, lists, and dicts):
+
+    - Object keys sorted lexicographically by code-point.
+    - No insignificant whitespace; ``,`` and ``:`` separators only.
+    - Strings emitted with UTF-8, escaping ``"``, ``\\``, and control chars.
+    - Numbers via Python's ``json.dumps`` (which matches IEEE 754 double
+      shortest round-trip for the typed values we use).
+
+    Note:
+        For card bodies that include arbitrary numeric edge cases (NaN,
+        ±Infinity, integers past 2**53), upgrade the number serializer
+        per RFC 8785 §3.2.2.3 before adopting this for those payloads.
+        The cards we sign do not produce those values today.
+    """
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _b64url(data: bytes) -> str:
+    """Base64-url-encode without padding (RFC 7515 §2)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Base64-url-decode, restoring padding."""
+    pad = -len(data) % 4
+    return base64.urlsafe_b64decode(data + ("=" * pad))
+
+
+# ---------------------------------------------------------------------------
+# Ed25519 keypair management
+# ---------------------------------------------------------------------------
+
+
+def generate_ed25519_keypair() -> tuple[bytes, bytes]:
+    """Generate a fresh Ed25519 keypair.
+
+    Returns:
+        ``(private_key_pkcs8_pem, public_key_spki_pem)``
+
+    The PEM-encoded private key is in PKCS#8 (the format read by
+    :class:`cryptography.hazmat.primitives.serialization.load_pem_private_key`)
+    and the public key is in SubjectPublicKeyInfo. Both formats round-trip
+    cleanly through ``cryptography`` and through standard JOSE libraries.
+    """
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+
+    private_key = Ed25519PrivateKey.generate()
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    public_pem = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return private_pem, public_pem
+
+
+# ---------------------------------------------------------------------------
+# JWS detached signature
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AgentCardSignature:
+    """A JWS-detached signature over a card's JCS canonicalization.
+
+    The card body is NOT inlined in the signature object — third-party
+    verifiers receive the canonical card body alongside the JWS and recompute
+    the same signing input. This matches RFC 7515 §A.5 (detached content)
+    and avoids drift between the body the system trusts internally and the
+    bytes the JWS attests to.
+    """
+
+    #: Compact-JWS string ``base64url(header).base64url(payload).base64url(sig)``
+    #: where ``payload`` is empty (detached) per RFC 7515 §A.5. Verifiers
+    #: must reconstruct the canonical card bytes from the body they see.
+    detached_jws: str
+
+    #: Key identifier — opaque to the protocol; a stable identifier such as
+    #: ``"agent-{agent_id}"`` or a thumbprint hex.
+    kid: str
+
+    #: Algorithm name from RFC 7518 §3.1; always ``"EdDSA"`` here.
+    alg: str = "EdDSA"
+
+
+def sign_agent_card(
+    card: AgentIdentityCard,
+    private_key_pem: bytes,
+    *,
+    kid: str | None = None,
+) -> AgentCardSignature:
+    """Sign a card body with the given Ed25519 PKCS#8 PEM private key.
+
+    Args:
+        card: The card to sign. Untouched by this call — the JCS bytes are
+            computed from a temporary dict so the caller's instance keeps
+            its existing ``card_hash`` semantics.
+        private_key_pem: PEM-encoded PKCS#8 Ed25519 private key, as produced
+            by :func:`generate_ed25519_keypair`.
+        kid: Optional key identifier. Defaults to ``"agent-{agent_id}"``.
+
+    Returns:
+        An :class:`AgentCardSignature` whose ``detached_jws`` carries an
+        empty payload segment (RFC 7515 §A.5).
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+
+    # Build the JWS protected header (RFC 7515 §4) then base64url it.
+    header = {"alg": "EdDSA", "typ": "agent-card+jws", "kid": kid or f"agent-{card.agent_id}"}
+    header_b64 = _b64url(canonicalize_jcs(header))
+
+    # JCS-canonicalize the card body. We do NOT include the body in the JWS
+    # payload segment (detached signature) but we do sign over its bytes.
+    body_b64 = _b64url(canonicalize_jcs(_card_to_dict(card)))
+
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    signature = private_key.sign(signing_input)
+    sig_b64 = _b64url(signature)
+
+    # RFC 7515 §A.5: detached content omits the payload — represented as the
+    # empty string between the header and signature dots.
+    detached = f"{header_b64}..{sig_b64}"
+    return AgentCardSignature(detached_jws=detached, kid=header["kid"])
+
+
+def verify_agent_card(
+    card: AgentIdentityCard,
+    signature: AgentCardSignature,
+    public_key_pem: bytes,
+) -> bool:
+    """Verify a detached JWS over a card body. Returns True iff valid."""
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import serialization
+
+    try:
+        header_b64, payload_b64, sig_b64 = signature.detached_jws.split(".")
+    except ValueError:
+        return False
+
+    if payload_b64:
+        # Not a detached signature — refuse rather than silently accept.
+        return False
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+    except (ValueError, json.JSONDecodeError):
+        return False
+
+    if header.get("alg") != "EdDSA":
+        return False
+
+    public_key = serialization.load_pem_public_key(public_key_pem)
+
+    body_b64 = _b64url(canonicalize_jcs(_card_to_dict(card)))
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    try:
+        sig = _b64url_decode(sig_b64)
+    except ValueError:
+        return False
+
+    try:
+        public_key.verify(sig, signing_input)
+    except InvalidSignature:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _card_to_dict(card: AgentIdentityCard) -> dict[str, Any]:
+    """Return the card body as a plain dict suitable for JCS canonicalization.
+
+    Mirrors ``AgentIdentityCard.to_json``'s ``asdict`` result so signing input
+    and the body shipped to verifiers agree byte-for-byte after canonicalization.
+    """
+    from dataclasses import asdict
+
+    return asdict(card)

--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -29,9 +29,10 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from .agent_identity import AgentIdentityCard
+if TYPE_CHECKING:
+    from .agent_identity import AgentIdentityCard
 
 __all__ = [
     "AgentCardSignature",

--- a/tests/unit/test_agent_card_signer.py
+++ b/tests/unit/test_agent_card_signer.py
@@ -1,0 +1,179 @@
+"""Tests for ``agent_card_signer`` — JWS over JCS, EdDSA."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from bernstein.core.security.agent_card_signer import (
+    AgentCardSignature,
+    canonicalize_jcs,
+    generate_ed25519_keypair,
+    sign_agent_card,
+    verify_agent_card,
+)
+from bernstein.core.security.agent_identity import (
+    AgentIdentityCard,
+    issue_identity_card,
+)
+
+
+# ---------------------------------------------------------------------------
+# JCS canonicalization
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalizeJCS:
+    def test_object_key_order_is_lexicographic(self) -> None:
+        a = canonicalize_jcs({"b": 1, "a": 2, "c": 3})
+        b = canonicalize_jcs({"a": 2, "c": 3, "b": 1})
+        assert a == b == b'{"a":2,"b":1,"c":3}'
+
+    def test_no_whitespace_separators(self) -> None:
+        out = canonicalize_jcs({"a": 1, "b": [1, 2, 3]})
+        assert b": " not in out
+        assert b", " not in out
+
+    def test_nested_objects_are_canonicalized(self) -> None:
+        a = canonicalize_jcs({"outer": {"z": 1, "a": 2}})
+        b = canonicalize_jcs({"outer": {"a": 2, "z": 1}})
+        assert a == b
+
+    def test_unicode_emitted_as_utf8(self) -> None:
+        # ensure_ascii=False so we sign actual UTF-8 bytes, matching RFC 8785.
+        out = canonicalize_jcs({"k": "værsågod"})
+        assert "værsågod".encode("utf-8") in out
+
+    def test_nan_and_infinity_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            canonicalize_jcs({"x": float("nan")})
+
+
+# ---------------------------------------------------------------------------
+# Keypair generation
+# ---------------------------------------------------------------------------
+
+
+class TestKeypair:
+    def test_generates_pem_pair(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        assert priv.startswith(b"-----BEGIN PRIVATE KEY-----")
+        assert pub.startswith(b"-----BEGIN PUBLIC KEY-----")
+
+    def test_keys_are_independent(self) -> None:
+        a_priv, a_pub = generate_ed25519_keypair()
+        b_priv, b_pub = generate_ed25519_keypair()
+        assert a_priv != b_priv
+        assert a_pub != b_pub
+
+
+# ---------------------------------------------------------------------------
+# Sign / verify round-trip
+# ---------------------------------------------------------------------------
+
+
+def _sample_card() -> AgentIdentityCard:
+    return issue_identity_card(
+        agent_id="claude-security-test123",
+        role="security",
+        adapter="claude-cli",
+        model="claude-opus-4-7",
+        scope=["src/", "tests/"],
+        max_budget_usd=5.0,
+        ttl_seconds=3600,
+    )
+
+
+class TestSignVerify:
+    def test_round_trip_succeeds(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        card = _sample_card()
+
+        sig = sign_agent_card(card, priv)
+        assert verify_agent_card(card, sig, pub) is True
+
+    def test_signature_is_detached(self) -> None:
+        priv, _ = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+
+        # RFC 7515 §A.5: detached → empty middle segment.
+        parts = sig.detached_jws.split(".")
+        assert len(parts) == 3
+        assert parts[1] == ""
+
+    def test_kid_default_includes_agent_id(self) -> None:
+        priv, _ = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+        assert sig.kid == "agent-claude-security-test123"
+
+    def test_kid_override(self) -> None:
+        priv, _ = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv, kid="bernstein-prod-2026-01")
+        assert sig.kid == "bernstein-prod-2026-01"
+
+    def test_alg_is_eddsa(self) -> None:
+        sig = AgentCardSignature(detached_jws="x..y", kid="k")
+        assert sig.alg == "EdDSA"
+
+    def test_tampered_card_fails_verification(self) -> None:
+        priv, pub = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+
+        tampered = _sample_card()
+        tampered.max_budget_usd = 9999.0  # privilege escalation attempt
+        assert verify_agent_card(tampered, sig, pub) is False
+
+    def test_wrong_public_key_fails_verification(self) -> None:
+        priv, _ = generate_ed25519_keypair()
+        _, other_pub = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+        assert verify_agent_card(card, sig, other_pub) is False
+
+    def test_malformed_jws_returns_false(self) -> None:
+        _, pub = generate_ed25519_keypair()
+        card = _sample_card()
+        # Only two segments instead of three.
+        bad = AgentCardSignature(detached_jws="abc.def", kid="k")
+        assert verify_agent_card(card, bad, pub) is False
+
+    def test_non_detached_payload_rejected(self) -> None:
+        """Refuse signatures whose payload segment isn't empty.
+
+        A non-detached JWS would let an attacker substitute a payload that
+        differs from the card body the verifier sees. We explicitly require
+        the empty middle segment.
+        """
+        priv, pub = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+        header_b64, _empty, sig_b64 = sig.detached_jws.split(".")
+        # Inject a payload claim where there should be none.
+        forged = AgentCardSignature(
+            detached_jws=f"{header_b64}.eyJmb28iOiJiYXIifQ.{sig_b64}",
+            kid=sig.kid,
+        )
+        assert verify_agent_card(card, forged, pub) is False
+
+    def test_bad_alg_in_header_rejected(self) -> None:
+        """A 'none' alg attack must fail even if the rest of the JWS looks ok."""
+        priv, pub = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+        header_b64, _empty, sig_b64 = sig.detached_jws.split(".")
+
+        from base64 import urlsafe_b64encode
+
+        bad_header = urlsafe_b64encode(
+            json.dumps({"alg": "none", "typ": "agent-card+jws"}).encode()
+        ).rstrip(b"=").decode("ascii")
+        forged = AgentCardSignature(
+            detached_jws=f"{bad_header}..{sig_b64}",
+            kid=sig.kid,
+        )
+        assert verify_agent_card(card, forged, pub) is False

--- a/tests/unit/test_agent_card_signer.py
+++ b/tests/unit/test_agent_card_signer.py
@@ -18,7 +18,6 @@ from bernstein.core.security.agent_identity import (
     issue_identity_card,
 )
 
-
 # ---------------------------------------------------------------------------
 # JCS canonicalization
 # ---------------------------------------------------------------------------
@@ -43,7 +42,7 @@ class TestCanonicalizeJCS:
     def test_unicode_emitted_as_utf8(self) -> None:
         # ensure_ascii=False so we sign actual UTF-8 bytes, matching RFC 8785.
         out = canonicalize_jcs({"k": "værsågod"})
-        assert "værsågod".encode("utf-8") in out
+        assert "værsågod".encode() in out
 
     def test_nan_and_infinity_rejected(self) -> None:
         with pytest.raises(ValueError):
@@ -165,7 +164,7 @@ class TestSignVerify:
         priv, pub = generate_ed25519_keypair()
         card = _sample_card()
         sig = sign_agent_card(card, priv)
-        header_b64, _empty, sig_b64 = sig.detached_jws.split(".")
+        _header_b64, _empty, sig_b64 = sig.detached_jws.split(".")
 
         from base64 import urlsafe_b64encode
 


### PR DESCRIPTION
## Summary

First focused step toward A2A v1.0 federation per #1095. This PR adds the signing primitives without changing existing behavior — `AgentIdentityCard.card_hash` and the body shape stay byte-stable so internal HMAC consumers and external A2A v1.0 verifiers can coexist during the transition.

## What this PR adds

### `src/bernstein/core/security/agent_card_signer.py`

| Function | Purpose |
|---|---|
| `canonicalize_jcs(value)` | RFC 8785 JSON Canonicalization. Rejects NaN/Infinity per spec. Sufficient for the typed shape `AgentIdentityCard` produces today (strings, ints, floats from `time.time()`, bools, lists, dicts) — explicit note in the docstring about extending the number serializer for arbitrary numeric edge cases. |
| `generate_ed25519_keypair()` | Returns `(private_pkcs8_pem, public_spki_pem)`. Reuses the `cryptography` package already a dep via `sigstore_attestation.py`. |
| `sign_agent_card(card, private_key_pem, *, kid=None)` | Produces an `AgentCardSignature` whose `detached_jws` is RFC 7515 compact form with the **payload segment empty** (RFC 7515 §A.5 detached content). Default `kid` = `agent-{agent_id}`. |
| `verify_agent_card(card, signature, public_key_pem)` | Verifies. Refuses non-detached payloads and any non-EdDSA algorithm — defeats the standard `alg`-substitution attack class. |

### `tests/unit/test_agent_card_signer.py`

14 tests grouped into three classes:

- **`TestCanonicalizeJCS`** — key order, no whitespace, nested objects, UTF-8 encoding, NaN/Infinity rejection.
- **`TestKeypair`** — PEM shape, independence between calls.
- **`TestSignVerify`** — round-trip, detached payload structure, default + explicit `kid`, `EdDSA` alg constant, tampered-card rejection, wrong-public-key rejection, malformed JWS rejection, **non-detached-payload rejection** (substitution attack), **`alg=none` downgrade rejection**.

The last two are the security ones — both are common JWS attack classes that off-the-shelf JOSE libraries have historically gotten wrong.

## Design choices worth flagging

- **Detached signature, not embedded.** The card body is shipped alongside the JWS rather than inside it (RFC 7515 §A.5). This keeps the existing internal `card_hash` semantics untouched and avoids drift between the body the system trusts internally and the bytes the JWS attests to. Verifiers reconstruct the canonical bytes from the body they see.
- **Card body left untouched.** No new fields on `AgentIdentityCard` in this PR. Adding `protocol_version`, `supported_interfaces`, `security_schemes`, `signatures` is a separate PR that I can sequence next if you want — splitting it lets reviewers evaluate the crypto in isolation from the schema migration.
- **Reuse existing crypto dep.** `cryptography>=45.0.0` is already in `pyproject.toml` (used by `sigstore_attestation.py` and the HIPAA AES-GCM helpers). No new dependencies.

## What this PR does NOT cover (deferred)

Flagged in the module docstring and the issue checklist:

- `/.well-known/agent.json` HTTP route
- JWKS endpoint at `/.well-known/agent.json/keys`
- Adding A2A v1.0 fields to `AgentIdentityCard` itself
- RFC 8707 Resource Indicators in `auth_middleware`
- Key rotation hookup via `key_rotation.py`

Each is a clear separate PR. Happy to sequence them in this order if you'd like, or pick the one you'd want next.

## Tests

Ran locally on the standalone module + crypto smoke-tested the round-trip / tamper-rejection / non-detached-rejection / 'none'-alg-rejection paths. The full test suite needs Python 3.12 (the project's `requires-python`); my dev box is on 3.9 so `pytest` over the whole repo isn't a clean signal here — flagging that explicitly so you can run CI against the branch.

Tracks #1095.