### PR TITLE
fix(doctor): airgap check works standalone

### DIFF
--- a/src/bernstein/cli/commands/doctor_airgap_cmd.py
+++ b/src/bernstein/cli/commands/doctor_airgap_cmd.py
@@ -5,11 +5,32 @@ Pure CLI layer; the checks themselves live in
 chooses between human-readable Rich output and JSON depending on
 the parent ``--json`` flag, and translates the aggregate report
 into a process exit code.
+
+Standalone semantics (bughunt 2026-05-13/2026-05-15)
+----------------------------------------------------
+``bernstein doctor airgap`` is documented as a pre-flight check the
+operator runs *before* invoking ``bernstein run --profile airgap``.
+In that pre-flight scenario the BERNSTEIN_PROFILE_MODE and
+BERNSTEIN_NETWORK_POLICY env vars are not yet set in the operator's
+shell — the run-bootstrap is what normally installs them. Without a
+fix, three of the pure-function checks (profile-active, deny-all,
+socket-guard) hard-FAIL even though nothing is actually wrong.
+
+We pick option (A) from the bughunt brief consistently across all
+three checks: the renderer simulates the airgap activation for the
+duration of the check battery (env vars + socket guard already
+self-installs once the profile env var is set), then restores the
+caller's environment exactly. This makes the standalone invocation
+report the four spec-mandated green rows when the host is clean,
+without forcing the operator to remember to ``export`` two env vars
+before each invocation.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 from dataclasses import asdict
 from typing import TYPE_CHECKING
 
@@ -22,8 +43,14 @@ from bernstein.core.distribution.doctor_airgap import (
     CheckStatus,
     run_airgap_checks,
 )
+from bernstein.core.security.network_policy import (
+    ENV_NETWORK_POLICY,
+    ENV_PROFILE_MODE,
+    PROFILE_AIRGAP,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 _STATUS_STYLE: dict[CheckStatus, str] = {
@@ -33,19 +60,76 @@ _STATUS_STYLE: dict[CheckStatus, str] = {
 }
 
 
+@contextlib.contextmanager
+def _simulated_airgap_env() -> Iterator[bool]:
+    """Activate airgap env vars for the duration of a standalone doctor run.
+
+    Mirrors the env-var slice of ``_install_network_policy`` /
+    ``install_policy`` (see ``cli/run_bootstrap.py``) but without
+    side-effects on the live socket guard — the existing per-check
+    option-(A) path in ``check_runtime_socket_guard_active`` handles
+    installing/uninstalling the guard, and that path triggers
+    automatically once ``BERNSTEIN_PROFILE_MODE`` is set.
+
+    Yields True when the doctor simulated the activation (i.e. the
+    operator was outside a live ``bernstein run`` and we provided
+    the airgap defaults). Yields False when the operator was already
+    inside a live profile — the doctor must not clobber that.
+
+    Both env vars are restored to their original state (including
+    absence) in the ``finally`` block. This is idempotent and has no
+    persistent operator-shell side effect: child processes spawned
+    by checks see the simulated values, the operator's parent shell
+    sees nothing.
+    """
+    prior_profile = os.environ.get(ENV_PROFILE_MODE)
+    prior_policy = os.environ.get(ENV_NETWORK_POLICY)
+    activated = False
+    # Only simulate when the operator has NOT already activated airgap.
+    # If they have, we leave their values intact — even if they chose
+    # a non-default allow-list — so the doctor reports what their
+    # actual run would see.
+    if (prior_profile or "").strip().lower() != PROFILE_AIRGAP:
+        os.environ[ENV_PROFILE_MODE] = PROFILE_AIRGAP
+        if prior_policy is None:
+            os.environ[ENV_NETWORK_POLICY] = "none"
+        activated = True
+    try:
+        yield activated
+    finally:
+        if activated:
+            if prior_profile is None:
+                os.environ.pop(ENV_PROFILE_MODE, None)
+            else:
+                os.environ[ENV_PROFILE_MODE] = prior_profile
+            if prior_policy is None:
+                os.environ.pop(ENV_NETWORK_POLICY, None)
+            else:
+                os.environ[ENV_NETWORK_POLICY] = prior_policy
+
+
 def run_doctor_airgap(*, workdir: Path | None = None, as_json: bool = False) -> int:
-    """Run the air-gap battery and render the report. Returns the exit code."""
-    report = run_airgap_checks(workdir=workdir)
+    """Run the air-gap battery and render the report. Returns the exit code.
+
+    Standalone invocation (no live ``bernstein run`` parent) is the
+    documented pre-flight workflow. When the airgap env vars are
+    absent we activate them for the duration of the checks so the
+    pure-function checks see the same environment a real airgap run
+    would expose, then restore the caller's environment.
+    """
+    with _simulated_airgap_env() as simulated:
+        report = run_airgap_checks(workdir=workdir)
     if as_json:
-        _render_json(report)
+        _render_json(report, simulated=simulated)
     else:
-        _render_human(report)
+        _render_human(report, simulated=simulated)
     return 0 if report.ok else 1
 
 
-def _render_json(report: AirgapReport) -> None:
+def _render_json(report: AirgapReport, *, simulated: bool = False) -> None:
     payload = {
         "ok": report.ok,
+        "simulated_airgap_env": simulated,
         "checks": [
             {
                 **asdict(check),
@@ -57,7 +141,7 @@ def _render_json(report: AirgapReport) -> None:
     console.print_json(json.dumps(payload))
 
 
-def _render_human(report: AirgapReport) -> None:
+def _render_human(report: AirgapReport, *, simulated: bool = False) -> None:
     console.print()
     if report.ok:
         console.print(
@@ -74,6 +158,14 @@ def _render_human(report: AirgapReport) -> None:
                 border_style="red",
                 expand=False,
             )
+        )
+
+    if simulated:
+        console.print(
+            "[dim]Note: airgap profile env vars were not set in this shell; the "
+            "doctor simulated --profile airgap + --allow-network none for the "
+            "duration of the checks. Set BERNSTEIN_PROFILE_MODE=airgap (or invoke "
+            "via 'bernstein run --profile airgap') to suppress this notice.[/dim]"
         )
 
     table = Table(show_header=True, header_style="bold", padding=(0, 2))

--- a/tests/unit/cli/test_doctor_airgap.py
+++ b/tests/unit/cli/test_doctor_airgap.py
@@ -16,6 +16,7 @@ socket-guard row.
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -130,3 +131,92 @@ def test_run_doctor_airgap_function_returns_zero_standalone(standalone_airgap_en
     """Direct call into the renderer -- belt and braces for the CLI test above."""
     rc = run_doctor_airgap(workdir=standalone_airgap_env, as_json=True)
     assert rc == 0
+
+
+def test_doctor_airgap_cli_simulates_airgap_when_env_unset(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Bughunt 2026-05-15: the doctor command must self-activate airgap env vars when absent.
+
+    This is the headline live-symptom regression: an operator who runs
+    ``bernstein doctor airgap`` without first ``export``-ing
+    ``BERNSTEIN_PROFILE_MODE=airgap`` and ``BERNSTEIN_NETWORK_POLICY=none``
+    used to see FAIL on profile-active + deny-all and WARN on the
+    socket-guard row. The doctor now simulates the activation for the
+    duration of the battery (option A extended consistently across the
+    three checks the bughunt brief scopes), restores the operator's
+    env exactly afterwards, and surfaces a "simulated" notice so the
+    operator knows nothing got persisted in their shell.
+    """
+    # Truly lax env: no profile, no policy, no pre-installed guard.
+    monkeypatch.delenv(ENV_PROFILE_MODE, raising=False)
+    monkeypatch.delenv(ENV_NETWORK_POLICY, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    uninstall_runtime_socket_guard()
+    assert not is_runtime_socket_guard_installed()
+
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["airgap"])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+    assert "FAILED" not in result.output
+    # Notice must be present so the operator is told the activation
+    # was a temporary simulation, not a persistent state change.
+    assert "simulated" in result.output.lower()
+
+    # And the env vars / socket guard must be exactly as they were
+    # before the doctor ran — no leakage into the operator's process.
+    assert ENV_PROFILE_MODE not in os.environ or os.environ.get(ENV_PROFILE_MODE, "") == ""
+    assert ENV_NETWORK_POLICY not in os.environ or os.environ.get(ENV_NETWORK_POLICY, "") == ""
+    assert not is_runtime_socket_guard_installed(), (
+        "doctor must restore socket.socket.connect even after a simulated airgap activation"
+    )
+
+
+def test_doctor_airgap_json_reports_simulated_flag_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """JSON payload must surface ``simulated_airgap_env`` so wrappers can detect the path."""
+    import json as _json
+
+    monkeypatch.delenv(ENV_PROFILE_MODE, raising=False)
+    monkeypatch.delenv(ENV_NETWORK_POLICY, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    uninstall_runtime_socket_guard()
+
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["--json", "airgap"])
+    assert result.exit_code == 0, result.output
+    payload = _json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["simulated_airgap_env"] is True
+
+
+def test_doctor_airgap_does_not_simulate_when_operator_already_in_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the operator already has airgap on, the doctor must respect their env, not overwrite it."""
+    import json as _json
+
+    monkeypatch.setenv(ENV_PROFILE_MODE, PROFILE_AIRGAP)
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "127.0.0.1")  # operator-chosen allow-list
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    uninstall_runtime_socket_guard()
+
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["--json", "airgap"])
+    payload = _json.loads(result.output)
+    # Operator's policy must NOT be mutated to "none"; the doctor
+    # reports their real allow-list as a WARN row.
+    assert payload["simulated_airgap_env"] is False
+    by_name = {row["name"]: row for row in payload["checks"]}
+    deny = by_name["network policy deny-all"]
+    assert deny["status"] in ("WARN", "PASS"), deny["detail"]
+    # The operator's chosen allow-list must round-trip into the policy
+    # row's detail when WARN is produced.
+    if deny["status"] == "WARN":
+        assert "127.0.0.1" in deny["detail"]

--- a/tests/unit/test_doctor_airgap.py
+++ b/tests/unit/test_doctor_airgap.py
@@ -224,9 +224,18 @@ def test_run_doctor_airgap_returns_zero_on_pass(
     assert rc == 0
 
 
-def test_run_doctor_airgap_returns_one_on_fail(lax_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_run_doctor_airgap_returns_one_on_fail(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The renderer returns non-zero when a FAIL is present.
+
+    The bughunt 2026-05-15 standalone fix makes the doctor self-activate
+    airgap defaults when env vars are absent, so to trigger a FAIL we
+    set ``BERNSTEIN_NETWORK_POLICY=any`` explicitly — that is a real
+    "the operator overrode the airgap default with allow-all" condition
+    the doctor must surface.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "any")
     rc = run_doctor_airgap(workdir=tmp_path, as_json=False)
     assert rc == 1
 
@@ -243,12 +252,47 @@ def test_doctor_airgap_cli_invokes_subcommand(
     assert "PASSED" in result.output
 
 
-def test_doctor_airgap_cli_fails_outside_profile(
+def test_doctor_airgap_cli_passes_standalone_without_env(
     lax_env: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Bughunt 2026-05-15: standalone pre-flight must succeed without pre-set env vars.
+
+    Before the fix, invoking ``bernstein doctor airgap`` outside a live
+    ``bernstein run --profile airgap`` reported FAIL on profile-active,
+    deny-all and (originally) socket-guard rows even when the host was
+    clean — the four spec-mandated green checks could not be produced.
+
+    Post-fix, the renderer activates the airgap env vars for the
+    duration of the battery (option A extended to all three checks),
+    so a clean host reports PASSED and exits 0. The user-facing notice
+    in the output tells the operator the activation was simulated.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(doctor_group, ["airgap"])
+    assert result.exit_code == 0, result.output
+    assert "PASSED" in result.output
+    assert "simulated" in result.output.lower()
+
+
+def test_doctor_airgap_cli_fails_when_operator_opts_into_allow_all(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the operator has already chosen ``--allow-network any`` we must NOT silently fix it.
+
+    The doctor's simulated-airgap context manager only fills in env
+    vars when they are absent. When the operator has explicitly opted
+    out of airgap (``BERNSTEIN_NETWORK_POLICY=any``) the doctor must
+    keep their choice and report the real FAIL state.
+    """
+    monkeypatch.delenv(ENV_PROFILE_MODE, raising=False)
+    monkeypatch.setenv(ENV_NETWORK_POLICY, "any")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.chdir(tmp_path)
+    uninstall_runtime_socket_guard()
     runner = CliRunner()
     result = runner.invoke(doctor_group, ["airgap"])
     assert result.exit_code == 1


### PR DESCRIPTION
## Summary

`bernstein doctor airgap` is documented as a pre-flight check the operator runs *before* invoking `bernstein run --profile airgap`. In that standalone scenario the `BERNSTEIN_PROFILE_MODE` and `BERNSTEIN_NETWORK_POLICY` env vars are not yet set — only the run-bootstrap installs them — so the pure-function checks reported FAIL on `airgap profile active` + `network policy deny-all` and WARN on `runtime socket guard active` even when the host was perfectly clean.

Live symptoms reproduced 2026-05-15:

```
$ bernstein doctor airgap
Air-gap doctor: FAILED
  FAIL  airgap profile active        BERNSTEIN_PROFILE_MODE unset
  FAIL  network policy deny-all      policy is allow-any (back-compat default)
  WARN  runtime socket guard active  airgap profile not active
```

## Fix

Extend **option (A)** from the bughunt brief consistently across the three checks the ticket scopes — not just the socket-guard row already covered by #1239. The CLI renderer (`run_doctor_airgap`) wraps the check battery in a `_simulated_airgap_env` context manager that:

- if the operator has NOT already activated airgap, sets `BERNSTEIN_PROFILE_MODE=airgap` + `BERNSTEIN_NETWORK_POLICY=none` for the duration of the checks
- restores the original env (including absence) in `finally`
- signals `simulated=True` so the human renderer surfaces an explanatory notice and the JSON renderer surfaces `simulated_airgap_env`
- leaves the operator's choice intact when airgap is already active (an operator-chosen allow-list still WARNs, never silently overwritten with deny-all; `BERNSTEIN_NETWORK_POLICY=any` still FAILS loudly)

The existing per-check option-(A) path in `check_runtime_socket_guard_active` already installs + restores `socket.socket.connect`, and it triggers automatically once `BERNSTEIN_PROFILE_MODE` is set — so the simulated env var is enough to make that row PASS as well, with no leaked guard in the operator's process.

### Why option (A) over (B)

- Install/restore of env vars is fully idempotent and reversible — finally restores exact prior state, including absence.
- Matches the socket-guard fix already on main (#1239); applying the same pattern across all three checks gives one consistent semantics instead of two different policies in adjacent rows.
- Produces the four spec-mandated green checks (zero egress / MCP catalog all-off / memo store local-only / audit chain valid) without forcing the operator to remember to `export` two env vars before each invocation.

### Live verification

```
$ env -u BERNSTEIN_PROFILE_MODE -u BERNSTEIN_NETWORK_POLICY bernstein doctor airgap
Air-gap doctor: PASSED
Note: airgap profile env vars were not set in this shell; the doctor simulated
--profile airgap + --allow-network none for the duration of the checks. ...
  PASS  airgap profile active             BERNSTEIN_PROFILE_MODE=airgap
  PASS  network policy deny-all           explicit deny-all (none)
  PASS  runtime socket guard active       socket.socket.connect patch verified
  PASS  policy blocks declared endpoints  3 declared endpoint(s) all blocked
  PASS  MCP catalog all-off               no user MCP config
  PASS  memo store on local disk          airgap pins memo to .sdd/runtime/memo
  WARN  audit chain HMAC valid            no audit dir — nothing to verify yet
  PASS  no external hostnames in runtime  no public endpoint references found
```

### Out of scope

The audit-chain HMAC FAIL visible in the original symptom output is a separate pre-existing operator-side concern (`2026-05-13-bughunt-audit-chain-pre-existing-drift`). It is untouched by this PR; the audit row will keep its independent status.

## Test plan

- [x] `uv run pytest tests/unit/ -k "doctor or airgap or socket_guard or network_policy"` -> 122 passed
- [x] `uv run ruff check src tests` -> clean
- [x] `uv run ruff format --check src tests` -> clean (one pre-existing unrelated file on main excluded)
- [x] Live `env -u BERNSTEIN_PROFILE_MODE -u BERNSTEIN_NETWORK_POLICY bernstein doctor airgap` -> PASSED
- [x] New regression test `test_doctor_airgap_cli_simulates_airgap_when_env_unset` pins env + guard non-leakage
- [x] New regression test `test_doctor_airgap_does_not_simulate_when_operator_already_in_profile` pins respect-the-operator-choice
- [x] New regression test `test_doctor_airgap_json_reports_simulated_flag_when_env_unset` pins the JSON contract