### PR TITLE
docs: v2.0.0 release notes + README web-UI announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable project changes are tracked here (code + docs).
 
+## [2.0.0] — Web UI
+
+Bernstein now ships a web interface. The major bump is signalling the new operator surface, not a breaking API change. v1.10.x configs, plans, adapters, audit chain, lineage, and CLI / TUI surfaces are unchanged.
+
+Hand-curated release notes: [`docs/release-notes/v2.0.0.md`](docs/release-notes/v2.0.0.md). Tracking issue: [#1262](https://github.com/sipyourdrink-ltd/bernstein/issues/1262).
+
+### Added — Web UI
+
+- **`bernstein gui serve`** boots a FastAPI server with the SPA mounted at `/ui` and the full `/api/v1/*` surface attached. Default `http://127.0.0.1:8052/ui/`. SPA bundle ships in the wheel (no Node toolchain required at install time).
+- **Top-level tabs**: Tasks, Agents, Approvals, Audit, Costs, Fleet (scaffold), Settings (placeholder).
+- **Per-task drawer** with tabs:
+  - **Summary** — KPIs (tokens / cost / branch / approvals), plan steps from `progress_log`, drag-resize, focus trap, ESC + click-outside close (#1254).
+  - **Logs** — SSE stream, ANSI rendering, virtualised list, search, level filters, throughput stats, keyboard shortcuts.
+  - **Diff** — `GET /tasks/{id}/diff`; split / unified view, syntax highlight, copy + `.patch` download (#1255).
+  - **Gates** — `GET /tasks/{id}/gates`; status buckets, auto-expand failures, polling that pauses on terminal tasks (#1258).
+  - **Deps** — `GET /tasks/{id}/graph-neighbors`; upstream / downstream graph, polling (#1260).
+  - **Trace** — `GET /tasks/{id}/trace` reading `.sdd/traces/{task_id}.jsonl`; filter chips, search, live polling while open (#1256).
+
+### Fixed
+
+- **Per-step `cli:` and `model:` in plan-driven runs** — three dispatch-pipeline bugs (POST payload dropping `model` / `effort`, role config.yaml clobbering per-task pin, merge gate ignoring `cli` mismatch) that silently collapsed plan steps onto the role default. Regression tests at `tests/unit/test_per_step_routing.py` (#1259).
+- **Startup banner** — `bernstein run` / `bernstein conduct` regained the banner; an earlier commit removed it under a false "already printed" comment. Pinned by `tests/unit/cli/test_run_banner.py` (#1257).
+- **`/openapi.json` 500** — FastAPI's OpenAPI builder tripped on `from __future__ import annotations` turning the GUI's response annotations into strings; `response_class` now declared explicitly on `/gui-meta` + `/ui` (#1253).
+- **dev-proxy double-prefix** — `apiGet` is now idempotent; the Logs panel's terminal-task fallback no longer 404s on `/api/v1/api/v1/...` (#1253).
+
+### Limitations (intentional)
+
+- A11y audit, dark / light theme toggle UI, mobile-responsive pass, Settings screen wiring, Fleet UI, front-end test suite, Playwright e2e — all open. See [#1262](https://github.com/sipyourdrink-ltd/bernstein/issues/1262) for contributor-welcome pointers.
+
 ## Unreleased
 
 ### Changed — chat bridge

--- a/README.md
+++ b/README.md
@@ -265,6 +265,22 @@ bernstein run plan.yaml           # skips LLM planning, goes straight to executi
 bernstein run --dry-run plan.yaml # preview tasks and estimated cost
 ```
 
+## web UI (v2.0.0)
+
+By popular demand, v2.0.0 ships a minimal, neat, calm web interface. It is not a priority development direction — the core is a stretch to keep up with on one set of hands. The UI is here because operators asked for it and the core was ready for it. If anyone wants to contribute, the door is open: see [#1262](https://github.com/sipyourdrink-ltd/bernstein/issues/1262).
+
+```bash
+bernstein gui serve               # http://127.0.0.1:8052/ui/
+bernstein gui serve --dev         # expects `npm run dev` on :5173
+bernstein gui serve --minimal     # skip the full /api/v1/* surface
+```
+
+The Vite bundle is committed under `src/bernstein/gui/static/`, so wheel installs work without a Node toolchain.
+
+Top-level tabs: **Tasks**, **Agents**, **Approvals**, **Audit**, **Costs**, **Fleet**, **Settings**. Per-task drawer: **Summary**, **Logs** (SSE + ANSI + virtualised + search + level filters), **Diff** (split / unified, syntax highlight, copy + `.patch`), **Gates** (status buckets, auto-expand failures, polling), **Deps** (upstream / downstream graph), **Trace** (`.sdd/traces/` timeline + filter chips + search).
+
+Full v2.0.0 release notes: [`docs/release-notes/v2.0.0.md`](docs/release-notes/v2.0.0.md).
+
 ## how it works
 
 Bernstein runs a four-stage pipeline per goal:

--- a/docs/release-notes/v2.0.0.md
+++ b/docs/release-notes/v2.0.0.md
@@ -1,0 +1,105 @@
+# Bernstein v2.0.0 — Web UI
+
+Hand-curated release notes for the v2.0.0 cut. Overrides the auto-drafter output when the tag is published.
+
+## Why 2.0.0
+
+Bernstein now ships a web interface. The CLI / TUI surface is unchanged. The major bump is signalling the new operator surface, not a breaking API change.
+
+For everything else, v2.0.0 is a strict superset of v1.10.x — wheels install the same way, configs don't move, agents and adapters work as before.
+
+## What's new — Web UI
+
+The UI ships in the wheel: `bernstein gui serve` boots a FastAPI server with the SPA mounted at `/ui` and the full `/api/v1/*` surface attached. No Node toolchain required at install time — the Vite bundle is committed under `src/bernstein/gui/static/`.
+
+Default: `http://127.0.0.1:8052/ui/`.
+
+### Top-level screens
+
+| Screen     | What it shows                                                           |
+|------------|-------------------------------------------------------------------------|
+| Tasks      | Live task list with per-task drawer (see below).                        |
+| Agents     | Registered adapters, status, last-seen.                                 |
+| Approvals  | Pending tool-call approvals; approve / deny from the operator surface.  |
+| Audit      | HMAC-signed audit chain browser + verifier.                             |
+| Costs      | Per-model spend, per-run summary, burn-rate.                            |
+| Fleet      | Multi-project fleet view (scaffold — data plane is real, UI is light). |
+| Settings   | Placeholder — wiring is contributor-welcome.                           |
+
+### Per-task drawer
+
+Click any task row → side drawer with six tabs:
+
+| Tab     | What it shows                                                                                    |
+|---------|--------------------------------------------------------------------------------------------------|
+| Summary | KPIs (tokens, cost, branch, approvals), plan steps from `progress_log`, basic task metadata.     |
+| Logs    | SSE-streamed live logs with ANSI rendering, virtualised list, search, level filters, throughput. |
+| Diff    | `git diff <base>...<branch>` rendered as split / unified, syntax highlight, copy + `.patch`.     |
+| Gates   | Quality gate report (`/tasks/{id}/gates`) with status buckets, auto-expand failures, polling.    |
+| Deps    | Upstream / downstream task graph for `depends_on`.                                               |
+| Trace   | Timeline from `.sdd/traces/{task_id}.jsonl` with filter chips and free-text search.              |
+
+### What landed in `feat/frontend-gui-phase1`
+
+8 PRs in the wave-4 sweep, plus the earlier production-grade Logs panel and the SPA build pipeline that preceded them:
+
+| PR    | Title                                                              |
+|-------|--------------------------------------------------------------------|
+| #1253 | `fix(gui): normalise dev-proxy routing` — `apiGet` contract hardened + a Pydantic `/openapi.json` 500 fix as a bonus. |
+| #1254 | `fix(gui): drawer close + KPI/Plan wiring + UX polish` — ESC, click-outside, focus trap, drag-resize. |
+| #1255 | `feat(gui): real diff viewer for the Diff tab` — `GET /tasks/{id}/diff` backend + split / unified UI. |
+| #1256 | `feat(gui): trace timeline panel` — `GET /tasks/{id}/trace` reading `.sdd/traces/*.jsonl`. |
+| #1257 | `fix(cli): restore startup banner` — regression from an earlier commit, now pinned by a test. |
+| #1258 | `feat(gui): quality-gates panel` — `GET /tasks/{id}/gates` with `generated_at` / `task_status` annotations. |
+| #1259 | `fix(orchestrator): honour per-step cli + model in plan-driven runs` — three dispatch-pipeline bugs that collapsed per-step `cli:` / `model:` directives. |
+| #1260 | `feat(gui): task dependency view` — `GET /tasks/{id}/graph-neighbors` + Deps panel. |
+
+The earlier work that the wave-4 PRs built on:
+
+- **Logs panel** (commit `4a872ca17`) — SSE stream, ANSI, virtualisation, search, level filters, throughput stats, keyboard shortcuts. The reference for every subsequent panel.
+- **Tab-content router with stub panels** (commit `e9eeb549c`) — the shape every wave-4 panel filled in.
+- **Bug-hunt rebuild** (`62589d0ef`, ~150 fixes) — the wheel-bundled SPA bundle baseline that wave-4 reset against.
+
+### Stack
+
+React + React Router + React Query + Tailwind. Vite for the build. No new heavy front-end deps beyond that — Redux, MUI, Recharts, etc. are intentionally not in the tree.
+
+## Limitations — read this before you file an issue
+
+This is a minimal demo of the operator surface, shipped because the core was capable of supporting it and operators asked for it. It is not a priority development direction for the maintainer. Specifically:
+
+- **No screenshot / GIF assets in the README yet.**
+- **A11y audit hasn't been done end-to-end** — several panels follow good patterns, but nothing has been verified against WCAG or screen readers.
+- **No dark / light theme toggle UI** — the provider is wired, the switch isn't.
+- **No mobile-responsive pass** — drawer + tables assume desktop viewports.
+- **Settings screen is a placeholder.**
+- **Fleet screen is scaffolding** — the data plane on the Python side is real, the UI is light.
+- **No front-end test suite** — Python backend routes are covered, TS components aren't.
+- **No Playwright / e2e smoke test in CI.**
+
+Tracking issue for everything above + contributor pointers: [#1262 — Web UI development — tracking issue + contributor welcome mat](https://github.com/sipyourdrink-ltd/bernstein/issues/1262).
+
+If you want to contribute — small PRs preferred, no need to coordinate. The integration branch was collaborative; staying that way.
+
+## Migration from v1.x
+
+Nothing breaks. The new commands are additive:
+
+- `bernstein gui` — the new subcommand group.
+- `bernstein gui serve [--host …] [--port …] [--no-open] [--dev] [--minimal]` — boots the FastAPI server with the SPA mounted.
+
+The default port is `8052`. `--minimal` skips mounting the full Bernstein API (useful for smoke tests). `--dev` skips the browser auto-open and expects a Vite dev server on `:5173` for HMR.
+
+If you have a wheel install, the SPA is already there. If you've checked the repo out and want to rebuild the SPA: `cd web && npm install && npm run build`.
+
+## Everything else
+
+- All v1.10.x adapters, plan formats, audit chain, lineage, MCP server mode, A2A, cluster mode, GitHub App, air-gap wheelhouse profile — unchanged.
+- The CLI / TUI surfaces are unchanged.
+- The pre-existing `bernstein dashboard` command (legacy TUI dashboard) is unchanged. The new web UI is a separate surface.
+
+## Source
+
+Integration branch: [`feat/frontend-gui-phase1`](https://github.com/sipyourdrink-ltd/bernstein/tree/feat/frontend-gui-phase1).
+
+Tracking issue: [#1262](https://github.com/sipyourdrink-ltd/bernstein/issues/1262).


### PR DESCRIPTION
## Summary

v2.0.0 ships a minimal web UI on top of the existing CLI / TUI surface. The major bump signals the new operator surface, not a breaking API change. v1.10.x configs, plans, adapters, audit chain, lineage, and CLI / TUI surfaces are unchanged.

This PR is the docs + tracking-issue companion to the integration branch [`feat/frontend-gui-phase1`](https://github.com/sipyourdrink-ltd/bernstein/tree/feat/frontend-gui-phase1) (PRs #1253–#1260 plus the earlier Logs panel and SPA build pipeline).

## What changed

- **`README.md`** — new "web UI (v2.0.0)" section between the existing CLI quick-start and "how it works". Launch command, tabs, drawer surfaces, pointer to #1262.
- **`CHANGELOG.md`** — new `[2.0.0]` block above `## Unreleased` summarising the wave-4 PRs, the four GUI-side fixes, and the intentional limitations.
- **`docs/release-notes/v2.0.0.md`** — hand-curated release notes (the auto-drafter output will be overridden by this when the tag is published).

## Path deviation

The task brief asked for `.sdd/release-notes-v2.0.0.md`, but `.sdd/` is gitignored and CI-blocked (`.github/workflows/ci.yml:146` asserts `.sdd` is never tracked). Notes live at `docs/release-notes/v2.0.0.md` instead.

## Tracking issue

[#1262 — Web UI development — tracking issue + contributor welcome mat](https://github.com/sipyourdrink-ltd/bernstein/issues/1262). Labels: `enhancement`, `web-dashboard`, `help wanted`, `good first issue`, `roadmap`, `ai-welcome`.

## Tone

Matches the maintainer's blurb: minimal, neat, not a priority development direction, contributions welcome. No marketing fluff. No AI attribution.

## Test plan

- [x] `uv run ruff check src/` — green (the lint job only runs against `src/`).
- [x] `cd web && npm run build` — not required (docs-only PR, no source touched).
- [ ] README renders correctly on GitHub.
- [ ] Tracking issue links resolve from both README and release notes.
- [ ] CI green.
