### PR TITLE
feat(cost): KF-6 slice 1 — bernstein run --max-cost-usd hard cap

### DIFF
--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -687,6 +687,7 @@ def cli(
         task_filter=task_filter,
         auto_pr=auto_pr,
         activity_log_path=activity_log_path,
+        max_cost_usd=None,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -215,6 +215,7 @@ def _propagate_env_flags(
     auto_pr: bool,
     activity_log_path: str | None,
     audit: bool,
+    max_cost_usd: float | None = None,
 ) -> None:
     """Set environment variables so orchestrator subprocesses inherit CLI flags."""
     _flag_map: list[tuple[bool, str]] = [
@@ -239,6 +240,13 @@ def _propagate_env_flags(
     for val, key in _str_map:
         if val:
             os.environ[key] = val
+
+    # KF-6 slice 1: per-run budget cap. Off-by-default: only propagated when
+    # the operator passes ``--max-cost-usd`` so existing runs are unaffected.
+    if max_cost_usd is not None and max_cost_usd > 0.0:
+        from bernstein.core.cost_tracker import ENV_MAX_COST_USD
+
+        os.environ[ENV_MAX_COST_USD] = f"{max_cost_usd:.6f}"
 
     if sandbox:
         os.environ["BERNSTEIN_CONTAINER"] = "1"
@@ -789,6 +797,17 @@ def exec_restart() -> None:
     default=None,
     help="Write activity to log file (default: .sdd/logs/activity.log).",
 )
+@click.option(
+    "--max-cost-usd",
+    "max_cost_usd",
+    type=float,
+    default=None,
+    help=(
+        "KF-6 cost autopilot: hard cap on total run spend in USD. Aggregated "
+        "across all agents; orchestrator stops spawning when reached. "
+        "Off-by-default (overrides bernstein.yaml ``budget`` and run_config.json)."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -820,6 +839,7 @@ def run(
     task_filter: str | None = None,
     auto_pr: bool = False,
     activity_log_path: str | None = None,
+    max_cost_usd: float | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -843,6 +863,7 @@ def run(
       bernstein conduct --sandbox docker       # run agents in Docker sandbox
       bernstein conduct --container --two-phase-sandbox  # two-phase sandboxed execution
       bernstein conduct --audit                # SOC 2 audit mode (HMAC-chained log + Merkle seal)
+      bernstein conduct --max-cost-usd 1.50    # hard cap total run spend at $1.50 (KF-6)
     """
     # Banner already printed by cli() — don't duplicate
 
@@ -874,6 +895,7 @@ def run(
         auto_pr=auto_pr,
         activity_log_path=activity_log_path,
         audit=audit,
+        max_cost_usd=max_cost_usd,
     )
 
     _install_network_policy(run_profile=run_profile, allow_network=allow_network)

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -38,6 +38,67 @@ from bernstein.core.tenanting import normalize_tenant_id
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
+# Run-level budget cap (KF-6 cost autopilot, slice 1)
+# ---------------------------------------------------------------------------
+
+# Env var honoured by the orchestrator startup path so a CLI flag
+# (``bernstein run --max-cost-usd N``) can override seed/run-config
+# defaults without a YAML edit. Off-by-default: when unset, behaviour
+# is identical to prior releases.
+ENV_MAX_COST_USD: str = "BERNSTEIN_MAX_COST_USD"
+
+
+def resolve_run_budget_usd(
+    *,
+    run_config_value: float | None = None,
+    seed_value: float | None = None,
+    env: dict[str, str] | None = None,
+    default: float = 0.0,
+) -> float:
+    """Resolve the per-run USD budget cap from layered sources.
+
+    Precedence (highest first):
+      1. ``BERNSTEIN_MAX_COST_USD`` env var (CLI flag propagation).
+      2. ``run_config_value`` (``.sdd/runtime/run_config.json``).
+      3. ``seed_value`` (``bernstein.yaml`` ``budget`` field).
+      4. ``default`` (``0.0`` = unlimited).
+
+    Invalid / non-numeric env values are ignored with a warning so that a
+    typo never silently disables the budget guard or crashes startup.
+    Non-positive values mean "unlimited" and are normalised to ``0.0``.
+
+    Args:
+        run_config_value: Budget read from ``run_config.json``.
+        seed_value: Budget read from ``bernstein.yaml`` (``seed.budget_usd``).
+        env: Optional environment mapping (defaults to :data:`os.environ`).
+            Exposed for tests so they don't have to mutate process state.
+        default: Fallback when no source provides a value.
+
+    Returns:
+        Non-negative budget cap in USD (``0.0`` = unlimited).
+    """
+    env_map = env if env is not None else os.environ
+    raw_env = env_map.get(ENV_MAX_COST_USD)
+    if raw_env is not None and raw_env.strip():
+        try:
+            env_value = float(raw_env)
+            if env_value < 0.0:
+                env_value = 0.0
+            return env_value
+        except ValueError:
+            logger.warning(
+                "Invalid %s=%r; falling back to run_config/seed/default budget.",
+                ENV_MAX_COST_USD,
+                raw_env,
+            )
+    if run_config_value is not None and run_config_value > 0.0:
+        return float(run_config_value)
+    if seed_value is not None and seed_value > 0.0:
+        return float(seed_value)
+    return max(0.0, float(default))
+
+
+# ---------------------------------------------------------------------------
 # Threshold defaults
 # ---------------------------------------------------------------------------
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4470,7 +4470,7 @@ if __name__ == "__main__":
             resource_limits=agent_rlimits,
             warm_pool=warm_pool,
         )
-        budget_usd = 0.0
+        run_config_budget_usd: float | None = None
         dry_run = False
         approval_mode = "auto"
         merge_strategy = "pr"
@@ -4480,7 +4480,7 @@ if __name__ == "__main__":
         if run_config_path.exists():
             try:
                 run_cfg = json.loads(run_config_path.read_text())
-                budget_usd = float(run_cfg.get("budget_usd", 0.0))
+                run_config_budget_usd = float(run_cfg.get("budget_usd", 0.0))
                 dry_run = bool(run_cfg.get("dry_run", False))
                 approval_mode = str(run_cfg.get("approval", "auto"))
                 merge_strategy = str(run_cfg.get("merge_strategy", "pr"))
@@ -4488,6 +4488,18 @@ if __name__ == "__main__":
                 workflow_mode = run_cfg.get("workflow") or None
             except ValueError:
                 pass
+
+        # KF-6 slice 1: layered budget resolution.
+        #   Precedence: BERNSTEIN_MAX_COST_USD > run_config.json > seed.budget_usd > 0.
+        # The env var is set by the ``bernstein run --max-cost-usd N`` CLI flag.
+        # Off-by-default: if neither flag, run-config, nor seed sets a positive
+        # cap the run remains unbounded (``budget_usd = 0.0``).
+        from bernstein.core.cost_tracker import resolve_run_budget_usd
+
+        budget_usd = resolve_run_budget_usd(
+            run_config_value=run_config_budget_usd,
+            seed_value=seed.budget_usd if seed is not None else None,
+        )
         # Env var override for workflow mode
         workflow_mode = os.environ.get("BERNSTEIN_WORKFLOW", workflow_mode or "") or None
 

--- a/tests/unit/test_max_cost_usd_flag.py
+++ b/tests/unit/test_max_cost_usd_flag.py
@@ -1,0 +1,257 @@
+"""Tests for KF-6 cost autopilot slice 1: per-run budget cap (--max-cost-usd).
+
+Covers:
+  * ``resolve_run_budget_usd`` precedence (env > run_config > seed > default).
+  * Invalid env values fall through to lower layers without raising.
+  * ``CostTracker.can_spawn`` enforces the resolved cap (cap-enforcement).
+  * Sub-cap runs are unaffected (no false positives).
+  * ``BudgetStatus.should_stop`` flips at the hard-stop threshold.
+
+The CLI flag (``bernstein run --max-cost-usd N``) is a thin propagation
+layer that sets the env var via :func:`_propagate_env_flags`; behaviour is
+exercised end-to-end through the resolver.
+"""
+
+from __future__ import annotations
+
+import pytest
+from bernstein.core.cost_tracker import (
+    ENV_MAX_COST_USD,
+    CostTracker,
+    resolve_run_budget_usd,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_run_budget_usd — precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePrecedence:
+    """Layered resolution: env > run_config > seed > default."""
+
+    def test_env_wins_over_run_config_and_seed(self) -> None:
+        env = {ENV_MAX_COST_USD: "2.50"}
+        result = resolve_run_budget_usd(
+            run_config_value=10.0,
+            seed_value=5.0,
+            env=env,
+        )
+        assert result == pytest.approx(2.50)
+
+    def test_run_config_used_when_env_unset(self) -> None:
+        result = resolve_run_budget_usd(
+            run_config_value=7.0,
+            seed_value=3.0,
+            env={},
+        )
+        assert result == pytest.approx(7.0)
+
+    def test_seed_used_when_env_and_run_config_missing(self) -> None:
+        result = resolve_run_budget_usd(
+            run_config_value=None,
+            seed_value=4.25,
+            env={},
+        )
+        assert result == pytest.approx(4.25)
+
+    def test_default_zero_when_no_source(self) -> None:
+        result = resolve_run_budget_usd(env={})
+        assert result == 0.0
+
+    def test_explicit_default_used(self) -> None:
+        result = resolve_run_budget_usd(env={}, default=1.5)
+        assert result == pytest.approx(1.5)
+
+    def test_run_config_zero_falls_through_to_seed(self) -> None:
+        # ``run_config.json`` defaults the field to 0.0 — that should not
+        # mask a positive seed value.
+        result = resolve_run_budget_usd(
+            run_config_value=0.0,
+            seed_value=2.0,
+            env={},
+        )
+        assert result == pytest.approx(2.0)
+
+    def test_seed_zero_falls_through_to_default(self) -> None:
+        result = resolve_run_budget_usd(
+            run_config_value=None,
+            seed_value=0.0,
+            env={},
+            default=0.0,
+        )
+        assert result == 0.0
+
+
+class TestResolveEnvParsing:
+    """Env-var hardening: typos, whitespace, negatives must not break startup."""
+
+    def test_invalid_env_string_falls_back(self) -> None:
+        env = {ENV_MAX_COST_USD: "not-a-number"}
+        result = resolve_run_budget_usd(
+            run_config_value=3.0,
+            env=env,
+        )
+        assert result == pytest.approx(3.0)
+
+    def test_blank_env_falls_back(self) -> None:
+        env = {ENV_MAX_COST_USD: "   "}
+        result = resolve_run_budget_usd(
+            run_config_value=2.0,
+            env=env,
+        )
+        assert result == pytest.approx(2.0)
+
+    def test_negative_env_clamped_to_zero(self) -> None:
+        env = {ENV_MAX_COST_USD: "-1.5"}
+        # Negative means "unlimited" — safer than honouring as a -$1.50 cap.
+        result = resolve_run_budget_usd(env=env)
+        assert result == 0.0
+
+    def test_env_supports_decimals(self) -> None:
+        env = {ENV_MAX_COST_USD: "0.0125"}
+        result = resolve_run_budget_usd(env=env)
+        assert result == pytest.approx(0.0125)
+
+
+# ---------------------------------------------------------------------------
+# Cap-enforcement via CostTracker
+# ---------------------------------------------------------------------------
+
+
+class TestCapEnforcement:
+    """End-to-end: resolved cap drives ``CostTracker.can_spawn`` / ``should_stop``."""
+
+    def test_sub_cap_runs_unaffected(self) -> None:
+        """At 50% of the cap the tracker still permits new agent spawns."""
+        cap = resolve_run_budget_usd(env={ENV_MAX_COST_USD: "1.00"})
+        tracker = CostTracker(run_id="kf6-sub-cap", budget_usd=cap)
+        tracker.record("agent-A", "task-1", "haiku", 1000, 500, cost_usd=0.50)
+
+        status = tracker.status()
+        assert status.percentage_used == pytest.approx(0.50)
+        assert status.should_stop is False
+        assert tracker.can_spawn() is True
+
+    def test_at_cap_stops_spawning(self) -> None:
+        """Reaching 100% of the cap flips ``should_stop`` and blocks spawns."""
+        cap = resolve_run_budget_usd(env={ENV_MAX_COST_USD: "1.00"})
+        tracker = CostTracker(run_id="kf6-at-cap", budget_usd=cap)
+        tracker.record("agent-A", "task-1", "haiku", 1000, 500, cost_usd=1.00)
+
+        status = tracker.status()
+        assert status.percentage_used == pytest.approx(1.00)
+        assert status.should_stop is True
+        assert tracker.can_spawn() is False
+
+    def test_over_cap_stays_blocked(self) -> None:
+        """Cumulative spend over the cap remains a hard-stop."""
+        cap = resolve_run_budget_usd(env={ENV_MAX_COST_USD: "0.50"})
+        tracker = CostTracker(run_id="kf6-over-cap", budget_usd=cap)
+        tracker.record("agent-A", "task-1", "sonnet", 1000, 500, cost_usd=0.40)
+        assert tracker.can_spawn() is True
+        tracker.record("agent-B", "task-2", "sonnet", 1000, 500, cost_usd=0.20)
+        assert tracker.can_spawn() is False
+
+    def test_aggregates_across_agents(self) -> None:
+        """Cap is per-RUN, not per-agent: spend by multiple agents adds up."""
+        cap = resolve_run_budget_usd(env={ENV_MAX_COST_USD: "0.30"})
+        tracker = CostTracker(run_id="kf6-multi-agent", budget_usd=cap)
+        tracker.record("agent-A", "task-1", "haiku", 100, 50, cost_usd=0.10)
+        tracker.record("agent-B", "task-2", "haiku", 100, 50, cost_usd=0.10)
+        # Two cheap agents under cap — still allowed.
+        assert tracker.can_spawn() is True
+        tracker.record("agent-C", "task-3", "haiku", 100, 50, cost_usd=0.15)
+        # Third agent pushes the run total to 0.35 >= 0.30 — hard-stop.
+        assert tracker.can_spawn() is False
+
+    def test_zero_cap_means_unlimited(self) -> None:
+        """When no cap is set the tracker never reports should_stop."""
+        cap = resolve_run_budget_usd(env={})
+        tracker = CostTracker(run_id="kf6-no-cap", budget_usd=cap)
+        tracker.record("agent-A", "task-1", "opus", 100_000, 50_000, cost_usd=99.99)
+        status = tracker.status()
+        assert status.should_stop is False
+        assert tracker.can_spawn() is True
+
+
+# ---------------------------------------------------------------------------
+# CLI propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCliPropagation:
+    """``--max-cost-usd N`` round-trips through ``_propagate_env_flags``."""
+
+    def test_flag_sets_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.cli.run_bootstrap import _propagate_env_flags
+
+        monkeypatch.delenv(ENV_MAX_COST_USD, raising=False)
+        _propagate_env_flags(
+            profile=False,
+            workflow=None,
+            routing=None,
+            compliance=None,
+            sandbox=None,
+            container=False,
+            container_image=None,
+            two_phase_sandbox=False,
+            quiet=False,
+            task_filter=None,
+            auto_pr=False,
+            activity_log_path=None,
+            audit=False,
+            max_cost_usd=2.5,
+        )
+        import os
+
+        assert os.environ.get(ENV_MAX_COST_USD) == "2.500000"
+
+    def test_no_flag_leaves_env_untouched(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.cli.run_bootstrap import _propagate_env_flags
+
+        monkeypatch.delenv(ENV_MAX_COST_USD, raising=False)
+        _propagate_env_flags(
+            profile=False,
+            workflow=None,
+            routing=None,
+            compliance=None,
+            sandbox=None,
+            container=False,
+            container_image=None,
+            two_phase_sandbox=False,
+            quiet=False,
+            task_filter=None,
+            auto_pr=False,
+            activity_log_path=None,
+            audit=False,
+            max_cost_usd=None,
+        )
+        import os
+
+        assert ENV_MAX_COST_USD not in os.environ
+
+    def test_zero_flag_is_treated_as_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from bernstein.cli.run_bootstrap import _propagate_env_flags
+
+        monkeypatch.delenv(ENV_MAX_COST_USD, raising=False)
+        _propagate_env_flags(
+            profile=False,
+            workflow=None,
+            routing=None,
+            compliance=None,
+            sandbox=None,
+            container=False,
+            container_image=None,
+            two_phase_sandbox=False,
+            quiet=False,
+            task_filter=None,
+            auto_pr=False,
+            activity_log_path=None,
+            audit=False,
+            max_cost_usd=0.0,
+        )
+        import os
+
+        # Off-by-default: 0.0 (or None) does not propagate so existing flows
+        # remain identical to the pre-KF-6 behaviour.
+        assert ENV_MAX_COST_USD not in os.environ


### PR DESCRIPTION
## Summary

Smallest-viable slice of [KF-6 cost autopilot epic](../.sdd/backlog/closed/2026-05-06-kf-6-cost-autopilot-free-first-cascade.md). **Option A (recommended in ticket)**: per-run hard cost cap with kill-switch, surfaced as a CLI flag.

- New CLI flag `bernstein run --max-cost-usd N` — off-by-default hard cap on total run spend (USD), aggregated across all agents.
- New helper `bernstein.core.cost.cost_tracker.resolve_run_budget_usd` with layered precedence: `BERNSTEIN_MAX_COST_USD` env > `run_config.json` > `seed.budget_usd` > 0 (unlimited). Hardens against typo / negative / blank env values so a bad flag cannot crash startup.
- Bug fix surfaced by the resolver: `seed.budget_usd` was previously **lost** on the orchestrator's initial boot path (only honoured by hot-reload). The resolver now wires it through, matching what every operator already expected.

## What shipped

| Layer | Change |
|---|---|
| Core | `resolve_run_budget_usd` helper + `ENV_MAX_COST_USD` constant |
| Orchestrator | Initial-boot budget now resolved via the helper (not just `run_config.json`) |
| CLI | `--max-cost-usd FLOAT` on `bernstein run` (`conduct`); propagated via `_propagate_env_flags` |
| Tests | 19 unit tests in `tests/unit/test_max_cost_usd_flag.py` covering precedence, env-parsing hardening, cap-enforcement (sub-cap unaffected; cap-at-100% blocks; aggregates across agents), and CLI round-trip |

## Deferred (tracked in follow-up tickets)

The parent epic is multi-week; this PR is a one-button slice. Remaining work:

- Cascade routing skeleton (`free-first` policy: Cloudflare AI / Groq / Ollama -> Haiku -> Sonnet -> Opus)
- Confidence-driven escalation wiring (`completion_confidence.py` -> tier bump)
- Per-task `cost_receipt.json` (counterfactual: "what this would have cost on Opus-only")
- End-of-run shareable summary print
- `bernstein cost autopilot enable|disable|status` + `cost receipt show|publish` CLI subcommands
- `autopilot:` config block in `bernstein.yaml`
- Docs page + launch blog draft

## Test plan

- [x] `pytest tests/unit/test_max_cost_usd_flag.py` — 19 passed
- [x] `pytest tests/unit/test_cost_tracker.py tests/unit/test_cost_autopilot.py tests/unit/test_budget_killswitch.py tests/unit/test_budget_actions.py tests/unit/test_budget_lock.py tests/unit/test_cli_run_params.py tests/unit/test_cost_tracker_bounded.py` — 88 passed (no regressions in adjacent modules)
- [x] `pytest tests/unit/test_orchestrator.py tests/unit/test_bootstrap.py tests/unit/test_dry_run_cmd.py tests/unit/test_run_report.py` — 234 passed
- [x] `ruff check` clean on all changed files
- [x] Pre-push lint + import-linter contracts pass

## Ticket

`.sdd/backlog/open/2026-05-06-kf-6-cost-autopilot-free-first-cascade.md` -> `.sdd/backlog/closed/...` (gitignored backlog dir; move performed locally per repo convention). First line of moved ticket annotated with: "Closing as the smallest-viable slice landed; remaining work tracked in follow-ups."

🤖 Generated with [Claude Code](https://claude.com/claude-code)