### PR TITLE
feat(memory): JSONL append-only log (KF-2 smallest slice)

### DIFF
--- a/src/bernstein/core/memory/jsonl_log.py
+++ b/src/bernstein/core/memory/jsonl_log.py
@@ -1,0 +1,172 @@
+"""Append-only JSONL memory log for cross-session per-key event recording.
+
+Lightweight complement to :mod:`bernstein.core.memory.sqlite_store`.  Whereas
+the SQLite store is a tag-indexed knowledge base (conventions, decisions,
+learnings), this module provides a flat *append-only* event log keyed by a
+short identifier.  Each key maps to exactly one JSONL file at
+``<root>/<key>.jsonl`` (default root: ``.bernstein/memory/``).
+
+Design goals (KF-2 smallest-viable slice):
+
+- No retrieval / scoring / decay — that lives in the SQLite layer.
+- No locking primitives beyond what append-write to a POSIX file gives us;
+  callers needing strict cross-process serialisation should use the SQLite
+  store instead.
+- Pure ``json`` + ``pathlib``; no third-party deps; no DB schema migrations.
+- Off-by-default: nothing in the orchestrator reads or writes here yet.  The
+  spawner-injection wiring listed in the parent ticket is deferred.
+
+Typical usage::
+
+    from bernstein.core.memory.jsonl_log import JSONLMemoryLog
+
+    log = JSONLMemoryLog(root=Path(".bernstein/memory"))
+    log.write("manager.lessons", {"task": "T-1", "lesson": "guard imports"})
+    entries = log.read("manager.lessons")  # list[dict]
+
+The on-disk format is one JSON object per line.  Malformed lines (truncated
+writes, manual edits) are skipped on read with a warning rather than raising,
+so a corrupted tail cannot brick the whole log.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Keys map directly to filenames; restrict to a conservative POSIX-safe set
+# so a poisoned key cannot escape ``root`` (path traversal) or collide with
+# OS-reserved characters.  Dots, dashes, underscores allowed: a key like
+# ``"manager.lessons"`` becomes ``manager.lessons.jsonl``.
+_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_MAX_KEY_LEN = 128
+
+
+def _validate_key(key: str) -> None:
+    """Reject keys that could escape the memory root or break the filesystem.
+
+    Args:
+        key: User-supplied memory key.
+
+    Raises:
+        ValueError: Key is empty, too long, or contains disallowed characters.
+    """
+    if not key or len(key) > _MAX_KEY_LEN:
+        raise ValueError(f"memory key must be 1..{_MAX_KEY_LEN} chars, got len={len(key)}")
+    if not _KEY_RE.fullmatch(key):
+        raise ValueError(
+            f"memory key {key!r} must match {_KEY_RE.pattern!r} "
+            "(alphanumerics + . _ - only, must start with alphanumeric)"
+        )
+
+
+@dataclass(frozen=True)
+class JSONLMemoryLog:
+    """Append-only per-key JSONL log under a single root directory.
+
+    Attributes:
+        root: Directory holding ``<key>.jsonl`` files.  Created on first
+            write if missing.
+    """
+
+    root: Path
+
+    def _path(self, key: str) -> Path:
+        """Return the on-disk path for *key*, validating it first."""
+        _validate_key(key)
+        return self.root / f"{key}.jsonl"
+
+    def write(self, key: str, entry: dict[str, Any]) -> None:
+        """Append *entry* (a JSON-serialisable dict) to the log for *key*.
+
+        Args:
+            key: Memory key (alphanumeric + ``._-``).
+            entry: A dict that ``json.dumps`` can serialise.
+
+        Raises:
+            ValueError: ``key`` fails validation.
+            TypeError: ``entry`` is not a dict or contains non-serialisable
+                values.
+        """
+        if not isinstance(entry, dict):
+            raise TypeError(f"entry must be a dict, got {type(entry).__name__}")
+        path = self._path(key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # ``ensure_ascii=False`` keeps unicode readable; compact separators
+        # mean a tail-corruption only loses one record.
+        line = json.dumps(entry, ensure_ascii=False, separators=(",", ":"))
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.write("\n")
+
+    def read(self, key: str) -> list[dict[str, Any]]:
+        """Return all entries previously written under *key*, oldest first.
+
+        Args:
+            key: Memory key.
+
+        Returns:
+            List of dict entries.  Empty list if the key has never been
+            written.  Malformed lines are skipped (and logged at warning
+            level) so a partial tail-write cannot brick the whole log.
+
+        Raises:
+            ValueError: ``key`` fails validation.
+        """
+        path = self._path(key)
+        if not path.exists():
+            return []
+        entries: list[dict[str, Any]] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    logger.warning("skipping malformed JSONL line %s:%d (%s)", path, lineno, exc)
+                    continue
+                if not isinstance(parsed, dict):
+                    logger.warning(
+                        "skipping non-dict JSONL entry %s:%d (got %s)",
+                        path,
+                        lineno,
+                        type(parsed).__name__,
+                    )
+                    continue
+                entries.append(parsed)
+        return entries
+
+    def list_keys(self) -> list[str]:
+        """Return all keys currently present on disk, lexicographically sorted."""
+        if not self.root.exists():
+            return []
+        return sorted(p.stem for p in self.root.glob("*.jsonl") if p.is_file())
+
+    def clear(self, key: str) -> bool:
+        """Delete the JSONL file for *key*.
+
+        Args:
+            key: Memory key.
+
+        Returns:
+            ``True`` if a file was removed, ``False`` if the key did not
+            exist.
+
+        Raises:
+            ValueError: ``key`` fails validation.
+        """
+        path = self._path(key)
+        if path.exists():
+            path.unlink()
+            return True
+        return False

--- a/tests/unit/test_jsonl_memory_log.py
+++ b/tests/unit/test_jsonl_memory_log.py
@@ -1,0 +1,174 @@
+"""Unit tests for :class:`JSONLMemoryLog` — KF-2 append-only memory primitive."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.memory.jsonl_log import JSONLMemoryLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def log(tmp_path: Path) -> JSONLMemoryLog:
+    """Return a JSONL log rooted in a clean temp dir."""
+    return JSONLMemoryLog(root=tmp_path / "memory")
+
+
+class TestRoundTrip:
+    """write() then read() returns what was stored."""
+
+    def test_single_entry_roundtrip(self, log: JSONLMemoryLog) -> None:
+        log.write("manager.lessons", {"task": "T-1", "lesson": "guard imports"})
+        entries = log.read("manager.lessons")
+        assert entries == [{"task": "T-1", "lesson": "guard imports"}]
+
+    def test_unicode_preserved(self, log: JSONLMemoryLog) -> None:
+        log.write("notes", {"text": "réfactor — Łódź"})
+        assert log.read("notes")[0]["text"] == "réfactor — Łódź"
+
+    def test_nested_structures_preserved(self, log: JSONLMemoryLog) -> None:
+        payload = {"ints": [1, 2, 3], "obj": {"k": "v"}, "bool": True, "null": None}
+        log.write("nested", payload)
+        assert log.read("nested") == [payload]
+
+
+class TestMultiEntryAppend:
+    """Append semantics: each write adds a line, read preserves order."""
+
+    def test_three_entries_in_order(self, log: JSONLMemoryLog) -> None:
+        log.write("events", {"i": 1})
+        log.write("events", {"i": 2})
+        log.write("events", {"i": 3})
+        assert log.read("events") == [{"i": 1}, {"i": 2}, {"i": 3}]
+
+    def test_separate_keys_isolated(self, log: JSONLMemoryLog) -> None:
+        log.write("a", {"v": "alpha"})
+        log.write("b", {"v": "beta"})
+        assert log.read("a") == [{"v": "alpha"}]
+        assert log.read("b") == [{"v": "beta"}]
+
+    def test_cross_instance_append_visible(self, tmp_path: Path) -> None:
+        """Writer instance commits to disk; a fresh reader instance sees it."""
+        root = tmp_path / "shared"
+        writer = JSONLMemoryLog(root=root)
+        writer.write("k", {"step": 1})
+
+        reader = JSONLMemoryLog(root=root)
+        assert reader.read("k") == [{"step": 1}]
+
+        # Further appends from a third instance accumulate.
+        appender = JSONLMemoryLog(root=root)
+        appender.write("k", {"step": 2})
+        assert reader.read("k") == [{"step": 1}, {"step": 2}]
+
+
+class TestEmptyAndMissing:
+    """Reading a missing key is a clean empty list, not an error."""
+
+    def test_read_missing_returns_empty(self, log: JSONLMemoryLog) -> None:
+        assert log.read("never-written") == []
+
+    def test_list_keys_empty_when_no_writes(self, log: JSONLMemoryLog) -> None:
+        assert log.list_keys() == []
+
+    def test_list_keys_after_writes(self, log: JSONLMemoryLog) -> None:
+        log.write("zeta", {})
+        log.write("alpha", {})
+        log.write("mid", {})
+        assert log.list_keys() == ["alpha", "mid", "zeta"]
+
+
+class TestClear:
+    """clear() removes a key file, leaves others untouched."""
+
+    def test_clear_removes_file(self, log: JSONLMemoryLog) -> None:
+        log.write("k", {"v": 1})
+        assert log.clear("k") is True
+        assert log.read("k") == []
+
+    def test_clear_missing_returns_false(self, log: JSONLMemoryLog) -> None:
+        assert log.clear("ghost") is False
+
+    def test_clear_does_not_touch_siblings(self, log: JSONLMemoryLog) -> None:
+        log.write("keep", {"v": 1})
+        log.write("drop", {"v": 2})
+        log.clear("drop")
+        assert log.list_keys() == ["keep"]
+        assert log.read("keep") == [{"v": 1}]
+
+
+class TestKeyValidation:
+    """Validation guards against path traversal and OS-reserved names."""
+
+    @pytest.mark.parametrize(
+        "bad_key",
+        [
+            "",
+            "../escape",
+            "with/slash",
+            "with space",
+            ".leading-dot",
+            "with\\backslash",
+            "with:colon",
+            "a" * 200,
+        ],
+    )
+    def test_invalid_keys_rejected(self, log: JSONLMemoryLog, bad_key: str) -> None:
+        with pytest.raises(ValueError):
+            log.write(bad_key, {"v": 1})
+        with pytest.raises(ValueError):
+            log.read(bad_key)
+        with pytest.raises(ValueError):
+            log.clear(bad_key)
+
+    @pytest.mark.parametrize(
+        "ok_key",
+        ["a", "manager.lessons", "with-dash", "with_underscore", "Mixed.Case-1"],
+    )
+    def test_valid_keys_accepted(self, log: JSONLMemoryLog, ok_key: str) -> None:
+        log.write(ok_key, {"v": 1})
+        assert log.read(ok_key) == [{"v": 1}]
+
+
+class TestEntryValidation:
+    """Non-dict entries and unserialisable payloads fail loudly."""
+
+    def test_non_dict_entry_rejected(self, log: JSONLMemoryLog) -> None:
+        with pytest.raises(TypeError):
+            log.write("k", [1, 2, 3])  # type: ignore[arg-type]
+
+    def test_non_serialisable_entry_raises(self, log: JSONLMemoryLog) -> None:
+        with pytest.raises(TypeError):
+            log.write("k", {"obj": object()})
+
+
+class TestCorruptionTolerance:
+    """A malformed tail line should not poison previously-good entries."""
+
+    def test_malformed_line_skipped(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        log = JSONLMemoryLog(root=root)
+        log.write("k", {"v": 1})
+        log.write("k", {"v": 2})
+
+        # Hand-corrupt the file by appending garbage + a valid third entry.
+        path = root / "k.jsonl"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("not-valid-json{\n")
+            fh.write('{"v":3}\n')
+
+        assert log.read("k") == [{"v": 1}, {"v": 2}, {"v": 3}]
+
+    def test_non_dict_json_line_skipped(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        log = JSONLMemoryLog(root=root)
+        log.write("k", {"v": 1})
+        path = root / "k.jsonl"
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("[1,2,3]\n")  # valid JSON, wrong shape
+            fh.write('{"v":2}\n')
+        assert log.read("k") == [{"v": 1}, {"v": 2}]


### PR DESCRIPTION
Refs #1088

## Summary

Smallest-viable slice of [KF-2](.sdd/backlog/closed/2026-05-06-kf-2-memory-and-skills-library.md) — Factory \"Droid memories\" parity epic.

**Option A** from the ticket prompt: append-only JSONL memory log at `.bernstein/memory/<key>.jsonl`.

## Shipped

- `src/bernstein/core/memory/jsonl_log.py` — `JSONLMemoryLog` dataclass with `read(key)` / `write(key, entry)` / `list_keys()` / `clear(key)`
- Pure stdlib (`json` + `pathlib` + `re`), no new deps
- Key validation rejects path-traversal (`../escape`, `with/slash`, leading-dot, etc.) and length > 128
- Malformed JSONL lines are skipped on read with a warning so a tail-corruption cannot brick the log
- 29 unit tests in `tests/unit/test_jsonl_memory_log.py`: round-trip, unicode, nested payloads, multi-entry append order, cross-instance read, validation, corruption tolerance

## Deferred (tracked in follow-ups)

- Spawner-pipeline auto-injection of `<lessons>` block into agent prompts
- Manager-role distil-lesson checklist in `templates/roles/manager/`
- `bernstein skills publish|install` flow + public skills repo
- Manifest validation extensions
- Docs + `--help` paid-competitor callout
- Wiring `JSONLMemoryLog` to the existing `SQLiteMemoryStore` retrieval path (kept as separate primitives intentionally — JSONL is event-log, SQLite is tag-indexed KB)

## Off-by-default

Nothing in the orchestrator imports or calls `JSONLMemoryLog` yet. It is an additive primitive ready for the next slice to wire into the spawner.

## Test plan

- [x] `uv run pytest tests/unit/test_jsonl_memory_log.py -v` → 29 passed
- [x] `uv run pytest tests/unit/test_sqlite_memory_store.py tests/unit/test_memory_store.py tests/unit/test_store_memory.py` → 37 passed (no regressions in adjacent memory modules)
- [x] `uv run ruff check` and `ruff format --check` clean on new files

## Ticket

Local-only file (`.sdd/` is gitignored), moved from `open/` → `closed/`:
`.sdd/backlog/closed/2026-05-06-kf-2-memory-and-skills-library.md`

Closing note added at top of ticket listing shipped slice + deferred items.
