### PR TITLE
feat(orchestration): explicit human-approval gates

### DIFF
--- a/src/bernstein/cli/commands/approve_cmd.py
+++ b/src/bernstein/cli/commands/approve_cmd.py
@@ -119,9 +119,7 @@ def approve(task_id: str, workdir: str, prompt: bool) -> None:
         return
 
     if decision_file.exists():
-        console.print(
-            f"[dim]Already approved:[/dim] task [bold]{task_id}[/bold] (no-op)"
-        )
+        console.print(f"[dim]Already approved:[/dim] task [bold]{task_id}[/bold] (no-op)")
         return
 
     if prompt and not _foreground_confirm(f"Approve task {task_id}?"):
@@ -130,9 +128,7 @@ def approve(task_id: str, workdir: str, prompt: bool) -> None:
 
     created = _atomic_write_text(decision_file, "approved")
     if created:
-        console.print(
-            f"[green]Approved:[/green] task [bold]{task_id}[/bold] — Bernstein will continue."
-        )
+        console.print(f"[green]Approved:[/green] task [bold]{task_id}[/bold] — Bernstein will continue.")
     else:
         console.print(f"[dim]Already approved:[/dim] task [bold]{task_id}[/bold] (no-op)")
 

--- a/src/bernstein/cli/commands/approve_cmd.py
+++ b/src/bernstein/cli/commands/approve_cmd.py
@@ -1,0 +1,140 @@
+"""``bernstein approve`` — resolve the human-in-the-loop approval gate.
+
+Originally lived in :mod:`bernstein.cli.commands.task_cmd`; pulled into a
+dedicated module for #1110 so the pre-spawn ``ApprovalSpec`` gate has a
+clear ownership boundary distinct from the post-completion review queue
+and the tool-call queue (``bernstein approve-tool``).
+
+The command writes ``<workdir>/.sdd/runtime/approvals/<task_id>.approved``
+which the orchestrator's pre-spawn gate (or the legacy review gate)
+detects via filesystem polling. Atomic writes (``os.replace``) make it
+idempotent: a second concurrent ``bernstein approve <task_id>`` call
+either lands a byte-identical payload or finds the file already
+resolved and exits with a "already resolved" message.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+
+
+def _atomic_write_text(path: Path, content: str) -> bool:
+    """Atomically write *content* to *path*; return ``True`` if newly created.
+
+    Uses ``os.replace`` so concurrent writers cannot interleave content,
+    and exposes a "first writer wins" hint (the return value) to the
+    caller so we can differentiate fresh resolutions from no-op repeats.
+
+    Args:
+        path: Target file path.
+        content: Text payload to persist.
+
+    Returns:
+        ``True`` if the path did not exist prior to the call (the caller
+        is the first writer); ``False`` when an existing file was simply
+        overwritten — useful for the idempotent "already resolved"
+        message used by both ``bernstein approve`` and ``bernstein
+        reject``.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    pre_exists = path.exists()
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+    return not pre_exists
+
+
+def _foreground_confirm(prompt: str) -> bool:
+    """Ask ``prompt y/n?`` on the controlling TTY and return ``True`` for yes.
+
+    Returns ``True`` only on an interactive ``stdin`` where the operator
+    presses ``y`` (case-insensitive). Background runs (where ``stdin``
+    is not a TTY) skip the prompt and return ``True`` immediately so
+    operator scripts and CI pipelines are not blocked on the read.
+    """
+    if not sys.stdin.isatty():
+        return True
+    try:
+        answer = input(f"{prompt} [y/N]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return False
+    return answer in ("y", "yes")
+
+
+@click.command("approve")
+@click.argument("task_id")
+@click.option(
+    "--workdir",
+    default=".",
+    help="Project root directory (parent of .sdd/).",
+    type=click.Path(),
+)
+@click.option(
+    "--prompt/--no-prompt",
+    default=True,
+    show_default=True,
+    help="Foreground TTY prompts confirm before writing the sentinel.",
+)
+def approve(task_id: str, workdir: str, prompt: bool) -> None:
+    """Approve a pending task (review gate or pre-spawn approval gate).
+
+    Writes a ``<task_id>.approved`` decision file under
+    ``.sdd/runtime/approvals/`` so a paused orchestrator (post-completion
+    review or pre-spawn ``ApprovalSpec`` gate, #1110) can move on.
+
+    Concurrent ``bernstein approve`` calls are idempotent: the first one
+    creates the file, subsequent invocations report ``already resolved``
+    and exit without rewriting state.
+
+    \b
+    Example:
+      bernstein approve T-abc123
+    """
+    approvals_dir = Path(workdir) / ".sdd" / "runtime" / "approvals"
+    approvals_dir.mkdir(parents=True, exist_ok=True)
+    decision_file = approvals_dir / f"{task_id}.approved"
+    rejected_file = approvals_dir / f"{task_id}.rejected"
+
+    if rejected_file.exists():
+        console.print(
+            f"[yellow]Already resolved:[/yellow] task [bold]{task_id}[/bold] was rejected; "
+            "leaving the rejection in place."
+        )
+        return
+
+    if decision_file.exists():
+        console.print(
+            f"[dim]Already approved:[/dim] task [bold]{task_id}[/bold] (no-op)"
+        )
+        return
+
+    if prompt and not _foreground_confirm(f"Approve task {task_id}?"):
+        console.print(f"[dim]Skipped[/dim] approval for [bold]{task_id}[/bold]")
+        return
+
+    created = _atomic_write_text(decision_file, "approved")
+    if created:
+        console.print(
+            f"[green]Approved:[/green] task [bold]{task_id}[/bold] — Bernstein will continue."
+        )
+    else:
+        console.print(f"[dim]Already approved:[/dim] task [bold]{task_id}[/bold] (no-op)")
+
+
+__all__ = ["approve"]

--- a/src/bernstein/cli/commands/pending_cmd.py
+++ b/src/bernstein/cli/commands/pending_cmd.py
@@ -1,0 +1,138 @@
+"""``bernstein pending`` — list outstanding human-approval gates.
+
+Surfaces two distinct queues:
+
+* **Approval-pending** (#1110): tasks paused at the pre-spawn
+  ``ApprovalSpec`` gate. Each entry has a ``<task_id>.pending`` JSON
+  sentinel under ``.sdd/runtime/approvals/`` written by
+  :func:`bernstein.core.orchestration.approval_gate.write_pending_sentinel`,
+  carrying the operator-facing prompt and TTL deadline.
+* **Spawn-pending** (legacy): tasks parked after janitor verification
+  awaiting a merge approval. Stored under
+  ``.sdd/runtime/pending_approvals/<task_id>.json`` by
+  :class:`bernstein.core.security.approval.ApprovalGate`.
+
+The two surfaces share a CLI verb because operators routinely run
+``bernstein pending`` to see "what is currently waiting on me"; merging
+them in a single command keeps that mental model intact while clearly
+labelling the source. Use ``bernstein pending --kind approval`` /
+``--kind spawn`` to filter when scripting.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import click
+from rich.table import Table
+
+from bernstein.cli.helpers import console, is_json, print_json
+from bernstein.core.orchestration.approval_gate import list_pending_approvals
+
+
+def _load_spawn_pending(workdir: Path) -> list[dict[str, Any]]:
+    """Return every entry in the legacy post-completion review queue."""
+    pending_dir = workdir / ".sdd" / "runtime" / "pending_approvals"
+    if not pending_dir.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    for entry in sorted(pending_dir.glob("*.json")):
+        try:
+            data = json.loads(entry.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            rows.append({"task_id": entry.stem, "error": "unreadable"})
+            continue
+        if not isinstance(data, dict):
+            data = {"task_id": entry.stem, "error": "not a JSON object"}
+        rows.append(data)
+    return rows
+
+
+def _render_approval_table(rows: list[dict[str, Any]]) -> Table:
+    """Render the pre-spawn approval queue as a Rich table."""
+    table = Table(title="Approval-pending tasks (#1110)", show_header=True, header_style="bold magenta")
+    table.add_column("Task ID", style="cyan")
+    table.add_column("Prompt")
+    table.add_column("Default Action", style="yellow")
+    table.add_column("Times out at")
+    for row in rows:
+        table.add_row(
+            str(row.get("task_id", "?")),
+            str(row.get("prompt", ""))[:80],
+            str(row.get("default_action", "reject")),
+            str(row.get("timeout_at_iso", "")),
+        )
+    return table
+
+
+def _render_spawn_table(rows: list[dict[str, Any]]) -> Table:
+    """Render the legacy review queue as a Rich table."""
+    table = Table(title="Spawn-pending tasks (post-completion review)", show_header=True, header_style="bold magenta")
+    table.add_column("Task ID", style="cyan")
+    table.add_column("Title")
+    table.add_column("Tests")
+    for row in rows:
+        table.add_row(
+            str(row.get("task_id", "?")),
+            str(row.get("task_title", "")),
+            str(row.get("test_summary", "")),
+        )
+    return table
+
+
+@click.command("pending")
+@click.option(
+    "--workdir",
+    default=".",
+    help="Project root directory (parent of .sdd/).",
+    type=click.Path(),
+)
+@click.option(
+    "--kind",
+    type=click.Choice(["all", "approval", "spawn"]),
+    default="all",
+    show_default=True,
+    help="Filter the listed queue: 'approval' = pre-spawn gates (#1110); "
+    "'spawn' = legacy post-completion review queue; 'all' shows both.",
+)
+def pending(workdir: str, kind: Literal["all", "approval", "spawn"]) -> None:
+    """List tasks waiting for a human approval decision.
+
+    Combines two file-backed queues:
+
+    * Pre-spawn ``ApprovalSpec`` gates (``*.pending`` sentinels) — tasks
+      that will not start until ``bernstein approve <id>`` writes the
+      decision file.
+    * Post-completion review gates — tasks parked after janitor
+      verification awaiting merge.
+
+    \b
+    Examples:
+      bernstein pending
+      bernstein pending --kind approval
+      bernstein pending --kind spawn
+    """
+    root = Path(workdir)
+    approval_rows = list_pending_approvals(root) if kind in ("all", "approval") else []
+    spawn_rows = _load_spawn_pending(root) if kind in ("all", "spawn") else []
+
+    if is_json():
+        print_json({"approval_pending": approval_rows, "spawn_pending": spawn_rows})
+        return
+
+    if not approval_rows and not spawn_rows:
+        console.print("[dim]No tasks pending approval.[/dim]")
+        return
+
+    if approval_rows:
+        console.print(_render_approval_table(approval_rows))
+    if spawn_rows:
+        console.print(_render_spawn_table(spawn_rows))
+
+    console.print("\n[dim]Approve with:[/dim] bernstein approve <task_id>")
+    console.print("[dim]Reject with:[/dim]  bernstein reject <task_id>")
+
+
+__all__ = ["pending"]

--- a/src/bernstein/cli/commands/reject_cmd.py
+++ b/src/bernstein/cli/commands/reject_cmd.py
@@ -61,9 +61,7 @@ def reject(task_id: str, workdir: str, prompt: bool) -> None:
         return
 
     if decision_file.exists():
-        console.print(
-            f"[dim]Already rejected:[/dim] task [bold]{task_id}[/bold] (no-op)"
-        )
+        console.print(f"[dim]Already rejected:[/dim] task [bold]{task_id}[/bold] (no-op)")
         return
 
     if prompt and not _foreground_confirm(f"Reject task {task_id}?"):
@@ -72,9 +70,7 @@ def reject(task_id: str, workdir: str, prompt: bool) -> None:
 
     created = _atomic_write_text(decision_file, "rejected")
     if created:
-        console.print(
-            f"[red]Rejected:[/red] task [bold]{task_id}[/bold] — work will be discarded."
-        )
+        console.print(f"[red]Rejected:[/red] task [bold]{task_id}[/bold] — work will be discarded.")
     else:
         console.print(f"[dim]Already rejected:[/dim] task [bold]{task_id}[/bold] (no-op)")
 

--- a/src/bernstein/cli/commands/reject_cmd.py
+++ b/src/bernstein/cli/commands/reject_cmd.py
@@ -1,0 +1,82 @@
+"""``bernstein reject`` — refuse a pending approval gate.
+
+Mirror of :mod:`bernstein.cli.commands.approve_cmd`: writes
+``<workdir>/.sdd/runtime/approvals/<task_id>.rejected`` so the
+post-completion review gate or the pre-spawn ``ApprovalSpec`` gate
+(#1110) unblocks with a refusal. Idempotent under concurrent
+invocations: the first writer wins via ``os.replace`` and subsequent
+callers see the existing decision and report ``already resolved``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from bernstein.cli.commands.approve_cmd import _atomic_write_text, _foreground_confirm
+from bernstein.cli.helpers import console
+
+
+@click.command("reject")
+@click.argument("task_id")
+@click.option(
+    "--workdir",
+    default=".",
+    help="Project root directory (parent of .sdd/).",
+    type=click.Path(),
+)
+@click.option(
+    "--prompt/--no-prompt",
+    default=True,
+    show_default=True,
+    help="Foreground TTY prompts confirm before writing the sentinel.",
+)
+def reject(task_id: str, workdir: str, prompt: bool) -> None:
+    """Reject a pending task (review gate or pre-spawn approval gate).
+
+    Writes a ``<task_id>.rejected`` decision file under
+    ``.sdd/runtime/approvals/``. The orchestrator marks the task failed
+    and skips the agent body (or, post-completion, discards the work
+    without merging).
+
+    Concurrent ``bernstein reject`` calls are idempotent: the first one
+    creates the file, subsequent invocations exit with ``already
+    resolved``.
+
+    \b
+    Example:
+      bernstein reject T-abc123
+    """
+    approvals_dir = Path(workdir) / ".sdd" / "runtime" / "approvals"
+    approvals_dir.mkdir(parents=True, exist_ok=True)
+    decision_file = approvals_dir / f"{task_id}.rejected"
+    approved_file = approvals_dir / f"{task_id}.approved"
+
+    if approved_file.exists():
+        console.print(
+            f"[yellow]Already resolved:[/yellow] task [bold]{task_id}[/bold] was approved; "
+            "leaving the approval in place."
+        )
+        return
+
+    if decision_file.exists():
+        console.print(
+            f"[dim]Already rejected:[/dim] task [bold]{task_id}[/bold] (no-op)"
+        )
+        return
+
+    if prompt and not _foreground_confirm(f"Reject task {task_id}?"):
+        console.print(f"[dim]Skipped[/dim] rejection for [bold]{task_id}[/bold]")
+        return
+
+    created = _atomic_write_text(decision_file, "rejected")
+    if created:
+        console.print(
+            f"[red]Rejected:[/red] task [bold]{task_id}[/bold] — work will be discarded."
+        )
+    else:
+        console.print(f"[dim]Already rejected:[/dim] task [bold]{task_id}[/bold] (no-op)")
+
+
+__all__ = ["reject"]

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -246,96 +246,14 @@ def review_cmd(
     )
 
 
-@click.command("approve")
-@click.argument("task_id")
-@click.option("--workdir", default=".", help="Project root directory.", type=click.Path())
-def approve(task_id: str, workdir: str) -> None:
-    """Approve a pending task review so Bernstein merges the work.
-
-    When running with ``--approval review``, Bernstein pauses after each
-    verified task and writes a pending approval file.  Run this command
-    to signal approval so the orchestrator continues with the merge.
-
-    \b
-    Example:
-      bernstein approve T-abc123
-    """
-    approvals_dir = Path(workdir) / ".sdd" / "runtime" / "approvals"
-    approvals_dir.mkdir(parents=True, exist_ok=True)
-    decision_file = approvals_dir / f"{task_id}.approved"
-    decision_file.write_text("approved")
-    console.print(f"[green]Approved:[/green] task [bold]{task_id}[/bold] — Bernstein will merge the work.")
-
-
-@click.command("reject")
-@click.argument("task_id")
-@click.option("--workdir", default=".", help="Project root directory.", type=click.Path())
-def reject(task_id: str, workdir: str) -> None:
-    """Reject a pending task review so Bernstein discards the work.
-
-    When running with ``--approval review``, Bernstein pauses after each
-    verified task and writes a pending approval file.  Run this command
-    to reject the work -- the worktree will be cleaned up without merging.
-
-    \b
-    Example:
-      bernstein reject T-abc123
-    """
-    approvals_dir = Path(workdir) / ".sdd" / "runtime" / "approvals"
-    approvals_dir.mkdir(parents=True, exist_ok=True)
-    decision_file = approvals_dir / f"{task_id}.rejected"
-    decision_file.write_text("rejected")
-    console.print(f"[red]Rejected:[/red] task [bold]{task_id}[/bold] — work will be discarded.")
-
-
-@click.command("pending")
-@click.option("--workdir", default=".", help="Project root directory.", type=click.Path())
-@click.pass_context
-def pending(ctx: click.Context, workdir: str) -> None:
-    """List tasks waiting for approval review.
-
-    Shows all tasks that have been verified and are waiting for a human
-    decision (``bernstein approve <id>`` or ``bernstein reject <id>``).
-    """
-    from rich.table import Table
-
-    pending_dir = Path(workdir) / ".sdd" / "runtime" / "pending_approvals"
-    if not pending_dir.exists() or not any(pending_dir.glob("*.json")):
-        if is_json():
-            print_json([])
-        else:
-            console.print("[dim]No tasks pending approval.[/dim]")
-        return
-
-    results: list[dict[str, Any]] = []
-    for f in sorted(pending_dir.glob("*.json")):
-        try:
-            import json as _json
-
-            data = _json.loads(f.read_text())
-            results.append(data)
-        except Exception:
-            results.append({"task_id": f.stem, "error": "unreadable"})
-
-    if is_json():
-        print_json(results)
-        return
-
-    table = Table(show_header=True, header_style="bold magenta")
-    table.add_column("Task ID", style="cyan")
-    table.add_column("Title")
-    table.add_column("Tests")
-
-    for res in results:
-        table.add_row(
-            res.get("task_id", "?"),
-            res.get("task_title", ""),
-            res.get("test_summary", ""),
-        )
-
-    console.print(table)
-    console.print("\n[dim]Approve with:[/dim] bernstein approve <task_id>")
-    console.print("[dim]Reject with:[/dim]  bernstein reject <task_id>")
+# NOTE: ``bernstein approve``, ``bernstein reject`` and ``bernstein pending``
+# moved to dedicated modules (``approve_cmd.py``, ``reject_cmd.py``,
+# ``pending_cmd.py``) as part of #1110. They are re-exported below so any
+# legacy ``from bernstein.cli.commands.task_cmd import approve`` import keeps
+# working without forcing every caller to update.
+from bernstein.cli.commands.approve_cmd import approve as approve  # noqa: E402
+from bernstein.cli.commands.pending_cmd import pending as pending  # noqa: E402
+from bernstein.cli.commands.reject_cmd import reject as reject  # noqa: E402
 
 
 def _build_graph_maps(

--- a/src/bernstein/core/orchestration/approval_gate.py
+++ b/src/bernstein/core/orchestration/approval_gate.py
@@ -1,0 +1,411 @@
+"""Pre-spawn human-in-the-loop approval gate (#1110).
+
+Provides :func:`wait_for_approval`, the runtime half of the explicit
+approval gate that ships with :class:`bernstein.core.models.ApprovalSpec`.
+On entry the gate writes a ``<task_id>.pending`` JSON sentinel under
+``.sdd/runtime/approvals/`` and emits an ``approval_pending`` event into
+the HMAC-chained audit log. Operator decisions arrive as plain
+``<task_id>.approved`` / ``<task_id>.rejected`` files written by the
+``bernstein approve`` / ``bernstein reject`` CLI commands (the same files
+the post-completion review gate already uses, so a single sentinel
+directory backs both gates without filename collisions).
+
+The gate is intentionally synchronous: the orchestrator tick path is
+file-driven and runs outside an asyncio loop, so polling with
+``time.monotonic`` keeps the implementation simple and free of event-loop
+ownership questions. Concurrency between racing ``bernstein approve``
+calls is resolved by atomic ``os.replace`` writes; the first writer wins
+and any subsequent writers see the resolved state and become no-ops with
+a clear "already resolved" log line. Atomic file replacement is also
+what makes the pending sentinel safe to read mid-update.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import tempfile
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from bernstein.core.security.audit import AuditLog
+    from bernstein.core.tasks.models import ApprovalSpec
+
+logger = logging.getLogger(__name__)
+
+#: Outcome of a :func:`wait_for_approval` call.
+ApprovalOutcome = Literal["approved", "rejected", "timeout"]
+
+#: Source of the resolution recorded in the audit chain.
+DecisionSource = Literal["cli", "tui", "timeout-default"]
+
+#: Default poll interval. Short enough to feel snappy in foreground, long
+#: enough to keep filesystem load negligible in background runs.
+_DEFAULT_POLL_INTERVAL_S: float = 0.5
+
+#: Relative directory where every approval sentinel lives. Keeping all
+#: gates under one folder lets ``bernstein pending`` enumerate every
+#: outstanding decision in a single ``glob``.
+_RUNTIME_REL = Path(".sdd") / "runtime" / "approvals"
+
+
+def _approvals_dir(workdir: Path) -> Path:
+    """Return the canonical approvals directory rooted at *workdir*."""
+    return workdir / _RUNTIME_REL
+
+
+def _atomic_write_json(path: Path, payload: dict[str, object]) -> None:
+    """Write *payload* to *path* atomically via ``os.replace``.
+
+    A temporary file is created in the same directory so the rename is on
+    one filesystem (cross-filesystem rename is not atomic on POSIX). On
+    failure the temp file is unlinked and the original exception
+    propagates.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+def _emit_audit(
+    audit_log: AuditLog | None,
+    *,
+    event_type: str,
+    task_id: str,
+    details: dict[str, object],
+) -> None:
+    """Append an ``approval_*`` event to the HMAC-chained audit log.
+
+    The lifecycle module owns the global :class:`AuditLog` singleton; we
+    look it up dynamically when *audit_log* is ``None`` so callers do not
+    have to thread the reference through. Failures are logged at debug
+    level: an audit-log write should never block a gate decision.
+    """
+    log = audit_log
+    if log is None:
+        try:
+            from bernstein.core.tasks.lifecycle import get_audit_log
+
+            log = get_audit_log()
+        except Exception:
+            logger.debug("approval gate: audit log lookup failed", exc_info=True)
+            return
+    if log is None:
+        return
+    try:
+        log.log(
+            event_type=event_type,
+            actor="approval_gate",
+            resource_type="task",
+            resource_id=task_id,
+            details=details,
+        )
+    except Exception:
+        # Audit log write is best-effort: a broken audit chain should
+        # surface elsewhere (``bernstein verify``), not silently abort the
+        # task lifecycle.
+        logger.warning(
+            "approval gate: failed to emit %s audit event for task %s",
+            event_type,
+            task_id,
+            exc_info=True,
+        )
+
+
+def _pending_path(workdir: Path, task_id: str) -> Path:
+    """Return the ``<task_id>.pending`` sentinel path."""
+    return _approvals_dir(workdir) / f"{task_id}.pending"
+
+
+def _approved_path(workdir: Path, task_id: str) -> Path:
+    """Return the ``<task_id>.approved`` decision path."""
+    return _approvals_dir(workdir) / f"{task_id}.approved"
+
+
+def _rejected_path(workdir: Path, task_id: str) -> Path:
+    """Return the ``<task_id>.rejected`` decision path."""
+    return _approvals_dir(workdir) / f"{task_id}.rejected"
+
+
+def write_pending_sentinel(
+    workdir: Path,
+    task_id: str,
+    spec: ApprovalSpec,
+    *,
+    now: float | None = None,
+) -> Path:
+    """Write the ``.pending`` sentinel for *task_id* and return its path.
+
+    The sentinel content is:
+
+    .. code-block:: json
+
+        {
+          "prompt": "...",
+          "timeout_at_iso": "...",
+          "created_iso": "...",
+          "default_action": "reject"
+        }
+
+    This is the canonical hand-off between the orchestrator and the CLI:
+    ``bernstein pending`` reads the sentinel to render the prompt while
+    ``bernstein approve``/``reject`` write the corresponding decision
+    file. The write is atomic so any concurrent reader observes either
+    the previous content or the full new payload, never a partial one.
+
+    Args:
+        workdir: Project root (parent of ``.sdd/``).
+        task_id: Identifier whose gate is being entered.
+        spec: Approval specification governing this gate.
+        now: Optional injected timestamp for deterministic tests.
+
+    Returns:
+        Absolute path to the sentinel that was written.
+    """
+    moment = time.time() if now is None else now
+    created = datetime.fromtimestamp(moment, tz=UTC)
+    timeout_at = created + timedelta(seconds=spec.timeout_seconds)
+    payload: dict[str, object] = {
+        "task_id": task_id,
+        "prompt": spec.prompt,
+        "timeout_at_iso": timeout_at.isoformat(),
+        "created_iso": created.isoformat(),
+        "default_action": spec.default_action,
+        "timeout_seconds": spec.timeout_seconds,
+    }
+    path = _pending_path(workdir, task_id)
+    _atomic_write_json(path, payload)
+    return path
+
+
+def _resolve_default_action(action: Literal["reject", "approve", "fail"]) -> ApprovalOutcome:
+    """Translate a spec's ``default_action`` into the wait-for-approval outcome.
+
+    ``"approve"`` lets the body run; ``"reject"`` and ``"fail"`` both halt
+    it. The two non-approve values are kept distinct in the audit chain
+    via the ``decision_source`` and ``outcome`` fields, but for the gate's
+    runtime contract they collapse to ``"rejected"``.
+    """
+    if action == "approve":
+        return "approved"
+    return "rejected"
+
+
+def _classify_decision_files(
+    approved: Path, rejected: Path
+) -> tuple[ApprovalOutcome, DecisionSource] | None:
+    """Return the resolved outcome if a decision file exists, else ``None``.
+
+    Both files are checked because a misbehaving operator could land
+    either; the first one to materialise wins. Approval files take
+    precedence on the (defensive) chance that both arrive in the same
+    poll tick — better to honour an explicit approve than to swallow
+    operator intent.
+    """
+    if approved.exists():
+        return "approved", "cli"
+    if rejected.exists():
+        return "rejected", "cli"
+    return None
+
+
+def _cleanup_pending(workdir: Path, task_id: str) -> None:
+    """Remove the ``.pending`` sentinel; ignore missing-file errors.
+
+    Called once a decision is recorded so :func:`list_pending_approvals`
+    does not surface stale entries on the next tick.
+    """
+    pending = _pending_path(workdir, task_id)
+    with contextlib.suppress(FileNotFoundError, OSError):
+        pending.unlink()
+
+
+def list_pending_approvals(workdir: Path) -> list[dict[str, object]]:
+    """Return every active ``<task_id>.pending`` sentinel under *workdir*.
+
+    Used by ``bernstein pending`` to surface approval-pending tasks
+    distinct from the post-completion review queue. Each entry is the raw
+    JSON dict written by :func:`write_pending_sentinel`, augmented with a
+    ``task_id`` key derived from the filename for callers that prefer it
+    over digging into the body.
+    """
+    approvals_dir = _approvals_dir(workdir)
+    if not approvals_dir.exists():
+        return []
+    entries: list[dict[str, object]] = []
+    for sentinel in sorted(approvals_dir.glob("*.pending")):
+        try:
+            data = json.loads(sentinel.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.debug("approval gate: skipping unreadable sentinel %s: %s", sentinel.name, exc)
+            continue
+        if not isinstance(data, dict):
+            continue
+        data.setdefault("task_id", sentinel.stem)
+        entries.append(data)
+    return entries
+
+
+def wait_for_approval(
+    task_id: str,
+    spec: ApprovalSpec,
+    *,
+    workdir: Path | None = None,
+    audit_log: AuditLog | None = None,
+    poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    now: float | None = None,
+    monotonic: object | None = None,
+    sleep: object | None = None,
+) -> ApprovalOutcome:
+    """Block until the operator decides or the TTL fires.
+
+    The gate is idempotent under concurrent ``bernstein approve`` /
+    ``bernstein reject`` calls: the underlying decision files are written
+    via atomic rename, so the first writer's contents persist and any
+    subsequent writer's content is silently dropped at the filesystem
+    level. The CLI commands also detect already-resolved tasks and emit
+    a "already resolved" message instead of re-resolving.
+
+    Args:
+        task_id: Identifier of the task being gated; appears in audit
+            events and on-disk sentinels.
+        spec: Approval specification driving prompt, timeout, and
+            default action.
+        workdir: Project root. Defaults to the current working directory.
+        audit_log: Optional explicit audit log; defaults to the
+            lifecycle-registered singleton.
+        poll_interval_s: Seconds between filesystem checks.
+        now: Optional injected wall-clock timestamp (used by
+            :func:`write_pending_sentinel` for deterministic ISO strings).
+        monotonic: Optional injected monotonic clock — useful in tests
+            that drive the timeout deterministically. Must accept zero
+            arguments and return a float; defaults to
+            :func:`time.monotonic`.
+        sleep: Optional injected sleep callable. Must accept a float;
+            defaults to :func:`time.sleep`.
+
+    Returns:
+        ``"approved"``, ``"rejected"``, or ``"timeout"``.
+
+    Notes:
+        On ``"timeout"`` the gate also resolves the task by writing the
+        appropriate decision file derived from ``spec.default_action``,
+        so subsequent CLI calls see a terminal state and the on-disk
+        history mirrors the in-memory outcome.
+    """
+    root = workdir if workdir is not None else Path.cwd()
+    monotonic_clock = monotonic if callable(monotonic) else time.monotonic
+    sleep_fn = sleep if callable(sleep) else time.sleep
+
+    approvals_dir = _approvals_dir(root)
+    approvals_dir.mkdir(parents=True, exist_ok=True)
+    approved = _approved_path(root, task_id)
+    rejected = _rejected_path(root, task_id)
+
+    # Honour decisions that arrived before we even started waiting (CLI
+    # may run while the orchestrator was busy in a previous tick).
+    early = _classify_decision_files(approved, rejected)
+    if early is not None:
+        outcome, source = early
+        write_pending_sentinel(root, task_id, spec, now=now)
+        _emit_audit(
+            audit_log,
+            event_type="approval_pending",
+            task_id=task_id,
+            details={
+                "prompt": spec.prompt,
+                "timeout_seconds": spec.timeout_seconds,
+                "default_action": spec.default_action,
+            },
+        )
+        _emit_audit(
+            audit_log,
+            event_type="approval_resolved",
+            task_id=task_id,
+            details={"outcome": outcome, "decision_source": source},
+        )
+        _cleanup_pending(root, task_id)
+        return outcome
+
+    # No decision yet — write sentinel + emit pending event, then poll.
+    write_pending_sentinel(root, task_id, spec, now=now)
+    _emit_audit(
+        audit_log,
+        event_type="approval_pending",
+        task_id=task_id,
+        details={
+            "prompt": spec.prompt,
+            "timeout_seconds": spec.timeout_seconds,
+            "default_action": spec.default_action,
+        },
+    )
+
+    deadline = monotonic_clock() + float(spec.timeout_seconds)  # type: ignore[operator]
+    while True:
+        decision = _classify_decision_files(approved, rejected)
+        if decision is not None:
+            outcome, source = decision
+            _emit_audit(
+                audit_log,
+                event_type="approval_resolved",
+                task_id=task_id,
+                details={"outcome": outcome, "decision_source": source},
+            )
+            _cleanup_pending(root, task_id)
+            return outcome
+
+        remaining = deadline - monotonic_clock()  # type: ignore[operator]
+        if remaining <= 0:
+            outcome = _resolve_default_action(spec.default_action)
+            # Persist a decision file so future readers see a terminal state.
+            terminal_path = approved if outcome == "approved" else rejected
+            try:
+                terminal_path.write_text(f"timeout-default:{spec.default_action}\n", encoding="utf-8")
+            except OSError as exc:
+                logger.warning(
+                    "approval gate: could not persist timeout decision for task %s: %s",
+                    task_id,
+                    exc,
+                )
+            _emit_audit(
+                audit_log,
+                event_type="approval_resolved",
+                task_id=task_id,
+                details={
+                    "outcome": "timeout",
+                    "decision_source": "timeout-default",
+                    "default_action": spec.default_action,
+                    "applied_outcome": outcome,
+                },
+            )
+            _cleanup_pending(root, task_id)
+            return "timeout"
+
+        sleep_fn(min(poll_interval_s, remaining))  # type: ignore[operator]
+
+
+__all__ = [
+    "ApprovalOutcome",
+    "DecisionSource",
+    "list_pending_approvals",
+    "wait_for_approval",
+    "write_pending_sentinel",
+]

--- a/src/bernstein/core/orchestration/approval_gate.py
+++ b/src/bernstein/core/orchestration/approval_gate.py
@@ -209,9 +209,7 @@ def _resolve_default_action(action: Literal["reject", "approve", "fail"]) -> App
     return "rejected"
 
 
-def _classify_decision_files(
-    approved: Path, rejected: Path
-) -> tuple[ApprovalOutcome, DecisionSource] | None:
+def _classify_decision_files(approved: Path, rejected: Path) -> tuple[ApprovalOutcome, DecisionSource] | None:
     """Return the resolved outcome if a decision file exists, else ``None``.
 
     Both files are checked because a misbehaving operator could land

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -279,9 +279,7 @@ class ApprovalSpec:
         if not self.prompt or not self.prompt.strip():
             raise ValueError("ApprovalSpec.prompt must be a non-empty string")
         if self.timeout_seconds <= 0:
-            raise ValueError(
-                f"ApprovalSpec.timeout_seconds must be > 0, got {self.timeout_seconds!r}"
-            )
+            raise ValueError(f"ApprovalSpec.timeout_seconds must be > 0, got {self.timeout_seconds!r}")
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-serialisable representation of the spec."""
@@ -308,9 +306,7 @@ class ApprovalSpec:
         """
         action = str(data.get("default_action", "reject"))
         if action not in ("reject", "approve", "fail"):
-            raise ValueError(
-                f"ApprovalSpec.default_action must be reject|approve|fail, got {action!r}"
-            )
+            raise ValueError(f"ApprovalSpec.default_action must be reject|approve|fail, got {action!r}")
         return cls(
             prompt=str(data["prompt"]),
             timeout_seconds=int(data.get("timeout_seconds", 86_400)),
@@ -456,9 +452,7 @@ class Task:
             eu_ai_act_risk=raw.get("eu_ai_act_risk", "minimal"),
             approval_required=bool(raw.get("approval_required", False)),
             approval_spec=(
-                ApprovalSpec.from_dict(raw["approval_spec"])
-                if isinstance(raw.get("approval_spec"), dict)
-                else None
+                ApprovalSpec.from_dict(raw["approval_spec"]) if isinstance(raw.get("approval_spec"), dict) else None
             ),
             risk_level=raw.get("risk_level", "low"),
             max_output_tokens=raw.get("max_output_tokens"),

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -238,6 +238,86 @@ class CompletionSignal:
     value: str  # path, glob pattern, test command, search string, or review instruction
 
 
+@dataclass(frozen=True)
+class ApprovalSpec:
+    """Explicit human-in-the-loop approval gate spec attached to a task.
+
+    Inspired by Archon's ``loop: interactive: true`` UX. When a task carries
+    an :class:`ApprovalSpec`, the orchestrator pauses *before* spawning the
+    agent body, emits an ``approval_pending`` event into the HMAC-chained
+    audit log, writes a ``.pending`` sentinel under
+    ``.sdd/runtime/approvals/`` and blocks until either an operator decision
+    file is written (``bernstein approve <task_id>`` /
+    ``bernstein reject <task_id>``) or the TTL expires.
+
+    Validation:
+        ``timeout_seconds`` MUST be strictly positive and ``prompt`` MUST be
+        non-empty after stripping whitespace; otherwise ``__post_init__``
+        raises :class:`ValueError`. The dataclass is frozen so the
+        validation runs exactly once at construction time.
+
+    Attributes:
+        prompt: Human-readable question presented to the operator. Must be
+            non-empty (whitespace-only counts as empty).
+        timeout_seconds: Maximum seconds to wait for an operator decision
+            before the gate falls back to ``default_action``. Must be > 0.
+            Default is 24 hours so background runs do not stall forever.
+        default_action: Outcome applied when the timeout fires. ``"reject"``
+            (the safe default) marks the task failed and skips the agent
+            spawn; ``"approve"`` continues with the body; ``"fail"`` is
+            equivalent to ``"reject"`` but is preserved as a distinct value
+            so future audit consumers can distinguish "human said no" from
+            "no human responded".
+    """
+
+    prompt: str
+    timeout_seconds: int = 86_400
+    default_action: Literal["reject", "approve", "fail"] = "reject"
+
+    def __post_init__(self) -> None:
+        """Enforce non-empty prompt and positive timeout at construction."""
+        if not self.prompt or not self.prompt.strip():
+            raise ValueError("ApprovalSpec.prompt must be a non-empty string")
+        if self.timeout_seconds <= 0:
+            raise ValueError(
+                f"ApprovalSpec.timeout_seconds must be > 0, got {self.timeout_seconds!r}"
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable representation of the spec."""
+        return {
+            "prompt": self.prompt,
+            "timeout_seconds": self.timeout_seconds,
+            "default_action": self.default_action,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ApprovalSpec:
+        """Build an :class:`ApprovalSpec` from a JSON-decoded mapping.
+
+        Args:
+            data: Mapping with at least ``prompt``; ``timeout_seconds`` and
+                ``default_action`` fall back to dataclass defaults.
+
+        Returns:
+            A validated :class:`ApprovalSpec`.
+
+        Raises:
+            ValueError: When the resulting spec violates the field
+                invariants enforced by :meth:`__post_init__`.
+        """
+        action = str(data.get("default_action", "reject"))
+        if action not in ("reject", "approve", "fail"):
+            raise ValueError(
+                f"ApprovalSpec.default_action must be reject|approve|fail, got {action!r}"
+            )
+        return cls(
+            prompt=str(data["prompt"]),
+            timeout_seconds=int(data.get("timeout_seconds", 86_400)),
+            default_action=action,  # type: ignore[arg-type]
+        )
+
+
 @dataclass
 class Task:
     """A unit of work for an agent."""
@@ -273,6 +353,13 @@ class Task:
     batch_eligible: bool | None = None  # Non-urgent: None=auto-detect, True=explicit batch, False=explicit realtime
     eu_ai_act_risk: Literal["minimal", "limited", "high", "unacceptable"] = "minimal"
     approval_required: bool = False  # Pause after completion until explicitly approved
+    # Pre-spawn human-in-the-loop gate (#1110). When set, the orchestrator
+    # blocks before invoking the agent body until an operator runs
+    # ``bernstein approve <task_id>`` / ``reject``, or the TTL fires and the
+    # spec's ``default_action`` is applied. The boolean ``approval_required``
+    # above continues to govern the *post-completion* review gate so that
+    # legacy approve/reject/pending tests stay intact.
+    approval_spec: ApprovalSpec | None = None
     risk_level: Literal["low", "medium", "high", "critical"] = "low"  # Risk for approval workflow routing
     sensitivity: Literal["public", "internal", "confidential"] = "internal"  # Data classification level
     max_output_tokens: int | None = None  # Escalated limit for model output
@@ -368,6 +455,11 @@ class Task:
             batch_eligible=(lambda v: None if v is None else bool(v))(raw.get("batch_eligible")),
             eu_ai_act_risk=raw.get("eu_ai_act_risk", "minimal"),
             approval_required=bool(raw.get("approval_required", False)),
+            approval_spec=(
+                ApprovalSpec.from_dict(raw["approval_spec"])
+                if isinstance(raw.get("approval_spec"), dict)
+                else None
+            ),
             risk_level=raw.get("risk_level", "low"),
             max_output_tokens=raw.get("max_output_tokens"),
             meta_messages=list(raw.get("meta_messages", [])),

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -1038,6 +1038,76 @@ def auto_decompose_task(
 # ---------------------------------------------------------------------------
 
 
+def _await_pre_spawn_approvals(
+    orch: Any,
+    batch: list[Task],
+    server_url: str,
+    result: Any,
+) -> bool:
+    """Block until every task with an :class:`ApprovalSpec` is resolved.
+
+    Implements the human-in-the-loop pre-spawn gate (#1110): each task
+    that carries an ``approval_spec`` is run through
+    :func:`bernstein.core.orchestration.approval_gate.wait_for_approval`,
+    which writes a sentinel and emits HMAC-chained audit events. On
+    rejection or reject-style timeout the entire batch is failed on the
+    server and the spawn is skipped — partial spawns would defeat the
+    point of the gate (denied tasks ride along with approved siblings).
+
+    Args:
+        orch: Orchestrator instance (provides ``_workdir`` and
+            ``_client``).
+        batch: Tasks scheduled to share an agent. All must be cleared
+            before any can spawn.
+        server_url: Base URL of the task server (for ``fail_task``).
+        result: Tick result accumulator; rejected tasks are appended to
+            ``result.errors`` with a ``approval-gate:`` prefix.
+
+    Returns:
+        ``True`` when the caller must skip the spawn (rejection or
+        timeout-with-default-action=reject), ``False`` when the entire
+        batch was approved and the body may run.
+    """
+    from bernstein.core.orchestration.approval_gate import wait_for_approval
+
+    workdir = getattr(orch, "_workdir", None)
+    if workdir is None:
+        # Without a workdir we cannot persist the sentinel; treat as
+        # rejected so we never silently bypass the gate.
+        for task in batch:
+            with contextlib.suppress(Exception):
+                fail_task(orch._client, server_url, task.id, "approval-gate: no workdir")
+        return True
+
+    rejected_ids: list[str] = []
+    for task in batch:
+        spec = task.approval_spec
+        if spec is None:
+            continue
+        try:
+            outcome = wait_for_approval(task.id, spec, workdir=workdir)
+        except Exception as exc:
+            logger.exception("approval gate: wait_for_approval crashed for %s", task.id)
+            outcome = "rejected"
+            with contextlib.suppress(Exception):
+                fail_task(orch._client, server_url, task.id, f"approval-gate crash: {exc}")
+            result.errors.append(f"approval-gate:{task.id}: {exc}")
+            rejected_ids.append(task.id)
+            continue
+        if outcome == "approved":
+            logger.info("approval gate: task %s approved -- proceeding to spawn", task.id)
+            continue
+        # outcome is "rejected" or "timeout"; the gate has already
+        # written a decision file mirroring the resolution.
+        rejected_ids.append(task.id)
+        reason = f"approval-gate {outcome} (default_action={spec.default_action})"
+        with contextlib.suppress(Exception):
+            fail_task(orch._client, server_url, task.id, reason)
+        result.errors.append(f"approval-gate:{task.id}: {outcome}")
+        logger.warning("approval gate: task %s -> %s; skipping spawn", task.id, outcome)
+    return bool(rejected_ids)
+
+
 def _pre_spawn_checks_pass(orch: Any, alive_count: int) -> bool:
     """Run pre-spawn guard checks; return False if spawning should be skipped."""
     if getattr(orch, "is_shutting_down", lambda: False)():
@@ -1416,6 +1486,17 @@ def claim_and_spawn_batches(
                 decomposed_task_ids=orch._decomposed_task_ids,
                 workdir=orch._workdir,
             )
+            continue
+
+        # Pre-spawn human-in-the-loop approval gate (#1110). When any task
+        # in this batch carries an ``approval_spec``, block until the
+        # operator decides via ``bernstein approve <id>`` / ``reject``,
+        # or the spec timeout fires. On rejection / reject-style timeout
+        # we mark every task in the batch failed and skip the spawn so
+        # the agent body never runs without explicit consent.
+        if any(t.approval_spec is not None for t in batch) and _await_pre_spawn_approvals(
+            orch, batch, base, result
+        ):
             continue
 
         # WAL: record pre-execution intent BEFORE the HTTP POST /claim so a

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -1494,9 +1494,7 @@ def claim_and_spawn_batches(
         # or the spec timeout fires. On rejection / reject-style timeout
         # we mark every task in the batch failed and skip the spawn so
         # the agent body never runs without explicit consent.
-        if any(t.approval_spec is not None for t in batch) and _await_pre_spawn_approvals(
-            orch, batch, base, result
-        ):
+        if any(t.approval_spec is not None for t in batch) and _await_pre_spawn_approvals(orch, batch, base, result):
             continue
 
         # WAL: record pre-execution intent BEFORE the HTTP POST /claim so a

--- a/tests/integration/test_approval_gate.py
+++ b/tests/integration/test_approval_gate.py
@@ -1,0 +1,318 @@
+"""Integration tests for the pre-spawn approval gate (#1110).
+
+Covers the full sentinel/audit handshake exercised by
+:func:`bernstein.core.orchestration.approval_gate.wait_for_approval`,
+plus the CLI surface (``bernstein approve``/``reject``/``pending``).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import ApprovalSpec
+from click.testing import CliRunner
+
+from bernstein.cli.commands.approve_cmd import approve
+from bernstein.cli.commands.pending_cmd import pending
+from bernstein.cli.commands.reject_cmd import reject
+from bernstein.core.orchestration.approval_gate import (
+    list_pending_approvals,
+    wait_for_approval,
+    write_pending_sentinel,
+)
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.tasks.lifecycle import set_audit_log
+
+
+@pytest.fixture()
+def audit_log(tmp_path: Path) -> Iterator[AuditLog]:
+    """Wire a real :class:`AuditLog` into the lifecycle module for the test.
+
+    Reset the global singleton afterwards so other integration tests do
+    not observe leaked state.
+    """
+    log = AuditLog(tmp_path / "audit", key=b"k" * 32)
+    set_audit_log(log)
+    try:
+        yield log
+    finally:
+        # Drop the global reference; downstream tests build their own.
+        import bernstein.core.tasks.lifecycle as _lifecycle
+
+        _lifecycle._audit_log = None
+
+
+def _read_audit(audit_dir: Path) -> list[dict[str, object]]:
+    """Return every audit row written under *audit_dir* in chain order."""
+    entries: list[dict[str, object]] = []
+    for log_file in sorted(audit_dir.glob("*.jsonl")):
+        for raw in log_file.read_text().splitlines():
+            if raw.strip():
+                entries.append(json.loads(raw))
+    return entries
+
+
+class TestWaitForApprovalSentinel:
+    def test_sentinel_created_on_entry_then_cleared_on_resolve(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="ship?", timeout_seconds=5)
+
+        # Drop the approval decision before the gate even starts so the
+        # poll loop exits on the first iteration.
+        approvals_dir = tmp_path / ".sdd" / "runtime" / "approvals"
+        approvals_dir.mkdir(parents=True)
+        (approvals_dir / "T-1.approved").write_text("approved")
+
+        outcome = wait_for_approval("T-1", spec, workdir=tmp_path, audit_log=audit_log)
+
+        assert outcome == "approved"
+        # Pending sentinel must be cleaned up so list_pending_approvals
+        # does not surface a stale entry.
+        assert not (approvals_dir / "T-1.pending").exists()
+
+    def test_sentinel_payload_matches_spec(self, tmp_path: Path) -> None:
+        spec = ApprovalSpec(prompt="ship?", timeout_seconds=42, default_action="approve")
+        path = write_pending_sentinel(tmp_path, "T-2", spec, now=1_700_000_000.0)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        assert payload["prompt"] == "ship?"
+        assert payload["task_id"] == "T-2"
+        assert payload["timeout_seconds"] == 42
+        assert payload["default_action"] == "approve"
+        assert payload["created_iso"].startswith("2023-")
+        assert payload["timeout_at_iso"].startswith("2023-")
+
+
+class TestApproveRejectCli:
+    def test_approve_cli_unblocks_gate(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="ship?", timeout_seconds=5)
+        outcomes: list[str] = []
+
+        def _runner() -> None:
+            outcomes.append(
+                wait_for_approval(
+                    "T-cli-approve",
+                    spec,
+                    workdir=tmp_path,
+                    audit_log=audit_log,
+                    poll_interval_s=0.05,
+                )
+            )
+
+        thread = threading.Thread(target=_runner)
+        thread.start()
+        # Give the gate a moment to write its sentinel before we land
+        # the decision.
+        deadline = time.monotonic() + 2.0
+        sentinel = tmp_path / ".sdd" / "runtime" / "approvals" / "T-cli-approve.pending"
+        while time.monotonic() < deadline and not sentinel.exists():
+            time.sleep(0.05)
+        assert sentinel.exists(), "pending sentinel never written"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            approve,
+            ["T-cli-approve", "--workdir", str(tmp_path), "--no-prompt"],
+        )
+        assert result.exit_code == 0, result.output
+
+        thread.join(timeout=5)
+        assert outcomes == ["approved"]
+
+    def test_reject_cli_unblocks_gate(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="ship?", timeout_seconds=5)
+        outcomes: list[str] = []
+
+        def _runner() -> None:
+            outcomes.append(
+                wait_for_approval(
+                    "T-cli-reject",
+                    spec,
+                    workdir=tmp_path,
+                    audit_log=audit_log,
+                    poll_interval_s=0.05,
+                )
+            )
+
+        thread = threading.Thread(target=_runner)
+        thread.start()
+        deadline = time.monotonic() + 2.0
+        sentinel = tmp_path / ".sdd" / "runtime" / "approvals" / "T-cli-reject.pending"
+        while time.monotonic() < deadline and not sentinel.exists():
+            time.sleep(0.05)
+        assert sentinel.exists(), "pending sentinel never written"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            reject,
+            ["T-cli-reject", "--workdir", str(tmp_path), "--no-prompt"],
+        )
+        assert result.exit_code == 0, result.output
+
+        thread.join(timeout=5)
+        assert outcomes == ["rejected"]
+
+    def test_concurrent_approve_calls_first_wins(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        approvals_dir = tmp_path / ".sdd" / "runtime" / "approvals"
+        approvals_dir.mkdir(parents=True)
+
+        first = runner.invoke(approve, ["T-race", "--workdir", str(tmp_path), "--no-prompt"])
+        assert first.exit_code == 0
+        assert "Approved" in first.output
+
+        # Second invocation must report the existing decision rather than
+        # silently rewriting state — that is what "first writer wins" means
+        # at the operator-experience layer.
+        second = runner.invoke(approve, ["T-race", "--workdir", str(tmp_path), "--no-prompt"])
+        assert second.exit_code == 0
+        assert "Already approved" in second.output
+
+    def test_reject_after_approve_keeps_approval(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(approve, ["T-cross", "--workdir", str(tmp_path), "--no-prompt"])
+        result = runner.invoke(reject, ["T-cross", "--workdir", str(tmp_path), "--no-prompt"])
+        assert result.exit_code == 0
+        assert "Already resolved" in result.output
+
+
+class TestTimeoutBehaviour:
+    def test_timeout_default_reject_resolves_to_rejected(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="?", timeout_seconds=1, default_action="reject")
+        # Force the monotonic clock past the deadline immediately.
+        clock = iter([0.0, 100.0, 100.0, 100.0])
+        outcome = wait_for_approval(
+            "T-timeout-reject",
+            spec,
+            workdir=tmp_path,
+            audit_log=audit_log,
+            monotonic=lambda: next(clock),
+            sleep=lambda _s: None,
+        )
+        assert outcome == "timeout"
+        # On reject-style timeout the gate persists a .rejected file so
+        # downstream readers see a terminal state.
+        assert (tmp_path / ".sdd" / "runtime" / "approvals" / "T-timeout-reject.rejected").exists()
+
+    def test_timeout_default_approve_resolves_to_approved(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="?", timeout_seconds=1, default_action="approve")
+        clock = iter([0.0, 100.0, 100.0, 100.0])
+        outcome = wait_for_approval(
+            "T-timeout-approve",
+            spec,
+            workdir=tmp_path,
+            audit_log=audit_log,
+            monotonic=lambda: next(clock),
+            sleep=lambda _s: None,
+        )
+        assert outcome == "timeout"
+        # default_action=approve persists an .approved file so the body
+        # would be allowed to run on resume.
+        assert (tmp_path / ".sdd" / "runtime" / "approvals" / "T-timeout-approve.approved").exists()
+
+
+class TestAuditChain:
+    def test_pending_then_resolved_events_in_order(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="ship?", timeout_seconds=5)
+        # Pre-place an .approved file so the gate resolves on first poll.
+        approvals_dir = tmp_path / ".sdd" / "runtime" / "approvals"
+        approvals_dir.mkdir(parents=True)
+        (approvals_dir / "T-audit.approved").write_text("approved")
+
+        outcome = wait_for_approval(
+            "T-audit",
+            spec,
+            workdir=tmp_path,
+            audit_log=audit_log,
+        )
+        assert outcome == "approved"
+
+        events = _read_audit(tmp_path / "audit")
+        approval_events = [e for e in events if str(e.get("event_type", "")).startswith("approval_")]
+        assert [e["event_type"] for e in approval_events] == [
+            "approval_pending",
+            "approval_resolved",
+        ]
+        # Both events must reference the gated task and the chain must verify.
+        assert all(e["resource_id"] == "T-audit" for e in approval_events)
+        valid, errors = audit_log.verify()
+        assert valid, errors
+
+    def test_timeout_emits_timeout_default_decision_source(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="?", timeout_seconds=1, default_action="reject")
+        clock = iter([0.0, 100.0, 100.0])
+        outcome = wait_for_approval(
+            "T-audit-timeout",
+            spec,
+            workdir=tmp_path,
+            audit_log=audit_log,
+            monotonic=lambda: next(clock),
+            sleep=lambda _s: None,
+        )
+        assert outcome == "timeout"
+
+        events = _read_audit(tmp_path / "audit")
+        resolved = [e for e in events if e.get("event_type") == "approval_resolved"]
+        assert resolved, "no approval_resolved event"
+        details = resolved[-1]["details"]
+        assert isinstance(details, dict)
+        assert details["decision_source"] == "timeout-default"
+        assert details["outcome"] == "timeout"
+        assert details["default_action"] == "reject"
+
+
+class TestPendingCommand:
+    def test_pending_lists_approval_sentinels(
+        self, tmp_path: Path, audit_log: AuditLog
+    ) -> None:
+        spec = ApprovalSpec(prompt="ship A?", timeout_seconds=600)
+        write_pending_sentinel(tmp_path, "T-A", spec)
+        spec_b = ApprovalSpec(prompt="ship B?", timeout_seconds=600, default_action="approve")
+        write_pending_sentinel(tmp_path, "T-B", spec_b)
+
+        rows = list_pending_approvals(tmp_path)
+        ids = {row.get("task_id") for row in rows}
+        assert ids == {"T-A", "T-B"}
+
+        runner = CliRunner()
+        result = runner.invoke(pending, ["--workdir", str(tmp_path), "--kind", "approval"])
+        assert result.exit_code == 0, result.output
+        assert "T-A" in result.output
+        assert "T-B" in result.output
+
+    def test_pending_distinguishes_approval_from_spawn(self, tmp_path: Path) -> None:
+        # Create a legacy spawn-pending entry alongside an approval-pending one.
+        approval_dir = tmp_path / ".sdd" / "runtime" / "approvals"
+        approval_dir.mkdir(parents=True)
+        write_pending_sentinel(tmp_path, "T-A", ApprovalSpec(prompt="approval gate"))
+
+        spawn_dir = tmp_path / ".sdd" / "runtime" / "pending_approvals"
+        spawn_dir.mkdir(parents=True)
+        (spawn_dir / "T-S.json").write_text(
+            json.dumps({"task_id": "T-S", "task_title": "spawn ready", "test_summary": "ok"})
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(pending, ["--workdir", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert "Approval-pending" in result.output
+        assert "Spawn-pending" in result.output
+        assert "T-A" in result.output
+        assert "T-S" in result.output

--- a/tests/unit/test_approval_spec.py
+++ b/tests/unit/test_approval_spec.py
@@ -1,0 +1,118 @@
+"""Unit tests for :class:`bernstein.core.models.ApprovalSpec` (#1110)."""
+
+from __future__ import annotations
+
+import pytest
+from bernstein.core.models import ApprovalSpec, Task
+
+
+class TestApprovalSpecValidation:
+    """Field invariants enforced at construction time."""
+
+    def test_default_timeout_is_24h(self) -> None:
+        spec = ApprovalSpec(prompt="ship?")
+        assert spec.timeout_seconds == 86_400
+
+    def test_default_action_is_reject(self) -> None:
+        spec = ApprovalSpec(prompt="ship?")
+        assert spec.default_action == "reject"
+
+    def test_blank_prompt_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ApprovalSpec(prompt="")
+
+    def test_whitespace_only_prompt_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ApprovalSpec(prompt="   \t\n")
+
+    def test_zero_timeout_rejected(self) -> None:
+        with pytest.raises(ValueError, match=">"):
+            ApprovalSpec(prompt="ok", timeout_seconds=0)
+
+    def test_negative_timeout_rejected(self) -> None:
+        with pytest.raises(ValueError, match=">"):
+            ApprovalSpec(prompt="ok", timeout_seconds=-1)
+
+    def test_explicit_approve_default(self) -> None:
+        spec = ApprovalSpec(prompt="ok", default_action="approve")
+        assert spec.default_action == "approve"
+
+    def test_explicit_fail_default(self) -> None:
+        spec = ApprovalSpec(prompt="ok", default_action="fail")
+        assert spec.default_action == "fail"
+
+
+class TestApprovalSpecSerialisation:
+    """Round-trip via :meth:`to_dict` / :meth:`from_dict`."""
+
+    def test_round_trip_preserves_fields(self) -> None:
+        original = ApprovalSpec(
+            prompt="Promote to prod?",
+            timeout_seconds=600,
+            default_action="approve",
+        )
+        dumped = original.to_dict()
+        rebuilt = ApprovalSpec.from_dict(dumped)
+        assert rebuilt == original
+
+    def test_from_dict_uses_defaults_for_missing_keys(self) -> None:
+        spec = ApprovalSpec.from_dict({"prompt": "go?"})
+        assert spec.prompt == "go?"
+        assert spec.timeout_seconds == 86_400
+        assert spec.default_action == "reject"
+
+    def test_from_dict_rejects_unknown_default_action(self) -> None:
+        with pytest.raises(ValueError):
+            ApprovalSpec.from_dict({"prompt": "go?", "default_action": "explode"})
+
+    def test_from_dict_propagates_validation_errors(self) -> None:
+        with pytest.raises(ValueError):
+            ApprovalSpec.from_dict({"prompt": "", "timeout_seconds": 60})
+
+
+class TestTaskApprovalSpecField:
+    """Wiring of the new optional ``Task.approval_spec`` field."""
+
+    def test_task_default_has_no_approval_spec(self) -> None:
+        task = Task(id="T-1", title="t", description="d", role="backend")
+        assert task.approval_spec is None
+        # Legacy boolean still defaults False so existing tests stay green.
+        assert task.approval_required is False
+
+    def test_task_accepts_approval_spec(self) -> None:
+        spec = ApprovalSpec(prompt="ok?")
+        task = Task(
+            id="T-1",
+            title="t",
+            description="d",
+            role="backend",
+            approval_spec=spec,
+        )
+        assert task.approval_spec is spec
+
+    def test_from_dict_round_trips_approval_spec(self) -> None:
+        raw = {
+            "id": "T-2",
+            "title": "ship",
+            "description": "ship the thing",
+            "role": "backend",
+            "approval_spec": {
+                "prompt": "ship?",
+                "timeout_seconds": 30,
+                "default_action": "approve",
+            },
+        }
+        task = Task.from_dict(raw)
+        assert task.approval_spec is not None
+        assert task.approval_spec.prompt == "ship?"
+        assert task.approval_spec.timeout_seconds == 30
+        assert task.approval_spec.default_action == "approve"
+
+    def test_from_dict_no_spec_when_absent(self) -> None:
+        raw = {
+            "id": "T-3",
+            "title": "ship",
+            "description": "no spec here",
+            "role": "backend",
+        }
+        assert Task.from_dict(raw).approval_spec is None


### PR DESCRIPTION
## Summary

Closes #1110.

- New `ApprovalSpec` dataclass (`prompt`, `timeout_seconds`, `default_action`) + optional `Task.approval_spec` field. Validation (non-empty prompt, positive timeout, enum default_action) runs in `__post_init__`.
- New `bernstein.core.orchestration.approval_gate.wait_for_approval` blocks before the agent body runs, writes a `<task_id>.pending` JSON sentinel, and emits HMAC-chained `approval_pending` + `approval_resolved` audit events. Decisions arrive via `<task_id>.approved` / `<task_id>.rejected` files written by the CLI; first writer wins (atomic `os.replace`); timeout falls back to the spec's `default_action`.
- Orchestrator wiring: `claim_and_spawn_batches` invokes the gate before claiming any task that carries `approval_spec`. Rejection or reject-style timeout fails the batch and skips the spawn — the agent body never runs without explicit consent.
- `bernstein approve` / `bernstein reject` / `bernstein pending` extracted into dedicated `cli/commands/` modules (`task_cmd.py` keeps re-exports). Approve/Reject now report `Already resolved`/`Already approved` on second invocations and read `y/N` on TTY when `--prompt` is on (default). `pending` separately surfaces approval-pending sentinels (#1110) and the legacy spawn-pending review queue.
- Constraints honoured: spawner core, cluster transport, lineage subsystem untouched; existing approve/reject/pending tests still pass; ruff clean on touched files; Google-style docstrings throughout.

## Test plan

- [x] `pytest tests/unit/test_approval_spec.py` — 16 cases (validation, serialisation, Task field wiring)
- [x] `pytest tests/integration/test_approval_gate.py` — 12 cases (sentinel lifecycle, CLI race, timeout default actions, audit chain, pending listing)
- [x] `pytest tests/unit/test_approval*.py tests/integration/test_approval*.py` — 131 passed (existing approval tests still green)
- [x] `pytest tests/unit/test_orchestrator*.py` — 277 passed
- [x] `pytest tests/unit/test_lifecycle*.py tests/unit/test_task_lifecycle*.py` — 301 passed
- [x] `pytest tests/unit/test_cli*.py tests/unit/test_main*.py` — 123 passed
- [x] `ruff check` — all touched files clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)