### PR TITLE
feat(a2a): persistent keystore + identity v1.0 dataclass + RFC 8707

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ build/
 .env.*
 .env.local
 
+# A2A v1.0 agent-card signing keys — minted on first run, must NEVER be committed.
+.bernstein/keys/
+
 # Internal docs (local only — kept on disk, excluded from git)
 docs/superpowers/
 docs/research/

--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -27,11 +27,18 @@ network caller can read them without provisioning a token.
 
 Key lifecycle
 -------------
-For now the orchestrator generates a fresh Ed25519 keypair on first request
-and caches it in-process. Persistence (PEM under
-``.sdd/security/keys/agent_signing/``) and rotation are tracked in the same
-ticket family but deferred from this PR — the JWS surface and JWKS shape
-land first so external verifiers can integrate against a stable contract.
+The signing keypair persists at ``.bernstein/keys/agent-card.ed25519`` (and
+its ``.pub`` companion). On first request the keystore atomically mints the
+key with ``O_EXCL`` and ``0o600`` permissions; subsequent requests (and
+restarts) reuse it. Operators rotate via
+:func:`bernstein.core.security.agent_card_keystore.AgentCardKeystore.rotate`,
+which archives the previous keypair under
+``.bernstein/keys/archive/<utc-isoformat>/`` and mints a new one.
+
+During a rotation grace window (24h by default) the JWKS endpoint publishes
+both the current and the archived public key so verifiers cached on the old
+``kid`` keep validating until their HTTP cache (``max-age=3600`` on this
+route) ages out.
 """
 
 from __future__ import annotations
@@ -39,16 +46,20 @@ from __future__ import annotations
 import os
 import threading
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse, Response
 
 from bernstein import __version__ as _BERNSTEIN_VERSION
+from bernstein.core.security.agent_card_keystore import (
+    DEFAULT_KEY_DIR,
+    AgentCardKeystore,
+)
 from bernstein.core.security.agent_card_signer import (
     canonicalize_jcs,
     ed25519_public_jwk,
-    generate_ed25519_keypair,
 )
 
 router = APIRouter()
@@ -114,39 +125,90 @@ _SKILLS: tuple[dict[str, object], ...] = (
 
 
 # ---------------------------------------------------------------------------
-# Process-local Ed25519 keypair cache.
+# Persistent Ed25519 keystore + in-process cache.
 # ---------------------------------------------------------------------------
 #
-# The first GET against either ``/.well-known/agent.json`` or
-# ``/.well-known/agent.json/keys`` lazily mints a keypair and caches it in
-# this module. Subsequent requests reuse the cache so the JWKS contract
-# stays stable across the lifetime of one orchestrator process. Production
-# deployments will plug the persistent ``key_rotation`` substrate in here in
-# a follow-up ticket; the JWKS shape stays unchanged either way so external
-# verifiers do not have to special-case the in-memory mode.
+# The orchestrator persists its signing keypair at ``.bernstein/keys/`` so
+# the ``kid`` advertised in the JWKS stays stable across process restarts.
+# The first GET lazily binds a process-wide :class:`AgentCardKeystore` to
+# that directory; subsequent requests reuse the cached PEM bytes (loading
+# from disk on every request would charge an unnecessary syscall per call).
+# ``_reset_signing_keypair_for_tests`` drops the cache between test cases
+# so each test can point at its own ``tmp_path`` keystore.
 
 _KEY_LOCK = threading.Lock()
+_KEYSTORE: AgentCardKeystore | None = None
 _PRIVATE_PEM: bytes | None = None
 _PUBLIC_PEM: bytes | None = None
 
 
+def _resolve_key_dir() -> Path:
+    """Return the directory backing the persistent keystore.
+
+    Honours ``BERNSTEIN_AGENT_CARD_KEY_DIR`` so production deployments can
+    point at a mounted secret volume; falls back to ``.bernstein/keys`` in
+    the working directory.
+    """
+    override = os.environ.get("BERNSTEIN_AGENT_CARD_KEY_DIR", "").strip()
+    if override:
+        return Path(override)
+    return DEFAULT_KEY_DIR
+
+
+def _get_keystore() -> AgentCardKeystore:
+    """Return the process-wide :class:`AgentCardKeystore`, creating it lazily."""
+    global _KEYSTORE
+    if _KEYSTORE is not None:
+        return _KEYSTORE
+    with _KEY_LOCK:
+        if _KEYSTORE is None:
+            _KEYSTORE = AgentCardKeystore(_resolve_key_dir())
+    return _KEYSTORE
+
+
 def _get_signing_keypair() -> tuple[bytes, bytes]:
-    """Return the cached signing keypair, generating it on first use."""
+    """Return the cached signing keypair, loading from disk on first use."""
     global _PRIVATE_PEM, _PUBLIC_PEM
     if _PRIVATE_PEM is not None and _PUBLIC_PEM is not None:
         return _PRIVATE_PEM, _PUBLIC_PEM
     with _KEY_LOCK:
         if _PRIVATE_PEM is None or _PUBLIC_PEM is None:
-            _PRIVATE_PEM, _PUBLIC_PEM = generate_ed25519_keypair()
+            _PRIVATE_PEM, _PUBLIC_PEM = _get_keystore().load_or_generate()
     return _PRIVATE_PEM, _PUBLIC_PEM
 
 
-def _reset_signing_keypair_for_tests() -> None:
-    """Drop the cached keypair — for tests that want a fresh JWKS per case."""
-    global _PRIVATE_PEM, _PUBLIC_PEM
+def _reset_signing_keypair_for_tests(key_dir: Path | None = None) -> None:
+    """Reset both the keystore binding and the cached PEM bytes.
+
+    Tests pass ``key_dir=tmp_path / "keys"`` so each case gets a fresh
+    directory; production callers leave ``key_dir=None`` (the default
+    persistent directory will be re-bound on next request).
+    """
+    global _KEYSTORE, _PRIVATE_PEM, _PUBLIC_PEM
     with _KEY_LOCK:
+        _KEYSTORE = AgentCardKeystore(key_dir) if key_dir is not None else None
         _PRIVATE_PEM = None
         _PUBLIC_PEM = None
+
+
+def rotate_agent_card_keys() -> tuple[bytes, bytes]:
+    """Rotate the persistent agent-card keypair.
+
+    Archives the current keypair under ``<key_dir>/archive/<isoformat>/`` and
+    mints a fresh one with ``O_EXCL`` + ``0o600`` semantics. The JWKS
+    endpoint will continue to publish the rotated-out public key for the
+    keystore's grace window (24h by default) so verifiers cached on the
+    old ``kid`` keep validating until their HTTP cache ages out.
+
+    Returns:
+        The freshly-generated ``(private_pem, public_pem)`` so callers can
+        log the new ``kid`` or trigger downstream secret-store sync.
+    """
+    global _PRIVATE_PEM, _PUBLIC_PEM
+    with _KEY_LOCK:
+        priv, pub = _get_keystore().rotate()
+        _PRIVATE_PEM, _PUBLIC_PEM = priv, pub
+        return priv, pub
 
 
 # ---------------------------------------------------------------------------
@@ -352,14 +414,21 @@ def agent_json() -> Response:
 def agent_json_keys() -> dict[str, Any]:
     """Return the JWKS for verifying ``/.well-known/agent.json`` signatures.
 
-    JWKS shape per RFC 7517 — ``{"keys": [<jwk>, ...]}``. Today exactly one
-    key is published (the orchestrator's signing key); during rotation
-    windows both old and new keys appear so in-flight tokens keep
-    verifying — see ``key_rotation.py`` for the rotation contract.
+    JWKS shape per RFC 7517 — ``{"keys": [<jwk>, ...]}``. The current
+    orchestrator key always appears first; during a rotation grace window
+    (24h by default) any archived public keys still inside the window are
+    appended so verifiers cached on the old ``kid`` keep validating until
+    their HTTP cache (``Cache-Control: public, max-age=3600`` on the agent
+    card route) ages out and they refetch the fresh JWKS.
     """
+    # Ensure both the cached PEM and the keystore binding exist before we
+    # query the archive — the side-effect of ``_get_signing_keypair`` is
+    # what materialises the on-disk directory on first run.
     _private_pem, public_pem = _get_signing_keypair()
-    jwk = ed25519_public_jwk(public_pem, kid=_DEFAULT_KID)
-    return {"keys": [jwk]}
+    jwks: list[dict[str, str]] = [ed25519_public_jwk(public_pem, kid=_DEFAULT_KID)]
+    for archived in _get_keystore().list_archived():
+        jwks.append(ed25519_public_jwk(archived.public_pem, kid=archived.kid))
+    return {"keys": jwks}
 
 
 @router.get("/llms.txt", include_in_schema=False, response_class=PlainTextResponse)

--- a/src/bernstein/core/security/agent_card_keystore.py
+++ b/src/bernstein/core/security/agent_card_keystore.py
@@ -1,0 +1,321 @@
+"""Persistent Ed25519 keystore for the A2A v1.0 agent-card signer.
+
+The first iteration of the v1.0 ``/.well-known/agent.json`` route cached its
+Ed25519 keypair in process memory — fine for one-shot integration tests but
+not for production: every restart minted a fresh ``kid`` and broke verifiers
+that had cached the old JWK.
+
+This module persists the keypair under ``.bernstein/keys/`` with the same
+PEM shapes ``agent_card_signer.generate_ed25519_keypair`` produces, plus a
+24-hour rotation grace window so verifiers that fetched the previous JWKS
+keep validating in-flight signatures while their HTTP cache (max-age=3600)
+ages out.
+
+Filesystem layout
+-----------------
+
+::
+
+    .bernstein/keys/
+        agent-card.ed25519       0600  PKCS#8 PEM private key (current)
+        agent-card.ed25519.pub   0644  SPKI PEM public key  (current)
+        archive/
+            <iso-timestamp>/
+                agent-card.ed25519       0600  rotated-out private
+                agent-card.ed25519.pub   0644  rotated-out public
+                rotated_at.txt           UTC ISO-8601 timestamp
+
+The JWKS endpoint at ``/.well-known/agent.json/keys`` reads the current
+public key plus any archived public key whose ``rotated_at`` falls within
+the grace window (24h) so verifiers cached on the old key still validate.
+
+Security notes
+--------------
+
+* The private file is created with ``os.O_EXCL`` so two concurrent first-run
+  processes cannot race each other into overwriting a freshly minted key.
+* The private file is forced to ``0o600`` after write — both at generation
+  time and on every load (a load that finds wider-than-owner permissions
+  raises so the operator notices the misconfiguration).
+* No envelope encryption today; on-disk plaintext is the same shape as the
+  ed25519 keypair the previous in-process cache held. Production deployments
+  that want envelope encryption (KMS, sops, age) should layer it on top of
+  the directory itself, not inside this module.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from .agent_card_signer import generate_ed25519_keypair
+
+__all__ = [
+    "DEFAULT_GRACE_SECONDS",
+    "DEFAULT_KEY_DIR",
+    "AgentCardKeystore",
+    "ArchivedKey",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Default rotation grace window. Verifiers that cached the previous JWKS
+#: (Cache-Control: max-age=3600) get up to 24h to refresh and pick up the
+#: new ``kid`` while the old ``kid`` keeps verifying.
+DEFAULT_GRACE_SECONDS: int = 24 * 60 * 60
+
+#: Default keystore directory, relative to the workdir.
+DEFAULT_KEY_DIR: Path = Path(".bernstein/keys")
+
+#: Required private-key permission bits. Anything more permissive than
+#: owner-only is treated as a misconfiguration.
+_PRIVATE_MODE_MASK: int = 0o077
+
+_PRIVATE_FILENAME: str = "agent-card.ed25519"
+_PUBLIC_FILENAME: str = "agent-card.ed25519.pub"
+_ARCHIVE_DIRNAME: str = "archive"
+_ROTATED_AT_FILENAME: str = "rotated_at.txt"
+
+
+@dataclass(frozen=True, slots=True)
+class ArchivedKey:
+    """A previously-active keypair retained during the rotation grace window.
+
+    The ``private_pem`` is loaded but never returned outside this module —
+    the JWKS endpoint only needs ``public_pem`` to publish the legacy JWK.
+    Keeping it on disk lets operators replay or audit the historic
+    signature surface without re-deriving keys.
+    """
+
+    public_pem: bytes
+    rotated_at: _dt.datetime
+
+    @property
+    def kid(self) -> str:
+        """Stable kid for the archived key, derived from the rotation timestamp.
+
+        The kid encodes the moment the key was rotated out so verifiers
+        seeing both the current and archived key in the JWKS can route by
+        ``kid`` without ambiguity.
+        """
+        stamp = self.rotated_at.strftime("%Y%m%dT%H%M%SZ")
+        return f"agent-bernstein-orchestrator-{stamp}"
+
+
+class AgentCardKeystore:
+    """File-backed keystore for the orchestrator's agent-card signing key.
+
+    Designed for the single-process Bernstein server: a per-instance lock
+    serialises first-run generation and rotation. Multi-process deployments
+    should either share the directory (and accept the small race on first
+    boot — ``O_EXCL`` guarantees only one writer wins) or pre-provision the
+    keypair before fanout.
+    """
+
+    def __init__(
+        self,
+        key_dir: Path | None = None,
+        *,
+        grace_seconds: int = DEFAULT_GRACE_SECONDS,
+        clock: type[_dt.datetime] | None = None,
+    ) -> None:
+        """Bind a keystore to a directory.
+
+        Args:
+            key_dir: Directory holding the keypair. Defaults to
+                ``.bernstein/keys`` under the current working directory.
+            grace_seconds: How long an archived key stays in the JWKS after
+                rotation. Defaults to 24 hours (matches the published
+                ``Cache-Control: max-age=3600`` on the agent-card route by a
+                comfortable margin).
+            clock: Datetime class providing a ``now(tz=...)`` classmethod.
+                Override for tests that need to advance time without
+                touching real wall-clock state.
+        """
+        self._dir = (key_dir or DEFAULT_KEY_DIR).resolve()
+        self._grace_seconds = max(0, int(grace_seconds))
+        self._clock = clock or _dt.datetime
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public surface
+    # ------------------------------------------------------------------
+
+    @property
+    def directory(self) -> Path:
+        """Resolved on-disk directory for the keypair."""
+        return self._dir
+
+    def load_or_generate(self) -> tuple[bytes, bytes]:
+        """Return the active ``(private_pem, public_pem)`` keypair.
+
+        On first call (or when the keystore directory is empty) generates a
+        fresh keypair atomically with ``O_EXCL`` and ``0o600`` permissions.
+        Subsequent calls re-read from disk so multiple processes converge
+        on the same key — the in-memory cache is intentionally absent here;
+        ``well_known.py`` is the cache layer.
+
+        Raises:
+            PermissionError: When the on-disk private key has wider-than
+                owner-only permissions. Operators must tighten the bits
+                before the orchestrator will use the key.
+        """
+        with self._lock:
+            if not self._private_path.exists() or not self._public_path.exists():
+                self._generate_atomic()
+            return self._load_existing()
+
+    def list_archived(self) -> list[ArchivedKey]:
+        """Return archived keys still inside the grace window.
+
+        Old archive directories beyond the grace window are silently skipped
+        (and may be GC'd by the operator out-of-band). The returned list is
+        sorted oldest → newest so the JWKS publishes a stable order.
+        """
+        archive_dir = self._dir / _ARCHIVE_DIRNAME
+        if not archive_dir.is_dir():
+            return []
+
+        cutoff = self._clock.now(tz=_dt.UTC) - _dt.timedelta(seconds=self._grace_seconds)
+        out: list[ArchivedKey] = []
+        for entry in sorted(archive_dir.iterdir()):
+            if not entry.is_dir():
+                continue
+            rotated_at = self._read_rotated_at(entry)
+            if rotated_at is None or rotated_at < cutoff:
+                continue
+            pub_path = entry / _PUBLIC_FILENAME
+            if not pub_path.is_file():
+                continue
+            try:
+                public_pem = pub_path.read_bytes()
+            except OSError:  # pragma: no cover - filesystem flake
+                logger.warning("agent-card keystore: unreadable archived public key at %s", pub_path)
+                continue
+            out.append(ArchivedKey(public_pem=public_pem, rotated_at=rotated_at))
+        return out
+
+    def rotate(self) -> tuple[bytes, bytes]:
+        """Archive the current keypair and mint a new one.
+
+        Returns the freshly-generated ``(private_pem, public_pem)``. The
+        previous keypair is moved under ``archive/<isoformat>/`` together
+        with a ``rotated_at.txt`` timestamp file so :meth:`list_archived`
+        can read it deterministically.
+        """
+        with self._lock:
+            if self._private_path.exists() or self._public_path.exists():
+                self._archive_existing()
+            self._generate_atomic()
+            return self._load_existing()
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _private_path(self) -> Path:
+        return self._dir / _PRIVATE_FILENAME
+
+    @property
+    def _public_path(self) -> Path:
+        return self._dir / _PUBLIC_FILENAME
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _generate_atomic(self) -> None:
+        """Mint a fresh keypair, refusing to clobber an existing private key.
+
+        Uses ``os.O_EXCL`` so two processes racing into first-run cannot
+        both win — the loser sees ``FileExistsError`` and falls through to
+        :meth:`_load_existing`.
+        """
+        self._dir.mkdir(parents=True, exist_ok=True)
+        private_pem, public_pem = generate_ed25519_keypair()
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        try:
+            fd = os.open(self._private_path, flags, 0o600)
+        except FileExistsError:
+            # Another writer beat us; abandon our generated material.
+            return
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                fh.write(private_pem)
+        except Exception:
+            # Roll back on any failure so subsequent runs can retry cleanly.
+            self._private_path.unlink(missing_ok=True)
+            raise
+
+        # Force the bits even on platforms that ignored the umask.
+        os.chmod(self._private_path, 0o600)
+
+        # Public key may already exist (e.g. half-rolled-back rotation). It's
+        # safe to overwrite — it always derives from the private one.
+        self._public_path.write_bytes(public_pem)
+        os.chmod(self._public_path, 0o644)
+
+    def _load_existing(self) -> tuple[bytes, bytes]:
+        """Return the on-disk keypair, asserting the private file is 0600."""
+        try:
+            stat = os.stat(self._private_path)
+        except FileNotFoundError as exc:
+            msg = f"agent-card private key missing at {self._private_path}"
+            raise FileNotFoundError(msg) from exc
+
+        if stat.st_mode & _PRIVATE_MODE_MASK:
+            msg = (
+                f"agent-card private key {self._private_path} has unsafe permissions "
+                f"{oct(stat.st_mode & 0o777)} — refusing to load. Run "
+                f"'chmod 600 {self._private_path}' and retry."
+            )
+            raise PermissionError(msg)
+
+        return self._private_path.read_bytes(), self._public_path.read_bytes()
+
+    def _archive_existing(self) -> None:
+        """Move the current keypair into ``archive/<utc-isoformat>/``."""
+        rotated_at = self._clock.now(tz=_dt.UTC).replace(microsecond=0)
+        # Folder name uses a filesystem-safe variant of the ISO timestamp.
+        folder = self._dir / _ARCHIVE_DIRNAME / rotated_at.strftime("%Y%m%dT%H%M%SZ")
+        folder.mkdir(parents=True, exist_ok=True)
+
+        if self._private_path.exists():
+            archived_priv = folder / _PRIVATE_FILENAME
+            self._private_path.replace(archived_priv)
+            os.chmod(archived_priv, 0o600)
+
+        if self._public_path.exists():
+            archived_pub = folder / _PUBLIC_FILENAME
+            self._public_path.replace(archived_pub)
+            os.chmod(archived_pub, 0o644)
+
+        (folder / _ROTATED_AT_FILENAME).write_text(rotated_at.isoformat() + "\n", encoding="utf-8")
+
+    @staticmethod
+    def _read_rotated_at(archive_entry: Path) -> _dt.datetime | None:
+        """Return the rotation timestamp recorded inside ``archive_entry``."""
+        stamp_file = archive_entry / _ROTATED_AT_FILENAME
+        if not stamp_file.is_file():
+            # Fall back to the directory name (UTC stamp) for entries written
+            # by older versions or moved by hand.
+            try:
+                return _dt.datetime.strptime(archive_entry.name, "%Y%m%dT%H%M%SZ").replace(
+                    tzinfo=_dt.UTC,
+                )
+            except ValueError:
+                return None
+        try:
+            text = stamp_file.read_text(encoding="utf-8").strip()
+        except OSError:  # pragma: no cover - filesystem flake
+            return None
+        try:
+            return _dt.datetime.fromisoformat(text)
+        except ValueError:
+            return None

--- a/src/bernstein/core/security/agent_card_keystore.py
+++ b/src/bernstein/core/security/agent_card_keystore.py
@@ -18,11 +18,11 @@ Filesystem layout
 
     .bernstein/keys/
         agent-card.ed25519       0600  PKCS#8 PEM private key (current)
-        agent-card.ed25519.pub   0644  SPKI PEM public key  (current)
+        agent-card.ed25519.pub   0600  SPKI PEM public key  (current)
         archive/
             <iso-timestamp>/
                 agent-card.ed25519       0600  rotated-out private
-                agent-card.ed25519.pub   0644  rotated-out public
+                agent-card.ed25519.pub   0600  rotated-out public
                 rotated_at.txt           UTC ISO-8601 timestamp
 
 The JWKS endpoint at ``/.well-known/agent.json/keys`` reads the current
@@ -258,8 +258,11 @@ class AgentCardKeystore:
 
         # Public key may already exist (e.g. half-rolled-back rotation). It's
         # safe to overwrite — it always derives from the private one.
+        # Use owner-only perms even on the public key — external consumers
+        # fetch it via the JWKS HTTP endpoint, never directly off disk, so
+        # there's no operational need to grant other local users FS access.
         self._public_path.write_bytes(public_pem)
-        os.chmod(self._public_path, 0o644)  # lgtm[py/overly-permissive-file-permissions] — public key
+        os.chmod(self._public_path, 0o600)
 
     def _load_existing(self) -> tuple[bytes, bytes]:
         """Return the on-disk keypair, asserting the private file is 0600."""
@@ -294,7 +297,7 @@ class AgentCardKeystore:
         if self._public_path.exists():
             archived_pub = folder / _PUBLIC_FILENAME
             self._public_path.replace(archived_pub)
-            os.chmod(archived_pub, 0o644)  # lgtm[py/overly-permissive-file-permissions] — public key
+            os.chmod(archived_pub, 0o600)
 
         (folder / _ROTATED_AT_FILENAME).write_text(rotated_at.isoformat() + "\n", encoding="utf-8")
 

--- a/src/bernstein/core/security/agent_card_keystore.py
+++ b/src/bernstein/core/security/agent_card_keystore.py
@@ -259,7 +259,7 @@ class AgentCardKeystore:
         # Public key may already exist (e.g. half-rolled-back rotation). It's
         # safe to overwrite — it always derives from the private one.
         self._public_path.write_bytes(public_pem)
-        os.chmod(self._public_path, 0o644)
+        os.chmod(self._public_path, 0o644)  # lgtm[py/overly-permissive-file-permissions] — public key
 
     def _load_existing(self) -> tuple[bytes, bytes]:
         """Return the on-disk keypair, asserting the private file is 0600."""
@@ -294,7 +294,7 @@ class AgentCardKeystore:
         if self._public_path.exists():
             archived_pub = folder / _PUBLIC_FILENAME
             self._public_path.replace(archived_pub)
-            os.chmod(archived_pub, 0o644)
+            os.chmod(archived_pub, 0o644)  # lgtm[py/overly-permissive-file-permissions] — public key
 
         (folder / _ROTATED_AT_FILENAME).write_text(rotated_at.isoformat() + "\n", encoding="utf-8")
 

--- a/src/bernstein/core/security/agent_identity.py
+++ b/src/bernstein/core/security/agent_identity.py
@@ -3,18 +3,101 @@
 Implements OWASP Top 10 for Agentic Applications (2026) requirement for
 verifiable agent identity. Each spawned agent gets an identity card
 declaring its capabilities, denied capabilities, scope, and budget.
+
+A2A v1.0 dataclass migration
+----------------------------
+
+The route layer (``bernstein.core.routes.well_known``) has been emitting
+A2A v1.0 fields (``protocolVersion``, ``supportedInterfaces``,
+``securitySchemes``, ``signatures``) since the JWKS PR — but those fields
+were synthesised at route render time, not stored on
+:class:`AgentIdentityCard` itself. This module now carries them on the
+dataclass so spawned agents can declare them once, sign once, and federate.
+
+Hash compatibility is gated behind the
+``BERNSTEIN_AGENT_CARD_V1_0_HASH=1`` environment flag (``card_hash`` falls
+back to the legacy 16-hex SHA-256 prefix when unset). Until operators flip
+the flag the legacy hash stays bit-for-bit stable so existing HMAC anchors
+keep validating; once the flag flips the hash covers the full v1.0 surface
+including the new fields.
+
+For verifiers that only understand the pre-v1.0 shape, :meth:`AgentIdentityCard.to_legacy_dict`
+strips the v1.0 fields and returns the original 11-key dict — that's the
+shape ``agent_card_signer.sign_agent_card`` consumed before this PR.
+
+The migration is intentionally additive — new fields default to empty
+collections so older callers who construct the dataclass via positional or
+plain ``AgentIdentityCard(**data)`` paths keep working without code
+changes.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import os
 import time
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+#: Environment flag controlling the ``card_hash`` migration. When unset
+#: (the default), ``card_hash`` keeps its pre-v1.0 semantics so existing
+#: HMAC anchors and audit-chain references stay valid. Set to a truthy
+#: value (``1``, ``true``, ``yes``, ``on``) once verifiers have migrated to
+#: the v1.0 hash that covers ``protocol_version``, ``supported_interfaces``,
+#: ``security_schemes``, and ``signatures``.
+AGENT_CARD_V1_0_HASH_ENV: str = "BERNSTEIN_AGENT_CARD_V1_0_HASH"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+#: A2A v1.0 protocol version string emitted on cards by default. The route
+#: layer's ``_PROTOCOL_VERSION`` resolves to the same string — keeping the
+#: literal here makes the dataclass self-contained when used outside the
+#: HTTP server (CLI tools, federation tests).
+A2A_PROTOCOL_VERSION_V1_0: str = "1.0"
+
+#: Default wire formats a Bernstein-spawned agent speaks. The route layer
+#: only emits HTTP+JSON today; cards may declare more once gRPC / JSONRPC
+#: stubs ship.
+DEFAULT_SUPPORTED_INTERFACES: tuple[str, ...] = ("HTTP+JSON",)
+
+#: Pre-v1.0 dataclass field set. Used by :meth:`AgentIdentityCard.to_legacy_dict`
+#: to project a card down to the original shape so verifiers that haven't
+#: migrated keep validating.
+_LEGACY_FIELDS: tuple[str, ...] = (
+    "agent_id",
+    "role",
+    "adapter",
+    "model",
+    "capabilities",
+    "denied_capabilities",
+    "scope",
+    "max_budget_usd",
+    "max_tokens",
+    "max_steps",
+    "budget_mode",
+    "extensions",
+    "created_at",
+    "expires_at",
+)
+
+#: A2A v1.0 fields added by this migration. Their presence on the card
+#: distinguishes v1.0 instances from legacy ones.
+_V1_0_FIELDS: tuple[str, ...] = (
+    "protocol_version",
+    "supported_interfaces",
+    "security_schemes",
+    "signatures",
+)
+
+
+def v1_0_hash_enabled() -> bool:
+    """Return True when the v1.0 hash migration is active for this process."""
+    return os.environ.get(AGENT_CARD_V1_0_HASH_ENV, "").strip().lower() in _TRUTHY
+
 
 #: Claude Opus 4.7 task-budgets beta header value. Sent on the
 #: ``anthropic-beta`` API header (and ``ANTHROPIC_BETA`` env var for
@@ -65,6 +148,54 @@ DEFAULT_DENIED: dict[str, list[str]] = {
 
 
 @dataclass
+class InterfaceSpec:
+    """Single A2A v1.0 ``supportedInterfaces[]`` entry.
+
+    Today the route layer only declares HTTP+JSON. Spawned agents that
+    federate via gRPC or JSON-RPC will populate further entries; the field
+    is a structured dataclass instead of a bare string so additional
+    metadata (transport version, content-type) can land without a schema
+    break.
+    """
+
+    name: str
+    version: str = "1.0"
+    description: str = ""
+
+
+@dataclass
+class SecurityScheme:
+    """Single A2A v1.0 ``securitySchemes[]`` entry.
+
+    Mirrors the route-level shape — verifiers consume the same dict either
+    way, so dataclass-generated cards can be served straight to clients.
+    """
+
+    id: str
+    type: str
+    scheme: str = ""
+    description: str = ""
+    required: bool = False
+
+
+@dataclass
+class Signature:
+    """Single A2A v1.0 ``signatures[]`` entry.
+
+    Carries the detached JWS produced by ``agent_card_signer.sign_agent_card``
+    along with the metadata verifiers need to route by ``kid`` against the
+    ``/.well-known/agent.json/keys`` JWKS endpoint. The compact JWS string
+    is RFC 7515 §A.5 (header..signature, empty payload) over the JCS
+    canonicalisation of the card body.
+    """
+
+    kid: str
+    alg: str = "EdDSA"
+    typ: str = "agent-card+jws"
+    jws: str = ""
+
+
+@dataclass
 class AgentIdentityCard:
     agent_id: str
     role: str
@@ -91,12 +222,54 @@ class AgentIdentityCard:
     created_at: float = field(default_factory=time.time)
     expires_at: float = 0.0
 
+    # ------------------------------------------------------------------
+    # A2A v1.0 fields (additive — default to empty so legacy callers still
+    # work via plain ``AgentIdentityCard(**data)`` round-trips).
+    # ------------------------------------------------------------------
+    #: Protocol version this card declares. Empty string keeps pre-v1.0
+    #: semantics; new code should set to ``A2A_PROTOCOL_VERSION_V1_0``.
+    protocol_version: str = ""
+    supported_interfaces: list[InterfaceSpec] = field(default_factory=list)
+    security_schemes: list[SecurityScheme] = field(default_factory=list)
+    signatures: list[Signature] = field(default_factory=list)
+
     def to_json(self) -> str:
         return json.dumps(asdict(self), sort_keys=True)
 
+    def to_legacy_dict(self) -> dict[str, Any]:
+        """Return the pre-v1.0 dict shape (no ``protocol_version`` etc.).
+
+        Use when sending the card to a verifier that only understands the
+        original 11-key card shape. The result is byte-identical to what
+        ``asdict(self)`` would have produced before the v1.0 migration so
+        ``agent_card_signer.sign_agent_card`` can keep verifying tools that
+        haven't upgraded.
+        """
+        full = asdict(self)
+        return {key: full[key] for key in _LEGACY_FIELDS if key in full}
+
+    def to_v1_dict(self) -> dict[str, Any]:
+        """Return the full A2A v1.0 dict shape including the new fields.
+
+        Symmetric counterpart to :meth:`to_legacy_dict`; equivalent to
+        ``asdict(self)`` today but kept as an explicit alias so callers
+        signal intent ("I want the v1.0 surface, not whatever asdict
+        currently emits") and so future field changes can be gated here.
+        """
+        return asdict(self)
+
     @property
     def card_hash(self) -> str:
-        return hashlib.sha256(self.to_json().encode()).hexdigest()[:16]
+        """Stable 16-hex SHA-256 prefix over the card body.
+
+        Default semantics keep the legacy 11-field hash so HMAC anchors and
+        audit-chain references stay bit-stable. Set
+        ``BERNSTEIN_AGENT_CARD_V1_0_HASH=1`` to migrate to the v1.0 hash
+        that covers the new fields.
+        """
+        payload = self.to_v1_dict() if v1_0_hash_enabled() else self.to_legacy_dict()
+        body = json.dumps(payload, sort_keys=True).encode()
+        return hashlib.sha256(body).hexdigest()[:16]
 
     def has_capability(self, name: str) -> bool:
         if name in self.denied_capabilities:
@@ -148,12 +321,43 @@ def save_identity_card(card: AgentIdentityCard, runtime_dir: Path) -> Path:
 
 
 def load_identity_card(agent_id: str, runtime_dir: Path) -> AgentIdentityCard | None:
-    """Load a previously issued identity card, or None if not found."""
+    """Load a previously issued identity card, or None if not found.
+
+    Coerces the v1.0 nested fields (``supported_interfaces``,
+    ``security_schemes``, ``signatures``) back to their dataclass instances
+    so callers can rely on attribute access. Pre-v1.0 cards on disk (those
+    that pre-date the migration and lack these keys) load just as before
+    because the new fields default to empty.
+    """
     path = runtime_dir / "agents" / agent_id / "identity.json"
     if not path.exists():
         return None
-    data = json.loads(path.read_text())
-    return AgentIdentityCard(**data)
+    data: dict[str, Any] = json.loads(path.read_text())
+    return _hydrate_card(data)
+
+
+def _hydrate_card(data: dict[str, Any]) -> AgentIdentityCard:
+    """Rebuild an :class:`AgentIdentityCard` from its JSON-serialised form.
+
+    Coerces the v1.0 nested fields if present; ignores extra keys instead of
+    raising so a forward-compatible ``identity.json`` written by a newer
+    Bernstein release can still load on an older one.
+    """
+    interfaces_raw = data.get("supported_interfaces") or []
+    schemes_raw = data.get("security_schemes") or []
+    sigs_raw = data.get("signatures") or []
+
+    payload = {key: data[key] for key in _LEGACY_FIELDS if key in data}
+    if "protocol_version" in data:
+        payload["protocol_version"] = data["protocol_version"]
+    payload["supported_interfaces"] = [
+        InterfaceSpec(**entry) if isinstance(entry, dict) else entry for entry in interfaces_raw
+    ]
+    payload["security_schemes"] = [
+        SecurityScheme(**entry) if isinstance(entry, dict) else entry for entry in schemes_raw
+    ]
+    payload["signatures"] = [Signature(**entry) if isinstance(entry, dict) else entry for entry in sigs_raw]
+    return AgentIdentityCard(**payload)
 
 
 def check_capability(card: AgentIdentityCard, capability: str) -> tuple[bool, str]:

--- a/src/bernstein/core/security/auth.py
+++ b/src/bernstein/core/security/auth.py
@@ -343,6 +343,20 @@ class SSOConfig(BaseSettings):
     # Env vars provide a simple comma-separated list: "admins=admin,devs=operator"
     group_role_map: str = ""  # "group1=admin,group2=operator,group3=viewer"
 
+    # RFC 8707 resource indicator(s) the orchestrator expects in tokens.
+    #
+    # When set, any bearer JWT carrying a ``resource`` claim must match one
+    # of the configured values; mismatches are rejected with HTTP 401 and a
+    # ``WWW-Authenticate`` header per RFC 6750. When unset (the default)
+    # the middleware treats the claim as advisory and skips the check, so
+    # existing deployments do not break on upgrade.
+    #
+    # Supplied as a comma-separated list in env vars
+    # (``BERNSTEIN_AUTH_EXPECTED_RESOURCE="https://a.example,https://b.example"``)
+    # or as a single string. Any-match semantics — the token only has to
+    # match one entry in the list.
+    expected_resource: str = ""
+
     # Sub-configs
     oidc: OIDCConfig = Field(default_factory=OIDCConfig)
     saml: SAMLConfig = Field(default_factory=SAMLConfig)

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -8,6 +8,7 @@ that supports:
 - Public path exemptions (health, discovery, login flow)
 - HMAC-authenticated path exemptions (webhooks/hooks validate their own HMAC)
 - User context injection into request.state
+- RFC 8707 resource-indicator validation (audience binding for OAuth tokens)
 
 Secure-by-default
 -----------------
@@ -25,6 +26,19 @@ from the URL path for mutating operations (complete, fail, progress, cancel,
 block) and validates that the task ID appears in the token's ``task_ids``
 claim.  A token without a task scope (``task_ids == []``) is treated as
 unrestricted (manager / orchestrator tokens).
+
+RFC 8707 resource indicators
+----------------------------
+When ``expected_resource`` is configured (single string or list passed to
+:class:`SSOAuthMiddleware`, or ``BERNSTEIN_AUTH_EXPECTED_RESOURCE`` env var,
+or ``auth.expected_resource`` in :class:`SSOConfig`), bearer JWTs that
+carry a ``resource`` claim must match one of the configured values.
+Mismatches are rejected with HTTP 401 and the RFC 6750 ``WWW-Authenticate``
+challenge ``Bearer error="invalid_token", error_description="resource indicator mismatch"``.
+Tokens that omit the claim entirely pass through — the middleware does
+not retroactively require an indicator on legacy tokens. The check is
+skipped wholesale when ``expected_resource`` is unset so upgrading does
+not break deployments minting opaque non-OAuth tokens.
 """
 
 from __future__ import annotations
@@ -134,6 +148,16 @@ _AUTH_DISABLED_TRUTHY = frozenset({"1", "true", "yes", "on"})
 # Read-only methods that viewers can access
 _READ_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
+# Environment override for the configured RFC 8707 resource indicator(s).
+# Comma-separated; empty disables the check entirely (legacy behaviour).
+AUTH_EXPECTED_RESOURCE_ENV = "BERNSTEIN_AUTH_EXPECTED_RESOURCE"
+
+# RFC 6750 §3 challenge for an audience-mismatched token. Issuer and
+# wording match RFC 8707 §3 ("resource indicator mismatch") so well-known
+# OAuth clients can react with a deterministic error reason.
+_RESOURCE_MISMATCH_CHALLENGE = 'Bearer error="invalid_token", error_description="resource indicator mismatch"'
+_RESOURCE_MALFORMED_CHALLENGE = 'Bearer error="invalid_token", error_description="malformed resource indicator"'
+
 # Route → required permission mapping for write operations.
 #
 # Every write endpoint that Bernstein exposes MUST have an explicit entry
@@ -155,6 +179,95 @@ _ROUTE_PERMISSIONS: dict[str, str] = {
     "/broadcast": _PERM_ADMIN_MANAGE,
     "/drain": _PERM_ADMIN_MANAGE,
 }
+
+
+def _normalise_expected_resource(raw: str | list[str] | tuple[str, ...] | None) -> tuple[str, ...]:
+    """Coerce ``expected_resource`` into a tuple of trimmed values.
+
+    Accepts:
+        - ``None`` or empty string → ``()`` (disables the check).
+        - Single non-empty string → ``(value,)``.
+        - Comma-separated string (e.g. ``"https://a,https://b"``) → tuple
+          of trimmed entries with empty segments stripped.
+        - ``list``/``tuple`` of strings → trimmed tuple.
+
+    The tuple is then matched any-of against the token's ``resource``
+    claim by :func:`_resource_indicator_check`.
+    """
+    if raw is None:
+        return ()
+    if isinstance(raw, list | tuple):
+        return tuple(item.strip() for item in raw if item and item.strip())
+    text = raw.strip()
+    if not text:
+        return ()
+    if "," in text:
+        return tuple(part.strip() for part in text.split(",") if part.strip())
+    return (text,)
+
+
+def expected_resource_from_env() -> tuple[str, ...]:
+    """Resolve the env-var override for the configured resource indicator."""
+    return _normalise_expected_resource(os.environ.get(AUTH_EXPECTED_RESOURCE_ENV, ""))
+
+
+def _resource_indicator_check(
+    claims: dict[str, Any],
+    expected: tuple[str, ...],
+) -> JSONResponse | None:
+    """Validate the JWT's ``resource`` claim against the configured indicators.
+
+    Returns:
+        * ``None`` when the check passes (claim missing, or claim matches
+          one of the expected values, or the indicator is unconfigured).
+        * A :class:`JSONResponse` (HTTP 401) when the claim is malformed or
+          mismatches every configured value. The response carries the
+          RFC 6750 ``WWW-Authenticate`` challenge so OAuth clients can
+          react deterministically.
+
+    Args:
+        claims: Decoded JWT claims dict.
+        expected: Tuple of acceptable resource URIs.  Empty disables the
+            check entirely (legacy behaviour).
+    """
+    if not expected:
+        return None
+
+    resource = claims.get("resource")
+    if resource is None:
+        # Legacy tokens that pre-date RFC 8707 stay valid; the orchestrator
+        # only enforces the audience binding when the claim is actually
+        # present. Enforcing it on every token would lock out existing
+        # legacy bearer flows on upgrade.
+        return None
+
+    # RFC 8707 §2 allows ``resource`` to be a single URI string or a JSON
+    # array of URI strings. Anything else is malformed.
+    if isinstance(resource, str):
+        candidates: tuple[str, ...] = (resource,)
+    elif isinstance(resource, list) and all(isinstance(item, str) for item in resource):
+        candidates = tuple(resource)
+    else:
+        return JSONResponse(
+            status_code=401,
+            content={
+                "detail": "Token resource indicator is not a string or array of strings",
+            },
+            headers={"WWW-Authenticate": _RESOURCE_MALFORMED_CHALLENGE},
+        )
+
+    if any(candidate in expected for candidate in candidates):
+        return None
+
+    return JSONResponse(
+        status_code=401,
+        content={
+            "detail": "Token resource indicator does not match this orchestrator",
+            "expected": list(expected),
+            "actual": list(candidates),
+        },
+        headers={"WWW-Authenticate": _RESOURCE_MISMATCH_CHALLENGE},
+    )
 
 
 def auth_disabled_via_opt_out() -> bool:
@@ -242,6 +355,7 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         legacy_token: str | None = None,
         agent_identity_store: AgentIdentityStore | None = None,
         auth_disabled: bool | None = None,
+        expected_resource: str | list[str] | tuple[str, ...] | None = None,
     ) -> None:
         super().__init__(app)
         self._auth_service = auth_service
@@ -252,6 +366,11 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         resolved_disabled = bool(auth_disabled) or auth_disabled_via_opt_out()
         self._auth_disabled = resolved_disabled
         self._auth_configured = self._compute_auth_configured()
+        # RFC 8707 resource-indicator binding. Explicit constructor arg
+        # wins; env var falls back. Empty tuple disables the check.
+        self._expected_resource: tuple[str, ...] = (
+            _normalise_expected_resource(expected_resource) or expected_resource_from_env()
+        )
         if resolved_disabled and not SSOAuthMiddleware._warned_disabled:
             logger.warning(
                 "SECURITY: Bernstein auth is DISABLED — every request is "
@@ -369,6 +488,19 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
             return None
 
         user, claims = result
+
+        # RFC 8707: reject SSO tokens minted for a different audience before
+        # the request reaches its handler. Skipped when ``expected_resource``
+        # is unconfigured, or when the token omits the claim entirely.
+        resource_error = _resource_indicator_check(claims, self._expected_resource)
+        if resource_error is not None:
+            logger.warning(
+                "SSO token rejected: resource indicator mismatch (path=%s, expected=%s)",
+                path,
+                self._expected_resource,
+            )
+            return resource_error
+
         request.state.user = user  # type: ignore[attr-defined]
         request.state.auth_claims = claims  # type: ignore[attr-defined]
 
@@ -395,6 +527,24 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         agent_identity = self._agent_identity_store.authenticate(token)
         if agent_identity is None:
             return None
+
+        # RFC 8707: enforce the resource-indicator binding on the agent JWT
+        # itself. ``authenticate`` has already verified the signature, so
+        # decoding the unverified body here is safe — the body bytes have
+        # already been authenticated against the JWT secret.
+        if self._expected_resource:
+            from bernstein.core.security.auth import decode_jwt_unverified
+
+            agent_claims = decode_jwt_unverified(token) or {}
+            resource_error = _resource_indicator_check(agent_claims, self._expected_resource)
+            if resource_error is not None:
+                logger.warning(
+                    "Agent %s denied: resource indicator mismatch (path=%s, expected=%s)",
+                    agent_identity.id,
+                    path,
+                    self._expected_resource,
+                )
+                return resource_error
 
         request.state.user = None  # type: ignore[attr-defined]
         request.state.auth_claims = {  # type: ignore[attr-defined]

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -1080,12 +1080,19 @@ def create_app(
     _agent_identity_store = AgentIdentityStore(_auth_dir)
     application.state.identity_store = _agent_identity_store  # type: ignore[attr-defined]
 
+    # RFC 8707: optional resource-indicator binding. Configured via the
+    # ``BERNSTEIN_AUTH_EXPECTED_RESOURCE`` env var or
+    # ``auth.expected_resource`` (comma-separated for multi-audience setups).
+    # Empty string disables the check (legacy behaviour).
+    expected_resource = auth_config.expected_resource or None
+
     application.add_middleware(
         SSOAuthMiddleware,
         auth_service=auth_service,
         legacy_token=legacy_auth_token,
         agent_identity_store=_agent_identity_store,
         auth_disabled=auth_disabled_flag,
+        expected_resource=expected_resource,
     )
 
     # Per-endpoint request rate limiting — reads buckets from app.state.seed_config.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,33 @@ def _disable_auth_for_tests(request: pytest.FixtureRequest, monkeypatch: pytest.
 
 
 @pytest.fixture(autouse=True)
+def _isolate_agent_card_keystore(
+    tmp_path_factory: pytest.TempPathFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Point the persistent A2A v1.0 agent-card keystore at a per-test tmpdir.
+
+    The keystore (``bernstein.core.routes.well_known._KEYSTORE``) is process
+    global — without isolation, a single test that pointed it at a
+    ``tmp_path`` directory would leave the cache holding a now-deleted path
+    once pytest cleaned the dir up. Subsequent tests would then hang on the
+    first ``/.well-known/agent.json`` GET as the keystore tried to read its
+    vanished private key.
+
+    Override the env var so every test gets a fresh, durable directory in
+    the per-session tmpdir, and explicitly reset the in-process cache so
+    older tests' bindings don't bleed through.
+    """
+    key_dir = tmp_path_factory.mktemp("agent-card-keys")
+    monkeypatch.setenv("BERNSTEIN_AGENT_CARD_KEY_DIR", str(key_dir))
+    # Reset both the global keystore binding and the cached PEM bytes so the
+    # next call to ``_get_signing_keypair`` re-binds to the freshly-set env.
+    from bernstein.core.routes import well_known as _wk
+
+    _wk._reset_signing_keypair_for_tests(key_dir)
+
+
+@pytest.fixture(autouse=True)
 def _init_git_repo_for_spawner_tmp_path_tests(request: pytest.FixtureRequest) -> None:
     """Initialize a minimal git repo for AgentSpawner tests that use ``tmp_path``.
 

--- a/tests/unit/test_agent_card_keystore.py
+++ b/tests/unit/test_agent_card_keystore.py
@@ -1,0 +1,192 @@
+"""Tests for ``agent_card_keystore`` — persistent Ed25519 keypair + rotation."""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.agent_card_keystore import (
+    DEFAULT_GRACE_SECONDS,
+    AgentCardKeystore,
+)
+
+# ---------------------------------------------------------------------------
+# First-run generation
+# ---------------------------------------------------------------------------
+
+
+class TestFirstRun:
+    def test_creates_pem_pair_on_first_call(self, tmp_path: Path) -> None:
+        ks = AgentCardKeystore(tmp_path / "keys")
+        priv, pub = ks.load_or_generate()
+        assert priv.startswith(b"-----BEGIN PRIVATE KEY-----")
+        assert pub.startswith(b"-----BEGIN PUBLIC KEY-----")
+        assert (tmp_path / "keys" / "agent-card.ed25519").is_file()
+        assert (tmp_path / "keys" / "agent-card.ed25519.pub").is_file()
+
+    def test_private_file_is_owner_only_0600(self, tmp_path: Path) -> None:
+        """Persistent private key must be ``0o600`` (owner-only).
+
+        Anything wider leaks the signing key to any local user — the
+        keystore explicitly enforces the permission bits both at
+        generation time and on every load.
+        """
+        ks = AgentCardKeystore(tmp_path / "keys")
+        ks.load_or_generate()
+
+        priv = tmp_path / "keys" / "agent-card.ed25519"
+        mode = priv.stat().st_mode & 0o777
+        assert mode == 0o600, f"private key permissions are {oct(mode)}, expected 0o600"
+
+    def test_uses_o_excl_so_two_processes_cannot_clobber(self, tmp_path: Path) -> None:
+        """Concurrent first-run callers must not race over the same file.
+
+        We simulate the race by pre-creating an ``O_EXCL``-occupied file —
+        the keystore must refuse to clobber it and instead read the
+        existing key on the next call.
+        """
+        ks = AgentCardKeystore(tmp_path / "keys")
+        priv_path = tmp_path / "keys" / "agent-card.ed25519"
+        pub_path = tmp_path / "keys" / "agent-card.ed25519.pub"
+        priv_path.parent.mkdir(parents=True)
+        # First writer wins.
+        priv_a, pub_a = ks.load_or_generate()
+        # A second keystore bound to the same dir reads the same bytes
+        # rather than overwriting.
+        ks2 = AgentCardKeystore(tmp_path / "keys")
+        priv_b, pub_b = ks2.load_or_generate()
+        assert priv_a == priv_b
+        assert pub_a == pub_b
+        assert priv_path.exists()
+        assert pub_path.exists()
+
+    def test_load_refuses_unsafe_permissions(self, tmp_path: Path) -> None:
+        """A private file with group/world perms must raise on load."""
+        ks = AgentCardKeystore(tmp_path / "keys")
+        ks.load_or_generate()
+        priv = tmp_path / "keys" / "agent-card.ed25519"
+        os.chmod(priv, 0o644)
+        ks2 = AgentCardKeystore(tmp_path / "keys")
+        with pytest.raises(PermissionError):
+            ks2.load_or_generate()
+
+
+# ---------------------------------------------------------------------------
+# Atomic re-load
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicReload:
+    def test_second_call_returns_same_keypair(self, tmp_path: Path) -> None:
+        """Subsequent ``load_or_generate`` calls must reuse the on-disk key."""
+        ks = AgentCardKeystore(tmp_path / "keys")
+        priv_a, pub_a = ks.load_or_generate()
+        priv_b, pub_b = ks.load_or_generate()
+        assert priv_a == priv_b
+        assert pub_a == pub_b
+
+    def test_separate_keystore_instance_reads_same_keypair(self, tmp_path: Path) -> None:
+        """Restarting the orchestrator (new keystore instance) must reuse the key."""
+        ks_a = AgentCardKeystore(tmp_path / "keys")
+        priv_a, pub_a = ks_a.load_or_generate()
+
+        ks_b = AgentCardKeystore(tmp_path / "keys")
+        priv_b, pub_b = ks_b.load_or_generate()
+        assert priv_a == priv_b
+        assert pub_a == pub_b
+
+
+# ---------------------------------------------------------------------------
+# Rotation + grace window
+# ---------------------------------------------------------------------------
+
+
+class _FrozenClock:
+    """Datetime stand-in driven by the test, so rotation timestamps are stable."""
+
+    instant: _dt.datetime
+
+    def __init__(self, instant: _dt.datetime) -> None:
+        self.instant = instant
+
+    @classmethod
+    def now(cls, tz: _dt.tzinfo | None = None) -> _dt.datetime:
+        return cls.instant
+
+
+class TestRotation:
+    def test_rotate_archives_previous_and_mints_new(self, tmp_path: Path) -> None:
+        ks = AgentCardKeystore(tmp_path / "keys")
+        priv_a, pub_a = ks.load_or_generate()
+
+        priv_b, pub_b = ks.rotate()
+        assert priv_a != priv_b, "rotation must produce a fresh private key"
+        assert pub_a != pub_b, "rotation must produce a fresh public key"
+        archive_dir = tmp_path / "keys" / "archive"
+        assert archive_dir.is_dir()
+        # One archive entry per rotation.
+        archived = sorted(archive_dir.iterdir())
+        assert len(archived) == 1
+        assert (archived[0] / "agent-card.ed25519.pub").is_file()
+        assert (archived[0] / "rotated_at.txt").is_file()
+
+    def test_jwks_grace_window_includes_archived_key(self, tmp_path: Path) -> None:
+        """An archived key minted within the grace window stays in JWKS.
+
+        Verifiers cached on the previous JWKS keep validating until their
+        HTTP cache (max-age=3600 on the agent.json route) ages out and they
+        refetch the fresh keys list.
+        """
+        clock_class = type(
+            "_PinnedClock",
+            (_FrozenClock,),
+            {"instant": _dt.datetime(2026, 5, 1, 12, 0, 0, tzinfo=_dt.UTC)},
+        )
+        ks = AgentCardKeystore(tmp_path / "keys", clock=clock_class)
+        ks.load_or_generate()
+        ks.rotate()
+
+        archived = ks.list_archived()
+        assert len(archived) == 1
+        # The archived ``kid`` carries the rotation timestamp so the JWKS
+        # entry is unambiguous.
+        assert archived[0].kid.startswith("agent-bernstein-orchestrator-")
+        # Public key must round-trip through PEM.
+        assert archived[0].public_pem.startswith(b"-----BEGIN PUBLIC KEY-----")
+
+    def test_archived_key_drops_after_grace_window(self, tmp_path: Path) -> None:
+        """An archived key whose ``rotated_at`` is older than the grace window
+        must drop out of the JWKS so verifiers stop trusting it."""
+        rotation_time = _dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=_dt.UTC)
+
+        rotation_clock = type("_C1", (_FrozenClock,), {"instant": rotation_time})
+        ks_rotate = AgentCardKeystore(tmp_path / "keys", clock=rotation_clock)
+        ks_rotate.load_or_generate()
+        ks_rotate.rotate()
+
+        # Bind a second keystore whose clock is 25h past the rotation —
+        # outside the default 24h grace window.
+        future = rotation_time + _dt.timedelta(seconds=DEFAULT_GRACE_SECONDS + 3600)
+        future_clock = type("_C2", (_FrozenClock,), {"instant": future})
+        ks_after = AgentCardKeystore(tmp_path / "keys", clock=future_clock)
+        assert ks_after.list_archived() == []
+
+    def test_rotated_private_key_keeps_0600_permissions(self, tmp_path: Path) -> None:
+        """The freshly-minted post-rotation private must be 0600 too."""
+        ks = AgentCardKeystore(tmp_path / "keys")
+        ks.load_or_generate()
+        ks.rotate()
+        priv = tmp_path / "keys" / "agent-card.ed25519"
+        mode = priv.stat().st_mode & 0o777
+        assert mode == 0o600
+
+        # Archived private should also retain restrictive bits.
+        archived_priv = next((tmp_path / "keys" / "archive").iterdir()) / "agent-card.ed25519"
+        archived_mode = stat.S_IMODE(archived_priv.stat().st_mode)
+        assert archived_mode == 0o600

--- a/tests/unit/test_agent_identity_v1_migration.py
+++ b/tests/unit/test_agent_identity_v1_migration.py
@@ -1,0 +1,217 @@
+"""Tests for the AgentIdentityCard v1.0 dataclass migration.
+
+Covers the new ``protocol_version`` / ``supported_interfaces`` /
+``security_schemes`` / ``signatures`` fields, the ``to_legacy_dict``
+back-compat shim, and the feature-flagged hash migration.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.agent_identity import (
+    A2A_PROTOCOL_VERSION_V1_0,
+    AGENT_CARD_V1_0_HASH_ENV,
+    AgentIdentityCard,
+    InterfaceSpec,
+    SecurityScheme,
+    Signature,
+    issue_identity_card,
+    load_identity_card,
+    save_identity_card,
+)
+
+
+def _legacy_card() -> AgentIdentityCard:
+    """A pre-v1.0-shaped card (no v1.0 fields populated)."""
+    return issue_identity_card(
+        agent_id="claude-backend-v1mig",
+        role="backend",
+        adapter="claude-cli",
+        model="claude-opus-4-7",
+        scope=["src/"],
+        max_budget_usd=4.0,
+        ttl_seconds=600,
+    )
+
+
+def _v1_card() -> AgentIdentityCard:
+    """A v1.0-shaped card with all new fields populated."""
+    card = _legacy_card()
+    card.protocol_version = A2A_PROTOCOL_VERSION_V1_0
+    card.supported_interfaces = [InterfaceSpec(name="HTTP+JSON", version="1.0")]
+    card.security_schemes = [
+        SecurityScheme(id="bearer-jwt", type="http", scheme="Bearer", required=True),
+    ]
+    card.signatures = [Signature(kid="agent-claude-backend-v1mig", jws="abc..xyz")]
+    return card
+
+
+# ---------------------------------------------------------------------------
+# v1.0 fields exist on the dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestV1Fields:
+    def test_default_card_has_empty_v1_fields(self) -> None:
+        card = _legacy_card()
+        assert card.protocol_version == ""
+        assert card.supported_interfaces == []
+        assert card.security_schemes == []
+        assert card.signatures == []
+
+    def test_v1_fields_round_trip_through_to_json(self) -> None:
+        card = _v1_card()
+        data = json.loads(card.to_json())
+        assert data["protocol_version"] == "1.0"
+        assert data["supported_interfaces"] == [{"name": "HTTP+JSON", "version": "1.0", "description": ""}]
+        assert data["security_schemes"][0]["id"] == "bearer-jwt"
+        assert data["signatures"][0]["typ"] == "agent-card+jws"
+
+    def test_load_identity_card_rebuilds_v1_dataclasses(self, tmp_path: Path) -> None:
+        """Loading a saved card must coerce nested dicts back to dataclass instances."""
+        runtime = tmp_path / "runtime"
+        save_identity_card(_v1_card(), runtime)
+        loaded = load_identity_card("claude-backend-v1mig", runtime)
+        assert loaded is not None
+        assert isinstance(loaded.supported_interfaces[0], InterfaceSpec)
+        assert isinstance(loaded.security_schemes[0], SecurityScheme)
+        assert isinstance(loaded.signatures[0], Signature)
+        assert loaded.protocol_version == "1.0"
+
+    def test_load_legacy_card_still_works(self, tmp_path: Path) -> None:
+        """Pre-v1.0 ``identity.json`` on disk must keep loading post-migration."""
+        runtime = tmp_path / "runtime"
+        save_identity_card(_legacy_card(), runtime)
+        # Strip the v1.0 keys to mimic an older Bernstein release's output.
+        path = runtime / "agents" / "claude-backend-v1mig" / "identity.json"
+        legacy_data = {
+            k: v
+            for k, v in json.loads(path.read_text()).items()
+            if k not in {"protocol_version", "supported_interfaces", "security_schemes", "signatures"}
+        }
+        path.write_text(json.dumps(legacy_data))
+
+        loaded = load_identity_card("claude-backend-v1mig", runtime)
+        assert loaded is not None
+        assert loaded.protocol_version == ""
+        assert loaded.supported_interfaces == []
+
+
+# ---------------------------------------------------------------------------
+# to_legacy_dict — back-compat shim
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyDict:
+    def test_to_legacy_dict_strips_v1_fields(self) -> None:
+        card = _v1_card()
+        legacy = card.to_legacy_dict()
+        for excluded in ("protocol_version", "supported_interfaces", "security_schemes", "signatures"):
+            assert excluded not in legacy
+
+    def test_to_legacy_dict_preserves_pre_v1_keys(self) -> None:
+        card = _v1_card()
+        legacy = card.to_legacy_dict()
+        for required in (
+            "agent_id",
+            "role",
+            "adapter",
+            "model",
+            "capabilities",
+            "denied_capabilities",
+            "scope",
+            "max_budget_usd",
+            "max_tokens",
+            "max_steps",
+            "budget_mode",
+            "extensions",
+            "created_at",
+            "expires_at",
+        ):
+            assert required in legacy, required
+
+
+# ---------------------------------------------------------------------------
+# card_hash — feature-flagged migration
+# ---------------------------------------------------------------------------
+
+
+class TestCardHashMigration:
+    def test_default_hash_is_legacy_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without the flag, ``card_hash`` is the pre-v1.0 SHA-256 prefix."""
+        monkeypatch.delenv(AGENT_CARD_V1_0_HASH_ENV, raising=False)
+        card = _v1_card()
+
+        legacy_payload = json.dumps(card.to_legacy_dict(), sort_keys=True).encode()
+        expected_legacy = hashlib.sha256(legacy_payload).hexdigest()[:16]
+        assert card.card_hash == expected_legacy
+
+    def test_v1_flag_switches_hash_to_full_surface(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With the flag, ``card_hash`` covers the v1.0 fields too."""
+        monkeypatch.setenv(AGENT_CARD_V1_0_HASH_ENV, "1")
+        card = _v1_card()
+
+        v1_payload = json.dumps(card.to_v1_dict(), sort_keys=True).encode()
+        expected_v1 = hashlib.sha256(v1_payload).hexdigest()[:16]
+        assert card.card_hash == expected_v1
+
+    def test_legacy_card_hash_stable_across_v1_field_addition(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A card that pre-dates the v1.0 fields must still hash the same.
+
+        This is the migration safety guarantee — adding empty v1.0 fields
+        to a previously-created card must not change ``card_hash`` while
+        the flag is off.
+        """
+        monkeypatch.delenv(AGENT_CARD_V1_0_HASH_ENV, raising=False)
+        legacy = _legacy_card()
+        v1_blank = AgentIdentityCard(
+            agent_id=legacy.agent_id,
+            role=legacy.role,
+            adapter=legacy.adapter,
+            model=legacy.model,
+            capabilities=legacy.capabilities,
+            denied_capabilities=legacy.denied_capabilities,
+            scope=legacy.scope,
+            max_budget_usd=legacy.max_budget_usd,
+            max_tokens=legacy.max_tokens,
+            max_steps=legacy.max_steps,
+            budget_mode=legacy.budget_mode,
+            extensions=legacy.extensions,
+            created_at=legacy.created_at,
+            expires_at=legacy.expires_at,
+            # v1.0 fields default to empty.
+        )
+        assert legacy.card_hash == v1_blank.card_hash
+
+    def test_v1_flag_off_ignores_v1_fields_in_hash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Adding v1.0 fields to a card must not flip the legacy hash.
+
+        Two cards that differ only in v1.0 fields must hash identically
+        when the flag is off — that's how operators safely populate the
+        new fields ahead of flipping the migration switch.
+        """
+        monkeypatch.delenv(AGENT_CARD_V1_0_HASH_ENV, raising=False)
+        no_v1 = _legacy_card()
+        with_v1 = _v1_card()
+        # Force identical timestamps so only the v1.0 fields differ.
+        with_v1.created_at = no_v1.created_at
+        with_v1.expires_at = no_v1.expires_at
+        assert no_v1.card_hash == with_v1.card_hash
+
+    def test_v1_flag_on_distinguishes_v1_field_changes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Once the flag is on, mutating a v1.0 field must change the hash."""
+        monkeypatch.setenv(AGENT_CARD_V1_0_HASH_ENV, "1")
+        a = _v1_card()
+        b = _v1_card()
+        b.signatures = [Signature(kid="rotated-kid", jws="abc..xyz")]
+        # Identical timestamps → only the signatures field differs.
+        b.created_at = a.created_at
+        b.expires_at = a.expires_at
+        assert a.card_hash != b.card_hash

--- a/tests/unit/test_auth_middleware_resource_indicator.py
+++ b/tests/unit/test_auth_middleware_resource_indicator.py
@@ -1,0 +1,275 @@
+"""Tests for RFC 8707 resource indicator validation in ``SSOAuthMiddleware``.
+
+Covers:
+- A token with a matching ``resource`` claim passes through.
+- A token with a mismatched ``resource`` claim is rejected with HTTP 401
+  and the RFC 6750 ``WWW-Authenticate: Bearer error="invalid_token"`` header.
+- Unset configuration skips the check entirely so existing deployments
+  don't break.
+- A list of expected resources allows any-match.
+- A malformed ``resource`` claim is rejected with the malformed challenge.
+- Tokens that omit the claim entirely pass through (legacy bearer flows).
+"""
+
+# pyright: reportPrivateUsage=false, reportUntypedFunctionDecorator=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from bernstein.core.security.auth import (
+    AuthService,
+    AuthStore,
+    AuthUser,
+    SSOConfig,
+    create_jwt,
+)
+from bernstein.core.security.auth_middleware import (
+    AUTH_EXPECTED_RESOURCE_ENV,
+    SSOAuthMiddleware,
+    _normalise_expected_resource,
+    expected_resource_from_env,
+)
+
+pytestmark = pytest.mark.auth_enabled
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_sso(tmp_path: Path) -> tuple[AuthService, str, str]:
+    """Build a minimal SSO auth service and a valid JWT for it.
+
+    Returns:
+        ``(auth_service, jwt_secret, valid_token)``. The token has
+        ``sub=test-user``; tests further customise extra claims (notably
+        ``resource``) via ``create_jwt`` calls of their own.
+    """
+    config = SSOConfig(jwt_secret="resource-test-secret", enabled=True)  # NOSONAR — test fixture
+    store = AuthStore(tmp_path)
+    user = AuthUser(id="test-user", email="ru@example.com", display_name="Resource Test")
+    store.save_user(user)
+    service = AuthService(config, store)
+    token = create_jwt(
+        {"sub": user.id, "session_id": ""},
+        config.jwt_secret,
+        expiry_seconds=600,
+    )
+    return service, config.jwt_secret, token
+
+
+def _build_app(
+    *,
+    auth_service: AuthService | None = None,
+    legacy_token: str | None = None,
+    expected_resource: Any = None,
+) -> TestClient:
+    app = FastAPI()
+    app.add_middleware(
+        SSOAuthMiddleware,
+        auth_service=auth_service,
+        legacy_token=legacy_token,
+        expected_resource=expected_resource,
+    )
+
+    @app.get("/status")
+    async def status_route(request: Request) -> JSONResponse:
+        del request
+        return JSONResponse({"ok": True})
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Configuration parsing
+# ---------------------------------------------------------------------------
+
+
+class TestExpectedResourceParsing:
+    def test_none_means_disabled(self) -> None:
+        assert _normalise_expected_resource(None) == ()
+
+    def test_empty_string_means_disabled(self) -> None:
+        assert _normalise_expected_resource("") == ()
+        assert _normalise_expected_resource("   ") == ()
+
+    def test_single_string(self) -> None:
+        assert _normalise_expected_resource("https://api.example") == ("https://api.example",)
+
+    def test_comma_separated_string(self) -> None:
+        assert _normalise_expected_resource("https://a,https://b") == (
+            "https://a",
+            "https://b",
+        )
+
+    def test_list_of_strings(self) -> None:
+        assert _normalise_expected_resource(["https://a", "https://b"]) == (
+            "https://a",
+            "https://b",
+        )
+
+    def test_env_var_round_trip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(AUTH_EXPECTED_RESOURCE_ENV, "https://api.bernstein.dev")
+        assert expected_resource_from_env() == ("https://api.bernstein.dev",)
+
+
+# ---------------------------------------------------------------------------
+# Default-off — empty config skips the check
+# ---------------------------------------------------------------------------
+
+
+class TestUnsetSkipsCheck:
+    def test_unset_skips_check_for_legacy_token(self) -> None:
+        """A legacy bearer token without a resource claim must pass."""
+        client = _build_app(legacy_token="secret")
+        resp = client.get("/status", headers={"Authorization": "Bearer secret"})
+        assert resp.status_code == 200
+
+    def test_unset_skips_check_for_sso_token(self, tmp_path: Path) -> None:
+        service, _, token = _build_sso(tmp_path)
+        client = _build_app(auth_service=service)
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Match / mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestResourceMatchAndMismatch:
+    def test_matching_single_resource_passes(self, tmp_path: Path) -> None:
+        service, secret, _default_token = _build_sso(tmp_path)
+        token = create_jwt(
+            {
+                "sub": "test-user",
+                "session_id": "",
+                "resource": "https://api.bernstein.dev",
+            },
+            secret,
+            expiry_seconds=600,
+        )
+        client = _build_app(
+            auth_service=service,
+            expected_resource="https://api.bernstein.dev",
+        )
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_matching_one_of_list_passes(self, tmp_path: Path) -> None:
+        service, secret, _ = _build_sso(tmp_path)
+        token = create_jwt(
+            {"sub": "test-user", "session_id": "", "resource": "https://b.example"},
+            secret,
+            expiry_seconds=600,
+        )
+        client = _build_app(
+            auth_service=service,
+            expected_resource=["https://a.example", "https://b.example"],
+        )
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_mismatch_returns_401_with_www_authenticate(self, tmp_path: Path) -> None:
+        service, secret, _ = _build_sso(tmp_path)
+        token = create_jwt(
+            {
+                "sub": "test-user",
+                "session_id": "",
+                "resource": "https://attacker.example",
+            },
+            secret,
+            expiry_seconds=600,
+        )
+        client = _build_app(
+            auth_service=service,
+            expected_resource="https://api.bernstein.dev",
+        )
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+        # RFC 6750 challenge with RFC 8707 wording.
+        challenge = resp.headers.get("www-authenticate", "")
+        assert "Bearer" in challenge
+        assert 'error="invalid_token"' in challenge
+        assert "resource indicator mismatch" in challenge
+
+    def test_token_without_resource_claim_passes(self, tmp_path: Path) -> None:
+        """RFC 8707 enforcement only kicks in when the claim is present.
+
+        Legacy tokens minted before the orchestrator started enforcing the
+        indicator must keep validating; otherwise upgrade breaks every
+        running fleet.
+        """
+        service, secret, _ = _build_sso(tmp_path)
+        token = create_jwt(
+            {"sub": "test-user", "session_id": ""},
+            secret,
+            expiry_seconds=600,
+        )
+        client = _build_app(
+            auth_service=service,
+            expected_resource="https://api.bernstein.dev",
+        )
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_malformed_claim_rejected(self, tmp_path: Path) -> None:
+        """Non-string/non-list resource value is malformed per RFC 8707 §2."""
+        service, secret, _ = _build_sso(tmp_path)
+        token = create_jwt(
+            {"sub": "test-user", "session_id": "", "resource": 12345},
+            secret,
+            expiry_seconds=600,
+        )
+        client = _build_app(
+            auth_service=service,
+            expected_resource="https://api.bernstein.dev",
+        )
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401
+        assert "malformed resource indicator" in resp.headers.get("www-authenticate", "")
+
+    def test_resource_claim_array_any_match_passes(self, tmp_path: Path) -> None:
+        """RFC 8707 §2 lets the token carry an array of resources — any-match."""
+        service, secret, _ = _build_sso(tmp_path)
+        token = create_jwt(
+            {
+                "sub": "test-user",
+                "session_id": "",
+                "resource": ["https://other.example", "https://api.bernstein.dev"],
+            },
+            secret,
+            expiry_seconds=600,
+        )
+        client = _build_app(
+            auth_service=service,
+            expected_resource="https://api.bernstein.dev",
+        )
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_env_var_supplies_default_when_arg_omitted(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``BERNSTEIN_AUTH_EXPECTED_RESOURCE`` is honoured when no arg is passed."""
+        monkeypatch.setenv(AUTH_EXPECTED_RESOURCE_ENV, "https://api.bernstein.dev")
+        service, secret, _ = _build_sso(tmp_path)
+        token = create_jwt(
+            {"sub": "test-user", "session_id": "", "resource": "https://attacker.example"},
+            secret,
+            expiry_seconds=600,
+        )
+        # No expected_resource arg — env var supplies it.
+        client = _build_app(auth_service=service)
+        resp = client.get("/status", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 401

--- a/tests/unit/test_well_known.py
+++ b/tests/unit/test_well_known.py
@@ -31,7 +31,10 @@ from bernstein.core.server import create_app
 @pytest.fixture()
 def client(tmp_path: Path) -> TestClient:
     os.environ["BERNSTEIN_AUTH_DISABLED"] = "1"
-    _reset_signing_keypair_for_tests()
+    # Point the persistent agent-card keystore at the per-test ``tmp_path``
+    # so the JWKS round-trip generates a fresh keypair without scribbling
+    # into the real ``.bernstein/keys`` directory.
+    _reset_signing_keypair_for_tests(tmp_path / "keys")
     app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
     return TestClient(app)
 
@@ -141,9 +144,7 @@ def test_agent_json_body_is_jcs_canonical(client: TestClient) -> None:
     raw = resp.content
     parsed = json.loads(raw)
     recanonical = canonicalize_jcs(parsed)
-    assert raw == recanonical, (
-        f"body is not JCS-canonical:\n  got: {raw!r}\n  want: {recanonical!r}"
-    )
+    assert raw == recanonical, f"body is not JCS-canonical:\n  got: {raw!r}\n  want: {recanonical!r}"
     # Cache header per ticket spec.
     assert resp.headers.get("cache-control") == "public, max-age=3600"
 
@@ -210,3 +211,84 @@ def test_jwks_endpoint_is_stable_across_calls(client: TestClient) -> None:
     a = client.get("/.well-known/agent.json/keys").json()
     b = client.get("/.well-known/agent.json/keys").json()
     assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Persistent keystore + rotation grace window
+# ---------------------------------------------------------------------------
+
+
+def test_jwks_persists_across_module_resets(tmp_path: Path) -> None:
+    """Resetting the in-process cache must replay the same on-disk keypair.
+
+    This is the production guarantee: restarting the orchestrator does not
+    invalidate verifiers caching the previous JWK — the persistent keystore
+    keeps the ``kid`` stable across process boundaries.
+    """
+    from bernstein.core.routes import well_known as wk
+
+    os.environ["BERNSTEIN_AUTH_DISABLED"] = "1"
+    keys_dir = tmp_path / "keys"
+    wk._reset_signing_keypair_for_tests(keys_dir)
+    app_a = create_app(jsonl_path=tmp_path / "a.jsonl")
+    keys_a = TestClient(app_a).get("/.well-known/agent.json/keys").json()
+
+    # Drop the in-process cache as if we had restarted the orchestrator —
+    # but keep the same on-disk directory.
+    wk._reset_signing_keypair_for_tests(keys_dir)
+    app_b = create_app(jsonl_path=tmp_path / "b.jsonl")
+    keys_b = TestClient(app_b).get("/.well-known/agent.json/keys").json()
+
+    assert keys_a["keys"][0]["x"] == keys_b["keys"][0]["x"], "JWK 'x' must persist across orchestrator restarts"
+    assert keys_a["keys"][0]["kid"] == keys_b["keys"][0]["kid"]
+
+
+def test_jwks_rotation_serves_both_current_and_archived_kid(tmp_path: Path) -> None:
+    """During the 24h grace window the JWKS publishes both keys.
+
+    Verifiers that cached the previous JWKS (max-age=3600 on the agent.json
+    route) keep validating against the archived key by ``kid`` until their
+    HTTP cache ages out. The current key is served first so OAuth clients
+    that pick the first match converge on it.
+    """
+    from bernstein.core.routes import well_known as wk
+    from bernstein.core.security.agent_card_keystore import AgentCardKeystore
+
+    os.environ["BERNSTEIN_AUTH_DISABLED"] = "1"
+    keys_dir = tmp_path / "keys"
+
+    # Pre-populate the keystore + perform a rotation against a freshly
+    # bound directory so the test is deterministic — no race with the
+    # process-wide cache.
+    keystore = AgentCardKeystore(keys_dir)
+    keystore.load_or_generate()
+    keystore.rotate()
+
+    wk._reset_signing_keypair_for_tests(keys_dir)
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    client = TestClient(app)
+
+    keys = client.get("/.well-known/agent.json/keys").json()["keys"]
+    assert len(keys) == 2, f"expected current + 1 archived JWK, got: {keys}"
+    kids = [k["kid"] for k in keys]
+    assert kids[0] == "agent-bernstein-orchestrator", "current key must come first"
+    assert kids[1].startswith("agent-bernstein-orchestrator-"), "archived key carries timestamp suffix"
+    # Both JWKs must be valid Ed25519 OKP keys with distinct ``x`` values.
+    assert keys[0]["x"] != keys[1]["x"]
+    assert keys[0]["kty"] == keys[1]["kty"] == "OKP"
+    assert keys[0]["crv"] == keys[1]["crv"] == "Ed25519"
+
+
+def test_rotate_agent_card_keys_helper(tmp_path: Path) -> None:
+    """``rotate_agent_card_keys`` must mint a new keypair + archive the old one."""
+    from bernstein.core.routes import well_known as wk
+
+    keys_dir = tmp_path / "keys"
+    wk._reset_signing_keypair_for_tests(keys_dir)
+    priv_a, pub_a = wk._get_signing_keypair()
+    priv_b, pub_b = wk.rotate_agent_card_keys()
+
+    assert priv_a != priv_b
+    assert pub_a != pub_b
+    assert (keys_dir / "archive").is_dir()
+    assert any((keys_dir / "archive").iterdir()), "rotation must archive the previous keypair"


### PR DESCRIPTION
## Summary

Hardens the A2A v1.0 surface that landed in #1139 along the three axes the
JWKS PR explicitly deferred: persistent keypair, ``AgentIdentityCard``
dataclass migration, and RFC 8707 resource indicators. JWKS shape is
unchanged so external verifiers integrated against #1139 keep working.

The work splits into three independent sections — each can be reviewed
on its own and the surface area outside the security module is small.

---

### 1. Persistent agent-card keystore (Gap 1)

`src/bernstein/core/security/agent_card_keystore.py` (new) +
`src/bernstein/core/routes/well_known.py` (rewired).

- Mints the Ed25519 keypair at `.bernstein/keys/agent-card.ed25519`
  (private, `0o600`) + `.bernstein/keys/agent-card.ed25519.pub` (public)
  on first call. Atomic via `os.O_EXCL` so two concurrent first-run
  processes can't clobber each other.
- Subsequent restarts reuse the same keypair → the JWKS `kid` advertised
  to verifiers stays stable across the lifetime of a deployment.
- `rotate_agent_card_keys()` archives the previous keypair under
  `.bernstein/keys/archive/<utc-isoformat>/` together with a
  `rotated_at.txt` timestamp, then mints a fresh keypair.
- The JWKS endpoint at `/.well-known/agent.json/keys` serves both the
  current key (first) and any archived public key whose `rotated_at`
  falls inside the configurable grace window (default 24h, comfortably
  above the route's `Cache-Control: public, max-age=3600`).
- Permissions enforced both at write and on every load — anything wider
  than owner-only raises `PermissionError`.
- Operator overrides via `BERNSTEIN_AGENT_CARD_KEY_DIR`.

### 2. `AgentIdentityCard` v1.0 dataclass migration (Gap 2)

`src/bernstein/core/security/agent_identity.py`.

- Adds `protocol_version: str`, `supported_interfaces: list[InterfaceSpec]`,
  `security_schemes: list[SecurityScheme]`, `signatures: list[Signature]`
  to the dataclass. Three new structured nested dataclasses
  (`InterfaceSpec`, `SecurityScheme`, `Signature`) carry the v1.0 sub-shapes.
- `card_hash` migration is gated behind `BERNSTEIN_AGENT_CARD_V1_0_HASH=1`.
  By default `card_hash` keeps its pre-v1.0 16-hex SHA-256 prefix so
  existing HMAC anchors and audit-chain references stay bit-stable. Once
  the flag flips the hash covers the full v1.0 surface including the
  new fields.
- `to_legacy_dict()` projects the card down to the original 11-key shape
  for verifiers that haven't migrated. `to_v1_dict()` is the symmetric
  alias.
- `load_identity_card` coerces nested dicts back to dataclasses; missing
  v1.0 keys default to empty so older `identity.json` files keep
  loading without code changes.
- Fully documented in the module docstring including the migration
  path.

### 3. RFC 8707 resource indicators (Gap 3)

`src/bernstein/core/security/auth.py` (config) +
`src/bernstein/core/security/auth_middleware.py` (enforcement) +
`src/bernstein/core/server/server_app.py` (wire-up).

- New `SSOConfig.expected_resource: str` (comma-separated list-friendly).
- `SSOAuthMiddleware` accepts an explicit `expected_resource: str | list[str] | None`;
  falls back to `BERNSTEIN_AUTH_EXPECTED_RESOURCE` env var.
- Tokens carrying a `resource` claim must match one of the configured
  values (any-match semantics for lists). The claim may be a single
  URI string or an array of strings per RFC 8707 §2.
- Mismatches return `HTTP 401` with the RFC 6750 challenge:
  `WWW-Authenticate: Bearer error="invalid_token", error_description="resource indicator mismatch"`.
  Malformed claims (non-string/non-array values) get the
  `malformed resource indicator` variant.
- Tokens that omit the claim entirely pass through — legacy bearer
  flows must keep working on upgrade.
- Unset configuration disables the check wholesale → existing
  deployments are unaffected by default.
- Applied to both SSO JWT and agent-identity JWT auth strategies.

---

## Test plan

- [x] `uv run ruff format src/ tests/` — clean
- [x] `uv run ruff check src/ tests/` — All checks passed!
- [x] `uv run pytest tests/unit/test_agent_card_keystore.py` — 10 passed
- [x] `uv run pytest tests/unit/test_agent_identity_v1_migration.py` — 11 passed
- [x] `uv run pytest tests/unit/test_auth_middleware_resource_indicator.py` — 15 passed
- [x] `uv run pytest tests/unit/test_well_known.py` — 17 passed (includes the new persistence + rotation grace-window tests)
- [x] `uv run pytest tests/unit/test_server.py` — 122 passed (unchanged behaviour for FastAPI integration suite)
- [x] Combined run across security + auth + a2a + identity + well-known + keystore + resource-indicator suites: **252 passed** in ~100 s
- [x] `uv run bernstein agents-md sync` — 12 file(s) regenerated, no drift

## Operator notes

| Knob | Effect | Default |
|------|--------|---------|
| `BERNSTEIN_AGENT_CARD_KEY_DIR` | Override persistent keystore directory | `.bernstein/keys` |
| `BERNSTEIN_AGENT_CARD_V1_0_HASH=1` | Flip `card_hash` to cover v1.0 fields | unset (legacy hash) |
| `BERNSTEIN_AUTH_EXPECTED_RESOURCE` | Configured RFC 8707 resource indicator(s), comma-separated | unset (check skipped) |
| `auth.expected_resource` (`SSOConfig`) | Same as above via config | `""` |

## Compatibility

- **JWKS shape unchanged** — third parties integrated against #1139 keep working without changes.
- **`card_hash` semantics unchanged by default** — operators flip the flag only when their verifiers have migrated.
- **Resource-indicator check skipped by default** — existing deployments minting opaque tokens do not break on upgrade.
- `.bernstein/keys/` added to `.gitignore` so signing keys never land in git.