### PR TITLE
feat(.bernstein): scenario + workflow library

### DIFF
--- a/.bernstein/scenarios/docs/rfc-drafting.yaml
+++ b/.bernstein/scenarios/docs/rfc-drafting.yaml
@@ -1,0 +1,59 @@
+id: rfc-drafting
+name: Cross-Team RFC Drafting
+version: "1.0"
+description: |
+  Author a cross-team RFC for an architectural change that touches more
+  than one bounded context. Produces a written proposal, a comment-ready
+  draft circulated to stakeholders, and an accepted decision recorded as
+  an ADR.
+tags:
+  - docs
+  - rfc
+  - architecture
+tasks:
+  - title: Capture the problem statement and success criteria
+    role: architect
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Open the RFC with the problem in concrete terms. Describe the user
+      or system pain in two paragraphs. List the success criteria the
+      change must meet to be considered accepted.
+  - title: Enumerate at least three options including a do-nothing branch
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Each option carries a cost, a benefit, a reversibility note, and
+      a fitness function or metric that would tell the team whether the
+      option worked. The do-nothing branch is mandatory.
+  - title: Run a threat model and capture privacy implications
+    role: security
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Apply STRIDE to the chosen direction. If the change touches personal
+      data, also apply LINDDUN. Capture findings under a risk section the
+      reviewers must read before approving.
+  - title: Circulate to stakeholders with a written comment window
+    role: manager
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Assign a comment deadline. Tag specific reviewers per section. A
+      missing reviewer is the author's problem; chase explicitly. Track
+      every comment and the author's response in the RFC itself.
+  - title: Promote to an accepted ADR
+    role: docs
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Once stakeholders sign off, write the ADR using MADR or Nygard
+      format. Reference the RFC. Mark the RFC superseded by the ADR.
+      Future readers should find the decision through the ADR, not the
+      original discussion thread.

--- a/.bernstein/scenarios/docs/wiki-refresh-from-code.yaml
+++ b/.bernstein/scenarios/docs/wiki-refresh-from-code.yaml
@@ -1,0 +1,58 @@
+id: wiki-refresh-from-code
+name: Internal Wiki Refresh from Code
+version: "1.0"
+description: |
+  Refresh an internal wiki against the current state of the codebase.
+  Surfaces stale pages, missing pages for new modules, and code samples
+  that no longer compile, then lands a single PR plus a follow-up backlog
+  for the deeper rewrites.
+tags:
+  - docs
+  - wiki
+  - onboarding
+tasks:
+  - title: Diff wiki structure against current module map
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Crawl the wiki. Compare topics covered against the current module
+      map. Flag every module without a page and every page that points
+      at a removed module.
+  - title: Verify every embedded code sample compiles
+    role: qa
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Extract every code sample. Run them through the project's compiler
+      or interpreter. Any sample that fails routes into the rewrite
+      backlog with the specific error captured.
+  - title: Update the most-trafficked pages first
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Sort wiki pages by view count. Refresh the top decile in the
+      current change. Lower-traffic pages move to follow-up tickets. The
+      change must be reviewable in one sitting, not gold-plated.
+  - title: Add a freshness header to every refreshed page
+    role: docs
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Stamp each refreshed page with a last-verified date and the source
+      commit hash. Future readers know whether the page can be trusted
+      without reading the entire history.
+  - title: Open follow-up tickets for stale or broken content
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Convert every flagged stale or broken page into a ticket. Assign
+      owners. The wiki is a living artifact; treat the rewrite backlog
+      as the maintenance pipeline, not a one-time cleanup.

--- a/.bernstein/scenarios/enterprise/legacy-modernization-program.yaml
+++ b/.bernstein/scenarios/enterprise/legacy-modernization-program.yaml
@@ -1,0 +1,112 @@
+id: legacy-modernization-program
+name: Legacy Modernization Program
+version: "1.0"
+description: |
+  Multi-quarter program to modernize a legacy estate (mainframe, COBOL,
+  RPG, classic ASP, on-prem ESB) into a target stack while keeping the
+  business running. Built around the Strangler Fig pattern with explicit
+  freeze rules, parallel-run reconciliation, and a regulator-grade audit
+  trail of every transformation.
+tags:
+  - modernization
+  - enterprise
+  - mainframe
+  - strangler-fig
+tasks:
+  - title: Inventory the legacy estate by program, data store, and dependency
+    role: architect
+    priority: 1
+    scope: large
+    complexity: high
+    description: |
+      Catalog every program, copybook, JCL job, screen, table, and external
+      interface. Capture line count, call frequency, business owner, and
+      regulatory classification. The inventory anchors every later
+      decision; treat it as a versioned artifact under source control.
+  - title: Classify each program by translation strategy
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      For each program, decide between rewrite, refactor in place, encapsulate
+      behind an API, or retire. Prefer retire where business owners cannot
+      name a single live consumer. Document the chosen strategy in a
+      machine-readable manifest.
+  - title: Stand up the parallel-run harness for behavior reconciliation
+    role: devops
+    priority: 1
+    scope: large
+    complexity: high
+    description: |
+      Build a shadow path that replays production inputs through both the
+      legacy system and the modernized target. Compare outputs at the field
+      level. Flag any divergence with sample evidence and a severity tier.
+  - title: Translate one bounded context end-to-end as the pilot
+    role: backend
+    priority: 1
+    scope: large
+    complexity: high
+    description: |
+      Pick the smallest context with a clean external interface and low
+      regulatory exposure. Translate end-to-end. Run through the parallel
+      harness for at least four weeks. Use the pilot to calibrate the
+      cost-per-program estimate.
+  - title: Lock the legacy edit-freeze policy
+    role: manager
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      No change to the legacy code outside critical regulatory or security
+      fixes once a context is in flight. Document the override path. The
+      freeze is the difference between a clean strangler cut and a
+      perpetual divergence.
+  - title: Generate transformation evidence for each translated module
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      For every translated module, capture: source hash, target hash,
+      tooling version, prompt or transformation rule used, validator
+      output, and the parallel-run reconciliation result. This is the
+      auditable evidence chain a regulator will demand.
+  - title: Migrate data with a documented dual-write window
+    role: backend
+    priority: 2
+    scope: large
+    complexity: high
+    description: |
+      For each data store, define the dual-write window, the cutover, and
+      the rollback. Validate the schema map with a samples-against-prod
+      run. Run for at least one full business cycle before cutover.
+  - title: Decommission legacy components on a published schedule
+    role: manager
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Publish a per-quarter decommission schedule. Confirm zero traffic
+      against each component for the full preceding quarter before pull.
+      Archive the source, the data, and the runbook.
+  - title: Train the operations team on the modernized stack
+    role: docs
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Build runbooks, dashboards, and on-call playbooks for the modernized
+      services. Run a paging drill before every decommission milestone.
+      The legacy operators carry institutional memory that does not
+      survive a pure code translation; capture it in writing.
+  - title: Track program-level metrics and report to executive sponsors
+    role: manager
+    priority: 1
+    scope: medium
+    complexity: low
+    description: |
+      Report monthly: programs translated, programs retired, parallel-run
+      divergence rate, cost-per-program trend, regulator-readiness status.
+      Sponsors lose patience when the dashboard is unclear; keep it
+      one-page and decision-relevant.

--- a/.bernstein/scenarios/enterprise/regulator-audit-evidence-pack.yaml
+++ b/.bernstein/scenarios/enterprise/regulator-audit-evidence-pack.yaml
@@ -1,0 +1,241 @@
+id: regulator-audit-evidence-pack
+name: Regulator Audit Evidence Pack
+version: "1.0"
+description: |
+  Produce a regulator-ready evidence pack for an AI-assisted coding pipeline
+  under EU AI Act Article 12 logging, DORA Articles 8 to 15 ICT-resilience
+  requirements, and SR 11-7 model-risk controls. The pack maps every
+  control to a deterministic artifact: tamper-evident audit logs, signed
+  release provenance, model-risk-tier classifications, and a written
+  incident-response runbook. Output is a single zip plus an attestation
+  index a third-party auditor can navigate without operator hand-holding.
+tags:
+  - compliance
+  - audit
+  - enterprise
+  - regulated
+  - ai-governance
+tasks:
+  - title: Identify regulatory scope and applicable controls
+    role: manager
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Confirm which regulations apply to the pipeline under review (EU AI
+      Act, DORA, SR 11-7, ISO 42001, NIST AI RMF Generative AI Profile).
+      Capture the control identifiers each one introduces. Output a single
+      control-inventory spreadsheet with one row per control.
+  - title: Classify the AI-coding pipeline against EU AI Act Article 6 risk tiers
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Walk every pipeline component (planner, executor, verifier, deploy
+      stage) and decide whether it lands in high-risk, limited-risk, or
+      minimal-risk under Article 6. Document the reasoning. This decision
+      drives which Article 9 to 15 obligations attach.
+  - title: Map every control to one or more deterministic artifacts
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      For each control in the inventory, pick the artifact that satisfies
+      it. Article 12 logging maps to the HMAC audit chain. Article 17
+      quality-management system maps to ADRs plus the change-management
+      runbook. Article 9 risk-management system maps to the threat-model
+      register. Output evidence-map.yaml.
+  - title: Implement automatic event logging that satisfies Article 12 paragraphs 2a to 2c
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Emit one structured log entry per agent action capturing: timestamp,
+      task identifier, planner decision, executor tool calls, model name
+      and version, prompt hash, response hash, and HMAC chain link to the
+      previous entry. Verify the log writer flushes synchronously to a
+      tamper-evident store before any tool call commits.
+  - title: Verify six-month retention of the audit log per Article 19
+    role: devops
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Confirm the audit-log store retains entries for at least six months,
+      with read-only access for auditors. Document the retention policy,
+      the storage location, and the access-control model. Add a recurring
+      job that proves retention by sampling old entries.
+  - title: Produce an HMAC-chain integrity proof for the most recent ninety-day window
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Verify the HMAC chain end-to-end across the most recent ninety days.
+      Output a proof file listing the head hash, the tail hash, every
+      rotation event, and any link the verifier could not resolve. A
+      single broken link blocks audit submission.
+  - title: Generate SBOM and SLSA build-provenance for every release in the audit window
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Produce CycloneDX SBOMs for every container image and binary released
+      during the audit window. Confirm SLSA Level 1 provenance attaches to
+      every artifact. Sign each artifact and SBOM with cosign or Sigstore.
+  - title: Capture deterministic build evidence for the orchestrator itself
+    role: devops
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Re-run the orchestrator's build pipeline from a clean environment
+      twice. Confirm bit-for-bit identical artifacts. Document the build
+      platform, the toolchain versions, and the hermetic-build policy.
+      This is the Article 12 traceability anchor.
+  - title: Document the risk-management system per Article 9
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Capture the risk-identification, risk-evaluation, and risk-mitigation
+      processes. Reference the OWASP Top 10 for LLM Applications 2025
+      checklist as the concrete attacker model. Include the threat-model
+      register and link every entry to a mitigating control.
+  - title: Produce a data-governance statement per Article 10
+    role: docs
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Describe training-data and prompt-data provenance, retention, and
+      access controls. If the pipeline uses retrieval, document the
+      corpus origin, refresh cadence, and PII-redaction policy. Tie this
+      to GDPR Article 32 if any personal data is in scope.
+  - title: Capture the human-oversight design per Article 14
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Document where humans approve, override, or pause the agent. List
+      every approval gate, the role authorized to approve, the median
+      review latency, and the escape-hatch behavior when no human is
+      available. The auditor will probe whether oversight is real or
+      ceremonial.
+  - title: Emit accuracy and robustness evidence per Article 15
+    role: qa
+    priority: 2
+    scope: medium
+    complexity: high
+    description: |
+      Run the agent against a regression-evaluation harness. Capture
+      pass-at-one rates, hallucination-detection rates, and sensitivity
+      to prompt-injection patterns. Plot the trend across the audit
+      window. Material drift warrants a written explanation in the pack.
+  - title: Document the incident-response runbook per DORA Article 17
+    role: devops
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Capture the detection-to-containment-to-recovery workflow with
+      specific time targets. Tie each step to a named on-call role.
+      Include the post-incident-review template. The runbook must list
+      the regulator-notification triggers and the contact path.
+  - title: Map ICT-third-party arrangements per DORA Articles 28 to 30
+    role: manager
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      List every third-party service the pipeline depends on (model
+      providers, vector stores, observability vendors). For each,
+      document the data shared, the contractual terms, the exit plan,
+      and whether the provider is a critical ICT third-party under
+      DORA designation.
+  - title: Run an internal red-team exercise against the AI-coding agent
+    role: security
+    priority: 2
+    scope: medium
+    complexity: high
+    description: |
+      Run prompt-injection, exfiltration, and excessive-agency scenarios
+      against the live agent in a sandboxed environment. Use Garak or
+      PyRIT plus a custom seed list tied to the deployment context.
+      Document findings, severity, and the remediation timeline.
+  - title: Produce a model-risk-tier classification per SR 11-7
+    role: architect
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Classify each model used in the pipeline by tier (1 high, 2
+      moderate, 3 low) per SR 11-7. Document the validation evidence
+      attached to each tier. Tier 1 models require independent
+      validation; capture the validator and the date.
+  - title: Build the auditor-navigable index
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: low
+    description: |
+      Produce one Markdown index that an auditor opens first. The index
+      lists every control identifier in the inventory, the evidence
+      artifact path, the responsible role, and a one-line plain-language
+      summary of how the control is satisfied. This is the auditor's
+      table of contents.
+  - title: Stress-test the evidence pack with a mock auditor pass
+    role: qa
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Hand the pack to an internal reviewer who has not worked on the
+      pipeline. Ask them to verify ten controls picked at random.
+      Track time-to-evidence and friction points. Anything that takes
+      more than ten minutes routes back to the pack author.
+  - title: Sign the pack and publish to the auditor delivery channel
+    role: security
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Generate a single zip of the evidence pack. Sign with cosign and
+      publish the signature alongside the artifact. Deliver via the
+      contracted channel (secure file transfer, regulated portal). Log
+      the delivery as the final entry in the audit chain.
+  - title: Schedule the next quarterly refresh
+    role: manager
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Calendar the next refresh. The audit window rolls forward; control
+      mappings may shift if regulations update; new third-party services
+      may enter scope. The pack is a living artifact, not a one-shot.
+  - title: Capture lessons learned and update the control inventory
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Record what surprised the team, which controls produced the most
+      pack-author friction, and which artifacts the auditor probed
+      hardest. Promote the lessons to the inventory as guidance for the
+      next pack.
+  - title: Update CLAUDE.md and AGENTS.md with the audit-pack workflow
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Persist the workflow into repo memory so the next agent that
+      generates a pack does not re-discover the artifact map. Reference
+      the evidence-map.yaml and the auditor index as the canonical
+      starting points.

--- a/.bernstein/scenarios/enterprise/supply-chain-hardening.yaml
+++ b/.bernstein/scenarios/enterprise/supply-chain-hardening.yaml
@@ -1,0 +1,86 @@
+id: supply-chain-hardening
+name: Software Supply Chain Hardening
+version: "1.0"
+description: |
+  Lift a repository from no supply-chain controls to SLSA Level 2 with a
+  signed-artifact policy, an SBOM-on-every-release pipeline, and verified
+  consumer-side attestation. Targeted at teams that need to satisfy EU
+  Cyber Resilience Act, Executive Order 14028 procurement gates, or
+  enterprise vendor due-diligence questionnaires.
+tags:
+  - supply-chain
+  - security
+  - sbom
+  - slsa
+tasks:
+  - title: Establish the build-platform baseline
+    role: devops
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Lock builds to a hosted CI runner with documented isolation. Confirm
+      the runner does not allow long-lived secrets and that build steps
+      cannot mutate prior steps. This is the SLSA Level 2 prerequisite.
+  - title: Generate SBOMs in CycloneDX and SPDX on every release
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Wire the CI to produce both formats per release artifact. Pin the
+      generator version. Publish SBOMs alongside the release; do not
+      tuck them into a private bucket.
+  - title: Sign every artifact with Sigstore and publish provenance
+    role: security
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Use cosign with keyless OIDC signing. Attach SLSA build provenance
+      via the GitHub attest-build-provenance action or its GitLab
+      equivalent. Verify the attestation tab populates after each release.
+  - title: Pin every transitive dependency in lockfiles and verify in CI
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Adopt a frozen lockfile policy. Add a CI gate that fails when the
+      lockfile drifts. Document the override path for emergency upgrades.
+  - title: Wire consumer-side verification into deploy pipelines
+    role: devops
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Verify signatures and provenance before any artifact lands in
+      production. Reject unsigned artifacts. Capture verification logs
+      under the audit chain.
+  - title: Publish a security-policy and a vulnerability-disclosure path
+    role: docs
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Add SECURITY.md and a security.txt. Document the disclosure SLA,
+      the contact channel, and the credit policy. Wire to the issue
+      tracker so submissions do not vanish.
+  - title: Achieve OpenSSF Scorecard score above seven
+    role: security
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Add the Scorecard GitHub Action. Address branch-protection,
+      dependency-update tooling, code-review, and pinned-dependencies
+      checks. Publish the badge in the README.
+  - title: Map controls to OSPS Baseline and EO 14028 procurement gates
+    role: security
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Produce a mapping from each implemented control to the OSPS Baseline
+      level and to the relevant EO 14028 procurement requirement. This
+      is the artifact a vendor-due-diligence questionnaire needs.

--- a/.bernstein/scenarios/growth/contributor-onboarding.yaml
+++ b/.bernstein/scenarios/growth/contributor-onboarding.yaml
@@ -1,0 +1,59 @@
+id: contributor-onboarding
+name: Contributor Onboarding Scaffold
+version: "1.0"
+description: |
+  Stand up the contributor-onboarding surface for an open-source repository:
+  CONTRIBUTING.md, code-of-conduct, development setup script, sample tasks,
+  and a clear path from drive-by interest to first merged PR. Targeted at
+  projects where most new contributors give up before they reach a working
+  local environment.
+tags:
+  - growth
+  - oss
+  - onboarding
+tasks:
+  - title: Write CONTRIBUTING.md with a thirty-minute path to first PR
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Walk a new contributor from cloning the repo to opening their first
+      PR in under thirty minutes. Capture every step with exact commands.
+      Test by running the path on a fresh machine.
+  - title: Add a one-command development environment setup
+    role: devops
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Provide a single script or devcontainer that installs dependencies,
+      seeds local data, and runs the test suite. Anything more than one
+      command loses contributors.
+  - title: Adopt a code of conduct and document enforcement
+    role: docs
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Adopt a recognized code of conduct (Contributor Covenant). Name the
+      enforcement contact and the response window. Code of conduct
+      without enforcement is decoration.
+  - title: Curate a starter-task list with explicit guidance
+    role: manager
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Pick five tasks that a new contributor can complete in under three
+      hours. Annotate each with the relevant code path and the expected
+      acceptance criteria. Refresh the list weekly.
+  - title: Add a maintainer-response SLA and publish it
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Commit to a response SLA on new PRs from first-time contributors.
+      Publish it in CONTRIBUTING.md. Track adherence; missed SLAs are
+      the single largest reason contributors do not return.

--- a/.bernstein/scenarios/growth/issue-triage-workflow.yaml
+++ b/.bernstein/scenarios/growth/issue-triage-workflow.yaml
@@ -1,0 +1,61 @@
+id: issue-triage-workflow
+name: Issue Triage Workflow
+version: "1.0"
+description: |
+  Convert an unstructured GitHub issue queue into a triaged backlog with
+  labels, owners, and SLAs. Targeted at projects where the queue grows
+  faster than maintainers can read it, and good-first-issues stay invisible
+  to drive-by contributors.
+tags:
+  - growth
+  - triage
+  - oss
+tasks:
+  - title: Classify open issues by intent
+    role: manager
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Walk every open issue and tag it as bug, feature, question, or
+      duplicate. Close duplicates with a pointer to the canonical issue.
+      Convert questions into a discussions thread when the platform
+      supports it.
+  - title: Add reproduction-required labels and stale-bot policy
+    role: devops
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Bug reports without a reproduction get a needs-repro label and a
+      grace window. Stale issues with no response close automatically
+      with a polite note and a path back. Document the policy in the
+      issue template.
+  - title: Surface good-first-issues with explicit guidance
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: low
+    description: |
+      Pick five to ten genuinely good first issues. For each, add a
+      checklist, a pointer to the relevant code, and an estimate. The
+      good-first-issue label without guidance is invisible to drive-by
+      contributors.
+  - title: Define SLA tiers and label backlog accordingly
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Pick three SLAs: critical, normal, deferred. Apply to the existing
+      backlog. Anything without an SLA gets reviewed at the next triage
+      session, not silently dropped.
+  - title: Run a recurring triage session
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Calendar a weekly or bi-weekly triage. Two maintainers walk new
+      issues together. The session ends when the queue is current; if
+      it does not end, the SLAs are wrong and need revision.

--- a/.bernstein/scenarios/research/market-scan.yaml
+++ b/.bernstein/scenarios/research/market-scan.yaml
@@ -1,0 +1,68 @@
+id: market-scan
+name: Market Scan
+version: "1.0"
+description: |
+  Map the live competitive landscape for a product category. Captures
+  named competitors, recent funding events, public roadmap signals, and
+  customer reviews into a single living dossier the team can refer to
+  during planning and pitch preparation.
+tags:
+  - research
+  - market
+  - competitive
+tasks:
+  - title: Enumerate competitors by direct, adjacent, and emerging tier
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Direct competitors solve the same problem the same way. Adjacent
+      competitors solve the same problem differently. Emerging entrants
+      cover the same problem at a smaller scale. Tag each entry so the
+      dossier is sortable.
+  - title: Pull recent funding, hiring, and product-launch signals
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      For each competitor, capture funding events in the last twelve
+      months, hiring patterns by function, and product launches in the
+      last six months. Cite each data point.
+  - title: Sample customer reviews and public discussion
+    role: docs
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      For each competitor, pull representative reviews from G2, Capterra,
+      Hacker News threads, and dev community channels. Note the most
+      common praise and the most common complaint.
+  - title: Build a feature-by-feature comparison matrix
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Pick the ten most decision-relevant features. Score each competitor
+      against them based on cited evidence. Refuse to score from marketing
+      copy alone; quote the source for every cell.
+  - title: Highlight the top three differentiation opportunities
+    role: manager
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Identify gaps the competitor set leaves open. Each opportunity
+      has a one-paragraph thesis, the cited evidence, and a falsifier
+      that would invalidate the thesis.
+  - title: Schedule the next refresh and assign owners
+    role: manager
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Market scans rot fast. Pick a refresh cadence (sixty or ninety
+      days). Assign per-competitor owners. The dossier is a living
+      artifact, not a one-time report.

--- a/.bernstein/scenarios/research/paper-digest-pipeline.yaml
+++ b/.bernstein/scenarios/research/paper-digest-pipeline.yaml
@@ -1,0 +1,58 @@
+id: paper-digest-pipeline
+name: Paper Digest Pipeline
+version: "1.0"
+description: |
+  Build a recurring digest of new arXiv and conference papers in a chosen
+  research area. Each run picks the top candidates, summarizes them with
+  citation, and routes notable findings into a watch list the team can
+  act on without reading every abstract.
+tags:
+  - research
+  - digest
+  - listening
+tasks:
+  - title: Define the topic taxonomy and seed query set
+    role: docs
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      List the subtopics the digest should cover. Capture two to four
+      seed queries per subtopic. The taxonomy is what keeps the digest
+      from drifting into noise over weeks.
+  - title: Pull and deduplicate candidates from arXiv and conference proceedings
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Run the seed queries. Deduplicate against prior runs by DOI,
+      arXiv id, and title hash. Output a candidate list with abstract,
+      authors, and venue.
+  - title: Score candidates by topical fit and signal strength
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Score each paper on relevance to the taxonomy, novelty against
+      the watch list, and reproducibility signals (open code, dataset).
+      Pick the top decile for the digest.
+  - title: Write a one-paragraph summary per top paper
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Each summary covers the question, the method, the headline
+      finding, and a calibrated note on confidence. Cite the paper.
+      Keep summaries readable in under one minute.
+  - title: Promote actionable findings to a watch list
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Anything worth a follow-up reading or an internal experiment lands
+      on the watch list. Each entry has an owner and a target date so
+      the watch list does not become a graveyard.

--- a/.bernstein/scenarios/software/api-breaking-migration.yaml
+++ b/.bernstein/scenarios/software/api-breaking-migration.yaml
@@ -1,0 +1,77 @@
+id: api-breaking-migration
+name: API Breaking-Change Migration
+version: "1.0"
+description: |
+  Plan and execute a breaking API change with deprecation period, parallel
+  versions, and a documented migration path. The scenario is built for
+  public APIs with external consumers, where flag-flipping the new shape
+  on is not an option.
+tags:
+  - api
+  - migration
+  - deprecation
+tasks:
+  - title: Capture every consumer of the breaking surface
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Walk telemetry, log analysis, and any registered partner list to
+      enumerate consumers. Output a table of consumers with contact
+      channel, integration depth, and last-seen call rate.
+  - title: Author a deprecation RFC with the new shape and the migration plan
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Document the why, the new shape, the rollout calendar, and the
+      compatibility window. Circulate to consumers for comment before
+      any code lands. Reference any precedent set by the project's prior
+      breaking changes.
+  - title: Implement the new API alongside the old one
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Ship the new endpoint or schema. Keep the old surface intact. Both
+      versions write through to the same persistence layer; reject any
+      design that requires data migration before launch.
+  - title: Add deprecation warnings on the old surface with a removal date
+    role: backend
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Emit a structured deprecation warning on every call to the old API.
+      Include the removal date and a link to the migration guide. Surface
+      the warning in OpenAPI metadata.
+  - title: Publish a migration guide with worked examples
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: low
+    description: |
+      Write a guide that takes a consumer through the migration in under
+      thirty minutes. Include before-and-after snippets in every supported
+      language, common gotchas, and a verification checklist.
+  - title: Track consumer migration progress and prompt stragglers
+    role: manager
+    priority: 2
+    scope: medium
+    complexity: low
+    description: |
+      Build a dashboard showing per-consumer call counts by API version.
+      Send a personal note to the slowest decile thirty days before
+      removal. Block-list any consumer that is unreachable.
+  - title: Remove the old surface after the deprecation window closes
+    role: backend
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Delete the old code path in a single PR. Run the full regression
+      suite. Tag the release with a migration boundary marker so future
+      maintainers can find this moment in history.

--- a/.bernstein/scenarios/software/dead-code-removal.yaml
+++ b/.bernstein/scenarios/software/dead-code-removal.yaml
@@ -1,0 +1,71 @@
+id: dead-code-removal
+name: Dead Code Removal
+version: "1.0"
+description: |
+  Identify and remove dead code with confidence. Combines static
+  reachability, runtime coverage from production tracing, and a
+  deprecation window so the deletion does not surprise downstream
+  consumers. Built for repositories where the import graph and the
+  call graph have drifted apart over years.
+tags:
+  - refactor
+  - cleanup
+  - quality
+tasks:
+  - title: Run static reachability analysis with at least two distinct tools
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Use language-native tools (vulture, ts-prune, deadcode, etc.) plus a
+      second source. Cross-reference results. Anything flagged dead by one
+      tool but live by another goes onto a manual-review list, not the
+      delete queue.
+  - title: Sample production traces to confirm static findings
+    role: devops
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Pull at least thirty days of production traces. For each candidate
+      file, function, or endpoint, confirm it has zero call-count. Endpoints
+      receiving zero calls but still publicly advertised stay on the keep
+      list until a deprecation cycle runs.
+  - title: Walk reflection, dynamic dispatch, and config-driven entry points
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Static tools miss reflection, plugin systems, and configuration-driven
+      handlers. Manually walk every reflection or plugin entry point and
+      verify the candidates are not summoned through one. Document each
+      review in a delete-decision log.
+  - title: Remove dead code in batches with bisectable commits
+    role: backend
+    priority: 2
+    scope: medium
+    complexity: low
+    description: |
+      Group deletions by module. Each commit deletes one logical unit so a
+      regression bisect lands on the minimum offending change. Run the full
+      suite after every commit.
+  - title: Re-run static and runtime analysis to verify the floor
+    role: qa
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Repeat the reachability analysis after the sweep. Confirm no new
+      candidates surfaced because of the deletions. Capture the metrics
+      so the next sweep starts from a known baseline.
+  - title: Update documentation and changelog with removed surfaces
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      List removed public surfaces in the changelog. Anything that was
+      not public stays out of the changelog but lands in an internal
+      lessons-learned note.

--- a/.bernstein/scenarios/software/dependency-upgrade-sweep.yaml
+++ b/.bernstein/scenarios/software/dependency-upgrade-sweep.yaml
@@ -1,0 +1,184 @@
+id: dependency-upgrade-sweep
+name: Dependency Upgrade Sweep
+version: "1.0"
+description: |
+  Coordinated upgrade across a multi-module repository. Drives a single
+  major-version bump (or a batch of minor bumps) through audit, staged
+  remediation, and verification, with a reversible rollout. Built for
+  repositories where naive Renovate auto-merges break compatibility because
+  cross-module type contracts shift in ways static scanners do not catch.
+tags:
+  - dependencies
+  - upgrade
+  - quality
+  - supply-chain
+tasks:
+  - title: Inventory current dependency graph and pin baseline
+    role: backend
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Generate a full lockfile snapshot for every package manager in the repo
+      (uv lock, pnpm-lock, go.sum, poetry.lock). Commit a baseline tag and a
+      machine-readable manifest under reports/deps-baseline.json so later
+      tasks have a single point of comparison.
+  - title: Classify upgrade targets by blast radius
+    role: architect
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      For each candidate upgrade, score blast radius across four axes: number
+      of importing modules, presence in public API contracts, transitive
+      surface, and reversibility (one-click revert vs schema migration).
+      Output a CSV the planner uses to sequence work risk-first.
+  - title: Build a dependency-impact graph for the highest-risk targets
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Run a static call-graph trace (ast-grep / Sourcegraph) for the top
+      five blast-radius dependencies. Capture every call site, every type
+      that crosses a module boundary, and any reflective use. Save under
+      reports/deps-callgraph/<dep>.md.
+  - title: Read each target dependency's CHANGELOG between current and target version
+    role: docs
+    priority: 1
+    scope: medium
+    complexity: low
+    description: |
+      Summarize behavior changes, deprecations, removed APIs, and security
+      fixes for every minor-or-major bump. Annotate which entries map to
+      call sites identified in the impact graph. Output deps-changelog.md.
+  - title: Spike the highest-risk upgrade in a worktree
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Pick the dependency with the largest call-graph footprint. Upgrade in
+      isolation. Capture every compile error, runtime stack trace, and
+      type-check failure. Produce a remediation plan that lists each break
+      with a proposed fix and a confidence label.
+  - title: Apply remediations to the spike branch
+    role: backend
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Implement the remediation plan one fix per commit. Keep refactors out
+      of feature commits. After each commit, run unit and lint suites to
+      keep the branch green.
+  - title: Add property-based tests for boundary-crossing types
+    role: qa
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Identify every type or shape that flows across the upgraded library's
+      API boundary. Add property tests (Hypothesis / fast-check) that pin
+      invariants the previous version held. These tests are the regression
+      gate for every subsequent upgrade in this sweep.
+  - title: Run mutation tests on critical modules touched by the upgrade
+    role: qa
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Run mutmut / Stryker on the modules whose imports changed. Mutation
+      score under 70% on a critical module blocks the upgrade and routes
+      the work back to test authoring.
+  - title: Verify the spike under a workload replay
+    role: qa
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Replay a representative production workload (sanitized request log,
+      load test, or scenario seed) against the spike branch. Compare error
+      rate, p95 latency, and memory footprint against baseline. Fail fast
+      if any regression exceeds a 10% noise band.
+  - title: Sequence remaining upgrades in batches of three to five
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Group the remaining upgrades by risk and module overlap. Each batch
+      should land independently, ship behind feature-flag-gated paths if
+      runtime behavior shifts, and have an explicit revert plan.
+  - title: Apply each batch with the same audit / remediate / verify loop
+    role: backend
+    priority: 2
+    scope: large
+    complexity: medium
+    description: |
+      Repeat the spike workflow for each batch. Reuse the property tests
+      and the workload replay as the gate. Land batches as separate PRs so
+      review stays under the four-hundred-LOC inspection band.
+  - title: Add a renovate / dependabot configuration that mirrors the new policy
+    role: devops
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Configure auto-update tooling so future minor bumps land continuously
+      while major bumps require human review. Pin renovate schedules to a
+      maintenance window where the workload replay can run.
+  - title: Update SBOM and re-sign release artifacts
+    role: security
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Regenerate CycloneDX or SPDX SBOM for the new dependency set. Re-sign
+      release artifacts with cosign. Verify SLSA provenance attaches to the
+      new artifact set.
+  - title: Add an upgrade postmortem to the ADR log
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Capture the decisions taken during this sweep as an ADR. Record which
+      dependencies surprised the team, which patterns of break repeated,
+      and what the next sweep should cache. This becomes the input to the
+      next dependency upgrade so that knowledge does not evaporate.
+  - title: Rotate maintenance ownership and schedule the next sweep
+    role: manager
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Assign a primary and secondary owner for the dependency surface.
+      Block out the next sweep on the calendar so this never becomes a
+      twelve-month backlog item again.
+  - title: Backport critical security upgrades to the previous release line
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      For every upgrade in the sweep tagged as a security fix, evaluate
+      whether the previous supported release line needs the same fix.
+      Cherry-pick, run the regression gate, and ship a patch release.
+  - title: Add a guardrail that blocks merges when SBOM diff and lockfile diff disagree
+    role: devops
+    priority: 3
+    scope: small
+    complexity: medium
+    description: |
+      Drift between the lockfile and the SBOM is the most common source of
+      silent supply-chain regressions. Add a CI check that fails when the
+      two go out of sync. Document the override path for emergency fixes.
+  - title: Publish the upgrade summary to the team wiki and changelog
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Write a one-page summary for downstream consumers: what shipped,
+      which behavior changed, what to watch for in production, and what
+      the next sweep is targeted to land. Link to the ADR.

--- a/.bernstein/scenarios/software/large-codebase-audit.yaml
+++ b/.bernstein/scenarios/software/large-codebase-audit.yaml
@@ -1,0 +1,76 @@
+id: large-codebase-audit
+name: Large Codebase Audit
+version: "1.0"
+description: |
+  Multi-week audit of a sprawling repository. Produces a defensible map of
+  hot-spots, code smells, and architectural drift before any refactor
+  starts. The output is a single report that anyone joining the team can
+  read in one sitting and use to plan work.
+tags:
+  - audit
+  - architecture
+  - quality
+tasks:
+  - title: Build a code-as-crime-scene report
+    role: architect
+    priority: 1
+    scope: large
+    complexity: medium
+    description: |
+      Cross-reference git churn, file-level complexity, and bug-fix history
+      to surface the top decile of risk-bearing files. Produce a sortable
+      table the team can act on directly.
+  - title: Map module boundaries against actual import graph
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Compare the documented module boundaries to the real import graph.
+      Flag every cross-boundary import that should not exist. Output a
+      list of violations with location and severity.
+  - title: Score every public API surface for breakage risk
+    role: backend
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      For every public function, class, or endpoint, capture caller count,
+      type-stability, and last-changed date. Highlight surfaces that move
+      frequently but carry many callers; those are the first refactor
+      targets.
+  - title: Identify dead code and orphaned modules
+    role: backend
+    priority: 2
+    scope: medium
+    complexity: low
+    description: |
+      Run static reachability analysis. Confirm with at least two distinct
+      tools per language. Output a candidate-removal list with a written
+      justification per entry; manual review is required before deletion.
+  - title: Evaluate test coverage and mutation score per module
+    role: qa
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Compute line and branch coverage. Then run mutation testing on the
+      five most critical modules. Capture the gap between line coverage
+      and mutation score; that gap is where future bugs hide.
+  - title: Surface architecture decision records that have rotted
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Walk every accepted ADR. Mark any whose decision the codebase no
+      longer reflects as superseded. Open a short note explaining why and
+      proposing a replacement decision.
+  - title: Publish the audit report and a prioritized backlog
+    role: manager
+    priority: 1
+    scope: medium
+    complexity: low
+    description: |
+      Produce a single report with one page per finding category. Link
+      every finding to a backlog entry with owner and target date.

--- a/.bernstein/scenarios/software/monorepo-extraction.yaml
+++ b/.bernstein/scenarios/software/monorepo-extraction.yaml
@@ -1,0 +1,90 @@
+id: monorepo-extraction
+name: Monorepo Service Extraction
+version: "1.0"
+description: |
+  Extract one bounded context out of a monolith into its own repository or
+  deployable service using the Strangler Fig pattern. Targeted at teams who
+  hit the wall where independent scaling, on-call ownership, or release
+  cadence demand a real boundary the import-graph cannot fake.
+tags:
+  - architecture
+  - refactor
+  - extraction
+tasks:
+  - title: Confirm the bounded context is genuinely separable
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Validate that the candidate context has a stable interface, owns its
+      data, and meets at least one of: independent scaling, distinct
+      release cadence, regulatory isolation, distinct on-call ownership.
+      A "clean module" is not a service; resist extraction without a
+      hard reason.
+  - title: Define the new service contract
+    role: architect
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Produce an OpenAPI or AsyncAPI contract for the new service. Pin
+      request and response shapes, error model, retry semantics, and
+      idempotency keys. The contract is the boundary; everything else
+      is implementation detail.
+  - title: Stand up the new service in a parallel deployment
+    role: devops
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Deploy the new service alongside the monolith. Both speak the new
+      contract; only the new service has new behavior. Configure observability,
+      health checks, and the rollout flag so traffic can swing back instantly.
+  - title: Route a small percentage of traffic via a feature flag
+    role: backend
+    priority: 1
+    scope: small
+    complexity: medium
+    description: |
+      Start at one percent of traffic. Compare error rates, latency, and
+      semantic correctness against the monolith path. Hold at each rollout
+      stage long enough for production noise to stabilize.
+  - title: Migrate persistent state to the new service's owned store
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Move the data the new service owns into its own database or schema.
+      Keep the monolith reading from the new store via the contract;
+      writes go through the contract too. Data migrations are one-way
+      doors and need a written rollback plan.
+  - title: Cut the monolith over to the contract for one hundred percent of calls
+    role: backend
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Ramp traffic to one hundred percent. Confirm the monolith no longer
+      reaches the old code path. Keep the old code path in place for one
+      release cycle as a safety net.
+  - title: Delete the old code path and the dual-write infrastructure
+    role: backend
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Once the new service has run cleanly through one release cycle,
+      delete the old implementation. Remove dual-write logic. Re-tag the
+      release so future maintainers can identify the extraction boundary.
+  - title: Move on-call ownership and document the runbook
+    role: manager
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Update the service catalog with the new ownership. Publish a runbook
+      covering normal operation, incident response, dependency map, and
+      escalation contacts. Verify the new owners can answer a paging
+      drill within target latency.

--- a/.bernstein/scenarios/software/security-fix-sweep.yaml
+++ b/.bernstein/scenarios/software/security-fix-sweep.yaml
@@ -1,0 +1,78 @@
+id: security-fix-sweep
+name: Security Fix Sweep
+version: "1.0"
+description: |
+  Triage and remediate the open security backlog in priority order. Combines
+  static-analysis findings, dependency CVEs, secret-scan hits, and
+  threat-model gaps into one coordinated sweep that lands behind feature
+  flags where behavior shifts.
+tags:
+  - security
+  - remediation
+  - supply-chain
+tasks:
+  - title: Triage the open security backlog by impact and exploitability
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Cross-reference each finding against CVSS, deployed surface, and
+      whether a working exploit exists in the wild. Drop findings that
+      do not apply with a written justification. The remaining list is
+      the sweep input.
+  - title: Pin and patch transitive dependencies with known CVEs
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Upgrade transitive dependencies to a fixed version. Where no fixed
+      version exists upstream, document the workaround and a watch-list
+      entry. Do not invent custom forks unless an explicit ADR signs off.
+  - title: Eliminate hard-coded secrets and rotate every credential found in history
+    role: security
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      Run a full git-history secret scan. Rotate every credential the
+      scanner finds, not only the ones still in HEAD. Capture the
+      rotation evidence in a private channel.
+  - title: Add output validation on every user-influenced LLM tool call
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: high
+    description: |
+      Map every place untrusted input reaches a tool call. Add a structured
+      output validator. Wire prompt-injection canaries that fail loud when
+      a model echoes injected instructions. This is the OWASP LLM Top 10
+      number-one defense layer.
+  - title: Tighten egress allowlists and tool-RBAC scopes
+    role: devops
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Move every agent runtime to default-deny network egress. Add an
+      allowlist sourced from declared tool manifests. Remove read-write
+      tool permissions where read-only is sufficient.
+  - title: Re-run the threat model against the patched system
+    role: security
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Replay STRIDE plus, where personal data is in scope, LINDDUN. Confirm
+      every previously open mitigation now closes. New findings route into
+      the next sweep, not this one.
+  - title: Publish a security-fix changelog and notify downstream consumers
+    role: docs
+    priority: 2
+    scope: small
+    complexity: low
+    description: |
+      Write a public-facing changelog covering the user-visible fixes.
+      Notify downstream consumers via the security advisory channel.
+      Pin the advisory to the project README until the next sweep.

--- a/.bernstein/scenarios/software/test-coverage-uplift.yaml
+++ b/.bernstein/scenarios/software/test-coverage-uplift.yaml
@@ -1,0 +1,76 @@
+id: test-coverage-uplift
+name: Test Coverage Uplift
+version: "1.0"
+description: |
+  Move a low-coverage repository into a known-good state with property
+  tests on invariants, contract tests on public APIs, and a mutation gate
+  on critical modules. Aimed at codebases where line coverage is misleading
+  because the suite tests mocks, not behavior.
+tags:
+  - testing
+  - quality
+  - regression
+tasks:
+  - title: Establish baseline metrics
+    role: qa
+    priority: 1
+    scope: small
+    complexity: low
+    description: |
+      Capture line coverage, branch coverage, and mutation score per module.
+      Identify modules where line coverage exceeds eighty percent but
+      mutation score sits below thirty; those are the priority targets.
+  - title: Add property-based tests for transformation and parsing modules
+    role: qa
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      For every parser, encoder, or pure-function transformation, define
+      two to three invariants and convert them into property tests. Capture
+      seeds for any failure so reproducers stay deterministic.
+  - title: Add consumer-driven contract tests for every public API
+    role: backend
+    priority: 1
+    scope: medium
+    complexity: medium
+    description: |
+      For each public HTTP or gRPC API, capture a Pact or Spring Cloud
+      Contract definition. Run can-i-deploy in CI as the merge gate.
+  - title: Replace mock-heavy unit tests with thin integration slices
+    role: backend
+    priority: 2
+    scope: medium
+    complexity: medium
+    description: |
+      Identify unit tests that mock the entire collaborator graph. Replace
+      with a thin integration test running a real implementation against
+      a sandboxed dependency. Prefer dropping the mocked test entirely if
+      coverage stays equivalent.
+  - title: Raise the mutation-score gate on critical modules
+    role: qa
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      For each module flagged as critical, set a mutation-score floor in
+      CI. Start at fifty percent and ratchet up over subsequent sprints.
+      Document the policy in CONTRIBUTING.md.
+  - title: Wire flake-detection and quarantine workflow
+    role: devops
+    priority: 2
+    scope: small
+    complexity: medium
+    description: |
+      Detect flaky tests via repeated runs. Quarantine and assign owners
+      with deadlines. A test that stays quarantined past its deadline is
+      deleted, not paused indefinitely.
+  - title: Update test documentation and onboarding guide
+    role: docs
+    priority: 3
+    scope: small
+    complexity: low
+    description: |
+      Capture the testing pyramid the project commits to, the property-test
+      conventions, and the contract-test workflow. New contributors should
+      reach a productive first PR without slack-asking for context.

--- a/.bernstein/workflows/audit-evidence-pack.yaml
+++ b/.bernstein/workflows/audit-evidence-pack.yaml
@@ -1,0 +1,97 @@
+# Audit evidence pack generation workflow.
+#
+# Demonstrates:
+#   - Parallel evidence collection (logs, SBOM, attestations) in one phase
+#   - Fan-in to assembly only after every evidence stream lands
+#   - Validator gate: mock-auditor pass blocks delivery if findings are open
+#   - Sign-and-deliver only after validator approves
+
+name: audit-evidence-pack
+version: "1.0.0"
+
+phases:
+  - name: scope
+    allowed_roles: [manager, architect]
+  - name: collect
+  - name: validate
+    allowed_roles: [qa, security]
+  - name: deliver
+    allowed_roles: [security, manager]
+
+nodes:
+  define-control-inventory:
+    phase: scope
+    role: architect
+    description: "Define the control inventory and the evidence map"
+    estimated_minutes: 60
+
+  collect-audit-logs:
+    phase: collect
+    role: security
+    description: "Verify HMAC chain integrity across the audit window"
+    estimated_minutes: 45
+    depends_on:
+      - define-control-inventory
+
+  collect-sboms-and-attestations:
+    phase: collect
+    role: security
+    description: "Generate SBOMs and verify SLSA provenance for every artifact"
+    estimated_minutes: 45
+    depends_on:
+      - define-control-inventory
+
+  collect-runbooks-and-policies:
+    phase: collect
+    role: docs
+    description: "Capture incident runbooks, threat models, and data-governance docs"
+    estimated_minutes: 60
+    depends_on:
+      - define-control-inventory
+
+  collect-eval-results:
+    phase: collect
+    role: qa
+    description: "Run the agent-evaluation harness and capture accuracy plus robustness evidence"
+    estimated_minutes: 60
+    depends_on:
+      - define-control-inventory
+
+  assemble-pack:
+    phase: validate
+    role: docs
+    description: "Build the auditor-navigable index and the zip"
+    estimated_minutes: 45
+    depends_on:
+      - collect-audit-logs
+      - collect-sboms-and-attestations
+      - collect-runbooks-and-policies
+      - collect-eval-results
+
+  mock-auditor-pass:
+    phase: validate
+    role: qa
+    description: "Hand the pack to an internal reviewer who has not worked on the pipeline"
+    estimated_minutes: 60
+    depends_on:
+      - assemble-pack
+
+  remediate-findings:
+    phase: collect
+    role: docs
+    description: "Address mock-auditor findings"
+    depends_on:
+      - source: mock-auditor-pass
+        condition: "status == 'failed'"
+    retry:
+      max_attempts: 3
+      until: "status == 'done'"
+
+  sign-and-deliver:
+    phase: deliver
+    role: security
+    description: "Sign the pack with cosign and deliver via the contracted channel"
+    estimated_minutes: 20
+    depends_on:
+      - source: mock-auditor-pass
+        condition: "status == 'done'"

--- a/.bernstein/workflows/parallel-review-merge.yaml
+++ b/.bernstein/workflows/parallel-review-merge.yaml
@@ -1,0 +1,74 @@
+# Parallel-review-then-merge workflow.
+#
+# Demonstrates:
+#   - Two reviewers run concurrently in fresh contexts (writer/reviewer pattern)
+#   - Reviewer fan-in: merge waits for both reviewers and the test gate
+#   - Conditional revision: revise-changes only runs if any reviewer requests it
+#   - Retry/loop: revise-changes retries until reviewers approve
+#   - Conditional merge: only when reviewers approve and tests pass
+
+name: parallel-review-merge
+version: "1.0.0"
+
+phases:
+  - name: implement
+  - name: review
+    allowed_roles: [reviewer, qa, security]
+  - name: merge
+    allowed_roles: [manager]
+
+nodes:
+  draft-change:
+    phase: implement
+    role: backend
+    description: "Produce the proposed change as a draft commit"
+    estimated_minutes: 45
+
+  reviewer-correctness:
+    phase: review
+    role: reviewer
+    description: "Review for correctness, scope, and design fit in a fresh context"
+    estimated_minutes: 20
+    depends_on:
+      - draft-change
+
+  reviewer-security:
+    phase: review
+    role: security
+    description: "Review for security regressions and supply-chain impact"
+    estimated_minutes: 15
+    depends_on:
+      - draft-change
+
+  run-tests:
+    phase: review
+    role: qa
+    description: "Run the full test suite plus mutation gate on changed modules"
+    estimated_minutes: 25
+    depends_on:
+      - draft-change
+
+  revise-changes:
+    phase: implement
+    role: backend
+    description: "Address review feedback"
+    depends_on:
+      - source: reviewer-correctness
+        condition: "status == 'changes_requested' or status == 'failed'"
+      - source: reviewer-security
+        condition: "status == 'changes_requested' or status == 'failed'"
+    retry:
+      max_attempts: 3
+      until: "status == 'done'"
+
+  merge:
+    phase: merge
+    role: manager
+    description: "Merge when reviewers approve and tests pass"
+    depends_on:
+      - source: reviewer-correctness
+        condition: "status == 'approved'"
+      - source: reviewer-security
+        condition: "status == 'approved'"
+      - source: run-tests
+        condition: "status == 'done'"

--- a/.bernstein/workflows/sequential-deprecation-rollout.yaml
+++ b/.bernstein/workflows/sequential-deprecation-rollout.yaml
@@ -1,0 +1,78 @@
+# Sequential deprecation rollout workflow.
+#
+# Demonstrates:
+#   - Strict sequential phases: announce -> ship-new -> warn -> migrate -> remove
+#   - Wait gates: each phase has a calendar or signal-driven hold
+#   - Conditional retract: roll back if telemetry shows blocked consumers
+#   - Final removal only after the deprecation window closes
+
+name: sequential-deprecation-rollout
+version: "1.0.0"
+
+phases:
+  - name: announce
+    allowed_roles: [manager, docs]
+  - name: ship-new
+  - name: warn
+  - name: migrate
+  - name: remove
+    allowed_roles: [manager]
+
+nodes:
+  publish-rfc:
+    phase: announce
+    role: architect
+    description: "Publish the deprecation RFC with new shape and removal date"
+    estimated_minutes: 60
+
+  notify-consumers:
+    phase: announce
+    role: docs
+    description: "Send notice to every known consumer with the migration link"
+    estimated_minutes: 20
+    depends_on:
+      - publish-rfc
+
+  ship-new-surface:
+    phase: ship-new
+    role: backend
+    description: "Ship the new API alongside the old"
+    estimated_minutes: 90
+    depends_on:
+      - notify-consumers
+
+  emit-deprecation-warnings:
+    phase: warn
+    role: backend
+    description: "Emit deprecation warnings on every old-surface call"
+    estimated_minutes: 30
+    depends_on:
+      - ship-new-surface
+
+  monitor-consumer-migration:
+    phase: migrate
+    role: manager
+    description: "Track consumer migration progress and prompt stragglers"
+    estimated_minutes: 30
+    depends_on:
+      - emit-deprecation-warnings
+    retry:
+      max_attempts: 12
+      until: "status == 'done' or migration_complete >= 0.95"
+
+  retract-deprecation:
+    phase: warn
+    role: backend
+    description: "Roll back if consumer pushback or telemetry blocks the cut"
+    depends_on:
+      - source: monitor-consumer-migration
+        condition: "status == 'blocked'"
+
+  remove-old-surface:
+    phase: remove
+    role: backend
+    description: "Delete the old code path once the window closes"
+    estimated_minutes: 60
+    depends_on:
+      - source: monitor-consumer-migration
+        condition: "status == 'done' or migration_complete >= 0.95"


### PR DESCRIPTION
Adds 14 scenario plans + 3 workflow DAGs under `.bernstein/scenarios/` and `.bernstein/workflows/`. Categories: software (6 new), enterprise (3), docs (2), research (2), growth (2). Two scenarios drilled to task level: `dependency-upgrade-sweep` (18 tasks) and `regulator-audit-evidence-pack` (22 tasks). All YAML validates; matches the existing `ci-remediation.yaml` + `ci-pipeline.yaml` schema.