### PR TITLE
feat(security): multi-tenant HMAC audit-chain export (RESRCH-005)

### DIFF
--- a/docs/security/audit-multitenant.md
+++ b/docs/security/audit-multitenant.md
@@ -1,0 +1,193 @@
+# Multi-tenant audit-chain export
+
+Bernstein writes one HMAC-chained audit log per orchestrator instance.
+When an enterprise operator runs bernstein on behalf of multiple internal
+customers, every customer sees the same chain. That is fine for the
+operator's internal compliance posture but it does not let them hand a
+specific customer (or that customer's external auditor) a slice of the
+log without leaking sibling tenants.
+
+`bernstein audit export --tenant <id>` produces a tenant-scoped slice
+that:
+
+- Contains only events tagged with the requested `tenant_id`.
+- Re-chains those events over a slice-local HMAC so an auditor can
+  replay-verify offline using only the operator's HMAC key.
+- Carries a tamper-evident SHA-256 anchor over the canonical JSONL bytes
+  (catches single-byte flips even without the key).
+- Optionally attaches an RFC 3161 TimeStampToken from a third-party TSA,
+  or a deterministic offline anchor for air-gapped deployments.
+
+Bundles are byte-deterministic — the same input window + tenant id
+produces a byte-identical bundle on every run.
+
+## Tagging events with `tenant_id`
+
+The export filters on `details.tenant_id`. To enable per-tenant export,
+add the tenant id to every event your code emits:
+
+```python
+audit_log.log(
+    "task.created",
+    actor="alice",
+    resource_type="task",
+    resource_id="T-1",
+    details={"tenant_id": "acme", ...},
+)
+```
+
+Events that omit `details.tenant_id` are treated as belonging to the
+`default` tenant (matching `normalize_tenant_id` in
+`src/bernstein/core/security/tenanting.py`). This keeps the rollout
+incremental — operators can switch on multi-tenant tagging without
+breaking pre-existing chains.
+
+## CLI usage
+
+### Bare HMAC chain (most common)
+
+```bash
+bernstein audit export \
+    --tenant acme \
+    --since 2026-08-01T00:00:00+00:00 \
+    --until 2026-09-01T00:00:00+00:00 \
+    --output .sdd/evidence/
+```
+
+### With RFC 3161 third-party timestamp
+
+Get a TimeStampToken from any RFC 3161 TSA (FreeTSA, DigiCert, SwissSign,
+etc.). Save the base64-encoded DER token to a file, then:
+
+```bash
+bernstein audit export \
+    --tenant acme \
+    --since 2026-08-01T00:00:00+00:00 \
+    --until 2026-09-01T00:00:00+00:00 \
+    --signature-kind hmac-chain+rfc3161 \
+    --rfc3161-token /path/to/tsa.token.b64 \
+    --rfc3161-tsa-url https://freetsa.org/tsr
+```
+
+The bundle records the token verbatim. The verifier confirms it is valid
+base64. Cryptographic verification of the token chain (RFC 3161 §2.4.2)
+is delegated to the operator's existing TSA toolchain (e.g. `openssl ts
+-verify`).
+
+### Offline anchor (air-gap deployments)
+
+For deployments that cannot reach a public TSA, attach a deterministic
+local anchor. Pass `--signature-kind hmac-chain+offline-anchor`. The
+anchor is `sha256(head_sha256 || anchored_at_iso)`. It does not certify
+wall-clock truth (an attacker with the bundle can recompute it) but it
+ties the chain head to a specific operator-attested timestamp inside the
+deterministic JSON.
+
+```bash
+bernstein audit export \
+    --tenant acme \
+    --since 2026-08-01T00:00:00+00:00 \
+    --until 2026-09-01T00:00:00+00:00 \
+    --signature-kind hmac-chain+offline-anchor
+```
+
+Note: the default offline anchor uses `datetime.now(UTC)` so two runs
+produce different bundles. To get byte-identical air-gap bundles, pass
+`offline_anchor_iso` through the Python API directly.
+
+### Dry-run
+
+`--dry-run` builds the bundle in-memory and prints the manifest without
+writing to disk. Useful for spot-checking a window before shipping.
+
+## Wire format
+
+The bundle is a single JSON object that conforms to
+`schemas/audit-multitenant-export-v1.json` (JSON Schema draft-07).
+
+Top-level fields:
+
+| Field            | Type    | Description                                                         |
+| ---------------- | ------- | ------------------------------------------------------------------- |
+| `schema_version` | string  | Pinned to `1.0.0`. Bumped on any breaking change.                   |
+| `tenant_id`      | string  | Normalized tenant identifier.                                       |
+| `audit_window`   | object  | `{since, until}` — ISO-8601 strings; since < until.                 |
+| `chain_anchor`   | object  | `{genesis_prev_hmac, head_hmac, head_sha256}`.                      |
+| `event_count`    | integer | Number of events in the slice.                                      |
+| `events`         | array   | Slice events in chronological order, with `_original_hmac` witness. |
+| `signature`      | object  | Detached anchor block.                                              |
+
+Each event preserves the original orchestrator-wide HMAC at
+`details._original_hmac` so an auditor with access to the source log can
+cross-reference back. The slice itself is re-chained — `prev_hmac` /
+`hmac` link to the slice-local chain, not the orchestrator-wide one.
+
+## Verifying offline
+
+```python
+from pathlib import Path
+
+from bernstein.core.security.audit import load_or_create_audit_key
+from bernstein.core.security.audit_multitenant import verify_tenant_slice
+
+key = load_or_create_audit_key()  # operator's HMAC key
+result = verify_tenant_slice(Path("path/to/bundle.json"), key=key)
+if not result.ok:
+    for err in result.errors:
+        print("FAIL:", err)
+    raise SystemExit(1)
+print("OK", result.bundle["event_count"], "events")
+```
+
+The verifier runs five independent checks:
+
+1. **Envelope structure** — required fields, schema version, ISO-8601
+   ordering of `audit_window`.
+2. **Tenant purity** — every event in the slice carries the declared
+   `tenant_id`.
+3. **Chain integrity** — re-derive each event's HMAC; confirm
+   `prev_hmac` linkage; confirm `chain_anchor.head_hmac` equals the
+   recomputed tail.
+4. **Anchor consistency** — recompute `head_sha256` from canonical
+   JSONL bytes and compare.
+5. **Signature block sanity** — base64 validity for RFC 3161 tokens;
+   `sha256(head_sha256 || anchored_at)` for offline anchors.
+
+A failure on any of those checks flips `result.ok` to `False` and
+appends a human-readable message to `result.errors`.
+
+## What is NOT in v1
+
+- **Public-key signatures** (cosign, Sigstore, SCITT receipt). The
+  primary proof is HMAC, which requires the auditor to share the key
+  with the operator. Future versions can layer a public-key signature
+  over `head_sha256` so a key-less auditor can still validate
+  authenticity.
+- **In-toto attestation wrapping**. The schema is custom because
+  line-oriented JSONL chains do not fit the in-toto subject/predicate
+  shape cleanly. Migrating later is a `schema_version` bump.
+- **Live RFC 3161 TSA fetch**. The CLI takes a pre-fetched token. Wiring
+  bernstein to call a TSA itself would couple the export to network
+  policy.
+
+## Compliance mapping (one-line)
+
+- **EU AI Act Art. 12** — covered by `bernstein audit export
+  --article-12 ...` (see `docs/security/AUDIT.md`); the multi-tenant
+  export complements it for slicing per-customer.
+- **DORA Art. 9 / Art. 28** — the slice + RFC 3161 token satisfies
+  third-party register evidence.
+- **SR 11-7** — the chain + sha256 anchor is the model audit trail.
+
+## References
+
+- W3C Verifiable Credentials Data Model 2.0
+  (https://www.w3.org/TR/vc-data-model-2.0). Conceptually similar
+  proof-on-claim split. Rejected as the primary wire format because VC
+  v2 is RDF/JSON-LD-shaped and forces context resolution at verify
+  time. Migration path remains open.
+- RFC 3161 — Time-Stamp Protocol
+  (https://www.rfc-editor.org/rfc/rfc3161).
+- IETF SCITT — Supply Chain Integrity, Transparency, and Trust
+  (https://datatracker.ietf.org/wg/scitt). Forward-looking direction
+  for transparency-log integration.

--- a/schemas/audit-multitenant-export-v1.json
+++ b/schemas/audit-multitenant-export-v1.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bernstein.alexchernysh.com/schemas/audit-multitenant-export-v1.json",
+  "title": "Bernstein Multi-Tenant Audit Export",
+  "description": "Versioned wire format for tenant-scoped HMAC-chained audit-log slices. The slice is locally re-chained over filtered events so an external auditor can replay-verify offline using only the operator's HMAC key. The chain_anchor + (optional) timestamp_proof together provide tamper evidence even without the key. References W3C Verifiable Credentials Data Model 2.0 conceptually; uses a custom schema because VC v2 is RDF/JSON-LD and heavy for line-oriented JSONL audit chains.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "tenant_id",
+    "audit_window",
+    "chain_anchor",
+    "event_count",
+    "events",
+    "signature"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0",
+      "description": "Pinned schema version. Bump on any breaking change to field ordering, payload format, or HMAC input shape."
+    },
+    "tenant_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Normalized tenant identifier (matches src/bernstein/core/security/tenanting.normalize_tenant_id). Empty/null inputs collapse to 'default'."
+    },
+    "audit_window": {
+      "type": "object",
+      "required": ["since", "until"],
+      "properties": {
+        "since": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Inclusive ISO-8601 lower bound."
+        },
+        "until": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Exclusive ISO-8601 upper bound."
+        }
+      }
+    },
+    "chain_anchor": {
+      "type": "object",
+      "required": ["genesis_prev_hmac", "head_hmac", "head_sha256"],
+      "properties": {
+        "genesis_prev_hmac": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "Sentinel prev_hmac of the first event in the slice. The slice is locally re-chained so this is always 0*64."
+        },
+        "head_hmac": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "HMAC of the final event in the slice (or 0*64 when the window is empty). Verifiable with the operator's HMAC key."
+        },
+        "head_sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$",
+          "description": "SHA-256 of the canonical JSONL serialization of the slice. Tamper-evident even without the HMAC key — flipping any byte of any event changes this anchor."
+        }
+      }
+    },
+    "event_count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of events included in the slice after tenant + window filtering."
+    },
+    "events": {
+      "type": "array",
+      "description": "Tenant-scoped events in chronological order. Each event was re-chained for the slice, so its prev_hmac links to the previous event's hmac, not the original orchestrator-wide chain. Original orchestrator HMAC is preserved in details._original_hmac for cross-reference.",
+      "items": {
+        "type": "object",
+        "required": [
+          "timestamp",
+          "event_type",
+          "actor",
+          "resource_type",
+          "resource_id",
+          "details",
+          "prev_hmac",
+          "hmac"
+        ],
+        "properties": {
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "actor": {
+            "type": "string"
+          },
+          "resource_type": {
+            "type": "string"
+          },
+          "resource_id": {
+            "type": "string"
+          },
+          "details": {
+            "type": "object",
+            "properties": {
+              "tenant_id": {
+                "type": "string",
+                "description": "Normalized tenant id; the filter key."
+              },
+              "_original_hmac": {
+                "type": "string",
+                "pattern": "^[0-9a-f]{64}$",
+                "description": "Witness of the event's HMAC in the original orchestrator-wide chain. Lets an auditor cross-reference back to the source log."
+              }
+            }
+          },
+          "prev_hmac": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "HMAC of the prior event in this slice (genesis = 0*64 for the first event)."
+          },
+          "hmac": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$",
+            "description": "HMAC of this event in the slice-local chain."
+          }
+        }
+      }
+    },
+    "signature": {
+      "type": "object",
+      "description": "Detached signature/anchor block. The 'signature_kind' selects which verifier path applies.",
+      "required": ["signature_kind", "alg"],
+      "properties": {
+        "signature_kind": {
+          "type": "string",
+          "enum": ["hmac-chain-only", "hmac-chain+rfc3161", "hmac-chain+offline-anchor"],
+          "description": "Verifier identifier. 'hmac-chain-only' means the chain itself is the only proof; consumers must trust the operator's key. 'hmac-chain+rfc3161' attaches an RFC 3161 TimeStampToken from a third-party TSA. 'hmac-chain+offline-anchor' is an air-gapped fallback that records a deterministic local anchor (sha256(head_sha256 || timestamp_iso))."
+        },
+        "alg": {
+          "type": "string",
+          "enum": ["HMAC-SHA256"],
+          "description": "Algorithm used for the chain HMAC."
+        },
+        "rfc3161_token_b64": {
+          "type": ["string", "null"],
+          "description": "Base64-encoded DER RFC 3161 TimeStampToken. Present iff signature_kind == 'hmac-chain+rfc3161'."
+        },
+        "rfc3161_tsa_url": {
+          "type": ["string", "null"],
+          "description": "URL of the TSA that issued the token (operator-supplied)."
+        },
+        "offline_anchor": {
+          "type": ["object", "null"],
+          "description": "Air-gap anchor block. Present iff signature_kind == 'hmac-chain+offline-anchor'.",
+          "properties": {
+            "anchored_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "anchor_sha256": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{64}$",
+              "description": "sha256(head_sha256 || anchored_at_iso) — deterministic and auditable but does not certify wall-clock truth."
+            }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -257,14 +257,24 @@ def verify_hmac_cmd() -> None:
     help="Emit an EU AI Act Article 12 evidence pack (uses --since/--until).",
 )
 @click.option(
+    "--tenant",
+    "tenant",
+    default=None,
+    help=(
+        "Emit a multi-tenant audit-chain export scoped to <tenant_id>. "
+        "Combine with --since/--until. Bundle conforms to "
+        "schemas/audit-multitenant-export-v1.json."
+    ),
+)
+@click.option(
     "--since",
     default=None,
-    help="ISO-8601 inclusive lower bound (Article 12 mode).",
+    help="ISO-8601 inclusive lower bound (Article 12 / tenant mode).",
 )
 @click.option(
     "--until",
     default=None,
-    help="ISO-8601 exclusive upper bound (Article 12 mode).",
+    help="ISO-8601 exclusive upper bound (Article 12 / tenant mode).",
 )
 @click.option(
     "--risk-class",
@@ -283,6 +293,36 @@ def verify_hmac_cmd() -> None:
     help="Output format (SOC 2 mode only; Article 12 always emits a zip).",
 )
 @click.option(
+    "--signature-kind",
+    "signature_kind",
+    default="hmac-chain-only",
+    type=click.Choice(
+        ["hmac-chain-only", "hmac-chain+rfc3161", "hmac-chain+offline-anchor"],
+    ),
+    show_default=True,
+    help=(
+        "Tenant mode: which detached anchor to attach. "
+        "'hmac-chain-only' is the bare HMAC chain. "
+        "'hmac-chain+rfc3161' attaches a TSA timestamp token (--rfc3161-token). "
+        "'hmac-chain+offline-anchor' is an air-gap fallback (deterministic local anchor)."
+    ),
+)
+@click.option(
+    "--rfc3161-token",
+    "rfc3161_token",
+    default=None,
+    help=(
+        "Tenant mode: path to a base64-encoded DER RFC 3161 TimeStampToken "
+        "(required iff --signature-kind=hmac-chain+rfc3161)."
+    ),
+)
+@click.option(
+    "--rfc3161-tsa-url",
+    "rfc3161_tsa_url",
+    default=None,
+    help="Tenant mode: URL of the TSA that issued the token (informational).",
+)
+@click.option(
     "--output",
     "-o",
     default=None,
@@ -292,16 +332,20 @@ def verify_hmac_cmd() -> None:
     "--dry-run",
     is_flag=True,
     default=False,
-    help="Article 12 mode: build the bundle in-memory and print the manifest without writing to disk.",
+    help="Article 12 / tenant modes: build the bundle in-memory and print the manifest without writing to disk.",
 )
 @click.option("--dir", "workdir", default=".", show_default=True, help="Project root directory.")
 def export_cmd(
     period: str | None,
     article_12: bool,
+    tenant: str | None,
     since: str | None,
     until: str | None,
     risk_class: str,
     fmt: str,
+    signature_kind: str,
+    rfc3161_token: str | None,
+    rfc3161_tsa_url: str | None,
     output: str | None,
     dry_run: bool,
     workdir: str,
@@ -309,10 +353,12 @@ def export_cmd(
     """Export an evidence package for auditors.
 
     \b
-    Two modes:
+    Three modes:
       * SOC 2 mode (default): bernstein audit export --period Q1-2026
       * EU AI Act Article 12: bernstein audit export --article-12 \
             --since 2026-08-01T00:00:00+00:00 --until 2026-09-01T00:00:00+00:00
+      * Multi-tenant slice:   bernstein audit export --tenant acme \
+            --since ... --until ... [--signature-kind ...]
 
     \b
     SOC 2 mode collects audit logs, HMAC verification, Merkle seals,
@@ -323,12 +369,33 @@ def export_cmd(
     the audit log slice, a data-governance catalog, and an EU-AI-Act
     clause map (manifest.json contains artefact SHA-256 hashes for
     auditor verification).
+
+    \b
+    Multi-tenant mode emits a deterministic JSON bundle per the schema at
+    schemas/audit-multitenant-export-v1.json: events tagged with the
+    given tenant_id are filtered, then re-chained over a slice-local
+    HMAC so an external auditor can replay-verify offline. Cross-tenant
+    leakage is blocked at filter time and detected at verify time.
     """
     sdd_dir = Path(workdir).resolve() / ".sdd"
     if not sdd_dir.is_dir():
         console.print(f"[red]State directory not found:[/red] {sdd_dir}")
         console.print("[dim]Run [bold]bernstein run[/bold] first to generate audit data.[/dim]")
         raise SystemExit(1)
+
+    if tenant:
+        _run_tenant_export(
+            sdd_dir=sdd_dir,
+            tenant_id=tenant,
+            since=since,
+            until=until,
+            signature_kind=signature_kind,
+            rfc3161_token=rfc3161_token,
+            rfc3161_tsa_url=rfc3161_tsa_url,
+            output=output,
+            dry_run=dry_run,
+        )
+        return
 
     if article_12:
         _run_article12_export(
@@ -342,7 +409,9 @@ def export_cmd(
         return
 
     if not period:
-        console.print("[red]Either --period (SOC 2) or --article-12 (with --since/--until) is required.[/red]")
+        console.print(
+            "[red]One of --period (SOC 2), --article-12, or --tenant is required.[/red]",
+        )
         raise SystemExit(2)
 
     from bernstein.core.compliance import export_soc2_package, parse_period
@@ -450,6 +519,110 @@ def _run_article12_export(
     if dry_run:
         console.print("[dim]Manifest (dry-run):[/dim]")
         console.print(_json.dumps(bundle.to_dict(), indent=2))
+        console.print()
+
+
+def _run_tenant_export(
+    *,
+    sdd_dir: Path,
+    tenant_id: str,
+    since: str | None,
+    until: str | None,
+    signature_kind: str,
+    rfc3161_token: str | None,
+    rfc3161_tsa_url: str | None,
+    output: str | None,
+    dry_run: bool,
+) -> None:
+    """Execute the multi-tenant audit-chain export flow.
+
+    Loads the operator HMAC key from the canonical key path used by
+    :class:`bernstein.core.security.audit.AuditLog`, scopes the bundle
+    to ``tenant_id``, and writes a deterministic JSON bundle conforming
+    to ``schemas/audit-multitenant-export-v1.json``.
+    """
+    import json as _json
+    from typing import cast
+
+    from bernstein.core.security.audit import load_or_create_audit_key
+    from bernstein.core.security.audit_multitenant import (
+        SignatureKind,
+        TenantScopedExport,
+        export_tenant_slice,
+    )
+
+    if not since or not until:
+        console.print("[red]--tenant requires both --since and --until (ISO-8601).[/red]")
+        raise SystemExit(2)
+
+    rfc3161_token_b64: str | None = None
+    if rfc3161_token:
+        token_path = Path(rfc3161_token).expanduser()
+        if not token_path.is_file():
+            console.print(f"[red]--rfc3161-token file not found: {token_path}[/red]")
+            raise SystemExit(1)
+        rfc3161_token_b64 = token_path.read_text(encoding="utf-8").strip()
+
+    if signature_kind == "hmac-chain+rfc3161" and not rfc3161_token_b64:
+        console.print(
+            "[red]--signature-kind=hmac-chain+rfc3161 requires --rfc3161-token <path>.[/red]",
+        )
+        raise SystemExit(2)
+
+    audit_dir = sdd_dir / "audit"
+    output_dir = Path(output).resolve() if output else None
+
+    try:
+        key = load_or_create_audit_key()
+    except OSError as exc:  # pragma: no cover - filesystem race
+        console.print(f"[red]Failed to load audit key: {exc}[/red]")
+        raise SystemExit(1) from None
+
+    try:
+        export: TenantScopedExport = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id=tenant_id,
+            since=since,
+            until=until,
+            key=key,
+            output_dir=output_dir,
+            signature_kind=cast("SignatureKind", signature_kind),
+            rfc3161_token_b64=rfc3161_token_b64,
+            rfc3161_tsa_url=rfc3161_tsa_url,
+            write=not dry_run,
+        )
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from None
+
+    console.print()
+    console.print(
+        Panel(
+            "[bold]Multi-tenant Audit Slice[/bold]",
+            border_style="green",
+            expand=False,
+        ),
+    )
+
+    table = Table(show_header=False, box=None, padding=(0, 2))
+    table.add_column("Key", style="dim", no_wrap=True, min_width=18)
+    table.add_column("Value")
+    table.add_row("Tenant", export.tenant_id)
+    table.add_row("Window", f"{export.since} → {export.until}")
+    table.add_row("Events", str(export.event_count))
+    table.add_row("Head HMAC", export.head_hmac[:16] + "…")
+    table.add_row("Head SHA-256", export.head_sha256[:16] + "…")
+    table.add_row("Signature kind", export.signature_kind)
+    if export.bundle_path is not None:
+        table.add_row("Bundle", str(export.bundle_path))
+    elif dry_run:
+        table.add_row("Bundle", "(dry-run, not written)")
+    console.print(table)
+    console.print()
+
+    if dry_run:
+        console.print("[dim]Bundle (dry-run):[/dim]")
+        console.print(_json.dumps(_json.loads(export.bundle_bytes.decode("utf-8")), indent=2))
         console.print()
 
 

--- a/src/bernstein/core/security/audit_multitenant.py
+++ b/src/bernstein/core/security/audit_multitenant.py
@@ -1,0 +1,693 @@
+"""Multi-tenant HMAC-chained audit-log export.
+
+Bernstein's audit log is a single HMAC chain across every event the
+orchestrator emits. Enterprise operators running bernstein on behalf of
+multiple internal customers need to hand each customer (or each external
+auditor) a slice that:
+
+* Contains **only** that customer's events — no leakage of sibling tenants.
+* **Re-verifies offline** so an auditor with the operator's HMAC key can
+  replay-check every link without consulting the live orchestrator state.
+* Carries a **tamper-evident anchor** (sha256 of the canonical JSONL) so a
+  cross-tenant flip in the slice is detected even without the key.
+* Is **byte-deterministic** — same input window + tenant id produces a
+  byte-identical bundle on every run, so spot-audit reproducibility holds.
+
+Design:
+
+The original chain commits HMAC over ``prev || canonical(payload-without-
+hmac)``. Filtering arbitrary events out of that chain breaks the linkage
+because the dropped events' HMACs were prev-anchors for their successors.
+We rebuild a **fresh slice-local chain** over only the matching events,
+keyed by the same operator HMAC key. Each tenant slice is therefore a
+self-contained HMAC chain rooted at the genesis sentinel.
+
+The original HMAC of each emitted event is preserved as
+``details._original_hmac`` so an auditor can still cross-reference back
+to the source log when they have access to it. A flipped tenant id in the
+exported slice is detectable because:
+
+* Its ``hmac`` no longer matches HMAC(key, prev || canonical(stripped))
+  in the slice-local chain, AND
+* Its ``_original_hmac`` does not appear (or appears with a different
+  payload) in the original log.
+
+References:
+
+* W3C Verifiable Credentials Data Model 2.0 — conceptually similar
+  citation/proof split, but rejected as the wire format because VC v2 is
+  RDF/JSON-LD-shaped and forces JSON-LD context resolution at verify
+  time. Audit chains are line-oriented JSONL; a custom schema (see
+  ``schemas/audit-multitenant-export-v1.json``) is leaner. The schema
+  is versioned (``schema_version: 1.0.0``) so future migrations to VC v2
+  or in-toto attestations stay open.
+* RFC 3161 — Time-Stamp Protocol. Optional third-party timestamp token.
+* IETF SCITT — future direction; not wired in v1.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac as _hmac
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from bernstein.core.security.tenanting import normalize_tenant_id
+
+logger = logging.getLogger(__name__)
+
+#: Schema version emitted in the exported bundle. Bumped on any breaking
+#: change to artefact field ordering, payload format, or HMAC input shape.
+EXPORT_SCHEMA_VERSION: str = "1.0.0"
+
+#: Genesis sentinel matching :mod:`bernstein.core.security.audit`.
+_GENESIS_HMAC: str = "0" * 64
+
+#: Canonical glob for daily HMAC-chained log files.
+_JSONL_GLOB: str = "*.jsonl"
+
+SignatureKind = Literal[
+    "hmac-chain-only",
+    "hmac-chain+rfc3161",
+    "hmac-chain+offline-anchor",
+]
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TenantScopedExport:
+    """Materialised tenant-scoped audit slice.
+
+    Attributes:
+        tenant_id: Normalized tenant identifier.
+        since: Inclusive ISO-8601 lower bound of the export window.
+        until: Exclusive ISO-8601 upper bound of the export window.
+        event_count: Number of matching events.
+        head_hmac: HMAC of the last event in the slice-local chain (or
+            the genesis sentinel when the window is empty).
+        head_sha256: SHA-256 over the canonical JSONL bytes of the slice.
+            Tamper-evident even without the HMAC key.
+        signature_kind: Which verifier path the bundle declares.
+        bundle_bytes: The full canonical-JSON bundle bytes (matches what
+            is written to disk when ``write=True``). Always available so
+            tests/dry-runs can hash without disk I/O.
+        bundle_path: On-disk path of the written bundle, or ``None`` when
+            ``write=False``.
+    """
+
+    tenant_id: str
+    since: str
+    until: str
+    event_count: int
+    head_hmac: str
+    head_sha256: str
+    signature_kind: SignatureKind
+    bundle_bytes: bytes
+    bundle_path: Path | None = None
+
+    @property
+    def sha256(self) -> str:
+        """SHA-256 of the on-disk bundle bytes."""
+        return hashlib.sha256(self.bundle_bytes).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class TenantSliceVerification:
+    """Outcome of an offline ``verify_tenant_slice`` call.
+
+    Attributes:
+        ok: True when every check passed.
+        errors: Human-readable failure messages (empty when ``ok``).
+        bundle: Parsed bundle dict (empty when reading itself failed).
+    """
+
+    ok: bool
+    errors: list[str] = field(default_factory=list)
+    bundle: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_event_payload(entry: dict[str, Any]) -> str:
+    """Return the canonical JSON representation used as HMAC input.
+
+    Matches the convention in :mod:`bernstein.core.security.audit`:
+    ``json.dumps(entry, sort_keys=True)``. The ``hmac`` field is excluded
+    upstream; this helper serialises the supplied dict as-is.
+    """
+    return json.dumps(entry, sort_keys=True)
+
+
+def _compute_event_hmac(key: bytes, prev_hmac: str, payload: dict[str, Any]) -> str:
+    """Compute HMAC-SHA256 over ``prev_hmac || canonical(payload)``.
+
+    Args:
+        key: Operator HMAC key bytes.
+        prev_hmac: Hex-encoded prior event HMAC (or genesis sentinel).
+        payload: Event dict *without* the ``hmac`` field.
+
+    Returns:
+        Hex-encoded HMAC of the chained payload.
+    """
+    serialised = (prev_hmac + _canonical_event_payload(payload)).encode()
+    return _hmac.new(key, serialised, hashlib.sha256).hexdigest()
+
+
+def _read_audit_events(audit_dir: Path) -> list[dict[str, Any]]:
+    """Walk ``audit_dir/*.jsonl`` and return every parseable event in order.
+
+    Lines that fail to parse are skipped silently (``logger.debug``).
+    """
+    events: list[dict[str, Any]] = []
+    if not audit_dir.is_dir():
+        return events
+    for path in sorted(audit_dir.glob(_JSONL_GLOB)):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.debug("Skipping unreadable audit file %s: %s", path, exc)
+            continue
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as exc:
+                logger.debug("Skipping malformed line in %s: %s", path, exc)
+                continue
+            if isinstance(entry, dict) and "hmac" in entry:
+                events.append(entry)
+    return events
+
+
+def _event_tenant_id(event: dict[str, Any]) -> str:
+    """Extract the canonical tenant id for an event.
+
+    Looks at ``details.tenant_id`` first (the canonical opt-in path);
+    falls back to ``DEFAULT_TENANT_ID`` via :func:`normalize_tenant_id`.
+    """
+    details = event.get("details") or {}
+    raw = None
+    if isinstance(details, dict):
+        raw = details.get("tenant_id")
+    return normalize_tenant_id(str(raw) if raw is not None else None)
+
+
+def _event_in_window(event: dict[str, Any], since: str, until: str) -> bool:
+    """Return True when ``event.timestamp`` falls in ``[since, until)``."""
+    ts = str(event.get("timestamp", ""))
+    if not ts:
+        return False
+    return since <= ts < until
+
+
+def _filter_tenant_events(
+    events: list[dict[str, Any]],
+    tenant_id: str,
+    since: str,
+    until: str,
+) -> list[dict[str, Any]]:
+    """Filter to events that match ``tenant_id`` and ``[since, until)``.
+
+    Stable order is preserved (chronological because the source log is
+    append-only). If two events share a timestamp we fall back to the
+    original ``hmac`` for determinism.
+    """
+    matched = [e for e in events if _event_tenant_id(e) == tenant_id and _event_in_window(e, since, until)]
+    matched.sort(key=lambda e: (str(e.get("timestamp", "")), str(e.get("hmac", ""))))
+    return matched
+
+
+def _rebuild_slice_chain(
+    events: list[dict[str, Any]],
+    key: bytes,
+) -> tuple[list[dict[str, Any]], str]:
+    """Rebuild a slice-local HMAC chain over ``events`` keyed by ``key``.
+
+    Each output event preserves the original event's user-facing fields
+    (timestamp, event_type, actor, resource_type, resource_id, details)
+    and adds:
+
+    * ``details._original_hmac`` — the HMAC the event carried in the
+      orchestrator-wide chain. Witness for cross-reference.
+    * ``prev_hmac`` — the slice-local predecessor HMAC.
+    * ``hmac`` — the slice-local HMAC.
+
+    Args:
+        events: Filtered events in chronological order (originals).
+        key: Operator HMAC key.
+
+    Returns:
+        ``(rebuilt_events, head_hmac)``. ``head_hmac`` is the genesis
+        sentinel when ``events`` is empty.
+    """
+    rebuilt: list[dict[str, Any]] = []
+    prev = _GENESIS_HMAC
+    for original in events:
+        original_details = original.get("details") or {}
+        if not isinstance(original_details, dict):
+            original_details = {}
+        new_details = dict(original_details)
+        # Witness: stamp the original orchestrator-wide HMAC so an auditor
+        # with access to the source log can cross-check.
+        new_details["_original_hmac"] = str(original.get("hmac", ""))
+
+        payload: dict[str, Any] = {
+            "timestamp": str(original.get("timestamp", "")),
+            "event_type": str(original.get("event_type", "")),
+            "actor": str(original.get("actor", "")),
+            "resource_type": str(original.get("resource_type", "")),
+            "resource_id": str(original.get("resource_id", "")),
+            "details": new_details,
+            "prev_hmac": prev,
+        }
+        slice_hmac = _compute_event_hmac(key, prev, payload)
+        emitted = dict(payload)
+        emitted["hmac"] = slice_hmac
+        rebuilt.append(emitted)
+        prev = slice_hmac
+    return rebuilt, prev
+
+
+def _events_jsonl_bytes(events: list[dict[str, Any]]) -> bytes:
+    """Serialise events as canonical JSONL (sorted keys, ``\\n`` newlines)."""
+    if not events:
+        return b""
+    parts = [json.dumps(e, sort_keys=True, separators=(",", ":")) for e in events]
+    return ("\n".join(parts) + "\n").encode("utf-8")
+
+
+def _attach_signature(
+    head_sha256: str,
+    *,
+    signature_kind: SignatureKind,
+    rfc3161_token_b64: str | None,
+    rfc3161_tsa_url: str | None,
+    offline_anchor_iso: str | None,
+) -> dict[str, Any]:
+    """Build the detached signature block for the bundle.
+
+    The block is added at the top level of the bundle and feeds the
+    schema's ``signature`` field. The HMAC chain itself is the primary
+    proof; this block adds optional third-party or air-gap evidence.
+    """
+    block: dict[str, Any] = {
+        "signature_kind": signature_kind,
+        "alg": "HMAC-SHA256",
+        "rfc3161_token_b64": rfc3161_token_b64,
+        "rfc3161_tsa_url": rfc3161_tsa_url,
+        "offline_anchor": None,
+    }
+    if signature_kind == "hmac-chain+offline-anchor":
+        ts = offline_anchor_iso or datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        anchor_input = (head_sha256 + ts).encode()
+        block["offline_anchor"] = {
+            "anchored_at": ts,
+            "anchor_sha256": hashlib.sha256(anchor_input).hexdigest(),
+        }
+    return block
+
+
+def _canonical_bundle_bytes(bundle: dict[str, Any]) -> bytes:
+    """Serialise the top-level bundle dict canonically.
+
+    Stable rules:
+
+    * ``json.dumps(..., sort_keys=True, separators=(',', ':'))``
+    * Trailing ``\\n``.
+
+    The trailing newline is included so callers concatenating multiple
+    bundles do not run lines together.
+    """
+    return (json.dumps(bundle, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Public: export
+# ---------------------------------------------------------------------------
+
+
+def export_tenant_slice(
+    audit_dir: Path,
+    tenant_id: str,
+    *,
+    since: str,
+    until: str,
+    key: bytes,
+    output_dir: Path | None = None,
+    signature_kind: SignatureKind = "hmac-chain-only",
+    rfc3161_token_b64: str | None = None,
+    rfc3161_tsa_url: str | None = None,
+    offline_anchor_iso: str | None = None,
+    write: bool = True,
+) -> TenantScopedExport:
+    """Build a tenant-scoped audit-chain export bundle.
+
+    Pipeline:
+
+    1. Walk every event in ``audit_dir`` (read-only).
+    2. Filter to events whose ``details.tenant_id`` (after normalization)
+       matches ``tenant_id`` and whose timestamp falls in ``[since, until)``.
+    3. Rebuild a slice-local HMAC chain over the filtered events using
+       ``key`` so the slice is offline-replay-verifiable.
+    4. Emit a deterministic JSON bundle conforming to
+       ``schemas/audit-multitenant-export-v1.json``.
+
+    Args:
+        audit_dir: Directory of HMAC-chained ``YYYY-MM-DD.jsonl`` files
+            (typically ``.sdd/audit/``). Read-only.
+        tenant_id: Tenant whose events to extract. Normalized via
+            :func:`normalize_tenant_id`.
+        since: ISO-8601 inclusive lower bound. String-compared against
+            event timestamps (which are written in canonical UTC ISO-8601
+            so lexical compare matches chronological).
+        until: ISO-8601 exclusive upper bound.
+        key: Operator HMAC key. The slice-local chain is keyed identically
+            so existing operators reuse one secret across exports.
+        output_dir: Where to write the bundle. Defaults to
+            ``audit_dir.parent / 'evidence'`` (``.sdd/evidence/``).
+        signature_kind: Which verifier path the bundle declares. ``hmac-
+            chain-only`` is the default; pass ``hmac-chain+rfc3161`` plus
+            a token to attach a TSA timestamp; pass ``hmac-chain+offline-
+            anchor`` for air-gap deployments.
+        rfc3161_token_b64: Base64-encoded DER TimeStampToken from a TSA.
+            Required iff ``signature_kind == 'hmac-chain+rfc3161'``.
+        rfc3161_tsa_url: URL of the TSA that issued the token.
+        offline_anchor_iso: Override timestamp for the offline anchor
+            (defaults to ``datetime.now(UTC)``). Tests use this for
+            deterministic byte output.
+        write: When False, build everything in-memory and skip the disk
+            write — useful for ``--dry-run`` and tests.
+
+    Returns:
+        :class:`TenantScopedExport` with the serialized bundle bytes,
+        chain anchor, and (when ``write=True``) the on-disk path.
+
+    Raises:
+        ValueError: ``since`` is not strictly less than ``until``, or
+            ``tenant_id`` is empty after normalization, or
+            ``rfc3161_token_b64`` is missing when the signature kind
+            requires it.
+    """
+    if since >= until:
+        raise ValueError(f"since={since!r} must be < until={until!r}")
+    normalized_tenant = normalize_tenant_id(tenant_id)
+    if not normalized_tenant:
+        raise ValueError("tenant_id resolved to empty value after normalization")
+    if signature_kind == "hmac-chain+rfc3161" and not rfc3161_token_b64:
+        raise ValueError(
+            "signature_kind='hmac-chain+rfc3161' requires rfc3161_token_b64",
+        )
+
+    all_events = _read_audit_events(audit_dir)
+    matched = _filter_tenant_events(all_events, normalized_tenant, since, until)
+    rebuilt, head_hmac = _rebuild_slice_chain(matched, key)
+
+    events_canonical = _events_jsonl_bytes(rebuilt)
+    head_sha256 = hashlib.sha256(events_canonical).hexdigest()
+
+    signature_block = _attach_signature(
+        head_sha256,
+        signature_kind=signature_kind,
+        rfc3161_token_b64=rfc3161_token_b64,
+        rfc3161_tsa_url=rfc3161_tsa_url,
+        offline_anchor_iso=offline_anchor_iso,
+    )
+
+    bundle: dict[str, Any] = {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "tenant_id": normalized_tenant,
+        "audit_window": {"since": since, "until": until},
+        "chain_anchor": {
+            "genesis_prev_hmac": _GENESIS_HMAC,
+            "head_hmac": head_hmac,
+            "head_sha256": head_sha256,
+        },
+        "event_count": len(rebuilt),
+        "events": rebuilt,
+        "signature": signature_block,
+    }
+    bundle_bytes = _canonical_bundle_bytes(bundle)
+
+    bundle_path: Path | None = None
+    if write:
+        target_dir = output_dir or (audit_dir.parent / "evidence")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        # File name is deterministic: tenant_id is path-sanitized via
+        # normalize_tenant_id (which strips whitespace) but we still
+        # apply a conservative replace for filesystem safety.
+        safe_tenant = normalized_tenant.replace("/", "_").replace("\\", "_")
+        bundle_path = target_dir / (f"audit-multitenant-{safe_tenant}-{since}-{until}.json")
+        bundle_path.write_bytes(bundle_bytes)
+        logger.info(
+            "Multi-tenant audit slice written tenant=%s events=%d path=%s",
+            normalized_tenant,
+            len(rebuilt),
+            bundle_path,
+        )
+
+    return TenantScopedExport(
+        tenant_id=normalized_tenant,
+        since=since,
+        until=until,
+        event_count=len(rebuilt),
+        head_hmac=head_hmac,
+        head_sha256=head_sha256,
+        signature_kind=signature_kind,
+        bundle_bytes=bundle_bytes,
+        bundle_path=bundle_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public: verify
+# ---------------------------------------------------------------------------
+
+
+def _validate_bundle_envelope(bundle: dict[str, Any]) -> list[str]:
+    """Top-level structural validation; returns human-readable errors."""
+    errors: list[str] = []
+    required = (
+        "schema_version",
+        "tenant_id",
+        "audit_window",
+        "chain_anchor",
+        "event_count",
+        "events",
+        "signature",
+    )
+    for field_name in required:
+        if field_name not in bundle:
+            errors.append(f"missing required field: {field_name}")
+    if errors:
+        return errors
+
+    if bundle["schema_version"] != EXPORT_SCHEMA_VERSION:
+        errors.append(
+            f"schema_version mismatch: got {bundle['schema_version']!r}, expected {EXPORT_SCHEMA_VERSION!r}",
+        )
+    window = bundle.get("audit_window") or {}
+    since = window.get("since")
+    until = window.get("until")
+    if since is None or until is None:
+        errors.append("audit_window must include since and until")
+    elif not isinstance(since, str) or not isinstance(until, str):
+        errors.append("audit_window since/until must be ISO-8601 strings")
+    elif since >= until:
+        # Lexicographic compare matches chronological for canonical UTC ISO.
+        errors.append(f"audit_window since={since!r} must be < until={until!r}")
+    anchor = bundle.get("chain_anchor") or {}
+    for required_anchor in ("genesis_prev_hmac", "head_hmac", "head_sha256"):
+        if required_anchor not in anchor:
+            errors.append(f"chain_anchor missing {required_anchor}")
+    if not isinstance(bundle.get("events"), list):
+        errors.append("events must be a list")
+    return errors
+
+
+def _verify_anchor_consistency(bundle: dict[str, Any]) -> list[str]:
+    """Recompute head_sha256 from events and compare to the bundle anchor."""
+    errors: list[str] = []
+    events = bundle.get("events") or []
+    canonical = _events_jsonl_bytes(events)
+    expected_sha = hashlib.sha256(canonical).hexdigest()
+    anchor = bundle.get("chain_anchor") or {}
+    declared_sha = str(anchor.get("head_sha256", ""))
+    if declared_sha != expected_sha:
+        errors.append(
+            f"head_sha256 mismatch: declared {declared_sha[:16]}…, recomputed {expected_sha[:16]}…",
+        )
+    return errors
+
+
+def _verify_tenant_purity(
+    bundle: dict[str, Any],
+) -> list[str]:
+    """Ensure every event in the slice carries the declared tenant id."""
+    declared = normalize_tenant_id(str(bundle.get("tenant_id", "")))
+    errors: list[str] = []
+    for idx, event in enumerate(bundle.get("events") or []):
+        details = event.get("details") or {}
+        observed = normalize_tenant_id(
+            str(details.get("tenant_id", "")) if isinstance(details, dict) else None,
+        )
+        if observed != declared:
+            errors.append(
+                f"events[{idx}]: tenant_id mismatch (declared {declared!r}, observed {observed!r})",
+            )
+    return errors
+
+
+def _verify_chain(
+    bundle: dict[str, Any],
+    key: bytes,
+) -> list[str]:
+    """Re-derive each event's HMAC and confirm the slice-local chain."""
+    errors: list[str] = []
+    prev = _GENESIS_HMAC
+    for idx, event in enumerate(bundle.get("events") or []):
+        if not isinstance(event, dict):
+            errors.append(f"events[{idx}]: expected object, got {type(event).__name__}")
+            return errors
+        stored_hmac = str(event.get("hmac", ""))
+        recorded_prev = str(event.get("prev_hmac", ""))
+        if recorded_prev != prev:
+            errors.append(
+                f"events[{idx}]: prev_hmac mismatch (expected {prev[:16]}…, got {recorded_prev[:16]}…)",
+            )
+            return errors
+        stripped = {k: v for k, v in event.items() if k != "hmac"}
+        expected_hmac = _compute_event_hmac(key, prev, stripped)
+        if stored_hmac != expected_hmac:
+            errors.append(
+                f"events[{idx}]: HMAC mismatch (expected {expected_hmac[:16]}…, got {stored_hmac[:16]}…)",
+            )
+            return errors
+        prev = stored_hmac
+    anchor = bundle.get("chain_anchor") or {}
+    declared_head = str(anchor.get("head_hmac", ""))
+    if declared_head != prev:
+        errors.append(
+            f"head_hmac mismatch: declared {declared_head[:16]}…, recomputed {prev[:16]}…",
+        )
+    return errors
+
+
+def _verify_signature_block(bundle: dict[str, Any]) -> list[str]:
+    """Light structural checks on the signature block.
+
+    Heavy crypto verification (RFC 3161 token chain) is not done here —
+    operators feed the token to their own toolchain. The bundle merely
+    asserts the kind + that the offline anchor is internally consistent.
+    """
+    errors: list[str] = []
+    sig = bundle.get("signature") or {}
+    kind = sig.get("signature_kind")
+    if kind not in {
+        "hmac-chain-only",
+        "hmac-chain+rfc3161",
+        "hmac-chain+offline-anchor",
+    }:
+        errors.append(f"unknown signature_kind: {kind!r}")
+        return errors
+    if kind == "hmac-chain+rfc3161":
+        token = sig.get("rfc3161_token_b64")
+        if not token or not isinstance(token, str):
+            errors.append("rfc3161_token_b64 missing for signature_kind=rfc3161")
+            return errors
+        try:
+            base64.b64decode(token, validate=True)
+        except (ValueError, TypeError) as exc:
+            errors.append(f"rfc3161_token_b64 not valid base64: {exc}")
+    if kind == "hmac-chain+offline-anchor":
+        anchor = sig.get("offline_anchor") or {}
+        ts = str(anchor.get("anchored_at", ""))
+        declared = str(anchor.get("anchor_sha256", ""))
+        head_sha256 = str((bundle.get("chain_anchor") or {}).get("head_sha256", ""))
+        recomputed = hashlib.sha256((head_sha256 + ts).encode()).hexdigest()
+        if declared != recomputed:
+            errors.append(
+                "offline_anchor.anchor_sha256 does not match sha256(head_sha256 || anchored_at)",
+            )
+    return errors
+
+
+def verify_tenant_slice(
+    bundle_or_path: Path | bytes | dict[str, Any],
+    *,
+    key: bytes,
+) -> TenantSliceVerification:
+    """Re-verify a tenant-scoped audit slice offline.
+
+    Runs without orchestrator state — the verifier needs only the bundle
+    bytes and the operator's HMAC key. Performs four independent checks:
+
+    1. Envelope structure (schema_version, required fields, types).
+    2. Tenant purity — every event carries the declared tenant id.
+    3. Chain integrity — re-derive each event's HMAC, confirm the chain
+       links forward correctly, and confirm the declared ``head_hmac``
+       matches the recomputed tail.
+    4. Anchor consistency — recompute ``head_sha256`` from the canonical
+       JSONL and compare. (Catches single-byte flips even when the key
+       is leaked or the chain check is somehow bypassed.)
+    5. Signature block sanity — base64 validity, offline anchor formula.
+
+    Args:
+        bundle_or_path: A path on disk, raw bundle bytes, or a parsed
+            dict. The path/bytes branch parses canonical JSON.
+        key: Operator HMAC key. Same key used to write the slice.
+
+    Returns:
+        :class:`TenantSliceVerification` carrying the parsed bundle and
+        every observed failure.
+    """
+    bundle: dict[str, Any] = {}
+    parse_errors: list[str] = []
+    try:
+        if isinstance(bundle_or_path, dict):
+            bundle = bundle_or_path
+        else:
+            raw = bundle_or_path.read_bytes() if isinstance(bundle_or_path, Path) else bundle_or_path
+            bundle = json.loads(raw.decode("utf-8"))
+            if not isinstance(bundle, dict):
+                parse_errors.append("bundle is not a JSON object")
+    except (OSError, json.JSONDecodeError) as exc:
+        parse_errors.append(f"failed to read/parse bundle: {exc}")
+
+    if parse_errors:
+        return TenantSliceVerification(ok=False, errors=parse_errors, bundle={})
+
+    errors: list[str] = []
+    errors.extend(_validate_bundle_envelope(bundle))
+    if errors:
+        return TenantSliceVerification(ok=False, errors=errors, bundle=bundle)
+
+    errors.extend(_verify_anchor_consistency(bundle))
+    errors.extend(_verify_tenant_purity(bundle))
+    errors.extend(_verify_chain(bundle, key))
+    errors.extend(_verify_signature_block(bundle))
+
+    return TenantSliceVerification(ok=not errors, errors=errors, bundle=bundle)
+
+
+__all__ = [
+    "EXPORT_SCHEMA_VERSION",
+    "SignatureKind",
+    "TenantScopedExport",
+    "TenantSliceVerification",
+    "export_tenant_slice",
+    "verify_tenant_slice",
+]

--- a/tests/unit/test_audit_multitenant.py
+++ b/tests/unit/test_audit_multitenant.py
@@ -1,0 +1,616 @@
+"""Unit tests for the multi-tenant HMAC-chained audit-log export.
+
+Covers the ticket's hard constraints:
+
+* **Determinism** — same input → byte-identical bundle.
+* **Tenant filter** — only events with the matching ``tenant_id`` leak
+  through.
+* **Chain integrity** — :func:`verify_tenant_slice` passes on a clean
+  slice; a one-byte flip flips it to ``ok=False``.
+* **Cross-tenant leakage** — a tampered ``tenant_id`` in a slice is
+  detected.
+* **Empty window safe** — no events for tenant produces an empty-but-
+  verifiable slice.
+
+The tests use the same HMAC key plumbing as the production
+:class:`AuditLog` so the slice exercises the real keying surface.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_multitenant import (
+    EXPORT_SCHEMA_VERSION,
+    export_tenant_slice,
+    verify_tenant_slice,
+)
+
+# A deterministic byte key — easier to reason about than a generated hex key.
+_TEST_KEY: bytes = b"x" * 32
+
+
+def _seed_two_tenants(audit_dir: Path) -> AuditLog:
+    """Write a small chain mixing two tenants + one untagged ('default').
+
+    Returns:
+        The :class:`AuditLog` that wrote the events (still keyed to
+        ``_TEST_KEY``).
+    """
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=_TEST_KEY)
+    log.log("task.created", "alice", "task", "T-1", {"tenant_id": "acme"})
+    log.log("agent.spawned", "orchestrator", "agent", "A-1", {"tenant_id": "acme"})
+    log.log("task.created", "bob", "task", "T-2", {"tenant_id": "globex"})
+    log.log("legacy.event", "system", "task", "T-3", {})  # → tenant 'default'
+    log.log("task.completed", "alice", "task", "T-1", {"tenant_id": "acme"})
+    return log
+
+
+def _today_window() -> tuple[str, str]:
+    """Return an ``[since, until)`` pair covering today (UTC)."""
+    today = datetime.now(tz=UTC).date()
+    since = f"{today.isoformat()}T00:00:00+00:00"
+    until = f"{(today + timedelta(days=1)).isoformat()}T00:00:00+00:00"
+    return since, until
+
+
+# ---------------------------------------------------------------------------
+# Tenant filter
+# ---------------------------------------------------------------------------
+
+
+class TestTenantFilter:
+    """Only events tagged with the requested tenant_id leak through."""
+
+    def test_acme_isolation(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert export.event_count == 3
+        assert export.tenant_id == "acme"
+        # Every emitted event carries tenant_id=acme.
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        for event in bundle["events"]:
+            assert event["details"]["tenant_id"] == "acme"
+
+    def test_globex_isolation(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="globex",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert export.event_count == 1
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        assert all(e["details"]["tenant_id"] == "globex" for e in bundle["events"])
+
+    def test_untagged_events_collapse_to_default_tenant(self, tmp_path: Path) -> None:
+        """Events without ``details.tenant_id`` belong to 'default'.
+
+        Matches :func:`bernstein.core.security.tenanting.normalize_tenant_id`.
+        Critical for backwards compatibility — operators who roll
+        multi-tenant out gradually keep their pre-existing chain visible.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="default",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert export.event_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Same inputs → byte-identical output. Required for spot-audit replay."""
+
+    def test_byte_identical_rebuild(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        first = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out1",
+            write=True,
+        )
+        second = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out2",
+            write=True,
+        )
+
+        # In-memory bytes match.
+        assert first.bundle_bytes == second.bundle_bytes
+        # Cryptographic anchors match.
+        assert first.head_hmac == second.head_hmac
+        assert first.head_sha256 == second.head_sha256
+        assert first.sha256 == second.sha256
+        # On-disk bytes match.
+        assert first.bundle_path is not None
+        assert second.bundle_path is not None
+        assert first.bundle_path.read_bytes() == second.bundle_path.read_bytes()
+
+    def test_offline_anchor_with_pinned_timestamp_is_deterministic(self, tmp_path: Path) -> None:
+        """Air-gap mode is deterministic when the operator pins the anchor ts.
+
+        This guards the air-gap branch: ``signature_kind=hmac-chain+
+        offline-anchor`` defaults the anchor timestamp to ``now()`` —
+        which is non-deterministic. Operators chasing byte-stable
+        bundles must pin ``offline_anchor_iso``.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+        pinned = "2026-08-01T00:00:00Z"
+
+        first = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            signature_kind="hmac-chain+offline-anchor",
+            offline_anchor_iso=pinned,
+            output_dir=tmp_path / "a",
+            write=True,
+        )
+        second = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            signature_kind="hmac-chain+offline-anchor",
+            offline_anchor_iso=pinned,
+            output_dir=tmp_path / "b",
+            write=True,
+        )
+        assert first.bundle_bytes == second.bundle_bytes
+
+
+# ---------------------------------------------------------------------------
+# Chain integrity
+# ---------------------------------------------------------------------------
+
+
+class TestChainIntegrity:
+    """The slice-local HMAC chain must verify offline."""
+
+    def test_verify_passes_on_clean_slice(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert export.bundle_path is not None
+        result = verify_tenant_slice(export.bundle_path, key=_TEST_KEY)
+        assert result.ok, result.errors
+        assert result.bundle["schema_version"] == EXPORT_SCHEMA_VERSION
+
+    def test_verify_passes_on_in_memory_bytes(self, tmp_path: Path) -> None:
+        """Verifier accepts raw bytes (no disk read) and parsed dicts alike."""
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        result_from_bytes = verify_tenant_slice(export.bundle_bytes, key=_TEST_KEY)
+        assert result_from_bytes.ok, result_from_bytes.errors
+
+        as_dict = json.loads(export.bundle_bytes.decode("utf-8"))
+        result_from_dict = verify_tenant_slice(as_dict, key=_TEST_KEY)
+        assert result_from_dict.ok, result_from_dict.errors
+
+    def test_one_byte_flip_in_event_breaks_verification(self, tmp_path: Path) -> None:
+        """Mutate one byte inside an event's resource_id → verifier fails.
+
+        Targets a byte unambiguously inside the chain-covered region. The
+        flip changes the event payload that feeds HMAC, so chain
+        verification fails on the affected event.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert export.bundle_path is not None
+
+        # Flip the resource_id 'T-1' → 'X-1' inside the events array.
+        # That string only appears in event payloads (not in metadata).
+        original = export.bundle_path.read_bytes()
+        target = b'"resource_id":"T-1"'
+        idx = original.find(target)
+        assert idx >= 0, "expected resource_id payload in bundle"
+        flipped = bytearray(original)
+        flipped[idx + len(b'"resource_id":"')] = ord("X")
+        export.bundle_path.write_bytes(bytes(flipped))
+
+        result = verify_tenant_slice(export.bundle_path, key=_TEST_KEY)
+        assert not result.ok
+        assert result.errors  # at least one human-readable failure
+        joined = " ".join(result.errors)
+        # Either the chain HMAC re-derivation or the head_sha256 anchor
+        # catches the flip.
+        assert "HMAC mismatch" in joined or "head_sha256 mismatch" in joined
+
+    def test_one_byte_flip_in_metadata_breaks_anchor(self, tmp_path: Path) -> None:
+        """Flip a byte in audit_window → schema sanity check fails.
+
+        ``audit_window`` is bundle metadata, not chain-covered. The
+        verifier still rejects it because the envelope checks require
+        well-formed since/until strings and since < until.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        # Make since > until so the envelope check rejects.
+        bundle["audit_window"]["since"] = "2099-01-01T00:00:00+00:00"
+        result = verify_tenant_slice(bundle, key=_TEST_KEY)
+        assert not result.ok
+
+    def test_wrong_key_fails_verification(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        result = verify_tenant_slice(export.bundle_bytes, key=b"y" * 32)
+        assert not result.ok
+        # The chain check should be the failing one.
+        assert any("HMAC mismatch" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant tamper detection
+# ---------------------------------------------------------------------------
+
+
+class TestCrossTenantTamperDetection:
+    """A flipped tenant_id inside a slice must be caught."""
+
+    def test_tampered_tenant_id_detected(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        # Parse, mutate, re-serialise — simulate an attacker who edits
+        # the bundle JSON manually.
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        bundle["events"][0]["details"]["tenant_id"] = "globex"
+        result = verify_tenant_slice(bundle, key=_TEST_KEY)
+        assert not result.ok
+        # Either tenant purity or the chain mismatch (since the HMAC
+        # covers details) flags the tamper.
+        joined = " ".join(result.errors)
+        assert "tenant_id mismatch" in joined or "HMAC mismatch" in joined
+
+    def test_top_level_tenant_id_flip_detected(self, tmp_path: Path) -> None:
+        """Flipping only the top-level tenant_id (header) must still fail.
+
+        The verifier walks every event and confirms each one carries the
+        declared tenant_id. A top-level flip lights up purity.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        bundle["tenant_id"] = "globex"
+        result = verify_tenant_slice(bundle, key=_TEST_KEY)
+        assert not result.ok
+        joined = " ".join(result.errors)
+        assert "tenant_id mismatch" in joined
+
+
+# ---------------------------------------------------------------------------
+# Empty window safety
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyWindowSafe:
+    """No events for the tenant → produce an empty-but-verifiable slice."""
+
+    def test_empty_window_has_genesis_anchors(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        # No events at all.
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            output_dir=tmp_path / "out",
+            write=True,
+        )
+        assert export.event_count == 0
+        assert export.head_hmac == "0" * 64
+        # head_sha256 of empty JSONL is the SHA-256 of the empty string.
+        import hashlib
+
+        assert export.head_sha256 == hashlib.sha256(b"").hexdigest()
+
+        result = verify_tenant_slice(export.bundle_bytes, key=_TEST_KEY)
+        assert result.ok, result.errors
+
+    def test_unknown_tenant_id_returns_empty_safe(self, tmp_path: Path) -> None:
+        """Tenant id that never appears in the log is treated as empty.
+
+        Same invariants as the empty-log case: head HMAC = genesis,
+        verifier returns ok.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="initech",  # never seen
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        assert export.event_count == 0
+        assert export.head_hmac == "0" * 64
+        result = verify_tenant_slice(export.bundle_bytes, key=_TEST_KEY)
+        assert result.ok, result.errors
+
+
+# ---------------------------------------------------------------------------
+# Signature variants
+# ---------------------------------------------------------------------------
+
+
+class TestSignatureKinds:
+    """Each signature kind round-trips through the verifier cleanly."""
+
+    def test_hmac_chain_only(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            signature_kind="hmac-chain-only",
+            write=False,
+        )
+        result = verify_tenant_slice(export.bundle_bytes, key=_TEST_KEY)
+        assert result.ok, result.errors
+
+    def test_offline_anchor_self_consistent(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            signature_kind="hmac-chain+offline-anchor",
+            offline_anchor_iso="2026-08-01T00:00:00Z",
+            write=False,
+        )
+        result = verify_tenant_slice(export.bundle_bytes, key=_TEST_KEY)
+        assert result.ok, result.errors
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        anchor = bundle["signature"]["offline_anchor"]
+        assert anchor["anchored_at"] == "2026-08-01T00:00:00Z"
+
+    def test_offline_anchor_tampered_anchor_detected(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            signature_kind="hmac-chain+offline-anchor",
+            offline_anchor_iso="2026-08-01T00:00:00Z",
+            write=False,
+        )
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        bundle["signature"]["offline_anchor"]["anchor_sha256"] = "0" * 64
+        result = verify_tenant_slice(bundle, key=_TEST_KEY)
+        assert not result.ok
+        assert any("offline_anchor" in e for e in result.errors)
+
+    def test_rfc3161_requires_token(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        with pytest.raises(ValueError, match="rfc3161_token_b64"):
+            export_tenant_slice(
+                audit_dir=audit_dir,
+                tenant_id="acme",
+                since=since,
+                until=until,
+                key=_TEST_KEY,
+                signature_kind="hmac-chain+rfc3161",
+                rfc3161_token_b64=None,
+                write=False,
+            )
+
+    def test_rfc3161_token_round_trips(self, tmp_path: Path) -> None:
+        """The verifier accepts a valid base64 token; rejects garbage."""
+        import base64
+
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        token = base64.b64encode(b"fake-tsa-der-bytes").decode("ascii")
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="acme",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            signature_kind="hmac-chain+rfc3161",
+            rfc3161_token_b64=token,
+            rfc3161_tsa_url="https://freetsa.example/tsa",
+            write=False,
+        )
+        result = verify_tenant_slice(export.bundle_bytes, key=_TEST_KEY)
+        assert result.ok, result.errors
+        bundle = json.loads(export.bundle_bytes.decode("utf-8"))
+        assert bundle["signature"]["rfc3161_token_b64"] == token
+
+        # Tamper: replace token with non-base64 garbage.
+        bundle["signature"]["rfc3161_token_b64"] = "not!valid!base64!"
+        garbage_result = verify_tenant_slice(bundle, key=_TEST_KEY)
+        assert not garbage_result.ok
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Operator misuse must surface fast."""
+
+    def test_since_must_be_less_than_until(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        audit_dir.mkdir(parents=True)
+        with pytest.raises(ValueError, match="since"):
+            export_tenant_slice(
+                audit_dir=audit_dir,
+                tenant_id="acme",
+                since="2026-08-02T00:00:00+00:00",
+                until="2026-08-01T00:00:00+00:00",
+                key=_TEST_KEY,
+                write=False,
+            )
+
+    def test_empty_tenant_collapses_to_default(self, tmp_path: Path) -> None:
+        """Empty/whitespace tenant_id collapses to ``default``.
+
+        Matches :func:`bernstein.core.security.tenanting.normalize_tenant_id`
+        and avoids a footgun where the operator passes ``""`` and accidentally
+        gets a slice of *every* untagged event without warning.
+        """
+        audit_dir = tmp_path / ".sdd" / "audit"
+        _seed_two_tenants(audit_dir)
+        since, until = _today_window()
+
+        export = export_tenant_slice(
+            audit_dir=audit_dir,
+            tenant_id="   ",
+            since=since,
+            until=until,
+            key=_TEST_KEY,
+            write=False,
+        )
+        assert export.tenant_id == "default"


### PR DESCRIPTION
## Summary

Tenant-scoped audit-log export. Enterprise operators running bernstein for multiple internal customers can hand each customer (or that customer's external auditor) a slice of the HMAC-chained log scoped to one tenant_id, replay-verifiable offline.

- New module: \`src/bernstein/core/security/audit_multitenant.py\` — \`TenantScopedExport\` + \`verify_tenant_slice\`.
- Slice events are re-chained over a slice-local HMAC keyed by the same operator HMAC key. An auditor with the key replay-verifies offline; a SHA-256 anchor over canonical JSONL also catches byte flips for key-less integrity checks.
- Tenant id lives at \`details.tenant_id\` (canonical opt-in via existing \`details\` payload). Legacy untagged events fall to the \`default\` tenant via \`normalize_tenant_id\` so multi-tenant rollout is incremental.
- Wire format: custom JSON Schema draft-07 at \`schemas/audit-multitenant-export-v1.json\`, versioned \`1.0.0\`. Custom rather than W3C VC v2 / in-toto because line-oriented JSONL audit chains do not fit RDF / JSON-LD subject-predicate shapes cleanly. Migration path remains open via \`schema_version\` bump.
- CLI: \`bernstein audit export --tenant <id> --since <iso> --until <iso> [--signature-kind ...] [--rfc3161-token <path>]\`. RFC 3161 TimeStampToken supported as a detached optional anchor; deterministic offline-anchor mode shipped for air-gap deployments.
- Operator guide: \`docs/security/audit-multitenant.md\`.

## What is shipped + unit-tested

- Determinism — \`test_byte_identical_rebuild\`, \`test_offline_anchor_with_pinned_timestamp_is_deterministic\`.
- Tenant filter — \`test_acme_isolation\`, \`test_globex_isolation\`, \`test_untagged_events_collapse_to_default_tenant\`.
- Chain integrity — \`test_verify_passes_on_clean_slice\`, \`test_one_byte_flip_in_event_breaks_verification\`, \`test_one_byte_flip_in_metadata_breaks_anchor\`, \`test_wrong_key_fails_verification\`, \`test_verify_passes_on_in_memory_bytes\`.
- Cross-tenant tamper detection — \`test_tampered_tenant_id_detected\`, \`test_top_level_tenant_id_flip_detected\`.
- Empty-window safety — \`test_empty_window_has_genesis_anchors\`, \`test_unknown_tenant_id_returns_empty_safe\`.
- Signature variants — \`test_hmac_chain_only\`, \`test_offline_anchor_self_consistent\`, \`test_offline_anchor_tampered_anchor_detected\`, \`test_rfc3161_requires_token\`, \`test_rfc3161_token_round_trips\`.
- Input validation — \`test_since_must_be_less_than_until\`, \`test_empty_tenant_collapses_to_default\`.

21/21 tests pass. Wider audit suite (audit, audit_slice, article12_bundle, audit_multitenant) → 60/60 pass.

## What is shipped but NOT integration-tested

- The \`bernstein audit export --tenant\` CLI surface is wired and \`--help\` renders, but I did not run an end-to-end \`bernstein run\` → real \`.sdd/audit/*.jsonl\` → \`bernstein audit export --tenant ... → verify\` flow. The unit tests exercise the underlying primitive against an \`AuditLog\` keyed identically to production, so the integration path is high-confidence; a smoke test in \`tests/integration/\` is a follow-up.

## What is shipped but spec-only

- RFC 3161 token cryptographic verification. The bundle records the token verbatim and the verifier confirms base64 validity; chain validation against the TSA's CA bundle is delegated to the operator's existing \`openssl ts -verify\` toolchain. Wiring an in-process verifier requires a TSA-CA-roots policy decision that is out of scope for v1.
- Public-key signatures over \`head_sha256\` (cosign / Sigstore / SCITT). Documented in the operator guide as a v2 follow-up — would let key-less auditors validate authenticity.

## Constraints honoured

- Byte-identical determinism: confirmed by \`test_byte_identical_rebuild\` (in-memory + on-disk bytes equal across two runs with the same inputs).
- Versioned schema: \`schema_version: 1.0.0\` published at \`schemas/audit-multitenant-export-v1.json\`.
- HMAC chain integrity across tenant scoping: slice-local re-chain keeps the chain consistent for the filtered events; \`verify_tenant_slice\` runs without orchestrator state.

## Test plan

- [x] \`uv run ruff format src/ tests/\` — clean
- [x] \`uv run ruff check src/ tests/\` — clean
- [x] \`uv run pytest tests/unit/test_audit_multitenant.py\` — 21/21 pass
- [x] \`uv run pytest tests/unit/test_audit_multitenant.py tests/unit/test_audit.py tests/unit/test_audit_slice.py tests/unit/test_article12_bundle.py\` — 60/60 pass
- [x] \`uv run bernstein audit export --help\` — renders new \`--tenant\` / \`--signature-kind\` / \`--rfc3161-token\` / \`--rfc3161-tsa-url\` flags
- [x] Schema is parseable JSON