### PR TITLE
docs(readme): refresh stale star/fork/adapter counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Bernstein is a deterministic Python scheduler that runs a crew of CLI coding age
 
 i wrote bernstein because i was paying $400/month in claude bills running three coding agents in parallel and getting nondeterministic merges.
 
-as of 2026-05-13: 338 stars, 37 forks, ~3,769 pypi downloads/day (mostly bots; ~54k/month), apache 2.0, solo maintained, no funding. numbers will drift; the line above is the source-of-truth date — re-run `pip stats` / GitHub API to refresh.
+as of 2026-05-15: 361 stars, 37 forks, ~3,769 pypi downloads/day (mostly bots; ~54k/month), apache 2.0, solo maintained, no funding. numbers will drift; the line above is the source-of-truth date — re-run `pip stats` / GitHub API to refresh.
 
 ### install in 30 seconds
 
@@ -416,7 +416,7 @@ The table above compares Bernstein against LLM-orchestration frameworks (they or
 
 | Feature | Bernstein | [claude-flow](https://github.com/ruvnet/claude-flow) | [Archon](https://github.com/coleam00/Archon) | [vibe-kanban](https://github.com/BloopAI/vibe-kanban) | [claude-squad](https://github.com/smtg-ai/claude-squad) | [Composio AO](https://github.com/ComposioHQ/agent-orchestrator) |
 |---------|-----------|-----------|-----------|-----------|-----------|-----------|
-| Stars (2026-05-13) | 338 | 49k | 21k | 26k | 7.4k | 7k |
+| Stars (2026-05-15) | 361 | 49k | 21k | 26k | 7.4k | 7k |
 | Their hook | regulated / on-prem / audit | swarm intelligence + 314 MCP tools | deterministic + repeatable, web UI | kanban board UI | polished Go TUI, tmux-native | TypeScript dashboard, CI fixer |
 | Shape | Python CLI + library + MCP server | CLI + web | CLI + web | desktop board | Go TUI | TypeScript CLI + dashboard |
 | Primary language | Python | TypeScript / Node | Python | TypeScript | Go | TypeScript |


### PR DESCRIPTION
## Summary

Doc-only refresh — reconcile two stale numbers/dates in `README.md` against the live GitHub repo and adapter registry as of 2026-05-15.

## Before / after

| Location           | Before                                | After                                 |
|--------------------|---------------------------------------|---------------------------------------|
| L53 (header stamp) | `as of 2026-05-13: 338 stars`         | `as of 2026-05-15: 361 stars`         |
| L419 (comparison)  | `Stars (2026-05-13) \| 338`           | `Stars (2026-05-15) \| 361`           |

Fork count stays at 37 (unchanged on live repo). Adapter count is consistent at 44 across all README mentions and matches `_ADAPTERS` in `src/bernstein/adapters/registry.py` — no edits needed there.

## Verification

- `gh repo view sipyourdrink-ltd/bernstein --json stargazerCount,forkCount` → `{"forkCount":37,"stargazerCount":361}`
- Adapter count from registry source: 44 entries in `_ADAPTERS` dict
- `uv run pytest tests/unit/test_readme_api_coverage.py tests/unit/test_readme_reminder.py -x -q` → 25 passed
- Diff is two lines in `README.md`, no code touched.

## Test plan

- [x] Live star/fork numbers fetched from GitHub API
- [x] Adapter registry count verified against source
- [x] README guard tests pass locally
- [x] Pre-push hooks (lint + import-linter) pass
