### PR TITLE
feat(cli): add `bernstein adapters list` command

### DIFF
--- a/src/bernstein/cli/commands/adapter_cmd.py
+++ b/src/bernstein/cli/commands/adapter_cmd.py
@@ -1,7 +1,10 @@
-"""One-shot adapter smoke command."""
+"""One-shot adapter smoke command and the ``adapters`` discovery group."""
 
 from __future__ import annotations
 
+import importlib
+import inspect
+import json
 import re
 import shutil
 import subprocess
@@ -15,6 +18,27 @@ from bernstein.adapters.base import CLIAdapter
 from bernstein.adapters.registry import get_adapter
 from bernstein.cli.helpers import console
 from bernstein.core.models import ModelConfig
+
+# Override map for adapters whose on-disk CLI binary name differs from the
+# registry key. Used by ``bernstein adapters list`` to detect whether the
+# upstream CLI is installed locally. Missing entries fall back to the
+# registry key.
+_BINARY_OVERRIDES: dict[str, str] = {
+    "claude": "claude",
+    "codex": "codex",
+    "devin_terminal": "devin",
+    "q_dev": "q",
+    "open_interpreter": "interpreter",
+    "openai_agents": "python",  # SDK adapter, not a standalone binary
+    "cloudflare": "wrangler",
+    "letta_code": "letta",
+    "continue": "continue",
+    "openhands": "openhands",
+    "mock": "",  # internal test adapter, no binary
+    "generic": "",  # generic wrapper, no binary
+    "composio": "ao",
+    "devin": "devin",
+}
 
 _DEFAULT_SMOKE_MODELS: dict[str, str] = {
     "aider": "sonnet",
@@ -128,3 +152,109 @@ def test_adapter(adapter_name: str, prompt: str, model: str | None, timeout: int
                 console.print(f"[dim]Cleaned up worktree: {worktree}[/dim]")
             except Exception as e:
                 console.print(f"[yellow]Warning: failed to clean up {worktree}: {e}[/yellow]")
+
+
+def _resolve_source_file(adapter_obj: Any) -> str:
+    """Return a repo-relative source path for the adapter's defining module."""
+    try:
+        target = adapter_obj if inspect.isclass(adapter_obj) else type(adapter_obj)
+        src = inspect.getsourcefile(target) or inspect.getfile(target)
+    except (TypeError, OSError):
+        return "<unknown>"
+    if not src:
+        return "<unknown>"
+    path = Path(src).resolve()
+    parts = path.parts
+    if "bernstein" in parts:
+        idx = parts.index("bernstein")
+        return str(Path(*parts[idx:]))
+    return path.name
+
+
+def _binary_for_adapter(name: str) -> str:
+    """Map a registry key to its expected CLI binary name."""
+    if name in _BINARY_OVERRIDES:
+        return _BINARY_OVERRIDES[name]
+    return name
+
+
+def _enumerate_adapters() -> list[dict[str, str]]:
+    """Snapshot the live adapter registry as plain dicts.
+
+    The registry is the source of truth — we never enumerate by scanning
+    files. Includes the synthetic ``generic`` adapter, which is built
+    on demand inside ``get_adapter`` and not present in the ``_ADAPTERS``
+    dict.
+    """
+    # Import lazily so test patches at module level keep working.
+    registry = importlib.import_module("bernstein.adapters.registry")
+    registry._load_entrypoint_adapters()
+    rows: list[dict[str, str]] = []
+    for name, adapter in sorted(registry._ADAPTERS.items()):
+        binary = _binary_for_adapter(name)
+        installed = bool(binary) and shutil.which(binary) is not None
+        rows.append(
+            {
+                "name": name,
+                "source": _resolve_source_file(adapter),
+                "binary": binary,
+                "status": "installed" if installed else "missing",
+            }
+        )
+    # The ``generic`` adapter is constructed lazily inside ``get_adapter``;
+    # surface it here so the listing matches what ``--help`` would suggest.
+    if not any(r["name"] == "generic" for r in rows):
+        rows.append(
+            {
+                "name": "generic",
+                "source": _resolve_source_file(importlib.import_module("bernstein.adapters.generic").GenericAdapter),
+                "binary": "",
+                "status": "n/a",
+            }
+        )
+    rows.sort(key=lambda r: r["name"])
+    return rows
+
+
+@click.group("adapters")
+def adapters_group() -> None:
+    """Inspect Bernstein's CLI agent adapters."""
+
+
+@adapters_group.command("list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a Rich table.",
+)
+def list_adapters(as_json: bool) -> None:
+    """Enumerate every CLI adapter Bernstein knows about.
+
+    Pulls the catalogue from ``bernstein.adapters.registry`` (built-ins
+    plus any third-party adapters registered through the
+    ``bernstein.adapters`` entry-point group). For each adapter we also
+    report whether its upstream CLI binary is on ``$PATH``.
+    """
+    rows = _enumerate_adapters()
+
+    if as_json:
+        click.echo(json.dumps({"count": len(rows), "adapters": rows}, indent=2, sort_keys=True))
+        return
+
+    from rich.table import Table
+
+    table = Table(title=f"Bernstein adapters ({len(rows)})", show_lines=False)
+    table.add_column("name", style="cyan", no_wrap=True)
+    table.add_column("source", style="dim")
+    table.add_column("binary", style="white")
+    table.add_column("status", style="green")
+    for row in rows:
+        status_style = {
+            "installed": "[green]installed[/green]",
+            "missing": "[yellow]missing[/yellow]",
+            "n/a": "[dim]n/a[/dim]",
+        }[row["status"]]
+        table.add_row(row["name"], row["source"], row["binary"] or "-", status_style)
+    console.print(table)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import click
 
-from bernstein.cli.adapter_cmd import test_adapter
+from bernstein.cli.adapter_cmd import adapters_group, test_adapter
 
 # Import commands from decomposed modules (NEW)
 from bernstein.cli.advanced_cmd import (
@@ -141,6 +141,7 @@ __all__ = [
     "SERVER_URL",
     "STATUS_COLORS",
     # Commands from task_cmd
+    "adapters_group",
     "add_task",
     "approve",
     "auth_group",
@@ -803,6 +804,7 @@ cli.add_command(ps_cmd, "ps")
 cli.add_command(commit_stats_cmd, "commit-stats")
 cli.add_command(stop)
 cli.add_command(test_adapter, "test-adapter")
+cli.add_command(adapters_group, "adapters")
 cli.add_command(run, "run")  # visible: `bernstein run [plan.yaml]`
 cli.add_command(cook, "cook")
 cli.add_command(init)

--- a/tests/unit/cli/test_adapters_cmd.py
+++ b/tests/unit/cli/test_adapters_cmd.py
@@ -1,0 +1,53 @@
+"""Tests for the ``bernstein adapters`` CLI group."""
+
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+
+
+def test_adapters_list_outputs_table_with_min_count() -> None:
+    """``bernstein adapters list`` lists at least 40 adapters from the registry."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["adapters", "list"])
+
+    assert result.exit_code == 0, result.output
+    # Title line includes the count; e.g. "Bernstein adapters (44)".
+    assert "Bernstein adapters" in result.output
+    # Sanity-check a handful of well-known adapter names appear in the table.
+    for expected in ("claude", "codex", "gemini", "aider", "cursor", "generic"):
+        assert expected in result.output, f"adapter {expected!r} missing from output"
+
+
+def test_adapters_list_json_is_valid_and_has_min_40_entries() -> None:
+    """``--json`` emits a parseable object with >=40 adapters."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["adapters", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, dict)
+    assert payload["count"] == len(payload["adapters"])
+    assert payload["count"] >= 40, f"expected >=40 adapters, got {payload['count']}"
+
+    # Every row has the documented schema.
+    expected_keys = {"name", "source", "binary", "status"}
+    for row in payload["adapters"]:
+        assert expected_keys.issubset(row.keys()), row
+        assert row["status"] in {"installed", "missing", "n/a"}
+
+    names = {row["name"] for row in payload["adapters"]}
+    # Spot-check core adapters.
+    assert {"claude", "codex", "gemini", "aider", "generic"}.issubset(names)
+
+
+def test_adapters_group_registered_on_main_cli() -> None:
+    """The ``adapters`` group is reachable from the top-level CLI."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["adapters", "--help"])
+
+    assert result.exit_code == 0
+    assert "list" in result.output


### PR DESCRIPTION
## Summary
- README and docs reference `bernstein adapters list`, but the CLI had no `adapters` group, so users hit `Error: No such command 'adapters'` (bughunt 2026-05-13, probe 1).
- Add a Click `adapters` group with a `list` subcommand that pulls the catalogue from `bernstein.adapters.registry` (the source of truth — never by scanning files) and prints name, source file, expected CLI binary, and install status; `--json` emits a machine-readable payload.
- Existing `bernstein test-adapter` is left in place to avoid breaking shell snippets and CI; the new group lives next to it in `cli/main.py`.

## Test plan
- [x] `uv run pytest tests/unit/cli/test_adapters_cmd.py -xvs` — 3 passed (table output, JSON schema + count ≥40, group registration).
- [x] `uv run pytest tests/unit/test_adapter_cmd.py -xvs` — existing test-adapter tests still pass.
- [x] `uv run ruff check` and `uv run ruff format` on touched files — clean.
- [x] `uv run bernstein adapters list | head` — prints 44 adapters with installed/missing flags; `--json` parses with `json.loads`.