### PR TITLE
feat: OSS visibility batch (footer, badge, citation, GHCR)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -136,6 +136,7 @@ alwaysApply: false
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
+| `badge.py`              | Powered-by badge helper for ``bernstein init --add-badge`` |
 | `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |

--- a/.goosehints
+++ b/.goosehints
@@ -137,6 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
+| `badge.py`              | Powered-by badge helper for ``bernstein init --add-badge`` |
 | `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
+| `badge.py`              | Powered-by badge helper for ``bernstein init --add-badge`` |
 | `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,43 @@
+cff-version: 1.2.0
+message: "If you use Bernstein in academic or industry work, please cite it using the metadata below."
+type: software
+title: "Bernstein: a deterministic Python orchestrator for CLI coding agents"
+abstract: >-
+  Bernstein is a deterministic Python scheduler that runs a crew of CLI
+  coding agents (Claude Code, Codex, Gemini CLI, and 40 more) against a
+  single goal in parallel git worktrees, with an HMAC-signed audit chain
+  over every step.  The scheduler contains zero LLM calls in its
+  coordination loop; replay of yesterday's plan reproduces yesterday's
+  task graph exactly.
+authors:
+  - given-names: Alex
+    family-names: Chernysh
+    email: alex@alexchernysh.com
+    affiliation: independent
+repository-code: "https://github.com/sipyourdrink-ltd/bernstein"
+url: "https://bernstein.run"
+license: Apache-2.0
+keywords:
+  - multi-agent
+  - agent-orchestration
+  - cli-coding-agents
+  - deterministic-scheduler
+  - hmac-audit
+  - parallel-worktrees
+  - claude-code
+  - codex-cli
+  - gemini-cli
+  - aider
+  - software-engineering
+version: "1.10.4"
+date-released: "2026-05-08"
+preferred-citation:
+  type: software
+  title: "Bernstein: a deterministic Python orchestrator for CLI coding agents"
+  authors:
+    - given-names: Alex
+      family-names: Chernysh
+      email: alex@alexchernysh.com
+  year: 2026
+  url: "https://bernstein.run"
+  repository-code: "https://github.com/sipyourdrink-ltd/bernstein"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
+| `badge.py`              | Powered-by badge helper for ``bernstein init --add-badge`` |
 | `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -137,6 +137,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | File                    | Purpose |
 |-------------------------|---------|
 | `api_warmup.py`         | API preconnect warmup -- send a minimal request to warm provider connections |
+| `badge.py`              | Powered-by badge helper for ``bernstein init --add-badge`` |
 | `commit_stats.py`       | Commit attribution stats: gather per-role commit stats via git log |
 | `dashboard.py`          | Bernstein TUI -- retro-futuristic agent orchestration dashboard |
 | `dashboard_actions.py`  | Dashboard side panels and expert views |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 [![CI](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml/badge.svg)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/bernstein)](https://pypi.org/project/bernstein/)
+[![GHCR](https://img.shields.io/badge/ghcr.io-bernstein-2496ed?logo=docker&logoColor=white)](https://ghcr.io/sipyourdrink-ltd/bernstein)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776ab?logo=python&logoColor=white)](https://python.org)
 [![License](https://img.shields.io/github/license/sipyourdrink-ltd/bernstein)](LICENSE)
 [![MseeP.ai](https://img.shields.io/badge/MseeP.ai-verified-2496ed)](https://mseep.ai/app/chernistry-bernstein)
@@ -470,6 +471,7 @@ bernstein fingerprint check src/foo.py                 # check generated code ag
 | **Homebrew** | `brew tap chernistry/tap && brew install bernstein` |
 | **Fedora / RHEL** | `sudo dnf copr enable alexchernysh/bernstein && sudo dnf install bernstein` |
 | **npm** (wrapper) | `npx bernstein-orchestrator` |
+| **Docker (GHCR)** | `docker run --rm -v "$PWD:/work" -w /work -e ANTHROPIC_API_KEY ghcr.io/sipyourdrink-ltd/bernstein:latest run -g "fix tests/test_foo.py"` |
 
 The one-liner scripts check for Python 3.12+, bootstrap pipx when it's missing, fix PATH for the current session, and install (or upgrade) `bernstein`. They handle brew-managed macOS environments and the Windows `py -3` launcher fallback. Script sources: [install.sh](scripts/install.sh) · [install.ps1](scripts/install.ps1).
 
@@ -493,6 +495,16 @@ Provider SDKs are optional so the base install stays lean. Pick what you need:
 Combine extras with brackets, e.g. `pip install 'bernstein[openai,docker,s3]'`.
 
 Editor extensions: [VS Marketplace](https://marketplace.visualstudio.com/items?itemName=alex-chernysh.bernstein) &middot; [Open VSX](https://open-vsx.org/extension/alex-chernysh/bernstein)
+
+## "powered by bernstein" badge (optional)
+
+If your project ships diffs that bernstein helped land, you can advertise it:
+
+```markdown
+[![signed by bernstein](https://img.shields.io/badge/signed_by-bernstein-FBBF24?logo=githubactions&logoColor=white&style=flat-square)](https://bernstein.run/?utm_source=badge&utm_medium=readme&utm_campaign=powered-by)
+```
+
+`bernstein init --add-badge` injects it into your README under the existing badge stack. Variants: `signed`, `audited-by`, `orchestrated-by`, `crew-managed-by` — pass via `--badge-variant`. Picky maintainers can keep their READMEs untouched: the flag is opt-in.
 
 ## contributing
 
@@ -548,6 +560,10 @@ Curated lists, newsletters, and peer projects that picked up Bernstein:
 - [**danielvaughan/codex-blog**](https://github.com/danielvaughan/codex-blog/blob/main/_posts/2026-04-09-loki-mode-autonomous-execution.md); comparison article positioning Bernstein on the deterministic end.
 
 </details>
+
+## cite
+
+If Bernstein helps your research or industry work, please cite it. Machine-readable metadata lives in [CITATION.cff](CITATION.cff) (CFF 1.2.0); GitHub renders the "Cite this repository" button automatically. A Zenodo DOI will be minted on the next release once Zenodo's GitHub integration is enabled — see [CITATION.cff](CITATION.cff) for the current canonical citation.
 
 ## license
 

--- a/src/bernstein/cli/badge.py
+++ b/src/bernstein/cli/badge.py
@@ -1,0 +1,187 @@
+"""Powered-by badge helper for ``bernstein init --add-badge``.
+
+The shields.io static-badge API (https://shields.io/badges/static-badge) is
+served from CDN-cached templates rendered at request time, so each variant
+is a permanent URL that costs the operator nothing.
+
+Variants
+--------
+
+We expose four restrained labels so a downstream maintainer can pick the
+phrasing that least bruises their README aesthetic:
+
+* ``signed``           — emphasises the HMAC audit-chain
+* ``audited-by``       — emphasises post-merge inspection
+* ``orchestrated-by``  — emphasises the multi-agent workflow
+* ``crew-managed-by``  — emphasises the parallel CLI-agent crew
+
+Behaviour contract
+------------------
+
+The injection helper is conservative: it never duplicates a badge that is
+already present, never reorders an existing badge stack, and never rewrites
+content outside the badge block at the top of the README.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# UTM params let bernstein.run measure inbound badge clicks without
+# touching the maintainer's analytics layer.
+_DEFAULT_LINK = "https://bernstein.run/?utm_source=badge&utm_medium=readme&utm_campaign=powered-by"
+
+# Shields static-badge URL.  ``message`` is the always-bold-right-side
+# label; ``label`` is the always-grey-left-side label.  ``color`` is a
+# hex without ``#``.  ``logo`` references one of shields' built-in slugs.
+_SHIELDS_TEMPLATE = (
+    "https://img.shields.io/badge/{label}-{message}-{color}?logo=githubactions&logoColor=white&style=flat-square"
+)
+
+
+@dataclass(frozen=True)
+class BadgeVariant:
+    """One shields.io static-badge variant."""
+
+    name: str
+    label: str
+    message: str
+    color: str
+    alt_text: str
+
+    def url(self) -> str:
+        """Return the shields.io image URL for this variant."""
+        return _SHIELDS_TEMPLATE.format(
+            label=self.label.replace(" ", "_").replace("-", "--"),
+            message=self.message.replace(" ", "_").replace("-", "--"),
+            color=self.color,
+        )
+
+    def markdown(self, *, link: str = _DEFAULT_LINK) -> str:
+        """Render the markdown ``[![alt](src)](href)`` snippet."""
+        return f"[![{self.alt_text}]({self.url()})]({link})"
+
+
+_VARIANTS: tuple[BadgeVariant, ...] = (
+    BadgeVariant(
+        name="signed",
+        label="signed_by",
+        message="bernstein",
+        color="FBBF24",
+        alt_text="signed by bernstein",
+    ),
+    BadgeVariant(
+        name="audited-by",
+        label="audited_by",
+        message="bernstein",
+        color="FBBF24",
+        alt_text="audited by bernstein",
+    ),
+    BadgeVariant(
+        name="orchestrated-by",
+        label="orchestrated_by",
+        message="bernstein",
+        color="FBBF24",
+        alt_text="orchestrated by bernstein",
+    ),
+    BadgeVariant(
+        name="crew-managed-by",
+        label="crew_managed_by",
+        message="bernstein",
+        color="FBBF24",
+        alt_text="crew managed by bernstein",
+    ),
+)
+
+
+def list_variants() -> tuple[BadgeVariant, ...]:
+    """Return every badge variant in deterministic order."""
+    return _VARIANTS
+
+
+def get_variant(name: str) -> BadgeVariant:
+    """Look up a variant by its short name; raises ``KeyError`` on miss."""
+    for variant in _VARIANTS:
+        if variant.name == name:
+            return variant
+    raise KeyError(f"unknown badge variant: {name!r}")
+
+
+_BADGE_URL_TOKENS: tuple[str, ...] = (
+    "/signed_by-bernstein",
+    "/audited_by-bernstein",
+    "/orchestrated_by-bernstein",
+    "/crew_managed_by-bernstein",
+)
+
+
+def _badge_already_present(readme_text: str) -> bool:
+    """Detect whether any bernstein powered-by badge is already in the README."""
+    haystack = readme_text.lower()
+    if "shields.io/badge" not in haystack:
+        return False
+    if "bernstein" not in haystack:
+        return False
+    # Conservative: only treat it as "already present" when the badge image
+    # URL itself contains ``bernstein``, not just a link target.
+    return any(token in haystack for token in _BADGE_URL_TOKENS)
+
+
+def _insertion_index(readme_text: str) -> int:
+    """Return the byte offset where the new badge line should be inserted.
+
+    Strategy:
+
+    1. If a badge stack exists in the first 30 lines, append to the END of
+       that stack (preserve maintainer's chosen ordering).
+    2. Otherwise, insert immediately after the H1 line at the top.
+    3. Otherwise, prepend to the file.
+    """
+    lines = readme_text.splitlines(keepends=True)
+    head = lines[:30]
+
+    last_badge_line = -1
+    for idx, raw in enumerate(head):
+        if "shields.io/badge/" in raw or "img.shields.io" in raw:
+            last_badge_line = idx
+    if last_badge_line >= 0:
+        return sum(len(line) for line in lines[: last_badge_line + 1])
+
+    for idx, raw in enumerate(head):
+        if raw.lstrip().startswith("# "):
+            return sum(len(line) for line in lines[: idx + 1])
+
+    return 0
+
+
+def inject_badge(
+    readme_path: Path,
+    variant: BadgeVariant,
+    *,
+    link: str = _DEFAULT_LINK,
+) -> bool:
+    """Insert *variant*'s markdown line into *readme_path*.
+
+    Returns ``True`` when the file was modified, ``False`` when the badge
+    was already present (idempotent) or the file is missing.
+    """
+    if not readme_path.exists():
+        return False
+
+    text = readme_path.read_text(encoding="utf-8")
+    if _badge_already_present(text):
+        return False
+
+    snippet = variant.markdown(link=link)
+    insert_at = _insertion_index(text)
+    prefix = text[:insert_at]
+    suffix = text[insert_at:]
+
+    needs_leading_nl = bool(prefix) and not prefix.endswith("\n")
+    glue = ("\n" if needs_leading_nl else "") + snippet + "\n"
+    readme_path.write_text(prefix + glue + suffix, encoding="utf-8")
+    return True

--- a/src/bernstein/cli/badge.py
+++ b/src/bernstein/cli/badge.py
@@ -25,11 +25,24 @@ content outside the badge block at the top of the README.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+# Detector for shields.io badge image references in markdown.
+# This is **not** URL sanitization — we are looking for the markdown image
+# pattern `![alt](https://img.shields.io/...)` so we can append a new badge
+# to the END of the existing stack.  The regex anchors on the canonical
+# domain pieces so an unrelated string like "shields.io.example.com" cannot
+# match.  Codepath only reads the maintainer's own README and never makes
+# a security decision based on the result.
+_BADGE_URL_PATTERN = re.compile(
+    r"!\[[^\]]*\]\(https?://(?:img\.)?shields\.io/",
+    re.IGNORECASE,
+)
 
 # UTM params let bernstein.run measure inbound badge clicks without
 # touching the maintainer's analytics layer.
@@ -146,7 +159,7 @@ def _insertion_index(readme_text: str) -> int:
 
     last_badge_line = -1
     for idx, raw in enumerate(head):
-        if "shields.io/badge/" in raw or "img.shields.io" in raw:
+        if _BADGE_URL_PATTERN.search(raw):
             last_badge_line = idx
     if last_badge_line >= 0:
         return sum(len(line) for line in lines[: last_badge_line + 1])

--- a/src/bernstein/cli/run.py
+++ b/src/bernstein/cli/run.py
@@ -6,6 +6,8 @@ Components are imported from :mod:`bernstein.cli.ui`.
 
 from __future__ import annotations
 
+import os
+import sys
 from typing import TYPE_CHECKING, Any, cast
 
 from rich.console import Console, Group
@@ -28,6 +30,80 @@ from bernstein.cli.ui import (
     format_duration,
     make_console,
 )
+
+# ---------------------------------------------------------------------------
+# Footer line (one-shot, opt-out, tty-only)
+# ---------------------------------------------------------------------------
+
+
+def _footer_suppressed() -> bool:
+    """Return True when the post-run footer line must not be printed.
+
+    The footer is suppressed in any of the following cases:
+
+    * ``BERNSTEIN_DISABLE_FOOTER=1`` (canonical opt-out) is set
+    * ``BERNSTEIN_NO_BANNER=1`` (legacy alias) is set
+    * ``NO_COLOR`` is set (footer is purely cosmetic)
+    * stderr is not a tty (pipe / file / non-interactive shell)
+    * a JSON output mode is active (``BERNSTEIN_OUTPUT=json``)
+    * ``BERNSTEIN_QUIET=1`` is set (mirrors the ``--quiet`` flag)
+    """
+
+    def _truthy(name: str) -> bool:
+        return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+    if _truthy("BERNSTEIN_DISABLE_FOOTER"):
+        return True
+    if _truthy("BERNSTEIN_NO_BANNER"):
+        return True
+    if _truthy("BERNSTEIN_QUIET"):
+        return True
+    if os.environ.get("NO_COLOR"):
+        return True
+    if os.environ.get("BERNSTEIN_OUTPUT", "").strip().lower() == "json":
+        return True
+    try:
+        if not sys.stderr.isatty():
+            return True
+    except (AttributeError, ValueError):
+        return True
+    return False
+
+
+def _emit_run_footer(console: Console | None = None) -> None:
+    """Print the one-line bernstein footer at the end of a run.
+
+    The footer is intentionally restrained: a single dim line with the
+    bernstein version and the project URL.  Honours every opt-out
+    documented in :func:`_footer_suppressed`.
+
+    Args:
+        console: Optional Rich Console.  When omitted, a fresh stderr
+            console is created so the footer never collides with
+            machine-readable stdout.
+    """
+    if _footer_suppressed():
+        return
+
+    try:
+        from bernstein import __version__ as _ver
+    except Exception:
+        _ver = "?"
+
+    con = console
+    if con is None:
+        con = Console(stderr=True, soft_wrap=True)
+    elif not con.is_terminal:
+        return
+
+    line = Text()
+    line.append("✓ run signed", style="dim cyan")
+    line.append(" · ", style="dim")
+    line.append(f"bernstein {_ver}", style="dim cyan")
+    line.append(" · ", style="dim")
+    line.append("bernstein.run", style="dim cyan")
+    con.print(line)
+
 
 # ---------------------------------------------------------------------------
 # Live dashboard
@@ -172,6 +248,9 @@ def render_run_summary(stats: RunStats, *, console: Console | None = None) -> No
             (f"${stats.total_cost_usd:.4f}", "bold green"),
         )
     )
+
+    # One-line tasteful footer (tty-only, opt-out via BERNSTEIN_DISABLE_FOOTER=1)
+    _emit_run_footer()
 
 
 def _normalize_agent_entries(payload: object) -> list[dict[str, Any]]:

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -497,7 +497,25 @@ def _generate_default_yaml(project_type: str) -> str:
     show_default=True,
     help="Directory to initialise (default: current directory).",
 )
-def init(target_dir: str) -> None:
+@click.option(
+    "--add-badge",
+    "add_badge",
+    is_flag=True,
+    default=False,
+    help=(
+        "Insert a shields.io 'powered by bernstein' badge into README.md. "
+        "Use --badge-variant to pick the wording (default: signed)."
+    ),
+)
+@click.option(
+    "--badge-variant",
+    "badge_variant",
+    default="signed",
+    show_default=True,
+    type=click.Choice(["signed", "audited-by", "orchestrated-by", "crew-managed-by"]),
+    help="Badge variant when --add-badge is passed.",
+)
+def init(target_dir: str, *, add_badge: bool = False, badge_variant: str = "signed") -> None:
     """Init workspace -- create .sdd/ structure."""
     print_banner()
     root = Path(target_dir).resolve()
@@ -557,6 +575,25 @@ def init(target_dir: str) -> None:
     else:
         root_gi_path.write_text(f"{gitignore_entry}\n")
         console.print(f"[green]Created[/green] .gitignore (added {gitignore_entry})")
+
+    # Optional: inject a "powered by bernstein" badge into README.md
+    if add_badge:
+        from bernstein.cli.badge import get_variant, inject_badge
+
+        readme_path = root / "README.md"
+        try:
+            variant = get_variant(badge_variant)
+        except KeyError:
+            console.print(f"[yellow]Skipped[/yellow] badge: unknown variant {badge_variant!r}")
+        else:
+            if not readme_path.exists():
+                console.print("[yellow]Skipped[/yellow] badge: README.md not found")
+            else:
+                changed = inject_badge(readme_path, variant)
+                if changed:
+                    console.print(f"[green]Updated[/green] README.md (added '{variant.name}' badge)")
+                else:
+                    console.print("[dim]README.md already has a bernstein badge — skipped.[/dim]")
 
     # Print clear next steps
     console.print("")

--- a/tests/unit/test_badge.py
+++ b/tests/unit/test_badge.py
@@ -1,0 +1,144 @@
+"""Tests for the powered-by badge helper."""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.badge import (
+    BadgeVariant,
+    _badge_already_present,
+    _insertion_index,
+    get_variant,
+    inject_badge,
+    list_variants,
+)
+
+
+class TestVariants:
+    def test_four_variants_present(self) -> None:
+        variants = list_variants()
+        assert len(variants) == 4
+        names = {v.name for v in variants}
+        assert names == {"signed", "audited-by", "orchestrated-by", "crew-managed-by"}
+
+    def test_get_variant_lookup(self) -> None:
+        v = get_variant("orchestrated-by")
+        assert isinstance(v, BadgeVariant)
+        assert v.name == "orchestrated-by"
+
+    def test_get_variant_raises_on_unknown(self) -> None:
+        with pytest.raises(KeyError):
+            get_variant("nonexistent")
+
+    def test_url_contains_shields(self) -> None:
+        v = get_variant("signed")
+        url = v.url()
+        assert url.startswith("https://img.shields.io/badge/")
+        assert "bernstein" in url
+
+    def test_markdown_contains_link_and_alt(self) -> None:
+        v = get_variant("signed")
+        md = v.markdown()
+        assert md.startswith("[![")
+        assert "bernstein.run" in md
+        assert "utm_source=badge" in md
+
+
+class TestPresenceDetection:
+    def test_empty_readme_returns_false(self) -> None:
+        assert _badge_already_present("") is False
+
+    def test_no_shields_returns_false(self) -> None:
+        assert _badge_already_present("# foo\n\nplain text") is False
+
+    def test_unrelated_shields_badge_returns_false(self) -> None:
+        text = "[![CI](https://img.shields.io/badge/ci-passing-green)](#)"
+        assert _badge_already_present(text) is False
+
+    def test_signed_by_badge_returns_true(self) -> None:
+        text = (
+            "[![signed by bernstein](https://img.shields.io/badge/signed_by-bernstein-FBBF24)](https://bernstein.run/)"
+        )
+        assert _badge_already_present(text) is True
+
+
+class TestInsertionIndex:
+    def test_inserts_after_h1_when_no_badge_stack(self) -> None:
+        text = "# my project\n\nbody\n"
+        idx = _insertion_index(text)
+        assert text[:idx] == "# my project\n"
+
+    def test_inserts_at_top_when_no_h1_no_badges(self) -> None:
+        text = "plain body\n"
+        idx = _insertion_index(text)
+        assert idx == 0
+
+    def test_appends_to_existing_badge_stack(self) -> None:
+        text = (
+            "# proj\n"
+            "[![CI](https://img.shields.io/badge/ci-passing-green)](#)\n"
+            "[![PyPI](https://img.shields.io/pypi/v/example)](#)\n"
+            "\nbody\n"
+        )
+        idx = _insertion_index(text)
+        before, after = text[:idx], text[idx:]
+        # Insertion must follow the LAST badge line.
+        assert before.endswith("[![PyPI](https://img.shields.io/pypi/v/example)](#)\n")
+        assert after.startswith("\nbody")
+
+
+class TestInjectBadge:
+    def test_writes_when_missing(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text("# myproj\n\nDoes a thing.\n", encoding="utf-8")
+
+        v = get_variant("signed")
+        changed = inject_badge(readme, v)
+        assert changed is True
+
+        new_text = readme.read_text(encoding="utf-8")
+        assert "img.shields.io/badge/signed_by-bernstein" in new_text
+        assert "Does a thing." in new_text
+
+    def test_idempotent_when_already_present(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "# proj\n\n"
+            "[![signed by bernstein]"
+            "(https://img.shields.io/badge/signed_by-bernstein-FBBF24)]"
+            "(https://bernstein.run/)\n",
+            encoding="utf-8",
+        )
+
+        v = get_variant("signed")
+        changed = inject_badge(readme, v)
+        assert changed is False
+
+    def test_returns_false_when_readme_missing(self, tmp_path: Path) -> None:
+        v = get_variant("signed")
+        assert inject_badge(tmp_path / "README.md", v) is False
+
+    def test_appends_after_existing_badge_stack(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text(
+            "# proj\n"
+            "[![CI](https://img.shields.io/badge/ci-passing-green)](#)\n"
+            "[![PyPI](https://img.shields.io/pypi/v/example)](#)\n\n"
+            "body\n",
+            encoding="utf-8",
+        )
+        v = get_variant("audited-by")
+        changed = inject_badge(readme, v)
+        assert changed is True
+
+        new_text = readme.read_text(encoding="utf-8")
+        # The new badge must appear after the existing PyPI badge but before "body".
+        ci_pos = new_text.find("/ci-passing-green")
+        pypi_pos = new_text.find("/pypi/v/example")
+        bernstein_pos = new_text.find("/audited_by-bernstein")
+        body_pos = new_text.find("\nbody\n")
+        assert ci_pos != -1 < pypi_pos < bernstein_pos < body_pos

--- a/tests/unit/test_run_footer.py
+++ b/tests/unit/test_run_footer.py
@@ -1,0 +1,161 @@
+"""Tests for the post-run footer line.
+
+Covers the contract from the OSS-visibility ticket:
+
+* one-line, dim, tty-only output at end of ``bernstein run``
+* honoured opt-outs: ``BERNSTEIN_DISABLE_FOOTER``, ``BERNSTEIN_NO_BANNER``,
+  ``BERNSTEIN_QUIET``, ``NO_COLOR``, ``BERNSTEIN_OUTPUT=json``
+* never printed to non-tty stderr (pipe / file redirect)
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bernstein.cli.run import _emit_run_footer, _footer_suppressed
+
+
+def _make_tty_console() -> MagicMock:
+    """Return a mock Console that pretends it is attached to a tty."""
+    console = MagicMock()
+    console.is_terminal = True
+    return console
+
+
+class TestFooterSuppressed:
+    """Unit tests for the suppression rules."""
+
+    def test_default_tty_not_suppressed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Strip every relevant env var, fake stderr.isatty() True
+        for var in (
+            "BERNSTEIN_DISABLE_FOOTER",
+            "BERNSTEIN_NO_BANNER",
+            "BERNSTEIN_QUIET",
+            "BERNSTEIN_OUTPUT",
+            "NO_COLOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = True
+            assert _footer_suppressed() is False
+
+    def test_disable_footer_env_suppresses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_DISABLE_FOOTER", "1")
+        assert _footer_suppressed() is True
+
+    def test_legacy_no_banner_env_suppresses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_DISABLE_FOOTER", raising=False)
+        monkeypatch.setenv("BERNSTEIN_NO_BANNER", "true")
+        assert _footer_suppressed() is True
+
+    def test_quiet_env_suppresses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_DISABLE_FOOTER", raising=False)
+        monkeypatch.setenv("BERNSTEIN_QUIET", "yes")
+        assert _footer_suppressed() is True
+
+    def test_no_color_suppresses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_DISABLE_FOOTER", raising=False)
+        monkeypatch.setenv("NO_COLOR", "1")
+        assert _footer_suppressed() is True
+
+    def test_json_output_suppresses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in ("BERNSTEIN_DISABLE_FOOTER", "BERNSTEIN_NO_BANNER", "BERNSTEIN_QUIET", "NO_COLOR"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("BERNSTEIN_OUTPUT", "json")
+        assert _footer_suppressed() is True
+
+    def test_non_tty_stderr_suppresses(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in (
+            "BERNSTEIN_DISABLE_FOOTER",
+            "BERNSTEIN_NO_BANNER",
+            "BERNSTEIN_QUIET",
+            "BERNSTEIN_OUTPUT",
+            "NO_COLOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        # Pipe / file redirect → isatty() returns False
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = False
+            assert _footer_suppressed() is True
+
+
+class TestEmitFooter:
+    """Behavioural tests for the renderer."""
+
+    def test_prints_when_console_is_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in (
+            "BERNSTEIN_DISABLE_FOOTER",
+            "BERNSTEIN_NO_BANNER",
+            "BERNSTEIN_QUIET",
+            "BERNSTEIN_OUTPUT",
+            "NO_COLOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = True
+            con = _make_tty_console()
+            _emit_run_footer(console=con)
+        assert con.print.call_count == 1
+        # The first positional argument should be a Rich Text instance whose
+        # plaintext contains the project URL.
+        rendered = con.print.call_args.args[0]
+        assert "bernstein.run" in rendered.plain
+        assert "✓ run signed" in rendered.plain
+
+    def test_skips_when_suppressed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_DISABLE_FOOTER", "1")
+        con = _make_tty_console()
+        _emit_run_footer(console=con)
+        con.print.assert_not_called()
+
+    def test_skips_when_console_is_not_terminal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for var in (
+            "BERNSTEIN_DISABLE_FOOTER",
+            "BERNSTEIN_NO_BANNER",
+            "BERNSTEIN_QUIET",
+            "BERNSTEIN_OUTPUT",
+            "NO_COLOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = True
+            con = MagicMock()
+            con.is_terminal = False
+            _emit_run_footer(console=con)
+        con.print.assert_not_called()
+
+    def test_default_console_writes_to_stderr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When no console is passed, output goes to stderr (not stdout)."""
+        for var in (
+            "BERNSTEIN_DISABLE_FOOTER",
+            "BERNSTEIN_NO_BANNER",
+            "BERNSTEIN_QUIET",
+            "BERNSTEIN_OUTPUT",
+            "NO_COLOR",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        captured: dict[str, Any] = {}
+
+        class _StubConsole:
+            def __init__(self, **kwargs: Any) -> None:
+                captured["init_kwargs"] = kwargs
+                self.is_terminal = True
+
+            def print(self, *args: Any, **kwargs: Any) -> None:
+                captured["printed"] = args[0] if args else None
+
+        with patch("sys.stderr") as mock_stderr, patch("bernstein.cli.run.Console", _StubConsole):
+            mock_stderr.isatty.return_value = True
+            _emit_run_footer()
+        assert captured.get("init_kwargs", {}).get("stderr") is True
+        assert captured.get("printed") is not None


### PR DESCRIPTION
## Summary

Five small surfaces that compound for OSS visibility:

- One-line footer at end of every `bernstein run` (tty-only, opt-out via `BERNSTEIN_DISABLE_FOOTER=1` or legacy `BERNSTEIN_NO_BANNER`)
- `bernstein init --add-badge` injects a shields.io "powered by bernstein" badge into the user's README; idempotent; four variants (`signed`, `audited-by`, `orchestrated-by`, `crew-managed-by`)
- `CITATION.cff` (CFF 1.2.0) at repo root — GitHub now renders "Cite this repository"; Zenodo will mint a DOI on the next tagged release once the operator enables Zenodo's GitHub integration
- README install table gains a Docker (GHCR) row + a GHCR badge in the badge stack
- Short "powered by bernstein" badge how-to section in README so downstream maintainers can copy-paste the snippet without running `init`

## Test plan

- [x] `pytest tests/unit/test_run_footer.py tests/unit/test_badge.py tests/unit/test_run_summary_issue_953.py` (41/41)
- [x] `cffconvert --validate` passes on the new CITATION.cff
- [x] `ruff check` + `ruff format` clean
- [x] `bernstein init --add-badge` in a tmp dir injects the badge into README.md and is a no-op the second time

## Notes

- Footer is dim cyan, single line, on stderr. Honours `NO_COLOR`, `BERNSTEIN_QUIET=1`, `BERNSTEIN_OUTPUT=json`, non-tty stderr.
- `--add-badge` is opt-in by design (operator's preference: badge insertion should never be a default in `init`).
- DOI badge will be added as a follow-up PR after Zenodo mints the first DOI; CITATION.cff is the citation source-of-truth in the meantime.