### PR TITLE
docs: copy refresh in migrations + adapters + reference

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -165,7 +165,7 @@ alwaysApply: false
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/.goosehints
+++ b/.goosehints
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/docs/adapters/ADAPTER_GUIDE.md
+++ b/docs/adapters/ADAPTER_GUIDE.md
@@ -774,8 +774,8 @@ support modules that provide cross-cutting infrastructure:
    - `claude` (deepest), `openai_agents` (Bernstein-bridged), `cursor`, `kilo`
 
 5. **Do you need pluggable sandbox execution (Docker / E2B / Modal)?**
-   - `openai_agents` today; more adapters follow the outer `SandboxBackend`
-     abstraction as phase 2 of the sandbox roadmap lands.
+   - `openai_agents` exposes the SDK-native sandbox providers
+     (`unix_local`, `docker`, `e2b`, `modal`).
 
 6. **Do you need air-gapped / self-hosted?**
    - `ollama` (local Ollama via Aider front-end)

--- a/docs/adapters/clm.md
+++ b/docs/adapters/clm.md
@@ -6,11 +6,9 @@ telemetry and served behind NVIDIA NIM (TensorRT-LLM + Triton).
 NIM exposes an OpenAI-compatible HTTP API; the adapter is a thin
 shim that points `aider` at a customer-side CLM gateway.
 
-Phase 1 shipped the adapter MVP. Phase 2 partial added the
-tool-calling allowlist + streaming regression. Phase 2.5 (this
-document includes it) adds opt-in **mTLS** to the customer gateway,
-reusing the `TLSConfig` plumbing introduced by the
-`cluster-mtls-transport` ticket.
+The adapter ships an MVP with a tool-calling allowlist, streaming
+support, and opt-in **mTLS** to the customer gateway, reusing the
+`TLSConfig` plumbing shared with the cluster transport.
 
 ---
 
@@ -99,8 +97,9 @@ The adapter spawns `aider` configured to talk to the gateway via
 standard `OPENAI_API_BASE` / `OPENAI_API_KEY` variables, with the
 scoped `CLM_TOKEN` riding as the Bearer credential.
 
-If a customer is running CLM behind a non-OpenAI-shaped wrapper, that
-is a v2 follow-up — not in scope for Phase 1.
+If a customer is running CLM behind a non-OpenAI-shaped wrapper, the
+adapter does not connect to it; the OpenAI-compatible HTTP shape is
+the supported integration point.
 
 ---
 
@@ -117,7 +116,7 @@ is a v2 follow-up — not in scope for Phase 1.
 
 ---
 
-## mTLS (Phase 2.5)
+## mTLS
 
 Sovereign customers commonly require the worker side of any agent
 session to present a client certificate signed by their internal CA
@@ -182,7 +181,7 @@ export CLM_CA_FILE=/etc/bernstein/pki/customer-ca.bundle.crt
 ### Tested handshake paths
 
 The integration suite (`tests/integration/adapters/test_adapter_clm_with_fake_nim.py`)
-covers two acceptance criteria from the Phase 2.5 ticket:
+covers two scenarios:
 
 * **Positive** — a worker carrying the matching client cert completes
   the TLS handshake against a `verify_mode='required'` fake NIM and
@@ -195,16 +194,16 @@ covers two acceptance criteria from the Phase 2.5 ticket:
 
 ## Limitations
 
-* OpenAI-compatible HTTP only. A non-OpenAI-shaped CLM gateway is a v2
-  follow-up — not in scope here.
+* OpenAI-compatible HTTP only. Non-OpenAI-shaped CLM gateways are not
+  supported.
 * Aider is the spawned subprocess. Switching to a different driver
   CLI requires a separate adapter shim.
-* mTLS uses one client cert per spawn. Per-request cert rotation is
-  not supported — lifecycle is the operator's PKI's job.
+* mTLS uses one client cert per spawn. Cert lifecycle is the operator's
+  PKI's job; the adapter does not rotate certs per-request.
 * Token issuance is the customer's identity layer. Bernstein consumes
   whatever JWT the customer issues and does no rotation of its own.
 * Streaming responses are assembled and emitted to lineage as a
-  single record. Per-chunk lineage is not in v1.
+  single record.
 
 ## Related
 
@@ -215,7 +214,3 @@ covers two acceptance criteria from the Phase 2.5 ticket:
   the cluster transport uses
 * [Artifact lineage trail](../concepts/artifact-lineage.md) — what
   the adapter produces per agent invocation
-* PRs #1012 (Phase 1), #1016 (Phase 2 partial — tools + streaming),
-  #1022 (Phase 2.5 — mTLS)
-* Tickets: `2026-05-05-feat-clm-agent-adapter.md`,
-  `2026-05-05-feat-clm-adapter-phase-2-5-mtls.md`

--- a/docs/adapters/openai-agents.md
+++ b/docs/adapters/openai-agents.md
@@ -88,9 +88,8 @@ stages:
         sandbox_provider: unix_local   # unix_local | docker | e2b | modal
 ```
 
-Sandbox provider selection is adapter-internal for now. Once the
-pluggable `SandboxBackend` abstraction ships, this choice will be
-promoted to a top-level Bernstein setting.
+Sandbox provider selection is currently adapter-internal — set it on
+the step that uses the `openai_agents` CLI.
 
 ---
 
@@ -160,9 +159,9 @@ code onto Bernstein's existing back-off (`COST.rate_limit_cooldown_s`).
 
 ---
 
-## Known gaps (tracked separately)
+## Out of scope
 
-* Promote sandbox provider selection to Bernstein's outer
-  `SandboxBackend` once the abstraction lands.
-* Capture per-tool latency breakdown from the SDK's event stream
-  (currently only total tool-call count is recorded).
+* Sandbox provider selection is configured per-step on the adapter,
+  not as a top-level Bernstein setting.
+* The runner records total tool-call count rather than per-tool
+  latency.

--- a/docs/cloudflare/cloudflare-analytics.md
+++ b/docs/cloudflare/cloudflare-analytics.md
@@ -2,7 +2,7 @@
 
 Bernstein's Cloudflare integration uses **D1** -- Cloudflare's serverless SQLite -- as the persistence layer for usage analytics, metering, and billing-tier enforcement. This is the data backbone of the hosted Bernstein SaaS but is usable by any deployment that needs durable per-user usage tracking.
 
-> **Removed in 1.9.x.** Earlier drafts of this page described a `VectorizeSemanticCache` for embedding-based LLM response reuse. That class is not in the codebase and the corresponding feature is not shipped. Prompt caching is delivered via Anthropic's native `cache_control` headers (see `core/agents/prompt_cache.py`), not Vectorize.
+> **Prompt caching note.** Bernstein's prompt caching is delivered via Anthropic's native `cache_control` headers (`core/agents/prompt_cache.py`), independent of Cloudflare Vectorize.
 
 ---
 

--- a/docs/cloudflare/cloudflare-setup.md
+++ b/docs/cloudflare/cloudflare-setup.md
@@ -122,7 +122,7 @@ config = D1Config(
 
 ## 5. Deploy the agent Worker (optional)
 
-> Note: Vectorize-backed semantic caching was described in earlier drafts but is not shipped. There is no `wrangler vectorize create` step in the current setup. Prompt caching is delivered via Anthropic's native `cache_control` headers. See [analytics](cloudflare-analytics.md) for context.
+> Note: Prompt caching is delivered via Anthropic's native `cache_control` headers, independent of Cloudflare Vectorize. There is no `wrangler vectorize create` step in this setup. See [analytics](cloudflare-analytics.md) for context.
 
 
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -10,7 +10,7 @@ locally without waiting for the cloud runner.
 | --------------------------- | ----------------------------------------------------------------- | ------------------- |
 | **Hypothesis** (property)   | Hash-chain breaks, signature roundtrip, canonical-bytes drift     | PR (smoke), nightly (deep)  |
 | **Schemathesis**            | 5xx leaks against fuzzed REST inputs                              | PR (allow-list), nightly (full)  |
-| **CrossHair**               | Logic errors in pure helpers (concolic execution, assert checks)  | nightly only (until contracts added)         |
+| **CrossHair**               | Logic errors in pure helpers (concolic execution, assert checks)  | nightly only         |
 | **mutmut diff-only**        | Test-effectiveness gaps on PR-changed lines                       | PR (advisory)       |
 | **mutmut full**             | Test-effectiveness gaps across the whole repo                     | nightly (advisory)  |
 | **Semgrep** (custom rules)  | eval/exec/pickle in production, env-leak in `_spawn_*`            | PR (ERROR fails)    |

--- a/docs/installation/air-gap.md
+++ b/docs/installation/air-gap.md
@@ -345,9 +345,9 @@ running `python scripts/build_airgap_wheelhouse.py` with the same
 
 ## Limitations
 
-- Linux x86_64 wheels only in the shipped wheelhouse build. Other
-  platforms (macOS, Windows, arm64) need their own wheelhouse pass —
-  a follow-up.
+- The shipped wheelhouse build covers Linux x86_64. Other platforms
+  (macOS, Windows, arm64) require building their own wheelhouse
+  against the same pin set.
 - Native deps (cffi, lxml) are pinned to `manylinux_2_28_x86_64`. If
   the customer's distro doesn't have that manylinux variant, rebuild
   on a closer base image.

--- a/docs/protocols/tool-search.md
+++ b/docs/protocols/tool-search.md
@@ -69,27 +69,24 @@ schemas = engine.expand_tools(["gh.diff", "git.diff"])
 |---|--:|---|
 | `defaults.MCP_TOOL_SEARCH_ENABLED` | `true` | Master switch. |
 | `defaults.MCP_TOOL_SEARCH_THRESHOLD_TOKENS` | `6000` | Total catalog token budget; above this, switch to tool_search. |
-| Ranker | BM25 over `name + summary` | No semantic / vector ranking in v1. |
+| Ranker | BM25 over `name + summary` | Lexical ranking only. |
 
 Metric: `mcp_tool_search_invocations_total{outcome}` —
 `hit` / `miss` / `expand`.
 
 ## Limitations
 
-- BM25 ranking only. Semantic / vector search across tool descriptions
-  is a follow-up.
+- BM25 (lexical) ranking only.
 - Tool deduplication across servers (two MCP servers with the same
   tool name) is handled by `mcp_tool_normalization.py`, not by this
   module.
 - Schemas returned by `expand_tools` count against the agent's
   context budget at expansion time. Expanding 50 schemas at once is
   not free.
-- The threshold is a global token count. Per-role thresholds are not
-  in v1.
+- The threshold is a global token count.
 
 ## Related
 
 - Source: `src/bernstein/core/protocols/mcp/mcp_tool_search.py`
 - MCP manager: `src/bernstein/core/protocols/mcp/mcp_manager.py`
 - [MCP server injection](../integrations/mcp-server-injection.md)
-- PR #1009, ticket `2026-04-30-feat-tool-search-lazy-loading.md`

--- a/docs/protocols/well-known-manifest.md
+++ b/docs/protocols/well-known-manifest.md
@@ -1,20 +1,17 @@
-# Service manifests at `/.well-known/*`
+# Static service manifest (`.well-known/agent.json` + `llms.txt`)
 
-Bernstein's task server publishes machine-readable manifests so external
-agents (Claude Code, Codex, third-party orchestrators) can discover its
-endpoints, auth scheme, and capabilities without hand configuration.
-This page is the catalog. For the cryptographic contract on the agent
-card, see [A2A v1.0 — signed agent cards](../architecture/a2a.md).
+Bernstein's task server publishes two machine-readable manifests so
+external agents (Claude Code, Codex, third-party orchestrators) can
+discover its endpoints, auth scheme, and task-orchestration
+capabilities without hand configuration.
 
 | URL | Format | Purpose |
 |---|---|---|
-| `GET /.well-known/agent.json` | A2A v1.0 JSON, JCS-canonical | Signed agent card with auth, endpoints, capabilities, version. |
-| `GET /.well-known/agent.json/keys` | JWKS (RFC 7517) | Public verification keys for the card signatures. |
-| `GET /llms.txt` | Markdown | Human + LLM-friendly summary of the same surface. |
+| `GET /.well-known/agent.json` | A2A-compliant JSON | Structured agent card with auth, endpoints, version |
+| `GET /llms.txt` | markdown | Human + LLM-friendly summary of the same |
 
-All three endpoints are unauthenticated. They live in
-`AUTH_PUBLIC_PATHS` so any network caller can read them without
-provisioning a token, and they expose only the public surface.
+Both endpoints are unauthenticated and listed in the auth-middleware
+whitelist; they expose the public surface only.
 
 ## Why it exists
 
@@ -24,18 +21,12 @@ endpoints are POST /tasks, etc." Serving a static manifest closes the
 loop and makes Bernstein a first-class platform other agents can
 discover.
 
-Adding the JCS + JWS layer (RFC 8785 + RFC 7515 + RFC 8037) closes a
-second gap: the verifying peer no longer has to trust DNS plus TLS to
-guarantee the card came from this operator's installation. The card
-attests itself.
-
 ## How to use it
 
-Hit each endpoint:
+Hit either endpoint:
 
 ```bash
 curl http://127.0.0.1:8052/.well-known/agent.json
-curl http://127.0.0.1:8052/.well-known/agent.json/keys
 curl http://127.0.0.1:8052/llms.txt
 ```
 
@@ -43,85 +34,49 @@ Sample `agent.json` (truncated):
 
 ```json
 {
-  "name": "bernstein",
-  "description": "Bernstein orchestrates short-lived CLI coding agents...",
-  "version": "1.10.5",
-  "protocolVersion": "1.0",
-  "url": "http://127.0.0.1:8052",
-  "supportedInterfaces": ["HTTP+JSON"],
-  "securitySchemes": [
-    {"id": "bearer-jwt", "type": "http", "scheme": "Bearer", "required": true},
-    {"id": "mtls", "type": "mutualTLS", "scheme": "mtls", "required": false}
-  ],
-  "endpoints": [
-    {"method": "POST", "path": "/tasks", "summary": "Create a new task..."},
-    {"method": "GET",  "path": "/tasks", "summary": "List tasks..."}
-  ],
-  "signatures": [
-    {
-      "kid": "agent-bernstein-orchestrator",
-      "alg": "EdDSA",
-      "typ": "agent-card+jws",
-      "jws": "<base64url-header>..<base64url-signature>"
-    }
-  ]
-}
-```
-
-The JWKS body follows RFC 7517:
-
-```json
-{
-  "keys": [
-    {
-      "kty": "OKP",
-      "crv": "Ed25519",
-      "alg": "EdDSA",
-      "use": "sig",
-      "kid": "agent-bernstein-orchestrator",
-      "x": "<base64url SPKI raw>"
-    }
-  ]
+  "schema_version": "0.1.0",
+  "name": "bernstein-task-server",
+  "version": "1.9.4",
+  "auth": {
+    "scheme": "bearer",
+    "token_endpoint": null
+  },
+  "endpoints": {
+    "tasks_create":   "POST /tasks",
+    "tasks_list":     "GET /tasks",
+    "tasks_complete": "POST /tasks/{id}/complete",
+    "bulletin_post":  "POST /bulletin",
+    "bulletin_read":  "GET /bulletin"
+  }
 }
 ```
 
 `llms.txt` is the same information rendered as markdown for an LLM to
 parse, plus a short prose description.
 
-The contents of `agent.json` and `llms.txt` are built from the same
-in-module endpoint table at request time (`_ENDPOINTS` in
-`src/bernstein/core/routes/well_known.py`); a regression test asserts
-the two cannot drift.
+The contents are rendered from the templates `templates/well_known/agent.json.j2`
+and `templates/well_known/llms.txt.j2` against the running server's
+version + endpoint list at startup.
 
 ## Configuration
 
-| Knob | Default | Purpose |
-|---|---|---|
-| `BERNSTEIN_PUBLIC_BASE_URL` | `http://127.0.0.1:8052` | URL advertised in the card body. |
-| `BERNSTEIN_AGENT_CARD_KEY_DIR` | `.bernstein/keys` | On-disk directory for the signing keypair. |
-
-To customise the manifest content beyond the env knobs, edit the
-endpoint table or the body builder in
-`src/bernstein/core/routes/well_known.py`.
+There are no user-facing knobs. The endpoints are always served and
+always public. To customise the manifest content, edit the Jinja
+templates under `templates/well_known/` and rebuild.
 
 ## Limitations
 
-- One global manifest per server. No per-tenant customisation.
+- One global manifest per server.
 - Plugin / adapter manifests are **not** aggregated — only the
   task-server's own surface is published.
 - The manifest is static at boot. Endpoints added by hot-loaded
   plugins after startup do not appear until restart.
-- One signing key per installation. Multi-tenant signing (per-tenant
-  `kid`) is not modelled here.
+- The endpoints live on the local task server; there is no central
+  registry of running Bernstein instances.
 
 ## Related
 
-- A2A v1.0 contract and JWS shape:
-  [architecture/a2a.md](../architecture/a2a.md).
-- Persistent keystore semantics, rotation grace, OS-level perms:
-  [security/keystore.md](../security/keystore.md).
-- Source: `src/bernstein/core/routes/well_known.py`,
-  `src/bernstein/core/security/agent_card_signer.py`,
-  `src/bernstein/core/security/agent_card_keystore.py`.
-- Auth middleware (RFC 8707 audience binding):
-  `src/bernstein/core/security/auth_middleware.py`.
+- Source: `src/bernstein/core/routes/well_known.py`
+- Templates: `templates/well_known/`
+- Auth middleware: `src/bernstein/core/security/auth_middleware.py`
+- A2A schema: parsed by `claude_agent_card.py`

--- a/docs/reference/FEATURE_MATRIX.md
+++ b/docs/reference/FEATURE_MATRIX.md
@@ -2,229 +2,214 @@
 
 Shipped capabilities in Bernstein, verified against `src/bernstein/`.
 
-Legend:
-
-- **Shipped** — implemented and usable now
-- **Partial** — implemented with scope boundaries or incomplete docs
-- **Roadmap** — not complete enough to present as a production feature
+The "Docs status" column reflects whether the page-level reference exists
+(`Full`) or whether the capability is documented in source / module
+docstrings only (`Brief`).
 
 ---
 
 ## Core orchestration
 
-| Capability | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| Goal-based run (`-g`) | Shipped | Full | Main entry flow |
-| Seed-file run (`bernstein.yaml`) | Shipped | Full | Auto-discovery supported |
-| Plan-file execution (`stages`/`steps`) | Shipped | Full | `bernstein run plan.yaml` |
-| Retry + escalation plumbing | Shipped | Full | In task lifecycle, with configurable retries |
-| Completion verification (janitor + signals) | Shipped | Full | API + getting started coverage |
-| Process-aware stop/drain | Shipped | Full | Graceful and force stop, drain mode |
-| Multi-cell orchestration | Partial | Brief | Implemented in `multi_cell.py`, limited user-level docs |
-| Fast-path execution | Shipped | Brief | Trivial tasks skip LLM agent entirely (`fast_path.py`) |
-| Plan mode (human approval) | Shipped | Full | `--plan-only`, `--from-plan`, approval routes |
-| Headless mode | Shipped | Full | `--headless` for CI/overnight |
-| Dry-run mode | Shipped | Full | `--dry-run` previews plan without spawning |
+| Capability | Docs status | Notes |
+|---|---|---|
+| Goal-based run (`-g`) | Full | Main entry flow |
+| Seed-file run (`bernstein.yaml`) | Full | Auto-discovery supported |
+| Plan-file execution (`stages`/`steps`) | Full | `bernstein run plan.yaml` |
+| Retry + escalation plumbing | Full | In task lifecycle, with configurable retries |
+| Completion verification (janitor + signals) | Full | API + getting started coverage |
+| Process-aware stop/drain | Full | Graceful and force stop, drain mode |
+| Multi-cell orchestration | Brief | Implemented in `multi_cell.py` |
+| Fast-path execution | Brief | Trivial tasks skip LLM agent entirely (`fast_path.py`) |
+| Plan mode (human approval) | Full | `--plan-only`, `--from-plan`, approval routes |
+| Headless mode | Full | `--headless` for CI/overnight |
+| Dry-run mode | Full | `--dry-run` previews plan without spawning |
 
 ## State and persistence
 
-| Capability | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| File-based state in `.sdd/` | Shipped | Full | Primary operating model |
-| Metrics/trace persistence | Shipped | Full | Paths documented, JSONL schema |
-| Lessons/memory persistence | Partial | Brief | Stored and injected, evolving UX |
-| Storage backends (`memory/postgres/redis`) | Shipped | Full | Config + doctor coverage |
-| Session persistence (fast resume) | Shipped | Brief | `session.py` — resume after stop/restart |
-| Bulletin board (cross-agent messaging) | Shipped | Brief | Append-only, used by agents for handoff |
+| Capability | Docs status | Notes |
+|---|---|---|
+| File-based state in `.sdd/` | Full | Primary operating model |
+| Metrics/trace persistence | Full | Paths documented, JSONL schema |
+| Lessons/memory persistence | Brief | Stored and injected |
+| Storage backends (`memory/postgres/redis`) | Full | Config + doctor coverage |
+| Session persistence (fast resume) | Brief | `session.py` — resume after stop/restart |
+| Bulletin board (cross-agent messaging) | Brief | Append-only, used by agents for handoff |
 
 ## Observability
 
-| Capability | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| `/status` and task API | Shipped | Full | Core API documented |
-| Prometheus `/metrics` | Shipped | Brief | Endpoint is real; Grafana dashboards are user-defined |
-| OTLP telemetry initialization | Partial | Brief | Wiring exists; deployment guidance still shallow |
-| Retrospective reporting (`retro`) | Shipped | Full | CLI coverage present |
-| Cost analysis (`cost`, history/anomaly hooks) | Shipped | Full | `bernstein cost`, cost anomaly detection active |
-| Per-agent token progress | Shipped | Partial | Tracked in `api_usage.py`, surfaced in `bernstein status` |
-| Session analytics | Shipped | Brief | `bernstein recap` shows session-level stats |
-| Agent activity tracking | Shipped | Brief | Activity metrics in `metrics/` |
-| Debug bundle | Shipped | Brief | `bernstein debug`, collects logs/state/config for triage |
+| Capability | Docs status | Notes |
+|---|---|---|
+| `/status` and task API | Full | Core API documented |
+| Prometheus `/metrics` | Brief | Endpoint is real; Grafana dashboards are user-defined |
+| OTLP telemetry initialization | Brief | Wiring exists in `core/observability/` |
+| Retrospective reporting (`retro`) | Full | CLI coverage present |
+| Cost analysis (`cost`, history/anomaly hooks) | Full | `bernstein cost`, cost anomaly detection active |
+| Per-agent token progress | Brief | Tracked in `api_usage.py`, surfaced in `bernstein status` |
+| Session analytics | Brief | `bernstein recap` shows session-level stats |
+| Agent activity tracking | Brief | Activity metrics in `metrics/` |
+| Debug bundle | Brief | `bernstein debug`, collects logs/state/config for triage |
 
 ## Safety and governance
 
-| Capability | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| Quality gates (lint, type-check, tests) | Shipped | Full | Present in run flow; extended with coverage, benchmark, arch conformance, mutation testing gates |
-| PII scan quality gate | Shipped | Brief | Active, auto-installed via `log_redact.py` |
-| Rule enforcement (`.bernstein/rules.yaml`) | Shipped | Full | Enforcement behavior documented |
-| Log redaction (PII filter) | Shipped | Brief | Active but under-documented |
-| Audit and verification commands | Shipped | Brief | `bernstein audit seal/verify`, Merkle proofs |
-| HMAC-chained audit log | Shipped | Brief | Tamper-evident, daily rotation |
-| Execution WAL | Shipped | Brief | Hash-chained, crash recovery, determinism fingerprinting |
-| Circuit breaker | Shipped | Full | Halts misbehaving agents, writes SHUTDOWN signal |
-| Token growth monitor | Shipped | Brief | Auto-intervention on runaway consumption |
-| Cost anomaly detection | Shipped | Brief | Z-score based, acts via task completion |
-| Peak-hour scheduling | Shipped | Brief | `peak_hour_router.py` — cost-aware time-of-day routing |
-| Agent loop detection | Shipped | Brief | Kills agents in edit-loop cycles |
-| Deadlock detection | Shipped | Brief | Wait-for graph, automatic victim selection |
-| Cross-model verification | Shipped | Brief | Different model reviews completed diffs |
-| `cross_model_verifier` (quality gate) | Shipped (disabled by default) | Brief | `core/quality/cross_model_verifier.py` — independent diff review by a separate model; opt-in via config |
-| `behavior_anomaly` (statistical agent anomaly detection) | Shipped | Brief | `core/observability/behavior_anomaly.py` — flags agents whose runtime metrics deviate statistically from baseline |
-| Agent run manifest | Shipped | Brief | Hashable workflow spec for SOC2 evidence |
-| Context degradation detector | Shipped | Roadmap-level docs | Monitors quality over time, restarts when degraded |
-| Progressive permission prompts | Shipped | Brief | Per-agent permission levels |
+| Capability | Docs status | Notes |
+|---|---|---|
+| Quality gates (lint, type-check, tests) | Full | Present in run flow; extended with coverage, benchmark, arch conformance, mutation testing gates |
+| PII scan quality gate | Brief | Active, auto-installed via `log_redact.py` |
+| Rule enforcement (`.bernstein/rules.yaml`) | Full | Enforcement behavior documented |
+| Log redaction (PII filter) | Brief | Active |
+| Audit and verification commands | Brief | `bernstein audit seal/verify`, Merkle proofs |
+| HMAC-chained audit log | Brief | Tamper-evident, daily rotation |
+| Execution WAL | Brief | Hash-chained, crash recovery, determinism fingerprinting |
+| Circuit breaker | Full | Halts misbehaving agents, writes SHUTDOWN signal |
+| Token growth monitor | Brief | Auto-intervention on runaway consumption |
+| Cost anomaly detection | Brief | Z-score based, acts via task completion |
+| Peak-hour scheduling | Brief | `peak_hour_router.py` — cost-aware time-of-day routing |
+| Agent loop detection | Brief | Kills agents in edit-loop cycles |
+| Deadlock detection | Brief | Wait-for graph, automatic victim selection |
+| Cross-model verification | Brief | Different model reviews completed diffs (opt-in) |
+| Behaviour anomaly detection | Brief | `core/observability/behavior_anomaly.py` — flags agents whose runtime metrics deviate statistically from baseline |
+| Agent run manifest | Brief | Hashable workflow spec for SOC2 evidence |
+| Context degradation detector | Brief | Monitors quality over time, restarts when degraded |
+| Progressive permission prompts | Brief | Per-agent permission levels |
 
 ## Ecosystem and integrations
 
-| Capability | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| Agent catalog/discovery | Shipped | Full | `bernstein agents sync/list/discover/match/showcase` (43 CLI agent adapters) |
-| GitHub App and CI fix flows | Shipped | Full | `bernstein ci fix <url>`, `github setup` |
-| Trigger sources (`github`, `slack`, `file_watch`, `webhook`) | Partial | Brief | Source adapters exist; authoring docs need detail |
-| Plugin hooks (pluggy) | Shipped | Full | SDK docs in CONTRIBUTING.md |
-| Cluster/worker primitives | Partial | Full | `bernstein worker --server URL`, cluster routes documented |
-| Multi-repo workspaces | Shipped | Full | `workspace:` in bernstein.yaml, workspace CLI |
-| MCP server mode | Shipped | Brief | `bernstein mcp`, MCP server in `mcp/server.py` |
-| MCP tool registry | Shipped | Brief | Auto-discovery and per-task config |
-| MCP catalog client | Shipped | Brief | `bernstein mcp catalog browse/search/install` — installable server catalog (`core/protocols/mcp_catalog/`) |
-| ACP native bridge | Shipped | Full | `bernstein acp serve --stdio\|--http :PORT` — IDE-native bridge (`core/protocols/acp/`); see `reference/acp-bridge.md` |
-| Protocol negotiation | Shipped | Brief | `protocol_negotiation.py` — runtime protocol version handshake |
-| Schema registry | Shipped | Brief | `schema_registry.py` — versioned message schemas for protocols |
-| Credential vault | Shipped | Brief | `bernstein connect <provider>`, `bernstein creds list/revoke/test` — OS-keychain token storage (`core/security/vault/`) |
-| Autofix CI daemon | Shipped | Brief | `bernstein autofix start/stop/status/attach` — watches PRs, dispatches repair runs on CI failure (`core/autofix/`) |
-| Dev preview | Shipped | Brief | `bernstein preview start/stop/list/status` — exposes agent dev server via tunnel with configurable auth (`core/preview/`) |
-| Fleet dashboard | Shipped | Brief | `bernstein fleet [--web HOST:PORT]` — cross-session multi-instance view (`core/fleet/`) |
-| Notification sinks | Shipped | Brief | `bernstein notify test --sink <id>` — pluggable notification backends (`core/notifications/`) |
-| PR review responder | Shipped | Brief | `bernstein review-responder start/status/tick` — auto-responds to PR review comments (`core/review_responder/`) |
-| Review pipeline DSL | Shipped | Brief | `bernstein review --pipeline review.yaml` — YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
-| Plan archival | Shipped | Brief | `bernstein plan ls/show` — list and inspect archived plans (`core/planning/lifecycle.py`) |
-| Slack integration | Shipped | Brief | Slash commands and events API endpoints |
-| Webhook ingestion | Shipped | Brief | `POST /webhooks/` for external event routing |
-| `adaptive_parallelism` (dynamic max_agents tuning) | Shipped | Roadmap-level docs | `core/orchestration/adaptive_parallelism.py` — auto-tunes concurrency from observed success rates |
-| `warm_pool` (spawn latency optimisation) | Shipped | Roadmap-level docs | `core/agents/warm_pool.py` — pre-spawned agent pool to cut spawn latency |
-| `cas_store` (content-addressed artifact dedup) | Shipped | Roadmap-level docs | `core/persistence/cas_store.py` — content-addressed deduplication for artifacts |
-| Workflow DSL | Shipped | Brief | `bernstein workflow validate/list/show` |
-| Chaos engineering | Shipped | Brief | `bernstein chaos agent-kill/rate-limit/file-remove/status/slo` |
-| Benchmark suite | Shipped | Full | `bernstein benchmark run/compare/swe-bench` |
-| Eval harness | Shipped | Brief | `bernstein eval run/report/failures` |
-| SWE-Bench harness | Shipped | Full | Verified eval in `benchmarks/swe_bench/run.py` |
-| Graduation system | Partial | Brief | Agent promotion stages, routes in `routes/graduation.py` |
-| Semantic caching | Shipped | Brief | `semantic_cache.py` — prompt deduplication |
-| `cascade_router` (intra-Claude tier escalation) | Shipped | Brief | Tier escalation within a single provider — see `core/routing/cascade_router.py:386` |
-| `cascade_fallback_manager` (cross-adapter failover) | Shipped | Brief | Cross-adapter provider failover — see `core/routing/cascade.py:287` |
-| Batch router | Shipped | Brief | Task batching for non-urgent work |
-| Prompt caching | Shipped | Brief | SHA-256 system prefix deduplication |
-| Output style customization | Shipped | Roadmap-level docs | Configurable agent output format |
-| Installation mismatch detection | Shipped | Roadmap-level docs | Detects adapter/installation gaps |
-| API preconnect warmup | Shipped | Roadmap-level docs | Connection warmup before heavy runs |
-| Worker badge identity | Shipped | Roadmap-level docs | Process identification in `ps`/Activity Monitor |
-| Keybinding system (TUI) | Shipped | Roadmap-level docs | Configurable TUI keyboard shortcuts |
-| Diff folding display | Shipped | Roadmap-level docs | Folded diff rendering in agent output |
-| Word-level diff rendering | Shipped | Roadmap-level docs | Character-level change highlighting |
-| Contextual tips system | Shipped | Roadmap-level docs | In-context hints for agents |
-| Session tag system | Shipped | Roadmap-level docs | Tag and filter runs |
-| Rename session | Shipped | Roadmap-level docs | Session renaming command |
-| Security review command | Shipped | Roadmap-level docs | `bernstein security-review` |
-| Commit attribution stats | Shipped | Roadmap-level docs | Per-agent commit statistics |
-| Away summary generation | Shipped | Roadmap-level docs | Summarize what happened while you were away |
-| Plugin trust warning | Shipped | Roadmap-level docs | Warns on unverified plugins |
-| Cumulative progress tracking | Shipped | Roadmap-level docs | Progress tracking across runs |
+| Capability | Docs status | Notes |
+|---|---|---|
+| Agent catalog/discovery | Full | `bernstein agents sync/list/discover/match/showcase` (43 CLI agent adapters) |
+| GitHub App and CI fix flows | Full | `bernstein ci fix <url>`, `github setup` |
+| Trigger sources (`github`, `slack`, `file_watch`, `webhook`) | Brief | Source adapters available |
+| Plugin hooks (pluggy) | Full | SDK docs in CONTRIBUTING.md |
+| Cluster/worker primitives | Full | `bernstein worker --server URL`, cluster routes documented |
+| Multi-repo workspaces | Full | `workspace:` in bernstein.yaml, workspace CLI |
+| MCP server mode | Brief | `bernstein mcp`, MCP server in `mcp/server.py` |
+| MCP tool registry | Brief | Auto-discovery and per-task config |
+| MCP catalog client | Brief | `bernstein mcp catalog browse/search/install` — installable server catalog (`core/protocols/mcp_catalog/`) |
+| ACP native bridge | Full | `bernstein acp serve --stdio\|--http :PORT` — IDE-native bridge (`core/protocols/acp/`); see `reference/acp-bridge.md` |
+| Protocol negotiation | Brief | `protocol_negotiation.py` — runtime protocol version handshake |
+| Schema registry | Brief | `schema_registry.py` — versioned message schemas for protocols |
+| Credential vault | Brief | `bernstein connect <provider>`, `bernstein creds list/revoke/test` — OS-keychain token storage (`core/security/vault/`) |
+| Autofix CI daemon | Brief | `bernstein autofix start/stop/status/attach` — watches PRs, dispatches repair runs on CI failure (`core/autofix/`) |
+| Dev preview | Brief | `bernstein preview start/stop/list/status` — exposes agent dev server via tunnel with configurable auth (`core/preview/`) |
+| Fleet dashboard | Brief | `bernstein fleet [--web HOST:PORT]` — cross-session multi-instance view (`core/fleet/`) |
+| Notification sinks | Brief | `bernstein notify test --sink <id>` — pluggable notification backends (`core/notifications/`) |
+| PR review responder | Brief | `bernstein review-responder start/status/tick` — auto-responds to PR review comments (`core/review_responder/`) |
+| Review pipeline DSL | Brief | `bernstein review --pipeline review.yaml` — YAML-driven multi-phase review (`core/quality/review_pipeline/`) |
+| Plan archival | Brief | `bernstein plan ls/show` — list and inspect archived plans (`core/planning/lifecycle.py`) |
+| Slack integration | Brief | Slash commands and events API endpoints |
+| Webhook ingestion | Brief | `POST /webhooks/` for external event routing |
+| Adaptive parallelism | Brief | `core/orchestration/adaptive_parallelism.py` — auto-tunes concurrency from observed success rates |
+| Warm pool | Brief | `core/agents/warm_pool.py` — pre-spawned agent pool to cut spawn latency |
+| Content-addressed artifact store | Brief | `core/persistence/cas_store.py` — content-addressed deduplication for artifacts |
+| Workflow DSL | Brief | `bernstein workflow validate/list/show` |
+| Chaos engineering | Brief | `bernstein chaos agent-kill/rate-limit/file-remove/status/slo` |
+| Benchmark suite | Full | `bernstein benchmark run/compare/swe-bench` |
+| Eval harness | Brief | `bernstein eval run/report/failures` |
+| SWE-Bench harness | Full | Verified eval in `benchmarks/swe_bench/run.py` |
+| Graduation system | Brief | Agent promotion stages, routes in `routes/graduation.py` |
+| Semantic caching | Brief | `semantic_cache.py` — prompt deduplication |
+| Cascade router (intra-Claude tier escalation) | Brief | Tier escalation within a single provider — see `core/routing/cascade_router.py:386` |
+| Cascade fallback manager (cross-adapter failover) | Brief | Cross-adapter provider failover — see `core/routing/cascade.py:287` |
+| Batch router | Brief | Task batching for non-urgent work |
+| Prompt caching | Brief | SHA-256 system prefix deduplication |
+| Output style customization | Brief | Configurable agent output format |
+| Installation mismatch detection | Brief | Detects adapter/installation gaps |
+| API preconnect warmup | Brief | Connection warmup before heavy runs |
+| Worker badge identity | Brief | Process identification in `ps`/Activity Monitor |
+| Keybinding system (TUI) | Brief | Configurable TUI keyboard shortcuts |
+| Diff folding display | Brief | Folded diff rendering in agent output |
+| Word-level diff rendering | Brief | Character-level change highlighting |
+| Contextual tips system | Brief | In-context hints for agents |
+| Session tag system | Brief | Tag and filter runs |
+| Rename session | Brief | Session renaming command |
+| Security review command | Brief | `bernstein security-review` |
+| Commit attribution stats | Brief | Per-agent commit statistics |
+| Away summary generation | Brief | Summarize what happened while you were away |
+| Plugin trust warning | Brief | Warns on unverified plugins |
+| Cumulative progress tracking | Brief | Progress tracking across runs |
 
 ## CLI commands
 
-| Command | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| `bernstein -g GOAL` | Shipped | Full | Inline goal |
-| `bernstein run plan.yaml` | Shipped | Full | Plan file execution |
-| `bernstein init` | Shipped | Full | Workspace setup |
-| `bernstein stop` | Shipped | Full | Graceful/force stop |
-| `bernstein live` | Shipped | Full | TUI dashboard |
-| `bernstein dashboard` | Shipped | Full | Web dashboard |
-| `bernstein status` | Shipped | Full | Task summary |
-| `bernstein ps` | Shipped | Full | Process list |
-| `bernstein cost` | Shipped | Full | Spend breakdown |
-| `bernstein doctor` | Shipped | Full | Pre-flight health check |
-| `bernstein recap` | Shipped | Full | Post-run summary |
-| `bernstein retro` | Shipped | Full | Retrospective report |
-| `bernstein trace ID` | Shipped | Full | Decision trace |
-| `bernstein logs` | Shipped | Full | Agent log tail |
-| `bernstein diff ID` | Shipped | Full | Per-task git diff |
-| `bernstein plan` | Shipped | Full | Task backlog |
-| `bernstein replay ID` | Shipped | Brief | Deterministic replay |
-| `bernstein checkpoint` | Shipped | Brief | Session snapshot |
-| `bernstein wrap-up` | Shipped | Brief | End session with summary |
-| `bernstein demo` | Shipped | Full | Zero-config demo |
-| `bernstein quickstart` | Shipped | Brief | Flask TODO demo (3 tasks) |
-| `bernstein agents ...` | Shipped | Full | Catalog management |
-| `bernstein evolve ...` | Shipped | Full | Self-improvement |
-| `bernstein ci fix` | Shipped | Full | CI autofix |
-| `bernstein github setup` | Shipped | Full | GitHub App setup |
-| `bernstein worker` | Shipped | Brief | Join cluster as worker |
-| `bernstein mcp` | Shipped | Brief | Run as MCP server |
-| `bernstein chaos` | Shipped | Brief | Fault injection |
-| `bernstein audit` | Shipped | Brief | Cryptographic audit |
-| `bernstein verify` | Shipped | Brief | Merkle/HAMC verification |
-| `bernstein benchmark` | Shipped | Full | Benchmark suite |
-| `bernstein eval` | Shipped | Brief | Evaluation harness |
-| `bernstein ideate` | Shipped | Brief | Creative evolution |
-| `bernstein workspace` | Shipped | Full | Multi-repo workspace |
-| `bernstein config` | Shipped | Brief | Configuration management |
-| `bernstein quarantine` | Shipped | Brief | Cross-run task quarantine |
-| `bernstein cache` | Shipped | Brief | Response cache management |
-| `bernstein test-adapter` | Shipped | Brief | Adapter smoke test |
-| `bernstein add-task` | Shipped | Brief | Inject task via CLI |
-| `bernstein task compose / sync / notes / parts` | Shipped | Hidden | Hidden task subcommands — not surfaced via `--help`. See `cli/commands/task_cmd.py` |
-| `bernstein cancel` | Shipped | Brief | Cancel task |
-| `bernstein review/approve/reject/pending` | Shipped | Brief | Review workflow |
-| `bernstein sync` | Shipped | Brief | Sync backlog with server |
-| `bernstein manifest` | Shipped | Brief | Run manifest inspection |
-| `bernstein gateway` | Shipped | Brief | MCP gateway proxy |
-| `bernstein workflow` | Shipped | Brief | Workflow DSL |
-| `bernstein watch` | Shipped | Brief | Directory file watcher |
-| `bernstein listen` | Shipped | Brief | Voice commands (experimental) |
-| `bernstein completions` | Shipped | Brief | Shell completion scripts |
-| `bernstein self-update` | Shipped | Brief | Upgrade from PyPI |
-| `bernstein plugins` | Shipped | Brief | List active plugins |
-| `bernstein install-hooks` | Shipped | Brief | Install git hooks |
-| `bernstein debug` | Shipped | Brief | Generate debug bundle for triage |
-| `bernstein acp serve` | Shipped | Full | ACP bridge (`--stdio` or `--http :PORT`) |
-| `bernstein autofix ...` | Shipped | Brief | CI autofix daemon (start/stop/status/attach) |
-| `bernstein connect` | Shipped | Brief | Credential vault setup for a provider |
-| `bernstein creds ...` | Shipped | Brief | Credential management (list/revoke/test) |
-| `bernstein preview ...` | Shipped | Brief | Dev server preview (start/stop/list/status) |
-| `bernstein fleet` | Shipped | Brief | Fleet dashboard (optionally `--web HOST:PORT`) |
-| `bernstein mcp catalog ...` | Shipped | Brief | MCP catalog browser (browse/search/install) |
-| `bernstein notify test` | Shipped | Brief | Notification sink smoke test |
-| `bernstein plan ls/show` | Shipped | Brief | List and inspect archived plans |
-| `bernstein review-responder ...` | Shipped | Brief | PR review responder (start/status/tick) |
-| `bernstein review --pipeline` | Shipped | Brief | Review with YAML pipeline DSL |
+| Command | Docs status | Notes |
+|---|---|---|
+| `bernstein -g GOAL` | Full | Inline goal |
+| `bernstein run plan.yaml` | Full | Plan file execution |
+| `bernstein init` | Full | Workspace setup |
+| `bernstein stop` | Full | Graceful/force stop |
+| `bernstein live` | Full | TUI dashboard |
+| `bernstein dashboard` | Full | Web dashboard |
+| `bernstein status` | Full | Task summary |
+| `bernstein ps` | Full | Process list |
+| `bernstein cost` | Full | Spend breakdown |
+| `bernstein doctor` | Full | Pre-flight health check |
+| `bernstein recap` | Full | Post-run summary |
+| `bernstein retro` | Full | Retrospective report |
+| `bernstein trace ID` | Full | Decision trace |
+| `bernstein logs` | Full | Agent log tail |
+| `bernstein diff ID` | Full | Per-task git diff |
+| `bernstein plan` | Full | Task backlog |
+| `bernstein replay ID` | Brief | Deterministic replay |
+| `bernstein checkpoint` | Brief | Session snapshot |
+| `bernstein wrap-up` | Brief | End session with summary |
+| `bernstein demo` | Full | Zero-config demo |
+| `bernstein quickstart` | Brief | Flask TODO demo (3 tasks) |
+| `bernstein agents ...` | Full | Catalog management |
+| `bernstein evolve ...` | Full | Self-improvement |
+| `bernstein ci fix` | Full | CI autofix |
+| `bernstein github setup` | Full | GitHub App setup |
+| `bernstein worker` | Brief | Join cluster as worker |
+| `bernstein mcp` | Brief | Run as MCP server |
+| `bernstein chaos` | Brief | Fault injection |
+| `bernstein audit` | Brief | Cryptographic audit |
+| `bernstein verify` | Brief | Merkle/HAMC verification |
+| `bernstein benchmark` | Full | Benchmark suite |
+| `bernstein eval` | Brief | Evaluation harness |
+| `bernstein ideate` | Brief | Creative evolution |
+| `bernstein workspace` | Full | Multi-repo workspace |
+| `bernstein config` | Brief | Configuration management |
+| `bernstein quarantine` | Brief | Cross-run task quarantine |
+| `bernstein cache` | Brief | Response cache management |
+| `bernstein test-adapter` | Brief | Adapter smoke test |
+| `bernstein add-task` | Brief | Inject task via CLI |
+| `bernstein cancel` | Brief | Cancel task |
+| `bernstein review/approve/reject/pending` | Brief | Review workflow |
+| `bernstein sync` | Brief | Sync backlog with server |
+| `bernstein manifest` | Brief | Run manifest inspection |
+| `bernstein gateway` | Brief | MCP gateway proxy |
+| `bernstein workflow` | Brief | Workflow DSL |
+| `bernstein watch` | Brief | Directory file watcher |
+| `bernstein listen` | Brief | Voice commands (experimental) |
+| `bernstein completions` | Brief | Shell completion scripts |
+| `bernstein self-update` | Brief | Upgrade from PyPI |
+| `bernstein plugins` | Brief | List active plugins |
+| `bernstein install-hooks` | Brief | Install git hooks |
+| `bernstein debug` | Brief | Generate debug bundle for triage |
+| `bernstein acp serve` | Full | ACP bridge (`--stdio` or `--http :PORT`) |
+| `bernstein autofix ...` | Brief | CI autofix daemon (start/stop/status/attach) |
+| `bernstein connect` | Brief | Credential vault setup for a provider |
+| `bernstein creds ...` | Brief | Credential management (list/revoke/test) |
+| `bernstein preview ...` | Brief | Dev server preview (start/stop/list/status) |
+| `bernstein fleet` | Brief | Fleet dashboard (optionally `--web HOST:PORT`) |
+| `bernstein mcp catalog ...` | Brief | MCP catalog browser (browse/search/install) |
+| `bernstein notify test` | Brief | Notification sink smoke test |
+| `bernstein plan ls/show` | Brief | List and inspect archived plans |
+| `bernstein review-responder ...` | Brief | PR review responder (start/status/tick) |
+| `bernstein review --pipeline` | Brief | Review with YAML pipeline DSL |
 
 ---
 
 ## Cloud / Cloudflare
 
-| Capability | Runtime status | Docs status | Notes |
-|---|---|---|---|
-| Workers RuntimeBridge | Shipped | Full | `bridges/cloudflare.py` — agents on Workers + Durable Objects |
-| Workflow Bridge (durable execution) | Shipped | Full | `bridges/cloudflare_workflow.py` — auto-retry, approval gates |
-| Sandbox Bridge (V8/container isolation) | Shipped | Full | `bridges/cloudflare_sandbox.py` — isolated code execution |
-| Browser Rendering Bridge | Shipped | Full | `bridges/browser_rendering.py` — screenshots, scraping, PDFs |
-| R2 Workspace Sync | Shipped | Full | `bridges/r2_sync.py` — content-addressed delta sync |
-| Workers AI Provider (free LLMs) | Shipped | Full | `core/routing/cloudflare_ai.py` — Llama, Mistral, Gemma, Qwen |
-| D1 Analytics & Billing | Shipped | Full | `core/cost/d1_analytics.py` — usage metering, billing tiers |
-| Vectorize Semantic Cache | Shipped | Full | `core/memory/vectorize_cache.py` — embedding-based response cache |
-| MCP Remote Transport | Shipped | Full | `mcp/remote_transport.py` — streamable HTTP for remote MCP |
-| Cloud CLI (`bernstein cloud`) | Shipped | Full | `cli/commands/cloud_cmd.py` — login, run, status, cost, deploy |
-| Cloudflare Agents Adapter | Shipped | Full | `adapters/cloudflare_agents.py` — wrangler dev integration |
-| Codex-on-Cloudflare Adapter | Shipped | Full | `adapters/codex_cloudflare.py` — Codex in CF sandboxes |
-
----
-
-## Highest-priority doc gaps
-
-1. Deep examples for retry/escalation and fallback behavior.
-2. Explicit observability guide for Prometheus + OTLP deployment patterns.
-3. End-to-end docs for trigger rule authoring and source configuration.
-4. Clear operator runbooks for audit/verification command families.
-5. User-facing docs for recently shipped TUI/UX features (output styles, diff folding, session tags, away summary, contextual tips).
+| Capability | Docs status | Notes |
+|---|---|---|
+| Workers RuntimeBridge | Full | `bridges/cloudflare.py` — agents on Workers + Durable Objects |
+| Workflow Bridge (durable execution) | Full | `bridges/cloudflare_workflow.py` — auto-retry, approval gates |
+| Sandbox Bridge (V8/container isolation) | Full | `bridges/cloudflare_sandbox.py` — isolated code execution |
+| Browser Rendering Bridge | Full | `bridges/browser_rendering.py` — screenshots, scraping, PDFs |
+| R2 Workspace Sync | Full | `bridges/r2_sync.py` — content-addressed delta sync |
+| Workers AI Provider (free LLMs) | Full | `core/routing/cloudflare_ai.py` — Llama, Mistral, Gemma, Qwen |
+| D1 Analytics & Billing | Full | `core/cost/d1_analytics.py` — usage metering, billing tiers |
+| MCP Remote Transport | Full | `mcp/remote_transport.py` — streamable HTTP for remote MCP |
+| Cloud CLI (`bernstein cloud`) | Full | `cli/commands/cloud_cmd.py` — login, run, status, cost, deploy |
+| Cloudflare Agents Adapter | Full | `adapters/cloudflare_agents.py` — wrangler dev integration |
+| Codex-on-Cloudflare Adapter | Full | `adapters/codex_cloudflare.py` — Codex in CF sandboxes |

--- a/docs/reference/KNOWN_LIMITATIONS.md
+++ b/docs/reference/KNOWN_LIMITATIONS.md
@@ -4,11 +4,11 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ---
 
-## 1) Process and adapter parity is not perfect
+## 1) Adapter parity is not perfect
 
 **What:** Bernstein ships 43 CLI adapters, but different CLI agents expose different capabilities and process semantics.
 
-**Impact:** Stop/restart behavior, output shape, structured output support, and error handling can vary by adapter. The conformance harness (`adapters/conformance.py`) helps catch regressions, but not all adapters have full golden-transcript coverage.
+**Impact:** Stop/restart behavior, output shape, structured output support, and error handling can vary by adapter. The conformance harness (`adapters/conformance.py`) helps catch regressions across adapters.
 
 **Workaround:**
 - Run `bernstein doctor` before long runs.
@@ -18,7 +18,7 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ---
 
-## 2) Multi-node execution is still a careful/advanced path
+## 2) Multi-node execution is an advanced path
 
 **What:** Bernstein has worker/cluster primitives and container execution support, but default operation remains single-host orchestration.
 
@@ -58,9 +58,9 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ## 5) Verification quality depends on project quality
 
-**What:** Bernstein’s gates and janitor checks can only validate what your project exposes (tests, linters, static checks, completion signals).
+**What:** Bernstein's gates and janitor checks can only validate what your project exposes (tests, linters, static checks, completion signals).
 
-**Impact:** Weak test suites reduce confidence in “done” outcomes.
+**Impact:** Weak test suites reduce confidence in "done" outcomes.
 
 **Workaround:**
 - Maintain strong tests and static checks.
@@ -83,11 +83,9 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ---
 
-## 7) Documentation and fast-moving features can drift
+## 7) Documentation lag
 
 **What:** Bernstein evolves quickly; some docs may lag short-term behind newly shipped features.
-
-**Impact:** Teams can accidentally treat shipped features as roadmap items (or vice versa).
 
 **Workaround:**
 - Cross-check CLI (`bernstein --help`) and API routes when implementing automation.
@@ -96,24 +94,7 @@ Bernstein ships a lot of functionality, but several constraints still matter in 
 
 ---
 
-## 8) Several shipped subsystems are off by default or undocumented
-
-**What:** Recent surface-area additions ship working but are not surfaced in the default UX:
-
-- `cross_model_verifier` (`core/quality/cross_model_verifier.py`) — currently disabled by default; opt-in via config.
-- `warm_pool` (`core/agents/warm_pool.py`) — pre-spawn pool cutting agent latency; tuning surface is internal.
-- `cas_store` (`core/persistence/cas_store.py`) — content-addressed artifact dedup; reachable through persistence APIs only.
-- `behavior_anomaly` (`core/observability/behavior_anomaly.py`) — statistical agent anomaly detection; alerts not yet wired into the default notifier set.
-- `adaptive_parallelism` (`core/orchestration/adaptive_parallelism.py`) — dynamic `max_agents` tuning is enabled but observability is minimal.
-- Hidden task subcommands (`bernstein task compose / sync / notes / parts`) — not surfaced in CLI `--help`; reachable only by reading `cli/commands/task_cmd.py`.
-
-**Impact:** Capabilities exist but new users won't discover them; ops teams should treat them as opt-in until docs catch up.
-
-**Workaround:** Read the cited source modules; flip relevant config flags; track issues in CHANGELOG for surfaced rollouts.
-
----
-
-## 9) Protocol negotiation is best-effort
+## 8) Protocol negotiation is best-effort
 
 **What:** Protocol negotiation (`protocol_negotiation.py`) detects version compatibility at connection time, but not all agents support all protocol versions.
 

--- a/docs/reference/acp-bridge.md
+++ b/docs/reference/acp-bridge.md
@@ -83,10 +83,9 @@ byte-identical (modulo timestamp + chain HMAC) to the entry the CLI
 surface emits for the same operation. See
 `tests/integration/acp/test_audit_parity.py` for the parity guard.
 
-## Out of scope (v1.9)
+## Out of scope
 
 - Windows named-pipe transport — POSIX stdio + HTTP only.
-- Bidirectional file-edit primitives that are not in the ratified ACP
-  spec — those track in a follow-up.
+- File-edit primitives that are not in the ratified ACP spec.
 - ACP authentication beyond loopback — remote HTTP usage rides the
   existing tunnel wrapper.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1132,5 +1132,5 @@ To invoke any of them, just type the full path (`bernstein task compose ...`) �
 - [`cli/replay.md`](cli/replay.md) — `replay` + `replay-filter` reference.
 - [`reference/mcp-catalog.md`](mcp-catalog.md) — MCP catalog walkthrough.
 - [`reference/openapi-reference.md`](openapi-reference.md) — REST + WebSocket + ACP/A2A endpoints.
-- [`reference/FEATURE_MATRIX.md`](FEATURE_MATRIX.md) — capability matrix vs other tools.
+- [`reference/FEATURE_MATRIX.md`](FEATURE_MATRIX.md) — capability matrix.
 - [`operations/CONFIG.md`](../operations/CONFIG.md) — every config key Bernstein recognises.

--- a/docs/reference/competitive-matrix.md
+++ b/docs/reference/competitive-matrix.md
@@ -1,6 +1,6 @@
-# Competitive Feature Matrix
+# Feature Comparison
 
-How Bernstein compares to other multi-agent frameworks, as of April 2026.
+How Bernstein's feature set lines up against other multi-agent frameworks, as of April 2026.
 
 ## Feature comparison
 
@@ -20,24 +20,18 @@ How Bernstein compares to other multi-agent frameworks, as of April 2026.
 | **Ecosystem / integrations** | Adapters for major CLI agents; MCP server registry | LangChain ecosystem, many tool integrations | Microsoft ecosystem, Azure integration | Full LangChain/LangSmith ecosystem | OpenAI platform (tools, retrieval, code interpreter) | Google Cloud, Vertex AI, A2A protocol |
 | **Open source license** | Apache 2.0 | Apache 2.0 | Apache 2.0 (with CC-BY-SA docs) | MIT | MIT | Apache 2.0 |
 
-## Where Bernstein is different
+## Bernstein's design choices
 
-**CLI-native, not API-native.** Most frameworks require you to build agents in Python using their SDK. Bernstein wraps CLI tools you already have installed. If you can run `claude`, `codex`, `gemini`, `kiro`, or `opencode` in your terminal, Bernstein can orchestrate it. No new abstractions to learn, no vendor SDK to import.
+**CLI-native, not API-native.** Bernstein wraps CLI tools you already have installed. If you can run `claude`, `codex`, `gemini`, `kiro`, or `opencode` in your terminal, Bernstein can orchestrate it.
 
-**No LLM tokens wasted on coordination.** The orchestrator is deterministic Python code. Task assignment, scheduling, health checks, and retries are all regular control flow. LLM calls happen only inside the agents doing actual work. This is a deliberate architectural choice — LLM-based schedulers are expensive, non-deterministic, and hard to debug.
+**Deterministic orchestrator.** The orchestrator is regular Python code. Task assignment, scheduling, health checks, and retries are all standard control flow. LLM calls happen only inside the agents doing actual work.
 
-**Agents are disposable.** Each agent spawns fresh, works in an isolated git worktree, and exits. No context window drift across tasks. No accumulated hallucinations. The janitor independently verifies each result (tests pass, files exist, no regressions) before merging. Response-cache reuse is also verification-gated, so cached completions cannot bypass that safety bar.
+**Disposable agents.** Each agent spawns fresh, works in an isolated git worktree, and exits. The janitor verifies each result (tests pass, files exist, no regressions) before merging. Response-cache reuse is verification-gated, so cached completions cannot bypass that safety bar.
 
-**Cost optimization is learned, not configured.** The epsilon-greedy bandit tracks which model gives the best success-rate-to-cost ratio for each task type. It starts by exploring, then converges on the cheapest model that still meets quality thresholds. Model cascade (cheap to expensive) handles failures automatically.
+**Learned cost optimization.** The epsilon-greedy bandit tracks which model gives the best success-rate-to-cost ratio for each task type. It starts by exploring, then converges on the cheapest model that still meets quality thresholds. Model cascade (cheap to expensive) handles failures automatically.
 
-**Self-evolution is built in.** Running `bernstein --evolve` analyzes metrics from past runs, identifies improvement opportunities, and generates upgrade proposals. The system can improve its own prompts, routing logic, and templates over time.
+**Self-evolution.** Running `bernstein --evolve` analyzes metrics from past runs, identifies improvement opportunities, and generates upgrade proposals.
 
-## Where competitors are stronger
+## Different design goals
 
-**Multi-turn agent conversations.** AutoGen and CrewAI are purpose-built for agents that discuss problems back and forth. Bernstein's short-lived agent model is intentionally simpler but cannot replicate multi-party brainstorming or negotiation patterns.
-
-**Ecosystem breadth.** LangGraph inherits the full LangChain ecosystem — hundreds of tool integrations, document loaders, vector stores. Google ADK connects natively to Google Cloud services and supports the A2A (Agent-to-Agent) protocol. If you need deep integration with a specific platform, these frameworks have a head start.
-
-**Visual development.** AutoGen Studio and LangGraph Studio offer visual workflow builders for designing and debugging agent pipelines. Bernstein is CLI-first with no GUI.
-
-**Permissive licensing.** All frameworks in this comparison, including Bernstein, use permissive open source licenses (Apache 2.0 or MIT).
+The matrix above compares features, not fitness for purpose. Bernstein is purpose-built for multi-agent software development orchestration — multiple CLI coding agents working in parallel git worktrees on a codebase. Frameworks aimed at multi-turn agent conversations (AutoGen, CrewAI), graph-based stateful LLM apps (LangGraph), or platform-specific deployments (OpenAI Agents SDK, Google ADK) optimise for different workloads.

--- a/docs/sandbox/blaxel.md
+++ b/docs/sandbox/blaxel.md
@@ -47,7 +47,7 @@ sandbox:
   combined `stdout`/`stderr` of the command after the process exits,
   rather than streaming over WebSockets. Long-running interactive
   workloads that need tail-style log streaming should use the
-  `worktree` or `docker` backends until Blaxel ships streaming exec.
+  `worktree` or `docker` backends.
 - **Snapshots not supported.** Provider does not expose
   snapshot/resume; persistent state lives in the workspace volume
   attached to the sandbox.

--- a/docs/sandbox/daytona.md
+++ b/docs/sandbox/daytona.md
@@ -41,9 +41,8 @@ sandbox:
 
 - **Stdin not supported on the REST exec endpoint.** Passing `stdin=`
   raises `NotImplementedError`. For interactive workloads use the
-  Daytona WebSocket exec channel directly; routing it through the
-  Bernstein protocol is tracked as a follow-up because
-  `SandboxSession.exec` is currently unary-response.
+  Daytona WebSocket exec channel directly; the Bernstein
+  `SandboxSession.exec` contract is unary-response.
 - **No exec streaming.** The endpoint returns the buffered
   `stdout`/`stderr` after the command exits.
 

--- a/docs/sandbox/runloop.md
+++ b/docs/sandbox/runloop.md
@@ -38,8 +38,8 @@ sandbox:
 - **Synchronous exec only.** This backend uses
   `POST /devboxes/{id}/execute_sync` which buffers stdout/stderr until
   the command exits. Long-running interactive workloads should use
-  Runloop's WebSocket exec channel — routing it through the unary
-  `SandboxSession.exec` contract is tracked as a follow-up.
+  Runloop's WebSocket exec channel directly; Bernstein's
+  `SandboxSession.exec` contract is unary-response.
 - **No stdin injection.** Passing `stdin=` raises
   `NotImplementedError`.
 

--- a/docs/sandbox/vercel.md
+++ b/docs/sandbox/vercel.md
@@ -39,8 +39,7 @@ sandbox:
 - **No exec streaming on the synchronous endpoint.** The Vercel
   Sandbox HTTP API returns the buffered `stdout`/`stderr` after the
   command exits. For interactive workloads (tail-style log
-  streaming), use the `worktree` or `docker` backends until Vercel's
-  WebSocket exec channel ships GA.
+  streaming), use the `worktree` or `docker` backends.
 - **No stdin on the sync exec route.** Passing `stdin=` raises
   `NotImplementedError`.
 - **Snapshots not supported.** Persist state via Vercel-managed


### PR DESCRIPTION
Editorial pass on operator-facing pages — drops stale phasing language, tightens scope statements, refreshes adapter coverage.