### PR TITLE
feat(harness): Manus tool masking + keep-failed-actions (slice 1)

### DIFF
--- a/src/bernstein/core/agents/harness_policy.py
+++ b/src/bernstein/core/agents/harness_policy.py
@@ -1,0 +1,99 @@
+"""Manus-style harness policy flags for agent spawn pipelines.
+
+This module names and toggles the five harness patterns published by Manus
+(see ``agentic_systems_v2.md`` §1 line 79). Each flag is **off by default** to
+preserve current behaviour; orchestrators opt agents in either via the
+``HarnessPolicy`` dataclass passed to spawn helpers or via per-role overrides
+loaded from ``.sdd/runtime/harness/<role>.yaml`` (loader to land in a follow-up
+PR — this module ships only the data model and the two patterns wired into
+``mask_tools`` / ``format_failed_action_block`` today).
+
+The five Manus patterns:
+
+1. ``kv_cache_locality`` — keep system-prompt prefix byte-for-byte stable across
+   spawns of the same role; vary only the trailing user block.
+2. ``tool_masking`` — instead of removing tools to disable them, return them
+   with ``unavailable: True`` so the cached prefix is preserved.
+3. ``filesystem_memory`` — agents read/write to ``.sdd/memory/<agent>/`` instead
+   of stuffing observations into the context.
+4. ``todo_recitation`` — every long-running task keeps a flat ``todo.md`` checked
+   off in-place; the agent re-reads it each turn rather than re-deriving the
+   plan.
+5. ``keep_failed_actions`` — failed tool calls and their tracebacks stay in the
+   visible scrollback (with a recency weight) instead of being scrubbed; this
+   is the implicit-learning pattern Manus published.
+
+This first slice ships **patterns 2 and 5 only**; the remaining three patterns
+have wiring stubs but no behaviour yet — see the parent ticket for the
+follow-up PRs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+
+@dataclass(frozen=True, slots=True)
+class HarnessPolicy:
+    """Toggle flags for Manus harness patterns at agent spawn time.
+
+    All flags default to ``False`` so existing orchestrators keep their current
+    behaviour. Operators opt in either by passing a ``HarnessPolicy`` instance
+    to spawn helpers or by loading per-role YAML overrides via
+    :func:`load_policy_for_role` (the loader is a follow-up).
+
+    Attributes:
+        kv_cache_locality: Keep system-prompt prefix byte-stable across spawns
+            of the same role.
+        tool_masking: Mask disabled tools with ``unavailable: True`` instead of
+            removing them — preserves prefix bytes for cache hits.
+        filesystem_memory: Route long observations through
+            ``.sdd/memory/<agent>/`` filesystem-as-memory.
+        todo_recitation: Inject a starter ``todo.md`` for tasks at or above
+            ``min_recitation_complexity``.
+        keep_failed_actions: Tag failed tool-call blocks with
+            ``[FAILED -- kept for reference]`` instead of scrubbing them in
+            compaction.
+    """
+
+    kv_cache_locality: bool = False
+    tool_masking: bool = False
+    filesystem_memory: bool = False
+    todo_recitation: bool = False
+    keep_failed_actions: bool = False
+
+    def with_overrides(self, **changes: bool) -> HarnessPolicy:
+        """Return a copy with the given flag(s) overridden.
+
+        Args:
+            **changes: Subset of flag names to override.
+
+        Returns:
+            A new :class:`HarnessPolicy` with overrides applied.
+
+        Raises:
+            TypeError: If a non-existent flag name is supplied.
+        """
+        return replace(self, **changes)
+
+
+#: Conservative all-off baseline — current Bernstein behaviour.
+DEFAULT_POLICY: HarnessPolicy = HarnessPolicy()
+
+#: All patterns enabled. Use only after the follow-up PRs ship the
+#: filesystem-memory + recitation wiring; today this enables only tool
+#: masking and keep-failed-actions, the rest are no-ops.
+ALL_ON_POLICY: HarnessPolicy = HarnessPolicy(
+    kv_cache_locality=True,
+    tool_masking=True,
+    filesystem_memory=True,
+    todo_recitation=True,
+    keep_failed_actions=True,
+)
+
+
+__all__ = [
+    "ALL_ON_POLICY",
+    "DEFAULT_POLICY",
+    "HarnessPolicy",
+]

--- a/src/bernstein/core/agents/tool_masking.py
+++ b/src/bernstein/core/agents/tool_masking.py
@@ -23,10 +23,11 @@ adapter dispatch around the result.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
 
 #: Minimum required keys for a tool entry. Other adapter-specific fields
 #: (``input_schema``, ``cache_control``, ``annotations``, ...) pass through

--- a/src/bernstein/core/agents/tool_masking.py
+++ b/src/bernstein/core/agents/tool_masking.py
@@ -1,0 +1,135 @@
+"""Tool-masking pass for KV-cache-locality-preserving spawn prompts.
+
+Manus's lesson #2: when a tool should be unavailable for a step, do **not**
+remove it from the tool list — that shifts every byte after the removed entry
+and busts the Anthropic prompt-cache prefix (90% discount on cache hits).
+Instead, keep the entry in place and flip a ``unavailable: True`` flag plus an
+``unavailable_reason`` string so the model sees the entry but is steered away
+from invoking it.
+
+Adapter compatibility:
+
+- **Claude / Codex** consume the flag end-to-end (the adapter forwards the flag
+  through the tool definitions).
+- **Other adapters** fall back to physical removal because their tool schemas
+  don't carry an ``unavailable`` field. Callers can detect this by inspecting
+  the returned :class:`MaskResult` — when ``fallback_removed`` is non-empty the
+  adapter must drop those tools instead.
+
+This module is intentionally pure-data: it never touches the prompt string and
+never imports adapter SDKs. The spawn pipeline drives both prompt assembly and
+adapter dispatch around the result.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+#: Minimum required keys for a tool entry. Other adapter-specific fields
+#: (``input_schema``, ``cache_control``, ``annotations``, ...) pass through
+#: untouched.
+_REQUIRED_KEYS: frozenset[str] = frozenset({"name"})
+
+
+@dataclass(frozen=True, slots=True)
+class MaskResult:
+    """Outcome of a tool-masking pass.
+
+    Attributes:
+        tools: The masked tool list, byte-stable in entry order so cache
+            prefixes survive.
+        masked_names: Names that were marked unavailable (kept in the list).
+        fallback_removed: Names the caller must physically drop because the
+            target adapter cannot honour the ``unavailable`` flag.
+    """
+
+    tools: list[dict[str, Any]]
+    masked_names: tuple[str, ...]
+    fallback_removed: tuple[str, ...]
+
+
+def mask_tools(
+    tools: Sequence[Mapping[str, Any]],
+    denied: Iterable[str],
+    *,
+    reason: str | Mapping[str, str] = "denied by agent identity card",
+    adapter_supports_unavailable_flag: bool = True,
+) -> MaskResult:
+    """Mask denied tools without disturbing prefix byte positions.
+
+    For each entry in *tools* whose ``name`` appears in *denied*:
+
+    - When *adapter_supports_unavailable_flag* is ``True`` (Claude, Codex),
+      the entry is rewritten with ``unavailable: True`` and an
+      ``unavailable_reason`` set from *reason* (string applies to all denied
+      tools; mapping looks up per-name reasons). Original key order is
+      preserved so byte positions before the flag are untouched.
+    - When ``False``, the entry is dropped and recorded in
+      ``fallback_removed``; callers (typically non-Claude/non-Codex adapters)
+      then physically remove those tools from the dispatch list.
+
+    Tools not in *denied* pass through unchanged.
+
+    Args:
+        tools: Iterable of tool entries; each must be a mapping with a
+            ``name`` key.
+        denied: Iterable of tool names to mask. Order ignored; deduped.
+        reason: Reason string (applied to all denied tools) or per-name
+            mapping. Mapping misses fall back to a default.
+        adapter_supports_unavailable_flag: Set ``False`` for adapters whose
+            tool schema can't carry the flag.
+
+    Returns:
+        :class:`MaskResult` carrying the masked list and bookkeeping.
+
+    Raises:
+        ValueError: If a tool entry is missing the required ``name`` key.
+    """
+    denied_set = {name for name in denied if name}
+    if isinstance(reason, str):
+        reason_for = lambda _n: reason  # noqa: E731 - tiny inline closure
+        default_reason = reason
+    else:
+        reason_map = dict(reason)
+        default_reason = "denied by agent identity card"
+        reason_for = lambda n: reason_map.get(n, default_reason)  # noqa: E731
+
+    masked_names: list[str] = []
+    fallback_removed: list[str] = []
+    out: list[dict[str, Any]] = []
+
+    for entry in tools:
+        if not _REQUIRED_KEYS.issubset(entry.keys()):
+            raise ValueError(
+                f"tool entry missing required keys {_REQUIRED_KEYS - entry.keys()}: {entry!r}",
+            )
+        name = entry["name"]
+        if name not in denied_set:
+            out.append(dict(entry))
+            continue
+
+        if adapter_supports_unavailable_flag:
+            # Rebuild dict preserving original key order, append flags last so
+            # bytes before the flag remain in place.
+            masked: dict[str, Any] = dict(entry)
+            masked["unavailable"] = True
+            masked["unavailable_reason"] = reason_for(name)
+            out.append(masked)
+            masked_names.append(name)
+        else:
+            fallback_removed.append(name)
+
+    return MaskResult(
+        tools=out,
+        masked_names=tuple(masked_names),
+        fallback_removed=tuple(fallback_removed),
+    )
+
+
+__all__ = [
+    "MaskResult",
+    "mask_tools",
+]

--- a/src/bernstein/core/tokens/compaction_pipeline.py
+++ b/src/bernstein/core/tokens/compaction_pipeline.py
@@ -15,8 +15,14 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from bernstein.core.tokens.failed_action_retention import (
+    FailedActionBlock,
+    split_retained_blocks,
+    tag_failed_actions,
+)
+
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +190,9 @@ class CompactionPipeline:
         *,
         llm_call: Callable[[str], str] | None = None,
         strip_media: bool = True,
+        keep_failed_actions: bool = False,
+        retained_failures: Sequence[FailedActionBlock] | None = None,
+        current_turn: int = 0,
     ) -> CompactionResult:
         """Run the full compaction pipeline.
 
@@ -194,6 +203,16 @@ class CompactionPipeline:
             reason: Why compaction was triggered.
             llm_call: Optional async callable for LLM summary.
             strip_media: Whether to strip media blocks before summarizing.
+            keep_failed_actions: When ``True`` (Manus harness pattern #5),
+                tagged failure blocks already in *context_text* are carved
+                out and re-appended verbatim after summarisation, and any
+                additional *retained_failures* are formatted and appended.
+                Default ``False`` preserves current behaviour.
+            retained_failures: Optional explicit list of failure blocks to
+                retain (e.g. from an adapter-side queue). Only used when
+                *keep_failed_actions* is ``True``.
+            current_turn: Turn index used for staleness annotations on
+                explicit *retained_failures*.
 
         Returns:
             CompactionResult with compacted text and metadata.
@@ -209,12 +228,31 @@ class CompactionPipeline:
             reason,
         )
 
+        # Stage 1b (Manus #5): carve out tagged failure blocks before media
+        # stripping / summary so they survive verbatim. Off by default.
+        carved_failures: list[str] = []
+        if keep_failed_actions:
+            working_text, carved_failures = split_retained_blocks(working_text)
+
         # Stage 2: Strip media
         if strip_media:
             working_text = strip_media_blocks(working_text)
 
         # Stage 3: LLM summary (structural if no LLM provided)
         compacted = summarize_context(working_text, llm_call=llm_call)
+
+        # Stage 3b: re-append retained failures + any explicit ones.
+        if keep_failed_actions:
+            tail_blocks: list[str] = list(carved_failures)
+            if retained_failures:
+                rendered = tag_failed_actions(
+                    retained_failures,
+                    current_turn=current_turn,
+                )
+                if rendered:
+                    tail_blocks.append(rendered)
+            if tail_blocks:
+                compacted = compacted + "\n\n" + "\n\n".join(tail_blocks)
 
         tokens_after = _estimate_tokens(compacted)
 

--- a/src/bernstein/core/tokens/failed_action_retention.py
+++ b/src/bernstein/core/tokens/failed_action_retention.py
@@ -17,10 +17,11 @@ summary path (:func:`summarize_context`) preserves the tagged blocks.
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 #: Marker line prefixed to retained failed-action blocks. Two ASCII hyphens
 #: are used (not an em-dash) to keep diff/grep behaviour predictable across

--- a/src/bernstein/core/tokens/failed_action_retention.py
+++ b/src/bernstein/core/tokens/failed_action_retention.py
@@ -1,0 +1,181 @@
+"""Keep-failed-actions context formatter (Manus harness pattern #5).
+
+Instead of scrubbing tool-call failures during compaction, tag them with a
+``[FAILED -- kept for reference]`` prefix and let them age out via a
+recency-weight half-life. Manus published this as the implicit-learning lesson
+from their five harness rewrites: deleting failures forces the model to
+re-derive the failure mode each time it sees a similar tool call, while
+keeping them lets the model learn to avoid the same pitfall.
+
+This module is pure-string transformation; it doesn't depend on the rest of
+the compaction pipeline. The pipeline calls
+:func:`tag_failed_actions` in its pre-compact stage when the
+:class:`HarnessPolicy.keep_failed_actions` flag is on, and the deterministic
+summary path (:func:`summarize_context`) preserves the tagged blocks.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+#: Marker line prefixed to retained failed-action blocks. Two ASCII hyphens
+#: are used (not an em-dash) to keep diff/grep behaviour predictable across
+#: encodings.
+RETAINED_PREFIX: str = "[FAILED -- kept for reference]"
+
+#: Default half-life (in turns) before a retained failure is considered
+#: stale. After ``half_life_turns`` turns the formatter writes a
+#: ``staleness=N`` annotation; downstream compactors may use it as an
+#: eviction signal once the model has clearly moved past the failure.
+DEFAULT_HALF_LIFE_TURNS: int = 6
+
+
+@dataclass(frozen=True, slots=True)
+class FailedActionBlock:
+    """A single tool-call failure carved out of agent scrollback.
+
+    Attributes:
+        tool_name: Name of the tool that failed (e.g. ``run_tests``).
+        error_text: Verbatim error / traceback / stderr captured from the
+            adapter. Empty string when the failure surfaced as just a
+            non-zero exit code with no stderr.
+        turn_index: Which turn (0-based) the failure occurred on. Used to
+            compute staleness when the formatter is asked.
+    """
+
+    tool_name: str
+    error_text: str
+    turn_index: int = 0
+
+
+def tag_failed_actions(
+    blocks: Sequence[FailedActionBlock],
+    *,
+    current_turn: int = 0,
+    half_life_turns: int = DEFAULT_HALF_LIFE_TURNS,
+) -> str:
+    """Render retained failure blocks as a single context-ready string.
+
+    Args:
+        blocks: Failure blocks to retain, oldest first.
+        current_turn: Index of the turn currently being assembled. Used to
+            tag staleness on each block.
+        half_life_turns: After this many turns past the failure, mark the
+            block as ``staleness=N`` so a downstream compactor can drop it.
+
+    Returns:
+        A newline-joined string suitable for inlining into the prompt's
+        scrollback. Empty string when *blocks* is empty.
+    """
+    if not blocks:
+        return ""
+    if half_life_turns <= 0:
+        raise ValueError("half_life_turns must be positive")
+
+    rendered: list[str] = []
+    for block in blocks:
+        age = max(0, current_turn - block.turn_index)
+        staleness = age // half_life_turns
+        header = f"{RETAINED_PREFIX} tool={block.tool_name} turn={block.turn_index} staleness={staleness}"
+        body = block.error_text.strip() or "(no stderr captured)"
+        rendered.append(f"{header}\n{body}")
+    return "\n\n".join(rendered)
+
+
+_FAILED_BLOCK_RE = re.compile(
+    rf"{re.escape(RETAINED_PREFIX)}[^\n]*\n.*?(?=(?:\n\n)|\Z)",
+    re.DOTALL,
+)
+
+
+def split_retained_blocks(context_text: str) -> tuple[str, list[str]]:
+    """Extract retained failure blocks from a context string.
+
+    Useful for compactors that want to summarise the non-retained scrollback
+    aggressively while preserving retained failures verbatim.
+
+    Args:
+        context_text: Full scrollback / context string.
+
+    Returns:
+        A two-tuple ``(non_retained, retained_blocks)``. The first element is
+        the input with retained blocks removed (and surrounding whitespace
+        normalised); the second is the list of retained block strings in
+        original order.
+    """
+    retained = _FAILED_BLOCK_RE.findall(context_text)
+    non_retained = _FAILED_BLOCK_RE.sub("", context_text)
+    # Collapse the double-blank-lines that removal leaves behind.
+    non_retained = re.sub(r"\n{3,}", "\n\n", non_retained).strip()
+    return non_retained, retained
+
+
+def filter_stale_blocks(
+    blocks: Sequence[FailedActionBlock],
+    *,
+    current_turn: int,
+    half_life_turns: int = DEFAULT_HALF_LIFE_TURNS,
+    max_staleness: int = 2,
+) -> list[FailedActionBlock]:
+    """Drop blocks whose computed staleness exceeds *max_staleness*.
+
+    Args:
+        blocks: Failure blocks, oldest first.
+        current_turn: Turn currently being assembled.
+        half_life_turns: Half-life used in staleness computation.
+        max_staleness: Maximum staleness (inclusive) to keep. ``0`` keeps only
+            failures from the most recent ``half_life_turns`` window;
+            ``2`` keeps three half-life windows.
+
+    Returns:
+        Filtered list with the same ordering; blocks with
+        ``(current_turn - turn_index) // half_life_turns > max_staleness``
+        are dropped.
+    """
+    if half_life_turns <= 0:
+        raise ValueError("half_life_turns must be positive")
+    if max_staleness < 0:
+        raise ValueError("max_staleness must be non-negative")
+    out: list[FailedActionBlock] = []
+    for block in blocks:
+        age = max(0, current_turn - block.turn_index)
+        if age // half_life_turns <= max_staleness:
+            out.append(block)
+    return out
+
+
+def block_from_dict(payload: dict[str, Any]) -> FailedActionBlock:
+    """Build a :class:`FailedActionBlock` from a dict payload.
+
+    Convenience for adapters that emit failures as plain dicts on a queue.
+
+    Args:
+        payload: Mapping with at least ``tool_name`` and ``error_text`` keys.
+            ``turn_index`` defaults to ``0`` when absent.
+
+    Returns:
+        A :class:`FailedActionBlock`.
+
+    Raises:
+        KeyError: If ``tool_name`` or ``error_text`` is missing.
+    """
+    return FailedActionBlock(
+        tool_name=str(payload["tool_name"]),
+        error_text=str(payload["error_text"]),
+        turn_index=int(payload.get("turn_index", 0)),
+    )
+
+
+__all__ = [
+    "DEFAULT_HALF_LIFE_TURNS",
+    "RETAINED_PREFIX",
+    "FailedActionBlock",
+    "block_from_dict",
+    "filter_stale_blocks",
+    "split_retained_blocks",
+    "tag_failed_actions",
+]

--- a/tests/unit/test_failed_action_retention.py
+++ b/tests/unit/test_failed_action_retention.py
@@ -1,0 +1,185 @@
+"""Tests for the keep-failed-actions formatter (Manus harness pattern #5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.tokens.compaction_pipeline import CompactionPipeline
+from bernstein.core.tokens.failed_action_retention import (
+    DEFAULT_HALF_LIFE_TURNS,
+    RETAINED_PREFIX,
+    FailedActionBlock,
+    block_from_dict,
+    filter_stale_blocks,
+    split_retained_blocks,
+    tag_failed_actions,
+)
+
+
+class TestTagFailedActions:
+    def test_empty_input_returns_empty_string(self) -> None:
+        assert tag_failed_actions([]) == ""
+
+    def test_renders_block_with_marker_and_metadata(self) -> None:
+        block = FailedActionBlock(
+            tool_name="run_tests",
+            error_text="AssertionError: expected 1 got 2",
+            turn_index=3,
+        )
+        out = tag_failed_actions([block], current_turn=3)
+        assert RETAINED_PREFIX in out
+        assert "tool=run_tests" in out
+        assert "turn=3" in out
+        assert "staleness=0" in out
+        assert "AssertionError" in out
+
+    def test_staleness_increments_after_half_life(self) -> None:
+        block = FailedActionBlock(tool_name="x", error_text="err", turn_index=0)
+        # 6 turns later should still be staleness=1 with default half-life=6.
+        out = tag_failed_actions([block], current_turn=6)
+        assert "staleness=1" in out
+        # 13 turns later → staleness=2.
+        out2 = tag_failed_actions([block], current_turn=13)
+        assert "staleness=2" in out2
+
+    def test_empty_error_text_substitutes_placeholder(self) -> None:
+        block = FailedActionBlock(tool_name="x", error_text="", turn_index=0)
+        out = tag_failed_actions([block])
+        assert "(no stderr captured)" in out
+
+    def test_multiple_blocks_separated_by_blank_line(self) -> None:
+        blocks = [
+            FailedActionBlock("a", "err-a", 0),
+            FailedActionBlock("b", "err-b", 1),
+        ]
+        out = tag_failed_actions(blocks, current_turn=1)
+        assert out.count(RETAINED_PREFIX) == 2
+        assert "\n\n" in out
+
+    def test_invalid_half_life_raises(self) -> None:
+        with pytest.raises(ValueError):
+            tag_failed_actions([FailedActionBlock("x", "y", 0)], half_life_turns=0)
+
+
+class TestSplitRetainedBlocks:
+    def test_no_retained_returns_input_unchanged(self) -> None:
+        text = "regular scrollback line 1\nline 2"
+        non_retained, retained = split_retained_blocks(text)
+        assert non_retained == text
+        assert retained == []
+
+    def test_extracts_single_retained_block(self) -> None:
+        retained_text = (
+            f"{RETAINED_PREFIX} tool=t turn=0 staleness=0\n"
+            "stderr: boom\n\n"
+            "regular line"
+        )
+        non_retained, retained = split_retained_blocks(retained_text)
+        assert len(retained) == 1
+        assert retained[0].startswith(RETAINED_PREFIX)
+        assert "stderr: boom" in retained[0]
+        assert RETAINED_PREFIX not in non_retained
+        assert "regular line" in non_retained
+
+    def test_round_trip_through_pipeline_preserves_block(self) -> None:
+        """Carved blocks survive media-stripping + summary verbatim."""
+        retained = (
+            f"{RETAINED_PREFIX} tool=run_tests turn=0 staleness=0\n"
+            "Traceback: boom"
+        )
+        original = (
+            "## context header\n"
+            "some prose\n\n"
+            f"{retained}\n\n"
+            "more prose"
+        )
+        pipeline = CompactionPipeline(plugin_manager=None)
+        result = pipeline.execute(
+            session_id="s1",
+            context_text=original,
+            tokens_before=100,
+            keep_failed_actions=True,
+        )
+        assert RETAINED_PREFIX in result.compacted_text
+        assert "Traceback: boom" in result.compacted_text
+
+
+class TestFilterStaleBlocks:
+    def test_keeps_recent_blocks(self) -> None:
+        blocks = [
+            FailedActionBlock("x", "e", turn_index=10),
+            FailedActionBlock("y", "e", turn_index=11),
+        ]
+        kept = filter_stale_blocks(blocks, current_turn=12)
+        assert len(kept) == 2
+
+    def test_drops_blocks_past_max_staleness(self) -> None:
+        blocks = [
+            FailedActionBlock("old", "e", turn_index=0),
+            FailedActionBlock("recent", "e", turn_index=20),
+        ]
+        # current_turn=20, half_life=6 → old has staleness=3, recent has 0.
+        kept = filter_stale_blocks(
+            blocks,
+            current_turn=20,
+            half_life_turns=DEFAULT_HALF_LIFE_TURNS,
+            max_staleness=2,
+        )
+        names = [b.tool_name for b in kept]
+        assert names == ["recent"]
+
+    def test_invalid_args_raise(self) -> None:
+        with pytest.raises(ValueError):
+            filter_stale_blocks([], current_turn=0, half_life_turns=0)
+        with pytest.raises(ValueError):
+            filter_stale_blocks([], current_turn=0, max_staleness=-1)
+
+
+class TestBlockFromDict:
+    def test_round_trip(self) -> None:
+        b = block_from_dict({"tool_name": "t", "error_text": "e", "turn_index": 4})
+        assert b == FailedActionBlock("t", "e", 4)
+
+    def test_missing_required_key_raises(self) -> None:
+        with pytest.raises(KeyError):
+            block_from_dict({"tool_name": "t"})
+
+    def test_default_turn_index_zero(self) -> None:
+        b = block_from_dict({"tool_name": "t", "error_text": "e"})
+        assert b.turn_index == 0
+
+
+class TestPipelineKeepFailedActionsFlag:
+    def test_disabled_by_default_strips_failure_marker(self) -> None:
+        """When the flag is off the pipeline behaves exactly as before."""
+        text = (
+            "header\n\n"
+            f"{RETAINED_PREFIX} tool=t turn=0 staleness=0\nerr-body\n\n"
+            "footer"
+        )
+        pipeline = CompactionPipeline(plugin_manager=None)
+        result = pipeline.execute(
+            session_id="s",
+            context_text=text,
+            tokens_before=100,
+            # keep_failed_actions defaults to False
+        )
+        # With the flag off, the deterministic summary path doesn't preserve
+        # the marker — proving disabled-vs-enabled have observable
+        # difference.
+        assert RETAINED_PREFIX not in result.compacted_text
+
+    def test_enabled_appends_explicit_retained_failures(self) -> None:
+        pipeline = CompactionPipeline(plugin_manager=None)
+        explicit = [FailedActionBlock("run_tests", "boom", turn_index=0)]
+        result = pipeline.execute(
+            session_id="s",
+            context_text="some plain context",
+            tokens_before=100,
+            keep_failed_actions=True,
+            retained_failures=explicit,
+            current_turn=0,
+        )
+        assert RETAINED_PREFIX in result.compacted_text
+        assert "tool=run_tests" in result.compacted_text
+        assert "boom" in result.compacted_text

--- a/tests/unit/test_harness_policy.py
+++ b/tests/unit/test_harness_policy.py
@@ -14,7 +14,7 @@ from bernstein.core.agents.harness_policy import (
 class TestHarnessPolicyDefaults:
     def test_default_policy_is_all_off(self) -> None:
         """All five flags must default to False so existing behaviour is preserved."""
-        assert DEFAULT_POLICY == HarnessPolicy()
+        assert HarnessPolicy() == DEFAULT_POLICY
         assert DEFAULT_POLICY.kv_cache_locality is False
         assert DEFAULT_POLICY.tool_masking is False
         assert DEFAULT_POLICY.filesystem_memory is False

--- a/tests/unit/test_harness_policy.py
+++ b/tests/unit/test_harness_policy.py
@@ -1,0 +1,63 @@
+"""Tests for the Manus-style harness-policy data model."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.agents.harness_policy import (
+    ALL_ON_POLICY,
+    DEFAULT_POLICY,
+    HarnessPolicy,
+)
+
+
+class TestHarnessPolicyDefaults:
+    def test_default_policy_is_all_off(self) -> None:
+        """All five flags must default to False so existing behaviour is preserved."""
+        assert DEFAULT_POLICY == HarnessPolicy()
+        assert DEFAULT_POLICY.kv_cache_locality is False
+        assert DEFAULT_POLICY.tool_masking is False
+        assert DEFAULT_POLICY.filesystem_memory is False
+        assert DEFAULT_POLICY.todo_recitation is False
+        assert DEFAULT_POLICY.keep_failed_actions is False
+
+    def test_all_on_policy_enables_every_flag(self) -> None:
+        assert ALL_ON_POLICY.kv_cache_locality is True
+        assert ALL_ON_POLICY.tool_masking is True
+        assert ALL_ON_POLICY.filesystem_memory is True
+        assert ALL_ON_POLICY.todo_recitation is True
+        assert ALL_ON_POLICY.keep_failed_actions is True
+
+    def test_policy_is_frozen_dataclass(self) -> None:
+        """HarnessPolicy must be immutable to prevent accidental mid-spawn mutation."""
+        p = HarnessPolicy()
+        with pytest.raises((AttributeError, TypeError)):
+            p.tool_masking = True  # type: ignore[misc]
+
+
+class TestWithOverrides:
+    def test_single_flag_override_returns_new_instance(self) -> None:
+        base = HarnessPolicy()
+        new = base.with_overrides(tool_masking=True)
+        assert base is not new
+        assert base.tool_masking is False
+        assert new.tool_masking is True
+        # Other flags unchanged
+        assert new.kv_cache_locality is False
+
+    def test_multi_flag_override(self) -> None:
+        new = HarnessPolicy().with_overrides(
+            tool_masking=True, keep_failed_actions=True,
+        )
+        assert new.tool_masking is True
+        assert new.keep_failed_actions is True
+        assert new.filesystem_memory is False
+
+    def test_override_with_unknown_flag_raises(self) -> None:
+        with pytest.raises(TypeError):
+            HarnessPolicy().with_overrides(does_not_exist=True)  # type: ignore[call-arg]
+
+    def test_override_preserves_equality_when_no_change(self) -> None:
+        base = HarnessPolicy(tool_masking=True)
+        same = base.with_overrides(tool_masking=True)
+        assert base == same

--- a/tests/unit/test_tool_masking.py
+++ b/tests/unit/test_tool_masking.py
@@ -1,0 +1,120 @@
+"""Tests for the prefix-preserving tool-masking pass."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.agents.tool_masking import MaskResult, mask_tools
+
+
+def _entry(name: str, **extra: object) -> dict[str, object]:
+    """Helper that builds a tool dict with ``name`` plus optional fields."""
+    base: dict[str, object] = {"name": name, "description": f"desc-{name}"}
+    base.update(extra)
+    return base
+
+
+class TestMaskToolsHappyPath:
+    def test_no_denied_returns_input_unchanged(self) -> None:
+        tools = [_entry("a"), _entry("b")]
+        result = mask_tools(tools, denied=[])
+        assert result.tools == tools
+        assert result.masked_names == ()
+        assert result.fallback_removed == ()
+
+    def test_masking_keeps_entry_and_flips_unavailable_flag(self) -> None:
+        tools = [_entry("a"), _entry("b")]
+        result = mask_tools(tools, denied=["b"], reason="role does not allow writes")
+        assert len(result.tools) == 2
+        assert result.tools[0] == _entry("a")
+        masked = result.tools[1]
+        assert masked["name"] == "b"
+        assert masked["unavailable"] is True
+        assert masked["unavailable_reason"] == "role does not allow writes"
+        assert "description" in masked  # original fields preserved
+        assert result.masked_names == ("b",)
+        assert result.fallback_removed == ()
+
+    def test_masking_preserves_entry_order(self) -> None:
+        """Critical for KV-cache locality: order of entries must not shift."""
+        tools = [_entry(name) for name in ("alpha", "bravo", "charlie", "delta")]
+        result = mask_tools(tools, denied=["bravo", "charlie"])
+        names = [t["name"] for t in result.tools]
+        assert names == ["alpha", "bravo", "charlie", "delta"]
+
+    def test_per_tool_reason_mapping(self) -> None:
+        tools = [_entry("read"), _entry("write"), _entry("delete")]
+        result = mask_tools(
+            tools,
+            denied=["write", "delete"],
+            reason={"write": "qa role", "delete": "always denied"},
+        )
+        masked = {t["name"]: t for t in result.tools if t.get("unavailable")}
+        assert masked["write"]["unavailable_reason"] == "qa role"
+        assert masked["delete"]["unavailable_reason"] == "always denied"
+
+    def test_per_tool_reason_falls_back_to_default(self) -> None:
+        """Names missing from the mapping use the documented default reason."""
+        tools = [_entry("write")]
+        result = mask_tools(tools, denied=["write"], reason={})
+        assert result.tools[0]["unavailable_reason"] == "denied by agent identity card"
+
+    def test_extra_keys_pass_through(self) -> None:
+        """Cache-control / input-schema fields must survive masking untouched."""
+        tools = [
+            _entry("a", input_schema={"type": "object"}, cache_control={"type": "ephemeral"}),
+        ]
+        result = mask_tools(tools, denied=["a"])
+        assert result.tools[0]["input_schema"] == {"type": "object"}
+        assert result.tools[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_dedupes_denied_set(self) -> None:
+        tools = [_entry("a")]
+        result = mask_tools(tools, denied=["a", "a", "a"])
+        assert result.masked_names == ("a",)
+
+
+class TestFallbackPath:
+    def test_fallback_removes_entries_when_flag_not_supported(self) -> None:
+        """For adapters that lack the ``unavailable`` field, entries are dropped."""
+        tools = [_entry("a"), _entry("b"), _entry("c")]
+        result = mask_tools(
+            tools,
+            denied=["b"],
+            adapter_supports_unavailable_flag=False,
+        )
+        names = [t["name"] for t in result.tools]
+        assert names == ["a", "c"]
+        assert result.masked_names == ()
+        assert result.fallback_removed == ("b",)
+
+
+class TestEdgeCases:
+    def test_empty_tools_returns_empty_result(self) -> None:
+        result = mask_tools([], denied=["whatever"])
+        assert result.tools == []
+        assert result.masked_names == ()
+        assert result.fallback_removed == ()
+
+    def test_denied_name_not_in_tools_is_silently_ignored(self) -> None:
+        result = mask_tools([_entry("a")], denied=["ghost"])
+        assert result.tools == [_entry("a")]
+        assert result.masked_names == ()
+
+    def test_missing_name_key_raises(self) -> None:
+        with pytest.raises(ValueError, match="name"):
+            mask_tools([{"description": "no name"}], denied=[])
+
+    def test_disabled_when_called_with_no_denied_set(self) -> None:
+        """Disabled-equivalent code path: ``denied=[]`` is the off switch."""
+        tools = [_entry("a"), _entry("b")]
+        result = mask_tools(tools, denied=[])
+        # Output is byte-equal to input modulo dict copies.
+        assert result.tools == tools
+        # Each output dict is a fresh copy, not the same identity.
+        assert result.tools[0] is not tools[0]
+
+    def test_empty_string_in_denied_is_filtered(self) -> None:
+        """Empty/falsy denied names must not match any real tool."""
+        result = mask_tools([_entry("a")], denied=["", "a"])
+        assert result.masked_names == ("a",)

--- a/tests/unit/test_tool_masking.py
+++ b/tests/unit/test_tool_masking.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from bernstein.core.agents.tool_masking import MaskResult, mask_tools
+from bernstein.core.agents.tool_masking import mask_tools
 
 
 def _entry(name: str, **extra: object) -> dict[str, object]:


### PR DESCRIPTION
## Summary

First slice of the Manus-harness-patterns ticket
(`.sdd/backlog/closed/2026-05-07-feat-manus-harness-patterns.md`).
Ships the two highest-leverage patterns from the published five, off by
default.

## Patterns shipped

- **#2 Tool masking** (`src/bernstein/core/agents/tool_masking.py`) —
  preserves KV-cache prefix bytes by flipping `unavailable: True` on
  denied tools instead of dropping them. Returns a `MaskResult` with a
  fallback-removed list for adapters whose schema can't carry the flag.
- **#5 Keep-failed-actions**
  (`src/bernstein/core/tokens/failed_action_retention.py` +
  `compaction_pipeline.py` integration) — tags failure blocks with
  `[FAILED -- kept for reference]`, ages them by half-life turns, and
  carves them out before media-stripping so they survive compaction
  verbatim.

Plus a shared `HarnessPolicy` frozen dataclass that names all five
flags so the data model is in place when the remaining patterns land.

## Patterns deferred

- **#1 KV-cache locality** (stable-tail prefix builder + drift counter)
- **#3 Filesystem-as-memory** (`.sdd/memory/<agent>/` + MCP resource)
- **#4 `todo.md` recitation** (starter file + heartbeat mtime check)

These are all wired into `HarnessPolicy` flags but the behaviour is a
no-op until the follow-up PRs land. Documented as deferred in the
ticket file.

## Test plan

- [x] `pytest tests/unit/test_harness_policy.py
  tests/unit/test_tool_masking.py
  tests/unit/test_failed_action_retention.py
  tests/unit/test_compaction_pipeline.py` -> 55 passed
- [x] `ruff check src/ tests/ scripts/` -> all checks passed
- [ ] CI: full suite + typecheck (kicked off automatically)

## Constraints honoured

- Off-by-default: `HarnessPolicy()` is all-False; pipeline kwargs default off.
- No new dependencies (pure stdlib).
- 95 existing spawn / compaction tests still green locally.
- Branch: `feat/manus-harness-patterns-1`; not pushed to `main`.

## Ticket

Moved local-only ticket file from `.sdd/backlog/open/` to
`.sdd/backlog/closed/2026-05-07-feat-manus-harness-patterns.md`.
(`.sdd/` is gitignored — not tracked in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)