### PR TITLE
docs: align adapter count + Junie/Q-Dev CHANGELOG entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable project changes are tracked here (code + docs).
 ### Added — adapters
 
 - **Devin for Terminal (Cognition).** First-class adapter with 558 lines of contract tests covering process tracking, env isolation, and timeout watchdogs. Drop-in for any plan via `cli_agent: devin_terminal`.
+- **JetBrains Junie CLI.** LLM-agnostic BYOK adapter (`cli_agent: junie`) — forwards whichever provider key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) the routed model needs and dynamically narrows the network allowlist to that provider's endpoints.
+- **AWS Q Developer CLI.** First-class adapter (`cli_agent: q_dev`) using `q chat --no-interactive --trust-all-tools`. Token bootstrap via `q login` is documented in the adapter docstring; missing token cache surfaces a clear error rather than a silent hang. IAM Identity Center role inheritance noted as a deployment risk.
 - **Cursor adapter rewrite.** Replaced shell to non-existent `cursor agent` binary with the real `cursor-agent` CLI surface (`-p --workspace --output-format stream-json --trust --approve-mcps --force`); 242 lines of new contract tests.
 
 ### Added — operator surfaces

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ ticket #1110 and currently raises a clear `NotImplementedError`.
 
 Bernstein auto-discovers installed CLI agents. Mix them in the same run. Cheap local models for boilerplate, heavier cloud models for architecture.
 
-42 CLI agent adapters: 39 third-party wrappers, 2 leaf-node delegators (Composio, Ralphex), plus a generic wrapper for anything with `--prompt`.
+44 CLI agent adapters: 41 third-party wrappers, 2 leaf-node delegators (Composio, Ralphex), plus a generic wrapper for anything with `--prompt`.
 
 | Agent | Models | Install |
 |-------|--------|---------|
@@ -342,7 +342,7 @@ performs vector search.
 | Feature | Bernstein | CrewAI | AutoGen [^autogen] | LangGraph |
 |---------|-----------|--------|---------|-----------|
 | Orchestrator | Deterministic code | LLM-driven (+ code Flows) | LLM-driven | Graph + LLM |
-| Works with | Any CLI agent (43 adapters) | Python SDK classes | Python agents | LangChain nodes |
+| Works with | Any CLI agent (44 adapters) | Python SDK classes | Python agents | LangChain nodes |
 | Git isolation | Worktrees per agent | No | No | No |
 | Pluggable sandboxes | Worktree, Docker, E2B, Modal | No | No | No |
 | Verification | Janitor + quality gates | Guardrails + Pydantic output | Termination conditions | Conditional edges |
@@ -367,7 +367,7 @@ The table above compares Bernstein against LLM-orchestration frameworks (they or
 | Shape | Python CLI + library + MCP server | Python CLI + tmux sessions + web UI | TypeScript CLI + local dashboard | Electron desktop app | Go CLI |
 | Primary language | Python | Python | TypeScript | TypeScript | Go |
 | Install | `pipx install bernstein` | `uv tool install cli-agent-orchestrator` | `npm install -g @aoagents/ao` | `.dmg` / `.msi` / `.AppImage` | `go install` / single binary |
-| Agent adapters | 42 | 5 (Kiro, Claude Code, Codex, Gemini, Kimi) | 3 (Claude Code, Codex, Aider) | 24 | 1 (Claude Code only) |
+| Agent adapters | 44 | 5 (Kiro, Claude Code, Codex, Gemini, Kimi) | 3 (Claude Code, Codex, Aider) | 24 | 1 (Claude Code only) |
 | Parallel multi-agent execution | Yes | Yes (tmux session per agent) | Yes | Yes | No (single sequential session) |
 | Git worktree per agent | Yes | No (planned, [#100](https://github.com/awslabs/cli-agent-orchestrator/issues/100)) | Yes | Yes | Optional `--worktree` flag |
 | MCP server mode (exposes self as MCP) | Yes (stdio + HTTP/SSE) | Yes (inter-agent comms) | No | No | No |


### PR DESCRIPTION
## Summary

Closes the doc-debt tail of `.sdd/backlog/open/2026-05-06-new-agent-adapters-sap-joule-and-others.md` (now moved to `.sdd/backlog/closed/`). The three adapters that ticket recommended already shipped via earlier PRs:

- **`devin_terminal`** (Devin for Terminal, Cognition) — merged via #1055-era work
- **`junie`** (JetBrains Junie CLI) — merged via #1058
- **`q_dev`** (AWS Q Developer CLI) — merged via #1055

This PR only catches the docs up with the shipped state:

- `README.md` — `42 CLI agent adapters` -> `44`; comparison table `42` -> `44`; CrewAI/AutoGen/LangGraph row `43` -> `44`. Breakdown is now `41 third-party + 2 leaf-node delegators + generic`.
- `CHANGELOG.md` (`[1.10.1]` Added — adapters) — added Junie + AWS Q Developer entries (Devin entry was already there).

## Verdicts (carried from ticket, no code changes here)

| Agent | Verdict | Status |
|---|---|---|
| **SAP Joule for Developers** | SKIP | Already documented in `docs/adapter-deferred.md` (no CLI surface; integration path is inverse — agents call Joule via MCP, future ticket) |
| **Devin for Terminal** (Cognition) | SHIP | Shipped on `main`: `src/bernstein/adapters/devin_terminal.py` |
| **JetBrains Junie CLI** | SHIP | Shipped on `main`: `src/bernstein/adapters/junie.py` |
| **AWS Q Developer CLI** | SHIP | Shipped on `main`: `src/bernstein/adapters/q_dev.py` |
| **Mistral Code / Devstral** | SHIP (stretch) | Already on `main`: `src/bernstein/adapters/mistral.py` |
| **Tessl Framework** | SKIP (peer) | Documented in `docs/adapter-deferred.md` |
| **Tabby (TabbyML)** | DEFER | Documented in `docs/adapter-deferred.md` |
| **Suna (Kortix)** | DEFER | Documented in `docs/adapter-deferred.md` |
| **DeepSeek CLI** | DEFER | Awaiting official binary |

## Ticket location

Moved: `.sdd/backlog/open/2026-05-06-new-agent-adapters-sap-joule-and-others.md` -> `.sdd/backlog/closed/2026-05-06-new-agent-adapters-sap-joule-and-others.md`. (`.sdd/` is gitignored so the move is filesystem-only — not part of this diff.)

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_devin_terminal.py tests/unit/test_adapter_junie.py tests/unit/test_adapter_q_dev.py -x -q --timeout=120` -> **92 passed in 7.37s**
- [ ] CI: README link checks
- [ ] CI: full unit suite