### PR TITLE
fix(orchestrator): honour per-step cli + model

### DIFF
--- a/src/bernstein/core/agents/spawner_warm_pool.py
+++ b/src/bernstein/core/agents/spawner_warm_pool.py
@@ -116,9 +116,17 @@ def _select_batch_config(
     Returns:
         ModelConfig suitable for the entire batch.
     """
-    # If a role-level config.yaml exists, use it as the baseline
+    # Per-task model/effort declared on the plan step take absolute precedence
+    # over the role's default config.yaml.  Otherwise a plan that says
+    # ``model: haiku`` for one step and ``model: flash`` for another would
+    # silently collapse onto the role's default (e.g. qa/config.yaml ->
+    # sonnet), defeating per-step routing for plan-driven runs.
     role = tasks[0].role
-    if templates_dir is not None:
+    if any(t.model or t.effort for t in tasks):
+        # Fall through to the per-task router below; do NOT short-circuit
+        # to the role's config.yaml.
+        pass
+    elif templates_dir is not None:
         role_config = _load_role_config(role, templates_dir)
         if role_config is not None:
             return role_config

--- a/src/bernstein/core/orchestration/manager.py
+++ b/src/bernstein/core/orchestration/manager.py
@@ -120,8 +120,16 @@ async def _post_task_to_server(
         "task_type": task.task_type.value,
     }
     # Forward routing hints declared on the task (per-step plan fields).
+    # ``cli`` selects the adapter (claude, gemini, codex …) and ``model`` /
+    # ``effort`` pin the model variant.  Dropping ``model`` here causes
+    # plan-driven runs to collapse onto the orchestrator default (sonnet),
+    # which silently violates per-step ``cli:``/``model:`` directives.
     if task.cli:
         body["cli"] = task.cli
+    if task.model:
+        body["model"] = task.model
+    if task.effort:
+        body["effort"] = task.effort
     # Include upgrade_details if present
     if task.upgrade_details:
         body["upgrade_details"] = asdict(task.upgrade_details)

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -97,6 +97,10 @@ def _group_model_hints(tasks: list[Task]) -> set[str]:
     return {task.model.strip().lower() for task in tasks if isinstance(task.model, str) and task.model.strip()}
 
 
+def _group_cli_hints(tasks: list[Task]) -> set[str]:
+    return {task.cli.strip().lower() for task in tasks if isinstance(task.cli, str) and task.cli.strip()}
+
+
 def _group_agent_hints(tasks: list[Task], agent_affinity: dict[str, str]) -> set[str]:
     return {
         agent_affinity[task.id].strip()
@@ -106,8 +110,16 @@ def _group_agent_hints(tasks: list[Task], agent_affinity: dict[str, str]) -> set
 
 
 def _groups_can_merge(left: list[Task], right: list[Task], agent_affinity: dict[str, str]) -> bool:
-    """Return True when two groups are compatible for batching."""
+    """Return True when two groups are compatible for batching.
+
+    Tasks with different per-step ``cli:`` or ``model:`` directives must
+    spawn separate agents — a single ``spawn_for_tasks`` call only consults
+    ``tasks[0].cli``/``tasks[0].model``, so merging would silently drop the
+    second task's routing hints.
+    """
     if len(_group_model_hints(left + right)) > 1:
+        return False
+    if len(_group_cli_hints(left + right)) > 1:
         return False
     return len(_group_agent_hints(left + right, agent_affinity)) <= 1
 

--- a/src/bernstein/core/planning/planner.py
+++ b/src/bernstein/core/planning/planner.py
@@ -77,8 +77,16 @@ async def _post_task_to_server(
         "task_type": task.task_type.value,
     }
     # Forward routing hints declared on the task (per-step plan fields).
+    # ``cli`` selects the adapter (claude, gemini, codex …) and ``model`` /
+    # ``effort`` pin the model variant.  Dropping ``model`` here causes
+    # plan-driven runs to collapse onto the orchestrator default (sonnet),
+    # which silently violates per-step ``cli:``/``model:`` directives.
     if task.cli:
         body["cli"] = task.cli
+    if task.model:
+        body["model"] = task.model
+    if task.effort:
+        body["effort"] = task.effort
     # Include upgrade_details if present
     if task.upgrade_details:
         body["upgrade_details"] = asdict(task.upgrade_details)

--- a/src/bernstein/core/tasks/task_grouping.py
+++ b/src/bernstein/core/tasks/task_grouping.py
@@ -73,6 +73,20 @@ def _classify_batches(batches: list[list[Task]]) -> list[int]:
     return [i for i, batch in enumerate(batches) if batch and all(_is_small_task(t) for t in batch)]
 
 
+def _routing_hints_compatible(batch: list[Task], candidate: list[Task]) -> bool:
+    """Return False when two batches carry incompatible per-step routing hints.
+
+    The spawner only consults ``tasks[0].cli`` / ``tasks[0].model`` from a
+    batch, so merging tasks that disagree on adapter or model would silently
+    drop the second task's routing directives.
+    """
+    models = {t.model.strip().lower() for t in (batch + candidate) if isinstance(t.model, str) and t.model.strip()}
+    if len(models) > 1:
+        return False
+    clis = {t.cli.strip().lower() for t in (batch + candidate) if isinstance(t.cli, str) and t.cli.strip()}
+    return len(clis) <= 1
+
+
 def _can_merge_batches(
     batch: list[Task],
     candidate: list[Task],
@@ -84,6 +98,8 @@ def _can_merge_batches(
     if len(batch) + len(candidate) > effective_max:
         return False
     if _estimated_sum(batch) + _estimated_sum(candidate) > TASK.max_combined_estimated_minutes:
+        return False
+    if not _routing_hints_compatible(batch, candidate):
         return False
     return not _batch_files_conflict(batch, candidate)
 

--- a/tests/unit/test_per_step_routing.py
+++ b/tests/unit/test_per_step_routing.py
@@ -1,0 +1,285 @@
+"""Regression tests for per-step ``cli`` / ``model`` routing in plan-driven runs.
+
+When a plan declares heterogeneous per-step ``cli`` and ``model`` directives,
+each (cli, model) combination must spawn its own agent.  Two earlier bugs
+collapsed everything onto the default adapter + ``sonnet``:
+
+1. ``_post_task_to_server`` forwarded ``task.cli`` but silently dropped
+   ``task.model`` / ``task.effort``, so the task arrived at the orchestrator
+   with no model hint.
+
+2. ``_select_batch_config`` short-circuited to the role's ``config.yaml``
+   default before checking ``task.model``, so even a correctly-posted task
+   was overridden by the role default.
+
+3. ``_groups_can_merge`` and ``_can_merge_batches`` only inspected ``model``,
+   never ``cli`` — so two tasks with the same role but different adapters
+   would be merged into a single batch and the second adapter dropped.
+
+This module guards all three regressions.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import bernstein.core.planner as planner
+import yaml
+from bernstein.core.models import Complexity, Scope, Task, TaskStatus, TaskType
+from bernstein.core.plan_loader import load_plan_from_yaml
+from bernstein.core.tick_pipeline import group_by_role
+
+import bernstein.core.orchestration.manager as orch_manager
+from bernstein.core.agents.spawner_warm_pool import _select_batch_config
+from bernstein.core.tasks.task_grouping import compact_small_tasks
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        return self._payload
+
+
+class _CapturingClient:
+    """Captures every POST body so we can assert routing fields survive."""
+
+    def __init__(self) -> None:
+        self.posts: list[dict[str, object]] = []
+        self._next_id = 0
+
+    async def post(self, url: str, json: dict[str, object]) -> _FakeResponse:
+        await asyncio.sleep(0)
+        self.posts.append({"url": url, "json": json})
+        self._next_id += 1
+        return _FakeResponse({"id": f"server-task-{self._next_id}"})
+
+
+def _make_task(
+    task_id: str,
+    *,
+    role: str = "qa",
+    cli: str | None = None,
+    model: str | None = None,
+    effort: str | None = None,
+) -> Task:
+    return Task(
+        id=task_id,
+        title=f"Task {task_id}",
+        description="",
+        role=role,
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        cli=cli,
+        model=model,
+        effort=effort,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug #1: _post_task_to_server must forward model + effort + cli
+# ---------------------------------------------------------------------------
+
+
+def test_planner_post_task_forwards_per_step_cli_and_model() -> None:
+    """``planner._post_task_to_server`` must forward ``cli``, ``model``, and ``effort``."""
+    client = _CapturingClient()
+    task = _make_task("t1", cli="gemini", model="flash", effort="low")
+
+    asyncio.run(planner._post_task_to_server(cast("Any", client), "http://server", task))
+
+    body = cast("dict[str, object]", client.posts[0]["json"])
+    assert body["cli"] == "gemini"
+    assert body["model"] == "flash"
+    assert body["effort"] == "low"
+
+
+def test_manager_post_task_forwards_per_step_cli_and_model() -> None:
+    """The duplicate ``manager._post_task_to_server`` must also forward routing fields."""
+    client = _CapturingClient()
+    task = _make_task("t1", cli="claude", model="haiku")
+
+    asyncio.run(orch_manager._post_task_to_server(cast("Any", client), "http://server", task))
+
+    body = cast("dict[str, object]", client.posts[0]["json"])
+    assert body["cli"] == "claude"
+    assert body["model"] == "haiku"
+
+
+def test_post_task_omits_routing_fields_when_unset() -> None:
+    """Plain plans without per-step routing must NOT introduce empty fields."""
+    client = _CapturingClient()
+    task = _make_task("t1", cli=None, model=None, effort=None)
+
+    asyncio.run(planner._post_task_to_server(cast("Any", client), "http://server", task))
+
+    body = cast("dict[str, object]", client.posts[0]["json"])
+    assert "cli" not in body
+    assert "model" not in body
+    assert "effort" not in body
+
+
+# ---------------------------------------------------------------------------
+# Bug #2: _select_batch_config must respect task.model over role config.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_select_batch_config_honours_per_task_model_over_role_default(tmp_path: Path) -> None:
+    """A role's ``config.yaml`` default must NOT override per-task ``model``."""
+    qa_dir = tmp_path / "qa"
+    qa_dir.mkdir()
+    (qa_dir / "config.yaml").write_text("default_model: sonnet\ndefault_effort: high\n")
+
+    task = _make_task("t1", role="qa", model="haiku", effort="low")
+    config = _select_batch_config([task], templates_dir=tmp_path)
+
+    assert config.model == "haiku"
+    assert config.effort == "low"
+
+
+def test_select_batch_config_falls_back_to_role_default_when_task_model_unset(tmp_path: Path) -> None:
+    """When no task pins a model, the role's ``config.yaml`` still wins (no regression)."""
+    qa_dir = tmp_path / "qa"
+    qa_dir.mkdir()
+    (qa_dir / "config.yaml").write_text("default_model: sonnet\ndefault_effort: high\n")
+
+    task = _make_task("t1", role="qa", model=None, effort=None)
+    config = _select_batch_config([task], templates_dir=tmp_path)
+
+    assert config.model == "sonnet"
+    assert config.effort == "high"
+
+
+# ---------------------------------------------------------------------------
+# Bug #3: group_by_role + compact_small_tasks must NOT merge across cli/model
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_role_does_not_merge_distinct_clis() -> None:
+    """Two same-role tasks with different ``cli`` must produce separate batches."""
+    gemini_task = _make_task("t1", cli="gemini", model="flash")
+    claude_task = _make_task("t2", cli="claude", model="haiku")
+
+    batches = group_by_role([gemini_task, claude_task], max_per_batch=4)
+
+    assert len(batches) == 2
+    pairs = sorted((b[0].cli, b[0].model) for b in batches)
+    assert pairs == [("claude", "haiku"), ("gemini", "flash")]
+
+
+def test_group_by_role_does_not_merge_distinct_models_same_cli() -> None:
+    """Two same-role tasks with same ``cli`` but different ``model`` must split."""
+    a = _make_task("t1", cli="claude", model="haiku")
+    b = _make_task("t2", cli="claude", model="sonnet")
+
+    batches = group_by_role([a, b], max_per_batch=4)
+
+    assert len(batches) == 2
+
+
+def test_group_by_role_still_batches_when_routing_matches() -> None:
+    """Tasks with identical routing hints can still share a batch (no regression)."""
+    a = _make_task("t1", cli="claude", model="haiku")
+    b = _make_task("t2", cli="claude", model="haiku")
+
+    batches = group_by_role([a, b], max_per_batch=4)
+
+    assert len(batches) == 1
+    assert {t.id for t in batches[0]} == {"t1", "t2"}
+
+
+def test_compact_small_tasks_does_not_merge_across_clis() -> None:
+    """``compact_small_tasks`` must respect cli/model boundaries too."""
+    a = _make_task("t1", cli="gemini", model="flash")
+    a.complexity = Complexity.LOW
+    a.scope = Scope.SMALL
+    a.estimated_minutes = 5
+
+    b = _make_task("t2", cli="claude", model="haiku")
+    b.complexity = Complexity.LOW
+    b.scope = Scope.SMALL
+    b.estimated_minutes = 5
+
+    compacted = compact_small_tasks([[a], [b]], max_per_batch=4)
+
+    assert len(compacted) == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: playground-style plan parses + posts heterogeneous tasks
+# ---------------------------------------------------------------------------
+
+
+def test_playground_style_plan_posts_one_request_per_cli_model(tmp_path: Path) -> None:
+    """A plan with two QA steps on different cli+model posts BOTH directives."""
+    plan_file = tmp_path / "plan.yaml"
+    plan_file.write_text(
+        yaml.dump(
+            {
+                "name": "Playground",
+                "stages": [
+                    {
+                        "name": "write-and-run",
+                        "parallel": True,
+                        "steps": [
+                            {
+                                "id": "gemini-step",
+                                "title": "Gemini step",
+                                "role": "qa",
+                                "cli": "gemini",
+                                "model": "flash",
+                            },
+                            {
+                                "id": "claude-step",
+                                "title": "Claude step",
+                                "role": "qa",
+                                "cli": "claude",
+                                "model": "haiku",
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+
+    tasks = load_plan_from_yaml(plan_file)
+    assert len(tasks) == 2
+    by_title = {t.title: t for t in tasks}
+    assert by_title["Gemini step"].cli == "gemini"
+    assert by_title["Gemini step"].model == "flash"
+    assert by_title["Claude step"].cli == "claude"
+    assert by_title["Claude step"].model == "haiku"
+
+    client = _CapturingClient()
+
+    async def _post_all() -> None:
+        for t in tasks:
+            await planner._post_task_to_server(cast("Any", client), "http://server", t)
+
+    asyncio.run(_post_all())
+
+    bodies = [cast("dict[str, object]", p["json"]) for p in client.posts]
+    posted = sorted((b.get("cli"), b.get("model")) for b in bodies)
+    assert posted == [("claude", "haiku"), ("gemini", "flash")]
+
+    # And the orchestrator's batching layer must keep them in separate batches.
+    batches = group_by_role(tasks, max_per_batch=4)
+    assert len(batches) == 2, "heterogeneous cli/model must not share a batch"
+    routings = sorted((b[0].cli, b[0].model) for b in batches)
+    assert routings == [("claude", "haiku"), ("gemini", "flash")]


### PR DESCRIPTION
## Problem

A multi-stage plan like ``seeds/playground.yaml`` declares per-step ``cli:`` and ``model:``:

```yaml
stages:
  - name: write-and-run
    parallel: true
    steps:
      - id: gemini-slow-suite
        role: qa
        cli: gemini
        model: flash
      - id: claude-slow-suite
        role: qa
        cli: claude
        model: haiku
```

Running ``bernstein run seeds/playground.yaml`` produced **one** QA agent labelled ``(agency) SONNET`` handling both steps -- the per-step directives were silently collapsed onto the default adapter + ``sonnet``.

## Root cause -- three bugs in the dispatch pipeline

| # | File:line | Bug |
|---|---|---|
| 1 | ``src/bernstein/core/planning/planner.py:80`` and ``src/bernstein/core/orchestration/manager.py:123`` | ``_post_task_to_server`` forwarded ``task.cli`` to the task server but silently dropped ``task.model`` / ``task.effort``. Plan tasks landed on the server with ``model=None``. |
| 2 | ``src/bernstein/core/agents/spawner_warm_pool.py:120-124`` (``_select_batch_config``) | Short-circuited to the role's ``templates/roles/<role>/config.yaml`` default before consulting ``task.model``. Even if the model had survived the POST, ``qa/config.yaml`` (``default_model: sonnet``) would override it. |
| 3 | ``src/bernstein/core/orchestration/tick_pipeline.py:108`` (``_groups_can_merge``) and ``src/bernstein/core/tasks/task_grouping.py:_can_merge_batches`` | Merge gates only checked ``model`` distinctness, not ``cli``. Two same-role tasks with different adapters could share a batch, after which ``spawn_for_tasks`` only consults ``tasks[0].cli`` -- the second adapter is dropped. |

### Call chain

```
bernstein run <plan>           cli/run_bootstrap.py
  -> load_plan_from_yaml       core/planning/plan_loader.py   (correct: parses cli/model per step)
  -> _post_plan_tasks          core/orchestration/bootstrap.py
    -> _post_task_to_server    core/planning/planner.py:80    BUG #1: drops model/effort
  -> orchestrator tick
    -> group_by_role           core/orchestration/tick_pipeline.py
      -> _groups_can_merge     BUG #3: ignores cli mismatches
    -> spawn_for_tasks         core/agents/spawner_core.py:1553
      -> _select_batch_config  core/agents/spawner_warm_pool.py:93   BUG #2: role config.yaml clobbers task.model
```

## Fix

- Forward ``model`` and ``effort`` alongside ``cli`` in both copies of ``_post_task_to_server``.
- ``_select_batch_config`` now skips the role's ``config.yaml`` shortcut whenever any task in the batch pins ``model`` or ``effort`` -- per-task fields fall through to the existing per-task router which already honours them.
- ``_groups_can_merge`` and ``_can_merge_batches`` now additionally block merges across distinct ``cli`` values.

Single-cli plans and the role-default fallback continue to work as before; verified by the new tests.

## Regression test

``tests/unit/test_per_step_routing.py`` (10 tests):

- ``test_planner_post_task_forwards_per_step_cli_and_model``
- ``test_manager_post_task_forwards_per_step_cli_and_model``
- ``test_post_task_omits_routing_fields_when_unset`` -- guards against introducing empty fields for plain plans
- ``test_select_batch_config_honours_per_task_model_over_role_default``
- ``test_select_batch_config_falls_back_to_role_default_when_task_model_unset`` -- no-regression for the role config.yaml path
- ``test_group_by_role_does_not_merge_distinct_clis``
- ``test_group_by_role_does_not_merge_distinct_models_same_cli``
- ``test_group_by_role_still_batches_when_routing_matches`` -- no-regression for batchable identical tasks
- ``test_compact_small_tasks_does_not_merge_across_clis``
- ``test_playground_style_plan_posts_one_request_per_cli_model`` -- end-to-end: parses a playground-shape plan, captures the POST bodies, asserts each step keeps its ``(cli, model)``, then asserts ``group_by_role`` produces one batch per ``(cli, model)``

The spawn subprocess is mocked via a ``_CapturingClient`` -- no real subprocess or HTTP traffic.

## Out of scope

- ``run --idle`` mock-adapter behaviour (known playground bug per the seed file) -- not touched.

## Test plan

- [x] ``uv run pytest tests/unit/test_per_step_routing.py -x -q`` -- 10 passed
- [x] ``uv run pytest`` over related modules (planner, plan_loader, tick_pipeline, task_grouping, task_affinity_hints, regression_orchestrator, spawner_warm_pool, orchestrator, etc.) -- 654 passed, 9 skipped, 0 failed
- [x] ``uv run ruff check`` / ``uv run ruff format --check`` on all changed files -- green