### PR TITLE
fix: hmac single-byte detection + owasp env-var truthy edge case

### DIFF
--- a/tests/unit/test_audit_chain_byteflip_regression.py
+++ b/tests/unit/test_audit_chain_byteflip_regression.py
@@ -122,3 +122,28 @@ def test_canonical_form_drift_is_detected(audit_log: AuditLog) -> None:
     valid, errors = audit_log.verify()
     assert valid is False, "non-canonical whitespace slipped past verify()"
     assert errors, "verify() returned invalid=True with empty errors list"
+
+
+def test_writer_uses_lf_only_terminator(audit_log: AuditLog) -> None:
+    """Writer must emit ``b"\\n"`` even on Windows (no CRLF translation).
+
+    Text-mode ``open("a")`` triggers Python's universal-newline translation
+    on Windows, replacing ``\\n`` with ``\\r\\n`` on disk. The strict
+    ``b"\\n"``-only verifier then sees ``}\\r\\n`` as the line, surfaces a
+    trailing ``\\r`` as ``non-canonical line bytes``, and fresh logs fail
+    verification on the very next read. Pinning binary append mode here so
+    a future refactor cannot silently regress to text mode.
+    """
+    audit_log.log("evt1", "actor", "task", "rid", {})
+    audit_log.log("evt2", "actor", "task", "rid", {})
+
+    target = sorted(audit_log._audit_dir.glob("*.jsonl"))[0]  # pyright: ignore[reportPrivateUsage]
+    raw = target.read_bytes()
+    assert b"\r\n" not in raw, f"writer emitted CRLF terminators (text-mode open?): {raw!r}"
+    # Two events → two LF terminators, the file must end with exactly one.
+    assert raw.count(b"\n") == 2, f"unexpected newline count: {raw!r}"
+    assert raw.endswith(b"\n") and not raw.endswith(b"\r\n"), f"file must end with bare LF, got: {raw[-4:]!r}"
+
+    valid, errors = audit_log.verify()
+    assert valid is True, f"freshly written log failed verify: {errors}"
+    assert errors == [], f"unexpected errors on fresh log: {errors}"


### PR DESCRIPTION
## Summary

Two pre-existing main-debt bugs surfaced by Hypothesis property sweeps on bare `origin/main`. Both pin fundamental security properties; neither was a code-change introduced in this PR.

### Bug 1 — `test_single_byte_flip_breaks_verification` (audit chain)

**File:** `src/bernstein/core/security/audit.py`

The HMAC-chain verifier read each JSONL log via `log_path.read_text().splitlines()`. `splitlines()` treats `\n`, `\v`, `\f`, `\r`, NEL and the unicode line/paragraph separators as equivalent — so an attacker flipping the terminator byte from `0x0A` to `0x0B` (vertical tab) left the lines structurally identical, the chain re-verified clean, and the tamper went undetected. Same hole at end-of-file: a `\n` → `\v` flip kept the file consumable by `splitlines()` while corrupting the byte-level stream.

A byte-by-byte sweep on a 621-byte two-entry log surfaced two undetected positions on main: byte 309 (`\n` between the two entries) and byte 620 (trailing `\n`). Pre-fix 619/621 detected, post-fix 621/621.

**Fix:** the verifier now reads `read_bytes()`, splits on `b"\n"` only via `_split_jsonl_bytes()`, treats absence of trailing `\n` as tamper-evidence, and re-canonicalises each entry against its on-disk bytes so incidental whitespace (e.g. trailing `\r` after `}`) can no longer round-trip through `json.loads`.

### Bug 2 — `test_owasp_env_var_truthy_semantics[None-False]`

**File:** `tests/property/test_capability_matrix_bughunt.py`

The property parametrize row contradicted the runtime contract pinned by the unit suite. PR #1153 flipped `is_owasp_asi_enabled` to default-on, and `test_is_owasp_asi_enabled_default_on` in `tests/unit/test_owasp_asi_detectors.py` already asserts `is_owasp_asi_enabled({}) is True`. PR #1156 added a parametrised property sweep whose `[None-False]` row asserted the legacy opt-in semantics for the same code path — any runtime satisfying the unit suite necessarily fails the property sweep.

**Fix:** aligned the parametrize table + docstring with the documented contract — no env var → `True` (default-on), explicit non-truthy strings still suppress so operators with `BERNSTEIN_ENABLE_OWASP_ASI=0` keep their disable behaviour.

### Regression test

`tests/unit/test_audit_chain_byteflip_regression.py` pins three concrete byte-flip shapes the Hypothesis search shrunk to:

* `\n` flipped to `\v` between two log lines
* `\n` flipped to `\v` at end of file
* Canonical-form drift (extra space inside JSON object literal that survives `json.loads`)

So the fix sticks even if the property sweep takes time to find the same case again on a fresh seed.

## Test plan

- [x] `uv run pytest tests/property/test_audit_chain_properties.py tests/property/test_capability_matrix_bughunt.py -q` → 32 passed, 7 xfailed (expected)
- [x] `uv run pytest tests/unit/test_audit*.py tests/unit/test_owasp*.py tests/unit/test_guardrail*.py -q` → 256 passed
- [x] `HYPOTHESIS_PROFILE=deep uv run pytest tests/property/test_audit_chain_properties.py -q` → 5 passed
- [x] `uv run ruff format src/ tests/ && uv run ruff check src/ tests/` → all clean
- [x] Manual byte-by-byte sweep on a 621-byte audit log: 621/621 flips now detected (pre-fix 619/621)