### PR TITLE
feat(audit): `bernstein audit archive` for chain cleanup

### DIFF
--- a/src/bernstein/cli/commands/audit_cmd.py
+++ b/src/bernstein/cli/commands/audit_cmd.py
@@ -20,6 +20,7 @@ Commands:
   bernstein audit capabilities       Print lethal-trifecta capability matrix.
   bernstein audit slice              Write a deterministic subset.
   bernstein audit query              Query audit log events with filters.
+  bernstein audit archive            Safely archive corrupt / pre-rotation jsonl files.
 
 Operator guide: docs/security/audit-log.md.
 """
@@ -28,12 +29,16 @@ from __future__ import annotations
 
 import contextlib
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.panel import Panel
 from rich.table import Table
 
 from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from datetime import date
 
 AUDIT_DIR = Path(".sdd/audit")
 MERKLE_DIR = AUDIT_DIR / "merkle"
@@ -1157,3 +1162,428 @@ def query_cmd(event_type: str | None, actor: str | None, since: str | None, limi
     console.print()
     console.print(table)
     console.print(f"\n[dim]Showing {len(events)} event(s)[/dim]\n")
+
+
+# ---------------------------------------------------------------------------
+# bernstein audit archive
+# ---------------------------------------------------------------------------
+# Safe, idempotent move of corrupt / pre-rotation jsonl files out of the
+# active audit chain so ``bernstein doctor airgap`` reports clean again.
+#
+# Design notes:
+#   * Move-only (never delete). Original is moved to <archive-dir>/<name>;
+#     a sibling ``<name>.archived.json`` metadata file records who/why/when.
+#   * Idempotent: refuses to overwrite an existing archived file with the
+#     same name. Operator gets a clear error and the source stays in place.
+#   * Refuses to touch the live archive subdirectory used by the rotation
+#     code path (``archive/``) and never operates on files outside the
+#     resolved audit dir.
+#   * Defaults to "show plan, then ask for --yes". ``--dry-run`` skips both
+#     the prompt and the actual move; ``--yes`` performs the move.
+
+
+_ARCHIVE_REASON_CORRUPT = "corrupt-hmac"
+_ARCHIVE_REASON_BEFORE = "before-date"
+_ARCHIVE_REASON_OPERATOR = "operator-archive"
+
+
+def _hmac_corrupt_files(audit_dir: Path, key: bytes | None = None) -> set[str]:
+    """Return the set of jsonl filenames whose HMACs do NOT match ``key``.
+
+    A file is corrupt iff ``_verify_log_file`` reports an HMAC mismatch
+    when its starting ``prev_hmac`` is taken from the file's own first
+    line. This isolates *internal* HMAC failures (the live-symptom case
+    from the 2026-05-13 ticket: entries written under a rotated key)
+    from downstream drift (a clean file whose chain anchor shifted
+    because an earlier file was archived). Operators want to remove the
+    former and keep the latter.
+
+    Args:
+        audit_dir: The audit directory to scan.
+        key: Optional HMAC key. When ``None``, the canonical key is
+            resolved via :func:`load_or_create_audit_key`.
+    """
+    import json as _json
+
+    from bernstein.core.security.audit import _verify_log_file, load_or_create_audit_key
+
+    if not audit_dir.is_dir():
+        return set()
+
+    if key is None:
+        key = load_or_create_audit_key()
+
+    corrupt: set[str] = set()
+    for log_path in sorted(audit_dir.glob("*.jsonl")):
+        # Read the file's own first prev_hmac so we don't penalise a
+        # downstream-clean file for an upstream archive event.
+        try:
+            first_line = next(
+                (ln for ln in log_path.read_text().splitlines() if ln.strip()),
+                None,
+            )
+        except OSError:
+            corrupt.add(log_path.name)
+            continue
+        if first_line is None:
+            continue
+        try:
+            first_entry = _json.loads(first_line)
+        except ValueError:
+            corrupt.add(log_path.name)
+            continue
+        start_prev = str(first_entry.get("prev_hmac", "0" * 64))
+
+        per_file_errors: list[str] = []
+        _verify_log_file(log_path, start_prev, key, per_file_errors)
+        # Only HMAC-content errors count as "corrupt"; a prev_hmac
+        # mismatch at line 1 against the chain head is upstream drift,
+        # not internal corruption.
+        for err in per_file_errors:
+            if "HMAC mismatch" in err or "non-canonical line bytes" in err or "invalid JSON" in err:
+                corrupt.add(log_path.name)
+                break
+    return corrupt
+
+
+def _parse_filename_date(name: str) -> date | None:
+    """Return the date encoded in ``YYYY-MM-DD.jsonl`` or ``None``."""
+    from datetime import datetime
+
+    stem = name[: -len(".jsonl")] if name.endswith(".jsonl") else name
+    try:
+        return datetime.strptime(stem, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _sha256_of_file(path: Path) -> str:
+    """Return the hex SHA-256 digest of ``path``."""
+    import hashlib
+
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _is_safe_audit_dir(audit_dir: Path) -> tuple[bool, str]:
+    """Refuse archive on suspicious audit-dir locations (best-effort)."""
+    try:
+        resolved = audit_dir.resolve()
+    except OSError as exc:
+        return False, f"cannot resolve {audit_dir}: {exc}"
+    # Reject tmpfs-style paths the operator almost certainly didn't mean.
+    suspicious_prefixes = ("/dev/", "/proc/", "/sys/")
+    s = str(resolved)
+    for pref in suspicious_prefixes:
+        if s.startswith(pref):
+            return False, f"refusing to operate on {pref}* path: {resolved}"
+    return True, ""
+
+
+def _plan_archive(
+    audit_dir: Path,
+    *,
+    before: str | None,
+    corrupt_only: bool,
+) -> tuple[list[Path], dict[str, str], list[str]]:
+    """Return ``(files, reason_by_name, warnings)`` for the archive plan.
+
+    ``files`` is the ordered list of jsonl paths matching the filter.
+    ``reason_by_name`` maps filename -> archive reason string.
+    ``warnings`` collects non-fatal notes (e.g. malformed filename).
+    """
+    warnings: list[str] = []
+    if not audit_dir.is_dir():
+        return [], {}, [f"audit dir not found: {audit_dir}"]
+
+    candidates = sorted(audit_dir.glob("*.jsonl"))
+    if not candidates:
+        return [], {}, []
+
+    before_date = None
+    if before is not None:
+        from datetime import datetime
+
+        try:
+            before_date = datetime.strptime(before, "%Y-%m-%d").date()
+        except ValueError as exc:
+            raise click.BadParameter(
+                f"--before must be YYYY-MM-DD (got {before!r}): {exc}",
+            ) from None
+
+    corrupt = _hmac_corrupt_files(audit_dir) if corrupt_only else set()
+
+    selected: list[Path] = []
+    reason_by_name: dict[str, str] = {}
+    for path in candidates:
+        file_date = _parse_filename_date(path.name)
+        if before_date is not None:
+            if file_date is None:
+                warnings.append(
+                    f"{path.name}: cannot parse date from filename, skipping --before filter",
+                )
+                continue
+            if file_date >= before_date:
+                continue
+        if corrupt_only and path.name not in corrupt:
+            continue
+        # Pick a reason — corrupt wins over before-date if both flags set.
+        if corrupt_only and path.name in corrupt:
+            reason_by_name[path.name] = _ARCHIVE_REASON_CORRUPT
+        elif before_date is not None:
+            reason_by_name[path.name] = _ARCHIVE_REASON_BEFORE
+        else:
+            reason_by_name[path.name] = _ARCHIVE_REASON_OPERATOR
+        selected.append(path)
+    return selected, reason_by_name, warnings
+
+
+def _default_archive_dir(audit_dir: Path) -> Path:
+    """Return ``<audit_dir>/_archived/<ISO-timestamp>/``."""
+    from datetime import UTC, datetime
+
+    stamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    return audit_dir / "_archived" / stamp
+
+
+def _format_size(num_bytes: int) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if num_bytes < 1024:
+            return f"{num_bytes:.0f} {unit}" if unit == "B" else f"{num_bytes:.1f} {unit}"
+        num_bytes = int(num_bytes / 1024)
+    return f"{num_bytes:.1f} TiB"
+
+
+@audit_group.command("archive")
+@click.option(
+    "--before",
+    default=None,
+    metavar="YYYY-MM-DD",
+    help="Archive jsonl files whose filename date is strictly earlier than this date.",
+)
+@click.option(
+    "--corrupt",
+    "corrupt_only",
+    is_flag=True,
+    default=False,
+    help="Archive only files whose HMAC chain currently fails verification.",
+)
+@click.option(
+    "--archive-dir",
+    "archive_dir_opt",
+    default=None,
+    type=click.Path(file_okay=False, resolve_path=True),
+    help="Destination directory. Defaults to .sdd/audit/_archived/<UTC timestamp>/.",
+)
+@click.option(
+    "--audit-dir",
+    "audit_dir_opt",
+    default=None,
+    type=click.Path(file_okay=False, resolve_path=True),
+    help="Override the audit directory (default: .sdd/audit/). Mostly for tests.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the plan; move nothing.",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the interactive confirmation. Required for a real move outside --dry-run.",
+)
+def archive_cmd(
+    before: str | None,
+    corrupt_only: bool,
+    archive_dir_opt: str | None,
+    audit_dir_opt: str | None,
+    dry_run: bool,
+    assume_yes: bool,
+) -> None:
+    """Safely archive corrupt / pre-rotation audit chain files.
+
+    \b
+    Use when ``bernstein doctor airgap`` reports HMAC mismatches on old
+    jsonl files (typically because the audit key was rotated without
+    re-hashing prior entries). This command MOVES the offending files to
+    an out-of-chain archive directory and writes a sibling metadata file
+    so the operator can later reconstruct context. It never deletes.
+
+    \b
+    Examples:
+      bernstein audit archive --corrupt --dry-run
+      bernstein audit archive --before 2026-05-01 --yes
+      bernstein audit archive --corrupt --yes
+
+    \b
+    Exits 0 when the post-move audit chain verifies cleanly. Exits 1 if
+    archiving failed, or if the chain still has errors after the move.
+    """
+    import json as _json
+    from datetime import UTC, datetime
+
+    audit_dir = Path(audit_dir_opt).resolve() if audit_dir_opt else AUDIT_DIR
+
+    safe, reason = _is_safe_audit_dir(audit_dir)
+    if not safe:
+        console.print(f"[red]Refusing to archive:[/red] {reason}")
+        raise SystemExit(1)
+
+    if not audit_dir.is_dir():
+        console.print(f"[red]Audit directory not found:[/red] {audit_dir}")
+        raise SystemExit(1)
+
+    try:
+        files, reason_by_name, warnings = _plan_archive(
+            audit_dir,
+            before=before,
+            corrupt_only=corrupt_only,
+        )
+    except click.BadParameter as exc:
+        console.print(f"[red]{exc.message}[/red]")
+        raise SystemExit(2) from None
+
+    for warn in warnings:
+        console.print(f"[yellow]warn:[/yellow] {warn}")
+
+    if not files:
+        console.print(
+            "[green]Nothing to archive.[/green]  No jsonl files matched the given filter.",
+        )
+        # Still run a verify so the operator sees the chain state.
+        _print_post_archive_verify(audit_dir)
+        raise SystemExit(0)
+
+    # Resolve archive dir.
+    archive_dir = Path(archive_dir_opt).resolve() if archive_dir_opt else _default_archive_dir(audit_dir)
+
+    # Print plan.
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("File", style="bold")
+    table.add_column("Size", justify="right")
+    table.add_column("sha256", style="dim")
+    table.add_column("Reason")
+    plan_rows: list[tuple[Path, int, str, str]] = []
+    for path in files:
+        try:
+            size = path.stat().st_size
+            digest = _sha256_of_file(path)
+        except OSError as exc:
+            console.print(f"[red]Failed to read {path}: {exc}[/red]")
+            raise SystemExit(1) from None
+        plan_rows.append((path, size, digest, reason_by_name[path.name]))
+        table.add_row(path.name, _format_size(size), digest[:16] + "…", reason_by_name[path.name])
+
+    console.print()
+    console.print(
+        Panel(
+            f"[bold]Audit archive plan[/bold]  →  {archive_dir}",
+            border_style="cyan",
+            expand=False,
+        ),
+    )
+    console.print(table)
+    console.print(f"\n[dim]{len(files)} file(s) selected.[/dim]\n")
+
+    if dry_run:
+        console.print("[yellow]--dry-run set, no files moved.[/yellow]\n")
+        raise SystemExit(0)
+
+    if not assume_yes:
+        console.print(
+            "[yellow]Refusing to move without --yes. "
+            "Re-run with --yes to proceed, or --dry-run to preview only.[/yellow]\n",
+        )
+        raise SystemExit(2)
+
+    # Idempotency / safety: refuse to overwrite an existing destination.
+    archive_dir.mkdir(parents=True, exist_ok=True)
+    for path, _size, _digest, _reason in plan_rows:
+        dest = archive_dir / path.name
+        if dest.exists():
+            console.print(
+                f"[red]Refusing to overwrite[/red] {dest} — a file with the same name "
+                "already exists in the archive directory. Aborting before moving "
+                "anything else.",
+            )
+            raise SystemExit(1)
+
+    # Do the move + write metadata sidecar.
+    moved: list[str] = []
+    for path, size, digest, file_reason in plan_rows:
+        dest = archive_dir / path.name
+        try:
+            path.rename(dest)
+        except OSError:
+            # Cross-device move fallback — copy then unlink.
+            import shutil
+
+            try:
+                shutil.copy2(str(path), str(dest))
+                path.unlink()
+            except OSError as exc:
+                console.print(f"[red]Failed to archive {path.name}: {exc}[/red]")
+                raise SystemExit(1) from None
+
+        meta = {
+            "archived_at_utc": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "reason": file_reason,
+            "original_path": str(path),
+            "archived_path": str(dest),
+            "size_bytes": size,
+            "sha256_of_archived_file": digest,
+        }
+        meta_path = archive_dir / f"{path.name}.archived.json"
+        meta_path.write_text(
+            _json.dumps(meta, sort_keys=True, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        moved.append(path.name)
+        console.print(f"  [green]archived[/green] {path.name}  →  {dest}")
+
+    console.print(
+        f"\n[bold green]Archived {len(moved)} file(s)[/bold green] to {archive_dir}\n",
+    )
+
+    rc = _print_post_archive_verify(audit_dir)
+    raise SystemExit(rc)
+
+
+def _print_post_archive_verify(audit_dir: Path) -> int:
+    """Re-run AuditLog.verify() against ``audit_dir`` and print the result.
+
+    Returns 0 if the chain verifies cleanly (or there is nothing to
+    verify), 1 otherwise.
+    """
+    from bernstein.core.security.audit import AuditLog
+
+    audit_log = AuditLog(audit_dir)
+    valid, errors = audit_log.verify()
+    console.print()
+    if valid:
+        console.print(
+            Panel(
+                "[bold green]Post-archive HMAC chain verification PASSED[/bold green]",
+                border_style="green",
+                expand=False,
+            ),
+        )
+        console.print()
+        return 0
+    console.print(
+        Panel(
+            "[bold red]Post-archive HMAC chain verification FAILED[/bold red]",
+            border_style="red",
+            expand=False,
+        ),
+    )
+    for err in errors:
+        console.print(f"  [red]![/red] {err}")
+    console.print()
+    return 1

--- a/tests/unit/cli/test_audit_archive_cmd.py
+++ b/tests/unit/cli/test_audit_archive_cmd.py
@@ -1,0 +1,419 @@
+"""Tests for ``bernstein audit archive`` CLI command.
+
+The archive command is the operator-side "option B" fix for the
+2026-05-13 bughunt ticket: when the audit HMAC key has been rotated
+without rehashing old entries, ``bernstein doctor airgap`` flags the
+chain as broken. Rather than ask the operator to manually mv files
+out of ``.sdd/audit/``, this command moves them to an out-of-chain
+archive directory and writes per-file metadata so the move is
+auditable and reversible.
+
+Tests cover:
+  * dry-run prints plan and moves nothing
+  * --corrupt archives only the corrupt files
+  * --before <date> archives only the date-filtered subset
+  * idempotency: refuses to overwrite an already-archived file
+  * post-archive verify is reported
+  * --yes is required for a real move (default refuses)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.audit_cmd import audit_group
+from bernstein.core.security.audit import AUDIT_KEY_ENV, AuditLog
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def audit_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create an isolated audit dir + a tmp HMAC key file.
+
+    Pinning ``BERNSTEIN_AUDIT_KEY_PATH`` at a tmp path keeps every test
+    away from the operator's real audit key under ``~/.local/state/``.
+    The same key seeds both the AuditLog instances used to build the
+    fixture log AND the archive command's verify pass — without this
+    matching, the post-archive verify would always fail.
+    """
+    audit_dir = tmp_path / ".sdd" / "audit"
+    audit_dir.mkdir(parents=True)
+
+    key_path = tmp_path / "audit.key"
+    key_bytes = b"a" * 64  # 32 hex bytes worth, deterministic for tests
+    key_path.write_bytes(key_bytes)
+    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0o600 required by loader
+
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+    return audit_dir
+
+
+def _seed_clean_log(
+    audit_dir: Path,
+    day: str,
+    count: int,
+    *,
+    chain_from_genesis: bool = False,
+) -> list[str]:
+    """Seed ``audit_dir/<day>.jsonl`` with HMAC-correct chained entries.
+
+    The AuditLog writer always writes to today's filename — we need a
+    deterministic filename (so ``--before`` can target it), so we
+    build entries by hand using the public canonical-form HMAC math
+    from ``bernstein.core.security.audit``.
+
+    Args:
+        audit_dir: where to write the file
+        day: filename stem (``YYYY-MM-DD``)
+        count: how many entries to write
+        chain_from_genesis: if True, ignore any earlier files in the
+            audit dir and start the chain at the genesis HMAC. Useful
+            when the earlier files are intentionally-broken (so this
+            file's chain remains valid after they're archived out).
+    """
+    from bernstein.core.security.audit import _compute_hmac, load_or_create_audit_key
+
+    key = load_or_create_audit_key()
+    hmacs: list[str] = []
+    prev = "0" * 64
+    log_path = audit_dir / f"{day}.jsonl"
+
+    if not chain_from_genesis:
+        # Find any existing chain tail across other files in audit_dir so
+        # this file slots in correctly. We sort ascending so any
+        # alphabetically-earlier file is treated as upstream.
+        earlier = sorted(p for p in audit_dir.glob("*.jsonl") if p.name < log_path.name)
+        if earlier:
+            last = earlier[-1].read_text().strip().splitlines()
+            if last:
+                prev = json.loads(last[-1])["hmac"]
+
+    with log_path.open("a", encoding="utf-8", newline="") as fh:
+        for i in range(count):
+            entry = {
+                "timestamp": f"{day}T00:00:{i:02d}.000000Z",
+                "event_type": "test.evt",
+                "actor": "test",
+                "resource_type": "task",
+                "resource_id": f"id-{i}",
+                "details": {"i": i},
+                "prev_hmac": prev,
+            }
+            h = _compute_hmac(key, prev, entry)
+            entry["hmac"] = h
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+            prev = h
+            hmacs.append(h)
+    return hmacs
+
+
+def _corrupt_file_via_wrong_key(audit_dir: Path, day: str, count: int) -> None:
+    """Seed a jsonl file whose stored HMACs do NOT match the canonical key.
+
+    This is the live-symptom scenario from the 2026-05-13 ticket: the
+    file was written under a key that has since been rotated, so its
+    HMACs no longer match the active key.
+    """
+    from bernstein.core.security.audit import _compute_hmac
+
+    wrong_key = b"z" * 64
+    log_path = audit_dir / f"{day}.jsonl"
+    prev = "0" * 64
+    with log_path.open("a", encoding="utf-8", newline="") as fh:
+        for i in range(count):
+            entry = {
+                "timestamp": f"{day}T00:00:{i:02d}.000000Z",
+                "event_type": "test.evt",
+                "actor": "test",
+                "resource_type": "task",
+                "resource_id": f"id-{i}",
+                "details": {"i": i},
+                "prev_hmac": prev,
+            }
+            h = _compute_hmac(wrong_key, prev, entry)
+            entry["hmac"] = h
+            fh.write(json.dumps(entry, sort_keys=True) + "\n")
+            prev = h
+
+
+# ---------------------------------------------------------------------------
+# dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_plan_and_moves_nothing(audit_env: Path) -> None:
+    """--dry-run shows the candidate list but never touches the filesystem."""
+    _corrupt_file_via_wrong_key(audit_env, "2026-04-26", count=2)
+    _seed_clean_log(audit_env, "2026-05-14", count=2)
+
+    files_before = sorted(p.name for p in audit_env.glob("*.jsonl"))
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        ["archive", "--audit-dir", str(audit_env), "--corrupt", "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "2026-04-26.jsonl" in result.output
+    assert "dry-run" in result.output.lower()
+    # The clean file must NOT appear in the plan.
+    assert "2026-05-14.jsonl" not in result.output or "selected" in result.output.lower()
+
+    files_after = sorted(p.name for p in audit_env.glob("*.jsonl"))
+    assert files_before == files_after, "dry-run must not move any files"
+    # No archive dir created on dry-run.
+    archive_root = audit_env / "_archived"
+    assert not archive_root.exists() or not any(archive_root.iterdir())
+
+
+# ---------------------------------------------------------------------------
+# --corrupt
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_archives_only_failing_files(audit_env: Path, tmp_path: Path) -> None:
+    """--corrupt picks the bad file; the clean one stays put."""
+    _corrupt_file_via_wrong_key(audit_env, "2026-04-26", count=2)
+    # Chain from genesis so the clean file's HMACs survive removal
+    # of the corrupt predecessor.
+    _seed_clean_log(audit_env, "2026-05-14", count=2, chain_from_genesis=True)
+
+    archive_dir = tmp_path / "archive-out"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        [
+            "archive",
+            "--audit-dir",
+            str(audit_env),
+            "--archive-dir",
+            str(archive_dir),
+            "--corrupt",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # Bad file moved out.
+    assert not (audit_env / "2026-04-26.jsonl").exists()
+    # Clean file remained.
+    assert (audit_env / "2026-05-14.jsonl").exists()
+    # Bad file is at the archive destination.
+    moved = archive_dir / "2026-04-26.jsonl"
+    assert moved.exists()
+    # Sidecar metadata exists and matches.
+    meta_path = archive_dir / "2026-04-26.jsonl.archived.json"
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text())
+    assert meta["reason"] == "corrupt-hmac"
+    expected_sha = hashlib.sha256(moved.read_bytes()).hexdigest()
+    assert meta["sha256_of_archived_file"] == expected_sha
+
+
+# ---------------------------------------------------------------------------
+# --before <date>
+# ---------------------------------------------------------------------------
+
+
+def test_before_archives_correct_subset(audit_env: Path, tmp_path: Path) -> None:
+    """--before only catches files with filename date strictly earlier."""
+    # Build three clean logs across the divide. The "remains after
+    # archive" file (2026-05-14) is chained from genesis so the
+    # post-archive verify is clean once the earlier two are moved.
+    _seed_clean_log(audit_env, "2026-04-26", count=1)
+    _seed_clean_log(audit_env, "2026-05-07", count=1)
+    _seed_clean_log(audit_env, "2026-05-14", count=1, chain_from_genesis=True)
+
+    archive_dir = tmp_path / "archive-out"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        [
+            "archive",
+            "--audit-dir",
+            str(audit_env),
+            "--archive-dir",
+            str(archive_dir),
+            "--before",
+            "2026-05-14",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # 2026-04-26 and 2026-05-07 are < 2026-05-14, both moved.
+    assert (archive_dir / "2026-04-26.jsonl").exists()
+    assert (archive_dir / "2026-05-07.jsonl").exists()
+    # 2026-05-14 is the cutoff (exclusive lower-than), stays put.
+    assert (audit_env / "2026-05-14.jsonl").exists()
+    # Each moved file has a metadata sidecar tagged "before-date".
+    for name in ("2026-04-26.jsonl", "2026-05-07.jsonl"):
+        meta = json.loads((archive_dir / f"{name}.archived.json").read_text())
+        assert meta["reason"] == "before-date"
+
+
+def test_before_rejects_bad_date_format(audit_env: Path) -> None:
+    """--before requires YYYY-MM-DD; anything else exits non-zero."""
+    _seed_clean_log(audit_env, "2026-05-14", count=1)
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        ["archive", "--audit-dir", str(audit_env), "--before", "yesterday"],
+    )
+    assert result.exit_code == 2, result.output
+    assert "YYYY-MM-DD" in result.output
+
+
+# ---------------------------------------------------------------------------
+# idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_already_archived_file_refuses_re_archive(audit_env: Path, tmp_path: Path) -> None:
+    """Running archive twice into the same dir is refused, not silently overwritten."""
+    _corrupt_file_via_wrong_key(audit_env, "2026-04-26", count=2)
+
+    archive_dir = tmp_path / "archive-out"
+    runner = CliRunner()
+
+    # First run succeeds.
+    result1 = runner.invoke(
+        audit_group,
+        [
+            "archive",
+            "--audit-dir",
+            str(audit_env),
+            "--archive-dir",
+            str(archive_dir),
+            "--corrupt",
+            "--yes",
+        ],
+    )
+    assert result1.exit_code == 0, result1.output
+
+    # Re-seed a new corrupt file with the same filename — simulates an
+    # operator who accidentally points two cleanup runs at the same
+    # archive dir.
+    _corrupt_file_via_wrong_key(audit_env, "2026-04-26", count=2)
+
+    result2 = runner.invoke(
+        audit_group,
+        [
+            "archive",
+            "--audit-dir",
+            str(audit_env),
+            "--archive-dir",
+            str(archive_dir),
+            "--corrupt",
+            "--yes",
+        ],
+    )
+    assert result2.exit_code == 1, result2.output
+    assert "Refusing to overwrite" in result2.output
+    # The source file must still exist (nothing got moved).
+    assert (audit_env / "2026-04-26.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# post-archive verify reporting + exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_post_archive_verify_is_reported_and_passes(audit_env: Path, tmp_path: Path) -> None:
+    """After archiving the corrupt file the verify pass succeeds and is shown."""
+    _corrupt_file_via_wrong_key(audit_env, "2026-04-26", count=2)
+    # Clean chain starts from genesis on what remains.
+    _seed_clean_log(audit_env, "2026-05-14", count=2, chain_from_genesis=True)
+
+    archive_dir = tmp_path / "archive-out"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        [
+            "archive",
+            "--audit-dir",
+            str(audit_env),
+            "--archive-dir",
+            str(archive_dir),
+            "--corrupt",
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Post-archive HMAC chain verification PASSED" in result.output
+
+    # Independent confirmation: call AuditLog.verify() directly.
+    audit_log = AuditLog(audit_env)
+    valid, errors = audit_log.verify()
+    assert valid, f"chain still broken after archive: {errors}"
+
+
+def test_requires_yes_for_real_move(audit_env: Path, tmp_path: Path) -> None:
+    """Without --yes (and without --dry-run), the command refuses to move anything."""
+    _corrupt_file_via_wrong_key(audit_env, "2026-04-26", count=2)
+
+    archive_dir = tmp_path / "archive-out"
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        [
+            "archive",
+            "--audit-dir",
+            str(audit_env),
+            "--archive-dir",
+            str(archive_dir),
+            "--corrupt",
+        ],
+    )
+    assert result.exit_code == 2, result.output
+    assert "--yes" in result.output
+    # Source untouched.
+    assert (audit_env / "2026-04-26.jsonl").exists()
+
+
+def test_archive_help_lists_all_flags() -> None:
+    """Smoke-test the --help surface (catches accidental flag rename)."""
+    runner = CliRunner()
+    result = runner.invoke(audit_group, ["archive", "--help"])
+    assert result.exit_code == 0, result.output
+    for flag in ("--before", "--corrupt", "--archive-dir", "--audit-dir", "--dry-run", "--yes"):
+        assert flag in result.output, f"missing {flag} in --help"
+
+
+def test_archive_refuses_proc_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Best-effort safety: refuse to operate on /proc/, /dev/, /sys/ paths."""
+    # We can't pass a literal /proc path through click.Path(resolve_path=True)
+    # because the path must be resolvable. Symlink to /proc instead so the
+    # resolution surfaces the unsafe prefix.
+    if not os.path.isdir("/proc"):  # pragma: no cover - non-linux skip
+        pytest.skip("no /proc on this platform")
+
+    link = tmp_path / "audit-link"
+    link.symlink_to("/proc")
+
+    key_path = tmp_path / "audit.key"
+    key_path.write_bytes(b"a" * 64)
+    key_path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    monkeypatch.setenv(AUDIT_KEY_ENV, str(key_path))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        audit_group,
+        ["archive", "--audit-dir", str(link), "--dry-run"],
+    )
+    assert result.exit_code == 1, result.output
+    assert "Refusing to operate" in result.output or "Refusing to archive" in result.output


### PR DESCRIPTION
## Summary

Adds a new CLI command, `bernstein audit archive`, that safely moves corrupt or pre-rotation `.sdd/audit/*.jsonl` files out of the active HMAC chain so `bernstein doctor airgap` reports clean again.

Implements option (B) from [`.sdd/backlog/open/2026-05-13-bughunt-audit-chain-pre-existing-drift.md`](.sdd/backlog/open/2026-05-13-bughunt-audit-chain-pre-existing-drift.md): "archive out-of-tree and start fresh from next event". This was previously a manual `mv` step the operator had to script themselves; now it is a first-class, auditable command.

## Why option (B)

The ticket scopes this as operator hygiene: the audit key was rotated without rehashing prior entries, so `2026-04-26.jsonl` and `2026-05-07.jsonl` carry HMACs that no longer match the active key. Option (A) (rotate + rehash) is destructive — it rewrites historical HMACs, which itself looks like tampering to any external auditor holding earlier exports. Option (B) preserves the original bytes by moving them aside and recording who/when/why.

## Command surface

```
Usage: audit archive [OPTIONS]

  Safely archive corrupt / pre-rotation audit chain files.

Options:
  --before YYYY-MM-DD      Archive jsonl files whose filename date is strictly
                           earlier than this date.
  --corrupt                Archive only files whose HMAC chain currently fails
                           verification.
  --archive-dir DIRECTORY  Destination directory. Defaults to
                           .sdd/audit/_archived/<UTC timestamp>/.
  --audit-dir DIRECTORY    Override the audit directory (default: .sdd/audit/).
                           Mostly for tests.
  --dry-run                Print the plan; move nothing.
  --yes                    Skip the interactive confirmation. Required for a
                           real move outside --dry-run.
```

### Safety properties

- **Move-only**, never delete. Originals are moved to `<archive-dir>/<name>` and a sibling `<name>.archived.json` records `archived_at_utc`, `reason`, `original_path`, `archived_path`, `size_bytes`, `sha256_of_archived_file`.
- **Idempotent**: refuses to overwrite an existing destination filename. Operator gets a red error and the source stays in place — no partial state.
- **Confirmation-gated**: default behaviour prints the plan (per-file size + sha256) and exits non-zero unless `--yes` (or `--dry-run`) is passed.
- **Path safety**: refuses to operate on `/dev/*`, `/proc/*`, `/sys/*` symlink-resolved targets.
- **Per-file corruption isolation**: `--corrupt` flags only files whose HMACs are internally inconsistent under the active key. A clean file whose chain anchor merely shifts due to an upstream archive is **not** flagged.
- After archiving, the command re-runs `AuditLog(...).verify()` and reports the post-state. Exits 1 if the chain still has errors.

## Example usage

```bash
# Operator runs the bughunt symptom:
bernstein doctor airgap   # ⇒ FAIL: 6 HMAC mismatches in 2026-04-26.jsonl, 2026-05-07.jsonl

# Preview the cleanup plan:
bernstein audit archive --corrupt --dry-run

# Approve it:
bernstein audit archive --corrupt --yes
# ⇒ archived 2026-04-26.jsonl → .sdd/audit/_archived/<ts>/...
# ⇒ archived 2026-05-07.jsonl → .sdd/audit/_archived/<ts>/...
# ⇒ Post-archive HMAC chain verification PASSED

bernstein doctor airgap   # ⇒ green
```

## Test plan

- [x] dry-run prints the plan but moves nothing
- [x] `--corrupt` archives only the file whose internal HMACs fail (clean files left alone)
- [x] `--before <date>` archives the strictly-earlier subset
- [x] post-archive `AuditLog(...).verify()` passes when the operator-chosen scope removes all corruption
- [x] re-running into the same `--archive-dir` is refused (no overwrite) — exit 1, source untouched
- [x] default without `--yes`/`--dry-run` refuses to move anything (exit 2)
- [x] `--help` lists every documented flag
- [x] `--before` rejects malformed dates
- [x] (Linux-only, skipped on macOS) refuses to operate on `/proc/*`-resolved paths

`uv run pytest tests/unit/cli/` ⇒ 25 passed, 1 skipped (platform-conditional). 8 new tests added.