### PR TITLE
feat(compliance): wire Article 12 + SOC 2 packs to real run-log integration

### DIFF
--- a/.github/workflows/soc2-evidence-nightly.yml
+++ b/.github/workflows/soc2-evidence-nightly.yml
@@ -1,0 +1,102 @@
+name: soc2-evidence-nightly
+
+# Weekly SOC 2 evidence-pack generator.
+#
+# Runs `bernstein audit pack --soc2` against the checked-out repo and
+# uploads the resulting Markdown checklist + JSON manifest as a CI
+# artefact. Gated by the `SOC2_EVIDENCE_ENABLED` repository secret so
+# upstream forks don't accidentally publish empty evidence packs.
+#
+# Deliverable: a per-control Markdown row pointing at the artefact (or
+# sha256 hash) that proves the control. Auditors download the artefact
+# and walk the checklist without round-tripping back to engineering.
+
+on:
+  schedule:
+    # 03:47 UTC every Monday. Offset to avoid colliding with eval-nightly
+    # (04:23) and cluster-e2e (03:17 nightly).
+    - cron: "47 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      include_runs:
+        description: "ISO-8601 lower bound for the run-log evidence row."
+        required: false
+        default: ""
+      period_label:
+        description: "Period label rendered into the markdown header."
+        required: false
+        default: "weekly"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: soc2-evidence-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: preflight (gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      enabled: ${{ steps.gate.outputs.enabled }}
+    steps:
+      - id: gate
+        env:
+          SOC2_EVIDENCE_ENABLED: ${{ secrets.SOC2_EVIDENCE_ENABLED }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${SOC2_EVIDENCE_ENABLED:-}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "SOC2_EVIDENCE_ENABLED detected — running pack generator."
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "SOC2_EVIDENCE_ENABLED unset; nothing to do."
+          fi
+
+  pack:
+    name: generate evidence pack
+    needs: preflight
+    if: needs.preflight.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      - name: Generate SOC 2 evidence pack
+        env:
+          INCLUDE_RUNS: ${{ github.event.inputs.include_runs }}
+          PERIOD_LABEL: ${{ github.event.inputs.period_label || 'weekly' }}
+        run: |
+          set -euo pipefail
+          INCLUDE_FLAG=()
+          if [[ -n "${INCLUDE_RUNS:-}" ]]; then
+            INCLUDE_FLAG=(--include-runs "${INCLUDE_RUNS}")
+          fi
+          uv run bernstein audit pack \
+            --soc2 \
+            --period-label "${PERIOD_LABEL}" \
+            --output .sdd/evidence/soc2 \
+            "${INCLUDE_FLAG[@]}"
+
+      - name: Upload evidence pack
+        uses: actions/upload-artifact@v4
+        with:
+          name: soc2-evidence-${{ github.run_id }}
+          path: |
+            .sdd/evidence/soc2/*.md
+            .sdd/evidence/soc2/*.json
+          if-no-files-found: error
+          retention-days: 90

--- a/config/eu_ai_act_clause_map.yaml
+++ b/config/eu_ai_act_clause_map.yaml
@@ -1,0 +1,78 @@
+# EU AI Act Article 12 conformance clause map.
+#
+# Each obligation is mapped to the concrete Bernstein subsystem (file/module)
+# that delivers the control surface. Auditors quote the `clause` field; the
+# `subsystem` block points them at the source of truth they can grep, the
+# `evidence_artefact` field tells them which file inside the bundle backs it.
+#
+# Schema:
+#   schema_version: monotonic integer (bump on breaking shape changes).
+#   regulation: human label of the source regulation.
+#   article: int — the article number this map covers.
+#   mappings: list of {clause, requirement, subsystem, evidence_artefact}.
+#     subsystem.module: dotted Python path or relative path inside the repo.
+#     subsystem.role: short label describing what the module provides.
+#
+# Operators may override this file by passing `--clause-map=<path>` when
+# calling `assemble_from_run`. Bernstein ships this default so the bundle
+# is self-describing on a fresh checkout.
+
+schema_version: 1
+regulation: "EU AI Act, Regulation (EU) 2024/1689"
+article: 12
+
+mappings:
+  - clause: "12(1)"
+    requirement: "Automatic recording of events ('logs') over the lifetime of the system."
+    subsystem:
+      module: "src/bernstein/core/security/audit.py"
+      role: "AuditLog — HMAC-chained append-only event log with daily rotation."
+    evidence_artefact: "events.jsonl"
+
+  - clause: "12(2)(a)"
+    requirement: >-
+      Identification of situations that may result in the AI system presenting
+      a risk within the meaning of Article 79(1) or in a substantial modification.
+    subsystem:
+      module: "src/bernstein/core/security/audit.py"
+      role: "AuditLog event_type/outcome fields capture risk-bearing transitions."
+    evidence_artefact: "events.jsonl (event_type, outcome fields)"
+
+  - clause: "12(2)(b)"
+    requirement: "Facilitation of the post-market monitoring."
+    subsystem:
+      module: "src/bernstein/core/persistence/lineage.py"
+      role: "Lineage records cross-reference output artefacts with producer + inputs."
+    evidence_artefact: "data_catalog.json"
+
+  - clause: "12(2)(c)"
+    requirement: >-
+      Monitoring of the operation of high-risk AI systems referred to in
+      Article 26(5).
+    subsystem:
+      module: "src/bernstein/core/security/audit.py"
+      role: "AuditLog.verify() establishes a single chain anchor for the slice."
+    evidence_artefact: "events.jsonl + chain_anchor in manifest.json"
+
+  - clause: "12(3)"
+    requirement: >-
+      Logs kept for at least 6 months unless otherwise provided; 10 years for
+      high-risk under Article 19(1).
+    subsystem:
+      module: "src/bernstein/core/security/article12_bundle.py"
+      role: "compute_retention_pin / validate_retention enforce the floor."
+    evidence_artefact: "manifest.json (retention block)"
+
+  - clause: "12 (transmission)"
+    requirement: >-
+      Implicit Article 15(4) obligation that records produced for Article 12
+      are transmitted to the conformity assessment body without compromise.
+    subsystem:
+      module: "src/bernstein/core/protocols/cluster/cluster_tls.py"
+      role: "Native mTLS for cluster transport — secure transmission of records."
+    evidence_artefact: "manifest.json (transmission_security note)"
+
+deferred:
+  - "Agent Card ledger (depends on a2a-v1-signed-agent-card)"
+  - "Storage backends (S3 Object Lock, immutable Postgres)"
+  - "Article 43 conformity-assessment paperwork"

--- a/scripts/demo_article12_export.py
+++ b/scripts/demo_article12_export.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""End-to-end demo for the EU AI Act Article 12 evidence pack.
+
+Boots a tiny in-process orchestrator surface, emits three high-risk-class
+events through the real per-run HMAC chain helper, calls
+:func:`assemble_from_run`, dumps the bundle to ``/tmp/article12-demo/``,
+verifies it via :func:`verify_bundle`, and prints the manifest.
+
+Usage:
+    uv run python scripts/demo_article12_export.py
+    uv run python scripts/demo_article12_export.py --output /tmp/my-demo
+
+Exit codes:
+    0 on success, 1 on bundle verification failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+# Allow running the script straight from the repo without installing.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from bernstein.core.persistence.lineage import (  # noqa: E402
+    AgentRef,
+    ArtifactRef,
+    LineageRecord,
+    LineageWriter,
+)
+from bernstein.core.security.article12_bundle import (  # noqa: E402
+    assemble_from_run,
+    emit_run_audit_event,
+    verify_bundle,
+)
+
+
+def _seed_lineage_record(
+    sdd_dir: Path,
+    run_id: str,
+    *,
+    output_path: str,
+    sha256: str,
+    regulatory_class: str,
+    timestamp: float,
+) -> None:
+    """Append one lineage record to the run's WAL via the real writer."""
+    writer = LineageWriter.for_run(run_id=run_id, sdd_dir=sdd_dir)
+    record = LineageRecord(
+        output_artifact=ArtifactRef(path=output_path, sha256=sha256),
+        inputs=[ArtifactRef(path="prompts/system.md", sha256="0" * 64)],
+        producer=AgentRef(agent_id="claude-code", run_id=run_id, tick_id="t-001"),
+        prompt_sha="deadbeef" * 8,
+        model="claude-sonnet-4.5",
+        cost_usd=0.0125,
+        tokens=1234,
+        timestamp=timestamp,
+        regulatory_class=regulatory_class,
+    )
+    writer.emit(record)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        default="/tmp/article12-demo",
+        help="Directory for the generated bundle (default: /tmp/article12-demo).",
+    )
+    parser.add_argument(
+        "--keep-workspace",
+        action="store_true",
+        help="Keep the temporary .sdd workspace for inspection (default: cleaned up).",
+    )
+    args = parser.parse_args()
+
+    output_root = Path(args.output).resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    # 1. Boot a tiny "run" workspace under tmp. Avoids polluting the
+    #    real .sdd/ on disk while still exercising the production
+    #    LineageWriter and audit helpers end-to-end.
+    workspace = Path(tempfile.mkdtemp(prefix="bernstein-article12-demo-"))
+    sdd_dir = workspace / ".sdd"
+    sdd_dir.mkdir(parents=True, exist_ok=True)
+    audit_key = b"x" * 32  # demo-only key — production loads from XDG state
+    run_id = f"demo-{datetime.now(tz=UTC).strftime('%Y%m%dT%H%M%SZ')}"
+
+    print(f"workspace : {workspace}")
+    print(f"run_id    : {run_id}")
+
+    # 2. Emit three real, HMAC-chained audit events through the same
+    #    helper :mod:`assemble_from_run` reads from. Each event tags a
+    #    high-risk-class action so the bundle's data catalog reflects
+    #    the regulatory weight.
+    base_time = datetime.now(tz=UTC)
+    events_payload = [
+        ("task.created", "alice", "task", "T-1001", {"role": "compliance"}),
+        ("agent.spawned", "orchestrator", "agent", "A-001", {"task": "T-1001"}),
+        ("task.completed", "alice", "task", "T-1001", {"status": "ok"}),
+    ]
+    for event_type, actor, resource_type, resource_id, details in events_payload:
+        emit_run_audit_event(
+            sdd_dir=sdd_dir,
+            run_id=run_id,
+            event_type=event_type,
+            actor=actor,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            details=details,
+            audit_key=audit_key,
+        )
+
+    # 3. Seed three lineage records so data_catalog.json picks them up.
+    #    Each record carries `regulatory_class="high-risk"` to mirror an
+    #    Article 6 high-risk classification.
+    for idx in range(3):
+        _seed_lineage_record(
+            sdd_dir=sdd_dir,
+            run_id=run_id,
+            output_path=f"src/handler_{idx}.py",
+            sha256=f"{idx:064d}",
+            regulatory_class="high-risk",
+            timestamp=base_time.timestamp() + idx,
+        )
+
+    # 4. Assemble the bundle from the run.
+    since = base_time - timedelta(minutes=1)
+    until = base_time + timedelta(minutes=5)
+    result = assemble_from_run(
+        run_id=run_id,
+        since=since,
+        until=until,
+        sdd_dir=sdd_dir,
+        workdir=ROOT,
+        risk_class="high",
+        audit_key=audit_key,
+        output_dir=output_root,
+    )
+    bundle = result.bundle
+    print(f"\nbundle id           : {bundle.bundle_id}")
+    print(f"window              : {bundle.since} → {bundle.until}")
+    print(f"event_count         : {bundle.event_count}")
+    print(f"chain_anchor        : {bundle.chain_anchor[:24]}…")
+    print(f"retention_until     : {bundle.retention.retention_until}")
+    print(f"sha256              : {bundle.sha256}")
+    print(f"archive_path        : {bundle.archive_path}")
+    print(f"chain_event_count   : {result.chain_event_count}")
+    print(f"catalog_artefacts   : {result.catalog_artefact_count}")
+
+    # 5. Verify it.
+    if bundle.archive_path is None:
+        print("\nERROR: bundle did not produce an archive path", file=sys.stderr)
+        return 1
+    verification = verify_bundle(bundle.archive_path)
+    if not verification.ok:
+        print("\nERROR: bundle verification FAILED", file=sys.stderr)
+        for err in verification.errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("\n--- manifest ---")
+    print(json.dumps(verification.manifest, indent=2, sort_keys=True))
+
+    print(f"\nVERIFIED. Bundle at: {bundle.archive_path}")
+
+    if not args.keep_workspace:
+        shutil.rmtree(workspace, ignore_errors=True)
+    else:
+        print(f"workspace kept at: {workspace}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -446,6 +446,107 @@ def _run_article12_export(
         console.print()
 
 
+@audit_group.command("pack")
+@click.option(
+    "--soc2",
+    "soc2",
+    is_flag=True,
+    default=False,
+    help="Emit a SOC 2 evidence-checklist Markdown pack with per-control evidence references.",
+)
+@click.option(
+    "--include-runs",
+    "include_runs",
+    default=None,
+    help="ISO-8601 timestamp; only include runs newer than this in the run-log evidence row.",
+)
+@click.option(
+    "--period-label",
+    "period_label",
+    default="current",
+    show_default=True,
+    help="Human-readable period label rendered into the markdown header.",
+)
+@click.option(
+    "--stale-after-days",
+    "stale_after_days",
+    default=30,
+    show_default=True,
+    type=int,
+    help="Mark sources whose mtime is older than this window as STALE.",
+)
+@click.option(
+    "--output",
+    "-o",
+    default=None,
+    help="Output directory (defaults to .sdd/evidence/soc2/).",
+)
+@click.option("--workdir", "workdir", default=".", show_default=True, help="Project root directory.")
+def pack_cmd(
+    soc2: bool,
+    include_runs: str | None,
+    period_label: str,
+    stale_after_days: int,
+    output: str | None,
+    workdir: str,
+) -> None:
+    """Build a SOC 2 evidence checklist with real per-control evidence refs.
+
+    \b
+    Each Trust Service Criteria row in the output Markdown carries a
+    concrete pointer (path on disk, sha256 hash, or pending marker).
+    Drives auditor walkthroughs without copy-pasting from JSON.
+    """
+    if not soc2:
+        console.print("[red]bernstein audit pack currently supports only --soc2.[/red]")
+        raise SystemExit(2)
+
+    from datetime import UTC, datetime
+
+    from bernstein.core.security.audit_pack import generate_audit_pack
+
+    since: datetime | None = None
+    if include_runs:
+        try:
+            cleaned = include_runs.replace("Z", "+00:00") if include_runs.endswith("Z") else include_runs
+            since = datetime.fromisoformat(cleaned)
+            if since.tzinfo is None:
+                since = since.replace(tzinfo=UTC)
+        except ValueError as exc:
+            console.print(f"[red]Invalid --include-runs timestamp: {exc}[/red]")
+            raise SystemExit(2) from None
+
+    output_path = Path(output).resolve() if output else None
+
+    result = generate_audit_pack(
+        workdir=Path(workdir).resolve(),
+        output_dir=output_path,
+        period_label=period_label,
+        include_since=since,
+        stale_after_days=stale_after_days,
+        write=True,
+    )
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=14)
+    table.add_column("Value")
+    ok_count = sum(1 for r in result.resolved if r.status == "OK")
+    pending_count = sum(1 for r in result.resolved if r.status == "PENDING")
+    stale_count = sum(1 for r in result.resolved if r.status == "STALE")
+    table.add_row("Period", period_label)
+    table.add_row("Sources", str(len(result.resolved)))
+    table.add_row("OK / Pending / Stale", f"{ok_count} / {pending_count} / {stale_count}")
+    if result.markdown_path is not None:
+        table.add_row("Markdown", str(result.markdown_path))
+    if result.manifest_path is not None:
+        table.add_row("Manifest", str(result.manifest_path))
+
+    console.print()
+    console.print(Panel("[bold]SOC 2 Evidence Pack[/bold]", border_style="green", expand=False))
+    console.print(table)
+    console.print()
+
+
 @audit_group.command("capabilities")
 @click.option(
     "--workdir",

--- a/src/bernstein/core/security/article12_bundle.py
+++ b/src/bernstein/core/security/article12_bundle.py
@@ -36,15 +36,20 @@ Deferred (not in this slice; tracked in the originating ticket):
 from __future__ import annotations
 
 import hashlib
+import hmac as _hmac
 import io
 import json
+import logging
 import zipfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
 
 #: Article 12(3) — high-risk AI systems must keep logs for the lifetime
 #: of the system *and* at least 10 years (Article 19(1)).  Bernstein
@@ -62,6 +67,19 @@ BUNDLE_SCHEMA_VERSION: str = "1.0.0"
 RiskClass = Literal["high", "limited", "minimal"]
 
 _GENESIS_HMAC = "0" * 64
+
+#: Per-run audit chain location. Each orchestrator run writes its
+#: HMAC-chained audit slice to ``<sdd>/runtime/audit/<run_id>.audit.jsonl``
+#: in addition to the calendar-rotated daily logs at ``<sdd>/audit/``.
+#: ``assemble_from_run`` reads this file directly so the bundle is anchored
+#: to one run rather than a wall-clock window.
+RUN_AUDIT_DIR_NAME: str = "runtime/audit"
+RUN_AUDIT_FILE_SUFFIX: str = ".audit.jsonl"
+
+#: Default location of the YAML clause map shipped with bernstein.
+#: Overridable via the ``clause_map_path`` argument to
+#: :func:`assemble_from_run`.
+DEFAULT_CLAUSE_MAP_PATH: str = "config/eu_ai_act_clause_map.yaml"
 
 
 @dataclass(frozen=True, slots=True)
@@ -542,15 +560,581 @@ def verify_bundle(archive_path: Path, *, now: datetime | None = None) -> Verific
     return VerificationResult(ok=not errors, errors=errors, manifest=manifest)
 
 
+# ---------------------------------------------------------------------------
+# Run-scoped audit chain reader (assemble_from_run helpers)
+# ---------------------------------------------------------------------------
+
+
+class ChainBreakError(RuntimeError):
+    """Raised when in-line HMAC chain verification fails for a run audit slice."""
+
+
+@dataclass(frozen=True)
+class _ChainEvent:
+    """Internal: an entry pulled from a per-run audit chain file.
+
+    Carries the full raw JSON entry plus the recomputed-vs-stored HMAC
+    used by :func:`_verify_run_chain` so the caller can both detect a
+    break *and* surface the exact line.
+    """
+
+    line_no: int
+    timestamp: str
+    raw: dict[str, Any]
+    stored_hmac: str
+    prev_hmac: str
+
+
+def _verify_run_chain(
+    run_audit_path: Path,
+    *,
+    key: bytes,
+) -> list[_ChainEvent]:
+    """Walk a per-run audit JSONL, verifying HMAC links eagerly.
+
+    The runtime per-run file uses the same canonical HMAC payload as
+    :class:`bernstein.core.security.audit.AuditLog` — ``HMAC(key,
+    prev_hmac + canonical_json(entry_without_hmac))`` — so we can
+    re-derive each event's MAC and refuse to proceed at the first break.
+
+    Args:
+        run_audit_path: Path to ``<run_id>.audit.jsonl``.
+        key: Raw HMAC key bytes (loader's responsibility).
+
+    Returns:
+        Verified events, in file order.
+
+    Raises:
+        ChainBreakError: First verification failure (with line number).
+        FileNotFoundError: When *run_audit_path* does not exist.
+    """
+    if not run_audit_path.is_file():
+        raise FileNotFoundError(f"run audit file not found: {run_audit_path}")
+
+    events: list[_ChainEvent] = []
+    prev = _GENESIS_HMAC
+    for line_no, raw_line in enumerate(run_audit_path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise ChainBreakError(f"{run_audit_path.name}:{line_no}: invalid JSON — {exc}") from None
+
+        if not isinstance(entry, dict):
+            raise ChainBreakError(
+                f"{run_audit_path.name}:{line_no}: expected object, got {type(entry).__name__}",
+            )
+
+        stored_hmac = str(entry.get("hmac", ""))
+        # Compute expected HMAC over the stripped payload (without 'hmac' key).
+        stripped = {k: v for k, v in entry.items() if k != "hmac"}
+        recorded_prev = str(stripped.get("prev_hmac", ""))
+        if recorded_prev != prev:
+            raise ChainBreakError(
+                f"{run_audit_path.name}:{line_no}: prev_hmac mismatch "
+                f"(expected {prev[:16]}…, got {recorded_prev[:16]}…)",
+            )
+
+        payload = prev + json.dumps(stripped, sort_keys=True)
+        expected = _hmac.new(key, payload.encode(), hashlib.sha256).hexdigest()
+        if stored_hmac != expected:
+            raise ChainBreakError(
+                f"{run_audit_path.name}:{line_no}: HMAC mismatch (expected {expected[:16]}…, got {stored_hmac[:16]}…)",
+            )
+
+        events.append(
+            _ChainEvent(
+                line_no=line_no,
+                timestamp=str(entry.get("timestamp", "")),
+                raw=entry,
+                stored_hmac=stored_hmac,
+                prev_hmac=prev,
+            ),
+        )
+        prev = stored_hmac
+
+    return events
+
+
+def _filter_events_by_window(
+    events: Iterable[_ChainEvent],
+    *,
+    since: datetime,
+    until: datetime,
+) -> list[_SourceEvent]:
+    """Project verified events into the ``[since, until)`` window."""
+    out: list[_SourceEvent] = []
+    for ev in events:
+        if not ev.timestamp:
+            continue
+        try:
+            ts_dt = _parse_iso(ev.timestamp)
+        except (ValueError, TypeError):
+            continue
+        if ts_dt < since or ts_dt >= until:
+            continue
+        out.append(_SourceEvent(timestamp=ev.timestamp, raw=ev.raw))
+    out.sort(key=lambda e: (e.timestamp, str(e.raw.get("hmac", ""))))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Lineage / data-catalog cross-reference
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _CatalogedArtifact:
+    """Internal: lineage record projected into the data-catalog shape."""
+
+    path: str
+    sha256: str
+    regulatory_class: str | None
+    producer_agent_id: str
+    producer_run_id: str
+    producer_tick_id: str | None
+    timestamp: float
+
+
+def _walk_lineage_records(
+    sdd_dir: Path,
+    *,
+    run_id: str,
+    since: datetime,
+    until: datetime,
+) -> list[_CatalogedArtifact]:
+    """Collect lineage records produced inside ``[since, until)`` for *run_id*.
+
+    Reads from the same WAL the orchestrator writes via
+    :class:`bernstein.core.persistence.lineage.LineageWriter`, so the
+    catalog is grounded in the production hash chain — not a parallel
+    file the agent would need to cooperate with separately.
+
+    Args:
+        sdd_dir: Project ``.sdd/`` directory (containing ``runtime/wal``).
+        run_id: Restrict to records produced by this run.
+        since: Inclusive lower bound (UTC).
+        until: Exclusive upper bound (UTC).
+
+    Returns:
+        Stable-ordered list of catalog projections.
+    """
+    # Lazy import — keeps article12_bundle a leaf-importable module for
+    # tooling that doesn't pull the persistence stack.
+    try:
+        from bernstein.core.persistence.lineage import LineageReader
+    except ImportError:  # pragma: no cover — defensive, lineage ships alongside
+        return []
+
+    reader = LineageReader(sdd_dir)
+    since_ts = since.timestamp()
+    until_ts = until.timestamp()
+    seen: set[tuple[str, str]] = set()
+    catalog: list[_CatalogedArtifact] = []
+    for record in reader.iter_records(run_id=run_id):
+        # Records pre-date timestamping in v1; treat 0.0 as "always inside" so
+        # we don't drop them silently.
+        ts = float(record.timestamp or 0.0)
+        if ts and (ts < since_ts or ts >= until_ts):
+            continue
+        out = record.output_artifact
+        if not out.path:
+            continue
+        key = (out.path, out.sha256)
+        if key in seen:
+            continue
+        seen.add(key)
+        catalog.append(
+            _CatalogedArtifact(
+                path=out.path,
+                sha256=out.sha256,
+                regulatory_class=record.regulatory_class,
+                producer_agent_id=record.producer.agent_id,
+                producer_run_id=record.producer.run_id,
+                producer_tick_id=record.producer.tick_id,
+                timestamp=ts,
+            ),
+        )
+    catalog.sort(key=lambda a: (a.path, a.sha256))
+    return catalog
+
+
+def _build_data_catalog_with_lineage(
+    events: list[_SourceEvent],
+    artefacts: list[_CatalogedArtifact],
+) -> bytes:
+    """Build the Article 12(1)(a) catalog enriched with lineage artefacts.
+
+    Combines the per-resource activity counters from
+    :func:`_build_data_catalog` with a flat list of lineage-tracked
+    artefacts so an auditor can correlate event activity with the
+    artefacts the run produced.
+    """
+    catalog: dict[str, dict[str, int]] = {}
+    for ev in events:
+        rtype = str(ev.raw.get("resource_type", "")) or "unknown"
+        rid = str(ev.raw.get("resource_id", "")) or "unknown"
+        bucket = catalog.setdefault(rtype, {})
+        bucket[rid] = bucket.get(rid, 0) + 1
+
+    artefact_payload = [
+        {
+            "path": a.path,
+            "sha256": a.sha256,
+            "regulatory_class": a.regulatory_class,
+            "producer": {
+                "agent_id": a.producer_agent_id,
+                "run_id": a.producer_run_id,
+                "tick_id": a.producer_tick_id,
+            },
+        }
+        for a in artefacts
+    ]
+
+    payload = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "resources": {rtype: dict(sorted(items.items())) for rtype, items in sorted(catalog.items())},
+        "total_events": len(events),
+        "lineage_artefacts": artefact_payload,
+        "lineage_artefact_count": len(artefact_payload),
+    }
+    return _canonical_json(payload)
+
+
+# ---------------------------------------------------------------------------
+# Clause map loading
+# ---------------------------------------------------------------------------
+
+
+def _load_clause_map_from_yaml(path: Path) -> bytes:
+    """Read the YAML clause-map config and serialise it canonically.
+
+    The on-disk YAML is the source of truth for the operator: the bundle
+    embeds the JSON projection so an auditor reading the bundle does not
+    need a YAML parser.
+
+    Args:
+        path: Path to the YAML clause map.
+
+    Returns:
+        Canonical-JSON bytes ready for inclusion in the bundle.
+
+    Raises:
+        FileNotFoundError: When *path* does not exist.
+        ValueError: When the YAML is structurally invalid for our schema.
+    """
+    if not path.is_file():
+        raise FileNotFoundError(f"clause map config not found: {path}")
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover — yaml ships in core deps
+        raise ImportError(
+            "PyYAML is required for assemble_from_run; install via the core dependency set",
+        ) from exc
+
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        raise ValueError(f"clause map at {path} is not a YAML mapping")
+    if "mappings" not in parsed or not isinstance(parsed["mappings"], list):
+        raise ValueError(f"clause map at {path} missing 'mappings' list")
+    return _canonical_json(parsed)
+
+
+# ---------------------------------------------------------------------------
+# Public: assemble_from_run
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RunBundleResult:
+    """Output of :func:`assemble_from_run` — the bundle plus catalog stats.
+
+    Attributes:
+        bundle: The :class:`Article12Bundle` describing the produced pack.
+        run_id: The run id that anchored the bundle.
+        chain_event_count: Total events read from the per-run chain file
+            *before* window filtering — useful for sanity-checking that
+            the window did not drop anything unexpectedly.
+        catalog_artefact_count: Number of lineage artefacts cross-
+            referenced into ``data_catalog.json``.
+    """
+
+    bundle: Article12Bundle
+    run_id: str
+    chain_event_count: int
+    catalog_artefact_count: int
+
+
+def _resolve_clause_map_path(
+    workdir: Path,
+    clause_map_path: Path | None,
+) -> Path:
+    """Pick the on-disk clause map file, falling back to the bundled default."""
+    if clause_map_path is not None:
+        return clause_map_path
+    candidate = workdir / DEFAULT_CLAUSE_MAP_PATH
+    if candidate.is_file():
+        return candidate
+    # Fall back to the package-local default shipped under repo root.
+    package_default = Path(__file__).resolve().parents[4] / DEFAULT_CLAUSE_MAP_PATH
+    return package_default
+
+
+def assemble_from_run(
+    run_id: str,
+    since: datetime,
+    until: datetime,
+    *,
+    sdd_dir: Path | None = None,
+    workdir: Path | None = None,
+    risk_class: RiskClass = "limited",
+    audit_key: bytes | None = None,
+    clause_map_path: Path | None = None,
+    output_dir: Path | None = None,
+    write: bool = True,
+) -> RunBundleResult:
+    """Assemble an Article 12 evidence pack from a real orchestrator run.
+
+    Pipeline:
+
+    1. Resolve the per-run audit chain at
+       ``<sdd>/runtime/audit/<run_id>.audit.jsonl`` and verify every
+       HMAC link in-place. A break aborts the bundle (no partial export).
+    2. Filter the verified events to ``[since, until)``.
+    3. Walk ``LineageReader`` for *run_id* and project each output
+       artefact in-window into ``data_catalog.json`` with the producer's
+       agent / tick ids and any ``regulatory_class``.
+    4. Resolve the clause map from the YAML config (override-friendly).
+    5. Emit a deterministic bundle with the standard manifest plus the
+       lineage-enriched catalog.
+
+    Args:
+        run_id: The run identifier whose chain to bundle.
+        since: Inclusive lower bound of the export window.
+        until: Exclusive upper bound of the export window.
+        sdd_dir: Override for the ``.sdd`` root (defaults to
+            ``workdir / .sdd``).
+        workdir: Project root; used to resolve default config paths.
+            Defaults to ``Path.cwd()``.
+        risk_class: EU AI Act risk classification driving retention.
+        audit_key: HMAC key bytes for chain verification. When ``None``,
+            uses :func:`load_or_create_audit_key` (matches the path the
+            orchestrator's :class:`AuditLog` uses).
+        clause_map_path: Optional override for the YAML clause-map file.
+        output_dir: Where to write the bundle zip. Defaults to
+            ``<sdd>/evidence``.
+        write: When False, build everything in-memory and skip the disk
+            write — useful for ``--dry-run`` and tests.
+
+    Returns:
+        :class:`RunBundleResult` carrying the bundle plus diagnostic
+        counts so callers can assert lineage cross-ref worked.
+
+    Raises:
+        ChainBreakError: HMAC verification of the per-run chain failed.
+        FileNotFoundError: Per-run audit file is missing.
+        ValueError: ``since`` is not strictly less than ``until``.
+    """
+    if since >= until:
+        raise ValueError(f"since={since.isoformat()} must be < until={until.isoformat()}")
+
+    workdir = (workdir or Path.cwd()).resolve()
+    resolved_sdd = (sdd_dir or workdir / ".sdd").resolve()
+    run_audit_path = resolved_sdd / RUN_AUDIT_DIR_NAME / f"{run_id}{RUN_AUDIT_FILE_SUFFIX}"
+
+    if audit_key is None:
+        # Lazy-import to avoid pulling the audit-key environment touch on
+        # callers that only build deterministic bundles from in-memory keys.
+        from bernstein.core.security.audit import load_or_create_audit_key
+
+        audit_key = load_or_create_audit_key()
+
+    chain_events = _verify_run_chain(run_audit_path, key=audit_key)
+    window_events = _filter_events_by_window(chain_events, since=since, until=until)
+
+    last_event_ts = window_events[-1].timestamp if window_events else since.isoformat()
+    chain_anchor = str(window_events[-1].raw.get("hmac", _GENESIS_HMAC)) if window_events else _GENESIS_HMAC
+    retention = compute_retention_pin(risk_class, last_event_ts)
+
+    lineage_artefacts = _walk_lineage_records(
+        resolved_sdd,
+        run_id=run_id,
+        since=since,
+        until=until,
+    )
+
+    event_log = _build_event_log(window_events)
+    data_catalog = _build_data_catalog_with_lineage(window_events, lineage_artefacts)
+    clause_map_file = _resolve_clause_map_path(workdir, clause_map_path)
+    clause_map = _load_clause_map_from_yaml(clause_map_file)
+
+    since_iso = since.isoformat()
+    until_iso = until.isoformat()
+    artefact_hashes = {
+        "events.jsonl": hashlib.sha256(event_log).hexdigest(),
+        "data_catalog.json": hashlib.sha256(data_catalog).hexdigest(),
+        "clause_map.json": hashlib.sha256(clause_map).hexdigest(),
+    }
+    manifest = {
+        "schema_version": BUNDLE_SCHEMA_VERSION,
+        "bundle_id": _bundle_id(since_iso, until_iso, risk_class),
+        "since": since_iso,
+        "until": until_iso,
+        "run_id": run_id,
+        "risk_class": risk_class,
+        "event_count": len(window_events),
+        "chain_anchor": chain_anchor,
+        "retention": retention.to_dict(),
+        "artefacts": dict(sorted(artefact_hashes.items())),
+        "lineage_artefact_count": len(lineage_artefacts),
+        "clause_map_source": str(clause_map_file.relative_to(workdir))
+        if clause_map_file.is_relative_to(workdir)
+        else str(clause_map_file),
+    }
+    manifest_bytes = _canonical_json(manifest)
+
+    archive_bytes = _zip_artefacts(
+        manifest_bytes=manifest_bytes,
+        event_log=event_log,
+        data_catalog=data_catalog,
+        clause_map=clause_map,
+    )
+    archive_sha256 = hashlib.sha256(archive_bytes).hexdigest()
+
+    archive_path: Path | None = None
+    if write:
+        target_dir = output_dir or (resolved_sdd / "evidence")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        archive_path = target_dir / f"article12_run_{run_id}_{manifest['bundle_id']}.zip"
+        archive_path.write_bytes(archive_bytes)
+
+    bundle = Article12Bundle(
+        bundle_id=str(manifest["bundle_id"]),
+        since=since_iso,
+        until=until_iso,
+        risk_class=risk_class,
+        event_count=len(window_events),
+        chain_anchor=chain_anchor,
+        retention=retention,
+        archive_path=archive_path,
+        sha256=archive_sha256,
+    )
+    logger.info(
+        "Article 12 run bundle assembled (run_id=%s, events=%d, lineage=%d)",
+        run_id,
+        len(window_events),
+        len(lineage_artefacts),
+    )
+    return RunBundleResult(
+        bundle=bundle,
+        run_id=run_id,
+        chain_event_count=len(chain_events),
+        catalog_artefact_count=len(lineage_artefacts),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-run audit emit helper (used by demo + integration tests)
+# ---------------------------------------------------------------------------
+
+
+def emit_run_audit_event(
+    *,
+    sdd_dir: Path,
+    run_id: str,
+    event_type: str,
+    actor: str,
+    resource_type: str,
+    resource_id: str,
+    details: dict[str, Any] | None = None,
+    audit_key: bytes | None = None,
+) -> dict[str, Any]:
+    """Append one HMAC-chained event to a per-run audit slice.
+
+    The orchestrator's :class:`AuditLog` writes calendar-rotated daily
+    files under ``<sdd>/audit/``. This helper writes to the additional
+    per-run slice at ``<sdd>/runtime/audit/<run_id>.audit.jsonl`` using
+    the same key + payload format, so :func:`assemble_from_run` can read
+    a chain anchored to a run rather than a wall-clock window.
+
+    Args:
+        sdd_dir: Project ``.sdd`` root.
+        run_id: Run identifier (validated for path safety).
+        event_type: Audit event type label.
+        actor: Originating actor.
+        resource_type: Affected resource type.
+        resource_id: Affected resource identifier.
+        details: Optional structured payload.
+        audit_key: HMAC key bytes. Falls back to the operator's keychain.
+
+    Returns:
+        The written entry (post-HMAC), useful for tests.
+
+    Raises:
+        ValueError: When *run_id* contains a path separator.
+    """
+    if "/" in run_id or "\\" in run_id or run_id in {"", ".", ".."}:
+        raise ValueError(f"unsafe run_id: {run_id!r}")
+
+    if audit_key is None:
+        from bernstein.core.security.audit import load_or_create_audit_key
+
+        audit_key = load_or_create_audit_key()
+
+    target_dir = sdd_dir / RUN_AUDIT_DIR_NAME
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"{run_id}{RUN_AUDIT_FILE_SUFFIX}"
+
+    prev = _GENESIS_HMAC
+    if target.is_file():
+        for line in reversed(target.read_text(encoding="utf-8").splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                last = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(last, dict) and "hmac" in last:
+                prev = str(last["hmac"])
+                break
+
+    ts = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    entry: dict[str, Any] = {
+        "timestamp": ts,
+        "event_type": event_type,
+        "actor": actor,
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "details": details or {},
+        "prev_hmac": prev,
+    }
+    payload = prev + json.dumps(entry, sort_keys=True)
+    entry["hmac"] = _hmac.new(audit_key, payload.encode(), hashlib.sha256).hexdigest()
+
+    with target.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, sort_keys=True) + "\n")
+    return entry
+
+
 __all__ = [
     "BUNDLE_SCHEMA_VERSION",
+    "DEFAULT_CLAUSE_MAP_PATH",
     "HIGH_RISK_RETENTION_YEARS",
     "MINIMUM_RETENTION_DAYS",
+    "RUN_AUDIT_DIR_NAME",
+    "RUN_AUDIT_FILE_SUFFIX",
     "Article12Bundle",
+    "ChainBreakError",
     "RetentionPin",
+    "RunBundleResult",
     "VerificationResult",
+    "assemble_from_run",
     "build_article12_bundle",
     "compute_retention_pin",
+    "emit_run_audit_event",
     "validate_retention",
     "verify_bundle",
 ]

--- a/src/bernstein/core/security/audit_pack.py
+++ b/src/bernstein/core/security/audit_pack.py
@@ -1,0 +1,646 @@
+"""SOC 2 evidence checklist generator with real run-log integration.
+
+The historical SOC 2 surface (``bernstein audit export --period``) emits
+the JSON evidence package consumed by :mod:`bernstein.core.security.compliance`
+and :mod:`bernstein.core.security.soc2_report`. Both stop short of giving
+auditors a *human-readable* checklist where each Trust Service Criteria
+control is paired with the concrete file or hash that proves it.
+
+This module provides that checklist:
+
+* :class:`EvidenceSource` — declarative pointer from a SOC 2 control to
+  the on-disk artefact that backs it (audit-chain HMAC tail, credential-
+  scoping policy, capability-matrix CI run, cluster-TLS cert validation
+  log, wheelhouse verification result).
+* :func:`resolve_evidence_sources` — walks the project root, materialises
+  each source into a path or sha256 reference, and records freshness so
+  the markdown can flag stale evidence (last-modified > N days).
+* :func:`generate_audit_pack` — renders the checklist as Markdown,
+  one row per (control, source).
+
+The markdown is self-contained so it can be uploaded as a CI artifact
+or pasted into an external GRC tool without further processing.
+
+Wired into the CLI as ``bernstein audit pack --soc2 [--include-runs <since>]``
+(see :mod:`bernstein.cli.commands.audit_cmd`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+#: How an evidence source materialises on disk. Drives the rendering
+#: branch in :func:`generate_audit_pack`.
+SourceKind = Literal[
+    "audit_chain",
+    "policy_file",
+    "capability_matrix",
+    "tls_cert_log",
+    "wheelhouse_verify",
+    "run_log",
+]
+
+#: Markdown stamp used when a source is configured but the artefact is
+#: not present on disk yet (the operator hasn't run the relevant flow).
+PENDING_EVIDENCE: str = "evidence: pending — artefact not produced"
+
+#: Pretty-printed status markers to keep the checklist scannable in
+#: terminal output and rendered Markdown alike.
+STATUS_OK: str = "OK"
+STATUS_PENDING: str = "PENDING"
+STATUS_STALE: str = "STALE"
+
+#: Default freshness window in days. Anything older flips a source to
+#: ``STALE``. Operators tune via :func:`generate_audit_pack(stale_after_days=N)`.
+DEFAULT_STALE_AFTER_DAYS: int = 30
+
+
+# ---------------------------------------------------------------------------
+# Declarative source definitions
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSource:
+    """Pointer from a SOC 2 control to the artefact that backs it.
+
+    Attributes:
+        control_id: TSC identifier (e.g. ``CC6.1``).
+        kind: Materialisation strategy. Drives the resolver.
+        relpath: Path inside the project root where the artefact lives.
+            Resolvers may treat this as a glob root (e.g. for capability-
+            matrix runs that emit timestamped JSON per CI run).
+        description: Operator-facing description of what proves the
+            control. Lands verbatim in the markdown row.
+    """
+
+    control_id: str
+    kind: SourceKind
+    relpath: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedEvidence:
+    """A materialised :class:`EvidenceSource`.
+
+    Attributes:
+        source: The originating declaration.
+        status: ``OK`` / ``PENDING`` / ``STALE``.
+        evidence_ref: Either a relative path on disk or
+            ``"sha256:<digest>"`` when the source is content-addressed.
+        last_modified: Unix mtime of the resolved artefact (``0.0`` when
+            pending).
+        details: Free-form structured data — e.g. wheelhouse counts, the
+            HMAC chain tail digest — that downstream renderers can show
+            without re-reading disk.
+    """
+
+    source: EvidenceSource
+    status: Literal["OK", "PENDING", "STALE"]
+    evidence_ref: str
+    last_modified: float = 0.0
+    details: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+# Registry: each row binds one TSC control to one concrete source. Multiple
+# rows per control is allowed (e.g. CC6.1 has both an audit-chain and a
+# credential-scoping policy proof).
+DEFAULT_EVIDENCE_SOURCES: tuple[EvidenceSource, ...] = (
+    EvidenceSource(
+        control_id="CC1.1",
+        kind="policy_file",
+        relpath="docs/security/CODE_OF_CONDUCT_REVIEW.md",
+        description="Demonstrates board-level commitment to integrity (CoC review minutes).",
+    ),
+    EvidenceSource(
+        control_id="CC1.2",
+        kind="policy_file",
+        relpath="CODE_OF_CONDUCT.md",
+        description="Code of conduct binding everyone with a Bernstein account.",
+    ),
+    EvidenceSource(
+        control_id="CC2.1",
+        kind="audit_chain",
+        relpath=".sdd/audit",
+        description="HMAC-chained audit log proves communication of internal control responsibilities.",
+    ),
+    EvidenceSource(
+        control_id="CC6.1",
+        kind="policy_file",
+        relpath="src/bernstein/core/credential_scoping.py",
+        description="Credential scoping policy proves least-privilege API key issuance (logical access).",
+    ),
+    EvidenceSource(
+        control_id="CC6.1",
+        kind="audit_chain",
+        relpath=".sdd/audit",
+        description="HMAC-chained audit log of every privileged operation.",
+    ),
+    EvidenceSource(
+        control_id="CC6.6",
+        kind="tls_cert_log",
+        relpath=".sdd/runtime/cluster_tls",
+        description="Cluster mTLS cert validation log proves boundary protection (cluster_tls.py).",
+    ),
+    EvidenceSource(
+        control_id="CC6.7",
+        kind="capability_matrix",
+        relpath=".sdd/runtime/spawn_capabilities",
+        description="Capability matrix run results prove lethal-trifecta enforcement (transmission integrity).",
+    ),
+    EvidenceSource(
+        control_id="CC6.8",
+        kind="wheelhouse_verify",
+        relpath=".sdd/runtime/wheelhouse",
+        description="bernstein verify wheelhouse — supply-chain integrity attestation for installed wheels.",
+    ),
+    EvidenceSource(
+        control_id="CC7.2",
+        kind="audit_chain",
+        relpath=".sdd/audit",
+        description="System monitoring proof — every event is HMAC-chained for tamper-evidence.",
+    ),
+    EvidenceSource(
+        control_id="CC7.4",
+        kind="run_log",
+        relpath=".sdd/runtime",
+        description="Recent orchestrator runs — proves incident response activity is recorded.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Resolvers — one per :class:`SourceKind`
+# ---------------------------------------------------------------------------
+
+
+def _hmac_chain_tail_digest(audit_dir: Path) -> tuple[str, float, dict[str, Any]]:
+    """Return ``(sha256_ref, mtime, details)`` for the audit chain tail.
+
+    The chain tail HMAC is a single content hash that summarises the
+    entire log — quoting it in the evidence pack lets an auditor pin a
+    specific tail without shipping the full chain inline.
+    """
+    if not audit_dir.is_dir():
+        return "", 0.0, {}
+
+    log_files = sorted(audit_dir.glob("*.jsonl"))
+    if not log_files:
+        return "", 0.0, {"reason": "no audit log files present"}
+
+    last = log_files[-1]
+    last_mtime = last.stat().st_mtime
+    tail_hmac = ""
+    line_count = 0
+    for line in last.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        line_count += 1
+        try:
+            entry = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict) and "hmac" in entry:
+            tail_hmac = str(entry["hmac"])
+    if not tail_hmac:
+        return "", last_mtime, {"file": last.name, "lines": line_count, "reason": "no hmac field found"}
+
+    return (
+        f"sha256:{tail_hmac}",
+        last_mtime,
+        {"file": last.name, "lines": line_count, "tail_hmac": tail_hmac[:16] + "…"},
+    )
+
+
+def _policy_file_digest(policy_path: Path) -> tuple[str, float, dict[str, Any]]:
+    """Return content-hash + mtime for a static policy file."""
+    if not policy_path.is_file():
+        return "", 0.0, {}
+    body = policy_path.read_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    return (
+        f"sha256:{digest}",
+        policy_path.stat().st_mtime,
+        {"size_bytes": len(body), "lines": body.count(b"\n") + 1},
+    )
+
+
+def _capability_matrix_summary(runtime_dir: Path) -> tuple[str, float, dict[str, Any]]:
+    """Summarise capability-matrix CI runs into one evidence reference."""
+    if not runtime_dir.is_dir():
+        return "", 0.0, {}
+    run_files = sorted(runtime_dir.glob("*.json"))
+    if not run_files:
+        return "", 0.0, {"reason": "no capability runs recorded"}
+    latest = run_files[-1]
+    body = latest.read_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    parsed: dict[str, Any] = {}
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        parsed = {}
+    return (
+        f"sha256:{digest}",
+        latest.stat().st_mtime,
+        {
+            "file": latest.name,
+            "run_count": len(run_files),
+            "latest_tools": parsed.get("tools", []),
+            "violations": parsed.get("violations", []),
+        },
+    )
+
+
+def _tls_cert_log_summary(tls_dir: Path) -> tuple[str, float, dict[str, Any]]:
+    """Summarise cluster-TLS cert validation log files."""
+    if not tls_dir.is_dir():
+        return "", 0.0, {}
+    log_files = sorted(tls_dir.glob("*.log")) + sorted(tls_dir.glob("*.json"))
+    if not log_files:
+        return "", 0.0, {"reason": "no cluster_tls validation logs"}
+    latest = log_files[-1]
+    body = latest.read_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    return (
+        f"sha256:{digest}",
+        latest.stat().st_mtime,
+        {"file": latest.name, "log_count": len(log_files)},
+    )
+
+
+def _wheelhouse_verify_summary(wheelhouse_dir: Path) -> tuple[str, float, dict[str, Any]]:
+    """Summarise the wheelhouse verify result."""
+    if not wheelhouse_dir.is_dir():
+        return "", 0.0, {}
+    verify_files = sorted(wheelhouse_dir.glob("verify*.json"))
+    if not verify_files:
+        return "", 0.0, {"reason": "no verify*.json file produced"}
+    latest = verify_files[-1]
+    body = latest.read_bytes()
+    digest = hashlib.sha256(body).hexdigest()
+    parsed: dict[str, Any] = {}
+    try:
+        parsed = json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        parsed = {}
+    details: dict[str, Any] = {"file": latest.name}
+    if isinstance(parsed, dict):
+        details["wheels_checked"] = parsed.get("wheels_checked")
+        details["all_valid"] = parsed.get("all_valid")
+    return f"sha256:{digest}", latest.stat().st_mtime, details
+
+
+def _run_log_summary(
+    runtime_dir: Path,
+    *,
+    include_since: datetime | None,
+) -> tuple[str, float, dict[str, Any]]:
+    """Aggregate recent runs into one evidence reference.
+
+    When ``include_since`` is set, only count runs newer than that
+    timestamp. The reference is a content hash over the sorted list of
+    run-id + mtime pairs so two re-runs of the generator over the same
+    inputs produce the same evidence ref.
+    """
+    if not runtime_dir.is_dir():
+        return "", 0.0, {}
+
+    cutoff = include_since.timestamp() if include_since else 0.0
+    audit_dir = runtime_dir / "audit"
+    runs: list[tuple[str, float]] = []
+    if audit_dir.is_dir():
+        for path in sorted(audit_dir.glob("*.audit.jsonl")):
+            mtime = path.stat().st_mtime
+            if mtime < cutoff:
+                continue
+            run_id = path.name.removesuffix(".audit.jsonl")
+            runs.append((run_id, mtime))
+
+    if not runs:
+        return "", 0.0, {"reason": "no run audit slices in window"}
+
+    summary_payload = json.dumps(
+        [{"run_id": r, "mtime": round(m, 3)} for r, m in runs],
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = hashlib.sha256(summary_payload).hexdigest()
+    latest_mtime = max(m for _, m in runs)
+    return (
+        f"sha256:{digest}",
+        latest_mtime,
+        {
+            "run_count": len(runs),
+            "latest_run_id": runs[-1][0],
+            "since": include_since.isoformat() if include_since else None,
+        },
+    )
+
+
+def _resolve_one(
+    source: EvidenceSource,
+    *,
+    workdir: Path,
+    include_since: datetime | None,
+    stale_after_days: int,
+    now_ts: float,
+) -> ResolvedEvidence:
+    """Materialise a single :class:`EvidenceSource` against *workdir*."""
+    target = (workdir / source.relpath).resolve()
+    if source.kind == "audit_chain":
+        ref, mtime, details = _hmac_chain_tail_digest(target)
+    elif source.kind == "policy_file":
+        ref, mtime, details = _policy_file_digest(target)
+    elif source.kind == "capability_matrix":
+        ref, mtime, details = _capability_matrix_summary(target)
+    elif source.kind == "tls_cert_log":
+        ref, mtime, details = _tls_cert_log_summary(target)
+    elif source.kind == "wheelhouse_verify":
+        ref, mtime, details = _wheelhouse_verify_summary(target)
+    elif source.kind == "run_log":
+        ref, mtime, details = _run_log_summary(target, include_since=include_since)
+    else:  # pragma: no cover — Literal exhaustively covered above
+        ref, mtime, details = "", 0.0, {"reason": f"unknown source kind {source.kind!r}"}
+
+    if not ref:
+        return ResolvedEvidence(
+            source=source,
+            status=STATUS_PENDING,
+            evidence_ref=PENDING_EVIDENCE,
+            details=details,
+        )
+
+    age_days = (now_ts - mtime) / 86400.0
+    if age_days > stale_after_days:
+        details = {**details, "age_days": round(age_days, 1)}
+        return ResolvedEvidence(
+            source=source,
+            status=STATUS_STALE,
+            evidence_ref=f"evidence: {ref} (stale, age={age_days:.1f}d)",
+            last_modified=mtime,
+            details=details,
+        )
+
+    # Either a relative path or a content-addressed reference. Prefer the
+    # file path when the source kind has one — content hashes alone are
+    # opaque without the file location.
+    pretty = f"evidence: {source.relpath} ({ref})"
+    return ResolvedEvidence(
+        source=source,
+        status=STATUS_OK,
+        evidence_ref=pretty,
+        last_modified=mtime,
+        details=details,
+    )
+
+
+def resolve_evidence_sources(
+    sources: Iterable[EvidenceSource] = DEFAULT_EVIDENCE_SOURCES,
+    *,
+    workdir: Path | None = None,
+    include_since: datetime | None = None,
+    stale_after_days: int = DEFAULT_STALE_AFTER_DAYS,
+    now: datetime | None = None,
+) -> list[ResolvedEvidence]:
+    """Resolve every declared :class:`EvidenceSource` against the project.
+
+    Args:
+        sources: Iterable of source declarations.
+        workdir: Project root. Defaults to ``Path.cwd()``.
+        include_since: When set, run-log resolvers filter to runs newer
+            than this datetime. Other resolvers ignore the value.
+        stale_after_days: Mark sources whose mtime is older than this
+            window as ``STALE``. Default 30 days.
+        now: Override clock for tests.
+
+    Returns:
+        Resolved entries in declaration order.
+    """
+    base = (workdir or Path.cwd()).resolve()
+    now_dt = now or datetime.now(tz=UTC)
+    now_ts = now_dt.timestamp()
+    return [
+        _resolve_one(
+            src,
+            workdir=base,
+            include_since=include_since,
+            stale_after_days=stale_after_days,
+            now_ts=now_ts,
+        )
+        for src in sources
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _format_status(resolved: ResolvedEvidence) -> str:
+    """Format the status column with a literal label (no emoji)."""
+    return f"`{resolved.status}`"
+
+
+def _format_details(details: dict[str, Any]) -> str:
+    """Render structured details as a one-line key=value summary."""
+    if not details:
+        return ""
+    parts = [f"{k}={details[k]!r}" for k in sorted(details)]
+    return "; ".join(parts)
+
+
+def render_markdown(
+    resolved: list[ResolvedEvidence],
+    *,
+    period_label: str,
+    generated_at: datetime | None = None,
+) -> str:
+    """Render the resolved evidence list as a SOC 2 checklist Markdown.
+
+    Args:
+        resolved: Output of :func:`resolve_evidence_sources`.
+        period_label: Human-readable label for the reporting period.
+        generated_at: Override clock for tests.
+
+    Returns:
+        Markdown body (newline-terminated).
+    """
+    ts = (generated_at or datetime.now(tz=UTC)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    lines: list[str] = [
+        "# SOC 2 Evidence Checklist",
+        "",
+        f"_Period: {period_label} | Generated: {ts}_",
+        "",
+        "## Controls",
+        "",
+        "| Control | Status | Evidence | Description |",
+        "| --- | --- | --- | --- |",
+    ]
+    for entry in resolved:
+        details = _format_details(entry.details)
+        evidence_cell = entry.evidence_ref
+        if details:
+            evidence_cell = f"{entry.evidence_ref} <br/>_{details}_"
+        lines.append(
+            f"| {entry.source.control_id} | {_format_status(entry)} | {evidence_cell} | {entry.source.description} |",
+        )
+    lines.extend(
+        [
+            "",
+            "## Summary",
+            "",
+            f"- Sources resolved: **{len(resolved)}**",
+            f"- OK: **{sum(1 for r in resolved if r.status == STATUS_OK)}**",
+            f"- Pending: **{sum(1 for r in resolved if r.status == STATUS_PENDING)}**",
+            f"- Stale: **{sum(1 for r in resolved if r.status == STATUS_STALE)}**",
+            "",
+        ],
+    )
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point — used by the CLI
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AuditPackResult:
+    """Output of :func:`generate_audit_pack`.
+
+    Attributes:
+        markdown: Rendered checklist body.
+        markdown_path: On-disk path to the saved markdown (``None`` when
+            ``write=False``).
+        manifest: JSON manifest with one row per resolved evidence
+            source — useful for machine-parseable downstream tooling
+            (CI artefacts, Vanta/Drata sync, etc.).
+        manifest_path: On-disk path to the saved manifest.
+        resolved: The resolved evidence list.
+    """
+
+    markdown: str
+    markdown_path: Path | None
+    manifest: dict[str, Any]
+    manifest_path: Path | None
+    resolved: list[ResolvedEvidence]
+
+
+def _build_manifest(
+    resolved: list[ResolvedEvidence],
+    *,
+    period_label: str,
+    generated_at: datetime,
+) -> dict[str, Any]:
+    """Compose the JSON manifest companion to the markdown."""
+    return {
+        "schema_version": 1,
+        "report_type": "soc2_evidence_pack",
+        "period": period_label,
+        "generated_at": generated_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "evidence": [
+            {
+                "control_id": entry.source.control_id,
+                "kind": entry.source.kind,
+                "relpath": entry.source.relpath,
+                "description": entry.source.description,
+                "status": entry.status,
+                "evidence_ref": entry.evidence_ref,
+                "last_modified": entry.last_modified,
+                "details": entry.details,
+            }
+            for entry in resolved
+        ],
+    }
+
+
+def generate_audit_pack(
+    *,
+    workdir: Path | None = None,
+    output_dir: Path | None = None,
+    period_label: str = "current",
+    sources: Iterable[EvidenceSource] = DEFAULT_EVIDENCE_SOURCES,
+    include_since: datetime | None = None,
+    stale_after_days: int = DEFAULT_STALE_AFTER_DAYS,
+    now: datetime | None = None,
+    write: bool = True,
+) -> AuditPackResult:
+    """Generate the SOC 2 evidence-checklist pack.
+
+    Args:
+        workdir: Project root. Defaults to ``Path.cwd()``.
+        output_dir: Where to write the markdown + manifest. Defaults to
+            ``<workdir>/.sdd/evidence/soc2/``.
+        period_label: Human label for the reporting window.
+        sources: Override the default registry (test/extension hook).
+        include_since: When set, ``run_log`` resolvers filter by this.
+        stale_after_days: Threshold for the ``STALE`` flag.
+        now: Override clock for tests.
+        write: When False, return rendered content without touching disk.
+
+    Returns:
+        :class:`AuditPackResult`.
+    """
+    base = (workdir or Path.cwd()).resolve()
+    generated_at = now or datetime.now(tz=UTC)
+    resolved = resolve_evidence_sources(
+        sources,
+        workdir=base,
+        include_since=include_since,
+        stale_after_days=stale_after_days,
+        now=generated_at,
+    )
+    markdown = render_markdown(resolved, period_label=period_label, generated_at=generated_at)
+    manifest = _build_manifest(resolved, period_label=period_label, generated_at=generated_at)
+
+    md_path: Path | None = None
+    manifest_path: Path | None = None
+    if write:
+        target_dir = (output_dir or base / ".sdd" / "evidence" / "soc2").resolve()
+        target_dir.mkdir(parents=True, exist_ok=True)
+        md_path = target_dir / f"soc2-evidence-{period_label}.md"
+        manifest_path = target_dir / f"soc2-evidence-{period_label}.json"
+        md_path.write_text(markdown, encoding="utf-8")
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        logger.info("SOC 2 evidence pack written: %s", md_path)
+
+    return AuditPackResult(
+        markdown=markdown,
+        markdown_path=md_path,
+        manifest=manifest,
+        manifest_path=manifest_path,
+        resolved=resolved,
+    )
+
+
+__all__ = [
+    "DEFAULT_EVIDENCE_SOURCES",
+    "DEFAULT_STALE_AFTER_DAYS",
+    "PENDING_EVIDENCE",
+    "STATUS_OK",
+    "STATUS_PENDING",
+    "STATUS_STALE",
+    "AuditPackResult",
+    "EvidenceSource",
+    "ResolvedEvidence",
+    "SourceKind",
+    "generate_audit_pack",
+    "render_markdown",
+    "resolve_evidence_sources",
+]

--- a/tests/integration/test_article12_real_run.py
+++ b/tests/integration/test_article12_real_run.py
@@ -1,0 +1,313 @@
+"""Integration: assemble_from_run against a real per-run audit chain.
+
+Boots a tiny in-process orchestrator surface (audit emit + lineage
+writer), produces real bytes through the production HMAC chain, and
+walks them back through :func:`assemble_from_run` + :func:`verify_bundle`.
+
+No mocks for the audit or lineage writers — the chain that signs the
+events is the same chain the production orchestrator would use.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.persistence.lineage import (
+    AgentRef,
+    ArtifactRef,
+    LineageRecord,
+    LineageWriter,
+)
+from bernstein.core.security.article12_bundle import (
+    ChainBreakError,
+    assemble_from_run,
+    emit_run_audit_event,
+    verify_bundle,
+)
+
+
+@pytest.fixture()
+def audit_key() -> bytes:
+    """Fixed key so the test does not touch the operator's keychain."""
+    return b"x" * 32
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path) -> Path:
+    """Project workspace with an empty ``.sdd`` root."""
+    (tmp_path / ".sdd").mkdir()
+    return tmp_path
+
+
+@pytest.fixture()
+def run_id() -> str:
+    return "run-integration-001"
+
+
+def _seed_run(
+    *,
+    sdd_dir: Path,
+    run_id: str,
+    audit_key: bytes,
+    event_count: int = 3,
+    base_time: datetime,
+) -> list[dict]:
+    """Emit *event_count* HMAC-chained audit events for *run_id*."""
+    events = []
+    for idx in range(event_count):
+        entry = emit_run_audit_event(
+            sdd_dir=sdd_dir,
+            run_id=run_id,
+            event_type=f"task.event_{idx}",
+            actor="orchestrator",
+            resource_type="task",
+            resource_id=f"T-{idx:03d}",
+            details={"idx": idx, "ts": base_time.timestamp() + idx},
+            audit_key=audit_key,
+        )
+        events.append(entry)
+    return events
+
+
+def _seed_lineage(
+    *,
+    sdd_dir: Path,
+    run_id: str,
+    base_time: datetime,
+    count: int = 2,
+) -> list[LineageRecord]:
+    """Append *count* lineage records to the run WAL via the real writer."""
+    writer = LineageWriter.for_run(run_id=run_id, sdd_dir=sdd_dir)
+    records = []
+    for idx in range(count):
+        record = LineageRecord(
+            output_artifact=ArtifactRef(path=f"src/feature_{idx}.py", sha256=f"{idx:064d}"),
+            inputs=[ArtifactRef(path="prompts/system.md", sha256="0" * 64)],
+            producer=AgentRef(agent_id="claude-code", run_id=run_id, tick_id=f"t-{idx}"),
+            prompt_sha="cafe" * 16,
+            model="claude-sonnet-4.5",
+            cost_usd=0.01 * (idx + 1),
+            tokens=100 * (idx + 1),
+            timestamp=base_time.timestamp() + idx,
+            regulatory_class="high-risk",
+        )
+        writer.emit(record)
+        records.append(record)
+    return records
+
+
+class TestAssembleFromRun:
+    """End-to-end exercise of the runtime audit chain integration."""
+
+    def test_real_run_produces_verifiable_bundle(
+        self,
+        workspace: Path,
+        run_id: str,
+        audit_key: bytes,
+    ) -> None:
+        sdd_dir = workspace / ".sdd"
+        base_time = datetime.now(tz=UTC)
+        _seed_run(sdd_dir=sdd_dir, run_id=run_id, audit_key=audit_key, base_time=base_time)
+        _seed_lineage(sdd_dir=sdd_dir, run_id=run_id, base_time=base_time, count=2)
+
+        since = base_time - timedelta(minutes=1)
+        until = base_time + timedelta(minutes=5)
+
+        result = assemble_from_run(
+            run_id=run_id,
+            since=since,
+            until=until,
+            sdd_dir=sdd_dir,
+            workdir=workspace,
+            risk_class="high",
+            audit_key=audit_key,
+        )
+
+        assert result.bundle.event_count == 3
+        assert result.chain_event_count == 3
+        assert result.catalog_artefact_count == 2
+        assert result.bundle.archive_path is not None
+        assert result.bundle.archive_path.exists()
+
+        verification = verify_bundle(result.bundle.archive_path)
+        assert verification.ok, verification.errors
+        assert verification.manifest["run_id"] == run_id
+        assert verification.manifest["lineage_artefact_count"] == 2
+        assert verification.manifest["risk_class"] == "high"
+        assert verification.manifest["chain_anchor"] != "0" * 64
+
+    def test_data_catalog_includes_lineage_artefacts(
+        self,
+        workspace: Path,
+        run_id: str,
+        audit_key: bytes,
+    ) -> None:
+        sdd_dir = workspace / ".sdd"
+        base_time = datetime.now(tz=UTC)
+        _seed_run(sdd_dir=sdd_dir, run_id=run_id, audit_key=audit_key, base_time=base_time)
+        records = _seed_lineage(sdd_dir=sdd_dir, run_id=run_id, base_time=base_time, count=3)
+
+        result = assemble_from_run(
+            run_id=run_id,
+            since=base_time - timedelta(minutes=1),
+            until=base_time + timedelta(minutes=5),
+            sdd_dir=sdd_dir,
+            workdir=workspace,
+            risk_class="limited",
+            audit_key=audit_key,
+        )
+
+        assert result.bundle.archive_path is not None
+        with zipfile.ZipFile(result.bundle.archive_path) as zf:
+            catalog = json.loads(zf.read("data_catalog.json").decode("utf-8"))
+
+        assert catalog["lineage_artefact_count"] == 3
+        cataloged_paths = {entry["path"] for entry in catalog["lineage_artefacts"]}
+        expected_paths = {r.output_artifact.path for r in records}
+        assert cataloged_paths == expected_paths
+        for entry in catalog["lineage_artefacts"]:
+            assert entry["regulatory_class"] == "high-risk"
+            assert entry["producer"]["run_id"] == run_id
+
+    def test_clause_map_loaded_from_yaml(
+        self,
+        workspace: Path,
+        run_id: str,
+        audit_key: bytes,
+    ) -> None:
+        sdd_dir = workspace / ".sdd"
+        base_time = datetime.now(tz=UTC)
+        _seed_run(sdd_dir=sdd_dir, run_id=run_id, audit_key=audit_key, base_time=base_time)
+
+        # Write a project-local clause map override so we know the
+        # bundle picked up the file (not an in-code default).
+        config_dir = workspace / "config"
+        config_dir.mkdir()
+        custom_map = config_dir / "eu_ai_act_clause_map.yaml"
+        custom_map.write_text(
+            """schema_version: 1
+regulation: "Custom regulation"
+article: 12
+mappings:
+  - clause: "12(custom)"
+    requirement: "Custom requirement under test."
+    subsystem:
+      module: "src/bernstein/core/security/audit.py"
+      role: "Custom role"
+    evidence_artefact: "events.jsonl"
+""",
+            encoding="utf-8",
+        )
+
+        result = assemble_from_run(
+            run_id=run_id,
+            since=base_time - timedelta(minutes=1),
+            until=base_time + timedelta(minutes=5),
+            sdd_dir=sdd_dir,
+            workdir=workspace,
+            risk_class="limited",
+            audit_key=audit_key,
+        )
+        assert result.bundle.archive_path is not None
+        with zipfile.ZipFile(result.bundle.archive_path) as zf:
+            clause_map = json.loads(zf.read("clause_map.json").decode("utf-8"))
+
+        assert clause_map["regulation"] == "Custom regulation"
+        clauses = [m["clause"] for m in clause_map["mappings"]]
+        assert "12(custom)" in clauses
+
+    def test_chain_break_aborts_bundle(
+        self,
+        workspace: Path,
+        run_id: str,
+        audit_key: bytes,
+    ) -> None:
+        sdd_dir = workspace / ".sdd"
+        base_time = datetime.now(tz=UTC)
+        _seed_run(sdd_dir=sdd_dir, run_id=run_id, audit_key=audit_key, base_time=base_time)
+
+        # Tamper: rewrite the second event's payload after the HMAC was
+        # computed. The chain should break on line 2.
+        run_audit_path = sdd_dir / "runtime" / "audit" / f"{run_id}.audit.jsonl"
+        lines = run_audit_path.read_text().splitlines()
+        tampered = json.loads(lines[1])
+        tampered["actor"] = "tampered-actor"
+        lines[1] = json.dumps(tampered, sort_keys=True)
+        run_audit_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        with pytest.raises(ChainBreakError, match="HMAC mismatch"):
+            assemble_from_run(
+                run_id=run_id,
+                since=base_time - timedelta(minutes=1),
+                until=base_time + timedelta(minutes=5),
+                sdd_dir=sdd_dir,
+                workdir=workspace,
+                risk_class="limited",
+                audit_key=audit_key,
+            )
+
+    def test_missing_run_chain_raises(
+        self,
+        workspace: Path,
+        audit_key: bytes,
+    ) -> None:
+        sdd_dir = workspace / ".sdd"
+        with pytest.raises(FileNotFoundError):
+            assemble_from_run(
+                run_id="never-existed",
+                since=datetime.now(tz=UTC) - timedelta(minutes=1),
+                until=datetime.now(tz=UTC) + timedelta(minutes=5),
+                sdd_dir=sdd_dir,
+                workdir=workspace,
+                risk_class="limited",
+                audit_key=audit_key,
+            )
+
+    def test_window_filters_events(
+        self,
+        workspace: Path,
+        run_id: str,
+        audit_key: bytes,
+    ) -> None:
+        sdd_dir = workspace / ".sdd"
+        base_time = datetime.now(tz=UTC)
+        _seed_run(
+            sdd_dir=sdd_dir,
+            run_id=run_id,
+            audit_key=audit_key,
+            base_time=base_time,
+            event_count=5,
+        )
+
+        # Window covers everything — sanity check.
+        full = assemble_from_run(
+            run_id=run_id,
+            since=base_time - timedelta(hours=1),
+            until=base_time + timedelta(hours=1),
+            sdd_dir=sdd_dir,
+            workdir=workspace,
+            risk_class="limited",
+            audit_key=audit_key,
+            write=False,
+        )
+        assert full.bundle.event_count == 5
+        assert full.chain_event_count == 5
+
+        # Past window — no events but chain still verifies.
+        past = assemble_from_run(
+            run_id=run_id,
+            since=base_time - timedelta(days=10),
+            until=base_time - timedelta(days=9),
+            sdd_dir=sdd_dir,
+            workdir=workspace,
+            risk_class="limited",
+            audit_key=audit_key,
+            write=False,
+        )
+        assert past.bundle.event_count == 0
+        assert past.chain_event_count == 5  # chain still walked top-to-bottom

--- a/tests/integration/test_soc2_real_evidence.py
+++ b/tests/integration/test_soc2_real_evidence.py
@@ -1,0 +1,265 @@
+"""Integration: SOC 2 evidence pack pulls real per-control references.
+
+Boots a minimal "run" by populating concrete artefacts under a temp
+project root (audit chain, credential-scoping policy, capability matrix
+runs, cluster-TLS log, wheelhouse verify result, run audit slices),
+calls :func:`generate_audit_pack`, and asserts every declared
+:class:`EvidenceSource` resolves to a non-empty reference.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.security.article12_bundle import emit_run_audit_event
+from bernstein.core.security.audit_pack import (
+    DEFAULT_EVIDENCE_SOURCES,
+    STATUS_OK,
+    STATUS_PENDING,
+    STATUS_STALE,
+    EvidenceSource,
+    generate_audit_pack,
+    resolve_evidence_sources,
+)
+
+
+@pytest.fixture()
+def project_root(tmp_path: Path) -> Path:
+    """Skeleton project root with the directories the resolvers need."""
+    (tmp_path / ".sdd" / "audit").mkdir(parents=True)
+    (tmp_path / ".sdd" / "runtime").mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def populated_project(project_root: Path) -> Path:
+    """A project root with one concrete artefact per evidence source.
+
+    Mirrors what a real Bernstein run would leave on disk: a daily audit
+    log, a credential-scoping policy file, a capability-matrix run
+    snapshot, a cluster-TLS validation log, a wheelhouse verify json,
+    and one per-run audit slice.
+    """
+    base = project_root
+    audit_key = b"x" * 32
+
+    # --- audit chain (.sdd/audit/<date>.jsonl) ---
+    audit_dir = base / ".sdd" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    chain_entry = {
+        "timestamp": f"{today}T00:00:00.000000Z",
+        "event_type": "task.created",
+        "actor": "tester",
+        "resource_type": "task",
+        "resource_id": "T-1",
+        "details": {},
+        "prev_hmac": "0" * 64,
+        "hmac": "abc" * 21 + "z",
+    }
+    (audit_dir / f"{today}.jsonl").write_text(json.dumps(chain_entry, sort_keys=True) + "\n")
+
+    # --- policy_file: CC1.2 (CODE_OF_CONDUCT.md) ---
+    (base / "CODE_OF_CONDUCT.md").write_text("# Code of Conduct\nIntegrity binds us.\n", encoding="utf-8")
+
+    # --- policy_file: CC1.1 (board CoC review minutes) ---
+    docs_dir = base / "docs" / "security"
+    docs_dir.mkdir(parents=True, exist_ok=True)
+    (docs_dir / "CODE_OF_CONDUCT_REVIEW.md").write_text(
+        "# CoC review\nReviewed 2026-01-15 by board.\n",
+        encoding="utf-8",
+    )
+
+    # --- policy_file: CC6.1 (credential_scoping.py) ---
+    src_dir = base / "src" / "bernstein" / "core"
+    src_dir.mkdir(parents=True, exist_ok=True)
+    (src_dir / "credential_scoping.py").write_text(
+        '"""Credential scoping policy."""\nDEFAULT_SCOPES = ()\n',
+        encoding="utf-8",
+    )
+
+    # --- capability_matrix run snapshot ---
+    cap_dir = base / ".sdd" / "runtime" / "spawn_capabilities"
+    cap_dir.mkdir(parents=True, exist_ok=True)
+    (cap_dir / "run-001.json").write_text(
+        json.dumps({"tools": ["bash", "edit"], "violations": []}),
+        encoding="utf-8",
+    )
+
+    # --- cluster_tls validation log ---
+    tls_dir = base / ".sdd" / "runtime" / "cluster_tls"
+    tls_dir.mkdir(parents=True, exist_ok=True)
+    (tls_dir / "validate.log").write_text(
+        "2026-01-15T10:00:00Z OK valid_until=2027-01-15\n",
+        encoding="utf-8",
+    )
+
+    # --- wheelhouse verify ---
+    wh_dir = base / ".sdd" / "runtime" / "wheelhouse"
+    wh_dir.mkdir(parents=True, exist_ok=True)
+    (wh_dir / "verify-2026-01-15.json").write_text(
+        json.dumps({"wheels_checked": 42, "all_valid": True}),
+        encoding="utf-8",
+    )
+
+    # --- run_log: per-run audit slice ---
+    emit_run_audit_event(
+        sdd_dir=base / ".sdd",
+        run_id="run-soc2-001",
+        event_type="task.created",
+        actor="orchestrator",
+        resource_type="task",
+        resource_id="T-1",
+        details={},
+        audit_key=audit_key,
+    )
+
+    return base
+
+
+class TestEvidenceResolution:
+    """Verify every declared EvidenceSource resolves to non-empty content."""
+
+    def test_default_sources_resolve_against_populated_project(
+        self,
+        populated_project: Path,
+    ) -> None:
+        resolved = resolve_evidence_sources(workdir=populated_project)
+        # All declared sources should produce one resolved row.
+        assert len(resolved) == len(DEFAULT_EVIDENCE_SOURCES)
+        # No row should be empty (status==PENDING with PENDING_EVIDENCE
+        # message) for the populated project.
+        for entry in resolved:
+            assert entry.status in {STATUS_OK, STATUS_STALE}, (
+                f"{entry.source.control_id}/{entry.source.kind} resolved to {entry.status}: {entry.evidence_ref!r}"
+            )
+            assert entry.evidence_ref, "evidence_ref must be non-empty when status != PENDING"
+            # Each kind must contribute *some* sha256 reference except
+            # for the run_log digest, which always emits a sha256 over
+            # the run summary.
+            assert "sha256:" in entry.evidence_ref or entry.source.relpath in entry.evidence_ref
+
+    def test_pending_sources_when_project_empty(self, project_root: Path) -> None:
+        resolved = resolve_evidence_sources(workdir=project_root)
+        # Empty project: at minimum the audit-chain, capability-matrix,
+        # cluster-tls, wheelhouse, and run-log sources should report PENDING.
+        pending_kinds = {r.source.kind for r in resolved if r.status == STATUS_PENDING}
+        assert {
+            "audit_chain",
+            "capability_matrix",
+            "tls_cert_log",
+            "wheelhouse_verify",
+            "run_log",
+        }.issubset(pending_kinds)
+
+    def test_include_runs_filters_run_log(self, populated_project: Path) -> None:
+        # Far-future cutoff — the run_log resolver should drop the
+        # in-tree slice and report PENDING.
+        future = datetime.now(tz=UTC) + timedelta(days=365)
+        resolved = resolve_evidence_sources(
+            workdir=populated_project,
+            include_since=future,
+        )
+        run_log_rows = [r for r in resolved if r.source.kind == "run_log"]
+        assert run_log_rows, "expected at least one run_log evidence source"
+        assert all(r.status == STATUS_PENDING for r in run_log_rows)
+
+    def test_stale_threshold_flips_status(
+        self,
+        populated_project: Path,
+    ) -> None:
+        # Backdate the audit chain by 90 days; with default threshold of
+        # 30 days the row must report STALE.
+        chain_path = next((populated_project / ".sdd" / "audit").glob("*.jsonl"))
+        old_mtime = (datetime.now(tz=UTC) - timedelta(days=90)).timestamp()
+        import os
+
+        os.utime(chain_path, (old_mtime, old_mtime))
+        resolved = resolve_evidence_sources(workdir=populated_project)
+        chain_rows = [r for r in resolved if r.source.kind == "audit_chain"]
+        assert chain_rows
+        assert any(r.status == STATUS_STALE for r in chain_rows)
+
+
+class TestGenerateAuditPack:
+    """Full pack generation against a populated project."""
+
+    def test_pack_writes_markdown_and_manifest(
+        self,
+        populated_project: Path,
+        tmp_path: Path,
+    ) -> None:
+        out = tmp_path / "out"
+        result = generate_audit_pack(
+            workdir=populated_project,
+            output_dir=out,
+            period_label="2026-Q1",
+            stale_after_days=999,  # disable staleness for this assertion
+        )
+
+        assert result.markdown_path is not None
+        assert result.manifest_path is not None
+        assert result.markdown_path.exists()
+        assert result.manifest_path.exists()
+
+        body = result.markdown_path.read_text(encoding="utf-8")
+        assert "# SOC 2 Evidence Checklist" in body
+        # Every declared control must appear at least once.
+        declared = {s.control_id for s in DEFAULT_EVIDENCE_SOURCES}
+        for control_id in declared:
+            assert control_id in body, f"{control_id} missing from markdown"
+        # No row should still be the bare TBD marker.
+        assert "evidence: TBD" not in body
+        # OK count must dominate now that the project is populated.
+        manifest = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+        ok_count = sum(1 for entry in manifest["evidence"] if entry["status"] == STATUS_OK)
+        assert ok_count >= len(DEFAULT_EVIDENCE_SOURCES) - 1
+
+    def test_manifest_includes_evidence_refs_per_control(
+        self,
+        populated_project: Path,
+        tmp_path: Path,
+    ) -> None:
+        result = generate_audit_pack(
+            workdir=populated_project,
+            output_dir=tmp_path / "out",
+            period_label="ci",
+            stale_after_days=999,
+        )
+        evidence_rows: list[dict[str, Any]] = result.manifest["evidence"]
+        for entry in evidence_rows:
+            if entry["status"] == STATUS_OK:
+                assert "sha256:" in entry["evidence_ref"] or entry["relpath"] in entry["evidence_ref"]
+                assert entry["last_modified"] > 0
+                assert entry["details"], f"OK row should carry details for {entry['control_id']}/{entry['kind']}"
+
+    def test_custom_source_extension(
+        self,
+        populated_project: Path,
+        tmp_path: Path,
+    ) -> None:
+        # Operators can supply their own EvidenceSource list — the
+        # generator must drive the resolver against it.
+        custom = (
+            EvidenceSource(
+                control_id="CUSTOM.1",
+                kind="policy_file",
+                relpath="CODE_OF_CONDUCT.md",
+                description="Custom proof",
+            ),
+        )
+        result = generate_audit_pack(
+            workdir=populated_project,
+            output_dir=tmp_path / "out",
+            period_label="custom",
+            sources=custom,
+            stale_after_days=999,
+        )
+        assert len(result.resolved) == 1
+        assert result.resolved[0].source.control_id == "CUSTOM.1"
+        assert result.resolved[0].status == STATUS_OK


### PR DESCRIPTION
## Summary

Two compliance scaffolds graduate from "spec + unit tests" to real run-log integration with end-to-end demo coverage.

### Section 1 — EU AI Act Article 12 evidence pack: real audit-chain integration

- `src/bernstein/core/security/article12_bundle.py` gains `assemble_from_run(run_id, since, until)` that:
  1. Reads HMAC-chained events from `.sdd/runtime/audit/<run_id>.audit.jsonl` (new per-run slice, written via the new `emit_run_audit_event` helper).
  2. Verifies every link in-place via `_verify_run_chain` and refuses the bundle on the first break (`ChainBreakError`).
  3. Cross-references `LineageReader` for the run; every output artefact in the window lands in `data_catalog.json` with sha256 + `regulatory_class` + producer agent / tick / run id.
  4. Resolves the clause map from `config/eu_ai_act_clause_map.yaml` (shipped as the default; mappings name `audit.py`, `lineage.py`, `cluster_tls.py`, etc., per Article 12 obligation).
- `scripts/demo_article12_export.py` boots an in-process orchestrator, emits 3 high-risk audit events through the real chain, calls `assemble_from_run`, dumps the bundle to `/tmp/article12-demo/`, verifies it via `verify_bundle`, prints the manifest. Verified locally, exit 0.

### Section 2 — SOC 2 evidence checklist: real per-control evidence

- New `src/bernstein/core/security/audit_pack.py` introduces `EvidenceSource` — declarative pointer from a TSC control to a concrete artefact. Default registry covers CC1.1, CC1.2, CC2.1, CC6.1 (×2), CC6.6, CC6.7, CC6.8, CC7.2, CC7.4.
- Resolver kinds:
  - `audit_chain` → tail HMAC of `.sdd/audit/`.
  - `policy_file` → sha256 of `credential_scoping.py`, `CODE_OF_CONDUCT.md`, etc.
  - `capability_matrix` → latest spawn-capability run snapshot.
  - `tls_cert_log` → cluster-TLS validation log digest.
  - `wheelhouse_verify` → `bernstein verify` result digest.
  - `run_log` → digest over recent run audit slices, filterable via `--include-runs <iso>`.
- Markdown rows now read `evidence: <path> (sha256:<digest>)` instead of `evidence: TBD`. Stale/pending statuses surfaced for any source older than `--stale-after-days` (default 30).
- New CLI: `bernstein audit pack --soc2 [--include-runs <iso>] [--period-label …]`. Verified locally — produces markdown + JSON manifest under `.sdd/evidence/soc2/`.
- New `.github/workflows/soc2-evidence-nightly.yml` runs weekly (Mon 03:47 UTC), gated by `SOC2_EVIDENCE_ENABLED` repo secret, uploads pack as artifact (90d retention).

## Test plan

- [x] `uv run pytest tests/integration/test_article12_real_run.py -v` — 6 passed
- [x] `uv run pytest tests/integration/test_soc2_real_evidence.py -v` — 7 passed
- [x] `uv run pytest tests/unit/test_article12_bundle.py tests/unit/test_soc2_report.py tests/unit/test_audit.py tests/unit/test_audit_export.py tests/unit/test_audit_slice.py -q` — 64 passed (no regressions)
- [x] `uv run python scripts/demo_article12_export.py` — exits 0, bundle verified
- [x] `uv run bernstein audit pack --soc2 --period-label demo --output /tmp/soc2-demo` — produces markdown + manifest
- [x] `uv run ruff format src/ scripts/ tests/integration/` — clean
- [x] `uv run ruff check src/ scripts/ tests/integration/` — clean