### PR TITLE
fix: main CI failures on article12 bytes, section rules, bridge SDK

### DIFF
--- a/src/bernstein/core/security/article12_bundle.py
+++ b/src/bernstein/core/security/article12_bundle.py
@@ -279,10 +279,20 @@ def _read_event_window(
 
 
 def _build_event_log(events: list[_SourceEvent]) -> bytes:
-    """Serialise events as canonical JSONL (sorted keys, ``\\n`` newlines)."""
+    """Serialise events as canonical JSONL (sorted keys, ``\\n`` newlines).
+
+    Must match the on-disk byte layout produced by
+    :class:`bernstein.core.security.audit.AuditLog` because
+    ``AuditLog.verify`` re-canonicalises each line and demands
+    byte-equality as anti-tamper evidence (see
+    ``security/audit.py::_canonical_line_check``). The audit writer uses
+    Python's default ``json.dumps`` separators (``', '`` / ``': '``);
+    we match that here so a bundle replayed through ``AuditLog.verify``
+    does not surface as ``non-canonical line bytes``.
+    """
     buf = io.BytesIO()
     for ev in events:
-        line = json.dumps(ev.raw, sort_keys=True, separators=(",", ":"))
+        line = json.dumps(ev.raw, sort_keys=True)
         buf.write(line.encode("utf-8"))
         buf.write(b"\n")
     return buf.getvalue()

--- a/tests/unit/test_chat_telegram_bridge.py
+++ b/tests/unit/test_chat_telegram_bridge.py
@@ -21,6 +21,14 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+# ``thisnotabot-bridge`` is currently distributed as a path install from
+# ``personal_core_services/thisnotabot`` (see ``pyproject.toml`` for the
+# tracking note). CI runners — and any contributor who does not have the
+# sibling repo checked out — will not have it on ``sys.path``. Skip the
+# whole module rather than fail collection so the rest of the suite stays
+# green until the SDK lands on the private index and we can pin it.
+pytest.importorskip("thisnotabot_bridge")
+
 if TYPE_CHECKING:
     from bernstein.core.chat.bridge import ChatMessage
 

--- a/tests/unit/test_conditional_context.py
+++ b/tests/unit/test_conditional_context.py
@@ -415,6 +415,7 @@ def test_section_rules_table_covers_expected_sections() -> None:
         "heartbeat",
         "recommendations",
         "lessons",
+        "memory_lessons",
         "predecessor",
         "project",
         "meta nudges",


### PR DESCRIPTION
## Root cause

Three independent regressions piled up between PRs #1150, #1181, and #1194 and the c08cea7 dependabot uv-lock-refresh was the first matrix run that exercised every combination end-to-end. None of them are lock-related; the ``Test (ubuntu-latest, 3.13/3.12)`` and ``Test (macos-latest, 3.13)`` cells were the first to surface them.

| # | Test | What broke | Trigger |
|---|------|-----------|---------|
| 1 | ``test_article12_bundle.py::TestArticle12BundleE2E::test_build_then_verify`` | Bundle's ``events.jsonl`` failed ``AuditLog.verify`` with ``non-canonical line bytes`` | #1181 added a re-canonicalise + byte-equality anti-tamper check in ``AuditLog.verify``; #1134's ``_build_event_log`` was emitting the same JSON with ``separators=(",", ":")`` (compact) while the audit writer uses default ``json.dumps`` separators (``', '`` / ``': '``). Replaying the slice through the verifier flagged every event. |
| 2 | ``test_conditional_context.py::test_section_rules_table_covers_expected_sections`` | ``set(SECTION_RULES.keys())`` had an unaccounted ``memory_lessons`` key | #1150 wired the JSONL memory injector and added ``"memory_lessons": SectionRule()`` to the rules table without extending this coverage test. |
| 3 | ``test_chat_telegram_bridge.py::*`` | ``ModuleNotFoundError: thisnotabot_bridge`` at collection time | #1194 migrated the Telegram driver to delegate via the standalone ``thisnotabot-bridge`` SDK. The SDK is currently a path install from ``personal_core_services/thisnotabot`` (documented in ``pyproject.toml``); CI runners and contributors without the sibling repo cannot import it. |

## Fix

- ``src/bernstein/core/security/article12_bundle.py``: drop the compact-separator override in ``_build_event_log`` so the bundle's ``events.jsonl`` lines are byte-identical to the on-disk audit log. The audit writer is the source of truth — the verifier's byte-equality check is intentional anti-tamper and must not be loosened. Added a docstring note tying the two together so this contract is visible at the call site.
- ``tests/unit/test_conditional_context.py``: add ``"memory_lessons"`` to the expected SECTION_RULES key set.
- ``tests/unit/test_chat_telegram_bridge.py``: ``pytest.importorskip("thisnotabot_bridge")`` at module load. The pyproject already tracks the "pin once published" plan, so the skip evaporates the moment the SDK lands on the private index.

LOC delta: **+21 / -2** across three files (1 src, 2 tests). No timeouts loosened, no test markers relaxed beyond the importorskip on a non-existent module. All audit chain integrity and byteflip regression tests stay green with the new canonical bytes — the verifier was the sole consumer that demanded matching bytes.

## Test plan

- [x] ``uv run pytest tests/unit/test_conditional_context.py tests/unit/test_chat_telegram_bridge.py tests/unit/test_article12_bundle.py`` — 10 passed, 1 module skipped (the bridge module on machines without the SDK on path).
- [x] ``uv run pytest tests/unit/test_audit_dsse.py tests/unit/test_audit_chain_byteflip_regression.py tests/unit/test_audit.py tests/unit/test_audit_integrity.py tests/integration/test_article12_real_run.py`` — 54 passed.
- [x] ``uv run pytest tests/property/test_lineage_eu_bughunt.py`` — 50 passed, 4 xfailed (pre-existing).
- [x] ``uv run pytest tests/unit/test_compliance.py tests/unit/test_audit_export.py`` — 46 passed.
- [x] ``uv run ruff format src/ tests/`` then ``uv run ruff check`` on the touched files — all clean.
- [ ] Watch full CI matrix on this PR; admin-merge when green so v1.10.5 auto-release unblocks.