### PR TITLE
feat(mcp): expose read-only bot tools via /.well-known/mcp-tools (off by default)

### DIFF
--- a/src/bernstein/core/protocols/mcp_bot_allowlist.py
+++ b/src/bernstein/core/protocols/mcp_bot_allowlist.py
@@ -1,0 +1,132 @@
+"""Read-only MCP-tool allowlist for the bernstein.run docs bot.
+
+The bernstein.run docs bot (RAG-001..004 in the bernstein_landing repo) may
+optionally consult the live cluster when answering operational questions
+("how many tasks are open", "what's the cluster health"). To keep that
+surface narrow we expose **only** the four read-only tools below; write
+tools (``bernstein_run``, ``bernstein_approve``, ``bernstein_stop``,
+``bernstein_create_subtask``) must never reach the bot.
+
+The allowlist lives in code — adding a tool to the bot surface requires a
+review of *this file*, not a config flip. That's deliberate: misconfigured
+MCP servers cannot grant the bot access to mutation tools by advertising
+them, because the discovery endpoint filters through this set.
+
+References:
+    - .sdd/backlog/open/2026-05-08-bernstein-mcp-bot-tools-exposure.md
+    - OWASP Top-10 for Agentic Apps (Dec 9 2025) — ASI02 Tool Misuse,
+      ASI04 Unauthorized Tool Invocation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+# ---------------------------------------------------------------------------
+# Allowlist
+# ---------------------------------------------------------------------------
+
+#: Read-only MCP tools the docs bot may invoke.  Anything not in this set is
+#: rejected at the discovery boundary even if the MCP server advertises it.
+ALLOWED_BOT_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "bernstein_status",
+        "bernstein_tasks",
+        "bernstein_health",
+        "bernstein_cost",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Tool specs (what we publish to the bot)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class BotToolSpec:
+    """Public-safe description of a bot-callable MCP tool.
+
+    Mirrors the subset of the MCP tool definition the docs bot needs to
+    plan a single tool call. We deliberately omit the JSON-schema args
+    surface for now — the four allowed tools take at most one optional
+    string argument (``status`` on ``bernstein_tasks``), which the system
+    prompt handles directly.
+
+    Attributes:
+        name: MCP tool name (e.g. ``"bernstein_status"``).
+        summary: One-line human description for the bot system prompt.
+        args_hint: Optional argument hint (``"status?: open|closed|failed"``).
+    """
+
+    name: str
+    summary: str
+    args_hint: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the JSON shape the discovery endpoint returns."""
+        payload: dict[str, Any] = {"name": self.name, "summary": self.summary}
+        if self.args_hint is not None:
+            payload["args_hint"] = self.args_hint
+        return payload
+
+
+#: Canonical descriptions of the four bot-callable tools.  Kept here (not in
+#: ``mcp/server.py``) so that adding the same tool to the MCP catalog later
+#: cannot accidentally widen the bot surface.
+BOT_TOOL_SPECS: Final[tuple[BotToolSpec, ...]] = (
+    BotToolSpec(
+        name="bernstein_status",
+        summary=(
+            "Cluster summary: orchestrator state, task counts, agent counts. "
+            "Call when the user asks about live progress."
+        ),
+    ),
+    BotToolSpec(
+        name="bernstein_tasks",
+        summary="List tasks. Call when the user asks 'how many tasks are X' or 'show me tasks'.",
+        args_hint='status?: "open"|"closed"|"failed"',
+    ),
+    BotToolSpec(
+        name="bernstein_health",
+        summary="Health check breakdown. Call when the user asks 'is bernstein up' or 'what's broken'.",
+    ),
+    BotToolSpec(
+        name="bernstein_cost",
+        summary="Spend summary. Call when the user asks about cost or budget.",
+    ),
+)
+
+
+def filter_to_allowed(tool_names: list[str] | tuple[str, ...]) -> list[BotToolSpec]:
+    """Return ``BotToolSpec``s for every input name that's on the allowlist.
+
+    Used by the discovery endpoint and by clients that want to defensively
+    re-filter an MCP-server response before handing it to the bot. The
+    function is total: unknown names are silently dropped (no exception),
+    keeping the discovery path fail-open.
+
+    Args:
+        tool_names: Names returned by the MCP server's ``list_tools`` call.
+
+    Returns:
+        Subset of ``BOT_TOOL_SPECS`` whose names appear in *tool_names* and
+        in :data:`ALLOWED_BOT_TOOLS`. Order matches :data:`BOT_TOOL_SPECS`.
+    """
+    requested = set(tool_names)
+    return [spec for spec in BOT_TOOL_SPECS if spec.name in ALLOWED_BOT_TOOLS and spec.name in requested]
+
+
+def all_allowed_specs() -> list[BotToolSpec]:
+    """Return every spec on the allowlist (used by the in-process discovery path)."""
+    return [spec for spec in BOT_TOOL_SPECS if spec.name in ALLOWED_BOT_TOOLS]
+
+
+__all__ = [
+    "ALLOWED_BOT_TOOLS",
+    "BOT_TOOL_SPECS",
+    "BotToolSpec",
+    "all_allowed_specs",
+    "filter_to_allowed",
+]

--- a/src/bernstein/core/routes/mcp_bot_tools.py
+++ b/src/bernstein/core/routes/mcp_bot_tools.py
@@ -1,0 +1,132 @@
+"""Discovery endpoint for the bernstein.run docs-bot tool surface.
+
+Exposes ``GET /.well-known/mcp-tools`` so the bernstein_landing docs bot
+(RAG-001..004) can probe whether this Bernstein cluster is willing to be
+called by the bot, and which read-only tools are on offer.
+
+Off by default. Enabled by setting the env var
+``BERNSTEIN_BOT_TOOLS_ENABLED=1`` (or the corresponding ``.sdd/config.yaml``
+``bot_tools.enabled: true`` flag, surfaced by the harness).
+
+Contract — the response body is intentionally minimal::
+
+    {
+      "version": 1,
+      "enabled": true,
+      "tools": [
+        {"name": "bernstein_status", "summary": "..."},
+        ...
+      ]
+    }
+
+When the flag is off the body is::
+
+    {"version": 1, "enabled": false, "tools": []}
+
+Either way the endpoint returns 200, so a docs-bot probing it can
+distinguish "Bernstein reachable but bot tools off" from "Bernstein not
+reachable at all" (which the bot already handles via timeout in its
+fail-open discovery loop). This is the Aporia fail-open pattern made
+explicit on the *server* side: the endpoint never 4xx/5xx for a configured
+state choice.
+
+References:
+    - .sdd/backlog/open/2026-05-08-bernstein-mcp-bot-tools-exposure.md
+    - bernstein_landing/.sdd/backlog/open/2026-05-08-rag-001-shared-ai-gateway-service.md
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Final
+
+from fastapi import APIRouter
+
+from bernstein.core.protocols.mcp_bot_allowlist import (
+    BotToolSpec,
+    all_allowed_specs,
+)
+
+router = APIRouter()
+
+# Public discovery path; mirrored into AUTH_PUBLIC_PATHS so anonymous
+# callers (the bernstein.run gateway probing whether to inject tools) can
+# read it without provisioning a token.
+DISCOVERY_PATH: Final[str] = "/.well-known/mcp-tools"
+
+# Env var driving the off-by-default flag.  Truthy values: ``1``, ``true``,
+# ``yes``, ``on`` (case-insensitive).  Anything else (including unset) keeps
+# the endpoint disabled.
+_ENABLE_ENV_VAR: Final[str] = "BERNSTEIN_BOT_TOOLS_ENABLED"
+_TRUTHY: Final[frozenset[str]] = frozenset({"1", "true", "yes", "on"})
+
+# Schema-version sentinel — bumped if the discovery payload shape changes.
+# Kept out of the response body's tool entries so the docs bot can switch
+# parsers based on this single integer.
+_SCHEMA_VERSION: Final[int] = 1
+
+
+def _is_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return ``True`` when the bot-tools surface is enabled.
+
+    Args:
+        env: Optional environment override (defaults to ``os.environ``).
+            Tests inject a stub mapping; production reads the live env on
+            every call so an operator can flip the flag with a sighup-free
+            container restart.
+
+    Returns:
+        ``True`` iff the env var resolves to a truthy literal.
+    """
+    source = env if env is not None else os.environ
+    raw = source.get(_ENABLE_ENV_VAR, "").strip().lower()
+    return raw in _TRUTHY
+
+
+def _serialise_specs(specs: list[BotToolSpec]) -> list[dict[str, Any]]:
+    """Convert ``BotToolSpec``s to the JSON-shaped dicts the bot consumes."""
+    return [spec.to_dict() for spec in specs]
+
+
+def discovery_payload(*, enabled: bool, specs: list[BotToolSpec] | None = None) -> dict[str, Any]:
+    """Build the response body for the discovery endpoint.
+
+    Pulled out of the route handler so tests can assert payload shape
+    without spinning up a TestClient, and so a future client-side helper
+    can render the same body deterministically.
+
+    Args:
+        enabled: Whether the surface is active.
+        specs: Allowlisted tool specs (defaults to :func:`all_allowed_specs`
+            when ``enabled`` is true; ignored otherwise).
+
+    Returns:
+        JSON-serialisable dict with keys ``version``, ``enabled``, ``tools``.
+    """
+    if not enabled:
+        return {"version": _SCHEMA_VERSION, "enabled": False, "tools": []}
+    resolved = specs if specs is not None else all_allowed_specs()
+    return {
+        "version": _SCHEMA_VERSION,
+        "enabled": True,
+        "tools": _serialise_specs(resolved),
+    }
+
+
+@router.get(DISCOVERY_PATH, include_in_schema=False)
+def mcp_tools_discovery() -> dict[str, Any]:
+    """Return the bot-callable MCP tool list (or an empty list when off).
+
+    Always 200. The docs bot's fail-open discovery treats both
+    ``enabled=false`` and a network error identically — it skips tool
+    injection and answers from passages alone — so we never need to 503
+    just because an operator has the flag off.
+    """
+    return discovery_payload(enabled=_is_enabled())
+
+
+__all__ = [
+    "DISCOVERY_PATH",
+    "discovery_payload",
+    "router",
+]

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -77,6 +77,7 @@ AUTH_PUBLIC_PATHS = frozenset(
         "/.well-known/agent.json",
         "/.well-known/agent.json/keys",
         "/.well-known/acp.json",
+        "/.well-known/mcp-tools",
         "/llms.txt",
         "/acp/v0/agents",
         # Auth flow endpoints (must be public for login to work)

--- a/src/bernstein/core/security/ip_allowlist.py
+++ b/src/bernstein/core/security/ip_allowlist.py
@@ -55,6 +55,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
             "/alive",
             "/.well-known/agent.json",
             "/.well-known/agent.json/keys",
+            "/.well-known/mcp-tools",
             "/docs",
             "/openapi.json",
         }

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1217,6 +1217,7 @@ def create_app(
     from bernstein.core.routes.health import router as health_deps_router
     from bernstein.core.routes.hooks import router as hooks_router
     from bernstein.core.routes.identities import router as identities_router
+    from bernstein.core.routes.mcp_bot_tools import router as mcp_bot_tools_router
     from bernstein.core.routes.paginated_tasks import router as paginated_tasks_router
     from bernstein.core.routes.plans import router as plans_router
     from bernstein.core.routes.predictive import router as predictive_router
@@ -1280,6 +1281,7 @@ def create_app(
         provider_latency_router,
         predictive_router,
         well_known_router,
+        mcp_bot_tools_router,
     ]
 
     for r in all_routers:

--- a/src/bernstein/core/server/server_middleware.py
+++ b/src/bernstein/core/server/server_middleware.py
@@ -37,6 +37,7 @@ _PUBLIC_PATHS = frozenset(
         "/.well-known/agent.json",
         "/.well-known/agent.json/keys",
         "/.well-known/acp.json",
+        "/.well-known/mcp-tools",
         "/acp/v0/agents",
         "/docs",
         "/redoc",

--- a/tests/unit/test_mcp_bot_tools_discovery.py
+++ b/tests/unit/test_mcp_bot_tools_discovery.py
@@ -1,0 +1,179 @@
+"""Tests for the docs-bot MCP-tool discovery surface.
+
+Covers:
+    - Allowlist boundaries (only the four read-only tools, no write tools).
+    - Off-by-default behaviour (env var unset -> empty payload, 200).
+    - On behaviour (env var set -> all four tool specs returned).
+    - HTTP route mounted under ``/.well-known/mcp-tools`` and accessible
+      without auth.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bernstein.core.protocols.mcp_bot_allowlist import (
+    ALLOWED_BOT_TOOLS,
+    BOT_TOOL_SPECS,
+    all_allowed_specs,
+    filter_to_allowed,
+)
+from bernstein.core.routes.mcp_bot_tools import (
+    DISCOVERY_PATH,
+    _is_enabled,
+    discovery_payload,
+)
+from bernstein.core.security.auth_middleware import AUTH_PUBLIC_PATHS
+from bernstein.core.server import create_app
+
+# ---------------------------------------------------------------------------
+# Allowlist invariants
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_contains_only_read_only_tools() -> None:
+    """The four read-only tools, nothing else (no run/approve/stop/subtask)."""
+    assert frozenset(
+        {"bernstein_status", "bernstein_tasks", "bernstein_health", "bernstein_cost"},
+    ) == ALLOWED_BOT_TOOLS
+
+
+@pytest.mark.parametrize(
+    "write_tool",
+    ["bernstein_run", "bernstein_approve", "bernstein_stop", "bernstein_create_subtask"],
+)
+def test_write_tools_blocked_by_allowlist(write_tool: str) -> None:
+    """Mutation tools must never appear in the allowlist."""
+    assert write_tool not in ALLOWED_BOT_TOOLS
+    assert filter_to_allowed([write_tool]) == []
+
+
+def test_specs_match_allowlist() -> None:
+    """Every published spec must be on the allowlist (no orphans)."""
+    spec_names = {spec.name for spec in BOT_TOOL_SPECS}
+    assert spec_names == ALLOWED_BOT_TOOLS
+
+
+def test_filter_drops_unknown_names() -> None:
+    """Unknown tool names are silently dropped — fail-open at the boundary."""
+    out = filter_to_allowed(["bernstein_status", "totally_made_up_tool", "bernstein_run"])
+    names = [s.name for s in out]
+    assert names == ["bernstein_status"]
+
+
+def test_all_allowed_specs_returns_full_set() -> None:
+    specs = all_allowed_specs()
+    assert {s.name for s in specs} == ALLOWED_BOT_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# Discovery payload (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_payload_when_disabled_is_empty() -> None:
+    payload = discovery_payload(enabled=False)
+    assert payload == {"version": 1, "enabled": False, "tools": []}
+
+
+def test_discovery_payload_when_enabled_lists_all_four_tools() -> None:
+    payload = discovery_payload(enabled=True)
+    assert payload["version"] == 1
+    assert payload["enabled"] is True
+    names = {t["name"] for t in payload["tools"]}
+    assert names == ALLOWED_BOT_TOOLS
+    # Every tool entry must have a non-empty summary.
+    for tool in payload["tools"]:
+        assert tool["summary"]
+
+
+def test_discovery_payload_respects_filtered_specs() -> None:
+    """Caller-supplied specs are used verbatim when ``enabled=True``."""
+    only_status = filter_to_allowed(["bernstein_status"])
+    payload = discovery_payload(enabled=True, specs=only_status)
+    assert [t["name"] for t in payload["tools"]] == ["bernstein_status"]
+
+
+# ---------------------------------------------------------------------------
+# _is_enabled env handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "ON"])
+def test_is_enabled_truthy_values(value: str) -> None:
+    assert _is_enabled({"BERNSTEIN_BOT_TOOLS_ENABLED": value}) is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_is_enabled_falsy_values(value: str) -> None:
+    assert _is_enabled({"BERNSTEIN_BOT_TOOLS_ENABLED": value}) is False
+
+
+def test_is_enabled_unset_defaults_to_false() -> None:
+    assert _is_enabled({}) is False
+
+
+# ---------------------------------------------------------------------------
+# HTTP integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setenv("BERNSTEIN_AUTH_DISABLED", "1")
+    # Default: flag off so the off-by-default test sees the disabled payload.
+    monkeypatch.delenv("BERNSTEIN_BOT_TOOLS_ENABLED", raising=False)
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    return TestClient(app)
+
+
+def test_route_returns_disabled_payload_by_default(client: TestClient) -> None:
+    resp = client.get(DISCOVERY_PATH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is False
+    assert body["tools"] == []
+    assert body["version"] == 1
+
+
+def test_route_returns_full_tool_list_when_enabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("BERNSTEIN_BOT_TOOLS_ENABLED", "1")
+    resp = client.get(DISCOVERY_PATH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    names = {t["name"] for t in body["tools"]}
+    assert names == ALLOWED_BOT_TOOLS
+
+
+def test_route_is_in_public_auth_paths() -> None:
+    """Discovery is anonymous — must live in AUTH_PUBLIC_PATHS."""
+    assert DISCOVERY_PATH in AUTH_PUBLIC_PATHS
+
+
+def test_route_does_not_503_when_disabled(client: TestClient) -> None:
+    """Aporia fail-open contract: disabled state still 200, never an error."""
+    resp = client.get(DISCOVERY_PATH)
+    assert resp.status_code == 200
+
+
+def test_route_unaffected_by_unrelated_env(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting other env vars must not flip the bot-tools flag accidentally."""
+    monkeypatch.setenv("SOME_OTHER_FLAG", "1")
+    resp = client.get(DISCOVERY_PATH)
+    assert resp.json()["enabled"] is False
+
+
+def teardown_module() -> None:
+    """Defensive: scrub the env var so other tests don't see leaked state."""
+    os.environ.pop("BERNSTEIN_BOT_TOOLS_ENABLED", None)


### PR DESCRIPTION
## Summary

Adds the **server side** of the bernstein.run docs-bot MCP-tool surface: a public discovery endpoint at `GET /.well-known/mcp-tools` listing the read-only Bernstein MCP tools the bot is allowed to call. The bot lives in the separate `bernstein_landing` repo (RAG-001..004); this PR ships only the bernstein side of the contract.

- New `src/bernstein/core/protocols/mcp_bot_allowlist.py` — frozen allowlist with the four read-only tools (`bernstein_status`, `bernstein_tasks`, `bernstein_health`, `bernstein_cost`). Write tools (`bernstein_run` / `_approve` / `_stop` / `_create_subtask`) cannot pass the boundary even if a misconfigured MCP server advertises them. Adding a tool to the bot surface requires a code change here, not a config flip.
- New `src/bernstein/core/routes/mcp_bot_tools.py` — `GET /.well-known/mcp-tools` route. Off by default (`BERNSTEIN_BOT_TOOLS_ENABLED=1` to enable). When disabled, returns `200 {"version":1,"enabled":false,"tools":[]}` — the **Aporia fail-open pattern made explicit on the server side**: the endpoint never 4xx/5xx for a configured state choice.
- Wired into `server_app.py` router list, `AUTH_PUBLIC_PATHS`, `IPAllowlistMiddleware._PUBLIC_PATHS`, and the bearer-auth public-paths set so anonymous callers (the docs-bot gateway) can probe it.
- 28 unit tests covering allowlist invariants, env-var resolution, payload shape, and HTTP integration.

## What's pending in the other repo

The bernstein_landing PR (gateway-side fail-open client) is the natural follow-up:

1. The gateway probes this endpoint at request time with a 200ms wall-clock budget.
2. If 200 + `enabled=true`, inject the listed tool descriptions into the generator's system prompt as a "TOOLS YOU MAY CALL" block.
3. If timeout / connection error / `enabled=false` / empty list, skip tool injection and answer from passages alone — never 503 the user.

Will be filed against `bernstein_landing` once RAG-001..004 land.

## Test plan

- [x] `pytest tests/unit/test_mcp_bot_tools_discovery.py` — 28 passed
- [x] `pytest tests/unit/test_well_known.py` (regression guard for the existing `/.well-known/agent.json` route) — 6 passed
- [x] `ruff check` — clean
- [x] Pre-push hook (lint + import-linter) — clean

## Ticket

`/.sdd/backlog/closed/2026-05-08-bernstein-mcp-bot-tools-exposure.md` (moved from open/).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>