### PR TITLE
fix(tests): drop removed mix_stderr arg and add no_watchdog_threads fixture

### DIFF
--- a/tests/unit/identity/test_decode_cli.py
+++ b/tests/unit/identity/test_decode_cli.py
@@ -38,7 +38,7 @@ def _reset_state(
 
 @pytest.fixture()
 def runner() -> CliRunner:
-    return CliRunner(mix_stderr=False)
+    return CliRunner()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_adapter_kiro.py
+++ b/tests/unit/test_adapter_kiro.py
@@ -7,14 +7,16 @@ import sys
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from bernstein.core.models import ApiTier, ModelConfig, ProviderType
 
 from bernstein.adapters.kiro import KiroAdapter
 
+pytestmark = pytest.mark.usefixtures("no_watchdog_threads")
+
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 def _make_popen_mock(pid: int) -> MagicMock:


### PR DESCRIPTION
## Summary

Click 8.3.x removed the `mix_stderr` parameter from `CliRunner.__init__` — stderr is now always captured separately by default. The `tests/unit/identity/test_decode_cli.py` `runner` fixture was passing `mix_stderr=False`, causing a `TypeError` at setup for every test in that file. This was one of the CI failures on main since `c08cea7`.

- `tests/unit/identity/test_decode_cli.py`: remove obsolete `mix_stderr=False` from `CliRunner()` — `result.stderr` still works correctly in Click 8.3.x.
- `tests/unit/test_adapter_kiro.py`: add `pytestmark = pytest.mark.usefixtures("no_watchdog_threads")` — the only remaining adapter test file missing it.

## Test plan

- [x] `pytest tests/unit/identity/test_decode_cli.py` — 10 passed locally
- [x] `pytest tests/unit/test_adapter_kiro.py` — 4 passed locally