### PR TITLE
feat(workflow): YAML workflow manifest + bernstein workflow CLI

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -51,6 +51,7 @@ alwaysApply: false
 | `tokens/`               | tokens sub-package |
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
+| `workflows/`            | Archon-inspired YAML workflow manifests |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/.goosehints
+++ b/.goosehints
@@ -52,6 +52,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `tokens/`               | tokens sub-package |
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
+| `workflows/`            | Archon-inspired YAML workflow manifests |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `tokens/`               | tokens sub-package |
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
+| `workflows/`            | Archon-inspired YAML workflow manifests |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `tokens/`               | tokens sub-package |
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
+| `workflows/`            | Archon-inspired YAML workflow manifests |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -52,6 +52,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `tokens/`               | tokens sub-package |
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
+| `workflows/`            | Archon-inspired YAML workflow manifests |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,38 @@ $ bernstein -g "Add JWT auth"
 [verify]  all gates pass. merging to main.
 ```
 
+### YAML workflow manifests (optional)
+
+When the open-ended `bernstein run -g "<goal>"` is too coarse-grained, the
+`bernstein workflow` family runs a declarative DAG of agent / command / loop
+nodes. Manifests are plain YAML, validated up-front, and dispatched through
+the same `AgentSpawner` the rest of Bernstein uses. No parallel spawn path,
+no LLM in the scheduler.
+
+```bash
+bernstein workflow list                       # bundled + user-installed
+bernstein workflow run idea-to-pr -g "Add JWT auth"
+bernstein workflow init my-flow               # scaffold a starter manifest
+bernstein workflow validate path/to/flow.yaml
+```
+
+Stock workflows that ship with the wheel:
+
+| Name                  | What it does                                         |
+| --------------------- | ---------------------------------------------------- |
+| `idea-to-pr`          | research → plan → implement → tests → PR             |
+| `refactor-with-tests` | find target → propose → implement → loop until green |
+| `security-review`     | scan → triage → patch → adversary review             |
+| `doc-update`          | audit → update → docs build                          |
+| `dependency-bump`     | bump → install → tests-loop → smoke                  |
+| `hot-fix`             | reproduce → fix → regression loop → changelog        |
+
+Loop nodes re-fire until a bash predicate exits 0 (`pytest -x` is a typical
+one). `fresh_context: true` mints a new agent session per iteration. The
+`interactive: true` flag is reserved for the approval-gate work tracked in
+ticket #1110 and currently raises a clear `NotImplementedError`.
+
+
 ## use cases
 
 - forward-deployed engineering — drop the swarm onto a client repo when you arrive, take it with you when you leave.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,10 @@ packages = ["src/bernstein"]
 # Lethal-trifecta capability matrix declarations.  Bundled so the
 # default-deny check can find tags right after pip install.
 "templates/capabilities" = "bernstein/_default_templates/capabilities"
+# Stock YAML workflow manifests (#1108) shipped with the wheel so
+# `bernstein workflow list` / `... run <name>` resolve immediately
+# without requiring a source checkout.
+"templates/workflows" = "bernstein/_default_templates/workflows"
 # ascii_logo.md now lives in-package at src/bernstein/_default_templates/ —
 # no force-include needed. The dev-repo copy at docs/assets/ascii_logo.md is
 # the display fallback read by cli/display/splash_v2.py when running from a

--- a/src/bernstein/cli/commands/workflow_cmd.py
+++ b/src/bernstein/cli/commands/workflow_cmd.py
@@ -1,7 +1,16 @@
-"""CLI commands for workflow DSL management.
+"""CLI commands for workflow management.
 
-Provides ``bernstein workflow validate``, ``bernstein workflow list``,
-and ``bernstein workflow show`` subcommands.
+Two manifest flavours coexist under ``bernstein workflow``:
+
+* The legacy **DSL** (conditional task DAGs that plug into the
+  orchestrator's deterministic crew-routing model — see
+  :mod:`bernstein.core.planning.workflow_dsl`).  Surface: the original
+  ``validate``/``list``/``show`` commands keep working unchanged.
+* The new **YAML manifest** flavour added in #1108 — Archon-inspired
+  agent / command / loop nodes executed via
+  :class:`bernstein.core.workflows.WorkflowRunner`.  Surface:
+  ``run``/``init`` plus dual-mode ``validate``/``list`` that auto-detect
+  manifest kind so a single command serves both schemas.
 """
 
 from __future__ import annotations
@@ -11,43 +20,153 @@ from typing import Any
 
 import click
 
+# ---------------------------------------------------------------------------
+# Schema detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_kind(path: Path) -> str:
+    """Sniff a YAML file and return ``'spec'``, ``'dsl'``, or ``'unknown'``.
+
+    The sniff stays purely structural — it doesn't import either parser
+    so a malformed file in one schema can't blow up the other path.
+
+    Args:
+        path: Filesystem path to a YAML manifest.
+
+    Returns:
+        ``'spec'`` for the new :class:`WorkflowSpec` schema (top-level
+        ``nodes`` is a list and the file lacks ``phases``); ``'dsl'``
+        for the conditional DAG DSL (top-level ``phases`` present);
+        ``'unknown'`` when the structure is inconclusive.
+    """
+    import yaml
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return "unknown"
+    if not isinstance(data, dict):
+        return "unknown"
+    if "phases" in data:
+        return "dsl"
+    nodes = data.get("nodes")
+    if isinstance(nodes, list):
+        return "spec"
+    if isinstance(nodes, dict):
+        return "dsl"
+    return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Top-level group
+# ---------------------------------------------------------------------------
+
 
 @click.group("workflow")
 def workflow_group() -> None:
-    """Manage workflow DSL definitions.
+    """Manage workflow manifests.
 
     \b
-    Workflow DSL files live in .bernstein/workflows/ and define
-    conditional task DAGs with fan-out/fan-in patterns.
+    Two manifest flavours are supported and auto-detected by validate/list:
+    - YAML manifest (Archon-style): nodes as a list, executed by
+      `bernstein workflow run`.
+    - DSL: nodes keyed by id with `phases:`, used by the orchestrator's
+      deterministic crew-routing model.
 
     \b
     Examples:
-      bernstein workflow validate .bernstein/workflows/ci.yaml
       bernstein workflow list
+      bernstein workflow run idea-to-pr -g "Add JWT auth"
+      bernstein workflow init my-flow
+      bernstein workflow validate path/to/flow.yaml
       bernstein workflow show ci-pipeline
     """
+
+
+# ---------------------------------------------------------------------------
+# validate (dual mode)
+# ---------------------------------------------------------------------------
 
 
 @workflow_group.command("validate")
 @click.argument("file", type=click.Path(exists=True))
 def validate_cmd(file: str) -> None:
-    """Validate a workflow DSL YAML file.
+    """Validate a workflow manifest (YAML manifest or DSL).
 
-    Checks for cycles, unreachable nodes, invalid phase references,
-    backward unconditional edges, and malformed conditions.
+    Auto-detects the manifest flavour and delegates to the matching
+    validator.  Exits 0 on success, 1 on validation failure.
 
     \b
     Example:
-      bernstein workflow validate .bernstein/workflows/ci.yaml
+      bernstein workflow validate templates/workflows/idea-to-pr.yaml
     """
     from rich.console import Console
+    from rich.panel import Panel
+
+    console = Console()
+    path = Path(file)
+    kind = _detect_kind(path)
+    if kind == "spec":
+        _validate_spec(path, console)
+        return
+    if kind == "dsl":
+        _validate_dsl(path, console)
+        return
+
+    # Last-ditch attempt: try spec then DSL so users get a useful error
+    # rather than a generic "unknown" message.
+    from bernstein.core.workflows import WorkflowSpecError, load_workflow_spec
+
+    try:
+        load_workflow_spec(path)
+    except WorkflowSpecError as exc:
+        console.print(f"[bold red]Validation failed:[/bold red] {exc}")
+        console.print(Panel("[bold red]Invalid[/bold red]", expand=False))
+        raise SystemExit(1) from exc
+    console.print(Panel("[bold green]Valid (manifest)[/bold green]", expand=False))
+
+
+def _validate_spec(path: Path, console: Any) -> None:
+    """Validate a WorkflowSpec manifest and print a tidy summary."""
+    from rich.panel import Panel
+    from rich.table import Table
+
+    from bernstein.core.workflows import WorkflowSpecError, load_workflow_spec
+
+    try:
+        spec = load_workflow_spec(path)
+    except WorkflowSpecError as exc:
+        console.print(f"[bold red]Validation failed:[/bold red] {exc}")
+        console.print(Panel("[bold red]Invalid[/bold red]", expand=False))
+        raise SystemExit(1) from exc
+
+    table = Table(title=f"Workflow: {spec.name}", show_lines=True)
+    table.add_column("Property", style="bold")
+    table.add_column("Value")
+    table.add_row("Name", spec.name)
+    table.add_row("Description", spec.description)
+    table.add_row("Version", spec.version)
+    table.add_row("Nodes", str(len(spec.nodes)))
+    table.add_row("Layers", str(len(spec.topological_order())))
+    agent_nodes = sum(1 for n in spec.nodes if n.kind == "agent")
+    table.add_row("Agent nodes", str(agent_nodes))
+    command_nodes = sum(1 for n in spec.nodes if n.kind == "command")
+    table.add_row("Command nodes", str(command_nodes))
+    loop_nodes = sum(1 for n in spec.nodes if n.loop is not None)
+    table.add_row("Loop nodes", str(loop_nodes))
+    interactive = sum(1 for n in spec.nodes if n.interactive)
+    table.add_row("Interactive nodes (stub)", str(interactive))
+    console.print(table)
+    console.print(Panel("[bold green]Valid (manifest)[/bold green]", expand=False))
+
+
+def _validate_dsl(path: Path, console: Any) -> None:
+    """Validate a workflow DSL file (legacy conditional DAG schema)."""
     from rich.panel import Panel
     from rich.table import Table
 
     from bernstein.core.workflow_dsl import DSLError, parse_workflow_yaml, validate_dag
-
-    console = Console()
-    path = Path(file)
 
     try:
         dag = parse_workflow_yaml(path)
@@ -55,42 +174,41 @@ def validate_cmd(file: str) -> None:
         console.print(f"[bold red]Validation failed:[/bold red] {exc}")
         raise SystemExit(1) from exc
 
-    # parse_workflow_yaml already validates, but run again for detailed output.
     result = validate_dag(dag)
 
-    # Summary table.
     table = Table(title=f"Workflow: {dag.definition.name}", show_lines=True)
     table.add_column("Property", style="bold")
     table.add_column("Value")
-
     table.add_row("Name", dag.definition.name)
     table.add_row("Version", dag.definition.version)
-    table.add_row("Phases", " → ".join(dag.definition.phase_names()))
+    table.add_row("Phases", " > ".join(dag.definition.phase_names()))
     table.add_row("Nodes", str(len(dag.nodes)))
     table.add_row("Edges", str(len(dag.edges)))
-
     conditional_count = sum(1 for e in dag.edges if e.condition is not None)
     table.add_row("Conditional edges", str(conditional_count))
-
     retry_count = sum(1 for n in dag.nodes if n.retry is not None)
     table.add_row("Nodes with retry", str(retry_count))
-
-    table.add_row("Hash", dag.definition_hash()[:16] + "…")
+    table.add_row("Hash", dag.definition_hash()[:16] + "...")
     console.print(table)
 
     if result.warnings:
         console.print()
         for warning in result.warnings:
-            console.print(f"  [yellow]⚠[/yellow]  {warning}")
+            console.print(f"  [yellow]![/yellow]  {warning}")
 
     if result.is_valid:
-        console.print(Panel("[bold green]✓ Valid[/bold green]", expand=False))
+        console.print(Panel("[bold green]Valid (DSL)[/bold green]", expand=False))
     else:
         console.print()
         for error in result.errors:
-            console.print(f"  [red]✗[/red]  {error}")
-        console.print(Panel("[bold red]✗ Invalid[/bold red]", expand=False))
+            console.print(f"  [red]X[/red]  {error}")
+        console.print(Panel("[bold red]Invalid (DSL)[/bold red]", expand=False))
         raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# list (dual mode)
+# ---------------------------------------------------------------------------
 
 
 @workflow_group.command("list")
@@ -99,62 +217,230 @@ def validate_cmd(file: str) -> None:
     "search_dir",
     default=None,
     type=click.Path(exists=True),
-    help="Override search directory (default: .bernstein/workflows/).",
+    help="Override search directory; defaults span bundled and user dirs.",
 )
-def list_cmd(search_dir: str | None) -> None:
-    """List available workflow DSL files.
+@click.option(
+    "--bundled-only",
+    is_flag=True,
+    default=False,
+    help="List only bundled YAML manifests (templates/workflows).",
+)
+def list_cmd(search_dir: str | None, bundled_only: bool) -> None:
+    """List bundled and user-installed workflow manifests.
+
+    Includes:
 
     \b
-    Scans .bernstein/workflows/ for .yaml/.yml files and shows a
-    summary of each valid workflow.
+    - YAML manifests from templates/workflows/ (bundled), .bernstein/
+      workflows/ (project), and ~/.bernstein/workflows/ (user).
+    - Legacy DSL files in .bernstein/workflows/ (best-effort).
     """
     from rich.console import Console
     from rich.table import Table
 
-    from bernstein.core.workflow_dsl import DSLError, parse_workflow_yaml
+    from bernstein.core.workflows import (
+        WorkflowSpecError,
+        discover_workflows,
+    )
 
     console = Console()
-    wf_dir = Path(search_dir) if search_dir else Path(".bernstein") / "workflows"
-
-    if not wf_dir.is_dir():
-        console.print(f"[dim]No workflow directory found at {wf_dir}[/dim]")
-        return
-
-    files = sorted(wf_dir.glob("*.yaml")) + sorted(wf_dir.glob("*.yml"))
-    if not files:
-        console.print(f"[dim]No workflow files found in {wf_dir}[/dim]")
-        return
-
-    table = Table(title="Workflow DSL Files")
+    table = Table(title="Workflow manifests")
     table.add_column("Name", style="bold")
-    table.add_column("Version")
-    table.add_column("Phases")
+    table.add_column("Kind")
+    table.add_column("Version / Phases")
     table.add_column("Nodes", justify="right")
-    table.add_column("Edges", justify="right")
-    table.add_column("Status")
+    table.add_column("Source")
 
-    for f in files:
-        try:
-            dag = parse_workflow_yaml(f)
-            table.add_row(
-                dag.definition.name,
-                dag.definition.version,
-                " → ".join(dag.definition.phase_names()),
-                str(len(dag.nodes)),
-                str(len(dag.edges)),
-                "[green]valid[/green]",
-            )
-        except DSLError as exc:
-            table.add_row(
-                f.stem,
-                "—",
-                "—",
-                "—",
-                "—",
-                f"[red]error: {exc}[/red]",
-            )
+    # New-style YAML manifests (auto-discovered or via --dir).
+    workdir = Path.cwd()
+    if search_dir:
+        directory = Path(search_dir)
+        candidates = sorted(directory.glob("*.yaml")) + sorted(directory.glob("*.yml"))
+        for path in candidates:
+            _add_spec_row(path, table, source=str(directory))
+    else:
+        for _, path in discover_workflows(workdir=workdir, include_bundled=True, include_user=not bundled_only):
+            _add_spec_row(path, table, source=path.parent.as_posix())
 
+    # Legacy DSL files for backward compatibility.
+    if not bundled_only:
+        from bernstein.core.workflow_dsl import DSLError, parse_workflow_yaml
+
+        dsl_dir = Path(search_dir) if search_dir else (workdir / ".bernstein" / "workflows")
+        if dsl_dir.is_dir():
+            for path in sorted(dsl_dir.glob("*.yaml")) + sorted(dsl_dir.glob("*.yml")):
+                if _detect_kind(path) != "dsl":
+                    continue
+                try:
+                    dag = parse_workflow_yaml(path)
+                    table.add_row(
+                        dag.definition.name,
+                        "DSL",
+                        " > ".join(dag.definition.phase_names()),
+                        str(len(dag.nodes)),
+                        path.parent.as_posix(),
+                    )
+                except DSLError as exc:
+                    table.add_row(path.stem, "DSL", "-", "-", f"[red]error: {exc}[/red]")
+
+    if table.row_count == 0:
+        console.print("[dim]No workflows found.[/dim]")
+        return
     console.print(table)
+    _ = WorkflowSpecError  # keep import live for static analysers
+
+
+def _add_spec_row(path: Path, table: Any, *, source: str) -> None:
+    """Append a row for a YAML manifest, capturing parse errors inline."""
+    from bernstein.core.workflows import WorkflowSpecError, load_workflow_spec
+
+    try:
+        spec = load_workflow_spec(path)
+        table.add_row(
+            spec.name,
+            "manifest",
+            spec.version,
+            str(len(spec.nodes)),
+            source,
+        )
+    except WorkflowSpecError as exc:
+        table.add_row(path.stem, "manifest", "-", "-", f"[red]error: {exc}[/red]")
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+@workflow_group.command("run")
+@click.argument("name_or_path")
+@click.option("-g", "--goal", default="", help="Goal text substituted into {goal} placeholders.")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Validate the manifest and print the execution plan without running it.",
+)
+def run_cmd(name_or_path: str, goal: str, dry_run: bool) -> None:
+    """Execute a YAML workflow manifest.
+
+    \b
+    Resolves the manifest by name (against bundled + user-installed dirs)
+    or by filesystem path.  Agent-typed nodes dispatch through the
+    existing AgentSpawner; command-typed nodes shell out; loop nodes
+    re-fire until their predicate exits 0 or max_iterations is hit.
+
+    \b
+    Examples:
+      bernstein workflow run idea-to-pr -g "Add JWT auth"
+      bernstein workflow run ./templates/workflows/refactor-with-tests.yaml
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    from bernstein.core.workflows import NodeStatus, WorkflowRunner, WorkflowSpecError
+    from bernstein.core.workflows.workflow_spec import resolve_workflow
+
+    console = Console()
+    try:
+        path, spec = resolve_workflow(name_or_path, workdir=Path.cwd())
+    except WorkflowSpecError as exc:
+        console.print(f"[bold red]Resolve failed:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(f"[bold]Workflow:[/bold] {spec.name} ({path})")
+    console.print(f"[dim]{spec.description}[/dim]")
+    console.print(f"[dim]Version {spec.version}; {len(spec.nodes)} node(s).[/dim]\n")
+
+    if dry_run:
+        layers = spec.topological_order()
+        for index, layer in enumerate(layers, start=1):
+            ids = ", ".join(node.id for node in layer)
+            console.print(f"  [bold]Layer {index}:[/bold] {ids}")
+        return
+
+    runner = WorkflowRunner(workdir=Path.cwd())
+    execution = runner.run(spec, goal=goal)
+
+    table = Table(title=f"Run {execution.run_id}")
+    table.add_column("Node")
+    table.add_column("Status")
+    table.add_column("Iters", justify="right")
+    table.add_column("Exit", justify="right")
+    table.add_column("Wall (s)", justify="right")
+    table.add_column("Note")
+    for node_exec in execution.nodes:
+        colour = (
+            "green"
+            if node_exec.status == NodeStatus.SUCCESS
+            else ("red" if node_exec.status == NodeStatus.FAILED else "yellow")
+        )
+        table.add_row(
+            node_exec.node_id,
+            f"[{colour}]{node_exec.status.value}[/{colour}]",
+            str(node_exec.iterations),
+            "-" if node_exec.exit_code is None else str(node_exec.exit_code),
+            f"{node_exec.wall_time_seconds:.2f}",
+            node_exec.error or "",
+        )
+    console.print(table)
+    if not execution.succeeded:
+        raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+@workflow_group.command("init")
+@click.argument("name")
+@click.option(
+    "--target",
+    default=None,
+    type=click.Path(),
+    help="Output path; defaults to .bernstein/workflows/<name>.yaml.",
+)
+@click.option("--force", is_flag=True, default=False, help="Overwrite an existing file.")
+def init_cmd(name: str, target: str | None, force: bool) -> None:
+    """Scaffold a new YAML workflow manifest.
+
+    \b
+    Example:
+      bernstein workflow init my-flow
+      bernstein workflow init my-flow --target ~/workflows/my-flow.yaml
+    """
+    from rich.console import Console
+
+    from bernstein.core.workflows.workflow_spec import (
+        WorkflowSpecError,
+        load_workflow_spec_from_text,
+        render_blank_template,
+    )
+
+    console = Console()
+    try:
+        body = render_blank_template(name)
+    except WorkflowSpecError as exc:
+        console.print(f"[bold red]Init failed:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+
+    # Sanity check: the rendered template must round-trip through the
+    # parser so users never get a scaffold that fails their own validate.
+    load_workflow_spec_from_text(body)
+
+    out_path = Path(target) if target else Path.cwd() / ".bernstein" / "workflows" / f"{name}.yaml"
+    if out_path.exists() and not force:
+        console.print(f"[bold red]Refusing to overwrite[/bold red] {out_path} (pass --force).")
+        raise SystemExit(1)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(body, encoding="utf-8")
+    console.print(f"[green]Scaffolded[/green] {out_path}")
+
+
+# ---------------------------------------------------------------------------
+# show (legacy DSL details)
+# ---------------------------------------------------------------------------
 
 
 def _build_phase_tree(dag: Any) -> Any:
@@ -188,7 +474,7 @@ def _build_edge_table(dag: Any) -> Any:
             edge.source,
             edge.target,
             edge.edge_type.value,
-            edge.condition.raw if edge.condition else "\u2014",
+            edge.condition.raw if edge.condition else "-",
         )
     return edge_table
 
@@ -203,7 +489,7 @@ def _build_edge_table(dag: Any) -> Any:
     help="Override search directory (default: .bernstein/workflows/).",
 )
 def show_cmd(name: str, search_dir: str | None) -> None:
-    """Show details of a workflow DSL by name.
+    """Show details of a workflow DSL by name (legacy conditional DAG).
 
     \b
     Example:
@@ -222,7 +508,6 @@ def show_cmd(name: str, search_dir: str | None) -> None:
         raise SystemExit(1)
 
     console.print(_build_phase_tree(dag))
-
     if dag.edges:
         console.print()
         console.print(_build_edge_table(dag))

--- a/src/bernstein/core/workflows/__init__.py
+++ b/src/bernstein/core/workflows/__init__.py
@@ -1,0 +1,49 @@
+"""Archon-inspired YAML workflow manifests.
+
+Companion to ``bernstein run -g <goal>``: a declarative way to run a
+DAG of agent / command / loop nodes through the existing
+:class:`bernstein.core.spawner.AgentSpawner` rather than introducing a
+parallel spawn path.
+
+Public surface:
+
+* :class:`WorkflowSpec` / :class:`WorkflowNode` / :class:`LoopSpec` —
+  Pydantic v2 schema for the YAML manifest (see
+  :mod:`bernstein.core.workflows.workflow_spec`).
+* :class:`WorkflowRunner` — DAG executor (see
+  :mod:`bernstein.core.workflows.workflow_runner`).
+"""
+
+from __future__ import annotations
+
+from bernstein.core.workflows.workflow_runner import (
+    NodeExecution,
+    NodeStatus,
+    WorkflowExecution,
+    WorkflowRunError,
+    WorkflowRunner,
+)
+from bernstein.core.workflows.workflow_spec import (
+    LoopSpec,
+    WorkflowNode,
+    WorkflowSpec,
+    WorkflowSpecError,
+    discover_workflows,
+    load_workflow_spec,
+    load_workflow_spec_from_text,
+)
+
+__all__ = [
+    "LoopSpec",
+    "NodeExecution",
+    "NodeStatus",
+    "WorkflowExecution",
+    "WorkflowNode",
+    "WorkflowRunError",
+    "WorkflowRunner",
+    "WorkflowSpec",
+    "WorkflowSpecError",
+    "discover_workflows",
+    "load_workflow_spec",
+    "load_workflow_spec_from_text",
+]

--- a/src/bernstein/core/workflows/workflow_runner.py
+++ b/src/bernstein/core/workflows/workflow_runner.py
@@ -1,0 +1,539 @@
+"""DAG runner for Archon-style YAML workflow manifests.
+
+Drives a :class:`bernstein.core.workflows.workflow_spec.WorkflowSpec`
+through a topological execution: every layer of ready nodes runs in
+parallel, agent-typed nodes dispatch through the existing
+:class:`bernstein.core.spawner.AgentSpawner`, and command-typed nodes
+shell out via :func:`subprocess.run`.
+
+Notes:
+
+* Approval gates (``interactive: true``) are deliberately stubbed.  Any
+  encounter raises ``NotImplementedError`` referencing ticket #1110,
+  which owns that feature.
+* Audit emission is best-effort: when no audit log is wired in we fall
+  back to a structured log line so workflow runs are still observable
+  in production.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import subprocess
+import time
+import uuid
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from bernstein.core.spawner import AgentSpawner
+    from bernstein.core.workflows.workflow_spec import LoopSpec, WorkflowNode, WorkflowSpec
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class NodeStatus(StrEnum):
+    """Terminal status for a single workflow node execution."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class WorkflowRunError(RuntimeError):
+    """Raised for unrecoverable runner-level failures.
+
+    Used for cycles caught at run time, missing agent spawners on
+    agent-typed nodes, exhausted loop iterations, and the explicit
+    interactive-gate stub.  Per-node failures are reported via
+    :class:`NodeExecution.status` rather than as exceptions so the
+    runner can surface partial results to the caller.
+    """
+
+
+@dataclass
+class NodeExecution:
+    """Outcome of running one node (with all its loop iterations).
+
+    Attributes:
+        node_id: The id of the executed node.
+        status: Terminal status.  ``SKIPPED`` is used when a node is
+            preempted because an upstream dependency failed.
+        iterations: How many times the node fired.  ``1`` for
+            non-looping nodes; up to ``loop.max_iterations`` for loops.
+        exit_code: Final exit code for command-typed nodes.  Always 0
+            on success; non-zero or ``None`` on failure (``None`` means
+            the process never produced an exit code, e.g. timeout).
+        stdout: Captured stdout of the last iteration.
+        stderr: Captured stderr of the last iteration.
+        session_id: Agent session id for agent-typed nodes (last
+            iteration if looping).  Empty string for command nodes.
+        error: Human-readable error message when status is FAILED.
+        wall_time_seconds: Wall clock spent in this node, end-to-end.
+    """
+
+    node_id: str
+    status: NodeStatus
+    iterations: int = 0
+    exit_code: int | None = None
+    stdout: str = ""
+    stderr: str = ""
+    session_id: str = ""
+    error: str = ""
+    wall_time_seconds: float = 0.0
+
+
+@dataclass
+class WorkflowExecution:
+    """Aggregate outcome of running a whole workflow.
+
+    Attributes:
+        spec_name: Workflow ``name`` from the manifest.
+        run_id: Random run identifier; surfaces in audit events so the
+            same logical run can be tied together across nodes.
+        nodes: Per-node results, in the order they finished.
+        wall_time_seconds: Total wall clock for the run.
+        succeeded: ``True`` only if every executed node ended in
+            :attr:`NodeStatus.SUCCESS`.
+    """
+
+    spec_name: str
+    run_id: str
+    nodes: list[NodeExecution] = field(default_factory=list)
+    wall_time_seconds: float = 0.0
+    succeeded: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Audit hook
+# ---------------------------------------------------------------------------
+
+# An audit emitter is a sync callable matching the loose contract used
+# elsewhere in core (handlers in core/protocols/acp use the same shape):
+# ``(event_type, resource_id, details)``.  Keeping it as a Callable
+# instead of importing :class:`AuditLog` avoids a hard dependency on the
+# security stack — the runner runs fine without it.
+AuditEmitter = Callable[[str, str, dict[str, Any]], None]
+
+
+def _default_audit_emitter(event_type: str, resource_id: str, details: dict[str, Any]) -> None:
+    """Log audit events at INFO level when no real audit log is wired in.
+
+    This keeps workflow runs observable in production without forcing the
+    user to bring up the HMAC chain — which is wired in higher layers
+    (orchestrator boot) and not always present in CLI-direct runs.
+    """
+    logger.info("workflow.audit event=%s resource=%s details=%s", event_type, resource_id, details)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+class WorkflowRunner:
+    """Executes :class:`WorkflowSpec` manifests.
+
+    Args:
+        spawner: Optional :class:`AgentSpawner` for agent-typed nodes.
+            When omitted, agent-typed nodes raise
+            :class:`WorkflowRunError`.  Tests building command-only
+            workflows can pass ``None`` here.
+        workdir: Working directory for command-typed ``subprocess.run``
+            invocations.  Defaults to the current process's cwd.
+        audit_emitter: Optional callable for audit events.  Defaults to
+            a logger that writes structured INFO lines.
+        max_parallel: Cap on concurrent node executions.  ``None``
+            uses ``min(layer_size, 8)`` per layer.
+        env: Environment overlay applied to command nodes.  ``None``
+            inherits the runner's environment.
+    """
+
+    def __init__(
+        self,
+        *,
+        spawner: AgentSpawner | None = None,
+        workdir: Path | None = None,
+        audit_emitter: AuditEmitter | None = None,
+        max_parallel: int | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._spawner = spawner
+        self._workdir = (workdir or Path.cwd()).resolve()
+        self._audit = audit_emitter or _default_audit_emitter
+        self._max_parallel = max_parallel
+        self._env = env
+
+    # ----- public entry -----------------------------------------------------
+
+    def run(
+        self,
+        spec: WorkflowSpec,
+        *,
+        goal: str = "",
+        run_id: str | None = None,
+    ) -> WorkflowExecution:
+        """Execute ``spec`` end-to-end.
+
+        Args:
+            spec: Validated workflow manifest.
+            goal: Free-text goal substituted into ``{goal}`` placeholders
+                in node prompts.  Mirrors ``bernstein run -g``.
+            run_id: Optional pre-allocated run id.  When ``None`` a fresh
+                short id is generated so audit consumers can correlate.
+
+        Returns:
+            A :class:`WorkflowExecution` describing every node that ran.
+            The runner does not raise on per-node failure: callers
+            inspect ``execution.succeeded`` and per-node statuses.
+        """
+        rid = run_id or uuid.uuid4().hex[:12]
+        execution = WorkflowExecution(spec_name=spec.name, run_id=rid)
+        start = time.monotonic()
+
+        self._audit(
+            "workflow.start",
+            spec.name,
+            {"run_id": rid, "node_count": len(spec.nodes), "goal": goal},
+        )
+
+        results: dict[str, NodeExecution] = {}
+        layers = spec.topological_order()
+        aborted = False
+
+        for layer in layers:
+            if aborted:
+                for node in layer:
+                    skipped = NodeExecution(node_id=node.id, status=NodeStatus.SKIPPED)
+                    results[node.id] = skipped
+                    execution.nodes.append(skipped)
+                continue
+
+            ready_nodes: list[WorkflowNode] = []
+            for node in layer:
+                if not all(results[dep].status == NodeStatus.SUCCESS for dep in node.depends_on if dep in results):
+                    skipped = NodeExecution(node_id=node.id, status=NodeStatus.SKIPPED)
+                    results[node.id] = skipped
+                    execution.nodes.append(skipped)
+                    continue
+                ready_nodes.append(node)
+
+            if not ready_nodes:
+                continue
+
+            layer_results = self._execute_layer(ready_nodes, goal=goal, run_id=rid)
+            for node_exec in layer_results:
+                results[node_exec.node_id] = node_exec
+                execution.nodes.append(node_exec)
+                if node_exec.status == NodeStatus.FAILED:
+                    aborted = True
+
+        execution.wall_time_seconds = time.monotonic() - start
+        execution.succeeded = not aborted and all(
+            r.status == NodeStatus.SUCCESS for r in execution.nodes if execution.nodes
+        )
+        self._audit(
+            "workflow.finish",
+            spec.name,
+            {
+                "run_id": rid,
+                "succeeded": execution.succeeded,
+                "wall_time_seconds": round(execution.wall_time_seconds, 3),
+            },
+        )
+        return execution
+
+    # ----- internal helpers -------------------------------------------------
+
+    def _execute_layer(
+        self,
+        nodes: list[WorkflowNode],
+        *,
+        goal: str,
+        run_id: str,
+    ) -> list[NodeExecution]:
+        """Run a layer of ready nodes in parallel and collect their results.
+
+        Args:
+            nodes: Nodes whose dependencies are already satisfied.
+            goal: Goal text passed through to agent prompts.
+            run_id: Run identifier propagated into audit events.
+
+        Returns:
+            One :class:`NodeExecution` per input node.
+        """
+        if len(nodes) == 1:
+            return [self._execute_node(nodes[0], goal=goal, run_id=run_id)]
+
+        cap = self._max_parallel if self._max_parallel is not None else max(1, min(len(nodes), 8))
+        results: list[NodeExecution] = []
+        with ThreadPoolExecutor(max_workers=cap, thread_name_prefix="workflow") as pool:
+            futures: dict[Future[NodeExecution], WorkflowNode] = {
+                pool.submit(self._execute_node, node, goal=goal, run_id=run_id): node for node in nodes
+            }
+            for future in as_completed(futures):
+                results.append(future.result())
+        # Sort to preserve stable, deterministic order for callers.
+        order = {node.id: idx for idx, node in enumerate(nodes)}
+        results.sort(key=lambda r: order.get(r.node_id, 0))
+        return results
+
+    def _execute_node(
+        self,
+        node: WorkflowNode,
+        *,
+        goal: str,
+        run_id: str,
+    ) -> NodeExecution:
+        """Run a single node, including any loop iterations.
+
+        Args:
+            node: The node to execute.
+            goal: Goal text for prompt substitution.
+            run_id: Run identifier for audit events.
+
+        Returns:
+            The terminal :class:`NodeExecution` for this node.
+        """
+        if node.interactive:
+            self._audit("workflow.interactive_blocked", node.id, {"run_id": run_id})
+            raise NotImplementedError(
+                f"node {node.id!r} requires an interactive approval gate; approval gates ship in #1110",
+            )
+
+        self._audit(
+            "workflow.node_start",
+            node.id,
+            {"run_id": run_id, "kind": node.kind, "loop": node.loop is not None},
+        )
+        start = time.monotonic()
+        result: NodeExecution
+        if node.loop is not None:
+            result = self._execute_loop_node(node, node.loop, goal=goal, run_id=run_id)
+        else:
+            result = self._execute_once(node, goal=goal, run_id=run_id, iteration=1)
+            result.iterations = 1
+        result.wall_time_seconds = time.monotonic() - start
+        self._audit(
+            "workflow.node_finish",
+            node.id,
+            {
+                "run_id": run_id,
+                "status": result.status.value,
+                "iterations": result.iterations,
+                "exit_code": result.exit_code,
+                "wall_time_seconds": round(result.wall_time_seconds, 3),
+            },
+        )
+        return result
+
+    def _execute_loop_node(
+        self,
+        node: WorkflowNode,
+        loop: LoopSpec,
+        *,
+        goal: str,
+        run_id: str,
+    ) -> NodeExecution:
+        """Re-fire a node until ``loop.until`` exits 0 or budget runs out.
+
+        Args:
+            node: The looping node.
+            loop: The :class:`LoopSpec` attached to ``node``.
+            goal: Goal text for prompt substitution.
+            run_id: Run identifier for audit events.
+
+        Returns:
+            The final :class:`NodeExecution`.  When iterations exhaust
+            without the predicate passing, status is FAILED with a
+            descriptive ``error`` message.
+        """
+        last: NodeExecution | None = None
+        for iteration in range(1, loop.max_iterations + 1):
+            last = self._execute_once(node, goal=goal, run_id=run_id, iteration=iteration)
+            last.iterations = iteration
+            if last.status == NodeStatus.FAILED:
+                return last
+            if self._loop_predicate_passes(loop.until):
+                return last
+            self._audit(
+                "workflow.loop_continue",
+                node.id,
+                {"run_id": run_id, "iteration": iteration, "predicate": loop.until},
+            )
+
+        # Exhausted without the predicate passing.
+        assert last is not None
+        last.status = NodeStatus.FAILED
+        last.error = f"loop exhausted after {loop.max_iterations} iterations; predicate never exited 0: {loop.until!r}"
+        return last
+
+    def _loop_predicate_passes(self, predicate: str) -> bool:
+        """Return ``True`` when the bash predicate exits with status 0."""
+        proc = subprocess.run(
+            predicate,
+            shell=True,
+            cwd=str(self._workdir),
+            env=self._env,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        return proc.returncode == 0
+
+    def _execute_once(
+        self,
+        node: WorkflowNode,
+        *,
+        goal: str,
+        run_id: str,
+        iteration: int,
+    ) -> NodeExecution:
+        """Run a single iteration of a node.
+
+        Routes by node kind: command-typed nodes shell out, agent-typed
+        nodes go through the spawner.  Errors are caught and converted
+        to FAILED :class:`NodeExecution` entries so the runner can
+        surface them without aborting the whole DAG via exception.
+        """
+        if node.kind == "command":
+            return self._execute_command(node)
+        return self._execute_agent(node, goal=goal, run_id=run_id, iteration=iteration)
+
+    def _execute_command(self, node: WorkflowNode) -> NodeExecution:
+        """Shell out for a command-typed node.
+
+        Uses ``shell=True`` so manifest authors can write idiomatic bash
+        (pipes, redirects, &&).  ``timeout_seconds`` becomes a hard
+        ``subprocess.TimeoutExpired`` boundary; on timeout we surface
+        a FAILED node with ``exit_code=None`` so the upstream runner
+        treats it as a definite failure.
+        """
+        assert node.command is not None
+        try:
+            proc = subprocess.run(
+                node.command,
+                shell=True,
+                cwd=str(self._workdir),
+                env=self._env,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=node.timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return NodeExecution(
+                node_id=node.id,
+                status=NodeStatus.FAILED,
+                exit_code=None,
+                stdout=(exc.stdout or "") if isinstance(exc.stdout, str) else "",
+                stderr=(exc.stderr or "") if isinstance(exc.stderr, str) else "",
+                error=f"command timed out after {node.timeout_seconds}s",
+            )
+        status = NodeStatus.SUCCESS if proc.returncode == 0 else NodeStatus.FAILED
+        return NodeExecution(
+            node_id=node.id,
+            status=status,
+            exit_code=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            error="" if status == NodeStatus.SUCCESS else f"exit {proc.returncode}",
+        )
+
+    def _execute_agent(
+        self,
+        node: WorkflowNode,
+        *,
+        goal: str,
+        run_id: str,
+        iteration: int,
+    ) -> NodeExecution:
+        """Dispatch an agent-typed node through the existing AgentSpawner.
+
+        Builds a one-shot :class:`Task` from the node's ``agent`` (role)
+        and ``prompt`` and feeds it to :meth:`AgentSpawner.spawn_for_tasks`.
+        Result correlation is via the returned :class:`AgentSession.id`.
+        """
+        if self._spawner is None:
+            return NodeExecution(
+                node_id=node.id,
+                status=NodeStatus.FAILED,
+                error="agent-typed node requires a configured AgentSpawner",
+            )
+        if node.agent is None or node.prompt is None:  # pragma: no cover — guarded by validator
+            return NodeExecution(
+                node_id=node.id,
+                status=NodeStatus.FAILED,
+                error="agent-typed node missing agent/prompt fields",
+            )
+
+        from bernstein.core.tasks.models import Task
+
+        prompt_body = _substitute_goal(node.prompt, goal)
+        # Carry workflow context inside the description so audit / token
+        # accounting can attribute the spend to the manifest, and so a
+        # ``fresh_context`` loop creates a distinct task id per iteration
+        # — the spawner uses task id as the session correlation key.
+        suffix = f"@iter{iteration}" if node.fresh_context or iteration > 1 else ""
+        task_id = f"wf-{node.id}-{run_id}{suffix}"
+        task = Task(
+            id=task_id,
+            title=f"workflow:{node.id}",
+            description=prompt_body,
+            role=node.agent,
+        )
+
+        try:
+            session = self._spawner.spawn_for_tasks([task])
+        except Exception as exc:
+            logger.exception("Spawner raised for node %s", node.id)
+            return NodeExecution(
+                node_id=node.id,
+                status=NodeStatus.FAILED,
+                error=f"spawn failed: {exc}",
+            )
+
+        return NodeExecution(
+            node_id=node.id,
+            status=NodeStatus.SUCCESS,
+            session_id=session.id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _substitute_goal(prompt: str, goal: str) -> str:
+    """Substitute ``{goal}`` placeholders without breaking literal braces.
+
+    A single-pass ``str.replace`` is sufficient — workflow prompts don't
+    use full Python ``str.format`` because nodes routinely embed shell
+    snippets and curly braces in code samples that we must not interpret.
+
+    Args:
+        prompt: Raw prompt text from the manifest.
+        goal: Goal string to substitute in.
+
+    Returns:
+        Prompt text with ``{goal}`` replaced.
+    """
+    if "{goal}" not in prompt:
+        return prompt
+    return prompt.replace("{goal}", goal)
+
+
+def shell_join(parts: list[str]) -> str:
+    """Public ``shlex.join`` wrapper for tests that build commands."""
+    return shlex.join(parts)

--- a/src/bernstein/core/workflows/workflow_spec.py
+++ b/src/bernstein/core/workflows/workflow_spec.py
@@ -1,0 +1,480 @@
+"""Pydantic v2 schema for Archon-style YAML workflow manifests.
+
+This module defines the data model that backs ``bernstein workflow run``.
+The format is intentionally small and orthogonal to the existing
+``workflow_dsl`` module (which models conditional task DAGs that plug
+into the orchestrator's lifecycle).  YAML manifests here are loaded and
+executed by :class:`bernstein.core.workflows.workflow_runner.WorkflowRunner`,
+which dispatches agent-typed nodes through the existing
+:class:`bernstein.core.spawner.AgentSpawner.spawn_for_tasks` path.
+
+Example manifest::
+
+    name: idea-to-pr
+    description: "Take a goal from idea to merged PR."
+    version: "1.0.0"
+    nodes:
+      - id: research
+        agent: manager
+        prompt: "Research {goal} and produce a one-page brief."
+      - id: plan
+        depends_on: [research]
+        agent: architect
+        prompt: "Turn the brief into a concrete plan."
+      - id: implement
+        depends_on: [plan]
+        agent: backend
+        prompt: "Implement the plan."
+        fresh_context: true
+      - id: tests-green
+        depends_on: [implement]
+        command: "pytest -x"
+        loop:
+          until: "pytest -x"
+          max_iterations: 5
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+# ---------------------------------------------------------------------------
+# Identifier and version constraints
+# ---------------------------------------------------------------------------
+
+# Node and workflow ids are slug-shaped: lowercase letters, digits, dashes,
+# underscores.  Keeping them filename-safe lets us round-trip workflow
+# names through bundled and user-installed directories without escaping.
+_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_\-]*$")
+
+# Permissive semver-ish: ``MAJOR.MINOR[.PATCH]`` plus optional pre-release.
+_VERSION_PATTERN = re.compile(r"^\d+\.\d+(?:\.\d+)?(?:-[A-Za-z0-9.-]+)?$")
+
+# Default node timeout — an hour matches the orchestrator's default
+# per-agent wall clock for medium-scope tasks.
+DEFAULT_NODE_TIMEOUT_SECONDS: int = 1800
+
+
+class WorkflowSpecError(ValueError):
+    """Raised when a workflow manifest is malformed or fails validation.
+
+    A separate exception class lets the CLI distinguish schema errors
+    from filesystem / YAML parsing errors when rendering messages.
+    """
+
+
+class LoopSpec(BaseModel):
+    """Loop predicate for re-firing a node until a bash check passes.
+
+    Attributes:
+        until: A bash predicate evaluated after each iteration.  Exit
+            code 0 means the loop terminates; non-zero means continue.
+        max_iterations: Safety cap on loop iterations.  Reaching this
+            without a 0 exit raises :class:`WorkflowRunError`.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    until: str = Field(min_length=1, description="Bash predicate evaluated after each iteration.")
+    max_iterations: int = Field(default=10, ge=1, le=1000, description="Safety cap on iterations.")
+
+
+class WorkflowNode(BaseModel):
+    """A single node in a workflow manifest.
+
+    Each node is one of:
+
+    * **command** — runs ``command`` via ``subprocess.run`` with timeout.
+    * **agent** — dispatches a task with ``agent`` (role) and ``prompt``
+      through :meth:`AgentSpawner.spawn_for_tasks`.
+    * **loop** — wraps a command-typed node and re-fires it until the
+      :attr:`LoopSpec.until` predicate exits 0 or
+      :attr:`LoopSpec.max_iterations` is reached.
+
+    Exactly one of ``command`` or ``agent`` must be set.  ``loop`` is
+    optional and may decorate either type.
+
+    Attributes:
+        id: Slug-shaped node identifier; unique within the workflow.
+        depends_on: Ids of nodes that must finish before this one starts.
+        command: Bash command to run, when this is a command-typed node.
+        agent: Agent role / spec name, when this is an agent-typed node.
+        prompt: Prompt body for agent-typed nodes.  May contain the
+            ``{goal}`` placeholder which the runner substitutes from
+            ``WorkflowRunner.run(goal=...)``.
+        loop: Optional loop predicate.  When set the node re-fires.
+        fresh_context: When ``True``, agent-typed nodes get a fresh
+            session per iteration (no carryover).  Ignored for command-
+            typed nodes.
+        interactive: Stub for human-approval gates.  When ``True`` the
+            runner raises ``NotImplementedError`` referencing #1110.
+        timeout_seconds: Per-iteration wall clock cap.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    id: str = Field(min_length=1, max_length=64)
+    depends_on: list[str] = Field(default_factory=list)
+    command: str | None = None
+    agent: str | None = None
+    prompt: str | None = None
+    loop: LoopSpec | None = None
+    fresh_context: bool = False
+    interactive: bool = False
+    timeout_seconds: int = Field(default=DEFAULT_NODE_TIMEOUT_SECONDS, ge=1, le=86_400)
+
+    @field_validator("id")
+    @classmethod
+    def _check_id(cls, value: str) -> str:
+        """Reject ids that are not slug-shaped."""
+        if not _ID_PATTERN.match(value):
+            raise ValueError(f"id {value!r} must match pattern {_ID_PATTERN.pattern}")
+        return value
+
+    @field_validator("depends_on")
+    @classmethod
+    def _check_depends_on_ids(cls, value: list[str]) -> list[str]:
+        """Each dependency must look like a valid node id."""
+        seen: set[str] = set()
+        for dep in value:
+            if not _ID_PATTERN.match(dep):
+                raise ValueError(f"depends_on entry {dep!r} is not a valid node id")
+            if dep in seen:
+                raise ValueError(f"depends_on contains duplicate {dep!r}")
+            seen.add(dep)
+        return value
+
+    @model_validator(mode="after")
+    def _check_node_kind(self) -> WorkflowNode:
+        """Exactly one of command / agent must be set, and prompts only on agent."""
+        has_command = self.command is not None and self.command.strip() != ""
+        has_agent = self.agent is not None and self.agent.strip() != ""
+        if has_command == has_agent:
+            raise ValueError(
+                f"node {self.id!r} must set exactly one of 'command' or 'agent'",
+            )
+        if has_command and self.prompt is not None:
+            raise ValueError(f"node {self.id!r} sets 'command'; 'prompt' is not allowed")
+        if has_agent and (self.prompt is None or self.prompt.strip() == ""):
+            raise ValueError(f"node {self.id!r} sets 'agent'; 'prompt' is required")
+        if self.id in set(self.depends_on):
+            raise ValueError(f"node {self.id!r} cannot depend on itself")
+        return self
+
+    @property
+    def kind(self) -> str:
+        """Return ``'command'`` or ``'agent'`` based on which field is set."""
+        return "agent" if self.agent else "command"
+
+
+class WorkflowSpec(BaseModel):
+    """Top-level workflow manifest model.
+
+    Attributes:
+        name: Slug-shaped manifest name.  Used for resolving by name on
+            the CLI and as a friendly label in audit events.
+        description: One-line human-readable description.
+        version: Permissive ``MAJOR.MINOR[.PATCH]`` string.  Bumped when
+            the on-disk schema changes in a way that breaks downstream
+            consumers (bundled stock workflows hold version ``1.0.0``).
+        nodes: Ordered list of :class:`WorkflowNode`.  Order is not
+            execution order; the runner computes a topological order
+            from ``depends_on``.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1, max_length=64)
+    description: str = Field(min_length=1, max_length=512)
+    version: str = Field(default="1.0.0")
+    nodes: list[WorkflowNode] = Field(min_length=1)
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, value: str) -> str:
+        """Names must be slug-shaped so they round-trip as filenames."""
+        if not _ID_PATTERN.match(value):
+            raise ValueError(f"workflow name {value!r} must match {_ID_PATTERN.pattern}")
+        return value
+
+    @field_validator("version")
+    @classmethod
+    def _check_version(cls, value: str) -> str:
+        """Permissive semver gate so we can bump majors when needed."""
+        if not _VERSION_PATTERN.match(value):
+            raise ValueError(f"version {value!r} must look like '1.2' or '1.2.3'")
+        return value
+
+    @model_validator(mode="after")
+    def _check_dag(self) -> WorkflowSpec:
+        """Enforce unique ids, valid depends_on refs, and acyclic graph."""
+        seen: set[str] = set()
+        for node in self.nodes:
+            if node.id in seen:
+                raise ValueError(f"duplicate node id {node.id!r}")
+            seen.add(node.id)
+
+        ids = {node.id for node in self.nodes}
+        for node in self.nodes:
+            for dep in node.depends_on:
+                if dep not in ids:
+                    raise ValueError(
+                        f"node {node.id!r} depends on unknown node {dep!r}",
+                    )
+
+        # Kahn's algorithm — if the topological queue drains before all
+        # nodes are visited, there's a cycle somewhere in depends_on.
+        indegree: dict[str, int] = {node.id: len(node.depends_on) for node in self.nodes}
+        children: dict[str, list[str]] = defaultdict(list)
+        for node in self.nodes:
+            for dep in node.depends_on:
+                children[dep].append(node.id)
+        queue: deque[str] = deque(nid for nid, deg in indegree.items() if deg == 0)
+        visited = 0
+        while queue:
+            nid = queue.popleft()
+            visited += 1
+            for child in children[nid]:
+                indegree[child] -= 1
+                if indegree[child] == 0:
+                    queue.append(child)
+        if visited != len(self.nodes):
+            unresolved = sorted(nid for nid, deg in indegree.items() if deg > 0)
+            raise ValueError(f"workflow has a cycle involving nodes {unresolved!r}")
+        return self
+
+    # -- query helpers -----------------------------------------------------
+
+    def node_by_id(self, node_id: str) -> WorkflowNode:
+        """Return the node with ``node_id`` or raise :class:`KeyError`."""
+        for node in self.nodes:
+            if node.id == node_id:
+                return node
+        raise KeyError(f"no node with id {node_id!r}")
+
+    def topological_order(self) -> list[list[WorkflowNode]]:
+        """Return nodes in topologically sorted layers.
+
+        Each inner list is a "layer" — a set of nodes whose dependencies
+        are all satisfied by previous layers.  The runner schedules every
+        node in a layer in parallel before advancing.
+        """
+        indegree: dict[str, int] = {node.id: len(node.depends_on) for node in self.nodes}
+        children: dict[str, list[str]] = defaultdict(list)
+        for node in self.nodes:
+            for dep in node.depends_on:
+                children[dep].append(node.id)
+        by_id = {node.id: node for node in self.nodes}
+
+        layers: list[list[WorkflowNode]] = []
+        ready = sorted(nid for nid, deg in indegree.items() if deg == 0)
+        while ready:
+            layer = [by_id[nid] for nid in ready]
+            layers.append(layer)
+            next_ready: list[str] = []
+            for nid in ready:
+                for child in children[nid]:
+                    indegree[child] -= 1
+                    if indegree[child] == 0:
+                        next_ready.append(child)
+            ready = sorted(next_ready)
+        return layers
+
+
+# ---------------------------------------------------------------------------
+# Loaders and discovery
+# ---------------------------------------------------------------------------
+
+
+def load_workflow_spec_from_text(text: str) -> WorkflowSpec:
+    """Parse ``text`` as YAML and coerce into a :class:`WorkflowSpec`.
+
+    Args:
+        text: Raw manifest text.
+
+    Returns:
+        A validated :class:`WorkflowSpec`.
+
+    Raises:
+        WorkflowSpecError: When YAML is malformed or validation fails.
+    """
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise WorkflowSpecError(f"malformed YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise WorkflowSpecError("workflow manifest must be a mapping at the top level")
+    try:
+        return WorkflowSpec.model_validate(data)
+    except ValidationError as exc:
+        raise WorkflowSpecError(str(exc)) from exc
+
+
+def load_workflow_spec(path: Path) -> WorkflowSpec:
+    """Load a workflow manifest from ``path``.
+
+    Args:
+        path: Path to a ``.yaml`` or ``.yml`` file on disk.
+
+    Returns:
+        A validated :class:`WorkflowSpec`.
+
+    Raises:
+        WorkflowSpecError: When the file is missing or invalid.
+    """
+    if not path.is_file():
+        raise WorkflowSpecError(f"workflow manifest not found: {path}")
+    return load_workflow_spec_from_text(path.read_text(encoding="utf-8"))
+
+
+def _bundled_workflows_dir() -> Path:
+    """Return the bundled stock-workflows directory.
+
+    Resolves either the wheel-installed ``_default_templates/workflows``
+    or the dev-checkout ``templates/workflows``.  Importing here keeps
+    :mod:`bernstein.core.workflows.workflow_spec` cheap to import.
+    """
+    from bernstein import _BUNDLED_TEMPLATES_DIR
+
+    return _BUNDLED_TEMPLATES_DIR / "workflows"
+
+
+def _user_workflows_dirs(workdir: Path | None = None) -> list[Path]:
+    """Return the user-installed workflow directories, in lookup order.
+
+    The project-local ``<workdir>/.bernstein/workflows/`` directory wins
+    over ``~/.bernstein/workflows/`` so a checked-in workflow shadows a
+    home-directory copy.
+    """
+    candidates: list[Path] = []
+    if workdir is not None:
+        candidates.append(workdir / ".bernstein" / "workflows")
+    candidates.append(Path.home() / ".bernstein" / "workflows")
+    return candidates
+
+
+def discover_workflows(
+    *,
+    workdir: Path | None = None,
+    include_bundled: bool = True,
+    include_user: bool = True,
+) -> Iterator[tuple[str, Path]]:
+    """Yield ``(name, path)`` pairs for every reachable manifest.
+
+    Names with multiple paths resolve to the first match in this order:
+
+    1. Project-local ``<workdir>/.bernstein/workflows/``
+    2. ``~/.bernstein/workflows/``
+    3. Bundled ``templates/workflows/`` (or wheel equivalent)
+
+    Args:
+        workdir: Project root for resolving project-local workflows.
+        include_bundled: Whether to scan bundled templates.
+        include_user: Whether to scan user directories.
+
+    Yields:
+        ``(name, path)`` tuples ordered as above.  Names are deduplicated
+        across sources — the first occurrence wins.
+    """
+    seen: set[str] = set()
+    dirs: list[Path] = []
+    if include_user:
+        dirs.extend(_user_workflows_dirs(workdir))
+    if include_bundled:
+        dirs.append(_bundled_workflows_dir())
+    for directory in dirs:
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.yaml")) + sorted(directory.glob("*.yml")):
+            name = path.stem
+            if name in seen:
+                continue
+            seen.add(name)
+            yield name, path
+
+
+def resolve_workflow(
+    name_or_path: str,
+    *,
+    workdir: Path | None = None,
+) -> tuple[Path, WorkflowSpec]:
+    """Resolve a name or filesystem path to a loaded :class:`WorkflowSpec`.
+
+    Args:
+        name_or_path: Either a path on disk or a bare workflow name.
+            Paths are detected by extension (``.yaml``/``.yml``) or by
+            existence on disk.
+        workdir: Project root for project-local discovery.
+
+    Returns:
+        ``(path, spec)`` for the resolved manifest.
+
+    Raises:
+        WorkflowSpecError: When the workflow can't be located or fails
+            validation.
+    """
+    candidate = Path(name_or_path)
+    if candidate.suffix in {".yaml", ".yml"} or candidate.exists():
+        return candidate.resolve(), load_workflow_spec(candidate)
+    for name, path in discover_workflows(workdir=workdir):
+        if name == name_or_path:
+            return path.resolve(), load_workflow_spec(path)
+    raise WorkflowSpecError(
+        f"workflow {name_or_path!r} not found; "
+        "pass a path or place a YAML in templates/workflows/, "
+        ".bernstein/workflows/, or ~/.bernstein/workflows/",
+    )
+
+
+def render_blank_template(name: str) -> str:
+    """Return a starter YAML manifest body for ``name``.
+
+    Used by ``bernstein workflow init`` to scaffold something a user can
+    edit.  Keeping the template inline avoids an extra round-trip to the
+    bundled directory and ensures the scaffolded file always parses.
+    """
+    if not _ID_PATTERN.match(name):
+        raise WorkflowSpecError(f"workflow name {name!r} must match {_ID_PATTERN.pattern}")
+    return f"""\
+name: {name}
+description: "Describe what this workflow does."
+version: "1.0.0"
+nodes:
+  - id: research
+    agent: manager
+    prompt: "Research the goal: {{goal}}"
+
+  - id: implement
+    depends_on: [research]
+    agent: backend
+    prompt: "Carry out the plan from research."
+
+  - id: tests
+    depends_on: [implement]
+    command: "pytest -x"
+"""
+
+
+def dump_spec_yaml(spec: WorkflowSpec) -> str:
+    """Render ``spec`` as a YAML string with stable key order.
+
+    Useful for tests and for ``bernstein workflow init`` to scaffold from
+    an in-memory model.  Keys are emitted in field-declaration order.
+
+    Args:
+        spec: Workflow specification to serialise.
+
+    Returns:
+        YAML-formatted manifest text ending in a trailing newline.
+    """
+    raw: dict[str, Any] = spec.model_dump(mode="json", exclude_none=True)
+    return yaml.safe_dump(raw, sort_keys=False, default_flow_style=False)

--- a/templates/workflows/dependency-bump.yaml
+++ b/templates/workflows/dependency-bump.yaml
@@ -1,0 +1,34 @@
+name: dependency-bump
+description: "Bump dependencies, run the test suite, and loop on flake fixes."
+version: "1.0.0"
+nodes:
+  - id: snapshot
+    command: "uv lock --snapshot 2>/dev/null || uv lock"
+    timeout_seconds: 300
+
+  - id: bump
+    depends_on: [snapshot]
+    agent: backend
+    prompt: |
+      Bump dependencies for: {goal}
+
+      Prefer minor bumps; surface major-version updates separately.
+      Update lockfile and any pinned versions in pyproject.toml.
+
+  - id: install
+    depends_on: [bump]
+    command: "uv sync"
+    timeout_seconds: 900
+
+  - id: tests
+    depends_on: [install]
+    command: "pytest -x -q"
+    loop:
+      until: "pytest -x -q"
+      max_iterations: 3
+    timeout_seconds: 1800
+
+  - id: smoke
+    depends_on: [tests]
+    command: "uv run python -c 'import bernstein; print(bernstein.__version__)'"
+    timeout_seconds: 120

--- a/templates/workflows/doc-update.yaml
+++ b/templates/workflows/doc-update.yaml
@@ -1,0 +1,31 @@
+name: doc-update
+description: "Audit and update project documentation against current code."
+version: "1.0.0"
+nodes:
+  - id: collect-diff
+    command: "git log --since='30 days ago' --oneline"
+    timeout_seconds: 60
+
+  - id: audit
+    depends_on: [collect-diff]
+    agent: docs
+    prompt: |
+      Audit docs against the recent change log for: {goal}
+
+      List doc files that drifted from the current code, missing
+      sections (CLI commands without a flag table, public APIs without
+      examples), and stale screenshots/links.
+
+  - id: update
+    depends_on: [audit]
+    agent: docs
+    prompt: |
+      Apply the doc updates from the audit. Keep each doc change
+      paired with the code change it documents. Run any docs build
+      command after editing to catch broken links.
+    timeout_seconds: 1800
+
+  - id: build
+    depends_on: [update]
+    command: "mkdocs build --strict"
+    timeout_seconds: 600

--- a/templates/workflows/hot-fix.yaml
+++ b/templates/workflows/hot-fix.yaml
@@ -1,0 +1,41 @@
+name: hot-fix
+description: "Reproduce, fix, regression-test, and ship a hotfix in a tight loop."
+version: "1.0.0"
+nodes:
+  - id: reproduce
+    agent: backend
+    prompt: |
+      Reproduce the incident: {goal}
+
+      Capture a minimal reproduction in debug/ and write the failing
+      test. Do not patch the code yet.
+
+  - id: confirm-failure
+    depends_on: [reproduce]
+    command: "pytest -x -q debug/ || true"
+    timeout_seconds: 600
+
+  - id: fix
+    depends_on: [confirm-failure]
+    agent: backend
+    prompt: |
+      Apply the smallest correct fix that turns the reproducing test
+      green. Avoid drive-by changes — the goal is "land tonight, clean
+      up tomorrow".
+    fresh_context: true
+    timeout_seconds: 1800
+
+  - id: regression
+    depends_on: [fix]
+    command: "pytest -x -q"
+    loop:
+      until: "pytest -x -q"
+      max_iterations: 3
+    timeout_seconds: 1800
+
+  - id: changelog
+    depends_on: [regression]
+    agent: docs
+    prompt: |
+      Add a CHANGELOG entry under "Fixed" pointing at the original
+      issue and the test that now guards against it.

--- a/templates/workflows/idea-to-pr.yaml
+++ b/templates/workflows/idea-to-pr.yaml
@@ -1,0 +1,43 @@
+name: idea-to-pr
+description: "Take a goal from idea to merged PR: research, plan, implement, test, ship."
+version: "1.0.0"
+nodes:
+  - id: research
+    agent: manager
+    prompt: |
+      Research the goal: {goal}
+
+      Produce a one-page brief covering scope, acceptance criteria,
+      affected files, and known risks. Cite any prior commits or open
+      tickets that overlap.
+
+  - id: plan
+    depends_on: [research]
+    agent: architect
+    prompt: |
+      Turn the research brief into a concrete plan for: {goal}
+
+      List the modules to touch, public surfaces to add or change,
+      tests to write, and the order to land changes. Surface any
+      decisions that need operator input rather than guessing.
+
+  - id: implement
+    depends_on: [plan]
+    agent: backend
+    prompt: |
+      Carry out the plan for: {goal}
+
+      Stay in scope. Keep each commit focused. Add tests alongside the
+      change. Run the local lint+format sweep before declaring done.
+    fresh_context: true
+    timeout_seconds: 3600
+
+  - id: tests
+    depends_on: [implement]
+    command: "pytest -x -q"
+    timeout_seconds: 1800
+
+  - id: open-pr
+    depends_on: [tests]
+    command: "git push -u origin HEAD && gh pr create --fill"
+    timeout_seconds: 300

--- a/templates/workflows/refactor-with-tests.yaml
+++ b/templates/workflows/refactor-with-tests.yaml
@@ -1,0 +1,37 @@
+name: refactor-with-tests
+description: "Find a target, propose a refactor, implement it, and loop on tests until green."
+version: "1.0.0"
+nodes:
+  - id: find-target
+    agent: architect
+    prompt: |
+      Identify the highest-value refactor target inside: {goal}
+
+      Explain why this target now (coupling, churn, cost). Output a list
+      of files and the smell each one carries.
+
+  - id: propose
+    depends_on: [find-target]
+    agent: architect
+    prompt: |
+      Propose a refactor for the target identified above.
+
+      Describe the refactoring move (Extract Method, Move Class, ...)
+      per file, the public-API delta, and the risk of regression.
+
+  - id: implement
+    depends_on: [propose]
+    agent: backend
+    prompt: |
+      Apply the proposed refactor. Keep behavioural diffs zero;
+      everything else (renames, splits, parameterisations) is fair
+      game. Write the missing tests required to verify the new shape.
+    timeout_seconds: 3600
+
+  - id: tests-green
+    depends_on: [implement]
+    command: "pytest -x -q"
+    loop:
+      until: "pytest -x -q"
+      max_iterations: 5
+    timeout_seconds: 1800

--- a/templates/workflows/security-review.yaml
+++ b/templates/workflows/security-review.yaml
@@ -1,0 +1,38 @@
+name: security-review
+description: "Static-scan, triage, patch, and adversary-review a security finding stream."
+version: "1.0.0"
+nodes:
+  - id: scan
+    command: "bandit -r src/ -ll || true"
+    timeout_seconds: 600
+
+  - id: secrets-scan
+    command: "gitleaks detect --redact --no-banner || true"
+    timeout_seconds: 600
+
+  - id: triage
+    depends_on: [scan, secrets-scan]
+    agent: security
+    prompt: |
+      Review the scan output and triage findings against: {goal}
+
+      For each issue mark severity (low/medium/high/critical), explain
+      the threat model, and produce a remediation plan ordered by
+      risk-to-fix ratio.
+
+  - id: patch
+    depends_on: [triage]
+    agent: backend
+    prompt: |
+      Apply the remediation plan from triage. Keep each fix in its own
+      commit. Add a regression test where the bug had an attacker-
+      reachable path.
+    timeout_seconds: 3600
+
+  - id: adversary-review
+    depends_on: [patch]
+    agent: security
+    prompt: |
+      Adversary-review the patches. For each fix, attempt one bypass
+      and document whether it succeeds. If any bypass succeeds, list
+      the next-step fix instead of declaring done.

--- a/tests/integration/test_workflow_runner.py
+++ b/tests/integration/test_workflow_runner.py
@@ -1,0 +1,504 @@
+"""Integration tests for the WorkflowRunner.
+
+Covers linear / fan-out / loop / fresh-context / interactive node
+behaviour, plus end-to-end agent dispatch through a real
+:class:`AgentSpawner` backed by the fake-CLI fixture.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from bernstein.core.models import ModelConfig
+from bernstein.core.spawner import AgentSpawner
+
+from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult
+from bernstein.core.workflows import (
+    NodeStatus,
+    WorkflowExecution,
+    WorkflowRunner,
+    WorkflowSpec,
+    load_workflow_spec_from_text,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner_workdir(tmp_path: Path) -> Path:
+    """Provide a clean working directory for command nodes."""
+    workdir = tmp_path / "run"
+    workdir.mkdir()
+    return workdir
+
+
+@pytest.fixture
+def captured_audit() -> tuple[list[tuple[str, str, dict[str, Any]]], Callable[..., None]]:
+    """Provide an in-memory audit emitter for assertions."""
+    log: list[tuple[str, str, dict[str, Any]]] = []
+
+    def _emit(event_type: str, resource_id: str, details: dict[str, Any]) -> None:
+        log.append((event_type, resource_id, dict(details)))
+
+    return log, _emit
+
+
+def _build_runner(
+    *,
+    workdir: Path,
+    audit: Callable[..., None] | None = None,
+    spawner: AgentSpawner | None = None,
+) -> WorkflowRunner:
+    """Construct a runner with the supplied workdir/audit."""
+    return WorkflowRunner(spawner=spawner, workdir=workdir, audit_emitter=audit)
+
+
+def _spec_from(text: str) -> WorkflowSpec:
+    """Load a manifest from inline YAML text."""
+    return load_workflow_spec_from_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Linear command-only DAG
+# ---------------------------------------------------------------------------
+
+
+def test_linear_command_dag_runs_each_node_once(runner_workdir: Path) -> None:
+    """A simple linear DAG of command nodes runs in order, all green."""
+    spec = _spec_from(
+        """
+name: linear-cmds
+description: "Three echo steps"
+version: "1.0.0"
+nodes:
+  - id: first
+    command: "echo first > stage1.txt"
+  - id: second
+    depends_on: [first]
+    command: "echo second > stage2.txt"
+  - id: third
+    depends_on: [second]
+    command: "echo third > stage3.txt"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    assert execution.succeeded is True
+    assert [n.node_id for n in execution.nodes] == ["first", "second", "third"]
+    assert all(n.iterations == 1 for n in execution.nodes)
+    assert (runner_workdir / "stage1.txt").read_text().strip() == "first"
+    assert (runner_workdir / "stage3.txt").read_text().strip() == "third"
+
+
+def test_failing_command_fails_run_and_skips_downstream(runner_workdir: Path) -> None:
+    """A failing node aborts the DAG; downstream nodes are SKIPPED."""
+    spec = _spec_from(
+        """
+name: fail-fast
+description: "Middle step exits non-zero"
+version: "1.0.0"
+nodes:
+  - id: ok
+    command: "true"
+  - id: bad
+    depends_on: [ok]
+    command: "exit 7"
+  - id: never
+    depends_on: [bad]
+    command: "echo nope > shouldnt-exist.txt"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    by_id = {n.node_id: n for n in execution.nodes}
+    assert execution.succeeded is False
+    assert by_id["ok"].status == NodeStatus.SUCCESS
+    assert by_id["bad"].status == NodeStatus.FAILED
+    assert by_id["bad"].exit_code == 7
+    assert by_id["never"].status == NodeStatus.SKIPPED
+    assert not (runner_workdir / "shouldnt-exist.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Fan-out parallel
+# ---------------------------------------------------------------------------
+
+
+def test_fan_out_runs_leaves_in_parallel(runner_workdir: Path) -> None:
+    """Parallel leaves both run and produce their outputs."""
+    spec = _spec_from(
+        """
+name: fan-out
+description: "Two leaves off one root"
+version: "1.0.0"
+nodes:
+  - id: root
+    command: "echo root > root.txt"
+  - id: leaf-a
+    depends_on: [root]
+    command: "echo a > a.txt"
+  - id: leaf-b
+    depends_on: [root]
+    command: "echo b > b.txt"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+    assert execution.succeeded is True
+    assert (runner_workdir / "a.txt").read_text().strip() == "a"
+    assert (runner_workdir / "b.txt").read_text().strip() == "b"
+
+
+# ---------------------------------------------------------------------------
+# Loop until predicate passes
+# ---------------------------------------------------------------------------
+
+
+def test_loop_until_predicate_passes(runner_workdir: Path) -> None:
+    """A loop fires repeatedly until the predicate exits 0."""
+    counter = runner_workdir / "counter.txt"
+    counter.write_text("0\n", encoding="utf-8")
+
+    spec = _spec_from(
+        f"""
+name: loop-pass
+description: "Increment until counter >= 3"
+version: "1.0.0"
+nodes:
+  - id: tick
+    command: "n=$(cat {counter}); echo $((n+1)) > {counter}"
+    loop:
+      until: "test $(cat {counter}) -ge 3"
+      max_iterations: 10
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+
+    tick = execution.nodes[0]
+    assert tick.status == NodeStatus.SUCCESS
+    assert tick.iterations >= 3
+    assert int(counter.read_text().strip()) >= 3
+
+
+def test_loop_max_iterations_exhausted_fails(runner_workdir: Path) -> None:
+    """A loop whose predicate never passes fails after max_iterations."""
+    spec = _spec_from(
+        """
+name: loop-exhaust
+description: "Predicate never passes"
+version: "1.0.0"
+nodes:
+  - id: spin
+    command: "true"
+    loop:
+      until: "false"
+      max_iterations: 3
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+    spin = execution.nodes[0]
+    assert spin.status == NodeStatus.FAILED
+    assert spin.iterations == 3
+    assert "exhausted" in spin.error
+
+
+# ---------------------------------------------------------------------------
+# Fresh context iteration
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_context_uses_distinct_task_ids_per_iteration(
+    runner_workdir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`fresh_context: true` mints a fresh task id per loop iteration."""
+    captured: list[str] = []
+
+    class StubSpawner:
+        """Stub that captures task ids and pretends every spawn is fine."""
+
+        def spawn_for_tasks(self, tasks: list[Any]) -> Any:
+            captured.append(tasks[0].id)
+            session = MagicMock()
+            session.id = f"sess-{len(captured)}"
+            return session
+
+    flag = runner_workdir / "loop-done.txt"
+    spec = _spec_from(
+        f"""
+name: fresh-loop
+description: "Fresh context every iteration"
+version: "1.0.0"
+nodes:
+  - id: think
+    agent: backend
+    prompt: "Think about goal: {{goal}}"
+    fresh_context: true
+    loop:
+      until: "test -f {flag}"
+      max_iterations: 4
+  - id: stop
+    depends_on: [think]
+    command: "echo done"
+"""
+    )
+
+    # Make the predicate flip to passing on the second iteration.
+    iterations = {"count": 0}
+    real_runner = WorkflowRunner(spawner=None, workdir=runner_workdir)
+
+    original_predicate = real_runner._loop_predicate_passes
+
+    def _flip(predicate: str) -> bool:
+        iterations["count"] += 1
+        if iterations["count"] >= 2:
+            flag.write_text("ok", encoding="utf-8")
+        return original_predicate(predicate)
+
+    monkeypatch.setattr(real_runner, "_loop_predicate_passes", _flip)
+    real_runner._spawner = StubSpawner()  # type: ignore[assignment]
+    execution = real_runner.run(spec, goal="JWT auth")
+
+    assert execution.succeeded is True
+    think = execution.nodes[0]
+    assert think.iterations == 2
+    # Each iteration receives a fresh task id ("@iter1", "@iter2", ...).
+    assert any("@iter1" in tid for tid in captured)
+    assert any("@iter2" in tid for tid in captured)
+
+
+# ---------------------------------------------------------------------------
+# Interactive stub for #1110
+# ---------------------------------------------------------------------------
+
+
+def test_interactive_node_raises_not_implemented_with_ticket(runner_workdir: Path) -> None:
+    """`interactive: true` is a stub that points at #1110."""
+    spec = _spec_from(
+        """
+name: needs-approval
+description: "Has a human gate"
+version: "1.0.0"
+nodes:
+  - id: gate
+    command: "true"
+    interactive: true
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    with pytest.raises(NotImplementedError, match="#1110"):
+        runner.run(spec)
+
+
+# ---------------------------------------------------------------------------
+# Real AgentSpawner dispatch via fake-CLI fixture
+# ---------------------------------------------------------------------------
+
+
+class _RecordingMockAdapter(CLIAdapter):
+    """Minimal adapter that records every spawn call.
+
+    Returns a fake :class:`SpawnResult` and exits immediately.  Lets the
+    integration test confirm that an agent-typed workflow node travels
+    through ``AgentSpawner.spawn_for_tasks`` end-to-end without bringing
+    up the full subprocess pipeline.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        log_path = workdir / "agent.log"
+        log_path.write_text("ok", encoding="utf-8")
+        self.calls.append({"prompt": prompt, "session_id": session_id})
+        return SpawnResult(pid=0, log_path=log_path)
+
+    def name(self) -> str:
+        return "recording-mock"
+
+    def is_alive(self, pid: int) -> bool:
+        return False
+
+    def is_rate_limited(self) -> bool:
+        return False
+
+    def kill(self, pid: int) -> None:
+        return None
+
+
+def test_agent_node_dispatches_through_real_spawner(tmp_path: Path) -> None:
+    """An agent-typed node reaches `AgentSpawner.spawn_for_tasks`."""
+    workdir = tmp_path / "proj"
+    workdir.mkdir()
+    templates_dir = workdir / "templates" / "roles" / "backend"
+    templates_dir.mkdir(parents=True)
+    (templates_dir / "system_prompt.md").write_text("You are a backend specialist.")
+
+    adapter = _RecordingMockAdapter()
+    spawner = AgentSpawner(
+        adapter=adapter,
+        templates_dir=workdir / "templates" / "roles",
+        workdir=workdir,
+        use_worktrees=False,
+    )
+
+    spec = _spec_from(
+        """
+name: agent-real
+description: "One agent node, dispatched via real spawner"
+version: "1.0.0"
+nodes:
+  - id: code-it
+    agent: backend
+    prompt: "Implement {goal}"
+"""
+    )
+    runner = WorkflowRunner(spawner=spawner, workdir=workdir)
+    execution = runner.run(spec, goal="JWT auth")
+
+    assert execution.succeeded is True
+    code_it = execution.nodes[0]
+    assert code_it.status == NodeStatus.SUCCESS
+    assert code_it.session_id  # populated by spawn_for_tasks
+    assert adapter.calls, "expected the adapter to be invoked"
+    rendered = adapter.calls[0]["prompt"]
+    assert "JWT auth" in rendered, "goal substitution must happen before the spawn"
+
+
+def test_agent_node_without_spawner_fails_node(runner_workdir: Path) -> None:
+    """An agent-typed node with no spawner produces a FAILED node."""
+    spec = _spec_from(
+        """
+name: orphan-agent
+description: "Agent without a spawner"
+version: "1.0.0"
+nodes:
+  - id: lonely
+    agent: backend
+    prompt: "Do work for {goal}"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir, spawner=None)
+    execution = runner.run(spec, goal="testing")
+    assert execution.succeeded is False
+    assert execution.nodes[0].status == NodeStatus.FAILED
+    assert "AgentSpawner" in execution.nodes[0].error
+
+
+# ---------------------------------------------------------------------------
+# Audit emit
+# ---------------------------------------------------------------------------
+
+
+def test_audit_emits_start_finish_and_per_node_events(
+    runner_workdir: Path,
+    captured_audit: tuple[list[tuple[str, str, dict[str, Any]]], Callable[..., None]],
+) -> None:
+    """The runner emits a start, per-node, and finish event sequence."""
+    log, emitter = captured_audit
+    spec = _spec_from(
+        """
+name: audited
+description: "One simple node"
+version: "1.0.0"
+nodes:
+  - id: only
+    command: "true"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir, audit=emitter)
+    runner.run(spec)
+
+    types = [event for event, _, _ in log]
+    assert "workflow.start" in types
+    assert "workflow.node_start" in types
+    assert "workflow.node_finish" in types
+    assert "workflow.finish" in types
+
+
+# ---------------------------------------------------------------------------
+# Malformed YAML / missing template / loop predicate exhaustion
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_yaml_raises_at_load_time(tmp_path: Path) -> None:
+    """Malformed YAML raises before the runner ever sees it."""
+    from bernstein.core.workflows import WorkflowSpecError, load_workflow_spec
+
+    bad = tmp_path / "broken.yaml"
+    bad.write_text("name: [\n", encoding="utf-8")
+    with pytest.raises(WorkflowSpecError):
+        load_workflow_spec(bad)
+
+
+def test_resolve_missing_template_raises_clearly(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Asking for an unknown workflow name raises with a useful message."""
+    from bernstein.core.workflows import WorkflowSpecError
+    from bernstein.core.workflows.workflow_spec import resolve_workflow
+
+    monkeypatch.setenv("HOME", str(tmp_path / "no-home"))
+    with pytest.raises(WorkflowSpecError, match="not found"):
+        resolve_workflow("does-not-exist-anywhere", workdir=tmp_path / "no-proj")
+
+
+def test_command_timeout_marks_node_failed(runner_workdir: Path) -> None:
+    """A command that exceeds its timeout is FAILED with exit_code=None."""
+    spec = _spec_from(
+        """
+name: slow-cmd
+description: "Sleep longer than allowed"
+version: "1.0.0"
+nodes:
+  - id: snooze
+    command: "sleep 5"
+    timeout_seconds: 1
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution = runner.run(spec)
+    snooze = execution.nodes[0]
+    assert snooze.status == NodeStatus.FAILED
+    assert snooze.exit_code is None
+    assert "timed out" in snooze.error
+
+
+def test_succeeded_flag_consistent_with_node_statuses(runner_workdir: Path) -> None:
+    """`execution.succeeded` is True iff every node SUCCEEDED."""
+    spec = _spec_from(
+        """
+name: split-outcome
+description: "One pass, one fail"
+version: "1.0.0"
+nodes:
+  - id: pass
+    command: "true"
+  - id: fail
+    depends_on: [pass]
+    command: "exit 1"
+"""
+    )
+    runner = _build_runner(workdir=runner_workdir)
+    execution: WorkflowExecution = runner.run(spec)
+    assert execution.succeeded is False
+    assert any(n.status == NodeStatus.FAILED for n in execution.nodes)

--- a/tests/unit/test_workflow_spec.py
+++ b/tests/unit/test_workflow_spec.py
@@ -1,0 +1,451 @@
+"""Unit tests for the Archon-style YAML workflow manifest schema.
+
+Covers parser round-trips, structural validation (cycles, missing
+references, duplicate ids), kind detection (command vs agent vs loop),
+schema versioning, and discovery across bundled / user directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.workflows.workflow_spec import (
+    DEFAULT_NODE_TIMEOUT_SECONDS,
+    LoopSpec,
+    WorkflowNode,
+    WorkflowSpecError,
+    discover_workflows,
+    dump_spec_yaml,
+    load_workflow_spec,
+    load_workflow_spec_from_text,
+    render_blank_template,
+    resolve_workflow,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+_LINEAR_YAML = """\
+name: linear-flow
+description: "Three steps in a row"
+version: "1.0.0"
+nodes:
+  - id: research
+    agent: manager
+    prompt: "Research {goal}"
+  - id: implement
+    depends_on: [research]
+    agent: backend
+    prompt: "Implement the plan"
+  - id: test
+    depends_on: [implement]
+    command: "pytest -x"
+"""
+
+
+_FAN_OUT_YAML = """\
+name: fan-out
+description: "One root, two leaves"
+version: "1.0"
+nodes:
+  - id: root
+    command: "echo hi"
+  - id: leaf-a
+    depends_on: [root]
+    command: "echo a"
+  - id: leaf-b
+    depends_on: [root]
+    command: "echo b"
+"""
+
+
+# ---------------------------------------------------------------------------
+# Parsing and round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_parses_linear_yaml_round_trip() -> None:
+    """Linear DAG round-trips through model_dump and reload."""
+    spec = load_workflow_spec_from_text(_LINEAR_YAML)
+    assert spec.name == "linear-flow"
+    assert spec.version == "1.0.0"
+    assert [n.id for n in spec.nodes] == ["research", "implement", "test"]
+    assert spec.nodes[0].kind == "agent"
+    assert spec.nodes[2].kind == "command"
+
+    redumped = dump_spec_yaml(spec)
+    again = load_workflow_spec_from_text(redumped)
+    assert again.model_dump() == spec.model_dump()
+
+
+def test_topological_layers_for_fan_out() -> None:
+    """Fan-out manifest produces a single root layer + parallel leaves."""
+    spec = load_workflow_spec_from_text(_FAN_OUT_YAML)
+    layers = spec.topological_order()
+    assert len(layers) == 2
+    assert [n.id for n in layers[0]] == ["root"]
+    assert sorted(n.id for n in layers[1]) == ["leaf-a", "leaf-b"]
+
+
+# ---------------------------------------------------------------------------
+# Validation: cycles, missing refs, duplicates
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_cycle() -> None:
+    """A two-node cycle is rejected at schema-validation time."""
+    text = """
+name: cyclic
+description: "Has a cycle"
+version: "1.0.0"
+nodes:
+  - id: a
+    depends_on: [b]
+    command: "true"
+  - id: b
+    depends_on: [a]
+    command: "true"
+"""
+    with pytest.raises(WorkflowSpecError, match="cycle"):
+        load_workflow_spec_from_text(text)
+
+
+def test_rejects_missing_dependency() -> None:
+    """A depends_on entry that doesn't match any node id is rejected."""
+    text = """
+name: missing-dep
+description: "Bad dep"
+version: "1.0.0"
+nodes:
+  - id: a
+    depends_on: [ghost]
+    command: "true"
+"""
+    with pytest.raises(WorkflowSpecError, match="ghost"):
+        load_workflow_spec_from_text(text)
+
+
+def test_rejects_duplicate_node_id() -> None:
+    """Two nodes sharing an id must be rejected."""
+    text = """
+name: duplicates
+description: "Has dup"
+version: "1.0.0"
+nodes:
+  - id: a
+    command: "true"
+  - id: a
+    command: "false"
+"""
+    with pytest.raises(WorkflowSpecError, match="duplicate"):
+        load_workflow_spec_from_text(text)
+
+
+def test_rejects_self_dependency() -> None:
+    """A node listing itself in depends_on is rejected."""
+    text = """
+name: self-dep
+description: "Self dep"
+version: "1.0.0"
+nodes:
+  - id: a
+    depends_on: [a]
+    command: "true"
+"""
+    with pytest.raises(WorkflowSpecError):
+        load_workflow_spec_from_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Validation: node kind exclusivity
+# ---------------------------------------------------------------------------
+
+
+def test_node_must_pick_command_or_agent() -> None:
+    """A node with both command and agent set must fail validation."""
+    text = """
+name: dual
+description: "Dual kind"
+version: "1.0.0"
+nodes:
+  - id: a
+    command: "echo hi"
+    agent: backend
+    prompt: "Do it"
+"""
+    with pytest.raises(WorkflowSpecError, match="exactly one"):
+        load_workflow_spec_from_text(text)
+
+
+def test_agent_node_requires_prompt() -> None:
+    """Agent-typed nodes without a prompt must be rejected."""
+    text = """
+name: noprompt
+description: "Missing prompt"
+version: "1.0.0"
+nodes:
+  - id: a
+    agent: backend
+"""
+    with pytest.raises(WorkflowSpecError, match="prompt"):
+        load_workflow_spec_from_text(text)
+
+
+def test_command_node_rejects_prompt() -> None:
+    """Command-typed nodes carrying a prompt must be rejected."""
+    text = """
+name: cmdprompt
+description: "Command + prompt"
+version: "1.0.0"
+nodes:
+  - id: a
+    command: "echo hi"
+    prompt: "Should not be here"
+"""
+    with pytest.raises(WorkflowSpecError, match="prompt"):
+        load_workflow_spec_from_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Validation: id and version shapes
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_non_slug_node_id() -> None:
+    """Node ids must be slug-shaped."""
+    text = """
+name: idtest
+description: "Bad id"
+version: "1.0.0"
+nodes:
+  - id: "Not A Slug"
+    command: "true"
+"""
+    with pytest.raises(WorkflowSpecError, match="match"):
+        load_workflow_spec_from_text(text)
+
+
+def test_rejects_invalid_version() -> None:
+    """Version must look like 1.2.3 (or 1.2)."""
+    text = """
+name: vtest
+description: "Bad version"
+version: "garbage"
+nodes:
+  - id: a
+    command: "true"
+"""
+    with pytest.raises(WorkflowSpecError, match="version"):
+        load_workflow_spec_from_text(text)
+
+
+def test_accepts_two_field_version() -> None:
+    """``MAJOR.MINOR`` is a valid version too."""
+    text = """
+name: short-version
+description: "Two-field ok"
+version: "1.0"
+nodes:
+  - id: a
+    command: "true"
+"""
+    spec = load_workflow_spec_from_text(text)
+    assert spec.version == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Loop and timeout semantics
+# ---------------------------------------------------------------------------
+
+
+def test_loop_spec_round_trips() -> None:
+    """LoopSpec parses both ``until`` and ``max_iterations``."""
+    text = """
+name: looptest
+description: "Has a loop"
+version: "1.0.0"
+nodes:
+  - id: a
+    command: "echo go"
+    loop:
+      until: "test -f done.txt"
+      max_iterations: 7
+"""
+    spec = load_workflow_spec_from_text(text)
+    assert spec.nodes[0].loop is not None
+    assert spec.nodes[0].loop.max_iterations == 7
+    assert spec.nodes[0].loop.until == "test -f done.txt"
+
+
+def test_default_timeout_applies_when_unset() -> None:
+    """Nodes without an explicit timeout fall back to the module default."""
+    spec = load_workflow_spec_from_text(_FAN_OUT_YAML)
+    for node in spec.nodes:
+        assert node.timeout_seconds == DEFAULT_NODE_TIMEOUT_SECONDS
+
+
+def test_loop_max_iterations_lower_bound() -> None:
+    """``max_iterations`` must be >= 1."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        LoopSpec(until="true", max_iterations=0)
+
+
+# ---------------------------------------------------------------------------
+# Discovery and resolution
+# ---------------------------------------------------------------------------
+
+
+def test_load_workflow_spec_missing_file(tmp_path: Path) -> None:
+    """Loading a non-existent path raises a friendly WorkflowSpecError."""
+    with pytest.raises(WorkflowSpecError, match="not found"):
+        load_workflow_spec(tmp_path / "absent.yaml")
+
+
+def test_load_workflow_spec_malformed_yaml(tmp_path: Path) -> None:
+    """Malformed YAML surfaces as WorkflowSpecError."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(":\n  -- not: yaml :\n", encoding="utf-8")
+    with pytest.raises(WorkflowSpecError):
+        load_workflow_spec(bad)
+
+
+def test_discovery_includes_user_and_bundled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """User-installed manifests are listed alongside bundled ones."""
+    # Plant a fake user workflow.
+    user_dir = tmp_path / "home" / ".bernstein" / "workflows"
+    user_dir.mkdir(parents=True)
+    (user_dir / "my-flow.yaml").write_text(
+        """
+name: my-flow
+description: "User-installed"
+version: "1.0.0"
+nodes:
+  - id: x
+    command: "true"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    names = {name for name, _ in discover_workflows(workdir=project)}
+    assert "my-flow" in names
+
+
+def test_discovery_project_local_shadows_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A project-local workflow shadows a same-named home workflow."""
+    home = tmp_path / "home" / ".bernstein" / "workflows"
+    home.mkdir(parents=True)
+    (home / "shared.yaml").write_text(
+        "name: shared\ndescription: Home\nversion: '1.0'\nnodes:\n - id: a\n   command: 'true'\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    project = tmp_path / "proj"
+    proj_dir = project / ".bernstein" / "workflows"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "shared.yaml").write_text(
+        "name: shared\ndescription: Project\nversion: '2.0'\nnodes:\n - id: a\n   command: 'true'\n",
+        encoding="utf-8",
+    )
+
+    pairs = dict(discover_workflows(workdir=project, include_bundled=False))
+    assert "shared" in pairs
+    spec = load_workflow_spec(pairs["shared"])
+    assert spec.description == "Project"
+    assert spec.version == "2.0"
+
+
+def test_resolve_by_path(tmp_path: Path) -> None:
+    """resolve_workflow accepts an explicit filesystem path."""
+    path = tmp_path / "flow.yaml"
+    path.write_text(_LINEAR_YAML, encoding="utf-8")
+    resolved_path, spec = resolve_workflow(str(path))
+    assert resolved_path == path.resolve()
+    assert spec.name == "linear-flow"
+
+
+def test_resolve_unknown_name_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolving a name that doesn't exist anywhere raises clearly."""
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    with pytest.raises(WorkflowSpecError, match="not found"):
+        resolve_workflow("does-not-exist", workdir=tmp_path / "no-proj")
+
+
+# ---------------------------------------------------------------------------
+# Templates and queries
+# ---------------------------------------------------------------------------
+
+
+def test_render_blank_template_round_trips() -> None:
+    """``render_blank_template`` outputs YAML that parses cleanly."""
+    body = render_blank_template("my-thing")
+    spec = load_workflow_spec_from_text(body)
+    assert spec.name == "my-thing"
+    assert any(n.kind == "agent" for n in spec.nodes)
+    assert any(n.kind == "command" for n in spec.nodes)
+
+
+def test_render_blank_template_rejects_non_slug() -> None:
+    """Init refuses non-slug names so we don't write unloadable files."""
+    with pytest.raises(WorkflowSpecError):
+        render_blank_template("Bad Name")
+
+
+def test_node_by_id_returns_node() -> None:
+    """``WorkflowSpec.node_by_id`` finds a node and KeyErrors on miss."""
+    spec = load_workflow_spec_from_text(_LINEAR_YAML)
+    assert spec.node_by_id("research").kind == "agent"
+    with pytest.raises(KeyError):
+        spec.node_by_id("nonexistent")
+
+
+def test_workflow_node_construction_minimal_command() -> None:
+    """A minimal command node constructs without optional fields."""
+    node = WorkflowNode(id="ok", command="true")
+    assert node.kind == "command"
+    assert node.depends_on == []
+    assert node.fresh_context is False
+
+
+def test_bundled_stock_workflows_load() -> None:
+    """Every bundled stock workflow parses cleanly."""
+    from bernstein.core.workflows.workflow_spec import _bundled_workflows_dir
+
+    bundled = _bundled_workflows_dir()
+    yaml_files = sorted(bundled.glob("*.yaml"))
+    # We ship six stock workflows in #1108.
+    assert len(yaml_files) >= 6
+    for path in yaml_files:
+        spec = load_workflow_spec(path)
+        assert spec.name
+        assert spec.nodes
+
+
+def test_top_level_must_be_mapping() -> None:
+    """A YAML scalar at the top is rejected."""
+    with pytest.raises(WorkflowSpecError, match="mapping"):
+        load_workflow_spec_from_text("just-a-string\n")
+
+
+def test_workflowspec_construction_rejects_extra_fields() -> None:
+    """Pydantic ``extra='forbid'`` prevents unknown top-level keys."""
+    text = """
+name: extra
+description: "Has extras"
+version: "1.0.0"
+nodes:
+  - id: a
+    command: "true"
+unknown_field: oops
+"""
+    with pytest.raises(WorkflowSpecError):
+        load_workflow_spec_from_text(text)


### PR DESCRIPTION
## Summary

- New Archon-inspired `bernstein workflow run|init|validate|list` surface that runs in parallel to the open-ended `bernstein run -g` entrypoint, validated up-front with Pydantic v2 and dispatched through the existing `AgentSpawner.spawn_for_tasks` path (no parallel spawn pipeline).
- Six stock manifests (idea-to-pr, refactor-with-tests, security-review, doc-update, dependency-bump, hot-fix) shipped in the wheel via hatch force-include.
- 28 unit + 14 integration tests covering parse round-trip, cycle / missing-dep / kind-exclusivity rejection, fan-out parallel, loop-until-pass, max_iterations exhaustion, fresh-context iteration, real-AgentSpawner dispatch, command timeout, malformed YAML, missing-template resolution, and the `interactive: true` stub that points at #1110.

## Shape

- `src/bernstein/core/workflows/{__init__,workflow_spec,workflow_runner}.py` — schema + DAG runner.
- `src/bernstein/cli/commands/workflow_cmd.py` — extended group with `run`/`init` and dual-mode `validate`/`list` (auto-detect manifest flavour so the legacy DSL keeps working).
- `templates/workflows/*.yaml` — 6 stock manifests, registered in `pyproject.toml` `[tool.hatch.build.targets.wheel.force-include]`.
- `tests/unit/test_workflow_spec.py` + `tests/integration/test_workflow_runner.py`.
- README install-block-adjacent section + stock-workflow table; `workflow` already in `DOCUMENTED_COMMANDS`.

## Test plan

- [x] `uv run pytest tests/unit/test_workflow_spec.py tests/integration/test_workflow_runner.py tests/unit/test_workflow_dsl.py tests/unit/test_readme_api_coverage.py` (111 passed)
- [x] `uv run ruff check src/bernstein/core/workflows src/bernstein/cli/commands/workflow_cmd.py tests/unit/test_workflow_spec.py tests/integration/test_workflow_runner.py` (clean)
- [x] `uv run ruff format --check` (clean for new files)
- [x] CLI smoke: `bernstein workflow list --bundled-only`, `bernstein workflow validate templates/workflows/idea-to-pr.yaml`, `bernstein workflow run idea-to-pr --dry-run`, `bernstein workflow init scratch-test --target /tmp/...`

Closes #1108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)