### PR TITLE
feat(lineage): v1 GATE + TIPS + MERGE + CLI + tests (ADR-009)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -30,6 +30,7 @@ alwaysApply: false
 | `integrations/`         | Integrations sub-package |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
+| `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
 | `memory/`               | memory sub-package — persistent memory stores |
 | `notifications/`        | Outbound notification subsystem (release 1.9) |
 | `observability/`        | observability sub-package |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,29 @@ jobs:
         with:
           reporter: github-check
 
+  lineage-gate:
+    # ADR-009 Lineage Gate — required check. Verifies the on-disk lineage
+    # log (.sdd/lineage/log.jsonl) is internally consistent: every entry
+    # signature verifies, no unresolved forks, parent_hashes resolve.
+    # No-op PASS when the log does not exist (pre-bootstrap state).
+    name: Lineage Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@00714ea9dc27830a1586fe47ef7ad28e4fd5db45 # v7
+        with:
+          enable-cache: true
+      - name: Run lineage gate
+        run: |
+          if [ -f .sdd/lineage/log.jsonl ]; then
+            uv run python scripts/check_lineage.py
+          else
+            echo "::notice::No .sdd/lineage/log.jsonl — lineage gate is a no-op PASS."
+          fi
+
   # ─── Medium checks (cancel old runs, 5-20 min) ────────────────────────
 
   typecheck:

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,7 @@ docs/**/MT-*.md
 docs/**/OAI-*.md
 docs/**/SDD-*.md
 docs/**/RAG-*.md
+
+# mutmut 3 working tree (./mutants/) and mutation-test cache (.mutmut-cache)
+mutants/
+.mutmut-cache

--- a/.goosehints
+++ b/.goosehints
@@ -31,6 +31,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `integrations/`         | Integrations sub-package |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
+| `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
 | `memory/`               | memory sub-package — persistent memory stores |
 | `notifications/`        | Outbound notification subsystem (release 1.9) |
 | `observability/`        | observability sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `integrations/`         | Integrations sub-package |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
+| `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
 | `memory/`               | memory sub-package — persistent memory stores |
 | `notifications/`        | Outbound notification subsystem (release 1.9) |
 | `observability/`        | observability sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `integrations/`         | Integrations sub-package |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
+| `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
 | `memory/`               | memory sub-package — persistent memory stores |
 | `notifications/`        | Outbound notification subsystem (release 1.9) |
 | `observability/`        | observability sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -31,6 +31,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `integrations/`         | Integrations sub-package |
 | `knowledge/`            | knowledge sub-package |
 | `lifecycle/`            | Lifecycle-hooks subsystem |
+| `lineage/`              | Lineage v1 — Sigstore-style per-artefact transparency log |
 | `memory/`               | memory sub-package — persistent memory stores |
 | `notifications/`        | Outbound notification subsystem (release 1.9) |
 | `observability/`        | observability sub-package |

--- a/docs/decisions/009-lineage-v1.md
+++ b/docs/decisions/009-lineage-v1.md
@@ -1,0 +1,517 @@
+# ADR-009: Lineage v1 — Sigstore-style per-artefact transparency log
+
+**Status**: Proposed
+**Date**: 2026-05-13
+**Context**: Bernstein multi-agent orchestration system
+
+---
+
+## TL;DR
+
+✅ **Problem.** Two agents in separate worktrees touch the same artefact. Last writer wins silently. No record of parallel edits. Brittle.
+
+✅ **Solution shape.** Append-only content-addressed lineage log per artefact + Ed25519-signed entries + Sigstore-style transparency model. Compatible with A2A v1.0, MCP, EU AI Act Article 12.
+
+✅ **Wrappers that make it sell.** `bernstein compliance pack` (one-command Article 12 evidence bundle) + `bernstein-verify` (standalone auditor CLI, no Bernstein install needed) + 3 reference demos (fintech / healthcare / EU manufacturer).
+
+⏳ **Build mode.** 5 parallel worktree agents under one steward branch `feat/lineage-v1`. Wall-clock target: 3-4 days dispatch + integration.
+
+---
+
+## 1. Scope
+
+### 1.1 What lineage covers
+
+| Artefact class | In scope | Why |
+|---|---|---|
+| Source files (git-tracked) | ✅ | Core case |
+| `.sdd/runtime/*` task specs, briefs, scratch | ✅ | Inter-agent shared state |
+| MCP tool results persisted to disk | ✅ | Memory-poisoning surface (OWASP ASI06) |
+| Generated config (e.g. agent cards, registry diffs) | ✅ | Privilege-escalation surface (OWASP ASI03) |
+| Mem0 / Zep / Graphiti entries | ❌ | Different store; defer to those systems' own audit |
+| Transient stdout / log lines | ❌ | Existing audit log handles |
+| `.git/` internals | ❌ | Git's own object DB |
+
+### 1.2 What lineage is NOT
+
+- Not a replacement for `audit.jsonl`. Audit logs every tool call; lineage logs every artefact write. They cross-link via `tool_call_id`.
+- Not a memory store. Doesn't recall content; recalls **provenance of content**.
+- Not a CRDT. Doesn't auto-merge concurrent writes — surfaces them as siblings for Steward.
+
+---
+
+## 2. Architecture
+
+### 2.1 High-level flow
+
+```
+Agent (in worktree)
+  │
+  │ writes file foo.py via Bernstein adapter
+  ▼
+LineageRecorder.record_write(artefact_path, new_content)
+  │
+  │ ① compute content_hash = sha256(new_content)
+  │ ② look up current tip(s) of foo.py from tips/<hash-of-path>.json
+  │ ③ build entry: {artefact_path, content_hash, parent_hashes: [tip], agent_id, ...}
+  │ ④ JCS-canonicalize entry (RFC 8785)
+  │ ⑤ sign canonical bytes with agent's Ed25519 key (JWS RFC 7515 detached)
+  │ ⑥ wrap in HMAC envelope (existing pattern)
+  │ ⑦ append to log.jsonl
+  │ ⑧ update by-artefact/<hash[:2]>/<hash>.jsonl projection
+  │ ⑨ update tips/<hash-of-path>.json
+  │
+  ▼
+OTel span emitted; cross-links to span_id in audit.jsonl
+```
+
+### 2.2 Components (one per worktree agent)
+
+| Component | Module | Lines (target) | Owner agent |
+|---|---|---|---|
+| `LineageRecorder` | `core/lineage/recorder.py` | ~300 | A |
+| Entry schema + JCS canonical | `core/lineage/entry.py` | ~150 | A |
+| Storage / log writer | `core/lineage/store.py` | ~250 | A |
+| Conflict detector + CI gate | `core/lineage/gate.py` | ~200 | B |
+| `bernstein lineage` CLI subcommand | `cli/commands/lineage_cmd.py` | ~200 | B |
+| `bernstein compliance pack` | `core/compliance/pack.py` | ~400 | C |
+| Article 12 evidence renderer (PDF + CSV + bundle) | `core/compliance/article12.py` | ~300 | C |
+| `bernstein-verify` standalone CLI (separate console_script) | `cli/verify_main.py` | ~250 | D |
+| MCP `lineage://artefact/<p>` resource | `mcp/resources/lineage.py` | ~150 | A |
+| 3 demo scenarios under `examples/lineage/` | `examples/lineage/{fintech,healthcare,eu-mfg}/` | ~200 each | E |
+
+Total: ~2,600 LOC across 5 agents.
+
+### 2.3 Reuses existing infra (no rewriting)
+
+| Existing module | What we use | Touched? |
+|---|---|---|
+| `core/security/lineage_kms.py` (432 LOC) | KMS-backed key storage | Read |
+| `core/security/audit_head_signature.py` (255 LOC) | HMAC head signing pattern | Read |
+| `core/persistence/merkle.py` | Merkle tree primitive | Read (verify chain) |
+| `core/agents/agent_identity.py` (862 LOC) | Ed25519 keypair per agent | Read + extend Agent Card emit |
+| `core/security/audit.py` | HMAC envelope | Wrap |
+| `core/observability/lineage_alert.py` (171 LOC) | Alert routing | Wire conflict events |
+| `core/git/commit_provenance.py` (356 LOC) | Trailer format | Cross-reference |
+
+---
+
+## 3. Data model
+
+### 3.1 Lineage entry schema (v1, JCS-canonical JSON)
+
+```jsonc
+{
+  "v": 1,
+  "artefact_path": "src/bernstein/cli/main.py",     // repo-relative POSIX
+  "artefact_kind": "file",                           // file | sdd-runtime | mcp-result | config
+  "content_hash": "sha256:a1b2c3...",                // sha256 of artefact bytes after write
+  "parent_hashes": ["sha256:01af..."],               // 0 = genesis, 1 = normal, ≥2 = merge
+  "agent_id": "agent:claude-worker-3",               // Bernstein-issued agent slug
+  "agent_card_kid": "key-2026-05-13-001",            // A2A Agent Card key id
+  "tool_call_id": "tc-7f3a8b9c",                     // cross-link to audit.jsonl
+  "span_id": "00f067aa0ba902b7",                     // OTel span hex
+  "ts_ns": 1715600000000000000,                      // ns since epoch
+  "operator_hmac": "deadbeef..."                     // existing HMAC envelope sig (operator secret)
+}
+```
+
+### 3.2 Detached signature (sidecar, NOT in canonical body)
+
+```jsonc
+{
+  "entry_hash": "sha256:...",                        // sha256 over JCS-canonical entry above
+  "jws": "eyJhbGc...",                                // Ed25519 JWS over entry_hash (RFC 7515 detached)
+  "agent_card_url": ".sdd/agents/<agent-id>/card.json"
+}
+```
+
+### 3.3 Why split entry vs signature
+
+- Entry is HMAC-protected via operator secret (Bernstein-internal tamper detection).
+- Signature is Ed25519 (asymmetric, third-party verifiable without operator secret).
+- An **external auditor** verifies the JWS with the publicly-fetched Agent Card; they don't need the operator HMAC key.
+- This is the Sigstore play: the entry is the log line, the signature is the verifiable provenance.
+
+---
+
+## 4. Storage layout
+
+```
+.sdd/lineage/
+├── log.jsonl                              # append-only, single source of truth
+├── log.jsonl.head-sig                     # rolling HMAC head signature (existing pattern)
+├── by-artefact/
+│   └── a1/                                # first 2 chars of sha256(artefact_path)
+│       └── a1b2c3d4...e5f6.jsonl          # full hash → projection of log.jsonl entries for that path
+├── tips/
+│   └── a1b2c3d4...e5f6.json               # {"open":[<entry_hash>...], "merged":[<entry_hash>...]}
+└── signatures/
+    └── a1/                                # mirrors by-artefact sharding
+        └── a1b2c3d4...e5f6/<entry_hash>.jws
+```
+
+**Invariants**:
+- `log.jsonl` is the source of truth. Everything else is a projection rebuildable via `bernstein lineage reindex`.
+- `tips/<hash>.json.open` has exactly 1 element in steady state; >1 = unresolved fork.
+- Signatures are per-entry files (not appended to log) — auditor downloads only entries they care about.
+
+---
+
+## 5. Identity + signing
+
+### 5.1 Agent Card emission
+
+When `bernstein conduct` spawns an agent:
+1. Generate Ed25519 keypair (or reuse from `agent_identity.py`).
+2. Emit Agent Card at `.sdd/agents/<agent-id>/card.json` following A2A v1.0 spec (`protocolVersion`, `name`, `url`, `capabilities`, `signatures[]`).
+3. Card itself is self-signed (RFC 7515 + RFC 8785 — JWS over JCS-canonical card body). **Bernstein default = Ed25519** across the lineage layer (entry signatures, card signatures). ES256 accepted on external (federated) Agent Cards per A2A spec but never emitted by us.
+4. Public key embedded in card; private key in `.sdd/agents/<agent-id>/key.pem` (chmod 600).
+
+### 5.2 Signing flow per write
+
+1. Recorder builds entry (without signature).
+2. Canonicalize per RFC 8785 (JCS).
+3. `entry_hash = sha256(canonical_bytes)`.
+4. `jws = Ed25519-JWS-detached(entry_hash, key=agent.private_key, kid=agent.card.kid)`.
+5. Write entry to `log.jsonl`.
+6. Write jws to `signatures/.../<entry_hash>.jws`.
+
+### 5.3 Verification
+
+External auditor (with `bernstein-verify`):
+1. Reads `log.jsonl`.
+2. For each entry: re-canonicalize, recompute `entry_hash`.
+3. Fetches Agent Card from `.sdd/agents/<agent-id>/card.json` or signed registry.
+4. Verifies JWS using card's public key.
+5. Walks `parent_hashes` chain back to genesis.
+6. Verifies tips: every artefact must have exactly one open tip OR a merge entry resolving prior forks.
+
+---
+
+## 6. Conflict detection + CI gate
+
+### 6.1 Fork detection algorithm
+
+For each artefact_path:
+1. Group entries by `parent_hashes`.
+2. If 2+ entries share the same single parent_hash with **different** content_hash → **fork**.
+3. Resolved if a later entry has `parent_hashes = [child1_hash, child2_hash]` (Steward merge).
+4. Unresolved fork at PR submission time → CI gate FAIL.
+
+### 6.2 CI gate (fitness function)
+
+New workflow check: `Lineage Gate`. Required for merge to main.
+
+```python
+# scripts/check_lineage.py (called from .github/workflows/ci.yml)
+def main():
+    log = read_jsonl(".sdd/lineage/log.jsonl")
+    by_path = group_by(log, key="artefact_path")
+    failures = []
+    for path, entries in by_path.items():
+        tips = compute_tips(entries)
+        if len(tips["open"]) > 1:
+            failures.append(f"{path}: {len(tips['open'])} unresolved tips: {tips['open']}")
+        for entry in entries:
+            if not verify_jws(entry):
+                failures.append(f"{path}: invalid signature on entry {entry['entry_hash']}")
+            if not verify_hmac(entry):
+                failures.append(f"{path}: HMAC mismatch on entry {entry['entry_hash']}")
+    if failures:
+        print("Lineage gate failed:\n" + "\n".join(failures))
+        sys.exit(1)
+```
+
+### 6.3 Steward responsibility
+
+When Steward merges N agent branches:
+1. For each artefact touched in >1 branch: read all open tips.
+2. Resolve content using a **conflict-resolution policy** (lookup order):
+   - `bernstein.lineage.merge_policy = "human"` (v1 default) — emit a `LineageConflict` event; block until operator runs `bernstein lineage merge <path>` (interactive prompt or accepts `--use-content <hash>`).
+   - `bernstein.lineage.merge_policy = "first-writer"` — pick the entry with the earliest `ts_ns`; tiebreak by `agent_id` lex order.
+   - `bernstein.lineage.merge_policy = "agent:<id>"` — designated agent's tip always wins (e.g. dedicated reviewer agent).
+3. Write merge entry: `parent_hashes = [tip1, tip2, ...]`, `content_hash = sha256(resolved_content)`, `merge_policy_used = "human"`.
+4. Steward signs with its own Agent Card key (Ed25519).
+5. CI gate now passes.
+
+Steward privilege is enforced by **policy** (allowlist of agent_ids permitted to write merge entries), not by signature shape. Same key type as workers.
+
+---
+
+## 7. MCP exposure
+
+### 7.1 Resources
+
+- `lineage://artefact/<repo-relative-path>` → returns full chain as JSONL
+- `lineage://stats` → counts: total entries, open forks, agents seen, last 24h activity
+
+### 7.2 Tools
+
+- `record_lineage_event(path, content_hash, parent_hashes, ...)` — for agents writing through non-adapter paths
+- `verify_chain(path)` — returns ok/err + reason
+
+### 7.3 Default off in untrusted contexts
+
+MCP exposure is gated by `bernstein.lineage.mcp.enabled` config (default `false` for remote MCP, `true` for local stdio).
+
+---
+
+## 8. Compliance pack (the killer feature for B2B)
+
+### 8.1 Command
+
+```bash
+bernstein compliance pack --since 2026-01-01 --until 2026-05-13 \
+  --org "Acme Corp" --output ./acme-compliance-2026-q2.zip
+```
+
+### 8.2 Bundle contents (the ZIP)
+
+```
+acme-compliance-2026-q2/
+├── README.md                              # cover page; what's in here
+├── article12-evidence.pdf                 # human-readable EU AI Act §12 summary
+├── article12-evidence.csv                 # machine-readable: every artefact write, agent, ts, content hash
+├── lineage-log.jsonl                      # raw log for re-verification
+├── signatures/                            # per-entry detached JWS sigs
+├── agent-cards/                           # all Agent Cards seen during period
+├── verify-instructions.md                 # how to run bernstein-verify against this bundle
+├── pack-manifest.json                     # SLSA-style provenance: who packed, when, hashes
+└── pack-manifest.json.sig                 # Operator-signed manifest (Ed25519, operator KMS key)
+```
+
+### 8.3 Why this matters
+
+A compliance officer at a regulated company can:
+1. Receive the ZIP from their engineering team.
+2. Run `bernstein-verify pack ./acme-compliance-2026-q2.zip` on their air-gapped laptop.
+3. Get a one-line PASS/FAIL plus a structured report mapped to Article 12 paragraph numbers.
+
+This is the **artifact** that closes a procurement loop. Without it, lineage is invisible to the buyer.
+
+---
+
+## 9. `bernstein-verify` — auditor CLI
+
+### 9.1 Why separate
+
+- Bundled in its **own wheel** (`bernstein-verify` on PyPI).
+- Pure-stdlib (no `bernstein` install required).
+- Auditor's laptop may not have Python frameworks; we keep it minimal.
+
+### 9.2 Commands
+
+```bash
+bernstein-verify chain <path> [--lineage-dir DIR]    # verify single artefact chain
+bernstein-verify pack <bundle.zip>                    # verify compliance pack end-to-end
+bernstein-verify forks <path> [--lineage-dir DIR]     # report unresolved forks (CI use)
+```
+
+### 9.3 Output
+
+- Exit 0 = all signatures valid + chains complete + no unresolved forks.
+- Exit 1 = any failure; structured JSON to stderr, human summary to stdout.
+
+---
+
+## 10. Three demo scenarios
+
+Each lives under `examples/lineage/<demo>/` with: README, mock `.sdd/lineage/` state, sample `compliance pack` output, and a `make demo` target.
+
+### 10.1 Fintech: SOC2 + Bernstein
+
+- Story: 4 agents (audit-helper, code-reviewer, security-scanner, docs-bot) edit a payment-flow file over a 2-week period.
+- Compliance pack shows: every change, every agent identity, every signature, no unresolved forks.
+- Bonus: a deliberate "rogue agent" attempt detected by `bernstein-verify forks`.
+
+### 10.2 Healthcare: HIPAA + EU AI Act
+
+- Story: An AI agent writes a triage decision-support config. Article 11 (technical docs) + Article 12 (event log) requirements explicit.
+- Compliance pack maps every Article 12 paragraph to specific log entries.
+
+### 10.3 EU manufacturer: high-risk AI Act Annex III
+
+- Story: Industrial automation agent updates a safety threshold config. EU AI Act high-risk classification.
+- Demo shows: 10-year retention via cold storage; chain reverification after restoring from cold storage.
+
+---
+
+## 11. Migration / bootstrap
+
+### 11.1 Existing repos
+
+- New install of Bernstein with lineage v1: existing files have NO lineage entries.
+- First time an agent writes an existing file: write a **genesis** entry (`parent_hashes: []`) with content_hash of the file BEFORE the agent's write, AND a child entry with content_hash AFTER. This anchors history at the moment lineage went live.
+- No retroactive history reconstruction. We never claim to know who wrote pre-existing files.
+
+### 11.2 Feature flag
+
+- `bernstein.lineage.enabled` (default `true` after this PR ships).
+- `bernstein.lineage.strict` (default `false` for first release, then `true`): when `true`, agent writes are REJECTED if lineage recording fails. When `false`, lineage failures log warnings but writes proceed.
+- One release (1.10.9 lineage-soft) → 30 days observation → 1.11.0 lineage-strict.
+
+### 11.3 Backward compat
+
+- `commit_provenance.py` trailer format: kept, deprecated in 1.12, removed in 2.0.
+- Existing `audit.jsonl`: unchanged. Lineage cross-links via `tool_call_id`.
+
+---
+
+## 12. Testing strategy
+
+### 12.1 Unit tests (per component)
+
+| Component | Coverage target | Notable cases |
+|---|---|---|
+| Entry canonicalization | 95% | RFC 8785 conformance suite, Unicode normalization edge cases |
+| JWS detached sign/verify | 95% | RFC 7515 conformance, key rotation, expired keys |
+| Storage / log writer | 90% | Concurrent writes (fsync, lock semantics), torn writes |
+| Conflict detector | 95% | All fork shapes: simple, diamond, criss-cross, N-way |
+| CI gate | 95% | Exit codes, JSON output, missing files |
+| Compliance pack | 90% | ZIP integrity, PDF rendering, CSV escaping |
+| bernstein-verify | 95% | Air-gap (no network), no-bernstein install, garbage input |
+
+### 12.2 Property-based tests (Hypothesis)
+
+These run as `tests/property/test_lineage_properties.py`:
+
+1. **Chain integrity invariant**: For any sequence of writes, every entry's parent_hashes point to entries that exist in the log.
+2. **Fork detection completeness**: If 2 entries share parent + differ in content, `compute_tips` reports them as open.
+3. **Merge resolution**: After a merge entry pointing to N forks, `compute_tips` reports those N as merged.
+4. **Signature roundtrip**: For any well-formed entry + key, JWS sign followed by verify always returns true; tampering with any byte fails verify.
+5. **JCS determinism**: For any input dict, canonical bytes are deterministic regardless of key order.
+6. **HMAC envelope tamper detection**: Flip any byte in entry → HMAC verify fails.
+
+### 12.3 Mutation testing (`mutmut`)
+
+Run on:
+- `core/lineage/recorder.py`
+- `core/lineage/gate.py`
+- `core/lineage/store.py`
+- `cli/verify_main.py`
+
+Threshold: ≥75% mutation kill rate on these critical modules.
+
+### 12.4 E2E tests
+
+`tests/integration/test_lineage_e2e.py`:
+
+1. **Parallel agent fight**: Spin up 2 worktree agents, have both write `same_file.py`, run CI gate → must FAIL with fork report. Have Steward write merge entry → CI gate now passes.
+2. **Compliance pack roundtrip**: Generate pack, unzip, run `bernstein-verify pack` → exit 0.
+3. **Auditor flow without bernstein installed**: In a clean venv with ONLY `bernstein-verify` installed, verify a pack generated by full Bernstein.
+4. **Air-gap verify**: bernstein-verify with no network access — must succeed (no remote lookups).
+5. **Tamper detection**: Flip a byte in `log.jsonl` → both `bernstein-verify chain` and `bernstein lineage gate` fail with specific error.
+6. **Chain replay against rebuilt indices**: Delete `by-artefact/` and `tips/`, run `bernstein lineage reindex`, verify state matches the pre-deletion state.
+
+### 12.5 Performance / load
+
+`tests/perf/test_lineage_perf.py` (smoke, not in required CI):
+
+- 10,000 writes across 100 artefacts: assert <30s on commodity hardware.
+- Compliance pack for 10,000 entries: assert <10s to generate.
+- bernstein-verify pack on 10,000 entries: assert <5s.
+
+### 12.6 Adversarial test (the "skeptical" part)
+
+`tests/security/test_lineage_adversarial.py`:
+
+1. **Replay attack**: replay an old entry into a new run → must be rejected (entry has run-id binding via span_id).
+2. **Substitution attack**: swap two entries' signatures → verify fails.
+3. **Privilege escalation**: worker agent writes a merge entry → CI policy rejects.
+4. **Forge attack**: synthetic JWS with fake kid → verify fails (kid not in known Agent Cards).
+5. **Path traversal in artefact_path**: `../../../etc/passwd` → recorder rejects.
+
+---
+
+## 13. Build sequence (parallel agents)
+
+Each agent runs in its own `git worktree` under `feat/lineage-v1` umbrella branch.
+
+```
+feat/lineage-v1                          (steward integration branch)
+├── feat/lineage-v1-core (agent A)       core recorder + entry + store + MCP resource
+├── feat/lineage-v1-gate (agent B)       conflict detector + CI gate + lineage_cmd
+├── feat/lineage-v1-compliance (agent C) pack + Article 12 renderer
+├── feat/lineage-v1-verify (agent D)     standalone bernstein-verify CLI
+└── feat/lineage-v1-demo (agent E)       3 demo scenarios + docs
+```
+
+### 13.1 Phase 0 — schema lock (no parallelism)
+
+Steward writes `src/bernstein/core/lineage/entry.py` first (just the schema + JCS canonical + dataclasses). Pushed to `feat/lineage-v1`. All other agents branch off THIS.
+
+### 13.2 Phase 1 — parallel fan-out (A, B, C, D, E all simultaneously)
+
+Each agent gets a focused prompt + the schema file + this design doc. They run in parallel via `Agent` tool with `run_in_background: true`.
+
+### 13.3 Phase 2 — Steward merge
+
+Steward rebases each branch onto `feat/lineage-v1`, resolves conflicts, runs full test suite locally, opens one PR.
+
+### 13.4 Phase 3 — CI + release
+
+PR runs full CI matrix (we already have it from bughunt). Once green: merge → version bump → auto-release.
+
+---
+
+## 14. Risks + mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| EU AI Act deferred to Dec 2027 (Omnibus) | 0.40 | Drops compliance urgency by 12mo | Pitch SOC2 + ISO 42001 angles as fallback |
+| GitHub Agent HQ ships native lineage in Q3 2026 | 0.30 | Subsumed | Differentiate via local-first + multi-vendor + open format |
+| Sigstore-style is too complex to operate | 0.25 | Adoption stalls | The `compliance pack` is the simple surface; complexity hidden |
+| AAIF publishes competing standard | 0.20 | Our format is outlier | Use A2A v1.0 + RFC 7515 + RFC 8785 → already in the standards camp |
+| Performance regression: 10k writes too slow | 0.15 | UX issue | Perf tests in §12.5; batch fsync; async store flush |
+| Operator key rotation breaks chain | 0.15 | Audit-chain HMAC mismatches (we've seen this) | Document rotation procedure; ship `bernstein lineage rotate-hmac` helper |
+| Steward becomes single point of failure | 0.10 | Merges blocked | Multiple Steward agents allowed; policy allowlist |
+
+---
+
+## 15. Success metrics (what tells us we won)
+
+### 15.1 Build-time
+
+- ✅ All tests pass (unit + property + mutation ≥75% + e2e + adversarial).
+- ✅ CI gate runs in <30s on typical PR.
+- ✅ Compliance pack for 10k entries generates in <10s.
+- ✅ bernstein-verify works in air-gap, no-bernstein-install scenario.
+
+### 15.2 Adoption (3-9 month horizon, per MPP scenario tree)
+
+- **S1 success indicator**: ≥1 design partner cites Article 12 evidence as procurement-unblocker. Target: 1 by end of Q3 2026.
+- **S2 success indicator**: ≥3 security blogs / Hacker News front page coverage citing the verify CLI. Target: 1 within 60 days of release.
+- **S3 fallback**: ≥1 OWASP / SLSA reference / talk submission accepted. Target: by end of 2026.
+
+### 15.3 Kill criteria
+
+If by end of Q3 2026:
+- No design partner conversation cites lineage as differentiator → reassess; pivot to cost-attribution feature.
+- Major platform ships equivalent → narrow to multi-vendor / on-prem niche.
+
+---
+
+## 16. Open questions (carry into writing-plans)
+
+1. **Operator HMAC vs Ed25519 dual-signing**: do we need BOTH? Decision deferred — start with both, can drop HMAC if Ed25519 alone passes operator security review.
+2. **Agent Card registry**: local-only files or also a signed remote registry? Start local; remote in v1.1.
+3. **Cold-storage / Article 11 10-year retention**: who packages it? Out of scope for v1; document the export path.
+4. **MCP authentication for lineage tools**: OAuth 2.1 per MCP June 2025 spec, or local-only? Local-only for v1.
+
+---
+
+## 17. References
+
+- `agentic_systems_v2.md` §3 Memory architecture (multi-agent shared memory unsolved problem)
+- `agentic_systems_v2.md` §f Enterprise governance (HMAC + signed audit pattern)
+- `agentic_systems_v2.md` Stage 0 §5 (HMAC audit envelope + signed Agent Card from day 1)
+- `software_development_v2.md` §2.4 (SLSA v1.0, Sigstore, SBOMs, signing)
+- `software_development_v2.md` §2.3 (fitness functions)
+- `software_development_v2.md` §3 phase 6 (property-based testing, mutation testing)
+- RFC 7515 JWS, RFC 7517 JWK, RFC 8785 JCS
+- A2A v1.0 Agent Card spec
+- Sigstore Rekor transparency log
+- SLSA v1.1 provenance
+- EU AI Act Articles 11, 12, 14
+- OWASP Top 10 for Agentic Apps: ASI03, ASI06, ASI07

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -603,3 +603,18 @@ dev = [
     # click>=8.3.3 / opentelemetry-sdk>=1.41.1 floors. Mirror of
     # [project.optional-dependencies].dev.
 ]
+
+[tool.mutmut]
+# Lineage v1 mutation testing — see scripts/mutmut_lineage.py for the
+# focused runner that exercises only the three lineage modules. The
+# project-wide conftest pulls heavyweight imports that mutmut 3's
+# `mutants/` shadow tree can't satisfy, so we ship a thin custom
+# harness alongside the standard config for ad-hoc deep runs.
+paths_to_mutate = [
+    "src/bernstein/core/lineage/gate.py",
+    "src/bernstein/core/lineage/tips.py",
+    "src/bernstein/core/lineage/merge.py",
+]
+tests_dir = ["tests/unit/lineage/"]
+pytest_add_cli_args = ["--no-cov", "-p", "no:cacheprovider"]
+do_not_mutate = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,10 @@ dependencies = [
     # hand-rolling a DER parser. Used exclusively by
     # ``bernstein.core.security.rfc3161_verifier``.
     "asn1crypto>=1.5",
+    # Pure-Python PDF generation for the EU AI Act Article 12 evidence pack
+    # rendered by `bernstein compliance pack`. MIT-licensed, no native deps.
+    # Used exclusively by ``bernstein.core.compliance.article12``.
+    "reportlab>=4.0,<5",
 ]
 
 [project.urls]

--- a/scripts/check_lineage.py
+++ b/scripts/check_lineage.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Lineage CI gate entry point (ADR-009 §6.2).
+
+Runs `bernstein.core.lineage.gate.check` against `.sdd/lineage/log.jsonl`
+and prints a structured report. Exit codes:
+
+  0 = log absent, OR all invariants pass.
+  1 = at least one invariant failed.
+
+Designed for `.github/workflows/ci.yml` — the "Lineage Gate" required
+check shells into this script with no arguments.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from bernstein.core.lineage.gate import GateResult, check
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Verify lineage log invariants.")
+    p.add_argument(
+        "--log",
+        type=Path,
+        default=Path(".sdd/lineage/log.jsonl"),
+        help="Path to log.jsonl (default: .sdd/lineage/log.jsonl)",
+    )
+    p.add_argument(
+        "--cards",
+        type=Path,
+        default=Path(".sdd/agents"),
+        help="Agent cards directory (default: .sdd/agents)",
+    )
+    p.add_argument(
+        "--steward-allowlist",
+        default=None,
+        help="Comma-separated list of agent_ids permitted to write merge entries.",
+    )
+    p.add_argument(
+        "--operator-secret-env",
+        default="BERNSTEIN_OPERATOR_SECRET",
+        help="Env var name carrying the operator HMAC secret (optional).",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON instead of human text.",
+    )
+    return p.parse_args(argv)
+
+
+def _emit_report(result: GateResult, *, machine: bool) -> None:
+    if machine:
+        print(json.dumps({"ok": result.ok, "failures": result.failures}, indent=2))
+        return
+    if result.ok:
+        print("Lineage gate: PASS")
+        return
+    print(f"Lineage gate: FAIL ({len(result.failures)} issue(s))", file=sys.stderr)
+    for fail in result.failures:
+        print(f"  - {fail}", file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    if not args.log.exists():
+        if args.json:
+            print(json.dumps({"ok": True, "failures": [], "skipped": "log missing"}))
+        else:
+            print(f"Lineage gate: SKIP (no log at {args.log})")
+        return 0
+
+    allowlist: frozenset[str] | None = None
+    if args.steward_allowlist:
+        allowlist = frozenset(s.strip() for s in args.steward_allowlist.split(",") if s.strip())
+
+    operator_secret: bytes | None = None
+    secret_str = os.environ.get(args.operator_secret_env)
+    if secret_str:
+        operator_secret = secret_str.encode("utf-8")
+
+    result = check(
+        log_path=args.log,
+        agent_cards_dir=args.cards,
+        operator_secret=operator_secret,
+        steward_allowlist=allowlist,
+    )
+    _emit_report(result, machine=args.json)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mutmut_lineage.py
+++ b/scripts/mutmut_lineage.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+"""Targeted mutation tester for the lineage v1 modules.
+
+The repo-wide mutmut config doesn't compose cleanly with our heavyweight
+`tests/conftest.py` (it imports the whole orchestrator). Rather than
+refactor the conftest, we run a focused set of well-known mutation
+operators against the three lineage files and execute the lineage test
+suite against each surviving mutation.
+
+Operators applied (subset of mutmut's standard set):
+
+  - `<`  <-> `<=` <-> `>=` <-> `>`           (comparison flips)
+  - `==` <-> `!=`                              (equality flip)
+  - `and` <-> `or`                             (boolean op flip)
+  - `True` <-> `False`                         (constant flip)
+  - `+= 1` -> `-= 1` (where applicable)
+  - drop `not` from `not x`
+  - `>= N` -> `> N` / `< N` -> `<= N`        (bound flips)
+
+Targets:
+  - src/bernstein/core/lineage/gate.py
+  - src/bernstein/core/lineage/tips.py
+  - src/bernstein/core/lineage/merge.py
+
+A mutation is "killed" if the lineage test suite fails (exit != 0) when
+that mutation is applied. Survival = the tests still pass with the
+mutation, indicating a coverage gap.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+TARGETS = [
+    REPO / "src/bernstein/core/lineage/gate.py",
+    REPO / "src/bernstein/core/lineage/tips.py",
+    REPO / "src/bernstein/core/lineage/merge.py",
+]
+TEST_PATHS = [
+    "tests/unit/lineage/",
+]
+
+# (search, replace) pairs applied one-at-a-time per line.
+MUTATIONS: list[tuple[str, str]] = [
+    (" < ", " <= "),
+    (" <= ", " < "),
+    (" > ", " >= "),
+    (" >= ", " > "),
+    (" == ", " != "),
+    (" != ", " == "),
+    (" and ", " or "),
+    (" or ", " and "),
+    ("True", "False"),
+    ("False", "True"),
+    ("not ", ""),
+    (" 0", " 1"),
+    (" 1", " 2"),
+    (" 2", " 1"),
+    ("[]", "[None]"),
+    ("return True", "return False"),
+    ("return False", "return True"),
+    ("len(", "0 * len("),
+]
+
+
+def _run_tests() -> bool:
+    """Returns True iff tests pass (mutation NOT killed)."""
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-x",
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+            *TEST_PATHS,
+        ],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return res.returncode == 0
+
+
+def _candidates(target: Path) -> list[tuple[int, str, str, str]]:
+    """Return (line_no, original_line, search, replace) for each candidate.
+
+    Skips:
+      - blank lines
+      - comments (#)
+      - any line inside a triple-quoted docstring block
+      - decorator argument lines (@dataclass(...), @click.command(...), etc.)
+        — those are configuration knobs, not behaviour, so flipping True/False
+        in them produces synthetic mutations that don't model real bugs.
+    """
+    out: list[tuple[int, str, str, str]] = []
+    text = target.read_text().splitlines(keepends=True)
+    in_docstring = False
+    for i, line in enumerate(text):
+        stripped = line.lstrip()
+        # Track docstring blocks: a line containing """ toggles state unless
+        # the line both opens and closes on the same line.
+        triple_count = line.count('"""') + line.count("'''")
+        if triple_count and triple_count % 2 == 1:
+            in_docstring = not in_docstring
+            continue
+        if in_docstring or stripped.startswith("#"):
+            continue
+        if stripped.startswith("@"):
+            continue
+        # Skip lines that are obviously decorator arg values across multiple
+        # lines (e.g. inside `@dataclass(...)`).
+        if line.rstrip().endswith(",") and "=" in line and "(" not in line:
+            # heuristic: kwarg-only line inside a call
+            continue
+        for search, replace in MUTATIONS:
+            if search in line and search != replace:
+                out.append((i, line, search, replace))
+    return out
+
+
+def main() -> int:
+    total = 0
+    killed = 0
+    survivors: list[str] = []
+    timeouts = 0
+
+    # Confirm baseline passes.
+    print("[baseline] running lineage tests...", flush=True)
+    if not _run_tests():
+        print("Baseline tests fail; cannot run mutation testing.", file=sys.stderr)
+        return 2
+    print("[baseline] ok", flush=True)
+
+    for target in TARGETS:
+        original = target.read_text()
+        candidates = _candidates(target)
+        # Cap per-file mutations to keep wall-clock reasonable.
+        candidates = candidates[:60]
+        print(f"[{target.name}] {len(candidates)} mutation(s) to try", flush=True)
+
+        for idx, (line_no, line, search, replace) in enumerate(candidates):
+            total += 1
+            new_line = line.replace(search, replace, 1)
+            lines = original.splitlines(keepends=True)
+            lines[line_no] = new_line
+            try:
+                target.write_text("".join(lines))
+                try:
+                    survived = _run_tests()
+                except subprocess.TimeoutExpired:
+                    timeouts += 1
+                    # Treat as killed — infinite loop also a meaningful signal.
+                    killed += 1
+                    continue
+                if survived:
+                    survivors.append(
+                        f"{target.relative_to(REPO)}:{line_no + 1} '{search}' -> '{replace}': {line.rstrip()}"
+                    )
+                    print(
+                        f"  [{idx + 1}/{len(candidates)}] SURVIVED line {line_no + 1}",
+                        flush=True,
+                    )
+                else:
+                    killed += 1
+                    if (idx + 1) % 10 == 0:
+                        print(
+                            f"  [{idx + 1}/{len(candidates)}] {killed}/{total} killed",
+                            flush=True,
+                        )
+            finally:
+                target.write_text(original)
+
+    pct = (100 * killed / total) if total else 0
+    print()
+    print("=== Mutation report ===")
+    print(f"Total mutations:  {total}")
+    print(f"Killed:           {killed}")
+    print(f"Survivors:        {len(survivors)}")
+    print(f"Timeouts:         {timeouts}")
+    print(f"Kill rate:        {pct:.1f}%")
+    if survivors:
+        print()
+        print("Surviving mutations (coverage gaps):")
+        for s in survivors:
+            print(f"  - {s}")
+    return 0 if pct >= 75 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bernstein/cli/commands/_lineage_v1_helpers.py
+++ b/src/bernstein/cli/commands/_lineage_v1_helpers.py
@@ -1,0 +1,87 @@
+"""Shared read/index helpers for the lineage v1 CLI subcommands.
+
+The lineage v1 commands (`gate`, `forks`, `chain`, `reindex`, `merge`) all
+need to parse `.sdd/lineage/log.jsonl` and update the on-disk projections
+(`by-artefact/` + `tips/`). These helpers stay deliberately small and
+file-system-only so the commands remain unit-testable without depending
+on the in-flight `LineageStore` work on the parallel branch.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+from bernstein.core.lineage.tips import compute_tips
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def read_entries(log_path: Path) -> list[LineageEntry]:
+    """Parse log.jsonl into LineageEntry objects. Skips malformed lines."""
+    out: list[LineageEntry] = []
+    if not log_path.exists():
+        return out
+    with log_path.open() as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+                out.append(LineageEntry(**obj))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                # Corrupt lines are surfaced by gate.check; reindex skips them.
+                continue
+    return out
+
+
+def reindex(log_path: Path) -> int:
+    """Rebuild by-artefact/<shard>/<hash>.jsonl and tips/<hash>.json.
+
+    Returns the number of projections written.
+    """
+    entries = read_entries(log_path)
+    log_dir = log_path.parent
+    by_artefact_root = log_dir / "by-artefact"
+    tips_root = log_dir / "tips"
+
+    by_path: dict[str, list[LineageEntry]] = {}
+    for e in entries:
+        by_path.setdefault(e.artefact_path, []).append(e)
+
+    tips = compute_tips(entries)
+
+    written = 0
+    for path, group in by_path.items():
+        digest = hashlib.sha256(path.encode("utf-8")).hexdigest()
+        shard = digest[:2]
+        out = by_artefact_root / shard / (digest + ".jsonl")
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w") as f:
+            for e in group:
+                f.write(json.dumps(_asdict(e), sort_keys=True) + "\n")
+        # Tips
+        tip_data = tips.get(path, {"open": [entry_hash(group[-1])], "merged": []})
+        tips_out = tips_root / (digest + ".json")
+        tips_out.parent.mkdir(parents=True, exist_ok=True)
+        tips_out.write_text(
+            json.dumps(
+                {"open": tip_data["open"], "merged": tip_data["merged"]},
+                sort_keys=True,
+            )
+        )
+        written += 1
+    return written
+
+
+def _asdict(entry: LineageEntry) -> dict[str, object]:
+    from dataclasses import asdict
+
+    return asdict(entry)
+
+
+__all__ = ["read_entries", "reindex"]

--- a/src/bernstein/cli/commands/lineage_cmd.py
+++ b/src/bernstein/cli/commands/lineage_cmd.py
@@ -175,3 +175,236 @@ def walk_cmd(target: str, workdir: str, run_id: str | None, limit: int) -> None:
 
 lineage_cmd.add_command(lineage_export_cmd, "export")
 lineage_cmd.add_command(lineage_verify_cmd, "verify")
+
+
+# ── ADR-009 lineage v1 subcommands ──────────────────────────────────────────
+
+
+@lineage_cmd.command(name="gate")
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".sdd/lineage/log.jsonl"),
+    show_default=True,
+    help="Lineage log path (ADR-009 §4).",
+)
+@click.option(
+    "--cards",
+    "cards_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".sdd/agents"),
+    show_default=True,
+    help="Agent cards directory.",
+)
+@click.option(
+    "--steward-allowlist",
+    default=None,
+    help="Comma-separated agent_ids permitted to write merge entries.",
+)
+@click.option(
+    "--operator-secret-env",
+    default="BERNSTEIN_OPERATOR_SECRET",
+    show_default=True,
+    help="Env var holding the HMAC operator secret (optional).",
+)
+@click.option("--output-json", is_flag=True, help="Emit JSON instead of human text.")
+def gate_cmd(
+    log_path: Path,
+    cards_dir: Path,
+    steward_allowlist: str | None,
+    operator_secret_env: str,
+    output_json: bool,
+) -> None:
+    """Run the lineage v1 CI gate. Exits 1 on failure."""
+    import json
+    import os
+    import sys
+
+    from bernstein.core.lineage.gate import check as gate_check
+
+    if not log_path.exists():
+        if output_json:
+            click.echo(json.dumps({"ok": True, "failures": [], "skipped": "log missing"}))
+        else:
+            console.print(f"[yellow]Lineage gate:[/yellow] SKIP (no log at {log_path})")
+        return
+
+    allow: frozenset[str] | None = None
+    if steward_allowlist:
+        allow = frozenset(s.strip() for s in steward_allowlist.split(",") if s.strip())
+
+    secret = os.environ.get(operator_secret_env)
+    operator_secret = secret.encode("utf-8") if secret else None
+
+    result = gate_check(
+        log_path=log_path,
+        agent_cards_dir=cards_dir,
+        operator_secret=operator_secret,
+        steward_allowlist=allow,
+    )
+    if output_json:
+        click.echo(json.dumps({"ok": result.ok, "failures": result.failures}, indent=2))
+    elif result.ok:
+        console.print("[green]Lineage gate:[/green] PASS")
+    else:
+        console.print(f"[red]Lineage gate:[/red] FAIL ({len(result.failures)} issue(s))")
+        for fail in result.failures:
+            console.print(f"  - {fail}")
+    if not result.ok:
+        sys.exit(1)
+
+
+@lineage_cmd.command(name="forks")
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".sdd/lineage/log.jsonl"),
+    show_default=True,
+)
+@click.option("--output-json", is_flag=True, help="Emit JSON output.")
+def forks_cmd(log_path: Path, output_json: bool) -> None:
+    """Report all unresolved forks in the lineage log."""
+    import json
+
+    from bernstein.cli.commands._lineage_v1_helpers import read_entries
+    from bernstein.core.lineage.tips import detect_forks
+
+    if not log_path.exists():
+        if output_json:
+            click.echo(json.dumps([]))
+        else:
+            console.print(f"[yellow]No log at {log_path}[/yellow]")
+        return
+
+    entries = read_entries(log_path)
+    forks = detect_forks(entries)
+    if output_json:
+        payload = [
+            {
+                "artefact_path": f.artefact_path,
+                "parent_hash": f.parent_hash,
+                "child_hashes": list(f.child_hashes),
+            }
+            for f in forks
+        ]
+        click.echo(json.dumps(payload, indent=2))
+        return
+    if not forks:
+        console.print("[green]No forks.[/green]")
+        return
+    console.print(f"[red]{len(forks)} fork(s) detected:[/red]")
+    for f in forks:
+        console.print(
+            f"  - {f.artefact_path} @ parent={f.parent_hash[:24]}... "
+            f"children={[c[:24] + '...' for c in f.child_hashes]}"
+        )
+
+
+@lineage_cmd.command(name="chain")
+@click.argument("artefact_path", required=True)
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".sdd/lineage/log.jsonl"),
+    show_default=True,
+)
+@click.option(
+    "--cards",
+    "cards_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".sdd/agents"),
+    show_default=True,
+)
+def chain_cmd(artefact_path: str, log_path: Path, cards_dir: Path) -> None:
+    """Verify the chain for a single artefact (ADR-009 §5.3)."""
+    import sys
+
+    from bernstein.cli.commands._lineage_v1_helpers import read_entries
+    from bernstein.core.lineage.gate import check as gate_check
+    from bernstein.core.lineage.tips import compute_tips
+
+    if not log_path.exists():
+        console.print(f"[yellow]No log at {log_path}[/yellow]")
+        return
+
+    entries = [e for e in read_entries(log_path) if e.artefact_path == artefact_path]
+    if not entries:
+        console.print(f"[yellow]No entries for {artefact_path}[/yellow]")
+        sys.exit(1)
+    # Reuse the full gate, then narrow output to this artefact.
+    result = gate_check(log_path=log_path, agent_cards_dir=cards_dir)
+    tips = compute_tips(entries).get(artefact_path, {"open": [], "merged": []})
+    relevant = [f for f in result.failures if artefact_path in f]
+    if relevant:
+        console.print(f"[red]chain FAIL ({len(relevant)}):[/red]")
+        for f in relevant:
+            console.print(f"  - {f}")
+        sys.exit(1)
+    console.print(f"[green]chain OK[/green] ({len(entries)} entry(ies))")
+    console.print(f"  open tips: {tips['open']}")
+    console.print(f"  merged:    {tips['merged']}")
+
+
+@lineage_cmd.command(name="reindex")
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".sdd/lineage/log.jsonl"),
+    show_default=True,
+)
+def reindex_cmd(log_path: Path) -> None:
+    """Rebuild by-artefact + tips projections from log.jsonl (§4 invariant)."""
+    from bernstein.cli.commands._lineage_v1_helpers import reindex
+
+    if not log_path.exists():
+        console.print(f"[yellow]No log at {log_path}[/yellow]")
+        return
+    written = reindex(log_path)
+    console.print(f"[green]Reindexed:[/green] {written} projection(s) under {log_path.parent}")
+
+
+@lineage_cmd.command(name="merge")
+@click.argument("artefact_path", required=True)
+@click.option(
+    "--use-content",
+    "use_content",
+    required=True,
+    help="Entry hash whose content_hash should win.",
+)
+@click.option(
+    "--log",
+    "log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=Path(".sdd/lineage/log.jsonl"),
+    show_default=True,
+)
+def merge_cmd(artefact_path: str, use_content: str, log_path: Path) -> None:
+    """Manually resolve a lineage fork via operator-chosen content (§6.3)."""
+    import sys
+
+    from bernstein.cli.commands._lineage_v1_helpers import read_entries
+    from bernstein.core.lineage.tips import detect_forks
+
+    if not log_path.exists():
+        console.print(f"[red]No log at {log_path}[/red]")
+        sys.exit(1)
+    entries = read_entries(log_path)
+    relevant = [f for f in detect_forks(entries) if f.artefact_path == artefact_path]
+    if not relevant:
+        console.print(f"[yellow]No fork for {artefact_path}[/yellow]")
+        return
+    valid_winners = {h for f in relevant for h in f.child_hashes}
+    if use_content not in valid_winners:
+        console.print(
+            f"[red]--use-content {use_content[:24]}... is not a candidate child for any fork on {artefact_path}[/red]"
+        )
+        sys.exit(1)
+    console.print(
+        "[green]Merge prepared.[/green] Steward signing happens in core; "
+        f"run `bernstein lineage gate` after `LineageStore.append` writes the merge entry "
+        f"with content from {use_content[:24]}..."
+    )

--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -1,0 +1,41 @@
+"""Lineage v1 — Sigstore-style per-artefact transparency log.
+
+See docs/decisions/009-lineage-v1.md for the design rationale.
+
+Public API:
+
+  - LineageEntry — frozen dataclass for a single write event
+  - canonicalise, entry_hash — RFC 8785 JCS bytes + sha256 digest
+  - AgentCard — minimal A2A v1.0 Agent Card subset
+  - generate_keypair, sign_detached, verify_detached — Ed25519 JWS RFC 7515
+
+Storage (LineageStore), recorder (LineageRecorder), gate, merge, compliance
+pack, and MCP resource live in sibling modules under this package and re-export
+through here once the corresponding feature branches land.
+"""
+
+from bernstein.core.lineage.entry import (
+    ARTEFACT_KINDS,
+    LINEAGE_ENTRY_VERSION,
+    LineageEntry,
+    canonicalise,
+    entry_hash,
+)
+from bernstein.core.lineage.identity import (
+    AgentCard,
+    generate_keypair,
+    sign_detached,
+    verify_detached,
+)
+
+__all__ = [
+    "ARTEFACT_KINDS",
+    "LINEAGE_ENTRY_VERSION",
+    "AgentCard",
+    "LineageEntry",
+    "canonicalise",
+    "entry_hash",
+    "generate_keypair",
+    "sign_detached",
+    "verify_detached",
+]

--- a/src/bernstein/core/lineage/__init__.py
+++ b/src/bernstein/core/lineage/__init__.py
@@ -21,21 +21,48 @@ from bernstein.core.lineage.entry import (
     canonicalise,
     entry_hash,
 )
+from bernstein.core.lineage.gate import GateResult
+from bernstein.core.lineage.gate import check as gate_check
 from bernstein.core.lineage.identity import (
     AgentCard,
     generate_keypair,
     sign_detached,
     verify_detached,
 )
+from bernstein.core.lineage.merge import (
+    AgentPolicy,
+    FirstWriterPolicy,
+    HumanPolicy,
+    LineageConflict,
+    MergePolicy,
+    StewardKey,
+    build_merge_entry,
+    resolve_policy,
+)
+from bernstein.core.lineage.tips import Fork, TipSet, compute_tips, detect_forks
 
 __all__ = [
     "ARTEFACT_KINDS",
     "LINEAGE_ENTRY_VERSION",
     "AgentCard",
+    "AgentPolicy",
+    "FirstWriterPolicy",
+    "Fork",
+    "GateResult",
+    "HumanPolicy",
+    "LineageConflict",
     "LineageEntry",
+    "MergePolicy",
+    "StewardKey",
+    "TipSet",
+    "build_merge_entry",
     "canonicalise",
+    "compute_tips",
+    "detect_forks",
     "entry_hash",
+    "gate_check",
     "generate_keypair",
+    "resolve_policy",
     "sign_detached",
     "verify_detached",
 ]

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -13,9 +13,7 @@ from dataclasses import asdict, dataclass
 
 LINEAGE_ENTRY_VERSION = 1
 
-ARTEFACT_KINDS: frozenset[str] = frozenset(
-    {"file", "sdd-runtime", "mcp-result", "config"}
-)
+ARTEFACT_KINDS: frozenset[str] = frozenset({"file", "sdd-runtime", "mcp-result", "config"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,14 +42,10 @@ class LineageEntry:
         if self.artefact_kind not in ARTEFACT_KINDS:
             raise ValueError(f"unknown artefact_kind: {self.artefact_kind!r}")
         if not self.content_hash.startswith("sha256:"):
-            raise ValueError(
-                f"content_hash must start with 'sha256:', got {self.content_hash!r}"
-            )
+            raise ValueError(f"content_hash must start with 'sha256:', got {self.content_hash!r}")
         for p in self.parent_hashes:
             if not p.startswith("sha256:"):
-                raise ValueError(
-                    f"parent_hash must start with 'sha256:', got {p!r}"
-                )
+                raise ValueError(f"parent_hash must start with 'sha256:', got {p!r}")
 
 
 def canonicalise(entry: LineageEntry) -> bytes:

--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -1,0 +1,74 @@
+"""Lineage entry schema + RFC 8785 JCS canonicalisation.
+
+A `LineageEntry` is a single immutable record of an agent writing an artefact.
+The canonical-bytes form (RFC 8785 JCS) is what gets HMAC'd and Ed25519-signed,
+so every entry has a stable wire-form regardless of how it's reconstructed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+
+LINEAGE_ENTRY_VERSION = 1
+
+ARTEFACT_KINDS: frozenset[str] = frozenset(
+    {"file", "sdd-runtime", "mcp-result", "config"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LineageEntry:
+    """Single lineage event.
+
+    Frozen + slots so the dataclass shape itself is canonical — no surprise
+    extra attributes can mutate the byte form.
+    """
+
+    v: int
+    artefact_path: str
+    artefact_kind: str
+    content_hash: str
+    parent_hashes: list[str]
+    agent_id: str
+    agent_card_kid: str
+    tool_call_id: str
+    span_id: str
+    ts_ns: int
+    operator_hmac: str
+
+    def __post_init__(self) -> None:
+        if self.v != LINEAGE_ENTRY_VERSION:
+            raise ValueError(f"unsupported entry version: {self.v}")
+        if self.artefact_kind not in ARTEFACT_KINDS:
+            raise ValueError(f"unknown artefact_kind: {self.artefact_kind!r}")
+        if not self.content_hash.startswith("sha256:"):
+            raise ValueError(
+                f"content_hash must start with 'sha256:', got {self.content_hash!r}"
+            )
+        for p in self.parent_hashes:
+            if not p.startswith("sha256:"):
+                raise ValueError(
+                    f"parent_hash must start with 'sha256:', got {p!r}"
+                )
+
+
+def canonicalise(entry: LineageEntry) -> bytes:
+    """RFC 8785 JSON Canonicalisation Scheme.
+
+    sort_keys=True + minimal separators + UTF-8 covers the subset relevant to
+    flat objects of strings / ints / lists-of-strings. We never put floats,
+    None, or nested objects into a LineageEntry, so the corner cases of RFC
+    8785 around ES6 number formatting and recursive ordering don't apply.
+    """
+    return json.dumps(
+        asdict(entry),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def entry_hash(entry: LineageEntry) -> str:
+    return "sha256:" + hashlib.sha256(canonicalise(entry)).hexdigest()

--- a/src/bernstein/core/lineage/gate.py
+++ b/src/bernstein/core/lineage/gate.py
@@ -1,0 +1,203 @@
+"""Lineage CI gate (ADR-009 §6.2).
+
+`check(log_path, agent_cards_dir)` returns a `GateResult` reporting whether
+every entry in `log.jsonl` is:
+
+  1. Parsable as JSON and satisfies the LineageEntry schema.
+  2. Backed by a matching detached JWS sidecar that verifies against the
+     agent's published Agent Card (Ed25519, RFC 7515 detached).
+  3. (Optional) HMAC-protected with the supplied operator secret.
+  4. Anchored — every `parent_hash` resolves to another entry in the log.
+  5. Free of unresolved forks (each open tip is single OR is a merge entry).
+  6. (Optional) Authored by a steward-allow-listed agent when the entry is
+     a merge (parent_hashes length >= 2).
+
+The check is read-only and does not depend on the LineageStore — it can
+operate on a frozen log + cards directory (e.g. an audit pack).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac as _hmac
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.identity import AgentCard, verify_detached
+from bernstein.core.lineage.tips import compute_tips, detect_forks
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class GateResult:
+    """Outcome of `check`. `ok` is True iff `failures` is empty."""
+
+    ok: bool
+    failures: list[str] = field(default_factory=list)
+
+
+def _load_cards(cards_dir: Path) -> dict[str, AgentCard]:
+    """Load all Agent Cards under cards_dir/<agent-id>/card.json."""
+    out: dict[str, AgentCard] = {}
+    if not cards_dir.exists():
+        return out
+    for card_file in cards_dir.glob("*/card.json"):
+        try:
+            data = json.loads(card_file.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        agent_id = data.get("agent_id")
+        kid = data.get("kid")
+        pub = data.get("public_key_pem")
+        if not (isinstance(agent_id, str) and isinstance(kid, str) and isinstance(pub, str)):
+            continue
+        out[agent_id] = AgentCard(
+            agent_id=agent_id,
+            kid=kid,
+            public_key_pem=pub,
+            protocol_version=data.get("protocolVersion", "a2a/1.0"),
+        )
+    return out
+
+
+def _shard_path(artefact_path: str) -> tuple[str, str]:
+    """Returns (shard, full_hash) for the per-artefact signatures layout."""
+    digest = hashlib.sha256(artefact_path.encode()).hexdigest()
+    return digest[:2], digest
+
+
+def _signature_path(log_dir: Path, entry: LineageEntry, eh: str) -> Path:
+    shard, full = _shard_path(entry.artefact_path)
+    return log_dir / "signatures" / shard / full / (eh.replace("sha256:", "") + ".jws")
+
+
+def _parse_log(log_path: Path) -> tuple[list[LineageEntry], list[str]]:
+    """Parse the JSONL log; return (entries, parse_failures)."""
+    entries: list[LineageEntry] = []
+    failures: list[str] = []
+    if not log_path.exists():
+        return entries, failures
+    with log_path.open() as f:
+        for line_no, line in enumerate(f, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                failures.append(f"log line {line_no}: parse error: {exc}")
+                continue
+            try:
+                entry = LineageEntry(**obj)
+            except (TypeError, ValueError) as exc:
+                failures.append(f"log line {line_no}: corrupt entry: {exc}")
+                continue
+            entries.append(entry)
+    return entries, failures
+
+
+def check(
+    log_path: Path,
+    agent_cards_dir: Path,
+    *,
+    operator_secret: bytes | None = None,
+    steward_allowlist: frozenset[str] | None = None,
+) -> GateResult:
+    """Run all lineage invariants against the log + cards on disk.
+
+    Args:
+        log_path: path to `.sdd/lineage/log.jsonl`.
+        agent_cards_dir: directory containing `<agent-id>/card.json`.
+        operator_secret: when given, verify each entry's `operator_hmac`
+            against an HMAC of the entry's canonical bytes (without the
+            HMAC field itself). When None, the HMAC check is skipped.
+        steward_allowlist: when given, every merge entry's `agent_id` must
+            be in this set or the gate fails (privilege escalation guard).
+
+    Returns:
+        GateResult with ok=True iff failures is empty.
+    """
+    failures: list[str] = []
+    entries, parse_fails = _parse_log(log_path)
+    failures.extend(parse_fails)
+
+    if not entries:
+        return GateResult(ok=not failures, failures=failures)
+
+    cards = _load_cards(agent_cards_dir)
+    log_dir = log_path.parent
+
+    # Per-entry signature + HMAC + card lookups.
+    known_hashes: set[str] = set()
+    for entry in entries:
+        eh = entry_hash(entry)
+        known_hashes.add(eh)
+        card = cards.get(entry.agent_id)
+        if card is None:
+            failures.append(f"{entry.artefact_path}: unknown agent card for {entry.agent_id!r} (entry {eh})")
+            continue
+        # Signature
+        sig_path = _signature_path(log_dir, entry, eh)
+        if not sig_path.exists():
+            failures.append(f"{entry.artefact_path}: missing signature sidecar for entry {eh}")
+        else:
+            try:
+                jws = sig_path.read_text().strip()
+            except OSError as exc:
+                failures.append(f"{entry.artefact_path}: cannot read signature {sig_path}: {exc}")
+                continue
+            canonical = canonicalise(entry)
+            if not verify_detached(canonical, jws, card):
+                failures.append(f"{entry.artefact_path}: invalid signature on entry {eh}")
+        # HMAC
+        if operator_secret is not None:
+            body = json.dumps(
+                {
+                    "p": entry.parent_hashes,
+                    "h": entry.content_hash,
+                    "ts": entry.ts_ns,
+                }
+            ).encode()
+            expected = _hmac.new(operator_secret, body, hashlib.sha256).hexdigest()
+            if not _hmac.compare_digest(expected, entry.operator_hmac):
+                failures.append(f"{entry.artefact_path}: HMAC mismatch on entry {eh}")
+        # Steward allow-list for merge entries.
+        if steward_allowlist is not None and len(entry.parent_hashes) >= 2 and entry.agent_id not in steward_allowlist:
+            failures.append(
+                f"{entry.artefact_path}: merge entry {eh} written by non-steward {entry.agent_id!r} (not in allowlist)"
+            )
+
+    # Parent-hash chain integrity.
+    for entry in entries:
+        for ph in entry.parent_hashes:
+            if ph not in known_hashes:
+                failures.append(f"{entry.artefact_path}: dangling parent_hash {ph} on entry {entry_hash(entry)}")
+
+    # Tip / fork analysis.
+    tips = compute_tips(entries)
+    for path, tipset in tips.items():
+        if len(tipset["open"]) > 1:
+            failures.append(f"{path}: {len(tipset['open'])} unresolved open tips: {tipset['open']}")
+    for fork in detect_forks(entries):
+        # A fork is "resolved" iff some entry has parent_hashes covering ALL
+        # of the fork's child_hashes (subset thereof — diamond merges count).
+        resolved = False
+        children = set(fork.child_hashes)
+        for entry in entries:
+            if len(entry.parent_hashes) >= 2 and children.issubset(set(entry.parent_hashes)):
+                resolved = True
+                break
+        if not resolved:
+            failures.append(
+                f"{fork.artefact_path}: unresolved fork at parent {fork.parent_hash} "
+                f"with children {list(fork.child_hashes)}"
+            )
+
+    return GateResult(ok=not failures, failures=failures)
+
+
+__all__ = ["GateResult", "check"]

--- a/src/bernstein/core/lineage/identity.py
+++ b/src/bernstein/core/lineage/identity.py
@@ -1,0 +1,122 @@
+"""Agent identity + Ed25519 JWS detached signing.
+
+The lineage layer signs every entry with an Ed25519 keypair issued per agent
+invocation. The Agent Card subset modelled here is the slice of the A2A v1.0
+Agent Card spec that's actually load-bearing for lineage verification — the
+agent id, the key id, and the PEM-encoded public key. External tools (auditor
+CLI) hold only the public side and a copy of the card; the operator-side
+recorder holds the private key.
+
+Detached JWS follows RFC 7515 Appendix F + the `b64=false` unencoded-payload
+option (RFC 7797). Algorithm is EdDSA per RFC 8037.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentCard:
+    """Subset of the A2A v1.0 Agent Card relevant to lineage signing."""
+
+    agent_id: str
+    kid: str
+    public_key_pem: str
+    protocol_version: str = "a2a/1.0"
+
+
+def generate_keypair() -> tuple[str, str]:
+    """Generate an Ed25519 keypair. Returns (private_pem, public_pem)."""
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    pub_pem = (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("ascii")
+    )
+    return priv_pem, pub_pem
+
+
+def sign_detached(payload: bytes, private_key_pem: str, *, kid: str) -> str:
+    """Produce an Ed25519 JWS in detached form (RFC 7515 + RFC 7797).
+
+    The compact serialisation is `<protected>..<signature>` — the middle
+    segment (payload) is empty because the verifier supplies the canonical
+    bytes out-of-band. This keeps the on-disk `.jws` file independent of
+    the entry it covers and lets the auditor re-canonicalise locally.
+    """
+    priv = serialization.load_pem_private_key(private_key_pem.encode("ascii"), password=None)
+    if not isinstance(priv, Ed25519PrivateKey):
+        raise TypeError("sign_detached requires an Ed25519 private key")
+    header = {"alg": "EdDSA", "kid": kid, "b64": False, "crit": ["b64"]}
+    protected = _b64url(json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    signing_input = protected.encode("ascii") + b"." + payload
+    sig = priv.sign(signing_input)
+    return protected + ".." + _b64url(sig)
+
+
+def verify_detached(payload: bytes, jws: str, card: AgentCard) -> bool:
+    """Verify a detached Ed25519 JWS against the Agent Card's public key.
+
+    Returns True on cryptographic success and matching kid; False on any
+    malformed input, mismatched kid, wrong key, or invalid signature.
+    Never raises on bad input.
+    """
+    try:
+        protected_b64, empty, sig_b64 = jws.split(".", maxsplit=2)
+    except ValueError:
+        return False
+    if empty != "":
+        return False
+    if "." in sig_b64:
+        return False  # 4+ segments
+    try:
+        header = json.loads(_b64url_decode(protected_b64))
+    except (ValueError, json.JSONDecodeError):
+        return False
+    if header.get("alg") != "EdDSA":
+        return False
+    if header.get("kid") != card.kid:
+        return False
+    try:
+        pub = serialization.load_pem_public_key(card.public_key_pem.encode("ascii"))
+    except (ValueError, TypeError):
+        return False
+    if not isinstance(pub, Ed25519PublicKey):
+        return False
+    signing_input = protected_b64.encode("ascii") + b"." + payload
+    try:
+        sig_bytes = _b64url_decode(sig_b64)
+    except (ValueError, base64.binascii.Error):
+        return False
+    try:
+        pub.verify(sig_bytes, signing_input)
+    except InvalidSignature:
+        return False
+    return True

--- a/src/bernstein/core/lineage/merge.py
+++ b/src/bernstein/core/lineage/merge.py
@@ -1,0 +1,169 @@
+"""Fork resolution + steward merge entry construction (ADR-009 §6.3).
+
+A merge entry is a lineage record with `parent_hashes` of length >= 2 that
+points to the resolved siblings of one fork. It carries the steward's
+`agent_id` + `agent_card_kid`, the `content_hash` of the resolved content,
+and the operator HMAC. The choice of WHICH sibling's content wins is made
+by a `MergePolicy`:
+
+  - `HumanPolicy` (`"human"`)        — default; raises `LineageConflict`
+                                       so the operator can run the CLI.
+  - `FirstWriterPolicy`              — earliest `ts_ns` wins; agent_id lex
+                                       tiebreak.
+  - `AgentPolicy("agent:<id>")`      — designated agent's tip always wins.
+
+Steward privilege is enforced by allow-listing at gate time, not by the
+shape of the entry (same key type as workers).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from bernstein.core.lineage.entry import LineageEntry, canonicalise
+from bernstein.core.lineage.identity import AgentCard, sign_detached
+
+if TYPE_CHECKING:
+    from bernstein.core.lineage.tips import Fork
+
+
+class LineageConflict(Exception):
+    """Raised when a merge cannot be resolved without operator input."""
+
+    def __init__(self, artefact_path: str, candidate_hashes: tuple[str, ...], reason: str) -> None:
+        super().__init__(f"{reason} (artefact={artefact_path}, candidates={candidate_hashes})")
+        self.artefact_path = artefact_path
+        self.candidate_hashes = candidate_hashes
+        self.reason = reason
+
+
+@runtime_checkable
+class MergePolicy(Protocol):
+    """Pick the winning entry for one fork."""
+
+    def resolve(self, fork: Fork, by_hash: dict[str, LineageEntry]) -> LineageEntry:
+        """Return the winning child entry. Raise `LineageConflict` if undecidable."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class HumanPolicy:
+    """Default. Always raises `LineageConflict` for operator-driven resolution."""
+
+    def resolve(self, fork: Fork, by_hash: dict[str, LineageEntry]) -> LineageEntry:
+        raise LineageConflict(
+            artefact_path=fork.artefact_path,
+            candidate_hashes=fork.child_hashes,
+            reason="merge policy is 'human' — operator must choose",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FirstWriterPolicy:
+    """Earliest ts_ns wins; agent_id lex order tiebreak."""
+
+    def resolve(self, fork: Fork, by_hash: dict[str, LineageEntry]) -> LineageEntry:
+        children = [by_hash[h] for h in fork.child_hashes]
+        children.sort(key=lambda e: (e.ts_ns, e.agent_id))
+        return children[0]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentPolicy:
+    """Designated agent's tip wins. Raises if no candidate matches."""
+
+    agent_id: str
+
+    def resolve(self, fork: Fork, by_hash: dict[str, LineageEntry]) -> LineageEntry:
+        matches = [by_hash[h] for h in fork.child_hashes if by_hash[h].agent_id == self.agent_id]
+        if not matches:
+            raise LineageConflict(
+                artefact_path=fork.artefact_path,
+                candidate_hashes=fork.child_hashes,
+                reason=f"no tip from designated agent {self.agent_id!r}",
+            )
+        # Latest write from the designated agent wins.
+        matches.sort(key=lambda e: e.ts_ns, reverse=True)
+        return matches[0]
+
+
+def resolve_policy(policy_name: str) -> MergePolicy:
+    """Construct a `MergePolicy` from a config-string name."""
+    if policy_name == "human":
+        return HumanPolicy()
+    if policy_name == "first-writer":
+        return FirstWriterPolicy()
+    if policy_name.startswith("agent:"):
+        # Strip the leading "agent:" once; if the agent_id itself starts with
+        # "agent:" the remainder is the canonical slug, otherwise we re-prepend.
+        rest = policy_name[len("agent:") :]
+        agent_id = rest if rest.startswith("agent:") else f"agent:{rest}"
+        return AgentPolicy(agent_id=agent_id)
+    raise ValueError(f"unknown merge policy: {policy_name!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class StewardKey:
+    """Steward's signing material — Agent Card + Ed25519 private key PEM."""
+
+    card: AgentCard
+    private_key_pem: str
+    operator_secret: bytes = b""
+
+    def hmac_of(self, payload: bytes) -> str:
+        return hmac.new(self.operator_secret, payload, hashlib.sha256).hexdigest()
+
+
+def _content_hash(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def build_merge_entry(
+    forks: list[Fork],
+    *,
+    resolved_content_by_path: dict[str, bytes],
+    steward: StewardKey,
+    now_ns: int,
+    tool_call_id: str = "tc-steward-merge",
+    span_id: str = "00steward",
+) -> list[tuple[LineageEntry, str]]:
+    """Construct one merge entry per fork.
+
+    Returns a list of `(entry, jws)` pairs. Caller is responsible for appending
+    them to the lineage log via `LineageStore.append`.
+    """
+    out: list[tuple[LineageEntry, str]] = []
+    for fork in forks:
+        content = resolved_content_by_path[fork.artefact_path]
+        entry = LineageEntry(
+            v=1,
+            artefact_path=fork.artefact_path,
+            artefact_kind="file",
+            content_hash=_content_hash(content),
+            parent_hashes=list(fork.child_hashes),
+            agent_id=steward.card.agent_id,
+            agent_card_kid=steward.card.kid,
+            tool_call_id=tool_call_id,
+            span_id=span_id,
+            ts_ns=now_ns,
+            operator_hmac=steward.hmac_of(content),
+        )
+        canonical = canonicalise(entry)
+        jws = sign_detached(canonical, steward.private_key_pem, kid=steward.card.kid)
+        out.append((entry, jws))
+    return out
+
+
+__all__ = [
+    "AgentPolicy",
+    "FirstWriterPolicy",
+    "HumanPolicy",
+    "LineageConflict",
+    "MergePolicy",
+    "StewardKey",
+    "build_merge_entry",
+    "resolve_policy",
+]

--- a/src/bernstein/core/lineage/tips.py
+++ b/src/bernstein/core/lineage/tips.py
@@ -1,0 +1,100 @@
+"""Tip + fork analysis over a lineage log (ADR-009 §6).
+
+A *tip* is an entry that no other entry uses as a parent. For a healthy
+artefact there is exactly one open tip; siblings sharing a parent with
+different content_hash are *forks* and must be resolved by a merge entry
+(`parent_hashes` of length >= 2) before the lineage gate will pass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+class TipSet(TypedDict):
+    """`{"open": [...], "merged": [...]}` per artefact path.
+
+    `open`   — entries with no descendant.
+    `merged` — entries that were the parent of a merge entry (resolved forks).
+    """
+
+    open: list[str]
+    merged: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class Fork:
+    """A point where two-or-more siblings share a parent with distinct content."""
+
+    artefact_path: str
+    parent_hash: str
+    child_hashes: tuple[str, ...]
+
+
+def _group_by_path(entries: Iterable[LineageEntry]) -> dict[str, list[LineageEntry]]:
+    out: dict[str, list[LineageEntry]] = {}
+    for e in entries:
+        out.setdefault(e.artefact_path, []).append(e)
+    return out
+
+
+def compute_tips(entries: Iterable[LineageEntry]) -> dict[str, TipSet]:
+    """Return open + merged tips per artefact path.
+
+    Algorithm: an entry is a tip if no other entry in the same artefact lists
+    it as a parent. An entry is "merged" if it appears in `parent_hashes` of
+    a merge entry (an entry with >= 2 parents).
+    """
+    by_path = _group_by_path(entries)
+    result: dict[str, TipSet] = {}
+    for path, group in by_path.items():
+        hashes: list[str] = [entry_hash(e) for e in group]
+        referenced_as_parent: set[str] = set()
+        merged_parents: set[str] = set()
+        for e in group:
+            for ph in e.parent_hashes:
+                referenced_as_parent.add(ph)
+            if len(e.parent_hashes) >= 2:
+                for ph in e.parent_hashes:
+                    merged_parents.add(ph)
+        open_tips = [h for h in hashes if h not in referenced_as_parent]
+        merged_hashes = [h for h in hashes if h in merged_parents]
+        result[path] = TipSet(open=open_tips, merged=merged_hashes)
+    return result
+
+
+def detect_forks(entries: Iterable[LineageEntry]) -> list[Fork]:
+    """Return all unresolved forks across the log.
+
+    A fork (per ADR-009 §6.1) is: 2+ entries share the SAME single parent_hash
+    on the same artefact_path and have DIFFERENT content_hash.
+    Idempotent re-records (same parent + same content) do NOT count.
+    """
+    by_path = _group_by_path(entries)
+    forks: list[Fork] = []
+    for path, group in by_path.items():
+        # Group children by their single parent (skip merge entries and genesis).
+        by_parent: dict[str, list[LineageEntry]] = {}
+        for e in group:
+            if len(e.parent_hashes) != 1:
+                continue
+            by_parent.setdefault(e.parent_hashes[0], []).append(e)
+        for parent_hash, children in by_parent.items():
+            # Need >= 2 children AND at least two distinct content_hashes.
+            if len(children) < 2:
+                continue
+            distinct_content = {c.content_hash for c in children}
+            if len(distinct_content) < 2:
+                continue
+            child_hashes = tuple(entry_hash(c) for c in children)
+            forks.append(Fork(artefact_path=path, parent_hash=parent_hash, child_hashes=child_hashes))
+    return forks
+
+
+__all__ = ["Fork", "TipSet", "compute_tips", "detect_forks"]

--- a/tests/integration/test_lineage_e2e.py
+++ b/tests/integration/test_lineage_e2e.py
@@ -1,0 +1,305 @@
+"""End-to-end scenarios for lineage v1 (ADR-009 §12.4).
+
+The compliance-pack roundtrip + air-gap auditor scenarios live with
+their owning agents (C/D); here we cover the gate-side scenarios:
+
+  1. Parallel-agent fight ends in CI gate FAIL until steward merge.
+  2. Tamper detection: any byte-flip in log.jsonl → gate FAIL.
+  3. Reindex round-trip: deleting projections + rebuilding reproduces state.
+  4. Steward allow-list rejects worker-authored merges.
+  5. Path-traversal artefact rejected on schema construction.
+  6. Replay of an old entry into a new log is detected as duplicate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from bernstein.cli.commands._lineage_v1_helpers import read_entries, reindex
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.gate import check
+from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
+from bernstein.core.lineage.merge import StewardKey, build_merge_entry
+from bernstein.core.lineage.tips import detect_forks
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+class _Agent:
+    def __init__(self, agent_id: str, kid: str) -> None:
+        self.agent_id = agent_id
+        self.kid = kid
+        self.priv, self.pub = generate_keypair()
+        self.card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=self.pub)
+
+
+def _write_card(cards_dir: Path, agent: _Agent) -> None:
+    d = cards_dir / agent.agent_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": agent.agent_id,
+                "kid": agent.kid,
+                "public_key_pem": agent.pub,
+            }
+        )
+    )
+
+
+def _entry(
+    agent: _Agent,
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    ts_ns: int,
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent.agent_id,
+        agent_card_kid=agent.kid,
+        tool_call_id=f"tc-{ts_ns}",
+        span_id=f"span-{ts_ns}",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+    )
+
+
+def _append(log_path: Path, entry: LineageEntry, agent: _Agent) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as f:
+        f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    canonical = canonicalise(entry)
+    jws = sign_detached(canonical, agent.priv, kid=agent.kid)
+    digest = hashlib.sha256(entry.artefact_path.encode()).hexdigest()
+    sig_dir = log_path.parent / "signatures" / digest[:2] / digest
+    sig_dir.mkdir(parents=True, exist_ok=True)
+    eh = entry_hash(entry)
+    (sig_dir / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+
+
+def _append_signed(log_path: Path, entry: LineageEntry, jws: str) -> None:
+    """Append a pre-signed entry (used when steward.build_merge_entry already signed)."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as f:
+        f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    digest = hashlib.sha256(entry.artefact_path.encode()).hexdigest()
+    sig_dir = log_path.parent / "signatures" / digest[:2] / digest
+    sig_dir.mkdir(parents=True, exist_ok=True)
+    eh = entry_hash(entry)
+    (sig_dir / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+
+
+# ── 1. Parallel-agent fight + steward merge ─────────────────────────────────
+
+
+def test_parallel_agent_fight_then_steward_merge_resolves(tmp_path: Path) -> None:
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    worker_a = _Agent("agent:worker-a", "ka")
+    worker_b = _Agent("agent:worker-b", "kb")
+    steward = _Agent("agent:steward", "ks")
+    _write_card(cards, worker_a)
+    _write_card(cards, worker_b)
+    _write_card(cards, steward)
+
+    g = _entry(worker_a, "shared.py", _h("1"), [], ts_ns=1)
+    _append(log, g, worker_a)
+    fa = _entry(worker_a, "shared.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    fb = _entry(worker_b, "shared.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    _append(log, fa, worker_a)
+    _append(log, fb, worker_b)
+
+    pre = check(log_path=log, agent_cards_dir=cards)
+    assert pre.ok is False
+    assert any("fork" in f.lower() or "tip" in f.lower() for f in pre.failures)
+
+    # Steward writes a merge entry resolving the fork.
+    forks = detect_forks(read_entries(log))
+    assert len(forks) == 1
+    sk = StewardKey(
+        card=steward.card,
+        private_key_pem=steward.priv,
+        operator_secret=b"",
+    )
+    merge_entries = build_merge_entry(
+        forks,
+        resolved_content_by_path={"shared.py": b"merged content"},
+        steward=sk,
+        now_ns=100,
+    )
+    for me, jws in merge_entries:
+        _append_signed(log, me, jws)
+
+    post = check(log_path=log, agent_cards_dir=cards)
+    assert post.ok is True, post.failures
+
+
+# ── 2. Tamper detection ─────────────────────────────────────────────────────
+
+
+def test_tamper_detection_byte_flip_in_log(tmp_path: Path) -> None:
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    g = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    _append(log, g, a)
+    pre = check(log_path=log, agent_cards_dir=cards)
+    assert pre.ok is True
+
+    # Flip the first byte of the content_hash hex region.
+    raw = log.read_text()
+    pos = raw.index(_h("1"))
+    flipped = bytearray(raw.encode())
+    flipped[pos + 8] = ord("9") if chr(flipped[pos + 8]) != "9" else ord("0")
+    log.write_bytes(bytes(flipped))
+
+    post = check(log_path=log, agent_cards_dir=cards)
+    assert post.ok is False
+
+
+# ── 3. Reindex round-trip ───────────────────────────────────────────────────
+
+
+def test_reindex_round_trip_state_matches(tmp_path: Path) -> None:
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    g = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    c = _entry(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    _append(log, g, a)
+    _append(log, c, a)
+    reindex(log)
+    digest = hashlib.sha256(b"x.py").hexdigest()
+    tips_path = log.parent / "tips" / (digest + ".json")
+    before = tips_path.read_text()
+
+    shutil.rmtree(log.parent / "by-artefact")
+    shutil.rmtree(log.parent / "tips")
+    assert not tips_path.exists()
+    reindex(log)
+    after = tips_path.read_text()
+    assert before == after
+
+
+# ── 4. Steward allow-list rejects worker merge ─────────────────────────────
+
+
+def test_steward_allowlist_rejects_worker_merge(tmp_path: Path) -> None:
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    worker = _Agent("agent:worker", "k1")
+    _write_card(cards, worker)
+    g = _entry(worker, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry(worker, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry(worker, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    # Worker maliciously writes a merge with itself as author.
+    rogue_merge = _entry(
+        worker,
+        "x.py",
+        _h("9"),
+        [entry_hash(f1), entry_hash(f2)],
+        ts_ns=4,
+    )
+    for e in [g, f1, f2, rogue_merge]:
+        _append(log, e, worker)
+    result = check(
+        log_path=log,
+        agent_cards_dir=cards,
+        steward_allowlist=frozenset({"agent:steward"}),
+    )
+    assert result.ok is False
+    assert any("merge" in f.lower() or "steward" in f.lower() for f in result.failures)
+
+
+# ── 5. Path traversal rejected on schema construction ──────────────────────
+
+
+def test_path_traversal_artefact_in_log_does_not_crash_gate(tmp_path: Path) -> None:
+    """A path-traversal artefact written into the log MUST NOT escape the
+    sandbox at gate-check time (no relative-path resolution against fs).
+
+    The recorder is responsible for rejecting such paths on write; the
+    gate's job is to refuse to silently accept them and to keep
+    signature/HMAC verification bounded inside the lineage_dir. We assert
+    the gate runs without filesystem escape and reports the entry against
+    its declared path."""
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    g = _entry(a, "../../../etc/passwd", _h("1"), [], ts_ns=1)
+    _append(log, g, a)
+    # Should run cleanly (or fail) but MUST NOT read or escape outside
+    # log.parent. Verify by checking the signatures path stays under
+    # log.parent.
+    sig_root = log.parent / "signatures"
+    for sig in sig_root.rglob("*.jws"):
+        assert log.parent in sig.parents
+    result = check(log_path=log, agent_cards_dir=cards)
+    # Whether the gate reports OK or FAIL is policy; the contract here
+    # is "no escape" — the test is green if the rglob assertion holds.
+    assert isinstance(result.ok, bool)
+
+
+# ── 6. Replay attack — duplicate entries by hash detection ──────────────────
+
+
+def test_replay_attack_duplicate_entry_hash_is_idempotent(tmp_path: Path) -> None:
+    """Replaying the same entry produces the same entry_hash; the gate does
+    not double-count it as a fork or treat it as a separate write."""
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    g = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    # Write the same entry twice — same body, same hash.
+    _append(log, g, a)
+    _append(log, g, a)
+    # Same content_hash + same parent_hash + same ts → idempotent replay,
+    # NOT a fork.
+    entries = read_entries(log)
+    assert len(entries) == 2
+    assert entry_hash(entries[0]) == entry_hash(entries[1])
+    forks = detect_forks(entries)
+    # Two children of [] with same content_hash and same content → not a fork.
+    assert forks == []
+
+
+# ── 7. CI script end-to-end ─────────────────────────────────────────────────
+
+
+def test_check_lineage_script_via_subprocess(tmp_path: Path) -> None:
+    import subprocess
+
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    g = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    _append(log, g, a)
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "check_lineage.py"
+    res = subprocess.run(
+        [sys.executable, str(script), "--log", str(log), "--cards", str(cards), "--json"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, res.stderr
+    parsed = json.loads(res.stdout)
+    assert parsed["ok"] is True

--- a/tests/property/test_lineage_properties.py
+++ b/tests/property/test_lineage_properties.py
@@ -1,0 +1,294 @@
+"""Property-based tests for lineage v1 invariants (ADR-009 §12.2).
+
+Each property covers one invariant and runs up to 500 examples under the
+``smoke`` profile (the ``deep`` nightly profile lifts that further). The
+shapes generated:
+
+  - random well-formed LineageEntry instances
+  - random linear chains over a single artefact
+  - random fork shapes (parent + N siblings + optional merge)
+  - random byte payloads for JCS determinism + JWS roundtrip
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+
+import hypothesis.strategies as st
+from hypothesis import HealthCheck, assume, given, settings
+
+from bernstein.core.lineage.entry import (
+    ARTEFACT_KINDS,
+    LineageEntry,
+    canonicalise,
+    entry_hash,
+)
+from bernstein.core.lineage.identity import (
+    AgentCard,
+    generate_keypair,
+    sign_detached,
+    verify_detached,
+)
+from bernstein.core.lineage.tips import compute_tips, detect_forks
+
+# ── Strategies ──────────────────────────────────────────────────────────────
+
+
+_SHA = st.text(alphabet="0123456789abcdef", min_size=64, max_size=64).map(lambda h: "sha256:" + h)
+_PATH = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Ll", "Lu", "Nd"),
+        whitelist_characters="/_.-",
+    ),
+    min_size=1,
+    max_size=40,
+).filter(lambda s: ".." not in s and not s.startswith("/"))
+_AGENT_ID = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz-0123456789",
+    min_size=1,
+    max_size=20,
+).map(lambda s: f"agent:{s}")
+_KIND = st.sampled_from(sorted(ARTEFACT_KINDS))
+
+
+def _entry_strategy() -> st.SearchStrategy[LineageEntry]:
+    return st.builds(
+        LineageEntry,
+        v=st.just(1),
+        artefact_path=_PATH,
+        artefact_kind=_KIND,
+        content_hash=_SHA,
+        parent_hashes=st.lists(_SHA, max_size=3),
+        agent_id=_AGENT_ID,
+        agent_card_kid=st.text(min_size=1, max_size=20),
+        tool_call_id=st.text(min_size=1, max_size=20),
+        span_id=st.text(min_size=1, max_size=20),
+        ts_ns=st.integers(min_value=0, max_value=10**18),
+        operator_hmac=st.text(alphabet="0123456789abcdef", min_size=64, max_size=64),
+    )
+
+
+# Pre-generated key reused across property runs to avoid Ed25519 keygen cost.
+_PRIV, _PUB = generate_keypair()
+_CARD = AgentCard(agent_id="agent:t", kid="k1", public_key_pem=_PUB)
+
+
+# ── Property 1: Chain integrity — every parent_hash resolves ───────────────
+
+
+@given(st.integers(min_value=1, max_value=20))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_chain_integrity_every_parent_resolves(length: int) -> None:
+    """Build a linear chain of `length` entries; every parent_hash must point
+    to an entry that exists in the log."""
+    entries: list[LineageEntry] = []
+    prev: list[str] = []
+    for i in range(length):
+        e = LineageEntry(
+            v=1,
+            artefact_path="x.py",
+            artefact_kind="file",
+            content_hash="sha256:" + hashlib.sha256(f"e{i}".encode()).hexdigest(),
+            parent_hashes=prev,
+            agent_id="agent:t",
+            agent_card_kid="k1",
+            tool_call_id=f"tc-{i}",
+            span_id=f"span-{i}",
+            ts_ns=i,
+            operator_hmac="00" * 32,
+        )
+        entries.append(e)
+        prev = [entry_hash(e)]
+
+    known = {entry_hash(e) for e in entries}
+    for e in entries:
+        for ph in e.parent_hashes:
+            assert ph in known
+
+
+# ── Property 2: Fork detection completeness ────────────────────────────────
+
+
+@given(st.integers(min_value=2, max_value=10))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_fork_detection_completeness(num_siblings: int) -> None:
+    """N siblings sharing the same parent with distinct content_hashes must
+    surface as one fork covering exactly those N siblings."""
+    parent = LineageEntry(
+        v=1,
+        artefact_path="x.py",
+        artefact_kind="file",
+        content_hash="sha256:" + "a" * 64,
+        parent_hashes=[],
+        agent_id="agent:t",
+        agent_card_kid="k1",
+        tool_call_id="tc",
+        span_id="span",
+        ts_ns=0,
+        operator_hmac="00" * 32,
+    )
+    siblings = [
+        LineageEntry(
+            v=1,
+            artefact_path="x.py",
+            artefact_kind="file",
+            content_hash="sha256:" + hashlib.sha256(f"sib{i}".encode()).hexdigest(),
+            parent_hashes=[entry_hash(parent)],
+            agent_id="agent:t",
+            agent_card_kid="k1",
+            tool_call_id="tc",
+            span_id="span",
+            ts_ns=i + 1,
+            operator_hmac="00" * 32,
+        )
+        for i in range(num_siblings)
+    ]
+    forks = detect_forks([parent, *siblings])
+    assert len(forks) == 1
+    assert set(forks[0].child_hashes) == {entry_hash(s) for s in siblings}
+
+
+# ── Property 3: Merge resolves siblings ────────────────────────────────────
+
+
+@given(st.integers(min_value=2, max_value=10))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_merge_resolves_siblings(num_siblings: int) -> None:
+    """A merge entry whose parent_hashes covers all siblings closes the fork:
+    every sibling appears in `merged`, and the merge is the only open tip."""
+    parent = LineageEntry(
+        v=1,
+        artefact_path="x.py",
+        artefact_kind="file",
+        content_hash="sha256:" + "a" * 64,
+        parent_hashes=[],
+        agent_id="agent:t",
+        agent_card_kid="k1",
+        tool_call_id="tc",
+        span_id="span",
+        ts_ns=0,
+        operator_hmac="00" * 32,
+    )
+    siblings = [
+        LineageEntry(
+            v=1,
+            artefact_path="x.py",
+            artefact_kind="file",
+            content_hash="sha256:" + hashlib.sha256(f"sib{i}".encode()).hexdigest(),
+            parent_hashes=[entry_hash(parent)],
+            agent_id="agent:t",
+            agent_card_kid="k1",
+            tool_call_id="tc",
+            span_id="span",
+            ts_ns=i + 1,
+            operator_hmac="00" * 32,
+        )
+        for i in range(num_siblings)
+    ]
+    merge = LineageEntry(
+        v=1,
+        artefact_path="x.py",
+        artefact_kind="file",
+        content_hash="sha256:" + "f" * 64,
+        parent_hashes=[entry_hash(s) for s in siblings],
+        agent_id="agent:steward",
+        agent_card_kid="ks",
+        tool_call_id="tc",
+        span_id="span",
+        ts_ns=10_000,
+        operator_hmac="00" * 32,
+    )
+    tips = compute_tips([parent, *siblings, merge])
+    assert tips["x.py"]["open"] == [entry_hash(merge)]
+    assert set(tips["x.py"]["merged"]) == {entry_hash(s) for s in siblings}
+
+
+# ── Property 4: Signature roundtrip + tamper detection ─────────────────────
+
+
+@given(st.binary(min_size=1, max_size=256))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_signature_roundtrip(payload: bytes) -> None:
+    jws = sign_detached(payload, _PRIV, kid="k1")
+    assert verify_detached(payload, jws, _CARD) is True
+
+
+@given(st.binary(min_size=1, max_size=128), st.integers(min_value=0))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_per_byte_tamper_rejected(payload: bytes, flip_seed: int) -> None:
+    """Flipping any byte in the signed payload MUST cause verify to fail."""
+    assume(len(payload) > 0)
+    jws = sign_detached(payload, _PRIV, kid="k1")
+    idx = flip_seed % len(payload)
+    flipped = bytearray(payload)
+    flipped[idx] ^= 0x01
+    assert verify_detached(bytes(flipped), jws, _CARD) is False
+
+
+# ── Property 5: JCS determinism ────────────────────────────────────────────
+
+
+@given(_entry_strategy(), _entry_strategy())
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_jcs_determinism_same_field_dict_same_bytes(e1: LineageEntry, e2: LineageEntry) -> None:
+    """For two entries with identical field values, canonical bytes must
+    match — regardless of insertion order during construction."""
+    if asdict(e1) == asdict(e2):
+        assert canonicalise(e1) == canonicalise(e2)
+
+
+@given(_entry_strategy())
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_jcs_round_trip_through_json(entry: LineageEntry) -> None:
+    """Serialise → deserialise → re-canonicalise must yield identical bytes."""
+    raw = canonicalise(entry)
+    obj = json.loads(raw)
+    rebuilt = LineageEntry(**obj)
+    assert canonicalise(rebuilt) == raw
+
+
+# ── Property 6: HMAC envelope tamper detection per byte flip ───────────────
+
+
+@given(st.binary(min_size=8, max_size=256), st.integers(min_value=0))
+@settings(max_examples=500, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_hmac_tamper_per_byte(payload: bytes, flip_seed: int) -> None:
+    """Recompute HMAC on payload; flip a byte; new HMAC must differ.
+
+    Models the operator HMAC envelope used in the lineage entry: any
+    single-bit tamper of the input is detectable by recomputing.
+    """
+    secret = b"operator-secret-32-bytes-of-randomness!!"
+    import hmac as _hmac
+
+    sig_a = _hmac.new(secret, payload, hashlib.sha256).hexdigest()
+    idx = flip_seed % len(payload)
+    tampered = bytearray(payload)
+    tampered[idx] ^= 0x80
+    sig_b = _hmac.new(secret, bytes(tampered), hashlib.sha256).hexdigest()
+    assert sig_a != sig_b
+
+
+# ── Property 7: Genesis entries are open tips ──────────────────────────────
+
+
+@given(st.integers(min_value=1, max_value=5))
+@settings(max_examples=200, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+def test_property_single_entry_is_open_tip(_n: int) -> None:
+    e = LineageEntry(
+        v=1,
+        artefact_path="z.py",
+        artefact_kind="file",
+        content_hash="sha256:" + "9" * 64,
+        parent_hashes=[],
+        agent_id="agent:t",
+        agent_card_kid="k1",
+        tool_call_id="tc",
+        span_id="span",
+        ts_ns=0,
+        operator_hmac="00" * 32,
+    )
+    tips = compute_tips([e])
+    assert tips["z.py"]["open"] == [entry_hash(e)]

--- a/tests/security/test_lineage_adversarial.py
+++ b/tests/security/test_lineage_adversarial.py
@@ -1,0 +1,285 @@
+"""Adversarial / red-team tests for lineage v1 (ADR-009 §12.6).
+
+Five attack classes:
+
+  1. Replay attack — old entry replayed into a new run.
+  2. Substitution attack — swap two entries' signatures.
+  3. Privilege escalation — worker writes a merge entry.
+  4. Forge attack — synthetic JWS with fake kid.
+  5. Path traversal in artefact_path.
+
+Each test sets up the minimum on-disk lineage state required to exercise
+the attack and asserts the gate (or the constructor) refuses to accept it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.gate import check
+from bernstein.core.lineage.identity import (
+    AgentCard,
+    generate_keypair,
+    sign_detached,
+    verify_detached,
+)
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+class _Agent:
+    def __init__(self, agent_id: str, kid: str) -> None:
+        self.agent_id = agent_id
+        self.kid = kid
+        self.priv, self.pub = generate_keypair()
+        self.card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=self.pub)
+
+
+def _write_card(cards_dir: Path, agent: _Agent) -> None:
+    d = cards_dir / agent.agent_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": agent.agent_id,
+                "kid": agent.kid,
+                "public_key_pem": agent.pub,
+            }
+        )
+    )
+
+
+def _entry(
+    agent: _Agent,
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    ts_ns: int,
+    *,
+    span_id: str = "span",
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent.agent_id,
+        agent_card_kid=agent.kid,
+        tool_call_id=f"tc-{ts_ns}",
+        span_id=span_id,
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+    )
+
+
+def _append(log_path: Path, entry: LineageEntry, agent: _Agent) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a") as f:
+        f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    canonical = canonicalise(entry)
+    jws = sign_detached(canonical, agent.priv, kid=agent.kid)
+    digest = hashlib.sha256(entry.artefact_path.encode()).hexdigest()
+    sig_dir = log_path.parent / "signatures" / digest[:2] / digest
+    sig_dir.mkdir(parents=True, exist_ok=True)
+    eh = entry_hash(entry)
+    (sig_dir / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+
+
+# ── 1. Replay attack ────────────────────────────────────────────────────────
+
+
+def test_attack_1_replay_old_entry_with_stale_span_id(tmp_path: Path) -> None:
+    """An attacker copies an entry from a previous run and appends it into a
+    fresh log. The replayed entry is byte-for-byte identical to the original,
+    so its signature verifies — but the gate must surface the duplicate as a
+    fork (two children of the same parent with the same hash) AND any
+    parent_hash referenced in the replay must still resolve.
+
+    Concretely: replaying without bringing the parent forward leaves the
+    chain dangling → gate FAIL.
+    """
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    # Attacker has a captured entry from prior run referencing an ancestor
+    # that doesn't exist in the new log.
+    replay = _entry(a, "x.py", _h("2"), [_h("9")], ts_ns=999, span_id="old-run-span")
+    _append(log, replay, a)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("dangling parent_hash" in f for f in result.failures)
+
+
+def test_attack_1b_duplicate_entry_in_same_log_is_surfaced(tmp_path: Path) -> None:
+    """Replaying the same entry into the same log produces two physical lines
+    with the same entry_hash. The gate surfaces this as a duplicate-tip
+    condition — silent duplication is NOT allowed (it would let an attacker
+    smuggle a 'second write' that looks identical).
+    """
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    g = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    _append(log, g, a)
+    _append(log, g, a)
+    result = check(log_path=log, agent_cards_dir=cards)
+    # Gate flags two open tips with the same hash — surfaced, not silenced.
+    assert result.ok is False
+    assert any("tip" in f.lower() or "duplicate" in f.lower() for f in result.failures)
+
+
+# ── 2. Substitution attack ──────────────────────────────────────────────────
+
+
+def test_attack_2_substitution_of_signature_fails(tmp_path: Path) -> None:
+    """Swap the JWS of entry A with the JWS of entry B; the gate must
+    detect the mismatch because each JWS is bound to its entry's canonical
+    bytes."""
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    e1 = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    e2 = _entry(a, "y.py", _h("2"), [], ts_ns=2)
+    _append(log, e1, a)
+    _append(log, e2, a)
+    # Swap the JWS files.
+    h1 = hashlib.sha256(b"x.py").hexdigest()
+    h2 = hashlib.sha256(b"y.py").hexdigest()
+    eh1 = entry_hash(e1).replace("sha256:", "")
+    eh2 = entry_hash(e2).replace("sha256:", "")
+    sig1 = log.parent / "signatures" / h1[:2] / h1 / (eh1 + ".jws")
+    sig2 = log.parent / "signatures" / h2[:2] / h2 / (eh2 + ".jws")
+    s1 = sig1.read_text()
+    s2 = sig2.read_text()
+    sig1.write_text(s2)
+    sig2.write_text(s1)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("signature" in f.lower() for f in result.failures)
+
+
+# ── 3. Privilege escalation ─────────────────────────────────────────────────
+
+
+def test_attack_3_worker_writes_merge_entry_rejected(tmp_path: Path) -> None:
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    worker = _Agent("agent:worker", "k1")
+    _write_card(cards, worker)
+    g = _entry(worker, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry(worker, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry(worker, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    rogue = _entry(worker, "x.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    for e in [g, f1, f2, rogue]:
+        _append(log, e, worker)
+    result = check(
+        log_path=log,
+        agent_cards_dir=cards,
+        steward_allowlist=frozenset({"agent:steward"}),
+    )
+    assert result.ok is False
+    assert any("non-steward" in f or "not in allowlist" in f for f in result.failures)
+
+
+# ── 4. Forge attack — synthetic JWS with fake kid ──────────────────────────
+
+
+def test_attack_4_forge_synthetic_jws_with_unknown_kid(tmp_path: Path) -> None:
+    """Attacker generates their own keypair and signs an entry that claims
+    a kid not present in any Agent Card. verify_detached must refuse to
+    match a kid that isn't in the card-driven registry."""
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    legit = _Agent("agent:legit", "k1")
+    _write_card(cards, legit)
+    # Attacker keypair NOT in cards directory.
+    attacker_priv, attacker_pub = generate_keypair()
+    forged = _entry(legit, "x.py", _h("1"), [], ts_ns=1)
+    # Hijack the log entry to claim a different kid the attacker controls.
+    forged_dict = asdict(forged)
+    forged_dict["agent_card_kid"] = "attacker-kid"
+    forged_entry = LineageEntry(**forged_dict)
+    log.parent.mkdir(parents=True, exist_ok=True)
+    with log.open("a") as f:
+        f.write(json.dumps(forged_dict, sort_keys=True) + "\n")
+    # Attacker signs with their own key + their own kid.
+    canonical = canonicalise(forged_entry)
+    jws = sign_detached(canonical, attacker_priv, kid="attacker-kid")
+    digest = hashlib.sha256(b"x.py").hexdigest()
+    sig_dir = log.parent / "signatures" / digest[:2] / digest
+    sig_dir.mkdir(parents=True, exist_ok=True)
+    eh = entry_hash(forged_entry).replace("sha256:", "")
+    (sig_dir / (eh + ".jws")).write_text(jws)
+    # Sanity: the forged JWS does NOT verify against the legit card.
+    assert verify_detached(canonical, jws, legit.card) is False
+    # Even though attacker_pub would technically verify, no card lists it.
+    fake_card = AgentCard(agent_id="agent:legit", kid="attacker-kid", public_key_pem=attacker_pub)
+    assert verify_detached(canonical, jws, fake_card) is True
+    # The gate must NOT consult attacker-provided keys — only those under
+    # cards_dir. Therefore the gate fails.
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+
+
+# ── 5. Path traversal ──────────────────────────────────────────────────────
+
+
+def test_attack_5_path_traversal_does_not_escape_lineage_dir(tmp_path: Path) -> None:
+    """An entry declaring an artefact_path of ``../../../etc/passwd`` must
+    not cause the gate to look up signatures outside ``log_path.parent``.
+
+    The recorder is the layer that should refuse the path; the gate's
+    contract here is "no escape" — signature lookup is always
+    sharded by sha256(artefact_path) under log_dir/signatures/."""
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    bad = _entry(a, "../../../etc/passwd", _h("1"), [], ts_ns=1)
+    _append(log, bad, a)
+    # Every signature path under tmp_path must stay under log.parent.
+    sig_root = log.parent / "signatures"
+    for sig in sig_root.rglob("*.jws"):
+        # `parents` is a parent-walk; require log.parent on the chain.
+        assert log.parent in sig.parents
+    # Gate runs — must not raise.
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert isinstance(result.ok, bool)
+
+
+# ── Bonus: forged HMAC ─────────────────────────────────────────────────────
+
+
+def test_attack_6_forged_operator_hmac_detected_when_secret_known(tmp_path: Path) -> None:
+    """The operator HMAC is the second line of defence below the Ed25519
+    signature. With the correct operator secret, the gate detects forged
+    HMACs even if the signature still verifies (e.g. an insider with
+    access to the agent's private key but not the operator secret).
+    """
+    log = tmp_path / "lineage" / "log.jsonl"
+    cards = tmp_path / "agents"
+    a = _Agent("agent:a", "k1")
+    _write_card(cards, a)
+    # Build an entry whose operator_hmac is a *valid hex string* (passes
+    # entry schema) but does NOT match the operator secret.
+    e = _entry(a, "x.py", _h("1"), [], ts_ns=1)
+    _append(log, e, a)
+    # With the right operator secret, the entry's mock HMAC should NOT match.
+    result = check(
+        log_path=log,
+        agent_cards_dir=cards,
+        operator_secret=b"the-real-operator-secret",
+    )
+    assert result.ok is False
+    assert any("hmac" in f.lower() for f in result.failures)

--- a/tests/unit/lineage/test_cli.py
+++ b/tests/unit/lineage/test_cli.py
@@ -1,0 +1,285 @@
+"""Tests for the `bernstein lineage` v1 CLI subcommands (ADR-009)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.lineage_cmd import lineage_cmd
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.identity import generate_keypair, sign_detached
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+def _mk_entry(
+    agent_id: str,
+    kid: str,
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    ts_ns: int,
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent_id,
+        agent_card_kid=kid,
+        tool_call_id="tc",
+        span_id="span",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+    )
+
+
+def _write_setup(tmp_path: Path, entries: list[LineageEntry]) -> tuple[Path, Path, str, str]:
+    log = tmp_path / "lineage" / "log.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    cards = tmp_path / "agents"
+    priv, pub = generate_keypair()
+    card_dir = cards / "agent:a"
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": "agent:a",
+                "kid": "k1",
+                "public_key_pem": pub,
+            }
+        )
+    )
+    with log.open("w") as f:
+        for e in entries:
+            f.write(json.dumps(asdict(e), sort_keys=True) + "\n")
+    # Sidecar JWS files.
+    sig_root = log.parent / "signatures"
+    for e in entries:
+        canonical = canonicalise(e)
+        jws = sign_detached(canonical, priv, kid="k1")
+        eh = entry_hash(e)
+        path_hash = hashlib.sha256(e.artefact_path.encode()).hexdigest()
+        d = sig_root / path_hash[:2] / path_hash
+        d.mkdir(parents=True, exist_ok=True)
+        (d / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+    return log, cards, priv, pub
+
+
+# ── gate ────────────────────────────────────────────────────────────────────
+
+
+def test_gate_pass(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, cards, *_ = _write_setup(tmp_path, [g])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["gate", "--log", str(log), "--cards", str(cards)], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "PASS" in result.output
+
+
+def test_gate_fail_exit_code(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    f1 = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    f2 = _mk_entry("agent:a", "k1", "x.py", _h("3"), [entry_hash(g)], 3)
+    log, cards, *_ = _write_setup(tmp_path, [g, f1, f2])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["gate", "--log", str(log), "--cards", str(cards)])
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+
+
+def test_gate_skip_when_log_missing(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["gate", "--log", str(tmp_path / "nope.jsonl")])
+    assert result.exit_code == 0
+    assert "SKIP" in result.output
+
+
+def test_gate_json_output(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, cards, *_ = _write_setup(tmp_path, [g])
+    runner = CliRunner()
+    result = runner.invoke(
+        lineage_cmd,
+        ["gate", "--log", str(log), "--cards", str(cards), "--output-json"],
+    )
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["ok"] is True
+
+
+# ── forks ───────────────────────────────────────────────────────────────────
+
+
+def test_forks_none(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, _, *_ = _write_setup(tmp_path, [g])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["forks", "--log", str(log)])
+    assert result.exit_code == 0
+    assert "No forks" in result.output
+
+
+def test_forks_detected(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    f1 = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    f2 = _mk_entry("agent:a", "k1", "x.py", _h("3"), [entry_hash(g)], 3)
+    log, _, *_ = _write_setup(tmp_path, [g, f1, f2])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["forks", "--log", str(log), "--output-json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert len(parsed) == 1
+    assert parsed[0]["artefact_path"] == "x.py"
+
+
+# ── chain ───────────────────────────────────────────────────────────────────
+
+
+def test_chain_ok(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, cards, *_ = _write_setup(tmp_path, [g])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["chain", "x.py", "--log", str(log), "--cards", str(cards)])
+    assert result.exit_code == 0
+    assert "chain OK" in result.output
+
+
+def test_chain_unknown_artefact(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, cards, *_ = _write_setup(tmp_path, [g])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["chain", "other.py", "--log", str(log), "--cards", str(cards)])
+    assert result.exit_code == 1
+
+
+# ── reindex ─────────────────────────────────────────────────────────────────
+
+
+def test_reindex_creates_projections(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    c = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    log, _, *_ = _write_setup(tmp_path, [g, c])
+    runner = CliRunner()
+    result = runner.invoke(lineage_cmd, ["reindex", "--log", str(log)])
+    assert result.exit_code == 0
+    digest = hashlib.sha256(b"x.py").hexdigest()
+    proj = log.parent / "by-artefact" / digest[:2] / (digest + ".jsonl")
+    tips = log.parent / "tips" / (digest + ".json")
+    assert proj.exists()
+    assert tips.exists()
+    tips_data = json.loads(tips.read_text())
+    assert tips_data["open"] == [entry_hash(c)]
+
+
+def test_reindex_round_trip_after_deletion(tmp_path: Path) -> None:
+    """ADR-009 §12.4 scenario 6."""
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    c = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    log, _, *_ = _write_setup(tmp_path, [g, c])
+    runner = CliRunner()
+    runner.invoke(lineage_cmd, ["reindex", "--log", str(log)])
+    digest = hashlib.sha256(b"x.py").hexdigest()
+    tips_a = (log.parent / "tips" / (digest + ".json")).read_text()
+    # Delete + rebuild.
+    import shutil
+
+    shutil.rmtree(log.parent / "by-artefact", ignore_errors=True)
+    shutil.rmtree(log.parent / "tips", ignore_errors=True)
+    runner.invoke(lineage_cmd, ["reindex", "--log", str(log)])
+    tips_b = (log.parent / "tips" / (digest + ".json")).read_text()
+    assert tips_a == tips_b
+
+
+# ── merge ───────────────────────────────────────────────────────────────────
+
+
+def test_merge_rejects_unknown_winner(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    f1 = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    f2 = _mk_entry("agent:a", "k1", "x.py", _h("3"), [entry_hash(g)], 3)
+    log, _, *_ = _write_setup(tmp_path, [g, f1, f2])
+    runner = CliRunner()
+    result = runner.invoke(
+        lineage_cmd,
+        ["merge", "x.py", "--use-content", _h("999"), "--log", str(log)],
+    )
+    assert result.exit_code == 1
+
+
+def test_merge_accepts_valid_winner(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    f1 = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    f2 = _mk_entry("agent:a", "k1", "x.py", _h("3"), [entry_hash(g)], 3)
+    log, _, *_ = _write_setup(tmp_path, [g, f1, f2])
+    runner = CliRunner()
+    result = runner.invoke(
+        lineage_cmd,
+        ["merge", "x.py", "--use-content", entry_hash(f1), "--log", str(log)],
+    )
+    assert result.exit_code == 0
+    assert "Merge prepared" in result.output
+
+
+# ── scripts/check_lineage.py ────────────────────────────────────────────────
+
+
+def test_check_lineage_script_pass(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    log, cards, *_ = _write_setup(tmp_path, [g])
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / "scripts" / "check_lineage.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--log",
+            str(log),
+            "--cards",
+            str(cards),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_check_lineage_script_fail(tmp_path: Path) -> None:
+    g = _mk_entry("agent:a", "k1", "x.py", _h("1"), [], 1)
+    f1 = _mk_entry("agent:a", "k1", "x.py", _h("2"), [entry_hash(g)], 2)
+    f2 = _mk_entry("agent:a", "k1", "x.py", _h("3"), [entry_hash(g)], 3)
+    log, cards, *_ = _write_setup(tmp_path, [g, f1, f2])
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / "scripts" / "check_lineage.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--log", str(log), "--cards", str(cards)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+
+
+def test_check_lineage_script_skip_no_log(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    script = repo_root / "scripts" / "check_lineage.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--log", str(tmp_path / "no.jsonl")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "SKIP" in result.stdout

--- a/tests/unit/lineage/test_entry.py
+++ b/tests/unit/lineage/test_entry.py
@@ -1,0 +1,95 @@
+"""Tests for lineage entry schema + RFC 8785 JCS canonicalisation."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.lineage.entry import (
+    ARTEFACT_KINDS,
+    LINEAGE_ENTRY_VERSION,
+    LineageEntry,
+    canonicalise,
+    entry_hash,
+)
+
+
+def _kwargs(**overrides):
+    base = dict(
+        v=1,
+        artefact_path="src/foo.py",
+        artefact_kind="file",
+        content_hash="sha256:" + "a" * 64,
+        parent_hashes=[],
+        agent_id="agent:claude-worker-3",
+        agent_card_kid="key-001",
+        tool_call_id="tc-7f3a",
+        span_id="00f067aa0ba902b7",
+        ts_ns=1_715_600_000_000_000_000,
+        operator_hmac="deadbeef" * 8,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_canonicalise_deterministic_across_constructions():
+    e1 = LineageEntry(**_kwargs(parent_hashes=["sha256:" + "0" * 64]))
+    e2 = LineageEntry(**_kwargs(parent_hashes=["sha256:" + "0" * 64]))
+    assert canonicalise(e1) == canonicalise(e2)
+
+
+def test_canonicalise_keys_sorted():
+    e = LineageEntry(**_kwargs())
+    b = canonicalise(e)
+    # First sorted key in our schema is "agent_card_kid"
+    assert b.startswith(b'{"agent_card_kid":')
+
+
+def test_canonicalise_no_whitespace_or_bom():
+    e = LineageEntry(**_kwargs())
+    b = canonicalise(e)
+    assert b"\n" not in b
+    assert b": " not in b  # JCS forbids whitespace after colon
+    assert b", " not in b
+    assert b[:1] != b"\xef"  # no BOM
+
+
+def test_entry_hash_format():
+    e = LineageEntry(**_kwargs())
+    h = entry_hash(e)
+    assert h.startswith("sha256:")
+    assert len(h) == len("sha256:") + 64
+
+
+def test_entry_hash_changes_with_content():
+    e1 = LineageEntry(**_kwargs())
+    e2 = LineageEntry(**_kwargs(ts_ns=e1.ts_ns + 1))
+    assert entry_hash(e1) != entry_hash(e2)
+
+
+def test_rejects_wrong_version():
+    with pytest.raises(ValueError, match="unsupported entry version"):
+        LineageEntry(**_kwargs(v=2))
+
+
+def test_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="unknown artefact_kind"):
+        LineageEntry(**_kwargs(artefact_kind="bogus"))
+
+
+def test_rejects_bad_content_hash_prefix():
+    with pytest.raises(ValueError, match="content_hash must"):
+        LineageEntry(**_kwargs(content_hash="md5:nope"))
+
+
+def test_rejects_bad_parent_hash_prefix():
+    with pytest.raises(ValueError, match="parent_hash must"):
+        LineageEntry(**_kwargs(parent_hashes=["nope"]))
+
+
+def test_accepts_all_artefact_kinds():
+    for kind in ARTEFACT_KINDS:
+        LineageEntry(**_kwargs(artefact_kind=kind))
+
+
+def test_version_constant():
+    assert LINEAGE_ENTRY_VERSION == 1

--- a/tests/unit/lineage/test_gate.py
+++ b/tests/unit/lineage/test_gate.py
@@ -1,0 +1,342 @@
+"""Tests for the lineage CI gate (ADR-009 §6.2)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.gate import GateResult, check
+from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
+
+# ── Test fixtures and helpers ───────────────────────────────────────────────
+
+
+class _TestAgent:
+    def __init__(self, agent_id: str, kid: str) -> None:
+        self.agent_id = agent_id
+        self.kid = kid
+        self.priv, self.pub = generate_keypair()
+        self.card = AgentCard(agent_id=agent_id, kid=kid, public_key_pem=self.pub)
+
+
+def _entry_for(
+    agent: _TestAgent,
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    *,
+    ts_ns: int = 1_715_600_000_000_000_000,
+    operator_secret: bytes = b"op-secret",
+) -> LineageEntry:
+    body = json.dumps({"p": parent_hashes, "h": content_hash, "ts": ts_ns}).encode()
+    op_hmac = hmac.new(operator_secret, body, hashlib.sha256).hexdigest()
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent.agent_id,
+        agent_card_kid=agent.kid,
+        tool_call_id="tc-x",
+        span_id="span-x",
+        ts_ns=ts_ns,
+        operator_hmac=op_hmac,
+    )
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+def _write_card(cards_dir: Path, agent: _TestAgent) -> None:
+    d = cards_dir / agent.agent_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": agent.agent_id,
+                "kid": agent.kid,
+                "public_key_pem": agent.pub,
+            }
+        )
+    )
+
+
+def _shard(s: str) -> str:
+    # "sha256:abcd..." → first 2 chars after the prefix
+    digest = s.split(":", 1)[1]
+    return digest[:2]
+
+
+def _write_log_and_sigs(
+    log_path: Path,
+    entries: list[tuple[LineageEntry, str | None]],  # (entry, agent_priv_or_none)
+    agents_by_id: dict[str, _TestAgent],
+) -> None:
+    """Write the log.jsonl + per-entry detached JWS sidecars."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    sig_root = log_path.parent / "signatures"
+    sig_root.mkdir(exist_ok=True)
+    with log_path.open("w") as f:
+        for entry, _ in entries:
+            f.write(json.dumps(asdict(entry), sort_keys=True) + "\n")
+    for entry, _ in entries:
+        agent = agents_by_id[entry.agent_id]
+        canonical = canonicalise(entry)
+        jws = sign_detached(canonical, agent.priv, kid=agent.kid)
+        eh = entry_hash(entry)
+        # Path-shard + entry-hash filename
+        path_hash = hashlib.sha256(entry.artefact_path.encode()).hexdigest()
+        dest_dir = sig_root / path_hash[:2] / path_hash
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        (dest_dir / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+
+def test_gate_passes_on_clean_chain(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "src/x.py", _h("1"), [], ts_ns=1)
+    c1 = _entry_for(a, "src/x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    _write_log_and_sigs(log, [(g, None), (c1, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert isinstance(result, GateResult)
+    assert result.ok is True
+    assert result.failures == []
+
+
+def test_gate_passes_when_log_missing(tmp_path: Path) -> None:
+    cards = tmp_path / "agents"
+    cards.mkdir()
+    # No log written.
+    result = check(log_path=tmp_path / "lineage" / "log.jsonl", agent_cards_dir=cards)
+    assert result.ok is True
+
+
+# ── Unresolved fork ─────────────────────────────────────────────────────────
+
+
+def test_gate_fails_on_unresolved_fork(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(a, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    _write_log_and_sigs(log, [(g, None), (f1, None), (f2, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("unresolved" in f.lower() or "fork" in f.lower() for f in result.failures)
+
+
+def test_gate_passes_after_merge_resolves_fork(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    s = _TestAgent("agent:steward", "ks")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    _write_card(cards, s)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(a, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    m = _entry_for(s, "x.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    _write_log_and_sigs(
+        log,
+        [(g, None), (f1, None), (f2, None), (m, None)],
+        {a.agent_id: a, s.agent_id: s},
+    )
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True, result.failures
+
+
+# ── Signature tampering ─────────────────────────────────────────────────────
+
+
+def test_gate_fails_on_missing_signature(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    _write_log_and_sigs(log, [(g, None)], {a.agent_id: a})
+    # Delete the JWS sidecar.
+    sig_root = log.parent / "signatures"
+    for jws_file in sig_root.rglob("*.jws"):
+        jws_file.unlink()
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("signature" in f.lower() or "missing" in f.lower() for f in result.failures)
+
+
+def test_gate_fails_on_tampered_entry(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    _write_log_and_sigs(log, [(g, None)], {a.agent_id: a})
+    # Tamper with the log: flip a byte in content_hash.
+    raw = log.read_text()
+    raw_tampered = raw.replace(_h("1"), _h("9"), 1)
+    assert raw_tampered != raw
+    log.write_text(raw_tampered)
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("signature" in f.lower() for f in result.failures)
+
+
+def test_gate_fails_on_tampered_hmac(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    # Build an entry, then write directly with mangled HMAC.
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    # Replace with garbage hmac.
+    bad_dict = asdict(g)
+    bad_dict["operator_hmac"] = "deadbeef" * 8
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text(json.dumps(bad_dict, sort_keys=True) + "\n")
+    # Write a valid JWS for the bad entry.
+    bad_entry = LineageEntry(**bad_dict)
+    canonical = canonicalise(bad_entry)
+    jws = sign_detached(canonical, a.priv, kid=a.kid)
+    eh = entry_hash(bad_entry)
+    path_hash = hashlib.sha256(bad_entry.artefact_path.encode()).hexdigest()
+    dest_dir = log.parent / "signatures" / path_hash[:2] / path_hash
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / (eh.replace("sha256:", "") + ".jws")).write_text(jws)
+    # Provide the operator secret that won't match.
+    result = check(log_path=log, agent_cards_dir=cards, operator_secret=b"op-secret")
+    assert result.ok is False
+    assert any("hmac" in f.lower() for f in result.failures)
+
+
+# ── Parent chain integrity ──────────────────────────────────────────────────
+
+
+def test_gate_fails_on_dangling_parent(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    orphan = _entry_for(a, "x.py", _h("2"), [_h("nonexistent")], ts_ns=2)
+    _write_log_and_sigs(log, [(orphan, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("parent" in f.lower() or "chain" in f.lower() for f in result.failures)
+
+
+# ── Missing Agent Card ──────────────────────────────────────────────────────
+
+
+def test_gate_fails_when_agent_card_unknown(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    cards.mkdir(parents=True, exist_ok=True)
+    # Do NOT write card for `a`.
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    _write_log_and_sigs(log, [(g, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("card" in f.lower() or "unknown agent" in f.lower() for f in result.failures)
+
+
+# ── Steward allow-list (privilege escalation) ───────────────────────────────
+
+
+def test_gate_rejects_worker_writing_merge_entry(tmp_path: Path) -> None:
+    worker = _TestAgent("agent:worker", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, worker)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(worker, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(worker, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(worker, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    # Worker tries to write a merge entry — must be rejected if allow-list set.
+    m = _entry_for(worker, "x.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    _write_log_and_sigs(log, [(g, None), (f1, None), (f2, None), (m, None)], {worker.agent_id: worker})
+    result = check(
+        log_path=log,
+        agent_cards_dir=cards,
+        steward_allowlist=frozenset({"agent:steward"}),
+    )
+    assert result.ok is False
+    assert any("merge" in f.lower() or "steward" in f.lower() for f in result.failures)
+
+
+def test_gate_allows_worker_merge_when_no_allowlist_configured(tmp_path: Path) -> None:
+    """Default: no allow-list => no privilege check. Steward role is policy-only."""
+    worker = _TestAgent("agent:worker", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, worker)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(worker, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(worker, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(worker, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    m = _entry_for(worker, "x.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    _write_log_and_sigs(log, [(g, None), (f1, None), (f2, None), (m, None)], {worker.agent_id: worker})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True
+
+
+# ── GateResult shape ────────────────────────────────────────────────────────
+
+
+def test_gate_result_is_tuple_like(tmp_path: Path) -> None:
+    cards = tmp_path / "agents"
+    cards.mkdir()
+    result = check(log_path=tmp_path / "noop.jsonl", agent_cards_dir=cards)
+    assert hasattr(result, "ok")
+    assert hasattr(result, "failures")
+    assert isinstance(result.failures, list)
+
+
+def test_gate_handles_corrupt_log_line(tmp_path: Path) -> None:
+    cards = tmp_path / "agents"
+    cards.mkdir()
+    log = tmp_path / "lineage" / "log.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("{not-json\n")
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    assert any("parse" in f.lower() or "corrupt" in f.lower() for f in result.failures)
+
+
+def test_gate_handles_card_directory_missing(tmp_path: Path) -> None:
+    log = tmp_path / "lineage" / "log.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("")
+    # No agents dir.
+    result = check(log_path=log, agent_cards_dir=tmp_path / "no-such-dir")
+    assert result.ok is True  # empty log → OK regardless of cards dir
+
+
+# ── Property-style: HMAC matches when operator_secret given ────────────────
+
+
+def test_gate_verifies_hmac_when_secret_provided(tmp_path: Path) -> None:
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1, operator_secret=b"op-secret")
+    _write_log_and_sigs(log, [(g, None)], {a.agent_id: a})
+    # Wrong operator secret → HMAC mismatch.
+    bad = check(log_path=log, agent_cards_dir=cards, operator_secret=b"WRONG")
+    assert bad.ok is False
+    # Right operator secret → OK.
+    good = check(log_path=log, agent_cards_dir=cards, operator_secret=b"op-secret")
+    assert good.ok is True, good.failures

--- a/tests/unit/lineage/test_gate.py
+++ b/tests/unit/lineage/test_gate.py
@@ -340,3 +340,160 @@ def test_gate_verifies_hmac_when_secret_provided(tmp_path: Path) -> None:
     # Right operator secret → OK.
     good = check(log_path=log, agent_cards_dir=cards, operator_secret=b"op-secret")
     assert good.ok is True, good.failures
+
+
+# ── Mutation-killing tests (close survivor gaps) ────────────────────────────
+
+
+def test_gate_rejects_malformed_agent_card_with_non_string_field(tmp_path: Path) -> None:
+    """`_load_cards` must skip cards where any of agent_id/kid/public_key_pem
+    is not a string. Kills the `and -> or` mutation in the isinstance chain."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    card_dir = cards / "agent:bad"
+    card_dir.mkdir(parents=True, exist_ok=True)
+    (card_dir / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": "agent:bad",
+                "kid": None,  # ← invalid; should cause card to be skipped
+                "public_key_pem": a.pub,
+            }
+        )
+    )
+    # Also a valid card for agent:a so we can issue a real entry.
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    _write_log_and_sigs(log, [(g, None)], {a.agent_id: a})
+    # The bad card was skipped, but agent:a is fine → gate passes.
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is True
+    # Now write an entry from agent:bad with no valid card → gate fails.
+    bad = _TestAgent("agent:bad", "k1")
+    g2 = _entry_for(bad, "y.py", _h("2"), [], ts_ns=2)
+    _write_log_and_sigs(log, [(g, None), (g2, None)], {a.agent_id: a, bad.agent_id: bad})
+    result2 = check(log_path=log, agent_cards_dir=cards)
+    assert result2.ok is False
+    assert any("agent:bad" in f and ("card" in f.lower() or "unknown" in f.lower()) for f in result2.failures)
+
+
+def test_gate_steward_allowlist_does_not_check_non_merge_entries(tmp_path: Path) -> None:
+    """The steward allow-list only applies when parent_hashes length >= 2.
+    A genesis or single-parent entry from a non-allowed agent must NOT
+    trigger the privilege check. Kills the `>= 2 -> >= 1` mutation."""
+    a = _TestAgent("agent:worker", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    c1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    _write_log_and_sigs(log, [(g, None), (c1, None)], {a.agent_id: a})
+    # Allowlist excludes "agent:worker", but no merge entries exist → pass.
+    result = check(
+        log_path=log,
+        agent_cards_dir=cards,
+        steward_allowlist=frozenset({"agent:steward"}),
+    )
+    assert result.ok is True, result.failures
+
+
+def test_gate_failure_count_appears_in_failure_message(tmp_path: Path) -> None:
+    """The open-tip failure message must contain the actual count, not zero.
+    Kills the `len( -> 0 * len(` mutation."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(a, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    f3 = _entry_for(a, "x.py", _h("4"), [entry_hash(g)], ts_ns=4)
+    _write_log_and_sigs(
+        log,
+        [(g, None), (f1, None), (f2, None), (f3, None)],
+        {a.agent_id: a},
+    )
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    # Match exact count "3 unresolved" — kills the zero-count mutation.
+    tip_msgs = [f for f in result.failures if "unresolved" in f and "tips" in f]
+    assert tip_msgs, result.failures
+    assert "3" in tip_msgs[0]
+
+
+def test_gate_fork_resolved_flag_initial_false_not_true(tmp_path: Path) -> None:
+    """The `resolved = False` initialisation must be False, not True, so that
+    forks without a covering merge entry are reported. Kills the
+    `False -> True` flip on the resolved sentinel.
+
+    We construct a scenario where the open-tip count is OK (1) but a
+    historical fork is still unresolved — that forces the gate to rely on
+    the resolved=False initial value.
+
+    Concretely: after a merge, write another genesis-style child of the
+    pre-merge state. The merge is the open tip; the fork is technically
+    closed in compute_tips terms, but detect_forks still surfaces it.
+    Easier test: use the existing unresolved-fork shape and check the
+    fork-level message appears alongside the tip-level one.
+    """
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(a, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    _write_log_and_sigs(log, [(g, None), (f1, None), (f2, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    # The gate must produce a fork-level message too — both classes of
+    # message must appear if the initial `resolved = False` is intact.
+    fork_msgs = [f for f in result.failures if "unresolved fork" in f]
+    assert fork_msgs, f"no fork-level message: {result.failures}"
+
+
+def test_gate_dangling_parent_hash_count_matches_input(tmp_path: Path) -> None:
+    """Multiple dangling parents must each produce a distinct failure message."""
+    a = _TestAgent("agent:a", "k1")
+    cards = tmp_path / "agents"
+    _write_card(cards, a)
+    log = tmp_path / "lineage" / "log.jsonl"
+    o1 = _entry_for(a, "x.py", _h("2"), [_h("ghost-1")], ts_ns=2)
+    o2 = _entry_for(a, "y.py", _h("3"), [_h("ghost-2"), _h("ghost-3")], ts_ns=3)
+    _write_log_and_sigs(log, [(o1, None), (o2, None)], {a.agent_id: a})
+    result = check(log_path=log, agent_cards_dir=cards)
+    assert result.ok is False
+    dangling = [f for f in result.failures if "dangling parent_hash" in f]
+    # o1 has 1 ghost, o2 has 2 ghosts → 3 dangling-parent messages.
+    assert len(dangling) == 3
+
+
+def test_compute_tips_distinguishes_open_vs_merged(tmp_path: Path) -> None:
+    """Ensure compute_tips classifies merge parents as 'merged', not 'open'.
+    Kills mutations that confuse the two sets in tips.py."""
+    from bernstein.core.lineage.tips import compute_tips
+
+    a = _TestAgent("agent:a", "k1")
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    f1 = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _entry_for(a, "x.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    m = _entry_for(a, "x.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    tips = compute_tips([g, f1, f2, m])
+    assert entry_hash(f1) not in tips["x.py"]["open"]
+    assert entry_hash(f2) not in tips["x.py"]["open"]
+    assert entry_hash(m) in tips["x.py"]["open"]
+    assert entry_hash(f1) in tips["x.py"]["merged"]
+    assert entry_hash(f2) in tips["x.py"]["merged"]
+
+
+def test_detect_forks_requires_at_least_two_children(tmp_path: Path) -> None:
+    """A parent with one child must NOT be reported as a fork.
+    Kills the `< 2 -> < 1` mutation in detect_forks."""
+    from bernstein.core.lineage.tips import detect_forks
+
+    a = _TestAgent("agent:a", "k1")
+    g = _entry_for(a, "x.py", _h("1"), [], ts_ns=1)
+    only_child = _entry_for(a, "x.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    assert detect_forks([g, only_child]) == []

--- a/tests/unit/lineage/test_identity.py
+++ b/tests/unit/lineage/test_identity.py
@@ -1,0 +1,115 @@
+"""Tests for AgentCard + Ed25519 JWS detached sign/verify (RFC 7515 + JWA EdDSA)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.lineage.identity import (
+    AgentCard,
+    generate_keypair,
+    sign_detached,
+    verify_detached,
+)
+
+
+def test_sign_verify_roundtrip():
+    priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub)
+    payload = b"some canonical bytes"
+    jws = sign_detached(payload, priv, kid="k1")
+    assert verify_detached(payload, jws, card) is True
+
+
+def test_tampered_payload_fails_verify():
+    priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub)
+    payload = b"some canonical bytes"
+    jws = sign_detached(payload, priv, kid="k1")
+    assert verify_detached(b"some canonical bytEs", jws, card) is False
+
+
+def test_wrong_kid_fails():
+    priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub)
+    payload = b"x"
+    jws = sign_detached(payload, priv, kid="WRONG")
+    assert verify_detached(payload, jws, card) is False
+
+
+def test_wrong_card_fails():
+    priv_a, _pub_a = generate_keypair()
+    _priv_b, pub_b = generate_keypair()
+    card_b = AgentCard(agent_id="agent:b", kid="k1", public_key_pem=pub_b)
+    payload = b"x"
+    jws = sign_detached(payload, priv_a, kid="k1")
+    assert verify_detached(payload, jws, card_b) is False
+
+
+def test_jws_compact_form_structure():
+    priv, _pub = generate_keypair()
+    jws = sign_detached(b"x", priv, kid="k1")
+    # Detached: <protected>..<signature>
+    parts = jws.split(".")
+    assert len(parts) == 3
+    assert parts[1] == ""
+
+
+def test_every_byte_flip_in_payload_fails():
+    priv, pub = generate_keypair()
+    card = AgentCard("agent:t", "k1", pub)
+    payload = b"abcdefghijklmnop"
+    jws = sign_detached(payload, priv, kid="k1")
+    for i in range(len(payload)):
+        flipped = bytearray(payload)
+        flipped[i] ^= 0x01
+        assert verify_detached(bytes(flipped), jws, card) is False, f"flip at {i}"
+
+
+def test_every_byte_flip_in_signature_fails():
+    priv, pub = generate_keypair()
+    card = AgentCard("agent:t", "k1", pub)
+    payload = b"some payload"
+    jws = sign_detached(payload, priv, kid="k1")
+    protected, _, sig = jws.split(".")
+    sig_bytes = bytearray(sig.encode("ascii"))
+    # Flip one character in the base64 signature — half should still decode,
+    # but the underlying bytes change → verify fails.
+    failures = 0
+    for i in range(len(sig_bytes)):
+        flipped = bytearray(sig_bytes)
+        # XOR with 0x01 sometimes lands on a non-base64 char; either way
+        # the verifier must NOT accept the tampered signature.
+        flipped[i] ^= 0x01
+        broken = protected + ".." + flipped.decode("ascii", errors="replace")
+        result = verify_detached(payload, broken, card)
+        if result is False:
+            failures += 1
+    assert failures == len(sig_bytes)
+
+
+def test_malformed_jws_rejected():
+    _priv, pub = generate_keypair()
+    card = AgentCard("agent:t", "k1", pub)
+    assert verify_detached(b"x", "not-a-jws", card) is False
+    assert verify_detached(b"x", "a.b.c.d", card) is False
+    assert verify_detached(b"x", "", card) is False
+
+
+def test_keypair_is_ed25519():
+    priv_pem, pub_pem = generate_keypair()
+    assert "PRIVATE KEY" in priv_pem
+    assert "PUBLIC KEY" in pub_pem
+
+
+def test_sign_with_non_ed25519_key_raises(tmp_path):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.rsa import generate_private_key
+
+    rsa = generate_private_key(public_exponent=65537, key_size=2048)
+    rsa_pem = rsa.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+    with pytest.raises(TypeError, match="Ed25519"):
+        sign_detached(b"x", rsa_pem, kid="k1")

--- a/tests/unit/lineage/test_merge.py
+++ b/tests/unit/lineage/test_merge.py
@@ -1,0 +1,237 @@
+"""Tests for merge policy resolution + merge entry construction (ADR-009 §6.3)."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.lineage.merge import (
+    AgentPolicy,
+    FirstWriterPolicy,
+    HumanPolicy,
+    LineageConflict,
+    MergePolicy,
+    StewardKey,
+    build_merge_entry,
+    resolve_policy,
+)
+from bernstein.core.lineage.tips import Fork
+
+
+def _mk(
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    *,
+    ts_ns: int = 1_715_600_000_000_000_000,
+    agent_id: str = "agent:a",
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent_id,
+        agent_card_kid="k1",
+        tool_call_id="tc-x",
+        span_id="span-x",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+    )
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+# ── resolve_policy ──────────────────────────────────────────────────────────
+
+
+def test_resolve_human_default() -> None:
+    p = resolve_policy("human")
+    assert isinstance(p, HumanPolicy)
+
+
+def test_resolve_first_writer() -> None:
+    p = resolve_policy("first-writer")
+    assert isinstance(p, FirstWriterPolicy)
+
+
+def test_resolve_agent_specific() -> None:
+    p = resolve_policy("agent:reviewer-bot")
+    assert isinstance(p, AgentPolicy)
+    assert p.agent_id == "agent:reviewer-bot"
+
+
+def test_resolve_agent_with_full_slug() -> None:
+    p = resolve_policy("agent:agent:reviewer-bot")
+    assert isinstance(p, AgentPolicy)
+    # "agent:" prefix stripped once → "agent:reviewer-bot"
+    assert p.agent_id == "agent:reviewer-bot"
+
+
+def test_resolve_unknown_policy_raises() -> None:
+    with pytest.raises(ValueError, match="unknown merge policy"):
+        resolve_policy("magic-policy")
+
+
+# ── HumanPolicy ─────────────────────────────────────────────────────────────
+
+
+def test_human_policy_emits_conflict_event() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2, agent_id="agent:a")
+    f2 = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3, agent_id="agent:b")
+    fork = Fork(
+        artefact_path="a.py",
+        parent_hash=entry_hash(g),
+        child_hashes=(entry_hash(f1), entry_hash(f2)),
+    )
+    policy = HumanPolicy()
+    with pytest.raises(LineageConflict) as ei:
+        policy.resolve(fork, {entry_hash(f1): f1, entry_hash(f2): f2})
+    assert ei.value.artefact_path == "a.py"
+    assert set(ei.value.candidate_hashes) == {entry_hash(f1), entry_hash(f2)}
+
+
+# ── FirstWriterPolicy ───────────────────────────────────────────────────────
+
+
+def test_first_writer_picks_earliest_ts() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f_late = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=200, agent_id="agent:a")
+    f_early = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=100, agent_id="agent:b")
+    fork = Fork(
+        artefact_path="a.py",
+        parent_hash=entry_hash(g),
+        child_hashes=(entry_hash(f_late), entry_hash(f_early)),
+    )
+    winner = FirstWriterPolicy().resolve(fork, {entry_hash(f_late): f_late, entry_hash(f_early): f_early})
+    assert winner == f_early
+
+
+def test_first_writer_lex_tiebreak_on_agent_id() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    fa = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=100, agent_id="agent:b")
+    fb = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=100, agent_id="agent:a")
+    fork = Fork(
+        artefact_path="a.py",
+        parent_hash=entry_hash(g),
+        child_hashes=(entry_hash(fa), entry_hash(fb)),
+    )
+    winner = FirstWriterPolicy().resolve(fork, {entry_hash(fa): fa, entry_hash(fb): fb})
+    assert winner.agent_id == "agent:a"
+
+
+# ── AgentPolicy ─────────────────────────────────────────────────────────────
+
+
+def test_agent_policy_picks_designated() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    fa = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=100, agent_id="agent:worker")
+    fb = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=200, agent_id="agent:reviewer")
+    fork = Fork(
+        artefact_path="a.py",
+        parent_hash=entry_hash(g),
+        child_hashes=(entry_hash(fa), entry_hash(fb)),
+    )
+    winner = AgentPolicy("agent:reviewer").resolve(fork, {entry_hash(fa): fa, entry_hash(fb): fb})
+    assert winner == fb
+
+
+def test_agent_policy_missing_designated_raises() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    fa = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=100, agent_id="agent:worker")
+    fb = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=200, agent_id="agent:other")
+    fork = Fork(
+        artefact_path="a.py",
+        parent_hash=entry_hash(g),
+        child_hashes=(entry_hash(fa), entry_hash(fb)),
+    )
+    with pytest.raises(LineageConflict, match="no tip from designated"):
+        AgentPolicy("agent:reviewer").resolve(fork, {entry_hash(fa): fa, entry_hash(fb): fb})
+
+
+# ── build_merge_entry ───────────────────────────────────────────────────────
+
+
+def _steward_key() -> StewardKey:
+    priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:steward", kid="steward-1", public_key_pem=pub)
+    return StewardKey(card=card, private_key_pem=priv)
+
+
+def test_build_merge_entry_creates_single_entry_for_one_fork() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2, agent_id="agent:a")
+    f2 = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3, agent_id="agent:b")
+    forks = [
+        Fork(
+            artefact_path="a.py",
+            parent_hash=entry_hash(g),
+            child_hashes=(entry_hash(f1), entry_hash(f2)),
+        )
+    ]
+    resolved_content = b"merged file content"
+    sk = _steward_key()
+    entries = build_merge_entry(
+        forks,
+        resolved_content_by_path={"a.py": resolved_content},
+        steward=sk,
+        now_ns=1_000,
+    )
+    assert len(entries) == 1
+    me, jws = entries[0]
+    assert me.artefact_path == "a.py"
+    assert set(me.parent_hashes) == {entry_hash(f1), entry_hash(f2)}
+    assert me.agent_id == "agent:steward"
+    assert me.agent_card_kid == "steward-1"
+    assert me.ts_ns == 1_000
+    expected = "sha256:" + hashlib.sha256(resolved_content).hexdigest()
+    assert me.content_hash == expected
+    # JWS not empty
+    assert jws.startswith("e") and ".." in jws
+
+
+def test_build_merge_entry_multiple_forks_multiple_entries() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    fa1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    fa2 = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    h = _mk("b.py", _h("4"), [], ts_ns=1)
+    fb1 = _mk("b.py", _h("5"), [entry_hash(h)], ts_ns=2)
+    fb2 = _mk("b.py", _h("6"), [entry_hash(h)], ts_ns=3)
+    forks = [
+        Fork("a.py", entry_hash(g), (entry_hash(fa1), entry_hash(fa2))),
+        Fork("b.py", entry_hash(h), (entry_hash(fb1), entry_hash(fb2))),
+    ]
+    sk = _steward_key()
+    entries = build_merge_entry(
+        forks,
+        resolved_content_by_path={"a.py": b"A", "b.py": b"B"},
+        steward=sk,
+        now_ns=1_000,
+    )
+    assert len(entries) == 2
+    paths = {e.artefact_path for e, _ in entries}
+    assert paths == {"a.py", "b.py"}
+
+
+def test_build_merge_entry_missing_content_raises() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)])
+    f2 = _mk("a.py", _h("3"), [entry_hash(g)])
+    forks = [Fork("a.py", entry_hash(g), (entry_hash(f1), entry_hash(f2)))]
+    sk = _steward_key()
+    with pytest.raises(KeyError):
+        build_merge_entry(forks, resolved_content_by_path={}, steward=sk, now_ns=1_000)
+
+
+def test_merge_policy_protocol() -> None:
+    """All concrete policies satisfy the MergePolicy protocol."""
+    assert isinstance(HumanPolicy(), MergePolicy)
+    assert isinstance(FirstWriterPolicy(), MergePolicy)
+    assert isinstance(AgentPolicy("x"), MergePolicy)

--- a/tests/unit/lineage/test_tips.py
+++ b/tests/unit/lineage/test_tips.py
@@ -1,0 +1,162 @@
+"""Tests for `compute_tips` and `detect_forks` (ADR-009 §6.1)."""
+
+from __future__ import annotations
+
+from bernstein.core.lineage.entry import LineageEntry, entry_hash
+from bernstein.core.lineage.tips import Fork, compute_tips, detect_forks
+
+
+def _mk(
+    artefact_path: str,
+    content_hash: str,
+    parent_hashes: list[str],
+    *,
+    ts_ns: int = 1_715_600_000_000_000_000,
+    agent_id: str = "agent:a",
+) -> LineageEntry:
+    return LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent_id,
+        agent_card_kid="k1",
+        tool_call_id="tc-x",
+        span_id="span-x",
+        ts_ns=ts_ns,
+        operator_hmac="deadbeef" * 8,
+    )
+
+
+def _h(seed: str) -> str:
+    return "sha256:" + (seed * 64)[:64]
+
+
+# ── compute_tips ────────────────────────────────────────────────────────────
+
+
+def test_empty_log_returns_empty_dict() -> None:
+    assert compute_tips([]) == {}
+
+
+def test_single_entry_one_open_tip() -> None:
+    e = _mk("a.py", _h("1"), [])
+    tips = compute_tips([e])
+    assert tips == {"a.py": {"open": [entry_hash(e)], "merged": []}}
+
+
+def test_linear_chain_only_head_is_open() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    c1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    c2 = _mk("a.py", _h("3"), [entry_hash(c1)], ts_ns=3)
+    tips = compute_tips([g, c1, c2])
+    assert tips["a.py"]["open"] == [entry_hash(c2)]
+    assert tips["a.py"]["merged"] == []
+
+
+def test_simple_fork_two_open_tips() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2, agent_id="agent:a")
+    f2 = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3, agent_id="agent:b")
+    tips = compute_tips([g, f1, f2])
+    assert set(tips["a.py"]["open"]) == {entry_hash(f1), entry_hash(f2)}
+    assert tips["a.py"]["merged"] == []
+
+
+def test_merge_resolves_fork() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    m = _mk("a.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    tips = compute_tips([g, f1, f2, m])
+    assert tips["a.py"]["open"] == [entry_hash(m)]
+    assert set(tips["a.py"]["merged"]) == {entry_hash(f1), entry_hash(f2)}
+
+
+def test_per_artefact_isolation() -> None:
+    a = _mk("a.py", _h("1"), [])
+    b = _mk("b.py", _h("2"), [])
+    tips = compute_tips([a, b])
+    assert set(tips.keys()) == {"a.py", "b.py"}
+    assert tips["a.py"]["open"] == [entry_hash(a)]
+    assert tips["b.py"]["open"] == [entry_hash(b)]
+
+
+def test_diamond_shape() -> None:
+    # g → a, g → b ; m: parents [a, b] ; c: parent m
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    a = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    b = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    m = _mk("a.py", _h("4"), [entry_hash(a), entry_hash(b)], ts_ns=4)
+    c = _mk("a.py", _h("5"), [entry_hash(m)], ts_ns=5)
+    tips = compute_tips([g, a, b, m, c])
+    assert tips["a.py"]["open"] == [entry_hash(c)]
+
+
+def test_n_way_fork_then_merge() -> None:
+    g = _mk("a.py", _h("0"), [], ts_ns=1)
+    children = [_mk("a.py", _h(str(i)), [entry_hash(g)], ts_ns=10 + i) for i in range(1, 6)]
+    m = _mk("a.py", _h("9"), [entry_hash(c) for c in children], ts_ns=100)
+    tips = compute_tips([g, *children, m])
+    assert tips["a.py"]["open"] == [entry_hash(m)]
+    assert set(tips["a.py"]["merged"]) == {entry_hash(c) for c in children}
+
+
+# ── detect_forks ────────────────────────────────────────────────────────────
+
+
+def test_detect_forks_empty() -> None:
+    assert detect_forks([]) == []
+
+
+def test_detect_forks_linear_no_fork() -> None:
+    g = _mk("a.py", _h("1"), [])
+    c = _mk("a.py", _h("2"), [entry_hash(g)])
+    assert detect_forks([g, c]) == []
+
+
+def test_detect_forks_simple() -> None:
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2)
+    f2 = _mk("a.py", _h("3"), [entry_hash(g)], ts_ns=3)
+    forks = detect_forks([g, f1, f2])
+    assert len(forks) == 1
+    fork = forks[0]
+    assert isinstance(fork, Fork)
+    assert fork.artefact_path == "a.py"
+    assert fork.parent_hash == entry_hash(g)
+    assert set(fork.child_hashes) == {entry_hash(f1), entry_hash(f2)}
+
+
+def test_detect_forks_criss_cross() -> None:
+    # Two parents, each have two children pointing to them (not really fork
+    # in the §6.1 sense unless same parent + different content)
+    # Here we model a real criss-cross: two independent forks on same artefact.
+    g1 = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g1)], ts_ns=2)
+    f2 = _mk("a.py", _h("3"), [entry_hash(g1)], ts_ns=3)
+    m = _mk("a.py", _h("4"), [entry_hash(f1), entry_hash(f2)], ts_ns=4)
+    f3 = _mk("a.py", _h("5"), [entry_hash(m)], ts_ns=5)
+    f4 = _mk("a.py", _h("6"), [entry_hash(m)], ts_ns=6)
+    forks = detect_forks([g1, f1, f2, m, f3, f4])
+    parents = {f.parent_hash for f in forks}
+    assert entry_hash(g1) in parents
+    assert entry_hash(m) in parents
+    assert len(forks) == 2
+
+
+def test_detect_forks_n_way() -> None:
+    g = _mk("a.py", _h("0"), [], ts_ns=1)
+    children = [_mk("a.py", _h(str(i)), [entry_hash(g)], ts_ns=10 + i) for i in range(1, 6)]
+    forks = detect_forks([g, *children])
+    assert len(forks) == 1
+    assert len(forks[0].child_hashes) == 5
+
+
+def test_fork_requires_distinct_content() -> None:
+    # Two entries with same parent AND same content_hash → NOT a fork (idempotent re-record)
+    g = _mk("a.py", _h("1"), [], ts_ns=1)
+    f1 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=2, agent_id="agent:a")
+    f2 = _mk("a.py", _h("2"), [entry_hash(g)], ts_ns=3, agent_id="agent:b")
+    assert detect_forks([g, f1, f2]) == []

--- a/typos.toml
+++ b/typos.toml
@@ -10,6 +10,10 @@ extend-ignore-re = [
     # Mask any alphanumeric run that contains an embedded ZWSP so fixtures
     # stay intact without globally allowlisting the fragment.
     "[A-Za-z]+​[A-Za-z]+",
+    # Lineage v1 byte-tamper fixtures intentionally case-flip "bytes" to
+    # exercise the per-byte signature-failure path; see
+    # tests/unit/lineage/test_identity.py.
+    "bytEs",
 ]
 
 [default.extend-words]

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "1.10.7"
+version = "1.10.8"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },
@@ -246,6 +246,7 @@ dependencies = [
     { name = "pyfiglet" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+    { name = "reportlab" },
     { name = "rich" },
     { name = "setproctitle" },
     { name = "signxml" },
@@ -394,6 +395,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=22.7" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "reportlab", specifier = ">=4.0,<5" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9" },
@@ -3528,6 +3530,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "reportlab"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charset-normalizer" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/3f/b3861b7e40c9d66f4a04e018958d681d16b948bfd1963c962d43a8c23f66/reportlab-4.5.1.tar.gz", hash = "sha256:9fdf68f4de9171ec66acb4a5feed8f8ca2af43479e707a6fbb0daa75d88e5494", size = 3939748, upload-time = "2026-05-12T10:14:13.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/45/ea7fad10122440de6e845568d106bffdc456ca0e8a1d8ae10b46016087e4/reportlab-4.5.1-py3-none-any.whl", hash = "sha256:06fce8cb56c83307cfa4909cdf4e6a2ddbb44e5d6ef4d2edca896d7e9769f091", size = 1957812, upload-time = "2026-05-12T10:14:10.622Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements ADR-009 §6 (conflict detection + gate) + §6.3 (merge policies) + the operator CLI surface, with TDD throughout and a full §12 test pyramid.

- **Modules:** \`core/lineage/{tips,merge,gate}.py\` — fork detection, three merge policies (\`human\`/\`first-writer\`/\`agent:<id>\`), and a read-only invariant checker over \`log.jsonl\` + agent cards
- **CLI:** \`bernstein lineage {gate,forks,chain,reindex,merge}\` plus \`scripts/check_lineage.py\` for CI
- **CI:** new \`Lineage Gate\` job in \`.github/workflows/ci.yml\` (no-op PASS until \`.sdd/lineage/log.jsonl\` appears)

## Test results

| Suite | Count | Status |
|---|---|---|
| Unit \`tests/unit/lineage/\` | 86 | PASS |
| Property \`tests/property/test_lineage_properties.py\` (500 examples each, also runs under \`deep\` profile = 1000) | 9 | PASS |
| Integration \`tests/integration/test_lineage_e2e.py\` (§12.4 scenarios) | 7 | PASS |
| Adversarial \`tests/security/test_lineage_adversarial.py\` (§12.6 attacks) | 7 | PASS |
| **Total** | **109** | **PASS** |

Mutation testing: **83.1 % kill rate** (49 / 59) on \`gate.py\` + \`tips.py\` + \`merge.py\` — target ≥ 75 %. Survivors are docstring-noise + truly equivalent mutations; full list in commit \`b1eb96e09\`.

## Naming deviation from spec (needs steward decision)

Spec asked for \`bernstein lineage verify <artefact_path>\` — but lineage v0 already owns \`verify <run_id>\` (back-compat). The new v1 single-artefact verifier is registered as **\`bernstein lineage chain <artefact_path>\`**. One-line rename if you want literal spec compliance.

## LineageStore coupling

None — gate reads \`log.jsonl\` from disk; CLI helpers do the same; steward's \`build_merge_entry\` returns \`(entry, jws)\` tuples for the caller to append. The parallel \`feat/lineage-v1-core\` branch's \`LineageStore\` drops in without changes here.

## Test plan

- [ ] CI \`Lineage Gate\` job goes green (no \`.sdd/lineage/log.jsonl\` yet → SKIP)
- [ ] Existing CI matrix passes (lint, typecheck, etc.)
- [ ] Rebase onto \`feat/lineage-v1-core\` once that branch lands; verify the integration test \`test_parallel_agent_fight_then_steward_merge_resolves\` still passes with the real \`LineageStore\`
- [ ] Decide on \`chain\` vs \`verify\` naming