### PR TITLE
chore(sonar): note org-LOC-cap blocker; close manual-review ticket

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,16 @@ sonar.organization=chernistry
 sonar.projectKey=chernistry_bernstein
 sonar.projectName=Bernstein
 
+# NOTE: The `chernistry` SonarCloud org is on the free public-projects plan
+# (~191k LOC soft cap). Main-branch analyses are currently rejected by the
+# compute engine ("maximum allowed lines limit") so the project has no stored
+# baseline and zero issues are reported, even though PR-scoped scans still
+# pass on the diff. Resolution requires admin action (plan upgrade, re-home
+# the project under the `sipyourdrink-ltd` org, or further `sonar.sources`
+# shrinkage) and cannot be fixed from the codebase alone. See
+# `.sdd/backlog/closed/2026-05-07-sonar-manual-review.md` for evidence and
+# the recommended path (option 2: re-home).
+
 # -------------------------------------------------------------------------
 # Scope
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves the SonarCloud manual-review ticket
(`.sdd/backlog/closed/2026-05-07-sonar-manual-review.md`).

The ticket asked for a concrete fix-list against SonarCloud findings.
The ticket body itself documents that **there are zero findings to fix**:
the `chernistry` SonarCloud organisation is on the free public-projects
plan and every `main`-branch analysis since at least 2026-05-05 has been
rejected by the compute engine for exceeding the ~191k LOC soft cap.
Without a stored baseline, SonarCloud reports `total: 0` for issues,
hotspots, and measures, even though PR-scoped scans still pass.

## What this PR does

- Adds a `# NOTE:` block to `sonar-project.properties` so the next
  engineer who opens the file immediately understands why the dashboard
  is empty and what the remediation options are.
- Moves the ticket from `.sdd/backlog/open/` to `.sdd/backlog/closed/`
  via filesystem `mv` (the `.sdd/` tree is `.gitignore`d project-wide,
  so `git mv` is not possible — the move is intentionally not in the
  diff).

## Findings addressed

None — the ticket lists no smell IDs, file paths, or line numbers
because SonarCloud has no stored issues for this project.

## Findings skipped (with reason)

- **Option 1 — upgrade plan**: requires SonarCloud org admin to change
  billing. Not automatable from the codebase.
- **Option 2 — re-home project under `sipyourdrink-ltd`** (ticket's
  recommended path): requires creating a new Sonar project, regenerating
  `SONAR_TOKEN`, updating the GitHub repo secret, and editing
  `sonar.organization` / `sonar.projectKey`. Token rotation must happen
  before the `properties` file change or CI breaks; cannot be safely
  done in a single PR by an automated agent.
- **Option 3 — shrink `sonar.sources` further**: ticket estimates 1-2 h
  to identify cheap cuts and verify `ncloc` after analysis. Pure value
  judgement and would widen scope past what Sonar flagged (Sonar flagged
  nothing).

The closed ticket retains all evidence (API responses, CE task IDs, CI
run numbers) so whichever option is chosen later can pick up where
this leaves off.

## Test plan

- [ ] CI green on this PR (the PR-scoped Sonar scan should still pass).
- [ ] Operator picks one of the three remediation options and lands the
  follow-up admin work outside this PR.

Ticket: `.sdd/backlog/closed/2026-05-07-sonar-manual-review.md`