### PR TITLE
fix(test): register `export` in DOCUMENTED_COMMANDS + README monitoring block

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ bernstein ps         # running agents
 bernstein cost       # spend by model/task
 bernstein doctor     # pre-flight checks
 bernstein recap      # post-run summary
+bernstein export     # shareable HTML/Markdown report of the latest run
 bernstein trace <ID> # agent decision trace
 bernstein run-changelog --hours 48  # changelog from agent-produced diffs
 bernstein explain <cmd>  # detailed help with examples

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -110,6 +110,7 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "gateway",
         "templates",
         # Reports & profiling
+        "export",
         "man-pages",
         "profile",
         "report",


### PR DESCRIPTION
## Summary

- Unblocks `main` CI: 3 Test jobs (ubuntu 3.12, ubuntu 3.13, macos 3.13) are red on `tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented` since PR #1215.
- PR #1215 (`feat: bernstein export`) registered the `export` Click command via `cli.add_command(export_cmd, "export")` but skipped the contract documented in `test_readme_api_coverage.py`'s module docstring: add to README **and** to `DOCUMENTED_COMMANDS`.
- This 2-line fix honors that contract; no behavior change.

## Failure quote

```
FAILED tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented
  - Failed: New CLI command(s) detected that are not in DOCUMENTED_COMMANDS: export
```

## Changes

| File | Change |
|------|--------|
| `README.md` | Added `bernstein export # shareable HTML/Markdown report of the latest run` to the `## monitoring` block, next to `recap`. |
| `tests/unit/test_readme_api_coverage.py` | Added `"export"` to `DOCUMENTED_COMMANDS` under "Reports & profiling". |

## Test plan

- [x] `pytest tests/unit/test_readme_api_coverage.py -v` — all 5 tests pass locally (3.12, macOS).
- [ ] CI: Test (ubuntu 3.12), Test (ubuntu 3.13), Test (macos 3.13) green.
- [ ] CI: Spelling (typos) green (no new words — `shareable` already used in `src/bernstein/cli/commands/export_cmd.py` docstring).