### PR TITLE
chore: auto-bump to v1.10.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.5"
+version = "1.10.6"
 description = "Multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more) — deterministic, declarative, zero vendor lock-in."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Automated patch bump from v1.10.5 → v1.10.6. Created manually because the auto-release workflow lacks pr-create permission. The next auto-release run on main will tag + publish v1.10.6.