### PR TITLE
feat(prompt-cache): enforce prefix locality + drift counter

### DIFF
--- a/src/bernstein/core/agents/prompt_cache_locality.py
+++ b/src/bernstein/core/agents/prompt_cache_locality.py
@@ -1,0 +1,309 @@
+"""Prompt-cache prefix locality enforcement and drift accounting.
+
+This module provides a thin wrapper around prompt assembly that guarantees
+byte-identical prefixes for cache hits across consecutive same-role spawns
+and increments a drift counter (in-memory + Prometheus) when the prefix
+changes between spawns.
+
+Anthropic's prompt cache awards a 90% input-token discount on cache hits,
+OpenAI's awards 50%, and Google's Gemini context cache charges per-hour
+storage; all three contracts require the *prefix* to be byte-identical
+between requests.  Bernstein already builds cacheable prefixes via
+``mark_cacheable_prefix`` and ``extract_system_prefix``; this module is
+the layer that *enforces* stability across spawns and surfaces drift so
+the operator can see the cost-leak the moment a prefix change broke
+the cache.
+
+Design choices:
+
+* The drift counter is per-role.  Different roles have different
+  prefixes by definition; only same-role drift is interesting.
+* The prefix is canonicalised before hashing: the stable header fields
+  are sorted lexicographically by key so that callers do not break the
+  cache by reordering ``role: backend\\ntemplates_hash: ...`` in their
+  rendering code.
+* The body of the prefix (role template, project context) is appended
+  verbatim and not re-sorted: rearranging real prompt text *would*
+  change the cache key on Anthropic's side, so a hash mismatch in that
+  region is a true drift signal.
+* Backed by a Prometheus counter on the shared registry so the metric
+  shows up on ``/metrics`` automatically; in-memory snapshot is also
+  kept for tests and the ``cache report`` CLI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Drift reason taxonomy — keep this closed so the Prometheus label set is
+# bounded.  Unknown values bucket under ``unknown``.
+# ---------------------------------------------------------------------------
+
+_KNOWN_DRIFT_REASONS: frozenset[str] = frozenset(
+    {
+        "tool_set_changed",
+        "time_inserted",
+        "role_template_edited",
+        "dynamic_field_in_prefix",
+        "header_field_changed",
+        "body_changed",
+        "unknown",
+    },
+)
+
+
+def _normalise_reason(raw: str) -> str:
+    """Normalise a drift reason against the closed taxonomy."""
+    value = (raw or "").strip().lower()
+    return value if value in _KNOWN_DRIFT_REASONS else "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Stable prefix construction
+# ---------------------------------------------------------------------------
+
+# Sentinel separator inserted between header and body so callers can split
+# the prefix back into its parts deterministically.  Chosen to be unlikely
+# to collide with real prompt content.
+_HEADER_SEPARATOR = "\n<!--bernstein:prefix-header-end-->\n"
+
+
+def build_stable_prefix(
+    *,
+    header: Mapping[str, str] | None = None,
+    body: str = "",
+) -> str:
+    """Build a byte-stable cache prefix from a header dict and a body string.
+
+    The header is canonicalised by sorting keys lexicographically and
+    rendering each entry as ``"<key>: <value>"`` on its own line.  This
+    means callers cannot break the cache by reordering header fields.
+    The body is appended verbatim after a fixed separator.
+
+    Args:
+        header: Mapping of stable header field names to values
+            (e.g. ``{"role": "backend", "templates_hash": "abc..."}``).
+            Keys and values are coerced to ``str``.  Empty-string values
+            are kept (they may carry meaning, e.g. an empty agent
+            protocol prefix).  ``None`` is treated as an empty mapping.
+        body: Free-form prefix body (role template, project context,
+            git safety protocol, etc.).  Appended verbatim.
+
+    Returns:
+        A deterministic prefix string.  Two calls with the same logical
+        inputs return byte-identical strings regardless of header
+        insertion order.
+    """
+    items = sorted((str(k), str(v)) for k, v in (header or {}).items())
+    header_str = "\n".join(f"{k}: {v}" for k, v in items)
+    return f"{header_str}{_HEADER_SEPARATOR}{body}"
+
+
+def hash_prefix(prefix: str) -> str:
+    """Compute the SHA-256 hex digest of *prefix* (UTF-8 encoded).
+
+    Args:
+        prefix: The cache prefix string.
+
+    Returns:
+        Lowercase 64-char hex string.
+    """
+    return hashlib.sha256(prefix.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Drift tracker — process-local, per-role.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DriftSnapshot:
+    """Per-role drift tracking state.
+
+    Attributes:
+        last_hash: Hash of the most recently seen prefix for this role.
+        drift_count: Number of drift events recorded for this role.
+        last_reason: Reason classifier for the most recent drift event,
+            or ``""`` if no drift has occurred.
+        spawn_count: Number of spawns observed for this role (including
+            the first one, which never counts as drift).
+    """
+
+    last_hash: str = ""
+    drift_count: int = 0
+    last_reason: str = ""
+    spawn_count: int = 0
+
+
+class PromptCacheLocality:
+    """Track per-role prefix hashes and increment a drift counter on change.
+
+    Thread-safe.  The first spawn for any role is *not* counted as drift —
+    drift is by definition a *change* relative to a previous observation.
+
+    Args:
+        prometheus_counter: Optional Prometheus ``Counter`` for
+            ``prompt_cache_drift_total{role,reason}``.  When ``None``,
+            only in-memory state is updated.  Tests typically pass
+            ``None`` to avoid global registry pollution.
+    """
+
+    def __init__(self, prometheus_counter: object | None = None) -> None:
+        self._lock = threading.Lock()
+        self._snapshots: dict[str, DriftSnapshot] = defaultdict(DriftSnapshot)
+        self._counter = prometheus_counter
+
+    def observe(
+        self,
+        *,
+        role: str,
+        prefix: str,
+        reason_hint: str = "",
+    ) -> DriftSnapshot:
+        """Record a prefix observation for *role* and surface drift.
+
+        Args:
+            role: Stable role name (e.g. ``"backend"``, ``"qa"``).  Used
+                as the Prometheus label and the in-memory key.
+            prefix: The fully assembled cache prefix (typically the
+                output of :func:`build_stable_prefix`).
+            reason_hint: Optional pre-classified drift reason.  When the
+                caller already knows *why* the prefix changed (e.g. the
+                tool set was edited), pass it here so the Prometheus
+                label is precise.  Falls back to ``body_changed`` when
+                empty and a drift is detected.
+
+        Returns:
+            A snapshot copy of the role's tracking state *after* the
+            observation has been applied.
+        """
+        digest = hash_prefix(prefix)
+        normalised_reason = _normalise_reason(reason_hint) if reason_hint else ""
+
+        with self._lock:
+            snap = self._snapshots[role]
+            snap.spawn_count += 1
+            drifted = bool(snap.last_hash) and snap.last_hash != digest
+            if drifted:
+                reason = normalised_reason or "body_changed"
+                snap.drift_count += 1
+                snap.last_reason = reason
+                self._record_metric(role=role, reason=reason)
+                logger.warning(
+                    "prompt cache drift role=%s reason=%s prev=%s new=%s",
+                    role,
+                    reason,
+                    snap.last_hash[:12],
+                    digest[:12],
+                )
+            snap.last_hash = digest
+            # Return a copy so callers can't mutate internal state.
+            return DriftSnapshot(
+                last_hash=snap.last_hash,
+                drift_count=snap.drift_count,
+                last_reason=snap.last_reason,
+                spawn_count=snap.spawn_count,
+            )
+
+    def snapshot(self, role: str) -> DriftSnapshot:
+        """Return a copy of the current tracking state for *role*."""
+        with self._lock:
+            snap = self._snapshots.get(role, DriftSnapshot())
+            return DriftSnapshot(
+                last_hash=snap.last_hash,
+                drift_count=snap.drift_count,
+                last_reason=snap.last_reason,
+                spawn_count=snap.spawn_count,
+            )
+
+    def reset(self) -> None:
+        """Drop all per-role tracking state.  Test-only helper."""
+        with self._lock:
+            self._snapshots.clear()
+
+    def _record_metric(self, *, role: str, reason: str) -> None:
+        """Best-effort Prometheus increment; never raises."""
+        if self._counter is None:
+            return
+        try:
+            # ``labels(...).inc()`` is the canonical Counter API and is
+            # supported by both real prometheus_client and Bernstein's
+            # in-process stub.  Wrap in try/except so a misconfigured
+            # registry never blocks the spawn path.
+            self._counter.labels(role=role, reason=reason).inc()  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover — defensive
+            logger.debug("prompt_cache_drift_total inc failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton wired to the shared Prometheus registry.
+# ---------------------------------------------------------------------------
+
+
+def _build_default_locality() -> PromptCacheLocality:
+    """Construct the singleton, attaching the Prometheus counter when
+    available.  The counter is registered on the shared Bernstein registry
+    in :mod:`bernstein.core.observability.prometheus`.
+    """
+    try:
+        from bernstein.core.observability.prometheus import (
+            prompt_cache_drift_total,
+        )
+    except Exception:  # pragma: no cover — prometheus optional on Windows
+        return PromptCacheLocality(prometheus_counter=None)
+    return PromptCacheLocality(prometheus_counter=prompt_cache_drift_total)
+
+
+_default_locality: PromptCacheLocality | None = None
+_default_lock = threading.Lock()
+
+
+def default_locality() -> PromptCacheLocality:
+    """Return the lazily-initialised module singleton."""
+    global _default_locality
+    if _default_locality is None:
+        with _default_lock:
+            if _default_locality is None:
+                _default_locality = _build_default_locality()
+    return _default_locality
+
+
+def observe_prefix(
+    *,
+    role: str,
+    prefix: str,
+    reason_hint: str = "",
+) -> DriftSnapshot:
+    """Shortcut: observe *prefix* on the module-level singleton.
+
+    Args:
+        role: Stable role name.
+        prefix: Fully assembled cache prefix.
+        reason_hint: Optional drift-reason classifier.
+
+    Returns:
+        The post-observation snapshot.
+    """
+    return default_locality().observe(role=role, prefix=prefix, reason_hint=reason_hint)
+
+
+__all__ = [
+    "DriftSnapshot",
+    "PromptCacheLocality",
+    "build_stable_prefix",
+    "default_locality",
+    "hash_prefix",
+    "observe_prefix",
+]

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -993,8 +993,14 @@ def render_prompt(
     meta_messages: list[str] | None = None,
     file_ownership: dict[str, str] | None = None,
 ) -> str:
-    """Public wrapper for compatibility-safe prompt rendering."""
-    return _render_prompt(
+    """Public wrapper for compatibility-safe prompt rendering.
+
+    Records the rendered cacheable prefix on the prompt-cache locality
+    tracker so that drift between consecutive same-role spawns surfaces
+    on ``prompt_cache_drift_total{role,reason}`` and in the in-memory
+    snapshot consumed by ``bernstein cache report``.
+    """
+    rendered = _render_prompt(
         tasks,
         templates_dir,
         workdir,
@@ -1007,6 +1013,33 @@ def render_prompt(
         meta_messages=meta_messages,
         file_ownership=file_ownership,
     )
+    _observe_cache_locality(rendered, tasks)
+    return rendered
+
+
+def _observe_cache_locality(prompt: str, tasks: list[Task]) -> None:
+    """Surface prefix drift on the locality tracker; never raises.
+
+    Splits the rendered prompt at the documented dynamic-section
+    boundary (see :func:`bernstein.core.tokens.prompt_caching.
+    extract_system_prefix`) and feeds the static prefix into the
+    per-role drift tracker.  Failures are swallowed so a tracker bug
+    never blocks an agent spawn.
+    """
+    if not tasks:
+        return
+    role = (getattr(tasks[0], "role", "") or "unknown").strip().lower()
+    try:
+        # Local imports keep spawn_prompt.py free of an unconditional
+        # dependency on tokens.prompt_caching, which would create an
+        # import cycle in some Bernstein test fixtures.
+        from bernstein.core.agents.prompt_cache_locality import observe_prefix
+        from bernstein.core.tokens.prompt_caching import extract_system_prefix
+
+        prefix, _suffix = extract_system_prefix(prompt)
+        observe_prefix(role=role, prefix=prefix)
+    except Exception:  # pragma: no cover — defensive, never block spawns
+        logger.debug("prompt cache locality observe failed", exc_info=True)
 
 
 def _render_fallback(

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -133,6 +133,7 @@ __all__ = [
     "memo_misses_total",
     "memo_size_bytes",
     "merge_duration",
+    "prompt_cache_drift_total",
     "record_transition_reason",
     "registry",
     "rework_rate_per_model",
@@ -358,6 +359,21 @@ cascade_auto_promotions_total: Counter = Counter(
     "bernstein_cascade_auto_promotions_total",
     "Cascade-router auto-promotion events triggered by rework-rate signal.",
     labelnames=["from_model", "to_model", "reason"],
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Prompt-cache locality — see ``bernstein.core.agents.prompt_cache_locality``.
+# Drift events fire when consecutive same-role spawns disagree on the
+# cacheable prefix, breaking Anthropic's 90% / OpenAI's 50% cache discount.
+# Reason labels are bucketed against a closed taxonomy in the locality
+# module; do not pass arbitrary strings.
+# ---------------------------------------------------------------------------
+
+prompt_cache_drift_total: Counter = Counter(
+    "bernstein_prompt_cache_drift_total",
+    "Prompt-cache prefix drift events between consecutive same-role spawns.",
+    labelnames=["role", "reason"],
     registry=registry,
 )
 

--- a/tests/unit/test_prompt_cache_locality.py
+++ b/tests/unit/test_prompt_cache_locality.py
@@ -1,0 +1,299 @@
+"""Tests for prompt-cache prefix locality enforcement and drift counting.
+
+Covers the three primary acceptance criteria of the
+``feat/prompt-cache-locality`` ticket:
+
+1. Two consecutive same-role spawns produce identical prefix bytes
+   (drift counter stays at zero).
+2. The drift counter increments when the prefix changes between
+   consecutive same-role spawns and records a usable reason label.
+3. The prefix is stable across reordering of stable header fields
+   (caller insertion order does not break Anthropic's byte-equality
+   contract).
+"""
+
+from __future__ import annotations
+
+from bernstein.core.agents.prompt_cache_locality import (
+    DriftSnapshot,
+    PromptCacheLocality,
+    build_stable_prefix,
+    hash_prefix,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_stable_prefix — header sorting + body verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStablePrefix:
+    """Verify the canonicalisation contract used for cache hits."""
+
+    def test_identical_inputs_produce_identical_bytes(self) -> None:
+        """Two calls with the same logical inputs must be byte-equal."""
+        header = {"role": "backend", "templates_hash": "abc123"}
+        body = "## Role\nYou are a backend engineer.\n"
+        first = build_stable_prefix(header=header, body=body)
+        second = build_stable_prefix(header=header, body=body)
+        assert first == second
+        assert hash_prefix(first) == hash_prefix(second)
+
+    def test_header_field_reordering_does_not_change_bytes(self) -> None:
+        """Caller insertion order must not break the cache."""
+        header_a = {"role": "backend", "templates_hash": "abc", "git_safety": "v1"}
+        header_b = {"templates_hash": "abc", "git_safety": "v1", "role": "backend"}
+        body = "static body"
+        prefix_a = build_stable_prefix(header=header_a, body=body)
+        prefix_b = build_stable_prefix(header=header_b, body=body)
+        assert prefix_a == prefix_b
+
+    def test_header_value_change_changes_bytes(self) -> None:
+        """A real header-field edit must produce a different prefix."""
+        body = "shared body"
+        prefix_a = build_stable_prefix(header={"role": "backend"}, body=body)
+        prefix_b = build_stable_prefix(header={"role": "qa"}, body=body)
+        assert prefix_a != prefix_b
+
+    def test_body_change_changes_bytes(self) -> None:
+        """Body edits must register as drift (cache would break on Anthropic)."""
+        header = {"role": "backend"}
+        prefix_a = build_stable_prefix(header=header, body="body v1")
+        prefix_b = build_stable_prefix(header=header, body="body v2")
+        assert prefix_a != prefix_b
+
+    def test_empty_header_is_safe(self) -> None:
+        """Missing header is allowed and still produces a deterministic prefix."""
+        prefix_a = build_stable_prefix(body="just a body")
+        prefix_b = build_stable_prefix(header={}, body="just a body")
+        prefix_c = build_stable_prefix(header=None, body="just a body")
+        assert prefix_a == prefix_b == prefix_c
+
+    def test_empty_string_value_preserved(self) -> None:
+        """Empty values in headers must round-trip (carry meaning)."""
+        prefix_with = build_stable_prefix(
+            header={"role": "backend", "agent_protocol_prefix": ""},
+            body="b",
+        )
+        prefix_without = build_stable_prefix(
+            header={"role": "backend"},
+            body="b",
+        )
+        # Both representations are *different* — the empty key is an
+        # explicit declaration; dropping it would silently change the
+        # cache key in production.
+        assert prefix_with != prefix_without
+
+
+# ---------------------------------------------------------------------------
+# hash_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_hash_prefix_is_deterministic() -> None:
+    """SHA-256 over UTF-8 produces identical digests for identical input."""
+    s = "## Role\nYou are a backend engineer.\n"
+    assert hash_prefix(s) == hash_prefix(s)
+
+
+def test_hash_prefix_differs_on_change() -> None:
+    """A single-byte difference flips the digest."""
+    assert hash_prefix("a") != hash_prefix("b")
+
+
+# ---------------------------------------------------------------------------
+# PromptCacheLocality.observe — drift accounting per role
+# ---------------------------------------------------------------------------
+
+
+class TestPromptCacheLocalityDriftCounter:
+    """Verify per-role drift counting against the ticket's primary AC."""
+
+    def test_two_consecutive_identical_spawns_no_drift(self) -> None:
+        """Same role, same prefix bytes → drift_count stays at zero."""
+        loc = PromptCacheLocality()
+        prefix = build_stable_prefix(
+            header={"role": "backend", "templates_hash": "h1"},
+            body="static body",
+        )
+        first = loc.observe(role="backend", prefix=prefix)
+        second = loc.observe(role="backend", prefix=prefix)
+        assert first.drift_count == 0
+        assert second.drift_count == 0
+        assert second.spawn_count == 2
+        assert first.last_hash == second.last_hash
+
+    def test_drift_counter_increments_on_prefix_change(self) -> None:
+        """Same role, different prefix bytes → drift_count == 1."""
+        loc = PromptCacheLocality()
+        body_v1 = "static body version 1"
+        body_v2 = "static body version 2"
+        loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body=body_v1),
+        )
+        snap = loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body=body_v2),
+        )
+        assert snap.drift_count == 1
+        assert snap.last_reason == "body_changed"
+        assert snap.spawn_count == 2
+
+    def test_drift_counter_does_not_increment_across_reordering(self) -> None:
+        """Reordering stable header fields is *not* drift."""
+        loc = PromptCacheLocality()
+        body = "shared body"
+        prefix_a = build_stable_prefix(
+            header={"role": "backend", "templates_hash": "h1", "git_safety": "v1"},
+            body=body,
+        )
+        prefix_b = build_stable_prefix(
+            header={"git_safety": "v1", "templates_hash": "h1", "role": "backend"},
+            body=body,
+        )
+        loc.observe(role="backend", prefix=prefix_a)
+        snap = loc.observe(role="backend", prefix=prefix_b)
+        assert snap.drift_count == 0, (
+            "header field reordering must not break the cache"
+        )
+
+    def test_first_spawn_never_counts_as_drift(self) -> None:
+        """The very first observation establishes the baseline."""
+        loc = PromptCacheLocality()
+        snap = loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="b"),
+        )
+        assert snap.drift_count == 0
+        assert snap.spawn_count == 1
+        assert snap.last_hash  # baseline recorded
+
+    def test_drift_per_role_is_isolated(self) -> None:
+        """Drift in one role must not pollute the count for another role."""
+        loc = PromptCacheLocality()
+        loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="v1"),
+        )
+        loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="v2"),
+        )
+        loc.observe(
+            role="qa",
+            prefix=build_stable_prefix(header={"role": "qa"}, body="v1"),
+        )
+
+        assert loc.snapshot("backend").drift_count == 1
+        assert loc.snapshot("qa").drift_count == 0
+
+    def test_reason_hint_is_recorded_on_drift(self) -> None:
+        """A caller-supplied reason hint must propagate to the snapshot."""
+        loc = PromptCacheLocality()
+        loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="v1"),
+        )
+        snap = loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="v2"),
+            reason_hint="role_template_edited",
+        )
+        assert snap.last_reason == "role_template_edited"
+
+    def test_unknown_reason_buckets_under_unknown(self) -> None:
+        """Reason labels outside the closed taxonomy bucket under ``unknown``."""
+        loc = PromptCacheLocality()
+        loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="v1"),
+        )
+        snap = loc.observe(
+            role="backend",
+            prefix=build_stable_prefix(header={"role": "backend"}, body="v2"),
+            reason_hint="something_invented_by_caller",
+        )
+        # An invalid hint normalises to "unknown"; the locality module
+        # records that as the reason on the snapshot.
+        assert snap.last_reason == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Prometheus integration — ensure the counter is incremented
+# ---------------------------------------------------------------------------
+
+
+class _RecordingCounter:
+    """Minimal stub matching the prometheus_client Counter API."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+        self._last: dict[str, str] = {}
+
+    def labels(self, **kwargs: str) -> _RecordingCounter:
+        self._last = dict(kwargs)
+        return self
+
+    def inc(self, value: float = 1.0) -> None:
+        self.calls.append(self._last)
+
+
+def test_prometheus_counter_incremented_on_drift() -> None:
+    """Drift events must call ``counter.labels(role, reason).inc()``."""
+    counter = _RecordingCounter()
+    loc = PromptCacheLocality(prometheus_counter=counter)
+    loc.observe(
+        role="backend",
+        prefix=build_stable_prefix(header={"role": "backend"}, body="v1"),
+    )
+    loc.observe(
+        role="backend",
+        prefix=build_stable_prefix(header={"role": "backend"}, body="v2"),
+        reason_hint="tool_set_changed",
+    )
+    assert len(counter.calls) == 1
+    assert counter.calls[0] == {"role": "backend", "reason": "tool_set_changed"}
+
+
+def test_prometheus_counter_silent_on_no_drift() -> None:
+    """No drift → no counter increments."""
+    counter = _RecordingCounter()
+    loc = PromptCacheLocality(prometheus_counter=counter)
+    prefix = build_stable_prefix(header={"role": "backend"}, body="b")
+    loc.observe(role="backend", prefix=prefix)
+    loc.observe(role="backend", prefix=prefix)
+    assert counter.calls == []
+
+
+# ---------------------------------------------------------------------------
+# DriftSnapshot is a copy — internal mutation is not exposed
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_is_independent_copy() -> None:
+    """Mutating a returned snapshot must not affect tracker state."""
+    loc = PromptCacheLocality()
+    loc.observe(
+        role="backend",
+        prefix=build_stable_prefix(header={"role": "backend"}, body="b"),
+    )
+    snap = loc.snapshot("backend")
+    snap.drift_count = 999
+    assert loc.snapshot("backend").drift_count == 0
+
+
+def test_unknown_role_returns_zero_snapshot() -> None:
+    """Querying a role with no observations returns a fresh empty snapshot."""
+    loc = PromptCacheLocality()
+    snap = loc.snapshot("never-spawned")
+    assert snap == DriftSnapshot()
+
+
+def test_reset_clears_state() -> None:
+    """``reset()`` drops all tracked roles."""
+    loc = PromptCacheLocality()
+    prefix = build_stable_prefix(header={"role": "backend"}, body="b")
+    loc.observe(role="backend", prefix=prefix)
+    loc.reset()
+    assert loc.snapshot("backend") == DriftSnapshot()

--- a/tests/unit/test_prompt_cache_locality.py
+++ b/tests/unit/test_prompt_cache_locality.py
@@ -21,7 +21,6 @@ from bernstein.core.agents.prompt_cache_locality import (
     hash_prefix,
 )
 
-
 # ---------------------------------------------------------------------------
 # build_stable_prefix — header sorting + body verbatim
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1089

## Summary

Smallest viable slice of `.sdd/backlog/closed/2026-05-07-feat-prompt-cache-locality.md`. Anthropic's 90% / OpenAI's 50% prompt-cache discount only triggers on byte-identical prefixes; today Bernstein's prefix is "best-effort", with no signal when a change broke cache hits.

This PR ships the enforcement substrate so subsequent slices (Anthropic 4-segment markers, OpenAI 256-token alignment, Gemini context-cache, `bernstein cache report` CLI) can build on a verified baseline.

### What ships

- `bernstein.core.agents.prompt_cache_locality.build_stable_prefix(header, body)` canonicalises stable header fields (sorted by key) before hashing, so caller insertion order cannot break the cache.
- `PromptCacheLocality.observe(role, prefix)` tracks per-role prefix hashes, increments an in-memory drift counter on change, and fires the new `bernstein_prompt_cache_drift_total{role,reason}` Prometheus counter (auto-exposed on `/metrics` via the shared registry).
- `render_prompt` (the most-used spawn entry point) calls into the locality tracker on every spawn. Failures are swallowed - never blocks an agent spawn.
- Drift reason taxonomy is closed (`tool_set_changed`, `role_template_edited`, `body_changed`, `time_inserted`, `dynamic_field_in_prefix`, `header_field_changed`, `unknown`) so Prometheus label cardinality stays bounded.

### What's deferred (tracked in the ticket)

- OpenAI 256-token boundary alignment helper (Step 2)
- Anthropic 4-segment `cache_control: ephemeral` marker rewrite (Step 3)
- Google Gemini context-cache handle persistence (Step 4)
- `bernstein cache report` CLI + `cost_receipt_cache.json` (Step 5)
- Documentation page (Step 6)

These are net-additive on top of this PR and were sliced out to keep review surface small. The drift counter exposed here is the prerequisite for measuring whether the deferred bits actually move the cache hit rate.

## Test plan

- [x] `uv run pytest tests/unit/test_prompt_cache_locality.py -x -q --timeout=120` -> 20 passed
- [x] `uv run pytest tests/unit/test_prompt_cache_hints.py tests/unit/test_prompt_caching.py tests/unit/test_cache_safe_params.py` -> 104 passed (no regression in sibling cache plumbing)
- [x] `uv run pytest tests/unit/test_spawn_prompt.py tests/unit/test_meta_messages.py tests/unit/test_conditional_context.py tests/unit/test_fork_subagent.py` -> 70 passed (no regression in `render_prompt` callers)
- [x] `uv run pytest tests/unit/test_lessons.py tests/unit/test_hot_reload.py tests/unit/test_output_styles.py tests/unit/test_spawner.py tests/unit/test_phase_schemas.py tests/unit/test_context_builder.py` -> 176 passed, 1 skipped
- [x] `uv run ruff check src/ tests/ scripts/` -> All checks passed
- [x] Smoke: `bernstein_prompt_cache_drift_total` shows up on `generate_latest(registry)` after a manual increment

Tickets: `.sdd/backlog/closed/2026-05-07-feat-prompt-cache-locality.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
