### PR TITLE
feat(cli): `bernstein analyze` — orchestration-readiness scan (#768)

### DIFF
--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -21,6 +21,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "adapter_cmd": "bernstein.cli.commands.adapter_cmd",
     "advanced_cmd": "bernstein.cli.commands.advanced_cmd",
     "agents_cmd": "bernstein.cli.commands.agents_cmd",
+    "analyze_cmd": "bernstein.cli.commands.analyze_cmd",
     "aliases": "bernstein.cli.utils.aliases",
     "api_check_cmd": "bernstein.cli.commands.api_check_cmd",
     "audit_cmd": "bernstein.cli.commands.audit_cmd",

--- a/src/bernstein/cli/commands/analyze_cmd.py
+++ b/src/bernstein/cli/commands/analyze_cmd.py
@@ -1,0 +1,160 @@
+"""CLI command: `bernstein analyze` — orchestration-readiness scan.
+
+Closes [#768](https://github.com/sipyourdrink-ltd/bernstein/issues/768).
+
+Scans the current repo (or `--path`) and prints a readiness score plus
+strengths / opportunities / recommended first run. Pure offline analysis;
+no LLM calls, no network.
+
+Use --json for a machine-readable report (e.g. for CI gates that want to
+fail builds with low orchestration-readiness scores).
+"""
+
+from __future__ import annotations
+
+import json as _json
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.knowledge.repo_analyzer import RepoAnalysis, analyze_repo
+
+
+@click.command("analyze")
+@click.option(
+    "--path",
+    "path",
+    type=click.Path(file_okay=False, dir_okay=True, exists=True),
+    default=".",
+    show_default=True,
+    help="Repo root to analyze.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a machine-readable JSON report instead of the rich console view.",
+)
+@click.option(
+    "--min-score",
+    "min_score",
+    type=float,
+    default=None,
+    help="Exit with non-zero status if the readiness score is below this threshold (0-10).",
+)
+def analyze_cmd(path: str, as_json: bool, min_score: float | None) -> None:
+    """Assess repo readiness for multi-agent orchestration.
+
+    \b
+    Scoring is the average of four components on a 0-10 scale:
+      1. Test coverage  (estimated from test/source file ratio)
+      2. Modularity     (penalises >300-line files + modules without tests)
+      3. CI presence    (10 if a CI config exists, else 0)
+      4. Type hints     (Python only; skipped on non-Python repos)
+
+    \b
+      bernstein analyze
+      bernstein analyze --path other/repo
+      bernstein analyze --json | jq .readiness_score
+      bernstein analyze --min-score 6   # exits 1 if score < 6
+    """
+    root = Path(path).resolve()
+    analysis = analyze_repo(root)
+
+    if as_json:
+        click.echo(_json.dumps(_to_json(analysis), indent=2))
+    else:
+        _render_rich(analysis)
+
+    if min_score is not None and analysis.readiness_score < min_score:
+        raise SystemExit(1)
+
+
+def _to_json(a: RepoAnalysis) -> dict:
+    """Convert an analysis to a JSON-serializable dict."""
+    return {
+        "root": str(a.root),
+        "totals": {
+            "files": a.total_files,
+            "source_files": a.total_source_files,
+            "lines": a.total_lines,
+            "largest_file_lines": a.largest_file_lines,
+            "largest_file_path": str(a.largest_file_path) if a.largest_file_path else None,
+        },
+        "languages": [{"name": lang.name, "files": lang.files, "pct": lang.pct} for lang in a.languages],
+        "tests": {
+            "test_files": a.test_files,
+            "estimated_coverage_pct": a.test_coverage_estimate_pct,
+            "modules_without_tests": [str(p) for p in a.modules_without_tests],
+        },
+        "ci": {"present": a.has_ci, "kind": a.ci_kind or None},
+        "smells": {
+            "files_over_300_lines": [{"path": str(p), "lines": n} for p, n in a.files_over_300_lines],
+            "python_files_without_type_hints": a.python_files_without_type_hints,
+        },
+        "readiness_score": a.readiness_score,
+        "strengths": a.strengths,
+        "opportunities": a.opportunities,
+        "recommended_first_run": a.recommended_first_run,
+    }
+
+
+def _render_rich(a: RepoAnalysis) -> None:
+    """Pretty-print the analysis to the console."""
+    console.print()
+    console.print(f"[bold]Repo Analysis[/bold] — [cyan]{a.root}[/cyan]")
+    console.print()
+
+    # Codebase block
+    console.print("  [bold]Codebase[/bold]:")
+    if a.languages:
+        lang_summary = ", ".join(f"{lang.name} ({lang.pct}%)" for lang in a.languages[:3])
+    else:
+        lang_summary = "(no recognized source files)"
+    console.print(f"    Language: {lang_summary}")
+    console.print(f"    Files: {a.total_files} (source: {a.total_source_files})")
+    console.print(f"    Lines: {a.total_lines:,}")
+    if a.test_coverage_estimate_pct:
+        console.print(
+            f"    Test coverage: ~{a.test_coverage_estimate_pct}% [dim](estimated from test file count)[/dim]"
+        )
+    else:
+        console.print("    Test coverage: [yellow]no tests detected[/yellow]")
+    console.print()
+
+    # Score block
+    score_color = (
+        "green"
+        if a.readiness_score >= 7
+        else ("yellow" if a.readiness_score >= 4 else "red")
+    )
+    console.print(
+        f"  [bold]Orchestration readiness[/bold]: [{score_color}]{a.readiness_score:.1f}/10[/{score_color}]"
+    )
+    console.print()
+
+    # Strengths
+    if a.strengths:
+        console.print("  [bold green]Strengths[/bold green]:")
+        for s in a.strengths:
+            console.print(f"    [green]✓[/green] {s}")
+        console.print()
+
+    # Opportunities
+    if a.opportunities:
+        console.print("  [bold yellow]Opportunities[/bold yellow]:")
+        for o in a.opportunities:
+            console.print(f"    [yellow]→[/yellow] {o}")
+        console.print()
+
+    # Recommended first run
+    if a.recommended_first_run:
+        console.print("  [bold]Recommended first run[/bold]:")
+        console.print(f"    [cyan]{a.recommended_first_run}[/cyan]")
+        console.print()
+
+    # Cost hint — keep loose; we don't try to predict actual model cost.
+    console.print("  [dim]Estimated cost: ~$2.50 (5 agents × ~500 tokens each)[/dim]")
+    console.print()

--- a/src/bernstein/cli/commands/analyze_cmd.py
+++ b/src/bernstein/cli/commands/analyze_cmd.py
@@ -125,14 +125,8 @@ def _render_rich(a: RepoAnalysis) -> None:
     console.print()
 
     # Score block
-    score_color = (
-        "green"
-        if a.readiness_score >= 7
-        else ("yellow" if a.readiness_score >= 4 else "red")
-    )
-    console.print(
-        f"  [bold]Orchestration readiness[/bold]: [{score_color}]{a.readiness_score:.1f}/10[/{score_color}]"
-    )
+    score_color = "green" if a.readiness_score >= 7 else ("yellow" if a.readiness_score >= 4 else "red")
+    console.print(f"  [bold]Orchestration readiness[/bold]: [{score_color}]{a.readiness_score:.1f}/10[/{score_color}]")
     console.print()
 
     # Strengths

--- a/src/bernstein/cli/commands/analyze_cmd.py
+++ b/src/bernstein/cli/commands/analyze_cmd.py
@@ -156,5 +156,5 @@ def _render_rich(a: RepoAnalysis) -> None:
         console.print()
 
     # Cost hint — keep loose; we don't try to predict actual model cost.
-    console.print("  [dim]Estimated cost: ~$2.50 (5 agents × ~500 tokens each)[/dim]")
+    console.print("  [dim]Estimated cost: ~$2.50 (5 agents x ~500 tokens each)[/dim]")
     console.print()

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -886,6 +886,7 @@ cli.add_command(lineage_cmd, "lineage")
 
 # Canonical AGENTS.md generator + cross-CLI rewrite (cursor / claude / aider / goose).
 from bernstein.cli.commands.agents_md_cmd import agents_md_cmd  # noqa: E402
+from bernstein.cli.commands.analyze_cmd import analyze_cmd  # noqa: E402
 
 cli.add_command(agents_md_cmd, "agents-md")
 
@@ -913,3 +914,4 @@ cli.add_command(handoff_group, "handoff")
 from bernstein.cli.commands.identity_cmd import identity_group  # noqa: E402
 
 cli.add_command(identity_group, "identity")
+cli.add_command(analyze_cmd, "analyze")  # noqa: E402  (issue #768)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -914,4 +914,4 @@ cli.add_command(handoff_group, "handoff")
 from bernstein.cli.commands.identity_cmd import identity_group  # noqa: E402
 
 cli.add_command(identity_group, "identity")
-cli.add_command(analyze_cmd, "analyze")  # noqa: E402  (issue #768)
+cli.add_command(analyze_cmd, "analyze")  # issue #768

--- a/src/bernstein/core/knowledge/repo_analyzer.py
+++ b/src/bernstein/core/knowledge/repo_analyzer.py
@@ -188,8 +188,7 @@ def analyze_repo(root: Path) -> RepoAnalysis:
     total_for_pct = max(analysis.total_source_files, 1)
     ranked = sorted(files_by_language.items(), key=lambda x: x[1], reverse=True)
     analysis.languages = [
-        LanguageBreakdown(name=name, files=count, pct=round(count / total_for_pct * 100, 1))
-        for name, count in ranked
+        LanguageBreakdown(name=name, files=count, pct=round(count / total_for_pct * 100, 1)) for name, count in ranked
     ]
 
     # Test coverage estimate (count-based, not line-based).
@@ -388,20 +387,14 @@ def _compute_score_and_narrative(a: RepoAnalysis) -> None:
     elif c_tests > 0:
         n = len(a.modules_without_tests)
         if n > 0:
-            opps.append(
-                f"{n} module{'s' if n != 1 else ''} have no tests; consider `bernstein -g \"add tests\"`"
-            )
+            opps.append(f'{n} module{"s" if n != 1 else ""} have no tests; consider `bernstein -g "add tests"`')
     else:
-        opps.append("No test files detected; consider `bernstein -g \"add tests for the public API\"` first")
+        opps.append('No test files detected; consider `bernstein -g "add tests for the public API"` first')
 
     if c_mod >= 8:
-        strengths.append(
-            f"Modular structure — no large monolith files (max: {a.largest_file_lines} lines)"
-        )
+        strengths.append(f"Modular structure — no large monolith files (max: {a.largest_file_lines} lines)")
     elif a.files_over_300_lines:
-        opps.append(
-            f"{len(a.files_over_300_lines)} files over 300 lines could benefit from decomposition"
-        )
+        opps.append(f"{len(a.files_over_300_lines)} files over 300 lines could benefit from decomposition")
 
     if c_ci == 10:
         strengths.append("CI configured — quality gates will work out of the box")

--- a/src/bernstein/core/knowledge/repo_analyzer.py
+++ b/src/bernstein/core/knowledge/repo_analyzer.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 # Reuse the file-discovery exclusion rules so `analyze` and `run` see the
 # same project surface.
@@ -83,13 +86,11 @@ def _is_test_file(path: Path) -> bool:
     stem = path.stem  # filename without extension
     if name.startswith("test_") or name.endswith("_test.py"):
         return True
-    if stem.endswith(".test") or stem.endswith(".spec"):
-        return True
-    return False
+    return stem.endswith(".test") or stem.endswith(".spec")
 
 
 def _should_skip_dir(name: str) -> bool:
-    return name in _IGNORED_DIRS or name.startswith(".") and name != ".github"
+    return name in _IGNORED_DIRS or (name.startswith(".") and name != ".github")
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +181,8 @@ def analyze_repo(root: Path) -> RepoAnalysis:
 
         if _is_test_file(path):
             analysis.test_files += 1
-        elif lang == "Python":
-            if not _has_type_hints(path):
-                analysis.python_files_without_type_hints += 1
+        elif lang == "Python" and not _has_type_hints(path):
+            analysis.python_files_without_type_hints += 1
 
     # Language ranking.
     total_for_pct = max(analysis.total_source_files, 1)
@@ -264,7 +264,7 @@ def _has_type_hints(path: Path) -> bool:
         return True  # don't penalize unreadable files
     # Simple substring checks — `: ` after an open-paren or `-> ` before `:`
     # is enough to indicate at least one annotation.
-    return ") -> " in text or ": " in text and "def " in text
+    return ") -> " in text or (": " in text and "def " in text)
 
 
 def _modules_without_tests(root: Path, analysis: RepoAnalysis) -> list[Path]:
@@ -410,7 +410,8 @@ def _compute_score_and_narrative(a: RepoAnalysis) -> None:
 
     if c_typed is not None and c_typed < 7:
         opps.append(
-            f"~{a.python_files_without_type_hints} Python files lack type annotations; consider `bernstein -g \"add type hints\"`"
+            f"~{a.python_files_without_type_hints} Python files lack type annotations; "
+            'consider `bernstein -g "add type hints"`'
         )
     elif c_typed is not None and c_typed >= 9:
         strengths.append("Type annotations broadly present — agents can use them as machine-readable specs")

--- a/src/bernstein/core/knowledge/repo_analyzer.py
+++ b/src/bernstein/core/knowledge/repo_analyzer.py
@@ -1,0 +1,429 @@
+"""Repo orchestration-readiness analysis.
+
+Implementation of [#768](https://github.com/sipyourdrink-ltd/bernstein/issues/768):
+`bernstein analyze` scans a repo and reports a readiness score for
+multi-agent orchestration, plus actionable opportunities.
+
+The module is pure-Python and offline — no network calls, no LLM calls.
+This keeps `bernstein analyze` cheap to run in CI and on first-clone
+before the user has configured an LLM provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+# Reuse the file-discovery exclusion rules so `analyze` and `run` see the
+# same project surface.
+_IGNORED_DIRS = frozenset(
+    {
+        ".git",
+        "__pycache__",
+        "node_modules",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "venv",
+        "dist",
+        "build",
+        ".egg-info",
+        ".tox",
+        ".sdd/runtime",
+        ".next",
+        ".turbo",
+        ".cache",
+        "target",  # rust
+        "vendor",  # go
+    }
+)
+_IGNORED_SUFFIXES = frozenset({".pyc", ".pyo", ".egg-info", ".lock"})
+
+# Language map keyed on file extension. Extensions chosen to cover the
+# stacks bernstein already supports first-class (py / ts) plus the most
+# common 'agent stack' siblings (rust, go, sol). Anything else lands in
+# "Other".
+_LANGUAGE_BY_EXT = {
+    ".py": "Python",
+    ".pyi": "Python",
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript",
+    ".js": "JavaScript",
+    ".jsx": "JavaScript",
+    ".mjs": "JavaScript",
+    ".cjs": "JavaScript",
+    ".rs": "Rust",
+    ".go": "Go",
+    ".sol": "Solidity",
+    ".java": "Java",
+    ".kt": "Kotlin",
+    ".swift": "Swift",
+    ".rb": "Ruby",
+    ".php": "PHP",
+    ".cs": "C#",
+    ".cpp": "C++",
+    ".cc": "C++",
+    ".c": "C",
+    ".h": "C",
+    ".hpp": "C++",
+}
+
+# Heuristic: file is a test if its name starts with `test_` or ends with
+# `.test.<ext>` / `.spec.<ext>`, OR it lives inside a `tests/` / `__tests__`
+# directory. Mirrors how most ecosystems mark test files.
+_TEST_DIR_NAMES = frozenset({"tests", "test", "__tests__", "spec", "specs"})
+
+
+def _is_test_file(path: Path) -> bool:
+    if any(p in _TEST_DIR_NAMES for p in path.parts):
+        return True
+    name = path.name
+    stem = path.stem  # filename without extension
+    if name.startswith("test_") or name.endswith("_test.py"):
+        return True
+    if stem.endswith(".test") or stem.endswith(".spec"):
+        return True
+    return False
+
+
+def _should_skip_dir(name: str) -> bool:
+    return name in _IGNORED_DIRS or name.startswith(".") and name != ".github"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LanguageBreakdown:
+    """Files-by-language summary."""
+
+    name: str
+    files: int
+    pct: float  # of total source files in the repo
+
+
+@dataclass
+class RepoAnalysis:
+    """Result of analyzing a repo for orchestration readiness."""
+
+    root: Path
+    total_files: int = 0
+    total_source_files: int = 0
+    total_lines: int = 0
+    largest_file_lines: int = 0
+    largest_file_path: Path | None = None
+
+    languages: list[LanguageBreakdown] = field(default_factory=list)
+
+    test_files: int = 0
+    source_files_without_tests_estimate: int = 0  # source files that have no matching test
+    test_coverage_estimate_pct: float = 0.0  # estimated, not measured
+
+    has_ci: bool = False
+    ci_kind: str = ""  # "github", "gitlab", "jenkins", or ""
+
+    modules_without_tests: list[Path] = field(default_factory=list)
+    files_over_300_lines: list[tuple[Path, int]] = field(default_factory=list)
+    python_files_without_type_hints: int = 0  # files where no `: ` annotation found
+
+    readiness_score: float = 0.0  # 0-10 scale
+    strengths: list[str] = field(default_factory=list)
+    opportunities: list[str] = field(default_factory=list)
+    recommended_first_run: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Analyzer
+# ---------------------------------------------------------------------------
+
+
+def analyze_repo(root: Path) -> RepoAnalysis:
+    """Run the full analysis on *root* and return the result.
+
+    Performs a single os.walk pass (cheap on a Macbook even for repos with
+    10k+ files) and computes every metric in-line. Returns a `RepoAnalysis`
+    with structured fields that callers can render however they want.
+    """
+    root = root.resolve()
+    if not root.is_dir():
+        raise NotADirectoryError(root)
+
+    analysis = RepoAnalysis(root=root)
+
+    files_by_language: dict[str, int] = {}
+    other_files = 0
+
+    # Single-pass walk.
+    for path in _walk_files(root):
+        analysis.total_files += 1
+        ext = path.suffix.lower()
+        lang = _LANGUAGE_BY_EXT.get(ext)
+        if lang is None:
+            other_files += 1
+            continue
+
+        analysis.total_source_files += 1
+        files_by_language[lang] = files_by_language.get(lang, 0) + 1
+
+        lines = _line_count(path)
+        analysis.total_lines += lines
+        if lines > analysis.largest_file_lines:
+            analysis.largest_file_lines = lines
+            analysis.largest_file_path = path.relative_to(root)
+
+        if lines > 300:
+            analysis.files_over_300_lines.append((path.relative_to(root), lines))
+
+        if _is_test_file(path):
+            analysis.test_files += 1
+        elif lang == "Python":
+            if not _has_type_hints(path):
+                analysis.python_files_without_type_hints += 1
+
+    # Language ranking.
+    total_for_pct = max(analysis.total_source_files, 1)
+    ranked = sorted(files_by_language.items(), key=lambda x: x[1], reverse=True)
+    analysis.languages = [
+        LanguageBreakdown(name=name, files=count, pct=round(count / total_for_pct * 100, 1))
+        for name, count in ranked
+    ]
+
+    # Test coverage estimate (count-based, not line-based).
+    non_test_source = analysis.total_source_files - analysis.test_files
+    if non_test_source > 0:
+        ratio = min(analysis.test_files / non_test_source, 1.0)
+        analysis.test_coverage_estimate_pct = round(ratio * 100, 1)
+
+    # Modules without tests — group source files by top-level package and
+    # flag packages with no test files at all.
+    analysis.modules_without_tests = _modules_without_tests(root, analysis)
+
+    # CI detection.
+    analysis.has_ci, analysis.ci_kind = _detect_ci(root)
+
+    # Compute readiness score + narrative.
+    _compute_score_and_narrative(analysis)
+
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Pass helpers
+# ---------------------------------------------------------------------------
+
+
+def _walk_files(root: Path) -> Iterable[Path]:
+    """Yield every non-ignored file under *root*."""
+    # Use os.walk-ish recursion via pathlib so we can skip ignored dirs
+    # cheaply without scanning their children.
+    stack: list[Path] = [root]
+    while stack:
+        d = stack.pop()
+        try:
+            entries = list(d.iterdir())
+        except (PermissionError, OSError):
+            continue
+        for entry in entries:
+            try:
+                if entry.is_dir():
+                    if _should_skip_dir(entry.name):
+                        continue
+                    stack.append(entry)
+                elif entry.is_file():
+                    if entry.suffix in _IGNORED_SUFFIXES:
+                        continue
+                    yield entry
+            except (PermissionError, OSError):
+                continue
+
+
+def _line_count(path: Path) -> int:
+    """Cheap line count. Returns 0 on any read error."""
+    try:
+        with path.open("rb") as f:
+            return sum(1 for _ in f)
+    except (OSError, PermissionError):
+        return 0
+
+
+def _has_type_hints(path: Path) -> bool:
+    """Heuristic: does this Python file have any function-level type hints?
+
+    Cheap-ish: looks for `def foo(...: T)` or `-> T:` patterns. Misses
+    decorator-stacked or `from typing import` cases where annotations
+    live elsewhere; that's acceptable as a heuristic. The goal is to
+    catch genuinely-untyped files, not to score 100% accuracy.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, PermissionError):
+        return True  # don't penalize unreadable files
+    # Simple substring checks — `: ` after an open-paren or `-> ` before `:`
+    # is enough to indicate at least one annotation.
+    return ") -> " in text or ": " in text and "def " in text
+
+
+def _modules_without_tests(root: Path, analysis: RepoAnalysis) -> list[Path]:
+    """Return top-level Python packages or src/ subdirs with zero test files."""
+    candidates: dict[Path, dict[str, bool]] = {}
+    for entry in _walk_files(root):
+        rel = entry.relative_to(root)
+        if rel.suffix not in (".py", ".ts", ".tsx", ".js", ".rs"):
+            continue
+        # Top-level "module" is the first directory component under src/
+        # or under the repo root.
+        parts = rel.parts
+        if len(parts) < 2:
+            continue
+        top = Path(parts[0]) if parts[0] != "src" else Path(*parts[:2])
+        info = candidates.setdefault(top, {"source": False, "test": False})
+        if _is_test_file(rel):
+            info["test"] = True
+        else:
+            info["source"] = True
+
+    return sorted([top for top, info in candidates.items() if info["source"] and not info["test"]])
+
+
+def _detect_ci(root: Path) -> tuple[bool, str]:
+    """Return (has_ci, ci_kind) by checking for known CI config files."""
+    if (root / ".github" / "workflows").is_dir() and any((root / ".github" / "workflows").iterdir()):
+        return True, "github"
+    if (root / ".gitlab-ci.yml").is_file():
+        return True, "gitlab"
+    if (root / "Jenkinsfile").is_file():
+        return True, "jenkins"
+    if (root / ".circleci" / "config.yml").is_file():
+        return True, "circle"
+    if (root / "azure-pipelines.yml").is_file():
+        return True, "azure"
+    return False, ""
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def _compute_score_and_narrative(a: RepoAnalysis) -> None:
+    """Fill in `readiness_score`, `strengths`, `opportunities`, and `recommended_first_run`.
+
+    The score is the average of four equally-weighted components on a 0-10 scale:
+
+      1. **Test coverage** — proxied by ratio of test files to source files.
+      2. **Modularity** — proxied by absence of files over 300 lines + presence
+         of test files in every top-level module.
+      3. **CI presence** — 10 if a CI config exists, else 0.
+      4. **Typed (Python only)** — 10 if 90%+ of Python files have at least
+         one annotation, falls linearly to 0 at 0% typed.
+
+    Each component contributes a maximum of 2.5 to the final out-of-10 score.
+    Repos with no Python source skip component 4 and rebalance to 1/3 each.
+    """
+    has_python = any(lang.name == "Python" for lang in a.languages)
+
+    # 1. Test coverage component (0-10).
+    cov_pct = a.test_coverage_estimate_pct
+    if cov_pct >= 80:
+        c_tests = 10.0
+    elif cov_pct >= 60:
+        c_tests = 8.0
+    elif cov_pct >= 40:
+        c_tests = 6.0
+    elif cov_pct >= 20:
+        c_tests = 4.0
+    elif cov_pct > 0:
+        c_tests = 2.0
+    else:
+        c_tests = 0.0
+
+    # 2. Modularity component (0-10).
+    over_300_count = len(a.files_over_300_lines)
+    modules_missing_tests = len(a.modules_without_tests)
+    c_mod = 10.0
+    if a.largest_file_lines > 1000:
+        c_mod -= 5
+    elif a.largest_file_lines > 500:
+        c_mod -= 2
+    if over_300_count > 10:
+        c_mod -= 3
+    elif over_300_count > 5:
+        c_mod -= 1.5
+    if modules_missing_tests > 0:
+        c_mod -= min(modules_missing_tests * 0.5, 3)
+    c_mod = max(c_mod, 0.0)
+
+    # 3. CI component.
+    c_ci = 10.0 if a.has_ci else 0.0
+
+    # 4. Type-annotation component (Python-only). `python_files_without_type_hints`
+    # is already counted excluding test files inside analyze_repo, so we divide
+    # by the count of non-test Python source files.
+    if has_python:
+        py_files = next((lang.files for lang in a.languages if lang.name == "Python"), 1)
+        # py_files counts ALL Python files including tests; subtract test files
+        # (approximate: assume tests are evenly distributed across languages
+        # which is fine because test_files is small relative to total).
+        py_non_test = max(py_files - a.test_files, 1)
+        typed_ratio = 1.0 - (a.python_files_without_type_hints / py_non_test)
+        typed_ratio = max(min(typed_ratio, 1.0), 0.0)
+        c_typed = round(typed_ratio * 10, 1)
+    else:
+        c_typed = None
+
+    if c_typed is None:
+        a.readiness_score = round((c_tests + c_mod + c_ci) / 3, 1)
+    else:
+        a.readiness_score = round((c_tests + c_mod + c_ci + c_typed) / 4, 1)
+
+    # Narrative.
+    strengths, opps = [], []
+
+    if c_tests >= 6:
+        strengths.append("Good test coverage — agents can verify their work")
+    elif c_tests > 0:
+        n = len(a.modules_without_tests)
+        if n > 0:
+            opps.append(
+                f"{n} module{'s' if n != 1 else ''} have no tests; consider `bernstein -g \"add tests\"`"
+            )
+    else:
+        opps.append("No test files detected; consider `bernstein -g \"add tests for the public API\"` first")
+
+    if c_mod >= 8:
+        strengths.append(
+            f"Modular structure — no large monolith files (max: {a.largest_file_lines} lines)"
+        )
+    elif a.files_over_300_lines:
+        opps.append(
+            f"{len(a.files_over_300_lines)} files over 300 lines could benefit from decomposition"
+        )
+
+    if c_ci == 10:
+        strengths.append("CI configured — quality gates will work out of the box")
+    else:
+        opps.append("No CI config detected; add .github/workflows/ci.yml before delegating to agents")
+
+    if c_typed is not None and c_typed < 7:
+        opps.append(
+            f"~{a.python_files_without_type_hints} Python files lack type annotations; consider `bernstein -g \"add type hints\"`"
+        )
+    elif c_typed is not None and c_typed >= 9:
+        strengths.append("Type annotations broadly present — agents can use them as machine-readable specs")
+
+    a.strengths = strengths
+    a.opportunities = opps
+
+    # Recommended first run — pick the highest-leverage opportunity.
+    if a.python_files_without_type_hints > 5:
+        a.recommended_first_run = 'bernstein -g "Add type annotations to all public functions in src/"'
+    elif a.modules_without_tests:
+        a.recommended_first_run = 'bernstein -g "Add unit tests for the modules that have none"'
+    elif a.files_over_300_lines:
+        a.recommended_first_run = 'bernstein -g "Decompose the largest files into smaller modules"'
+    else:
+        a.recommended_first_run = 'bernstein -g "Add a docs/ARCHITECTURE.md summarising the codebase"'

--- a/tests/unit/test_repo_analyzer.py
+++ b/tests/unit/test_repo_analyzer.py
@@ -1,0 +1,184 @@
+"""Unit tests for `bernstein.core.knowledge.repo_analyzer`.
+
+Covers the issue [#768](https://github.com/sipyourdrink-ltd/bernstein/issues/768)
+implementation. Builds synthetic repos under `tmp_path` to exercise each
+scoring branch deterministically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.knowledge.repo_analyzer import (
+    _detect_ci,
+    _is_test_file,
+    analyze_repo,
+)
+
+if TYPE_CHECKING:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(root: Path, rel: str, content: str = "") -> Path:
+    """Write *content* to root/rel, creating parents."""
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# is_test_file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel,expected",
+    [
+        ("src/foo.py", False),
+        ("src/bar/quux.ts", False),
+        ("tests/test_foo.py", True),
+        ("tests/conftest.py", True),
+        ("src/foo/__tests__/baz.test.ts", True),
+        ("src/foo/bar.test.ts", True),
+        ("src/foo/bar.spec.js", True),
+        ("test/foo.py", True),
+        ("packages/sdk/spec/api.test.ts", True),
+        ("src/foo_test.py", True),
+    ],
+)
+def test_is_test_file_matrix(rel: str, expected: bool) -> None:
+    assert _is_test_file(Path(rel)) is expected
+
+
+# ---------------------------------------------------------------------------
+# CI detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_ci_github(tmp_path: Path) -> None:
+    _write(tmp_path, ".github/workflows/ci.yml", "name: ci\n")
+    has, kind = _detect_ci(tmp_path)
+    assert has is True
+    assert kind == "github"
+
+
+def test_detect_ci_gitlab(tmp_path: Path) -> None:
+    _write(tmp_path, ".gitlab-ci.yml", "stages: [test]\n")
+    has, kind = _detect_ci(tmp_path)
+    assert has is True
+    assert kind == "gitlab"
+
+
+def test_detect_ci_none(tmp_path: Path) -> None:
+    _write(tmp_path, "README.md", "# repo\n")
+    has, kind = _detect_ci(tmp_path)
+    assert has is False
+    assert kind == ""
+
+
+# ---------------------------------------------------------------------------
+# Full analyze_repo passes
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_minimal_repo(tmp_path: Path) -> None:
+    _write(tmp_path, "src/foo.py", "def hello() -> str:\n    return 'hi'\n")
+    a = analyze_repo(tmp_path)
+    assert a.total_files == 1
+    assert a.total_source_files == 1
+    assert a.languages[0].name == "Python"
+    assert a.test_files == 0
+    assert a.has_ci is False
+
+
+def test_analyze_well_structured_repo(tmp_path: Path) -> None:
+    """Realistic repo with tests, CI, type hints — should score high."""
+    _write(tmp_path, "src/myapp/__init__.py", "")
+    _write(tmp_path, "src/myapp/api.py", "def f(x: int) -> int:\n    return x + 1\n")
+    _write(tmp_path, "src/myapp/db.py", "def q(s: str) -> list:\n    return [s]\n")
+    _write(tmp_path, "tests/test_api.py", "def test_f() -> None:\n    assert True\n")
+    _write(tmp_path, "tests/test_db.py", "def test_q() -> None:\n    assert True\n")
+    _write(tmp_path, ".github/workflows/ci.yml", "name: ci\n")
+    a = analyze_repo(tmp_path)
+    assert a.has_ci is True
+    assert a.test_files == 2
+    assert a.test_coverage_estimate_pct > 0
+    # Well-structured repo should land above 6/10
+    assert a.readiness_score >= 6
+    assert a.files_over_300_lines == []
+
+
+def test_analyze_messy_repo(tmp_path: Path) -> None:
+    """Repo with one giant file, no tests, no CI — should score low."""
+    big_body = "x = 1\n" * 1500
+    _write(tmp_path, "src/giant.py", big_body)
+    a = analyze_repo(tmp_path)
+    assert a.has_ci is False
+    assert a.test_files == 0
+    assert a.test_coverage_estimate_pct == 0
+    assert a.largest_file_lines == 1500
+    assert any(p.name == "giant.py" for p, _ in a.files_over_300_lines)
+    assert a.readiness_score < 4
+    assert "No CI config detected" in " ".join(a.opportunities)
+
+
+def test_analyze_skips_ignored_dirs(tmp_path: Path) -> None:
+    _write(tmp_path, "node_modules/big-pkg/index.js", "// pretend this is huge\n" * 200)
+    _write(tmp_path, "src/foo.py", "x = 1\n")
+    a = analyze_repo(tmp_path)
+    assert a.total_source_files == 1
+    assert a.languages[0].name == "Python"
+
+
+def test_analyze_multilang_repo(tmp_path: Path) -> None:
+    _write(tmp_path, "src/api.ts", "export const x = 1\n")
+    _write(tmp_path, "src/lib.rs", "fn main() {}\n")
+    _write(tmp_path, "contracts/Escrow.sol", "// SPDX-License-Identifier: MIT\n")
+    a = analyze_repo(tmp_path)
+    langs = {lang.name for lang in a.languages}
+    assert langs == {"TypeScript", "Rust", "Solidity"}
+
+
+def test_analyze_json_serializable(tmp_path: Path) -> None:
+    """Sanity check that the rich CLI's JSON output mode has no Path objects."""
+    import json as _json
+
+    _write(tmp_path, "src/foo.py", "def f() -> int: return 1\n")
+    _write(tmp_path, ".github/workflows/ci.yml", "name: ci\n")
+    from bernstein.cli.commands.analyze_cmd import _to_json
+
+    a = analyze_repo(tmp_path)
+    payload = _to_json(a)
+    s = _json.dumps(payload)
+    assert "readiness_score" in s
+    assert "totals" in s
+
+
+def test_analyze_min_score_exit(tmp_path: Path) -> None:
+    """The CLI returns SystemExit(1) when --min-score is unmet."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.analyze_cmd import analyze_cmd
+
+    _write(tmp_path, "src/giant.py", "x = 1\n" * 2000)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        analyze_cmd,
+        ["--path", str(tmp_path), "--min-score", "6.0", "--json"],
+    )
+    assert result.exit_code == 1
+    result = runner.invoke(
+        analyze_cmd,
+        ["--path", str(tmp_path), "--min-score", "0.0", "--json"],
+    )
+    assert result.exit_code == 0

--- a/tests/unit/test_repo_analyzer.py
+++ b/tests/unit/test_repo_analyzer.py
@@ -8,7 +8,6 @@ scoring branch deterministically.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -17,10 +16,6 @@ from bernstein.core.knowledge.repo_analyzer import (
     _is_test_file,
     analyze_repo,
 )
-
-if TYPE_CHECKING:
-    pass
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
Closes #768.

## What

`bernstein analyze` does an **offline, no-LLM** scan of a repo and reports a 0-10 readiness score for multi-agent orchestration, plus actionable strengths / opportunities and a recommended first run.

```
$ bernstein analyze --path /path/to/your/project

Repo Analysis — /path/to/your/project

  Codebase:
    Language: Python (92%), TypeScript (8%)
    Files: 234 (source: 189)
    Lines: 48,291
    Test coverage: ~67% (estimated from test file count)

  Orchestration readiness: 8.5/10

  Strengths:
    ✓ Good test coverage — agents can verify their work
    ✓ Modular structure — no large monolith files
    ✓ CI configured — quality gates will work out of the box
    ✓ Type annotations broadly present

  Opportunities:
    → 12 modules have no tests; consider `bernstein -g "add tests"`

  Recommended first run:
    bernstein -g "Add type annotations to all public functions in src/"

  Estimated cost: ~$2.50 (5 agents × ~500 tokens each)
```

## Scoring

The score is the average of four equally-weighted components on a 0-10 scale:

| Component | What it measures |
|---|---|
| **Test coverage** | Ratio of test files to non-test source files (rough proxy — count-based, not line-based). |
| **Modularity** | Penalises files >300 lines, top-level modules without any test files, and very large monoliths (>1000 lines). |
| **CI presence** | 10 if `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml`, or `azure-pipelines.yml` is found, else 0. |
| **Type hints (Python only)** | 0..10 based on the share of non-test Python files that have at least one annotation. Skipped on non-Python repos; the score then averages the other three. |

Each component contributes a max of 2.5 (or 3.33 on non-Python repos) to the final 0-10.

## CLI surface

```
bernstein analyze
bernstein analyze --path other/repo
bernstein analyze --json | jq .readiness_score
bernstein analyze --min-score 6   # exits 1 if score < 6
```

`--min-score` is the CI-gate use-case: fail builds when readiness drops below a threshold, similar to how coverage tools fail at coverage <N%.

## Files

Matches the spec in the issue:

- `src/bernstein/core/knowledge/repo_analyzer.py` — pure-Python single-pass analyzer, ~430 lines. Reuses the existing `_IGNORED_DIRS` family of skip rules so `analyze` and `run` see the same project surface (`node_modules`, `.venv`, `target`, `vendor`, etc.).
- `src/bernstein/cli/commands/analyze_cmd.py` — Click command with rich console output + `--json` mode. Calls into `_to_json` which is also exercised by the test suite.
- `tests/unit/test_repo_analyzer.py` — 20 cases: parametrized `is_test_file` matrix, CI detection branches, full-repo passes (minimal / well-structured / messy / multi-lang / ignored-dir-skipping / JSON-round-trip / `--min-score` exit code).

Command wired in via `_CLI_REDIRECT_MAP` in `cli/__init__.py` and `cli.add_command(analyze_cmd, "analyze")` in `cli/main.py`. No new runtime deps.

## Verified

```bash
$ uv run --python 3.12 python -m pytest tests/unit/test_repo_analyzer.py -v
  ...
  20 passed in 1.05s
```

Real-world smoke runs against a couple of my own repos (different shapes — one TypeScript-only, one Python+Markdown) produced sensible scores (5.0 and 3.3 respectively, both with accurate strengths/opportunities).

## Notes

- `_has_type_hints` is a heuristic (substring scan for `) -> ` / `def …(: T`); it's not an AST walk. That's deliberate — keeping the analyzer fast on 10k+ file repos was a higher priority than being 100% accurate on annotation detection. A future PR could replace this with `ast.parse` if you'd prefer.
- The "recommended first run" selection logic is heuristic and ordered: untyped Python first, then untested modules, then large files, then a fallback ("Add docs/ARCHITECTURE.md"). Easy to tune in `_compute_score_and_narrative`.
- The `Estimated cost` line at the bottom of the rich output is a placeholder copying the issue spec verbatim. It's not derived from the scan; happy to drop it or wire it to actual model pricing if you'd prefer.

— @kite-builds