### PR TITLE
feat(audit): SOC 2 evidence checklist generator (KF-10 slice A)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,16 @@ sonar.organization=chernistry
 sonar.projectKey=chernistry_bernstein
 sonar.projectName=Bernstein
 
+# NOTE: The `chernistry` SonarCloud org is on the free public-projects plan
+# (~191k LOC soft cap). Main-branch analyses are currently rejected by the
+# compute engine ("maximum allowed lines limit") so the project has no stored
+# baseline and zero issues are reported, even though PR-scoped scans still
+# pass on the diff. Resolution requires admin action (plan upgrade, re-home
+# the project under the `sipyourdrink-ltd` org, or further `sonar.sources`
+# shrinkage) and cannot be fixed from the codebase alone. See
+# `.sdd/backlog/closed/2026-05-07-sonar-manual-review.md` for evidence and
+# the recommended path (option 2: re-home).
+
 # -------------------------------------------------------------------------
 # Scope
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## status

superseded by #1149 — that PR shipped the comprehensive `EvidenceSource`-based generator with real run-log integration on `bernstein audit pack --soc2`. this branch's lighter `generate_soc2_checklist(deployment_label=…)` plus its KF-10 unit tests were dropped during rebase against `origin/main` because the surface area no longer exists.

remaining content on this branch: a sonar-project.properties note documenting the org-LOC-cap blocker for the main-branch SonarCloud baseline. that note is unrelated to KF-10 and can either ride this PR through or be split out — operator's call.

## what was originally proposed

- `bernstein audit pack --soc2` deterministic Markdown evidence-checklist generator mapping each SOC 2 TSC control to bernstein modules + CLI commands.
- 20-test unit suite covering determinism, label substitution, schema marker, control coverage, CLI stdout/file output, and missing-flag rejection.
- declared scope: smallest viable slice of KF-10 (Option A), deliberately disjoint from EU AI Act Article 12 work in #1134.

## what merged via #1149 instead

- `EvidenceSource` + `ResolvedEvidence` dataclasses driving real evidence resolution (audit-chain HMAC tail digest, policy-file content hashes, capability-matrix run summaries, mTLS cert log scans, wheelhouse verification outputs, run-log freshness windows).
- `bernstein audit pack --soc2 [--include-runs SINCE] [--period-label LABEL] [--stale-after-days N] [-o DIR]`.
- `tests/integration/test_soc2_real_evidence.py` covering the resolved-evidence pipeline against real artefacts.

## deferred (re-open KF-10 follow-ups as needed)

- HIPAA / GDPR templates.
- hardened docker-compose + terraform stubs (Option B from the ticket).
- `bernstein compliance verify` runtime pass/block report.
- SBOM + sigstore attestation packaging on pack output.
- datadog / splunk / cloudwatch ingestion configs.
- full directory-bundle generator (`bernstein compliance pack <fw> --out <dir>`).
- partner case-study payload + docs page mapping modules to control frameworks.

## ticket

`.sdd/backlog/closed/2026-05-06-kf-10-compliance-audit-pack.md`.