### PR TITLE
fix(doctor): role-templates check — accept .md/.yaml/.j2, not just .md

### DIFF
--- a/src/bernstein/tui/context_files_doctor.py
+++ b/src/bernstein/tui/context_files_doctor.py
@@ -118,17 +118,26 @@ def check_context_files(workdir: Path) -> list[DoctorWarning]:
     for rel_path, fmt in _CONTEXT_FILES:
         _check_single_context_file(workdir, rel_path, fmt, results)
 
-    # Check for role template references that don't exist
+    # Check for role template references that don't exist.
+    # Role templates live in per-role subdirs (templates/roles/<role>/) and use
+    # multiple extensions: .md (system_prompt.md, task_prompt.md), .yaml
+    # (config.yaml), and historically .j2/.jinja2. The check passes when at least
+    # one role template file of any supported extension is present anywhere
+    # under templates/roles/.
     templates_dir = workdir / "templates" / "roles"
-    if templates_dir.exists() and not list(templates_dir.glob("*.md")):
-        results.append(
-            DoctorWarning(
-                name="Role templates",
-                ok=False,
-                detail="templates/roles/ exists but contains no .md files",
-                fix="Add role template files to templates/roles/",
+    if templates_dir.exists():
+        role_template_exts = ("*.md", "*.yaml", "*.yml", "*.j2", "*.jinja2")
+        has_role_files = any(next(templates_dir.rglob(pat), None) is not None for pat in role_template_exts)
+        if not has_role_files:
+            results.append(
+                DoctorWarning(
+                    name="Role templates",
+                    ok=False,
+                    detail="templates/roles/ exists but contains no role template files (.md/.yaml/.j2)",
+                    fix="Add role template files (system_prompt.md, task_prompt.md, config.yaml) "
+                    "under templates/roles/<role>/",
+                )
             )
-        )
 
     _check_large_context_files(workdir, results)
 

--- a/tests/unit/test_context_files_doctor.py
+++ b/tests/unit/test_context_files_doctor.py
@@ -63,7 +63,44 @@ class TestCheckContextFiles:
         roles_dir.mkdir(parents=True)
         results = check_context_files(project_dir)
         warn = _first_bad(results)
-        assert "no .md files" in warn.detail
+        assert "no role template files" in warn.detail
+
+    def test_template_roles_dir_with_md_and_yaml_passes(self, project_dir: Path) -> None:
+        """Real layout: per-role subdir with .md prompts and .yaml config."""
+        role_dir = project_dir / "templates" / "roles" / "backend"
+        role_dir.mkdir(parents=True)
+        (role_dir / "system_prompt.md").write_text("# backend\n")
+        (role_dir / "task_prompt.md").write_text("# backend task\n")
+        (role_dir / "config.yaml").write_text("name: backend\n")
+        results = check_context_files(project_dir)
+        assert all(w.ok for w in results), f"unexpected warnings: {results}"
+
+    def test_template_roles_dir_with_only_yaml_passes(self, project_dir: Path) -> None:
+        """YAML-only role still counts as a present role template."""
+        role_dir = project_dir / "templates" / "roles" / "manager"
+        role_dir.mkdir(parents=True)
+        (role_dir / "config.yaml").write_text("name: manager\n")
+        results = check_context_files(project_dir)
+        assert all(w.ok for w in results), f"unexpected warnings: {results}"
+
+    def test_template_roles_dir_with_only_j2_passes(self, project_dir: Path) -> None:
+        """Legacy Jinja2 templates still count."""
+        role_dir = project_dir / "templates" / "roles" / "qa"
+        role_dir.mkdir(parents=True)
+        (role_dir / "prompt.j2").write_text("{{ task }}")
+        results = check_context_files(project_dir)
+        assert all(w.ok for w in results), f"unexpected warnings: {results}"
+
+    def test_real_repo_templates_roles_passes(self) -> None:
+        """Doctor must accept the real repo's templates/roles/ as-is."""
+        repo_root = Path(__file__).resolve().parents[2]
+        roles_dir = repo_root / "templates" / "roles"
+        if not roles_dir.exists():
+            pytest.skip("templates/roles/ not present in this checkout")
+        results = check_context_files(repo_root)
+        role_warns = [w for w in results if w.name == "Role templates"]
+        # Either no warning at all (passes silently), or only OK warnings.
+        assert all(w.ok for w in role_warns), f"Role templates check failed: {role_warns}"
 
 
 # --- TestCheckMcpServers ---


### PR DESCRIPTION
## Summary
- `bernstein doctor` reported a red `✗` on **Role templates: templates/roles/ exists but contains no .md files** despite the directory being well-populated.
- The glob was `templates/roles/*.md` (non-recursive, .md-only). Real layout is `templates/roles/<role>/{system_prompt.md, task_prompt.md, config.yaml}` — zero files at the top level.
- Fix: recurse with `rglob` and accept `.md / .yaml / .yml / .j2 / .jinja2`. Passes when ≥1 role template of any supported extension exists anywhere under `templates/roles/`.

## Before / After
```
# before
│ Role templates  │ ✗  │ templates/roles/ exists but contains no .md files │

# after
│ Context files   │ ✓  │ all present and well-formed                       │
```

## Test plan
- [x] `uv run pytest tests/unit/test_context_files_doctor.py` — 19 passed (added 4 new tests: md+yaml, yaml-only, j2-only, real repo tree).
- [x] `uv run ruff format` + `uv run ruff check` — clean.
- [x] `uv run bernstein doctor` — Role templates no longer red; Context files is `✓`.
- [x] Pre-push hooks (lint, import-linter) — passed.