### PR TITLE
feat(whiteboard): per-run shared whiteboard primitive (slice)

### DIFF
--- a/src/bernstein/core/communication/whiteboard.py
+++ b/src/bernstein/core/communication/whiteboard.py
@@ -1,0 +1,370 @@
+"""Per-run shared whiteboard primitive (smallest-viable slice).
+
+A *whiteboard* is a per-run, append-only JSONL log that any agent in
+the run can write to and read back. This module ships the foundation
+the larger ticket calls for — append + filtered-read + schema
+validation — without the conflict-resolution machinery, MCP wiring,
+or watcher integration. Those remain explicitly deferred (see
+``2026-05-07-feat-multi-agent-shared-whiteboard.md`` follow-ups).
+
+Design notes
+------------
+
+* Append-only at the line granularity — POSIX append semantics give
+  us per-line atomicity below ``PIPE_BUF`` (per
+  ``atomic_write.py``'s discussion); a process-local
+  :class:`threading.Lock` plus an ``fcntl.LOCK_EX`` advisory lock
+  keep multi-thread *and* multi-process appends linearised.
+* Read-time visibility filter — the writer declares a list of role
+  names that may read the entry. Readers pass their role; entries
+  whose ``visibility`` does not include that role are skipped.
+  Empty visibility means "public to the run".
+* No conflict resolution — overlapping subjects are preserved as
+  separate entries; ordering follows the file. ``last-write-wins``
+  / ``merge-union`` / ``human-review`` strategies are deferred.
+* No HMAC envelope yet — ``audit.py`` integration is a later slice.
+* Off-by-default — nothing wires this into the orchestrator. Callers
+  opt in by constructing a :class:`Whiteboard` directly.
+
+Schema
+------
+
+Each line is a JSON object with the keys validated by
+:func:`_validate_entry`::
+
+    {
+        "key": str,
+        "scope": str,
+        "value": <any JSON>,
+        "owner_agent_id": str,
+        "visibility": [<role>, ...],
+        "ts_ns": int,
+    }
+
+``visibility=[]`` means the entry is readable by every role.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Public role label that overrides per-entry visibility — a reader
+# whose role is "*" is treated as "see everything", useful for
+# orchestrator-side debugging utilities. Regular agents should always
+# pass a concrete role string.
+WILDCARD_ROLE = "*"
+
+_WHITEBOARD_FILENAME = "whiteboard.jsonl"
+
+
+@dataclass(frozen=True, slots=True)
+class WhiteboardEntry:
+    """Single immutable record on the whiteboard.
+
+    Attributes:
+        key: Logical name within ``scope`` (e.g. ``"api_contract"``).
+        scope: Bucket label, free-form (e.g. ``"backend"``).
+        value: JSON-serialisable payload.
+        owner_agent_id: Identifier of the writing agent.
+        visibility: Roles that may read the entry. Empty tuple means
+            the entry is public within the run.
+        ts_ns: Nanosecond timestamp from :func:`time.time_ns`. Useful
+            for deterministic ordering in tests.
+    """
+
+    key: str
+    scope: str
+    value: Any
+    owner_agent_id: str
+    visibility: tuple[str, ...] = ()
+    ts_ns: int = field(default_factory=time.time_ns)
+
+    def to_json_line(self) -> str:
+        """Serialise to a single JSON line (no trailing newline)."""
+        return json.dumps(
+            {
+                "key": self.key,
+                "scope": self.scope,
+                "value": self.value,
+                "owner_agent_id": self.owner_agent_id,
+                "visibility": list(self.visibility),
+                "ts_ns": self.ts_ns,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> WhiteboardEntry:
+        """Build an entry from a parsed JSON dict.
+
+        Performs the same shape validation as the writer would so
+        out-of-band edits cannot smuggle malformed records back in.
+
+        Raises:
+            ValueError: If *raw* is missing required fields or has
+                values of the wrong type.
+        """
+        _validate_entry(raw)
+        return cls(
+            key=raw["key"],
+            scope=raw["scope"],
+            value=raw["value"],
+            owner_agent_id=raw["owner_agent_id"],
+            visibility=tuple(raw.get("visibility", ()) or ()),
+            ts_ns=int(raw["ts_ns"]),
+        )
+
+
+def _validate_entry(raw: dict[str, Any]) -> None:
+    """Raise ``ValueError`` if *raw* is not a well-formed entry.
+
+    Validation is intentionally loose — we accept any JSON-serialisable
+    ``value`` — but the structural keys must be the right type so a
+    downstream consumer never has to defensively coerce them.
+    """
+    required = {"key", "scope", "value", "owner_agent_id", "ts_ns"}
+    missing = required - raw.keys()
+    if missing:
+        raise ValueError(f"whiteboard entry missing fields: {sorted(missing)}")
+    for str_field in ("key", "scope", "owner_agent_id"):
+        if not isinstance(raw[str_field], str) or not raw[str_field]:
+            raise ValueError(
+                f"whiteboard entry '{str_field}' must be a non-empty string",
+            )
+    if not isinstance(raw["ts_ns"], int):
+        raise ValueError("whiteboard entry 'ts_ns' must be an int")
+    visibility = raw.get("visibility", [])
+    if visibility is None:
+        return
+    if not isinstance(visibility, list) or any(
+        not isinstance(item, str) for item in visibility
+    ):
+        raise ValueError("whiteboard entry 'visibility' must be a list of strings")
+
+
+class Whiteboard:
+    """Append-only JSONL whiteboard for a single run.
+
+    The whiteboard lives at ``<root>/<run_id>/whiteboard.jsonl``.
+    Concurrent writers are linearised via a per-instance lock plus a
+    POSIX advisory lock on the file handle, which is a cheap way to
+    keep multi-process tests deterministic without pulling in a real
+    coordination service.
+
+    Example:
+        >>> wb = Whiteboard(root, run_id="run-1")
+        >>> wb.append(WhiteboardEntry(
+        ...     key="api_contract",
+        ...     scope="backend",
+        ...     value={"version": 1},
+        ...     owner_agent_id="agent-backend-1",
+        ...     visibility=("backend", "qa"),
+        ... ))
+        >>> entries = wb.read(reader_role="qa")
+    """
+
+    def __init__(self, root: Path, run_id: str) -> None:
+        """Bind the whiteboard to ``<root>/<run_id>/whiteboard.jsonl``.
+
+        Args:
+            root: Directory that hosts per-run subfolders. Conventionally
+                ``.bernstein/runs`` inside the active workspace, but the
+                caller chooses — nothing in this module assumes the
+                Bernstein path layout, which keeps it usable from tests
+                and from one-off scripts.
+            run_id: Identifier for the current run. Must not contain
+                path separators; we still defensively reject them.
+        """
+        if "/" in run_id or "\\" in run_id or run_id in {"", ".", ".."}:
+            raise ValueError(f"invalid run_id: {run_id!r}")
+        self._run_dir = root / run_id
+        self._path = self._run_dir / _WHITEBOARD_FILENAME
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        """Filesystem path to the underlying JSONL file."""
+        return self._path
+
+    def append(self, entry: WhiteboardEntry) -> None:
+        """Append *entry* as a single JSON line.
+
+        Concurrent writers from the same process are serialised by
+        ``self._lock``; cross-process writers contend for ``LOCK_EX``
+        on the file descriptor. The append is followed by ``fsync`` to
+        keep the on-disk record durable.
+        """
+        line = entry.to_json_line() + "\n"
+        with self._lock:
+            self._run_dir.mkdir(parents=True, exist_ok=True)
+            # 0o600 — consistent with atomic_write defaults; runtime state
+            # may carry task metadata that should not be world-readable.
+            fd = os.open(
+                str(self._path),
+                os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                0o600,
+            )
+            try:
+                _flock_exclusive(fd)
+                try:
+                    os.write(fd, line.encode("utf-8"))
+                    with contextlib.suppress(OSError):
+                        os.fsync(fd)
+                finally:
+                    _flock_release(fd)
+            finally:
+                os.close(fd)
+
+    def read(
+        self,
+        reader_role: str,
+        *,
+        scope: str | None = None,
+        key: str | None = None,
+    ) -> list[WhiteboardEntry]:
+        """Return entries visible to *reader_role*, optionally filtered.
+
+        Args:
+            reader_role: Role label of the reading agent. Pass
+                :data:`WILDCARD_ROLE` to bypass the visibility filter
+                (only orchestrator-side debugging should do this).
+            scope: If set, only return entries from this scope.
+            key: If set, only return entries whose ``key`` matches.
+
+        Returns:
+            Entries in file order — i.e. write order, since each line
+            is appended atomically. Malformed lines are skipped and
+            logged at warning level so a single bad record does not
+            poison every reader.
+        """
+        if not self._path.exists():
+            return []
+        with self._path.open("r", encoding="utf-8") as fh:
+            return list(self._iter_filtered(fh, reader_role, scope, key))
+
+    def iter_visible(
+        self,
+        reader_role: str,
+        *,
+        scope: str | None = None,
+        key: str | None = None,
+    ) -> Iterator[WhiteboardEntry]:
+        """Stream visible entries one at a time.
+
+        Useful when the whiteboard grows beyond what callers want to
+        materialise at once. Same semantics as :meth:`read`, just
+        lazy.
+        """
+        if not self._path.exists():
+            return iter(())
+        # The file is opened eagerly so the descriptor lifetime is
+        # bound to the iterator generator; closing happens when the
+        # generator is exhausted or garbage-collected.
+        fh = self._path.open("r", encoding="utf-8")
+        try:
+            yield from self._iter_filtered(fh, reader_role, scope, key)
+        finally:
+            fh.close()
+
+    def _iter_filtered(
+        self,
+        fh: Iterable[str],
+        reader_role: str,
+        scope: str | None,
+        key: str | None,
+    ) -> Iterator[WhiteboardEntry]:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+                entry = WhiteboardEntry.from_dict(payload)
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.warning(
+                    "skipping malformed whiteboard line in %s: %s",
+                    self._path,
+                    exc,
+                )
+                continue
+            if scope is not None and entry.scope != scope:
+                continue
+            if key is not None and entry.key != key:
+                continue
+            if not _is_visible(entry, reader_role):
+                continue
+            yield entry
+
+
+def _is_visible(entry: WhiteboardEntry, reader_role: str) -> bool:
+    """Return whether *reader_role* may see *entry*.
+
+    Visibility rules:
+
+    * Empty ``visibility`` list — entry is public within the run.
+    * ``reader_role == WILDCARD_ROLE`` — bypass filter.
+    * Otherwise the role must appear in ``entry.visibility``.
+
+    The owning agent does not get an automatic free pass on the
+    grounds that visibility is *the* place to encode "this entry is
+    private", and a writer that wants to keep the record visible to
+    itself should add its own role to ``visibility`` explicitly. That
+    keeps the rule stateless and easy to reason about in tests.
+    """
+    if reader_role == WILDCARD_ROLE:
+        return True
+    if not entry.visibility:
+        return True
+    return reader_role in entry.visibility
+
+
+def _flock_exclusive(fd: int) -> None:
+    """Best-effort exclusive advisory lock on *fd*.
+
+    On platforms without :mod:`fcntl` (Windows) we fall through
+    silently; the per-instance threading lock still serialises writers
+    inside one process.
+    """
+    try:
+        import fcntl  # platform-conditional import
+    except ImportError:
+        return
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError as exc:
+        if exc.errno in {errno.EINVAL, errno.ENOLCK, errno.ENOTSUP}:
+            logger.debug("flock not supported on this fd: %s", exc)
+            return
+        raise
+
+
+def _flock_release(fd: int) -> None:
+    """Release the advisory lock acquired by :func:`_flock_exclusive`."""
+    try:
+        import fcntl
+    except ImportError:
+        return
+    with contextlib.suppress(OSError):
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+__all__ = [
+    "WILDCARD_ROLE",
+    "Whiteboard",
+    "WhiteboardEntry",
+]

--- a/src/bernstein/core/communication/whiteboard.py
+++ b/src/bernstein/core/communication/whiteboard.py
@@ -151,9 +151,7 @@ def _validate_entry(raw: dict[str, Any]) -> None:
     visibility = raw.get("visibility", [])
     if visibility is None:
         return
-    if not isinstance(visibility, list) or any(
-        not isinstance(item, str) for item in visibility
-    ):
+    if not isinstance(visibility, list) or any(not isinstance(item, str) for item in visibility):
         raise ValueError("whiteboard entry 'visibility' must be a list of strings")
 
 

--- a/tests/unit/test_whiteboard.py
+++ b/tests/unit/test_whiteboard.py
@@ -1,0 +1,218 @@
+"""Unit tests for the whiteboard primitive (smallest-viable slice).
+
+Covers:
+
+* round-trip append + read
+* multiple writers, file-order preservation
+* per-agent visibility filter at read time
+* malformed-line resilience
+* schema validation on ``from_dict``
+* run_id sanitisation
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.communication.whiteboard import (
+    WILDCARD_ROLE,
+    Whiteboard,
+    WhiteboardEntry,
+)
+
+
+def _make_entry(**overrides: object) -> WhiteboardEntry:
+    """Build an entry with sensible defaults for each test."""
+    base: dict[str, object] = {
+        "key": "api_contract",
+        "scope": "backend",
+        "value": {"version": 1},
+        "owner_agent_id": "agent-backend-1",
+        "visibility": ("backend",),
+    }
+    base.update(overrides)
+    return WhiteboardEntry(**base)  # type: ignore[arg-type]
+
+
+def test_append_and_read_round_trip(tmp_path: Path) -> None:
+    """A single writer's entry round-trips through the file."""
+    wb = Whiteboard(tmp_path, run_id="run-1")
+    entry = _make_entry()
+
+    wb.append(entry)
+    rows = wb.read(reader_role="backend")
+
+    assert len(rows) == 1
+    assert rows[0].key == "api_contract"
+    assert rows[0].scope == "backend"
+    assert rows[0].value == {"version": 1}
+    assert rows[0].owner_agent_id == "agent-backend-1"
+    assert rows[0].visibility == ("backend",)
+    assert rows[0].ts_ns > 0
+
+
+def test_append_creates_run_dir_lazily(tmp_path: Path) -> None:
+    """Run directory is created on first append, not on construction."""
+    wb = Whiteboard(tmp_path, run_id="run-deferred")
+    assert not (tmp_path / "run-deferred").exists()
+
+    wb.append(_make_entry())
+
+    assert (tmp_path / "run-deferred" / "whiteboard.jsonl").exists()
+
+
+def test_read_before_any_append_returns_empty(tmp_path: Path) -> None:
+    """Reading from a fresh whiteboard returns an empty list, not an error."""
+    wb = Whiteboard(tmp_path, run_id="run-empty")
+
+    assert wb.read(reader_role="backend") == []
+
+
+def test_visibility_filter_hides_unallowed_roles(tmp_path: Path) -> None:
+    """A role outside ``visibility`` cannot read the entry."""
+    wb = Whiteboard(tmp_path, run_id="run-vis")
+    wb.append(_make_entry(visibility=("backend",)))
+
+    qa_view = wb.read(reader_role="qa")
+    backend_view = wb.read(reader_role="backend")
+
+    assert qa_view == []
+    assert len(backend_view) == 1
+
+
+def test_visibility_empty_means_public(tmp_path: Path) -> None:
+    """Empty ``visibility`` makes the entry public to every reader."""
+    wb = Whiteboard(tmp_path, run_id="run-pub")
+    wb.append(_make_entry(visibility=()))
+
+    assert len(wb.read(reader_role="qa")) == 1
+    assert len(wb.read(reader_role="backend")) == 1
+    assert len(wb.read(reader_role="anything-goes")) == 1
+
+
+def test_wildcard_role_bypasses_filter(tmp_path: Path) -> None:
+    """Reader role ``"*"`` sees every entry (orchestrator/debug use)."""
+    wb = Whiteboard(tmp_path, run_id="run-star")
+    wb.append(_make_entry(visibility=("backend",)))
+    wb.append(_make_entry(key="other", visibility=("qa",)))
+
+    assert len(wb.read(reader_role=WILDCARD_ROLE)) == 2
+
+
+def test_filter_by_scope_and_key(tmp_path: Path) -> None:
+    """``scope`` and ``key`` arguments narrow the result set."""
+    wb = Whiteboard(tmp_path, run_id="run-filter")
+    wb.append(_make_entry(scope="backend", key="api"))
+    wb.append(_make_entry(scope="backend", key="schema"))
+    wb.append(_make_entry(scope="frontend", key="api"))
+
+    backend_only = wb.read(reader_role=WILDCARD_ROLE, scope="backend")
+    api_only = wb.read(reader_role=WILDCARD_ROLE, key="api")
+
+    assert {e.key for e in backend_only} == {"api", "schema"}
+    assert {e.scope for e in api_only} == {"backend", "frontend"}
+
+
+def test_two_agents_writing_same_run_preserves_all_entries(tmp_path: Path) -> None:
+    """Concurrent in-process writers all land; file order matches lock order."""
+    wb = Whiteboard(tmp_path, run_id="run-multi")
+    n_writers = 8
+    entries_per_writer = 5
+    barrier = threading.Barrier(n_writers)
+
+    def _worker(agent_id: str) -> None:
+        barrier.wait()
+        for i in range(entries_per_writer):
+            wb.append(
+                _make_entry(
+                    key=f"key-{i}",
+                    owner_agent_id=agent_id,
+                    visibility=(),
+                ),
+            )
+
+    with ThreadPoolExecutor(max_workers=n_writers) as pool:
+        for idx in range(n_writers):
+            pool.submit(_worker, f"agent-{idx}")
+
+    rows = wb.read(reader_role=WILDCARD_ROLE)
+    assert len(rows) == n_writers * entries_per_writer
+
+    owners = {row.owner_agent_id for row in rows}
+    assert owners == {f"agent-{idx}" for idx in range(n_writers)}
+
+
+def test_malformed_line_is_skipped_with_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A bad JSONL line is logged + skipped rather than raising."""
+    wb = Whiteboard(tmp_path, run_id="run-bad")
+    wb.append(_make_entry())
+    # Inject a junk line directly so we know the reader is resilient
+    # against out-of-band edits or partial writes that slipped past
+    # ``LOCK_EX`` (e.g. a crashed cross-process writer).
+    with wb.path.open("a", encoding="utf-8") as fh:
+        fh.write("{not json\n")
+        fh.write(json.dumps({"key": "k", "scope": "s"}) + "\n")
+
+    caplog.set_level("WARNING")
+    rows = wb.read(reader_role=WILDCARD_ROLE)
+
+    assert len(rows) == 1
+    warnings = [rec for rec in caplog.records if rec.levelname == "WARNING"]
+    assert len(warnings) == 2  # one per malformed line
+
+
+def test_iter_visible_streams_entries(tmp_path: Path) -> None:
+    """``iter_visible`` yields the same entries as ``read``."""
+    wb = Whiteboard(tmp_path, run_id="run-iter")
+    wb.append(_make_entry(key="a"))
+    wb.append(_make_entry(key="b"))
+    wb.append(_make_entry(key="c", visibility=("qa",)))
+
+    streamed = list(wb.iter_visible(reader_role="backend"))
+
+    assert {e.key for e in streamed} == {"a", "b"}
+
+
+def test_from_dict_rejects_missing_fields() -> None:
+    """Schema validation rejects entries missing required keys."""
+    with pytest.raises(ValueError, match="missing fields"):
+        WhiteboardEntry.from_dict({"key": "k", "scope": "s"})
+
+
+def test_from_dict_rejects_wrong_visibility_type() -> None:
+    """Visibility must be a list of strings or absent."""
+    with pytest.raises(ValueError, match="visibility"):
+        WhiteboardEntry.from_dict(
+            {
+                "key": "k",
+                "scope": "s",
+                "value": 1,
+                "owner_agent_id": "a",
+                "ts_ns": 1,
+                "visibility": "backend",
+            },
+        )
+
+
+def test_invalid_run_id_rejected(tmp_path: Path) -> None:
+    """Path-traversal flavoured ``run_id`` values are rejected up-front."""
+    for bad in ("..", "a/b", "a\\b", ""):
+        with pytest.raises(ValueError, match="run_id"):
+            Whiteboard(tmp_path, run_id=bad)
+
+
+def test_to_json_line_round_trip() -> None:
+    """to_json_line / from_dict is loss-less for the schema fields."""
+    entry = _make_entry(visibility=("backend", "qa"))
+
+    parsed = WhiteboardEntry.from_dict(json.loads(entry.to_json_line()))
+
+    assert parsed == entry


### PR DESCRIPTION
Refs #1093

## Summary

Smallest-viable slice (Option A) of `.sdd/backlog/2026-05-07-feat-multi-agent-shared-whiteboard.md` — research-named "unsolved problem" — landing the foundation, not a full solution.

## Shipped

- `src/bernstein/core/communication/whiteboard.py`
  - Append-only JSONL whiteboard at `<root>/<run_id>/whiteboard.jsonl`
  - Read-time visibility filter (writers tag entries with allowed reader roles; `[]` = public; `"*"` reader bypasses, for orchestrator/debug paths)
  - Cross-thread + cross-process linearisation via `threading.Lock` + `fcntl.LOCK_EX`; per-line POSIX append atomicity
  - Schema validation on every parse, malformed-line resilience (logged + skipped)
  - `WhiteboardEntry` (frozen dataclass), `Whiteboard.append/read/iter_visible`
- `tests/unit/test_whiteboard.py` — 14 unit tests covering round-trip, **N=8 concurrent writers**, visibility filter, schema validation, malformed-line resilience, `run_id` sanitisation, JSON round-trip
- Ticket moved `.sdd/backlog/open/` → `.sdd/backlog/closed/` with closing note (`.sdd/` is gitignored, so the move isn't in the diff)

## Deferred (tracked in follow-ups)

- Conflict-resolution strategies — `last-write-wins` / `merge-union` / `human-review` quarantine
- HMAC envelope via `core.security.audit` chain (write provenance + tamper detection)
- Per-key history file alongside the shared JSONL
- MCP resource `bernstein/whiteboard` (`get` / `set` / `list` / `history`)
- CLI surface (`bernstein whiteboard …`)
- `llm_watcher` `whiteboard_conflict_storm` detector
- Distributed-write semantics across runners

The storage path and schema are forward-compatible with these layers — adding per-key history files and an HMAC field is purely additive.

## Off-by-default

Nothing in the orchestrator imports the new module yet; callers opt in by constructing a `Whiteboard` directly. No behaviour change to existing flows.

## Hard fence (per ticket)

No Loki RARV / swarm semantics introduced — this is a passive shared-state primitive, agents do not coordinate through it, and there is no consensus protocol or inter-agent voting.

## Test plan

- [x] `pytest tests/unit/test_whiteboard.py` — **14/14 pass** (~3s)
- [x] `pytest tests/unit/test_bulletin.py tests/unit/test_bulletin_status_notification.py tests/unit/test_bulletin_activity_summary.py` — 17/17 pass (no regression in adjacent communication module)
- [x] `ruff check` clean

Ticket: `.sdd/backlog/closed/2026-05-07-feat-multi-agent-shared-whiteboard.md`
