### PR TITLE
chore: bump to v1.10.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.6"
+version = "1.10.7"
 description = "Multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more) — deterministic, declarative, zero vendor lock-in."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Manual bump PR. The auto-release workflow created this branch on its previous run but couldn't open the PR itself — `sipyourdrink-ltd` blocks Actions from creating pull requests (`GraphQL: GitHub Actions is not permitted to create or approve pull requests`), so the auto-bump-PR step in `auto-release.yml` exits 1.

Opening it manually so the next auto-release run on main sees `pyproject.toml = 1.10.7` with no matching tag yet, and proceeds straight to tag + build + publish.

Release notes will be overridden post-publish to match the house style (operator-facing narrative, not the auto-bucket format).