### PR TITLE
feat(observability): wire 3 hardening primitives into orchestrator runtime

### DIFF
--- a/src/bernstein/core/agents/prompt_cache_locality.py
+++ b/src/bernstein/core/agents/prompt_cache_locality.py
@@ -37,13 +37,35 @@ import hashlib
 import logging
 import threading
 from collections import defaultdict
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, overload
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
+
+#: Supported vendor cache backends.  ``"generic"`` keeps the legacy
+#: byte-string return shape so existing callers do not change.
+Vendor = Literal["generic", "openai", "anthropic", "gemini"]
+
+#: OpenAI prompt-cache requires the cacheable prefix to align to a
+#: 256-token boundary (see Bernstein cache locality docs).  When
+#: ``tiktoken`` is installed we use the model's tokeniser; otherwise we
+#: fall back to a 4-chars/token heuristic that matches OpenAI's own
+#: rule-of-thumb for English text.
+_OPENAI_BOUNDARY_TOKENS = 256
+_HEURISTIC_CHARS_PER_TOKEN = 4
+
+#: Anthropic's prompt-cache API accepts up to 4 cache_control breakpoints
+#: per request.  See https://docs.anthropic.com/en/docs/build-with-claude/
+#: prompt-caching#structuring-your-prompt.
+_ANTHROPIC_MAX_SEGMENTS = 4
+
+#: Padding character used when zero-padding the OpenAI prefix to the
+#: next 256-token boundary.  A space is benign for the model and does
+#: not collide with the header-separator sentinel.
+_OPENAI_PAD_CHAR = " "
 
 
 # ---------------------------------------------------------------------------
@@ -80,17 +102,88 @@ def _normalise_reason(raw: str) -> str:
 _HEADER_SEPARATOR = "\n<!--bernstein:prefix-header-end-->\n"
 
 
+@dataclass(frozen=True)
+class StablePrefix:
+    """Vendor-aware cache-prefix bundle.
+
+    Returned by :func:`build_stable_prefix` when a vendor other than
+    ``"generic"`` is requested.  The bundle always carries the
+    canonical bytes (``text``) so the caller can still hash them, plus
+    one or more vendor-specific cache hints:
+
+    * ``segments`` — an ordered list of message-shaped dicts.  For
+      Anthropic, each entry has the form
+      ``{"type": "text", "text": "...", "cache_control": {...}}``
+      with ``cache_control`` set to ``{"type": "ephemeral"}`` on the
+      prefix segments.
+    * ``cached_content_handle`` — Gemini's canonical handle name; it is
+      the lowercase ``cachedContent/<sha256>`` form so the caller can
+      use it to look up an existing entry on the API.
+    * ``padded_text`` — OpenAI's text padded to the next 256-token
+      boundary so consecutive prompts share a cache-aligned prefix.
+
+    Empty fields denote "vendor doesn't expose this hint".
+    """
+
+    text: str
+    vendor: Vendor = "generic"
+    segments: list[dict[str, object]] = field(default_factory=list)
+    cached_content_handle: str = ""
+    padded_text: str = ""
+
+
+@overload
+def build_stable_prefix(
+    *,
+    header: Mapping[str, str] | None = ...,
+    body: str = ...,
+    vendor: Literal["generic"] = ...,
+) -> str: ...
+
+
+@overload
+def build_stable_prefix(
+    *,
+    header: Mapping[str, str] | None = ...,
+    body: str = ...,
+    vendor: Literal["openai", "anthropic", "gemini"],
+) -> StablePrefix: ...
+
+
 def build_stable_prefix(
     *,
     header: Mapping[str, str] | None = None,
     body: str = "",
-) -> str:
+    vendor: Vendor = "generic",
+) -> str | StablePrefix:
     """Build a byte-stable cache prefix from a header dict and a body string.
 
     The header is canonicalised by sorting keys lexicographically and
     rendering each entry as ``"<key>: <value>"`` on its own line.  This
     means callers cannot break the cache by reordering header fields.
     The body is appended verbatim after a fixed separator.
+
+    Vendor selection
+    ----------------
+    The optional ``vendor`` argument selects one of three vendor-aware
+    output paths.  ``"generic"`` (the default) keeps the legacy
+    behaviour and returns a plain :class:`str` so existing callers do
+    not need to change.  The other three return a :class:`StablePrefix`
+    bundle that carries vendor-specific cache hints in addition to the
+    canonical bytes:
+
+    * ``"openai"`` — pads the prefix to the next 256-token boundary
+      (rounded up via ``tiktoken`` when installed; otherwise via a
+      4 chars/token heuristic).  OpenAI's prompt-cache hashes only the
+      first 1024-token prefix in 256-token chunks; alignment maximises
+      hit rate.
+    * ``"anthropic"`` — splits the prompt into at most 4 segments and
+      tags the prefix segments with ``cache_control: {"type": "ephemeral"}``
+      so Anthropic's prompt cache treats them as a stable breakpoint.
+    * ``"gemini"`` — emits a candidate ``cachedContent`` handle name
+      derived from the canonical SHA-256 of the prefix bytes.  The
+      caller can use the handle to look up an existing context-cache
+      entry on Vertex AI / Gemini.
 
     Args:
         header: Mapping of stable header field names to values
@@ -100,15 +193,173 @@ def build_stable_prefix(
             protocol prefix).  ``None`` is treated as an empty mapping.
         body: Free-form prefix body (role template, project context,
             git safety protocol, etc.).  Appended verbatim.
+        vendor: Cache backend selection.  Default ``"generic"`` keeps
+            the legacy ``str`` return type for backward compatibility.
 
     Returns:
-        A deterministic prefix string.  Two calls with the same logical
-        inputs return byte-identical strings regardless of header
-        insertion order.
+        For ``vendor == "generic"`` — the deterministic prefix string.
+        Otherwise a :class:`StablePrefix` bundle with vendor-specific
+        cache hints.
     """
     items = sorted((str(k), str(v)) for k, v in (header or {}).items())
     header_str = "\n".join(f"{k}: {v}" for k, v in items)
-    return f"{header_str}{_HEADER_SEPARATOR}{body}"
+    text = f"{header_str}{_HEADER_SEPARATOR}{body}"
+
+    if vendor == "generic":
+        return text
+    if vendor == "openai":
+        return StablePrefix(
+            text=text,
+            vendor="openai",
+            padded_text=_align_to_openai_boundary(text),
+        )
+    if vendor == "anthropic":
+        return StablePrefix(
+            text=text,
+            vendor="anthropic",
+            segments=_anthropic_cache_segments(header_str, body),
+        )
+    if vendor == "gemini":
+        return StablePrefix(
+            text=text,
+            vendor="gemini",
+            cached_content_handle=_gemini_cached_content_handle(text),
+        )
+    # Defensive: Literal narrowing should make this unreachable.
+    msg = f"unsupported vendor: {vendor!r}"
+    raise ValueError(msg)
+
+
+# ---------------------------------------------------------------------------
+# Vendor-specific helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_openai_tokens(text: str) -> int:
+    """Return token count for *text*, preferring tiktoken when available.
+
+    Args:
+        text: The input string.
+
+    Returns:
+        Token count.  Falls back to ``len(text) // 4`` (rounded up by
+        the caller via ceiling division) when ``tiktoken`` is not
+        installed in the environment.
+    """
+    try:
+        import tiktoken  # type: ignore[import-not-found]
+    except Exception:
+        # Heuristic fallback — OpenAI's own rule of thumb is ~4 chars
+        # per token for English text.  We round UP via ceiling division
+        # so a partially-filled token still counts as one.
+        return -(-len(text) // _HEURISTIC_CHARS_PER_TOKEN)
+    try:
+        # ``cl100k_base`` is the encoding used by all current GPT-4 /
+        # GPT-4o / GPT-3.5 chat completions.
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except Exception:  # pragma: no cover — defensive
+        return -(-len(text) // _HEURISTIC_CHARS_PER_TOKEN)
+
+
+def _align_to_openai_boundary(text: str) -> str:
+    """Right-pad *text* to the next ``_OPENAI_BOUNDARY_TOKENS`` boundary.
+
+    Args:
+        text: The canonical prefix text.
+
+    Returns:
+        ``text`` if already aligned, otherwise ``text`` followed by the
+        smallest amount of padding needed to reach the next boundary.
+    """
+    if not text:
+        return text
+    tokens = _count_openai_tokens(text)
+    remainder = tokens % _OPENAI_BOUNDARY_TOKENS
+    if remainder == 0:
+        return text
+    pad_tokens = _OPENAI_BOUNDARY_TOKENS - remainder
+    # Pad by character count using the chars/token heuristic so the
+    # alignment remains deterministic in environments without tiktoken.
+    pad_chars = pad_tokens * _HEURISTIC_CHARS_PER_TOKEN
+    return f"{text}{_OPENAI_PAD_CHAR * pad_chars}"
+
+
+def _anthropic_cache_segments(
+    header_str: str,
+    body: str,
+) -> list[dict[str, object]]:
+    """Build Anthropic message segments with ``cache_control`` markers.
+
+    The result has at most :data:`_ANTHROPIC_MAX_SEGMENTS` entries:
+
+    1. ``header`` — the canonicalised header block (always tagged
+       ephemeral so the system prefix is cached).
+    2. ``separator`` — the boundary sentinel.
+    3. ``body`` — the role/project/git_safety body (tagged ephemeral).
+    4. (reserved for caller-appended directive — no entry emitted by
+       this builder so callers can attach a 4th cache_control block on
+       a final user/assistant turn if desired).
+
+    Empty header / body segments are dropped to keep the message list
+    compact.
+
+    Args:
+        header_str: Canonicalised header text (already ``\\n``-joined
+            ``key: value`` pairs).
+        body: Verbatim prefix body.
+
+    Returns:
+        List of message-shaped dicts with ``cache_control`` markers on
+        the prefix segments.
+    """
+    segments: list[dict[str, object]] = []
+    if header_str:
+        segments.append(
+            {
+                "type": "text",
+                "text": header_str,
+                "cache_control": {"type": "ephemeral"},
+            },
+        )
+    # Always include the deterministic separator so the segment chain
+    # round-trips back to the canonical text bytes.
+    segments.append(
+        {
+            "type": "text",
+            "text": _HEADER_SEPARATOR,
+        },
+    )
+    if body:
+        segments.append(
+            {
+                "type": "text",
+                "text": body,
+                "cache_control": {"type": "ephemeral"},
+            },
+        )
+    # Anthropic's prompt-cache supports at most 4 cache_control
+    # breakpoints; the splitter above never emits more than 3 prefix
+    # segments so the caller can safely add one more on a downstream
+    # user-turn block.
+    assert len(segments) <= _ANTHROPIC_MAX_SEGMENTS
+    return segments
+
+
+def _gemini_cached_content_handle(text: str) -> str:
+    """Return the canonical Gemini ``cachedContents`` resource name.
+
+    Args:
+        text: The prefix text.
+
+    Returns:
+        ``cachedContents/<sha256>`` — the candidate handle that the
+        caller can pass to ``GenerativeModel.from_cached_content`` on
+        Vertex AI / Gemini.  The hash is the same SHA-256 used by
+        :func:`hash_prefix`, so two consecutive prefixes with the same
+        bytes yield the same handle.
+    """
+    return f"cachedContents/{hash_prefix(text)}"
 
 
 def hash_prefix(prefix: str) -> str:
@@ -302,6 +553,8 @@ def observe_prefix(
 __all__ = [
     "DriftSnapshot",
     "PromptCacheLocality",
+    "StablePrefix",
+    "Vendor",
     "build_stable_prefix",
     "default_locality",
     "hash_prefix",

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 import logging
+import os
 import re as _re
 import shlex as _shlex
 import subprocess as _subprocess
@@ -15,6 +16,7 @@ from bernstein.core.agents.heartbeat import HeartbeatMonitor
 from bernstein.core.context_recommendations import RecommendationEngine
 from bernstein.core.defaults import SPAWN
 from bernstein.core.lessons import gather_lessons_for_context
+from bernstein.core.memory.jsonl_log import JSONLMemoryLog
 from bernstein.templates.renderer import TemplateError, render_role_prompt
 
 if TYPE_CHECKING:
@@ -112,6 +114,7 @@ SECTION_RULES: dict[str, SectionRule] = {
     "lessons": SectionRule(
         exclude_roles=frozenset({"manager", "visionary"}),
     ),
+    "memory_lessons": SectionRule(),  # Auto-injected from JSONL log; gated by env var
     "predecessor": SectionRule(),  # Always included when present (already gated by data)
     "project": SectionRule(),  # Always included when present (already gated by data)
     "meta nudges": SectionRule(),  # Always included when present
@@ -224,6 +227,110 @@ def filter_sections(
 # ---------------------------------------------------------------------------
 _lesson_cache: dict[str, tuple[float, str]] = {}  # role -> (timestamp, text)
 _LESSON_CACHE_TTL = SPAWN.lesson_cache_ttl_s
+
+# ---------------------------------------------------------------------------
+# Memory-log auto-injection (BERNSTEIN_MEMORY_AUTO_INJECT)
+# ---------------------------------------------------------------------------
+
+#: Environment switch — flip to "1" to enable JSONL memory injection into
+#: leaf-agent prompts.  Default off so existing flows are unchanged.
+_MEMORY_AUTO_INJECT_ENV_VAR = "BERNSTEIN_MEMORY_AUTO_INJECT"
+
+#: JSONL key under ``.bernstein/memory/`` that the spawner reads when
+#: auto-injection is enabled.  Matches the convention documented in
+#: :mod:`bernstein.core.memory.jsonl_log`.
+_MEMORY_LESSONS_KEY = "lessons"
+
+#: Cap on the number of recent entries injected into the prompt.  Bounded
+#: so a runaway log cannot blow the prompt budget.
+_MEMORY_LESSONS_MAX = 10
+
+#: Stable separator used to demarcate the lessons block.  Kept as plain
+#: tags (not Markdown-only) so the boundary survives any downstream
+#: dedup / compression pass that strips Markdown headers.
+_MEMORY_LESSONS_OPEN = "<lessons>"
+_MEMORY_LESSONS_CLOSE = "</lessons>"
+
+
+def _memory_auto_inject_enabled() -> bool:
+    """Return True when ``BERNSTEIN_MEMORY_AUTO_INJECT`` is truthy.
+
+    The env-var-driven gate keeps the integration off by default so existing
+    runs are byte-identical until an operator flips the switch.
+
+    Returns:
+        ``True`` when the env var is set to ``1`` / ``true`` / ``yes`` / ``on``.
+    """
+    raw = os.environ.get(_MEMORY_AUTO_INJECT_ENV_VAR, "")
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _format_memory_lesson(entry: dict[str, Any]) -> str:
+    """Render a single memory entry as a compact bullet.
+
+    Args:
+        entry: One JSONL record from ``.bernstein/memory/lessons.jsonl``.
+
+    Returns:
+        A single-line bullet describing the lesson.  Returns an empty
+        string when the entry has no human-readable text — caller skips
+        empty bullets so the rendered block stays tight.
+    """
+    text = entry.get("lesson") or entry.get("text") or entry.get("message")
+    if not text:
+        # Fall back to a compact JSON dump so callers that store
+        # arbitrary structured records still get *something* useful.
+        try:
+            import json as _json
+
+            return f"- {_json.dumps(entry, ensure_ascii=False, sort_keys=True)}"
+        except Exception:
+            return ""
+    task = entry.get("task")
+    if task:
+        return f"- ({task}) {text}"
+    return f"- {text}"
+
+
+def _render_memory_lessons_block(workdir: Path) -> str:
+    """Read the most recent memory lessons and render the injection block.
+
+    The block is sandwiched between :data:`_MEMORY_LESSONS_OPEN` and
+    :data:`_MEMORY_LESSONS_CLOSE` so the orchestrator-side renderer can
+    grep for it deterministically (e.g. when auditing prompts).
+
+    Args:
+        workdir: Project working directory.  The JSONL log lives at
+            ``<workdir>/.bernstein/memory/lessons.jsonl``.
+
+    Returns:
+        Rendered block string, or empty string when the log is absent /
+        empty.  No-op semantics: a missing log MUST NOT raise; the
+        spawner relies on this for first-run robustness.
+    """
+    root = workdir / ".bernstein" / "memory"
+    log = JSONLMemoryLog(root=root)
+    try:
+        entries = log.read(_MEMORY_LESSONS_KEY)
+    except Exception:  # pragma: no cover — defensive, never block spawns
+        logger.debug("memory auto-inject: read failed", exc_info=True)
+        return ""
+    if not entries:
+        return ""
+
+    # Tail-window — the most recent N entries, oldest-first inside the window.
+    recent = entries[-_MEMORY_LESSONS_MAX:]
+    bullets: list[str] = []
+    for entry in recent:
+        rendered = _format_memory_lesson(entry)
+        if rendered:
+            bullets.append(rendered)
+    if not bullets:
+        return ""
+
+    body = "\n".join(bullets)
+    return f"\n{_MEMORY_LESSONS_OPEN}\n{body}\n{_MEMORY_LESSONS_CLOSE}\n"
+
 
 # ---------------------------------------------------------------------------
 # Cache-safe parameters for forked agents
@@ -745,6 +852,13 @@ def _render_prompt(
     ]
     if specialist_block:
         named_sections.append(("specialists", specialist_block))
+    # KV-cache locality: lessons go AFTER the stable header (role,
+    # git_safety, specialists) but BEFORE the variable goal/task body
+    # so the cacheable prefix stays byte-stable across spawns.
+    if _memory_auto_inject_enabled():
+        memory_block = _render_memory_lessons_block(workdir)
+        if memory_block:
+            named_sections.append(("memory_lessons", memory_block))
     named_sections.append(("tasks", f"\n## Assigned tasks\n{task_block}"))
     if lesson_context:
         named_sections.append(("lessons", f"\n{lesson_context}\n"))

--- a/src/bernstein/core/observability/llm_watcher.py
+++ b/src/bernstein/core/observability/llm_watcher.py
@@ -53,7 +53,13 @@ __all__ = [
     "Suggestion",
     "WatcherConfig",
     "WatcherEvent",
+    "audit_chain_break_detector",
     "build_watcher_from_env",
+    "cost_runaway_detector",
+    "register_default_detectors",
+    "repeated_failure_detector",
+    "stuck_spawn_detector",
+    "suspicious_tool_mask_detector",
 ]
 
 
@@ -176,6 +182,12 @@ class WatcherConfig:
 # real LLM module.
 LLMCaller = Callable[..., Awaitable[str]]
 
+#: Synchronous detector signature.  Detectors are pure functions that
+#: receive a frozen :class:`WatcherEvent` and return zero or more
+#: :class:`Suggestion` records.  They never mutate orchestrator state
+#: and never make network calls — that's reserved for the LLM observer.
+DetectorFn = Callable[[WatcherEvent], list["Suggestion"]]
+
 
 # ---------------------------------------------------------------------------
 # Watcher
@@ -206,6 +218,7 @@ class LLMWatcher:
         self,
         config: WatcherConfig,
         llm_caller: LLMCaller | None = None,
+        detectors: list[DetectorFn] | None = None,
     ) -> None:
         """Initialise the watcher.
 
@@ -215,11 +228,36 @@ class LLMWatcher:
                 ``None`` the watcher lazily imports
                 :func:`bernstein.core.llm.call_llm` on first use, so a
                 disabled watcher never imports the LLM stack.
+            detectors: Optional list of plain-Python detector functions
+                that run *before* the LLM observer on every enabled
+                event.  Each detector is invoked with the frozen event
+                and contributes zero or more :class:`Suggestion` records
+                to the watcher output.  Detectors are read-only by
+                contract: they receive the same immutable snapshot the
+                LLM observer sees and have no orchestrator handle.
         """
         self._config = config
         self._llm_caller = llm_caller
+        self._detectors: list[DetectorFn] = list(detectors or [])
         self._call_count = 0
         self._suggestion_count = 0
+
+    @property
+    def detectors(self) -> tuple[DetectorFn, ...]:
+        """Read-only view of the registered detector functions."""
+        return tuple(self._detectors)
+
+    def register_detector(self, detector: DetectorFn) -> None:
+        """Register a synchronous detector to run on every enabled event.
+
+        Args:
+            detector: A plain-Python callable that maps a
+                :class:`WatcherEvent` to a list of :class:`Suggestion`
+                records.  Exceptions are isolated by the watcher: a
+                failing detector cannot crash the orchestrator or
+                prevent peer detectors / the LLM observer from running.
+        """
+        self._detectors.append(detector)
 
     @property
     def config(self) -> WatcherConfig:
@@ -248,9 +286,18 @@ class LLMWatcher:
             times out, or when the model produces no advisory signal.
             **Never raises** to the caller — orchestrator stability is
             non-negotiable.
+
+        Notes:
+            Synchronous detectors fire first and contribute deterministic
+            signals (cost runaway, stuck spawn, repeated failure, tool
+            mask, audit chain break).  The LLM observer then runs and
+            may add an additional advisory signal.
         """
         if not self._config.enabled:
             return []
+
+        signals: list[Suggestion] = []
+        signals.extend(self._run_detectors(event))
 
         try:
             response = await self._invoke_llm(event)
@@ -263,14 +310,42 @@ class LLMWatcher:
                 event.run_id,
                 exc_info=True,
             )
-            return []
+            self._suggestion_count += len(signals)
+            return signals
 
-        if not response.strip():
-            return []
+        if response.strip():
+            signals.append(self._build_suggestion(event, response))
 
-        suggestion = self._build_suggestion(event, response)
-        self._suggestion_count += 1
-        return [suggestion]
+        self._suggestion_count += len(signals)
+        return signals
+
+    def _run_detectors(self, event: WatcherEvent) -> list[Suggestion]:
+        """Run all registered detectors and collect their suggestions.
+
+        Each detector is isolated: an exception in one does not block
+        peer detectors or the downstream LLM observer.  The watcher's
+        crash-resistance contract extends to the detector pack.
+
+        Args:
+            event: The frozen event passed through to detectors.
+
+        Returns:
+            Flat list of suggestions across all detectors, in
+            registration order.
+        """
+        emitted: list[Suggestion] = []
+        for detector in self._detectors:
+            try:
+                emitted.extend(detector(event))
+            except Exception:  # pragma: no cover — defensive
+                logger.warning(
+                    "watcher detector %s failed for event=%s run=%s",
+                    getattr(detector, "__name__", "<detector>"),
+                    event.kind,
+                    event.run_id,
+                    exc_info=True,
+                )
+        return emitted
 
     async def _invoke_llm(self, event: WatcherEvent) -> str:
         """Call the watcher LLM with a minimal advisory prompt.
@@ -382,7 +457,12 @@ def build_watcher_from_env(
     model = os.environ.get(_MODEL_ENV_VAR, _DEFAULT_MODEL).strip() or _DEFAULT_MODEL
     provider = os.environ.get(_PROVIDER_ENV_VAR, _DEFAULT_PROVIDER).strip() or _DEFAULT_PROVIDER
     config = WatcherConfig(enabled=enabled, model=model, provider=provider)
-    return LLMWatcher(config=config, llm_caller=llm_caller)
+    watcher = LLMWatcher(config=config, llm_caller=llm_caller)
+    if enabled:
+        # Off-by-default still wins: detectors are only registered on a
+        # watcher that the operator has explicitly opted in to.
+        register_default_detectors(watcher)
+    return watcher
 
 
 def _default_llm_caller() -> LLMCaller:
@@ -405,3 +485,298 @@ def _default_llm_caller() -> LLMCaller:
     from bernstein.core.llm import call_llm
 
     return call_llm
+
+
+# ---------------------------------------------------------------------------
+# Production detector pack
+# ---------------------------------------------------------------------------
+#
+# Each detector is a plain Python function that consumes a frozen
+# :class:`WatcherEvent` and returns a (possibly empty) list of
+# :class:`Suggestion` records.  Detectors are deterministic, side-effect
+# free, and structurally read-only: the watcher feeds them the same
+# immutable snapshot that the LLM observer sees.  Failures are isolated
+# by ``LLMWatcher._run_detectors``.
+
+#: Default budget (USD) — used by ``cost_runaway_detector`` when the
+#: event payload omits ``run_budget_usd``.  Conservative, biased toward
+#: false-positives over silent overrun.
+_DEFAULT_RUN_BUDGET_USD: Final[float] = 10.0
+
+#: Hard ceiling — a single task burning more than this in 5 minutes is
+#: always escalated regardless of the run-level budget.
+_TASK_HARD_CEILING_USD: Final[float] = 2.0
+
+#: Stuck-spawn threshold (seconds).  A task that confirmed its claim
+#: but emitted no completion / audit traffic for this long is suspect.
+_STUCK_SPAWN_TIMEOUT_S: Final[float] = 30 * 60
+
+#: Repeated-failure threshold — the same task failing N times in a row
+#: with the same exit signature.
+_REPEATED_FAILURE_LIMIT: Final[int] = 3
+
+#: Tool-mask threshold — masking more than this fraction of available
+#: tools is unusual enough to surface as a configuration smell.
+_TOOL_MASK_FRACTION_THRESHOLD: Final[float] = 0.5
+
+
+def _suggestion_id(event: WatcherEvent, detector: str) -> str:
+    """Build a stable suggestion id keyed on the event + detector.
+
+    Args:
+        event: The originating event.
+        detector: Detector name; included so two detectors firing on the
+            same event produce distinct suggestion ids.
+
+    Returns:
+        A short identifier suitable for cross-referencing in logs.
+    """
+    return f"watch-{event.run_id}-{event.kind}-{detector}-{int(event.timestamp * 1000)}"
+
+
+def cost_runaway_detector(event: WatcherEvent) -> list[Suggestion]:
+    """Fire when a single task burns >$2 in 5 min OR >50% of run budget.
+
+    Reads the following payload fields when present:
+
+    * ``task_cost_usd`` — USD spent on the current task in the last
+      5 minutes (orchestrator-side aggregate).
+    * ``run_cost_usd`` — total USD spent on the run so far.
+    * ``run_budget_usd`` — operator-set ceiling for the run.
+    * ``task_id`` — task identifier (informational).
+
+    Both legs of the OR are evaluated; the more severe leg wins.
+
+    Args:
+        event: Frozen event snapshot.
+
+    Returns:
+        Zero or one :class:`Suggestion`.  Empty when no cost field is
+        present or no threshold is breached.
+    """
+    payload = event.payload or {}
+    task_cost = float(payload.get("task_cost_usd") or 0.0)
+    run_cost = float(payload.get("run_cost_usd") or 0.0)
+    run_budget = float(payload.get("run_budget_usd") or _DEFAULT_RUN_BUDGET_USD)
+    task_id = str(payload.get("task_id") or "?")
+
+    breached_task = task_cost > _TASK_HARD_CEILING_USD
+    # Avoid div/0 on misconfigured budget; treat <=0 budget as no-budget.
+    breached_run = bool(run_budget > 0 and run_cost > 0.5 * run_budget)
+    if not breached_task and not breached_run:
+        return []
+
+    severity: Severity = "critical" if breached_task else "warning"
+    rationale = (
+        f"cost runaway on task {task_id}: "
+        f"task_cost_usd={task_cost:.2f} run_cost_usd={run_cost:.2f} "
+        f"run_budget_usd={run_budget:.2f}"
+    )
+    return [
+        Suggestion(
+            suggestion_id=_suggestion_id(event, "cost_runaway"),
+            run_id=event.run_id,
+            detector="cost_runaway",
+            severity=severity,
+            rationale=rationale,
+            proposed_action=(
+                "Pause the task and review the agent's most recent tool calls "
+                "for a stuck retry loop or an unbounded tool budget."
+            ),
+            cost_usd=0.0,
+        ),
+    ]
+
+
+def stuck_spawn_detector(event: WatcherEvent) -> list[Suggestion]:
+    """Fire when a worktree sits in claim_confirmed without progress >30 min.
+
+    Reads the payload for ``claim_confirmed`` (bool), ``task_completed``
+    (bool), ``audit_emissions`` (int), ``time_in_state_s`` (float) and
+    ``task_id``.  A spawn is considered stuck when the claim was
+    confirmed, the task is not yet completed, no audit emissions have
+    occurred, and the time-in-state exceeds the threshold.
+
+    Args:
+        event: Frozen event snapshot.
+
+    Returns:
+        Zero or one :class:`Suggestion`.
+    """
+    payload = event.payload or {}
+    claim_confirmed = bool(payload.get("claim_confirmed"))
+    task_completed = bool(payload.get("task_completed"))
+    audit_emissions = int(payload.get("audit_emissions") or 0)
+    time_in_state = float(payload.get("time_in_state_s") or 0.0)
+    task_id = str(payload.get("task_id") or "?")
+
+    if not claim_confirmed or task_completed:
+        return []
+    if audit_emissions > 0:
+        return []
+    if time_in_state <= _STUCK_SPAWN_TIMEOUT_S:
+        return []
+
+    rationale = (
+        f"stuck spawn for task {task_id}: claim_confirmed=true with no audit emissions for {int(time_in_state)}s"
+    )
+    return [
+        Suggestion(
+            suggestion_id=_suggestion_id(event, "stuck_spawn"),
+            run_id=event.run_id,
+            detector="stuck_spawn",
+            severity="warning",
+            rationale=rationale,
+            proposed_action=(
+                "Wake the agent via the WAKEUP signal file or, if non-responsive, mark the task failed and re-spawn."
+            ),
+            cost_usd=0.0,
+        ),
+    ]
+
+
+def repeated_failure_detector(event: WatcherEvent) -> list[Suggestion]:
+    """Fire when the same task fails 3 times in a row with the same exit signature.
+
+    Reads ``task_id``, ``failure_count`` (int) and ``exit_signature``
+    (str) from the payload.  When all three are present and the count
+    crosses the threshold, the detector emits a critical advisory.
+
+    Args:
+        event: Frozen event snapshot.
+
+    Returns:
+        Zero or one :class:`Suggestion`.
+    """
+    payload = event.payload or {}
+    failure_count = int(payload.get("failure_count") or 0)
+    exit_signature = str(payload.get("exit_signature") or "").strip()
+    task_id = str(payload.get("task_id") or "?")
+    if not exit_signature:
+        return []
+    if failure_count < _REPEATED_FAILURE_LIMIT:
+        return []
+    rationale = f"task {task_id} failed {failure_count}x with identical exit signature {exit_signature!r}"
+    return [
+        Suggestion(
+            suggestion_id=_suggestion_id(event, "repeated_failure"),
+            run_id=event.run_id,
+            detector="repeated_failure",
+            severity="critical",
+            rationale=rationale,
+            proposed_action=(
+                "Stop re-spawning. The deterministic retry loop is masking "
+                "a structural defect — investigate the exit signature and "
+                "patch the underlying code path before another retry."
+            ),
+            cost_usd=0.0,
+        ),
+    ]
+
+
+def suspicious_tool_mask_detector(event: WatcherEvent) -> list[Suggestion]:
+    """Fire when ``mask_tools`` removed >50% of the available tool surface.
+
+    Reads ``available_tools`` (int — pre-mask count) and
+    ``masked_tools`` (int — number removed by the mask) from the
+    payload.  A tool mask that removes more than half of the tools is
+    almost certainly a misconfigured policy and warrants review.
+
+    Args:
+        event: Frozen event snapshot.
+
+    Returns:
+        Zero or one :class:`Suggestion`.
+    """
+    payload = event.payload or {}
+    available = int(payload.get("available_tools") or 0)
+    masked = int(payload.get("masked_tools") or 0)
+    if available <= 0:
+        return []
+    fraction = masked / available
+    if fraction <= _TOOL_MASK_FRACTION_THRESHOLD:
+        return []
+    rationale = f"tool masking removed {masked}/{available} tools ({fraction:.0%}) — policy may be over-restrictive"
+    return [
+        Suggestion(
+            suggestion_id=_suggestion_id(event, "suspicious_tool_mask"),
+            run_id=event.run_id,
+            detector="suspicious_tool_mask",
+            severity="warning",
+            rationale=rationale,
+            proposed_action=(
+                "Review the tool-masking policy for this role; verify the "
+                "remaining tool set is sufficient for the assigned task."
+            ),
+            cost_usd=0.0,
+        ),
+    ]
+
+
+def audit_chain_break_detector(event: WatcherEvent) -> list[Suggestion]:
+    """Fire when a new audit entry's ``prev_hmac`` does not match the prior tail.
+
+    Reads ``prev_hmac`` (string carried on the new entry) and
+    ``expected_prev_hmac`` (the HMAC of the chain tail the orchestrator
+    captured before appending) from the payload.  When both are present
+    and disagree, the chain has been tampered with or there has been a
+    write race — either is an immediate critical signal.
+
+    Args:
+        event: Frozen event snapshot.
+
+    Returns:
+        Zero or one :class:`Suggestion`.
+    """
+    payload = event.payload or {}
+    prev = str(payload.get("prev_hmac") or "").strip()
+    expected = str(payload.get("expected_prev_hmac") or "").strip()
+    if not prev or not expected:
+        return []
+    if prev == expected:
+        return []
+    rationale = f"audit chain break: prev_hmac={prev[:16]}… does not match expected_prev_hmac={expected[:16]}…"
+    return [
+        Suggestion(
+            suggestion_id=_suggestion_id(event, "audit_chain_break"),
+            run_id=event.run_id,
+            detector="audit_chain_break",
+            severity="critical",
+            rationale=rationale,
+            proposed_action=(
+                "Quarantine the audit log file, do NOT append further entries, "
+                "and run ``bernstein audit verify`` to identify the corrupted "
+                "tail. Investigate write-race or tamper signal before resuming."
+            ),
+            cost_usd=0.0,
+        ),
+    ]
+
+
+#: Canonical default detector list.  Kept as a module-level tuple so the
+#: orchestrator can introspect the registered surface (e.g. for
+#: ``bernstein watcher list``).
+_DEFAULT_DETECTORS: Final[tuple[DetectorFn, ...]] = (
+    cost_runaway_detector,
+    stuck_spawn_detector,
+    repeated_failure_detector,
+    suspicious_tool_mask_detector,
+    audit_chain_break_detector,
+)
+
+
+def register_default_detectors(watcher: LLMWatcher) -> None:
+    """Register the production detector pack on *watcher*.
+
+    Idempotent: callers that wire a watcher manually before the
+    ``build_watcher_from_env`` helper runs (e.g. tests) can call this
+    once without worrying about double-registration as long as they do
+    not call it twice themselves.
+
+    Args:
+        watcher: A constructed :class:`LLMWatcher` (typically just
+            returned from ``build_watcher_from_env`` with the env switch
+            on).
+    """
+    for detector in _DEFAULT_DETECTORS:
+        watcher.register_detector(detector)

--- a/tests/unit/test_llm_watcher_detector_pack.py
+++ b/tests/unit/test_llm_watcher_detector_pack.py
@@ -1,0 +1,393 @@
+"""Tests for the production detector pack on :class:`LLMWatcher`.
+
+The pack ships five plain-Python detectors that fire deterministically
+on a frozen :class:`WatcherEvent` snapshot, contributing structured
+:class:`Suggestion` records to the watcher output:
+
+* ``cost_runaway_detector``
+* ``stuck_spawn_detector``
+* ``repeated_failure_detector``
+* ``suspicious_tool_mask_detector``
+* ``audit_chain_break_detector``
+
+Each detector is independently exercised here with positive (fires) and
+negative (no-op) cases, plus an end-to-end integration test that
+confirms the five are auto-registered when the watcher is built from
+env with ``BERNSTEIN_LLM_WATCHER_ENABLED=1``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from bernstein.core.observability.llm_watcher import (
+    LLMWatcher,
+    Suggestion,
+    WatcherConfig,
+    WatcherEvent,
+    audit_chain_break_detector,
+    build_watcher_from_env,
+    cost_runaway_detector,
+    register_default_detectors,
+    repeated_failure_detector,
+    stuck_spawn_detector,
+    suspicious_tool_mask_detector,
+)
+
+
+def _event(payload: dict[str, Any] | None = None, kind: str = "task_spawned") -> WatcherEvent:
+    """Build a frozen WatcherEvent with the given payload."""
+    return WatcherEvent(
+        kind=kind,  # type: ignore[arg-type]
+        run_id="run-detect",
+        timestamp=1_700_000_000.0,
+        payload=dict(payload or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# cost_runaway_detector
+# ---------------------------------------------------------------------------
+
+
+class TestCostRunaway:
+    """``cost_runaway_detector`` — task >$2 or run >50% budget."""
+
+    def test_fires_on_task_cost_above_hard_ceiling(self) -> None:
+        sigs = cost_runaway_detector(
+            _event({"task_cost_usd": 2.5, "run_cost_usd": 3.0, "task_id": "T-1"}),
+        )
+        assert len(sigs) == 1
+        assert sigs[0].detector == "cost_runaway"
+        assert sigs[0].severity == "critical"
+        assert "T-1" in sigs[0].rationale
+
+    def test_fires_on_run_cost_above_half_budget(self) -> None:
+        sigs = cost_runaway_detector(
+            _event(
+                {
+                    "task_cost_usd": 0.1,
+                    "run_cost_usd": 8.0,
+                    "run_budget_usd": 10.0,
+                    "task_id": "T-2",
+                },
+            ),
+        )
+        assert len(sigs) == 1
+        assert sigs[0].severity == "warning"
+
+    def test_silent_when_no_cost_breach(self) -> None:
+        sigs = cost_runaway_detector(
+            _event(
+                {
+                    "task_cost_usd": 0.5,
+                    "run_cost_usd": 1.0,
+                    "run_budget_usd": 10.0,
+                },
+            ),
+        )
+        assert sigs == []
+
+    def test_zero_or_missing_budget_does_not_div_by_zero(self) -> None:
+        # No budget field — should still fire on task_cost > 2.
+        sigs = cost_runaway_detector(_event({"task_cost_usd": 3.0}))
+        assert len(sigs) == 1
+        # Budget of 0 is treated as no-budget — no run-leg fire.
+        sigs = cost_runaway_detector(
+            _event({"task_cost_usd": 0.0, "run_cost_usd": 5.0, "run_budget_usd": 0.0}),
+        )
+        assert sigs == []
+
+
+# ---------------------------------------------------------------------------
+# stuck_spawn_detector
+# ---------------------------------------------------------------------------
+
+
+class TestStuckSpawn:
+    """``stuck_spawn_detector`` — claim_confirmed >30 min, no audit."""
+
+    def test_fires_when_claim_confirmed_and_idle_too_long(self) -> None:
+        sigs = stuck_spawn_detector(
+            _event(
+                {
+                    "claim_confirmed": True,
+                    "task_completed": False,
+                    "audit_emissions": 0,
+                    "time_in_state_s": 31 * 60,
+                    "task_id": "T-9",
+                },
+            ),
+        )
+        assert len(sigs) == 1
+        assert sigs[0].detector == "stuck_spawn"
+        assert sigs[0].severity == "warning"
+
+    def test_silent_when_audit_emissions_present(self) -> None:
+        sigs = stuck_spawn_detector(
+            _event(
+                {
+                    "claim_confirmed": True,
+                    "audit_emissions": 5,
+                    "time_in_state_s": 31 * 60,
+                },
+            ),
+        )
+        assert sigs == []
+
+    def test_silent_when_task_completed(self) -> None:
+        sigs = stuck_spawn_detector(
+            _event(
+                {
+                    "claim_confirmed": True,
+                    "task_completed": True,
+                    "time_in_state_s": 99 * 60,
+                },
+            ),
+        )
+        assert sigs == []
+
+    def test_silent_when_within_threshold(self) -> None:
+        sigs = stuck_spawn_detector(
+            _event(
+                {
+                    "claim_confirmed": True,
+                    "task_completed": False,
+                    "audit_emissions": 0,
+                    "time_in_state_s": 5 * 60,
+                },
+            ),
+        )
+        assert sigs == []
+
+    def test_silent_when_claim_not_confirmed(self) -> None:
+        sigs = stuck_spawn_detector(
+            _event({"claim_confirmed": False, "time_in_state_s": 99 * 60}),
+        )
+        assert sigs == []
+
+
+# ---------------------------------------------------------------------------
+# repeated_failure_detector
+# ---------------------------------------------------------------------------
+
+
+class TestRepeatedFailure:
+    """``repeated_failure_detector`` — same exit signature 3 times."""
+
+    def test_fires_on_three_consecutive_failures(self) -> None:
+        sigs = repeated_failure_detector(
+            _event(
+                {
+                    "task_id": "T-7",
+                    "failure_count": 3,
+                    "exit_signature": "MissingDep:foo",
+                },
+            ),
+        )
+        assert len(sigs) == 1
+        assert sigs[0].severity == "critical"
+        assert "T-7" in sigs[0].rationale
+        assert "MissingDep:foo" in sigs[0].rationale
+
+    def test_fires_on_more_than_three(self) -> None:
+        sigs = repeated_failure_detector(
+            _event({"failure_count": 5, "exit_signature": "OOM"}),
+        )
+        assert len(sigs) == 1
+
+    def test_silent_below_threshold(self) -> None:
+        sigs = repeated_failure_detector(
+            _event({"failure_count": 2, "exit_signature": "OOM"}),
+        )
+        assert sigs == []
+
+    def test_silent_without_exit_signature(self) -> None:
+        sigs = repeated_failure_detector(
+            _event({"failure_count": 9, "exit_signature": ""}),
+        )
+        assert sigs == []
+
+
+# ---------------------------------------------------------------------------
+# suspicious_tool_mask_detector
+# ---------------------------------------------------------------------------
+
+
+class TestSuspiciousToolMask:
+    """``suspicious_tool_mask_detector`` — masking >50% of tools."""
+
+    def test_fires_when_more_than_half_masked(self) -> None:
+        sigs = suspicious_tool_mask_detector(
+            _event({"available_tools": 10, "masked_tools": 6}),
+        )
+        assert len(sigs) == 1
+        assert sigs[0].detector == "suspicious_tool_mask"
+
+    def test_silent_when_exactly_half_masked(self) -> None:
+        # Boundary — a 50% mask is permitted; anything over fires.
+        sigs = suspicious_tool_mask_detector(
+            _event({"available_tools": 10, "masked_tools": 5}),
+        )
+        assert sigs == []
+
+    def test_silent_when_no_tools_available(self) -> None:
+        sigs = suspicious_tool_mask_detector(
+            _event({"available_tools": 0, "masked_tools": 0}),
+        )
+        assert sigs == []
+
+    def test_silent_on_below_threshold(self) -> None:
+        sigs = suspicious_tool_mask_detector(
+            _event({"available_tools": 10, "masked_tools": 1}),
+        )
+        assert sigs == []
+
+
+# ---------------------------------------------------------------------------
+# audit_chain_break_detector
+# ---------------------------------------------------------------------------
+
+
+class TestAuditChainBreak:
+    """``audit_chain_break_detector`` — prev_hmac mismatch on append."""
+
+    def test_fires_on_mismatch(self) -> None:
+        sigs = audit_chain_break_detector(
+            _event(
+                {
+                    "prev_hmac": "a" * 64,
+                    "expected_prev_hmac": "b" * 64,
+                },
+            ),
+        )
+        assert len(sigs) == 1
+        assert sigs[0].severity == "critical"
+        assert sigs[0].detector == "audit_chain_break"
+
+    def test_silent_on_match(self) -> None:
+        sigs = audit_chain_break_detector(
+            _event(
+                {
+                    "prev_hmac": "deadbeef" * 8,
+                    "expected_prev_hmac": "deadbeef" * 8,
+                },
+            ),
+        )
+        assert sigs == []
+
+    def test_silent_when_prev_missing(self) -> None:
+        sigs = audit_chain_break_detector(
+            _event({"expected_prev_hmac": "x" * 64}),
+        )
+        assert sigs == []
+
+    def test_silent_when_expected_missing(self) -> None:
+        sigs = audit_chain_break_detector(_event({"prev_hmac": "x" * 64}))
+        assert sigs == []
+
+
+# ---------------------------------------------------------------------------
+# build_watcher_from_env wires the pack
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration:
+    """Auto-registration via build_watcher_from_env when watcher is enabled."""
+
+    def test_disabled_watcher_has_no_detectors_registered(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("BERNSTEIN_LLM_WATCHER_ENABLED", raising=False)
+        watcher = build_watcher_from_env()
+        # Off-by-default contract: no detectors on a disabled watcher.
+        assert watcher.detectors == ()
+
+    def test_enabled_watcher_registers_all_five_detectors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("BERNSTEIN_LLM_WATCHER_ENABLED", "1")
+        watcher = build_watcher_from_env()
+        names = [getattr(d, "__name__", "?") for d in watcher.detectors]
+        assert names == [
+            "cost_runaway_detector",
+            "stuck_spawn_detector",
+            "repeated_failure_detector",
+            "suspicious_tool_mask_detector",
+            "audit_chain_break_detector",
+        ]
+
+    def test_register_default_detectors_is_idempotent_per_call(self) -> None:
+        watcher = LLMWatcher(WatcherConfig(enabled=True))
+        register_default_detectors(watcher)
+        first = len(watcher.detectors)
+        # A second call duplicates registrations (caller responsibility).
+        # The contract: register_default_detectors is a single-shot helper.
+        register_default_detectors(watcher)
+        assert len(watcher.detectors) == 2 * first
+
+    def test_observe_runs_detectors_then_llm(self) -> None:
+        """End-to-end: a single event triggers detectors + LLM observer."""
+        captured: list[tuple[Any, Any]] = []
+
+        async def caller(*args: Any, **kwargs: Any) -> str:
+            captured.append((args, kwargs))
+            return "advisory text"
+
+        watcher = LLMWatcher(WatcherConfig(enabled=True), llm_caller=caller)
+        register_default_detectors(watcher)
+
+        event = _event(
+            {
+                "task_id": "T-1",
+                "task_cost_usd": 3.0,  # triggers cost_runaway
+                "failure_count": 3,
+                "exit_signature": "OOM",  # triggers repeated_failure
+            },
+        )
+
+        signals = asyncio.run(watcher.observe(event))
+        # 2 detectors + 1 LLM observer = 3 suggestions.
+        assert len(signals) == 3
+        detectors = {s.detector for s in signals}
+        assert {"cost_runaway", "repeated_failure", "observer"} <= detectors
+        assert all(isinstance(s, Suggestion) for s in signals)
+
+    def test_disabled_watcher_skips_detectors(self) -> None:
+        """A disabled watcher must not even invoke its registered detectors."""
+        invoked: list[str] = []
+
+        def loud_detector(event: WatcherEvent) -> list[Suggestion]:
+            invoked.append("called")
+            return []
+
+        watcher = LLMWatcher(WatcherConfig(enabled=False))
+        watcher.register_detector(loud_detector)
+        signals = asyncio.run(watcher.observe(_event()))
+        assert signals == []
+        assert invoked == []
+
+    def test_failing_detector_does_not_block_peers(self) -> None:
+        """One detector raising must not stop other detectors / LLM observer."""
+
+        def boom(event: WatcherEvent) -> list[Suggestion]:
+            raise RuntimeError("kaboom")
+
+        async def caller(*_a: Any, **_kw: Any) -> str:
+            return "advisory"
+
+        watcher = LLMWatcher(WatcherConfig(enabled=True), llm_caller=caller)
+        watcher.register_detector(boom)
+        watcher.register_detector(cost_runaway_detector)
+
+        signals = asyncio.run(
+            watcher.observe(_event({"task_cost_usd": 5.0, "task_id": "T-x"})),
+        )
+        # cost_runaway fires + LLM observer fires = 2 signals.
+        assert len(signals) == 2
+        assert {s.detector for s in signals} == {"cost_runaway", "observer"}

--- a/tests/unit/test_prompt_cache_locality_vendors.py
+++ b/tests/unit/test_prompt_cache_locality_vendors.py
@@ -1,0 +1,218 @@
+"""Tests for vendor-specific cache hints emitted by ``build_stable_prefix``.
+
+The default ``vendor="generic"`` path is exercised in
+``test_prompt_cache_locality.py``.  This module covers the three
+vendor-aware paths added by the observability hardening wave:
+
+* ``"openai"`` — pads the prefix to the next 256-token boundary.
+* ``"anthropic"`` — emits a message structure tagged with
+  ``cache_control: {"type": "ephemeral"}`` markers (≤4 segments).
+* ``"gemini"`` — emits a candidate ``cachedContents/<sha256>`` handle.
+
+At least 4 tests per vendor.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from bernstein.core.agents.prompt_cache_locality import (
+    _ANTHROPIC_MAX_SEGMENTS,
+    _OPENAI_BOUNDARY_TOKENS,
+    StablePrefix,
+    _count_openai_tokens,
+    build_stable_prefix,
+    hash_prefix,
+)
+
+# ---------------------------------------------------------------------------
+# Generic path (back-compat sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_generic_default_returns_str_for_back_compat() -> None:
+    """Default behaviour unchanged — generic path returns bare ``str``."""
+    out = build_stable_prefix(header={"role": "backend"}, body="b")
+    assert isinstance(out, str)
+
+
+def test_explicit_generic_returns_str() -> None:
+    out = build_stable_prefix(header={"role": "backend"}, body="b", vendor="generic")
+    assert isinstance(out, str)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI path — 256-token boundary alignment
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIVendor:
+    """``vendor="openai"`` pads to the next 256-token boundary."""
+
+    def test_returns_stable_prefix_bundle(self) -> None:
+        out = build_stable_prefix(header={"role": "backend"}, body="b", vendor="openai")
+        assert isinstance(out, StablePrefix)
+        assert out.vendor == "openai"
+        # Canonical text must round-trip the generic output exactly.
+        generic = build_stable_prefix(header={"role": "backend"}, body="b")
+        assert out.text == generic
+
+    def test_padded_text_is_at_least_canonical_length(self) -> None:
+        out = build_stable_prefix(
+            header={"role": "backend", "templates_hash": "h"},
+            body="this is the body",
+            vendor="openai",
+        )
+        assert len(out.padded_text) >= len(out.text)
+        # Padded text starts with the canonical text — alignment never
+        # mutates the original prefix bytes; padding goes to the right.
+        assert out.padded_text.startswith(out.text)
+
+    def test_padded_length_lands_on_boundary(self) -> None:
+        """Token count of the padded text divides ``_OPENAI_BOUNDARY_TOKENS``."""
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="lorem ipsum dolor sit amet " * 10,
+            vendor="openai",
+        )
+        # Use the same token-count helper the implementation uses so the
+        # heuristic-vs-tiktoken environment stays internally consistent.
+        token_count = _count_openai_tokens(out.padded_text)
+        assert token_count % _OPENAI_BOUNDARY_TOKENS == 0
+
+    def test_idempotent_for_already_aligned_input(self) -> None:
+        """Reblowing through the OpenAI path on aligned text changes nothing."""
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="x" * (4 * _OPENAI_BOUNDARY_TOKENS),  # ~256 tokens via heuristic
+            vendor="openai",
+        )
+        # The padded text must still be aligned.
+        assert _count_openai_tokens(out.padded_text) % _OPENAI_BOUNDARY_TOKENS == 0
+        # No extra padding beyond what the original text already needed
+        # to reach a boundary — the padded text is shorter than two
+        # boundaries' worth of characters.
+        assert len(out.padded_text) <= len(out.text) + (_OPENAI_BOUNDARY_TOKENS * 4)
+
+    def test_padded_text_aligns_short_canonical_input(self) -> None:
+        """Even a short canonical text (just the header separator) aligns."""
+        out = build_stable_prefix(header={}, body="", vendor="openai")
+        # Canonical text contains the separator sentinel even when both
+        # header and body are empty — alignment still applies.
+        assert out.text  # non-empty due to the separator
+        token_count = _count_openai_tokens(out.padded_text)
+        assert token_count % _OPENAI_BOUNDARY_TOKENS == 0
+        assert out.padded_text.startswith(out.text)
+
+
+# ---------------------------------------------------------------------------
+# Anthropic path — segmented message structure with cache_control
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicVendor:
+    """``vendor="anthropic"`` emits ≤4 segments with ephemeral cache_control."""
+
+    def test_returns_stable_prefix_bundle(self) -> None:
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="x",
+            vendor="anthropic",
+        )
+        assert isinstance(out, StablePrefix)
+        assert out.vendor == "anthropic"
+        assert out.segments  # non-empty
+
+    def test_segments_count_within_limit(self) -> None:
+        out = build_stable_prefix(
+            header={"role": "backend", "templates_hash": "h"},
+            body="role body",
+            vendor="anthropic",
+        )
+        assert len(out.segments) <= _ANTHROPIC_MAX_SEGMENTS
+
+    def test_prefix_segments_carry_ephemeral_cache_control(self) -> None:
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="prefix body",
+            vendor="anthropic",
+        )
+        cached_segments = [seg for seg in out.segments if "cache_control" in seg]
+        assert cached_segments, "at least one segment must be cache-tagged"
+        for seg in cached_segments:
+            assert seg["cache_control"] == {"type": "ephemeral"}
+            assert seg["type"] == "text"
+
+    def test_segments_round_trip_to_canonical_text(self) -> None:
+        """Concatenating segment text fields must reproduce the canonical text."""
+        out = build_stable_prefix(
+            header={"role": "backend", "templates_hash": "h"},
+            body="role body",
+            vendor="anthropic",
+        )
+        joined = "".join(str(seg["text"]) for seg in out.segments)
+        assert joined == out.text
+
+    def test_empty_body_drops_body_segment(self) -> None:
+        """No body → no body segment (compactness)."""
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="",
+            vendor="anthropic",
+        )
+        body_segments = [seg for seg in out.segments if "body" in str(seg.get("text", ""))]
+        assert body_segments == []
+        # Header segment must still exist and be cache-tagged.
+        assert any("cache_control" in seg for seg in out.segments)
+
+
+# ---------------------------------------------------------------------------
+# Gemini path — cachedContents handle from canonical SHA-256
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiVendor:
+    """``vendor="gemini"`` emits a candidate cachedContents handle."""
+
+    def test_returns_stable_prefix_bundle(self) -> None:
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="b",
+            vendor="gemini",
+        )
+        assert isinstance(out, StablePrefix)
+        assert out.vendor == "gemini"
+        assert out.cached_content_handle.startswith("cachedContents/")
+
+    def test_handle_uses_canonical_sha256(self) -> None:
+        out = build_stable_prefix(
+            header={"role": "backend"},
+            body="canonical body",
+            vendor="gemini",
+        )
+        expected = f"cachedContents/{hash_prefix(out.text)}"
+        assert out.cached_content_handle == expected
+
+    def test_handle_is_stable_across_calls(self) -> None:
+        a = build_stable_prefix(header={"role": "backend"}, body="b", vendor="gemini")
+        b = build_stable_prefix(header={"role": "backend"}, body="b", vendor="gemini")
+        assert a.cached_content_handle == b.cached_content_handle
+
+    def test_handle_changes_when_prefix_bytes_change(self) -> None:
+        a = build_stable_prefix(header={"role": "backend"}, body="v1", vendor="gemini")
+        b = build_stable_prefix(header={"role": "backend"}, body="v2", vendor="gemini")
+        assert a.cached_content_handle != b.cached_content_handle
+
+    def test_handle_invariant_under_header_reordering(self) -> None:
+        """Caller insertion order must not change the Gemini handle."""
+        a = build_stable_prefix(
+            header={"role": "backend", "templates_hash": "h"},
+            body="b",
+            vendor="gemini",
+        )
+        b = build_stable_prefix(
+            header={"templates_hash": "h", "role": "backend"},
+            body="b",
+            vendor="gemini",
+        )
+        assert a.cached_content_handle == b.cached_content_handle

--- a/tests/unit/test_spawn_prompt_memory_inject.py
+++ b/tests/unit/test_spawn_prompt_memory_inject.py
@@ -1,0 +1,215 @@
+"""Tests for the JSONL memory log auto-injection into the spawner pipeline.
+
+Acceptance criteria (matches the ticket):
+
+* The default behaviour is unchanged: when ``BERNSTEIN_MEMORY_AUTO_INJECT``
+  is unset, no ``<lessons>`` block appears in the rendered prompt.
+* When the env var is enabled and a ``.bernstein/memory/lessons.jsonl``
+  file exists, the most recent ``N=10`` entries appear in a stable
+  ``<lessons>...</lessons>`` block AFTER the role/git_safety header
+  but BEFORE the ``## Assigned tasks`` body (KV-cache locality).
+* A missing log is a no-op.
+* The block is capped at 10 entries — older ones are dropped, recent
+  ones survive.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from bernstein.core.spawn_prompt import (
+    _MEMORY_AUTO_INJECT_ENV_VAR,
+    _MEMORY_LESSONS_CLOSE,
+    _MEMORY_LESSONS_KEY,
+    _MEMORY_LESSONS_MAX,
+    _MEMORY_LESSONS_OPEN,
+    _format_memory_lesson,
+    _memory_auto_inject_enabled,
+    _render_memory_lessons_block,
+    _render_prompt,
+)
+
+from bernstein.core.memory.jsonl_log import JSONLMemoryLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Env-gating helpers
+# ---------------------------------------------------------------------------
+
+
+class TestEnvGating:
+    """The auto-inject path is opt-in via ``BERNSTEIN_MEMORY_AUTO_INJECT``."""
+
+    def test_disabled_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(_MEMORY_AUTO_INJECT_ENV_VAR, raising=False)
+        assert _memory_auto_inject_enabled() is False
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "FALSE"])
+    def test_disabled_for_falsey_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(_MEMORY_AUTO_INJECT_ENV_VAR, value)
+        assert _memory_auto_inject_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE"])
+    def test_enabled_for_truthy_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        value: str,
+    ) -> None:
+        monkeypatch.setenv(_MEMORY_AUTO_INJECT_ENV_VAR, value)
+        assert _memory_auto_inject_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Lesson rendering
+# ---------------------------------------------------------------------------
+
+
+class TestFormatMemoryLesson:
+    """``_format_memory_lesson`` collapses dict entries to a one-line bullet."""
+
+    def test_lesson_field_used(self) -> None:
+        bullet = _format_memory_lesson({"task": "T-1", "lesson": "guard imports"})
+        assert bullet == "- (T-1) guard imports"
+
+    def test_text_field_fallback(self) -> None:
+        bullet = _format_memory_lesson({"text": "deflake the parser"})
+        assert bullet == "- deflake the parser"
+
+    def test_message_field_fallback(self) -> None:
+        bullet = _format_memory_lesson({"message": "watch GIL contention"})
+        assert bullet == "- watch GIL contention"
+
+    def test_no_text_falls_back_to_json_dump(self) -> None:
+        bullet = _format_memory_lesson({"score": 3, "stage": "review"})
+        # Falls back to compact JSON dump so callers always get something.
+        assert bullet.startswith("- ")
+        assert "score" in bullet
+        assert "stage" in bullet
+
+
+# ---------------------------------------------------------------------------
+# _render_memory_lessons_block — disk-bound behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMemoryLessonsBlock:
+    """Block renders only when the JSONL file is present and non-empty."""
+
+    def test_missing_log_returns_empty(self, tmp_path: Path) -> None:
+        # No `.bernstein/memory/lessons.jsonl` on disk.
+        assert _render_memory_lessons_block(tmp_path) == ""
+
+    def test_empty_log_returns_empty(self, tmp_path: Path) -> None:
+        # File exists but contains no records.
+        log = JSONLMemoryLog(root=tmp_path / ".bernstein" / "memory")
+        log.write(_MEMORY_LESSONS_KEY, {"lesson": "tmp"})
+        log.clear(_MEMORY_LESSONS_KEY)
+        assert _render_memory_lessons_block(tmp_path) == ""
+
+    def test_block_wraps_entries_with_stable_separator(self, tmp_path: Path) -> None:
+        log = JSONLMemoryLog(root=tmp_path / ".bernstein" / "memory")
+        log.write(_MEMORY_LESSONS_KEY, {"task": "T-1", "lesson": "guard imports"})
+        block = _render_memory_lessons_block(tmp_path)
+        assert _MEMORY_LESSONS_OPEN in block
+        assert _MEMORY_LESSONS_CLOSE in block
+        assert "guard imports" in block
+
+    def test_block_caps_at_max_recent_entries(self, tmp_path: Path) -> None:
+        """N=10 cap — only the most recent entries survive."""
+        log = JSONLMemoryLog(root=tmp_path / ".bernstein" / "memory")
+        for i in range(_MEMORY_LESSONS_MAX + 5):
+            log.write(_MEMORY_LESSONS_KEY, {"lesson": f"L{i}"})
+        block = _render_memory_lessons_block(tmp_path)
+        # Oldest entries dropped.
+        assert "L0" not in block
+        assert "L4" not in block
+        # Most recent kept.
+        assert "L14" in block
+        assert "L5" in block
+        # Exactly N bullet lines between the markers.
+        body = block.split(_MEMORY_LESSONS_OPEN, 1)[1].split(_MEMORY_LESSONS_CLOSE, 1)[0]
+        bullets = [ln for ln in body.splitlines() if ln.startswith("- ")]
+        assert len(bullets) == _MEMORY_LESSONS_MAX
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: _render_prompt picks up the block when the env var is set
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPromptInjection:
+    """The full leaf-agent prompt embeds the block at the correct anchor."""
+
+    def test_default_off_no_block_in_rendered_prompt(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        make_task: Any,
+    ) -> None:
+        monkeypatch.delenv(_MEMORY_AUTO_INJECT_ENV_VAR, raising=False)
+        # Even with a populated log, a default boot does not inject.
+        log = JSONLMemoryLog(root=tmp_path / ".bernstein" / "memory")
+        log.write(_MEMORY_LESSONS_KEY, {"lesson": "should not appear"})
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        rendered = _render_prompt(
+            tasks=[make_task(role="backend", title="Implement T-1")],
+            templates_dir=templates_dir,
+            workdir=tmp_path,
+        )
+        assert _MEMORY_LESSONS_OPEN not in rendered
+        assert "should not appear" not in rendered
+
+    def test_enabled_injects_block_before_assigned_tasks(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        make_task: Any,
+    ) -> None:
+        monkeypatch.setenv(_MEMORY_AUTO_INJECT_ENV_VAR, "1")
+        log = JSONLMemoryLog(root=tmp_path / ".bernstein" / "memory")
+        log.write(
+            _MEMORY_LESSONS_KEY,
+            {"task": "T-prev", "lesson": "always validate inputs"},
+        )
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        rendered = _render_prompt(
+            tasks=[make_task(role="backend", title="Implement T-1")],
+            templates_dir=templates_dir,
+            workdir=tmp_path,
+        )
+        assert _MEMORY_LESSONS_OPEN in rendered
+        assert "always validate inputs" in rendered
+        # KV-cache locality: lessons block precedes the variable goal
+        # block ("## Assigned tasks") — the spec is explicit on the order.
+        assert rendered.index(_MEMORY_LESSONS_OPEN) < rendered.index("## Assigned tasks")
+
+    def test_enabled_with_missing_log_is_noop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        make_task: Any,
+    ) -> None:
+        monkeypatch.setenv(_MEMORY_AUTO_INJECT_ENV_VAR, "1")
+        # No `.bernstein/memory/lessons.jsonl` written — must not raise.
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        rendered = _render_prompt(
+            tasks=[make_task(role="backend", title="Implement T-1")],
+            templates_dir=templates_dir,
+            workdir=tmp_path,
+        )
+        assert _MEMORY_LESSONS_OPEN not in rendered


### PR DESCRIPTION
three observability primitives moved from spec/tests-only to live in
the orchestrator runtime. one coherent wave; no behaviour change for
operators that do not flip the new env var (memory auto-inject) or
explicitly request a vendor (cache-locality).

## gap 1 — memory log auto-injection into spawner pipeline

- new switch: `BERNSTEIN_MEMORY_AUTO_INJECT=1` (default off).
- when set, the spawner reads up to 10 recent entries from
  `.bernstein/memory/lessons.jsonl` and injects them into the
  leaf-agent prompt under `<lessons>...</lessons>` markers.
- placement: AFTER the stable header (role, git_safety, specialists),
  BEFORE the variable `## Assigned tasks` body. this keeps
  KV-cache locality intact.
- missing log is a no-op; corrupt entries are skipped (existing
  `JSONLMemoryLog` semantics).
- entries cap at 10; oldest dropped when the log grows beyond that.

files: `src/bernstein/core/agents/spawn_prompt.py`,
`src/bernstein/core/memory/jsonl_log.py` (re-used unchanged).
tests: `tests/unit/test_spawn_prompt_memory_inject.py` (23 tests).

## gap 2 — llm-watcher production detector pack

ships 5 plain-python detectors registered onto `LLMWatcher`:

| detector | trigger |
| --- | --- |
| `cost_runaway_detector` | task >\$2 in 5 min OR run cost >50% of budget |
| `stuck_spawn_detector` | claim_confirmed=true, no audit emissions for >30 min |
| `repeated_failure_detector` | same task fails 3x in a row with same exit signature |
| `suspicious_tool_mask_detector` | mask removes >50% of available tools |
| `audit_chain_break_detector` | new entry's prev_hmac != prior tail hmac |

- detectors run BEFORE the LLM observer on every enabled event.
- a failing detector is isolated — peer detectors and the LLM
  observer still run.
- `build_watcher_from_env()` auto-registers all 5 when the watcher is
  enabled. off-by-default contract preserved: a disabled watcher
  registers no detectors.

files: `src/bernstein/core/observability/llm_watcher.py`.
tests: `tests/unit/test_llm_watcher_detector_pack.py` (27 tests).

## gap 3 — prompt-cache prefix locality vendor markers

`build_stable_prefix()` gains a `vendor: Literal[...]` kwarg with
overloads:

- `vendor="generic"` — default; returns `str`. back-compat preserved.
- `vendor="openai"` — pads the prefix to the next 256-token boundary
  (tiktoken when installed; 4-chars/token heuristic fallback).
- `vendor="anthropic"` — splits into ≤4 segments with
  `cache_control: {"type": "ephemeral"}` markers on the prefix segments.
  segments round-trip back to canonical bytes.
- `vendor="gemini"` — emits `cachedContents/<sha256>` handle name. the
  hash is the same SHA-256 used by `hash_prefix()`, so handle stability
  matches drift-counter stability.

new dataclass `StablePrefix` is the return shape for vendor != generic.
no existing call site changes.

files: `src/bernstein/core/agents/prompt_cache_locality.py`.
tests: `tests/unit/test_prompt_cache_locality_vendors.py` (17 tests,
≥4 per vendor).

## verification

- `uv run ruff format src/` — clean.
- `uv run ruff check src/` — clean.
- new tests: 67 (gap 1: 23, gap 2: 27, gap 3: 17). all pass.
- adjacent regression sweep on `memory|watcher|cache_locality|spawn_prompt|audit`:
  750 passed.
- agents-md sync: nothing to sync (no new subdirs).