### PR TITLE
feat(a2a): A2A v1.0 signed agent card + JWKS at /.well-known

### DIFF
--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -1,26 +1,55 @@
-"""Static service manifest routes — A2A agent card and llms.txt summary.
+"""Static service manifest routes — A2A v1.0 agent card, JWKS, llms.txt.
 
 External agents (Claude Code, Codex, third-party orchestrators) discover the
-Bernstein task API by fetching ``/.well-known/agent.json`` (A2A-compliant
-JSON card) or ``/llms.txt`` (markdown summary).  Both endpoints derive from
-a single in-module ``_ENDPOINTS`` table so the markdown summary cannot drift
-from the structured manifest — the regression test in
+Bernstein task API by fetching ``/.well-known/agent.json`` (A2A v1.0 card,
+JCS-canonical body + detached JWS), ``/.well-known/agent.json/keys`` (JWKS
+of the signing keys), or ``/llms.txt`` (markdown summary).
+
+The structured manifest and the markdown summary derive from the same
+in-module ``_ENDPOINTS`` table so the markdown summary cannot drift from
+the structured manifest — the regression test in
 ``tests/unit/test_well_known.py`` enforces that every entry in the table is
 mentioned in the rendered llms.txt body.
 
+A2A v1.0 conformance
+--------------------
+- ``protocolVersion: "1.0"`` (RFC 8785 + RFC 7515 baseline).
+- ``supportedInterfaces[]`` — the wire formats this server speaks.
+- ``securitySchemes[]`` — Bearer JWT today, with a stub for the upcoming
+  ``mtls`` scheme that ``auth_middleware.py`` will land in a follow-up.
+- ``signatures[]`` — list of detached JWS objects (RFC 7515 §A.5) over the
+  JCS-canonical body bytes (RFC 8785). Verifiers strip ``signatures`` from
+  the body, recompute the canonical bytes, and verify the JWS using the
+  matching ``kid`` from the JWKS endpoint.
+
 Both routes are unauthenticated; they live in ``AUTH_PUBLIC_PATHS`` so any
 network caller can read them without provisioning a token.
+
+Key lifecycle
+-------------
+For now the orchestrator generates a fresh Ed25519 keypair on first request
+and caches it in-process. Persistence (PEM under
+``.sdd/security/keys/agent_signing/``) and rotation are tracked in the same
+ticket family but deferred from this PR — the JWS surface and JWKS shape
+land first so external verifiers can integrate against a stable contract.
 """
 
 from __future__ import annotations
 
+import os
+import threading
 from dataclasses import dataclass
 from typing import Any
 
 from fastapi import APIRouter
-from fastapi.responses import PlainTextResponse
+from fastapi.responses import PlainTextResponse, Response
 
 from bernstein import __version__ as _BERNSTEIN_VERSION
+from bernstein.core.security.agent_card_signer import (
+    canonicalize_jcs,
+    ed25519_public_jwk,
+    generate_ed25519_keypair,
+)
 
 router = APIRouter()
 
@@ -31,9 +60,18 @@ _AGENT_DESCRIPTION = (
     "Clients submit tasks, query status, and post cross-agent bulletins "
     "via the documented endpoints below."
 )
-_PROTOCOL_VERSION = "0.2"
+_PROTOCOL_VERSION = "1.0"
 _DEFAULT_BASE_URL = "http://127.0.0.1:8052"
 _DOCS_URL = "https://github.com/sipyourdrink-ltd/bernstein"
+
+#: A2A v1.0 wire formats this server speaks. Today only HTTP+JSON; gRPC and
+#: JSONRPC are tracked in follow-up tickets but listed here as the ticket
+#: enumerates the v1.0 surface.
+_SUPPORTED_INTERFACES: tuple[str, ...] = ("HTTP+JSON",)
+
+#: Stable kid used for the orchestrator's signing key. Format follows the
+#: convention in ``agent_card_signer.sign_agent_card``: ``agent-<id>``.
+_DEFAULT_KID = "agent-bernstein-orchestrator"
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,14 +113,85 @@ _SKILLS: tuple[dict[str, object], ...] = (
 )
 
 
-def _agent_card_payload(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
-    """Build the A2A agent-card dict served at /.well-known/agent.json.
+# ---------------------------------------------------------------------------
+# Process-local Ed25519 keypair cache.
+# ---------------------------------------------------------------------------
+#
+# The first GET against either ``/.well-known/agent.json`` or
+# ``/.well-known/agent.json/keys`` lazily mints a keypair and caches it in
+# this module. Subsequent requests reuse the cache so the JWKS contract
+# stays stable across the lifetime of one orchestrator process. Production
+# deployments will plug the persistent ``key_rotation`` substrate in here in
+# a follow-up ticket; the JWKS shape stays unchanged either way so external
+# verifiers do not have to special-case the in-memory mode.
+
+_KEY_LOCK = threading.Lock()
+_PRIVATE_PEM: bytes | None = None
+_PUBLIC_PEM: bytes | None = None
+
+
+def _get_signing_keypair() -> tuple[bytes, bytes]:
+    """Return the cached signing keypair, generating it on first use."""
+    global _PRIVATE_PEM, _PUBLIC_PEM
+    if _PRIVATE_PEM is not None and _PUBLIC_PEM is not None:
+        return _PRIVATE_PEM, _PUBLIC_PEM
+    with _KEY_LOCK:
+        if _PRIVATE_PEM is None or _PUBLIC_PEM is None:
+            _PRIVATE_PEM, _PUBLIC_PEM = generate_ed25519_keypair()
+    return _PRIVATE_PEM, _PUBLIC_PEM
+
+
+def _reset_signing_keypair_for_tests() -> None:
+    """Drop the cached keypair — for tests that want a fresh JWKS per case."""
+    global _PRIVATE_PEM, _PUBLIC_PEM
+    with _KEY_LOCK:
+        _PRIVATE_PEM = None
+        _PUBLIC_PEM = None
+
+
+# ---------------------------------------------------------------------------
+# Card body construction.
+# ---------------------------------------------------------------------------
+
+
+def _security_schemes() -> list[dict[str, Any]]:
+    """Return the A2A v1.0 ``securitySchemes`` array.
+
+    Today only ``Bearer`` is fully wired. ``mtls`` is listed as a stub
+    (``"required": false``) because client-cert verification at the
+    middleware layer is the next ticket in the same family — declaring it
+    early lets external clients negotiate it as soon as it lands without a
+    discovery-cache miss.
+    """
+    return [
+        {
+            "id": "bearer-jwt",
+            "type": "http",
+            "scheme": "Bearer",
+            "description": "JWT bearer token in the Authorization header.",
+            "required": True,
+        },
+        {
+            "id": "mtls",
+            "type": "mutualTLS",
+            "scheme": "mtls",
+            "description": "TLS client cert (deferred — declared for forward-compat).",
+            "required": False,
+        },
+    ]
+
+
+def _agent_card_body(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
+    """Build the A2A v1.0 card body — the bytes the JWS attests to.
+
+    The result excludes the ``signatures`` array; ``_agent_card_payload``
+    appends the JWS list after JCS-canonicalising this body.
 
     Args:
         base_url: Public base URL of the task server.
 
     Returns:
-        JSON-serialisable dict accepted by ``parse_agent_card``.
+        JSON-serialisable dict with the v1.0-mandated fields.
     """
     return {
         "name": _AGENT_NAME,
@@ -91,6 +200,8 @@ def _agent_card_payload(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
         "protocolVersion": _PROTOCOL_VERSION,
         "url": base_url,
         "documentationUrl": _DOCS_URL,
+        "supportedInterfaces": list(_SUPPORTED_INTERFACES),
+        "securitySchemes": _security_schemes(),
         "capabilities": [
             {"name": "task-crud", "description": "Create / read / complete / fail tasks."},
             {"name": "bulletin", "description": "Post and read cross-agent bulletins."},
@@ -101,7 +212,12 @@ def _agent_card_payload(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
         "defaultOutputModes": ["application/json"],
         "authentication": {
             "schemes": ["Bearer"],
-            "publicPaths": ["/health", "/.well-known/agent.json", "/llms.txt"],
+            "publicPaths": [
+                "/health",
+                "/.well-known/agent.json",
+                "/.well-known/agent.json/keys",
+                "/llms.txt",
+            ],
             "description": (
                 "Bearer token in Authorization header.  Set BERNSTEIN_AUTH_DISABLED=1 "
                 "for local development (no token required)."
@@ -109,6 +225,77 @@ def _agent_card_payload(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
         },
         "endpoints": [{"method": e.method, "path": e.path, "summary": e.summary} for e in _ENDPOINTS],
     }
+
+
+def _sign_canonical_body(canonical_body: bytes, private_pem: bytes, *, kid: str) -> str:
+    """Produce a detached JWS over ``canonical_body`` (RFC 7515 §A.5).
+
+    Mirrors :func:`agent_card_signer.sign_agent_card` but operates on the
+    raw canonical bytes — the agent card we publish here is a server-card
+    (not an ``AgentIdentityCard`` instance), so we cannot reuse
+    ``sign_agent_card`` directly without inventing a synthetic dataclass.
+    The signing input shape (header.body) and ``typ`` value match exactly,
+    so verifiers that already understand ``agent-card+jws`` interoperate.
+
+    Args:
+        canonical_body: JCS-canonicalised body bytes.
+        private_pem: PEM PKCS#8 Ed25519 private key.
+        kid: Key identifier — must match the JWK published at
+            ``/.well-known/agent.json/keys``.
+
+    Returns:
+        Compact-form detached JWS string ``header..signature``.
+    """
+    import base64
+
+    from cryptography.hazmat.primitives import serialization
+
+    private_key = serialization.load_pem_private_key(private_pem, password=None)
+    header = {"alg": "EdDSA", "typ": "agent-card+jws", "kid": kid}
+    header_b64 = base64.urlsafe_b64encode(canonicalize_jcs(header)).rstrip(b"=").decode("ascii")
+    body_b64 = base64.urlsafe_b64encode(canonical_body).rstrip(b"=").decode("ascii")
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    signature = private_key.sign(signing_input)
+    sig_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+    return f"{header_b64}..{sig_b64}"
+
+
+def _resolve_base_url() -> str:
+    """Return the base URL to advertise in the card.
+
+    Priority: ``BERNSTEIN_PUBLIC_BASE_URL`` env override → default. Keeping
+    this configurable lets reverse-proxied deployments expose the correct
+    canonical URL without hardcoding it at build time.
+    """
+    return os.environ.get("BERNSTEIN_PUBLIC_BASE_URL", _DEFAULT_BASE_URL)
+
+
+def _agent_card_payload(base_url: str = _DEFAULT_BASE_URL) -> dict[str, Any]:
+    """Build the full A2A v1.0 card payload — body plus signatures.
+
+    Verifiers strip ``signatures`` from this payload, JCS-canonicalise the
+    rest, and compare against the ``signatures[].jws`` header+sig segments
+    using the public key fetched from ``/.well-known/agent.json/keys``.
+
+    Args:
+        base_url: Public base URL of the task server.
+
+    Returns:
+        Full v1.0 payload dict ready to JSON-serialise.
+    """
+    body = _agent_card_body(base_url)
+    canonical = canonicalize_jcs(body)
+    private_pem, _public_pem = _get_signing_keypair()
+    jws = _sign_canonical_body(canonical, private_pem, kid=_DEFAULT_KID)
+    body["signatures"] = [
+        {
+            "kid": _DEFAULT_KID,
+            "alg": "EdDSA",
+            "typ": "agent-card+jws",
+            "jws": jws,
+        }
+    ]
+    return body
 
 
 def _render_llms_txt() -> str:
@@ -131,16 +318,48 @@ def _render_llms_txt() -> str:
         "## Auth",
         "",
         "Send `Authorization: Bearer <token>` on every request.  Public paths: "
-        "`/health`, `/.well-known/agent.json`, `/llms.txt`.",
+        "`/health`, `/.well-known/agent.json`, `/.well-known/agent.json/keys`, "
+        "`/llms.txt`.",
         "",
     ]
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
 @router.get("/.well-known/agent.json", include_in_schema=False)
-def agent_json() -> dict[str, Any]:
-    """Return the A2A-compliant agent card for this task server."""
-    return _agent_card_payload()
+def agent_json() -> Response:
+    """Return the A2A v1.0 signed agent card for this task server.
+
+    Body bytes are JCS-canonical (RFC 8785) so verifiers can recompute the
+    JWS signing input bit-perfect after stripping the ``signatures`` array.
+    Cache for an hour — the card body changes only when the server config
+    or the orchestrator's signing key rotates.
+    """
+    payload = _agent_card_payload(_resolve_base_url())
+    body = canonicalize_jcs(payload)
+    return Response(
+        content=body,
+        media_type="application/json",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.get("/.well-known/agent.json/keys", include_in_schema=False)
+def agent_json_keys() -> dict[str, Any]:
+    """Return the JWKS for verifying ``/.well-known/agent.json`` signatures.
+
+    JWKS shape per RFC 7517 — ``{"keys": [<jwk>, ...]}``. Today exactly one
+    key is published (the orchestrator's signing key); during rotation
+    windows both old and new keys appear so in-flight tokens keep
+    verifying — see ``key_rotation.py`` for the rotation contract.
+    """
+    _private_pem, public_pem = _get_signing_keypair()
+    jwk = ed25519_public_jwk(public_pem, kid=_DEFAULT_KID)
+    return {"keys": [jwk]}
 
 
 @router.get("/llms.txt", include_in_schema=False, response_class=PlainTextResponse)

--- a/src/bernstein/core/security/agent_card_signer.py
+++ b/src/bernstein/core/security/agent_card_signer.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 __all__ = [
     "AgentCardSignature",
     "canonicalize_jcs",
+    "ed25519_public_jwk",
     "generate_ed25519_keypair",
     "sign_agent_card",
     "verify_agent_card",
@@ -119,6 +120,41 @@ def generate_ed25519_keypair() -> tuple[bytes, bytes]:
         serialization.PublicFormat.SubjectPublicKeyInfo,
     )
     return private_pem, public_pem
+
+
+def ed25519_public_jwk(public_key_pem: bytes, *, kid: str) -> dict[str, str]:
+    """Render a SPKI Ed25519 public key as a JWK (RFC 8037 §2).
+
+    The JWK shape is what verifiers consume from the orchestrator's JWKS
+    endpoint at ``/.well-known/agent.json/keys``. A2A v1.0 picks the OKP
+    key type with curve ``Ed25519`` for ``EdDSA`` signatures.
+
+    Args:
+        public_key_pem: SPKI PEM bytes as produced by
+            :func:`generate_ed25519_keypair`.
+        kid: Key identifier embedded in the JWS header — must match the
+            ``kid`` from the corresponding :class:`AgentCardSignature` so
+            verifiers can route by key.
+
+    Returns:
+        JWK dict with ``kty``, ``crv``, ``x``, ``alg``, ``use``, ``kid``
+        keys. Caller composes ``{"keys": [<jwk>, ...]}`` for the JWKS.
+    """
+    from cryptography.hazmat.primitives import serialization
+
+    public_key = serialization.load_pem_public_key(public_key_pem)
+    raw = public_key.public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    )
+    return {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "alg": "EdDSA",
+        "use": "sig",
+        "kid": kid,
+        "x": _b64url(raw),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -75,6 +75,7 @@ AUTH_PUBLIC_PATHS = frozenset(
         "/alive",
         # Agent / protocol discovery
         "/.well-known/agent.json",
+        "/.well-known/agent.json/keys",
         "/.well-known/acp.json",
         "/llms.txt",
         "/acp/v0/agents",

--- a/src/bernstein/core/security/ip_allowlist.py
+++ b/src/bernstein/core/security/ip_allowlist.py
@@ -54,6 +54,7 @@ class IPAllowlistMiddleware(BaseHTTPMiddleware):
             "/ready",
             "/alive",
             "/.well-known/agent.json",
+            "/.well-known/agent.json/keys",
             "/docs",
             "/openapi.json",
         }

--- a/src/bernstein/core/server/server_middleware.py
+++ b/src/bernstein/core/server/server_middleware.py
@@ -35,6 +35,7 @@ _PUBLIC_PATHS = frozenset(
         "/ready",
         "/alive",
         "/.well-known/agent.json",
+        "/.well-known/agent.json/keys",
         "/.well-known/acp.json",
         "/acp/v0/agents",
         "/docs",

--- a/tests/unit/test_agent_card_signer.py
+++ b/tests/unit/test_agent_card_signer.py
@@ -9,6 +9,7 @@ import pytest
 from bernstein.core.security.agent_card_signer import (
     AgentCardSignature,
     canonicalize_jcs,
+    ed25519_public_jwk,
     generate_ed25519_keypair,
     sign_agent_card,
     verify_agent_card,
@@ -221,3 +222,54 @@ class TestSignVerify:
             kid=sig.kid,
         )
         assert verify_agent_card(card, forged, pub) is False
+
+
+# ---------------------------------------------------------------------------
+# JWK rendering for the JWKS endpoint at /.well-known/agent.json/keys.
+# ---------------------------------------------------------------------------
+
+
+class TestEd25519PublicJWK:
+    def test_jwk_shape_matches_rfc_8037(self) -> None:
+        _, pub = generate_ed25519_keypair()
+        jwk = ed25519_public_jwk(pub, kid="agent-test")
+        assert jwk["kty"] == "OKP"
+        assert jwk["crv"] == "Ed25519"
+        assert jwk["alg"] == "EdDSA"
+        assert jwk["use"] == "sig"
+        assert jwk["kid"] == "agent-test"
+        assert isinstance(jwk["x"], str) and "=" not in jwk["x"]
+
+    def test_x_decodes_to_32_raw_bytes(self) -> None:
+        from base64 import urlsafe_b64decode
+
+        _, pub = generate_ed25519_keypair()
+        jwk = ed25519_public_jwk(pub, kid="k")
+        raw = urlsafe_b64decode(jwk["x"] + "=" * (-len(jwk["x"]) % 4))
+        assert len(raw) == 32
+
+    def test_jwk_round_trips_through_cryptography(self) -> None:
+        """The JWK ``x`` must reconstruct an Ed25519PublicKey byte-identical
+        to the SPKI input — this is what verifiers do at runtime.
+        """
+        from base64 import urlsafe_b64decode
+
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+
+        _, pub_pem = generate_ed25519_keypair()
+        original_raw = serialization.load_pem_public_key(pub_pem).public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        jwk = ed25519_public_jwk(pub_pem, kid="k")
+        rebuilt = Ed25519PublicKey.from_public_bytes(
+            urlsafe_b64decode(jwk["x"] + "=" * (-len(jwk["x"]) % 4))
+        )
+        rebuilt_raw = rebuilt.public_bytes(
+            serialization.Encoding.Raw,
+            serialization.PublicFormat.Raw,
+        )
+        assert rebuilt_raw == original_raw

--- a/tests/unit/test_well_known.py
+++ b/tests/unit/test_well_known.py
@@ -1,7 +1,14 @@
-"""Tests for static service manifest routes (/.well-known/agent.json, /llms.txt)."""
+"""Tests for static service manifest routes (/.well-known/agent.json, /llms.txt).
+
+Covers both the legacy server-info expectations and the A2A v1.0 surface
+landed in feat/a2a-v1-well-known-agent-json: signed-card body, JWKS keys
+endpoint, JCS-canonical body, signature verification round-trip.
+"""
 
 from __future__ import annotations
 
+import base64
+import json
 import os
 from pathlib import Path
 
@@ -10,10 +17,13 @@ from fastapi.testclient import TestClient
 
 from bernstein.core.agents.claude_agent_card import parse_agent_card
 from bernstein.core.routes.well_known import (
+    _DEFAULT_KID,
     _ENDPOINTS,
     _agent_card_payload,
     _render_llms_txt,
+    _reset_signing_keypair_for_tests,
 )
+from bernstein.core.security.agent_card_signer import canonicalize_jcs
 from bernstein.core.security.auth_middleware import AUTH_PUBLIC_PATHS
 from bernstein.core.server import create_app
 
@@ -21,6 +31,7 @@ from bernstein.core.server import create_app
 @pytest.fixture()
 def client(tmp_path: Path) -> TestClient:
     os.environ["BERNSTEIN_AUTH_DISABLED"] = "1"
+    _reset_signing_keypair_for_tests()
     app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
     return TestClient(app)
 
@@ -72,6 +83,7 @@ def test_llms_txt_mentions_every_documented_endpoint() -> None:
 
 def test_well_known_paths_are_public_in_auth_middleware() -> None:
     assert "/.well-known/agent.json" in AUTH_PUBLIC_PATHS
+    assert "/.well-known/agent.json/keys" in AUTH_PUBLIC_PATHS
     assert "/llms.txt" in AUTH_PUBLIC_PATHS
 
 
@@ -79,3 +91,122 @@ def test_agent_card_payload_supports_custom_base_url() -> None:
     payload = _agent_card_payload(base_url="https://api.example.com")
     assert payload["url"] == "https://api.example.com"
     assert payload["authentication"]["schemes"] == ["Bearer"]
+
+
+# ---------------------------------------------------------------------------
+# A2A v1.0 surface — protocolVersion, supportedInterfaces, securitySchemes,
+# signatures.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_json_advertises_protocol_v1(client: TestClient) -> None:
+    """A2A v1.0 conformance flag — verifiers route off this string."""
+    data = client.get("/.well-known/agent.json").json()
+    assert data["protocolVersion"] == "1.0"
+
+
+def test_agent_json_supported_interfaces(client: TestClient) -> None:
+    data = client.get("/.well-known/agent.json").json()
+    assert "HTTP+JSON" in data["supportedInterfaces"]
+
+
+def test_agent_json_security_schemes_include_bearer(client: TestClient) -> None:
+    data = client.get("/.well-known/agent.json").json()
+    schemes = {s["id"]: s for s in data["securitySchemes"]}
+    assert "bearer-jwt" in schemes
+    assert schemes["bearer-jwt"]["scheme"] == "Bearer"
+    assert schemes["bearer-jwt"]["required"] is True
+    # mTLS is declared as a forward-compat stub (deferred).
+    assert "mtls" in schemes
+    assert schemes["mtls"]["required"] is False
+
+
+def test_agent_json_signature_present(client: TestClient) -> None:
+    data = client.get("/.well-known/agent.json").json()
+    assert isinstance(data["signatures"], list)
+    assert len(data["signatures"]) == 1
+    sig = data["signatures"][0]
+    assert sig["alg"] == "EdDSA"
+    assert sig["typ"] == "agent-card+jws"
+    assert sig["kid"] == _DEFAULT_KID
+    # Detached JWS — header..signature shape.
+    parts = sig["jws"].split(".")
+    assert len(parts) == 3
+    assert parts[1] == "", "JWS payload segment must be empty (RFC 7515 A.5)"
+
+
+def test_agent_json_body_is_jcs_canonical(client: TestClient) -> None:
+    """Raw response bytes must match ``canonicalize_jcs`` of the parsed dict."""
+    resp = client.get("/.well-known/agent.json")
+    raw = resp.content
+    parsed = json.loads(raw)
+    recanonical = canonicalize_jcs(parsed)
+    assert raw == recanonical, (
+        f"body is not JCS-canonical:\n  got: {raw!r}\n  want: {recanonical!r}"
+    )
+    # Cache header per ticket spec.
+    assert resp.headers.get("cache-control") == "public, max-age=3600"
+
+
+# ---------------------------------------------------------------------------
+# JWKS endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_endpoint_shape(client: TestClient) -> None:
+    resp = client.get("/.well-known/agent.json/keys")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "keys" in data
+    assert isinstance(data["keys"], list)
+    assert len(data["keys"]) >= 1
+    jwk = data["keys"][0]
+    assert jwk["kty"] == "OKP"
+    assert jwk["crv"] == "Ed25519"
+    assert jwk["alg"] == "EdDSA"
+    assert jwk["use"] == "sig"
+    assert jwk["kid"] == _DEFAULT_KID
+    # x is the raw 32-byte public key, base64url without padding.
+    raw = base64.urlsafe_b64decode(jwk["x"] + "=" * (-len(jwk["x"]) % 4))
+    assert len(raw) == 32
+
+
+def test_jws_signature_verifies_against_jwks(client: TestClient) -> None:
+    """End-to-end: sign on /agent.json verifies with the JWKS pubkey.
+
+    This is the contract a third-party A2A v1.0 verifier executes — strip
+    ``signatures`` from the body, JCS-canonicalise the rest, and verify
+    each signature against the matching ``kid`` from the JWKS endpoint.
+    """
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PublicKey,
+    )
+
+    card_resp = client.get("/.well-known/agent.json")
+    keys_resp = client.get("/.well-known/agent.json/keys")
+    card = json.loads(card_resp.content)
+    sig = card["signatures"][0]
+    jwks = keys_resp.json()
+    jwk = next(k for k in jwks["keys"] if k["kid"] == sig["kid"])
+    raw_pub = base64.urlsafe_b64decode(jwk["x"] + "=" * (-len(jwk["x"]) % 4))
+    pub = Ed25519PublicKey.from_public_bytes(raw_pub)
+
+    # Reconstruct the signing input: header_b64 + "." + body_b64 where the
+    # body is the JCS canonicalisation of the response with ``signatures``
+    # stripped.
+    header_b64, _empty, sig_b64 = sig["jws"].split(".")
+    body_for_signing = {k: v for k, v in card.items() if k != "signatures"}
+    canonical = canonicalize_jcs(body_for_signing)
+    body_b64 = base64.urlsafe_b64encode(canonical).rstrip(b"=").decode("ascii")
+    signing_input = f"{header_b64}.{body_b64}".encode("ascii")
+    signature_bytes = base64.urlsafe_b64decode(sig_b64 + "=" * (-len(sig_b64) % 4))
+
+    # No exception → signature is valid.
+    pub.verify(signature_bytes, signing_input)
+
+
+def test_jwks_endpoint_is_stable_across_calls(client: TestClient) -> None:
+    """The cached keypair means JWKS bytes don't shift across GETs."""
+    a = client.get("/.well-known/agent.json/keys").json()
+    b = client.get("/.well-known/agent.json/keys").json()
+    assert a == b


### PR DESCRIPTION
Refs #1095

## Summary

- Brings ``/.well-known/agent.json`` to A2A v1.0 production grade: ``protocolVersion: 1.0``, ``supportedInterfaces[]``, ``securitySchemes[]``, and ``signatures[]`` carrying a detached JWS over the JCS-canonical body (RFC 8785 + RFC 7515 §A.5, EdDSA).
- New ``/.well-known/agent.json/keys`` endpoint serves the orchestrator's Ed25519 public key in RFC 7517 JWKS / RFC 8037 OKP JWK shape so external A2A v1.0 verifiers can verify the card without out-of-band trust.
- Body bytes are emitted JCS-canonical with ``Cache-Control: public, max-age=3600``.

Predecessors: #1106 (JWS+JCS Ed25519 signing module) and #1118 (typ-header lock).

Ticket: ``.sdd/backlog/closed/2026-05-07-feat-a2a-v1-signed-agent-card.md``.

## Shipped

- A2A v1.0 fields on the card: ``protocolVersion``, ``supportedInterfaces``, ``securitySchemes`` (Bearer live, mTLS as forward-compat stub), ``signatures``.
- ``/.well-known/agent.json/keys`` JWKS endpoint with kty=OKP / crv=Ed25519 / alg=EdDSA / use=sig / kid + raw 32-byte ``x``.
- Process-local Ed25519 keypair cache with reset hook for tests.
- Public-paths frozen sets in ``auth_middleware``, ``ip_allowlist``, ``server_middleware`` updated for the new ``/keys`` route.
- ``ed25519_public_jwk`` helper added to ``agent_card_signer``.

## Deferred (called out in commit body)

- Persistent / rotated keypair (today: lazy in-process cache). JWKS shape will not change when ``key_rotation`` plugs in.
- Adding ``protocol_version`` / ``supported_interfaces`` / ``security_schemes`` / ``signatures`` to the ``AgentIdentityCard`` dataclass — that mutates ``card_hash`` semantics and needs a coordinated migration; route-level v1.0 fields ship now so external verifiers can integrate.
- RFC 8707 Resource Indicators in ``auth_middleware``.
- ES256 / RS256 alg negotiation.
- mTLS client-cert verification (declared as scheme stub only).

## Test plan

- [x] ``uv run pytest tests/unit/test_agent_card_signer.py tests/unit/test_well_known.py -x -q --timeout=120`` (36 passed)
- [x] ``uv run pytest tests/unit/test_a2a.py tests/unit/test_a2a_messages.py tests/unit/test_a2a_federation.py tests/unit/test_agent_identity.py tests/unit/test_agent_identity_card.py tests/unit/test_claude_agent_card.py -x -q --timeout=120`` (138 passed — no regressions)
- [x] ``uv run pytest tests/unit/test_auth_middleware.py tests/unit/test_auth_middleware_defaults.py tests/unit/test_ip_allowlist.py -x -q --timeout=120`` (57 passed)
- [ ] Manual: GET ``/.well-known/agent.json`` and ``/.well-known/agent.json/keys`` against a running server; cross-verify with a third-party A2A v1.0 client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
