### PR TITLE
sec(agent-card-signer): require typ='agent-card+jws' header in verify

### DIFF
--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -218,6 +218,15 @@ def verify_agent_card(
     if header.get("alg") != "EdDSA":
         return False
 
+    # Lock the JWS down to this issuer's intended ``typ``. Without this
+    # check, a signature minted for an entirely different JWS context with
+    # the same issuer key (a fictitious ``foo+jws`` typ used elsewhere in
+    # the system) would verify as a valid agent-card signature here. The
+    # ``typ`` header is set by ``sign_agent_card`` so legitimate signatures
+    # always carry it; rejection on mismatch is conservative and cheap.
+    if header.get("typ") != "agent-card+jws":
+        return False
+
     public_key = serialization.load_pem_public_key(public_key_pem)
 
     body_b64 = _b64url(canonicalize_jcs(_card_to_dict(card)))

--- a/tests/unit/test_agent_card_signer.py
+++ b/tests/unit/test_agent_card_signer.py
@@ -168,11 +168,56 @@ class TestSignVerify:
 
         from base64 import urlsafe_b64encode
 
-        bad_header = urlsafe_b64encode(
-            json.dumps({"alg": "none", "typ": "agent-card+jws"}).encode()
-        ).rstrip(b"=").decode("ascii")
+        bad_header = (
+            urlsafe_b64encode(json.dumps({"alg": "none", "typ": "agent-card+jws"}).encode())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
         forged = AgentCardSignature(
             detached_jws=f"{bad_header}..{sig_b64}",
+            kid=sig.kid,
+        )
+        assert verify_agent_card(card, forged, pub) is False
+
+    def test_wrong_typ_in_header_rejected(self) -> None:
+        """A signature minted for a different JWS context must not verify here.
+
+        Without the typ check, a signature produced by the same issuer key
+        but for a different ``typ`` (e.g. an unrelated internal JWS like
+        ``"deploy-attestation+jws"``) would verify as a valid agent-card
+        signature. The ``typ`` header pins the signature to its intended
+        protocol surface.
+        """
+        priv, pub = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+        _header_b64, _empty, sig_b64 = sig.detached_jws.split(".")
+
+        from base64 import urlsafe_b64encode
+
+        wrong_typ_header = (
+            urlsafe_b64encode(json.dumps({"alg": "EdDSA", "typ": "deploy-attestation+jws"}).encode())
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        forged = AgentCardSignature(
+            detached_jws=f"{wrong_typ_header}..{sig_b64}",
+            kid=sig.kid,
+        )
+        assert verify_agent_card(card, forged, pub) is False
+
+    def test_missing_typ_in_header_rejected(self) -> None:
+        """A header that omits ``typ`` entirely must also be refused."""
+        priv, pub = generate_ed25519_keypair()
+        card = _sample_card()
+        sig = sign_agent_card(card, priv)
+        _header_b64, _empty, sig_b64 = sig.detached_jws.split(".")
+
+        from base64 import urlsafe_b64encode
+
+        no_typ_header = urlsafe_b64encode(json.dumps({"alg": "EdDSA"}).encode()).rstrip(b"=").decode("ascii")
+        forged = AgentCardSignature(
+            detached_jws=f"{no_typ_header}..{sig_b64}",
             kid=sig.kid,
         )
         assert verify_agent_card(card, forged, pub) is False


### PR DESCRIPTION
## Why

Hardening follow-up to #1106. The merged `verify_agent_card` checks `alg=EdDSA` but didn't enforce the `typ` header. Without `typ` enforcement, a signature minted by the same issuer key for a different JWS context (e.g. a hypothetical `deploy-attestation+jws`) would verify as a valid agent-card signature here -- a cross-context substitution attack class.

## What

Add `if header.get('typ') != 'agent-card+jws': return False` in `verify_agent_card`. `sign_agent_card` already emits `typ='agent-card+jws'`, so legitimate signatures always carry it.

Two regression tests:
- `test_wrong_typ_in_header_rejected`: different-but-plausible `typ` refused.
- `test_missing_typ_in_header_rejected`: missing `typ` refused.

19/19 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)