### PR TITLE
docs: run savings summary + handoff h_ token prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ A `bernstein cloud init` scaffold for `wrangler.toml` and bindings is planned.
 
 **Controls**. HMAC-chained audit logs, policy engine, PII output gating, WAL-backed crash recovery (experimental multi-worker safety), OAuth 2.0 PKCE. SSO/SAML/OIDC support is in progress.
 
-**Observability**. Prometheus `/metrics`, OTel exporter presets, Grafana dashboards. Per-model cost tracking (`bernstein cost`). Terminal TUI and web dashboard. Agent process visibility in `ps`.
+**Observability**. Prometheus `/metrics`, OTel exporter presets, Grafana dashboards. Per-model cost tracking (`bernstein cost`) plus a [run savings summary](docs/operations/cost-optimization.md#run-savings-summary) on every `bernstein run`. Terminal TUI and web dashboard. Agent process visibility in `ps`.
 
 **Ecosystem**. MCP server mode, A2A protocol support, GitHub App integration, pluggy-based plugin system, multi-repo workspaces, cluster mode for distributed execution, self-evolution via `--evolve` (experimental).
 

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -130,6 +130,11 @@ Run summary — 1 task completed in 1m 47s
 Total: $0.03 · 1 merged · 0 failed
 ```
 
+The summary card also reports a **Model routing savings** number when the
+cascade router downgraded any task off Opus — see
+[run savings summary](../operations/cost-optimization.md#run-savings-summary)
+for how it is computed and what the caveats are.
+
 Inspect a specific task:
 
 ```bash

--- a/docs/migrations/migration-guides.md
+++ b/docs/migrations/migration-guides.md
@@ -258,3 +258,14 @@ Bernstein agents have built-in terminal access and can run any command directly.
 4. **Use existing CLI agents.** Do not rewrite custom tools. Claude Code, Codex, and other agents already know how to edit files, run tests, and use git.
 
 5. **Use quality gates instead of LLM-based evaluation.** Instead of asking an LLM "is this good?", run concrete checks: tests pass, lint clean, type check clean.
+
+## Version migrations
+
+### `1.10.0` → `1.10.1`: handoff tokens prefixed with `h_`
+
+`bernstein handoff emit` tokens now start with the literal `h_` (e.g.
+`h_3F8aQ2Kh9-Vb7c1dEs4Z6P-tGmRoYvLk`). If you scripted against the older
+format — regex without the prefix, DB `CHECK` constraint on length or
+starting character, or a fixture hard-coding a `1.10.0` token — update
+them. See
+[session handoff → token format](../operations/session-handoff.md#token-format).

--- a/docs/operations/cost-optimization.md
+++ b/docs/operations/cost-optimization.md
@@ -153,6 +153,58 @@ bernstein cost --json
 
 Cost forecasting is handled by `src/bernstein/core/cost/spend_forecast.py` and `src/bernstein/core/cost/cost_forecast.py`.
 
+### Run savings summary
+
+Every `bernstein run` ends with a summary card. Since `v1.10.1` the card
+includes a **Model routing savings** row that estimates how much spend
+the cascade router avoided versus running the same plan single-shot
+through the most expensive routed model.
+
+```text
+╭─────────────────────── Run Complete ───────────────────────╮
+│ Metric                                          Value      │
+│ Tasks completed                                 12/12      │
+│ Total time                                      4m 18s     │
+│ Total cost                                      $0.4231    │
+│ Cost per task                                   $0.0353    │
+│ Model routing savings                           $1.8742    │
+│ Quality score                                   92%        │
+╰────────────────────────────────────────────────────────────╯
+```
+
+The same number is persisted to `.sdd/runs/<run-id>/summary.json`
+(`routing_savings_usd`) for `bernstein recap` and downstream dashboards.
+
+**Baseline anchor.** The comparison model is **Opus** — the most
+expensive tier in the default cascade (`haiku → sonnet → opus`). Picking
+the top of the cascade gives an intentionally generous "what if I had
+just used the smartest model for everything" number; the buyer-facing
+question the card is built to answer.
+
+**How it is computed.** For every completed task the run priced through
+something other than Opus, multiply its total tokens (prompt +
+completion) by the Opus per-1K rate, subtract the actual spend, and sum
+the positive deltas. Tasks already routed to Opus, fast-path bypasses,
+and zero-token tasks contribute nothing. Implementation:
+`compute_savings_vs_opus()` in `src/bernstein/core/cost/cost.py`,
+wrapped by `calculate_savings()` in
+`src/bernstein/core/cost/savings_calculator.py`.
+
+**Caveats.**
+
+- This is an **estimate**, not a counterfactual replay. Opus would have
+  used a different prompt strategy and likely a different token count;
+  the number assumes identical token usage across tiers.
+- Savings can read as zero on a run that was already 100% Opus or 100%
+  fast-path — there is nothing to compare.
+- Token rates come from the static catalogue in
+  `_MODEL_COST_USD_PER_1K`. When provider pricing changes, the catalogue
+  needs to move with it, otherwise the savings number drifts.
+
+For a multi-run aggregate of the same comparison see `bernstein cost` —
+the `--json` payload includes `savings_vs_opus_usd` over the configured
+window.
+
 ## Peak-hour routing
 
 Route non-urgent tasks to off-peak windows to reduce costs:

--- a/docs/operations/session-handoff.md
+++ b/docs/operations/session-handoff.md
@@ -1,0 +1,77 @@
+# Session handoff
+
+`bernstein handoff` moves a live session between surfaces — terminal,
+web dashboard, chat bridge — without losing the active task or stream
+tail. The source surface freezes and prints a short-lived token; the
+destination presents the token and re-attaches.
+
+```bash
+# on the laptop terminal that started the run
+bernstein handoff emit --session $SESSION_ID --from terminal
+
+# token printed to stdout, e.g.
+# h_3F8aQ2Kh9-Vb7c1dEs4Z6P-tGmRoYvLk
+
+# on the dashboard host (or another terminal, or the chat bridge)
+bernstein handoff claim h_3F8aQ2Kh9-Vb7c1dEs4Z6P-tGmRoYvLk
+```
+
+Tokens live for **5 minutes** and are **single-use**. The on-disk
+registry is `.sdd/runtime/handoff_tokens.json`; expired entries are
+swept on every load.
+
+## Token format
+
+Every token issued by `bernstein handoff emit` since `v1.10.1` is
+prefixed with the literal string `h_`. A typical token looks like:
+
+```text
+h_3F8aQ2Kh9-Vb7c1dEs4Z6P-tGmRoYvLk
+```
+
+Anatomy:
+
+| Segment | Length | Source |
+|---------|--------|--------|
+| `h_` prefix | 2 chars | Constant — used to recognise a handoff token in logs and to keep the token from starting with `-`. |
+| Body | ~32 chars | URL-safe base64 from `secrets.token_urlsafe(24)`; alphabet is `A-Z a-z 0-9 - _`. |
+
+Total length is therefore around 34 characters. Match against
+`^h_[A-Za-z0-9_-]+$` if you need a regex.
+
+### Why the prefix
+
+`secrets.token_urlsafe()` occasionally produces a token whose first
+character is `-`. Click — the CLI parser Bernstein uses — then misreads
+`bernstein handoff claim -Vb7c1...` as the option `-V` followed by junk,
+and the claim fails with an obscure `No such option` error. Roughly
+1.5% of issued tokens hit this edge case. Forcing every token to start
+with `h_` removes the ambiguity for click and gives operators a
+single-glance way to spot a handoff token in a log line.
+
+## Back-compat note for `v1.10.0` consumers
+
+If you wrote any of the following against `v1.10.0` tokens, update for
+`v1.10.1+`:
+
+- A regex that did **not** include `h_` (e.g. `^[A-Za-z0-9_-]{32,}$`).
+- A database column with a `CHECK` constraint on token shape, length,
+  or starting character.
+- A log scraper that parsed tokens by position from the
+  `bernstein handoff emit` stdout.
+- A test fixture hard-coding a `1.10.0`-shaped token.
+
+The token is still URL-safe and printable, just two characters longer
+and prefixed with `h_`. Old tokens issued by `1.10.0` are not
+re-validated by `claim` — any token still in flight at the upgrade
+boundary will fail closed; re-emit on the new version.
+
+Implementation: `HandoffTokenStore.issue()` in
+`src/bernstein/core/handoff/tokens.py`.
+
+## Related
+
+- [Voice control](voice-control.md) — `recap` / `show recap` voice
+  commands wrap `bernstein recap`, which inherits the same session.
+- [Autofix](autofix.md) — the `autofix attach` command uses the same
+  resume-from-any-terminal handoff pattern for chat-control sessions.


### PR DESCRIPTION
Refs #1086

## Summary

- documents the per-run savings summary card (Opus baseline anchor, formula, caveats, sample card output) on `docs/operations/cost-optimization.md`; cross-links from README observability bullet and `docs/getting-started/first-run.md`
- adds a new `docs/operations/session-handoff.md` covering the v1.10.1 `h_` token prefix (anatomy, regex, click-parsing rationale, back-compat list for 1.10.0 consumers) plus a sample literal `h_3F8aQ2Kh9-Vb7c1dEs4Z6P-tGmRoYvLk`
- new "Version migrations" section in `docs/migrations/migration-guides.md` with a one-paragraph migration note linking back to the token-format section

closes the doc gap from `.sdd/backlog/open/2026-05-07-doc-gap-run-savings-summary-and-handoff-token-prefix.md` (moved to closed/).

pure docs — no code, no deps. ~140 LOC of MD across one new page and three existing pages.

## Test plan

- [ ] `mkdocs build` cleanly resolves the new internal links (`#run-savings-summary`, `#token-format`)
- [ ] sample card output renders correctly in a fixed-width font
- [ ] sample `h_…` token literal matches `^h_[A-Za-z0-9_-]+$`
- [ ] `docs/operations/session-handoff.md` shows up in the operations sidebar / nav generator

🤖 Generated with [Claude Code](https://claude.com/claude-code)
