### PR TITLE
fix(agents-md): include _REDIRECT_MAP back-compat note in architecture section

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -11,3 +11,5 @@ Top-level entry points exposed by the package:
 |--------------------|---------|
 | `bernstein`        | bernstein.cli.main:cli |
 | `bernstein-worker` | bernstein.core.worker:main |
+
+**Back-compat aliases.** Legacy import paths (e.g. `bernstein.core.orchestrator`) are served by a `sys.meta_path` finder, not by physical shim files. The mechanism lives in `src/bernstein/core/__init__.py` as `_CoreRedirectFinder` driven by the `_REDIRECT_MAP` dict — add new aliases there rather than creating shim modules at the old path.

--- a/.goosehints
+++ b/.goosehints
@@ -343,6 +343,8 @@ Top-level entry points exposed by the package:
 | `bernstein`        | bernstein.cli.main:cli |
 | `bernstein-worker` | bernstein.core.worker:main |
 
+**Back-compat aliases.** Legacy import paths (e.g. `bernstein.core.orchestrator`) are served by a `sys.meta_path` finder, not by physical shim files. The mechanism lives in `src/bernstein/core/__init__.py` as `_CoreRedirectFinder` driven by the `_REDIRECT_MAP` dict — add new aliases there rather than creating shim modules at the old path.
+
 ## Git workflow
 
 Default branch: `main`.

--- a/.release-notes-v1.10.4.draft.md
+++ b/.release-notes-v1.10.4.draft.md
@@ -1,0 +1,82 @@
+## v1.10.4 — closing the dogfood + integration-test gaps
+
+This release does the boring-but-load-bearing work the v1.10.x cycle had been deferring: dogfood the AGENTS.md generator on Bernstein itself, run real cosign / GPG / `unshare -n` against the air-gap path, exercise A2A federation across two processes, hit five adapters end-to-end with a fake-CLI harness, and assert capability-matrix refusal lands as a real audit event. Every gap surfaced production bugs in the underlying code; every bug got a regression test before it got a fix.
+
+### AGENTS.md generator now dogfooded
+
+Bernstein's own `AGENTS.md`, `CLAUDE.md`, `CONVENTIONS.md` + `.aider.conf.yml`, `.goosehints`, and seven `.cursor/rules/*.mdc` files are now produced by `bernstein agents-md sync`. CI runs `bernstein agents-md verify --workdir .` on every PR and fails on drift. Five real bugs surfaced and got closed:
+
+- Cursor `.mdc` outputs were missing the `<!-- AUTO-GENERATED -->` marker, so silent hand-edits would survive the next sync.
+- `agents-md sync --dry-run` reported "0 files synced" because the dry-run write path returns 0 and the print summed those zeros.
+- `_collect_subpackage_rows` appended every sub-package's full `*.py` listing as parenthetical noise, producing 50-name description cells.
+- The repo-name fallback was the workdir basename, breaking H1s when running from agent worktrees like `agent-a2a1a37879151af4e/`. Now reads `pyproject.toml` `[project] name` first, then `package.json` `"name"`.
+- `verify` re-rendered every target just to count files. Tracked count inline.
+
+The architecture section now also detects `_REDIRECT_MAP` + `_CoreRedirectFinder` in `core/__init__.py` and emits a "Back-compat aliases" paragraph so the audit-012 invariant survives auto-generation.
+
+### Air-gap distribution: real cosign, real GPG, real network namespace
+
+`scripts/build_airgap_wheelhouse.py` plus `bernstein verify <wheelhouse>` were already shipping, but the cosign and GPG subprocess calls were monkeypatched in CI. v1.10.4 adds 37 integration tests on `test_airgap_offline_e2e.py` that exercise:
+
+- Real `cosign generate-key-pair` + `sign-blob` + `verify-blob` round-trip on a fixture 5-wheel synthetic wheelhouse, plus byte-tamper and manifest-sha-tamper detection.
+- Real `gpg --detach-sign` + `gpg --verify` round-trip with the same tamper-detection assertions.
+- Linux `unshare -n` namespace isolation for the verify path (probed at runtime; falls back when CAP_SYS_ADMIN is absent on shared CI runners).
+- Per-battery breaks of `bernstein doctor airgap` — each of the four checks (zero-egress run, MCP catalog all-off, memo store local-only, audit HMAC valid) is broken in isolation and the doctor proves it catches its target failure.
+
+Three more bugs closed in the process:
+
+- **Cosign called Rekor on every "offline" verify.** `CosignVerifier` did not pass `--insecure-ignore-tlog`, so the signature path quietly tried to dial `rekor.sigstore.dev`. Added the flag in both the verifier and the matching `--tlog-upload=false` in the signing helper.
+- **UTF-8 BOM regression in `_load_manifest`.** A wheelhouse manifest written on Windows would fail verify because of the BOM byte. Now read with `utf-8-sig`.
+- **`bernstein.core.security.socket_guard`** — new module that patches `socket.socket.connect` under `--profile airgap` so undeclared egress raises `NetworkPolicyDenied` even from third-party libraries that bypass the per-adapter declared-endpoints layer. Surfaced as a new "runtime socket guard active" check in the doctor battery.
+
+### A2A federation: real HTTP delegation across two processes
+
+`A2AFederation.delegate_task_http` now POSTs to `{peer.endpoint}/a2a/v0/tasks` via `httpx.AsyncClient`, retries on 5xx and connection errors with exponential backoff, transactionally updates the local ledger on success / rejection / failure, and toggles peer state ACTIVE / UNREACHABLE accordingly. Inbound POST `/a2a/v0/tasks` validates sender card at the boundary (400 / 409). The sync `delegate_task` is preserved as the bookkeeping primitive so the existing 25 federation unit tests pass unchanged.
+
+10 integration tests in `test_a2a_federation_e2e.py` spin up two real uvicorn servers on random ports and exercise the full cross-process delegation path. Three production bugs surfaced:
+
+- `accept_inbound_task` was non-idempotent. A duplicate `(peer_name, remote_task_id)` POST (the canonical retry case) inserted a second inbound row. Now returns the existing entry.
+- Outbound ledger entries got stuck in PENDING when an unexpected `BaseException` (e.g. `asyncio.CancelledError` during a retry sleep) escaped the inner `try`. Added a safety net that flips status to FAILED.
+- Concurrent same-peer delegations interleaved their state writes. Added a per-peer `asyncio.Lock`.
+
+Signed Agent Cards (issue #1095, JWS over JCS, RFC-8707) remain a separate scope. This release ships the wire transport without the signature.
+
+### Adapter end-to-end coverage with a fake-CLI harness
+
+42 adapters share a consistent `CLIAdapter` contract test, but until this release every per-adapter test mocked `subprocess.Popen` and asserted on argv only. v1.10.4 ships a stdlib-only fake-CLI harness at `tests/integration/fake_cli/`:
+
+- A profile-shaped script that, when invoked as `<cli-name> [args]`, reads its argv, validates the request shape, and emits NDJSON stream-json (Claude), JSON-lines (Codex), single-JSON (Gemini), or free-form (Aider / Ollama) output.
+- Five behaviour modes: `success`, `error`, `stream_then_die`, `hang`, `no_output`.
+- A pytest fixture that writes per-CLI POSIX-shell wrappers into a tempdir, prepends them to `PATH`, and exposes a handle for in-test control of the fake's behaviour.
+
+25 integration tests exercise the full Popen → bernstein-worker → fake-CLI → log-capture → exit-code path for the top five adapters. Two real adapter bugs surfaced:
+
+- `AiderAdapter` and `OllamaAdapter` dropped the live `Popen` handle when building `SpawnResult`; only Codex / Gemini / Claude threaded `proc=proc` through. Without it, callers cannot distinguish a live agent from an unreaped zombie via `Popen.poll()`.
+- `CLIAdapter._read_last_lines` only consulted `log_path`, but the Claude adapter pipes upstream stdout through a stream-json wrapper that drops non-JSON. Rate-limit banners arriving on stderr (or as non-JSON stdout) never reached `_is_rate_limit_error`, so `_probe_fast_exit` raised generic `SpawnError` instead of `RateLimitError` and the orchestrator's cooldown never engaged.
+
+Both fixes carry regression tests in `TestAdapterBugRegressions`.
+
+### Lethal-trifecta refusal now emits an audit event
+
+The capability-matrix refusal path had 29 adversarial unit tests covering nine bypass vectors, but no integration test exercising end-to-end agent-spawn refusal. v1.10.4 adds 17 integration cases in `test_capability_matrix_spawn_refusal.py` that drive real `AgentSpawner.spawn_for_tasks` against catalog configurations whose tool chain unions `PRIVATE_DATA + UNTRUSTED_INPUT + EXTERNAL_COMM`. Cases include declared trifecta refusal, registered-alias refusal, runtime catalog hot-swap, mutation immutability, and `BERNSTEIN_BYPASS_PERMISSIONS=1` override attempts (still refused; `bypass_immune` overrides `bypass_enabled`).
+
+Two bugs closed:
+
+- **Refusal did not emit an audit event into the HMAC-chained log.** Only `logger.error` and a JSON manifest were written. Auditors could not verify "no trifecta-prone agent ever spawned without a matching deny event" without parsing log lines. `_emit_capability_matrix_refusal_audit_event()` now appends a `capability_matrix_refusal` event to `<workdir>/.sdd/audit/`. Audit failures never mask the deny path.
+- The aliasing-defence semantics were under-documented; spelled out in the docstring.
+
+### Quality-of-life
+
+- `auto-release.yml` binds the release job to a `pypi` environment so successful publishes show up green in the repo sidebar Deployments view. The stale failure record from 2026-04-26 (a `Generate App token` 404 from before the App-token step was removed) was deleted via API and the new binding prevents the same kind of stale-record-blocking-the-view from recurring.
+- `_git_default_branch` in `agents_md_generator` now resolves the same way across developer checkouts, shallow `actions/checkout` runs, worktrees, and detached-HEAD environments. The Repo hygiene CI job uses `fetch-depth: 0` plus `git remote set-head origin -a` to give CI the same git topology a developer machine has.
+- `audit._enforce_key_permissions` skips the POSIX bitmask check on Windows. NTFS does not implement POSIX mode bits and `Path.stat().st_mode` returns 0o666 for any user-owned file regardless of the actual ACL. Flagging that as insecure was a false positive on every Windows runner.
+
+### Install
+
+```bash
+pipx install --upgrade bernstein
+```
+
+Container: `ghcr.io/sipyourdrink-ltd/bernstein:1.10.4`.
+
+**Full changelog:** https://github.com/sipyourdrink-ltd/bernstein/compare/v1.10.3...v1.10.4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,6 +343,8 @@ Top-level entry points exposed by the package:
 | `bernstein`        | bernstein.cli.main:cli |
 | `bernstein-worker` | bernstein.core.worker:main |
 
+**Back-compat aliases.** Legacy import paths (e.g. `bernstein.core.orchestrator`) are served by a `sys.meta_path` finder, not by physical shim files. The mechanism lives in `src/bernstein/core/__init__.py` as `_CoreRedirectFinder` driven by the `_REDIRECT_MAP` dict — add new aliases there rather than creating shim modules at the old path.
+
 ## Git workflow
 
 Default branch: `main`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,8 @@ Top-level entry points exposed by the package:
 | `bernstein`        | bernstein.cli.main:cli |
 | `bernstein-worker` | bernstein.core.worker:main |
 
+**Back-compat aliases.** Legacy import paths (e.g. `bernstein.core.orchestrator`) are served by a `sys.meta_path` finder, not by physical shim files. The mechanism lives in `src/bernstein/core/__init__.py` as `_CoreRedirectFinder` driven by the `_REDIRECT_MAP` dict — add new aliases there rather than creating shim modules at the old path.
+
 ## Git workflow
 
 Default branch: `main`.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -343,6 +343,8 @@ Top-level entry points exposed by the package:
 | `bernstein`        | bernstein.cli.main:cli |
 | `bernstein-worker` | bernstein.core.worker:main |
 
+**Back-compat aliases.** Legacy import paths (e.g. `bernstein.core.orchestrator`) are served by a `sys.meta_path` finder, not by physical shim files. The mechanism lives in `src/bernstein/core/__init__.py` as `_CoreRedirectFinder` driven by the `_REDIRECT_MAP` dict — add new aliases there rather than creating shim modules at the old path.
+
 ## Git workflow
 
 Default branch: `main`.

--- a/src/bernstein/core/knowledge/agents_md_generator.py
+++ b/src/bernstein/core/knowledge/agents_md_generator.py
@@ -451,11 +451,18 @@ def _build_setup(repo_path: Path) -> AgentsMdSection | None:
 
 
 def _build_architecture(repo_path: Path) -> AgentsMdSection | None:
-    """Surface entry points from ``[project.scripts]`` in pyproject.toml.
+    """Surface entry points from ``[project.scripts]`` plus any back-compat
+    redirect map declared in ``src/<pkg>/core/__init__.py``.
 
     Skipped silently when no entry points are declared. We deliberately
     don't pull every callable out of ast_symbol_graph — for AGENTS.md the
     operator wants ~5 starting points, not the full call graph.
+
+    The redirect-map detection covers a load-bearing audit invariant
+    (audit-012): when a project ships a ``sys.meta_path`` finder for
+    legacy import paths, the AGENTS.md surface must point readers at
+    the real mechanism so the documentation never drifts back to
+    "shim file lives at <name>.py" claims that aren't true.
     """
     pyproj = repo_path / "pyproject.toml"
     if not pyproj.is_file():
@@ -464,7 +471,14 @@ def _build_architecture(repo_path: Path) -> AgentsMdSection | None:
     if not scripts:
         return None
     rows = [(f"`{name}`", target) for name, target in scripts.items()]
-    body = "Top-level entry points exposed by the package:\n\n" + _render_two_column_table(rows, "Command")
+    body = "Top-level entry points exposed by the package:\n\n" + _render_two_column_table(
+        rows, "Command"
+    )
+
+    redirect_note = _detect_back_compat_redirect_map(repo_path)
+    if redirect_note:
+        body = body + "\n\n" + redirect_note
+
     return AgentsMdSection(
         key="architecture",
         title="Architecture (entry points)",
@@ -472,6 +486,43 @@ def _build_architecture(repo_path: Path) -> AgentsMdSection | None:
         kind="architecture",
         always_apply=True,
     )
+
+
+def _detect_back_compat_redirect_map(repo_path: Path) -> str | None:
+    """Return a markdown note when ``core/__init__.py`` declares a back-
+    compat redirect map.
+
+    Looks for the canonical pair ``_REDIRECT_MAP`` + ``_CoreRedirectFinder``
+    inside any ``src/*/core/__init__.py`` file. Both names must be present
+    for the section to fire — finding only one is ambiguous (could be
+    a renamed-but-not-replaced alias) and we'd rather emit nothing than
+    misdescribe.
+    """
+    src_dir = repo_path / "src"
+    if not src_dir.is_dir():
+        return None
+    for pkg_dir in sorted(src_dir.iterdir()):
+        if not pkg_dir.is_dir():
+            continue
+        init_path = pkg_dir / "core" / "__init__.py"
+        if not init_path.is_file():
+            continue
+        try:
+            text = init_path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if "_REDIRECT_MAP" not in text or "_CoreRedirectFinder" not in text:
+            continue
+        rel = init_path.relative_to(repo_path).as_posix()
+        return (
+            "**Back-compat aliases.** Legacy import paths (e.g. "
+            f"`{pkg_dir.name}.core.orchestrator`) are served by a "
+            "`sys.meta_path` finder, not by physical shim files. The mechanism "
+            f"lives in `{rel}` as `_CoreRedirectFinder` driven by the "
+            "`_REDIRECT_MAP` dict — add new aliases there rather than creating "
+            "shim modules at the old path."
+        )
+    return None
 
 
 def _build_conventions(repo_path: Path, opts: GenerateOptions) -> AgentsMdSection | None:

--- a/src/bernstein/core/knowledge/agents_md_generator.py
+++ b/src/bernstein/core/knowledge/agents_md_generator.py
@@ -471,9 +471,7 @@ def _build_architecture(repo_path: Path) -> AgentsMdSection | None:
     if not scripts:
         return None
     rows = [(f"`{name}`", target) for name, target in scripts.items()]
-    body = "Top-level entry points exposed by the package:\n\n" + _render_two_column_table(
-        rows, "Command"
-    )
+    body = "Top-level entry points exposed by the package:\n\n" + _render_two_column_table(rows, "Command")
 
     redirect_note = _detect_back_compat_redirect_map(repo_path)
     if redirect_note:


### PR DESCRIPTION
PR #1101 dogfood replaced hand-written CLAUDE.md, dropping refs to `_CoreRedirectFinder`/`_REDIRECT_MAP` and breaking the audit-012 guard test on macos 3.13 + ubuntu 3.12/3.13. Generator now scans `core/__init__.py` for both symbols and emits a 'Back-compat aliases' paragraph when found. All 5 renderers updated.

Locally: `pytest tests/unit/test_agents_md_*.py tests/integration/test_agents_md_dogfood.py tests/unit/test_claude_md_shim_doc.py` → green (84 + 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)