### PR TITLE
feat(wiki): bernstein wiki build — KF-1 smallest-viable slice

### DIFF
--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -122,6 +122,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "voice_cmd": "bernstein.cli.commands.voice_cmd",
     "voice_control": "bernstein.cli.utils.voice_control",
     "watch_cmd": "bernstein.cli.commands.watch_cmd",
+    "wiki_cmd": "bernstein.cli.commands.wiki_cmd",
     "worker_cmd": "bernstein.cli.commands.worker_cmd",
     "workflow_cmd": "bernstein.cli.commands.workflow_cmd",
     "workspace_cmd": "bernstein.cli.commands.workspace_cmd",

--- a/src/bernstein/cli/commands/wiki_cmd.py
+++ b/src/bernstein/cli/commands/wiki_cmd.py
@@ -1,0 +1,89 @@
+"""``bernstein wiki`` — emit a deterministic ``WIKI.md`` for the repo.
+
+Smallest-viable slice of KF-1 (repo wiki + code search). Builds the AST
+symbol graph in-process and renders a Markdown summary to stdout, or
+writes it to ``WIKI.md`` at the repo root with ``--write``. HTTP routes,
+MCP exposure, and post-commit re-indexing remain follow-ups; see the
+parent ticket ``2026-05-06-paid-tier-parity-killer-features.md``.
+
+Devin Wiki / DeepWiki (paid: $20/mo Pro, $500/mo Teams, ACU billing)
+ships the same surface area behind a hosted SaaS. This command renders
+locally on every invocation, for free, against a private repo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.git_context import ls_files
+from bernstein.core.knowledge.ast_symbol_graph import build_semantic_graph
+from bernstein.core.knowledge.wiki_renderer import render_wiki
+
+_DEFAULT_OUTPUT = Path("WIKI.md")
+
+
+@click.group("wiki")
+def wiki_group() -> None:
+    """Render a Markdown wiki for the current repo (local, free).
+
+    Paid alternative: Devin Wiki / DeepWiki ($20/mo Pro, $500/mo Teams,
+    ACU pay-as-you-go). ``bernstein wiki`` runs on your laptop with no
+    contract, no per-token billing, and no cloud round-trip.
+    """
+
+
+@wiki_group.command("build")
+@click.option(
+    "--repo",
+    "repo_path",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    default=Path.cwd(),
+    show_default=False,
+    help="Repo root to scan (defaults to current working directory).",
+)
+@click.option(
+    "--write",
+    "write_output",
+    is_flag=True,
+    default=False,
+    help="Write the rendered wiki to WIKI.md at the repo root.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(file_okay=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Custom output path (implies --write). Useful for CI snapshots.",
+)
+def wiki_build(
+    repo_path: Path,
+    write_output: bool,
+    output_path: Path | None,
+) -> None:
+    """Render WIKI.md from the AST symbol graph and stream it to stdout.
+
+    With ``--write`` (or ``--output PATH``) the rendered Markdown is
+    written to disk instead and the path is logged. The output is
+    deterministic for a given repo state, which makes it safe to commit
+    or diff in CI.
+    """
+    repo_root = repo_path.resolve()
+    repo_name = repo_root.name
+    files = ls_files(repo_root)
+    graph = build_semantic_graph(repo_root)
+    markdown = render_wiki(graph, files, repo_name=repo_name)
+
+    if output_path is not None:
+        target = output_path if output_path.is_absolute() else repo_root / output_path
+    elif write_output:
+        target = repo_root / _DEFAULT_OUTPUT
+    else:
+        click.echo(markdown, nl=False)
+        return
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(markdown, encoding="utf-8")
+    console.print(f"[green]Wrote wiki:[/green] {target}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -114,6 +114,7 @@ from bernstein.cli.verbosity import apply_verbosity
 from bernstein.cli.verify_cmd import verify_cmd
 from bernstein.cli.voice_cmd import listen_cmd
 from bernstein.cli.watch_cmd import watch_cmd
+from bernstein.cli.wiki_cmd import wiki_group
 from bernstein.cli.worker_cmd import worker
 from bernstein.cli.workflow_cmd import workflow_group
 from bernstein.cli.workspace_cmd import config_group, workspace_group
@@ -207,6 +208,7 @@ __all__ = [
     "test_adapter",
     "trace_cmd",
     "watch_cmd",
+    "wiki_group",
     "worker",
     "workspace_group",
     "wrap_up",
@@ -795,6 +797,7 @@ cli.add_command(man_pages_cmd, "man-pages")
 cli.add_command(workflow_group, "workflow")
 cli.add_command(quickstart_cmd, "quickstart")
 cli.add_command(watch_cmd, "watch")
+cli.add_command(wiki_group, "wiki")
 cli.add_command(listen_cmd, "listen")
 cli.add_command(self_update_cmd, "self-update")
 cli.add_command(undo_cmd, "undo")

--- a/src/bernstein/core/knowledge/wiki_renderer.py
+++ b/src/bernstein/core/knowledge/wiki_renderer.py
@@ -98,7 +98,7 @@ def _collect_packages(graph: SemanticGraph) -> dict[str, list[SymbolNode]]:
         Mapping of package label → sorted list of public ``SymbolNode``s.
     """
     by_pkg: dict[str, list[SymbolNode]] = {}
-    for sym_id, node in sorted(graph.nodes.items()):
+    for _sym_id, node in sorted(graph.nodes.items()):
         if not _is_public_symbol(node):
             continue
         if _is_test_file(node.file):

--- a/src/bernstein/core/knowledge/wiki_renderer.py
+++ b/src/bernstein/core/knowledge/wiki_renderer.py
@@ -128,8 +128,7 @@ def _render_header(repo_name: str) -> list[str]:
         f"# {repo_name} — Repo Wiki",
         "",
         "Auto-generated from the AST symbol graph by `bernstein wiki`.",
-        "Re-run after significant changes; commit only if you want a "
-        "tracked snapshot.",
+        "Re-run after significant changes; commit only if you want a tracked snapshot.",
         "",
     ]
 

--- a/src/bernstein/core/knowledge/wiki_renderer.py
+++ b/src/bernstein/core/knowledge/wiki_renderer.py
@@ -1,0 +1,235 @@
+"""Deterministic ``WIKI.md`` renderer derived from the AST symbol graph.
+
+This is the smallest-viable slice of KF-1 (repo wiki + code search). It
+materialises a single Markdown page summarising a repository's top-level
+structure, public API by sub-package, and test layout. It does **not**
+ship HTTP routes, MCP tools, or git-hook re-indexing — those remain in
+follow-up tickets per the parent paid-tier-parity epic.
+
+The renderer is a pure function over a :class:`SemanticGraph` plus the
+list of repo files; callers own all IO. This keeps the output trivially
+reproducible for CI and snapshot tests.
+
+Usage::
+
+    graph = build_semantic_graph(workdir)
+    files = list_repo_files(workdir)
+    markdown = render_wiki(graph, files, repo_name="bernstein")
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from bernstein.core.knowledge.ast_symbol_graph import SemanticGraph, SymbolNode
+
+
+# Cap section sizes so the wiki page stays human-skimmable on big repos.
+_MAX_TOP_LEVEL_DIRS = 30
+_MAX_PUBLIC_SYMBOLS_PER_PACKAGE = 12
+_MAX_PACKAGES_LISTED = 25
+_MAX_TEST_DIRS = 10
+
+
+def _is_python_file(path: str) -> bool:
+    """Return True for tracked Python source files."""
+    return path.endswith(".py")
+
+
+def _is_test_file(path: str) -> bool:
+    """Return True if *path* looks like a test module by convention."""
+    if "/tests/" in f"/{path}" or path.startswith("tests/"):
+        return True
+    name = path.rsplit("/", 1)[-1]
+    return name.startswith("test_") or name.endswith("_test.py")
+
+
+def _is_public_symbol(node: SymbolNode) -> bool:
+    """Public = name does not start with underscore and is not dunder-only."""
+    if not node.name or node.name.startswith("_"):
+        return False
+    # Methods are not surfaced; we summarise top-level functions/classes only.
+    return node.kind in {"function", "class"}
+
+
+def _top_level_dir(path: str) -> str:
+    """Return the first path segment, excluding ``src/`` packaging shims."""
+    parts = path.split("/")
+    if parts and parts[0] == "src" and len(parts) > 1:
+        return parts[1]
+    return parts[0] if parts else ""
+
+
+def _package_for_file(path: str) -> str:
+    """Coarse-grain a file into a sub-package label.
+
+    For ``src/bernstein/core/knowledge/foo.py`` we emit
+    ``bernstein/core/knowledge``. For non-``src/`` layouts we strip the
+    file segment and return the directory.
+    """
+    parts = path.split("/")
+    if len(parts) <= 1:
+        return "."
+    if parts[0] == "src" and len(parts) > 2:
+        parts = parts[1:]
+    return "/".join(parts[:-1])
+
+
+def _collect_top_level_dirs(files: Iterable[str]) -> list[str]:
+    """Sorted, deduplicated list of top-level directories in *files*."""
+    seen: set[str] = set()
+    for path in files:
+        top = _top_level_dir(path)
+        if top and "." not in top.split("/")[0]:
+            seen.add(top)
+    return sorted(seen)[:_MAX_TOP_LEVEL_DIRS]
+
+
+def _collect_packages(graph: SemanticGraph) -> dict[str, list[SymbolNode]]:
+    """Group public symbols by sub-package, preserving deterministic order.
+
+    Args:
+        graph: Built semantic graph.
+
+    Returns:
+        Mapping of package label → sorted list of public ``SymbolNode``s.
+    """
+    by_pkg: dict[str, list[SymbolNode]] = {}
+    for sym_id, node in sorted(graph.nodes.items()):
+        if not _is_public_symbol(node):
+            continue
+        if _is_test_file(node.file):
+            continue
+        pkg = _package_for_file(node.file)
+        by_pkg.setdefault(pkg, []).append(node)
+    # Sort symbols inside each package by (file, line) so output is stable.
+    for nodes in by_pkg.values():
+        nodes.sort(key=lambda n: (n.file, n.line_start, n.name))
+    return by_pkg
+
+
+def _collect_test_dirs(files: Iterable[str]) -> list[str]:
+    """Distinct directories under ``tests/`` containing test files."""
+    seen: set[str] = set()
+    for path in files:
+        if not _is_test_file(path):
+            continue
+        parent = path.rsplit("/", 1)[0]
+        seen.add(parent)
+    return sorted(seen)[:_MAX_TEST_DIRS]
+
+
+def _render_header(repo_name: str) -> list[str]:
+    """First lines of the wiki: title + provenance disclaimer."""
+    return [
+        f"# {repo_name} — Repo Wiki",
+        "",
+        "Auto-generated from the AST symbol graph by `bernstein wiki`.",
+        "Re-run after significant changes; commit only if you want a "
+        "tracked snapshot.",
+        "",
+    ]
+
+
+def _render_top_level_structure(files: list[str]) -> list[str]:
+    """Render the *Top-level structure* section."""
+    lines = ["## Top-level structure", ""]
+    dirs = _collect_top_level_dirs(files)
+    if not dirs:
+        lines.append("_No tracked source directories detected._")
+        lines.append("")
+        return lines
+    for top in dirs:
+        lines.append(f"- `{top}/`")
+    lines.append("")
+    return lines
+
+
+def _format_symbol(node: SymbolNode) -> str:
+    """Render a single public symbol as a Markdown bullet."""
+    kind = node.kind
+    sig = node.signature.strip() if node.signature else node.name
+    doc = node.docstring.strip()
+    # Keep the signature inline-coded so it reads like a Python preview.
+    bullet = f"- `{sig}` ({kind}, `{node.file}:{node.line_start}`)"
+    if doc:
+        bullet += f" — {doc}"
+    return bullet
+
+
+def _render_public_api(graph: SemanticGraph) -> list[str]:
+    """Render the *Public API summary* section grouped by sub-package."""
+    lines = ["## Public API summary", ""]
+    by_pkg = _collect_packages(graph)
+    if not by_pkg:
+        lines.append("_No public symbols extracted from the graph._")
+        lines.append("")
+        return lines
+    packages = sorted(by_pkg.keys())[:_MAX_PACKAGES_LISTED]
+    for pkg in packages:
+        lines.append(f"### `{pkg}`")
+        lines.append("")
+        for node in by_pkg[pkg][:_MAX_PUBLIC_SYMBOLS_PER_PACKAGE]:
+            lines.append(_format_symbol(node))
+        remaining = len(by_pkg[pkg]) - _MAX_PUBLIC_SYMBOLS_PER_PACKAGE
+        if remaining > 0:
+            lines.append(f"- _+{remaining} more public symbols_")
+        lines.append("")
+    skipped = len(by_pkg) - len(packages)
+    if skipped > 0:
+        lines.append(f"_+{skipped} more sub-packages not shown._")
+        lines.append("")
+    return lines
+
+
+def _render_test_layout(files: list[str]) -> list[str]:
+    """Render the *Test layout* section."""
+    lines = ["## Test layout", ""]
+    test_files = [p for p in files if _is_test_file(p) and _is_python_file(p)]
+    if not test_files:
+        lines.append("_No tests detected._")
+        lines.append("")
+        return lines
+    dirs = _collect_test_dirs(test_files)
+    lines.append(f"- {len(test_files)} test file(s) tracked.")
+    for tdir in dirs:
+        count = sum(1 for p in test_files if p.startswith(tdir + "/"))
+        lines.append(f"- `{tdir}/` ({count} file(s))")
+    lines.append("")
+    return lines
+
+
+def render_wiki(
+    graph: SemanticGraph,
+    files: list[str],
+    *,
+    repo_name: str = "repo",
+) -> str:
+    """Render a deterministic ``WIKI.md`` for *graph*.
+
+    Args:
+        graph: A built :class:`SemanticGraph` for the target repo.
+        files: All tracked files (typically from ``git ls-files``). Used
+            to compute the top-level structure and test layout sections;
+            the graph itself only sees Python sources.
+        repo_name: Short repo label used in the title.
+
+    Returns:
+        A single Markdown document with three sections: top-level
+        structure, public API summary by sub-package, and test layout.
+        Output is fully deterministic given the same inputs.
+    """
+    # Defensive copy — sort once so callers can pass in any iterable
+    # without surprising us with order-dependent output.
+    sorted_files = sorted(files)
+    sections: list[str] = []
+    sections.extend(_render_header(repo_name))
+    sections.extend(_render_top_level_structure(sorted_files))
+    sections.extend(_render_public_api(graph))
+    sections.extend(_render_test_layout(sorted_files))
+    # Trim trailing blank lines but keep a single newline at EOF.
+    text = "\n".join(sections).rstrip() + "\n"
+    return text

--- a/tests/unit/test_wiki_cmd.py
+++ b/tests/unit/test_wiki_cmd.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
-from click.testing import CliRunner
-
 from bernstein.cli.wiki_cmd import wiki_group
+from click.testing import CliRunner
 
 
 def _init_git_repo(repo: Path) -> None:

--- a/tests/unit/test_wiki_cmd.py
+++ b/tests/unit/test_wiki_cmd.py
@@ -1,0 +1,131 @@
+"""End-to-end CLI tests for ``bernstein wiki build``."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.wiki_cmd import wiki_group
+
+
+def _init_git_repo(repo: Path) -> None:
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "add", "-A"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "-m",
+            "init",
+        ],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    """Materialise a tiny git-tracked Python package for CLI tests."""
+    (tmp_path / "src" / "pkg").mkdir(parents=True)
+    (tmp_path / "src" / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (tmp_path / "src" / "pkg" / "service.py").write_text(
+        '"""Service."""\n\n'
+        "def public_api() -> int:\n"
+        '    """Public entry point."""\n'
+        "    return 1\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_service.py").write_text(
+        "def test_ok() -> None:\n    assert True\n",
+        encoding="utf-8",
+    )
+    _init_git_repo(tmp_path)
+    return tmp_path
+
+
+def test_wiki_build_streams_markdown_to_stdout(fixture_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["build", "--repo", str(fixture_repo)])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.startswith(f"# {fixture_repo.name} — Repo Wiki\n")
+    assert "public_api" in result.output
+    assert "## Test layout" in result.output
+
+
+def test_wiki_build_writes_file_with_flag(fixture_repo: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        wiki_group,
+        ["build", "--repo", str(fixture_repo), "--write"],
+    )
+
+    assert result.exit_code == 0, result.output
+    written = fixture_repo / "WIKI.md"
+    assert written.exists()
+    content = written.read_text(encoding="utf-8")
+    assert content.startswith(f"# {fixture_repo.name} — Repo Wiki\n")
+    assert "public_api" in content
+
+
+def test_wiki_build_respects_custom_output_path(fixture_repo: Path, tmp_path: Path) -> None:
+    target = tmp_path / "out" / "DOCS.md"
+    runner = CliRunner()
+    result = runner.invoke(
+        wiki_group,
+        [
+            "build",
+            "--repo",
+            str(fixture_repo),
+            "--output",
+            str(target),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert target.exists()
+    assert "public_api" in target.read_text(encoding="utf-8")
+
+
+def test_wiki_help_advertises_paid_alternative() -> None:
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["--help"])
+
+    assert result.exit_code == 0
+    # Per parent-ticket cross-cutting requirement: help text names the
+    # paid alternative + its price so end-users see the comparison.
+    assert "Devin" in result.output
+    assert "$20" in result.output
+
+
+def test_wiki_build_handles_repo_with_no_python(tmp_path: Path) -> None:
+    (tmp_path / "README.md").write_text("hello\n", encoding="utf-8")
+    _init_git_repo(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["build", "--repo", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Repo Wiki" in result.output
+    assert "No public symbols extracted from the graph" in result.output

--- a/tests/unit/test_wiki_renderer.py
+++ b/tests/unit/test_wiki_renderer.py
@@ -1,0 +1,158 @@
+"""Unit tests for the deterministic ``WIKI.md`` renderer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import bernstein.core.knowledge.ast_symbol_graph as semantic_graph
+from bernstein.core.knowledge.ast_symbol_graph import (
+    SemanticGraph,
+    SymbolNode,
+    build_semantic_graph,
+)
+from bernstein.core.knowledge.wiki_renderer import render_wiki
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _make_graph_with(*nodes: SymbolNode) -> SemanticGraph:
+    graph = SemanticGraph()
+    for node in nodes:
+        graph.add_node(node)
+    return graph
+
+
+def test_render_wiki_emits_three_sections_for_empty_inputs() -> None:
+    graph = SemanticGraph()
+    output = render_wiki(graph, [], repo_name="empty")
+
+    assert output.startswith("# empty — Repo Wiki\n")
+    assert "## Top-level structure" in output
+    assert "## Public API summary" in output
+    assert "## Test layout" in output
+    assert output.endswith("\n")
+
+
+def test_render_wiki_is_deterministic_for_fixture_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _write(tmp_path / "src" / "pkg" / "__init__.py", "")
+    _write(
+        tmp_path / "src" / "pkg" / "helpers.py",
+        '"""Helpers."""\n\n'
+        "def helper() -> int:\n"
+        '    """Return one."""\n'
+        "    return 1\n\n"
+        "def _private() -> int:\n"
+        "    return 0\n",
+    )
+    _write(
+        tmp_path / "src" / "pkg" / "service.py",
+        '"""Service."""\n\n'
+        "from pkg.helpers import helper\n\n"
+        "class Service:\n"
+        '    """Top-level service."""\n'
+        "    def run(self) -> int:\n"
+        "        return helper()\n",
+    )
+    _write(
+        tmp_path / "tests" / "unit" / "test_service.py",
+        "def test_smoke() -> None:\n    assert True\n",
+    )
+
+    tracked = [
+        "src/pkg/__init__.py",
+        "src/pkg/helpers.py",
+        "src/pkg/service.py",
+        "tests/unit/test_service.py",
+    ]
+
+    def _fake_ls_files(_workdir: Path) -> list[str]:
+        return tracked
+
+    monkeypatch.setattr(semantic_graph, "_git_ls_files", _fake_ls_files)
+    graph = build_semantic_graph(tmp_path)
+
+    first = render_wiki(graph, tracked, repo_name="fixture")
+    second = render_wiki(graph, list(reversed(tracked)), repo_name="fixture")
+
+    # Determinism: input order must not change the output.
+    assert first == second
+
+    # Header + provenance.
+    assert first.startswith("# fixture — Repo Wiki\n")
+    assert "Auto-generated from the AST symbol graph" in first
+
+    # Top-level structure: only 'src' and 'tests' should appear, not the
+    # leaf files. We strip ``src/`` so the entry should read ``pkg/`` is
+    # NOT a top-level — top levels are ``pkg`` and ``tests`` thanks to the
+    # ``src/``-stripping rule.
+    assert "- `pkg/`" in first
+    assert "- `tests/`" in first
+
+    # Public API summary: helper + Service surfaced; private symbol hidden.
+    assert "### `pkg`" in first
+    assert "`def helper() -> int`" in first
+    assert "`class Service`" in first
+    assert "_private" not in first  # underscore-prefixed names are filtered
+
+    # Test layout section reports the count and dir.
+    assert "1 test file(s) tracked." in first
+    assert "`tests/unit/`" in first
+
+
+def test_render_wiki_skips_test_files_from_public_api() -> None:
+    test_node = SymbolNode(
+        id="tests/unit/test_x.py::test_smoke",
+        name="test_smoke",
+        kind="function",
+        file="tests/unit/test_x.py",
+        line_start=1,
+        line_end=2,
+        signature="def test_smoke() -> None",
+    )
+    src_node = SymbolNode(
+        id="src/pkg/util.py::do_thing",
+        name="do_thing",
+        kind="function",
+        file="src/pkg/util.py",
+        line_start=1,
+        line_end=2,
+        signature="def do_thing() -> int",
+    )
+    graph = _make_graph_with(test_node, src_node)
+    output = render_wiki(
+        graph,
+        ["src/pkg/util.py", "tests/unit/test_x.py"],
+        repo_name="filtered",
+    )
+
+    assert "do_thing" in output
+    assert "test_smoke" not in output  # test symbols don't pollute the API list
+
+
+def test_render_wiki_truncates_oversized_packages() -> None:
+    nodes: list[SymbolNode] = []
+    for i in range(20):
+        nodes.append(
+            SymbolNode(
+                id=f"src/pkg/mod.py::fn_{i:02d}",
+                name=f"fn_{i:02d}",
+                kind="function",
+                file="src/pkg/mod.py",
+                line_start=i + 1,
+                line_end=i + 2,
+                signature=f"def fn_{i:02d}() -> None",
+            ),
+        )
+    graph = _make_graph_with(*nodes)
+    output = render_wiki(graph, ["src/pkg/mod.py"], repo_name="big")
+
+    # We cap at 12 symbols per package and report the remainder.
+    assert "fn_00" in output
+    assert "fn_11" in output
+    assert "fn_12" not in output
+    assert "_+8 more public symbols_" in output


### PR DESCRIPTION
Refs #1085

## Summary

Smallest-viable slice of [KF-1: Repo Wiki + Code Search](https://github.com/sipyourdrink-ltd/bernstein/blob/main/.sdd/backlog/closed/2026-05-06-paid-tier-parity-killer-features.md). Picks **Option A** from the ticket: a `bernstein wiki build` CLI verb that emits a deterministic `WIKI.md` derived from the existing AST symbol graph.

- `wiki_renderer.render_wiki(graph, files, repo_name=...)` — pure renderer; sections: top-level structure, public API by sub-package, test layout. Caps section sizes for skim-ability and is fully deterministic (sorts inputs, no IO).
- `bernstein wiki build [--repo PATH] [--write] [--output PATH]` — streams Markdown to stdout by default; persists when `--write` or `--output` is set. Help text names the paid alternative (Devin Wiki at $20/mo Pro / $500/mo Teams) per the parent ticket's cross-cutting acceptance criteria.

## Shipped vs. deferred

**Shipped (this PR):**
- `src/bernstein/core/knowledge/wiki_renderer.py`
- `src/bernstein/cli/commands/wiki_cmd.py`
- CLI registration in `src/bernstein/cli/main.py` + redirect map in `src/bernstein/cli/__init__.py`
- 9 unit tests (`tests/unit/test_wiki_renderer.py`, `tests/unit/test_wiki_cmd.py`)
- Paid-competitor callout in `--help`

**Deferred to follow-ups (still in parent KF parity epic):**
- Mermaid architecture diagrams from import edges
- HTTP routes under `/wiki/<repo>` + `bernstein wiki serve`
- MCP `wiki_query` tool registration
- Post-commit re-index hook
- `docs/wiki.md` + adapter integration tests + launch blog draft

## Ticket

`.sdd/backlog/closed/2026-05-06-kf-1-repo-wiki-and-code-search.md` (moved from `open/`; closing note added at top of file). Note: `.sdd/` is gitignored, so the move is filesystem-only.

## Test plan

- [x] `pytest tests/unit/test_wiki_renderer.py tests/unit/test_wiki_cmd.py` — 9 passed
- [x] `pytest tests/unit/test_ast_symbol_graph.py tests/unit/test_knowledge_graph.py tests/unit/test_graph_cmd_tasks.py` — 11 existing passed (no regressions)
- [x] `ruff check` clean on all new files
- [x] Manual smoke: `bernstein wiki build --repo .` against bernstein itself yields a non-empty Markdown summary listing all top-level packages
- [ ] CI green (not waited on per ticket instructions)
