### PR TITLE
feat(adapter): DeepSeek V4-Flash + V4-Pro w/ EU-residency self-hosted guard

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -104,7 +104,7 @@ alwaysApply: false
 | `manager.py`               |  |
 | `mistral.py`               | Mistral Vibe CLI adapter |
 | `mock.py`                  | Mock CLI adapter for zero-API-key demos and testing |
-| `ollama.py`                | Ollama local LLM adapter — run coding agents without cloud API keys |
+| `ollama.py`                | Ollama / OpenAI-compatible local LLM adapter — run coding agents without cloud API keys |
 | `open_interpreter.py`      | Open Interpreter CLI adapter |
 | `openai_agents.py`         | OpenAI Agents SDK v2 adapter |
 | `openai_agents_runner.py`  | Python entrypoint that runs an OpenAI Agents SDK session |

--- a/.goosehints
+++ b/.goosehints
@@ -105,7 +105,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `manager.py`               |  |
 | `mistral.py`               | Mistral Vibe CLI adapter |
 | `mock.py`                  | Mock CLI adapter for zero-API-key demos and testing |
-| `ollama.py`                | Ollama local LLM adapter — run coding agents without cloud API keys |
+| `ollama.py`                | Ollama / OpenAI-compatible local LLM adapter — run coding agents without cloud API keys |
 | `open_interpreter.py`      | Open Interpreter CLI adapter |
 | `openai_agents.py`         | OpenAI Agents SDK v2 adapter |
 | `openai_agents_runner.py`  | Python entrypoint that runs an OpenAI Agents SDK session |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,7 +105,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `manager.py`               |  |
 | `mistral.py`               | Mistral Vibe CLI adapter |
 | `mock.py`                  | Mock CLI adapter for zero-API-key demos and testing |
-| `ollama.py`                | Ollama local LLM adapter — run coding agents without cloud API keys |
+| `ollama.py`                | Ollama / OpenAI-compatible local LLM adapter — run coding agents without cloud API keys |
 | `open_interpreter.py`      | Open Interpreter CLI adapter |
 | `openai_agents.py`         | OpenAI Agents SDK v2 adapter |
 | `openai_agents_runner.py`  | Python entrypoint that runs an OpenAI Agents SDK session |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `manager.py`               |  |
 | `mistral.py`               | Mistral Vibe CLI adapter |
 | `mock.py`                  | Mock CLI adapter for zero-API-key demos and testing |
-| `ollama.py`                | Ollama local LLM adapter — run coding agents without cloud API keys |
+| `ollama.py`                | Ollama / OpenAI-compatible local LLM adapter — run coding agents without cloud API keys |
 | `open_interpreter.py`      | Open Interpreter CLI adapter |
 | `openai_agents.py`         | OpenAI Agents SDK v2 adapter |
 | `openai_agents_runner.py`  | Python entrypoint that runs an OpenAI Agents SDK session |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -105,7 +105,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `manager.py`               |  |
 | `mistral.py`               | Mistral Vibe CLI adapter |
 | `mock.py`                  | Mock CLI adapter for zero-API-key demos and testing |
-| `ollama.py`                | Ollama local LLM adapter — run coding agents without cloud API keys |
+| `ollama.py`                | Ollama / OpenAI-compatible local LLM adapter — run coding agents without cloud API keys |
 | `open_interpreter.py`      | Open Interpreter CLI adapter |
 | `openai_agents.py`         | OpenAI Agents SDK v2 adapter |
 | `openai_agents_runner.py`  | Python entrypoint that runs an OpenAI Agents SDK session |

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -1,8 +1,9 @@
-"""Ollama local LLM adapter — run coding agents without cloud API keys.
+"""Ollama / OpenAI-compatible local LLM adapter — run coding agents without cloud API keys.
 
-Uses Aider as the coding frontend with Ollama as the local LLM backend.
-This enables full code editing capabilities in air-gapped, privacy-sensitive,
-or cost-zero environments.
+Uses Aider as the coding frontend with Ollama (or any OpenAI-compatible
+local server such as vLLM, llama.cpp's HTTP server, LM Studio) as the LLM
+backend.  This enables full code editing capabilities in air-gapped,
+privacy-sensitive, EU-residency, or cost-zero environments.
 
 Last verified against upstream Ollama 0.21.x on 2026-05-05.
 
@@ -11,7 +12,21 @@ Prerequisites:
       ``curl -fsSL https://ollama.com/install.sh | sh``)
     - Aider: ``pip install aider-chat``
     - A pulled model: ``ollama pull qwen2.5-coder:7b`` (or the larger
-      ``qwen3-coder``, ``deepseek-r1:70b``, ``llama3.1`` as VRAM allows).
+      ``qwen3-coder``, ``deepseek-v4-flash``, ``deepseek-r1:70b``,
+      ``llama3.1`` as VRAM allows).
+
+EU-residency / vLLM note:
+    For DeepSeek V4-Pro (1.6T MoE / 49B active) the single-GPU Ollama
+    profile is too small; deploy via vLLM tensor-parallel and point
+    ``OLLAMA_API_BASE`` at the vLLM ``/v1`` endpoint — aider/litellm's
+    OpenAI-compatible path treats the two interchangeably.  Callers
+    that need an EU-residency guarantee MUST pass ``eu_residency=True``
+    AND pin ``base_url`` to a self-hosted (e.g. RFC-1918 / *.internal /
+    EU-located) endpoint.  Combine this adapter with
+    :class:`bernstein.core.security.data_residency.DataResidencyController`
+    (set ``allowed_regions={EU_WEST, EU_CENTRAL}``,
+    ``enforce_strict=True``) for the full Article-12 evidence story.
+    See FEAT ``deepseek-v4-flash-eu`` for the full profile spec.
 """
 
 from __future__ import annotations
@@ -30,8 +45,15 @@ if TYPE_CHECKING:
 # Default Ollama API endpoint
 OLLAMA_BASE_URL = "http://localhost:11434"
 
-# Maps Bernstein abstract model names to Ollama model IDs.
-# Users can also pass native ollama model IDs directly (e.g. "qwen2.5-coder:32b").
+# Maps Bernstein abstract model names to Ollama / OpenAI-compatible model IDs.
+# Users can also pass native model IDs directly (e.g. "qwen2.5-coder:32b").
+#
+# DeepSeek V4 entries (added 2026-05-07 — FEAT deepseek-v4-flash-eu):
+#   - ``deepseek-v4-flash`` — 284B / 13B-active MoE, MIT-licensed, fits a
+#     single H100/A100; primary cheap-first arm for EU-residency runs.
+#   - ``deepseek-v4-pro``   — 1.6T / 49B-active MoE, MIT-licensed, requires
+#     vLLM tensor-parallel deployment (does not fit single-GPU Ollama).
+#     Set ``OLLAMA_API_BASE`` to the vLLM ``/v1`` endpoint to route here.
 _MODEL_MAP: dict[str, str] = {
     # Bernstein tiers → sensible local defaults
     "opus": "deepseek-r1:70b",
@@ -41,6 +63,8 @@ _MODEL_MAP: dict[str, str] = {
     "codellama": "codellama",
     "deepseek-coder": "deepseek-coder-v2",
     "deepseek-r1": "deepseek-r1",
+    "deepseek-v4-flash": "deepseek-v4-flash",
+    "deepseek-v4-pro": "deepseek-v4-pro",
     "qwen2.5-coder": "qwen2.5-coder",
     "qwen3-coder": "qwen3-coder",
     "llama3.1": "llama3.1",
@@ -51,29 +75,107 @@ _MODEL_MAP: dict[str, str] = {
     "starcoder2": "starcoder2",
 }
 
+# Models that require a self-hosted endpoint when invoked under the
+# ``eu-residency`` profile.  These are MIT-licensed open weights; running
+# them against the hosted ``deepseek.com`` API leaks tokens out of the EU
+# and breaks the Article-12 evidence story.  When the requested model is
+# on this set OR the adapter was constructed with ``eu_residency=True``,
+# :meth:`OllamaAdapter.spawn` rejects non-self-hosted endpoints with a
+# structured ``RESIDENCY_VIOLATION`` error.
+_EU_RESIDENCY_MODELS: frozenset[str] = frozenset(
+    {
+        "deepseek-v4-flash",
+        "deepseek-v4-pro",
+    }
+)
+
 
 class OllamaAdapter(CLIAdapter):
-    """Spawn coding agent sessions using local Ollama LLMs.
+    """Spawn coding agent sessions using local Ollama / OpenAI-compatible LLMs.
 
-    Uses Aider as the coding agent with Ollama as the LLM provider, giving
-    full file-editing capabilities without any cloud API keys.
+    Uses Aider as the coding agent with Ollama (or vLLM, llama.cpp, LM
+    Studio, etc.) as the LLM provider, giving full file-editing capabilities
+    without any cloud API keys.
 
     Model selection:
-        - Pass a Bernstein tier name (opus/sonnet/haiku) → maps to a capable local model
-        - Pass a native Ollama model ID (e.g. "qwen2.5-coder:7b") → used as-is
-        - Override OLLAMA_BASE_URL env var to point at a remote Ollama instance
+        - Pass a Bernstein tier name (opus/sonnet/haiku) → maps to a
+          capable local model
+        - Pass a native model ID (e.g. ``"qwen2.5-coder:7b"``,
+          ``"deepseek-v4-flash"``) → used as-is
+        - Override OLLAMA_BASE_URL (or pass ``base_url=``) to point at a
+          remote Ollama / vLLM / OpenAI-compatible inference server
 
     Args:
-        base_url: Ollama API base URL. Defaults to http://localhost:11434.
+        base_url: Ollama / OpenAI-compatible API base URL.  Defaults to
+            ``http://localhost:11434``.
+        eu_residency: When True, the spawn() method enforces that the
+            configured endpoint is self-hosted (i.e. not the public
+            ``deepseek.com`` / ``openrouter.ai`` / etc. hosted APIs).
+            This is the operative deployment mode for FEAT
+            ``deepseek-v4-flash-eu`` and integrates with
+            :class:`bernstein.core.security.data_residency.DataResidencyController`
+            for the full Article-12 evidence story.  Defaults to False so
+            existing callers keep their behaviour.  Note: even when this
+            flag is False, the residency guard still fires for any model
+            in :data:`_EU_RESIDENCY_MODELS` because routing those to a
+            hosted API would silently violate the ticket's promise.
     """
 
-    def __init__(self, *, base_url: str = OLLAMA_BASE_URL) -> None:
+    def __init__(self, *, base_url: str = OLLAMA_BASE_URL, eu_residency: bool = False) -> None:
         super().__init__()
         self._base_url = base_url
+        self._eu_residency = eu_residency
+
+    @property
+    def eu_residency(self) -> bool:
+        """Return whether the EU-residency self-hosted guard is active."""
+        return self._eu_residency
 
     def _resolve_model(self, model_name: str) -> str:
-        """Map Bernstein model name to Ollama model ID."""
+        """Map Bernstein model name to Ollama / OpenAI-compatible model ID."""
         return _MODEL_MAP.get(model_name, model_name)
+
+    def _is_self_hosted_endpoint(self, base_url: str) -> bool:
+        """Return True when ``base_url`` points at a self-hosted endpoint.
+
+        Default-closed: this returns ``True`` only when the host is
+        unambiguously self-hosted (loopback, RFC-1918 private range,
+        ``*.internal`` / ``*.local`` / ``*.svc``).  Any public IP or
+        unrecognised hostname is treated as non-self-hosted because the
+        residency profile cannot prove the endpoint sits inside the EU
+        boundary.  Operators who run a private inference cluster on a
+        public IP must front it with a hostname under one of the
+        recognised internal suffixes (or extend this allow-list).
+
+        Args:
+            base_url: The configured Ollama / OpenAI-compatible base URL.
+
+        Returns:
+            True if the endpoint looks self-hosted, False otherwise.
+        """
+        from urllib.parse import urlparse
+
+        host = (urlparse(base_url).hostname or "").lower()
+        if not host:
+            # Empty / malformed URL — fail closed under residency mode.
+            return False
+        if host in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}:
+            return True
+        # RFC 1918 ranges: 10.0.0.0/8, 192.168.0.0/16, 172.16.0.0/12.
+        if host.startswith(("10.", "192.168.")):
+            return True
+        if host.startswith("172."):
+            try:
+                second = int(host.split(".", 2)[1])
+                if 16 <= second <= 31:
+                    return True
+            except (ValueError, IndexError):
+                pass
+        if host.endswith((".internal", ".local", ".svc", ".cluster.local")):
+            return True
+        # Anything else — public IP, hosted-API hostname, or unrecognised
+        # FQDN — is rejected.  We cannot prove EU residency for it.
+        return False
 
     def spawn(
         self,
@@ -103,6 +205,20 @@ class OllamaAdapter(CLIAdapter):
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
         ollama_model = self._resolve_model(model_config.model)
+
+        # FEAT deepseek-v4-flash-eu: when caller activates ``eu_residency``,
+        # OR when the requested model is on the self-hosted-only list,
+        # refuse to spawn against a non-self-hosted endpoint.  Loud,
+        # structured failure: never silently fall back to a public API.
+        residency_active = self._eu_residency or ollama_model in _EU_RESIDENCY_MODELS
+        if residency_active and not self._is_self_hosted_endpoint(self._base_url):
+            raise RuntimeError(
+                "RESIDENCY_VIOLATION: model "
+                f"{ollama_model!r} requires a self-hosted endpoint under the "
+                f"eu-residency profile, got {self._base_url!r}. "
+                "Set OLLAMA_API_BASE / OLLAMA_HOST to a self-hosted (e.g. "
+                "vLLM, Ollama on a private/EU node) endpoint and retry."
+            )
 
         # aider supports ollama via litellm: --model ollama/<model>
         # Smaller repo map keeps local model context usage manageable.

--- a/src/bernstein/adapters/ollama.py
+++ b/src/bernstein/adapters/ollama.py
@@ -171,11 +171,11 @@ class OllamaAdapter(CLIAdapter):
                     return True
             except (ValueError, IndexError):
                 pass
-        if host.endswith((".internal", ".local", ".svc", ".cluster.local")):
-            return True
-        # Anything else — public IP, hosted-API hostname, or unrecognised
-        # FQDN — is rejected.  We cannot prove EU residency for it.
-        return False
+        # Anything else (public IP, hosted-API hostname, unrecognised FQDN)
+        # is rejected — we cannot prove EU residency for it.  Operators
+        # who run a private inference cluster on a public IP must front
+        # it with a hostname under one of the recognised internal suffixes.
+        return host.endswith((".internal", ".local", ".svc", ".cluster.local"))
 
     def spawn(
         self,

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -81,6 +81,17 @@ MODEL_COSTS_PER_1M_TOKENS: dict[str, ModelUsdPer1MTokens] = {
     MODEL_GEMINI_3_1_PRO: {"input": 0.50, "output": 3.00, "cache_read": 0.02},
     "gemini-3-flash": {"input": 0.15, "output": 1.00, "cache_read": 0.005},
     "qwen3-coder": {"input": 0.22, "output": 0.9},
+    # DeepSeek V4 family (FEAT deepseek-v4-flash-eu, added 2026-05-07).
+    # Hosted prices from deepseek.com release pages; the structural
+    # arbitrage comes from V4-Flash at ~$1.74/MTok input (CAISI 2026-04
+    # evaluation places the model ~8 months behind frontier — adequate
+    # for the 60-70% of agentic workloads that are not the hardest 30%).
+    # Self-hosted runs (Ollama / vLLM via :class:`OllamaAdapter`) reduce
+    # input cost to electricity; the hosted entries below are the
+    # opportunity-cost reference used by ``CostTracker`` to narrate
+    # "saved $X by self-hosting" in the run summary.
+    "deepseek-v4-flash": {"input": 1.74, "output": 0.20},
+    "deepseek-v4-pro": {"input": 4.50, "output": 1.50},
     # Blended-only entries in ``_MODEL_COST_USD_PER_1K`` — approximate 40/60 input/output split of total $/1M.
     "qwen-max": {"input": 0.8, "output": 1.2},
     "qwen-plus": {"input": 0.4, "output": 0.6},
@@ -121,6 +132,14 @@ _MODEL_COST_USD_PER_1K: dict[str, float] = {
     "qwen-max": 0.001,
     "qwen-plus": 0.0005,
     "qwen-turbo": 0.0002,
+    # DeepSeek V4 family — FEAT deepseek-v4-flash-eu.  Self-hosted runs
+    # against vLLM/Ollama drop the marginal cost to electricity; these
+    # blended figures reflect the hosted ``deepseek.com`` API prices and
+    # are used as the opportunity-cost reference.  ``deepseek-v4-flash``
+    # appears before ``deepseek-v4-pro`` so the narrower SKU wins on
+    # left-to-right substring iteration in :func:`_model_cost`.
+    "deepseek-v4-flash": 0.00097,  # ($1.74 + $0.20) / 2 / 1000
+    "deepseek-v4-pro": 0.003,  # ($4.50 + $1.50) / 2 / 1000
 }
 
 # Cascade order — sonnet first (haiku removed: on Max plan sonnet is

--- a/tests/unit/test_deepseek_v4_eu_residency.py
+++ b/tests/unit/test_deepseek_v4_eu_residency.py
@@ -1,0 +1,239 @@
+"""Tests for DeepSeek V4 adapter dispatch + EU-residency profile + pricing.
+
+Covers FEAT ``deepseek-v4-flash-eu``:
+
+* :class:`OllamaAdapter` dispatches ``deepseek-v4-flash`` and
+  ``deepseek-v4-pro`` model names through ``_resolve_model``.
+* Constructing the adapter with ``eu_residency=True`` flips the
+  enforcement flag, and the public ``eu_residency`` property reflects it.
+* :meth:`OllamaAdapter._is_self_hosted_endpoint` is default-closed: it
+  accepts loopback / RFC-1918 / ``*.internal`` hosts and rejects public
+  IPs, hosted-API hostnames, and unrecognised FQDNs.
+* The pricing tables (``MODEL_COSTS_PER_1M_TOKENS`` and the blended
+  ``_MODEL_COST_USD_PER_1K``) carry the new SKUs and ``estimate_cost``
+  arithmetic matches the per-MTok numbers from the ticket.
+* ``spawn`` raises a structured ``RESIDENCY_VIOLATION`` when called
+  against a non-self-hosted endpoint with a residency-tagged model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from bernstein.adapters.ollama import (
+    OLLAMA_BASE_URL,
+    _EU_RESIDENCY_MODELS,
+    _MODEL_MAP,
+    OllamaAdapter,
+)
+from bernstein.core.cost.cost import (
+    MODEL_COSTS_PER_1M_TOKENS,
+    _MODEL_COST_USD_PER_1K,
+    _model_cost,
+)
+from bernstein.core.cost.cost_tracker import estimate_cost
+from bernstein.core.models import ModelConfig
+
+# ---------------------------------------------------------------------------
+# Model-name dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestModelDispatch:
+    """Bernstein abstract names map to the right local model IDs."""
+
+    def test_deepseek_v4_flash_resolves_to_native_id(self) -> None:
+        adapter = OllamaAdapter()
+        assert adapter._resolve_model("deepseek-v4-flash") == "deepseek-v4-flash"
+
+    def test_deepseek_v4_pro_resolves_to_native_id(self) -> None:
+        adapter = OllamaAdapter()
+        assert adapter._resolve_model("deepseek-v4-pro") == "deepseek-v4-pro"
+
+    def test_unknown_model_passes_through(self) -> None:
+        """Custom Ollama model IDs (e.g. user-tagged) are not rewritten."""
+        adapter = OllamaAdapter()
+        assert adapter._resolve_model("custom:7b") == "custom:7b"
+
+    def test_model_map_contains_both_v4_skus(self) -> None:
+        assert "deepseek-v4-flash" in _MODEL_MAP
+        assert "deepseek-v4-pro" in _MODEL_MAP
+
+    def test_eu_residency_set_includes_both_v4_skus(self) -> None:
+        assert "deepseek-v4-flash" in _EU_RESIDENCY_MODELS
+        assert "deepseek-v4-pro" in _EU_RESIDENCY_MODELS
+
+
+# ---------------------------------------------------------------------------
+# EU-residency profile flag
+# ---------------------------------------------------------------------------
+
+
+class TestEuResidencyFlag:
+    """Adapter construction flips the residency-enforcement flag."""
+
+    def test_default_flag_is_false(self) -> None:
+        adapter = OllamaAdapter()
+        assert adapter.eu_residency is False
+
+    def test_explicit_true_flips_flag(self) -> None:
+        adapter = OllamaAdapter(eu_residency=True)
+        assert adapter.eu_residency is True
+
+    def test_default_base_url(self) -> None:
+        """Default base URL is the local loopback address."""
+        adapter = OllamaAdapter()
+        assert adapter._base_url == OLLAMA_BASE_URL
+        assert adapter._is_self_hosted_endpoint(adapter._base_url) is True
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost:11434",
+            "http://127.0.0.1:11434",
+            "http://[::1]:11434",
+            "http://0.0.0.0:11434",
+            "http://10.0.0.5:8000",
+            "http://192.168.1.100:11434",
+            "http://172.16.0.1:8000",
+            "http://172.31.255.1:8000",
+            "http://vllm.internal:8000/v1",
+            "http://gpu-host.local:11434",
+            "http://ollama.svc.cluster.local:11434",
+        ],
+    )
+    def test_self_hosted_urls_pass(self, url: str) -> None:
+        """Loopback, RFC-1918, and ``*.internal`` hosts count as self-hosted."""
+        adapter = OllamaAdapter()
+        assert adapter._is_self_hosted_endpoint(url) is True, url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://api.deepseek.com",
+            "https://deepseek.com/v1",
+            "https://api.openai.com/v1",
+            "https://openrouter.ai/api/v1",
+            "https://api.anthropic.com",
+            "https://generativelanguage.googleapis.com",
+            "https://api.together.xyz",
+            "https://api.groq.com",
+            # Public IP outside RFC-1918 — fail closed.
+            "http://8.8.8.8:8000",
+            "http://172.32.5.5:8000",  # 172.16/12 boundary check
+            "http://172.15.0.1:8000",  # below 16, also out of range
+            # Unrecognised public hostname — fail closed.
+            "https://random-public-host.example.com",
+            # Empty / malformed.
+            "",
+            "not-a-url",
+        ],
+    )
+    def test_non_self_hosted_urls_rejected(self, url: str) -> None:
+        adapter = OllamaAdapter()
+        assert adapter._is_self_hosted_endpoint(url) is False, url
+
+
+# ---------------------------------------------------------------------------
+# Spawn rejects residency violations
+# ---------------------------------------------------------------------------
+
+
+class TestResidencyEnforcement:
+    """The spawn() guard refuses non-self-hosted endpoints under residency."""
+
+    def _model_cfg(self, model: str = "deepseek-v4-flash") -> ModelConfig:
+        return ModelConfig(model=model, effort="normal")
+
+    def test_v4_model_with_hosted_endpoint_raises(self, tmp_path: Path) -> None:
+        """A residency-tagged model + hosted endpoint = RESIDENCY_VIOLATION."""
+        adapter = OllamaAdapter(base_url="https://api.deepseek.com")
+        with pytest.raises(RuntimeError, match="RESIDENCY_VIOLATION"):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=self._model_cfg(),
+                session_id="backend-1",
+            )
+
+    def test_eu_flag_forces_check_on_non_v4_model(self, tmp_path: Path) -> None:
+        """``eu_residency=True`` enforces the check even for non-V4 models."""
+        adapter = OllamaAdapter(
+            base_url="https://api.openrouter.ai",
+            eu_residency=True,
+        )
+        with pytest.raises(RuntimeError, match="RESIDENCY_VIOLATION"):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen2.5-coder", effort="normal"),
+                session_id="backend-2",
+            )
+
+    def test_violation_error_is_structured(self, tmp_path: Path) -> None:
+        """Error message names the model and the offending endpoint."""
+        adapter = OllamaAdapter(base_url="https://api.deepseek.com")
+        with pytest.raises(RuntimeError) as exc_info:
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=self._model_cfg("deepseek-v4-pro"),
+                session_id="backend-3",
+            )
+        msg = str(exc_info.value)
+        assert "RESIDENCY_VIOLATION" in msg
+        assert "deepseek-v4-pro" in msg
+        assert "deepseek.com" in msg
+
+
+# ---------------------------------------------------------------------------
+# Pricing table lookup
+# ---------------------------------------------------------------------------
+
+
+class TestPricingLookup:
+    """The pricing tables carry the DeepSeek V4 SKUs at ticket-spec values."""
+
+    def test_flash_per_mtok_input_price(self) -> None:
+        """Ticket pins V4-Flash hosted input at ~$1.74/MTok."""
+        assert MODEL_COSTS_PER_1M_TOKENS["deepseek-v4-flash"]["input"] == 1.74
+
+    def test_flash_per_mtok_output_price(self) -> None:
+        assert MODEL_COSTS_PER_1M_TOKENS["deepseek-v4-flash"]["output"] == pytest.approx(0.20)
+
+    def test_pro_per_mtok_prices(self) -> None:
+        pricing = MODEL_COSTS_PER_1M_TOKENS["deepseek-v4-pro"]
+        assert pricing["input"] == 4.50
+        assert pricing["output"] == 1.50
+
+    def test_blended_table_carries_both_skus(self) -> None:
+        assert "deepseek-v4-flash" in _MODEL_COST_USD_PER_1K
+        assert "deepseek-v4-pro" in _MODEL_COST_USD_PER_1K
+
+    def test_blended_substring_lookup_picks_specific_sku(self) -> None:
+        """``_model_cost`` substring lookup must hit the correct row."""
+        assert _model_cost("deepseek-v4-flash") == _MODEL_COST_USD_PER_1K["deepseek-v4-flash"]
+        assert _model_cost("deepseek-v4-pro") == _MODEL_COST_USD_PER_1K["deepseek-v4-pro"]
+
+    def test_flash_cheaper_than_pro(self) -> None:
+        """V4-Flash must come in cheaper than V4-Pro — that's the entire pitch."""
+        assert _MODEL_COST_USD_PER_1K["deepseek-v4-flash"] < _MODEL_COST_USD_PER_1K["deepseek-v4-pro"]
+        assert (
+            MODEL_COSTS_PER_1M_TOKENS["deepseek-v4-flash"]["input"]
+            < MODEL_COSTS_PER_1M_TOKENS["deepseek-v4-pro"]["input"]
+        )
+
+    def test_estimate_cost_matches_mtok_rate(self) -> None:
+        """1M input tokens of V4-Flash should bill at exactly $1.74."""
+        assert estimate_cost("deepseek-v4-flash", 1_000_000, 0) == pytest.approx(1.74)
+
+    def test_estimate_cost_combines_input_and_output(self) -> None:
+        """1M in + 1M out for V4-Flash = $1.74 + $0.20 = $1.94."""
+        assert estimate_cost("deepseek-v4-flash", 1_000_000, 1_000_000) == pytest.approx(1.94)
+
+    def test_v4_flash_undercuts_opus_input_by_at_least_2x(self) -> None:
+        """The whole pitch: V4-Flash hosted input << Claude Opus input."""
+        flash_input = MODEL_COSTS_PER_1M_TOKENS["deepseek-v4-flash"]["input"]
+        opus_input = MODEL_COSTS_PER_1M_TOKENS["opus"]["input"]
+        assert flash_input <= opus_input / 2.0

--- a/tests/unit/test_deepseek_v4_eu_residency.py
+++ b/tests/unit/test_deepseek_v4_eu_residency.py
@@ -21,19 +21,20 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from bernstein.core.models import ModelConfig
+
 from bernstein.adapters.ollama import (
-    OLLAMA_BASE_URL,
     _EU_RESIDENCY_MODELS,
     _MODEL_MAP,
+    OLLAMA_BASE_URL,
     OllamaAdapter,
 )
 from bernstein.core.cost.cost import (
-    MODEL_COSTS_PER_1M_TOKENS,
     _MODEL_COST_USD_PER_1K,
+    MODEL_COSTS_PER_1M_TOKENS,
     _model_cost,
 )
 from bernstein.core.cost.cost_tracker import estimate_cost
-from bernstein.core.models import ModelConfig
 
 # ---------------------------------------------------------------------------
 # Model-name dispatch


### PR DESCRIPTION
## Summary
- Adds DeepSeek V4-Flash (284B / 13B-active) and V4-Pro (1.6T / 49B-active) as recognised model IDs in `OllamaAdapter._MODEL_MAP`. Both ride the existing OpenAI-compatible Ollama transport — V4-Pro is documented to deploy via vLLM tensor-parallel by pointing `OLLAMA_API_BASE` at the vLLM `/v1` endpoint, no new HTTP client.
- Adds `eu_residency=True` constructor flag + default-closed self-hosted endpoint check (loopback / RFC-1918 / `*.internal` allow-list); residency-tagged models also auto-trigger the guard. Hosted endpoints (api.deepseek.com, openrouter.ai, public IPs, unrecognised FQDNs) raise a structured `RESIDENCY_VIOLATION` `RuntimeError` naming the offending model + endpoint.
- Adds DeepSeek V4 entries to both `MODEL_COSTS_PER_1M_TOKENS` ($1.74/$0.20 flash, $4.50/$1.50 pro) and the blended `_MODEL_COST_USD_PER_1K`. `estimate_cost()` now narrates the hosted opportunity-cost figure the ticket pitches as the "saved $X by self-hosting" lever.

## Shipped
- `OllamaAdapter` model dispatch + `eu_residency` flag + structured residency guard.
- Pricing-table entries for `deepseek-v4-flash` / `deepseek-v4-pro`.
- 45 unit tests in `tests/unit/test_deepseek_v4_eu_residency.py` covering dispatch, the EU flag default+override, the self-hosted allow-list (loopback, RFC-1918, `*.internal` × hosted-API + public-IP + boundary cases like `172.32.x.x` and `172.15.x.x`), the spawn-time `RESIDENCY_VIOLATION` error, and per-MTok / blended price-table arithmetic.

## Deferred (per ticket option (a) — clear flag + docstring)
- Standalone `vllm.py` adapter — the OpenAI-compatible `OLLAMA_API_BASE` redirect already covers vLLM and the docstring spells out the tensor-parallel deployment path; no new HTTP client adds value.
- `core/config/profiles/eu_residency.yaml` preset + `config_loader` wiring.
- `bernstein doctor airgap --eu` pre-flight + `docs/self-hosted-llm.md`.

## Ticket
- `.sdd/backlog/closed/2026-05-07-feat-deepseek-v4-flash-eu.md` (moved from `open/`).

## Test plan
- [x] `uv run pytest tests/unit/test_deepseek_v4_eu_residency.py -x -q --timeout=120` → 45 passed in 3.54s.
- [x] `uv run pytest tests/unit/test_cost_tracker.py tests/unit/test_cost_tracker_bounded.py tests/unit/test_cost_estimation.py tests/unit/test_cost_estimate.py tests/unit/test_data_residency.py` → 86 passed in 6.17s.
- [x] `uv run pytest tests/unit/test_cost_arbitrage.py` → 33 passed in 2.83s.
- [x] `uv run pytest tests/unit/ -k "ollama or adapter_autodetect or adapter_contract"` → 551 passed, 3 skipped.
- [x] Pre-push hook: lint + architecture contracts pass; pyright is advisory.
- [ ] Manual: spin up vLLM with V4-Flash on a single A100, run `bernstein run` against `eu_residency=True` adapter, confirm `tcpdump` shows zero outbound non-EU traffic. (Deferred — requires GPU host.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)