### PR TITLE
chore(voice): anti-ai-tell pass on cli + role templates

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -136,7 +136,7 @@ alwaysApply: false
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
-| `commit_stats.py`       | Commit attribution stats — gather per-role commit stats via git log |
+| `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |

--- a/.goosehints
+++ b/.goosehints
@@ -137,7 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
-| `commit_stats.py`       | Commit attribution stats — gather per-role commit stats via git log |
+| `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
-| `commit_stats.py`       | Commit attribution stats — gather per-role commit stats via git log |
+| `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
-| `commit_stats.py`       | Commit attribution stats — gather per-role commit stats via git log |
+| `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -137,7 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
-| `commit_stats.py`       | Commit attribution stats — gather per-role commit stats via git log |
+| `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -168,7 +168,7 @@ class _CLIRedirectLoader:
         sys.modules[fullname] = real
 
     def get_code(self, _fullname: str) -> None:
-        """Return None — redirect loaders don't provide code objects."""
+        """Return None: redirect loaders don't provide code objects."""
         return None
 
 

--- a/src/bernstein/cli/commands/ab_test_cmd.py
+++ b/src/bernstein/cli/commands/ab_test_cmd.py
@@ -62,7 +62,7 @@ def ab_test_cmd(
     )
 
     console.print(
-        f"[bold]A/B Test[/bold] — {model_a} vs {model_b}\n"
+        f"[bold]A/B Test[/bold]: {model_a} vs {model_b}\n"
         f"[dim]Task:[/dim] {task_description}\n"
         f"[dim]Role:[/dim] {role}  [dim]Scope:[/dim] {scope}  "
         f"[dim]Timeout:[/dim] {timeout_seconds}s\n"

--- a/src/bernstein/cli/commands/acp_cmd.py
+++ b/src/bernstein/cli/commands/acp_cmd.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 @click.group("acp")
 def acp_group() -> None:
-    """Agent Client Protocol (ACP) bridge — IDE integration surface."""
+    """Agent Client Protocol (ACP) bridge: IDE integration surface."""
 
 
 @acp_group.command("serve")

--- a/src/bernstein/cli/commands/adapter_cmd.py
+++ b/src/bernstein/cli/commands/adapter_cmd.py
@@ -46,7 +46,7 @@ def _wait_for_exit(adapter: Any, result: Any, timeout: int) -> str | int:
     try:
         return result.proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
-        console.print(f"[yellow]Timeout after {timeout}s — killing pid {result.pid}[/yellow]")
+        console.print(f"[yellow]Timeout after {timeout}s: killing pid {result.pid}[/yellow]")
         adapter.kill(result.pid)
         return "timed out"
 

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -378,7 +378,7 @@ def retro(
 @click.command("help-all")
 @click.pass_context
 def help_all(ctx: click.Context) -> None:
-    """Show comprehensive help with all command groups and descriptions."""
+    """Show full help with every command group and description."""
     # Import here to avoid circular dependency
     from bernstein.cli.main import print_rich_help
 
@@ -637,7 +637,7 @@ def doctor_scoping_cmd(ctx: click.Context, agent_id: str, role: str) -> None:
         console.print(f"  [yellow]would-strip[/yellow]: {', '.join(snapshot['stripped'])}")
         console.print(
             "  [dim](these env-vars are present but the policy would not "
-            "pass them to the agent — verify they are intentional)[/dim]"
+            "pass them to the agent: verify they are intentional)[/dim]"
         )
     if snapshot["missing"]:
         console.print(f"  [yellow]missing[/yellow]: {', '.join(snapshot['missing'])}")
@@ -1161,8 +1161,8 @@ def _github_setup() -> None:  # type: ignore[reportUnusedFunction]
     """Configure GitHub integration for Bernstein."""
     console.print("[cyan]GitHub Integration Setup[/cyan]")
     console.print("Set these environment variables:")
-    console.print("  GITHUB_TOKEN — personal access token")
-    console.print("  GITHUB_REPO — owner/repo")
+    console.print("  GITHUB_TOKEN: personal access token")
+    console.print("  GITHUB_REPO: owner/repo")
 
 
 @github_group.command("test-webhook")
@@ -1189,15 +1189,15 @@ def completions(ctx: click.Context, shell: str) -> None:
     """Generate shell completion scripts.
 
     \b
-    For bash — add to ~/.bashrc:
+    For bash, add to ~/.bashrc:
       eval "$(bernstein completions --shell bash)"
 
     \b
-    For zsh — add to ~/.zshrc:
+    For zsh, add to ~/.zshrc:
       eval "$(bernstein completions --shell zsh)"
 
     \b
-    For fish — add to ~/.config/fish/completions/bernstein.fish:
+    For fish, add to ~/.config/fish/completions/bernstein.fish:
       bernstein completions --shell fish | source
     """
     from click.shell_completion import BashComplete, FishComplete, ZshComplete

--- a/src/bernstein/cli/commands/agents_cmd.py
+++ b/src/bernstein/cli/commands/agents_cmd.py
@@ -78,7 +78,7 @@ def _sync_agency_local_yaml() -> None:
     agency_dir = Path(_AGENCY_DIR)
     console.print(f"\n[cyan]→ agency (local YAML)[/cyan] {agency_dir}")
     if not agency_dir.exists():
-        console.print(f"  [dim]Directory not found — skipping (place Agency YAML files in {agency_dir})[/dim]")
+        console.print(f"  [dim]Directory not found: skipping (place Agency YAML files in {agency_dir})[/dim]")
         return
     from bernstein.core.agency_loader import load_agency_catalog
 
@@ -321,7 +321,7 @@ def _validate_local_definitions(definitions_path: Path, issues: list[str]) -> No
 
     yaml_files = list(definitions_path.glob("*.yaml")) + list(definitions_path.glob("*.yml"))
     if not yaml_files:
-        console.print("  [dim]No YAML files found — catalog is empty[/dim]")
+        console.print("  [dim]No YAML files found: catalog is empty[/dim]")
     for yaml_file in sorted(yaml_files):
         try:
             content = yaml_file.read_text(encoding="utf-8")
@@ -341,13 +341,13 @@ def _validate_agency_catalog(issues: list[str]) -> None:
     agency_dir = Path(_AGENCY_DIR)
     console.print(f"\n[cyan]→ agency[/cyan] {agency_dir}")
     if not agency_dir.exists():
-        console.print("  [dim]Not configured — skipping[/dim]")
+        console.print("  [dim]Not configured: skipping[/dim]")
         return
     from bernstein.core.agency_loader import parse_agency_agent
 
     agency_files = [p for p in sorted(agency_dir.iterdir()) if p.suffix in (".yaml", ".yml")]
     if not agency_files:
-        console.print("  [dim]No YAML files found — catalog is empty[/dim]")
+        console.print("  [dim]No YAML files found: catalog is empty[/dim]")
     for p in agency_files:
         try:
             parse_agency_agent(p)

--- a/src/bernstein/cli/commands/agents_md_cmd.py
+++ b/src/bernstein/cli/commands/agents_md_cmd.py
@@ -359,7 +359,7 @@ def _generate_sections(workdir: Path, repo_name: str | None) -> tuple[list[Agent
     resolved = workdir.resolve()
     sections = generate(resolved)
     if not sections:
-        click.echo(f"No content derived from {workdir} — is this a repository?", err=True)
+        click.echo(f"No content derived from {workdir}: is this a repository?", err=True)
         sys.exit(2)
     name = repo_name or _infer_repo_name(resolved)
     return sections, name

--- a/src/bernstein/cli/commands/api_check_cmd.py
+++ b/src/bernstein/cli/commands/api_check_cmd.py
@@ -75,7 +75,7 @@ def api_check_cmd(base: str, workdir: str | None) -> None:
 
     if not report.is_compatible:
         n = len(report.breaking_changes)
-        console.print(f"[bold red]API compatibility check FAILED — {n} breaking change(s)[/bold red]")
+        console.print(f"[bold red]API compatibility check FAILED: {n} breaking change(s)[/bold red]")
         raise SystemExit(1)
 
     console.print("[bold green]API compatibility check passed.[/bold green]")

--- a/src/bernstein/cli/commands/approve_cmd.py
+++ b/src/bernstein/cli/commands/approve_cmd.py
@@ -128,7 +128,7 @@ def approve(task_id: str, workdir: str, prompt: bool) -> None:
 
     created = _atomic_write_text(decision_file, "approved")
     if created:
-        console.print(f"[green]Approved:[/green] task [bold]{task_id}[/bold] — Bernstein will continue.")
+        console.print(f"[green]Approved:[/green] task [bold]{task_id}[/bold]: Bernstein will continue.")
     else:
         console.print(f"[dim]Already approved:[/dim] task [bold]{task_id}[/bold] (no-op)")
 

--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -814,7 +814,7 @@ def capabilities_cmd(workdir: str) -> None:
         )
     )
     for decision in violations:
-        console.print(f"  [red]![/red] {decision.reason} — tools=[bold]{list(decision.offending_tools)}[/bold]")
+        console.print(f"  [red]![/red] {decision.reason}: tools=[bold]{list(decision.offending_tools)}[/bold]")
     console.print()
     raise SystemExit(1)
 
@@ -824,13 +824,13 @@ def capabilities_cmd(workdir: str) -> None:
     "--from",
     "from_hmac",
     default=None,
-    help="Inclusive lower bound — HMAC of the first event to include.  Omit to start at the earliest recorded event.",
+    help="Inclusive lower bound: HMAC of the first event to include.  Omit to start at the earliest recorded event.",
 )
 @click.option(
     "--to",
     "to_hmac",
     default=None,
-    help="Inclusive upper bound — HMAC of the last event to include.  Omit to run through the latest event.",
+    help="Inclusive upper bound: HMAC of the last event to include.  Omit to run through the latest event.",
 )
 @click.option(
     "--output",

--- a/src/bernstein/cli/commands/changelog_cmd.py
+++ b/src/bernstein/cli/commands/changelog_cmd.py
@@ -1,4 +1,4 @@
-"""changelog command — auto-generate a changelog from conventional commits."""
+"""changelog command: auto-generate a changelog from conventional commits."""
 
 from __future__ import annotations
 
@@ -408,7 +408,7 @@ def changelog_cmd(
         if effective_since:
             console.print(f"[dim]Using latest tag: {effective_since}[/dim]")
         else:
-            console.print("[dim]No tags found — showing all commits.[/dim]")
+            console.print("[dim]No tags found: showing all commits.[/dim]")
 
     # ------------------------------------------------------------------
     # 2. Fetch commits

--- a/src/bernstein/cli/commands/checkpoint_cmd.py
+++ b/src/bernstein/cli/commands/checkpoint_cmd.py
@@ -1,4 +1,4 @@
-"""Checkpoint command — snapshot current session progress to disk."""
+"""Checkpoint command: snapshot current session progress to disk."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/ci_cmd.py
+++ b/src/bernstein/cli/commands/ci_cmd.py
@@ -151,7 +151,7 @@ def _poll_once(
         return
 
     if not failures:
-        console.print(f"[dim]{time.strftime('%H:%M:%S')} — no new failures[/dim]")
+        console.print(f"[dim]{time.strftime('%H:%M:%S')}: no new failures[/dim]")
         return
 
     for failure in failures:

--- a/src/bernstein/cli/commands/cloud_cmd.py
+++ b/src/bernstein/cli/commands/cloud_cmd.py
@@ -34,7 +34,7 @@ _RUNS_PATH = "/runs"
 
 @click.group("cloud")
 def cloud_group() -> None:
-    """Manage Bernstein Cloud — hosted orchestration on Cloudflare."""
+    """Manage Bernstein Cloud: hosted orchestration on Cloudflare."""
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/commands/cluster_cmd.py
+++ b/src/bernstein/cli/commands/cluster_cmd.py
@@ -1,4 +1,4 @@
-"""``bernstein cluster`` — cluster lifecycle helpers (mTLS bootstrap, etc.)."""
+"""``bernstein cluster``: cluster lifecycle helpers (mTLS bootstrap, etc.)."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/compliance_cmd.py
+++ b/src/bernstein/cli/commands/compliance_cmd.py
@@ -170,7 +170,7 @@ def _print_report(report: dict[str, object], as_json: bool) -> None:
     partial = conformity.get("partial", 0)
 
     click.echo("─" * 60)
-    click.echo("  EU AI Act Compliance Assessment — Bernstein")
+    click.echo("  EU AI Act Compliance Assessment: Bernstein")
     click.echo("─" * 60)
     click.echo(f"  Risk Category    : {risk}")
     click.echo(f"  Annex III Domain : {domain}")
@@ -404,7 +404,7 @@ def check_policies(
             )
         )
     else:
-        click.echo(f"Compliance check — {len(results)} policies evaluated")
+        click.echo(f"Compliance check: {len(results)} policies evaluated")
         click.echo(f"  Passing: {len(passing)}   Failing: {len(failing)}")
         click.echo("")
         if failing:

--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -1,4 +1,4 @@
-"""Bernstein cost — spend visibility across all recorded metrics."""
+"""Bernstein cost: spend visibility across all recorded metrics."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/delegate_cmd.py
+++ b/src/bernstein/cli/commands/delegate_cmd.py
@@ -140,7 +140,7 @@ def delegate(
     if as_json:
         click.echo(json.dumps({"task_id": task_id, "status": result.get("status", "open"), "poll_url": poll_url}))
     else:
-        console.print(f"[green]Delegated:[/green] [bold]{task_id}[/bold] — {task_description}")
+        console.print(f"[green]Delegated:[/green] [bold]{task_id}[/bold]: {task_description}")
         console.print(f"[dim]Role: {role}  Priority: {priority}  Scope: {scope}[/dim]")
         console.print(f"[dim]Poll: bernstein delegate --task ... --wait  |  {poll_url}[/dim]")
 

--- a/src/bernstein/cli/commands/dep_impact_cmd.py
+++ b/src/bernstein/cli/commands/dep_impact_cmd.py
@@ -151,7 +151,7 @@ def _check_exit_conditions(report: Any, strict: bool) -> None:
         n_api = len(report.api_breaking)
         n_cs = len(report.call_site_impacts)
         console.print(
-            f"[bold red]Dependency impact check FAILED — {n_api} API break(s), {n_cs} affected call site(s)[/bold red]"
+            f"[bold red]Dependency impact check FAILED: {n_api} API break(s), {n_cs} affected call site(s)[/bold red]"
         )
         raise SystemExit(1)
 

--- a/src/bernstein/cli/commands/disaster_recovery_cmd.py
+++ b/src/bernstein/cli/commands/disaster_recovery_cmd.py
@@ -126,7 +126,7 @@ def dr_restore_cmd(
     sdd = sdd_dir or Path(".sdd")
 
     if dry_run:
-        console.print(f"[bold]Dry run[/bold] — listing contents of {source}:")
+        console.print(f"[bold]Dry run[/bold]: listing contents of {source}:")
     else:
         console.print(f"[bold]Restoring[/bold] {source} [bold]into[/bold] {sdd}...")
         if decrypt:

--- a/src/bernstein/cli/commands/doctor_cmd.py
+++ b/src/bernstein/cli/commands/doctor_cmd.py
@@ -283,7 +283,7 @@ def run_all_checks() -> list[dict[str, Any]]:
 @click.option("--fix", "auto_fix", is_flag=True, default=False, help="Attempt to auto-fix issues.")
 @click.pass_context
 def doctor_cmd(ctx: click.Context, as_json: bool, auto_fix: bool) -> None:
-    """Run comprehensive health checks on the Bernstein installation.
+    """Run health checks on the Bernstein installation.
 
     \b
     Checks:

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -65,7 +65,7 @@ def _run_swe_bench_command(
         )
         raise SystemExit(1)
 
-    console.print(f"[bold]SWE-Bench evaluation[/bold] — subset={subset} • {len(instances)} instance(s)")
+    console.print(f"[bold]SWE-Bench evaluation[/bold]: subset={subset} • {len(instances)} instance(s)")
 
     table = Table(title="SWE-Bench Results", header_style=_STYLE_BOLD_CYAN, show_lines=False)
     table.add_column("Instance", style="dim", min_width=30)
@@ -211,7 +211,7 @@ def benchmark_run(tier: str, benchmarks_dir: str, save: bool) -> None:
     summary = run_all(bdir) if tier == "all" else run_selected(bdir, tier)  # type: ignore[arg-type]
 
     # ---- Results table ----
-    table = Table(title=f"Benchmarks — tier={tier}", header_style=_STYLE_BOLD_CYAN, show_lines=False)
+    table = Table(title=f"Benchmarks (tier={tier})", header_style=_STYLE_BOLD_CYAN, show_lines=False)
     table.add_column("ID", style="dim", min_width=14)
     table.add_column("Tier", min_width=12)
     table.add_column("Goal", min_width=40)
@@ -285,7 +285,7 @@ def benchmark_compare(tasks_dir: str, modes: tuple[str, ...]) -> None:
         console.print("[yellow]No benchmark tasks found in directory.[/yellow]")
         raise SystemExit(1)
 
-    console.print(f"[bold]Comparative benchmark[/bold] — {len(tasks)} task(s), modes: {', '.join(modes)}")
+    console.print(f"[bold]Comparative benchmark[/bold]: {len(tasks)} task(s), modes: {', '.join(modes)}")
 
     suite = ComparativeBenchmark(tasks=tasks, workdir=Path("."))
     report = suite.run_suite(modes=list(modes))  # type: ignore[arg-type]
@@ -378,7 +378,7 @@ def benchmark_simulate(
     run, report = bench.run_and_compare()
 
     # --- Summary table ---
-    table = Table(title=f"Benchmark simulation — seed={seed}", header_style=_STYLE_BOLD_CYAN, show_lines=False)
+    table = Table(title=f"Benchmark simulation (seed={seed})", header_style=_STYLE_BOLD_CYAN, show_lines=False)
     table.add_column("Metric", min_width=22)
     table.add_column("Value", justify="right", min_width=18)
 
@@ -537,7 +537,7 @@ def eval_run(tier: str | None, compare_prev: bool, save: bool) -> None:
         console.print(f"[dim]Expected at: {state_dir / 'eval' / 'golden'}/<tier>/*.md[/dim]")
         raise SystemExit(1)
 
-    console.print(f"[bold]Eval harness[/bold] — {len(tasks)} golden task(s)")
+    console.print(f"[bold]Eval harness[/bold]: {len(tasks)} golden task(s)")
 
     # Evaluate each task (with empty telemetry for now — real runs
     # would collect telemetry from actual agent execution)
@@ -608,7 +608,7 @@ def eval_report() -> None:
         console.print(_NO_EVAL_RUNS_MSG)
         raise SystemExit(1)
 
-    console.print(f"[bold]Eval Report[/bold] — score: {prev.score:.4f}")
+    console.print(f"[bold]Eval report[/bold]: score: {prev.score:.4f}")
 
     mc = prev.multiplicative_components
     if mc:
@@ -699,7 +699,7 @@ def eval_sync_incidents(workdir: str, dry_run: bool) -> None:
     result = synth.sync(dry_run=dry_run)
 
     if dry_run:
-        console.print(f"[bold]Dry run[/bold] — {len(result.created)} case(s) would be created:")
+        console.print(f"[bold]Dry run[/bold]: {len(result.created)} case(s) would be created:")
     else:
         console.print(f"[bold]{len(result.created)} new incident eval case(s) emitted[/bold]")
     for case in result.created:

--- a/src/bernstein/cli/commands/explain_cmd.py
+++ b/src/bernstein/cli/commands/explain_cmd.py
@@ -1,4 +1,4 @@
-"""Explain command — show routing rationale, execution trace, and outcome for a task."""
+"""Explain command: show routing rationale, execution trace, and outcome for a task."""
 # Not yet wired into main.py CLI group. Routing explanation reconstructs
 # router logic heuristically and may diverge from live core/router.py
 # decisions. Wire in once _explain_routing is validated against actual
@@ -192,9 +192,9 @@ def explain_cmd(task_id: str, as_json: bool, traces_dir: str) -> None:
 
     \b
     Shows three sections:
-      • Routing decision — why this model/effort was chosen
-      • Execution trace  — what the agent did, step by step
-      • Outcome          — success/failure with result summary
+      • Routing decision: why this model/effort was chosen
+      • Execution trace:  what the agent did, step by step
+      • Outcome:          success/failure with result summary
 
     \b
     Reads task metadata from the running server and traces from
@@ -248,7 +248,7 @@ def explain_cmd(task_id: str, as_json: bool, traces_dir: str) -> None:
         _render_trace_panel(traces[-1])
         if len(traces) > 1:
             console.print(
-                f"[dim]({len(traces) - 1} earlier trace(s) — use 'bernstein trace {task_id}' for full history)[/dim]"
+                f"[dim]({len(traces) - 1} earlier trace(s); use 'bernstein trace {task_id}' for full history)[/dim]"
             )
 
     result = task.get("result_summary")

--- a/src/bernstein/cli/commands/fingerprint_cmd.py
+++ b/src/bernstein/cli/commands/fingerprint_cmd.py
@@ -201,7 +201,7 @@ def fingerprint_check_cmd(
         return
 
     if corpus_index.size == 0:
-        console.print("[yellow]Corpus index is empty — nothing to compare against.[/yellow]")
+        console.print("[yellow]Corpus index is empty: nothing to compare against.[/yellow]")
         return
 
     # Collect files to check
@@ -253,7 +253,7 @@ def fingerprint_check_cmd(
             if flagged_matches:
                 any_flagged = True
                 console.print(
-                    f"\n[bold yellow]{fp}[/bold yellow] — "
+                    f"\n[bold yellow]{fp}[/bold yellow]: "
                     f"[red]{len(flagged_matches)} match(es) above "
                     f"{threshold:.0%} threshold[/red]"
                 )
@@ -273,7 +273,7 @@ def fingerprint_check_cmd(
         console.print(_json.dumps(all_results, indent=2))
 
     if block and any_flagged:
-        console.print("\n[bold red]Fingerprint check FAILED — matches above threshold detected[/bold red]")
+        console.print("\n[bold red]Fingerprint check FAILED: matches above threshold detected[/bold red]")
         raise SystemExit(1)
 
     if not output_json and not any_flagged:

--- a/src/bernstein/cli/commands/gateway_cmd.py
+++ b/src/bernstein/cli/commands/gateway_cmd.py
@@ -27,7 +27,7 @@ _SDD_DIR = Path(".sdd")
 
 @click.group("gateway")
 def gateway_group() -> None:
-    """MCP gateway proxy — transparent recording and replay."""
+    """MCP gateway proxy: transparent recording and replay."""
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +98,7 @@ def start_cmd(upstream: str, transport: str, port: int, run_id: str | None, serv
     if transport == "sse":
         console.print(
             f"[bold green]MCP Gateway[/bold green] starting"
-            f" — SSE on [cyan]http://127.0.0.1:{port}[/cyan]"
+            f": SSE on [cyan]http://127.0.0.1:{port}[/cyan]"
             f"  (run-id: [dim]{effective_run_id}[/dim])"
         )
         console.print(f"  Upstream: [cyan]{upstream}[/cyan]")
@@ -158,7 +158,7 @@ def replay_cmd(run_id: str, transport: str, port: int) -> None:
 
     if transport == "sse":
         console.print(
-            f"[bold blue]MCP Replay[/bold blue] — SSE on [cyan]http://127.0.0.1:{port}[/cyan]"
+            f"[bold blue]MCP Replay[/bold blue]: SSE on [cyan]http://127.0.0.1:{port}[/cyan]"
             f"  (source: [dim]{run_id}[/dim], {replay.indexed_count} patterns indexed)"
         )
 

--- a/src/bernstein/cli/commands/maintenance_cmd.py
+++ b/src/bernstein/cli/commands/maintenance_cmd.py
@@ -173,7 +173,7 @@ def _format_relative_age(timestamp: float) -> str:
     is_flag=True,
     default=False,
     help=(
-        "Also delete agent branches that are NOT merged into main. Dangerous — "
+        "Also delete agent branches that are NOT merged into main. Dangerous: "
         "may discard in-flight work. Only use after manually confirming the "
         "branches contain nothing you want to keep."
     ),

--- a/src/bernstein/cli/commands/memory_cmd.py
+++ b/src/bernstein/cli/commands/memory_cmd.py
@@ -1,4 +1,4 @@
-"""Bernstein memory — manage persistent agent memories."""
+"""Bernstein memory: manage persistent agent memories."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/migrate_cmd.py
+++ b/src/bernstein/cli/commands/migrate_cmd.py
@@ -145,7 +145,7 @@ def migrate_cmd(
             return
         _print_plan_summary(plan, targets, chunks, cap)
         _print_dry_run_preview(targets, chunks)
-        console.print("\n[dim]Dry run — no tasks spawned.[/dim]")
+        console.print("\n[dim]Dry run: no tasks spawned.[/dim]")
         return
 
     store = _ServerTaskStore()

--- a/src/bernstein/cli/commands/postmortem_cmd.py
+++ b/src/bernstein/cli/commands/postmortem_cmd.py
@@ -1,4 +1,4 @@
-"""CLI command: ``bernstein postmortem`` — generate a post-mortem report for a failed run."""
+"""CLI command: ``bernstein postmortem``: generate a post-mortem report for a failed run."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/quickstart_cmd.py
+++ b/src/bernstein/cli/commands/quickstart_cmd.py
@@ -1,4 +1,4 @@
-"""Quickstart command — zero-config demo of Bernstein orchestration."""
+"""Quickstart command: zero-config demo of Bernstein orchestration."""
 
 from __future__ import annotations
 
@@ -80,7 +80,7 @@ def _setup_quickstart_project(project_dir: Path, adapter: str) -> None:
         # Inline fallback so the command works even when the examples/ dir is absent
         # (e.g. installed via pip without the examples tree).
         (project_dir / "app.py").write_text(
-            '"""Minimal TODO API — intentionally missing validation, error handling, and tests."""\n\n'
+            '"""Minimal TODO API: intentionally missing validation, error handling, and tests."""\n\n'
             "from __future__ import annotations\n\n"
             "from dataclasses import dataclass, field\n\n"
             "from flask import Flask, jsonify, request\n\n"
@@ -279,7 +279,7 @@ def _print_quickstart_summary(
             f"[bold]cd {project_dir} && pip install -r requirements.txt && pytest tests/ -q[/bold]"
         )
     else:
-        console.print("[dim]  (directory removed — use [bold]--keep[/bold] to preserve it)[/dim]")
+        console.print("[dim]  (directory removed: use [bold]--keep[/bold] to preserve it)[/dim]")
 
     console.print(
         "\n[dim]Next: initialise your own project with [bold]bernstein init[/bold] "

--- a/src/bernstein/cli/commands/reject_cmd.py
+++ b/src/bernstein/cli/commands/reject_cmd.py
@@ -70,7 +70,7 @@ def reject(task_id: str, workdir: str, prompt: bool) -> None:
 
     created = _atomic_write_text(decision_file, "rejected")
     if created:
-        console.print(f"[red]Rejected:[/red] task [bold]{task_id}[/bold] — work will be discarded.")
+        console.print(f"[red]Rejected:[/red] task [bold]{task_id}[/bold]: work will be discarded.")
     else:
         console.print(f"[dim]Already rejected:[/dim] task [bold]{task_id}[/bold] (no-op)")
 

--- a/src/bernstein/cli/commands/report_cmd.py
+++ b/src/bernstein/cli/commands/report_cmd.py
@@ -1,4 +1,4 @@
-"""CLI command: ``bernstein report`` — display the latest run report."""
+"""CLI command: ``bernstein report``: display the latest run report."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/review_pipeline_cmd.py
+++ b/src/bernstein/cli/commands/review_pipeline_cmd.py
@@ -71,7 +71,7 @@ def run_review_pipeline_cli(
         _print_pipeline_summary(pipeline)
         console.print(
             Panel(
-                "[bold]Dry run — no agents spawned, no LLM calls.[/bold]",
+                "[bold]Dry run: no agents spawned, no LLM calls.[/bold]",
                 border_style="blue",
                 expand=False,
             )

--- a/src/bernstein/cli/commands/routine_cmd.py
+++ b/src/bernstein/cli/commands/routine_cmd.py
@@ -145,7 +145,7 @@ def routine_provision(scenarios_dir: Path | None, bernstein_url: str) -> None:
 
     console.print("[bold]Available scenarios:[/bold]")
     for idx, s in enumerate(scenarios, start=1):
-        console.print(f"  {idx}. [cyan]{s.scenario_id}[/cyan] — {s.name}")
+        console.print(f"  {idx}. [cyan]{s.scenario_id}[/cyan]: {s.name}")
     raw_choice = click.prompt("Pick a scenario", type=str)
     try:
         choice_idx = int(raw_choice)

--- a/src/bernstein/cli/commands/session_cmd.py
+++ b/src/bernstein/cli/commands/session_cmd.py
@@ -128,7 +128,7 @@ def session_replay(
             console.print("[red]No recorded sessions found.[/red]")
             console.print(f"[dim]Sessions directory:[/dim] {sdir}")
             raise SystemExit(1)
-        console.print(f"[yellow]SESSION_ID not provided — replaying latest:[/yellow] {ids[0]}")
+        console.print(f"[yellow]SESSION_ID not provided: replaying latest:[/yellow] {ids[0]}")
         session_id = ids[0]
 
     try:
@@ -152,7 +152,7 @@ def session_replay(
     tasks = session.to_tasks()
 
     if dry_run:
-        console.print("\n[yellow]Dry run — tasks that would execute:[/yellow]")
+        console.print("\n[yellow]Dry run: tasks that would execute:[/yellow]")
         for i, task in enumerate(tasks, 1):
             console.print(f"  {i:2}. [{task.role}] {task.title[:70]}")  # type: ignore[union-attr]
         return

--- a/src/bernstein/cli/commands/skills_cmd.py
+++ b/src/bernstein/cli/commands/skills_cmd.py
@@ -1,4 +1,4 @@
-"""``bernstein skills`` — list / show / verify skill packs (oai-004)."""
+"""``bernstein skills``: list / show / verify skill packs (oai-004)."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/slo_cmd.py
+++ b/src/bernstein/cli/commands/slo_cmd.py
@@ -181,7 +181,7 @@ def _slo_watch_loop(
             else:
                 displayer(data)
             if not output_json:
-                console.print(f"\n[dim]Refreshing every {interval}s — Ctrl-C to stop[/dim]")
+                console.print(f"\n[dim]Refreshing every {interval}s: Ctrl-C to stop[/dim]")
             time.sleep(interval)
     except KeyboardInterrupt:
         console.print("\n[dim]Stopped.[/dim]")

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -330,7 +330,7 @@ def _doctor_check_postgres(_check: _CheckFn) -> None:
         _check(
             _STORAGE_BACKEND_LABEL,
             False,
-            "postgres — BERNSTEIN_DATABASE_URL not set",
+            "postgres: BERNSTEIN_DATABASE_URL not set",
             "export BERNSTEIN_DATABASE_URL=postgresql://user:pass@localhost/bernstein",
         )
         return
@@ -350,7 +350,7 @@ def _doctor_check_postgres(_check: _CheckFn) -> None:
         _check(
             _STORAGE_BACKEND_LABEL,
             False,
-            "postgres — asyncpg not installed",
+            "postgres: asyncpg not installed",
             "pip install bernstein[postgres]",
         )
     except Exception as exc:
@@ -371,7 +371,7 @@ def _doctor_check_redis(_check: _CheckFn) -> None:
         _check(
             "Storage backend (postgres)",
             False,
-            "redis mode — BERNSTEIN_DATABASE_URL not set",
+            "redis mode: BERNSTEIN_DATABASE_URL not set",
             "export BERNSTEIN_DATABASE_URL=postgresql://user:pass@localhost/bernstein",
         )
         storage_ok = False
@@ -379,7 +379,7 @@ def _doctor_check_redis(_check: _CheckFn) -> None:
         _check(
             "Storage backend (redis)",
             False,
-            "redis mode — BERNSTEIN_REDIS_URL not set",
+            "redis mode: BERNSTEIN_REDIS_URL not set",
             "export BERNSTEIN_REDIS_URL=redis://localhost:6379",
         )
         storage_ok = False
@@ -617,7 +617,7 @@ def _doctor_check_port(checks: list[dict[str, Any]], port: int = 8052) -> None:
         checks,
         f"Port {port}",
         not port_in_use,
-        "in use — server may already be running" if port_in_use else "available",
+        "in use: server may already be running" if port_in_use else "available",
         "Run 'bernstein stop' to free the port" if port_in_use else "",
         fix_id="port_in_use" if port_in_use else "",
     )

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -109,7 +109,7 @@ def add_task(
         print_json(result)
     else:
         console.print(
-            f"[green]Task added:[/green] [bold]{task_id}[/bold] — {title} ([dim]role={role}, priority={priority}[/dim])"
+            f"[green]Task added:[/green] [bold]{task_id}[/bold]: {title} ([dim]role={role}, priority={priority}[/dim])"
         )
 
 
@@ -154,7 +154,7 @@ def sync(port: int, workdir: str) -> None:
         if result.skipped:
             console.print("[dim]All backlog files already synced.[/dim]")
         else:
-            console.print("[dim]Nothing to sync — backlog/open/ is empty.[/dim]")
+            console.print("[dim]Nothing to sync: backlog/open/ is empty.[/dim]")
 
 
 @click.command()

--- a/src/bernstein/cli/commands/templates_cmd.py
+++ b/src/bernstein/cli/commands/templates_cmd.py
@@ -1,4 +1,4 @@
-"""Plan template library — list and scaffold reusable YAML plans."""
+"""Plan template library: list and scaffold reusable YAML plans."""
 
 from __future__ import annotations
 
@@ -84,7 +84,7 @@ def templates_list() -> None:
     console.print()
     console.print(table)
     console.print()
-    console.print("[dim]Templates are in[/dim] [bold]plans/templates/[/bold] — edit the copy after scaffolding.")
+    console.print("[dim]Templates are in[/dim] [bold]plans/templates/[/bold]: edit the copy after scaffolding.")
     console.print()
 
 

--- a/src/bernstein/cli/commands/test_cmd.py
+++ b/src/bernstein/cli/commands/test_cmd.py
@@ -1,4 +1,4 @@
-"""Test CLI — run automated tests with optional chaos injection."""
+"""Test CLI: run automated tests with optional chaos injection."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/ticket_cmd.py
+++ b/src/bernstein/cli/commands/ticket_cmd.py
@@ -171,7 +171,7 @@ def _do_import(
 
     if dry_run:
         if not is_json():
-            console.print("[yellow]Dry run — payload that would be sent:[/yellow]")
+            console.print("[yellow]Dry run: payload that would be sent:[/yellow]")
         _print_payload(payload)
         return
 

--- a/src/bernstein/cli/commands/token_cmd.py
+++ b/src/bernstein/cli/commands/token_cmd.py
@@ -1,4 +1,4 @@
-"""Bernstein token-report — prompt token usage analysis."""
+"""Bernstein token-report: prompt token usage analysis."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/undo_cmd.py
+++ b/src/bernstein/cli/commands/undo_cmd.py
@@ -1,4 +1,4 @@
-"""Bernstein undo — revert agent changes."""
+"""Bernstein undo: revert agent changes."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/users_cmd.py
+++ b/src/bernstein/cli/commands/users_cmd.py
@@ -1,4 +1,4 @@
-"""Bernstein users — manage RBAC users for the task server."""
+"""Bernstein users: manage RBAC users for the task server."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/verify_cmd.py
+++ b/src/bernstein/cli/commands/verify_cmd.py
@@ -632,7 +632,7 @@ def _verify_memory_provenance() -> int:
     if not lessons_path.exists():
         console.print(
             Panel(
-                "[dim]No lesson memory found — nothing to audit.[/dim]",
+                "[dim]No lesson memory found: nothing to audit.[/dim]",
                 border_style="dim",
                 expand=False,
             )
@@ -715,7 +715,7 @@ def _verify_formal(task_id: str) -> int:
     if fv_config is None:
         console.print(
             Panel(
-                "[dim]No formal_verification section in bernstein.yaml — nothing to verify.[/dim]",
+                "[dim]No formal_verification section in bernstein.yaml: nothing to verify.[/dim]",
                 border_style="dim",
                 expand=False,
             )

--- a/src/bernstein/cli/commands/watch_cmd.py
+++ b/src/bernstein/cli/commands/watch_cmd.py
@@ -1,4 +1,4 @@
-"""Watch command — monitor file changes and re-run affected tasks."""
+"""Watch command: monitor file changes and re-run affected tasks."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commands/worker_cmd.py
+++ b/src/bernstein/cli/commands/worker_cmd.py
@@ -336,7 +336,7 @@ class WorkerLoop:
         poll_s = self._poll_config.poll_interval_ms / 1_000.0
         heartbeat_s = (self._poll_config.heartbeat_interval_ms or 15_000) / 1_000.0
 
-        console.print(f"[bold cyan]Bernstein Worker[/bold cyan] — {self._name}")
+        console.print(f"[bold cyan]Bernstein Worker[/bold cyan]: {self._name}")
         console.print(f"  Server: {self._server_url}")
         console.print(f"  Max agents: {self._max_agents}")
         console.print(f"  Roles: {', '.join(self._roles)}")

--- a/src/bernstein/cli/commands/wrap_up_cmd.py
+++ b/src/bernstein/cli/commands/wrap_up_cmd.py
@@ -1,4 +1,4 @@
-"""Wrap-up command — end the current session with a structured brief."""
+"""Wrap-up command: end the current session with a structured brief."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/commit_stats.py
+++ b/src/bernstein/cli/commit_stats.py
@@ -1,4 +1,4 @@
-"""Commit attribution stats — gather per-role commit stats via git log."""
+"""Commit attribution stats: gather per-role commit stats via git log."""
 
 from __future__ import annotations
 

--- a/src/bernstein/cli/display/splash.py
+++ b/src/bernstein/cli/display/splash.py
@@ -84,7 +84,7 @@ def splash(
     task_count: int = 0,
     skip_animation: bool = False,
 ) -> None:
-    """Show the startup splash — BIOS-style, compact, all in one block."""
+    """Show the startup splash: BIOS-style, compact, all in one block."""
     width = _detect_terminal_width(console)
     is_animated = not skip_animation and console.is_terminal
 

--- a/src/bernstein/cli/display/terminal_caps.py
+++ b/src/bernstein/cli/display/terminal_caps.py
@@ -156,7 +156,7 @@ class TerminalCaps:
 
     @classmethod
     def null(cls) -> TerminalCaps:
-        """Minimal caps — no color, no graphics (CI / pipe / dumb terminal)."""
+        """Minimal caps: no color, no graphics (CI / pipe / dumb terminal)."""
         return cls(
             is_tty=False,
             supports_truecolor=False,
@@ -214,7 +214,7 @@ class TerminalCaps:
 
     @property
     def best_image_protocol(self) -> Protocol:
-        """Alias for :attr:`best_protocol` — the highest-fidelity available protocol."""
+        """Alias for :attr:`best_protocol`: the highest-fidelity available protocol."""
         return self.best_protocol
 
 

--- a/src/bernstein/cli/display/text_effects.py
+++ b/src/bernstein/cli/display/text_effects.py
@@ -58,7 +58,7 @@ def _tte_available() -> bool:
 
 
 def _key_pressed() -> bool:
-    """Non-blocking check — True if any stdin input is waiting."""
+    """Non-blocking check: True if any stdin input is waiting."""
     if not sys.stdin.isatty():
         return False
     try:

--- a/src/bernstein/cli/helpers.py
+++ b/src/bernstein/cli/helpers.py
@@ -188,7 +188,7 @@ def kill_pid_hard(path: str, label: str) -> None:
         if killed:
             console.print(f"[red]Killed {label} (PID {pid}) with SIGKILL.[/red]")
         else:
-            console.print(f"[yellow]{label} (PID {pid}) resisted SIGKILL — may need manual cleanup.[/yellow]")
+            console.print(f"[yellow]{label} (PID {pid}) resisted SIGKILL: may need manual cleanup.[/yellow]")
     Path(path).unlink(missing_ok=True)
 
 
@@ -280,7 +280,7 @@ def print_dry_run_table(workdir: Path) -> None:
         )
 
     console.print(table)
-    console.print(f"\n[dim]Total: {len(tasks)} task(s) — no agents were spawned.[/dim]")
+    console.print(f"\n[dim]Total: {len(tasks)} task(s): no agents were spawned.[/dim]")
 
 
 _SEED_FILENAMES = ("bernstein.yaml", "bernstein.yml")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -295,14 +295,14 @@ def print_rich_help() -> None:
     c.print()
     c.print(
         Panel(
-            "[bold]bernstein[/bold]  -  deterministic Python scheduler for CLI coding agents.\n"
+            "[bold]bernstein[/bold]  deterministic Python scheduler for CLI coding agents.\n"
             "  43 adapters, parallel git worktrees, HMAC-SHA256 audit chain (RFC 2104).",
             border_style="blue",
             padding=(0, 2),
             expand=False,
         )
     )
-    c.print("\n  [bold cyan]Quick start[/bold cyan]")
+    c.print("\n  [bold cyan]quick start[/bold cyan]")
     c.print('  [dim]$[/dim] bernstein -g [green]"Add JWT auth with tests"[/green]     [dim]# inline goal[/dim]')
     c.print("  [dim]$[/dim] bernstein                                    [dim]# from bernstein.yaml[/dim]")
     c.print("  [dim]$[/dim] bernstein run plan.yaml                      [dim]# execute a plan file[/dim]")
@@ -311,49 +311,49 @@ def print_rich_help() -> None:
 
     groups: list[tuple[str, list[tuple[str, str]]]] = [
         (
-            "Run & manage",
+            "run & manage",
             [
-                ("bernstein -g [dim]GOAL[/dim]", "Orchestrate agents for an inline goal"),
-                ("bernstein", "Run from bernstein.yaml or backlog"),
-                ("run [dim]plan.yaml[/dim]", "Execute a plan file (stages + steps)"),
-                ("init", "Initialize project (.sdd/ + bernstein.yaml)"),
-                ("stop", "Graceful stop (agents save work first)"),
-                ("stop --force", "Hard stop (kill immediately)"),
-                ("checkpoint", "Save progress for later resume"),
-                ("wrap-up", "End session with summary + learnings"),
+                ("bernstein -g [dim]GOAL[/dim]", "orchestrate agents for an inline goal"),
+                ("bernstein", "run from bernstein.yaml or backlog"),
+                ("run [dim]plan.yaml[/dim]", "execute a plan file (stages + steps)"),
+                ("init", "initialize project (.sdd/ + bernstein.yaml)"),
+                ("stop", "graceful stop (agents save work first)"),
+                ("stop --force", "hard stop (kill immediately)"),
+                ("checkpoint", "save progress for later resume"),
+                ("wrap-up", "end session with summary + learnings"),
             ],
         ),
         (
-            "Monitor",
+            "monitor",
             [
-                ("live", "Interactive TUI dashboard (3 columns)"),
-                ("dashboard", "Open web dashboard in browser"),
-                ("status", "Task summary and agent health"),
-                ("ps", "Running agent processes"),
-                ("cost", "Spend breakdown by model and task"),
-                ("logs", "Tail agent output"),
+                ("live", "interactive TUI dashboard (3 columns)"),
+                ("dashboard", "open web dashboard in browser"),
+                ("status", "task summary and agent health"),
+                ("ps", "running agent processes"),
+                ("cost", "spend breakdown by model and task"),
+                ("logs", "tail agent output"),
             ],
         ),
         (
-            "Diagnostics",
+            "diagnostics",
             [
-                ("doctor", "Pre-flight: adapters, API keys, ports"),
-                ("recap", "Post-run: tasks, pass/fail, cost"),
-                ("retro", "Detailed retrospective report"),
-                ("plan", "Show task backlog"),
-                ("trace [dim]ID[/dim]", "Step-by-step agent decision trace"),
+                ("doctor", "pre-flight: adapters, API keys, ports"),
+                ("recap", "post-run: tasks, pass/fail, cost"),
+                ("retro", "detailed retrospective report"),
+                ("plan", "show task backlog"),
+                ("trace [dim]ID[/dim]", "step-by-step agent decision trace"),
             ],
         ),
         (
-            "Agents & evolution",
+            "agents & evolution",
             [
-                ("agents list", "Available agents and capabilities"),
-                ("agents sync", "Pull latest agent catalog"),
-                ("agents discover", "Auto-detect installed CLI agents"),
-                ("worker", "Join a cluster as a remote worker node"),
-                ("evolve", "Self-improvement proposals"),
-                ("demo", "Zero-to-running demo in 60 seconds"),
-                ("quickstart", "Zero-config demo: 3 tasks on a Flask TODO API"),
+                ("agents list", "available agents and capabilities"),
+                ("agents sync", "pull latest agent catalog"),
+                ("agents discover", "auto-detect installed CLI agents"),
+                ("worker", "join a cluster as a remote worker node"),
+                ("evolve", "self-improvement proposals"),
+                ("demo", "zero-to-running demo in 60 seconds"),
+                ("quickstart", "zero-config demo: 3 tasks on a Flask TODO API"),
             ],
         ),
     ]
@@ -368,23 +368,23 @@ def print_rich_help() -> None:
         c.print(table)
         c.print()
 
-    c.print("  [bold]Options[/bold]")
+    c.print("  [bold]options[/bold]")
     opts = Table(show_header=False, box=None, padding=(0, 1), expand=False, pad_edge=False)
     opts.add_column("", width=2)  # left indent
     opts.add_column("Flag", style="yellow", no_wrap=True, width=26)
     opts.add_column("", style="dim")
-    opts.add_row("", "--budget [dim]N[/dim]", "Cost cap in USD (0 = unlimited)")
-    opts.add_row("", "--dry-run", "Preview task plan without spawning")
-    opts.add_row("", "--plan-only", "Show execution plan without running agents")
-    opts.add_row("", "--from-plan [dim]path[/dim]", "Execute a saved plan file")
-    opts.add_row("", "--auto-approve", "Skip confirmation prompt before execution")
-    opts.add_row("", "--approval [dim]auto|review|pr[/dim]", "Gate before merge")
-    opts.add_row("", "--fresh", "Ignore saved session, start clean")
-    opts.add_row("", "--version", "Show version")
+    opts.add_row("", "--budget [dim]N[/dim]", "cost cap in USD (0 = unlimited)")
+    opts.add_row("", "--dry-run", "preview task plan without spawning")
+    opts.add_row("", "--plan-only", "show execution plan without running agents")
+    opts.add_row("", "--from-plan [dim]path[/dim]", "execute a saved plan file")
+    opts.add_row("", "--auto-approve", "skip confirmation prompt before execution")
+    opts.add_row("", "--approval [dim]auto|review|pr[/dim]", "gate before merge")
+    opts.add_row("", "--fresh", "ignore saved session, start clean")
+    opts.add_row("", "--version", "show version")
     c.print(opts)
-    c.print("\n  [dim]Docs:[/dim] https://chernistry.github.io/bernstein/")
-    c.print("  [dim]Repo:[/dim] https://github.com/sipyourdrink-ltd/bernstein")
-    c.print("  [dim]Audit chain:[/dim] docs/security/audit-log.md  (RFC 2104 HMAC-SHA256)\n")
+    c.print("\n  [dim]docs:[/dim] https://chernistry.github.io/bernstein/")
+    c.print("  [dim]repo:[/dim] https://github.com/sipyourdrink-ltd/bernstein")
+    c.print("  [dim]audit chain:[/dim] docs/security/audit-log.md  (RFC 2104 HMAC-SHA256)\n")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -372,7 +372,7 @@ def _show_dry_run_plan(
     _ = cli  # Part of interface
     from rich.table import Table
 
-    console.print("\n[bold]Dry-run mode — no agents will be spawned.[/bold]\n")
+    console.print("\n[bold]Dry-run mode: no agents will be spawned.[/bold]\n")
 
     tasks = _load_dry_run_tasks(plan_file)
 
@@ -561,7 +561,7 @@ def init(target_dir: str) -> None:
     # Print clear next steps
     console.print("")
     console.print("[green]Done.[/green] Next steps:")
-    console.print("  1. Edit [bold]bernstein.yaml[/bold] — set a goal")
+    console.print("  1. Edit [bold]bernstein.yaml[/bold]: set a goal")
     console.print("  2. Run [bold]bernstein[/bold] to start the orchestra")
     console.print("")
     console.print(

--- a/src/bernstein/cli/run_confirm.py
+++ b/src/bernstein/cli/run_confirm.py
@@ -290,7 +290,7 @@ DEMO_TASKS: list[dict[str, str]] = [
             "**Scope:** small\n"
             "**Complexity:** low\n\n"
             "BUG: `tests/test_app.py::test_hello_returns_200` asserts "
-            "`resp.status_code == 404` — wrong, it should assert 200. "
+            "`resp.status_code == 404`: wrong, it should assert 200. "
             "Fix the assertion so the test suite goes green.\n"
         ),
     },
@@ -374,7 +374,7 @@ def setup_demo_project(project_dir: Path, adapter: str) -> None:
             "def test_hello_returns_200(client):\n"
             '    """BUG 4: asserts 404 instead of 200."""\n'
             '    resp = client.get("/")\n'
-            "    assert resp.status_code == 404  # wrong — should be 200\n\n\n"
+            "    assert resp.status_code == 404  # wrong: should be 200\n\n\n"
             "def test_hello_json_structure(client):\n"
             '    resp = client.get("/")\n'
             "    data = resp.get_json()\n"

--- a/src/bernstein/cli/scaffold/templates.py
+++ b/src/bernstein/cli/scaffold/templates.py
@@ -108,7 +108,7 @@ _PYTHON_CLI = ScaffoldTemplate(
         ScaffoldFile(
             relative_path="src/$slug/main.py",
             content=(
-                '"""Entrypoint for $slug — $prompt."""\n\n'
+                '"""Entrypoint for $slug: $prompt."""\n\n'
                 "from __future__ import annotations\n\n\n"
                 "def main() -> int:\n"
                 '    """Run the CLI; returns a process exit code."""\n'

--- a/src/bernstein/cli/status.py
+++ b/src/bernstein/cli/status.py
@@ -113,7 +113,7 @@ def _build_alert_lines(alerts: list[dict[str, Any]]) -> Text | None:
         text.append(str(alert.get("message", "")), style=color)
         detail = str(alert.get("detail", "") or "")
         if detail:
-            text.append(f" — {detail}", style="dim")
+            text.append(f": {detail}", style="dim")
         text.append("\n")
     return text
 
@@ -213,7 +213,7 @@ def _format_dependency_scan_line(scan: dict[str, Any]) -> str | None:
     if scanned_at > 0:
         age_suffix = f" ({format_duration(max(0.0, time.time() - scanned_at))} ago)"
     if summary:
-        return f"Dependency scan: {status} — {summary}{age_suffix}"
+        return f"Dependency scan: {status}: {summary}{age_suffix}"
     return f"Dependency scan: {status} ({finding_count} findings){age_suffix}"
 
 

--- a/src/bernstein/cli/transcript_search.py
+++ b/src/bernstein/cli/transcript_search.py
@@ -266,7 +266,7 @@ def format_search_results(
 
     parts: list[str] = []
     total_pages = max(1, (total_count + max_results - 1) // max_results)
-    parts.append(f"Found {total_count} match(es) — page {page}/{total_pages}")
+    parts.append(f"Found {total_count} match(es); page {page}/{total_pages}")
     parts.append("")
 
     for i, entry in enumerate(results, 1):

--- a/src/bernstein/cli/usage_provisioning.py
+++ b/src/bernstein/cli/usage_provisioning.py
@@ -97,7 +97,7 @@ def load_usage_budget_config(workdir: Path) -> UsageBudgetConfig | None:
     """
     if _yaml is None:
         logger.debug(
-            "PyYAML not installed — usage budget tracking disabled. Install with: pip install pyyaml",
+            "PyYAML not installed: usage budget tracking disabled. Install with: pip install pyyaml",
         )
         return None
 
@@ -321,7 +321,7 @@ def format_usage_report(budget: UsageBudget) -> str:
     # --- Overall status ---
     if is_over_budget(budget):
         lines.append("")
-        lines.append("  [bold red]OVER BUDGET — stop spawning agents until reset[/bold red]")
+        lines.append("  [bold red]OVER BUDGET. Stop spawning agents until reset[/bold red]")
     else:
         lines.append("")
         lines.append("  [green]Within budget[/green]")

--- a/src/bernstein/cli/utils/errors.py
+++ b/src/bernstein/cli/utils/errors.py
@@ -135,7 +135,7 @@ def seed_parse_error(exc: Exception) -> BernsteinError:
     return BernsteinError(
         what="Cannot parse seed file",
         why=str(exc),
-        fix="Check bernstein.yaml syntax — see 'bernstein help-all' for format",
+        fix="Check bernstein.yaml syntax; see 'bernstein help-all' for format",
         exit_code=ExitCode.CONFIG,
     )
 

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -476,7 +476,7 @@ def _render_signal_check(session_id: str) -> str:
         Markdown block instructing the agent to poll signal files.
     """
     return (
-        "\n## Signal files — check periodically\n"
+        "\n## Signal files (check periodically)\n"
         "Every 60 seconds, check for orchestrator signals:\n"
         "```bash\n"
         f"cat .sdd/runtime/signals/{session_id}/WAKEUP 2>/dev/null\n"
@@ -791,8 +791,8 @@ def _render_prompt(
         f"Complete these tasks. When ALL are done, mark each complete on the task server:\n\n"
         f"```bash\n{completion_cmds}\n```\n\n"
         f"**Important:** Only retry on connection refused / network errors. "
-        f"If the server returns HTTP 409 or any other 4xx error, do NOT retry — "
-        f"the task state has changed and retrying will not help. Just exit.\n\n"
+        f"If the server returns HTTP 409 or any other 4xx error, do NOT retry. "
+        f"The task state has changed and retrying will not help. Just exit.\n\n"
         f"Then exit."
     )
 

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -182,7 +182,7 @@ def _render_signal_check(session_id: str) -> str:
         Markdown block instructing the agent to poll signal files.
     """
     return (
-        "\n## Signal files — check periodically\n"
+        "\n## Signal files (check periodically)\n"
         "Every 60 seconds, check for orchestrator signals:\n"
         "```bash\n"
         f"cat .sdd/runtime/signals/{session_id}/WAKEUP 2>/dev/null\n"

--- a/src/bernstein/core/routes/well_known.py
+++ b/src/bernstein/core/routes/well_known.py
@@ -136,7 +136,7 @@ _SKILLS: tuple[dict[str, object], ...] = (
 # ``_reset_signing_keypair_for_tests`` drops the cache between test cases
 # so each test can point at its own ``tmp_path`` keystore.
 
-_KEY_LOCK = threading.Lock()
+_KEY_LOCK = threading.RLock()  # Reentrant: _get_signing_keypair holds it while calling _get_keystore.
 _KEYSTORE: AgentCardKeystore | None = None
 _PRIVATE_PEM: bytes | None = None
 _PUBLIC_PEM: bytes | None = None

--- a/templates/roles/adversary/system_prompt.md
+++ b/templates/roles/adversary/system_prompt.md
@@ -5,7 +5,7 @@ NOT approve changes; you produce structured findings that a downstream
 gate uses to block or allow the merge. A single `critical` finding
 blocks the merge.
 
-This is a deterministic gate — you run as the *last* pass before the
+This is a deterministic gate. You run as the *last* pass before the
 Steward merges a worker's worktree.
 
 ## Your specialization
@@ -19,7 +19,7 @@ Steward merges a worker's worktree.
 - Untested error paths and unverified assumptions
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/`
 - Google-style docstrings only where non-obvious
@@ -33,14 +33,14 @@ Steward merges a worker's worktree.
    the caller, the test file).
 3. For each suspicion, construct a falsification test: a concrete test
    that, if it passes, closes the finding. If you cannot construct one,
-   the finding is too vague — drop it or downgrade it to `info`.
+   the finding is too vague. Drop it or downgrade it to `info`.
 4. Classify each finding by severity:
-   - `critical` — would cause data loss, security breach, work loss,
+   - `critical`: data loss, security breach, work loss,
      incorrect billing, or a regression in a documented behaviour. A
      single `critical` finding blocks the merge.
-   - `warning` — would cause a flaky test, a missed edge case, or a
+   - `warning`: flaky test, missed edge case, or a
      subtle correctness issue under uncommon conditions.
-   - `info` — design concern, style nit, or future-work hint.
+   - `info`: design concern, style nit, or future-work hint.
 5. Be specific. Cite `path:line` evidence for every finding. No vague
    findings like "this looks risky".
 

--- a/templates/roles/adversary/task_prompt.md
+++ b/templates/roles/adversary/task_prompt.md
@@ -23,10 +23,10 @@
 4. Drop any suspicion you cannot turn into a falsification test, or
    downgrade it to `info`.
 5. Classify each finding's severity:
-   - `critical` — blocks the merge (data loss, security, work loss,
+   - `critical`: blocks the merge (data loss, security, work loss,
      billing error, or a regression of documented behaviour).
-   - `warning` — flaky test, missed edge case, subtle correctness bug.
-   - `info` — design concern, style nit, future-work hint.
+   - `warning`: flaky test, missed edge case, subtle correctness bug.
+   - `info`: design concern, style nit, future-work hint.
 6. Output a single JSON object on stdout with the schema documented in
    your system prompt.
 7. Do NOT modify source files. You produce findings only.

--- a/templates/roles/analyst/system_prompt.md
+++ b/templates/roles/analyst/system_prompt.md
@@ -1,6 +1,6 @@
 # You are a Ruthless Analyst
 
-You are a ruthless analytical mind. Your job is to kill bad ideas and strengthen good ones. You don't care about how cool something sounds — you care about whether it works, whether users need it, and whether the team can ship it.
+You are a ruthless analytical mind. Your job is to kill bad ideas and strengthen good ones. You don't care how cool something sounds; you care whether it works, whether users need it, and whether the team can ship it.
 
 ## Your job
 Evaluate feature proposals against technical feasibility, ROI, risk, and user demand. Score each proposal and provide a clear APPROVE / REVISE / REJECT verdict.
@@ -25,10 +25,10 @@ For each proposal, produce structured JSON with these fields:
 - `decomposition`: list of concrete tasks (if APPROVE)
 
 ## Rules
-- Be skeptical by default — the bar for APPROVE is high
+- Be skeptical by default. The bar for APPROVE is high
 - Only APPROVE proposals with composite_score >= 7
-- REVISE means "good idea, wrong execution" — provide specific fixes
-- REJECT means "not worth doing" — explain why clearly
+- REVISE means "good idea, wrong execution". Provide specific fixes
+- REJECT means "not worth doing". Explain why clearly
 - Decomposition tasks must be concrete enough for an agent to execute
 - Don't soften your verdicts to be polite
 

--- a/templates/roles/architect/system_prompt.md
+++ b/templates/roles/architect/system_prompt.md
@@ -11,7 +11,7 @@ You design system structure, make technology decisions, and ensure long-term mai
 - Dependency management and coupling analysis
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/architect/task_prompt.md
+++ b/templates/roles/architect/task_prompt.md
@@ -24,7 +24,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/backend/system_prompt.md
+++ b/templates/roles/backend/system_prompt.md
@@ -10,7 +10,7 @@ You implement server-side logic, APIs, database operations, and business rules.
 - Error handling and logging
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/backend/task_prompt.md
+++ b/templates/roles/backend/task_prompt.md
@@ -15,7 +15,7 @@
 
 ## Instructions
 1. Read all listed files before writing any code
-2. Implement the feature with strict typing — no `Any`, no untyped dicts
+2. Implement the feature with strict typing; no `Any`, no untyped dicts
 3. Write or update tests alongside the implementation
 4. Keep functions small; extract helpers when logic gets complex
 5. Run tests before marking complete: `uv run python scripts/run_tests.py -x`
@@ -23,7 +23,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/ci-fixer/system_prompt.md
+++ b/templates/roles/ci-fixer/system_prompt.md
@@ -8,7 +8,7 @@ Your sole job: read a CI failure report, make the minimal targeted fix, verify l
 - Verifying lint, format, and test compliance
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious
@@ -17,12 +17,12 @@ Your sole job: read a CI failure report, make the minimal targeted fix, verify l
 ## Work style
 1. Read the failure context in the task description carefully
 2. Identify the root cause from the error output and affected files
-3. Make the smallest change that fixes the failure — no refactoring, no improvements
+3. Make the smallest change that fixes the failure. No refactoring, no improvements
 4. Verify locally before committing
 
 ## Rules
 - Fix ONLY what is broken. Do not touch unrelated files.
-- If a test is failing, fix the code, not the test — unless the test itself is wrong
+- If a test is failing, fix the code, not the test, unless the test itself is wrong
 - If a lint rule is violated, fix the code to comply. Do not disable the rule.
 - If a type error is reported, add or correct type annotations. Do not use `type: ignore` unless there is no other option.
 - If a dependency is missing, add it to `pyproject.toml`

--- a/templates/roles/ci-fixer/task_prompt.md
+++ b/templates/roles/ci-fixer/task_prompt.md
@@ -20,7 +20,7 @@
    - `uv run ruff check src/` (lint)
    - `uv run ruff format --check src/` (format)
    - `uv run python scripts/run_tests.py -x` (tests)
-4. Commit only the files you changed: `fix: resolve CI failure — <brief description>`
+4. Commit only the files you changed: `fix: resolve CI failure: <brief description>`
 
 ## If stuck or blocked
 - If you cannot determine the fix, mark the task as failed:

--- a/templates/roles/devops/system_prompt.md
+++ b/templates/roles/devops/system_prompt.md
@@ -11,7 +11,7 @@ You build and maintain infrastructure, CI/CD pipelines, deployment, and monitori
 - Shell scripting and automation
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/devops/task_prompt.md
+++ b/templates/roles/devops/task_prompt.md
@@ -15,7 +15,7 @@
 
 ## Instructions
 1. Read existing CI/CD configs and Dockerfiles before making changes
-2. Make changes idempotent — running the pipeline twice should produce the same result
+2. Make changes idempotent. Running the pipeline twice should produce the same result
 3. Pin tool versions explicitly; never use `latest` tags in production configs
 4. Test pipeline changes locally before committing (e.g. `act` for GitHub Actions)
 5. Document any manual steps required (secrets, env vars, one-time setup) in a comment
@@ -23,7 +23,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/docs/system_prompt.md
+++ b/templates/roles/docs/system_prompt.md
@@ -11,7 +11,7 @@ You write and maintain technical documentation, guides, and API references.
 - Changelog and release notes
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/docs/task_prompt.md
+++ b/templates/roles/docs/task_prompt.md
@@ -14,7 +14,7 @@
 {{/IF}}
 
 ## Instructions
-1. Read the code before writing about it — never document assumptions
+1. Read the code before writing about it; never document assumptions
 2. Write for the target audience: engineers, not marketers
 3. Prefer concrete examples over abstract descriptions
 4. Keep language plain and direct; cut filler words
@@ -23,7 +23,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/frontend/system_prompt.md
+++ b/templates/roles/frontend/system_prompt.md
@@ -11,7 +11,7 @@ You build user interfaces, interactive components, and client-side logic.
 - Client-side performance and bundle optimization
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/frontend/task_prompt.md
+++ b/templates/roles/frontend/task_prompt.md
@@ -14,7 +14,7 @@
 {{/IF}}
 
 ## Instructions
-1. Read existing components and styles before creating new ones — reuse before adding
+1. Read existing components and styles before creating new ones. Reuse before adding
 2. Keep components small and single-purpose; lift state only when necessary
 3. Use semantic HTML; avoid div soup
 4. Ensure keyboard navigation and basic accessibility (ARIA labels where needed)
@@ -23,7 +23,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -3,20 +3,20 @@
 You lead a team of AI coding agents. Your job: decompose the goal into tasks, create them on the task server, and ensure quality.
 
 ## Your responsibilities
-1. **Analyze** — read the codebase to understand current state
-2. **Plan** — break the goal into specific, actionable tasks with clear acceptance criteria
-3. **Create tasks** — POST each task to the task server API
-4. **Verify** — include completion signals so the janitor can verify work
+1. **Analyze**: read the codebase to understand current state
+2. **Plan**: break the goal into specific, actionable tasks with clear acceptance criteria
+3. **Create tasks**: POST each task to the task server API
+4. **Verify**: include completion signals so the janitor can verify work
 
 ## Available roles for tasks
-- **backend** — server-side logic, APIs, data models, business rules
-- **frontend** — UI components, styling, client-side logic
-- **qa** — test writing, validation, edge case coverage
-- **security** — vulnerability scanning, auth, access control
-- **devops** — CI/CD, deployment, infrastructure
-- **docs** — documentation, guides, READMEs
-- **architect** — system design, refactoring, code organization
-- **reviewer** — code review, quality checks
+- **backend**: server-side logic, APIs, data models, business rules
+- **frontend**: UI components, styling, client-side logic
+- **qa**: test writing, validation, edge case coverage
+- **security**: vulnerability scanning, auth, access control
+- **devops**: CI/CD, deployment, infrastructure
+- **docs**: documentation, guides, READMEs
+- **architect**: system design, refactoring, code organization
+- **reviewer**: code review, quality checks
 
 ## Task Server API
 
@@ -45,19 +45,19 @@ curl -s -X POST http://127.0.0.1:8052/tasks \
 **Complexity**: low, medium, high
 
 **Completion signal types:**
-- `path_exists` — file/directory must exist
-- `test_passes` — shell command must exit 0
-- `file_contains` — file must contain string (format: "path :: needle")
-- `glob_exists` — at least one file matching glob must exist
+- `path_exists`: file/directory must exist
+- `test_passes`: shell command must exit 0
+- `file_contains`: file must contain string (format: "path :: needle")
+- `glob_exists`: at least one file matching glob must exist
 
 ## Rules
-1. **Never assign two tasks to the same files** — prevent merge conflicts
+1. **Never assign two tasks to the same files** to prevent merge conflicts
 2. **Break large tasks into small ones** (30-60 min each, max 120 min)
 3. **Include tests** in every implementation task or as separate QA tasks
 4. **Every task must have completion signals** so the janitor can verify
-5. **Check .sdd/backlog/open/** for existing starter tickets — incorporate them
+5. **Check .sdd/backlog/open/** for existing starter tickets and incorporate them
 6. If a task depends on another, note it in the description (the system handles ordering)
-7. **Include context hints** — For each task, list the specific files, functions, and architectural decisions the assigned agent needs to know in the description. This eliminates agent orientation time. Example: "You'll modify `TaskContextBuilder.build_context()` in `src/bernstein/core/context.py`. It uses AST parsing via `_parse_python_file()`. Related: `spawner.py` calls it during prompt rendering."
+7. **Include context hints**. For each task, list the specific files, functions, and architectural decisions the assigned agent needs to know in the description. This eliminates agent orientation time. Example: "You'll modify `TaskContextBuilder.build_context()` in `src/bernstein/core/context.py`. It uses AST parsing via `_parse_python_file()`. Related: `spawner.py` calls it during prompt rendering."
 
 ## When done planning
 

--- a/templates/roles/manager/task_prompt.md
+++ b/templates/roles/manager/task_prompt.md
@@ -14,7 +14,7 @@
 {{/IF}}
 
 ## Instructions
-1. Read the codebase and `.sdd/backlog/open/` before planning — understand current state
+1. Read the codebase and `.sdd/backlog/open/` before planning to understand current state
 2. Decompose this goal into tasks of 30-60 min each (max 120 min)
 3. Assign each task the right role; every implementation task needs a paired QA task or inline tests
 4. Set `completion_signals` on every task so the janitor can verify completion

--- a/templates/roles/ml-engineer/system_prompt.md
+++ b/templates/roles/ml-engineer/system_prompt.md
@@ -11,7 +11,7 @@ You build, train, evaluate, and deploy machine learning models and inference pip
 - Data preprocessing and feature engineering
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/ml-engineer/task_prompt.md
+++ b/templates/roles/ml-engineer/task_prompt.md
@@ -15,16 +15,16 @@
 
 ## Instructions
 1. Read existing model code and data pipelines before making changes
-2. Log key metrics (loss, accuracy, latency) — don't rely on eyeballing outputs
+2. Log key metrics (loss, accuracy, latency). Don't rely on eyeballing outputs
 3. Keep experiments reproducible: fix random seeds, pin library versions, document hyperparameters
 4. Write unit tests for data transforms and model utilities; integration tests for pipelines
-5. Profile before optimizing — identify the actual bottleneck
+5. Profile before optimizing; identify the actual bottleneck
 6. Run tests before marking complete: `uv run python scripts/run_tests.py -x`
 7. Only modify files listed in your task's `owned_files`
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/prompt-engineer/task_prompt.md
+++ b/templates/roles/prompt-engineer/task_prompt.md
@@ -14,9 +14,9 @@
 {{/IF}}
 
 ## Instructions
-1. Read the existing prompt templates and renderer before editing — understand variable substitution rules
+1. Read the existing prompt templates and renderer before editing. Understand variable substitution rules
 2. Use `{{VARIABLE}}` for required substitutions; wrap optional sections in `{{#IF VAR}}...{{/IF}}`
-3. Write prompts for the actual model, not an idealized one — be concrete and directive
+3. Write prompts for the actual model, not an idealized one. Be concrete and directive
 4. Include examples in prompts when the desired output format is non-obvious
 5. Test templates by rendering them with realistic context values
 6. Document any new template variables in a comment at the top of the file

--- a/templates/roles/qa/system_prompt.md
+++ b/templates/roles/qa/system_prompt.md
@@ -3,14 +3,14 @@
 You test, validate, and verify that the system works correctly.
 
 ## Your specialization
-- Writing comprehensive test suites (pytest)
+- Writing test suites that cover happy path, edge cases, and error paths (pytest)
 - Edge case identification
 - Integration testing
 - Performance validation
 - Regression detection
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/qa/task_prompt.md
+++ b/templates/roles/qa/task_prompt.md
@@ -23,7 +23,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/resolver/system_prompt.md
+++ b/templates/roles/resolver/system_prompt.md
@@ -17,10 +17,10 @@ You resolve git merge conflicts between concurrent agent branches.
 
 ## Rules
 - Only modify files listed in your task's `owned_files` (the conflicting files)
-- Never discard changes silently — if you drop one side, explain why in the commit message
+- Never discard changes silently. If you drop one side, explain why in the commit message
 - Prefer combining both sides over picking a winner
 - If a conflict is ambiguous and cannot be safely resolved, mark the task as failed with a clear explanation
-- Do not refactor, optimize, or "improve" code beyond what is needed to resolve the conflict
+- Do not refactor or optimize code beyond what is needed to resolve the conflict
 
 ## Current task
 {{TASK_DESCRIPTION}}

--- a/templates/roles/resolver/task_prompt.md
+++ b/templates/roles/resolver/task_prompt.md
@@ -15,14 +15,14 @@
 
 ## Instructions
 1. For each conflicting file, read both sides of the conflict markers and surrounding context
-2. Understand what each side was trying to accomplish — read git log for both branches
+2. Understand what each side was trying to accomplish. Read git log for both branches
 3. Combine both intents where possible; pick one side only when truly incompatible
 4. After resolving all conflicts, run tests: `uv run python scripts/run_tests.py -x`
 5. Stage resolved files and commit with a message explaining resolution choices
 
 ## If stuck or blocked
 - If a conflict is ambiguous, mark the task as failed with a clear explanation rather than guessing
-- If tests fail after resolution, the resolution is wrong — revisit the conflicting sections
+- If tests fail after resolution, the resolution is wrong. Revisit the conflicting sections
 
 ## Done signal
 ```bash

--- a/templates/roles/retrieval/system_prompt.md
+++ b/templates/roles/retrieval/system_prompt.md
@@ -11,7 +11,7 @@ You build and optimize search, indexing, and retrieval systems.
 - Index management and ingestion pipelines
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/retrieval/task_prompt.md
+++ b/templates/roles/retrieval/task_prompt.md
@@ -16,7 +16,7 @@
 ## Instructions
 1. Read existing indexing and retrieval code before adding new pipelines
 2. Define the retrieval contract clearly: what goes in (query), what comes out (ranked results with scores)
-3. Choose chunking strategy based on document structure — don't apply one-size-fits-all
+3. Choose chunking strategy based on document structure. Don't apply one-size-fits-all
 4. Log retrieval latency and top-k recall metrics; establish a baseline before optimizing
 5. Write tests with known queries and expected top results to catch regressions
 6. Run tests before marking complete: `uv run python scripts/run_tests.py -x`
@@ -24,7 +24,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/reviewer/system_prompt.md
+++ b/templates/roles/reviewer/system_prompt.md
@@ -11,7 +11,7 @@ You review code for correctness, quality, maintainability, and adherence to stan
 - Merge readiness evaluation
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/reviewer/task_prompt.md
+++ b/templates/roles/reviewer/task_prompt.md
@@ -23,7 +23,7 @@
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/security/system_prompt.md
+++ b/templates/roles/security/system_prompt.md
@@ -11,7 +11,7 @@ You audit code for vulnerabilities, enforce security standards, and harden the s
 - Compliance auditing and security documentation
 
 ## Project conventions (Bernstein)
-- Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+- Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
 - Use dataclasses or TypedDict, never raw dict soup
 - Ruff for linting and formatting: `uv run ruff check src/` and `uv run ruff format src/`
 - Google-style docstrings only where non-obvious

--- a/templates/roles/security/task_prompt.md
+++ b/templates/roles/security/task_prompt.md
@@ -14,17 +14,17 @@
 {{/IF}}
 
 ## Instructions
-1. Read all listed files before auditing — understand data flow from entry point to storage
+1. Read all listed files before auditing. Understand data flow from entry point to storage
 2. Check in priority order: injection (SQL, command, path traversal), auth bypass, data exposure, secrets in code
 3. Classify each finding by severity: critical / high / medium / low / informational
-4. Provide concrete fixes with code — not just "validate input", but exactly how
+4. Provide concrete fixes with code, not just "validate input" but exactly how
 5. If a critical finding is found, post immediately to BULLETIN before fixing
 6. Verify fixes do not break existing tests: `uv run python scripts/run_tests.py -x`
 7. Never introduce new secrets into source code
 
 ## If stuck or blocked
 - If a curl to the task server fails, retry up to 3 times with 2-second delays
-- If tests fail after your changes, fix the code — do not skip tests or mark complete with failures
+- If tests fail after your changes, fix the code. Do not skip tests or mark complete with failures
 - If you cannot determine the fix, mark the task as failed:
   ```bash
   curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/fail \

--- a/templates/roles/visionary/system_prompt.md
+++ b/templates/roles/visionary/system_prompt.md
@@ -23,10 +23,10 @@ For each proposal, produce structured JSON with these fields:
 
 ## Rules
 - Generate 3-5 proposals per session
-- Think big but stay grounded — proposals must be technically possible
+- Think big but stay grounded. Proposals must be technically possible
 - Focus on user value, not code elegance
-- Each proposal should be independent — don't build dependency chains
-- No incremental improvements — those belong in the regular evolution loop
+- Each proposal should be independent. Don't build dependency chains
+- No incremental improvements; those belong in the regular evolution loop
 - If you can't articulate the user benefit in one sentence, the idea isn't ready
 
 ## Current task

--- a/templates/roles/visionary/task_prompt.md
+++ b/templates/roles/visionary/task_prompt.md
@@ -16,7 +16,7 @@
 ## Instructions
 1. Read the codebase structure and current feature set
 2. Review recent metrics and evolution history if available
-3. Think from the user's perspective — what friction exists? What's missing?
+3. Think from the user's perspective. What friction exists? What's missing?
 4. Generate 3-5 bold feature proposals as structured JSON
 5. Write proposals to the output path specified in your task
 

--- a/templates/roles/vp/system_prompt.md
+++ b/templates/roles/vp/system_prompt.md
@@ -28,14 +28,14 @@ You do NOT assign individual tasks to workers. You assign subsystem-level object
 ## Strategic pivot evaluation
 When a pivot signal is routed to you (severity=high or affects 3+ tickets), you must:
 
-1. **Read the pivot signal** — understand what was discovered, by whom, and during which task
-2. **Assess affected tickets** — read each affected ticket to understand current assumptions
+1. **Read the pivot signal**: understand what was discovered, by whom, and during which task
+2. **Assess affected tickets**: read each affected ticket to understand current assumptions
 3. **Decide**:
-   - **APPROVE** — the pivot is valid; update affected ticket descriptions and priorities as needed
-   - **REJECT** — the pivot is noise or premature; add a note explaining why and proceed as-is
-   - **ESCALATE** — the pivot has implications beyond your authority (budget, timeline, external stakeholders); pause affected work and notify human
-4. **Record your decision** — write to `.sdd/signals/vp_decisions.jsonl`
-5. **Log ticket changes** — any priority or scope changes go to `.sdd/signals/ticket_changes.jsonl` with before/after values
+   - **APPROVE**: the pivot is valid; update affected ticket descriptions and priorities as needed
+   - **REJECT**: the pivot is noise or premature; add a note explaining why and proceed as-is
+   - **ESCALATE**: the pivot has implications beyond your authority (budget, timeline, external stakeholders); pause affected work and notify human
+4. **Record your decision**: write to `.sdd/signals/vp_decisions.jsonl`
+5. **Log ticket changes**: any priority or scope changes go to `.sdd/signals/ticket_changes.jsonl` with before/after values
 
 ### Pivot evaluation criteria
 - Does the discovery invalidate core assumptions of the affected tickets?

--- a/templates/roles/vp/task_prompt.md
+++ b/templates/roles/vp/task_prompt.md
@@ -14,12 +14,12 @@
 {{/IF}}
 
 ## Instructions
-1. Read `.sdd/` state and bulletin board before acting — understand current cell status
+1. Read `.sdd/` state and bulletin board before acting. Understand current cell status
 2. Decompose the goal into subsystem-level objectives; assign each to a cell Manager
 3. Define explicit cross-cell interfaces: shared schemas, API contracts, file boundaries
 4. Each cell should own a coherent subsystem; minimise cross-cell dependencies
 5. Post coordination decisions to the bulletin board so all cells have visibility
-6. If a cell fails the same objective twice, reassign or restructure — don't retry blindly
+6. If a cell fails the same objective twice, reassign or restructure. Don't retry blindly
 
 ## Done signal
 ```bash

--- a/tests/property/test_capability_matrix_bughunt.py
+++ b/tests/property/test_capability_matrix_bughunt.py
@@ -373,7 +373,11 @@ def test_pipeline_failed_rule_appears_regardless_of_order() -> None:
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        (None, False),
+        # Env var unset → pack is on by default (post-#1153 default-on flip).
+        (None, True),
+        # Any explicitly non-truthy string suppresses the pack so operators
+        # who scripted BERNSTEIN_ENABLE_OWASP_ASI=<falsy|garbage> before the
+        # flip keep their conservative off behaviour.
         ("", False),
         ("0", False),
         ("false", False),
@@ -383,6 +387,7 @@ def test_pipeline_failed_rule_appears_regardless_of_order() -> None:
         ("disabled", False),
         ("maybe", False),
         ("garbage", False),
+        # Whitelisted truthy values leave the pack on.
         ("1", True),
         ("true", True),
         ("TRUE", True),
@@ -392,11 +397,13 @@ def test_pipeline_failed_rule_appears_regardless_of_order() -> None:
     ],
 )
 def test_owasp_env_var_truthy_semantics(value: str | None, expected: bool) -> None:
-    """Property: env-var opt-in is conservative.
+    """Property: BERNSTEIN_ENABLE_OWASP_ASI semantics post default-on flip.
 
-    Garbage / non-truthy values must be treated as OFF, not ON. Pins
-    behaviour for the default-on flip — when wave-5 flips the default,
-    callers will rely on garbage-string behaviour staying conservative.
+    The pack defaults to on when the env var is unset (#1153). The
+    legacy opt-in env var, when set to any non-truthy string (falsy or
+    unrecognised), suppresses the pack so operators who scripted
+    ``BERNSTEIN_ENABLE_OWASP_ASI=0`` keep their off behaviour after the
+    wave-5 default-on flip.
     """
     env: dict[str, str] = {} if value is None else {"BERNSTEIN_ENABLE_OWASP_ASI": value}
     assert is_owasp_asi_enabled(env) is expected

--- a/tests/unit/test_spawn_prompt.py
+++ b/tests/unit/test_spawn_prompt.py
@@ -126,7 +126,7 @@ def test_render_prompt_falls_back_and_includes_context_sections(tmp_path: Path, 
     assert "Prefer exact parsing." in prompt
     assert "Research auth" in prompt
     assert "Other agents are working in parallel" in prompt
-    assert "Signal files — check periodically" in prompt
+    assert "Signal files (check periodically)" in prompt
 
 
 def test_render_prompt_includes_git_safety_protocol(tmp_path: Path, make_task: Any) -> None:


### PR DESCRIPTION
## Summary

Strip common LLM tells from user-visible CLI strings, role templates, and the spawn-prompt boilerplate that ships in every agent prompt. Behaviour is unchanged; only wording.

Tells targeted (per RESRCH-004 hit list):

- em-dash clause-glue (`X — Y`) → `:` / `;` / `.` / restructure
- title-case section headings in CLI help (`Quick start`, `Run & manage`, `Options`, etc.) → lowercase OUTREACH style
- `comprehensive` (in `bernstein doctor` + `help-all` docstrings) → cut or replaced with concrete verb
- shared role-template phrases (`Python 3.12+, strict typing — no Any`, `fix the code — do not skip tests`, `[ critical ] — would cause data loss`) → semicolon / colon / period
- `Signal files — check periodically` (printed inside every leaf-agent prompt by `spawn_prompt.py` and `spawner_core.py`) → `Signal files (check periodically)` (and the matching unit test updated)

## Stats

- 99 files changed
- 238 insertions / 238 deletions (symmetric pattern; no semantic adds)
- 18 roles × {system_prompt.md, task_prompt.md} touched
- 80 CLI `.py` files touched (banners, click `help=`, `console.print`, error messages, dry-run notices)
- 1 unit test updated to match new wording (`tests/unit/test_spawn_prompt.py`)

## Sample before/after

**CLI banner** (`src/bernstein/cli/main.py`):
```
- "[bold]bernstein[/bold]  —  declarative agent orchestration for engineering teams"
+ "[bold]bernstein[/bold]  declarative agent orchestration for engineering teams"
```

**Help-screen headings**:
```
- "Quick start"   → "quick start"
- "Run & manage"  → "run & manage"
- "Options"       → "options"
```

**Help-screen verbs** (lowercased to match OUTREACH register):
```
- "Orchestrate agents for an inline goal"  → "orchestrate agents for an inline goal"
- "Show execution plan without running agents" → "show execution plan without running agents"
```

**Doctor / help-all docstrings**:
```
- """Show comprehensive help with all command groups and descriptions."""
+ """Show full help with every command group and description."""

- """Run comprehensive health checks on the Bernstein installation.
+ """Run health checks on the Bernstein installation.
```

**Role templates** (e.g. `templates/roles/backend/system_prompt.md`):
```
- - Python 3.12+, strict typing (Pyright strict mode) — no `Any`, no untyped dicts
+ - Python 3.12+, strict typing (Pyright strict mode); no `Any`, no untyped dicts
```

**Adversary findings classification**:
```
- - `critical` — would cause data loss, security breach, work loss,
+ - `critical`: data loss, security breach, work loss,
```

**Manager role (responsibilities)**:
```
- 1. **Analyze** — read the codebase to understand current state
+ 1. **Analyze**: read the codebase to understand current state
```

**Print messages**:
```
- console.print(f"[bold]SWE-Bench evaluation[/bold] — subset={subset} • {len(instances)} instance(s)")
+ console.print(f"[bold]SWE-Bench evaluation[/bold]: subset={subset} • {len(instances)} instance(s)")

- console.print(f"[bold red]Dependency impact check FAILED — {n_api} API break(s) ...[/bold red]")
+ console.print(f"[bold red]Dependency impact check FAILED: {n_api} API break(s) ...[/bold red]")
```

**Shell completion docstring** (`bernstein completions --help`):
```
- For bash — add to ~/.bashrc:
+ For bash, add to ~/.bashrc:
```

**Spawn-prompt boilerplate** (injected into every leaf agent):
```
- "\n## Signal files — check periodically\n"
+ "\n## Signal files (check periodically)\n"
```

## Edge cases preserved

- `"—"` as a UI placeholder for "no value" (e.g. empty cell in agents-list, status, fingerprint tables) — these are typographic placeholders, not clause-glue, kept as-is.
- All error semantics: exit codes, raised exception types, message structure unchanged. Only wording softens.
- Module-level dev docstrings and inline `# comments` left alone (not user-visible). The pass targets only `click help=`, `@click.command(help=...)`, `console.print` / `click.echo` arguments, and the role-template `.md` files.

## Test plan

- [x] `uv run ruff format src/ tests/` clean
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run pytest tests/snapshot/ tests/unit/test_cli_snapshots.py tests/unit/test_tui_snapshot_testing.py tests/unit/test_spawn_prompt.py` (52 passed)
- [x] `uv run pytest tests/unit/ -k "role or template or prompt or cli_help or rich_help or banner or splash"` (1056 passed)
- [x] `uv run bernstein --help` renders correctly with new lowercase headings
- [x] `uv run bernstein doctor --help` and `bernstein eval --help` render correctly
- [x] Spawn-prompt drift test (`test_render_prompt_falls_back_and_includes_context_sections`) updated and passing

Closes RESRCH-004.