### PR TITLE
feat(compliance): EU AI Act Article 12 evidence pack

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -288,7 +288,7 @@ def verify_hmac_cmd() -> None:
     "without writing to disk.",
 )
 @click.option("--dir", "workdir", default=".", show_default=True, help="Project root directory.")
-def export_cmd(  # noqa: PLR0913 — CLI surface mirrors documented flags
+def export_cmd(
     period: str | None,
     article_12: bool,
     since: str | None,

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -236,37 +236,111 @@ def verify_hmac_cmd() -> None:
 
 
 @audit_group.command("export")
-@click.option("--period", required=True, help="Time period to export (e.g. Q1-2026, 2026-03, 2026).")
+@click.option(
+    "--period",
+    default=None,
+    help="SOC 2 time period to export (e.g. Q1-2026, 2026-03, 2026).",
+)
+@click.option(
+    "--article-12",
+    "article_12",
+    is_flag=True,
+    default=False,
+    help="Emit an EU AI Act Article 12 evidence pack (uses --since/--until).",
+)
+@click.option(
+    "--since",
+    default=None,
+    help="ISO-8601 inclusive lower bound (Article 12 mode).",
+)
+@click.option(
+    "--until",
+    default=None,
+    help="ISO-8601 exclusive upper bound (Article 12 mode).",
+)
+@click.option(
+    "--risk-class",
+    "risk_class",
+    default="limited",
+    type=click.Choice(["high", "limited", "minimal"]),
+    show_default=True,
+    help="EU AI Act risk class driving Article 12(3) retention horizon.",
+)
 @click.option(
     "--format",
     "fmt",
     default="zip",
     type=click.Choice(["zip", "dir"]),
     show_default=True,
-    help="Output format.",
+    help="Output format (SOC 2 mode only; Article 12 always emits a zip).",
 )
-@click.option("--output", "-o", default=None, help="Output directory (defaults to .sdd/evidence/).")
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    help="Output directory (defaults to .sdd/evidence/).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Article 12 mode: build the bundle in-memory and print the manifest "
+    "without writing to disk.",
+)
 @click.option("--dir", "workdir", default=".", show_default=True, help="Project root directory.")
-def export_cmd(period: str, fmt: str, output: str | None, workdir: str) -> None:
-    """Export a SOC 2 evidence package for auditors.
+def export_cmd(  # noqa: PLR0913 — CLI surface mirrors documented flags
+    period: str | None,
+    article_12: bool,
+    since: str | None,
+    until: str | None,
+    risk_class: str,
+    fmt: str,
+    output: str | None,
+    dry_run: bool,
+    workdir: str,
+) -> None:
+    """Export an evidence package for auditors.
 
     \b
-    Collects audit logs, HMAC verification, Merkle seals, compliance config,
-    WAL entries, and SBOM into a single package.
+    Two modes:
+      * SOC 2 mode (default): bernstein audit export --period Q1-2026
+      * EU AI Act Article 12: bernstein audit export --article-12 \
+            --since 2026-08-01T00:00:00+00:00 --until 2026-09-01T00:00:00+00:00
 
     \b
-    Examples:
-      bernstein audit export --period Q1-2026
-      bernstein audit export --period Q1-2026 --format dir
-      bernstein audit export --period 2026-03 -o /tmp/evidence
+    SOC 2 mode collects audit logs, HMAC verification, Merkle seals,
+    compliance config, WAL entries, and SBOM into a single package.
+
+    \b
+    Article 12 mode emits a deterministic, retention-pinned bundle with
+    the audit log slice, a data-governance catalog, and an EU-AI-Act
+    clause map (manifest.json contains artefact SHA-256 hashes for
+    auditor verification).
     """
-    from bernstein.core.compliance import export_soc2_package, parse_period
-
     sdd_dir = Path(workdir).resolve() / ".sdd"
     if not sdd_dir.is_dir():
         console.print(f"[red]State directory not found:[/red] {sdd_dir}")
         console.print("[dim]Run [bold]bernstein run[/bold] first to generate audit data.[/dim]")
         raise SystemExit(1)
+
+    if article_12:
+        _run_article12_export(
+            sdd_dir=sdd_dir,
+            since=since,
+            until=until,
+            risk_class=risk_class,
+            output=output,
+            dry_run=dry_run,
+        )
+        return
+
+    if not period:
+        console.print(
+            "[red]Either --period (SOC 2) or --article-12 (with --since/--until) is required.[/red]"
+        )
+        raise SystemExit(2)
+
+    from bernstein.core.compliance import export_soc2_package, parse_period
 
     # Validate period before doing work
     try:
@@ -301,6 +375,77 @@ def export_cmd(period: str, fmt: str, output: str | None, workdir: str) -> None:
     table.add_row("Output", str(result))
     console.print(table)
     console.print()
+
+
+def _run_article12_export(
+    *,
+    sdd_dir: Path,
+    since: str | None,
+    until: str | None,
+    risk_class: str,
+    output: str | None,
+    dry_run: bool,
+) -> None:
+    """Execute the EU AI Act Article 12 evidence-pack flow."""
+    import json as _json
+    from typing import cast
+
+    from bernstein.core.security.article12_bundle import (
+        Article12Bundle,
+        RiskClass,
+        build_article12_bundle,
+    )
+
+    if not since or not until:
+        console.print("[red]--article-12 requires both --since and --until (ISO-8601).[/red]")
+        raise SystemExit(2)
+
+    audit_dir = sdd_dir / "audit"
+    output_dir = Path(output).resolve() if output else None
+
+    try:
+        bundle: Article12Bundle = build_article12_bundle(
+            audit_dir=audit_dir,
+            since=since,
+            until=until,
+            risk_class=cast("RiskClass", risk_class),
+            output_dir=output_dir,
+            write=not dry_run,
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+
+    console.print()
+    console.print(
+        Panel(
+            "[bold]EU AI Act Article 12 Evidence Pack[/bold]",
+            border_style="green",
+            expand=False,
+        )
+    )
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=18)
+    table.add_column("Value")
+    table.add_row("Bundle ID", bundle.bundle_id)
+    table.add_row("Window", f"{bundle.since} → {bundle.until}")
+    table.add_row("Risk class", bundle.risk_class)
+    table.add_row("Events", str(bundle.event_count))
+    table.add_row("Chain anchor", bundle.chain_anchor[:16] + "…")
+    table.add_row("Retention until", bundle.retention.retention_until)
+    table.add_row("SHA-256", bundle.sha256[:16] + "…")
+    if bundle.archive_path is not None:
+        table.add_row("Archive", str(bundle.archive_path))
+    elif dry_run:
+        table.add_row("Archive", "(dry-run, not written)")
+    console.print(table)
+    console.print()
+
+    if dry_run:
+        console.print("[dim]Manifest (dry-run):[/dim]")
+        console.print(_json.dumps(bundle.to_dict(), indent=2))
+        console.print()
 
 
 @audit_group.command("capabilities")

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -284,8 +284,7 @@ def verify_hmac_cmd() -> None:
     "--dry-run",
     is_flag=True,
     default=False,
-    help="Article 12 mode: build the bundle in-memory and print the manifest "
-    "without writing to disk.",
+    help="Article 12 mode: build the bundle in-memory and print the manifest without writing to disk.",
 )
 @click.option("--dir", "workdir", default=".", show_default=True, help="Project root directory.")
 def export_cmd(
@@ -335,9 +334,7 @@ def export_cmd(
         return
 
     if not period:
-        console.print(
-            "[red]Either --period (SOC 2) or --article-12 (with --since/--until) is required.[/red]"
-        )
+        console.print("[red]Either --period (SOC 2) or --article-12 (with --since/--until) is required.[/red]")
         raise SystemExit(2)
 
     from bernstein.core.compliance import export_soc2_package, parse_period

--- a/src/bernstein/core/security/article12_bundle.py
+++ b/src/bernstein/core/security/article12_bundle.py
@@ -41,8 +41,10 @@ import json
 import zipfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 #: Article 12(3) — high-risk AI systems must keep logs for the lifetime
 #: of the system *and* at least 10 years (Article 19(1)).  Bernstein
@@ -155,11 +157,13 @@ def compute_retention_pin(
         ValueError: If ``last_event_ts`` is not parseable as ISO-8601.
     """
     last_dt = _parse_iso(last_event_ts)
-    if risk_class == "high":
-        # 10 years (Article 19(1)).  365.25 average accounts for leap years.
-        days = int(round(HIGH_RISK_RETENTION_YEARS * 365.25))
-    else:
-        days = MINIMUM_RETENTION_DAYS
+    # 10 years (Article 19(1)) for high-risk; 6-month floor otherwise.
+    # 365.25 average accounts for leap years.
+    days = (
+        round(HIGH_RISK_RETENTION_YEARS * 365.25)
+        if risk_class == "high"
+        else MINIMUM_RETENTION_DAYS
+    )
     until = (last_dt + timedelta(days=days)).date().isoformat()
     return RetentionPin(
         risk_class=risk_class,
@@ -189,7 +193,7 @@ def validate_retention(
     elapsed = (current - last_dt).days
 
     floor = (
-        int(round(HIGH_RISK_RETENTION_YEARS * 365.25))
+        round(HIGH_RISK_RETENTION_YEARS * 365.25)
         if pin.risk_class == "high"
         else MINIMUM_RETENTION_DAYS
     )

--- a/src/bernstein/core/security/article12_bundle.py
+++ b/src/bernstein/core/security/article12_bundle.py
@@ -159,11 +159,7 @@ def compute_retention_pin(
     last_dt = _parse_iso(last_event_ts)
     # 10 years (Article 19(1)) for high-risk; 6-month floor otherwise.
     # 365.25 average accounts for leap years.
-    days = (
-        round(HIGH_RISK_RETENTION_YEARS * 365.25)
-        if risk_class == "high"
-        else MINIMUM_RETENTION_DAYS
-    )
+    days = round(HIGH_RISK_RETENTION_YEARS * 365.25) if risk_class == "high" else MINIMUM_RETENTION_DAYS
     until = (last_dt + timedelta(days=days)).date().isoformat()
     return RetentionPin(
         risk_class=risk_class,
@@ -192,24 +188,18 @@ def validate_retention(
     last_dt = _parse_iso(pin.last_event_ts)
     elapsed = (current - last_dt).days
 
-    floor = (
-        round(HIGH_RISK_RETENTION_YEARS * 365.25)
-        if pin.risk_class == "high"
-        else MINIMUM_RETENTION_DAYS
-    )
+    floor = round(HIGH_RISK_RETENTION_YEARS * 365.25) if pin.risk_class == "high" else MINIMUM_RETENTION_DAYS
     if pin.retention_days < floor:
         return (
             False,
-            f"retention_days={pin.retention_days} below Article 12(3) "
-            f"floor of {floor} for risk_class={pin.risk_class}",
+            f"retention_days={pin.retention_days} below Article 12(3) floor of {floor} for risk_class={pin.risk_class}",
         )
 
     horizon = _parse_iso(pin.retention_until + "T00:00:00+00:00")
     if current >= horizon:
         return (
             False,
-            f"retention horizon {pin.retention_until} reached "
-            f"({elapsed}d since last event)",
+            f"retention horizon {pin.retention_until} reached ({elapsed}d since last event)",
         )
 
     return True, ""
@@ -294,9 +284,7 @@ def _build_data_catalog(events: list[_SourceEvent]) -> bytes:
         bucket[rid] = bucket.get(rid, 0) + 1
     payload = {
         "schema_version": BUNDLE_SCHEMA_VERSION,
-        "resources": {
-            rtype: dict(sorted(items.items())) for rtype, items in sorted(catalog.items())
-        },
+        "resources": {rtype: dict(sorted(items.items())) for rtype, items in sorted(catalog.items())},
         "total_events": len(events),
     }
     return _canonical_json(payload)
@@ -315,10 +303,7 @@ def _build_clause_map() -> bytes:
         "mappings": [
             {
                 "clause": "12(1)",
-                "requirement": (
-                    "Automatic recording of events ('logs') over the lifetime "
-                    "of the system."
-                ),
+                "requirement": ("Automatic recording of events ('logs') over the lifetime of the system."),
                 "artefact": "events.jsonl",
             },
             {
@@ -337,10 +322,7 @@ def _build_clause_map() -> bytes:
             },
             {
                 "clause": "12(2)(c)",
-                "requirement": (
-                    "Monitoring of the operation of high-risk AI systems "
-                    "referred to in Article 26(5)."
-                ),
+                "requirement": ("Monitoring of the operation of high-risk AI systems referred to in Article 26(5)."),
                 "artefact": "events.jsonl + chain_anchor in manifest.json",
             },
             {
@@ -406,9 +388,7 @@ def build_article12_bundle(
     clause_map = _build_clause_map()
 
     last_event_ts = events[-1].timestamp if events else since
-    chain_anchor = (
-        str(events[-1].raw.get("hmac", _GENESIS_HMAC)) if events else _GENESIS_HMAC
-    )
+    chain_anchor = str(events[-1].raw.get("hmac", _GENESIS_HMAC)) if events else _GENESIS_HMAC
     retention = compute_retention_pin(risk_class, last_event_ts)
 
     artefact_hashes = {

--- a/src/bernstein/core/security/article12_bundle.py
+++ b/src/bernstein/core/security/article12_bundle.py
@@ -1,0 +1,572 @@
+"""EU AI Act Article 12 evidence-pack generator.
+
+Article 12 of the EU AI Act (Regulation (EU) 2024/1689) requires high-risk
+AI systems to keep automatic event-logs, retain them at least 6 months
+and up to 10 years for high-risk classifications, and produce them on
+request for a conformity assessment.
+
+This module implements the smallest viable Article-12-conformant evidence
+pack:
+
+    bernstein audit export --article-12 \
+        --since ISO --until ISO [--output PATH] [--risk-class high|limited|minimal]
+
+The resulting bundle is:
+
+* **HMAC-chained** — the full audit log slice for the period, with each
+  entry's chain anchor preserved (verifiable by the existing
+  ``AuditLog.verify`` API or the standalone verifier shipped here).
+* **Deterministic** — the same input window produces a byte-identical
+  bundle on every run (sorted JSONL, fixed key order, no timestamps in
+  the bundle metadata that depend on wall-clock).
+* **Retention-pinned** — bundle metadata records the ``retention_until``
+  date matching Article 12(3): 10 years for high-risk systems, 6 months
+  minimum otherwise.
+* **Self-describing** — manifests for the input/output catalog (data
+  governance evidence per Article 10 / Annex IV §2(d)) and a clause map
+  showing which bundle artefact maps to which Article 12 sub-clause.
+
+Deferred (not in this slice; tracked in the originating ticket):
+
+* archival/storage layer (S3 Object Lock, immutable Postgres)
+* Agent Card ledger (depends on ``a2a-v1-signed-agent-card``)
+* full conformity-assessment paperwork (Article 43)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+#: Article 12(3) — high-risk AI systems must keep logs for the lifetime
+#: of the system *and* at least 10 years (Article 19(1)).  Bernstein
+#: pins 10 years as the default cap; operators can opt to keep longer.
+HIGH_RISK_RETENTION_YEARS: int = 10
+
+#: Article 12(3) — minimum retention for any AI system covered by
+#: Article 12 ("at least six months").
+MINIMUM_RETENTION_DAYS: int = 183  # half a calendar year, leap-safe lower bound
+
+#: Schema version emitted in the bundle manifest. Bump on any breaking
+#: change to artefact ordering, file names, or hash inputs.
+BUNDLE_SCHEMA_VERSION: str = "1.0.0"
+
+RiskClass = Literal["high", "limited", "minimal"]
+
+_GENESIS_HMAC = "0" * 64
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPin:
+    """Article 12(3) retention metadata for an evidence bundle.
+
+    Attributes:
+        risk_class: EU AI Act risk classification driving retention.
+        retention_days: Computed retention horizon in days.
+        retention_until: ISO-8601 date by which deletion is forbidden.
+        last_event_ts: ISO-8601 timestamp of the latest covered event.
+    """
+
+    risk_class: RiskClass
+    retention_days: int
+    retention_until: str
+    last_event_ts: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable view of this pin."""
+        return {
+            "risk_class": self.risk_class,
+            "retention_days": self.retention_days,
+            "retention_until": self.retention_until,
+            "last_event_ts": self.last_event_ts,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Article12Bundle:
+    """Result of an Article 12 evidence-pack export.
+
+    Attributes:
+        bundle_id: Stable hash over (since, until, risk_class) — the
+            deterministic identifier auditors can quote when referring
+            to a bundle.
+        since: Inclusive lower bound of the export window (ISO-8601).
+        until: Exclusive upper bound of the export window (ISO-8601).
+        risk_class: Risk classification driving retention pin.
+        event_count: Number of audit events in the bundle.
+        chain_anchor: HMAC of the last event in the period (or the
+            genesis sentinel when no events were captured).
+        retention: Article 12(3) retention metadata.
+        archive_path: On-disk path to the produced zip (``None`` when
+            ``write=False``).
+        sha256: SHA-256 of the produced zip's canonical contents.
+    """
+
+    bundle_id: str
+    since: str
+    until: str
+    risk_class: RiskClass
+    event_count: int
+    chain_anchor: str
+    retention: RetentionPin
+    archive_path: Path | None
+    sha256: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable view of this bundle's manifest."""
+        return {
+            "schema_version": BUNDLE_SCHEMA_VERSION,
+            "bundle_id": self.bundle_id,
+            "since": self.since,
+            "until": self.until,
+            "risk_class": self.risk_class,
+            "event_count": self.event_count,
+            "chain_anchor": self.chain_anchor,
+            "retention": self.retention.to_dict(),
+            "sha256": self.sha256,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Retention enforcement
+# ---------------------------------------------------------------------------
+
+
+def compute_retention_pin(
+    risk_class: RiskClass,
+    last_event_ts: str,
+) -> RetentionPin:
+    """Compute the Article 12(3) retention horizon for a bundle.
+
+    Args:
+        risk_class: EU AI Act risk class for the covered system.
+        last_event_ts: ISO-8601 timestamp of the last logged event.
+
+    Returns:
+        A :class:`RetentionPin` with the deletion horizon.
+
+    Raises:
+        ValueError: If ``last_event_ts`` is not parseable as ISO-8601.
+    """
+    last_dt = _parse_iso(last_event_ts)
+    if risk_class == "high":
+        # 10 years (Article 19(1)).  365.25 average accounts for leap years.
+        days = int(round(HIGH_RISK_RETENTION_YEARS * 365.25))
+    else:
+        days = MINIMUM_RETENTION_DAYS
+    until = (last_dt + timedelta(days=days)).date().isoformat()
+    return RetentionPin(
+        risk_class=risk_class,
+        retention_days=days,
+        retention_until=until,
+        last_event_ts=last_event_ts,
+    )
+
+
+def validate_retention(
+    pin: RetentionPin,
+    now: datetime | None = None,
+) -> tuple[bool, str]:
+    """Validate that a retention pin still satisfies Article 12(3).
+
+    Args:
+        pin: The retention pin attached to the bundle at export time.
+        now: Override clock for tests.  Defaults to UTC ``now``.
+
+    Returns:
+        ``(ok, reason)``.  ``ok`` is True when the deletion horizon is
+        in the future *and* the minimum retention floor is respected
+        for the risk class; ``reason`` is empty when ``ok`` is True.
+    """
+    current = now or datetime.now(tz=UTC)
+    last_dt = _parse_iso(pin.last_event_ts)
+    elapsed = (current - last_dt).days
+
+    floor = (
+        int(round(HIGH_RISK_RETENTION_YEARS * 365.25))
+        if pin.risk_class == "high"
+        else MINIMUM_RETENTION_DAYS
+    )
+    if pin.retention_days < floor:
+        return (
+            False,
+            f"retention_days={pin.retention_days} below Article 12(3) "
+            f"floor of {floor} for risk_class={pin.risk_class}",
+        )
+
+    horizon = _parse_iso(pin.retention_until + "T00:00:00+00:00")
+    if current >= horizon:
+        return (
+            False,
+            f"retention horizon {pin.retention_until} reached "
+            f"({elapsed}d since last event)",
+        )
+
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembler
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SourceEvent:
+    """Internal representation of an audit event read from disk."""
+
+    timestamp: str
+    raw: dict[str, Any]
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse an ISO-8601 string permissively, normalising trailing ``Z``."""
+    cleaned = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    return datetime.fromisoformat(cleaned)
+
+
+def _read_event_window(
+    audit_dir: Path,
+    since: str,
+    until: str,
+) -> list[_SourceEvent]:
+    """Read audit events from JSONL files within ``[since, until)``.
+
+    Args:
+        audit_dir: Directory of daily ``YYYY-MM-DD.jsonl`` audit files.
+        since: ISO-8601 lower bound (inclusive).
+        until: ISO-8601 upper bound (exclusive).
+
+    Returns:
+        Events sorted by ``timestamp`` then by their original chain
+        ``hmac`` to break ties deterministically.
+    """
+    events: list[_SourceEvent] = []
+    if not audit_dir.is_dir():
+        return events
+    for path in sorted(audit_dir.glob("*.jsonl")):
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = str(entry.get("timestamp", ""))
+            if not ts or ts < since or ts >= until:
+                continue
+            events.append(_SourceEvent(timestamp=ts, raw=entry))
+    events.sort(key=lambda e: (e.timestamp, str(e.raw.get("hmac", ""))))
+    return events
+
+
+def _build_event_log(events: list[_SourceEvent]) -> bytes:
+    """Serialise events as canonical JSONL (sorted keys, ``\\n`` newlines)."""
+    buf = io.BytesIO()
+    for ev in events:
+        line = json.dumps(ev.raw, sort_keys=True, separators=(",", ":"))
+        buf.write(line.encode("utf-8"))
+        buf.write(b"\n")
+    return buf.getvalue()
+
+
+def _build_data_catalog(events: list[_SourceEvent]) -> bytes:
+    """Build the input/output data-governance catalog (Article 12(1)(a)).
+
+    Aggregates per-resource activity counts so an auditor can see what
+    data classes were touched without scanning the raw log.
+    """
+    catalog: dict[str, dict[str, int]] = {}
+    for ev in events:
+        rtype = str(ev.raw.get("resource_type", "")) or "unknown"
+        rid = str(ev.raw.get("resource_id", "")) or "unknown"
+        bucket = catalog.setdefault(rtype, {})
+        bucket[rid] = bucket.get(rid, 0) + 1
+    payload = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "resources": {
+            rtype: dict(sorted(items.items())) for rtype, items in sorted(catalog.items())
+        },
+        "total_events": len(events),
+    }
+    return _canonical_json(payload)
+
+
+def _build_clause_map() -> bytes:
+    """Build the Article 12 conformance clause map.
+
+    Maps each artefact in the bundle to the Article 12 sub-clause it
+    addresses. Auditors use this to short-circuit their checklist.
+    """
+    payload = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "regulation": "EU AI Act, Regulation (EU) 2024/1689",
+        "article": 12,
+        "mappings": [
+            {
+                "clause": "12(1)",
+                "requirement": (
+                    "Automatic recording of events ('logs') over the lifetime "
+                    "of the system."
+                ),
+                "artefact": "events.jsonl",
+            },
+            {
+                "clause": "12(2)(a)",
+                "requirement": (
+                    "Identification of situations that may result in the AI "
+                    "system presenting a risk within the meaning of Article "
+                    "79(1) or in a substantial modification."
+                ),
+                "artefact": "events.jsonl (event_type, outcome fields)",
+            },
+            {
+                "clause": "12(2)(b)",
+                "requirement": "Facilitation of the post-market monitoring.",
+                "artefact": "data_catalog.json",
+            },
+            {
+                "clause": "12(2)(c)",
+                "requirement": (
+                    "Monitoring of the operation of high-risk AI systems "
+                    "referred to in Article 26(5)."
+                ),
+                "artefact": "events.jsonl + chain_anchor in manifest.json",
+            },
+            {
+                "clause": "12(3)",
+                "requirement": (
+                    "Logs kept for at least 6 months unless otherwise "
+                    "provided; 10 years for high-risk under Article 19(1)."
+                ),
+                "artefact": "manifest.json (retention block)",
+            },
+        ],
+        "deferred": [
+            "Agent Card ledger (depends on a2a-v1-signed-agent-card)",
+            "Storage backends (S3 Object Lock, immutable Postgres)",
+            "Article 43 conformity-assessment paperwork",
+        ],
+    }
+    return _canonical_json(payload)
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    """Serialise a dict as deterministic JSON suitable for hashing."""
+    return (json.dumps(payload, sort_keys=True, indent=2) + "\n").encode("utf-8")
+
+
+def _bundle_id(since: str, until: str, risk_class: str) -> str:
+    """Compute the deterministic bundle id."""
+    seed = f"{since}|{until}|{risk_class}".encode()
+    return hashlib.sha256(seed).hexdigest()[:32]
+
+
+def build_article12_bundle(
+    audit_dir: Path,
+    since: str,
+    until: str,
+    *,
+    risk_class: RiskClass = "limited",
+    output_dir: Path | None = None,
+    write: bool = True,
+) -> Article12Bundle:
+    """Assemble an Article 12 evidence pack for ``[since, until)``.
+
+    Args:
+        audit_dir: Directory containing HMAC-chained ``*.jsonl`` audit
+            log files (typically ``.sdd/audit``).
+        since: ISO-8601 inclusive lower bound.
+        until: ISO-8601 exclusive upper bound.
+        risk_class: EU AI Act risk classification driving retention.
+        output_dir: Where to write the bundle zip.  Defaults to
+            ``audit_dir.parent / 'evidence'`` (i.e. ``.sdd/evidence/``).
+        write: If False, build the bundle in-memory only and skip the
+            on-disk write — useful for ``--dry-run`` and tests.
+
+    Returns:
+        An :class:`Article12Bundle` describing the produced pack.
+    """
+    if since >= until:
+        raise ValueError(f"since={since!r} must be < until={until!r}")
+
+    events = _read_event_window(audit_dir, since, until)
+    event_log = _build_event_log(events)
+    data_catalog = _build_data_catalog(events)
+    clause_map = _build_clause_map()
+
+    last_event_ts = events[-1].timestamp if events else since
+    chain_anchor = (
+        str(events[-1].raw.get("hmac", _GENESIS_HMAC)) if events else _GENESIS_HMAC
+    )
+    retention = compute_retention_pin(risk_class, last_event_ts)
+
+    artefact_hashes = {
+        "events.jsonl": hashlib.sha256(event_log).hexdigest(),
+        "data_catalog.json": hashlib.sha256(data_catalog).hexdigest(),
+        "clause_map.json": hashlib.sha256(clause_map).hexdigest(),
+    }
+    manifest = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "bundle_id": _bundle_id(since, until, risk_class),
+        "since": since,
+        "until": until,
+        "risk_class": risk_class,
+        "event_count": len(events),
+        "chain_anchor": chain_anchor,
+        "retention": retention.to_dict(),
+        "artefacts": dict(sorted(artefact_hashes.items())),
+    }
+    manifest_bytes = _canonical_json(manifest)
+
+    archive_bytes = _zip_artefacts(
+        manifest_bytes=manifest_bytes,
+        event_log=event_log,
+        data_catalog=data_catalog,
+        clause_map=clause_map,
+    )
+    archive_sha256 = hashlib.sha256(archive_bytes).hexdigest()
+
+    archive_path: Path | None = None
+    if write:
+        target_dir = output_dir or (audit_dir.parent / "evidence")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = target_dir / f"article12_{manifest['bundle_id']}.zip"
+        archive_path.write_bytes(archive_bytes)
+
+    return Article12Bundle(
+        bundle_id=str(manifest["bundle_id"]),
+        since=since,
+        until=until,
+        risk_class=risk_class,
+        event_count=len(events),
+        chain_anchor=chain_anchor,
+        retention=retention,
+        archive_path=archive_path,
+        sha256=archive_sha256,
+    )
+
+
+def _zip_artefacts(
+    *,
+    manifest_bytes: bytes,
+    event_log: bytes,
+    data_catalog: bytes,
+    clause_map: bytes,
+) -> bytes:
+    """Pack all artefacts into a deterministic zip.
+
+    Determinism rules:
+
+    * Fixed file order (sorted).
+    * Fixed mtime (zip cannot store < 1980 so we use 1980-01-01).
+    * Stored mode 0644.
+    """
+    fixed_dt = (1980, 1, 1, 0, 0, 0)
+    files: tuple[tuple[str, bytes], ...] = tuple(
+        sorted(
+            (
+                ("manifest.json", manifest_bytes),
+                ("events.jsonl", event_log),
+                ("data_catalog.json", data_catalog),
+                ("clause_map.json", clause_map),
+            ),
+            key=lambda kv: kv[0],
+        )
+    )
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in files:
+            info = zipfile.ZipInfo(filename=name, date_time=fixed_dt)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            zf.writestr(info, payload)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Standalone verifier (used by the CLI; can also be invoked from a script)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VerificationResult:
+    """Outcome of verifying an Article 12 bundle.
+
+    Attributes:
+        ok: True iff every check passed.
+        errors: Per-check failure messages.
+        manifest: The parsed manifest, when readable.
+    """
+
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    manifest: dict[str, Any] = field(default_factory=dict)
+
+
+def verify_bundle(archive_path: Path, *, now: datetime | None = None) -> VerificationResult:
+    """Verify a bundle's manifest hashes and retention pin.
+
+    The check is intentionally narrow: it confirms (a) artefact hashes
+    in the manifest match the on-disk content and (b) the retention pin
+    still satisfies Article 12(3).  HMAC-chain verification of the
+    embedded ``events.jsonl`` requires the original key and is delegated
+    to :class:`bernstein.core.security.audit.AuditLog.verify` (or the
+    forthcoming standalone verifier script).
+
+    Args:
+        archive_path: Path to the produced bundle zip.
+        now: Override clock (for tests).
+
+    Returns:
+        A :class:`VerificationResult`.
+    """
+    errors: list[str] = []
+    manifest: dict[str, Any] = {}
+    try:
+        with zipfile.ZipFile(archive_path) as zf:
+            manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+            for name, expected in manifest.get("artefacts", {}).items():
+                got = hashlib.sha256(zf.read(name)).hexdigest()
+                if got != expected:
+                    errors.append(f"hash mismatch for {name}: {got!r} != {expected!r}")
+    except (KeyError, zipfile.BadZipFile, json.JSONDecodeError) as exc:
+        errors.append(f"failed to read bundle: {exc}")
+        return VerificationResult(ok=False, errors=errors, manifest=manifest)
+
+    retention = manifest.get("retention") or {}
+    if retention:
+        pin = RetentionPin(
+            risk_class=retention.get("risk_class", "limited"),
+            retention_days=int(retention.get("retention_days", 0)),
+            retention_until=str(retention.get("retention_until", "")),
+            last_event_ts=str(retention.get("last_event_ts", "")),
+        )
+        ok, reason = validate_retention(pin, now=now)
+        if not ok:
+            errors.append(f"retention check failed: {reason}")
+    else:
+        errors.append("manifest missing retention block")
+
+    return VerificationResult(ok=not errors, errors=errors, manifest=manifest)
+
+
+__all__ = [
+    "BUNDLE_SCHEMA_VERSION",
+    "HIGH_RISK_RETENTION_YEARS",
+    "MINIMUM_RETENTION_DAYS",
+    "Article12Bundle",
+    "RetentionPin",
+    "VerificationResult",
+    "build_article12_bundle",
+    "compute_retention_pin",
+    "validate_retention",
+    "verify_bundle",
+]

--- a/tests/unit/test_article12_bundle.py
+++ b/tests/unit/test_article12_bundle.py
@@ -1,0 +1,223 @@
+"""End-to-end fixture test for the EU AI Act Article 12 evidence pack.
+
+Builds a synthetic HMAC-chained audit log, generates a bundle through
+:func:`build_article12_bundle`, then verifies:
+
+* the bundle's manifest hashes match the on-disk artefact contents
+* the embedded ``events.jsonl`` HMAC chain validates against the original
+  ``AuditLog`` key
+* :func:`compute_retention_pin` produces correct horizons for each risk
+  class (Article 12(3) — 6-month minimum, 10-year for high-risk)
+* a second build of the same window is byte-identical (deterministic
+  export — required for spot-audit reproducibility)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from bernstein.core.security.article12_bundle import (
+    BUNDLE_SCHEMA_VERSION,
+    HIGH_RISK_RETENTION_YEARS,
+    MINIMUM_RETENTION_DAYS,
+    build_article12_bundle,
+    compute_retention_pin,
+    validate_retention,
+    verify_bundle,
+)
+from bernstein.core.security.audit import AuditLog
+
+
+def _seed_audit_log(audit_dir: Path) -> AuditLog:
+    """Populate ``audit_dir`` with three HMAC-chained events.
+
+    Args:
+        audit_dir: Directory to write the daily JSONL log into.
+
+    Returns:
+        The :class:`AuditLog` used to write the events (still tied to the
+        same key file via the default key-loader).
+    """
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=b"x" * 32)
+    log.log("task.created", "alice", "task", "T-1", {"role": "backend"})
+    log.log("agent.spawned", "orchestrator", "agent", "A-1", {"task": "T-1"})
+    log.log("task.completed", "alice", "task", "T-1", {"status": "ok"})
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Retention helper
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionPin:
+    """Article 12(3) retention math."""
+
+    def test_high_risk_pins_ten_years(self) -> None:
+        last_event_ts = "2026-08-01T00:00:00+00:00"
+        pin = compute_retention_pin("high", last_event_ts)
+        assert pin.risk_class == "high"
+        # 10 * 365.25 = 3652.5 → 3653 (round-half-to-even or up).
+        assert pin.retention_days >= HIGH_RISK_RETENTION_YEARS * 365
+        assert pin.retention_until.startswith("2036-")
+
+    def test_limited_pins_six_months(self) -> None:
+        pin = compute_retention_pin("limited", "2026-08-01T00:00:00+00:00")
+        assert pin.retention_days == MINIMUM_RETENTION_DAYS
+
+    def test_validate_rejects_below_floor(self) -> None:
+        last_event_ts = "2026-08-01T00:00:00+00:00"
+        bad = compute_retention_pin("limited", last_event_ts)
+        # Manually shrink retention_days to simulate tampering.
+        from dataclasses import replace
+
+        shrunk = replace(bad, retention_days=30)
+        ok, reason = validate_retention(
+            shrunk,
+            now=datetime(2026, 8, 2, tzinfo=UTC),
+        )
+        assert not ok
+        assert "below Article 12(3) floor" in reason
+
+    def test_validate_rejects_after_horizon(self) -> None:
+        pin = compute_retention_pin("limited", "2020-01-01T00:00:00+00:00")
+        ok, reason = validate_retention(pin, now=datetime(2026, 8, 1, tzinfo=UTC))
+        assert not ok
+        assert "horizon" in reason
+
+    def test_validate_passes_within_window(self) -> None:
+        pin = compute_retention_pin("high", "2026-08-01T00:00:00+00:00")
+        ok, reason = validate_retention(pin, now=datetime(2027, 1, 1, tzinfo=UTC))
+        assert ok, reason
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembler
+# ---------------------------------------------------------------------------
+
+
+class TestArticle12BundleE2E:
+    """Generate a tiny audit chain → export → verify."""
+
+    def test_build_then_verify(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        log = _seed_audit_log(audit_dir)
+        # Sanity: the chain we just produced must validate.
+        ok, errors = log.verify()
+        assert ok, errors
+
+        # Window covers all of today (UTC).
+        today = datetime.now(tz=UTC).date()
+        since = f"{today.isoformat()}T00:00:00+00:00"
+        until = f"{(today + timedelta(days=1)).isoformat()}T00:00:00+00:00"
+
+        output_dir = tmp_path / ".sdd" / "evidence"
+        bundle = build_article12_bundle(
+            audit_dir=audit_dir,
+            since=since,
+            until=until,
+            risk_class="high",
+            output_dir=output_dir,
+            write=True,
+        )
+
+        assert bundle.event_count == 3
+        assert bundle.archive_path is not None
+        assert bundle.archive_path.exists()
+        assert bundle.risk_class == "high"
+        assert bundle.chain_anchor != "0" * 64
+        # Retention horizon must be pinned ~10 years out.
+        expected_year_prefix = f"{today.year + HIGH_RISK_RETENTION_YEARS}"
+        assert bundle.retention.retention_until.startswith(expected_year_prefix)
+
+        # Verifier must approve the produced bundle.
+        result = verify_bundle(bundle.archive_path)
+        assert result.ok, result.errors
+        assert result.manifest["schema_version"] == BUNDLE_SCHEMA_VERSION
+        assert result.manifest["event_count"] == 3
+        assert result.manifest["chain_anchor"] == bundle.chain_anchor
+
+        # The events.jsonl extracted from the bundle must verify under
+        # the original AuditLog key — we replay it through a fresh
+        # AuditLog rooted at a tmp dir that holds only the slice.
+        replay_dir = tmp_path / "replay"
+        replay_dir.mkdir()
+        with zipfile.ZipFile(bundle.archive_path) as zf:
+            (replay_dir / f"{today.isoformat()}.jsonl").write_bytes(
+                zf.read("events.jsonl")
+            )
+        replay_log = AuditLog(replay_dir, key=b"x" * 32)
+        replay_ok, replay_errors = replay_log.verify()
+        assert replay_ok, replay_errors
+
+    def test_deterministic_byte_identical_rebuild(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_audit_log(audit_dir)
+        today = datetime.now(tz=UTC).date()
+        since = f"{today.isoformat()}T00:00:00+00:00"
+        until = f"{(today + timedelta(days=1)).isoformat()}T00:00:00+00:00"
+
+        first = build_article12_bundle(
+            audit_dir=audit_dir,
+            since=since,
+            until=until,
+            risk_class="limited",
+            output_dir=tmp_path / "out1",
+            write=True,
+        )
+        second = build_article12_bundle(
+            audit_dir=audit_dir,
+            since=since,
+            until=until,
+            risk_class="limited",
+            output_dir=tmp_path / "out2",
+            write=True,
+        )
+
+        assert first.bundle_id == second.bundle_id
+        assert first.sha256 == second.sha256
+        assert first.archive_path is not None
+        assert second.archive_path is not None
+        assert (
+            hashlib.sha256(first.archive_path.read_bytes()).hexdigest()
+            == hashlib.sha256(second.archive_path.read_bytes()).hexdigest()
+        )
+
+    def test_dry_run_does_not_write(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_audit_log(audit_dir)
+        today = datetime.now(tz=UTC).date()
+        since = f"{today.isoformat()}T00:00:00+00:00"
+        until = f"{(today + timedelta(days=1)).isoformat()}T00:00:00+00:00"
+        bundle = build_article12_bundle(
+            audit_dir=audit_dir,
+            since=since,
+            until=until,
+            risk_class="minimal",
+            output_dir=tmp_path / "out",
+            write=False,
+        )
+        assert bundle.archive_path is None
+        assert bundle.event_count == 3
+        assert bundle.sha256  # still computed from the in-memory bytes
+
+    def test_empty_window_safe(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        audit_dir.mkdir(parents=True)
+        bundle = build_article12_bundle(
+            audit_dir=audit_dir,
+            since="2026-08-01T00:00:00+00:00",
+            until="2026-08-02T00:00:00+00:00",
+            risk_class="limited",
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert bundle.event_count == 0
+        assert bundle.chain_anchor == "0" * 64
+        assert bundle.archive_path is not None
+        # Retention pin uses ``since`` as last-event proxy when window is empty.
+        assert bundle.retention.last_event_ts == "2026-08-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary

* New `bernstein.core.security.article12_bundle` — deterministic,
  retention-pinned EU AI Act Article 12 evidence-pack assembler. Emits
  HMAC-chained `events.jsonl`, `data_catalog.json`, `clause_map.json`,
  and `manifest.json` (with per-artefact SHA-256s).
* New `bernstein audit export --article-12 --since ISO --until ISO
  [--risk-class high|limited|minimal] [--dry-run]` CLI verb (added
  alongside the existing SOC 2 `--period` mode).
* Retention enforcer matches Article 12(3): 10 years for high-risk
  (Article 19(1)) and a 6-month floor otherwise; `validate_retention`
  rejects below-floor or past-horizon configurations.
* End-to-end fixture test seeds a synthetic HMAC chain, exports a
  bundle, replays the embedded slice through a fresh `AuditLog` to
  confirm the chain still verifies, and asserts byte-equal rebuilds
  on the same window.

## Deferred (per ticket scope)

* S3 Object Lock / immutable-Postgres / `chattr +i` storage backends
* Agent Card ledger (depends on `a2a-v1-signed-agent-card` ticket)
* Article 43 conformity-assessment paperwork
* Standalone pure-stdlib verifier *script* (in-process verifier shipped;
  the standalone script will be split out in a follow-up)

## Predecessor

Predecessor ticket `road-128-eu-ai-act-compliance-module` is already
in `.sdd/backlog/closed/`; this PR closes the Article 12 follow-on at
`.sdd/backlog/open/2026-05-07-feat-eu-ai-act-article-12-pack.md` and
moves it to `.sdd/backlog/closed/`. (`.sdd/` is gitignored, so the
move is local to operator workstations.)

## Test plan

- [x] `pytest tests/unit/test_article12_bundle.py` — 9/9 pass
- [x] `pytest tests/unit/test_eu_ai_act.py tests/unit/test_audit_export.py
      tests/unit/test_eu_ai_act_task_risk.py tests/unit/test_compliance.py`
      — 92/92 pass (no regression)
- [x] `bernstein audit export --help` shows both modes; SOC 2 mode
      unchanged when `--period` is used.
- [x] Smoke run: synthesised audit log → `build_article12_bundle` →
      `verify_bundle` returns `ok=True` with retention pinned to
      `2036-05-08` (10y / high-risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)