### PR TITLE
chore: bump version 1.10.7 -> 1.10.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.7"
+version = "1.10.8"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
Triggers auto-release for the bughunt 2026-05-13 fix wave.

PRs included in this release:
- #1234 — `bernstein analyze` orchestration-readiness scan (closes #768)
- #1235 — codex adapter: `--full-auto` → `--sandbox workspace-write`
- #1236 — README claim drift (44 adapters / 338 stars / 37 forks / 2026-05-13)
- #1237 — cluster bootstrap-ca: SKI/AKI/KeyUsage extensions (OpenSSL 3.x strict)
- #1238 — doctor: role-templates check accepts `.md/.yaml/.j2` recursively
- #1239 — doctor airgap: socket-guard check works standalone
- #1240 — eval: golden/smoke fixtures ship in wheel
- #1241 — `bernstein adapters list` command added
- #1242 — Generic adapter registered (`len(_ADAPTERS) == 44`)

## Test plan
- [x] CI green (auto-release will tag v1.10.8 + publish on merge)