### PR TITLE
chore: auto-bump to v1.10.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.4"
+version = "1.10.5"
 description = "Multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more) — deterministic, declarative, zero vendor lock-in."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Automated patch bump from v1.10.4 → v1.10.5. Auto-merge enabled; the next auto-release run on main will tag + publish v1.10.5.

The `auto/bump-v1.10.5` branch was created by the auto-release workflow after CI passed on main (2026-05-10T05:06:41Z), but the PR creation step was canceled mid-flight by the concurrency group. This PR recreates it manually to unblock the release pipeline.