### PR TITLE
chore: copy refresh in src/ docstrings + comments

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -165,7 +165,7 @@ alwaysApply: false
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/.goosehints
+++ b/.goosehints
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -166,7 +166,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
 | `plan/`                 | plan sub-package |
-| `scaffold/`             | Bernstein scaffold subsystem (KF-8 slice) |
+| `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |
 
 ### `src/bernstein/evolution/` — self-evolution engine

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -356,7 +356,7 @@ class CLIAdapter(ABC):
         Sends SIGTERM first, polls for exit for a short grace period, then
         escalates to SIGKILL if the group is still alive.  Without this
         escalation, agents that trap SIGTERM survive reap paths (wall-clock
-        timeout and stale heartbeat) — see audit-011.
+        timeout and stale heartbeat) — see prior audit.
         """
         kill_process_group_graceful(pid)
 

--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -179,7 +179,7 @@ class CachingAdapter(CLIAdapter):
         # Forward ALL kwargs from the base CLIAdapter.spawn interface explicitly
         # so that type checkers catch future drift — missing budget_multiplier
         # or system_addendum silently broke retry budgets and role-scoped
-        # system prompts (audit-129).
+        # system prompts.
         return self._inner.spawn(
             prompt=prompt,
             workdir=workdir,

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -623,7 +623,7 @@ class ClaudeCodeAdapter(CLIAdapter):
         # ``kill_process_group_graceful`` sends SIGTERM, polls briefly, and
         # escalates to SIGKILL if the group is still alive.  Without the
         # escalation, agents that trap SIGTERM survive reap paths — see
-        #.
+        # .
         kill_process_group_graceful(pid)
         # Also kill the wrapper process with the same TERM→KILL escalation
         wrapper_pid = self._wrapper_pids.pop(pid, None)

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -2,8 +2,7 @@
 
 The heavy-lifting helpers for MCP config merging, cache-control block
 construction, and the inline wrapper-script source live in three sibling
-modules extracted by audit-142:
-
+modules extracted by
 * :mod:`bernstein.adapters.claude_mcp_loader` — ``load_mcp_config`` / ``_resolve_env_vars``
 * :mod:`bernstein.adapters.claude_cache_control` — ``build_cacheable_system_blocks``
 * :mod:`bernstein.adapters.claude_wrapper_script` — ``build_wrapper_script``
@@ -29,7 +28,7 @@ from typing import Any, ClassVar, cast
 from bernstein.adapters.base import DEFAULT_TIMEOUT_SECONDS, CLIAdapter, SpawnResult, build_worker_cmd
 from bernstein.adapters.claude_agents import build_agents_json
 
-# Re-export helpers that were inlined here before audit-142 split them
+# Re-export helpers that were inlined here before split them
 # into sibling modules.  Callers and tests import these names directly
 # from ``bernstein.adapters.claude`` so the re-exports MUST stay.  The
 # explicit ``as`` aliases tell Pyright these are intentional re-exports
@@ -186,7 +185,7 @@ class ClaudeCodeAdapter(CLIAdapter):
     # Scope → base budget mapping.  Opus tasks get a 2x multiplier because
     # opus input/output tokens cost roughly twice as much as sonnet.
     # Widened to ``Mapping`` because ``defaults.COST`` returns a
-    # ``MappingProxyType`` view (audit-155).
+    # ``MappingProxyType`` view.
     _SCOPE_BUDGET_USD: ClassVar[Mapping[str, float]] = COST.scope_budget_usd
 
     # Scope multipliers: large tasks get proportionally more turns so they
@@ -325,7 +324,7 @@ class ClaudeCodeAdapter(CLIAdapter):
         :mod:`bernstein.adapters.claude_wrapper_script`.  Kept as a
         ``@staticmethod`` on the adapter so tests and external callers
         that reference ``ClaudeCodeAdapter._wrapper_script`` continue
-        to work unchanged after the audit-142 extraction.
+        to work unchanged after the extraction.
 
         Args:
             session_id: Agent session ID, accepted for API parity.
@@ -624,7 +623,7 @@ class ClaudeCodeAdapter(CLIAdapter):
         # ``kill_process_group_graceful`` sends SIGTERM, polls briefly, and
         # escalates to SIGKILL if the group is still alive.  Without the
         # escalation, agents that trap SIGTERM survive reap paths — see
-        # audit-011.
+        #.
         kill_process_group_graceful(pid)
         # Also kill the wrapper process with the same TERM→KILL escalation
         wrapper_pid = self._wrapper_pids.pop(pid, None)

--- a/src/bernstein/adapters/claude_cache_control.py
+++ b/src/bernstein/adapters/claude_cache_control.py
@@ -1,6 +1,6 @@
 """Anthropic API cache-control block builder for the Claude Code adapter.
 
-Extracted from :mod:`bernstein.adapters.claude` in audit-142.  The builder
+Extracted from :mod:`bernstein.adapters.claude` in. The builder
 is a pure function and has no side effects, so moving it out keeps the
 adapter shell focused on spawn orchestration.  The public entry point
 :func:`build_cacheable_system_blocks` is re-exported from ``claude`` for

--- a/src/bernstein/adapters/claude_mcp_loader.py
+++ b/src/bernstein/adapters/claude_mcp_loader.py
@@ -1,6 +1,6 @@
 """MCP config loading and merging for the Claude Code adapter.
 
-Extracted from :mod:`bernstein.adapters.claude` in audit-142.  Keeps the
+Extracted from :mod:`bernstein.adapters.claude` in. Keeps the
 loader and env-var resolver in a focused module so the adapter shell stays
 readable.  The public entry points :func:`load_mcp_config` and
 :func:`_resolve_env_vars` are re-exported from ``claude`` for backwards

--- a/src/bernstein/adapters/claude_stream_parser.py
+++ b/src/bernstein/adapters/claude_stream_parser.py
@@ -42,7 +42,7 @@ _EVENT_SYSTEM = "system"
 _CAST_DICT_STR_ANY = "dict[str, Any]"
 
 # Maximum number of text blocks retained for deduplication.  Bounded LRU
-# prevents unbounded growth in long-running sessions (audit-143).
+# prevents unbounded growth in long-running sessions.
 _SEEN_TEXT_MAX: int = 10_000
 
 
@@ -120,7 +120,7 @@ class ClaudeStreamParser:
 
     def __init__(self) -> None:
         self.state = StreamParserState()
-        # Bounded LRU of recently-seen text blocks (audit-143).  OrderedDict
+        # Bounded LRU of recently-seen text blocks. OrderedDict
         # gives O(1) membership test, O(1) move-to-end on hit, and O(1)
         # FIFO eviction via popitem(last=False).
         self._seen_text: OrderedDict[str, None] = OrderedDict()

--- a/src/bernstein/adapters/claude_wrapper_script.py
+++ b/src/bernstein/adapters/claude_wrapper_script.py
@@ -1,6 +1,6 @@
 """Inline wrapper script source + assembly for the Claude Code adapter.
 
-Extracted from :mod:`bernstein.adapters.claude` in audit-142.  The wrapper
+Extracted from :mod:`bernstein.adapters.claude` in. The wrapper
 script is a short Python program that reads Claude Code's stream-json
 NDJSON output, prints human-readable text to the adapter's log file,
 records token usage to a sidecar, touches a heartbeat file on every
@@ -10,7 +10,7 @@ event.  Keeping it in its own module leaves the adapter shell free of
 
 The public entry point :func:`build_wrapper_script` preserves the exact
 behaviour of the original ``ClaudeCodeAdapter._wrapper_script`` staticmethod
-so golden-replay tests from audit-141 pass unchanged.
+so golden-replay tests from pass unchanged.
 """
 
 from __future__ import annotations

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -151,7 +151,7 @@ def build_filtered_env(
     When ``agent_id`` is provided, ``extra_keys`` is further filtered
     through the :class:`~bernstein.core.credential_scoping.AgentCredentialPolicy`
     so each agent only inherits the credential env vars it is
-    authorised to see (audit-051).  If no ``credential_policy`` is
+    authorised to see. If no ``credential_policy`` is
     supplied the module-level default is consulted.
 
     Args:

--- a/src/bernstein/adapters/goose.py
+++ b/src/bernstein/adapters/goose.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Model mapping: Bernstein logical names → Goose model IDs
-# Updated 2026-04-17 (audit-140) — keep Opus alias in sync with claude.py canonical ID.
+# Updated 2026-04-17 — keep Opus alias in sync with claude.py canonical ID.
 _MODEL_MAP: dict[str, str] = {
     "opus": "claude-opus-4-7",
     "opus-4-6": "claude-opus-4-6",  # pinned fallback

--- a/src/bernstein/cli/dashboard_polling.py
+++ b/src/bernstein/cli/dashboard_polling.py
@@ -272,7 +272,7 @@ _RETRY_PATTERNS = (
 def _task_retry_count(task: dict[str, Any]) -> int:
     """Return the retry count for a task dict from the API.
 
-    audit-017: prefer the typed ``retry_count`` field (single source of
+    prefer the typed ``retry_count`` field (single source of
     truth).  Fall back to scanning legacy ``[RETRY N]`` / ``[retry:N]``
     markers in the title or description when the typed field is missing
     or zero, so historical tasks still render a correct counter in the

--- a/src/bernstein/core/__init__.py
+++ b/src/bernstein/core/__init__.py
@@ -49,7 +49,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "agent_trust": "bernstein.core.agents.agent_trust",
     "agent_turn_state": "bernstein.core.agents.agent_turn_state",
     "agent_utilization": "bernstein.core.agents.agent_utilization",
-    # alert_rules: removed in audit-170 — dead code, no production importers.
+    # alert_rules: removed — dead code, no production importers.
     "always_allow": "bernstein.core.security.always_allow",
     "api_compat": "bernstein.core.server.api_compat",
     "api_compat_checker": "bernstein.core.server.api_compat_checker",
@@ -59,7 +59,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "apm_integration": "bernstein.core.observability.apm_integration",
     "approval": "bernstein.core.security.approval",
     "arch_conformance": "bernstein.core.quality.arch_conformance",
-    # audit-177: new primary name for the AST-derived symbol graph.
+    # new primary name for the AST-derived symbol graph.
     "ast_symbol_graph": "bernstein.core.knowledge.ast_symbol_graph",
     "audit": "bernstein.core.security.audit",
     "audit_export": "bernstein.core.security.audit_export",
@@ -73,9 +73,9 @@ _REDIRECT_MAP: dict[str, str] = {
     "backlog_parser": "bernstein.core.tasks.backlog_parser",
     "bandit_router": "bernstein.core.routing.bandit_router",
     "batch_api": "bernstein.core.tasks.batch_api",
-    # batch_mode: removed in audit-026 — dead code, no production importers.
+    # batch_mode: removed — dead code, no production importers.
     "batch_router": "bernstein.core.tasks.batch_router",
-    # batch_transitions: removed in audit-026 — dead code, no production importers.
+    # batch_transitions: removed — dead code, no production importers.
     "behavior_anomaly": "bernstein.core.observability.behavior_anomaly",
     "benchmark_gate": "bernstein.core.quality.benchmark_gate",
     "blocking_hooks": "bernstein.core.security.blocking_hooks",
@@ -159,13 +159,13 @@ _REDIRECT_MAP: dict[str, str] = {
     "cross_agent_consistency": "bernstein.core.agents.cross_agent_consistency",
     "cross_model_verifier": "bernstein.core.quality.cross_model_verifier",
     "custom_metrics": "bernstein.core.observability.custom_metrics",
-    # cycle_detector: removed in audit-192 — dead code, no production importers.
+    # cycle_detector: removed — dead code, no production importers.
     "dashboard_auth": "bernstein.core.server.dashboard_auth",
     "data_residency": "bernstein.core.security.data_residency",
     "datadog_export": "bernstein.core.observability.datadog_export",
     "dead_code_detector": "bernstein.core.quality.dead_code_detector",
     "dead_letter_queue": "bernstein.core.tasks.dead_letter_queue",
-    # degraded_mode: removed in audit-170 — dead code, no production importers.
+    # degraded_mode: removed — dead code, no production importers.
     "denial_tracker": "bernstein.core.security.denial_tracker",
     "dep_impact": "bernstein.core.quality.dep_impact",
     "dep_validator": "bernstein.core.quality.dep_validator",
@@ -176,17 +176,17 @@ _REDIRECT_MAP: dict[str, str] = {
     "disaster_recovery": "bernstein.core.persistence.disaster_recovery",
     "dlp_scanner": "bernstein.core.security.dlp_scanner",
     "dlp_scanner_v2": "bernstein.core.security.dlp_scanner_v2",
-    # doc_generator: removed in audit-169 — dead code, no production importers.
+    # doc_generator: removed — dead code, no production importers.
     "dp_telemetry": "bernstein.core.security.dp_telemetry",
     "drain": "bernstein.core.orchestration.drain",
     "drain_merge": "bernstein.core.orchestration.drain_merge",
     "dual_approval": "bernstein.core.security.dual_approval",
-    # duplicate_detector: removed in audit-192 — dead code, no production importers.
+    # duplicate_detector: removed — dead code, no production importers.
     "duration_predictor": "bernstein.core.planning.duration_predictor",
     "education_tier": "bernstein.core.cost.education_tier",
     "effectiveness": "bernstein.core.quality.effectiveness",
-    # embedding_scorer: removed in audit-169 — dead code, no production importers.
-    # error_classifier: removed in audit-170 — dead code, no production importers.
+    # embedding_scorer: removed — dead code, no production importers.
+    # error_classifier: removed — dead code, no production importers.
     "eu_ai_act": "bernstein.core.security.eu_ai_act",
     "evolution": "bernstein.core.orchestration.evolution",
     "external_policy_hook": "bernstein.core.security.external_policy_hook",
@@ -200,7 +200,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "formal_verification": "bernstein.core.quality.formal_verification",
     "frame_headers": "bernstein.core.server.frame_headers",
     "free_tier": "bernstein.core.cost.free_tier",
-    # gate_cache: removed in audit-192 — dead mixin, no production importers.
+    # gate_cache: removed — dead mixin, no production importers.
     "gate_commands": "bernstein.core.quality.gate_commands",
     "gate_pipeline": "bernstein.core.quality.gate_pipeline",
     "gate_plugins": "bernstein.core.quality.gate_plugins",
@@ -212,15 +212,15 @@ _REDIRECT_MAP: dict[str, str] = {
     "git_ops": "bernstein.core.git.git_ops",
     "git_pr": "bernstein.core.git.git_pr",
     "github": "bernstein.core.git.github",
-    # graduated_memory_guard: removed in audit-169 — dead code, no production importers.
+    # graduated_memory_guard: removed — dead code, no production importers.
     "graduation": "bernstein.core.quality.graduation",
     "grafana_dashboard": "bernstein.core.observability.grafana_dashboard",
-    # audit-177: graph.py -> task_graph.py. Shim kept for back-compat callers.
+    # graph.py -> task_graph.py. Shim kept for back-compat callers.
     "graph": "bernstein.core.knowledge.task_graph",
     "grpc_client": "bernstein.core.protocols.grpc.grpc_client",
     "grpc_server": "bernstein.core.protocols.grpc.grpc_server",
     "guardrails": "bernstein.core.security.guardrails",
-    # health_score: removed in audit-170 — dead code, no production importers.
+    # health_score: removed — dead code, no production importers.
     "heartbeat": "bernstein.core.agents.heartbeat",
     "heartbeat_escalation": "bernstein.core.agents.heartbeat_escalation",
     "hijacker": "bernstein.core.routing.hijacker",
@@ -258,7 +258,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "log_redact": "bernstein.core.observability.log_redact",
     "log_search": "bernstein.core.observability.log_search",
     "loop_detector": "bernstein.core.observability.loop_detector",
-    # mailbox: removed in audit-176 — dead code, superseded by bulletin.py +
+    # mailbox: removed — dead code, superseded by bulletin.py +
     # signals.py; no production importers.
     "manager": "bernstein.core.orchestration.manager",
     "manager_models": "bernstein.core.orchestration.manager_models",
@@ -293,7 +293,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "mcp_usage_analytics": "bernstein.core.protocols.mcp.mcp_usage_analytics",
     "mcp_verifier": "bernstein.core.protocols.mcp.mcp_verifier",
     "mcp_version_compat": "bernstein.core.protocols.mcp.mcp_version_compat",
-    # audit-191: back-compat shims for old ``bernstein.core.protocols.
+    # back-compat shims for old ``bernstein.core.protocols.
     # <mcp_*|a2a_*|cluster_*|grpc_*>`` import paths. Modules now live in
     # subpackages (protocols.mcp.mcp_foo etc.) but external plugins and
     # test files may import from the old top-level path. These dotted
@@ -332,11 +332,11 @@ _REDIRECT_MAP: dict[str, str] = {
     "protocols.mcp_usage_analytics": "bernstein.core.protocols.mcp.mcp_usage_analytics",
     "protocols.mcp_verifier": "bernstein.core.protocols.mcp.mcp_verifier",
     "protocols.mcp_version_compat": "bernstein.core.protocols.mcp.mcp_version_compat",
-    # memory_extractor: removed in audit-169 — dead code, no production importers.
+    # memory_extractor: removed — dead code, no production importers.
     "memory_guard": "bernstein.core.knowledge.memory_guard",
     "memory_integrity": "bernstein.core.knowledge.memory_integrity",
     "memory_lock_protocol": "bernstein.core.knowledge.memory_lock_protocol",
-    # memory_sanitizer: removed in audit-169 — dead code, no production importers.
+    # memory_sanitizer: removed — dead code, no production importers.
     "merge_queue": "bernstein.core.git.merge_queue",
     "merkle": "bernstein.core.persistence.merkle",
     "metric_collector": "bernstein.core.observability.metric_collector",
@@ -369,7 +369,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "orphan_tool_result": "bernstein.core.agents.orphan_tool_result",
     "outcome_pricing": "bernstein.core.cost.outcome_pricing",
     "output_fingerprint": "bernstein.core.quality.output_fingerprint",
-    # output_normalizer: removed in audit-192 — dead code, no production importers.
+    # output_normalizer: removed — dead code, no production importers.
     "permission_delegation": "bernstein.core.security.permission_delegation",
     "permission_graph": "bernstein.core.security.permission_graph",
     "permission_matrix": "bernstein.core.security.permission_matrix",
@@ -418,11 +418,11 @@ _REDIRECT_MAP: dict[str, str] = {
     "quota_probe": "bernstein.core.protocols.quota_probe",
     "rag": "bernstein.core.knowledge.rag",
     "rate_limit_tracker": "bernstein.core.observability.rate_limit_tracker",
-    # rate_limited_logger: removed in audit-170 — dead code, no production importers.
+    # rate_limited_logger: removed — dead code, no production importers.
     "rbac": "bernstein.core.security.rbac",
     "readme_reminder": "bernstein.core.quality.readme_reminder",
     "recorder": "bernstein.core.persistence.recorder",
-    # repo_index: removed in audit-169 — dead code, no production importers.
+    # repo_index: removed — dead code, no production importers.
     "request_dedup": "bernstein.core.server.request_dedup",
     "request_logging": "bernstein.core.server.request_logging",
     "researcher": "bernstein.core.knowledge.researcher",
@@ -431,7 +431,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "retry_budget": "bernstein.core.cost.planned.retry_budget",
     "review_rubric": "bernstein.core.quality.review_rubric",
     "rework_ledger": "bernstein.core.routing.rework_ledger",
-    # reviewer: removed in audit-192 — dead code, no production importers.
+    # reviewer: removed — dead code, no production importers.
     "roadmap_runtime": "bernstein.core.planning.roadmap_runtime",
     "role_classifier": "bernstein.core.routing.role_classifier",
     "rolling_restart": "bernstein.core.orchestration.rolling_restart",
@@ -454,7 +454,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "sanitize": "bernstein.core.security.sanitize",
     "sbom": "bernstein.core.security.sbom",
     "scenario_library": "bernstein.core.planning.scenario_library",
-    # scratchpad: removed in audit-176 — dead code, cross-worker state
+    # scratchpad: removed — dead code, cross-worker state
     # superseded by bulletin.py + signals.py; no production importers.
     "sdk_generator": "bernstein.core.plugins_core.sdk_generator",
     "seccomp_profiles": "bernstein.core.security.seccomp_profiles",
@@ -467,7 +467,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "seed_config": "bernstein.core.config.seed_config",
     "seed_parser": "bernstein.core.config.seed_parser",
     "semantic_cache": "bernstein.core.knowledge.semantic_cache",
-    # audit-177: semantic_graph.py -> ast_symbol_graph.py. Shim kept for back-compat.
+    # semantic_graph.py -> ast_symbol_graph.py. Shim kept for back-compat.
     "semantic_graph": "bernstein.core.knowledge.ast_symbol_graph",
     "sensitive_data": "bernstein.core.security.sensitive_data",
     "sensitive_file_detector": "bernstein.core.security.sensitive_file_detector",
@@ -477,7 +477,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "server_models": "bernstein.core.server.server_models",
     "server_supervisor": "bernstein.core.server.server_supervisor",
     "session": "bernstein.core.persistence.session",
-    # session_checkpoint: removed in audit-084 — SessionCheckpoint had zero
+    # session_checkpoint: removed — SessionCheckpoint had zero
     # production callers; CheckpointState (now aliased to
     # checkpoint.PartialState) is the operator-visible progress slice.
     "session_continuity": "bernstein.core.persistence.session_continuity",
@@ -487,7 +487,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "skill_badges": "bernstein.core.plugins_core.skill_badges",
     "skill_discovery": "bernstein.core.plugins_core.skill_discovery",
     "skill_md": "bernstein.core.plugins_core.skill_md",
-    # sla_monitor: removed in audit-170 — dead code, no production importers.
+    # sla_monitor: removed — dead code, no production importers.
     "slo": "bernstein.core.observability.slo",
     "soc2_report": "bernstein.core.security.soc2_report",
     "spawn_analyzer": "bernstein.core.agents.spawn_analyzer",
@@ -503,9 +503,9 @@ _REDIRECT_MAP: dict[str, str] = {
     "spend_forecast": "bernstein.core.cost.spend_forecast",
     "ssh_backend": "bernstein.core.protocols.ssh_backend",
     "sso_oidc": "bernstein.core.security.sso_oidc",
-    # stack_detector: removed in audit-170 — dead code, no production importers.
+    # stack_detector: removed — dead code, no production importers.
     "staggered_shutdown": "bernstein.core.orchestration.staggered_shutdown",
-    # startup_selftest: removed in audit-170 — dead code, no production importers.
+    # startup_selftest: removed — dead code, no production importers.
     "state_encryption": "bernstein.core.security.state_encryption",
     "store": "bernstein.core.persistence.store",
     "store_factory": "bernstein.core.persistence.store_factory",
@@ -513,33 +513,33 @@ _REDIRECT_MAP: dict[str, str] = {
     "store_redis": "bernstein.core.persistence.store_redis",
     "swarm_migration": "bernstein.core.tasks.swarm_migration",
     "sync": "bernstein.core.persistence.sync",
-    # synthesis: removed in audit-169 — dead code, no production importers.
+    # synthesis: removed — dead code, no production importers.
     "task_claim": "bernstein.core.tasks.task_claim",
-    # task_completion: removed in audit-018 — collect_completion_data lives in
+    # task_completion: removed — collect_completion_data lives in
     # bernstein.core.tasks.task_lifecycle; no shim is provided to keep the
     # duplicate implementation from re-appearing.
-    # task_diff_preview: removed in audit-026 — dead code, no production importers.
-    # task_event_store: removed in audit-026 — dead code, no production importers.
-    # audit-177: new primary name for the task-dependency DAG.
+    # task_diff_preview: removed — dead code, no production importers.
+    # task_event_store: removed — dead code, no production importers.
+    # new primary name for the task-dependency DAG.
     "task_graph": "bernstein.core.knowledge.task_graph",
     "task_grouping": "bernstein.core.tasks.task_grouping",
     "task_lifecycle": "bernstein.core.tasks.task_lifecycle",
     "task_retry": "bernstein.core.tasks.task_retry",
     "task_spawn_bridge": "bernstein.core.tasks.task_spawn_bridge",
     "task_splitter": "bernstein.core.tasks.task_splitter",
-    # task_status_history: removed in audit-026 — dead code, no production importers.
+    # task_status_history: removed — dead code, no production importers.
     "task_store": "bernstein.core.tasks.task_store",
     "task_store_core": "bernstein.core.tasks.task_store_core",
-    # task_tagging: removed in audit-026 — dead code, no production importers.
-    # task_templates: removed in audit-026 — dead code, no production importers.
+    # task_tagging: removed — dead code, no production importers.
+    # task_templates: removed — dead code, no production importers.
     "task_tools": "bernstein.core.tasks.task_tools",
     "team_state": "bernstein.core.persistence.team_state",
     "telemetry": "bernstein.core.observability.telemetry",
     "tenant_isolation": "bernstein.core.security.tenant_isolation",
     "tenant_rate_limiter": "bernstein.core.security.tenant_rate_limiter",
     "tenanting": "bernstein.core.security.tenanting",
-    # test_data_gen: removed in audit-192 — dead code, no production importers.
-    # test_expansion: removed in audit-192 — dead code, no production importers.
+    # test_data_gen: removed — dead code, no production importers.
+    # test_expansion: removed — dead code, no production importers.
     "test_impact": "bernstein.core.quality.test_impact",
     "tick_anomaly": "bernstein.core.orchestration.tick_anomaly",
     "tick_budget": "bernstein.core.orchestration.tick_budget",
@@ -553,13 +553,13 @@ _REDIRECT_MAP: dict[str, str] = {
     "token_estimation": "bernstein.core.tokens.token_estimation",
     "token_monitor": "bernstein.core.tokens.token_monitor",
     "token_waste_report": "bernstein.core.tokens.token_waste_report",
-    # tool_timing: removed in audit-170 — dead code, no production importers.
+    # tool_timing: removed — dead code, no production importers.
     "tool_use_context": "bernstein.core.agents.tool_use_context",
-    # trace_correlation: removed in audit-170 — dead code, no production importers.
+    # trace_correlation: removed — dead code, no production importers.
     "traces": "bernstein.core.observability.traces",
     "trigger_manager": "bernstein.core.orchestration.trigger_manager",
     "upgrade_executor": "bernstein.core.config.upgrade_executor",
-    # usage_telemetry: removed in audit-170 — dead code, no production importers.
+    # usage_telemetry: removed — dead code, no production importers.
     "vault_injector": "bernstein.core.security.vault_injector",
     "verification_nudge": "bernstein.core.quality.verification_nudge",
     "vertical_packs": "bernstein.core.plugins_core.vertical_packs",
@@ -571,7 +571,7 @@ _REDIRECT_MAP: dict[str, str] = {
     "wal_replication": "bernstein.core.persistence.wal_replication",
     "warm_pool": "bernstein.core.agents.warm_pool",
     "watchdog": "bernstein.core.observability.watchdog",
-    # web_graph: removed in audit-169 — dead code, no production importers.
+    # web_graph: removed — dead code, no production importers.
     "webhook_handler": "bernstein.core.server.webhook_handler",
     "webhook_signatures": "bernstein.core.server.webhook_signatures",
     "webhook_verify": "bernstein.core.server.webhook_verify",
@@ -592,7 +592,7 @@ class _CoreRedirectFinder(MetaPathFinder):
     """Redirect ``bernstein.core.<old_name>`` to ``bernstein.core.<subpkg>.<old_name>``.
 
     Most keys in ``_REDIRECT_MAP`` are direct children of ``bernstein.core``
-    (e.g. ``mcp_manager`` → ``protocols.mcp.mcp_manager``). audit-191 added
+    (e.g. ``mcp_manager`` → ``protocols.mcp.mcp_manager``). added
     dotted keys (``protocols.mcp_manager``) so callers that still import via
     the old ``bernstein.core.protocols.<mcp_*|a2a_*|cluster_*|grpc_*>`` paths
     after the subpackage split keep working. Dotted keys match submodule

--- a/src/bernstein/core/agents/adapter_autodetect.py
+++ b/src/bernstein/core/agents/adapter_autodetect.py
@@ -1,4 +1,4 @@
-"""Adapter auto-detection (AGENT-015).
+"""Adapter auto-detection.
 
 Scans PATH for known CLI tools and auto-registers discovered adapters
 with the adapter registry.  This allows ``bernstein run`` to work

--- a/src/bernstein/core/agents/adapter_health.py
+++ b/src/bernstein/core/agents/adapter_health.py
@@ -1,4 +1,4 @@
-"""Per-adapter health monitoring (AGENT-009).
+"""Per-adapter health monitoring.
 
 Tracks success/failure rates per adapter.  Adapters that exceed a 50%
 failure rate are automatically disabled.  They are re-enabled after a

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -577,7 +577,7 @@ def _patch_retry_with_compaction(
         logger.warning("Failed to list open tasks for compaction patch: %s", exc)
         return
 
-    # audit-017: look the retry task up by metadata.original_task_id and an
+    # look the retry task up by metadata.original_task_id and an
     # incremented retry_count.  Falls back to a title-prefix match for
     # legacy tasks whose retry clones still carry the old ``[RETRY N]``
     # prefix (no new ones are created by the orchestrator).
@@ -743,7 +743,7 @@ def _handle_failure_detection(
 def _resolve_budget_remaining_usd(orch: Any) -> float | None:
     """Return the orchestrator's current remaining budget in USD, or None.
 
-    audit-102: used to wire budget-awareness into both the cascade fallback
+    used to wire budget-awareness into both the cascade fallback
     manager and the module-level router guard.  Returns ``None`` when the
     orchestrator has no cost tracker, the budget is unlimited, or the
     lookup fails for any reason — callers must treat ``None`` as "unknown"
@@ -776,7 +776,7 @@ def _run_cascade_fallback(
     from bernstein.core.cascade import CascadeDecision, CascadeFallbackManager
     from bernstein.core.routing.router_core import set_budget_context
 
-    # audit-102: thread budget awareness into cascade + module-level router
+    # thread budget awareness into cascade + module-level router
     # guard so that a single opus task near the cap cannot overshoot by 150%+.
     _budget_remaining = _resolve_budget_remaining_usd(orch)
     _budget_flag = bool(getattr(orch._config, "budget_aware_routing_enabled", True))
@@ -1515,7 +1515,7 @@ def reap_dead_agents(
 # from the bottom of this module (see the ``from agent_recycling import ...``
 # block at EOF) so existing importers of ``bernstein.core.agent_lifecycle``
 # continue to work while the constants and algorithm have a single source
-# of truth.  This closes audit-010 — previously ``_detect_idle_reason`` and
+# of truth. This closes — previously ``_detect_idle_reason`` and
 # its four ``_IDLE_*`` thresholds existed in parallel copies that could
 # (and did) silently diverge when one was tuned and the other was not.
 #
@@ -1622,7 +1622,7 @@ def _release_task_to_session(orch: Any, task_ids: list[str]) -> None:
 # Re-exports: canonical idle-detection / recycling implementation.
 #
 # Deferred to end-of-module to avoid a circular import via
-# ``agent_recycling -> agent_reaping -> agent_lifecycle``.  See audit-010.
+# ``agent_recycling -> agent_reaping -> agent_lifecycle``. See.
 # ---------------------------------------------------------------------------
 
 from bernstein.core.agents.agent_recycling import (  # noqa: E402, F401 — re-exported for back-compat

--- a/src/bernstein/core/agents/spawn_dry_run.py
+++ b/src/bernstein/core/agents/spawn_dry_run.py
@@ -1,4 +1,4 @@
-"""Spawn dry-run mode (AGENT-017).
+"""Spawn dry-run mode.
 
 Validates adapter availability, model configuration, prompt rendering,
 worktree setup, and MCP config without actually spawning any agents.

--- a/src/bernstein/core/agents/spawn_errors.py
+++ b/src/bernstein/core/agents/spawn_errors.py
@@ -1,4 +1,4 @@
-"""Categorized spawn failure errors with retry strategy metadata (AGENT-001).
+"""Categorized spawn failure errors with retry strategy metadata.
 
 Each error type maps to a retry strategy that the spawner can use to decide
 how to recover:

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -864,7 +864,7 @@ def _render_prompt(
         named_sections.append(("lessons", f"\n{lesson_context}\n"))
     if rich_context:
         named_sections.append(("context", f"\n{rich_context}\n"))
-    # Parent context inheritance (AGENT-012): inject parent's context summary
+    # Parent context inheritance: inject parent's context summary
     parent_ctx_parts: list[str] = []
     for t in tasks:
         if t.parent_context:

--- a/src/bernstein/core/agents/spawn_rate_limiter.py
+++ b/src/bernstein/core/agents/spawn_rate_limiter.py
@@ -1,4 +1,4 @@
-"""Spawn rate limiter — prevent API throttling from too-rapid spawns (AGENT-007).
+"""Spawn rate limiter — prevent API throttling from too-rapid spawns.
 
 Limits the number of agent spawns per provider within a configurable time
 window.  Default: max 2 spawns per 10 seconds per provider.

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -676,7 +676,7 @@ def _render_prompt(
         sections.append(f"\n{rich_context}\n")
     if file_scope_context:
         sections.append(deduplicate_section(f"\n## File-scope context\n{file_scope_context}\n"))
-    # Parent context inheritance (AGENT-012): inject parent's context summary
+    # Parent context inheritance: inject parent's context summary
     # when a task was created from decomposing a larger parent task.
     parent_ctx_parts: list[str] = []
     for t in tasks:
@@ -888,7 +888,7 @@ class AgentSpawner:
         # Set by the orchestrator via :meth:`set_merge_queue` after construction.
         # When present, merges are serialised through the FIFO queue so the
         # dashboard can observe pending jobs and so merge-tree conflict checks
-        # can be inserted on the queue's boundary (audit-091 fix).
+        # can be inserted on the queue's boundary ( fix).
         self._merge_queue: Any = None
         self._traces: dict[str, AgentTrace] = {}
         self._trace_store = TraceStore(workdir / ".sdd" / "traces")
@@ -1070,7 +1070,7 @@ class AgentSpawner:
         Called after construction because the orchestrator owns the queue
         and constructs the spawner before itself.  When set, all agent
         merges enqueue through this queue instead of using the ad-hoc
-        per-repo lock dict -- fixing audit-091.
+        per-repo lock dict -- fixing.
         """
         self._merge_queue = merge_queue
 
@@ -1877,7 +1877,7 @@ class AgentSpawner:
         except Exception as _token_exc:
             logger.warning("Zero-trust token issuance failed for %s: %s", session_id, _token_exc)
 
-        # Prompt size pre-check (AGENT-003): estimate token count and reject or
+        # Prompt size pre-check: estimate token count and reject or
         # truncate before spending a worktree + adapter spawn on an oversized prompt.
         from bernstein.core.prompt_precheck import PromptAction, check_prompt_size, truncate_prompt
 
@@ -1990,7 +1990,7 @@ class AgentSpawner:
         # Write a task-specific CLAUDE.md at the worktree root so the agent
         # inherits its assigned tasks, role constraints, owned file paths,
         # and context files instead of only the generic project CLAUDE.md
-        # (audit-095).  The helper also marks the file as skip-worktree so
+        #. The helper also marks the file as skip-worktree so
         # the override never lands in merge commits.
         _task_context_files: list[str] = []
         for _t in tasks:

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1990,7 +1990,7 @@ class AgentSpawner:
         # Write a task-specific CLAUDE.md at the worktree root so the agent
         # inherits its assigned tasks, role constraints, owned file paths,
         # and context files instead of only the generic project CLAUDE.md
-        #. The helper also marks the file as skip-worktree so
+        # . The helper also marks the file as skip-worktree so
         # the override never lands in merge commits.
         _task_context_files: list[str] = []
         for _t in tasks:

--- a/src/bernstein/core/agents/spawner_merge.py
+++ b/src/bernstein/core/agents/spawner_merge.py
@@ -92,7 +92,7 @@ def _do_merge(
 
     When ``merge_queue`` is provided, the job is enqueued and processed in
     strict FIFO order under :attr:`MergeQueue.merge_lock` -- this fixes
-    audit-091 where the queue was instantiated but never fed.  The legacy
+    where the queue was instantiated but never fed. The legacy
     per-repo ``merge_locks`` path is kept as a fallback for callers (and
     tests) that don't plumb a queue through.
 

--- a/src/bernstein/core/agents/zombie_cleanup.py
+++ b/src/bernstein/core/agents/zombie_cleanup.py
@@ -1,4 +1,4 @@
-"""Zombie process cleanup on orchestrator startup (AGENT-006).
+"""Zombie process cleanup on orchestrator startup.
 
 On startup, scans ``.sdd/runtime/pids/`` for PID files from prior runs,
 checks if the recorded processes are still alive, and sends SIGTERM to

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -544,8 +544,7 @@ class BernsteinConfig(BaseModel):
                 # Auto-disable the defaulted feature so the config validates.
                 object.__setattr__(self, "auto_decompose", False)
                 logger.info(
-                    "internal_llm_provider='%s' — auto_decompose "
-                    "auto-disabled. Set an LLM provider to re-enable.",
+                    "internal_llm_provider='%s' — auto_decompose auto-disabled. Set an LLM provider to re-enable.",
                     self.internal_llm_provider,
                 )
 
@@ -558,8 +557,7 @@ class BernsteinConfig(BaseModel):
             elif self.evolution_enabled:
                 object.__setattr__(self, "evolution_enabled", False)
                 logger.info(
-                    "internal_llm_provider='%s' — evolution_enabled "
-                    "auto-disabled. Set an LLM provider to re-enable.",
+                    "internal_llm_provider='%s' — evolution_enabled auto-disabled. Set an LLM provider to re-enable.",
                     self.internal_llm_provider,
                 )
 

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -336,7 +336,7 @@ class CustomMetricSchema(BaseModel):
 
 
 class ModelFallbackSchema(BaseModel):
-    """Model fallback chain configuration (AGENT-004).
+    """Model fallback chain configuration.
 
     Controls which HTTP error types trigger a model switch and which
     fallback models to try in sequence.
@@ -458,7 +458,7 @@ class BernsteinConfig(BaseModel):
     )
 
     # --- LLM provider ---
-    # audit-150: default 'none' so a fresh clone without OPENROUTER_API_KEY_*
+    # default 'none' so a fresh clone without OPENROUTER_API_KEY_*
     # env vars no longer crashes on first auto_decompose/evolution LLM call.
     # When set to 'none', evolution_enabled and auto_decompose are auto-disabled
     # unless the user explicitly enabled them (in which case we raise so the
@@ -526,7 +526,7 @@ class BernsteinConfig(BaseModel):
                 f"budget is {budget_val} which is negative. Use 0 or '$0' for unlimited, or a positive value for a cap."
             )
 
-        # audit-150: When internal_llm_provider is 'none' (or ""), features that
+        # When internal_llm_provider is 'none' (or ""), features that
         # require an LLM must be disabled. If the user did not explicitly opt in
         # to the feature, silently disable it; if they explicitly enabled it,
         # surface a loud error so the misconfig is obvious.
@@ -544,7 +544,7 @@ class BernsteinConfig(BaseModel):
                 # Auto-disable the defaulted feature so the config validates.
                 object.__setattr__(self, "auto_decompose", False)
                 logger.info(
-                    "audit-150: internal_llm_provider='%s' — auto_decompose "
+                    "internal_llm_provider='%s' — auto_decompose "
                     "auto-disabled. Set an LLM provider to re-enable.",
                     self.internal_llm_provider,
                 )
@@ -558,19 +558,19 @@ class BernsteinConfig(BaseModel):
             elif self.evolution_enabled:
                 object.__setattr__(self, "evolution_enabled", False)
                 logger.info(
-                    "audit-150: internal_llm_provider='%s' — evolution_enabled "
+                    "internal_llm_provider='%s' — evolution_enabled "
                     "auto-disabled. Set an LLM provider to re-enable.",
                     self.internal_llm_provider,
                 )
 
         # Preflight: openrouter_free requires OPENROUTER_API_KEY_FREE or _PAID.
         # Emit a loud warning (not a hard error) so fresh clones see the hint
-        # before the first LLM call crashes. See audit-150.
+        # before the first LLM call crashes. See.
         if self.internal_llm_provider == "openrouter_free" and not (
             os.environ.get("OPENROUTER_API_KEY_FREE") or os.environ.get("OPENROUTER_API_KEY_PAID")
         ):
             logger.warning(
-                "audit-150: internal_llm_provider='openrouter_free' but neither "
+                "internal_llm_provider='openrouter_free' but neither "
                 "OPENROUTER_API_KEY_FREE nor OPENROUTER_API_KEY_PAID is set. "
                 "LLM calls will fail at runtime. Set one of those env vars, or "
                 "switch to 'internal_llm_provider: none' in bernstein.yaml to "

--- a/src/bernstein/core/config/config_watcher.py
+++ b/src/bernstein/core/config/config_watcher.py
@@ -153,9 +153,9 @@ def discover_config_paths(workdir: Path) -> list[tuple[str, Path]]:
     The returned list has six entries, one per cascade layer actually consumed
     by :func:`bernstein.core.config.config_schema.load_and_validate`: user,
     project, project_alt, local, cli_overrides, managed.  The legacy
-    ``sdd_project`` slot (``.sdd/config.yaml``) was dropped in audit-157 because
+    ``sdd_project`` slot (``.sdd/config.yaml``) was dropped in because
     no loader reads it -- the earlier ``settings_cascade`` reference was
-    removed by audit-151.
+    removed by.
 
     Args:
         workdir: Project root directory.

--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def check_internal_llm_preflight(provider: str) -> str | None:
     """Return a migration hint if ``provider`` needs env vars that are missing.
 
-    audit-150: a fresh clone with ``internal_llm_provider: openrouter_free``
+    a fresh clone with ``internal_llm_provider: openrouter_free``
     but no ``OPENROUTER_API_KEY_FREE`` / ``OPENROUTER_API_KEY_PAID`` crashes
     on the first LLM call. Callers (seed parser, orchestrator bootstrap) can
     invoke this to emit the hint early and suggest switching to ``'none'``.
@@ -199,7 +199,7 @@ class RateLimitConfig:
 
 @dataclass(frozen=True)
 class ModelFallbackSeedConfig:
-    """Model fallback chain configuration from bernstein.yaml (AGENT-004).
+    """Model fallback chain configuration from bernstein.yaml.
 
     Attributes:
         fallback_chain: Ordered list of model names to try in sequence.
@@ -317,7 +317,7 @@ class SeedConfig:
     network: NetworkConfig | None = None
     rate_limit: RateLimitConfig | None = None
     tenants: tuple[TenantConfig, ...] = ()
-    # audit-150: default 'none' disables evolution/auto_decompose gracefully
+    # default 'none' disables evolution/auto_decompose gracefully
     # on fresh clones without OPENROUTER_API_KEY_* env vars. Callers that want
     # the previous behavior must set 'internal_llm_provider: openrouter_free'
     # explicitly and export the matching API key.
@@ -337,7 +337,7 @@ class SeedConfig:
     mcp_signing_mode: Literal["warn", "strict", "off"] = "warn"
 
     def __post_init__(self) -> None:
-        """Emit preflight warnings for provider/env mismatches (audit-150)."""
+        """Emit preflight warnings for provider/env mismatches."""
         hint = check_internal_llm_preflight(self.internal_llm_provider)
         if hint is not None:
-            logger.warning("audit-150 preflight: %s", hint)
+            logger.warning(" preflight: %s", hint)

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -274,7 +274,7 @@ def _parse_network_config(raw: object) -> NetworkConfig | None:
     return NetworkConfig(allowed_ips=allowed_ips)
 
 
-# audit-118: Accepted glob origin shape — scheme and host are literal, only
+# Accepted glob origin shape — scheme and host are literal, only
 # the port may be a ``*`` wildcard (e.g. ``http://localhost:*``).  Anything
 # outside this shape is rejected with a clear error because
 # ``starlette.middleware.cors.CORSMiddleware`` compares ``allow_origins``

--- a/src/bernstein/core/cost/cost.py
+++ b/src/bernstein/core/cost/cost.py
@@ -3,7 +3,7 @@
 Provides:
 - EpsilonGreedyBandit: thin facade over ``BanditRouter`` (LinUCB) used for
   legacy callers that still speak the per-(role, model) arm API. The epsilon-
-  greedy learning logic itself was retired in audit-071; the class now
+  greedy learning logic itself was retired in ; the class now
   delegates selection, reward recording, and persistence to the canonical
   bandit so cost forecasts and model selection can never disagree.
 - ModelCascade: provides cascade config (cheapest viable → escalate on failure)
@@ -147,7 +147,7 @@ _MODEL_COST_USD_PER_1K: dict[str, float] = {
 CASCADE: list[str] = ["sonnet", "opus"]
 
 # Additional cheap, provably-adequate arms the bandit may explore once it
-# has been given priors (audit-069). Kept outside :data:`CASCADE` to preserve
+# has been given priors. Kept outside :data:`CASCADE` to preserve
 # the cheapest-first ordering used by :func:`get_cascade_model`. Callers that
 # want to let the bandit explore beyond the cascade should request
 # :func:`get_all_bandit_arms` when building the candidate list.
@@ -213,7 +213,7 @@ class BanditArm:
     @property
     def success_rate(self) -> float:
         if self.observations == 0:
-            # Pessimistic cold-start (audit-069): a never-observed arm should
+            # Pessimistic cold-start: a never-observed arm should
             # not greedily win selection just because its nominal price is
             # low. Returning 0.5 keeps it below ``QUALITY_THRESHOLD`` (0.8)
             # so new arms must earn their way in through explicit
@@ -315,7 +315,7 @@ def _migrate_legacy_bandit_state(metrics_dir: Path, routing_dir: Path) -> list[B
             except Exception as exc:
                 logger.debug("Skipping malformed legacy arm entry: %s", exc)
         logger.info(
-            "audit-071: migrated %d legacy bandit arms from %s → %s",
+            "migrated %d legacy bandit arms from %s → %s",
             len(arms),
             legacy_path,
             routing_dir,
@@ -334,7 +334,7 @@ def _migrate_legacy_bandit_state(metrics_dir: Path, routing_dir: Path) -> list[B
 class EpsilonGreedyBandit:
     """Facade over :class:`BanditRouter` for legacy per-(role, model) callers.
 
-    The epsilon-greedy learning loop was retired in audit-071 to unify model
+    The epsilon-greedy learning loop was retired in to unify model
     selection and cost forecasting on a single store. This class preserves
     the original API — ``select``, ``record``, ``seed_arm``, ``get_arm``,
     ``summary``, ``save``, ``load`` — but every mutation is now mirrored into
@@ -387,7 +387,7 @@ class EpsilonGreedyBandit:
     def load(cls, metrics_dir: Path) -> EpsilonGreedyBandit:
         """Load bandit state from disk, returning a fresh instance on error.
 
-        Also runs the audit-071 migration: if a legacy
+        Also runs the migration: if a legacy
         ``.sdd/metrics/bandit_state.json`` exists while no unified
         ``.sdd/routing/policy.json`` is present yet, its observations are
         copied into the in-memory arms and the LinUCB policy is seeded with
@@ -500,7 +500,7 @@ class EpsilonGreedyBandit:
 
         # Exploitation: pick cheapest arm that meets the quality threshold.
         #
-        # Cold-start policy (audit-069): a truly unseen arm (observations==0)
+        # Cold-start policy: a truly unseen arm (observations==0)
         # has a pessimistic ``success_rate`` of 0.5, which sits below
         # ``QUALITY_THRESHOLD``. That prevents new cheap arms (e.g. freshly
         # added ``gemini-3-flash`` / ``qwen3-coder``) from greedily winning
@@ -646,7 +646,7 @@ class EpsilonGreedyBandit:
         """Return the canonical ``BanditRouter`` for this facade, if any.
 
         Lazy-imported because ``BanditRouter`` now lives in
-        ``bernstein.core.routing`` (audit-193); delaying the import avoids
+        ``bernstein.core.routing``; delaying the import avoids
         triggering routing package initialization just to load cost tables.
         """
         if self._routing_dir is None:

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -106,13 +106,13 @@ DEFAULT_WARN_THRESHOLD: float = 0.80
 DEFAULT_CRITICAL_THRESHOLD: float = 0.95
 DEFAULT_HARD_STOP_THRESHOLD: float = 1.00
 
-# audit-056: default grace window between SHUTDOWN signals and SIGKILL
+# default grace window between SHUTDOWN signals and SIGKILL
 # once ``should_stop`` flips.  Kept here (rather than on OrchestratorConfig)
 # because the kill-switch semantics are owned by the cost tracker.
 DEFAULT_KILL_GRACE_PERIOD_S: int = 30
 
 # ---------------------------------------------------------------------------
-# Usage history buffer (audit-057)
+# Usage history buffer
 # ---------------------------------------------------------------------------
 
 # Default number of recent ``TokenUsage`` records kept in memory per tracker.
@@ -346,13 +346,13 @@ class CostTracker:
     warn_threshold: float = DEFAULT_WARN_THRESHOLD
     critical_threshold: float = DEFAULT_CRITICAL_THRESHOLD
     hard_stop_threshold: float = DEFAULT_HARD_STOP_THRESHOLD
-    # audit-056: once ``should_stop`` transitions True the orchestrator
+    # once ``should_stop`` transitions True the orchestrator
     # sends SHUTDOWN to every live agent, waits ``kill_grace_period_s``
     # for them to commit WIP, and SIGKILLs any still alive afterwards.
     # 0 disables the grace window (immediate SIGKILL — not recommended
     # outside tests).
     kill_grace_period_s: int = DEFAULT_KILL_GRACE_PERIOD_S
-    # audit-057: bound in-memory usage history. ``None`` → resolve from
+    # bound in-memory usage history. ``None`` → resolve from
     # ``BERNSTEIN_COST_USAGE_BUFFER`` env var (default 10_000). 0 disables
     # the cap (unbounded) for legacy/test use only; not recommended.
     usage_buffer_size: int | None = None
@@ -470,7 +470,7 @@ class CostTracker:
         evicted: TokenUsage | None = None
         with self._lock:
             # Ring-buffer append: capture the row that would be evicted so we
-            # can rotate it to JSONL before it falls off the end (audit-057).
+            # can rotate it to JSONL before it falls off the end.
             if self._usages.maxlen is not None and len(self._usages) >= self._usages.maxlen:
                 evicted = self._usages[0]
             self._usages.append(usage)
@@ -626,7 +626,7 @@ class CostTracker:
         """Recent token usage entries (read-only copy).
 
         Returns at most :attr:`usage_buffer_size` rows; older rows are
-        evicted to keep memory bounded (see audit-057). Per-agent and
+        evicted to keep memory bounded (see prior audit). Per-agent and
         per-model analytics remain exact via accumulators, but anyone
         iterating this list for raw per-row analysis should consult the
         JSONL rotation files under :attr:`rotation_dir` if full history is
@@ -715,7 +715,7 @@ class CostTracker:
                     tracker._spent_by_agent.get(usage.agent_id, 0.0) + usage.cost_usd
                 )
                 tracker._spent_by_model[usage.model] = tracker._spent_by_model.get(usage.model, 0.0) + usage.cost_usd
-                # audit-057: rebuild running accumulators so breakdowns survive
+                # rebuild running accumulators so breakdowns survive
                 # across reload (otherwise model_breakdowns() returns empty).
                 tracker._update_accumulators(usage)
 
@@ -753,7 +753,7 @@ class CostTracker:
         Returns:
             Multi-line markdown string.
         """
-        # audit-057: consult the running accumulator so the summary reflects
+        # consult the running accumulator so the summary reflects
         # the entire run history even after older rows are evicted from the
         # in-memory ring buffer.
         savings = max(0.0, self._opus_baseline_savings_usd)
@@ -782,7 +782,7 @@ class CostTracker:
         """Build per-agent cost summaries from the accumulators.
 
         Uses the running per-agent accumulator so that summaries stay exact
-        even after older ``_usages`` have been evicted (audit-057).
+        even after older ``_usages`` have been evicted.
 
         Returns:
             List of :class:`AgentCostSummary` sorted by total cost descending.
@@ -801,7 +801,7 @@ class CostTracker:
         """Build per-model cost breakdowns from the accumulators.
 
         Uses the running per-model accumulator so that breakdowns stay
-        exact even after older ``_usages`` have been evicted (audit-057).
+        exact even after older ``_usages`` have been evicted.
 
         Returns:
             List of :class:`ModelCostBreakdown` sorted by total cost descending.
@@ -858,7 +858,7 @@ class CostTracker:
 
         Uses the running :attr:`_cache_savings_usd` accumulator so the
         reported figure covers every usage ever recorded — not just the
-        ones currently held in the bounded in-memory buffer (audit-057).
+        ones currently held in the bounded in-memory buffer.
 
         Returns:
             Estimated savings in USD (always >= 0).
@@ -918,7 +918,7 @@ class CostTracker:
 
         Called under :attr:`_lock` so callers do not need additional
         synchronisation. The accumulators let analytics survive eviction of
-        older rows from the bounded :attr:`_usages` buffer (audit-057).
+        older rows from the bounded :attr:`_usages` buffer.
 
         Args:
             usage: The newly-recorded :class:`TokenUsage`.
@@ -985,7 +985,7 @@ class CostTracker:
         Does nothing when :attr:`rotation_dir` is unset — in that case the
         row is simply dropped (its stats are still carried in the
         accumulators). Failures are logged and swallowed so that telemetry
-        IO never blocks the orchestrator hot path (audit-057).
+        IO never blocks the orchestrator hot path.
         """
         rotation_dir = self.rotation_dir
         if rotation_dir is None:

--- a/src/bernstein/core/credential_scoping.py
+++ b/src/bernstein/core/credential_scoping.py
@@ -9,7 +9,7 @@ Provides two layers of scoping:
 
 2. **Environment credential policy** (:class:`AgentCredentialPolicy`) —
    restrict which OS-level API-key env vars an agent subprocess is allowed
-   to inherit.  This closes the audit-051 gap where every agent received
+   to inherit. This closes the gap where every agent received
    the full provider key set from ``build_filtered_env``'s ``extra_keys``.
 
 The policy is fail-closed: agents not explicitly listed receive **no**
@@ -438,7 +438,7 @@ _default_manager = CredentialScopeManager()
 
 
 # ---------------------------------------------------------------------------
-# Environment-level per-agent credential policy (audit-051)
+# Environment-level per-agent credential policy
 # ---------------------------------------------------------------------------
 
 

--- a/src/bernstein/core/defaults.py
+++ b/src/bernstein/core/defaults.py
@@ -13,7 +13,7 @@ To override at runtime (e.g., from parsed bernstein.yaml)::
     from bernstein.core.defaults import override
     override("orchestrator", {"drain_timeout_s": 120.0})
 
-Safety model (audit-155)
+Safety model
 ------------------------
 All ``*Defaults`` dataclasses are ``frozen=True`` — direct attribute mutation
 (``COST.foo = 1``) raises :class:`dataclasses.FrozenInstanceError`.  Dict
@@ -403,7 +403,7 @@ class TriggerDefaults:
 
 
 # ---------------------------------------------------------------------------
-# Janitor / retention defaults (audit-081)
+# Janitor / retention defaults
 # ---------------------------------------------------------------------------
 
 
@@ -412,7 +412,7 @@ class JanitorDefaults:
     """Disk retention policy for long-running orchestrator artifacts.
 
     Controls both JSONL append-log rotation thresholds and directory-level
-    pruning of per-run artifacts. See audit-081.
+    pruning of per-run artifacts. See.
     """
 
     # Per-run directory retention

--- a/src/bernstein/core/git/merge_queue.py
+++ b/src/bernstein/core/git/merge_queue.py
@@ -289,7 +289,7 @@ class MergeQueue:
         job is dequeued, the lock is released, and other waiters are woken.
 
         This is the intended entry point for production callers — it
-        guarantees ``enqueue`` is actually called (fixing audit-091) and
+        guarantees ``enqueue`` is actually called (fixing ) and
         keeps the ordering invariant even when multiple threads contend.
 
         Usage::

--- a/src/bernstein/core/git/salvage.py
+++ b/src/bernstein/core/git/salvage.py
@@ -1,4 +1,4 @@
-"""Salvage uncommitted agent work before worktree cleanup (audit-088).
+"""Salvage uncommitted agent work before worktree cleanup.
 
 When an agent fails, is killed, or its worktree is otherwise reaped while it
 still has dirty state, ``git worktree remove --force`` silently discards the
@@ -186,7 +186,7 @@ def _write_patch_fallback(
     # 3. Human-readable marker so operators can spot the salvage at a glance.
     try:
         (out_dir / "README.txt").write_text(
-            "Salvaged uncommitted worktree state (audit-088).\n"
+            "Salvaged uncommitted worktree state.\n"
             f"session_id: {session_id}\n"
             f"timestamp: {ts}\n"
             f"untracked_count: {len(untracked_payload)}\n"
@@ -244,7 +244,7 @@ def _try_salvage_branch(
 
     # 2. Commit.  --allow-empty so we leave a breadcrumb even when the diff
     #    is purely whitespace or already staged-and-reverted.
-    msg = f"WIP: salvage {session_id} (audit-088)"
+    msg = f"WIP: salvage {session_id}"
     commit_r = run_git(
         [
             "-c",

--- a/src/bernstein/core/git/worktree.py
+++ b/src/bernstein/core/git/worktree.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 _WORKTREE_BASE = ".sdd/worktrees"
 _SETUP_COMMAND_TIMEOUT_S = 300  # 5 minutes max for setup commands
 
-# Graveyard for unmerged commits rescued from crashed agents (audit-097).
+# Graveyard for unmerged commits rescued from crashed agents.
 _GRAVEYARD_DIR_REL = ".sdd/graveyard"
 _GRAVEYARD_REF_PREFIX = "refs/graveyard/"
 _GRAVEYARD_GIT_TIMEOUT_S = 30
@@ -337,7 +337,7 @@ def setup_worktree_env(
 
 
 def _count_unmerged_commits(repo_root: Path, branch: str, base: str = "main") -> int:
-    """Return how many commits on *branch* are not reachable from *base* (audit-097).
+    """Return how many commits on *branch* are not reachable from *base*.
 
     Uses ``git rev-list <branch> ^<base> --count``.  If the branch is missing
     or the command fails, returns ``0`` — callers treat that as "nothing to
@@ -413,7 +413,7 @@ def preserve_branch_to_graveyard(
     branch: str | None = None,
     now: float | None = None,
 ) -> Path | None:
-    """Move *branch* to ``refs/graveyard/<sid>-<ts>`` and export a bundle (audit-097).
+    """Move *branch* to ``refs/graveyard/<sid>-<ts>`` and export a bundle.
 
     Called before a destructive worktree cleanup when the session branch has
     unmerged commits.  The rescue path is:
@@ -516,7 +516,7 @@ def preserve_branch_to_graveyard(
 
 
 def purge_graveyard(repo_root: Path, older_than_days: int = _GRAVEYARD_DEFAULT_PURGE_DAYS) -> int:
-    """Remove graveyard refs and bundles older than *older_than_days* (audit-097).
+    """Remove graveyard refs and bundles older than *older_than_days*.
 
     Intended for operator-driven cleanup — never called automatically.  Both
     the ``refs/graveyard/*`` ref and the on-disk ``.sdd/graveyard/*.bundle``
@@ -734,7 +734,7 @@ class WorktreeManager:
         Before the destructive ``git worktree remove --force`` call, any
         uncommitted work in the worktree is salvaged via
         :func:`~bernstein.core.git.salvage.salvage_worktree` so the diff is
-        recoverable post-cleanup (audit-088).  The salvage step is purely
+        recoverable post-cleanup. The salvage step is purely
         best-effort: on failure the original cleanup proceeds as before.
 
         Args:
@@ -743,7 +743,7 @@ class WorktreeManager:
         worktree_path = self._base_dir / session_id
         branch_name = f"agent/{session_id}"
 
-        # 0. Salvage uncommitted work BEFORE anything destructive happens (audit-088).
+        # 0. Salvage uncommitted work BEFORE anything destructive happens.
         self._last_salvage = None
         if self._salvage_on_cleanup and worktree_path.exists():
             try:
@@ -814,7 +814,7 @@ class WorktreeManager:
         reachable from ``main`` is preserved to
         ``refs/graveyard/<sid>-<ts>`` with an accompanying bundle at
         ``.sdd/graveyard/<sid>-<ts>.bundle`` *before* the destructive
-        cleanup runs (audit-097).  This prevents ``kill -9`` / OOM of a
+        cleanup runs. This prevents ``kill -9`` / OOM of a
         prior orchestrator from silently wiping unmerged agent work on
         the next startup.
 
@@ -845,7 +845,7 @@ class WorktreeManager:
                     continue
 
                 # Preserve unmerged commits to the graveyard before we nuke
-                # the branch (audit-097).  A crashed agent may have committed
+                # the branch. A crashed agent may have committed
                 # work locally that never reached main; ``git worktree
                 # remove --force`` followed by ``git branch -D`` would make
                 # those commits unreachable and gc-eligible.

--- a/src/bernstein/core/git/worktree_claude_md.py
+++ b/src/bernstein/core/git/worktree_claude_md.py
@@ -170,7 +170,7 @@ def write_claude_md(
     # The project-level CLAUDE.md is tracked, so .gitignore alone does not
     # suppress the modification.  Mark it as skip-worktree in the worktree's
     # index — git will then ignore local edits and salvage's ``git add -A``
-    # will not stage the override (audit-095).
+    # will not stage the override.
     _mark_claude_md_skip_worktree(worktree_path)
 
     return claude_md_path

--- a/src/bernstein/core/git/worktree_isolation.py
+++ b/src/bernstein/core/git/worktree_isolation.py
@@ -1,4 +1,4 @@
-"""Worktree isolation validation after creation (AGENT-002).
+"""Worktree isolation validation after creation.
 
 Validates that a newly-created worktree is properly isolated:
 1. .sdd/ directory is NOT shared (not a symlink into the parent repo).

--- a/src/bernstein/core/knowledge/agents_md_generator.py
+++ b/src/bernstein/core/knowledge/agents_md_generator.py
@@ -459,7 +459,7 @@ def _build_architecture(repo_path: Path) -> AgentsMdSection | None:
     operator wants ~5 starting points, not the full call graph.
 
     The redirect-map detection covers a load-bearing audit invariant
-    (audit-012): when a project ships a ``sys.meta_path`` finder for
+    : when a project ships a ``sys.meta_path`` finder for
     legacy import paths, the AGENTS.md surface must point readers at
     the real mechanism so the documentation never drifts back to
     "shim file lives at <name>.py" claims that aren't true.

--- a/src/bernstein/core/observability/__init__.py
+++ b/src/bernstein/core/observability/__init__.py
@@ -1,10 +1,10 @@
 """observability sub-package.
 
-audit-173: the previous implementation exposed a ``__getattr__`` that walked
+the previous implementation exposed a ``__getattr__`` that walked
 ``pkgutil.iter_modules`` and lazy-imported every submodule on first attribute
 access. That magic defeated static analysis tools (Pyright, Vulture, unimport)
 because any attribute could be resolved at runtime, so dead submodules in this
-package accreted undetected (see audit-170).
+package accreted undetected (see prior audit).
 
 All production importers use fully-qualified submodule paths
 (``from bernstein.core.observability.<submodule> import X``) or submodule-style

--- a/src/bernstein/core/observability/metric_collector.py
+++ b/src/bernstein/core/observability/metric_collector.py
@@ -951,7 +951,7 @@ class MetricsCollector:
             try:
                 # Bound per-file growth: rotate *before* appending so the new
                 # write starts a fresh file once the threshold is crossed.
-                # See audit-068 — previously these JSONL files grew unbounded.
+                # See — previously these JSONL files grew unbounded.
                 rotate_log_file(
                     filepath,
                     max_bytes=_METRIC_FILE_ROTATE_BYTES,

--- a/src/bernstein/core/orchestration/bootstrap.py
+++ b/src/bernstein/core/orchestration/bootstrap.py
@@ -296,7 +296,7 @@ def _register_ci_parsers() -> None:
 
     Without this call the registry is empty at runtime, so
     ``bernstein ci fix --parser gitlab_ci`` and the self-healing CI
-    pipeline silently no-op (see audit-031). The helper in
+    pipeline silently no-op (see prior audit). The helper in
     :mod:`bernstein.adapters.ci` is idempotent, so calling it here on
     top of the import-time side-effect is safe.
     """
@@ -431,7 +431,7 @@ def bootstrap_from_seed(
         remote: If True, bind to 0.0.0.0 for remote access.
         force_fresh: Ignore any saved session and start from scratch.
         evolve_mode: Retained for back-compat. Uvicorn ``--reload`` was
-            removed 2026-04-17 (audit-115); this flag no longer alters
+            removed 2026-04-17 ; this flag no longer alters
             the server launch. Agents pick up source changes only when
             the supervisor restarts the server for real (crash/health).
         cli: Optional CLI override (e.g. "claude", "codex"). Overrides seed config.
@@ -485,7 +485,7 @@ def bootstrap_from_seed(
     _apply_compliance_env()
 
     # Populate CI log parser registry so `bernstein ci fix` and pipeline
-    # self-healing can find GitHub Actions / GitLab CI parsers (audit-031).
+    # self-healing can find GitHub Actions / GitLab CI parsers.
     _register_ci_parsers()
 
     # 3. Load secrets provider if configured
@@ -990,7 +990,7 @@ def _bootstrap_from_goal_impl(
                 console.print(f"  [red]{v}[/red]")
         write_lockfile(workdir)
 
-    # Populate CI log parser registry (audit-031).
+    # Populate CI log parser registry.
     _register_ci_parsers()
 
     bind_host = _resolve_bind_host()

--- a/src/bernstein/core/orchestration/dependency_scan_tasks.py
+++ b/src/bernstein/core/orchestration/dependency_scan_tasks.py
@@ -1,7 +1,7 @@
 """Scheduled dependency-scan helpers for the orchestrator.
 
 Extracted from the retired ``orchestrator_tick`` module as part of
-audit-002 (orchestrator_tick zombie). Only these three helpers were ever
+(orchestrator_tick zombie). Only these three helpers were ever
 imported from the outside; the rest of ``orchestrator_tick`` duplicated
 ``Orchestrator.tick`` without being called.
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -480,7 +480,7 @@ class Orchestrator:
         self._budget_policy: BudgetPolicy = BudgetPolicy.default()
         # Track last-seen policy action so we only notify on transitions.
         self._last_budget_action: BudgetAction = BudgetAction.CONTINUE
-        # audit-056: kill-switch state.  When ``should_stop`` transitions
+        # kill-switch state. When ``should_stop`` transitions
         # True we record the timestamp here and SHUTDOWN all live agents;
         # subsequent ticks that run ``kill_grace_period_s`` seconds later
         # SIGKILL any session still alive so budget overrun stays bounded.
@@ -737,7 +737,7 @@ class Orchestrator:
                 capacity_fn=self._current_capacity,
             )
 
-        # CI autofix poller (audit-035): lazily constructed on first use so
+        # CI autofix poller: lazily constructed on first use so
         # the orchestrator doesn't import httpx-async machinery unless the
         # flag is enabled.  _last_ci_poll_ts enforces the poll_interval_s
         # cadence regardless of tick frequency.
@@ -1164,7 +1164,7 @@ class Orchestrator:
             except Exception as exc:
                 logger.warning("Stale claim release failed: %s", exc)
 
-        # 1b-i.6. Priority aging (audit-020): boost long-waiting open/blocked tasks
+        # 1b-i.6. Priority aging: boost long-waiting open/blocked tasks
         # so that lower-priority work does not starve behind a steady stream of
         # P1 tickets. Gated behind the ``priority_aging_enabled`` config flag
         # (default OFF) and run every ``priority_aging_interval_ticks`` ticks.
@@ -1398,7 +1398,7 @@ class Orchestrator:
                 spent_usd=round(_bs.spent_usd, 4),
                 percent_used=round(_bs.percentage_used * 100, 1),
             )
-            # audit-056: ABORT used to only skip spawn, so in-flight agents
+            # ABORT used to only skip spawn, so in-flight agents
             # kept draining budget until they completed on their own.  Now
             # we SHUTDOWN every live session and (after ``kill_grace_period_s``)
             # SIGKILL any still alive so overruns stay bounded.
@@ -1564,7 +1564,7 @@ class Orchestrator:
         # 4d-iv. Real-time cost recording: update budget status from live tokens
         self._record_live_costs()
 
-        # 4d-v. CI autofix poll (audit-035): opt-in via config.ci_autofix.enabled.
+        # 4d-v. CI autofix poll: opt-in via config.ci_autofix.enabled.
         # _maybe_poll_ci_autofix internally rate-limits to poll_interval_s
         # (default 60s) and short-circuits when the flag is off, so calling
         # every tick is cheap.
@@ -1583,7 +1583,7 @@ class Orchestrator:
         #     or no heartbeat for idle threshold). SHUTDOWN → 30s grace → SIGKILL.
         recycle_idle_agents(self, tasks_by_status)
 
-        # 4e-ii. Log-growth idle heuristic (audit-006): catch agents wedged in a
+        # 4e-ii. Log-growth idle heuristic: catch agents wedged in a
         #     dead MCP/tool call that still emit heartbeats from a side thread but
         #     produce no log output or git activity. Complements recycle_idle_agents
         #     (heartbeat-based) — gated behind _run_normal since the log tail scan
@@ -1935,13 +1935,13 @@ class Orchestrator:
         ``task_spawn_confirmed``) are actively retried: a ``task_retry`` WAL
         entry is recorded and ``POST /tasks/{id}/force-claim`` is called with
         reason ``crash_recovery`` so the task returns to the *open* queue
-        instead of being silently abandoned (audit-001).  Any prior
+        instead of being silently abandoned. Any prior
         worktrees with uncommitted work are moved to
         ``.sdd/worktrees/preserved/`` and surfaced on the bulletin board so
         fresh agents can resume that work.
 
         Before the legacy acknowledgement path runs, the
-        :class:`WALReplayEngine` (audit-073) performs an idempotent replay:
+        :class:`WALReplayEngine` performs an idempotent replay:
         uncommitted ``task_claimed`` entries whose task the server still
         reports as *claimed* are transitioned to FAILED with reason
         ``claimed but never spawned`` so the standard retry machinery picks
@@ -1952,7 +1952,7 @@ class Orchestrator:
             List of (run_id, WALEntry) tuples for all uncommitted entries found.
         """
         sdd_dir = self._workdir / ".sdd"
-        # audit-073: run the WALReplayEngine first so uncommitted task_claimed
+        # run the WALReplayEngine first so uncommitted task_claimed
         # entries that are still claimed on the server are transitioned to
         # FAILED (reason "claimed but never spawned") with idempotency
         # protection.  Any failure is logged and swallowed so startup is never
@@ -1979,7 +1979,7 @@ class Orchestrator:
         # Identify orphaned claims: uncommitted task_claimed entries with
         # no matching task_spawn_confirmed in the same run.  These are the
         # work-loss cases the prior implementation only logged and acked
-        # (audit-001).  Use a (run_id, seq) key for O(1) membership checks.
+        #. Use a (run_id, seq) key for O(1) membership checks.
         orphaned = WALRecovery.find_orphaned_claims(
             sdd_dir,
             exclude_run_id=self._run_id,
@@ -1989,7 +1989,7 @@ class Orchestrator:
         # Identify orphaned claim_confirmed entries: the spawn created a
         # worktree but the process was SIGKILL'd before task_spawn_confirmed
         # was written.  These represent potentially valuable WIP on disk
-        # that must not be silently reaped (audit-013).
+        # that must not be silently reaped.
         crashed_spawns = self._find_orphaned_claim_confirmed(sdd_dir)
         crashed_spawn_keys = {(run_id, entry.seq) for run_id, entry in crashed_spawns}
         # task_ids that already have a claim_confirmed crash entry -- skip
@@ -2033,7 +2033,7 @@ class Orchestrator:
                 logger.debug("WAL write failed for recovery ack (run=%s seq=%d)", run_id, entry.seq)
 
         # Actively retry orphaned claims so each task returns to the open
-        # queue instead of being silently abandoned (audit-001 fix part a).
+        # queue instead of being silently abandoned ( fix part a).
         # Skip tasks that also have a claim_confirmed crash entry -- those
         # are handled by the crashed-spawn path below so the worktree is
         # preserved to the graveyard before the task is /fail'd.
@@ -2047,18 +2047,18 @@ class Orchestrator:
         # For claim_confirmed orphans: preserve the materialised worktree to
         # ``.sdd/graveyard/<task_id>/<ts>/`` (if dirty or has commits) then
         # POST /tasks/{id}/fail so the task returns to the open queue with a
-        # clear reason operators can review (audit-013).
+        # clear reason operators can review.
         crashed_recovered = 0
         for run_id, entry in crashed_spawns:
             if self._recover_crashed_spawn(run_id, entry):
                 crashed_recovered += 1
 
         # Preserve any prior worktrees that still have uncommitted changes
-        # so a fresh agent can resume them (audit-001 fix part b).
+        # so a fresh agent can resume them ( fix part b).
         preserved_paths = self._preserve_prior_worktrees_with_wip()
 
         # Close every prior-run WAL we observed so future boots do not
-        # re-scan the same uncommitted entries forever (audit-072).
+        # re-scan the same uncommitted entries forever.
         # We close the union of run_ids that held uncommitted entries and
         # run_ids that held orphaned claims -- in practice these are the
         # only WALs whose entries were returned by the scan helpers.
@@ -2109,7 +2109,7 @@ class Orchestrator:
     def _replay_wal_with_engine(self, sdd_dir: Path) -> None:
         """Run :class:`WALReplayEngine` to transition orphaned claims to FAILED.
 
-        audit-073: wires :meth:`WALReplayEngine.scan_and_replay` into startup
+        wires :meth:`WALReplayEngine.scan_and_replay` into startup
         so uncommitted ``task_claimed`` entries from a crashed prior run are
         not only logged.  For each orphan whose task is still reported as
         *claimed* on the server, the engine's replay handler:
@@ -2130,7 +2130,7 @@ class Orchestrator:
         # Fetch the set of task IDs currently marked as claimed on the
         # server.  If the server is unreachable we treat the set as empty
         # which means the replay handler will decline to fail anything and
-        # fall back to the legacy force-claim path (audit-001) below.
+        # fall back to the legacy force-claim path below.
         claimed_on_server: set[str] = set()
         try:
             resp = self._client.get(f"{self._config.server_url}/tasks?status=claimed")
@@ -2284,9 +2284,9 @@ class Orchestrator:
         materialised but BEFORE ``task_spawn_confirmed``.  On a SIGKILL in
         that window the worktree exists on disk but no committed entry
         exists.  The returned tuples drive graveyard preservation + /fail
-        so no work is silently reaped (audit-013).
+        so no work is silently reaped.
 
-        WALs with a ``.closed`` sidecar marker are skipped (audit-072) so
+        WALs with a ``.closed`` sidecar marker are skipped so
         crashed spawns handled by a prior recovery are not retried forever.
 
         Args:
@@ -2329,7 +2329,7 @@ class Orchestrator:
         return crashed
 
     def _recover_crashed_spawn(self, run_id: str, entry: Any) -> bool:
-        """Preserve a crashed-spawn worktree and /fail the task (audit-013).
+        """Preserve a crashed-spawn worktree and /fail the task.
 
         Moves the materialised worktree (recorded in ``entry.inputs``) to
         ``.sdd/graveyard/<task_id>/<ts>/`` when it contains unsaved work
@@ -2767,7 +2767,7 @@ class Orchestrator:
     def _enforce_budget_killswitch(self) -> None:
         """Terminate in-flight agents once the budget kill-switch has fired.
 
-        audit-056: prior to this hook the ABORT branch only blocked new
+        prior to this hook the ABORT branch only blocked new
         spawns, so any agents still running when ``should_stop`` flipped
         kept consuming budget (overruns of 150%+ observed).  The new
         contract is:
@@ -2926,7 +2926,7 @@ class Orchestrator:
             self._task_to_session.pop(tid, None)
 
     def _maybe_poll_ci_autofix(self) -> list[str]:
-        """Poll GitHub Actions for failing runs if the feature flag is enabled (audit-035).
+        """Poll GitHub Actions for failing runs if the feature flag is enabled.
 
         Calls :meth:`CIMonitor.poll` at most once per ``poll_interval_s`` seconds,
         tracked via ``_last_ci_poll_ts``.  Lazily constructs the monitor and
@@ -4383,7 +4383,7 @@ if __name__ == "__main__":
             elif seed_path.exists():
                 load_model_policy_from_yaml(seed_path, router)
 
-        # Configure model fallback tracker from bernstein.yaml (AGENT-004).
+        # Configure model fallback tracker from bernstein.yaml.
         # Reads model_fallback: section and wires the configurable chain into
         # the process-global singleton before any agents are spawned.
         if seed and getattr(seed, "model_fallback", None):
@@ -4397,7 +4397,7 @@ if __name__ == "__main__":
                 trigger_codes=frozenset(mf.trigger_codes),
             )
 
-        # Resolve + install the per-agent credential policy (audit-051).
+        # Resolve + install the per-agent credential policy.
         # Default-on: walks DEFAULT_POLICY_PATHS for a config file and
         # falls back to the bundled examples/credential-policies/default.yaml
         # so a fresh checkout still gets fail-closed env-var scoping.
@@ -4563,7 +4563,7 @@ if __name__ == "__main__":
                 workdir=workdir,
             )
 
-        # Parse agent resource limits from config (AGENT-013)
+        # Parse agent resource limits from config
         from bernstein.core.resource_limits import DEFAULT_AGENT_LIMITS
         from bernstein.core.resource_limits import ResourceLimits as _ResourceLimits
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1979,7 +1979,7 @@ class Orchestrator:
         # Identify orphaned claims: uncommitted task_claimed entries with
         # no matching task_spawn_confirmed in the same run.  These are the
         # work-loss cases the prior implementation only logged and acked
-        #. Use a (run_id, seq) key for O(1) membership checks.
+        # . Use a (run_id, seq) key for O(1) membership checks.
         orphaned = WALRecovery.find_orphaned_claims(
             sdd_dir,
             exclude_run_id=self._run_id,

--- a/src/bernstein/core/orchestration/orchestrator_cleanup.py
+++ b/src/bernstein/core/orchestration/orchestrator_cleanup.py
@@ -160,7 +160,7 @@ def cleanup(orch: Any) -> None:
     # Save session state before releasing resources
     save_session_state(orch)
 
-    # audit-081: prune old runs/ and runtime/wal/ entries so long-running
+    # prune old runs/ and runtime/wal/ entries so long-running
     # bernstein instances do not accumulate unbounded per-run state.
     try:
         from bernstein.core.persistence.disk_retention import run_retention

--- a/src/bernstein/core/orchestration/staggered_shutdown.py
+++ b/src/bernstein/core/orchestration/staggered_shutdown.py
@@ -1,4 +1,4 @@
-"""Staggered agent shutdown during drain (AGENT-014).
+"""Staggered agent shutdown during drain.
 
 Kills agents in reverse-priority order with configurable intervals
 between each kill, giving high-priority agents the most time to

--- a/src/bernstein/core/persistence/checkpoint.py
+++ b/src/bernstein/core/persistence/checkpoint.py
@@ -1,6 +1,6 @@
 """Orchestrator checkpoint/restore for long-running plans.
 
-Two complementary checkpoint shapes live here (audit-084):
+Two complementary checkpoint shapes live here:
 
 1. :class:`Checkpoint` — the canonical, atomic full-snapshot written by the
    orchestrator for crash recovery.  Captures task graph, agent sessions,
@@ -14,7 +14,7 @@ Two complementary checkpoint shapes live here (audit-084):
 :class:`bernstein.core.persistence.session.CheckpointState` is a
 back-compat alias for :class:`PartialState` so the CLI and existing tests
 keep working.  The older ``session_checkpoint.SessionCheckpoint`` was
-removed in audit-084 (no production callers).
+removed in (no production callers).
 """
 
 from __future__ import annotations
@@ -272,7 +272,7 @@ def _checkpoint_from_dict(data: dict[str, Any]) -> Checkpoint:
 
 
 # ---------------------------------------------------------------------------
-# PartialState — operator-visible progress slice (audit-084)
+# PartialState — operator-visible progress slice
 # ---------------------------------------------------------------------------
 
 

--- a/src/bernstein/core/persistence/disk_retention.py
+++ b/src/bernstein/core/persistence/disk_retention.py
@@ -1,4 +1,4 @@
-"""Disk-level retention janitor for per-run artifacts (audit-081).
+"""Disk-level retention janitor for per-run artifacts.
 
 Retains the newest N run directories and WAL files, deleting older ones.
 Called from the orchestrator cleanup path so that long-running bernstein
@@ -178,7 +178,7 @@ def run_retention(
     run_retention_count: int | None = None,
     wal_retention_count: int | None = None,
 ) -> RetentionResult:
-    """Sweep both runs/ and runtime/wal/ in a single pass (audit-081).
+    """Sweep both runs/ and runtime/wal/ in a single pass.
 
     Args:
         sdd_dir: The ``.sdd`` directory root.

--- a/src/bernstein/core/persistence/file_health.py
+++ b/src/bernstein/core/persistence/file_health.py
@@ -500,7 +500,7 @@ class FileHealthTracker:
         )
 
         # Append to health log — rotate before appending to cap disk growth
-        #. get_all()/get() dedupe by path on read so older entries
+        # . get_all()/get() dedupe by path on read so older entries
         # in the rotated backup are naturally replaced by fresher ones.
         rotate_log_file(self._health_path, max_bytes=JANITOR.file_health_rotate_bytes)
         try:

--- a/src/bernstein/core/persistence/file_health.py
+++ b/src/bernstein/core/persistence/file_health.py
@@ -500,7 +500,7 @@ class FileHealthTracker:
         )
 
         # Append to health log — rotate before appending to cap disk growth
-        # (audit-081). get_all()/get() dedupe by path on read so older entries
+        #. get_all()/get() dedupe by path on read so older entries
         # in the rotated backup are naturally replaced by fresher ones.
         rotate_log_file(self._health_path, max_bytes=JANITOR.file_health_rotate_bytes)
         try:

--- a/src/bernstein/core/persistence/file_locks.py
+++ b/src/bernstein/core/persistence/file_locks.py
@@ -330,7 +330,7 @@ class FileLockManager:
             self._locks = {}
 
     def _save(self) -> None:
-        """Persist current lock state to disk atomically (audit-076, audit-077).
+        """Persist current lock state to disk atomically ().
 
         Callers must hold the cross-process OS lock (via :meth:`_guard`).
         Routes through :func:`write_atomic_json` which does temp-file +

--- a/src/bernstein/core/persistence/recorder.py
+++ b/src/bernstein/core/persistence/recorder.py
@@ -72,7 +72,7 @@ class RunRecorder:
             "event": event,
         }
         entry.update(data)
-        # audit-081: cap unbounded replay.jsonl. `bernstein replay` may stitch
+        # cap unbounded replay.jsonl. `bernstein replay` may stitch
         # live + rotated backups if needed — see load_replay_events.
         rotate_log_file(self._path, max_bytes=JANITOR.replay_rotate_bytes)
         try:

--- a/src/bernstein/core/persistence/session.py
+++ b/src/bernstein/core/persistence/session.py
@@ -19,7 +19,7 @@ from bernstein.core.persistence.atomic_write import write_atomic_json
 from bernstein.core.persistence.checkpoint import PartialState
 from bernstein.core.persistence.runtime_state import rotate_log_file
 
-# Back-compat alias (audit-084): ``CheckpointState`` is the legacy name for
+# Back-compat alias: ``CheckpointState`` is the legacy name for
 # the operator-visible progress slice.  Canonical home is
 # :class:`bernstein.core.persistence.checkpoint.PartialState`.  The alias is
 # preserved so the ``bernstein checkpoint`` CLI and existing tests keep
@@ -386,7 +386,7 @@ def record_bridge_event(workdir: Path, event: BridgeTransportEvent) -> None:
     """Append a bridge transport event to the lineage JSONL file (T549, T550, T551).
 
     The file is rotated once it crosses
-    :attr:`JanitorDefaults.bridge_lineage_rotate_bytes` (audit-081).
+    :attr:`JanitorDefaults.bridge_lineage_rotate_bytes`.
 
     Args:
         workdir: Project root directory.
@@ -486,7 +486,7 @@ def emit_task_notification(workdir: Path, notification: TaskStatusNotification) 
     """Append a task status notification to the JSONL log (T574).
 
     The file is rotated once it crosses
-    :attr:`JanitorDefaults.task_notifications_rotate_bytes` (audit-081).
+    :attr:`JanitorDefaults.task_notifications_rotate_bytes`.
 
     Args:
         workdir: Project root directory.

--- a/src/bernstein/core/persistence/session_continuity.py
+++ b/src/bernstein/core/persistence/session_continuity.py
@@ -1,4 +1,4 @@
-"""Agent session continuity across retries (AGENT-016).
+"""Agent session continuity across retries.
 
 Preserves conversation context, file state, and partial work when
 retrying a failed agent.  Captures a snapshot before failure and

--- a/src/bernstein/core/persistence/team_state.py
+++ b/src/bernstein/core/persistence/team_state.py
@@ -127,7 +127,7 @@ class TeamStateStore:
             return {}
 
     def _write_all(self, members: dict[str, TeamMember]) -> None:
-        """Atomically persist the full team roster (audit-076)."""
+        """Atomically persist the full team roster."""
         payload = {
             "updated_at": time.time(),
             "members": [m.to_dict() for m in members.values()],

--- a/src/bernstein/core/persistence/wal.py
+++ b/src/bernstein/core/persistence/wal.py
@@ -68,7 +68,7 @@ def _compute_entry_hash(payload: dict[str, Any]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# UncommittedIndex (audit-085)
+# UncommittedIndex
 # ---------------------------------------------------------------------------
 
 
@@ -200,7 +200,7 @@ class UncommittedIndex:
         """Remove every row whose ``run_id`` matches *run_id*.
 
         Returns the number of rows removed.  Called after a run's WAL is
-        closed (audit-072) so that subsequent scans are not slowed by
+        closed so that subsequent scans are not slowed by
         stale rows pointing at an already-recovered WAL.
         """
         try:
@@ -238,7 +238,7 @@ class WALWriter:
         self._path = sdd_dir / "runtime" / "wal" / f"{run_id}.wal.jsonl"
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._seq, self._prev_hash = self._load_tail()
-        # Sidecar index of uncommitted entries (audit-085). Lazily instantiated
+        # Sidecar index of uncommitted entries. Lazily instantiated
         # so tests that only exercise the reader do not create the index file.
         self._index: UncommittedIndex | None = None
 
@@ -253,7 +253,7 @@ class WALWriter:
 
         Returns (-1, GENESIS_HASH) for a new or empty WAL.
 
-        Implementation (audit-082): seeks to end and reads backward in
+        Implementation: seeks to end and reads backward in
         fixed-size chunks until a complete non-empty line is recovered
         (or the start of the file is reached). Avoids an O(N) full-file
         read on every construction of a ``WALWriter``.
@@ -391,7 +391,7 @@ class WALWriter:
             f.flush()
             os.fsync(f.fileno())
 
-        # audit-085: update the sidecar index after the WAL line has been
+        # update the sidecar index after the WAL line has been
         # durably written. Index corruption only degrades startup speed
         # (scan_all_uncommitted falls back to a full scan and rebuilds)
         # so we swallow the error rather than failing the append.
@@ -452,7 +452,7 @@ class WALReader:
     def iter_entries(self) -> Iterator[WALEntry]:
         """Yield all :class:`WALEntry` objects in write order.
 
-        Streams the WAL file line-by-line (audit-082): entries are parsed
+        Streams the WAL file line-by-line: entries are parsed
         lazily so memory usage is O(1) in the WAL size. A malformed
         trailing line (e.g. torn write after a crash) is logged and
         skipped rather than aborting the iteration.
@@ -502,7 +502,7 @@ class WALReader:
         1. Each entry's ``prev_hash`` equals the previous entry's ``entry_hash``.
         2. Each entry's ``entry_hash`` matches the SHA-256 of its payload.
 
-        Streams the WAL line-by-line (audit-082): only the running
+        Streams the WAL line-by-line: only the running
         ``prev_hash`` and the collected error list are held in memory,
         so verification is O(1) in working set regardless of WAL size.
 
@@ -581,7 +581,7 @@ class WALRecovery:
     Once ``close_wal`` has been called, subsequent scans (via
     :meth:`scan_all_uncommitted` / :meth:`find_orphaned_claims`) skip the
     WAL so the same uncommitted entries are not re-reported forever
-    (audit-072).
+    .
     """
 
     def __init__(self, run_id: str, sdd_dir: Path) -> None:
@@ -598,7 +598,7 @@ class WALRecovery:
             return []
 
     # ------------------------------------------------------------------
-    # Closed-WAL sidecar marker (audit-072)
+    # Closed-WAL sidecar marker
     # ------------------------------------------------------------------
 
     @staticmethod
@@ -613,7 +613,7 @@ class WALRecovery:
         A closed marker signals that a previous recovery cycle has
         already observed and handled every uncommitted entry in the
         corresponding WAL — future scans must skip it to prevent
-        unbounded re-scanning of the same entries (audit-072).
+        unbounded re-scanning of the same entries.
         """
         return WALRecovery._closed_marker_path(run_id, sdd_dir).exists()
 
@@ -664,7 +664,7 @@ class WALRecovery:
             f.flush()
             os.fsync(f.fileno())
 
-        # audit-085: drop stale uncommitted-index rows for the now-closed
+        # drop stale uncommitted-index rows for the now-closed
         # run so future scans do not have to filter them out.
         try:
             UncommittedIndex(sdd_dir).remove_run(run_id)
@@ -682,7 +682,7 @@ class WALRecovery:
 
         Iterates over every ``*.wal.jsonl`` file in the WAL directory, skipping
         *exclude_run_id* (typically the current run) and any WAL whose
-        ``.closed`` sidecar marker is present (audit-072 — prevents
+        ``.closed`` sidecar marker is present ( — prevents
         unbounded re-scanning of already-recovered WALs). Returns a flat
         list of ``(run_id, WALEntry)`` pairs for every entry with
         ``committed=False``.
@@ -729,7 +729,7 @@ class WALRecovery:
         task would otherwise sit in *claimed* forever (or be abandoned by
         ``_reconcile_claimed_tasks`` without a dedicated retry audit trail).
 
-        WALs with a ``.closed`` sidecar marker are skipped (audit-072) so
+        WALs with a ``.closed`` sidecar marker are skipped so
         that orphans handled by a prior recovery are not retried forever.
 
         Args:

--- a/src/bernstein/core/persistence/wal_replay.py
+++ b/src/bernstein/core/persistence/wal_replay.py
@@ -95,7 +95,7 @@ class IdempotencyStore:
         """Load previously recorded execution markers from disk.
 
         Scans the live ``idempotency.jsonl`` plus any rotated ``.N`` backups
-        (audit-081) so that rotation never silently forgets a marker.
+        so that rotation never silently forgets a marker.
         """
         candidates: list[Path] = []
         if self._path.exists():
@@ -155,7 +155,7 @@ class IdempotencyStore:
 
         try:
             self._path.parent.mkdir(parents=True, exist_ok=True)
-            # audit-081: cap unbounded idempotency.jsonl. _load() scans
+            # cap unbounded idempotency.jsonl. _load() scans
             # rotated .N backups as well so rotation does not lose markers.
             rotate_log_file(self._path, max_bytes=JANITOR.idempotency_rotate_bytes)
             with self._path.open("a", encoding="utf-8") as f:

--- a/src/bernstein/core/plugins_core/__init__.py
+++ b/src/bernstein/core/plugins_core/__init__.py
@@ -1,6 +1,6 @@
 """plugins_core sub-package.
 
-audit-173: the previous implementation exposed a ``__getattr__`` that walked
+the previous implementation exposed a ``__getattr__`` that walked
 ``pkgutil.iter_modules`` and lazy-imported every submodule on first attribute
 access. That magic defeated static analysis tools (Pyright, Vulture, unimport)
 because any attribute could be resolved at runtime, so dead submodules in this

--- a/src/bernstein/core/protocols/a2a/__init__.py
+++ b/src/bernstein/core/protocols/a2a/__init__.py
@@ -1,4 +1,4 @@
-"""A2A protocol modules (audit-191 split).
+"""A2A protocol modules ( split).
 
 Re-exports from ``.a2a`` so ``from bernstein.core.protocols.a2a import X``
 keeps working for callers that previously imported from the ``a2a.py``

--- a/src/bernstein/core/protocols/cluster/__init__.py
+++ b/src/bernstein/core/protocols/cluster/__init__.py
@@ -1,4 +1,4 @@
-"""Cluster protocol modules (audit-191 split).
+"""Cluster protocol modules ( split).
 
 Re-exports from ``.cluster`` so ``from bernstein.core.protocols.cluster
 import NodeRegistry`` keeps working for callers that previously imported

--- a/src/bernstein/core/protocols/cluster/cluster_auth.py
+++ b/src/bernstein/core/protocols/cluster/cluster_auth.py
@@ -1,4 +1,4 @@
-"""ENT-002: Cluster node registration hardening with JWT authentication.
+"""Cluster node registration hardening with JWT authentication.
 
 Adds JWT-based authentication for node registration and heartbeats.
 Unauthenticated nodes are rejected. Tokens carry a ``node`` scope and

--- a/src/bernstein/core/protocols/cluster/cluster_autoscaler.py
+++ b/src/bernstein/core/protocols/cluster/cluster_autoscaler.py
@@ -1,4 +1,4 @@
-"""ENT-013: Cluster auto-scaling based on task queue depth.
+"""Cluster auto-scaling based on task queue depth.
 
 Monitors the task queue depth across cluster nodes and recommends scaling
 decisions (scale-up or scale-down).  Integrates with the load scaler for

--- a/src/bernstein/core/protocols/cluster/cluster_task_stealing.py
+++ b/src/bernstein/core/protocols/cluster/cluster_task_stealing.py
@@ -1,4 +1,4 @@
-"""ENT-007: Cluster task stealing for load balancing.
+"""Cluster task stealing for load balancing.
 
 Idle nodes claim tasks from busy nodes to balance work across the cluster.
 The stealing algorithm uses a pull-based approach: idle nodes periodically

--- a/src/bernstein/core/protocols/grpc/__init__.py
+++ b/src/bernstein/core/protocols/grpc/__init__.py
@@ -1,1 +1,1 @@
-"""gRPC protocol modules (audit-191 split)."""
+"""gRPC protocol modules ( split)."""

--- a/src/bernstein/core/protocols/mcp/__init__.py
+++ b/src/bernstein/core/protocols/mcp/__init__.py
@@ -1,1 +1,1 @@
-"""MCP protocol modules (audit-191 split)."""
+"""MCP protocol modules ( split)."""

--- a/src/bernstein/core/protocols/mcp/mcp_readiness.py
+++ b/src/bernstein/core/protocols/mcp/mcp_readiness.py
@@ -1,4 +1,4 @@
-"""MCP server readiness probe before agent spawn (AGENT-005).
+"""MCP server readiness probe before agent spawn.
 
 After starting an MCP server subprocess, the orchestrator should verify that
 the server is actually ready to accept connections before spawning an agent

--- a/src/bernstein/core/protocols/mcp_bot_allowlist.py
+++ b/src/bernstein/core/protocols/mcp_bot_allowlist.py
@@ -1,6 +1,6 @@
 """Read-only MCP-tool allowlist for the bernstein.run docs bot.
 
-The bernstein.run docs bot (RAG-001..004 in the bernstein_landing repo) may
+The bernstein.run docs bot may
 optionally consult the live cluster when answering operational questions
 ("how many tasks are open", "what's the cluster health"). To keep that
 surface narrow we expose **only** the four read-only tools below; write

--- a/src/bernstein/core/quality/__init__.py
+++ b/src/bernstein/core/quality/__init__.py
@@ -1,10 +1,10 @@
 """quality sub-package.
 
-audit-192: the previous implementation exposed a ``__getattr__`` that walked
+the previous implementation exposed a ``__getattr__`` that walked
 ``pkgutil.iter_modules`` and lazy-imported every submodule on first attribute
 access. That magic defeated static analysis tools (Pyright, Vulture, unimport)
 because any attribute could be resolved at runtime, so dead submodules in this
-package could accrete undetected (see audit-033, audit-036, audit-040, audit-192).
+package could accrete undetected (see prior audit,, ).
 
 All production importers use fully-qualified submodule paths
 (``from bernstein.core.quality.<submodule> import X``) or submodule-style

--- a/src/bernstein/core/quality/ci_monitor.py
+++ b/src/bernstein/core/quality/ci_monitor.py
@@ -181,7 +181,7 @@ class CIMonitor:
         *,
         per_page: int = 10,
     ) -> list[str]:
-        """Synchronous poll: discover new failures, create fix tasks (audit-035).
+        """Synchronous poll: discover new failures, create fix tasks.
 
         Runs the full CLI-style cycle (list failing runs -> parse each log
         -> invoke ``pipeline.create_fix_task``) inside a blocking call so

--- a/src/bernstein/core/quality/coverage_gate.py
+++ b/src/bernstein/core/quality/coverage_gate.py
@@ -4,7 +4,7 @@ The coverage gate compares the current branch's measured coverage against a
 baseline captured from the configured base ref (usually ``main``). Measuring
 baseline synchronously during a task completion is expensive — it requires a
 full test run against a freshly checked-out worktree and historically blocked
-agent progress for 5+ minutes (see audit-032).
+agent progress for 5+ minutes (see prior audit).
 
 Behavior now:
 

--- a/src/bernstein/core/quality/effectiveness.py
+++ b/src/bernstein/core/quality/effectiveness.py
@@ -296,7 +296,7 @@ class EffectivenessScorer:
     def _retry_count(self, task: Task) -> int:
         """Return the retry count for a task.
 
-        audit-017: prefer the typed ``task.retry_count`` field; fall back to
+        prefer the typed ``task.retry_count`` field; fall back to
         a legacy ``[RETRY N]`` title prefix only when the typed field is 0
         so historical tasks still score correctly.
         """

--- a/src/bernstein/core/quality/quality_gate_coalescer.py
+++ b/src/bernstein/core/quality/quality_gate_coalescer.py
@@ -15,7 +15,7 @@ Flow:
   wakes up and returns its own real result.
 
 Previously this class returned a lightweight ``passed=True`` for coalesced
-callers — a silent gate bypass under concurrent completions (audit-037).  The
+callers — a silent gate bypass under concurrent completions. The
 "trailing-run-only" optimisation is unsafe because each task has its own
 worktree and its own diff; reusing one run's result for another task means
 gates are never actually executed against the second task's changes.

--- a/src/bernstein/core/routes/hooks.py
+++ b/src/bernstein/core/routes/hooks.py
@@ -6,7 +6,7 @@ adapter injects these hooks into ``.claude/settings.local.json`` before
 spawning so every tool invocation and lifecycle event is reported in
 real time.
 
-Authentication (audit-113)
+Authentication
 --------------------------
 The endpoint is mounted outside the bearer-auth gate because Claude Code's
 hook runner cannot carry Bearer tokens.  Instead, each request is signed
@@ -15,7 +15,7 @@ with HMAC-SHA256 using the shared secret configured via
 Requests without a matching ``X-Bernstein-Hook-Signature-256`` header are
 rejected with 401.
 
-Security (audit-114)
+Security
 --------------------
 ``session_id`` is strictly validated before any filesystem work.  Values
 containing path separators, ``..``, null bytes, or anything outside
@@ -130,8 +130,8 @@ async def receive_hook(session_id: str, request: Request) -> JSONResponse:
     ``X-Bernstein-Hook-Signature-256`` (HMAC-SHA256 over the raw body,
     keyed with ``BERNSTEIN_HOOK_SECRET``) *before* any parsing or
     filesystem work — this is the authentication boundary for the
-    endpoint (audit-113).  The ``session_id`` is then validated against
-    a strict allowlist to prevent path traversal (audit-114).
+    endpoint. The ``session_id`` is then validated against
+    a strict allowlist to prevent path traversal.
 
     Args:
         session_id: Agent session identifier from the URL path.

--- a/src/bernstein/core/routes/mcp_bot_tools.py
+++ b/src/bernstein/core/routes/mcp_bot_tools.py
@@ -1,7 +1,7 @@
 """Discovery endpoint for the bernstein.run docs-bot tool surface.
 
 Exposes ``GET /.well-known/mcp-tools`` so the bernstein_landing docs bot
-(RAG-001..004) can probe whether this Bernstein cluster is willing to be
+can probe whether this Bernstein cluster is willing to be
 called by the bot, and which read-only tools are on offer.
 
 Off by default. Enabled by setting the env var

--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -401,7 +401,7 @@ async def create_task(body: TaskCreate, request: Request) -> TaskResponse:
     )
 
     with start_span("task.create", {"task.role": effective_body.role, "task.title": effective_body.title}):
-        # ENT-001: Tenant quota enforcement
+        # Tenant quota enforcement
         from bernstein.core.tenant_isolation import TenantIsolationManager  # noqa: TC001
 
         tenant_mgr: TenantIsolationManager | None = getattr(
@@ -697,7 +697,7 @@ async def complete_task(task_id: str, body: TaskCompleteRequest, request: Reques
     """Mark a task as done with a result summary.
 
     If ``result_summary`` is empty the task is auto-transitioned to
-    ``FAILED`` with ``reason='completion missing summary'`` (audit-028) and
+    ``FAILED`` with ``reason='completion missing summary'`` and
     a 422 is returned with the failed task payload so the client knows the
     slot was released.
     """
@@ -717,7 +717,7 @@ async def complete_task(task_id: str, body: TaskCompleteRequest, request: Reques
         except KeyError:
             raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found") from None
         except EmptyCompletionError as exc:
-            # audit-028: empty summary is handled inside ``complete()``
+            # empty summary is handled inside ``complete()``
             # (task is auto-failed under the lock).  Surface a structured
             # 422 so the client knows the slot was released.
             failed_task = exc.task

--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -29,7 +29,7 @@ _GENERIC_WEBHOOK_SECRET_ENV = "BERNSTEIN_WEBHOOK_SECRET"
 _GENERIC_WEBHOOK_SIGNATURE_HEADER = "x-bernstein-webhook-signature-256"
 _GENERIC_WEBHOOK_TIMESTAMP_HEADER = "x-bernstein-timestamp"
 # Replay window: reject requests whose timestamp drifts more than this
-# many seconds from the server clock (audit-121).  Five minutes matches
+# many seconds from the server clock. Five minutes matches
 # the Slack v0 and AWS SigV4 recommendations — short enough to bound
 # replay risk while tolerating modest clock skew between sender and
 # receiver.
@@ -60,7 +60,7 @@ def _parse_timestamp_header(raw: str) -> int | None:
 def _verify_generic_webhook_secret(request: Request, body: bytes) -> JSONResponse | None:
     """Verify the HMAC signature + timestamp freshness for POST ``/webhook``.
 
-    Fail-closed semantics (audit-042 + audit-121): when
+    Fail-closed semantics ( + ): when
     ``BERNSTEIN_WEBHOOK_SECRET`` is not configured the endpoint is
     disabled and every POST returns 503.  When a secret *is*
     configured, callers MUST supply:
@@ -74,7 +74,7 @@ def _verify_generic_webhook_secret(request: Request, body: bytes) -> JSONRespons
       capturing a valid pair.
 
     The plaintext ``X-Bernstein-Webhook-Secret`` fallback has been
-    removed (audit-121) — there is no remaining code path that
+    removed — there is no remaining code path that
     compares the raw secret against a request header.
     """
 
@@ -160,10 +160,10 @@ async def generic_webhook(body: WebhookTaskCreate, request: Request) -> WebhookT
 
     The endpoint is intentionally small and separate from the trigger-manager
     flow: callers POST a task-shaped payload and Bernstein creates one task.
-    ``BERNSTEIN_WEBHOOK_SECRET`` must be configured (fail-closed; audit-042)
+    ``BERNSTEIN_WEBHOOK_SECRET`` must be configured (fail-closed; )
     and each request must carry a fresh ``X-Bernstein-Timestamp`` header
     plus a matching ``X-Bernstein-Webhook-Signature-256`` HMAC over
-    ``f"{timestamp}.".encode() + body`` (audit-121).  The plaintext
+    ``f"{timestamp}.".encode() + body``. The plaintext
     ``X-Bernstein-Webhook-Secret`` fallback has been removed; callers
     relying on it must upgrade to the HMAC + timestamp flow.
     """
@@ -307,10 +307,10 @@ async def github_webhook(request: Request) -> JSONResponse:
       ``MAX_CI_RETRIES`` active attempts per branch.
 
     Reads ``GITHUB_WEBHOOK_SECRET`` from environment for HMAC verification.
-    Fail-closed (audit-042): when the secret is not configured the
+    Fail-closed: when the secret is not configured the
     endpoint is disabled and returns 503; unsigned GitHub webhooks are
     never accepted.
-    Replay protection (audit-121): if the caller includes an
+    Replay protection: if the caller includes an
     ``X-Bernstein-Timestamp`` header the request is additionally
     checked for freshness — drift greater than five minutes returns
     401.  Real GitHub deliveries omit this header and continue to
@@ -325,7 +325,7 @@ async def github_webhook(request: Request) -> JSONResponse:
     store = _get_store(request)
     body = await request.body()
 
-    # Verify HMAC signature — secret MUST be configured (audit-042).
+    # Verify HMAC signature — secret MUST be configured.
     gh_webhook_secret = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
     if not gh_webhook_secret:
         logger.error(
@@ -343,7 +343,7 @@ async def github_webhook(request: Request) -> JSONResponse:
                 ),
             },
         )
-    # audit-121: opt-in timestamp freshness check.  GitHub itself does
+    # opt-in timestamp freshness check. GitHub itself does
     # not send ``X-Bernstein-Timestamp``, but bernstein-internal relays
     # and test harnesses can, and when they do we enforce the same
     # five-minute skew window as the generic webhook.
@@ -486,11 +486,11 @@ def _gitlab_pipeline_to_task(payload: dict[str, Any], retry_count: int) -> dict[
 def _verify_gitlab_token(request: Request) -> JSONResponse | None:
     """Verify the GitLab webhook token and optional timestamp freshness.
 
-    Fail-closed semantics (audit-042): when ``GITLAB_WEBHOOK_TOKEN`` is
+    Fail-closed semantics: when ``GITLAB_WEBHOOK_TOKEN`` is
     not configured the endpoint is disabled and every POST returns 503;
     unsigned / unauthenticated GitLab webhooks are never accepted.
     Missing / mismatched tokens return 401.  Replay protection
-    (audit-121): when the caller includes ``X-Bernstein-Timestamp`` the
+    : when the caller includes ``X-Bernstein-Timestamp`` the
     request is rejected if its drift exceeds five minutes — GitLab
     itself never sends this header, so real deliveries are unaffected;
     the check hardens bernstein-internal relays.
@@ -517,7 +517,7 @@ def _verify_gitlab_token(request: Request) -> JSONResponse | None:
         return JSONResponse(status_code=401, content={"detail": "Missing GitLab webhook token"})
     if not hmac.compare_digest(provided_token, gitlab_token):
         return JSONResponse(status_code=401, content={"detail": "Invalid GitLab webhook token"})
-    # audit-121: opt-in timestamp freshness check — mirrors the generic
+    # opt-in timestamp freshness check — mirrors the generic
     # webhook.  Real GitLab deliveries never send this header; internal
     # relays may and, when they do, we fail closed on stale timestamps.
     ts_raw = request.headers.get(_GENERIC_WEBHOOK_TIMESTAMP_HEADER, "")

--- a/src/bernstein/core/routing/bandit_router.py
+++ b/src/bernstein/core/routing/bandit_router.py
@@ -11,7 +11,7 @@ Effort level (``low``/``high``/``max``) is learned by a separate UCB1
 model-derived heuristic until it has seen at least
 ``_EFFORT_MIN_PULLS_PER_KEY`` completions for the active key.  Rewards for
 both bandits are fed from the same ``record_outcome`` call, so effort
-preferences converge alongside model preferences (see audit-111).
+preferences converge alongside model preferences (see prior audit).
 
 Feature vector (``TaskContext.to_vector()``):
     [complexity_norm, scope_norm, priority_norm, log_repo_size,
@@ -787,7 +787,7 @@ class EffortBandit:
     arm maximises reward for a given context vector. Effort level was
     historically a fixed ``if/else`` on the chosen model, so the system never
     explored whether ``"max"`` beats ``"high"`` on a given task type (see
-    audit-111).  This class closes that loop with a lightweight, independent
+    ). This class closes that loop with a lightweight, independent
     policy: one UCB1 bandit per ``(task_type, model)`` key over the effort
     arms defined in :data:`_EFFORT_ARMS`.
 
@@ -1062,7 +1062,7 @@ class BanditRouter:
         self._selection_counts: dict[str, int] = {}
         # Arms seeded via ``seed_arm()`` keyed by ``(role, model)``. Persists
         # metadata so cost forecasts can refine estimates without keeping a
-        # second state store (audit-071).
+        # second state store.
         self._seeded_arms: dict[tuple[str, str], dict[str, float | int]] = {}
         self._exploration_history: dict[str, list[float]] = {}
         self._shadow_pending: dict[str, dict[str, Any]] = {}
@@ -1132,7 +1132,7 @@ class BanditRouter:
         Cold-start delegates to static cascade routing. Once warmed up, the
         LinUCB bandit chooses the arm and the result is clamped to a
         per-task :func:`_capability_floor` so high-stakes work still cannot
-        drop below a safe minimum (see audit-112). Whenever the clamp kicks
+        drop below a safe minimum (see prior audit). Whenever the clamp kicks
         in, the bandit's raw pick is recorded as a shadow decision so the
         override can be evaluated against observed rewards.
 
@@ -1291,7 +1291,7 @@ class BanditRouter:
     ) -> None:
         """Seed a ``(role, model)`` arm with prior knowledge.
 
-        Ported from ``EpsilonGreedyBandit.seed_arm`` in audit-071 so
+        Ported from ``EpsilonGreedyBandit.seed_arm`` in so
         effectiveness data (role/model success rates from
         :class:`EffectivenessScorer`) feeds a single, unified bandit state
         rather than the retired parallel epsilon-greedy store.
@@ -1376,7 +1376,7 @@ class BanditRouter:
 
         Invoked from :meth:`select` whenever :func:`_clamp_to_floor` lifts a
         bandit pick to satisfy the per-task capability floor. We persist the
-        clamp to the standard shadow-decisions stream so audit-112 can
+        clamp to the standard shadow-decisions stream so can
         evaluate over time whether the override cost us reward.
         """
         self._shadow_counters["floor_clamp_count"] += 1.0
@@ -1677,7 +1677,7 @@ def _is_high_stakes(task: Task) -> bool:
     Used by :func:`_static_select` during cold-start to keep high-stakes
     work off ``haiku`` before the bandit has any signal. Post-warmup the
     softer :func:`_capability_floor` / :func:`_clamp_to_floor` pair takes
-    over (audit-112) so the bandit can still learn on high-stakes tasks.
+    over so the bandit can still learn on high-stakes tasks.
     """
     return (
         task.role in _HIGH_STAKES_ROLES

--- a/src/bernstein/core/routing/model_fallback.py
+++ b/src/bernstein/core/routing/model_fallback.py
@@ -1,10 +1,10 @@
-"""Model fallback tracker — consecutive provider errors trigger model switch (T444, AGENT-004).
+"""Model fallback tracker — consecutive provider errors trigger model switch (T444).
 
 After consecutive error responses (529, 429, 503, timeouts) from a provider,
 the tracker signals that the agent should switch to a configured fallback
 model.  Counters are scoped per session to avoid cross-talk between agents.
 
-AGENT-004 extends the original 529-only tracker to handle all common error
+Extends the original 529-only tracker to handle all common error
 types with a configurable fallback chain.
 """
 
@@ -57,7 +57,7 @@ def is_model_unavailable_error(text: str) -> bool:
 
 @dataclass
 class FallbackChainConfig:
-    """Configuration for a model fallback chain (AGENT-004).
+    """Configuration for a model fallback chain.
 
     Defines which status codes trigger fallback, the strike limit, and
     an ordered list of fallback models to try in sequence.
@@ -140,7 +140,7 @@ def _classify_error_type(status_code: int) -> str:
 
 
 class ModelFallbackTracker:
-    """Track consecutive provider errors per session and signal fallback (T444, AGENT-004).
+    """Track consecutive provider errors per session and signal fallback (T444).
 
     When a session hits the configured number of consecutive error responses
     (429, 503, 529, or timeouts), ``record_response()`` returns a

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 _CAST_DICT_STR_ANY = "dict[str, Any]"
 
 # ---------------------------------------------------------------------------
-# audit-102: budget-aware routing
+# budget-aware routing
 # ---------------------------------------------------------------------------
 #
 # When the run is close to its budget cap, ``_check_opus_override`` refuses to
@@ -901,7 +901,7 @@ def route_task(
     approximately 50% cost reduction.  Critical tasks (priority=1) and
     manager-specified overrides are never routed to batch.
 
-    audit-102: when ``budget_aware_routing_enabled`` is True and the
+    when ``budget_aware_routing_enabled`` is True and the
     remaining budget cannot absorb another opus task, high-stakes tasks are
     routed to sonnet instead of opus.  Defaults come from the module-level
     ``set_budget_context`` state when not passed explicitly.
@@ -910,8 +910,8 @@ def route_task(
         task: Task to route.
         bandit_metrics_dir: Optional path to ``.sdd/metrics`` for bandit state.
         workdir: Optional project root for effectiveness scorer data.
-        budget_remaining_usd: Remaining run budget in USD (audit-102).
-        budget_aware_routing_enabled: Feature flag for audit-102 downgrade.
+        budget_remaining_usd: Remaining run budget in USD.
+        budget_aware_routing_enabled: Feature flag for downgrade.
 
     Returns:
         ModelConfig with selected model and effort (and is_batch flag).
@@ -941,7 +941,7 @@ def _check_opus_override(
 ) -> str | None:
     """Return a reason string if the task requires opus/max, otherwise None.
 
-    audit-102: when ``budget_aware_routing_enabled`` (default: module-level
+    when ``budget_aware_routing_enabled`` (default: module-level
     flag) is True and ``budget_remaining_usd`` < 2x estimated opus task cost,
     the override returns None so the caller routes to sonnet instead — a
     single opus task near the cap can overshoot by 150%+.  Explicit keyword
@@ -1095,7 +1095,7 @@ def _select_model_config(
     """Internal: select model/effort without applying batch flag.
 
     When ``budget_aware_routing_enabled`` is True and remaining budget cannot
-    absorb another opus task (audit-102), the opus override is skipped and
+    absorb another opus task, the opus override is skipped and
     the task lands on sonnet via the heuristic path.
     """
     # Manager-specified overrides take precedence
@@ -1114,7 +1114,7 @@ def _select_model_config(
         return ModelConfig(model=model, effort=effort)
 
     # High-stakes roles/scope/priority skip bandit — always use premium models
-    # (unless budget-aware routing downgrades the call: audit-102).
+    # (unless budget-aware routing downgrades the call: ).
     opus_reason = _check_opus_override(
         task,
         budget_remaining_usd=budget_remaining_usd,

--- a/src/bernstein/core/security/always_allow.py
+++ b/src/bernstein/core/security/always_allow.py
@@ -9,7 +9,7 @@ Rules take **highest precedence** — an ALLOW from this engine overrides
 any ASK or DENY from other guardrails (except IMMUNE and SAFETY which
 remain bypass-immune).
 
-Security model (audit-046):
+Security model:
     ALLOW decisions from this engine override almost every other guardrail,
     so the rules file must be *read-only from the agent's perspective*. The
     loader enforces this by:

--- a/src/bernstein/core/security/audit_export.py
+++ b/src/bernstein/core/security/audit_export.py
@@ -1,4 +1,4 @@
-"""ENT-012: Audit log export to external SIEM systems.
+"""Audit log export to external SIEM systems.
 
 Exports Bernstein audit log entries to Splunk (HEC), Elasticsearch,
 AWS CloudWatch Logs, syslog, webhook, and local files.  Each exporter

--- a/src/bernstein/core/security/auth.py
+++ b/src/bernstein/core/security/auth.py
@@ -849,7 +849,7 @@ def _verify_saml_signature(xml_bytes: bytes, idp_x509_cert: str) -> bytes:
     cert_pem = _normalize_idp_cert(idp_x509_cert)
 
     try:
-        # resolve_entities=False mitigates XXE; see audit-054.
+        # resolve_entities=False mitigates XXE; see prior audit.
         parser = etree.XMLParser(resolve_entities=False, no_network=True)
         root = etree.fromstring(xml_bytes, parser=parser)
     except etree.XMLSyntaxError as exc:
@@ -1116,7 +1116,7 @@ class AuthService:
         DTDs, external entities, and *internal* entity expansion are refused
         outright. stdlib ``xml.etree`` happily expands nested internal entities,
         which is sufficient for a billion-laughs / quadratic-blowup DoS even
-        though ``xml.etree`` blocks external entities by default (audit-054).
+        though ``xml.etree`` blocks external entities by default.
         """
         # defusedxml.ElementTree is a drop-in for xml.etree.ElementTree and
         # re-exports stdlib ``ParseError``; it additionally raises

--- a/src/bernstein/core/security/data_residency.py
+++ b/src/bernstein/core/security/data_residency.py
@@ -1,4 +1,4 @@
-"""ENT-009: Data residency controls.
+"""Data residency controls.
 
 Ensures task data, logs, and agent outputs stay within configured geographic
 regions.  Provides region tagging, residency validation, and attestation

--- a/src/bernstein/core/security/jwt_tokens.py
+++ b/src/bernstein/core/security/jwt_tokens.py
@@ -130,7 +130,7 @@ class JWTManager:
         Verifies the header ``alg`` claim against ``self._algorithm`` *before*
         computing any HMAC. This blocks the classic ``{"alg": "none"}``
         bypass and future alg-confusion attacks (e.g. an RS256 token forged
-        under an HS256 verifier). See security audit-053.
+        under an HS256 verifier). See security.
 
         Args:
             token: JWT token string.

--- a/src/bernstein/core/security/license_manager.py
+++ b/src/bernstein/core/security/license_manager.py
@@ -1,4 +1,4 @@
-"""ENT-014: Enterprise license management with feature gates.
+"""Enterprise license management with feature gates.
 
 Manages license keys, validates entitlements, and enforces feature gates.
 Licenses are signed JSON payloads with expiration dates, seat counts, and

--- a/src/bernstein/core/security/pii_output_gate.py
+++ b/src/bernstein/core/security/pii_output_gate.py
@@ -307,7 +307,7 @@ def _scan_line(
     each reported, while exact duplicates (same rule hitting the same span —
     possible if scans ever overlap) are not counted twice. This prevents the
     scanner-evasion bug where a single rule's dedup would silently drop the
-    second/third secret of the same type (audit-044).
+    second/third secret of the same type.
     """
     if _is_allowlisted(line, allowlist_prefixes):
         return

--- a/src/bernstein/core/security/resource_limits.py
+++ b/src/bernstein/core/security/resource_limits.py
@@ -1,4 +1,4 @@
-"""Agent process resource limits (AGENT-013).
+"""Agent process resource limits.
 
 Applies CPU, memory, and disk I/O limits to agent processes using
 ``resource.setrlimit`` (POSIX) or advisory tracking when OS-level

--- a/src/bernstein/core/security/soc2_report.py
+++ b/src/bernstein/core/security/soc2_report.py
@@ -1,4 +1,4 @@
-"""ENT-004: SOC 2 compliance reporting.
+"""SOC 2 compliance reporting.
 
 Transforms the raw audit export into a structured compliance package with:
 - Control mappings (SOC 2 Type II trust service criteria)

--- a/src/bernstein/core/security/sso_oidc.py
+++ b/src/bernstein/core/security/sso_oidc.py
@@ -1,4 +1,4 @@
-"""ENT-006: SSO/OIDC authentication for web dashboard.
+"""SSO/OIDC authentication for web dashboard.
 
 Standard OpenID Connect Authorization Code flow with configurable provider.
 Supports auto-discovery via ``.well-known/openid-configuration``, PKCE,

--- a/src/bernstein/core/security/tenant_isolation.py
+++ b/src/bernstein/core/security/tenant_isolation.py
@@ -1,4 +1,4 @@
-"""ENT-001: Multi-tenant task isolation.
+"""Multi-tenant task isolation.
 
 Adds tenant_id scoping to task queries, WAL paths, and metrics directories.
 Data paths follow the layout: ``.sdd/{tenant_id}/``.

--- a/src/bernstein/core/security/tenant_rate_limiter.py
+++ b/src/bernstein/core/security/tenant_rate_limiter.py
@@ -1,4 +1,4 @@
-"""ENT-008: Per-tenant rate limiting and quota enforcement.
+"""Per-tenant rate limiting and quota enforcement.
 
 Provides tenant-scoped rate limiting with configurable quotas per tenant.
 Each tenant gets independent rate limit windows, task quotas, and agent

--- a/src/bernstein/core/server/access_log.py
+++ b/src/bernstein/core/server/access_log.py
@@ -103,7 +103,7 @@ def extract_remote_ip(request: Request) -> str:
 class StructuredAccessLogMiddleware(BaseHTTPMiddleware):
     """Emit one structured JSONL access record for every API response.
 
-    Performance notes (audit-080):
+    Performance notes:
         Rotation is debounced — we call :func:`rotate_log_file` (which stats
         the file) at most once per :data:`_ROTATE_CHECK_INTERVAL_SECONDS`
         OR after cumulative in-memory byte writes cross

--- a/src/bernstein/core/server/hooks_receiver.py
+++ b/src/bernstein/core/server/hooks_receiver.py
@@ -16,7 +16,7 @@ Design:
 - ``PostToolUse`` events update an activity timestamp file so the heartbeat
   monitor has a second source of liveness signals.
 
-Security (audit-114):
+Security:
 - ``session_id`` arrives from an untrusted URL path parameter and is used
   verbatim as a filename for marker/sidecar/heartbeat files.  An attacker
   who can reach the endpoint (which is explicitly public because hooks

--- a/src/bernstein/core/server/server_app.py
+++ b/src/bernstein/core/server/server_app.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# audit-117: body-size cap middleware
+# body-size cap middleware
 # ---------------------------------------------------------------------------
 
 # Default cap for request bodies.  Starlette accepts unlimited bodies by
@@ -313,7 +313,7 @@ def task_to_response(task: Task) -> TaskResponse:
         progress_log=list(cast("list[ProgressEntry]", task.progress_log)),  # type: ignore[reportUnknownMemberType]
         version=task.version,
         parent_session_id=task.parent_session_id,
-        # audit-017: expose typed retry bookkeeping so clients read the
+        # expose typed retry bookkeeping so clients read the
         # single source of truth rather than regex-ing the title.
         retry_count=task.retry_count,
         max_retries=task.max_retries,
@@ -339,25 +339,25 @@ class SSEBus:
     - Queue buffer size limit prevents unbounded memory growth.
     - Heartbeat pings enable disconnect detection.
     - Stale subscriber cleanup prevents leaked queue references.
-    - audit-122: reconnect-frequency limiter blocks IPs that churn
+    - reconnect-frequency limiter blocks IPs that churn
       subscribe/unsubscribe faster than ``RECONNECT_MAX_PER_WINDOW``
       inside ``RECONNECT_WINDOW_S``.
-    - audit-122: per-IP buffer budget caps total events across all
+    - per-IP buffer budget caps total events across all
       queues belonging to the same IP (defends slow-client DoS).
-    - audit-122: dropped-event counter with warn logging to flag
+    - dropped-event counter with warn logging to flag
       slow clients without killing the orchestrator.
     """
 
     # Maximum events buffered per subscriber before dropping
     MAX_BUFFER_SIZE: int = 256
-    # Maximum total events buffered per IP across all its queues (audit-122)
+    # Maximum total events buffered per IP across all its queues
     MAX_BUFFER_PER_IP: int = 1024
     # Seconds after which a subscriber with no reads is considered stale
-    # (audit-122: lowered from 120s to 30s for /events slow-client DoS)
+    # (lowered from 120s to 30s for /events slow-client DoS)
     STALE_TIMEOUT_S: float = 30.0
     # Heartbeat interval for SSE keep-alive pings
     HEARTBEAT_INTERVAL_S: float = 15.0
-    # audit-122: reconnect-frequency limiter parameters. Three clean
+    # reconnect-frequency limiter parameters. Three clean
     # reconnects inside RECONNECT_WINDOW_S tolerates a flaky wifi drop
     # (heartbeat timeout ~= 60s so one cycle per minute is realistic).
     RECONNECT_MAX_PER_WINDOW: int = 3
@@ -376,26 +376,26 @@ class SSEBus:
     ) -> None:
         self._subscribers: list[asyncio.Queue[str]] = []
         self._subscriber_last_read: dict[int, float] = {}
-        # audit-122: map queue id -> owning IP so per-IP accounting works
+        # map queue id -> owning IP so per-IP accounting works
         self._subscriber_ip: dict[int, str] = {}
         self._max_buffer = max_buffer
         self._stale_timeout_s = stale_timeout_s
         self._max_buffer_per_ip = max_buffer_per_ip
-        # audit-122: sliding-window record of recent subscribe() timestamps
+        # sliding-window record of recent subscribe() timestamps
         # per IP. Bounded by RECONNECT_MAX_PER_WINDOW + 1 to avoid unbounded
         # growth for abusive clients.
         _max_hist = reconnect_max_per_window + 1
         self._recent_connects: dict[str, deque[float]] = defaultdict(lambda: deque(maxlen=_max_hist))
-        # audit-122: cooldown expiry per IP (monotonic timestamp)
+        # cooldown expiry per IP (monotonic timestamp)
         self._reconnect_cooldown_until: dict[str, float] = {}
         self._reconnect_max_per_window = reconnect_max_per_window
         self._reconnect_window_s = reconnect_window_s
         self._reconnect_cooldown_s = reconnect_cooldown_s
-        # audit-122: dropped-event counters (total + last warn ts)
+        # dropped-event counters (total + last warn ts)
         self._dropped_events_total: int = 0
         self._last_drop_warning_ts: float = 0.0
 
-    # ---- reconnect tracking (audit-122) -----------------------------------
+    # ---- reconnect tracking -----------------------------------
 
     def is_blocked(self, ip: str, *, now: float | None = None) -> bool:
         """Return ``True`` when *ip* is inside its reconnect-cooldown window."""
@@ -444,7 +444,7 @@ class SSEBus:
 
         Args:
             client_ip: Optional remote IP string. When provided, the
-                connection is subject to the audit-122 reconnect-frequency
+                connection is subject to the reconnect-frequency
                 limiter and the per-IP buffer budget. ``None`` opts out
                 (used by synthetic callers — heartbeat loop, unit tests).
 
@@ -496,7 +496,7 @@ class SSEBus:
         """Push an event to all subscribers (non-blocking).
 
         If a subscriber's queue is full, or pushing would exceed the
-        per-IP buffer budget (audit-122), the event is dropped for that
+        per-IP buffer budget, the event is dropped for that
         subscriber. A warning is logged when drops are observed.
         """
         message = f"event: {event_type}\ndata: {data}\n\n"
@@ -553,7 +553,7 @@ class SSEBus:
 
 
 # ---------------------------------------------------------------------------
-# audit-122: SSE reconnect limiter middleware
+# SSE reconnect limiter middleware
 # ---------------------------------------------------------------------------
 
 
@@ -701,7 +701,7 @@ def _split_cors_origins(
 
     ``starlette.middleware.cors.CORSMiddleware`` compares ``allow_origins``
     literally — ``"http://localhost:*"`` never matches a real browser
-    origin such as ``"http://localhost:3000"``.  audit-118 requires us to
+    origin such as ``"http://localhost:3000"``. requires us to
     translate glob-style origins into an ``allow_origin_regex`` that
     CORSMiddleware actually honors.
 
@@ -829,7 +829,7 @@ def preflight_multi_worker_guard() -> None:
     Bernstein's ``TaskStore`` coordinates mutations with an in-process
     ``asyncio.Lock`` and appends to JSONL without ``fcntl.flock`` — running
     under ``uvicorn --workers N`` (or ``WEB_CONCURRENCY>1``) causes torn
-    JSONL lines and duplicate task claims (audit-025).
+    JSONL lines and duplicate task claims.
 
     The guard fires at app-factory time so each uvicorn worker subprocess
     re-runs it on import and bails out with a clear message instead of
@@ -884,7 +884,7 @@ def create_app(
         SystemExit: Via ``preflight_multi_worker_guard`` when the operator
             requests more than one uvicorn worker — the ``TaskStore`` is
             single-process and multi-worker mode corrupts state
-            (audit-025).
+            .
     """
     preflight_multi_worker_guard()
     setup_json_logging()
@@ -924,7 +924,7 @@ def create_app(
         _nodes_persist = _runtime_dir / "nodes.json"
     node_registry = NodeRegistry(effective_cluster, persist_path=_nodes_persist)
 
-    # Cluster JWT authentication (ENT-002)
+    # Cluster JWT authentication
     from bernstein.core.cluster_auth import ClusterAuthConfig, ClusterAuthenticator
 
     _cluster_auth_secret = effective_cluster.auth_token or ""
@@ -993,7 +993,7 @@ def create_app(
         ):
             signal.signal(signal.SIGHUP, previous_sighup)
         await store.flush_buffer()
-        # Close the persistent access-log file handle (audit-080).
+        # Close the persistent access-log file handle.
         middleware_stack = getattr(app, "middleware_stack", None)
         while middleware_stack is not None:
             if isinstance(middleware_stack, StructuredAccessLogMiddleware):
@@ -1041,7 +1041,7 @@ def create_app(
     # Crash guard — outermost middleware, catches unhandled exceptions
     application.add_middleware(CrashGuardMiddleware)
 
-    # audit-117: body-size cap.  Added BEFORE auth/rate-limit so oversized bodies
+    # body-size cap. Added BEFORE auth/rate-limit so oversized bodies
     # are rejected with 413 without ever being buffered into memory.  Starlette
     # orders ``add_middleware`` calls from innermost (first to handle the
     # response) to outermost (first to see the request), so registering this
@@ -1098,7 +1098,7 @@ def create_app(
     # Per-endpoint request rate limiting — reads buckets from app.state.seed_config.
     application.add_middleware(RequestRateLimitMiddleware)
 
-    # audit-122: SSE reconnect-frequency limiter. Rejects /events clients that
+    # SSE reconnect-frequency limiter. Rejects /events clients that
     # reconnect faster than 3 times per 60 s for a 5-minute cooldown.
     application.add_middleware(SSEReconnectLimiterMiddleware)
 
@@ -1122,7 +1122,7 @@ def create_app(
 
     from starlette.middleware.cors import CORSMiddleware
 
-    # audit-118: starlette.middleware.cors.CORSMiddleware compares
+    # starlette.middleware.cors.CORSMiddleware compares
     # ``allow_origins`` LITERALLY — so ``http://localhost:*`` never matches
     # a real ``http://localhost:3000``.  Detect glob patterns, strip them
     # from the literal list, and translate them to a regex passed via
@@ -1171,7 +1171,7 @@ def create_app(
     application.state.seed_config = None  # type: ignore[attr-defined]
     application.state.tenant_registry = None  # type: ignore[attr-defined]
 
-    # ENT-001: Multi-tenant task isolation manager
+    # Multi-tenant task isolation manager
     from bernstein.core.tenant_isolation import TenantIsolationManager
 
     tenant_isolation_mgr = TenantIsolationManager(sdd_dir)

--- a/src/bernstein/core/server/server_launch.py
+++ b/src/bernstein/core/server/server_launch.py
@@ -234,7 +234,7 @@ def _start_server(
         cluster_enabled: Enable cluster endpoints and node reaper.
         auth_token: Bearer token for API auth.
         evolve_mode: Retained for signature compatibility. Uvicorn
-            ``--reload`` was removed 2026-04-17 per audit-115 because
+            ``--reload`` was removed 2026-04-17 per because
             auto-reload is catastrophic in self-modifying runs
             (file writes → restart → dropped HTTP connections → WAL
             replay duplicate claims). The flag no longer affects the
@@ -247,16 +247,16 @@ def _start_server(
         RuntimeError: If a server is already running on the PID file.
         SystemExit: If ``BERNSTEIN_WORKERS`` / ``WEB_CONCURRENCY`` request
             more than one uvicorn worker. Bernstein's ``TaskStore`` is
-            single-process (audit-025) and multi-worker mode corrupts
+            single-process and multi-worker mode corrupts
             JSONL and allows double-claims.
     """
-    # audit-025: refuse to launch multi-worker in the parent process so the
+    # refuse to launch multi-worker in the parent process so the
     # operator sees the error on the bernstein CLI instead of in server.log
     # after a silent subprocess crash.
     from bernstein.core.server.server_app import preflight_multi_worker_guard
 
     preflight_multi_worker_guard()
-    logger.info("Starting task server on %s:%d (single-worker mode, audit-025)", bind_host, port)
+    logger.info("Starting task server on %s:%d (single-worker mode)", bind_host, port)
 
     pid_path = workdir / ".sdd" / "runtime" / "server.pid"
     existing = _read_pid(pid_path)
@@ -272,7 +272,7 @@ def _start_server(
     env["BERNSTEIN_BIND_HOST"] = bind_host
     if auth_token:
         env["BERNSTEIN_AUTH_TOKEN"] = auth_token
-    # audit-025: pin the child to single-worker even if the parent env had
+    # pin the child to single-worker even if the parent env had
     # WEB_CONCURRENCY set (the preflight above already rejected that case,
     # but we belt-and-braces here in case a future code path bypasses it).
     env["BERNSTEIN_WORKERS"] = "1"
@@ -313,7 +313,7 @@ def _start_server(
                     "2" if cluster_tls.verify_mode == "required" else "1",
                 ]
             )
-    # ``--reload`` was removed 2026-04-17 per audit-115 / incident
+    # ``--reload`` was removed 2026-04-17 per / incident
     # 2026-04-11.  Bernstein agents continuously edit src/bernstein/*.py,
     # so auto-reload causes a uvicorn restart on every write — in-flight
     # requests drop, the bind port races, and WAL replay produces

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -27,11 +27,11 @@ class CompletionSignalSchema(BaseModel):
     value: str
 
 
-# audit-117: input-size caps for TaskCreate (prevents OOM via 200MB descriptions).
+# input-size caps for TaskCreate (prevents OOM via 200MB descriptions).
 # Titles are short human-readable summaries; descriptions can carry a plan but must
 # stay below the per-request body cap (1MB) enforced by ContentLengthMiddleware.
 _MAX_TITLE_LEN = 500  # Raised from 200 — real backlog/audit tickets use
-# long descriptive titles (audit-169-… runs to 206 chars). 500 still caps
+# long descriptive titles (-… runs to 206 chars). 500 still caps
 # abusive multi-MB titles but stops ingest_backlog batch POSTs 422-ing every
 # 20 s whenever the backlog carries any title > 200.
 _MAX_DESCRIPTION_LEN = 100_000
@@ -67,7 +67,7 @@ def _enforce_dict_size(value: dict[str, Any] | None, *, field_name: str) -> dict
 class TaskCreate(BaseModel):
     """Body for POST /tasks."""
 
-    # audit-117: bounded string lengths prevent trivial memory exhaustion.
+    # bounded string lengths prevent trivial memory exhaustion.
     title: str = Field(max_length=_MAX_TITLE_LEN)
     description: str = Field(max_length=_MAX_DESCRIPTION_LEN)
     role: str = Field(default="auto", max_length=_MAX_SHORT_STR_LEN)
@@ -97,7 +97,7 @@ class TaskCreate(BaseModel):
     deadline: float | None = None  # Epoch timestamp when task must be complete
     parent_session_id: str | None = Field(default=None, max_length=_MAX_SHORT_STR_LEN)
     parent_context: str | None = Field(default=None, max_length=_MAX_DESCRIPTION_LEN)
-    # Retry bookkeeping (audit-017): retry_count is the single source of truth.
+    # Retry bookkeeping: retry_count is the single source of truth.
     # When a retry task is created, the orchestrator sets retry_count=previous+1.
     retry_count: int | None = None  # Current retry attempt number (0 = first attempt)
     max_retries: int | None = None  # Per-task override of default retry limit
@@ -106,7 +106,7 @@ class TaskCreate(BaseModel):
     max_output_tokens: int | None = None  # Per-task output-token cap (escalated on retry)
     meta_messages: list[str] | None = Field(default=None, max_length=_MAX_LIST_LEN)
 
-    # audit-117: cap serialized size of dict-of-any fields to block deeply-nested
+    # cap serialized size of dict-of-any fields to block deeply-nested
     # or very wide payloads from wedging the server at pydantic-validation time.
     def model_post_init(self, _context: Any) -> None:
         """Enforce serialized-size caps on dict fields and meta_messages entries."""
@@ -187,7 +187,7 @@ class TaskResponse(BaseModel):
     progress_log: list[ProgressEntry] = Field(default_factory=list)
     version: int = 1
     parent_session_id: str | None = None  # Coordinator session that owns this task
-    # Retry bookkeeping (audit-017): typed fields are the single source of truth.
+    # Retry bookkeeping: typed fields are the single source of truth.
     retry_count: int = 0
     max_retries: int = 3
     retry_delay_s: float = 0.0

--- a/src/bernstein/core/server/server_supervisor.py
+++ b/src/bernstein/core/server/server_supervisor.py
@@ -158,7 +158,7 @@ def _launch_server(state: _SupervisorState) -> int:
         "--port",
         str(port),
     ]
-    # ``--reload`` was removed 2026-04-17 per audit-115 / incident 2026-04-11.
+    # ``--reload`` was removed 2026-04-17 per / incident 2026-04-11.
     # In a self-modifying system (bernstein agents constantly edit
     # src/bernstein/*.py) uvicorn --reload is catastrophic: every file write
     # triggers a uvicorn restart, which drops in-flight HTTP connections,
@@ -166,7 +166,7 @@ def _launch_server(state: _SupervisorState) -> int:
     # with duplicate task claims. Evolve cycles already restart via the
     # supervisor on real crashes — auto-reload is never wanted here.
     # ``state.evolve_mode`` is intentionally not consulted when building the
-    # uvicorn argv; if you're tempted to re-add --reload, read audit-115
+    # uvicorn argv; if you're tempted to re-add --reload, read
     # first.
 
     log_path = workdir / ".sdd" / "runtime" / "server.log"

--- a/src/bernstein/core/server/webhook_verify.py
+++ b/src/bernstein/core/server/webhook_verify.py
@@ -62,7 +62,7 @@ class WebhookSignatureVerifier:
     async def __call__(self, request: Request) -> None:
         """Verify the webhook signature or raise 401/403/503.
 
-        Fail-closed (audit-042): when no secret is configured (neither
+        Fail-closed: when no secret is configured (neither
         constructor argument, ``request.app.state.webhook_secret``, nor
         the configured environment variable) the dependency raises HTTP
         503 — the endpoint is considered disabled and unsigned requests

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1186,7 +1186,7 @@ class OrchestratorConfig:
     kill_on_memory_leak: bool = False
     evolve_mode: bool = False
     budget_usd: float = 0.0  # Stop spawning when cumulative cost reaches this (0 = unlimited)
-    budget_aware_routing_enabled: bool = True # downgrade opus→sonnet near budget cap
+    budget_aware_routing_enabled: bool = True  # downgrade opus→sonnet near budget cap
     dry_run: bool = False  # Preview planned spawns without actually spawning agents
     auth_token: str | None = None  # Bearer token for authenticated API calls
     merge_strategy: str = "pr"  # "pr" | "direct" — how agent work reaches the main branch
@@ -1240,7 +1240,7 @@ class OrchestratorConfig:
     # while per-tenant caps prevent any tenant from monopolising the worker pool.
     # Default off; enable once multi-tenant workloads exist.
     fair_scheduling_enabled: bool = False
-    cost_autopilot: bool = False # Wire CostAutopilot when True
+    cost_autopilot: bool = False  # Wire CostAutopilot when True
 
     def __post_init__(self) -> None:
         """Parse nested workflow config if dict provided."""

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -1116,7 +1116,7 @@ class ConvergenceGuardConfig:
 
 @dataclass(frozen=True)
 class CIAutofixConfig:
-    """Configuration for orchestrator-driven CI autofix polling (audit-035).
+    """Configuration for orchestrator-driven CI autofix polling.
 
     When ``enabled`` is True, the orchestrator tick periodically polls the
     GitHub Actions API for failing workflow runs and creates Bernstein fix
@@ -1172,7 +1172,7 @@ class OrchestratorConfig:
     # via ``tuning.orchestrator.tick_interval_s`` actually change the tick rate.
     poll_interval_s: int = field(default_factory=_default_poll_interval_s)
     smtp: SmtpConfig | None = None
-    # Unified with AGENT.heartbeat_stale_s (audit-147). Previously 900s; now defaults to 120s.
+    # Unified with AGENT.heartbeat_stale_s. Previously 900s; now defaults to 120s.
     # Deployments that explicitly relied on the 900s value must set this field explicitly.
     heartbeat_timeout_s: int = field(default_factory=lambda: int(AGENT.heartbeat_stale_s))
     heartbeat_enabled: bool = True
@@ -1186,7 +1186,7 @@ class OrchestratorConfig:
     kill_on_memory_leak: bool = False
     evolve_mode: bool = False
     budget_usd: float = 0.0  # Stop spawning when cumulative cost reaches this (0 = unlimited)
-    budget_aware_routing_enabled: bool = True  # audit-102: downgrade opus→sonnet near budget cap
+    budget_aware_routing_enabled: bool = True # downgrade opus→sonnet near budget cap
     dry_run: bool = False  # Preview planned spawns without actually spawning agents
     auth_token: str | None = None  # Bearer token for authenticated API calls
     merge_strategy: str = "pr"  # "pr" | "direct" — how agent work reaches the main branch
@@ -1230,17 +1230,17 @@ class OrchestratorConfig:
     drain_timeout_s: float = field(
         default_factory=lambda: _defaults.ORCHESTRATOR.drain_timeout_s,
     )  # Seconds to wait for agents during drain before cleanup
-    # Priority-aging janitor (audit-020): boost long-waiting low-priority tasks
+    # Priority-aging janitor: boost long-waiting low-priority tasks
     # so they do not starve behind a steady stream of P1 work.  Default off
     # until run data confirms behaviour; interval is measured in orchestrator ticks.
     priority_aging_enabled: bool = False
     priority_aging_interval_ticks: int = 60
-    # Weighted fair scheduling across tenants (audit-020): re-order batches by
+    # Weighted fair scheduling across tenants: re-order batches by
     # deficit round-robin so high-weight tenants get proportionally more slots
     # while per-tenant caps prevent any tenant from monopolising the worker pool.
     # Default off; enable once multi-tenant workloads exist.
     fair_scheduling_enabled: bool = False
-    cost_autopilot: bool = False  # Wire CostAutopilot when True (audit-060)
+    cost_autopilot: bool = False # Wire CostAutopilot when True
 
     def __post_init__(self) -> None:
         """Parse nested workflow config if dict provided."""

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -208,7 +208,7 @@ def check_file_overlap(
 def prepare_speculative_warm_pool(orch: Any, task_graph: Any, tasks: list[Task]) -> None:
     """Pre-create warm-pool capacity for tasks that are one dependency away.
 
-    This keeps AGENT-022 aligned with Bernstein's short-lived-agent invariant:
+    This keeps aligned with Bernstein's short-lived-agent invariant:
     only worktrees/adapter capacity are prepared ahead of time. No task is
     claimed and no sleeping agent process is created.
 
@@ -420,7 +420,7 @@ def maybe_retry_task(
     if task.id in retried_task_ids:
         return False
 
-    # audit-017: ``task.retry_count`` is the single source of truth.  Title
+    # ``task.retry_count`` is the single source of truth. Title
     # prefixes and ``[retry:N]`` description markers are no longer consulted
     # or written.  Legacy tasks with a stale ``[RETRY N]`` prefix retain it
     # in the title until they complete, but the counter they report is the
@@ -551,7 +551,7 @@ def _enqueue_dlq_if_workdir(
     reason: str,
     original_error: str,
 ) -> None:
-    """Record a permanently-failed task in the Dead Letter Queue (audit-019).
+    """Record a permanently-failed task in the Dead Letter Queue.
 
     Looks up ``<workdir>/.sdd`` and appends an entry to ``runtime/dlq.jsonl``.
     A ``None`` workdir preserves legacy behaviour (no DLQ), and any OS or
@@ -626,11 +626,11 @@ def retry_or_fail_task(
     """Re-queue a task for retry, or fail it permanently if max retries reached.
 
     Reads the current retry count from the typed ``task.retry_count`` field —
-    the single source of truth (audit-017).  Title and description are copied
+    the single source of truth. Title and description are copied
     verbatim; no ``[RETRY N]`` / ``[retry:N]`` markers are written.  If the
     typed counter is below ``min(task.max_retries, dynamic_limit(reason))`` a
     new open task is created with ``retry_count`` incremented; otherwise the
-    task is moved to the Dead Letter Queue (audit-019) and failed with a
+    task is moved to the Dead Letter Queue and failed with a
     ``"Max retries exceeded"`` reason.
 
     Args:
@@ -645,7 +645,7 @@ def retry_or_fail_task(
             extra HTTP round-trip when the task is already in cache.
         workdir: Orchestrator working directory.  When provided, tasks that
             exhaust their retry budget are also enqueued into the Dead Letter
-            Queue under ``<workdir>/.sdd/runtime/dlq.jsonl`` (audit-019).
+            Queue under ``<workdir>/.sdd/runtime/dlq.jsonl``.
             Callers without a workdir (e.g. ad-hoc scripts or legacy tests)
             fall back to the historical behaviour of plain failure.
     """
@@ -680,7 +680,7 @@ def retry_or_fail_task(
         return
     retried_task_ids.add(task_id)
 
-    # audit-017: source of truth is ``task.retry_count`` (typed field).
+    # source of truth is ``task.retry_count`` (typed field).
     retry_count = task.retry_count
     per_task_limit = task.max_retries if task.max_retries > 0 else max_task_retries
     effective_limit = min(per_task_limit, dynamic_limit)
@@ -786,7 +786,7 @@ def retry_or_fail_task(
         with contextlib.suppress(httpx.HTTPError):
             fail_task(client, base, task_id, f"Retried: {reason}")
     else:
-        # audit-019: retry budget exhausted — move to Dead Letter Queue
+        # retry budget exhausted — move to Dead Letter Queue
         # before marking the task failed so permanently-failed work is not
         # silently dropped.
         _enqueue_dlq_if_workdir(
@@ -839,7 +839,7 @@ def should_auto_decompose(
     if task.title.startswith("[DECOMPOSE]"):
         return False
 
-    # audit-017: use the typed retry counter (source of truth), falling back
+    # use the typed retry counter (source of truth), falling back
     # to a legacy ``[RETRY N]`` title prefix only when the typed field is 0
     # (so in-flight pre-migration tasks still decompose correctly).
     import re
@@ -1140,7 +1140,7 @@ def _pre_spawn_checks_pass(orch: Any, alive_count: int) -> bool:
 
 
 def _apply_fair_scheduling(orch: Any, batches: list[list[Task]]) -> list[list[Task]]:
-    """Re-order batches using the weighted fair scheduler (audit-020).
+    """Re-order batches using the weighted fair scheduler.
 
     Feeds one representative task per batch into a :class:`FairScheduler`
     keyed by ``task.tenant_id``.  The scheduler emits a deficit-round-robin
@@ -1241,7 +1241,7 @@ def claim_and_spawn_batches(
     if not _pre_spawn_checks_pass(orch, alive_count):
         return
 
-    # Fair scheduling (audit-020): when enabled, re-order batches using
+    # Fair scheduling: when enabled, re-order batches using
     # weighted deficit round-robin across tenants so multi-tenant workloads
     # get proportional service instead of FIFO starvation.  Runs before
     # the HTTP /claim calls below. Default-off via ``fair_scheduling_enabled``.
@@ -1500,7 +1500,7 @@ def claim_and_spawn_batches(
         # WAL: record pre-execution intent BEFORE the HTTP POST /claim so a
         # SIGKILL between the server-side claim transition and the local WAL
         # write can never produce a server-side "claimed" task with no WAL
-        # trace (audit-013).  The legacy ``task_claimed`` decision_type is
+        # trace. The legacy ``task_claimed`` decision_type is
         # reused so existing recovery wiring (``find_orphaned_claims``)
         # continues to force-claim abandoned tasks back to the open queue.
         # Worktree path is not yet known -- it is recorded in the follow-up
@@ -1800,7 +1800,7 @@ def claim_and_spawn_batches(
                 len(batch),
                 [t.id for t in batch],
             )
-            # WAL: record the worktree materialisation (audit-013).
+            # WAL: record the worktree materialisation.
             # This intermediate ``claim_confirmed`` entry ties every claimed
             # task_id to its concrete worktree_path BEFORE the final commit.
             # A SIGKILL between here and ``task_spawn_confirmed`` leaves an

--- a/src/bernstein/core/tasks/task_spawn_bridge.py
+++ b/src/bernstein/core/tasks/task_spawn_bridge.py
@@ -54,7 +54,7 @@ def should_auto_decompose(
     if task.title.startswith("[DECOMPOSE]"):
         return False
 
-    # audit-017: prefer the typed retry counter; fall back to a legacy
+    # prefer the typed retry counter; fall back to a legacy
     # ``[RETRY N]`` title prefix only when the typed field is 0.
     import re
 

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -85,7 +85,7 @@ class TaskRecord(TypedDict):
     parent_session_id: str | None
     subtask_wait_started_at: float | None
     parent_context: str | None
-    # audit-017: typed retry bookkeeping (optional for backward compat).
+    # typed retry bookkeeping (optional for backward compat).
     retry_count: NotRequired[int]
     max_retries: NotRequired[int]
     retry_delay_s: NotRequired[float]
@@ -184,7 +184,7 @@ class TaskCreateRequest(Protocol):
     parent_session_id: str | None
     parent_context: str | None
 
-    # Retry bookkeeping (audit-017): typed retry fields are the single source
+    # Retry bookkeeping: typed retry fields are the single source
     # of truth.  When orchestrator clones a task for retry, it passes
     # ``retry_count=previous+1`` in the request.  These fields are optional on
     # the wire (``None`` / missing => fall back to the Task dataclass default).
@@ -259,10 +259,10 @@ DEFAULT_ARCHIVE_PATH = Path(".sdd/archive/tasks.jsonl")
 # before any cleanup pass may evict them from the active task set.
 PANEL_GRACE_MS: int = 30_000
 
-# audit-028: reason used when auto-failing a task due to empty result_summary.
+# reason used when auto-failing a task due to empty result_summary.
 _EMPTY_COMPLETION_REASON = "completion missing summary"
 
-# audit-023: rotate the per-task progress JSONL file once it exceeds 5 MiB.
+# rotate the per-task progress JSONL file once it exceeds 5 MiB.
 # Old rollovers become ``{task_id}.jsonl.1``; replay also reads them so no
 # history is silently dropped between restarts.
 _PROGRESS_ROTATE_BYTES: int = 5 * 1024 * 1024
@@ -292,7 +292,7 @@ class TaskStore:
 
     All mutations go through this class so the JSONL log stays consistent.
 
-    Concurrency model (audit-025):
+    Concurrency model:
         Mutations are coordinated by an in-process ``asyncio.Lock`` and the
         JSONL append path does NOT take an OS-level file lock (no
         ``fcntl.flock``). The store is therefore **single-process only** —
@@ -339,7 +339,7 @@ class TaskStore:
         self._cost_cache_offset: int = 0
         # In-memory progress snapshots for stall detection (last 10 per task)
         self._progress_snapshots: dict[str, deque[ProgressSnapshot]] = {}
-        # audit-023: directory for per-task progress JSONL files.  Each
+        # directory for per-task progress JSONL files. Each
         # ``add_progress``/``add_snapshot`` call appends (and fsyncs) a line
         # here so that progress history survives a server crash.  Rebuilt on
         # startup by ``replay_progress()``.
@@ -374,7 +374,7 @@ class TaskStore:
         Each line is a JSON object with at least ``id`` and ``status``.
         Lines are replayed in order so the last write wins.
 
-        audit-023: after the task log is replayed we also replay the
+        after the task log is replayed we also replay the
         per-task progress JSONL files so ``progress_log`` and
         ``_progress_snapshots`` survive a server restart.  Progress replay
         runs unconditionally so fresh installations with only progress on
@@ -425,7 +425,7 @@ class TaskStore:
         during startup.
 
         The release is persisted to the JSONL log synchronously (bug
-        ``audit-015``): without this, the in-memory reset is lost on crash and
+        ````): without this, the in-memory reset is lost on crash and
         the stale CLAIMED line replays on the next restart, enabling duplicate
         execution.
 
@@ -625,7 +625,7 @@ class TaskStore:
 
         await _retry_io(_write)
 
-    # -- audit-023: per-task progress JSONL persistence ---------------------
+    # -- per-task progress JSONL persistence ---------------------
 
     def _progress_file(self, task_id: str) -> Path:
         """Return the JSONL file storing progress/snapshot records for *task_id*.
@@ -775,7 +775,7 @@ class TaskStore:
             "claimed_by_session": task.claimed_by_session,
             "parent_session_id": task.parent_session_id,
             "subtask_wait_started_at": task.subtask_wait_started_at,
-            # audit-017: retry bookkeeping (typed source of truth).
+            # retry bookkeeping (typed source of truth).
             "retry_count": task.retry_count,
             "max_retries": task.max_retries,
             "retry_delay_s": task.retry_delay_s,
@@ -871,7 +871,7 @@ class TaskStore:
             _cls = classify_task(_probe)
             batch_eligible = _cls.level in (TaskLevel.L0, TaskLevel.L1)
 
-        # audit-017: Forward retry bookkeeping so the typed fields survive
+        # Forward retry bookkeeping so the typed fields survive
         # across task clones.  ``None`` => keep Task dataclass default.
         retry_count_raw = getattr(req, "retry_count", None)
         max_retries_raw = getattr(req, "max_retries", None)
@@ -1230,7 +1230,7 @@ class TaskStore:
                     f"role mismatch: task {task_id} requires role '{task.role}', agent has role '{agent_role}'"
                 )
             if task.status != TaskStatus.OPEN:
-                # audit-014: never silently re-return an already-claimed or
+                # never silently re-return an already-claimed or
                 # terminal task — that enables double-claim. Raise so the
                 # HTTP layer can map it to 409 Conflict.
                 raise ValueError(
@@ -1313,14 +1313,14 @@ class TaskStore:
 
         Raises:
             KeyError: If task_id does not exist.
-            EmptyCompletionError: If *result_summary* is empty (audit-028).
+            EmptyCompletionError: If *result_summary* is empty.
                 The task is auto-transitioned to ``FAILED`` with
                 ``reason='completion missing summary'`` before this is
                 raised, so the slot is released atomically and the
                 watchdog does not need to intervene.  The HTTP layer
                 maps this to a 422 response.
         """
-        # audit-028: when result_summary is empty/None, auto-fail the task
+        # when result_summary is empty/None, auto-fail the task
         # under the lock so the slot is freed atomically.  A caller that
         # bailed out of ``complete()`` previously left the task CLAIMED
         # until the watchdog flipped it, allowing a fresh agent to
@@ -1478,7 +1478,7 @@ class TaskStore:
         re-entering ``self._lock`` (``asyncio.Lock`` is not re-entrant) and the
         ``visited`` set guards against parent_task_id cycles from bad data.
 
-        Fix for audit-029: previously only the immediate parent was promoted, so
+        Fix for previously only the immediate parent was promoted, so
         a grandparent G never bubbled up and stayed ``WAITING_FOR_SUBTASKS``
         until timeout escalation forced it to ``BLOCKED``.
         """
@@ -1530,7 +1530,7 @@ class TaskStore:
             entry: ProgressEntry = {"timestamp": time.time(), "message": message, "percent": percent}
             progress: list[ProgressEntry] = cast("list[ProgressEntry]", task.progress_log)  # type: ignore[reportUnknownMemberType]
             progress.append(entry)
-            # audit-023: durably record the entry so progress history survives
+            # durably record the entry so progress history survives
             # a server crash.  I/O happens inside the lock (like
             # ``_append_jsonl``) to preserve ordering with in-memory state.
             await asyncio.to_thread(
@@ -1569,7 +1569,7 @@ class TaskStore:
         )
         q = self._progress_snapshots.setdefault(task_id, deque(maxlen=10))
         q.append(snap)
-        # audit-023: persist alongside progress entries so snapshot history
+        # persist alongside progress entries so snapshot history
         # is recovered after a crash.  Keeping snapshots and entries in the
         # same file simplifies replay (one pass per task).
         self._append_progress_record(

--- a/src/bernstein/core/tokens/context_inheritance.py
+++ b/src/bernstein/core/tokens/context_inheritance.py
@@ -5,7 +5,7 @@ subagents need Bernstein's task context and file ownership rules.  This
 module writes configuration to CLAUDE.md and .claude/settings.local.json
 in the worktree so subagents inherit the parent agent's constraints.
 
-Extended for AGENT-012: full parent context inheritance including role
+Extended for full parent context inheritance including role
 constraints, environment variables, and resource limits.
 """
 
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Inherited context dataclass (AGENT-012)
+# Inherited context dataclass
 # ---------------------------------------------------------------------------
 
 

--- a/src/bernstein/core/tokens/prompt_precheck.py
+++ b/src/bernstein/core/tokens/prompt_precheck.py
@@ -1,4 +1,4 @@
-"""Prompt size pre-check before agent spawn (AGENT-003).
+"""Prompt size pre-check before agent spawn.
 
 Estimates prompt token count using a simple chars-per-token heuristic (~4
 chars/token) and compares against the model's context limit.  Two thresholds:

--- a/src/bernstein/core/tokens/token_monitor.py
+++ b/src/bernstein/core/tokens/token_monitor.py
@@ -303,7 +303,7 @@ class TokenGrowthMonitor:
         self._nudge_text: str = nudge_text if nudge_text is not None else self._DEFAULT_NUDGE_TEXT
         self._history: dict[str, AgentTokenHistory] = {}
         self._compaction_breakers: dict[str, AutoCompactCircuitBreaker] = {}
-        #: Per-tenant kill-threshold overrides (audit-070).  Mutable so callers
+        #: Per-tenant kill-threshold overrides. Mutable so callers
         #: can update the map at runtime without rebuilding the monitor.
         self.tenant_kill_thresholds: dict[str, int] = dict(tenant_kill_thresholds or {})
         self._warn_reset_clean_samples: int = warn_reset_clean_samples
@@ -505,7 +505,7 @@ class TokenGrowthMonitor:
         Called from the orchestrator tick when quadratic growth is *not*
         detected for a session.  After ``warn_reset_clean_samples`` consecutive
         clean observations, the warned flag is cleared so the next burst of
-        quadratic growth can fire the warning again (audit-070).
+        quadratic growth can fire the warning again.
 
         Args:
             session_id: Agent session identifier.
@@ -797,7 +797,7 @@ def _handle_auto_kill(orch: Any, session: Any, monitor: Any, total: int) -> bool
 
     Resolves the kill threshold per-tenant via ``TOKEN_CFG`` (module-level
     override) or the monitor's own ``tenant_kill_thresholds`` map so
-    multi-tenant deployments can diverge limits between tiers (audit-070).
+    multi-tenant deployments can diverge limits between tiers.
     """
     files_changed = _get_files_changed(orch, session, orch._config.server_url)
     tenant_id = _resolve_tenant_id(session)


### PR DESCRIPTION
Editorial pass on internal docstrings and inline comments. No code logic touched. `ruff check src/` passes.