### PR TITLE
feat(eval): A/B runner primitive (KF-9 slice, Option A)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -195,6 +195,7 @@ alwaysApply: false
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |

--- a/.goosehints
+++ b/.goosehints
@@ -196,6 +196,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -196,6 +196,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 
 | File                      | Purpose |
 |---------------------------|---------|
+| `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -710,5 +710,88 @@ def eval_sync_incidents(workdir: str, dry_run: bool) -> None:
     )
 
 
+@eval_group.command("ab")
+@click.option(
+    "--variant-a",
+    "variant_a_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="YAML file with the A variant (keys: name, prompt, [model], [metadata]).",
+)
+@click.option(
+    "--variant-b",
+    "variant_b_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="YAML file with the B variant.",
+)
+@click.option(
+    "--tasks",
+    "tasks_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False),
+    help="YAML file with a top-level 'tasks: [...]' list.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Write comparison JSON here (stdout if omitted).",
+)
+@click.option(
+    "--scorer",
+    type=click.Choice(["exact", "none"]),
+    default="exact",
+    show_default=True,
+    help="Built-in scorer to apply (synthetic-friendly).",
+)
+def eval_ab(
+    variant_a_path: str,
+    variant_b_path: str,
+    tasks_path: str,
+    output_path: str | None,
+    scorer: str,
+) -> None:
+    """Run two prompt variants over a task set; emit a comparison JSON.
+
+    Synthetic-only slice (KF-9): uses the deterministic ``echo_executor``
+    so this command runs offline with zero LLM cost. Real executors plug
+    in via the Python API (``bernstein.eval.ab_runner.run_ab``).
+
+    \b
+      bernstein eval ab --variant-a a.yaml --variant-b b.yaml --tasks tasks.yaml
+      bernstein eval ab --variant-a a.yaml --variant-b b.yaml --tasks t.yaml --output report.json
+    """
+    from bernstein.eval.ab_runner import (
+        echo_executor,
+        exact_match_scorer,
+        load_tasks_yaml,
+        load_variant_yaml,
+        run_ab,
+    )
+
+    variant_a = load_variant_yaml(Path(variant_a_path))
+    variant_b = load_variant_yaml(Path(variant_b_path))
+    tasks = load_tasks_yaml(Path(tasks_path))
+
+    chosen_scorer = exact_match_scorer if scorer == "exact" else None
+
+    comparison = run_ab(
+        variant_a,
+        variant_b,
+        tasks,
+        executor=echo_executor,
+        scorer=chosen_scorer,
+    )
+
+    payload = comparison.to_json()
+    if output_path:
+        Path(output_path).write_text(payload + "\n", encoding="utf-8")
+        console.print(f"[green]wrote[/green] {output_path}  winner={comparison.winner}")
+    else:
+        click.echo(payload)
+
+
 # ---------------------------------------------------------------------------
 # workspace — multi-repo workspace management

--- a/src/bernstein/eval/ab_runner.py
+++ b/src/bernstein/eval/ab_runner.py
@@ -23,8 +23,10 @@ import json
 import statistics
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Public types

--- a/src/bernstein/eval/ab_runner.py
+++ b/src/bernstein/eval/ab_runner.py
@@ -1,0 +1,472 @@
+"""A/B runner primitive — deterministic prompt-vs-prompt comparison.
+
+This is the *primitive* layer for KF-9 (eval harness + A/B). It runs two
+prompt variants over the same task set, scores each output, and produces a
+deterministic comparison artefact (JSON-serialisable). Synthetic / dummy
+executors are first-class so this slice has zero LLM-cost test path.
+
+Design notes:
+    * Pure functions; no I/O coupling beyond explicit ``executor`` /
+      ``scorer`` callables passed in.
+    * Deterministic ordering: tasks iterate in input order; comparison
+      output uses ``sort_keys`` JSON dump for stable diffs.
+    * Companion to ``bernstein.core.quality.ab_test`` (model-vs-model on a
+      single live task via httpx). This module covers prompt-vs-prompt
+      offline / synthetic eval.
+    * Benchmark loaders (SWE-bench Pro, Terminal-Bench) are intentionally
+      out of scope — see ``feat-swe-bench-pro-terminal-bench-nightly``.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Variant:
+    """A prompt or model variant under test.
+
+    Attributes:
+        name: Human-readable variant id (e.g. ``"reviewer-v1"``).
+        prompt: Prompt template / system prompt body.
+        model: Optional model hint (``"haiku"`` etc.); not interpreted by
+            the runner — surfaced for downstream executors.
+        metadata: Free-form extra fields persisted into the comparison.
+    """
+
+    name: str
+    prompt: str
+    model: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Task:
+    """A single evaluation task.
+
+    Attributes:
+        task_id: Stable identifier (used for grouping in the comparison).
+        input: Task input — typed as ``Any`` so YAML / synthetic / real
+            payloads all flow through.
+        expected: Optional reference answer used by deterministic scorers.
+    """
+
+    task_id: str
+    input: Any
+    expected: Any = None
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """One executor invocation's outcome for a (variant, task) pair.
+
+    Attributes:
+        variant: Variant name that produced ``output``.
+        task_id: Task that was executed.
+        output: Raw executor output (string, dict, …).
+        score: Normalised score in ``[0.0, 1.0]``.
+        duration_ms: Wall-clock duration in milliseconds.
+        passed: Whether the task is considered successful (score >= 0.5
+            by default; can be overridden by the scorer).
+    """
+
+    variant: str
+    task_id: str
+    output: Any
+    score: float
+    duration_ms: float = 0.0
+    passed: bool = False
+
+
+@dataclass(frozen=True)
+class VariantStats:
+    """Aggregate stats for one variant across the task set.
+
+    Attributes:
+        name: Variant name.
+        n: Total task count for this variant.
+        pass_count: Number of tasks where ``passed`` is True.
+        pass_rate: ``pass_count / n`` (0.0 when n=0).
+        mean_score: Arithmetic mean of per-task scores.
+        mean_duration_ms: Arithmetic mean of per-task durations.
+    """
+
+    name: str
+    n: int
+    pass_count: int
+    pass_rate: float
+    mean_score: float
+    mean_duration_ms: float
+
+
+@dataclass(frozen=True)
+class TaskDelta:
+    """Per-task score delta between A and B (B - A).
+
+    Attributes:
+        task_id: Task identifier.
+        score_a: Variant A's score (NaN-safe: 0.0 if missing).
+        score_b: Variant B's score.
+        delta: ``score_b - score_a``; positive => B beats A.
+    """
+
+    task_id: str
+    score_a: float
+    score_b: float
+    delta: float
+
+
+@dataclass(frozen=True)
+class Comparison:
+    """A/B comparison artefact — the deliverable of this primitive.
+
+    Attributes:
+        variant_a: Stats for the A side.
+        variant_b: Stats for the B side.
+        per_task: Per-task deltas, in input order.
+        winner: ``"a"``, ``"b"``, or ``"tie"`` based on pass-rate then
+            mean-score (5% tolerance band).
+        reason: Human-readable explanation.
+    """
+
+    variant_a: VariantStats
+    variant_b: VariantStats
+    per_task: tuple[TaskDelta, ...]
+    winner: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a deterministic dict suitable for JSON serialisation."""
+        return {
+            "variant_a": _stats_to_dict(self.variant_a),
+            "variant_b": _stats_to_dict(self.variant_b),
+            "per_task": [_delta_to_dict(d) for d in self.per_task],
+            "winner": self.winner,
+            "reason": self.reason,
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Render as a deterministic JSON string."""
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Executor / scorer protocols (typed callables, no Protocol class needed)
+# ---------------------------------------------------------------------------
+
+
+Executor = Callable[[Variant, Task], RunResult]
+"""Synchronous executor: run one variant on one task, return RunResult.
+
+Implementations should set ``score`` and ``passed`` themselves *or* leave
+them at default (0.0 / False) and rely on the scorer.
+"""
+
+Scorer = Callable[[Variant, Task, Any], tuple[float, bool]]
+"""Optional scorer: ``(variant, task, raw_output) -> (score, passed)``.
+
+When supplied to :func:`run_ab`, the scorer runs after the executor and
+overwrites the executor's score / passed. Use this for deterministic
+post-hoc grading.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Built-in scorers (synthetic-friendly)
+# ---------------------------------------------------------------------------
+
+
+def exact_match_scorer(_variant: Variant, task: Task, output: Any) -> tuple[float, bool]:
+    """Score 1.0 iff ``str(output) == str(task.expected)``.
+
+    Args:
+        _variant: Unused (kept for protocol compatibility).
+        task: The task being scored — uses ``task.expected``.
+        output: Raw executor output.
+
+    Returns:
+        ``(1.0, True)`` on exact-string match, else ``(0.0, False)``.
+    """
+    matched = str(output) == str(task.expected)
+    return (1.0 if matched else 0.0, matched)
+
+
+# ---------------------------------------------------------------------------
+# Built-in executor for tests / dry-runs
+# ---------------------------------------------------------------------------
+
+
+def echo_executor(variant: Variant, task: Task) -> RunResult:
+    """Deterministic dummy executor — returns ``f"{prompt}::{input}"``.
+
+    Used by the test fixtures and as a smoke-test default. Score is left
+    at 0.0; pair with a scorer (e.g. :func:`exact_match_scorer`) to make
+    a meaningful comparison.
+
+    Args:
+        variant: Variant whose prompt is echoed.
+        task: Task whose input is echoed.
+
+    Returns:
+        ``RunResult`` with deterministic ``output`` and zero duration.
+    """
+    output = f"{variant.prompt}::{task.input}"
+    return RunResult(
+        variant=variant.name,
+        task_id=task.task_id,
+        output=output,
+        score=0.0,
+        duration_ms=0.0,
+        passed=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core runner
+# ---------------------------------------------------------------------------
+
+
+def run_ab(
+    variant_a: Variant,
+    variant_b: Variant,
+    tasks: Iterable[Task],
+    *,
+    executor: Executor = echo_executor,
+    scorer: Scorer | None = None,
+    tolerance: float = 0.05,
+) -> Comparison:
+    """Run two variants over the same task set and build a comparison.
+
+    Tasks are iterated once; each task is executed for variant A then
+    variant B. Results are aggregated into :class:`VariantStats` and
+    per-task deltas are computed in input order.
+
+    Args:
+        variant_a: First variant (the baseline / control).
+        variant_b: Second variant (the candidate / treatment).
+        tasks: Iterable of :class:`Task`. Consumed once.
+        executor: Callable that runs one variant on one task. Defaults to
+            :func:`echo_executor` for synthetic test paths.
+        scorer: Optional callable that overrides executor scoring with a
+            deterministic post-hoc grade.
+        tolerance: Pass-rate / mean-score tolerance band for tie-calling.
+            Default 5% (``0.05``).
+
+    Returns:
+        A populated :class:`Comparison`.
+
+    Raises:
+        ValueError: If ``variant_a.name == variant_b.name`` (would cause
+            ambiguous deltas).
+    """
+    if variant_a.name == variant_b.name:
+        msg = f"variant names must differ; got {variant_a.name!r} twice"
+        raise ValueError(msg)
+
+    task_list = list(tasks)
+    results_a: list[RunResult] = []
+    results_b: list[RunResult] = []
+
+    for task in task_list:
+        results_a.append(_score_one(variant_a, task, executor, scorer))
+        results_b.append(_score_one(variant_b, task, executor, scorer))
+
+    stats_a = _aggregate(variant_a.name, results_a)
+    stats_b = _aggregate(variant_b.name, results_b)
+
+    deltas: list[TaskDelta] = []
+    by_task_a = {r.task_id: r for r in results_a}
+    by_task_b = {r.task_id: r for r in results_b}
+    for task in task_list:
+        ra = by_task_a.get(task.task_id)
+        rb = by_task_b.get(task.task_id)
+        sa = ra.score if ra else 0.0
+        sb = rb.score if rb else 0.0
+        deltas.append(TaskDelta(task_id=task.task_id, score_a=sa, score_b=sb, delta=sb - sa))
+
+    winner, reason = _decide_winner(stats_a, stats_b, tolerance=tolerance)
+
+    return Comparison(
+        variant_a=stats_a,
+        variant_b=stats_b,
+        per_task=tuple(deltas),
+        winner=winner,
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# YAML / JSON I/O helpers (thin wrappers — keep deps light)
+# ---------------------------------------------------------------------------
+
+
+def load_variant_yaml(path: Path) -> Variant:
+    """Load a Variant from a YAML file with keys ``name``, ``prompt``.
+
+    Args:
+        path: Path to the YAML file.
+
+    Returns:
+        Parsed :class:`Variant`.
+
+    Raises:
+        ValueError: If required keys are missing.
+    """
+    import yaml  # local import: only needed for CLI / file path
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if "name" not in raw or "prompt" not in raw:
+        msg = f"variant YAML {path} missing required keys 'name'/'prompt'"
+        raise ValueError(msg)
+    return Variant(
+        name=str(raw["name"]),
+        prompt=str(raw["prompt"]),
+        model=raw.get("model"),
+        metadata=raw.get("metadata", {}) or {},
+    )
+
+
+def load_tasks_yaml(path: Path) -> list[Task]:
+    """Load a list of Tasks from a YAML file with a top-level ``tasks`` key.
+
+    Expected schema::
+
+        tasks:
+          - id: t1
+            input: "hello"
+            expected: "world"
+
+    Args:
+        path: Path to the YAML file.
+
+    Returns:
+        List of :class:`Task`, in YAML order.
+
+    Raises:
+        ValueError: If the file lacks a ``tasks`` list.
+    """
+    import yaml  # local import
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    items = raw.get("tasks")
+    if not isinstance(items, list):
+        msg = f"tasks YAML {path} must have top-level 'tasks: [...]' list"
+        raise ValueError(msg)
+    return [
+        Task(
+            task_id=str(item.get("id", f"t{idx}")),
+            input=item.get("input"),
+            expected=item.get("expected"),
+        )
+        for idx, item in enumerate(items)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _score_one(
+    variant: Variant,
+    task: Task,
+    executor: Executor,
+    scorer: Scorer | None,
+) -> RunResult:
+    """Run executor and (optionally) override score with scorer."""
+    res = executor(variant, task)
+    if scorer is None:
+        return res
+    score, passed = scorer(variant, task, res.output)
+    return RunResult(
+        variant=res.variant,
+        task_id=res.task_id,
+        output=res.output,
+        score=score,
+        duration_ms=res.duration_ms,
+        passed=passed,
+    )
+
+
+def _aggregate(name: str, results: list[RunResult]) -> VariantStats:
+    """Compute :class:`VariantStats` from a list of run results."""
+    n = len(results)
+    if n == 0:
+        return VariantStats(name=name, n=0, pass_count=0, pass_rate=0.0, mean_score=0.0, mean_duration_ms=0.0)
+    pass_count = sum(1 for r in results if r.passed)
+    return VariantStats(
+        name=name,
+        n=n,
+        pass_count=pass_count,
+        pass_rate=pass_count / n,
+        mean_score=statistics.fmean(r.score for r in results),
+        mean_duration_ms=statistics.fmean(r.duration_ms for r in results),
+    )
+
+
+def _decide_winner(
+    a: VariantStats,
+    b: VariantStats,
+    *,
+    tolerance: float,
+) -> tuple[str, str]:
+    """Pick winner from pass-rate (primary) then mean-score (secondary)."""
+    pr_diff = b.pass_rate - a.pass_rate
+    if abs(pr_diff) > tolerance:
+        if pr_diff > 0:
+            return "b", f"{b.name} pass_rate {b.pass_rate:.2%} beat {a.name} {a.pass_rate:.2%}"
+        return "a", f"{a.name} pass_rate {a.pass_rate:.2%} beat {b.name} {b.pass_rate:.2%}"
+
+    score_diff = b.mean_score - a.mean_score
+    if abs(score_diff) > tolerance:
+        if score_diff > 0:
+            return "b", f"{b.name} mean_score {b.mean_score:.3f} beat {a.name} {a.mean_score:.3f}"
+        return "a", f"{a.name} mean_score {a.mean_score:.3f} beat {b.name} {b.mean_score:.3f}"
+
+    return "tie", f"variants within {tolerance:.0%} tolerance on pass-rate and mean-score"
+
+
+def _stats_to_dict(s: VariantStats) -> dict[str, Any]:
+    return {
+        "name": s.name,
+        "n": s.n,
+        "pass_count": s.pass_count,
+        "pass_rate": s.pass_rate,
+        "mean_score": s.mean_score,
+        "mean_duration_ms": s.mean_duration_ms,
+    }
+
+
+def _delta_to_dict(d: TaskDelta) -> dict[str, Any]:
+    return {
+        "task_id": d.task_id,
+        "score_a": d.score_a,
+        "score_b": d.score_b,
+        "delta": d.delta,
+    }
+
+
+__all__ = [
+    "Comparison",
+    "Executor",
+    "RunResult",
+    "Scorer",
+    "Task",
+    "TaskDelta",
+    "Variant",
+    "VariantStats",
+    "echo_executor",
+    "exact_match_scorer",
+    "load_tasks_yaml",
+    "load_variant_yaml",
+    "run_ab",
+]

--- a/tests/unit/test_ab_runner.py
+++ b/tests/unit/test_ab_runner.py
@@ -1,0 +1,278 @@
+"""Tests for the A/B runner primitive (KF-9 slice).
+
+These tests use synthetic deterministic fixtures only — no LLM calls,
+no httpx, no live tasks. The contract under test is:
+
+  * ``run_ab`` produces a stable :class:`Comparison` for fixed inputs.
+  * ``Comparison.to_json`` is byte-stable (sort_keys=True).
+  * Built-in scorers / executors compose correctly.
+  * Winner logic respects the tolerance band.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.eval.ab_runner import (
+    Comparison,
+    RunResult,
+    Task,
+    Variant,
+    VariantStats,
+    echo_executor,
+    exact_match_scorer,
+    load_tasks_yaml,
+    load_variant_yaml,
+    run_ab,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _tasks() -> list[Task]:
+    return [
+        Task(task_id="t1", input="hello", expected="A::hello"),
+        Task(task_id="t2", input="world", expected="A::world"),
+        Task(task_id="t3", input="foo", expected="B::foo"),
+    ]
+
+
+@pytest.fixture
+def variant_a() -> Variant:
+    return Variant(name="A", prompt="A")
+
+
+@pytest.fixture
+def variant_b() -> Variant:
+    return Variant(name="B", prompt="B")
+
+
+# ---------------------------------------------------------------------------
+# Echo executor + scorer composition
+# ---------------------------------------------------------------------------
+
+
+def test_echo_executor_is_deterministic() -> None:
+    """Echo executor must produce stable output for a fixed (variant, task)."""
+    v = Variant(name="A", prompt="hello")
+    t = Task(task_id="t1", input="world")
+
+    r1 = echo_executor(v, t)
+    r2 = echo_executor(v, t)
+
+    assert r1 == r2
+    assert r1.output == "hello::world"
+    assert r1.variant == "A"
+    assert r1.passed is False  # baseline executor leaves scoring to the scorer
+
+
+def test_exact_match_scorer_marks_passed() -> None:
+    """The exact-match scorer flips ``passed`` based on string equality."""
+    v = Variant(name="A", prompt="A")
+    t = Task(task_id="t1", input="x", expected="A::x")
+
+    score, passed = exact_match_scorer(v, t, "A::x")
+    assert (score, passed) == (1.0, True)
+
+    score, passed = exact_match_scorer(v, t, "different")
+    assert (score, passed) == (0.0, False)
+
+
+# ---------------------------------------------------------------------------
+# run_ab — deterministic comparison
+# ---------------------------------------------------------------------------
+
+
+def test_run_ab_deterministic_with_echo_and_exact_match(
+    variant_a: Variant,
+    variant_b: Variant,
+) -> None:
+    """A vs B over fixed tasks must produce the same Comparison every run.
+
+    With echo_executor + exact_match_scorer:
+      * A passes t1, t2 (expected starts with ``A::``) → 2/3
+      * B passes t3 (expected ``B::foo``) → 1/3
+      * Winner: A (pass-rate gap 33.3% > tolerance 5%).
+    """
+    cmp1 = run_ab(variant_a, variant_b, _tasks(), scorer=exact_match_scorer)
+    cmp2 = run_ab(variant_a, variant_b, _tasks(), scorer=exact_match_scorer)
+
+    assert cmp1 == cmp2  # frozen dataclasses → structural equality
+
+    assert cmp1.variant_a == VariantStats(
+        name="A", n=3, pass_count=2, pass_rate=2 / 3, mean_score=2 / 3, mean_duration_ms=0.0
+    )
+    assert cmp1.variant_b == VariantStats(
+        name="B", n=3, pass_count=1, pass_rate=1 / 3, mean_score=1 / 3, mean_duration_ms=0.0
+    )
+
+    assert cmp1.winner == "a"
+    assert "pass_rate" in cmp1.reason
+
+
+def test_run_ab_per_task_deltas_in_input_order(
+    variant_a: Variant,
+    variant_b: Variant,
+) -> None:
+    """Per-task deltas preserve task input order and compute B - A."""
+    cmp = run_ab(variant_a, variant_b, _tasks(), scorer=exact_match_scorer)
+
+    ids = [d.task_id for d in cmp.per_task]
+    assert ids == ["t1", "t2", "t3"]
+
+    # t1: A=1.0, B=0.0 → delta = -1.0
+    assert cmp.per_task[0].score_a == 1.0
+    assert cmp.per_task[0].score_b == 0.0
+    assert cmp.per_task[0].delta == -1.0
+
+    # t3: A=0.0, B=1.0 → delta = +1.0
+    assert cmp.per_task[2].delta == 1.0
+
+
+def test_run_ab_tie_within_tolerance() -> None:
+    """If both variants score identically, the winner must be 'tie'."""
+    a = Variant(name="A", prompt="A")
+    b = Variant(name="B", prompt="A")  # B uses the same prompt body
+    tasks = [Task(task_id="t1", input="x", expected="A::x")]
+
+    cmp = run_ab(a, b, tasks, scorer=exact_match_scorer)
+
+    assert cmp.winner == "tie"
+    assert cmp.variant_a.pass_rate == cmp.variant_b.pass_rate == 1.0
+
+
+def test_run_ab_rejects_duplicate_variant_names() -> None:
+    """Same name on both sides would make deltas ambiguous; raise."""
+    v = Variant(name="same", prompt="x")
+    with pytest.raises(ValueError, match="variant names must differ"):
+        run_ab(v, v, [Task(task_id="t1", input="x")])
+
+
+def test_run_ab_handles_empty_task_list(variant_a: Variant, variant_b: Variant) -> None:
+    """Empty task set yields zero stats and a tie verdict."""
+    cmp = run_ab(variant_a, variant_b, [])
+
+    assert cmp.variant_a.n == 0
+    assert cmp.variant_b.n == 0
+    assert cmp.winner == "tie"
+    assert cmp.per_task == ()
+
+
+# ---------------------------------------------------------------------------
+# Custom executor path
+# ---------------------------------------------------------------------------
+
+
+def test_run_ab_with_custom_executor(variant_a: Variant, variant_b: Variant) -> None:
+    """A custom executor that pre-scores must flow through unchanged."""
+
+    def biased_executor(variant: Variant, task: Task) -> RunResult:
+        return RunResult(
+            variant=variant.name,
+            task_id=task.task_id,
+            output=variant.name,
+            score=1.0 if variant.name == "B" else 0.0,
+            duration_ms=10.0,
+            passed=variant.name == "B",
+        )
+
+    tasks = [Task(task_id=f"t{i}", input=i) for i in range(4)]
+    cmp = run_ab(variant_a, variant_b, tasks, executor=biased_executor)
+
+    assert cmp.variant_a.pass_rate == 0.0
+    assert cmp.variant_b.pass_rate == 1.0
+    assert cmp.winner == "b"
+    assert cmp.variant_a.mean_duration_ms == 10.0
+
+
+# ---------------------------------------------------------------------------
+# JSON serialisation / round-trip stability
+# ---------------------------------------------------------------------------
+
+
+def test_comparison_to_json_is_byte_stable(variant_a: Variant, variant_b: Variant) -> None:
+    """Two identical runs must yield byte-identical JSON output."""
+    cmp1 = run_ab(variant_a, variant_b, _tasks(), scorer=exact_match_scorer)
+    cmp2 = run_ab(variant_a, variant_b, _tasks(), scorer=exact_match_scorer)
+
+    json1 = cmp1.to_json()
+    json2 = cmp2.to_json()
+    assert json1 == json2
+
+    # And the JSON must be parseable back to a dict matching to_dict()
+    parsed = json.loads(json1)
+    assert parsed == cmp1.to_dict()
+    # Sort_keys → top-level keys are alphabetical
+    top_level_keys = list(parsed.keys())
+    assert top_level_keys == sorted(top_level_keys)
+
+
+def test_comparison_dict_shape() -> None:
+    """``to_dict`` exposes a stable schema for downstream consumers."""
+    cmp = Comparison(
+        variant_a=VariantStats(
+            name="A", n=1, pass_count=1, pass_rate=1.0, mean_score=1.0, mean_duration_ms=0.0
+        ),
+        variant_b=VariantStats(
+            name="B", n=1, pass_count=0, pass_rate=0.0, mean_score=0.0, mean_duration_ms=0.0
+        ),
+        per_task=(),
+        winner="a",
+        reason="A pass_rate 100.00% beat B 0.00%",
+    )
+    expected_keys = {"variant_a", "variant_b", "per_task", "winner", "reason"}
+    assert set(cmp.to_dict().keys()) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# YAML loaders
+# ---------------------------------------------------------------------------
+
+
+def test_load_variant_yaml_round_trip(tmp_path: Path) -> None:
+    """Round-trip a Variant via YAML."""
+    p = tmp_path / "variant.yaml"
+    p.write_text(
+        "name: my-variant\nprompt: |\n  hello world\nmodel: haiku\nmetadata:\n  source: test\n",
+        encoding="utf-8",
+    )
+    v = load_variant_yaml(p)
+    assert v.name == "my-variant"
+    assert v.prompt.strip() == "hello world"
+    assert v.model == "haiku"
+    assert v.metadata == {"source": "test"}
+
+
+def test_load_variant_yaml_missing_keys_raises(tmp_path: Path) -> None:
+    """Missing required keys → ValueError, not KeyError."""
+    p = tmp_path / "bad.yaml"
+    p.write_text("name: only-name\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing required keys"):
+        load_variant_yaml(p)
+
+
+def test_load_tasks_yaml_round_trip(tmp_path: Path) -> None:
+    """Round-trip a task list via YAML, preserving order."""
+    p = tmp_path / "tasks.yaml"
+    p.write_text(
+        "tasks:\n"
+        "  - id: t1\n    input: hello\n    expected: A::hello\n"
+        "  - id: t2\n    input: world\n    expected: A::world\n",
+        encoding="utf-8",
+    )
+    tasks = load_tasks_yaml(p)
+    assert [t.task_id for t in tasks] == ["t1", "t2"]
+    assert tasks[0].expected == "A::hello"
+
+
+def test_load_tasks_yaml_rejects_non_list(tmp_path: Path) -> None:
+    """Top-level must be a 'tasks' list."""
+    p = tmp_path / "bad.yaml"
+    p.write_text("not_tasks: []\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="top-level 'tasks"):
+        load_tasks_yaml(p)


### PR DESCRIPTION
## Summary
- KF-9 ticket slice — **Option A: A/B runner primitive**.
- New `bernstein.eval.ab_runner` module with `Variant` / `Task` / `RunResult` /
  `Comparison` dataclasses, `run_ab()`, deterministic `echo_executor` +
  `exact_match_scorer`, YAML loaders, byte-stable JSON serialisation.
- New CLI: `bernstein eval ab --variant-a <yaml> --variant-b <yaml> --tasks <yaml>`
  emits a deterministic comparison JSON (synthetic-only path, zero LLM cost).
- 14 unit tests covering deterministic comparison output, per-task delta order,
  tie tolerance, custom executor, JSON byte-stability, YAML round-trip.

## Shipped
- `src/bernstein/eval/ab_runner.py` — primitive layer.
- `src/bernstein/cli/commands/eval_benchmark_cmd.py` — `eval ab` subcommand.
- `tests/unit/test_ab_runner.py` — 14 tests.

## Deferred (kept on the ticket for follow-ups)
- Real golden corpora (PR-corpus, task-corpus loaders).
- Parallel matrix runner (multi-dimensional grid, scheduler fan-out).
- HTML reports + Plotly charts.
- Wilcoxon / bootstrap significance testing.
- Drill-down to KF-5 replay / KF-6 cost receipts.
- Adapter-coverage integration tests, blog/paper payload.

## Coordination with parallel work
- Companion to `core.quality.ab_test` (server-bound model-vs-model on a single
  task); this slice covers the prompt-vs-prompt offline path.
- Benchmark loaders (SWE-bench Pro, Terminal-Bench 2.0, SWE-rebench) are
  intentionally **out of scope** here — they belong to PR #1129
  (feat-swe-bench-pro-terminal-bench-nightly).

## Test plan
- [x] `uv run pytest tests/unit/test_ab_runner.py` — 14 passed
- [x] `uv run pytest tests/unit/test_ab_test.py tests/unit/test_eval_framework.py tests/unit/test_ab_test_results.py` — 66 passed (no regression in neighbouring eval/ab modules)
- [x] CLI smoke via `CliRunner`: `bernstein eval ab` returns deterministic JSON
- [x] `uv run ruff check` — clean on new files
- [ ] CI to confirm full lint + import-linter pass

## Ticket
Moved from `.sdd/backlog/open/2026-05-06-kf-9-eval-harness-and-ab.md` →
`.sdd/backlog/closed/` (note: `.sdd/` is gitignored, move is local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)