### PR TITLE
chore: copy refresh in root markdown + config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,8 @@ version: "3.9"
 #   bernstein-worker      — claims and executes tasks (scale with --scale)
 #   prometheus            — scrapes /metrics from bernstein-server (port 9090)
 #   grafana               — pre-built agent dashboards (port 3000, admin/admin)
-#   postgres              — shared relational state (future: persistent task store)
-#   redis                 — distributed locks + bulletin board (future)
+#   postgres              — shared relational state for the task store
+#   redis                 — distributed locks and bulletin board
 #
 # Usage:
 #   docker compose up -d
@@ -39,7 +39,7 @@ x-bernstein-common: &bernstein-common
     GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
     OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
     TAVILY_API_KEY: ${TAVILY_API_KEY:-}
-    # Future: database / cache URLs
+    # Database / cache URLs
     BERNSTEIN_DATABASE_URL: postgresql://bernstein:bernstein@postgres:5432/bernstein  # NOSONAR — development-only default, not used in production
     BERNSTEIN_REDIS_URL: redis://redis:6379/0
   volumes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,8 @@ dependencies = [
     "signxml>=4.0",
     # Hardened XML parser. Used in src/bernstein/core/security/auth.py to
     # parse SAML assertions without expanding internal entities. Mitigates
-    # billion-laughs / quadratic-blowup DoS on unauthenticated IdP responses
-    # (audit-054). defusedxml.ElementTree is a drop-in for xml.etree.ElementTree.
+    # billion-laughs / quadratic-blowup DoS on unauthenticated IdP responses.
+    # defusedxml.ElementTree is a drop-in for xml.etree.ElementTree.
     "defusedxml>=0.7.1",
     # OS-keychain transport for the credential vault (release 1.9). Pulls in
     # macOS Keychain / Linux Secret Service / Windows Credential Manager
@@ -85,9 +85,9 @@ dependencies = [
     # pipeline does not silently degrade if a transitive owner drops it.
     "jsonschema>=4.17",
     # RFC 3161 TimeStampToken ASN.1 parsing for the multi-tenant audit
-    # export verifier (resrch-005 v2). Pure-Python, MIT-licensed, ~250KB
-    # wheel; ships the ``tsp.TSTInfo`` / ``cms.ContentInfo`` types we need
-    # without us hand-rolling a DER parser. Used exclusively by
+    # export verifier. Pure-Python, MIT-licensed, ~250KB wheel; ships the
+    # ``tsp.TSTInfo`` / ``cms.ContentInfo`` types we need without us
+    # hand-rolling a DER parser. Used exclusively by
     # ``bernstein.core.security.rfc3161_verifier``.
     "asn1crypto>=1.5",
 ]
@@ -244,15 +244,14 @@ packages = ["src/bernstein"]
 [tool.hatch.build.targets.wheel.force-include]
 "templates/prompts" = "bernstein/_default_templates/prompts"
 "templates/bernstein.yaml" = "bernstein/_default_templates/bernstein.yaml"
-# Progressive-disclosure skill packs (oai-004) — shipped alongside the wheel
-# so installed packages get the index without requiring a checkout of
+# Progressive-disclosure skill packs — shipped alongside the wheel so
+# installed packages get the index without requiring a checkout of
 # templates/.
 "templates/skills" = "bernstein/_default_templates/skills"
 "templates/roles" = "bernstein/_default_templates/roles"
-# Review pipeline DSL (release_1.9_review_pipeline_dsl) — built-in stage
-# templates and the default 3-phase pipeline. Loaded by
-# bernstein.core.quality.review_pipeline at runtime when users omit a
-# pipeline path.
+# Review pipeline DSL — built-in stage templates and the default 3-phase
+# pipeline. Loaded by bernstein.core.quality.review_pipeline at runtime
+# when users omit a pipeline path.
 "templates/review" = "bernstein/_default_templates/review"
 # Lethal-trifecta capability matrix declarations.  Bundled so the
 # default-deny check can find tags right after pip install.


### PR DESCRIPTION
Editorial pass on root markdown + dotfile config. Drops stale framing, harmonises naming.