### PR TITLE
fix(cluster): bootstrap-ca certs — SKI/AKI/KeyUsage for OpenSSL 3.x strict

### DIFF
--- a/src/bernstein/cli/commands/cluster_cmd.py
+++ b/src/bernstein/cli/commands/cluster_cmd.py
@@ -50,13 +50,14 @@ def _write_pem(path: Path, data: bytes, *, mode: int) -> None:
 
 def _build_ca(out_dir: Path) -> tuple[x509.Certificate, rsa.RSAPrivateKey]:
     key = _generate_key()
+    public_key = key.public_key()
     name = _build_name("Bernstein Self-Signed CA")
     now = datetime.datetime.now(datetime.UTC)
     cert = (
         x509.CertificateBuilder()
         .subject_name(name)
         .issuer_name(name)
-        .public_key(key.public_key())
+        .public_key(public_key)
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=CA_VALID_DAYS))
@@ -74,6 +75,14 @@ def _build_ca(out_dir: Path) -> tuple[x509.Certificate, rsa.RSAPrivateKey]:
                 decipher_only=False,
             ),
             critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(public_key),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(public_key),
+            critical=False,
         )
         .sign(key, hashes.SHA256())
     )
@@ -101,6 +110,7 @@ def _issue_leaf(
     is_server: bool,
 ) -> None:
     key = _generate_key()
+    public_key = key.public_key()
     now = datetime.datetime.now(datetime.UTC)
     eku = (
         x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.SERVER_AUTH, x509.ExtendedKeyUsageOID.CLIENT_AUTH])
@@ -111,14 +121,36 @@ def _issue_leaf(
         x509.CertificateBuilder()
         .subject_name(_build_name(common_name))
         .issuer_name(ca_cert.subject)
-        .public_key(key.public_key())
+        .public_key(public_key)
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=LEAF_VALID_DAYS))
         .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
         .add_extension(eku, critical=False)
         .add_extension(
             x509.SubjectAlternativeName([x509.DNSName(d) for d in san_dns]),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(public_key),
+            critical=False,
+        )
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_cert.public_key()),
             critical=False,
         )
         .sign(ca_key, hashes.SHA256())

--- a/tests/unit/cli/test_cluster_cmd.py
+++ b/tests/unit/cli/test_cluster_cmd.py
@@ -1,0 +1,110 @@
+"""Regression tests for ``bernstein cluster bootstrap-ca`` certificate extensions.
+
+OpenSSL 3.x strict-mode parsing requires SubjectKeyIdentifier (SKI),
+AuthorityKeyIdentifier (AKI), and KeyUsage extensions on leaf certs.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from cryptography import x509
+from cryptography.x509.oid import ExtensionOID
+
+from bernstein.cli.commands.cluster_cmd import cluster_group
+
+
+def _run_bootstrap(out_dir: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cluster_group,
+        ["bootstrap-ca", "--out-dir", str(out_dir)],
+    )
+    assert result.exit_code == 0, f"bootstrap-ca failed: {result.output}\n{result.exception!r}"
+
+
+def _load(path: Path) -> x509.Certificate:
+    return x509.load_pem_x509_certificate(path.read_bytes())
+
+
+class TestBootstrapCaExtensions:
+    """Verify CA and leaf certs include SKI/AKI/KeyUsage (OpenSSL 3.x strict)."""
+
+    def test_ca_cert_has_ski_and_aki(self, tmp_path: Path) -> None:
+        _run_bootstrap(tmp_path)
+        ca = _load(tmp_path / "ca.crt")
+
+        ski = ca.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_KEY_IDENTIFIER)
+        aki = ca.extensions.get_extension_for_oid(ExtensionOID.AUTHORITY_KEY_IDENTIFIER)
+
+        assert ski.value.digest, "CA cert missing SubjectKeyIdentifier digest"
+        # Self-signed CA: AKI key identifier must match SKI digest.
+        assert aki.value.key_identifier == ski.value.digest, (
+            "CA AKI key identifier must match its own SKI (self-signed CA)"
+        )
+
+    def test_ca_cert_keeps_key_usage(self, tmp_path: Path) -> None:
+        _run_bootstrap(tmp_path)
+        ca = _load(tmp_path / "ca.crt")
+        ku = ca.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE).value
+        assert ku.key_cert_sign is True
+        assert ku.crl_sign is True
+        assert ku.digital_signature is True
+
+    @pytest.mark.parametrize("leaf_name", ["server", "node"])
+    def test_leaf_cert_has_ski_aki_key_usage(self, tmp_path: Path, leaf_name: str) -> None:
+        _run_bootstrap(tmp_path)
+        ca = _load(tmp_path / "ca.crt")
+        leaf = _load(tmp_path / f"{leaf_name}.crt")
+
+        # SKI present
+        ski = leaf.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_KEY_IDENTIFIER)
+        assert ski.value.digest
+
+        # AKI present and chains to CA's SKI
+        ca_ski = ca.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_KEY_IDENTIFIER).value.digest
+        aki = leaf.extensions.get_extension_for_oid(ExtensionOID.AUTHORITY_KEY_IDENTIFIER)
+        assert aki.value.key_identifier == ca_ski, f"{leaf_name} AKI must reference CA SKI for chain validation"
+
+        # KeyUsage with the correct flags
+        ku_ext = leaf.extensions.get_extension_for_oid(ExtensionOID.KEY_USAGE)
+        ku = ku_ext.value
+        assert ku_ext.critical is True
+        assert ku.digital_signature is True
+        assert ku.key_encipherment is True
+        assert ku.key_cert_sign is False
+        assert ku.crl_sign is False
+
+    def test_leaf_cert_keeps_extended_key_usage(self, tmp_path: Path) -> None:
+        _run_bootstrap(tmp_path)
+        server = _load(tmp_path / "server.crt")
+        node = _load(tmp_path / "node.crt")
+
+        server_eku = server.extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE).value
+        node_eku = node.extensions.get_extension_for_oid(ExtensionOID.EXTENDED_KEY_USAGE).value
+        assert x509.ExtendedKeyUsageOID.SERVER_AUTH in server_eku
+        assert x509.ExtendedKeyUsageOID.CLIENT_AUTH in server_eku
+        assert x509.ExtendedKeyUsageOID.SERVER_AUTH not in node_eku
+        assert x509.ExtendedKeyUsageOID.CLIENT_AUTH in node_eku
+
+    def test_openssl_x509_text_lists_new_extensions(self, tmp_path: Path) -> None:
+        """Optional shell-out check: ``openssl x509 -text`` lists SKI + AKI."""
+        if shutil.which("openssl") is None:
+            pytest.skip("openssl binary not available")
+
+        _run_bootstrap(tmp_path)
+        for pem in ("ca.crt", "server.crt", "node.crt"):
+            out = subprocess.run(
+                ["openssl", "x509", "-in", str(tmp_path / pem), "-noout", "-text"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            assert "X509v3 Subject Key Identifier" in out, f"{pem} missing SKI in openssl text"
+            assert "X509v3 Authority Key Identifier" in out, f"{pem} missing AKI in openssl text"
+            if pem != "ca.crt":
+                assert "X509v3 Key Usage" in out, f"{pem} missing KeyUsage in openssl text"


### PR DESCRIPTION
## Summary

- `bernstein cluster bootstrap-ca` previously emitted certificates that lacked extensions required by OpenSSL 3.x strict-mode parsing (the MASTER-RU Q22 demo path).
- CA cert was missing **SubjectKeyIdentifier (SKI)** and **AuthorityKeyIdentifier (AKI)**.
- Leaf certs (server/node) were missing **SKI**, **AKI**, **and KeyUsage** (only ExtendedKeyUsage was set).

## What changed

`src/bernstein/cli/commands/cluster_cmd.py`

- `_build_ca`: add `SubjectKeyIdentifier.from_public_key(...)` and `AuthorityKeyIdentifier.from_issuer_public_key(...)` (self-referencing because the CA is self-signed).
- `_issue_leaf`: add SKI from the leaf public key, AKI from the CA public key, and `KeyUsage(digital_signature=True, key_encipherment=True)` (critical). ExtendedKeyUsage and SubjectAlternativeName remain unchanged.

`tests/unit/cli/test_cluster_cmd.py` (new)

- Runs `bootstrap-ca` into `tmp_path`, parses each PEM via `cryptography.x509`, asserts SKI/AKI/KeyUsage are present and correct for the CA and both leaves.
- Verifies the leaf AKI key identifier matches the CA SKI digest (chain integrity).
- Optional shell-out: `openssl x509 -text` must list `X509v3 Subject Key Identifier` and `X509v3 Authority Key Identifier` (and `X509v3 Key Usage` for leaves).

## Sample `openssl x509 -text` on the regenerated server cert

```
X509v3 Key Usage: critical
    Digital Signature, Key Encipherment
X509v3 Extended Key Usage:
    TLS Web Server Authentication, TLS Web Client Authentication
X509v3 Subject Key Identifier:
    0A:35:4E:14:03:F6:5E:35:9D:AD:26:77:2F:9E:D0:35:46:4E:DA:B4
X509v3 Authority Key Identifier:
    12:77:18:13:B4:A1:E8:D2:D7:C1:BF:48:36:A5:EC:F5:25:81:55:20
```

The leaf AKI matches the CA SKI, confirming the chain.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_cluster_cmd.py -xvs` → 6 passed
- [x] `uv run ruff format` clean
- [x] `uv run ruff check` clean
- [x] Manual `openssl x509 -text` inspection on regenerated CA/server/node certs