### PR TITLE
fix(doctor): airgap socket-guard check works standalone (no live run required)

### DIFF
--- a/src/bernstein/core/distribution/doctor_airgap.py
+++ b/src/bernstein/core/distribution/doctor_airgap.py
@@ -244,16 +244,38 @@ def check_no_external_hostnames(workdir: Path) -> Check:
 
 
 def check_runtime_socket_guard_active() -> Check:
-    """Verify the process-wide runtime socket guard is patched in.
+    """Verify the process-wide runtime socket guard can be patched in.
 
     Under ``--profile airgap`` the orchestrator installs a
     :class:`socket.socket.connect` hook so an un-declared outbound dial
     raises :class:`NetworkPolicyDenied`. The hook only patches when
     ``BERNSTEIN_PROFILE_MODE=airgap`` is set; outside airgap it is a
-    no-op. The doctor surfaces both a missing patch (FAIL) and a
-    "we're not in airgap right now" state (WARN).
+    no-op.
+
+    Standalone ``bernstein doctor airgap`` is the documented pre-flight
+    workflow -- it runs *before* ``bernstein run``. The guard is therefore
+    not yet installed in the doctor's own process. Reporting FAIL on
+    that legitimate state used to mislead operators (bughunt 2026-05-13).
+
+    We pick option (A) from the bughunt brief: install the guard for
+    the duration of this check and uninstall right after. The guard is
+    documented idempotent (see ``socket_guard.install_runtime_socket_guard``
+    docstring), ``uninstall_runtime_socket_guard()`` fully restores the
+    original ``socket.socket.connect``, and the doctor command is a
+    short-lived CLI process with no concurrent socket work to disturb.
+    Bonus: round-tripping install/uninstall actually *exercises* the
+    guard's monkeypatch logic, so a regression in the guard itself
+    would surface here -- a strictly stronger signal than option (B)'s
+    "code-path inventory only" WARN.
+
+    Outside airgap the check still WARNs (the guard is intentionally a
+    no-op there; nothing to assert).
     """
-    from bernstein.core.security.socket_guard import is_runtime_socket_guard_installed
+    from bernstein.core.security.socket_guard import (
+        install_runtime_socket_guard,
+        is_runtime_socket_guard_installed,
+        uninstall_runtime_socket_guard,
+    )
 
     if os.environ.get(ENV_PROFILE_MODE, "").strip().lower() != PROFILE_AIRGAP:
         return Check(
@@ -267,13 +289,29 @@ def check_runtime_socket_guard_active() -> Check:
             status=CheckStatus.PASS,
             detail="socket.socket.connect is patched to consult the network policy",
         )
-    return Check(
-        name="runtime socket guard active",
-        status=CheckStatus.FAIL,
-        detail="airgap profile is active but socket.socket.connect is NOT patched",
-        fix="rerun bernstein run --profile airgap (re-installs the guard) or "
-        "import bernstein.core.security.socket_guard and call install_runtime_socket_guard()",
-    )
+    # Pre-flight scenario: airgap profile is set in the operator's
+    # shell but ``bernstein run`` has not yet been invoked, so the
+    # run-bootstrap installer has not fired. Install the guard
+    # ourselves, verify the patch, then restore. If any step fails,
+    # surface that as a real FAIL.
+    installed_here = False
+    try:
+        installed_here = install_runtime_socket_guard()
+        if not installed_here or not is_runtime_socket_guard_installed():
+            return Check(
+                name="runtime socket guard active",
+                status=CheckStatus.FAIL,
+                detail="install_runtime_socket_guard() did not patch socket.socket.connect",
+                fix="inspect bernstein.core.security.socket_guard for import-time errors",
+            )
+        return Check(
+            name="runtime socket guard active",
+            status=CheckStatus.PASS,
+            detail="socket.socket.connect patch verified (installed-and-restored by doctor)",
+        )
+    finally:
+        if installed_here:
+            uninstall_runtime_socket_guard()
 
 
 def check_policy_blocks_known_endpoints() -> Check:

--- a/tests/integration/test_airgap_offline_e2e.py
+++ b/tests/integration/test_airgap_offline_e2e.py
@@ -749,14 +749,19 @@ def test_doctor_airgap_runtime_socket_guard_check_passes_when_installed(airgap_e
     assert guard_row.status is CheckStatus.PASS
 
 
-def test_doctor_airgap_runtime_socket_guard_check_fails_when_missing(
+def test_doctor_airgap_runtime_socket_guard_check_self_installs_when_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Inside airgap without the guard the check must FAIL.
+    """Inside airgap without the guard, the doctor self-installs for the check.
 
-    Operators who set the env vars but skipped the guard install (e.g. a
-    third-party bootstrap that forgot to call install_runtime_socket_guard)
-    need to see the boundary is incomplete.
+    Standalone ``bernstein doctor airgap`` is the documented pre-flight
+    workflow (run before ``bernstein run``), so the run-bootstrap installer
+    has not yet fired. Per bughunt 2026-05-13 fix, the check installs the
+    guard, verifies the monkeypatch, then restores -- exercising the guard's
+    install/uninstall logic round-trip so a regression in the guard itself
+    would still surface here.
+
+    Cleanup: the doctor must restore ``socket.socket.connect`` after the check.
     """
     monkeypatch.setenv(ENV_PROFILE_MODE, PROFILE_AIRGAP)
     monkeypatch.setenv(ENV_NETWORK_POLICY, "none")
@@ -766,7 +771,8 @@ def test_doctor_airgap_runtime_socket_guard_check_fails_when_missing(
     report = run_airgap_checks(workdir=workdir)
     by_name = {c.name: c for c in report.checks}
     guard_row = by_name["runtime socket guard active"]
-    assert guard_row.status is CheckStatus.FAIL
+    assert guard_row.status is CheckStatus.PASS
+    assert not is_runtime_socket_guard_installed()
 
 
 def test_doctor_airgap_cli_exit_code(airgap_env: None, tmp_path: Path) -> None:

--- a/tests/unit/cli/test_doctor_airgap.py
+++ b/tests/unit/cli/test_doctor_airgap.py
@@ -1,0 +1,132 @@
+"""Regression tests for ``bernstein doctor airgap`` standalone invocation.
+
+Bughunt 2026-05-13: the doctor's ``runtime socket guard active`` row
+used to FAIL whenever the command was invoked outside an active
+``bernstein run --profile airgap`` process, because the guard is
+installed by the run bootstrap, not by the doctor itself. Operators
+following the documented pre-flight workflow saw a red row that did
+not reflect real misbehaviour.
+
+These tests pin the fixed contract: with the airgap profile set in
+the environment and no live run, the doctor reports 4 green PASS
+rows for the spec-mandated checks (zero egress / MCP catalog all-off /
+memo store local-only / audit chain valid), plus the now-also-green
+socket-guard row.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.advanced_cmd import doctor as doctor_group
+from bernstein.cli.commands.doctor_airgap_cmd import run_doctor_airgap
+from bernstein.core.distribution.doctor_airgap import (
+    CheckStatus,
+    check_runtime_socket_guard_active,
+    run_airgap_checks,
+)
+from bernstein.core.security.network_policy import (
+    ENV_NETWORK_POLICY,
+    ENV_PROFILE_MODE,
+    PROFILE_AIRGAP,
+)
+from bernstein.core.security.socket_guard import (
+    is_runtime_socket_guard_installed,
+    uninstall_runtime_socket_guard,
+)
+
+
+@pytest.fixture
+def standalone_airgap_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[Path]:
+    """Mimic an operator who set the airgap env vars but has NOT run ``bernstein run``.
+
+    Matches the documented pre-flight workflow: the operator exports
+    ``BERNSTEIN_PROFILE_MODE=airgap`` plus ``BERNSTEIN_NETWORK_POLICY=none``
+    in their shell, then invokes ``bernstein doctor airgap`` to verify
+    the host is ready *before* spinning up agents. Critically, the
+    socket guard is NOT pre-installed in the doctor's process.
+    """
+    # Ensure no prior test left the guard patched in.
+    uninstall_runtime_socket_guard()
+    monkeypatch.setenv(ENV_PROFILE_MODE, PROFILE_AIRGAP)
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "none")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    assert not is_runtime_socket_guard_installed(), (
+        "fixture precondition: socket guard must NOT be installed before the doctor runs"
+    )
+    try:
+        yield tmp_path
+    finally:
+        # Doctor's option-A path uninstalls on its own; defensively
+        # clean up in case a future regression leaves it installed.
+        uninstall_runtime_socket_guard()
+
+
+def test_socket_guard_check_passes_standalone(standalone_airgap_env: Path) -> None:
+    """The bughunt regression: the row must be PASS, not FAIL."""
+    row = check_runtime_socket_guard_active()
+    assert row.status is CheckStatus.PASS, f"expected PASS, got {row.status.value}: {row.detail}"
+
+
+def test_socket_guard_check_restores_original_connect(standalone_airgap_env: Path) -> None:
+    """Option (A) requires the guard to be UNinstalled after the check returns.
+
+    If the doctor leaks the patch into the operator's process, subsequent
+    network calls in the same Python session would silently hit the
+    air-gap guard -- a real side effect that would justify falling back
+    to option (B). Pin the no-leak contract.
+    """
+    check_runtime_socket_guard_active()
+    assert not is_runtime_socket_guard_installed(), "doctor must restore socket.socket.connect after its assertion"
+
+
+def test_doctor_airgap_standalone_returns_four_green_checks(standalone_airgap_env: Path) -> None:
+    """The headline expected behaviour from MASTER-RU Q21 + airgap profile docs.
+
+    The spec calls out four green checks for a standalone pre-flight:
+      1. zero egress       -> network policy deny-all
+      2. MCP catalog all-off
+      3. memo store local-only
+      4. audit chain valid (WARN-acceptable when no audit dir yet)
+
+    Plus the socket-guard row, which post-fix should also be PASS.
+    """
+    report = run_airgap_checks(workdir=standalone_airgap_env)
+
+    fails = [c for c in report.checks if c.status is CheckStatus.FAIL]
+    assert fails == [], f"unexpected FAIL rows: {[(c.name, c.detail) for c in fails]}"
+    assert report.ok is True
+
+    by_name = {c.name: c for c in report.checks}
+    # The four spec-mandated green rows:
+    assert by_name["network policy deny-all"].status is CheckStatus.PASS
+    assert by_name["MCP catalog all-off"].status is CheckStatus.PASS
+    assert by_name["memo store on local disk"].status is CheckStatus.PASS
+    # Audit chain check WARNs when there is no audit dir yet -- that
+    # is the spec-correct standalone state (nothing to verify), but
+    # it still must not be a FAIL.
+    audit = by_name["audit chain HMAC valid"]
+    assert audit.status in (CheckStatus.PASS, CheckStatus.WARN), audit.detail
+    # The bughunt row itself:
+    assert by_name["runtime socket guard active"].status is CheckStatus.PASS
+
+
+def test_doctor_airgap_cli_exits_zero_standalone(standalone_airgap_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """End-to-end: the Click subcommand must return rc=0 in the standalone scenario."""
+    monkeypatch.chdir(standalone_airgap_env)
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["airgap"])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+    assert "FAILED" not in result.output
+
+
+def test_run_doctor_airgap_function_returns_zero_standalone(standalone_airgap_env: Path) -> None:
+    """Direct call into the renderer -- belt and braces for the CLI test above."""
+    rc = run_doctor_airgap(workdir=standalone_airgap_env, as_json=True)
+    assert rc == 0


### PR DESCRIPTION
## Summary

Bughunt 2026-05-13: `bernstein doctor airgap` (the documented pre-flight workflow) reported FAIL on `runtime socket guard active` whenever it was invoked outside a live `bernstein run --profile airgap` process. The guard is installed by `run_bootstrap`, not by the doctor — so the FAIL never reflected real misbehaviour, only a process-lifecycle gap.

- Picked **option (A)** from the bughunt brief: install the guard for the duration of the check, then uninstall. Justified by `install_runtime_socket_guard` being documented idempotent and `uninstall_runtime_socket_guard` being fully round-trippable. Doctor is short-lived, no concurrent socket work to disturb. Round-tripping the patch also actively exercises the guard logic — strictly stronger signal than option (B)'s "code-path inventory only" WARN.
- Outside airgap the check still WARNs (guard is a no-op there).
- New regression suite at `tests/unit/cli/test_doctor_airgap.py` pins standalone PASS, no-leak of the patch into operator process, the four spec-mandated green checks (zero egress / MCP all-off / memo store local-only / audit chain valid) per MASTER-RU Q21, and end-to-end Click rc=0.

## Test plan

- [x] `uv run pytest tests/unit/cli/test_doctor_airgap.py -xvs` → 5 passed
- [x] `uv run pytest tests/unit/test_doctor_airgap.py -x` → 23 passed (no regression on pre-existing suite)
- [x] `uv run ruff format` + `ruff check` on touched files → clean
- [ ] Manual: `BERNSTEIN_PROFILE_MODE=airgap BERNSTEIN_NETWORK_POLICY=none bernstein doctor airgap` reports PASSED end-to-end

## Out of scope

The pre-existing `.sdd/audit/2026-04-26.jsonl` and `2026-05-07.jsonl` HMAC mismatches are local runtime state from key rotation, not a code bug — tracked separately.