### PR TITLE
fix(tests): allowlist 'adapters' + 'analyze' in README API coverage check

### DIFF
--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -185,6 +185,9 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "identity",
         # Per-role adapter allow/deny-list inspection (role-adapter-policy group)
         "security",
+        # Bughunt 2026-05-13 release wave
+        "adapters",
+        "analyze",
     }
 )
 


### PR DESCRIPTION
## Summary
- Bughunt-wave PRs #1241 (\`bernstein adapters list\`) and #1234 (\`bernstein analyze\`) added two top-level CLI commands
- Their CI run on main got concurrency-cancelled by the rapid merges
- \`tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented\` is red on main right now

## Fix
Add both names to \`DOCUMENTED_COMMANDS\` — they're real, intentional, and the README's command reference covers them.

## Test plan
- [x] \`uv run pytest tests/unit/test_readme_api_coverage.py -v\` → 5 passed locally
- [ ] CI matrix green
- [ ] After merge: auto-release promotes v1.10.8 draft → latest