### PR TITLE
feat(audit): `audit slice` deterministic subset extractor (KF-5)

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -5,6 +5,7 @@ Commands:
   bernstein audit seal             Compute and store a Merkle root.
   bernstein audit seal --anchor-git  Also create a git tag.
   bernstein audit verify --merkle  Verify the Merkle tree against disk.
+  bernstein audit slice            Write a deterministic subset (KF-5).
 """
 
 from __future__ import annotations
@@ -377,6 +378,81 @@ def capabilities_cmd(workdir: str) -> None:
         console.print(f"  [red]![/red] {decision.reason} — tools=[bold]{list(decision.offending_tools)}[/bold]")
     console.print()
     raise SystemExit(1)
+
+
+@audit_group.command("slice")
+@click.option(
+    "--from",
+    "from_hmac",
+    default=None,
+    help="Inclusive lower bound — HMAC of the first event to include.  Omit to start at the earliest recorded event.",
+)
+@click.option(
+    "--to",
+    "to_hmac",
+    default=None,
+    help="Inclusive upper bound — HMAC of the last event to include.  Omit to run through the latest event.",
+)
+@click.option(
+    "--output",
+    "-o",
+    required=True,
+    type=click.Path(dir_okay=False, writable=True, resolve_path=True),
+    help="Path to the output JSONL file.",
+)
+def slice_cmd(from_hmac: str | None, to_hmac: str | None, output: str) -> None:
+    """Write a deterministic subset of the audit log between two HMACs.
+
+    \b
+    Foundation for KF-5 time-travel replay.  The output is byte-stable
+    JSONL — each line is sort-keys-serialised — so downstream replayers
+    can hash the slice directly.  The HMAC chain inside the slice is
+    re-verified before writing; a structural mismatch aborts the export.
+
+    \b
+    Examples:
+      bernstein audit slice --from <hash> --to <hash> -o /tmp/slice.jsonl
+      bernstein audit slice --to <hash> -o /tmp/head.jsonl
+      bernstein audit slice --from <hash> -o /tmp/tail.jsonl
+    """
+    from bernstein.core.security.audit_slice import (
+        AuditSliceError,
+        slice_audit_log,
+        verify_slice_chain,
+        write_slice_jsonl,
+    )
+
+    if not AUDIT_DIR.is_dir():
+        console.print(f"[red]Audit directory not found:[/red] {AUDIT_DIR}")
+        raise SystemExit(1)
+
+    try:
+        result = slice_audit_log(AUDIT_DIR, from_hmac=from_hmac, to_hmac=to_hmac)
+    except AuditSliceError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+
+    valid, errors = verify_slice_chain(result)
+    if not valid:
+        console.print(Panel("[bold red]Slice chain check FAILED[/bold red]", border_style="red", expand=False))
+        for err in errors:
+            console.print(f"  [red]![/red] {err}")
+        raise SystemExit(1)
+
+    out_path = write_slice_jsonl(result, Path(output))
+
+    console.print()
+    console.print(Panel("[bold]Audit slice written[/bold]", border_style="green", expand=False))
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+    table.add_column("Value")
+    table.add_row("Events", str(result.event_count))
+    table.add_row("From", result.from_hmac or "(genesis)")
+    table.add_row("To", result.to_hmac or "(latest)")
+    table.add_row("Source files", ", ".join(result.source_files) or "—")
+    table.add_row("Output", str(out_path))
+    console.print(table)
+    console.print()
 
 
 @audit_group.command("query")

--- a/src/bernstein/core/security/audit_slice.py
+++ b/src/bernstein/core/security/audit_slice.py
@@ -149,9 +149,7 @@ def slice_audit_log(
         end = hmac_to_index[to_hmac]
 
     if start > end:
-        raise AuditSliceError(
-            f"--from must precede --to in the chain (from index {start}, to index {end})"
-        )
+        raise AuditSliceError(f"--from must precede --to in the chain (from index {start}, to index {end})")
 
     sliced = entries[start : end + 1]
     out_events = [entry for _, entry in sliced]
@@ -207,8 +205,6 @@ def verify_slice_chain(result: AuditSliceResult) -> tuple[bool, list[str]]:
         cur_prev = str(entry.get("prev_hmac", ""))
         cur_hmac = str(entry.get("hmac", ""))
         if prev_hmac is not None and cur_prev != prev_hmac:
-            errors.append(
-                f"slice[{idx}]: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {cur_prev[:16]}…)"
-            )
+            errors.append(f"slice[{idx}]: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {cur_prev[:16]}…)")
         prev_hmac = cur_hmac
     return len(errors) == 0, errors

--- a/src/bernstein/core/security/audit_slice.py
+++ b/src/bernstein/core/security/audit_slice.py
@@ -29,7 +29,10 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/src/bernstein/core/security/audit_slice.py
+++ b/src/bernstein/core/security/audit_slice.py
@@ -1,0 +1,211 @@
+"""KF-5 slice extractor — deterministic subset of the HMAC-chained audit log.
+
+First slice of the time-travel/replay epic.  Given a ``--from`` and ``--to``
+HMAC fence-post, return the contiguous run of audit events whose HMACs fall
+within the range.  Output is byte-deterministic JSONL (sorted keys, trailing
+newline) so the slice can be hashed, signed, or shipped to a downstream
+replayer with no ambiguity.
+
+Design notes:
+    * Read-only.  The source ``.sdd/audit/*.jsonl`` is never mutated.
+    * Chain still verifies inside the slice when re-anchored at
+      ``from_hmac``: every event's ``prev_hmac`` chains to its predecessor,
+      and the final event's HMAC equals ``to_hmac`` (when supplied).
+    * "from" / "to" semantics: each is the HMAC OF an event already in the
+      log (not its ``prev_hmac``).  Both bounds are inclusive — so a slice
+      with ``from == to`` yields exactly one event.  Pass ``from_hmac=None``
+      to start at the genesis event; pass ``to_hmac=None`` to run to the
+      last recorded event.
+    * No PII redaction in this slice — that is deferred to the
+      ``replay publish`` flow (KF-5 step 6).  Operators slicing locally
+      already trust the audit dir.
+
+This module is intentionally CLI-agnostic so future ``replay`` and ``fork``
+commands can reuse the same primitives.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_JSONL_GLOB = "*.jsonl"
+
+
+class AuditSliceError(ValueError):
+    """Raised when a slice request is malformed or unresolvable."""
+
+
+@dataclass(frozen=True)
+class AuditSliceResult:
+    """Outcome of a slice extraction.
+
+    Attributes:
+        events: The matched JSONL entries in chronological order.  Each
+            element is the raw dict that was on disk (HMAC + prev_hmac
+            included) so consumers can re-verify the chain offline.
+        from_hmac: The lower-bound HMAC actually used.  ``None`` means
+            "from genesis".
+        to_hmac: The upper-bound HMAC actually used.  ``None`` means
+            "through end of log".
+        source_files: Sorted log file names that contributed events.
+    """
+
+    events: list[dict] = field(default_factory=list)
+    from_hmac: str | None = None
+    to_hmac: str | None = None
+    source_files: list[str] = field(default_factory=list)
+
+    @property
+    def event_count(self) -> int:
+        """Number of events in the slice."""
+        return len(self.events)
+
+
+def _iter_audit_entries(audit_dir: Path) -> list[tuple[str, dict]]:
+    """Walk every JSONL file in chronological order, yielding ``(file, entry)``.
+
+    Malformed lines are skipped with a debug log so a corrupted tail does
+    not abort an otherwise-valid slice.
+    """
+    out: list[tuple[str, dict]] = []
+    for log_path in sorted(audit_dir.glob(_JSONL_GLOB)):
+        try:
+            text = log_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.debug("Skipping unreadable audit file %s: %s", log_path, exc)
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.debug("Skipping malformed line in %s: %s", log_path, exc)
+                continue
+            if isinstance(entry, dict) and "hmac" in entry:
+                out.append((log_path.name, entry))
+    return out
+
+
+def slice_audit_log(
+    audit_dir: Path,
+    *,
+    from_hmac: str | None = None,
+    to_hmac: str | None = None,
+) -> AuditSliceResult:
+    """Extract the contiguous run of audit events between two HMAC fence-posts.
+
+    Args:
+        audit_dir: Directory containing daily ``YYYY-MM-DD.jsonl`` audit files.
+        from_hmac: Lower bound — inclusive.  Must be the HMAC of an event in
+            the log.  Pass ``None`` to start at the first recorded event.
+        to_hmac: Upper bound — inclusive.  Must be the HMAC of an event in
+            the log and must occur at or after ``from_hmac``.  Pass ``None``
+            to run to the final event.
+
+    Returns:
+        ``AuditSliceResult`` with the matched entries and the bounds that
+        were actually applied.
+
+    Raises:
+        AuditSliceError: ``audit_dir`` does not exist, either bound was
+            specified but does not match any event, or the bounds are
+            out of order.
+    """
+    if not audit_dir.is_dir():
+        raise AuditSliceError(f"Audit directory not found: {audit_dir}")
+
+    entries = _iter_audit_entries(audit_dir)
+    if not entries:
+        raise AuditSliceError(f"Audit directory is empty: {audit_dir}")
+
+    # Build hmac -> index map for O(1) bound resolution.  The chain is
+    # supposed to be unique-by-HMAC; if a duplicate ever appears we keep
+    # the first occurrence so behaviour is deterministic.
+    hmac_to_index: dict[str, int] = {}
+    for idx, (_, entry) in enumerate(entries):
+        h = str(entry.get("hmac", ""))
+        hmac_to_index.setdefault(h, idx)
+
+    start = 0
+    if from_hmac is not None:
+        if from_hmac not in hmac_to_index:
+            raise AuditSliceError(f"--from hash not found in audit log: {from_hmac}")
+        start = hmac_to_index[from_hmac]
+
+    end = len(entries) - 1
+    if to_hmac is not None:
+        if to_hmac not in hmac_to_index:
+            raise AuditSliceError(f"--to hash not found in audit log: {to_hmac}")
+        end = hmac_to_index[to_hmac]
+
+    if start > end:
+        raise AuditSliceError(
+            f"--from must precede --to in the chain (from index {start}, to index {end})"
+        )
+
+    sliced = entries[start : end + 1]
+    out_events = [entry for _, entry in sliced]
+    source_files = sorted({fname for fname, _ in sliced})
+
+    return AuditSliceResult(
+        events=out_events,
+        from_hmac=from_hmac,
+        to_hmac=to_hmac,
+        source_files=source_files,
+    )
+
+
+def write_slice_jsonl(result: AuditSliceResult, out_path: Path) -> Path:
+    """Write a slice result to a deterministic JSONL file.
+
+    Output bytes are stable across runs: each line uses ``sort_keys=True``
+    and ends with a single ``\\n``.  No trailing whitespace, no header
+    comments — so downstream consumers can hash the file directly.
+
+    Args:
+        result: Slice produced by :func:`slice_audit_log`.
+        out_path: Target file.  Parent directories are created.
+
+    Returns:
+        The resolved path that was written.
+    """
+    out_path = out_path.expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fh:
+        for entry in result.events:
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+    return out_path
+
+
+def verify_slice_chain(result: AuditSliceResult) -> tuple[bool, list[str]]:
+    """Confirm that ``prev_hmac`` linkage is intact across the slice.
+
+    This is a structural check only — it does NOT recompute HMACs against
+    the signing key (that requires ``AuditLog.verify`` against the source
+    files).  The check ensures the slice itself is contiguous, i.e. each
+    event's ``prev_hmac`` matches the previous event's ``hmac``.
+
+    Args:
+        result: Slice to validate.
+
+    Returns:
+        ``(valid, errors)`` — ``errors`` lists every gap or mismatch.
+    """
+    errors: list[str] = []
+    prev_hmac: str | None = None
+    for idx, entry in enumerate(result.events):
+        cur_prev = str(entry.get("prev_hmac", ""))
+        cur_hmac = str(entry.get("hmac", ""))
+        if prev_hmac is not None and cur_prev != prev_hmac:
+            errors.append(
+                f"slice[{idx}]: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {cur_prev[:16]}…)"
+            )
+        prev_hmac = cur_hmac
+    return len(errors) == 0, errors

--- a/tests/unit/test_audit_slice.py
+++ b/tests/unit/test_audit_slice.py
@@ -11,9 +11,9 @@ import json
 from pathlib import Path
 
 import pytest
+from bernstein.core.audit import AuditLog
 from click.testing import CliRunner
 
-from bernstein.core.audit import AuditLog
 from bernstein.core.security.audit_slice import (
     AuditSliceError,
     slice_audit_log,

--- a/tests/unit/test_audit_slice.py
+++ b/tests/unit/test_audit_slice.py
@@ -1,0 +1,250 @@
+"""Tests for the KF-5 audit-slice extractor.
+
+Slice semantics: ``--from`` and ``--to`` name the HMAC of an event already
+recorded in the log; both bounds are inclusive.  The slice must remain
+chain-contiguous after extraction and must hash deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.core.audit import AuditLog
+from bernstein.core.security.audit_slice import (
+    AuditSliceError,
+    slice_audit_log,
+    verify_slice_chain,
+    write_slice_jsonl,
+)
+
+
+def _build_log(audit_dir: Path, count: int = 5) -> list[str]:
+    """Seed an audit log with ``count`` events.  Returns each event's HMAC."""
+    log = AuditLog(audit_dir, key=b"test-key")
+    return [
+        log.log("evt", "actor", "task", f"id-{i}", {"i": i}).hmac for i in range(count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# slice_audit_log core API
+# ---------------------------------------------------------------------------
+
+
+def test_slice_full_range_returns_all_events(tmp_path: Path) -> None:
+    """No bounds = whole chain."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 4)
+
+    result = slice_audit_log(audit_dir)
+
+    assert result.event_count == 4
+    assert [e["hmac"] for e in result.events] == hmacs
+    assert result.from_hmac is None
+    assert result.to_hmac is None
+
+
+def test_slice_with_from_and_to_inclusive(tmp_path: Path) -> None:
+    """Both bounds inclusive — slice covers from..to events."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 5)
+
+    result = slice_audit_log(audit_dir, from_hmac=hmacs[1], to_hmac=hmacs[3])
+
+    assert [e["hmac"] for e in result.events] == hmacs[1:4]
+    assert result.event_count == 3
+
+
+def test_slice_single_event_when_from_equals_to(tmp_path: Path) -> None:
+    """``from == to`` yields exactly that event."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 3)
+
+    result = slice_audit_log(audit_dir, from_hmac=hmacs[1], to_hmac=hmacs[1])
+
+    assert result.event_count == 1
+    assert result.events[0]["hmac"] == hmacs[1]
+
+
+def test_slice_to_only_yields_head(tmp_path: Path) -> None:
+    """Only ``--to`` set: include genesis through that event."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 4)
+
+    result = slice_audit_log(audit_dir, to_hmac=hmacs[2])
+
+    assert [e["hmac"] for e in result.events] == hmacs[:3]
+
+
+def test_slice_from_only_yields_tail(tmp_path: Path) -> None:
+    """Only ``--from`` set: include from that event through end."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 4)
+
+    result = slice_audit_log(audit_dir, from_hmac=hmacs[2])
+
+    assert [e["hmac"] for e in result.events] == hmacs[2:]
+
+
+def test_slice_unknown_from_hash_raises(tmp_path: Path) -> None:
+    """Unknown ``--from`` hash → AuditSliceError."""
+    audit_dir = tmp_path / "audit"
+    _build_log(audit_dir, 3)
+
+    with pytest.raises(AuditSliceError, match="--from hash not found"):
+        slice_audit_log(audit_dir, from_hmac="0" * 64)
+
+
+def test_slice_unknown_to_hash_raises(tmp_path: Path) -> None:
+    """Unknown ``--to`` hash → AuditSliceError."""
+    audit_dir = tmp_path / "audit"
+    _build_log(audit_dir, 3)
+
+    with pytest.raises(AuditSliceError, match="--to hash not found"):
+        slice_audit_log(audit_dir, to_hmac="f" * 64)
+
+
+def test_slice_from_after_to_raises(tmp_path: Path) -> None:
+    """``--from`` later in chain than ``--to`` → AuditSliceError."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 4)
+
+    with pytest.raises(AuditSliceError, match="must precede"):
+        slice_audit_log(audit_dir, from_hmac=hmacs[3], to_hmac=hmacs[1])
+
+
+def test_slice_missing_audit_dir_raises(tmp_path: Path) -> None:
+    """No audit directory → AuditSliceError."""
+    with pytest.raises(AuditSliceError, match="not found"):
+        slice_audit_log(tmp_path / "nope")
+
+
+def test_slice_empty_audit_dir_raises(tmp_path: Path) -> None:
+    """Audit directory exists but no JSONL files → AuditSliceError."""
+    audit_dir = tmp_path / "audit"
+    audit_dir.mkdir()
+
+    with pytest.raises(AuditSliceError, match="empty"):
+        slice_audit_log(audit_dir)
+
+
+# ---------------------------------------------------------------------------
+# verify_slice_chain
+# ---------------------------------------------------------------------------
+
+
+def test_slice_chain_verifies(tmp_path: Path) -> None:
+    """Slice from a healthy log must self-verify (prev_hmac linkage)."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 4)
+
+    result = slice_audit_log(audit_dir, from_hmac=hmacs[1], to_hmac=hmacs[3])
+
+    valid, errors = verify_slice_chain(result)
+    assert valid is True
+    assert errors == []
+
+
+# ---------------------------------------------------------------------------
+# write_slice_jsonl — determinism guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_slice_jsonl_is_byte_deterministic(tmp_path: Path) -> None:
+    """Two writes of the same slice produce byte-identical files."""
+    audit_dir = tmp_path / "audit"
+    _build_log(audit_dir, 3)
+
+    result = slice_audit_log(audit_dir)
+    out1 = write_slice_jsonl(result, tmp_path / "a.jsonl")
+    out2 = write_slice_jsonl(result, tmp_path / "b.jsonl")
+
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+def test_slice_jsonl_contains_expected_events(tmp_path: Path) -> None:
+    """Output JSONL round-trips back to the source events."""
+    audit_dir = tmp_path / "audit"
+    hmacs = _build_log(audit_dir, 5)
+
+    result = slice_audit_log(audit_dir, from_hmac=hmacs[0], to_hmac=hmacs[2])
+    out_path = write_slice_jsonl(result, tmp_path / "slice.jsonl")
+
+    lines = out_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    parsed = [json.loads(line) for line in lines]
+    assert [e["hmac"] for e in parsed] == hmacs[:3]
+
+
+def test_slice_jsonl_keys_are_sorted(tmp_path: Path) -> None:
+    """Each line's keys are in canonical (sorted) order — required for hashing."""
+    audit_dir = tmp_path / "audit"
+    _build_log(audit_dir, 1)
+
+    result = slice_audit_log(audit_dir)
+    out_path = write_slice_jsonl(result, tmp_path / "slice.jsonl")
+
+    line = out_path.read_text(encoding="utf-8").splitlines()[0]
+    # Expect "actor" before "details" before "event_type" — confirms sort_keys.
+    actor_pos = line.index('"actor"')
+    details_pos = line.index('"details"')
+    event_type_pos = line.index('"event_type"')
+    assert actor_pos < details_pos < event_type_pos
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — `bernstein audit slice`
+# ---------------------------------------------------------------------------
+
+
+def _audit_dir_in_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Build a log at ``<tmp>/.sdd/audit`` and chdir there for the CLI."""
+    monkeypatch.chdir(tmp_path)
+    audit_dir = tmp_path / ".sdd" / "audit"
+    audit_dir.mkdir(parents=True)
+    return audit_dir
+
+
+def test_cli_slice_writes_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`bernstein audit slice` happy path — exits 0 and writes the events."""
+    audit_dir = _audit_dir_in_cwd(tmp_path, monkeypatch)
+    hmacs = _build_log(audit_dir, 4)
+
+    from bernstein.cli.commands.audit_cmd import audit_group
+
+    out_path = tmp_path / "out.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        ["slice", "--from", hmacs[1], "--to", hmacs[2], "-o", str(out_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert out_path.is_file()
+    parsed = [json.loads(line) for line in out_path.read_text().splitlines()]
+    assert [e["hmac"] for e in parsed] == hmacs[1:3]
+
+
+def test_cli_slice_unknown_hash_exits_1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown HMAC bound aborts with a non-zero exit and a helpful message."""
+    audit_dir = _audit_dir_in_cwd(tmp_path, monkeypatch)
+    _build_log(audit_dir, 2)
+
+    from bernstein.cli.commands.audit_cmd import audit_group
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        ["slice", "--from", "0" * 64, "-o", str(tmp_path / "out.jsonl")],
+    )
+
+    assert result.exit_code == 1
+    assert "--from hash not found" in result.output


### PR DESCRIPTION
Refs #1092

## Summary

Smallest-viable slice of **KF-5: Time-travel debugger + session rewind + fork** (Option C — audit-log slice extractor).

- New CLI: `bernstein audit slice --from <hash> --to <hash> -o <out>` writes a deterministic subset of the HMAC-chained audit log between two fence-posts (each bound inclusive; either may be omitted to anchor at genesis or run to the latest event).
- New core API `bernstein.core.security.audit_slice`: `slice_audit_log`, `write_slice_jsonl`, `verify_slice_chain` — CLI-agnostic so the upcoming `replay` and `fork` commands can reuse the same primitives.
- Output is byte-stable JSONL (`sort_keys=True`, trailing `\n`) so consumers can hash the slice directly. Structural chain check (`prev_hmac` → `hmac` contiguity) runs before the file is written; a mismatch aborts non-zero.

## Shipped

- `src/bernstein/core/security/audit_slice.py` — slice / write / verify primitives + `AuditSliceError`.
- `src/bernstein/cli/commands/audit_cmd.py` — registered `bernstein audit slice` subcommand under the existing `audit` click group.
- `tests/unit/test_audit_slice.py` — 16 unit tests covering bound semantics (full range, single event, head, tail, inclusive), error paths (unknown hash, inverted bounds, missing/empty audit dir), determinism (byte-identical re-write, sorted keys), `verify_slice_chain`, and the CLI happy path / unknown-hash failure.
- Ticket moved to `.sdd/backlog/closed/2026-05-06-kf-5-time-travel-replay-and-fork.md` with a top-of-file note listing what shipped and what's deferred.

## Deferred to follow-up tickets

The KF-5 epic is multi-week. This PR ships the foundation only; later slices will own:

- Step 1 — `journal.py` per-step JSONL (prompt / tool I/O / file edit / model response).
- Step 2 — spawner + adapter instrumentation that emits `JournalEvent` records.
- Step 3 — `bernstein replay <agent_id>` interactive TUI with step navigation.
- Step 4 — `bernstein fork --from-step N --prompt "..."` to reconstruct context and spawn.
- Step 5 — compaction + retention (`disk_retention.py`).
- Step 6 — privacy-aware `bernstein replay publish` with PII redaction.
- Docs (`docs/replay.md`), demo recording, launch-blog draft.

## Test plan

- [x] `pytest tests/unit/test_audit_slice.py` — 16 passed
- [x] `pytest tests/unit/test_audit.py tests/unit/test_audit_integrity.py tests/unit/test_audit_export.py` — 38 passed (regression check on neighbouring audit modules)
- [x] `ruff check src/bernstein/core/security/audit_slice.py src/bernstein/cli/commands/audit_cmd.py tests/unit/test_audit_slice.py` — clean
- [ ] Manual `bernstein audit slice --help` smoke test against a real `.sdd/audit/` dir

## Ticket

`.sdd/backlog/closed/2026-05-06-kf-5-time-travel-replay-and-fork.md`
