### PR TITLE
fix(adapters): codex — replace deprecated --full-auto with --sandbox workspace-write

### DIFF
--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -54,7 +54,8 @@ class CodexAdapter(CLIAdapter):
         cmd = [
             "codex",
             "exec",
-            "--full-auto",
+            "--sandbox",
+            "workspace-write",
             "-m",
             model_config.model,
             "--json",

--- a/tests/integration/fake_cli/fake_cli.py
+++ b/tests/integration/fake_cli/fake_cli.py
@@ -298,7 +298,7 @@ def _validate_argv(profile: str, argv: list[str]) -> None:
         # Adapter must request stream-json output and bypass permissions
         required = {"--output-format", "--permission-mode"}
     elif profile == "codex":
-        required = {"exec", "--full-auto", "--json"}
+        required = {"exec", "--sandbox", "workspace-write", "--json"}
     elif profile == "gemini":
         required = {"-p", "-m", "--yolo"}
     elif profile in {"aider", "ollama"}:

--- a/tests/integration/test_adapter_e2e.py
+++ b/tests/integration/test_adapter_e2e.py
@@ -374,7 +374,8 @@ class TestCodexEndToEnd:
         # Codex argv contains the prompt as a positional after flags
         argv = fake_cli_fixture.read_argv()
         assert "exec" in argv
-        assert "--full-auto" in argv
+        assert "--sandbox" in argv
+        assert argv[argv.index("--sandbox") + 1] == "workspace-write"
         assert "--json" in argv
 
     def test_fast_exit_with_nonzero_raises_spawn_error(

--- a/tests/unit/test_adapter_codex.py
+++ b/tests/unit/test_adapter_codex.py
@@ -71,7 +71,7 @@ class TestCodexAdapterSpawn:
         assert "-m" in inner
         assert inner[inner.index("-m") + 1] == "o3-mini"
 
-    def test_full_auto_flag_present(self, tmp_path: Path) -> None:
+    def test_sandbox_flag_present(self, tmp_path: Path) -> None:
         adapter = CodexAdapter()
         proc_mock = _make_popen_mock(pid=102)
         with patch("bernstein.adapters.codex.subprocess.Popen", return_value=proc_mock) as popen:
@@ -82,7 +82,10 @@ class TestCodexAdapterSpawn:
                 session_id="codex-s3",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--full-auto" in inner
+        assert "--sandbox" in inner
+        assert inner[inner.index("--sandbox") + 1] == "workspace-write"
+        # Upstream codex 0.130+ deprecated --full-auto; ensure we no longer emit it.
+        assert "--full-auto" not in inner
 
     def test_json_output_flag_present(self, tmp_path: Path) -> None:
         adapter = CodexAdapter()

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -123,7 +123,7 @@ class TestCodexAdapterSpawn:
         assert "-m" in inner
         assert inner[inner.index("-m") + 1] == "gpt-5.4-mini"
 
-    def test_exec_mode_full_auto(self, tmp_path: Path) -> None:
+    def test_exec_mode_sandbox(self, tmp_path: Path) -> None:
         adapter = CodexAdapter()
         proc_mock = _make_popen_mock(pid=103)
         with patch("bernstein.adapters.codex.subprocess.Popen", return_value=proc_mock) as popen:
@@ -134,7 +134,7 @@ class TestCodexAdapterSpawn:
                 session_id="s3",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert inner[:3] == ["codex", "exec", "--full-auto"]
+        assert inner[:4] == ["codex", "exec", "--sandbox", "workspace-write"]
 
     def test_json_output_file_flags(self, tmp_path: Path) -> None:
         adapter = CodexAdapter()


### PR DESCRIPTION
## Summary

- Upstream @openai/codex 0.130+ deprecated `--full-auto`. The flag still runs but emits a warning that pollutes Bernstein's spawn logs.
- `codex exec --help` documents `-s, --sandbox <SANDBOX_MODE>` with values `read-only | workspace-write | danger-full-access`. `workspace-write` is the canonical replacement for prior `--full-auto` behavior.
- `CodexAdapter.spawn` argv now emits `--sandbox workspace-write` instead of `--full-auto`. Tests and the fake-CLI argv contract updated to match.

## Files changed

| File | Change |
|------|--------|
| `src/bernstein/adapters/codex.py` | argv builder swaps flag |
| `tests/unit/test_adapter_codex.py` | rename test, assert sandbox flag + value, assert `--full-auto` absent |
| `tests/unit/test_adapter_non_claude.py` | update prefix assertion to first 4 tokens |
| `tests/integration/fake_cli/fake_cli.py` | required-flag set switched to `--sandbox` / `workspace-write` |
| `tests/integration/test_adapter_e2e.py` | e2e argv assertion updated |

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_codex.py -xvs` — 27 passed
- [x] `uv run pytest tests/unit/test_adapter_non_claude.py -xvs -k codex` — 14 passed
- [x] `uv run ruff check` (changed files) — clean
- [x] `uv run ruff format` (changed files) — no diff
- [x] Verified upstream: `codex exec --help` lists `--sandbox workspace-write`; `--full-auto` no longer documented (local codex installed at /opt/homebrew/bin/codex)
- [ ] Integration suite (`tests/integration/test_adapter_e2e.py::...codex`) — relies on fake-CLI; covered by argv assertion update