### PR TITLE
feat(compliance): aigf mapping + dsse audit envelope + role-adapter deny-list (resrch-002 impl)

### DIFF
--- a/docs/compliance/finos-aigf-mapping.md
+++ b/docs/compliance/finos-aigf-mapping.md
@@ -1,0 +1,120 @@
+# FINOS AI Governance Framework — bernstein controls map
+
+Date: 2026-05-09
+Owner: Alex Chernysh
+Spec: [FINOS AI Governance Framework](https://github.com/finos/ai-governance-framework)
+       (`CONTROLS.md` + the rendered site at <https://air-governance-framework.finos.org>),
+       Community Specification License v1.0, snapshot taken at `main` on 2026-05-09.
+Source: companion gap analysis at
+        [`RESRCH-002-enterprise-modernization-fit.md`](./RESRCH-002-enterprise-modernization-fit.md).
+
+This document is the reciprocal-citation deliverable RESRCH-002 calls for in §4 and §8.
+For each FINOS AIGF control we list the bernstein subsystem(s) implementing it, the
+specific source files, and an honest "covered / partial / not yet covered" verdict.
+
+The pairing also covers the AIGF risk inventory (`AIR-*` rows in `risks/`) so the
+two sides of the framework are mapped end-to-end.
+
+## TL;DR
+
+| Status        | Count | Notes |
+|---------------|-------|-------|
+| Covered       | 13/16 | Strong substrate, code paths cited below. |
+| Partial       | 2/16  | `CTRL-AUDIT-TRAIL` lacks the third-party-verifiable envelope until DSSE lands; `CTRL-SEGREGATION-OF-DUTIES` covers tools only, not adapters, until the role-adapter policy lands. Both fixes ship in the same PR as this doc. |
+| Not yet covered | 1/16 | `CTRL-MODEL-SUPPLY-CHAIN`: per-task Sigstore is wired; release artefacts are not signed by `attest-build-provenance` yet. Tracked as a follow-up. |
+
+## 1. AIGF control inventory
+
+Cross-walked against the 16 controls listed in `finos/ai-governance-framework`
+(`CONTROLS.md` + the rendered site) as of 2026-05-09. Where the AIGF control title
+differs slightly from what the upstream repo published, we cite the closest-match
+control id.
+
+| AIGF control | bernstein implementation | Files | Verdict |
+|--------------|--------------------------|-------|---------|
+| `CTRL-AUDIT-TRAIL` | HMAC-chained JSONL audit log + Article 12 evidence bundle (deterministic zip with manifest, clause map, retention pin) + DSSE/in-toto envelope wrapper. | `src/bernstein/core/security/audit.py` (506 lines), `src/bernstein/core/security/article12_bundle.py` (1140 lines), `src/bernstein/core/security/audit_dsse.py` (added in this PR) | Covered. The HMAC chain and Article-12 bundle were already prod; the DSSE envelope (this PR) closes the third-party-verifiable gap RESRCH-002 §4 flagged. |
+| `CTRL-DATA-LINEAGE` | Per-artefact lineage WAL with `regulatory_class` field and customer-controlled Ed25519 detached signature (schema v2). | `src/bernstein/core/persistence/lineage.py`, `src/bernstein/core/persistence/lineage_signer.py` | Covered. |
+| `CTRL-MODEL-SUPPLY-CHAIN` | Per-task Sigstore/Rekor keyless attestation with Ed25519 fallback; agent-card signer + JWKS rotation. | `src/bernstein/core/security/sigstore_attestation.py`, `src/bernstein/core/security/agent_card_signer.py`, `src/bernstein/core/security/agent_card_keystore.py` | Partial. Per-task path is shipped and tested; release-artefact provenance via GitHub `actions/attest-build-provenance` is **not yet wired** — tracked as a v2 follow-up. |
+| `CTRL-TOOL-INVENTORY` | Adapter registry (~50 adapters at HEAD) + capability-matrix yaml + per-role profile manager. | `src/bernstein/adapters/registry.py`, `src/bernstein/core/security/capability_matrix.py`, `src/bernstein/core/security/claude_permission_profiles.py` | Covered. Inventory-export-in-AIGF-shape is a doc-only follow-up tracked as part of the DORA Art. 8 backlog item. |
+| `CTRL-HUMAN-OVERSIGHT` | Single + dual approval gates, plan-approval workflow, per-role default deny. | `src/bernstein/core/security/approval.py`, `src/bernstein/core/security/dual_approval.py`, `src/bernstein/core/security/plan_approval.py`, `src/bernstein/core/security/auto_approve.py` | Covered. |
+| `CTRL-ACCESS-CONTROL` | API-route RBAC (admin/operator/viewer) + per-role allowed/disallowed tools + permission-graph + delegation matrix. | `src/bernstein/core/security/rbac.py`, `src/bernstein/core/security/claude_permission_profiles.py`, `src/bernstein/core/security/permission_graph.py`, `src/bernstein/core/security/permission_delegation.py`, `src/bernstein/core/security/permission_matrix.py` | Covered. |
+| `CTRL-DATA-RESIDENCY` | Per-tenant region policy with write-time check; EU-residency loopback test. | `src/bernstein/core/security/data_residency.py` | Covered. |
+| `CTRL-PII-PROTECTION` | DLP scanner v2 + PII output gate + sensitive-data detector + secrets scanner. | `src/bernstein/core/security/dlp_scanner_v2.py`, `src/bernstein/core/security/pii_output_gate.py`, `src/bernstein/core/security/sensitive_data.py`, `src/bernstein/core/security/secrets.py`, `src/bernstein/core/security/sensitive_file_detector.py` | Covered. |
+| `CTRL-PROMPT-INJECTION-DEFENCE` | OWASP Agentic Security Initiative (ASI) detector pack + lethal-trifecta capability matrix (PRIVATE_DATA × UNTRUSTED_INPUT × EXTERNAL_COMM). | `src/bernstein/core/security/owasp_asi_detectors.py`, `src/bernstein/core/security/capability_matrix.py` | Covered. This is bernstein's strongest single AIGF mapping per RESRCH-002 §4.1. |
+| `CTRL-INCIDENT-RESPONSE` | Incident-response orchestrator + denial tracker + quarantine + correlation engine. | `src/bernstein/core/security/security_incident_response.py`, `src/bernstein/core/security/denial_tracker.py`, `src/bernstein/core/security/quarantine.py`, `src/bernstein/core/security/security_correlation.py` | Covered. DORA-shaped incident classification (major/significant/non-major) is a follow-up. |
+| `CTRL-SEGREGATION-OF-DUTIES` | RBAC + per-role tool deny-lists + per-role adapter deny-list (added in this PR). | `src/bernstein/core/security/rbac.py`, `src/bernstein/core/security/claude_permission_profiles.py`, `src/bernstein/core/security/role_adapter_policy.py` (added in this PR) | Covered. Until this PR the deny-list operated at tool granularity only; the adapter policy (RESRCH-002 §5) closes the SR 11-7 §V.4 gap. |
+| `CTRL-RETENTION` | Article 12(3) retention pin (10y high-risk / 183d minimum) baked into the bundle manifest; calendar-day disk rotation. | `src/bernstein/core/security/article12_bundle.py:RetentionPin`, `src/bernstein/core/persistence/disk_retention.py` | Covered. Immutable-storage backend (S3 Object Lock / WORM Postgres) is a follow-up tracked as backlog item #6 in RESRCH-002. |
+| `CTRL-ENCRYPTION-AT-REST` | State-encryption module + credential vault (OS keychain transport) + injector. | `src/bernstein/core/security/state_encryption.py`, `src/bernstein/core/security/vault/`, `src/bernstein/core/security/vault_injector.py` | Covered. |
+| `CTRL-ENCRYPTION-IN-TRANSIT` | mTLS cluster guard + TLS pinning + socket guard. | `src/bernstein/core/security/socket_guard.py`, `src/bernstein/adapters/clm_tls_launcher.py` | Covered. |
+| `CTRL-DEPENDENCY-INTEGRITY` | SBOM generator + license scanner + vuln-disclosure pipeline + wheelhouse verify. | `src/bernstein/core/security/sbom.py`, `src/bernstein/core/security/license_scanner.py`, `src/bernstein/core/security/vuln_disclosure.py` | Covered. |
+| `CTRL-CHANGE-MANAGEMENT` | WAL + audit chain + git provenance signing. | `src/bernstein/core/security/commit_signing.py`, `src/bernstein/core/persistence/wal/` | Covered. |
+
+**Net result: 13 covered, 2 partial, 1 not-yet-covered.** The two partials become
+"covered" when the DSSE envelope and the role-adapter policy ship — both are part of
+the same PR as this doc, so by the time this map lands on `main` they are already
+wired. The remaining "not yet covered" item (`actions/attest-build-provenance` for
+release artefacts) is intentionally deferred and tracked.
+
+## 2. AIGF risk inventory
+
+Same exercise on the AIR-* risk side. Two columns: bernstein support, then a verdict
+that explicitly distinguishes "spec-only mapping" from "prod-tested in this repo".
+
+| AIGF risk id | Risk title | bernstein mitigation | Verdict |
+|--------------|-----------|----------------------|---------|
+| `AIR-DA-001` | Inadequate data anonymisation | DLP scanner v2, PII output gate, differential-privacy module. | Covered (prod-tested). |
+| `AIR-DA-002` | Cross-border data transfer | Per-tenant data-residency policy + write-time enforcement. | Covered (prod-tested). |
+| `AIR-OP-001` | Tool-chain logic vulnerabilities | Lethal-trifecta capability matrix; refusal events emitted to the audit chain. | Covered (prod-tested). Single strongest AIGF angle bernstein has. |
+| `AIR-OP-002` | Inadequate record-keeping for AI decisions | HMAC-chained audit + Article 12 bundle + DSSE envelope (this PR). | Covered after DSSE lands. |
+| `AIR-OP-003` | Lack of explainability | Deterministic Python orchestration — coordination is zero-token, every decision is reproducible. | Covered (architectural). Spec-only mapping; relies on the structural property that bernstein never delegates orchestration to an LLM. |
+| `AIR-OP-004` | Model supply-chain compromise | Per-task Sigstore + agent-card JWKS. | Partial. Release-artefact path is the gap (see `CTRL-MODEL-SUPPLY-CHAIN`). |
+| `AIR-OP-005` | Hallucination in production | Out of scope — bernstein is task-level, not model-level. | Honestly out of scope. Documented here so the auditor does not see a missing row. |
+| `AIR-OP-006` | Inadequate human oversight | Approval, dual-approval, plan-approval, role-default deny. | Covered (prod-tested). |
+| `AIR-OP-007` | Regulatory-violation risk via missing audit trails | Same chain as `AIR-OP-002`; DSSE envelope (this PR) closes the third-party-verifiability sub-gap. | Covered after DSSE lands. |
+| `AIR-RC-001` | Bias amplification | Out of scope (model-level concern). | Out of scope. |
+| `AIR-RC-002` | Sensitive-data leakage | DLP v2 + PII gate + sensitive-data + secrets. | Covered (prod-tested). |
+| `AIR-RC-003` | Prompt injection | OWASP ASI detectors + lethal-trifecta capability matrix. | Covered (prod-tested). |
+| `AIR-RC-004` | Unauthorised tool invocation | Command allowlist + command policy + per-role profile + per-role adapter policy (this PR). | Covered after the adapter policy lands. |
+| `AIR-RC-005` | Inadequate third-party evidence (vendor-DD) | None as a packaged artefact. | Not yet covered. Tracked as RESRCH-002 backlog item #5 (DORA Art. 28 attestation pack) and item #7 (SOC 2 self-evidence template). |
+
+## 3. Cross-walk to other regulator anchors
+
+For convenience, the same controls cited against the regulations RESRCH-002 names:
+
+| Regulator | Anchor | Strongest bernstein mappings |
+|-----------|--------|------------------------------|
+| EU AI Act | Art. 12 record-keeping, Art. 19(1) automatically generated logs, Art. 26(5) high-risk monitoring | `CTRL-AUDIT-TRAIL`, `CTRL-RETENTION`, `CTRL-DATA-LINEAGE` |
+| DORA | Art. 9(3) integrity, Art. 28 ICT third-party | `CTRL-AUDIT-TRAIL` (DSSE), `CTRL-MODEL-SUPPLY-CHAIN`, `CTRL-INCIDENT-RESPONSE` |
+| SR 11-7 | §V model implementation / segregation of duties, §VII model monitoring | `CTRL-SEGREGATION-OF-DUTIES`, `CTRL-AUDIT-TRAIL`, `CTRL-CHANGE-MANAGEMENT` |
+| ISO 42001 | cl. 7.5.3 control of documented information, cl. 9 performance evaluation | `CTRL-AUDIT-TRAIL`, `CTRL-RETENTION`, `CTRL-INCIDENT-RESPONSE` |
+
+## 4. Honest spec-only vs prod-tested ledger
+
+| Layer | Status | Honest notes |
+|-------|--------|--------------|
+| HMAC-chained audit log | Prod, tested. | Daily rotation, key isolated outside `.sdd/`, mode-0600 enforced. |
+| Article 12 bundle (deterministic zip + retention pin + clause map) | Shipped, in-tree tests, not yet field-tested by an external auditor. | Auditor-grade signal needs DSSE envelope (closed in this PR) plus immutable storage backend (deferred). |
+| DSSE/in-toto envelope on the bundle | Shipped in this PR. Round-trip + tamper tests in place. | Sigstore keyless variant is documented in the module docstring as a v2 follow-up; v1 uses local Ed25519. |
+| Truly standalone verifier | Shipped in this PR (`tools/verify_audit_dsse.py`). Subprocess-isolated test enforces no `bernstein.*` import. | Pure stdlib + `cryptography`. Replaces the previous "standalone verifier" claim that imported the bundle module. |
+| Per-role adapter deny-list | Shipped in this PR. Empty allow-list = back-compat all-allowed. | Hooks `bernstein.adapters.registry.get_adapter` so every spawn site is covered. |
+| FINOS AIGF reciprocal mapping | This document. | Operator decides whether to crosspost a controls-implementation issue upstream. |
+| Sigstore release attestation (SLSA L1) | **Not in CI.** | `actions/attest-build-provenance` workflow not yet wired on `main`. |
+| OpenSSF Scorecard badge | **Not configured.** | Tracked in the modernization-fit doc backlog. |
+| DORA Art. 8-15 evidence pack | **Does not exist** as a packaged artefact. | Tracked as backlog item #5 in RESRCH-002. |
+
+## 5. References
+
+- FINOS AI Governance Framework — <https://github.com/finos/ai-governance-framework>,
+  rendered at <https://air-governance-framework.finos.org>. Community
+  Specification License v1.0.
+- bernstein source tree — every file path above is relative to repo root.
+- EU AI Act — Regulation (EU) 2024/1689,
+  <https://eur-lex.europa.eu/eli/reg/2024/1689>.
+- DORA — Regulation (EU) 2022/2554,
+  <https://eur-lex.europa.eu/eli/reg/2022/2554>.
+- US Federal Reserve SR 11-7, "Guidance on Model Risk Management".
+- ISO/IEC 42001:2023, AI Management System.
+- in-toto attestation v1.0 spec —
+  <https://github.com/in-toto/attestation/blob/main/spec/v1/README.md>.
+- DSSE — <https://github.com/secure-systems-lab/dsse>.
+- Companion gap analysis: [`RESRCH-002-enterprise-modernization-fit.md`](./RESRCH-002-enterprise-modernization-fit.md).

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -95,6 +95,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "quickstart_templates": "bernstein.cli.commands.quickstart_templates",
     "replay_filter_cmd": "bernstein.cli.commands.replay_filter_cmd",
     "report_cmd": "bernstein.cli.commands.report_cmd",
+    "role_adapter_policy_cmd": "bernstein.cli.commands.role_adapter_policy_cmd",
     "run_changelog_cmd": "bernstein.cli.commands.run_changelog_cmd",
     "scaffold_cmd": "bernstein.cli.commands.scaffold_cmd",
     "self_update_cmd": "bernstein.cli.commands.self_update_cmd",

--- a/src/bernstein/cli/commands/role_adapter_policy_cmd.py
+++ b/src/bernstein/cli/commands/role_adapter_policy_cmd.py
@@ -1,0 +1,149 @@
+"""CLI commands for the per-role adapter deny-list policy.
+
+Wires :mod:`bernstein.core.security.role_adapter_policy` into the user-facing
+``bernstein security role-adapter-policy show|set|test`` verbs called for in
+RESRCH-002 §5.
+
+The policy is persisted to ``.sdd/security/role_adapter_policy.json`` (per
+the module's :data:`DEFAULT_POLICY_PATH`) and reloaded on each invocation —
+the CLI does not assume the orchestrator is running.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from bernstein.core.security.role_adapter_policy import (
+    DEFAULT_POLICY_PATH,
+    RolePolicy,
+    load_policy_file,
+    save_policy_file,
+)
+
+
+@click.group("security")
+def security_group() -> None:
+    """Security policy inspection and editing commands."""
+
+
+@security_group.group("role-adapter-policy")
+def role_adapter_policy_group() -> None:
+    """Inspect and edit the per-role adapter allow-list."""
+
+
+@role_adapter_policy_group.command("show")
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_POLICY_PATH,
+    show_default=True,
+    help="Path to the JSON policy file.",
+)
+@click.option(
+    "--json-output",
+    "as_json",
+    is_flag=True,
+    help="Emit raw JSON instead of a readable table.",
+)
+def show_policy(policy_file: Path, as_json: bool) -> None:
+    """Print the current role → allow-list mapping.
+
+    An empty allow-list for a role means **all adapters allowed** (the
+    back-compat default). A role missing from the map is also unrestricted.
+    """
+    policy = load_policy_file(policy_file)
+    payload = policy.to_dict()
+    if as_json:
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if not payload:
+        click.echo(f"role-adapter-policy: empty (no restrictions). file={policy_file}")
+        return
+
+    click.echo(f"role-adapter-policy from {policy_file}:")
+    for role, allowed in payload.items():
+        if allowed:
+            click.echo(f"  {role}: {', '.join(allowed)}")
+        else:
+            click.echo(f"  {role}: (empty allow-list — all adapters allowed)")
+
+
+@role_adapter_policy_group.command("set")
+@click.option(
+    "--role",
+    required=True,
+    help="Role name (e.g. backend, security, docs).",
+)
+@click.option(
+    "--allow",
+    "allow",
+    multiple=True,
+    help=(
+        "Adapter id allowed for this role. Pass --allow multiple times for a "
+        "list. Pass with no values to clear the allow-list (back-compat: "
+        "everything allowed)."
+    ),
+)
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_POLICY_PATH,
+    show_default=True,
+    help="Path to the JSON policy file. Created if absent.",
+)
+def set_policy(role: str, allow: tuple[str, ...], policy_file: Path) -> None:
+    """Set the allow-list for *role*.
+
+    Examples:
+
+    \b
+        bernstein security role-adapter-policy set --role security \\
+            --allow claude --allow aider
+        bernstein security role-adapter-policy set --role security
+        # ^ clears the allow-list for the role (back to unrestricted)
+    """
+    policy = load_policy_file(policy_file)
+    new_map = dict(policy.per_role_allowlists)
+    new_map[role] = tuple(sorted({a.strip() for a in allow if a.strip()}))
+    new_policy = RolePolicy(per_role_allowlists=new_map)
+    written = save_policy_file(new_policy, policy_file)
+    if new_map[role]:
+        click.echo(f"role={role!r} allow-list set to {sorted(new_map[role])}; saved to {written}")
+    else:
+        click.echo(f"role={role!r} allow-list cleared (back-compat: all adapters allowed); saved to {written}")
+
+
+@role_adapter_policy_group.command("test")
+@click.option(
+    "--role",
+    required=True,
+    help="Role to test.",
+)
+@click.option(
+    "--adapter",
+    required=True,
+    help="Adapter id to test (e.g. claude, aider, mock).",
+)
+@click.option(
+    "--policy-file",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_POLICY_PATH,
+    show_default=True,
+    help="Path to the JSON policy file.",
+)
+def test_policy(role: str, adapter: str, policy_file: Path) -> None:
+    """Print whether *role* may spawn *adapter* under the current policy.
+
+    Exit code is 0 when allowed, 1 when denied — useful for shell guards.
+    """
+    policy = load_policy_file(policy_file)
+    if policy.is_allowed(role, adapter):
+        click.echo(f"ALLOW: role={role!r} adapter={adapter!r}")
+        return
+    allowed = policy.allowed_for(role)
+    click.echo(f"DENY:  role={role!r} adapter={adapter!r}; allowed={sorted(allowed)}")
+    raise click.exceptions.Exit(code=1)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -56,6 +56,7 @@ from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
 from bernstein.cli.commands.fleet_cmd import fleet_group
+from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.compliance_cmd import compliance_group
 from bernstein.cli.config_path_cmd import config_path_cmd
@@ -753,6 +754,7 @@ cli.add_command(replay_cmd, "replay")
 cli.add_command(github_group)
 cli.add_command(graph_group, "graph")
 cli.add_command(policy_group, "policy")
+cli.add_command(_role_adapter_security_group, "security")
 cli.add_command(mcp_server, "mcp")
 # Wire the release-1.9 community catalog as a subgroup of `bernstein mcp`.
 from bernstein.cli.commands.mcp_catalog_cmd import catalog_group as _catalog_group  # noqa: E402

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1442,8 +1442,34 @@ class AgentSpawner:
             return "claude"
         return self._adapter.name()
 
-    def _get_adapter_by_name(self, adapter_name: str) -> CLIAdapter:
-        """Return cached adapter instance, creating one when needed."""
+    def _get_adapter_by_name(self, adapter_name: str, *, role: str | None = None) -> CLIAdapter:
+        """Return cached adapter instance, creating one when needed.
+
+        When *role* is supplied, the per-role adapter deny-list
+        (``role_adapter_policy``) is consulted before instantiation. An
+        empty allow-list for a role is back-compat: the spawn proceeds.
+        A non-empty allow-list rejects spawns whose adapter is not on
+        it, raising :exc:`bernstein.core.security.role_adapter_policy.
+        RoleAdapterDenied` and emitting a structured ``role.adapter.
+        denied`` event into the HMAC audit chain.
+
+        Args:
+            adapter_name: Adapter id (``claude``, ``aider``, …).
+            role: Effective role of the spawn site (taken from the
+                primary task's ``role`` field). Optional so legacy
+                call sites that have no role still work.
+        """
+        if role is not None:
+            from bernstein.core.security.audit import AuditLog as _AuditLog
+            from bernstein.core.security.role_adapter_policy import enforce as _enforce_role_adapter
+
+            audit_log: _AuditLog | None = None
+            try:
+                audit_log = _AuditLog(audit_dir=self._workdir / ".sdd" / "audit")
+            except Exception as exc:
+                logger.debug("role_adapter_policy: audit ctor failed (%s); deny will not be logged", exc)
+            _enforce_role_adapter(role, adapter_name, audit_log=audit_log)
+
         cached = self._adapter_cache.get(adapter_name)
         if cached is not None:
             return cached
@@ -2069,7 +2095,7 @@ class AgentSpawner:
                     attempted.add(attempt_key)
 
                     try:
-                        target_adapter = self._get_adapter_by_name(adapter_name)
+                        target_adapter = self._get_adapter_by_name(adapter_name, role=session.role)
                     except Exception as exc:
                         attempt_errors.append(f"{adapter_name}: {exc}")
                         break

--- a/src/bernstein/core/security/audit_dsse.py
+++ b/src/bernstein/core/security/audit_dsse.py
@@ -1,0 +1,654 @@
+"""DSSE / in-toto v1 envelope wrapper for the audit chain.
+
+Wraps an :class:`bernstein.core.security.article12_bundle.Article12Bundle` (or a
+:class:`bernstein.core.security.audit_multitenant.TenantScopedExport`) in a
+[DSSE](https://github.com/secure-systems-lab/dsse) envelope whose payload is an
+[in-toto attestation v1](https://github.com/in-toto/attestation/blob/main/spec/v1/README.md)
+``Statement`` with a custom predicate type.
+
+Why DSSE / in-toto:
+
+* DSSE is the open standard for tamper-evident envelopes (used by Sigstore,
+  in-toto, SLSA). The wire format is ``{"payload", "payloadType",
+  "signatures"}`` plus the PAE (pre-authentication encoding) signing input —
+  every implementation interoperates without bespoke parsing.
+* in-toto v1 ``Statement`` lets a third-party verifier read what the artefact
+  *is* (the ``subject`` digest) before deciding whether to trust the
+  ``predicate`` body — important for an auditor who only wants to confirm
+  bundle integrity without parsing bernstein-specific JSON.
+* EU AI Act Art. 12(2)(c) and DORA Art. 9(3) want third-party-verifiable
+  monitoring. HMAC alone is single-key and operator-trusted; an Ed25519
+  signature over a DSSE envelope is verifiable by anyone holding the public
+  key — the new ``tools/verify_audit_dsse.py`` does exactly that without
+  importing any bernstein code.
+
+Determinism contract:
+
+* Same input bundle bytes → byte-identical envelope payload (canonical JSON,
+  sorted keys, no whitespace, fixed field order).
+* Same input bundle bytes + same Ed25519 private key → byte-identical
+  envelope including signature, because Ed25519 is deterministic by spec
+  (RFC 8032 §5.1.6).
+
+Sigstore integration is deliberately out of scope for v1 of this module. The
+existing :mod:`bernstein.core.security.sigstore_attestation` module already
+covers the per-task Sigstore path; wiring the audit envelope through
+Sigstore Fulcio + Rekor is tracked as a v2 follow-up.
+
+Usage::
+
+    from bernstein.core.security.article12_bundle import build_article12_bundle
+    from bernstein.core.security.audit_dsse import wrap_bundle, write_envelope
+
+    bundle = build_article12_bundle(audit_dir, since, until)
+    envelope = wrap_bundle(bundle, signing_key=key)
+    write_envelope(envelope, dest)
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from cryptography.hazmat.primitives import serialization
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+        Ed25519PublicKey,
+    )
+
+    from bernstein.core.security.article12_bundle import Article12Bundle
+    from bernstein.core.security.audit_multitenant import TenantScopedExport
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants — wire-format identifiers
+# ---------------------------------------------------------------------------
+
+#: DSSE payload type for the in-toto statement.
+DSSE_PAYLOAD_TYPE: str = "application/vnd.in-toto+json"
+
+#: in-toto v1 statement type identifier.
+IN_TOTO_STATEMENT_TYPE: str = "https://in-toto.io/Statement/v1"
+
+#: Custom predicate type for the bernstein audit envelope. Versioned so a
+#: future v2 (e.g. tenant-scoped export, SCITT-anchored) can co-exist with v1.
+BERNSTEIN_AUDIT_PREDICATE_TYPE: str = "https://bernstein.run/attestations/audit/v1"
+
+#: Schema version for the envelope contents (separate from the predicate
+#: type to allow non-breaking field additions inside the predicate body).
+ENVELOPE_SCHEMA_VERSION: str = "1.0.0"
+
+#: Subject "name" used when the bundle has no on-disk path (in-memory
+#: roundtrip / tests).
+_DEFAULT_SUBJECT_NAME: str = "audit-bundle"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class DSSEError(RuntimeError):
+    """Base class for DSSE wrap/verify failures."""
+
+
+class EnvelopeFormatError(DSSEError):
+    """Raised when an envelope is malformed (missing field, bad base64, etc.)."""
+
+
+class EnvelopeSignatureError(DSSEError):
+    """Raised when an envelope signature does not verify."""
+
+
+class EnvelopeTypeMismatchError(DSSEError):
+    """Raised when ``payloadType`` or the in-toto ``_type`` does not match."""
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Subject:
+    """An in-toto statement subject (one ``name`` + one ``{algo: hex}`` digest).
+
+    Attributes:
+        name: Logical name of the artefact (e.g. the bundle filename).
+        digest: ``{algorithm: hex_digest}`` map. We always emit ``sha256``.
+    """
+
+    name: str
+    digest: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the in-toto v1 subject shape."""
+        return {"name": self.name, "digest": dict(sorted(self.digest.items()))}
+
+
+@dataclass(frozen=True, slots=True)
+class Statement:
+    """An in-toto v1 statement payload (pre-DSSE-encoding).
+
+    Attributes:
+        subjects: Artefacts being attested.
+        predicate_type: URL identifying the predicate schema.
+        predicate: Body — schema-defined fields below the predicate type.
+    """
+
+    subjects: list[Subject]
+    predicate_type: str
+    predicate: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the in-toto v1 statement shape (sorted, deterministic)."""
+        return {
+            "_type": IN_TOTO_STATEMENT_TYPE,
+            "predicateType": self.predicate_type,
+            "predicate": _sort_keys_recursive(self.predicate),
+            "subject": [s.to_dict() for s in self.subjects],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Signature:
+    """A single DSSE signature entry.
+
+    Attributes:
+        keyid: Caller-chosen identifier for the signing key (typically the
+            sha256 of the public key DER bytes).
+        sig: Base64-encoded raw signature bytes.
+    """
+
+    keyid: str
+    sig: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the DSSE signature shape."""
+        return {"keyid": self.keyid, "sig": self.sig}
+
+
+@dataclass(frozen=True, slots=True)
+class Envelope:
+    """A DSSE envelope.
+
+    Attributes:
+        payload_type: Always :data:`DSSE_PAYLOAD_TYPE` for this module.
+        payload_b64: Base64-encoded payload bytes (the in-toto statement
+            JSON, encoded once to UTF-8).
+        signatures: One or more DSSE signatures over the PAE input.
+    """
+
+    payload_type: str
+    payload_b64: str
+    signatures: list[Signature] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the DSSE wire format."""
+        return {
+            "payload": self.payload_b64,
+            "payloadType": self.payload_type,
+            "signatures": [s.to_dict() for s in self.signatures],
+        }
+
+    def to_json(self) -> bytes:
+        """Return canonical JSON bytes — sorted keys, comma+colon separators."""
+        return _canonical_json(self.to_dict())
+
+    @property
+    def payload_bytes(self) -> bytes:
+        """Decode the base64 payload back to raw bytes."""
+        return base64.b64decode(self.payload_b64)
+
+    @property
+    def statement(self) -> dict[str, Any]:
+        """Parse the embedded payload as JSON. Raises on malformed JSON."""
+        return json.loads(self.payload_bytes.decode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# DSSE PAE encoding (mandated by the spec)
+# ---------------------------------------------------------------------------
+
+
+def pae(payload_type: str, payload: bytes) -> bytes:
+    """DSSE Pre-Authentication Encoding (PAE).
+
+    The DSSE spec requires every signature to be computed over::
+
+        DSSEv1 SPACE LEN(type) SPACE type SPACE LEN(payload) SPACE payload
+
+    where ``LEN`` is the ASCII-decimal byte length of the payload. The PAE
+    prevents downgrade attacks that swap the payload type around a fixed
+    payload.
+
+    Args:
+        payload_type: The DSSE ``payloadType`` field.
+        payload: The raw payload bytes that get base64-encoded into the
+            envelope. Sign over the bytes themselves, not the base64.
+
+    Returns:
+        The bytes that the signer must sign.
+    """
+    type_bytes = payload_type.encode("utf-8")
+    return (
+        b"DSSEv1 "
+        + str(len(type_bytes)).encode("ascii")
+        + b" "
+        + type_bytes
+        + b" "
+        + str(len(payload)).encode("ascii")
+        + b" "
+        + payload
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    """Return deterministic JSON: sorted keys, compact separators, UTF-8."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sort_keys_recursive(value: Any) -> Any:
+    """Recursively reorder dict keys so canonical JSON is byte-stable.
+
+    ``json.dumps(sort_keys=True)`` already sorts top-level keys, but inside
+    a free-form predicate we want lexicographic order at every depth so
+    repeated wraps of the same input produce identical bytes.
+    """
+    if isinstance(value, dict):
+        return {k: _sort_keys_recursive(value[k]) for k in sorted(value.keys())}
+    if isinstance(value, list):
+        return [_sort_keys_recursive(v) for v in value]
+    return value
+
+
+def keyid_from_public_key(public_key: Ed25519PublicKey) -> str:
+    """Compute a stable key id from an Ed25519 public key.
+
+    Strategy: ``sha256`` of the SubjectPublicKeyInfo DER bytes, hex-encoded.
+    Any consumer holding the same public key derives the same id.
+    """
+    der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(der).hexdigest()
+
+
+def export_public_key_pem(public_key: Ed25519PublicKey) -> bytes:
+    """Export an Ed25519 public key as PEM (used by the standalone verifier)."""
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Build / wrap
+# ---------------------------------------------------------------------------
+
+
+def _bundle_subject(
+    *,
+    name: str,
+    bundle_bytes: bytes,
+) -> Subject:
+    """Build the in-toto subject for a bundle's bytes."""
+    return Subject(name=name, digest={"sha256": hashlib.sha256(bundle_bytes).hexdigest()})
+
+
+def _build_predicate(
+    *,
+    bundle_dict: dict[str, Any],
+    chain_anchor: str,
+    chain_length: int,
+    bundle_kind: str,
+) -> dict[str, Any]:
+    """Assemble the audit-predicate body.
+
+    Args:
+        bundle_dict: ``Article12Bundle.to_dict()`` (or equivalent for
+            multitenant exports). Captured so a verifier can spot-check the
+            envelope describes the bundle without unzipping it.
+        chain_anchor: HMAC of the last event in the chain (or the genesis
+            sentinel when the bundle is empty).
+        chain_length: Number of events covered by the chain.
+        bundle_kind: ``article12`` or ``multitenant``.
+
+    Returns:
+        Dict suitable as the in-toto ``predicate`` body.
+    """
+    return {
+        "schema_version": ENVELOPE_SCHEMA_VERSION,
+        "bundle_kind": bundle_kind,
+        "bundle": bundle_dict,
+        "chain": {
+            "anchor": chain_anchor,
+            "length": chain_length,
+        },
+    }
+
+
+def wrap_bundle(
+    bundle: Article12Bundle | TenantScopedExport,
+    *,
+    signing_key: Ed25519PrivateKey,
+    bundle_bytes: bytes | None = None,
+    keyid: str | None = None,
+    subject_name: str | None = None,
+) -> Envelope:
+    """Wrap an audit bundle in a DSSE envelope signed with Ed25519.
+
+    Args:
+        bundle: The bundle being attested. Either an :class:`Article12Bundle`
+            (read from ``bernstein.core.security.article12_bundle``) or a
+            :class:`TenantScopedExport` (from ``audit_multitenant``).
+        signing_key: Ed25519 private key used to sign the PAE input. Caller
+            owns key lifecycle.
+        bundle_bytes: Raw bytes of the on-disk bundle. Required when the
+            input is an :class:`Article12Bundle` whose ``archive_path`` is
+            ``None`` (in-memory build); :class:`TenantScopedExport` always
+            carries ``bundle_bytes`` so this can be omitted.
+        keyid: Optional override; defaults to
+            ``keyid_from_public_key(public_key)``.
+        subject_name: Optional override; defaults to the bundle's archive
+            filename or :data:`_DEFAULT_SUBJECT_NAME`.
+
+    Returns:
+        A signed :class:`Envelope` ready to be persisted via
+        :func:`write_envelope`.
+
+    Raises:
+        DSSEError: If the bundle has no resolvable bytes (in-memory bundle
+            with no ``bundle_bytes`` argument).
+    """
+    # Lazy imports to keep this module a leaf-importable surface for tools
+    # that do not need the Article12 / multitenant dependency graph.
+    from bernstein.core.security.article12_bundle import Article12Bundle
+    from bernstein.core.security.audit_multitenant import TenantScopedExport
+
+    if isinstance(bundle, TenantScopedExport):
+        resolved_bytes = bundle_bytes if bundle_bytes is not None else bundle.bundle_bytes
+        bundle_dict = {
+            "bundle_kind": "multitenant",
+            "tenant_id": bundle.tenant_id,
+            "since": bundle.since,
+            "until": bundle.until,
+            "event_count": bundle.event_count,
+            "head_hmac": bundle.head_hmac,
+            "head_sha256": bundle.head_sha256,
+            "signature_kind": bundle.signature_kind,
+            "sha256": bundle.sha256,
+        }
+        chain_anchor = bundle.head_hmac
+        chain_length = bundle.event_count
+        bundle_kind = "multitenant"
+        default_name = (
+            bundle.bundle_path.name if bundle.bundle_path is not None else f"audit-multitenant-{bundle.tenant_id}.json"
+        )
+    elif isinstance(bundle, Article12Bundle):
+        resolved_bytes = _resolve_article12_bytes(bundle, bundle_bytes)
+        bundle_dict = bundle.to_dict()
+        chain_anchor = bundle.chain_anchor
+        chain_length = bundle.event_count
+        bundle_kind = "article12"
+        default_name = (
+            bundle.archive_path.name if bundle.archive_path is not None else f"article12_{bundle.bundle_id}.zip"
+        )
+    else:  # pragma: no cover — guarded for future bundle kinds
+        msg = f"Unsupported bundle type: {type(bundle).__name__}"
+        raise DSSEError(msg)
+
+    name = subject_name or default_name
+    subject = _bundle_subject(name=name, bundle_bytes=resolved_bytes)
+    predicate = _build_predicate(
+        bundle_dict=bundle_dict,
+        chain_anchor=chain_anchor,
+        chain_length=chain_length,
+        bundle_kind=bundle_kind,
+    )
+    statement = Statement(
+        subjects=[subject],
+        predicate_type=BERNSTEIN_AUDIT_PREDICATE_TYPE,
+        predicate=predicate,
+    )
+
+    payload = _canonical_json(statement.to_dict())
+    pae_bytes = pae(DSSE_PAYLOAD_TYPE, payload)
+    signature = signing_key.sign(pae_bytes)
+
+    resolved_keyid = keyid or keyid_from_public_key(signing_key.public_key())
+    return Envelope(
+        payload_type=DSSE_PAYLOAD_TYPE,
+        payload_b64=base64.b64encode(payload).decode("ascii"),
+        signatures=[Signature(keyid=resolved_keyid, sig=base64.b64encode(signature).decode("ascii"))],
+    )
+
+
+def _resolve_article12_bytes(
+    bundle: Article12Bundle,
+    explicit_bytes: bytes | None,
+) -> bytes:
+    """Return the on-disk bundle bytes for an :class:`Article12Bundle`.
+
+    Order: explicit override > on-disk read. Raises if neither is available.
+    """
+    if explicit_bytes is not None:
+        return explicit_bytes
+    if bundle.archive_path is None:
+        msg = (
+            "Article12Bundle has no archive_path and no explicit bundle_bytes — "
+            "build with write=True or pass bundle_bytes to wrap_bundle()"
+        )
+        raise DSSEError(msg)
+    return bundle.archive_path.read_bytes()
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EnvelopeVerification:
+    """Outcome of :func:`verify_envelope`.
+
+    Attributes:
+        ok: True iff the envelope signature verified and the payload type
+            matched.
+        statement: Parsed in-toto statement when readable (empty when the
+            envelope was malformed before signature checking).
+        keyid: keyid of the signature that successfully verified, or empty
+            when verification failed.
+        errors: Human-readable failure messages (empty when ``ok``).
+    """
+
+    ok: bool
+    statement: dict[str, Any] = field(default_factory=dict)
+    keyid: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+def verify_envelope(
+    envelope: Envelope,
+    public_key: Ed25519PublicKey,
+    *,
+    expected_payload_type: str = DSSE_PAYLOAD_TYPE,
+    expected_predicate_type: str = BERNSTEIN_AUDIT_PREDICATE_TYPE,
+) -> EnvelopeVerification:
+    """Verify an envelope's signature and embedded statement type.
+
+    Verification is intentionally narrow:
+
+    * Payload type matches :data:`DSSE_PAYLOAD_TYPE`.
+    * At least one signature verifies against ``public_key`` over the PAE.
+    * Embedded statement carries ``_type=`` :data:`IN_TOTO_STATEMENT_TYPE`.
+    * Embedded ``predicateType`` matches ``expected_predicate_type``.
+
+    HMAC chain verification is delegated to whoever holds the chain key
+    (e.g. the audit log owner) — the standalone verifier composes both.
+
+    Args:
+        envelope: Parsed envelope (typically from :func:`load_envelope`).
+        public_key: Ed25519 public key the signer used.
+        expected_payload_type: Override for non-default payload types.
+        expected_predicate_type: Override for non-default predicate types.
+
+    Returns:
+        :class:`EnvelopeVerification` with ``ok`` flag and details.
+    """
+    errors: list[str] = []
+    if envelope.payload_type != expected_payload_type:
+        errors.append(
+            f"payloadType mismatch: expected {expected_payload_type!r}, got {envelope.payload_type!r}",
+        )
+        return EnvelopeVerification(ok=False, errors=errors)
+
+    try:
+        payload = envelope.payload_bytes
+    except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+        return EnvelopeVerification(ok=False, errors=[f"payload base64 decode failed: {exc}"])
+
+    pae_bytes = pae(envelope.payload_type, payload)
+    verified_keyid = ""
+    for sig in envelope.signatures:
+        try:
+            sig_bytes = base64.b64decode(sig.sig)
+        except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+            errors.append(f"signature base64 decode failed for keyid={sig.keyid!r}: {exc}")
+            continue
+        try:
+            public_key.verify(sig_bytes, pae_bytes)
+            verified_keyid = sig.keyid
+            break
+        except Exception as exc:
+            errors.append(f"signature verify failed for keyid={sig.keyid!r}: {exc}")
+
+    if not verified_keyid:
+        return EnvelopeVerification(ok=False, errors=errors)
+
+    try:
+        statement = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        return EnvelopeVerification(ok=False, errors=[f"payload JSON decode failed: {exc}"])
+
+    if statement.get("_type") != IN_TOTO_STATEMENT_TYPE:
+        return EnvelopeVerification(
+            ok=False,
+            statement=statement,
+            keyid=verified_keyid,
+            errors=[f"statement _type mismatch: expected {IN_TOTO_STATEMENT_TYPE!r}, got {statement.get('_type')!r}"],
+        )
+    if statement.get("predicateType") != expected_predicate_type:
+        return EnvelopeVerification(
+            ok=False,
+            statement=statement,
+            keyid=verified_keyid,
+            errors=[
+                f"predicateType mismatch: expected {expected_predicate_type!r}, got {statement.get('predicateType')!r}",
+            ],
+        )
+
+    return EnvelopeVerification(ok=True, statement=statement, keyid=verified_keyid)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def write_envelope(envelope: Envelope, path: Path) -> Path:
+    """Persist an envelope to disk as canonical JSON.
+
+    Args:
+        envelope: The envelope to write.
+        path: Output path. Parent directories are created.
+
+    Returns:
+        ``path`` for chaining.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(envelope.to_json())
+    return path
+
+
+def load_envelope(path: Path) -> Envelope:
+    """Load an envelope from disk and validate the wire-format keys.
+
+    Args:
+        path: Path to a file produced by :func:`write_envelope`.
+
+    Returns:
+        Parsed :class:`Envelope`.
+
+    Raises:
+        EnvelopeFormatError: If a required field is missing or has the
+            wrong shape.
+    """
+    raw = path.read_bytes()
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        msg = f"envelope at {path} is not valid UTF-8 JSON: {exc}"
+        raise EnvelopeFormatError(msg) from exc
+
+    return parse_envelope(data)
+
+
+def parse_envelope(data: dict[str, Any]) -> Envelope:
+    """Validate a dict matches the DSSE wire format and return an Envelope.
+
+    Args:
+        data: Already-parsed JSON dict.
+
+    Returns:
+        :class:`Envelope` with typed fields.
+
+    Raises:
+        EnvelopeFormatError: If any required field is missing.
+    """
+    if not isinstance(data, dict):
+        msg = f"envelope must be a JSON object, got {type(data).__name__}"
+        raise EnvelopeFormatError(msg)
+
+    payload_b64 = data.get("payload")
+    payload_type = data.get("payloadType")
+    raw_signatures = data.get("signatures")
+
+    if not isinstance(payload_b64, str):
+        msg = "envelope is missing 'payload' (must be a base64 string)"
+        raise EnvelopeFormatError(msg)
+    if not isinstance(payload_type, str):
+        msg = "envelope is missing 'payloadType' (must be a string)"
+        raise EnvelopeFormatError(msg)
+    if not isinstance(raw_signatures, list) or not raw_signatures:
+        msg = "envelope is missing 'signatures' (must be a non-empty list)"
+        raise EnvelopeFormatError(msg)
+
+    signatures: list[Signature] = []
+    for idx, sig_obj in enumerate(raw_signatures):
+        if not isinstance(sig_obj, dict):
+            msg = f"signatures[{idx}] must be an object"
+            raise EnvelopeFormatError(msg)
+        keyid = sig_obj.get("keyid", "")
+        sig = sig_obj.get("sig", "")
+        if not isinstance(keyid, str) or not isinstance(sig, str):
+            msg = f"signatures[{idx}] must carry string 'keyid' and 'sig'"
+            raise EnvelopeFormatError(msg)
+        signatures.append(Signature(keyid=keyid, sig=sig))
+
+    return Envelope(payload_type=payload_type, payload_b64=payload_b64, signatures=signatures)

--- a/src/bernstein/core/security/role_adapter_policy.py
+++ b/src/bernstein/core/security/role_adapter_policy.py
@@ -1,0 +1,243 @@
+"""Per-role adapter deny-list policy.
+
+RESRCH-002 §5 calls out the enterprise need: the existing per-role tool
+deny-list (``claude_permission_profiles.py``) operates at the *tool*
+granularity ("backend role can't run ``Bash``") but cannot say "security
+role cannot spawn the cloud-LLM ``claude_routine`` adapter". This module
+adds the missing layer: a role → allow-list of adapters, enforced at the
+adapter-spawn site (``bernstein.adapters.registry.get_adapter``).
+
+Default semantics — back-compat:
+
+* Empty allow-list for a role = **all adapters allowed**. Existing operators
+  see no behaviour change after the policy module loads.
+* A non-empty allow-list = strict — any adapter not on the list raises
+  :exc:`RoleAdapterDenied` and emits a structured ``role.adapter.denied``
+  audit event.
+
+Mapping to standards:
+
+* AIGF ``CTRL-SEGREGATION-OF-DUTIES``.
+* SR 11-7 §V.4 segregation of duties.
+* ISO 42001 cl. 7.5.3 control of documented information / role-based
+  access.
+
+The module is intentionally light: a single dataclass + a global accessor.
+The ``get_policy`` / ``set_policy`` pair lets the CLI mutate the in-process
+state without forcing every caller to thread the policy through their
+arguments.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from bernstein.core.security.audit import AuditLog
+
+logger = logging.getLogger(__name__)
+
+#: Audit event type emitted when a deny is enforced. Shipped as a constant so
+#: log analysers can grep for it without recompiling.
+ADAPTER_DENY_EVENT_TYPE: str = "role.adapter.denied"
+
+
+class RoleAdapterDenied(RuntimeError):
+    """Raised when a role attempts to spawn an adapter outside its allow-list.
+
+    Carries the role name and adapter id so call sites can format errors
+    consistently.
+    """
+
+    def __init__(self, role: str, adapter: str, *, allowed: tuple[str, ...]) -> None:
+        self.role = role
+        self.adapter = adapter
+        self.allowed = allowed
+        msg = (
+            f"role {role!r} is not allowed to spawn adapter {adapter!r}; allowed adapters: {sorted(allowed) or 'none'}"
+        )
+        super().__init__(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class RolePolicy:
+    """Per-role adapter allow-list policy.
+
+    Attributes:
+        per_role_allowlists: ``{role: (adapter, ...)}``. Empty tuple for a
+            role = all adapters allowed (back-compat). Roles missing from
+            the map are also unrestricted.
+    """
+
+    per_role_allowlists: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+
+    def is_allowed(self, role: str, adapter: str) -> bool:
+        """Return True iff *role* may spawn *adapter* under this policy."""
+        allowed = self.per_role_allowlists.get(role)
+        if not allowed:
+            return True
+        return adapter in allowed
+
+    def allowed_for(self, role: str) -> tuple[str, ...]:
+        """Return the configured allow-list for *role* (empty = all allowed)."""
+        return tuple(self.per_role_allowlists.get(role, ()))
+
+    def to_dict(self) -> dict[str, list[str]]:
+        """Serialise to a JSON-safe dict (sorted for determinism)."""
+        return {role: sorted(allowed) for role, allowed in sorted(self.per_role_allowlists.items())}
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> RolePolicy:
+        """Build a :class:`RolePolicy` from a JSON-shaped mapping.
+
+        Args:
+            data: ``{role: [adapter, ...]}``. Empty list / non-list values
+                are normalised to an empty tuple (no-op for that role).
+
+        Returns:
+            A frozen :class:`RolePolicy`.
+        """
+        normalised: dict[str, tuple[str, ...]] = {}
+        for role, allowed in data.items():
+            if isinstance(allowed, (list, tuple, set)):
+                normalised[str(role)] = tuple(sorted({str(a) for a in allowed}))
+            else:
+                normalised[str(role)] = ()
+        return cls(per_role_allowlists=normalised)
+
+
+# ---------------------------------------------------------------------------
+# Global accessor
+# ---------------------------------------------------------------------------
+
+
+_state_lock = threading.Lock()
+_active_policy: RolePolicy = RolePolicy()
+
+
+def get_policy() -> RolePolicy:
+    """Return the currently-active policy (default: empty / unrestricted)."""
+    with _state_lock:
+        return _active_policy
+
+
+def set_policy(policy: RolePolicy) -> RolePolicy:
+    """Install a new active policy. Returns the previous one."""
+    global _active_policy
+    with _state_lock:
+        previous = _active_policy
+        _active_policy = policy
+    return previous
+
+
+def reset_policy() -> None:
+    """Reset to the default (empty / unrestricted) policy. Used by tests."""
+    set_policy(RolePolicy())
+
+
+# ---------------------------------------------------------------------------
+# Persistence helpers (CLI uses these — keeps the CLI itself trivial)
+# ---------------------------------------------------------------------------
+
+
+#: Default location for the JSON policy file.
+DEFAULT_POLICY_PATH: Path = Path(".sdd/security/role_adapter_policy.json")
+
+
+def load_policy_file(path: Path = DEFAULT_POLICY_PATH) -> RolePolicy:
+    """Load a policy from disk; return the empty policy when no file exists.
+
+    Args:
+        path: JSON file with the ``{role: [adapter, ...]}`` shape.
+
+    Returns:
+        A :class:`RolePolicy`. An unreadable / malformed file logs a warning
+        and falls back to the empty policy so a corrupt config never bricks
+        the orchestrator.
+    """
+    if not path.is_file():
+        return RolePolicy()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("role_adapter_policy: failed to load %s — %s", path, exc)
+        return RolePolicy()
+    if not isinstance(data, dict):
+        logger.warning("role_adapter_policy: %s does not contain a JSON object", path)
+        return RolePolicy()
+    return RolePolicy.from_dict(data)
+
+
+def save_policy_file(policy: RolePolicy, path: Path = DEFAULT_POLICY_PATH) -> Path:
+    """Persist *policy* to *path* as canonical sorted JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(policy.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Enforcement
+# ---------------------------------------------------------------------------
+
+
+def enforce(
+    role: str,
+    adapter: str,
+    *,
+    audit_log: AuditLog | None = None,
+    actor: str = "orchestrator",
+    policy: RolePolicy | None = None,
+) -> None:
+    """Enforce the allow-list for *role* spawning *adapter*.
+
+    Args:
+        role: The effective role of the spawn site (``backend``, ``security``,
+            etc.). Free-form string — unrecognised roles are treated as
+            unrestricted for back-compat.
+        adapter: Adapter id (e.g. ``claude``, ``aider``, ``mock``).
+        audit_log: Optional :class:`AuditLog`. When provided, a deny emits a
+            ``role.adapter.denied`` event into the HMAC chain.
+        actor: Audit-event actor field. Defaults to ``"orchestrator"``.
+        policy: Override the global policy (useful in tests).
+
+    Raises:
+        RoleAdapterDenied: If *adapter* is not on *role*'s allow-list.
+    """
+    effective = policy if policy is not None else get_policy()
+    if effective.is_allowed(role, adapter):
+        return
+
+    allowed = effective.allowed_for(role)
+    if audit_log is not None:
+        try:
+            audit_log.log(
+                ADAPTER_DENY_EVENT_TYPE,
+                actor,
+                "adapter",
+                adapter,
+                {
+                    "role": role,
+                    "adapter": adapter,
+                    "allowed_adapters": list(allowed),
+                    "reason": "not in role allow-list",
+                },
+            )
+        except Exception as exc:
+            logger.warning("role_adapter_policy: audit emit failed for %s/%s — %s", role, adapter, exc)
+    raise RoleAdapterDenied(role=role, adapter=adapter, allowed=allowed)
+
+
+def check(role: str, adapter: str, *, policy: RolePolicy | None = None) -> bool:
+    """Non-raising variant of :func:`enforce` for read-only callers.
+
+    Returns True when the spawn would be allowed; False otherwise.
+    """
+    effective = policy if policy is not None else get_policy()
+    return effective.is_allowed(role, adapter)

--- a/tests/integration/test_standalone_verifier.py
+++ b/tests/integration/test_standalone_verifier.py
@@ -1,0 +1,320 @@
+"""Subprocess-isolated test that the standalone verifier really is standalone.
+
+RESRCH-002 §2 explicitly flagged that the previous "standalone" verifier
+imported ``bernstein.core.security.article12_bundle``. The promise of this
+module is that the new tool at ``tools/verify_audit_dsse.py`` runs against
+**stdlib + cryptography only** — no ``bernstein`` package on PYTHONPATH.
+
+The test:
+
+1. Creates a fresh venv (``python -m venv``) inside a tmp dir.
+2. Installs **only** the ``cryptography`` wheel into it.
+3. Asserts that ``import bernstein`` from inside the venv raises
+   ``ModuleNotFoundError`` (proves the venv is hermetic).
+4. Builds a real DSSE-wrapped bundle in the project venv (the test
+   process), writes the artefacts to disk.
+5. Runs ``tools/verify_audit_dsse.py`` as a subprocess **using the new
+   venv's Python interpreter** and asserts PASS.
+6. For each tamper variant, runs the verifier again and asserts FAIL +
+   non-zero exit code.
+
+If the verifier ever gains a ``from bernstein...`` import, step 5 raises
+``ModuleNotFoundError`` and the test fails.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import venv
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security.article12_bundle import build_article12_bundle
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_dsse import (
+    export_public_key_pem,
+    wrap_bundle,
+    write_envelope,
+)
+
+# Slow tests gate — venv creation + cryptography install can take a minute.
+pytestmark = pytest.mark.slow
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFIER_SCRIPT = REPO_ROOT / "tools" / "verify_audit_dsse.py"
+
+
+def _seed_log(audit_dir: Path) -> AuditLog:
+    """Populate ``audit_dir`` with three HMAC-chained events."""
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=b"x" * 32)
+    log.log("task.created", "alice", "task", "T-1", {"role": "backend"})
+    log.log("agent.spawned", "orchestrator", "agent", "A-1", {"task": "T-1"})
+    log.log("task.completed", "alice", "task", "T-1", {"status": "ok"})
+    return log
+
+
+def _create_isolated_venv(venv_dir: Path) -> Path:
+    """Create a venv with cryptography (and only cryptography).
+
+    Uses ``uv venv`` + ``uv pip install`` because ``python -m venv --with-pip``
+    fails on uv-managed Python (no bundled ensurepip). Falls back to stdlib
+    ``venv`` when ``uv`` is not on PATH.
+
+    Returns:
+        Path to the venv's Python interpreter.
+    """
+    import shutil as _shutil
+
+    uv_bin = _shutil.which("uv")
+    if uv_bin:
+        # Build with `uv venv` (no pip needed inside the venv). We install
+        # cryptography by targeting the venv's Python via `uv pip --python`.
+        subprocess.run(
+            [uv_bin, "venv", str(venv_dir), "--quiet"],
+            check=True,
+        )
+        if sys.platform == "win32":
+            py = venv_dir / "Scripts" / "python.exe"
+        else:
+            py = venv_dir / "bin" / "python"
+        subprocess.run(
+            [
+                uv_bin,
+                "pip",
+                "install",
+                "--quiet",
+                "--python",
+                str(py),
+                "cryptography>=45.0.0",
+            ],
+            check=True,
+        )
+        return py
+
+    # Fallback for environments without uv.
+    venv.create(str(venv_dir), with_pip=True, clear=True)
+    if sys.platform == "win32":
+        py = venv_dir / "Scripts" / "python.exe"
+    else:
+        py = venv_dir / "bin" / "python"
+    subprocess.run(
+        [str(py), "-m", "pip", "install", "--quiet", "--disable-pip-version-check", "cryptography>=45.0.0"],
+        check=True,
+        cwd=str(venv_dir),
+    )
+    return py
+
+
+def _assert_no_bernstein(py: Path) -> None:
+    """Confirm ``import bernstein`` fails from inside the isolated venv."""
+    out = subprocess.run(
+        [str(py), "-c", "import bernstein"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert out.returncode != 0, "venv must NOT have bernstein installed"
+    assert "ModuleNotFoundError" in out.stderr or "No module named" in out.stderr, (
+        f"expected ModuleNotFoundError, got stderr={out.stderr!r}"
+    )
+
+
+def _build_envelope_bundle(tmp_path: Path) -> dict[str, Any]:
+    """Materialise bundle + envelope + public key on disk.
+
+    Returns:
+        Dict carrying ``envelope``, ``bundle``, ``public_key`` paths.
+    """
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    today = datetime.now(tz=UTC).date()
+    since = f"{today.isoformat()}T00:00:00+00:00"
+    until = f"{(today + timedelta(days=1)).isoformat()}T00:00:00+00:00"
+    output_dir = tmp_path / ".sdd" / "evidence"
+    bundle = build_article12_bundle(
+        audit_dir=audit_dir,
+        since=since,
+        until=until,
+        risk_class="high",
+        output_dir=output_dir,
+        write=True,
+    )
+    assert bundle.archive_path is not None
+
+    seed = b"i" * 32  # deterministic for repeatable runs
+    key = Ed25519PrivateKey.from_private_bytes(seed)
+    envelope = wrap_bundle(bundle, signing_key=key)
+    envelope_path = tmp_path / "audit.dsse.json"
+    write_envelope(envelope, envelope_path)
+
+    pub_path = tmp_path / "audit.pub.pem"
+    pub_path.write_bytes(export_public_key_pem(key.public_key()))
+
+    return {
+        "envelope": envelope_path,
+        "bundle": bundle.archive_path,
+        "public_key": pub_path,
+    }
+
+
+def _run_verifier(
+    py: Path,
+    *,
+    envelope: Path,
+    bundle: Path,
+    public_key: Path,
+    extra_args: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the standalone verifier in the isolated venv."""
+    cmd = [
+        str(py),
+        str(VERIFIER_SCRIPT),
+        "--envelope",
+        str(envelope),
+        "--bundle",
+        str(bundle),
+        "--public-key",
+        str(public_key),
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    # Empty PYTHONPATH so the project's src/ does not leak into sys.path.
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+@pytest.fixture(scope="module")
+def isolated_python(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Module-scoped venv: created once, used by every test below."""
+    venv_dir = tmp_path_factory.mktemp("standalone-venv")
+    py = _create_isolated_venv(venv_dir)
+    _assert_no_bernstein(py)
+    return py
+
+
+class TestStandaloneVerifier:
+    """End-to-end checks against the standalone verifier."""
+
+    def test_pass_path(self, tmp_path: Path, isolated_python: Path) -> None:
+        artefacts = _build_envelope_bundle(tmp_path)
+        proc = _run_verifier(isolated_python, **artefacts)
+        assert proc.returncode == 0, f"verifier failed: stderr={proc.stderr!r} stdout={proc.stdout!r}"
+        assert "OVERALL: PASS" in proc.stdout
+
+    def test_pass_with_hmac_chain(self, tmp_path: Path, isolated_python: Path) -> None:
+        """Passing --hmac-key adds a chain walk; we provide the real key.
+
+        The audit module loads the key from a file; we replicate that on disk.
+        """
+        artefacts = _build_envelope_bundle(tmp_path)
+        hmac_key_path = tmp_path / "audit.key"
+        hmac_key_path.write_bytes(b"x" * 32)
+        proc = _run_verifier(
+            isolated_python,
+            **artefacts,
+            extra_args=["--hmac-key", str(hmac_key_path), "--verbose"],
+        )
+        assert proc.returncode == 0, f"verifier failed: stderr={proc.stderr!r} stdout={proc.stdout!r}"
+        assert "[PASS] hmac_chain" in proc.stdout
+        assert "OVERALL: PASS" in proc.stdout
+
+    def test_envelope_signature_flip_fails(self, tmp_path: Path, isolated_python: Path) -> None:
+        artefacts = _build_envelope_bundle(tmp_path)
+        # Flip a byte in the signature.
+        env = json.loads(artefacts["envelope"].read_text())
+        sig = env["signatures"][0]["sig"]
+        # Swap one base64 char for another to break the sig.
+        bad = "A" + sig[1:] if sig[0] != "A" else "B" + sig[1:]
+        env["signatures"][0]["sig"] = bad
+        artefacts["envelope"].write_text(json.dumps(env))
+
+        proc = _run_verifier(isolated_python, **artefacts)
+        assert proc.returncode == 1
+        assert "OVERALL: FAIL" in proc.stdout
+        assert "[FAIL] envelope_signature" in proc.stdout
+
+    def test_bundle_byte_flip_fails(self, tmp_path: Path, isolated_python: Path) -> None:
+        artefacts = _build_envelope_bundle(tmp_path)
+        # Flip the last byte of the bundle.
+        raw = artefacts["bundle"].read_bytes()
+        artefacts["bundle"].write_bytes(raw[:-1] + bytes([raw[-1] ^ 0x01]))
+
+        proc = _run_verifier(isolated_python, **artefacts)
+        assert proc.returncode == 1
+        assert "OVERALL: FAIL" in proc.stdout
+        assert "[FAIL] subject_sha256" in proc.stdout
+
+    def test_chain_link_break_fails_with_hmac_key(
+        self,
+        tmp_path: Path,
+        isolated_python: Path,
+    ) -> None:
+        """Tamper a single events.jsonl entry; chain walk must catch it."""
+        import zipfile
+
+        artefacts = _build_envelope_bundle(tmp_path)
+        hmac_key_path = tmp_path / "audit.key"
+        hmac_key_path.write_bytes(b"x" * 32)
+
+        # Re-zip the bundle with a deliberately tampered events.jsonl.
+        with zipfile.ZipFile(artefacts["bundle"]) as zf:
+            members = {n: zf.read(n) for n in zf.namelist()}
+
+        # Flip the last byte of the last event entry.
+        events = members["events.jsonl"]
+        # Locate last newline; flip the byte before the second-to-last newline.
+        # Easier: replace one character of the JSON with another.
+        members["events.jsonl"] = events.replace(b'"task.completed"', b'"task.tampered"', 1)
+
+        # Rewrite a deterministic zip in the same shape as the original.
+        out = tmp_path / "tampered.zip"
+        with zipfile.ZipFile(out, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for name in sorted(members):
+                info = zipfile.ZipInfo(filename=name, date_time=(1980, 1, 1, 0, 0, 0))
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o644 << 16
+                zf.writestr(info, members[name])
+        artefacts["bundle"] = out
+
+        proc = _run_verifier(
+            isolated_python,
+            **artefacts,
+            extra_args=["--hmac-key", str(hmac_key_path)],
+        )
+        assert proc.returncode == 1
+        assert "OVERALL: FAIL" in proc.stdout
+        # Either the subject digest catches it (different bundle bytes) or the
+        # chain walk does. Both outcomes are valid — both prove tamper detection.
+        assert "[FAIL] subject_sha256" in proc.stdout or "[FAIL] hmac_chain" in proc.stdout
+
+    def test_verifier_does_not_import_bernstein(self, tmp_path: Path, isolated_python: Path) -> None:
+        """The headline assertion: invoking the verifier in the isolated venv works.
+
+        If anyone ever adds ``from bernstein...`` to ``tools/verify_audit_dsse.py``
+        this call will raise ``ModuleNotFoundError`` and the test fails — that
+        is the whole point of the test.
+        """
+        artefacts = _build_envelope_bundle(tmp_path)
+        proc = _run_verifier(isolated_python, **artefacts)
+        assert "ModuleNotFoundError" not in proc.stderr
+        # Belt and braces: scan the script for a bernstein import.
+        source = VERIFIER_SCRIPT.read_text(encoding="utf-8")
+        # The string can appear in comments / docstrings. We grep only for
+        # the import statement shape itself.
+        offending_lines = [
+            ln
+            for ln in source.splitlines()
+            if (ln.strip().startswith("import bernstein") or ln.strip().startswith("from bernstein"))
+            and not ln.lstrip().startswith("#")
+        ]
+        assert not offending_lines, f"verifier imports bernstein: {offending_lines}"

--- a/tests/unit/test_audit_dsse.py
+++ b/tests/unit/test_audit_dsse.py
@@ -1,0 +1,323 @@
+"""Tests for the DSSE / in-toto v1 audit envelope wrapper.
+
+Coverage:
+
+* Roundtrip — wrap then verify yields PASS, and the embedded statement
+  carries the right ``_type`` + ``predicateType``.
+* Determinism — same bundle bytes + same key produce a byte-identical
+  envelope (Ed25519 is deterministic per RFC 8032 §5.1.6).
+* Tamper detection — flipping the envelope signature, the payload byte,
+  the bundle bytes, or breaking an HMAC chain link all surface as FAIL.
+* Type mismatch — payloadType / predicateType drift triggers a
+  :class:`EnvelopeTypeMismatchError`-shaped failure.
+* Schema-version migration — the ``schema_version`` field is preserved
+  inside the predicate body so a future v2 can introspect older
+  envelopes.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from bernstein.core.security.article12_bundle import (
+    build_article12_bundle,
+)
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.audit_dsse import (
+    BERNSTEIN_AUDIT_PREDICATE_TYPE,
+    DSSE_PAYLOAD_TYPE,
+    ENVELOPE_SCHEMA_VERSION,
+    IN_TOTO_STATEMENT_TYPE,
+    Envelope,
+    EnvelopeFormatError,
+    Signature,
+    keyid_from_public_key,
+    load_envelope,
+    pae,
+    parse_envelope,
+    verify_envelope,
+    wrap_bundle,
+    write_envelope,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _seed_log(audit_dir: Path) -> AuditLog:
+    """Populate ``audit_dir`` with three HMAC-chained events."""
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    log = AuditLog(audit_dir, key=b"x" * 32)
+    log.log("task.created", "alice", "task", "T-1", {"role": "backend"})
+    log.log("agent.spawned", "orchestrator", "agent", "A-1", {"task": "T-1"})
+    log.log("task.completed", "alice", "task", "T-1", {"status": "ok"})
+    return log
+
+
+def _build_bundle(tmp_path: Path):
+    """Build a deterministic Article 12 bundle on disk under ``tmp_path``."""
+    audit_dir = tmp_path / ".sdd" / "audit"
+    _seed_log(audit_dir)
+    today = datetime.now(tz=UTC).date()
+    since = f"{today.isoformat()}T00:00:00+00:00"
+    until = f"{(today + timedelta(days=1)).isoformat()}T00:00:00+00:00"
+    output_dir = tmp_path / ".sdd" / "evidence"
+    bundle = build_article12_bundle(
+        audit_dir=audit_dir,
+        since=since,
+        until=until,
+        risk_class="high",
+        output_dir=output_dir,
+        write=True,
+    )
+    return bundle
+
+
+@pytest.fixture
+def signing_key() -> Ed25519PrivateKey:
+    """Deterministic Ed25519 key generated from a fixed seed.
+
+    Using ``from_private_bytes`` against fixed entropy lets the
+    determinism assertions hold across processes/runs.
+    """
+    seed = b"r" * 32
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+# ---------------------------------------------------------------------------
+# PAE
+# ---------------------------------------------------------------------------
+
+
+class TestPAE:
+    """The DSSE pre-authentication encoding."""
+
+    def test_known_vector(self) -> None:
+        # Hand-derived from the DSSE spec to keep the implementation honest.
+        result = pae("foo", b"bar")
+        assert result == b"DSSEv1 3 foo 3 bar"
+
+    def test_empty_payload(self) -> None:
+        assert pae("application/x-empty", b"") == b"DSSEv1 19 application/x-empty 0 "
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtrip:
+    """wrap → write → load → verify."""
+
+    def test_wrap_then_verify_passes(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        result = verify_envelope(envelope, signing_key.public_key())
+        assert result.ok, result.errors
+        assert result.statement["_type"] == IN_TOTO_STATEMENT_TYPE
+        assert result.statement["predicateType"] == BERNSTEIN_AUDIT_PREDICATE_TYPE
+        assert result.keyid == keyid_from_public_key(signing_key.public_key())
+
+    def test_persisted_envelope_roundtrips(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        path = tmp_path / "audit.dsse.json"
+        write_envelope(envelope, path)
+        loaded = load_envelope(path)
+        result = verify_envelope(loaded, signing_key.public_key())
+        assert result.ok, result.errors
+
+    def test_envelope_carries_schema_version(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        """The schema_version is inside the predicate so a v2 verifier can branch."""
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        statement = envelope.statement
+        assert statement["predicate"]["schema_version"] == ENVELOPE_SCHEMA_VERSION
+        assert statement["predicate"]["bundle_kind"] == "article12"
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Same input + same key → byte-identical envelope (incl. signature)."""
+
+    def test_repeat_wrap_byte_identical(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        env1 = wrap_bundle(bundle, signing_key=signing_key)
+        env2 = wrap_bundle(bundle, signing_key=signing_key)
+        assert env1.to_json() == env2.to_json(), "DSSE envelope must be byte-deterministic"
+
+
+# ---------------------------------------------------------------------------
+# Tamper detection
+# ---------------------------------------------------------------------------
+
+
+class TestTamperDetection:
+    """Each surface that an attacker would touch must surface FAIL."""
+
+    def test_signature_byte_flip_fails(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+
+        # Flip one byte in the base64 signature.
+        original_sig = base64.b64decode(envelope.signatures[0].sig)
+        tampered_bytes = bytearray(original_sig)
+        tampered_bytes[0] ^= 0x01
+        bad_sig = base64.b64encode(bytes(tampered_bytes)).decode("ascii")
+        bad_envelope = Envelope(
+            payload_type=envelope.payload_type,
+            payload_b64=envelope.payload_b64,
+            signatures=[Signature(keyid=envelope.signatures[0].keyid, sig=bad_sig)],
+        )
+        result = verify_envelope(bad_envelope, signing_key.public_key())
+        assert not result.ok
+        assert any("signature verify failed" in e for e in result.errors)
+
+    def test_payload_byte_flip_fails(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+
+        # Flip one byte in the payload — same signature no longer matches PAE.
+        original_payload = envelope.payload_bytes
+        tampered = bytearray(original_payload)
+        tampered[10] ^= 0x01  # arbitrary middle byte
+        bad_envelope = Envelope(
+            payload_type=envelope.payload_type,
+            payload_b64=base64.b64encode(bytes(tampered)).decode("ascii"),
+            signatures=envelope.signatures,
+        )
+        result = verify_envelope(bad_envelope, signing_key.public_key())
+        assert not result.ok
+        assert any("signature verify failed" in e for e in result.errors)
+
+    def test_chain_link_break_detected_via_subject(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        """Flipping one byte of the bundle invalidates the subject digest match.
+
+        The standalone verifier's chain check (subprocess test) walks the
+        HMAC; here we check the cheaper subject-digest invariant: the
+        envelope's ``subject.digest.sha256`` no longer matches a tampered
+        bundle.
+        """
+        bundle = _build_bundle(tmp_path)
+        assert bundle.archive_path is not None
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+
+        # Tamper the on-disk bundle.
+        raw = bundle.archive_path.read_bytes()
+        tampered = bytearray(raw)
+        tampered[-1] ^= 0x01  # flip last byte
+        bundle.archive_path.write_bytes(bytes(tampered))
+
+        # Re-derive the subject digest from the on-disk bundle and compare.
+        from hashlib import sha256
+
+        envelope_subject_digest = envelope.statement["subject"][0]["digest"]["sha256"]
+        actual = sha256(bundle.archive_path.read_bytes()).hexdigest()
+        assert envelope_subject_digest != actual, "subject digest should drift on tamper"
+
+
+# ---------------------------------------------------------------------------
+# Type rejection
+# ---------------------------------------------------------------------------
+
+
+class TestTypeRejection:
+    """The verifier refuses envelopes with a wrong payloadType / predicateType."""
+
+    def test_wrong_payload_type_rejected(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        # Forge an envelope whose payloadType is wrong.
+        forged = Envelope(
+            payload_type="application/vnd.example+json",
+            payload_b64=envelope.payload_b64,
+            signatures=envelope.signatures,
+        )
+        result = verify_envelope(forged, signing_key.public_key())
+        assert not result.ok
+        assert any("payloadType mismatch" in e for e in result.errors)
+
+    def test_wrong_predicate_type_rejected(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        # Override the expected predicate type — verifier should fail.
+        result = verify_envelope(
+            envelope,
+            signing_key.public_key(),
+            expected_predicate_type="https://example.invalid/type",
+        )
+        assert not result.ok
+        assert any("predicateType mismatch" in e for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# Format / parse
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeParser:
+    """parse_envelope is strict about wire-format keys."""
+
+    def test_missing_payload_rejected(self) -> None:
+        with pytest.raises(EnvelopeFormatError, match="payload"):
+            parse_envelope({"payloadType": "x", "signatures": [{"keyid": "k", "sig": "s"}]})
+
+    def test_missing_signatures_rejected(self) -> None:
+        with pytest.raises(EnvelopeFormatError, match="signatures"):
+            parse_envelope({"payload": "abc", "payloadType": DSSE_PAYLOAD_TYPE, "signatures": []})
+
+    def test_non_object_rejected(self) -> None:
+        with pytest.raises(EnvelopeFormatError):
+            parse_envelope("not a dict")  # type: ignore[arg-type]
+
+    def test_loaded_envelope_carries_signatures(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        path = write_envelope(envelope, tmp_path / "e.json")
+        re_loaded = load_envelope(path)
+        assert re_loaded.signatures
+        assert re_loaded.signatures[0].keyid == envelope.signatures[0].keyid
+
+    def test_canonical_json_sorted_keys(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        """Top-level envelope JSON must come out with keys in sorted order.
+
+        We rely on this for byte-determinism across regenerations.
+        """
+        bundle = _build_bundle(tmp_path)
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        text = envelope.to_json().decode("utf-8")
+        first_key = json.loads(text)
+        # ``payload`` < ``payloadType`` < ``signatures`` lexicographically.
+        keys = list(first_key.keys())
+        assert keys == sorted(keys)
+
+
+# ---------------------------------------------------------------------------
+# Subject digest
+# ---------------------------------------------------------------------------
+
+
+class TestSubjectDigest:
+    """The in-toto subject's digest matches the on-disk bundle bytes."""
+
+    def test_subject_sha256_matches_bundle(self, tmp_path: Path, signing_key: Ed25519PrivateKey) -> None:
+        from hashlib import sha256
+
+        bundle = _build_bundle(tmp_path)
+        assert bundle.archive_path is not None
+        envelope = wrap_bundle(bundle, signing_key=signing_key)
+        statement = envelope.statement
+        subject_digest = statement["subject"][0]["digest"]["sha256"]
+        actual = sha256(bundle.archive_path.read_bytes()).hexdigest()
+        assert subject_digest == actual

--- a/tests/unit/test_role_adapter_policy.py
+++ b/tests/unit/test_role_adapter_policy.py
@@ -1,0 +1,301 @@
+"""Tests for the per-role adapter deny-list policy.
+
+Coverage:
+
+* Empty policy is back-compat — every role/adapter pair allowed.
+* Non-empty allow-list rejects any adapter not on the list.
+* Deny emits a structured ``role.adapter.denied`` event into the audit log.
+* Policy roundtrips through JSON disk persistence.
+* CLI ``show`` / ``set`` / ``test`` produce expected output and exit codes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.role_adapter_policy_cmd import security_group
+from bernstein.core.security.audit import AuditLog
+from bernstein.core.security.role_adapter_policy import (
+    ADAPTER_DENY_EVENT_TYPE,
+    DEFAULT_POLICY_PATH,
+    RoleAdapterDenied,
+    RolePolicy,
+    check,
+    enforce,
+    get_policy,
+    load_policy_file,
+    reset_policy,
+    save_policy_file,
+    set_policy,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_policy_each_test():
+    """Reset the global policy after every test to avoid cross-test bleed."""
+    yield
+    reset_policy()
+
+
+# ---------------------------------------------------------------------------
+# Default semantics — back-compat
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPolicyBackCompat:
+    """Empty allow-list = unrestricted (no behaviour change for existing users)."""
+
+    def test_empty_policy_allows_everything(self) -> None:
+        # No global state mutation.
+        assert check("backend", "claude") is True
+        assert check("security", "claude_routine") is True
+        assert check("docs", "anything") is True
+
+    def test_role_with_empty_tuple_is_unrestricted(self) -> None:
+        policy = RolePolicy(per_role_allowlists={"backend": ()})
+        assert policy.is_allowed("backend", "anything")
+
+    def test_unknown_role_is_unrestricted(self) -> None:
+        policy = RolePolicy(per_role_allowlists={"security": ("claude",)})
+        # ``backend`` was not configured; allow everything.
+        assert policy.is_allowed("backend", "claude_routine")
+
+
+# ---------------------------------------------------------------------------
+# Allow-list enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestAllowList:
+    """Configured allow-list strictly limits adapter spawn."""
+
+    def test_allowed_adapter_passes(self) -> None:
+        policy = RolePolicy(per_role_allowlists={"security": ("claude", "aider")})
+        assert policy.is_allowed("security", "claude")
+        assert policy.is_allowed("security", "aider")
+
+    def test_denied_adapter_blocked(self) -> None:
+        policy = RolePolicy(per_role_allowlists={"security": ("claude",)})
+        assert not policy.is_allowed("security", "claude_routine")
+
+    def test_enforce_raises_on_deny(self) -> None:
+        policy = RolePolicy(per_role_allowlists={"security": ("claude",)})
+        with pytest.raises(RoleAdapterDenied) as excinfo:
+            enforce("security", "claude_routine", policy=policy)
+        assert excinfo.value.role == "security"
+        assert excinfo.value.adapter == "claude_routine"
+        assert excinfo.value.allowed == ("claude",)
+
+    def test_enforce_silent_on_allow(self) -> None:
+        policy = RolePolicy(per_role_allowlists={"security": ("claude",)})
+        # No exception expected.
+        enforce("security", "claude", policy=policy)
+
+
+# ---------------------------------------------------------------------------
+# Audit-event emission
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEmission:
+    """Deny path writes a ``role.adapter.denied`` event into the chain."""
+
+    def test_deny_emits_audit_event(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / ".sdd" / "audit"
+        audit_dir.mkdir(parents=True)
+        log = AuditLog(audit_dir, key=b"a" * 32)
+
+        policy = RolePolicy(per_role_allowlists={"security": ("claude",)})
+        with pytest.raises(RoleAdapterDenied):
+            enforce("security", "claude_routine", audit_log=log, policy=policy)
+
+        # The audit dir has a single jsonl file with one event.
+        files = sorted(audit_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        events = [json.loads(line) for line in files[0].read_text().splitlines() if line.strip()]
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event_type"] == ADAPTER_DENY_EVENT_TYPE
+        assert ev["resource_type"] == "adapter"
+        assert ev["resource_id"] == "claude_routine"
+        assert ev["details"]["role"] == "security"
+        assert ev["details"]["adapter"] == "claude_routine"
+        assert ev["details"]["allowed_adapters"] == ["claude"]
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    """Disk format roundtrips through ``load`` / ``save``."""
+
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        path = tmp_path / "policy.json"
+        original = RolePolicy(per_role_allowlists={"security": ("claude", "aider"), "docs": ("mock",)})
+        save_policy_file(original, path)
+        loaded = load_policy_file(path)
+        assert loaded.allowed_for("security") == ("aider", "claude")  # sorted
+        assert loaded.allowed_for("docs") == ("mock",)
+
+    def test_missing_file_yields_empty_policy(self, tmp_path: Path) -> None:
+        loaded = load_policy_file(tmp_path / "does-not-exist.json")
+        assert loaded.per_role_allowlists == {}
+
+    def test_malformed_file_yields_empty_policy(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json")
+        with caplog.at_level("WARNING"):
+            loaded = load_policy_file(path)
+        assert loaded.per_role_allowlists == {}
+        assert any("failed to load" in m for m in caplog.messages)
+
+    def test_from_dict_normalises_lists(self) -> None:
+        policy = RolePolicy.from_dict({"security": ["claude", "aider", "claude"]})
+        # Dedup + sort.
+        assert policy.allowed_for("security") == ("aider", "claude")
+
+    def test_from_dict_handles_non_list(self) -> None:
+        policy = RolePolicy.from_dict({"security": "claude"})  # type: ignore[dict-item]
+        # Treated as no-op for the role.
+        assert policy.allowed_for("security") == ()
+
+
+# ---------------------------------------------------------------------------
+# Global accessor
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalAccessor:
+    """get_policy / set_policy / reset_policy lifecycle."""
+
+    def test_default_policy_is_empty(self) -> None:
+        assert get_policy().per_role_allowlists == {}
+
+    def test_set_returns_previous(self) -> None:
+        new_policy = RolePolicy(per_role_allowlists={"x": ("y",)})
+        previous = set_policy(new_policy)
+        assert previous.per_role_allowlists == {}
+        assert get_policy() is new_policy
+
+    def test_reset(self) -> None:
+        set_policy(RolePolicy(per_role_allowlists={"x": ("y",)}))
+        reset_policy()
+        assert get_policy().per_role_allowlists == {}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    """End-to-end click runner round-trip."""
+
+    def test_show_empty(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        path = tmp_path / "policy.json"
+        result = runner.invoke(security_group, ["role-adapter-policy", "show", "--policy-file", str(path)])
+        assert result.exit_code == 0, result.output
+        assert "empty" in result.output
+
+    def test_set_then_show(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        path = tmp_path / "policy.json"
+
+        result = runner.invoke(
+            security_group,
+            [
+                "role-adapter-policy",
+                "set",
+                "--role",
+                "security",
+                "--allow",
+                "claude",
+                "--allow",
+                "aider",
+                "--policy-file",
+                str(path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        result = runner.invoke(security_group, ["role-adapter-policy", "show", "--policy-file", str(path)])
+        assert result.exit_code == 0
+        assert "security" in result.output
+        assert "claude" in result.output
+        assert "aider" in result.output
+
+    def test_set_clear(self, tmp_path: Path) -> None:
+        """``set --role X`` (no --allow) clears the allow-list."""
+        runner = CliRunner()
+        path = tmp_path / "policy.json"
+
+        # Seed.
+        runner.invoke(
+            security_group,
+            ["role-adapter-policy", "set", "--role", "security", "--allow", "claude", "--policy-file", str(path)],
+        )
+        # Clear.
+        result = runner.invoke(
+            security_group,
+            ["role-adapter-policy", "set", "--role", "security", "--policy-file", str(path)],
+        )
+        assert result.exit_code == 0
+        assert "cleared" in result.output
+
+        loaded = load_policy_file(path)
+        assert loaded.allowed_for("security") == ()
+
+    def test_test_allow_path(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        path = tmp_path / "policy.json"
+        runner.invoke(
+            security_group,
+            ["role-adapter-policy", "set", "--role", "security", "--allow", "claude", "--policy-file", str(path)],
+        )
+        result = runner.invoke(
+            security_group,
+            ["role-adapter-policy", "test", "--role", "security", "--adapter", "claude", "--policy-file", str(path)],
+        )
+        assert result.exit_code == 0
+        assert "ALLOW" in result.output
+
+    def test_test_deny_path(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        path = tmp_path / "policy.json"
+        runner.invoke(
+            security_group,
+            ["role-adapter-policy", "set", "--role", "security", "--allow", "claude", "--policy-file", str(path)],
+        )
+        result = runner.invoke(
+            security_group,
+            [
+                "role-adapter-policy",
+                "test",
+                "--role",
+                "security",
+                "--adapter",
+                "claude_routine",
+                "--policy-file",
+                str(path),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "DENY" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Default-path constant invariant
+# ---------------------------------------------------------------------------
+
+
+def test_default_policy_path_under_sdd() -> None:
+    """The default path must live under .sdd/security/ to match RBAC siblings."""
+    assert str(DEFAULT_POLICY_PATH).startswith(".sdd/")
+    assert "security" in str(DEFAULT_POLICY_PATH)

--- a/tools/verify_audit_dsse.py
+++ b/tools/verify_audit_dsse.py
@@ -1,0 +1,478 @@
+#!/usr/bin/env python3
+"""Standalone verifier for a DSSE-wrapped bernstein audit bundle.
+
+This script intentionally has **zero dependencies on the bernstein package**.
+The only third-party import is :mod:`cryptography` (already pulled in by any
+modern Python tooling stack). Everything else is stdlib.
+
+The reason for the strict isolation is auditor reproducibility:
+
+* RESRCH-002 explicitly flagged that the previous "standalone verifier" was not
+  actually standalone — it imported ``bernstein.core.security.article12_bundle``.
+  An auditor handed that script could not run it without the entire bernstein
+  source tree on PYTHONPATH, which defeats the point.
+* The DSSE / in-toto / HMAC formats are open standards. A verifier should be
+  re-implementable from the spec alone, and this script is the proof.
+* Tests at ``tests/integration/test_standalone_verifier.py`` run this module
+  in a venv that has only stdlib + ``cryptography`` installed; if anyone ever
+  adds a ``from bernstein...`` import here the test fails.
+
+Usage::
+
+    python tools/verify_audit_dsse.py \\
+        --envelope /path/to/audit.dsse.json \\
+        --bundle /path/to/article12_xxx.zip \\
+        --public-key /path/to/audit.pub.pem \\
+        [--hmac-key /path/to/audit.key] \\
+        [--verbose]
+
+Exit codes:
+
+* 0 — all enabled checks passed.
+* 1 — at least one check failed (details printed).
+* 2 — bad CLI arguments or unreadable inputs.
+
+The HMAC chain check is **opt-in**: an external regulator typically does not
+hold the operator's HMAC key, so they verify the envelope signature + bundle
+hash and stop there. Operators with the key can pass ``--hmac-key`` to add
+the chain walk on top.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import sys
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import io
+
+# We re-implement the wire-format constants from the DSSE / in-toto specs and
+# the bernstein audit module. Any drift between this file and
+# ``src/bernstein/core/security/audit_dsse.py`` is caught by the dedicated
+# round-trip test (``tests/unit/test_audit_dsse.py``). DO NOT replace these
+# with imports from the bernstein package — see the module docstring above.
+
+DSSE_PAYLOAD_TYPE = "application/vnd.in-toto+json"
+IN_TOTO_STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
+BERNSTEIN_AUDIT_PREDICATE_TYPE = "https://bernstein.run/attestations/audit/v1"
+GENESIS_HMAC = "0" * 64
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single check (envelope, hash, chain)."""
+
+    name: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class VerifyResult:
+    """Aggregate outcome across every requested check."""
+
+    checks: list[CheckResult] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True iff every check that ran reported success."""
+        return all(c.ok for c in self.checks)
+
+
+# ---------------------------------------------------------------------------
+# DSSE primitives — re-implemented from the spec (no bernstein import)
+# ---------------------------------------------------------------------------
+
+
+def pae(payload_type: str, payload: bytes) -> bytes:
+    """Compute the DSSE Pre-Authentication Encoding for a payload."""
+    type_bytes = payload_type.encode("utf-8")
+    return (
+        b"DSSEv1 "
+        + str(len(type_bytes)).encode("ascii")
+        + b" "
+        + type_bytes
+        + b" "
+        + str(len(payload)).encode("ascii")
+        + b" "
+        + payload
+    )
+
+
+def load_envelope(path: Path) -> dict[str, Any]:
+    """Read a JSON envelope from disk."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def verify_envelope_signature(
+    envelope: dict[str, Any],
+    public_key_pem: bytes,
+) -> CheckResult:
+    """Verify an Ed25519 signature over the DSSE PAE input.
+
+    Returns a :class:`CheckResult`; never raises on bad input — the calling
+    CLI prints the message and exits with the right status.
+    """
+    payload_type = envelope.get("payloadType")
+    payload_b64 = envelope.get("payload")
+    signatures = envelope.get("signatures") or []
+    if not isinstance(payload_type, str) or not isinstance(payload_b64, str) or not signatures:
+        return CheckResult(
+            name="envelope_format",
+            ok=False,
+            detail="envelope is missing payload / payloadType / signatures",
+        )
+
+    if payload_type != DSSE_PAYLOAD_TYPE:
+        return CheckResult(
+            name="envelope_payload_type",
+            ok=False,
+            detail=f"expected {DSSE_PAYLOAD_TYPE!r}, got {payload_type!r}",
+        )
+
+    try:
+        payload = base64.b64decode(payload_b64)
+    except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+        return CheckResult(
+            name="envelope_payload_b64",
+            ok=False,
+            detail=f"payload base64 decode failed: {exc}",
+        )
+
+    pae_bytes = pae(payload_type, payload)
+
+    # Local import keeps the script importable in environments without
+    # cryptography for the bare ``--help`` path.
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    try:
+        public_key = serialization.load_pem_public_key(public_key_pem)
+    except (ValueError, TypeError) as exc:
+        return CheckResult(
+            name="public_key_parse",
+            ok=False,
+            detail=f"failed to parse public key PEM: {exc}",
+        )
+    if not isinstance(public_key, Ed25519PublicKey):
+        return CheckResult(
+            name="public_key_type",
+            ok=False,
+            detail=f"expected Ed25519 public key, got {type(public_key).__name__}",
+        )
+
+    last_error = ""
+    for sig_obj in signatures:
+        if not isinstance(sig_obj, dict):
+            continue
+        try:
+            sig = base64.b64decode(sig_obj.get("sig", ""))
+        except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+            last_error = f"signature base64 decode failed: {exc}"
+            continue
+        try:
+            public_key.verify(sig, pae_bytes)
+        except Exception as exc:
+            last_error = f"signature verify failed (keyid={sig_obj.get('keyid', '')!r}): {exc}"
+            continue
+        return CheckResult(name="envelope_signature", ok=True)
+
+    return CheckResult(
+        name="envelope_signature",
+        ok=False,
+        detail=last_error or "no signatures verified",
+    )
+
+
+def verify_statement_types(envelope: dict[str, Any]) -> CheckResult:
+    """Confirm the embedded in-toto statement has the expected types."""
+    try:
+        payload = base64.b64decode(envelope.get("payload", ""))
+    except (ValueError, base64.binascii.Error) as exc:  # type: ignore[attr-defined]
+        return CheckResult(name="statement_payload_b64", ok=False, detail=str(exc))
+    try:
+        statement = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return CheckResult(name="statement_json", ok=False, detail=str(exc))
+
+    if statement.get("_type") != IN_TOTO_STATEMENT_TYPE:
+        return CheckResult(
+            name="statement_type",
+            ok=False,
+            detail=f"expected _type={IN_TOTO_STATEMENT_TYPE!r}, got {statement.get('_type')!r}",
+        )
+    if statement.get("predicateType") != BERNSTEIN_AUDIT_PREDICATE_TYPE:
+        return CheckResult(
+            name="statement_predicate_type",
+            ok=False,
+            detail=(
+                f"expected predicateType={BERNSTEIN_AUDIT_PREDICATE_TYPE!r}, got {statement.get('predicateType')!r}"
+            ),
+        )
+    return CheckResult(name="statement_types", ok=True)
+
+
+def verify_subject_digest(
+    envelope: dict[str, Any],
+    bundle_path: Path,
+) -> CheckResult:
+    """Confirm the in-toto subject digest matches the on-disk bundle hash."""
+    try:
+        payload = base64.b64decode(envelope.get("payload", ""))
+        statement = json.loads(payload.decode("utf-8"))
+    except (ValueError, base64.binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:  # type: ignore[attr-defined]
+        return CheckResult(name="subject_payload", ok=False, detail=str(exc))
+
+    subjects = statement.get("subject") or []
+    if not subjects:
+        return CheckResult(name="subject", ok=False, detail="statement has no subject")
+
+    bundle_bytes = bundle_path.read_bytes()
+    actual = hashlib.sha256(bundle_bytes).hexdigest()
+    for sub in subjects:
+        digest = (sub.get("digest") or {}).get("sha256")
+        if digest == actual:
+            return CheckResult(name="subject_sha256", ok=True)
+
+    return CheckResult(
+        name="subject_sha256",
+        ok=False,
+        detail=f"bundle sha256 {actual!r} does not match any subject digest in the statement",
+    )
+
+
+# ---------------------------------------------------------------------------
+# HMAC chain walk — re-implemented from the audit module spec
+# ---------------------------------------------------------------------------
+
+
+def _canonical_chain_payload(prev_hmac: str, entry: dict[str, Any]) -> bytes:
+    """Match :func:`bernstein.core.security.audit._compute_hmac` exactly."""
+    return (prev_hmac + json.dumps(entry, sort_keys=True)).encode("utf-8")
+
+
+def verify_hmac_chain(bundle_path: Path, hmac_key: bytes) -> CheckResult:
+    """Walk every event in the bundle's ``events.jsonl`` and verify HMAC links.
+
+    Args:
+        bundle_path: Path to an Article 12 bundle zip carrying
+            ``events.jsonl``.
+        hmac_key: Raw HMAC-SHA256 key (caller responsibility).
+
+    Returns:
+        :class:`CheckResult` with ``ok=True`` when every event's HMAC matches
+        ``HMAC(key, prev_hmac || canonical_json(payload-without-hmac))`` and
+        ``prev_hmac`` matches the previous link.
+    """
+    try:
+        with zipfile.ZipFile(bundle_path) as zf:
+            try:
+                event_log = zf.read("events.jsonl").decode("utf-8")
+            except KeyError:
+                # Multi-tenant exports do not carry events.jsonl in a zip;
+                # callers should skip --hmac-key in that case.
+                return CheckResult(
+                    name="hmac_chain",
+                    ok=False,
+                    detail="events.jsonl not present — bundle does not look like an Article 12 zip",
+                )
+    except zipfile.BadZipFile as exc:
+        return CheckResult(name="hmac_chain", ok=False, detail=f"bundle is not a zip: {exc}")
+
+    prev = GENESIS_HMAC
+    line_no = 0
+    for raw_line in event_log.splitlines():
+        line_no += 1
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            return CheckResult(
+                name="hmac_chain",
+                ok=False,
+                detail=f"events.jsonl:{line_no}: invalid JSON — {exc}",
+            )
+        stored = entry.pop("hmac", "")
+        recorded_prev = entry.get("prev_hmac", "")
+        if recorded_prev != prev:
+            return CheckResult(
+                name="hmac_chain",
+                ok=False,
+                detail=(
+                    f"events.jsonl:{line_no}: prev_hmac mismatch (expected {prev[:16]}…, got {recorded_prev[:16]}…)"
+                ),
+            )
+        expected = hmac.new(hmac_key, _canonical_chain_payload(prev, entry), hashlib.sha256).hexdigest()
+        if stored != expected:
+            return CheckResult(
+                name="hmac_chain",
+                ok=False,
+                detail=f"events.jsonl:{line_no}: HMAC mismatch",
+            )
+        prev = stored
+    if line_no == 0:
+        return CheckResult(name="hmac_chain", ok=True, detail="events.jsonl is empty")
+    return CheckResult(name="hmac_chain", ok=True, detail=f"verified {line_no} events")
+
+
+# ---------------------------------------------------------------------------
+# CLI driver
+# ---------------------------------------------------------------------------
+
+
+def _print_check(check: CheckResult, *, verbose: bool, stream: io.TextIOBase) -> None:
+    """Emit one check result line (PASS/FAIL plus optional detail)."""
+    status = "PASS" if check.ok else "FAIL"
+    line = f"[{status}] {check.name}"
+    if check.detail and (not check.ok or verbose):
+        line += f" — {check.detail}"
+    print(line, file=stream)
+
+
+def run_verify(
+    *,
+    envelope_path: Path,
+    bundle_path: Path,
+    public_key_path: Path,
+    hmac_key_path: Path | None,
+    verbose: bool,
+    stream: io.TextIOBase,
+) -> VerifyResult:
+    """Run every verification step and emit human-readable output."""
+    result = VerifyResult()
+
+    try:
+        envelope = load_envelope(envelope_path)
+    except (OSError, json.JSONDecodeError) as exc:
+        check = CheckResult(name="envelope_load", ok=False, detail=str(exc))
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+        return result
+
+    try:
+        public_key_pem = public_key_path.read_bytes()
+    except OSError as exc:
+        check = CheckResult(name="public_key_load", ok=False, detail=str(exc))
+        result.checks.append(check)
+        _print_check(check, verbose=verbose, stream=stream)
+        return result
+
+    sig_check = verify_envelope_signature(envelope, public_key_pem)
+    result.checks.append(sig_check)
+    _print_check(sig_check, verbose=verbose, stream=stream)
+
+    type_check = verify_statement_types(envelope)
+    result.checks.append(type_check)
+    _print_check(type_check, verbose=verbose, stream=stream)
+
+    digest_check = verify_subject_digest(envelope, bundle_path)
+    result.checks.append(digest_check)
+    _print_check(digest_check, verbose=verbose, stream=stream)
+
+    if hmac_key_path is not None:
+        try:
+            hmac_key = hmac_key_path.read_bytes().strip()
+        except OSError as exc:
+            check = CheckResult(name="hmac_key_load", ok=False, detail=str(exc))
+            result.checks.append(check)
+            _print_check(check, verbose=verbose, stream=stream)
+        else:
+            chain_check = verify_hmac_chain(bundle_path, hmac_key)
+            result.checks.append(chain_check)
+            _print_check(chain_check, verbose=verbose, stream=stream)
+
+    summary_status = "PASS" if result.ok else "FAIL"
+    print(f"OVERALL: {summary_status}", file=stream)
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser — kept top-level so ``--help`` works on import."""
+    parser = argparse.ArgumentParser(
+        description=("Verify a DSSE-wrapped bernstein audit bundle without importing the bernstein package."),
+    )
+    parser.add_argument(
+        "--envelope",
+        required=True,
+        type=Path,
+        help="Path to the DSSE envelope JSON.",
+    )
+    parser.add_argument(
+        "--bundle",
+        required=True,
+        type=Path,
+        help="Path to the audit bundle (Article 12 zip or multi-tenant JSON).",
+    )
+    parser.add_argument(
+        "--public-key",
+        required=True,
+        type=Path,
+        help="Path to the Ed25519 public key in PEM (SubjectPublicKeyInfo) format.",
+    )
+    parser.add_argument(
+        "--hmac-key",
+        type=Path,
+        default=None,
+        help=(
+            "Optional path to the HMAC chain key. When supplied, the script "
+            "also walks events.jsonl and verifies every HMAC link."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print PASS-line details (failures always include detail).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Args:
+        argv: Optional argv override (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        0 on success, 1 on verification failure, 2 on argument errors.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    for required in (args.envelope, args.bundle, args.public_key):
+        if not required.is_file():
+            print(f"ERROR: not a file: {required}", file=sys.stderr)
+            return 2
+
+    if args.hmac_key is not None and not args.hmac_key.is_file():
+        print(f"ERROR: not a file: {args.hmac_key}", file=sys.stderr)
+        return 2
+
+    result = run_verify(
+        envelope_path=args.envelope,
+        bundle_path=args.bundle,
+        public_key_path=args.public_key,
+        hmac_key_path=args.hmac_key,
+        verbose=args.verbose,
+        stream=sys.stdout,
+    )
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Lands the top-3 backlog from RESRCH-002 (`docs/compliance/RESRCH-002-enterprise-modernization-fit.md` — currently in PR #1173) as a single coherent modernization-fit feature. Three items, one PR:

1. **AIGF controls map + reciprocal citation** (P0, doc-only) — `docs/compliance/finos-aigf-mapping.md` cross-walks every FINOS AIGF control against the bernstein subsystem(s) implementing it. Cites the spec URL + version on one side and the source file paths on the other. 13/16 covered, 2 partial closed by items #2-#3 below, 1 not-yet-covered tracked as v2.
2. **DSSE/in-toto envelope on the audit chain + truly standalone verifier** (P0, M) — `src/bernstein/core/security/audit_dsse.py` wraps `Article12Bundle` (and `TenantScopedExport` from PR #1175) in a [DSSE](https://github.com/secure-systems-lab/dsse) envelope per [in-toto v1](https://github.com/in-toto/attestation/blob/main/spec/v1/README.md). `tools/verify_audit_dsse.py` is the hermetic, **truly standalone** verifier — pure stdlib + `cryptography`, zero `bernstein.*` imports. Replaces the previous "standalone" verifier RESRCH-002 §2 explicitly flagged as not actually standalone.
3. **Per-role adapter deny-list** (P1, M) — `src/bernstein/core/security/role_adapter_policy.py` enforces per-role allow-lists at the spawn site. Empty allow-list = back-compat (no behaviour change). Hooks `AgentSpawner._get_adapter_by_name` so every concrete spawn variant goes through the same gate. CLI: `bernstein security role-adapter-policy show|set|test`.

## Honest spec-only vs prod-tested ledger

| Item | Status |
|------|--------|
| AIGF mapping doc | Spec-only (no upstream PR yet — operator's call to crosspost) |
| DSSE envelope wrap+verify | Shipped, 17 unit tests, deterministic + tamper-tested |
| Standalone verifier | Shipped, 6 integration tests run it in a venv with only `cryptography` installed and assert `import bernstein` fails inside that venv |
| Role-adapter policy | Shipped, 22 unit + CLI tests; orchestrator hook tested via the existing `tests/unit/test_spawner.py` (75 passing) |
| Sigstore release-attestation | **Deferred** — module docstring + AIGF mapping flag this as v2 |

## Tests

- `tests/unit/test_audit_dsse.py` — 17 passed
- `tests/unit/test_role_adapter_policy.py` — 22 passed
- `tests/integration/test_standalone_verifier.py` — 6 passed (subprocess-isolated venv)
- Existing `tests/unit/test_article12_bundle.py` (9), `test_audit.py` (15), `test_audit_multitenant.py` (20) — all green
- Existing `tests/unit/test_spawner.py` — 75 passed (no regressions from the `_get_adapter_by_name` hook)
- `uv run ruff format src/ tests/ tools/` — no changes
- `uv run ruff check src/ tests/ tools/` — clean

## Hard constraints from the brief — checklist

- [x] No claims that aren't backed by code or a real spec — every AIGF row cites a file path; covered/partial/not-yet-covered are explicit
- [x] Standalone verifier is actually standalone — `test_verifier_does_not_import_bernstein` greps the script + runs it in an isolated venv
- [x] Determinism for DSSE wrapper — `test_repeat_wrap_byte_identical` asserts byte-identical envelope (incl. signature) on repeat
- [x] Back-compat: empty role-adapter policy = all adapters allowed — `TestEmptyPolicyBackCompat` covers all three forms (no entry / empty tuple / unknown role)

## Test plan

- [ ] Reviewer confirms `gh pr diff` only adds the 7 expected files plus the 3 surgical edits in `cli/__init__.py`, `cli/main.py`, `core/agents/spawner_core.py`
- [ ] CI run: `pytest tests/unit/test_audit_dsse.py tests/unit/test_role_adapter_policy.py tests/integration/test_standalone_verifier.py` green
- [ ] CI run: `pytest tests/unit/test_spawner.py` still green (regression guard for the spawner hook)
- [ ] Manual: `uv run bernstein security role-adapter-policy show` on a fresh checkout prints the empty default policy