### PR TITLE
chore: bump to 1.11.0 (lineage v1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "1.10.8"
+version = "1.11.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Triggers auto-release for the lineage v1 minor.

ADR-009: docs/decisions/009-lineage-v1.md
