### PR TITLE
ci(release-drafter): skip update_release_draft on fork PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,15 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Skip on PRs from forks: ``pull_request`` events from external
+    # repositories receive a read-only ``GITHUB_TOKEN`` regardless of
+    # the workflow-level ``permissions:`` block, so the action fails
+    # with "Resource not accessible by integration" when it tries to
+    # create or update the draft release. The draft will refresh on
+    # the next push to main after the fork PR merges.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7
         with:


### PR DESCRIPTION
## Why

PR #1106 (from `kite-builds/bernstein`, an external contributor picking up #1095) failed the `update_release_draft` check with `Resource not accessible by integration`.

Cause: `pull_request` events from forked repositories receive a read-only `GITHUB_TOKEN` regardless of workflow-level `permissions:` block. The action tries to create/update the draft release via Releases API and gets 403.

## What

Guard the job with `if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository`. Skips on fork PRs (no harm — the draft refreshes on the next `push` trigger to main after merge). Same-repo branch PRs and main pushes unaffected.

## Side effect

PR #1106's failed check turns into a skipped check, unblocking review/merge for that PR (subject to the maintainer's actual review of the JWS signer code itself — this PR doesn't approve #1106's content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)