### PR TITLE
fix(orchestrator): manager auth to task server (#1261)

### DIFF
--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -203,26 +203,48 @@ def _render_auth_section(token_path: Path) -> str:
     The token file path is referenced by path rather than embedding the raw
     token so that credentials do not appear in prompt logs.
 
+    The path is coerced to absolute form so the ``cat`` examples resolve
+    correctly even when the agent's spawn cwd differs from the orchestrator
+    workdir (the worktree case — see #1261). ``resolve(strict=False)``
+    keeps the call cheap when the file has not yet been written and never
+    fails on missing intermediates.
+
     Args:
         token_path: Path to the session-scoped JWT token file (mode 0600).
 
     Returns:
         Markdown block instructing the agent to authenticate all requests.
     """
+    absolute = token_path if token_path.is_absolute() else token_path.resolve(strict=False)
     return (
         "\n## Task Server Authentication\n"
-        "Your agent token is stored at (do NOT print or log its contents):\n"
-        f"```\n{token_path}\n```\n"
-        "Include this header in **all** task server requests:\n"
+        "Your agent token is stored at this absolute path (do NOT print or "
+        "log its contents):\n"
+        f"```\n{absolute}\n```\n"
+        "Include this header in **all** task server requests — the path is "
+        "absolute, so it works regardless of your current shell directory:\n"
         "```bash\n"
-        f'-H "Authorization: Bearer $(cat {token_path})"\n'
+        f'-H "Authorization: Bearer $(cat {absolute})"\n'
+        "```\n"
+        "Example — creating a subtask:\n"
+        "```bash\n"
+        f"curl -s -X POST http://127.0.0.1:8052/tasks \\\n"
+        f'  -H "Authorization: Bearer $(cat {absolute})" \\\n'
+        '  -H "Content-Type: application/json" \\\n'
+        '  -d \'{"title": "...", "role": "backend", "description": "..."}\'\n'
         "```\n"
         "Example — marking a task complete:\n"
         "```bash\n"
         f"curl -s -X POST http://127.0.0.1:8052/tasks/<TASK_ID>/complete \\\n"
-        f'  -H "Authorization: Bearer $(cat {token_path})" \\\n'
+        f'  -H "Authorization: Bearer $(cat {absolute})" \\\n'
         '  -H "Content-Type: application/json" \\\n'
         '  -d \'{"result_summary": "Done"}\'\n'
+        "```\n"
+        "If the token file is unreadable for any reason, fall back to the\n"
+        "`BERNSTEIN_AUTH_TOKEN` environment variable, which is exported into\n"
+        "your shell:\n"
+        "```bash\n"
+        '-H "Authorization: Bearer $BERNSTEIN_AUTH_TOKEN"\n'
         "```\n"
     )
 
@@ -951,13 +973,22 @@ class AgentSpawner:
         The token file path is recorded in ``_agent_token_files`` for cleanup
         when the agent is reaped.
 
+        The returned path is resolved to an absolute path (#1261) — agents
+        spawn with cwd set to a git worktree under
+        ``.sdd/worktrees/<session>/``, so a relative path here would resolve
+        against the worktree at ``cat`` time and miss the real token that
+        lives under the orchestrator's project root. The auth section
+        injected into the prompt by :func:`_render_auth_section` then ends
+        up pointing at a non-existent file, the agent loops on
+        ``find ... -name "*.token"``, and every ``POST /tasks`` returns 401.
+
         Args:
             session_id: The agent session ID (used as identity ID).
             role: The agent's role.
             task_ids: Task IDs the agent is authorised to act on.
 
         Returns:
-            Path to the written token file.
+            Absolute path to the written token file.
         """
         import os
 
@@ -968,7 +999,11 @@ class AgentSpawner:
             metadata={"source": "spawner"},
         )
 
-        tokens_dir = self._workdir / ".sdd" / "runtime" / "agent_tokens"
+        # ``resolve(strict=False)`` returns an absolute path even when the
+        # directory does not yet exist on disk, so the prompt injection
+        # always references the canonical project-root location regardless
+        # of the agent's spawn cwd (worktree, container, sandbox).
+        tokens_dir = (self._workdir / ".sdd" / "runtime" / "agent_tokens").resolve(strict=False)
         tokens_dir.mkdir(parents=True, exist_ok=True)
         token_path = tokens_dir / f"{session_id}.token"
 

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -20,10 +20,15 @@ You lead a team of AI coding agents. Your job: decompose the goal into tasks, cr
 
 ## Task Server API
 
-The task server runs at **http://127.0.0.1:8052**. Use curl to create tasks:
+The task server runs at **http://127.0.0.1:8052** and **requires bearer-token authentication**.
+Read the `## Task Server Authentication` section appended to this prompt for the exact
+absolute path to your token file, then include the `Authorization` header on **every**
+request. Without that header the server returns 401 and no task is created.
 
 ```bash
+TOKEN=$(cat <absolute-token-path-from-auth-section>)
 curl -s -X POST http://127.0.0.1:8052/tasks \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "title": "Implement feature X",
@@ -61,10 +66,12 @@ curl -s -X POST http://127.0.0.1:8052/tasks \
 
 ## When done planning
 
-Mark your own task as complete:
+Mark your own task as complete (remember the `Authorization` header):
 
 ```bash
+TOKEN=$(cat <absolute-token-path-from-auth-section>)
 curl -s -X POST http://127.0.0.1:8052/tasks/{YOUR_TASK_ID}/complete \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"result_summary": "Created N tasks to achieve goal: ..."}'
 ```

--- a/templates/roles/manager/task_prompt.md
+++ b/templates/roles/manager/task_prompt.md
@@ -22,8 +22,16 @@
 6. Post tasks to the task server, then mark your own task complete
 
 ## Task creation
+
+The task server requires bearer-token auth — see the `## Task Server Authentication`
+section appended below for the absolute token file path. Every POST needs the
+`Authorization: Bearer $(cat …)` header (or `Authorization: Bearer $BERNSTEIN_AUTH_TOKEN`
+as a fallback).
+
 ```bash
+TOKEN=$(cat <absolute-token-path-from-auth-section>)
 curl -s -X POST http://127.0.0.1:8052/tasks \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
     "title": "...",
@@ -39,7 +47,9 @@ curl -s -X POST http://127.0.0.1:8052/tasks \
 
 ## Done signal
 ```bash
+TOKEN=$(cat <absolute-token-path-from-auth-section>)
 curl -s -X POST http://127.0.0.1:8052/tasks/{{TASK_ID}}/complete \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"result_summary": "{{TASK_TITLE}}: created N tasks"}'
 ```

--- a/tests/integration/test_manager_auth_to_task_server.py
+++ b/tests/integration/test_manager_auth_to_task_server.py
@@ -1,0 +1,353 @@
+"""End-to-end regression for #1261 — manager auth to the task server.
+
+Boots a real uvicorn server with the legacy bearer token enabled, then
+spawns a subprocess in a *worktree-like* cwd (a subdir of the
+orchestrator workdir, mirroring the runtime layout the production
+spawner produces). The subprocess receives exactly the env that
+:func:`bernstein.adapters.env_isolation.build_filtered_env` would hand a
+real agent — i.e. the ``BERNSTEIN_AUTH_TOKEN`` env var passes through
+the allowlist — and is given the prompt fragment :func:`_render_auth_section`
+would inject.
+
+The subprocess then POSTs to ``/tasks`` using both auth channels:
+
+1. The Bearer header sourced from the absolute path embedded in the
+   prompt (the primary channel — broken before this fix, because the
+   path could resolve as relative and miss the real token file when the
+   spawn cwd was a git worktree).
+2. The Bearer header sourced from ``$BERNSTEIN_AUTH_TOKEN`` (the
+   documented fallback — also surfaced in the auth section after the
+   fix).
+
+Without the #1261 fix the first POST returns 401 (path resolves against
+the worktree, ``cat`` reads no file, openssl signs empty body, Bearer is
+literally the empty string). With the fix both POSTs return 201.
+
+Skipped on Windows for the same reason as the federation suite — uvicorn
++ asyncio fixture mechanics are fragile under ProactorEventLoop.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import subprocess
+import sys
+import textwrap
+import threading
+import time
+from collections.abc import Generator
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI
+
+from bernstein.adapters.env_isolation import build_filtered_env
+from bernstein.core.agents.spawner_core import (
+    AgentSpawner,
+    _render_auth_section,
+)
+from bernstein.core.server import create_app
+
+if TYPE_CHECKING:
+    from bernstein.core.models import ModelConfig
+
+    from bernstein.adapters.base import SpawnResult
+
+pytestmark = [
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="uvicorn + asyncio + httpx fixtures fragile on Windows CI runners",
+    ),
+    # The whole module exercises the real auth middleware — opt out of the
+    # global ``BERNSTEIN_AUTH_DISABLED=1`` test default (see tests/conftest.py).
+    pytest.mark.auth_enabled,
+]
+
+
+_BEARER_TOKEN = "regression-1261-bearer"
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+class _AuthServer:
+    """A FastAPI task server running uvicorn in a background thread."""
+
+    def __init__(self, app: FastAPI, port: int) -> None:
+        self.app = app
+        self.port = port
+        self.endpoint = f"http://127.0.0.1:{port}"
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self, *, timeout: float = 10.0) -> None:
+        config = uvicorn.Config(
+            self.app,
+            host="127.0.0.1",
+            port=self.port,
+            log_level="error",
+            lifespan="off",
+        )
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True, name=f"taskserver-{self.port}")
+        thread.start()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline and not server.started:
+            time.sleep(0.02)
+        if not server.started:
+            server.should_exit = True
+            thread.join(timeout=2)
+            raise RuntimeError(f"task server on port {self.port} did not start within {timeout}s")
+        self._server = server
+        self._thread = thread
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.should_exit = True
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+
+@pytest.fixture
+def auth_server(tmp_path: Path) -> Generator[_AuthServer, None, None]:
+    """Start a task server with the legacy bearer token wired through."""
+    jsonl_path = tmp_path / "server" / "tasks.jsonl"
+    jsonl_path.parent.mkdir(parents=True)
+    app = create_app(jsonl_path=jsonl_path, auth_token=_BEARER_TOKEN)
+    server = _AuthServer(app, _free_port())
+    server.start()
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def test_server_rejects_unauthenticated_post(auth_server: _AuthServer) -> None:
+    """Sanity guard: the task server actually requires the bearer.
+
+    Without this assertion the rest of the suite could silently pass even
+    if the middleware were broken (e.g. accidentally letting anonymous
+    POSTs through).
+    """
+    resp = httpx.post(
+        f"{auth_server.endpoint}/tasks",
+        json={
+            "title": "should-be-rejected",
+            "role": "backend",
+            "description": "anonymous post — must 401 before validation runs",
+        },
+        timeout=5.0,
+    )
+    assert resp.status_code == 401, resp.text
+
+
+def test_manager_subprocess_can_post_via_token_file(
+    tmp_path: Path,
+    auth_server: _AuthServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Subprocess in worktree cwd reads the absolute token path → POST succeeds.
+
+    Reproduces the #1261 setup: orchestrator workdir = ``tmp/project``,
+    spawner issues a token under ``project/.sdd/runtime/agent_tokens/``,
+    auth section embeds the absolute path, subprocess runs with
+    cwd=worktree (a sibling subdir) and uses ``cat $TOKEN_PATH`` to
+    extract the bearer. Asserts the server returns 201.
+    """
+    # 1. Project root + worktree layout
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    worktree_dir = project_root / ".sdd" / "worktrees" / "manager-deadbeef"
+    worktree_dir.mkdir(parents=True)
+
+    # 2. Build the spawner with a *relative* workdir to exercise the
+    #    absolutisation guarantee of the fix.
+    monkeypatch.chdir(tmp_path)
+    spawner = _make_offline_spawner(Path("project"))
+    spawner._identity_store_instance = MagicMock(  # pyright: ignore[reportPrivateUsage]
+        create_identity=MagicMock(return_value=(MagicMock(), _BEARER_TOKEN)),
+    )
+
+    # 3. Issue the token + render the auth section the same way the
+    #    production spawner does.
+    token_path = spawner._issue_agent_token(  # pyright: ignore[reportPrivateUsage]
+        session_id="manager-deadbeef",
+        role="manager",
+        task_ids=["T-001"],
+    )
+    auth_section = _render_auth_section(token_path)
+
+    # The fix invariant: the path embedded in the prompt is absolute.
+    assert token_path.is_absolute(), token_path
+    assert str(token_path) in auth_section
+
+    # 4. Build the env the env_isolation layer would hand the agent.
+    #    BERNSTEIN_AUTH_TOKEN passes through the allowlist.
+    monkeypatch.setenv("BERNSTEIN_AUTH_TOKEN", _BEARER_TOKEN)
+    agent_env = build_filtered_env()
+    assert agent_env.get("BERNSTEIN_AUTH_TOKEN") == _BEARER_TOKEN
+
+    # 5. The subprocess script: reads the token from the absolute path
+    #    embedded in the prompt and POSTs to /tasks. Mirrors what the
+    #    manager would do via curl, only in Python so we do not depend on
+    #    openssl / curl being on the test host's PATH.
+    script = textwrap.dedent(
+        f"""
+        import json
+        import os
+        import sys
+        import urllib.request
+
+        # Sanity: the subprocess cwd is the worktree, NOT the project root.
+        assert os.getcwd().endswith("manager-deadbeef"), os.getcwd()
+
+        token_path = {str(token_path)!r}
+        with open(token_path) as fh:
+            token = fh.read().strip()
+
+        req = urllib.request.Request(
+            "{auth_server.endpoint}/tasks",
+            method="POST",
+            data=json.dumps({{"title": "subtask-via-file", "role": "backend",
+                              "description": "issue-1261 regression"}}).encode(),
+            headers={{
+                "Authorization": f"Bearer {{token}}",
+                "Content-Type": "application/json",
+            }},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                print(resp.status)
+        except urllib.error.HTTPError as exc:
+            print(exc.code)
+            sys.exit(1)
+        """
+    ).strip()
+
+    # 6. Run the subprocess in the worktree cwd with the agent env.
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=worktree_dir,
+        env=agent_env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, (
+        f"Manager subprocess failed to POST /tasks.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    )
+    assert result.stdout.strip() == "201", result.stdout
+
+
+def test_manager_subprocess_can_post_via_env_var_fallback(
+    tmp_path: Path,
+    auth_server: _AuthServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``BERNSTEIN_AUTH_TOKEN`` env fallback also reaches the server with 201.
+
+    Defence-in-depth half of #1261 — if the per-agent token file is
+    missing or unreadable, the env var (passed through the
+    env_isolation allowlist) must still authenticate the request. This
+    guards against silent regressions in the env allowlist as much as in
+    the path-resolution fix.
+    """
+    project_root = tmp_path / "project-env"
+    project_root.mkdir()
+    worktree_dir = project_root / ".sdd" / "worktrees" / "manager-cafefeed"
+    worktree_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("BERNSTEIN_AUTH_TOKEN", _BEARER_TOKEN)
+    agent_env = build_filtered_env()
+    assert agent_env.get("BERNSTEIN_AUTH_TOKEN") == _BEARER_TOKEN
+
+    script = textwrap.dedent(
+        f"""
+        import json
+        import os
+        import sys
+        import urllib.request
+
+        token = os.environ["BERNSTEIN_AUTH_TOKEN"]
+        req = urllib.request.Request(
+            "{auth_server.endpoint}/tasks",
+            method="POST",
+            data=json.dumps({{"title": "subtask-via-env", "role": "backend",
+                              "description": "issue-1261 env fallback"}}).encode(),
+            headers={{
+                "Authorization": f"Bearer {{token}}",
+                "Content-Type": "application/json",
+            }},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                print(resp.status)
+        except urllib.error.HTTPError as exc:
+            print(exc.code)
+            sys.exit(1)
+        """
+    ).strip()
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=worktree_dir,
+        env=agent_env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == 0, f"Env-fallback subprocess failed.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
+    assert result.stdout.strip() == "201", result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _NoopAdapter:
+    """Adapter shell — :func:`_make_offline_spawner` never invokes spawn()."""
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict | None = None,  # type: ignore[type-arg]
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        raise NotImplementedError
+
+    def name(self) -> str:
+        return "noop"
+
+    def is_alive(self, pid: int) -> bool:  # pragma: no cover — never invoked
+        return False
+
+    def kill(self, pid: int) -> None:  # pragma: no cover — never invoked
+        pass
+
+
+def _make_offline_spawner(workdir: Path) -> AgentSpawner:
+    """Construct a spawner with worktree creation disabled."""
+    templates_dir = workdir / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(
+        adapter=_NoopAdapter(),  # type: ignore[arg-type]
+        templates_dir=templates_dir,
+        workdir=workdir,
+        use_worktrees=False,
+    )

--- a/tests/unit/test_spawner_agent_token.py
+++ b/tests/unit/test_spawner_agent_token.py
@@ -1,0 +1,230 @@
+"""Regression tests for the manager → task-server auth flow (#1261).
+
+Covers:
+
+* :func:`_render_auth_section` always emits an **absolute** token file path
+  so the agent's ``cat $TOKEN_PATH`` resolves to the real token regardless
+  of the agent's spawn cwd (project root vs git worktree).
+* :meth:`AgentSpawner._issue_agent_token` writes the token to an absolute
+  path under the orchestrator workdir, even when the spawner is
+  constructed with a relative ``workdir`` argument.
+* The auth section instructions reference the absolute path AND the
+  ``BERNSTEIN_AUTH_TOKEN`` env fallback so the agent has two independent
+  ways to reach the task server.
+
+The original bug (#1261): the manager agent runs in
+``.sdd/worktrees/<session>/`` (cwd ≠ orchestrator project root); the
+auth section embedded a path that, depending on caller arguments, could
+end up relative; the agent's ``cat <relative>`` resolved against the
+worktree, missed the real token in the project root's
+``.sdd/runtime/agent_tokens/``, and every ``POST /tasks`` returned 401.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.base import CLIAdapter, SpawnResult
+from bernstein.core.agents.spawner_core import (
+    AgentSpawner,
+    _render_auth_section,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _NoopAdapter(CLIAdapter):
+    """Stub adapter — never spawns a process; just satisfies the constructor."""
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: ModelConfig,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> SpawnResult:
+        raise NotImplementedError
+
+    def name(self) -> str:
+        return "noop"
+
+
+def _make_spawner(workdir: Path) -> AgentSpawner:
+    """Build an AgentSpawner with worktrees disabled (fast, deterministic)."""
+    templates_dir = workdir / "templates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+    return AgentSpawner(
+        adapter=_NoopAdapter(),
+        templates_dir=templates_dir,
+        workdir=workdir,
+        use_worktrees=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _render_auth_section — path absolutisation
+# ---------------------------------------------------------------------------
+
+
+def test_render_auth_section_absolutises_relative_path(tmp_path: Path) -> None:
+    """A relative ``token_path`` must be rewritten to absolute in the prompt.
+
+    Without this guarantee the agent's ``cat`` command resolves the path
+    against its spawn cwd (the worktree) instead of the orchestrator
+    workdir, and authentication silently breaks.
+    """
+    # cwd is set to tmp_path so we can construct a relative path that
+    # resolves under tmp_path/.sdd/...
+    monkey_cwd = tmp_path
+    os.chdir(monkey_cwd)
+    relative = Path(".sdd/runtime/agent_tokens/manager-abc12345.token")
+    assert not relative.is_absolute()
+
+    section = _render_auth_section(relative)
+
+    # The rendered block must contain the absolute resolution of the path,
+    # not the relative form.
+    expected_abs = relative.resolve(strict=False)
+    assert str(expected_abs) in section
+    assert "## Task Server Authentication" in section
+    # The instruction text must mention the absolute path quality so the
+    # agent does not assume cwd-relative addressing.
+    assert "absolute path" in section.lower()
+
+
+def test_render_auth_section_preserves_absolute_path(tmp_path: Path) -> None:
+    """An already-absolute path is passed through verbatim."""
+    absolute = (tmp_path / ".sdd" / "runtime" / "agent_tokens" / "manager-deadbeef.token").resolve()
+    section = _render_auth_section(absolute)
+    assert str(absolute) in section
+
+
+def test_render_auth_section_mentions_env_fallback(tmp_path: Path) -> None:
+    """The auth section advertises ``BERNSTEIN_AUTH_TOKEN`` as a fallback.
+
+    Even if the token file is unreadable (filesystem race, permission
+    change, missing parent dir) the agent must have a documented second
+    channel — env var inheritance via the env_isolation allowlist.
+    """
+    section = _render_auth_section(tmp_path / "token")
+    assert "BERNSTEIN_AUTH_TOKEN" in section
+
+
+def test_render_auth_section_includes_authorization_header_example(tmp_path: Path) -> None:
+    """The section must show a curl example with the Authorization header."""
+    section = _render_auth_section(tmp_path / "manager.token")
+    assert "Authorization: Bearer $(cat" in section
+    assert "POST http://127.0.0.1:8052/tasks" in section
+
+
+# ---------------------------------------------------------------------------
+# _issue_agent_token — writes the token file at an absolute path
+# ---------------------------------------------------------------------------
+
+
+def test_issue_agent_token_returns_absolute_path(tmp_path: Path, monkeypatch: Any) -> None:
+    """Even when the spawner workdir is relative, the token path is absolute.
+
+    Regression for #1261: a relative workdir → relative token_path →
+    agent's ``cat`` (executed inside the worktree) misses the file.
+    """
+    # Construct the spawner with a relative workdir. We chdir to the
+    # parent so the relative path is well-defined.
+    monkeypatch.chdir(tmp_path)
+    relative_workdir = Path("project-root")
+    relative_workdir.mkdir()
+
+    spawner = _make_spawner(relative_workdir)
+
+    # Stub out identity-store credential issuance — we are not testing JWT
+    # signing here, just path handling.
+    stub_identity = MagicMock()
+    stub_identity.create_identity = MagicMock(return_value=(MagicMock(), "fake-jwt-token-body"))
+    spawner._identity_store_instance = stub_identity
+
+    token_path = spawner._issue_agent_token(
+        session_id="manager-abcd1234",
+        role="manager",
+        task_ids=["T-001"],
+    )
+
+    assert token_path.is_absolute(), f"Token path must be absolute, got {token_path}"
+    assert token_path.exists()
+    # The file lives under the resolved workdir, not the cwd-relative form.
+    expected_root = relative_workdir.resolve() / ".sdd" / "runtime" / "agent_tokens"
+    assert token_path.parent == expected_root
+    assert token_path.read_text() == "fake-jwt-token-body"
+
+
+def test_issue_agent_token_file_mode_is_0600(tmp_path: Path) -> None:
+    """The token file is written with 0600 permissions (owner read/write only).
+
+    Defence-in-depth: even with the absolute-path fix, a world-readable
+    token file would leak credentials to other local users.
+    """
+    if os.name == "nt":  # pragma: no cover — POSIX-only file modes
+        return
+
+    spawner = _make_spawner(tmp_path)
+    spawner._identity_store_instance = MagicMock(
+        create_identity=MagicMock(return_value=(MagicMock(), "secret-jwt")),
+    )
+
+    token_path = spawner._issue_agent_token(
+        session_id="manager-aaaabbbb",
+        role="manager",
+        task_ids=[],
+    )
+
+    mode = token_path.stat().st_mode & 0o777
+    assert mode == 0o600, f"Expected 0600, got {oct(mode)}"
+
+
+def test_auth_section_in_prompt_resolves_when_agent_cwd_is_worktree(tmp_path: Path) -> None:
+    """End-to-end: prompt-embedded path resolves to a real file from a worktree.
+
+    Simulates the manager agent's runtime: ``cat $TOKEN_PATH`` is
+    invoked with cwd set to ``.sdd/worktrees/<session>/`` (a subdir of
+    the orchestrator workdir). With the #1261 fix the absolute path
+    survives the cwd change and the token file is readable.
+    """
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    spawner = _make_spawner(project_root)
+    spawner._identity_store_instance = MagicMock(
+        create_identity=MagicMock(return_value=(MagicMock(), "live-token-bytes")),
+    )
+
+    token_path = spawner._issue_agent_token(
+        session_id="manager-ccccdddd",
+        role="manager",
+        task_ids=[],
+    )
+    section = _render_auth_section(token_path)
+
+    # Extract the path from the rendered section the same way an agent
+    # would parse it — the absolute path appears in the fenced block.
+    assert str(token_path) in section
+    assert token_path.is_absolute()
+
+    # Now simulate the worktree cwd: change to a subdir and verify the
+    # absolute path still reads back the token.
+    worktree_dir = project_root / ".sdd" / "worktrees" / "manager-ccccdddd"
+    worktree_dir.mkdir(parents=True)
+    os.chdir(worktree_dir)
+    assert token_path.read_text() == "live-token-bytes"


### PR DESCRIPTION
## Root cause

`AgentSpawner._issue_agent_token` (`src/bernstein/core/agents/spawner_core.py:971`) built the per-agent JWT path as `self._workdir / ".sdd" / "runtime" / "agent_tokens" / "<session>.token"` without resolving it. When the orchestrator was started with a relative working directory, the path stayed relative; `_render_auth_section` then embedded it verbatim into the agent prompt. The manager agent runs with `cwd = .sdd/worktrees/<session>/` (worktree isolation), so `cat <relative-path>` resolved against the worktree and missed the real token file in the project root. With no token, every `POST /tasks` returned 401 — manager looped on `find ... -name "*.token"`, the watchdog killed the unresponsive server after 60s, and no child workers were ever spawned.

This is **hypothesis H1** from the brief: env propagation works (`BERNSTEIN_AUTH_TOKEN` is on the `env_isolation` allowlist), per-agent JWT signing works, prompt injection works — only the path resolution broke.

## The fix in one sentence

Resolve the per-agent token path to absolute when issuing it (defensively again in `_render_auth_section`) and document the env-var fallback, so the agent can authenticate regardless of its spawn cwd.

## Regression tests

- `tests/unit/test_spawner_agent_token.py` — asserts `_render_auth_section` always emits an absolute path, mentions the `BERNSTEIN_AUTH_TOKEN` fallback, and that `_issue_agent_token` writes 0600 token files at absolute paths even from a relative spawner workdir.
- `tests/integration/test_manager_auth_to_task_server.py` — boots a real uvicorn task server with the legacy bearer enabled, drives a subprocess in a worktree-like cwd with the env `build_filtered_env` would hand a real agent, and asserts the subprocess can `POST /tasks` (201) via both the token-file path and the env-var fallback. The token-file test fails on `main` without the spawner_core change.

## Out of scope

- The manager's prompt template was already pointed at HTTP curl; the deeper "move manager → workers spawn off the HTTP path entirely" rework is left for a follow-up.
- Worker role templates (`backend`, `qa`, etc.) also POST to `/tasks/.../complete`; they already received the same `_render_auth_section` injection, so the absolute-path fix here covers them too.

## Test plan

- [x] `uv run pytest tests/unit/test_spawner_agent_token.py tests/integration/test_manager_auth_to_task_server.py -x -q`
- [x] Broader regression scan: `uv run pytest tests/unit/ -k "spawn or env_isol or auth_middleware or adapter_manager or spawn_prompt or render_auth"` (1240 passed, 16 skipped)
- [x] `uv run ruff check` + `uv run ruff format --check` on changed files
- [ ] CI green on this PR

Closes #1261