### PR TITLE
sec(deps): override fast-uri to >=3.1.1 for CVE-2026-6321 path traversal

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -4239,9 +4239,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -111,6 +111,7 @@
     "typescript": "^5.4"
   },
   "overrides": {
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "fast-uri": ">=3.1.1"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert #18 (GHSA-q3j6-qgpj-74h6, CVE-2026-6321, CVSS 7.5 high).

`fast-uri <= 3.1.0` decodes `%2F` and `%2E` before dot-segment removal in `normalize()` / `equal()`. Distinct URIs collapse to the same normalized path; path-policy comparators can be bypassed.

Transitive dep: `packages/vscode` → `ovsx@0.9.5` → `fast-uri@3.1.0`.

Fix: `"fast-uri": ">=3.1.1"` added to existing overrides block. npm resolved to **3.1.2** (latest patched). `npm audit` clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)