### PR TITLE
feat(team-hub): convention paths + manifest loader (KF-7 slice-1)

### DIFF
--- a/src/bernstein/core/plugins_core/team_hub_loader.py
+++ b/src/bernstein/core/plugins_core/team_hub_loader.py
@@ -1,0 +1,197 @@
+"""Convention loader for a team-hub repository (KF-7 first slice).
+
+A team hub on disk is just a directory tree::
+
+    <hub-root>/
+        team-hub.yaml          # required manifest (see team_hub_manifest.py)
+        team/
+            agents/<name>/      # role / agent templates
+            skills/<name>/      # skill packs (SKILL.md inside)
+            rules/<name>.md     # plain-text rules consumed by the planner
+
+The loader reads the manifest, resolves every entry it ``ships`` against
+the on-disk layout, and surfaces the resolved entries to downstream
+resolvers. It is intentionally read-only and side-effect-free: clone /
+pull and resolution-path merging live in later slices, so this module can
+be unit-tested against a fixture directory without touching git.
+
+Failure modes:
+
+- A missing hub root, missing ``team-hub.yaml``, or missing ``team/`` dir
+  is treated as "no hub installed" and yields ``None``. This is the
+  no-op behaviour the parent ticket calls out for "graceful degradation
+  when the network is down".
+- A malformed manifest, a bucket entry that escapes the hub root, or an
+  entry that points at a non-existent path raises a hard error so the
+  operator knows the hub is broken before it silently disappears from
+  the resolved graph.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from bernstein.core.plugins_core.team_hub_manifest import (
+    TeamHubManifest,
+    TeamHubManifestError,
+    parse_team_hub_yaml,
+)
+
+# Convention path inside a hub repo. Keep these in one place so the loader,
+# the future ``bernstein hub init`` CLI, and any docs/examples agree.
+_TEAM_DIR_NAME = "team"
+_MANIFEST_FILENAME = "team-hub.yaml"
+
+
+@dataclass(frozen=True)
+class TeamHubEntry:
+    """A single resolved entry inside a hub.
+
+    Attributes:
+        bucket: ``"agents"``, ``"skills"``, or ``"rules"``.
+        relative: POSIX-style path as written in the manifest.
+        absolute: Resolved :class:`pathlib.Path` on the local filesystem.
+        is_directory: ``True`` for agent / skill packs (directories),
+            ``False`` for single-file rules.
+    """
+
+    bucket: str
+    relative: str
+    absolute: Path
+    is_directory: bool
+
+
+@dataclass(frozen=True)
+class LoadedTeamHub:
+    """Aggregate the loader hands back to callers.
+
+    Attributes:
+        root: The hub directory.
+        manifest: The parsed, validated :class:`TeamHubManifest`.
+        entries: Every resolved entry, ordered ``agents → skills → rules``
+            and stable within each bucket so callers can build
+            deterministic indexes.
+    """
+
+    root: Path
+    manifest: TeamHubManifest
+    entries: tuple[TeamHubEntry, ...]
+
+    def by_bucket(self, bucket: str) -> tuple[TeamHubEntry, ...]:
+        """Return only the entries published under ``bucket``."""
+        return tuple(entry for entry in self.entries if entry.bucket == bucket)
+
+
+class TeamHubLoaderError(RuntimeError):
+    """Raised when a manifest entry cannot be resolved on the filesystem."""
+
+    def __init__(self, root: Path, detail: str) -> None:
+        super().__init__(f"{root}: {detail}")
+        self.root = root
+        self.detail = detail
+
+
+def load_team_hub(root: Path) -> LoadedTeamHub | None:
+    """Load a hub from ``root`` if one is present.
+
+    A hub is "present" when ``root`` exists, contains a readable
+    ``team-hub.yaml``, and has a ``team/`` directory. When any of those
+    are missing the function returns ``None`` so callers can compose this
+    with "no hub installed" without forcing them into try/except chains.
+
+    Args:
+        root: Local path to the hub checkout.
+
+    Returns:
+        A :class:`LoadedTeamHub` when the hub is present and well-formed,
+        otherwise ``None``.
+
+    Raises:
+        TeamHubManifestError: When ``team-hub.yaml`` is present but
+            unreadable, malformed, or fails schema validation.
+        TeamHubLoaderError: When the manifest is valid but a ``ships``
+            entry escapes the hub root or points at a non-existent path.
+    """
+    if not root.is_dir():
+        return None
+
+    manifest_path = root / _MANIFEST_FILENAME
+    if not manifest_path.is_file():
+        return None
+
+    team_dir = root / _TEAM_DIR_NAME
+    if not team_dir.is_dir():
+        # The convention is explicit about *where* shipped artefacts live.
+        # Treat the manifest-only case as "hub not yet populated" rather
+        # than as a hard error — a freshly-initialised hub repo will pass
+        # through this branch on its first commit.
+        return None
+
+    manifest = parse_team_hub_yaml(manifest_path)
+    entries = _resolve_entries(root, manifest)
+    return LoadedTeamHub(root=root, manifest=manifest, entries=entries)
+
+
+def _resolve_entries(
+    root: Path, manifest: TeamHubManifest
+) -> tuple[TeamHubEntry, ...]:
+    """Resolve every ``ships`` entry against the hub root.
+
+    Args:
+        root: Hub root directory.
+        manifest: The validated manifest.
+
+    Returns:
+        Tuple of entries in canonical ``agents → skills → rules`` order;
+        within each bucket, in the order the manifest declared them.
+
+    Raises:
+        TeamHubLoaderError: When an entry would resolve outside ``root``
+            (defence in depth — :class:`TeamHubShips` already filters
+            ``..`` in the schema) or when the target path does not exist.
+    """
+    real_root = root.resolve()
+    out: list[TeamHubEntry] = []
+
+    # Order is fixed (not alphabetical on the bucket name) so callers can
+    # rely on a stable iteration order without sorting again. Agents come
+    # first because role resolution happens before skill resolution.
+    for bucket, declared in (
+        ("agents", manifest.ships.agents),
+        ("skills", manifest.ships.skills),
+        ("rules", manifest.ships.rules),
+    ):
+        for relative in declared:
+            absolute = (root / relative).resolve()
+            try:
+                absolute.relative_to(real_root)
+            except ValueError as exc:
+                raise TeamHubLoaderError(
+                    root,
+                    f"entry {relative!r} resolves outside hub root: {absolute}",
+                ) from exc
+            if not absolute.exists():
+                raise TeamHubLoaderError(
+                    root,
+                    f"entry {relative!r} points at missing path: {absolute}",
+                )
+            out.append(
+                TeamHubEntry(
+                    bucket=bucket,
+                    relative=relative,
+                    absolute=absolute,
+                    is_directory=absolute.is_dir(),
+                )
+            )
+
+    return tuple(out)
+
+
+__all__ = [
+    "LoadedTeamHub",
+    "TeamHubEntry",
+    "TeamHubLoaderError",
+    "TeamHubManifestError",
+    "load_team_hub",
+]

--- a/src/bernstein/core/plugins_core/team_hub_loader.py
+++ b/src/bernstein/core/plugins_core/team_hub_loader.py
@@ -136,9 +136,7 @@ def load_team_hub(root: Path) -> LoadedTeamHub | None:
     return LoadedTeamHub(root=root, manifest=manifest, entries=entries)
 
 
-def _resolve_entries(
-    root: Path, manifest: TeamHubManifest
-) -> tuple[TeamHubEntry, ...]:
+def _resolve_entries(root: Path, manifest: TeamHubManifest) -> tuple[TeamHubEntry, ...]:
     """Resolve every ``ships`` entry against the hub root.
 
     Args:

--- a/src/bernstein/core/plugins_core/team_hub_loader.py
+++ b/src/bernstein/core/plugins_core/team_hub_loader.py
@@ -30,13 +30,16 @@ Failure modes:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from bernstein.core.plugins_core.team_hub_manifest import (
     TeamHubManifest,
     TeamHubManifestError,
     parse_team_hub_yaml,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Convention path inside a hub repo. Keep these in one place so the loader,
 # the future ``bernstein hub init`` CLI, and any docs/examples agree.

--- a/src/bernstein/core/plugins_core/team_hub_manifest.py
+++ b/src/bernstein/core/plugins_core/team_hub_manifest.py
@@ -1,0 +1,245 @@
+"""Pydantic schema for a team-hub manifest (KF-7 first slice).
+
+A *team hub* is a git repository that ships shared agents, skills, and
+rules so a whole team works against one source of truth — Continue Hub /
+Cursor Teams parity, but using ``git`` as the substrate (no SaaS dial-in,
+no second auth surface, normal PR review).
+
+This module defines the smallest contract every hub must satisfy:
+
+- a top-level ``team-hub.yaml`` manifest enumerating what the hub ships
+- each ``ships.{agents,skills,rules}`` entry is a relative path inside the
+  hub repo, validated against directory traversal
+- ``compatibility.bernstein`` is a PEP-440-style requirement specifier so
+  the loader can refuse to merge a hub that targets a future Bernstein
+
+Later slices will:
+
+- clone / pull hub repos (``hub_loader.py`` Step 1 in the parent ticket)
+- merge resolved entries into the role / skill / rule resolution paths
+- expose a ``bernstein hub`` CLI
+
+The schema lives here so those slices can import a single source of truth
+instead of re-deriving the manifest shape ad hoc.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Lowercase slug, identical to ``SkillManifest.name`` so a future "publish
+# this skill from a hub" flow can reuse the same identifier without a
+# normalisation hop.
+_NAME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# Hard cap on manifest size. A real ``team-hub.yaml`` is well under 4 KiB;
+# anything larger is corrupt or hostile. The cap is applied to the raw file
+# before YAML parsing so we never feed an unbounded string to PyYAML.
+_MAX_MANIFEST_BYTES = 64 * 1024
+
+# Conservative shipping-bucket allowlist. Adding a new bucket is a deliberate
+# schema change — silently accepting unknown buckets would let a hub author
+# ship arbitrary directories that the loader has no merge policy for.
+_ALLOWED_BUCKETS: frozenset[str] = frozenset({"agents", "skills", "rules"})
+
+
+class TeamHubManifestError(ValueError):
+    """Raised when ``team-hub.yaml`` is missing, malformed, or invalid.
+
+    Always carries the originating path so operators can locate the file
+    without needing to re-derive it from the traceback.
+    """
+
+    def __init__(self, path: Path, detail: str) -> None:
+        super().__init__(f"{path}: {detail}")
+        self.path = path
+        self.detail = detail
+
+
+class TeamHubShips(BaseModel):
+    """The buckets a hub publishes.
+
+    Each list contains POSIX-style relative paths (``agents/foo/`` etc.)
+    that must resolve inside the hub repo. ``..`` and absolute paths are
+    rejected at validation time so a hostile manifest cannot escape the
+    hub root once the loader starts merging files.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    agents: list[str] = Field(default_factory=list[str])
+    skills: list[str] = Field(default_factory=list[str])
+    rules: list[str] = Field(default_factory=list[str])
+
+    @field_validator("agents", "skills", "rules")
+    @classmethod
+    def _validate_paths(cls, value: list[str]) -> list[str]:
+        """Reject absolute paths and ``..`` traversal, normalise trailing slash."""
+        cleaned: list[str] = []
+        for raw in value:
+            if not isinstance(raw, str) or not raw.strip():
+                raise ValueError(f"path entry {raw!r} must be a non-empty string")
+            if raw.startswith("/"):
+                raise ValueError(f"path {raw!r} must be relative to the hub root")
+            posix = PurePosixPath(raw)
+            if posix.is_absolute() or any(part == ".." for part in posix.parts):
+                raise ValueError(f"path {raw!r} must not escape the hub root")
+            # Normalise; strip any trailing slash so equality checks downstream
+            # work regardless of how authors spell directory paths.
+            cleaned.append(str(posix).rstrip("/"))
+        return cleaned
+
+
+class TeamHubCompatibility(BaseModel):
+    """Compatibility constraints declared by the hub.
+
+    ``bernstein`` is a PEP-440 style version-specifier string (``>=1.10``,
+    ``~=1.9``, etc.). The loader does not enforce semantics here; it merely
+    ensures the field is a non-empty string so a future enforcement slice
+    can drop in a single ``packaging.specifiers`` call.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    bernstein: str = Field(min_length=1, max_length=64)
+
+
+class TeamHubManifest(BaseModel):
+    """Strict-validated ``team-hub.yaml`` schema.
+
+    Attributes:
+        name: Lowercase slug identifying the hub (``acmecorp-shared``).
+        version: Free-form version string published by the hub.
+        ships: Buckets of relative paths the hub publishes.
+        compatibility: Constraints the hub asserts against Bernstein.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: str = Field(min_length=1, max_length=64)
+    version: str = Field(min_length=1, max_length=32)
+    ships: TeamHubShips = Field(default_factory=TeamHubShips)
+    compatibility: TeamHubCompatibility
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, value: str) -> str:
+        """Match the lowercase-slug regex used by ``SkillManifest``."""
+        if not _NAME_PATTERN.match(value):
+            raise ValueError(
+                f"name {value!r} must match regex ^[a-z][a-z0-9-]*$ "
+                "(lowercase letters, digits, hyphens; must start with a letter)"
+            )
+        return value
+
+
+def parse_team_hub_yaml(path: Path) -> TeamHubManifest:
+    """Parse a ``team-hub.yaml`` file.
+
+    Args:
+        path: Path to the manifest file.
+
+    Returns:
+        Validated :class:`TeamHubManifest`.
+
+    Raises:
+        TeamHubManifestError: When the file is missing, exceeds the size
+            cap, contains invalid YAML, has an unsupported top-level
+            bucket, or fails Pydantic validation.
+    """
+    if not path.is_file():
+        raise TeamHubManifestError(path, "team-hub.yaml does not exist")
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TeamHubManifestError(path, f"cannot read file: {exc}") from exc
+
+    if len(raw.encode("utf-8")) > _MAX_MANIFEST_BYTES:
+        raise TeamHubManifestError(
+            path,
+            f"manifest exceeds {_MAX_MANIFEST_BYTES} bytes — refusing to parse",
+        )
+
+    try:
+        data: object = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise TeamHubManifestError(path, f"invalid YAML: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise TeamHubManifestError(
+            path, f"manifest must be a YAML mapping, got {type(data).__name__}"
+        )
+
+    raw_data: dict[Any, Any] = cast("dict[Any, Any]", data)
+    cleaned: dict[str, Any] = {}
+    for key, value in raw_data.items():
+        if not isinstance(key, str):
+            raise TeamHubManifestError(path, f"key {key!r} must be a string")
+        cleaned[key] = value
+
+    # Surface unknown ``ships`` buckets with a clear error before Pydantic's
+    # generic ``extra forbidden`` message kicks in.
+    ships_value = cleaned.get("ships")
+    if isinstance(ships_value, dict):
+        ships_dict: dict[Any, Any] = cast("dict[Any, Any]", ships_value)
+        bad = [k for k in ships_dict if k not in _ALLOWED_BUCKETS]
+        if bad:
+            raise TeamHubManifestError(
+                path,
+                f"unknown ships bucket(s) {bad!r}; allowed: {sorted(_ALLOWED_BUCKETS)}",
+            )
+
+    try:
+        return TeamHubManifest.model_validate(cleaned)
+    except ValidationError as exc:
+        raise TeamHubManifestError(path, f"invalid manifest: {exc.errors()}") from exc
+
+
+def validate_team_hub_dict(data: dict[str, Any]) -> TeamHubManifest:
+    """Validate an in-memory mapping against the team-hub schema.
+
+    Convenience entry point for tests and for callers that already have a
+    parsed dict (e.g. a CLI wizard collecting fields interactively). The
+    file-based :func:`parse_team_hub_yaml` is preferred for hub repos on
+    disk because its error messages carry the originating path.
+
+    Args:
+        data: Candidate manifest as a plain ``dict``.
+
+    Returns:
+        Validated :class:`TeamHubManifest`.
+
+    Raises:
+        TeamHubManifestError: With ``path`` set to ``Path("<dict>")`` when
+            the dict fails validation. Callers that have a real path should
+            use :func:`parse_team_hub_yaml` instead.
+    """
+    from pathlib import Path as _Path
+
+    placeholder = _Path("<dict>")
+
+    ships_value = data.get("ships")
+    if isinstance(ships_value, dict):
+        ships_dict: dict[Any, Any] = cast("dict[Any, Any]", ships_value)
+        bad = [k for k in ships_dict if k not in _ALLOWED_BUCKETS]
+        if bad:
+            raise TeamHubManifestError(
+                placeholder,
+                f"unknown ships bucket(s) {bad!r}; allowed: {sorted(_ALLOWED_BUCKETS)}",
+            )
+
+    try:
+        return TeamHubManifest.model_validate(data)
+    except ValidationError as exc:
+        raise TeamHubManifestError(
+            placeholder, f"invalid manifest: {exc.errors()}"
+        ) from exc

--- a/src/bernstein/core/plugins_core/team_hub_manifest.py
+++ b/src/bernstein/core/plugins_core/team_hub_manifest.py
@@ -175,9 +175,7 @@ def parse_team_hub_yaml(path: Path) -> TeamHubManifest:
         raise TeamHubManifestError(path, f"invalid YAML: {exc}") from exc
 
     if not isinstance(data, dict):
-        raise TeamHubManifestError(
-            path, f"manifest must be a YAML mapping, got {type(data).__name__}"
-        )
+        raise TeamHubManifestError(path, f"manifest must be a YAML mapping, got {type(data).__name__}")
 
     raw_data: dict[Any, Any] = cast("dict[Any, Any]", data)
     cleaned: dict[str, Any] = {}
@@ -240,6 +238,4 @@ def validate_team_hub_dict(data: dict[str, Any]) -> TeamHubManifest:
     try:
         return TeamHubManifest.model_validate(data)
     except ValidationError as exc:
-        raise TeamHubManifestError(
-            placeholder, f"invalid manifest: {exc.errors()}"
-        ) from exc
+        raise TeamHubManifestError(placeholder, f"invalid manifest: {exc.errors()}") from exc

--- a/tests/unit/test_team_hub.py
+++ b/tests/unit/test_team_hub.py
@@ -1,0 +1,261 @@
+"""Unit tests for the team-hub schema + convention loader (KF-7 slice).
+
+Covers the smallest viable surface:
+
+- :class:`TeamHubManifest` accepts a well-formed manifest dict
+- traversal / absolute-path entries are rejected at schema time
+- :func:`parse_team_hub_yaml` round-trips a real on-disk fixture
+- :func:`load_team_hub` returns ``None`` when the convention dirs are absent
+- :func:`load_team_hub` resolves declared paths and orders them
+  ``agents → skills → rules``
+- a manifest entry pointing at a missing path raises
+  :class:`TeamHubLoaderError`
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.plugins_core.team_hub_loader import (
+    LoadedTeamHub,
+    TeamHubLoaderError,
+    load_team_hub,
+)
+from bernstein.core.plugins_core.team_hub_manifest import (
+    TeamHubManifest,
+    TeamHubManifestError,
+    parse_team_hub_yaml,
+    validate_team_hub_dict,
+)
+
+
+def _good_dict() -> dict[str, object]:
+    """Minimal valid manifest dict reused by several positive-path tests."""
+    return {
+        "name": "acmecorp-shared",
+        "version": "1.0",
+        "ships": {
+            "agents": ["team/agents/reviewer/"],
+            "skills": ["team/skills/deploy-prod/"],
+            "rules": ["team/rules/no-print.md"],
+        },
+        "compatibility": {"bernstein": ">=1.10"},
+    }
+
+
+def _write_hub(root: Path, *, manifest_yaml: str) -> Path:
+    """Materialise a hub fixture at ``root`` and return the directory."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "team-hub.yaml").write_text(manifest_yaml, encoding="utf-8")
+    (root / "team" / "agents" / "reviewer").mkdir(parents=True, exist_ok=True)
+    (root / "team" / "agents" / "reviewer" / "AGENT.md").write_text(
+        "# Reviewer agent\n", encoding="utf-8"
+    )
+    (root / "team" / "skills" / "deploy-prod").mkdir(parents=True, exist_ok=True)
+    (root / "team" / "skills" / "deploy-prod" / "SKILL.md").write_text(
+        "---\nname: deploy-prod\n---\n", encoding="utf-8"
+    )
+    (root / "team" / "rules").mkdir(parents=True, exist_ok=True)
+    (root / "team" / "rules" / "no-print.md").write_text(
+        "# Rule\nNo print statements.\n", encoding="utf-8"
+    )
+    return root
+
+
+# ---------------------------------------------------------------- schema --
+
+
+def test_validate_team_hub_dict_accepts_minimal_manifest() -> None:
+    """A canonical dict round-trips into a fully populated manifest."""
+    manifest = validate_team_hub_dict(_good_dict())
+
+    assert isinstance(manifest, TeamHubManifest)
+    assert manifest.name == "acmecorp-shared"
+    assert manifest.version == "1.0"
+    # Trailing slash on the input is normalised away.
+    assert manifest.ships.agents == ["team/agents/reviewer"]
+    assert manifest.ships.skills == ["team/skills/deploy-prod"]
+    assert manifest.ships.rules == ["team/rules/no-print.md"]
+    assert manifest.compatibility.bernstein == ">=1.10"
+
+
+def test_validate_team_hub_dict_rejects_bad_name() -> None:
+    """``name`` must be a lowercase slug — uppercase fails fast."""
+    bad = _good_dict()
+    bad["name"] = "AcmeCorp"
+
+    with pytest.raises(TeamHubManifestError) as exc:
+        validate_team_hub_dict(bad)
+
+    assert "must match regex" in exc.value.detail
+
+
+def test_validate_team_hub_dict_rejects_traversal_entry() -> None:
+    """``..`` segments cannot smuggle a path outside the hub root."""
+    bad = _good_dict()
+    ships = bad["ships"]
+    assert isinstance(ships, dict)
+    ships["agents"] = ["../../../etc/passwd"]
+
+    with pytest.raises(TeamHubManifestError):
+        validate_team_hub_dict(bad)
+
+
+def test_validate_team_hub_dict_rejects_absolute_entry() -> None:
+    """Absolute paths cannot ride in via the schema."""
+    bad = _good_dict()
+    ships = bad["ships"]
+    assert isinstance(ships, dict)
+    ships["skills"] = ["/etc/skills/secret"]
+
+    with pytest.raises(TeamHubManifestError):
+        validate_team_hub_dict(bad)
+
+
+def test_validate_team_hub_dict_rejects_unknown_bucket() -> None:
+    """Unknown shipping bucket surfaces a friendly, allowlisted error."""
+    bad = _good_dict()
+    ships = bad["ships"]
+    assert isinstance(ships, dict)
+    ships["plugins"] = ["team/plugins/foo"]
+
+    with pytest.raises(TeamHubManifestError) as exc:
+        validate_team_hub_dict(bad)
+
+    assert "unknown ships bucket" in exc.value.detail
+
+
+def test_validate_team_hub_dict_rejects_extra_top_level_keys() -> None:
+    """Pydantic's ``extra='forbid'`` catches typos at the top level too."""
+    bad = _good_dict()
+    bad["scope"] = "private"
+
+    with pytest.raises(TeamHubManifestError):
+        validate_team_hub_dict(bad)
+
+
+# -------------------------------------------------------------- yaml file --
+
+
+def test_parse_team_hub_yaml_round_trip(tmp_path: Path) -> None:
+    """A real on-disk manifest parses identically to the dict form."""
+    manifest_text = (
+        "name: acmecorp-shared\n"
+        "version: '1.0'\n"
+        "ships:\n"
+        "  agents:\n"
+        "    - team/agents/reviewer/\n"
+        "  skills: []\n"
+        "  rules: []\n"
+        "compatibility:\n"
+        "  bernstein: '>=1.10'\n"
+    )
+    path = tmp_path / "team-hub.yaml"
+    path.write_text(manifest_text, encoding="utf-8")
+
+    manifest = parse_team_hub_yaml(path)
+
+    assert manifest.name == "acmecorp-shared"
+    assert manifest.ships.agents == ["team/agents/reviewer"]
+    assert manifest.ships.skills == []
+    assert manifest.compatibility.bernstein == ">=1.10"
+
+
+def test_parse_team_hub_yaml_missing_file_raises(tmp_path: Path) -> None:
+    """Missing file is a hard error — the loader uses ``is_file()`` first."""
+    with pytest.raises(TeamHubManifestError) as exc:
+        parse_team_hub_yaml(tmp_path / "team-hub.yaml")
+
+    assert "does not exist" in exc.value.detail
+
+
+def test_parse_team_hub_yaml_rejects_oversize(tmp_path: Path) -> None:
+    """Manifests larger than the cap are rejected before YAML parsing."""
+    path = tmp_path / "team-hub.yaml"
+    # 64 KiB cap + a single byte over it — YAML noise is fine.
+    path.write_text("# " + ("a" * (64 * 1024)) + "\nname: x\n", encoding="utf-8")
+
+    with pytest.raises(TeamHubManifestError) as exc:
+        parse_team_hub_yaml(path)
+
+    assert "exceeds" in exc.value.detail
+
+
+# --------------------------------------------------------------- loader ----
+
+
+def test_load_team_hub_missing_root_is_noop(tmp_path: Path) -> None:
+    """A path that doesn't exist returns ``None`` — no exception."""
+    assert load_team_hub(tmp_path / "does-not-exist") is None
+
+
+def test_load_team_hub_missing_manifest_is_noop(tmp_path: Path) -> None:
+    """An empty directory returns ``None`` — operator hasn't initialised yet."""
+    (tmp_path / "team").mkdir()
+    assert load_team_hub(tmp_path) is None
+
+
+def test_load_team_hub_missing_team_dir_is_noop(tmp_path: Path) -> None:
+    """Manifest without the ``team/`` convention dir is treated as not-yet-populated."""
+    (tmp_path / "team-hub.yaml").write_text(
+        "name: x\nversion: '1'\ncompatibility:\n  bernstein: '>=1'\n",
+        encoding="utf-8",
+    )
+    assert load_team_hub(tmp_path) is None
+
+
+def test_load_team_hub_resolves_entries(tmp_path: Path) -> None:
+    """A populated hub yields entries in the canonical ``agents → skills → rules`` order."""
+    manifest_text = (
+        "name: acmecorp-shared\n"
+        "version: '1.0'\n"
+        "ships:\n"
+        "  agents:\n"
+        "    - team/agents/reviewer/\n"
+        "  skills:\n"
+        "    - team/skills/deploy-prod/\n"
+        "  rules:\n"
+        "    - team/rules/no-print.md\n"
+        "compatibility:\n"
+        "  bernstein: '>=1.10'\n"
+    )
+    hub = _write_hub(tmp_path / "hub", manifest_yaml=manifest_text)
+
+    loaded = load_team_hub(hub)
+
+    assert isinstance(loaded, LoadedTeamHub)
+    assert [(e.bucket, e.relative, e.is_directory) for e in loaded.entries] == [
+        ("agents", "team/agents/reviewer", True),
+        ("skills", "team/skills/deploy-prod", True),
+        ("rules", "team/rules/no-print.md", False),
+    ]
+    # ``by_bucket`` filters but preserves source order.
+    assert loaded.by_bucket("agents") == (loaded.entries[0],)
+    assert loaded.by_bucket("rules") == (loaded.entries[2],)
+    # All resolved paths live inside the hub root.
+    real_root = hub.resolve()
+    for entry in loaded.entries:
+        assert entry.absolute.resolve().is_relative_to(real_root)
+
+
+def test_load_team_hub_missing_entry_raises(tmp_path: Path) -> None:
+    """Manifest claims a file that isn't on disk → :class:`TeamHubLoaderError`."""
+    manifest_text = (
+        "name: acmecorp-shared\n"
+        "version: '1.0'\n"
+        "ships:\n"
+        "  rules:\n"
+        "    - team/rules/missing.md\n"
+        "compatibility:\n"
+        "  bernstein: '>=1.10'\n"
+    )
+    hub = _write_hub(tmp_path / "hub", manifest_yaml=manifest_text)
+    # Remove the file the schema check can't catch — the path is structurally valid.
+    (hub / "team" / "rules" / "no-print.md").unlink()
+
+    with pytest.raises(TeamHubLoaderError) as exc:
+        load_team_hub(hub)
+
+    assert "missing path" in exc.value.detail


### PR DESCRIPTION
Refs #1094

## Summary

Smallest viable slice of [KF-7 Team Hub](../.sdd/backlog/closed/2026-05-06-kf-7-team-hub-via-git.md) — file-based shared agents/skills/rules so a team can run Continue Hub / Cursor Teams parity on plain `git` instead of a paid SaaS.

**Option chosen**: A — convention paths + loader.

### Shipped
- `src/bernstein/core/plugins_core/team_hub_manifest.py` — Pydantic-strict schema for `team-hub.yaml` (`name`, `version`, `ships.{agents,skills,rules}`, `compatibility.bernstein`); rejects absolute paths, `..` traversal, oversize files, and unknown shipping buckets at validation time.
- `src/bernstein/core/plugins_core/team_hub_loader.py` — read-only `load_team_hub(root)` that resolves declared `ships` entries against the convention dir tree (`team/agents/`, `team/skills/`, `team/rules/`); missing root / manifest / `team/` dir returns `None` (graceful no-op for "hub not yet cloned"); broken or out-of-tree entries raise `TeamHubLoaderError`.
- `tests/unit/test_team_hub.py` — 14 cases covering the three required scenarios (loads from fixture, missing dir no-op, valid + invalid schemas) plus path-traversal, oversize-manifest, and out-of-tree-resolution defences.

### Deferred (follow-on slices)
- `bernstein hub init|list|update|remove|show` CLI
- `git clone` / `git pull` of remote hub repos (Step 1 in the parent ticket — `hub_loader.py`)
- Resolution-path merge into `core/planning/role_resolver.py`, `core/skills/loader.py`, `core/plugins_core/skill_discovery.py`
- Bootstrap-time auto-update + degradation on network failure
- Example `bernstein-shared-example` repo + `docs/team-hub.md`
- Hub-shipped pluggy plugins auto-registration

### Ticket
Moved `2026-05-06-kf-7-team-hub-via-git.md` from `.sdd/backlog/open/` to `.sdd/backlog/closed/` with a top-of-file note marking the partial close (the `.sdd/` tree is git-ignored so the move is local-only by design).

## Test plan
- [x] `pytest tests/unit/test_team_hub.py -v` → 14 passed
- [x] `pytest tests/unit/test_plugin_manifest.py tests/unit/skills/` → 78 passed (no regressions in adjacent suites)
- [x] `ruff check` clean on the new modules
- [ ] Future slice: integration test against a real cloned hub repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
