### PR TITLE
fix(tests): drop redundant 'generic' append in test_adapter_consistency

### DIFF
--- a/tests/unit/test_adapter_consistency.py
+++ b/tests/unit/test_adapter_consistency.py
@@ -30,13 +30,13 @@ from bernstein.adapters.registry import _ADAPTERS, get_adapter
 
 
 def _all_adapter_names() -> list[str]:
-    """Return names of all registered adapters (including generic)."""
-    return sorted([*_ADAPTERS.keys(), "generic"])
+    """Return names of all registered adapters."""
+    return sorted(_ADAPTERS.keys())
 
 
 def _instantiate_adapter(name: str) -> CLIAdapter:
     """Instantiate an adapter by name, handling special cases."""
-    # GenericAdapter is not in _ADAPTERS but is a valid adapter
+    # Generic adapter needs cli_command + display_name; route through get_adapter.
     if name == "generic":
         return get_adapter("generic")
     entry = _ADAPTERS[name]


### PR DESCRIPTION
## Summary
- `test_no_duplicate_names` started failing on main after PR #1242 registered the Generic adapter in `_ADAPTERS`
- `_all_adapter_names()` was also manually appending `'generic'` — duplicate
- Drop the manual append; `_instantiate_adapter('generic')` still routes through `get_adapter('generic')` so construction with `cli_command` + `display_name` is preserved

## Why
On main, CI run [25800951528](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/25800951528) failed on macos/ubuntu Python 3.12+3.13:
```
tests/unit/test_adapter_consistency.py:330: in test_no_duplicate_names
    assert len(names) == len(set(names)), "Duplicate adapter names found"
E   assert 45 == 44
```
The bump-to-1.10.8 PR merged on a CI run that was concurrency-cancelled, so the regression slipped onto main and auto-release skipped.

## Test plan
- [x] `uv run pytest tests/unit/test_adapter_consistency.py::TestAdapterNames -v` → both tests pass
- [ ] Full Test matrix (macos/ubuntu/windows × py3.12/3.13) green on this PR
- [ ] After merge: auto-release picks up the green run and promotes v1.10.8 draft → latest