### PR TITLE
feat(orchestrator): detect stalled manager + actionable error

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1555,6 +1555,16 @@ class Orchestrator:
         if _run_slow:
             self._watchdog.sync(collect_watchdog_findings(self))
 
+        # 4d-ii.7 Stalled-manager detector (#1261). Run BEFORE the generic
+        # supervisor times out and emits a misleading "Server unresponsive"
+        # kill so operators see the real cause + remediation pointer.
+        from bernstein.core.orchestration.stalled_manager import handle_stalled_manager
+
+        if handle_stalled_manager(self) is not None:
+            # Diagnostic already logged + persisted; _running is now False so
+            # _run_loop will exit cleanly on its next iteration.
+            return result
+
         # 4d-iii. Cost anomaly detection: burn rate projection, stop on budget overrun
         # Gated behind _run_slow — anomaly detection doesn't need every-tick granularity.
         if _run_slow:

--- a/src/bernstein/core/orchestration/orchestrator_run.py
+++ b/src/bernstein/core/orchestration/orchestrator_run.py
@@ -35,10 +35,19 @@ def run(orch: Any) -> None:
 
     Args:
         orch: The orchestrator instance.
+
+    Raises:
+        SystemExit(2): If the stalled-manager detector (#1261) tripped during
+            the run. The orchestrator drains and persists state first; the
+            non-zero exit makes the failure visible to the parent CLI without
+            having to grep the orchestrator log.
     """
     _run_startup(orch)
     _run_loop(orch)
     _run_shutdown(orch)
+    diagnostic = getattr(orch, "_stalled_manager_diagnostic", None)
+    if diagnostic is not None:
+        raise SystemExit(2)
 
 
 def _run_startup(orch: Any) -> None:

--- a/src/bernstein/core/orchestration/stalled_manager.py
+++ b/src/bernstein/core/orchestration/stalled_manager.py
@@ -1,0 +1,318 @@
+"""Stalled-manager detection — actionable error when manager never creates children.
+
+The manager agent is responsible for decomposing the seed goal into child tasks
+by POSTing to the task server. When the manager process is alive (heartbeats
+present, hook events being recorded) but never makes a successful ``POST /tasks``
+call — typically because of an auth-token issue between the manager worktree
+and the task server — the generic watchdog eventually kills the task server
+with a misleading "Server unresponsive" message after roughly three minutes.
+
+This module detects that specific failure mode directly:
+
+* A manager-role session has been alive for ``STALL_THRESHOLD_S`` seconds.
+* No child tasks exist on the server (only the manager's own seed task).
+
+When that combination holds, we
+
+1. log a clear single-line orchestrator message (no false "unresponsive" claim),
+2. write a structured failure record to ``.sdd/runtime/failures/`` with the
+   manager session id, hook event count, last few bash commands, redacted env,
+   and a remediation pointer,
+3. request a clean orchestrator shutdown (``_running = False``) so the parent
+   ``bernstein run`` invocation exits non-zero with the diagnostic visible.
+
+The detector is purely observability + UX; it never restarts the server,
+never kills the manager, and never modifies the auth flow itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# How long the manager may run with zero child tasks before we declare a stall.
+# Chosen to comfortably exceed the manager's own LLM-call latency (typically
+# 30-60 s) while firing well inside the generic 3-minute watchdog window.
+STALL_THRESHOLD_S: float = 90.0
+
+# Path to the operator-facing remediation doc. A sibling effort owns the
+# actual document; if it already lives elsewhere we still emit a pointer so
+# operators can grep for it.
+REMEDIATION_DOC: str = "docs/architecture/manager-auth.md"
+
+# Env vars whose names we surface in the failure record (values redacted).
+# Anything that looks like a secret is redacted regardless of being on the
+# allowlist — see ``_redact_env``.
+_TRACKED_ENV_PREFIXES: tuple[str, ...] = ("BERNSTEIN_", "ANTHROPIC_", "OPENAI_", "OPENROUTER_")
+
+# Substrings used to redact env values whose names suggest secrets.
+_SENSITIVE_NAME_HINTS: tuple[str, ...] = (
+    "TOKEN",
+    "SECRET",
+    "KEY",
+    "PASSWORD",
+    "AUTH",
+    "CREDENTIAL",
+)
+
+
+@dataclass(frozen=True)
+class StalledManagerDiagnostic:
+    """Structured diagnostic for a stalled-manager incident."""
+
+    session_id: str
+    manager_task_id: str
+    runtime_s: float
+    hook_event_count: int
+    last_bash_commands: list[str] = field(default_factory=list)
+    env_seen: dict[str, str] = field(default_factory=dict)
+    remediation: str = REMEDIATION_DOC
+
+    def message(self) -> str:
+        """Return the one-line operator-facing console message."""
+        return (
+            f"Manager session {self.session_id} ran for {self.runtime_s:.0f}s without "
+            f"creating any child tasks ({self.hook_event_count} hook event(s) recorded). "
+            f"This is NOT a generic server timeout — the manager likely cannot authenticate "
+            f"to the task server. See {self.remediation} for remediation."
+        )
+
+    def to_record(self) -> dict[str, Any]:
+        """Serializable failure record for ``.sdd/runtime/failures/``."""
+        return {
+            "kind": "stalled_manager",
+            "session_id": self.session_id,
+            "manager_task_id": self.manager_task_id,
+            "runtime_s": round(self.runtime_s, 2),
+            "hook_event_count": self.hook_event_count,
+            "last_bash_commands": list(self.last_bash_commands),
+            "env_seen": dict(self.env_seen),
+            "remediation": self.remediation,
+            "detected_at": time.time(),
+        }
+
+
+def _is_sensitive_name(name: str) -> bool:
+    upper = name.upper()
+    return any(hint in upper for hint in _SENSITIVE_NAME_HINTS)
+
+
+def _redact_env(env: dict[str, str]) -> dict[str, str]:
+    """Filter to tracked prefixes and redact obviously sensitive values."""
+    out: dict[str, str] = {}
+    for name, value in env.items():
+        if not any(name.startswith(p) for p in _TRACKED_ENV_PREFIXES):
+            continue
+        if _is_sensitive_name(name):
+            out[name] = "<redacted>" if value else "<unset>"
+        else:
+            # Even non-sensitive entries are truncated to keep the record small.
+            out[name] = value[:120]
+    return out
+
+
+def _read_hook_events(workdir: Path, session_id: str, *, tail: int = 200) -> list[dict[str, Any]]:
+    """Read the last ``tail`` JSONL records from the hook sidecar for a session."""
+    hooks_path = workdir / ".sdd" / "runtime" / "hooks" / f"{session_id}.jsonl"
+    if not hooks_path.exists():
+        return []
+    try:
+        raw = hooks_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    events: list[dict[str, Any]] = []
+    for line in raw[-tail:]:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            events.append(parsed)
+    return events
+
+
+def _extract_last_bash_commands(events: list[dict[str, Any]], *, limit: int = 5) -> list[str]:
+    """Pull the last ``limit`` Bash tool inputs from a hook event stream."""
+    bashes: list[str] = []
+    for event in events:
+        if event.get("tool_name") == "Bash":
+            cmd = str(event.get("tool_input", ""))[:200]
+            if cmd:
+                bashes.append(cmd)
+    return bashes[-limit:]
+
+
+def _find_manager_session(agents: dict[str, Any], now: float) -> Any | None:
+    """Return the oldest live ``role == "manager"`` session, if any."""
+    candidates: list[tuple[float, Any]] = []
+    for session in agents.values():
+        if getattr(session, "role", "") != "manager":
+            continue
+        if getattr(session, "status", "") == "dead":
+            continue
+        runtime = max(now - float(getattr(session, "spawn_ts", now)), 0.0)
+        candidates.append((runtime, session))
+    if not candidates:
+        return None
+    # Oldest session first — that's the one we judge against the threshold.
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def _has_child_tasks(latest_tasks: dict[str, Any], manager_task_id: str) -> bool:
+    """Return True if any task other than the manager's seed task exists."""
+    return any(task_id != manager_task_id for task_id in latest_tasks)
+
+
+def _write_failure_record(workdir: Path, diagnostic: StalledManagerDiagnostic) -> Path | None:
+    """Persist the diagnostic to ``.sdd/runtime/failures/`` if writable."""
+    failures_dir = workdir / ".sdd" / "runtime" / "failures"
+    try:
+        failures_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    ts = time.strftime("%Y%m%dT%H%M%S")
+    path = failures_dir / f"manager-stalled-{ts}-{diagnostic.session_id}.json"
+    try:
+        path.write_text(json.dumps(diagnostic.to_record(), indent=2), encoding="utf-8")
+    except OSError:
+        return None
+    return path
+
+
+def _append_orchestrator_log(workdir: Path, line: str) -> None:
+    """Append a single line to ``.sdd/runtime/orchestrator.log``, best-effort."""
+    log_dir = workdir / ".sdd" / "runtime"
+    try:
+        log_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+    log_path = log_dir / "orchestrator.log"
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"[{ts}] {line}\n")
+    except OSError:
+        pass
+
+
+def build_diagnostic(
+    workdir: Path,
+    session: Any,
+    *,
+    now: float,
+    manager_env: dict[str, str] | None = None,
+) -> StalledManagerDiagnostic:
+    """Assemble a diagnostic record from filesystem + session state."""
+    session_id = str(getattr(session, "id", ""))
+    task_ids = getattr(session, "task_ids", []) or []
+    manager_task_id = str(task_ids[0]) if task_ids else ""
+    runtime = max(now - float(getattr(session, "spawn_ts", now)), 0.0)
+    events = _read_hook_events(workdir, session_id)
+    bashes = _extract_last_bash_commands(events)
+    env_seen = _redact_env(manager_env or {})
+    return StalledManagerDiagnostic(
+        session_id=session_id,
+        manager_task_id=manager_task_id,
+        runtime_s=runtime,
+        hook_event_count=len(events),
+        last_bash_commands=bashes,
+        env_seen=env_seen,
+    )
+
+
+def detect_stalled_manager(orch: Any) -> StalledManagerDiagnostic | None:
+    """Return a diagnostic if a manager session has stalled, else ``None``.
+
+    Pure detection — never mutates orchestrator state. The caller decides
+    whether to log, write the failure record, or abort the run.
+    """
+    workdir = getattr(orch, "_workdir", None)
+    if not isinstance(workdir, Path):
+        return None
+
+    agents_raw = getattr(orch, "_agents", {})
+    if not isinstance(agents_raw, dict):
+        return None
+    agents: dict[str, Any] = dict(agents_raw)
+
+    now = time.time()
+    session = _find_manager_session(agents, now)
+    if session is None:
+        return None
+
+    runtime = max(now - float(getattr(session, "spawn_ts", now)), 0.0)
+    threshold = float(getattr(getattr(orch, "_config", None), "stalled_manager_threshold_s", STALL_THRESHOLD_S))
+    if runtime < threshold:
+        return None
+
+    task_ids = getattr(session, "task_ids", []) or []
+    manager_task_id = str(task_ids[0]) if task_ids else ""
+
+    latest_tasks_raw = getattr(orch, "_latest_tasks_by_id", {})
+    if not isinstance(latest_tasks_raw, dict):
+        return None
+    latest_tasks: dict[str, Any] = dict(latest_tasks_raw)
+
+    if _has_child_tasks(latest_tasks, manager_task_id):
+        return None
+
+    manager_env = getattr(orch, "_manager_env_snapshot", None)
+    return build_diagnostic(workdir, session, now=now, manager_env=manager_env)
+
+
+def handle_stalled_manager(orch: Any) -> StalledManagerDiagnostic | None:
+    """Detect, surface, and request shutdown when the manager is stalled.
+
+    Returns the diagnostic on detection (also written to logs + failures dir);
+    returns ``None`` when no stall is present. Setting ``_running = False`` on
+    the orchestrator triggers the existing clean-drain path in
+    ``orchestrator_run._run_loop`` — no generic-watchdog kill is required.
+    """
+    # Avoid emitting the same diagnostic on every tick.
+    if getattr(orch, "_stalled_manager_emitted", False):
+        return None
+
+    diagnostic = detect_stalled_manager(orch)
+    if diagnostic is None:
+        return None
+
+    workdir = getattr(orch, "_workdir", None)
+    message = diagnostic.message()
+    logger.error("%s", message)
+
+    if isinstance(workdir, Path):
+        _append_orchestrator_log(workdir, f"stalled_manager: {message}")
+        record_path = _write_failure_record(workdir, diagnostic)
+        if record_path is not None:
+            logger.error("Stalled-manager diagnostic written to %s", record_path)
+
+    # Best-effort console surface for operators running ``bernstein run``
+    # in the foreground.  The orchestrator does not assume a Rich console
+    # is present; ``print`` reaches stdout/stderr regardless.
+    print(f"[bernstein] {message}")
+
+    # Bulletin / notification channel if the orchestrator wires one in.
+    bulletin = getattr(orch, "_post_bulletin", None)
+    if callable(bulletin):
+        try:
+            bulletin("alert", f"stalled_manager: {message}")
+        except Exception:
+            logger.debug("post_bulletin raised while reporting stalled manager", exc_info=True)
+
+    # Request clean shutdown so the run aborts with a non-zero exit *and* the
+    # operator sees the actionable diagnostic instead of the generic
+    # "Server unresponsive" message that the supervisor would emit later.
+    orch._running = False
+    orch._stalled_manager_emitted = True
+    orch._stalled_manager_diagnostic = diagnostic
+    return diagnostic

--- a/tests/unit/test_stalled_manager.py
+++ b/tests/unit/test_stalled_manager.py
@@ -1,0 +1,283 @@
+"""Unit tests for the stalled-manager detector (#1261)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from bernstein.core.models import AgentSession, ModelConfig, Task
+
+from bernstein.core.orchestration.stalled_manager import (
+    REMEDIATION_DOC,
+    STALL_THRESHOLD_S,
+    StalledManagerDiagnostic,
+    _redact_env,
+    build_diagnostic,
+    detect_stalled_manager,
+    handle_stalled_manager,
+)
+
+
+def _manager_session(*, spawn_ts: float, task_id: str = "manager-task-1") -> AgentSession:
+    return AgentSession(
+        id="manager-abc12345",
+        role="manager",
+        task_ids=[task_id],
+        status="working",
+        spawn_ts=spawn_ts,
+        model_config=ModelConfig("opus", "max"),
+    )
+
+
+def _build_orch(
+    workdir: Path,
+    *,
+    session: AgentSession,
+    extra_tasks: list[str] | None = None,
+    manager_env: dict[str, str] | None = None,
+) -> SimpleNamespace:
+    task_ids = [session.task_ids[0], *(extra_tasks or [])]
+    latest_tasks = {
+        tid: Task(
+            id=tid,
+            title="Plan and decompose goal into tasks" if tid == session.task_ids[0] else f"Child {tid}",
+            description="",
+            role="manager" if tid == session.task_ids[0] else "backend",
+        )
+        for tid in task_ids
+    }
+    bulletins: list[tuple[str, str]] = []
+
+    def _post_bulletin(kind: str, body: str) -> None:
+        bulletins.append((kind, body))
+
+    orch = SimpleNamespace(
+        _workdir=workdir,
+        _agents={session.id: session},
+        _latest_tasks_by_id=latest_tasks,
+        _config=SimpleNamespace(stalled_manager_threshold_s=STALL_THRESHOLD_S),
+        _manager_env_snapshot=manager_env or {},
+        _running=True,
+        _post_bulletin=_post_bulletin,
+    )
+    # Expose bulletins for assertion convenience.
+    orch.bulletins = bulletins  # type: ignore[attr-defined]
+    return orch
+
+
+def _write_hook_events(workdir: Path, session_id: str, events: list[dict[str, Any]]) -> None:
+    path = workdir / ".sdd" / "runtime" / "hooks" / f"{session_id}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# detect_stalled_manager
+# ---------------------------------------------------------------------------
+
+
+def test_detect_returns_none_when_manager_under_threshold(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 30.0)  # 30s alive
+    orch = _build_orch(tmp_path, session=session)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        assert detect_stalled_manager(orch) is None
+
+
+def test_detect_returns_none_when_child_tasks_exist(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 120.0)  # past threshold
+    orch = _build_orch(tmp_path, session=session, extra_tasks=["task-2"])
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        assert detect_stalled_manager(orch) is None
+
+
+def test_detect_fires_when_manager_alive_with_no_children(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 120.0)
+    _write_hook_events(
+        tmp_path,
+        session.id,
+        [
+            {"event": "PostToolUse", "tool_name": "Bash", "tool_input": "find .sdd -type f"},
+            {"event": "PostToolUse", "tool_name": "Bash", "tool_input": "curl http://127.0.0.1:8052/tasks"},
+            {"event": "PostToolUse", "tool_name": "Grep", "tool_input": "auth"},
+        ],
+    )
+    orch = _build_orch(tmp_path, session=session)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        diag = detect_stalled_manager(orch)
+    assert diag is not None
+    assert diag.session_id == session.id
+    assert diag.manager_task_id == "manager-task-1"
+    assert diag.runtime_s == 120.0
+    assert diag.hook_event_count == 3
+    # Last 5 Bash commands — there are only 2 here.
+    assert diag.last_bash_commands == [
+        "find .sdd -type f",
+        "curl http://127.0.0.1:8052/tasks",
+    ]
+    assert diag.remediation == REMEDIATION_DOC
+
+
+def test_detect_ignores_dead_manager_session(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 200.0)
+    session.status = "dead"
+    orch = _build_orch(tmp_path, session=session)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        assert detect_stalled_manager(orch) is None
+
+
+def test_detect_ignores_non_manager_roles(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 200.0)
+    session.role = "backend"
+    orch = _build_orch(tmp_path, session=session)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        assert detect_stalled_manager(orch) is None
+
+
+# ---------------------------------------------------------------------------
+# handle_stalled_manager: side effects
+# ---------------------------------------------------------------------------
+
+
+def test_handle_writes_failure_record_and_log_and_aborts(tmp_path: Path, capsys: Any) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 120.0)
+    _write_hook_events(
+        tmp_path,
+        session.id,
+        [
+            {"event": "PostToolUse", "tool_name": "Bash", "tool_input": "curl /tasks"},
+            {"event": "PostToolUse", "tool_name": "Write", "tool_input": "/tmp/task1.json"},
+        ],
+    )
+    orch = _build_orch(
+        tmp_path,
+        session=session,
+        manager_env={
+            "BERNSTEIN_AUTH_TOKEN": "super-secret-abc123",
+            "BERNSTEIN_SERVER_URL": "http://127.0.0.1:8052",
+            "ANTHROPIC_API_KEY": "sk-ant-xxx",
+            "HOME": "/home/user",  # should be filtered out
+        },
+    )
+
+    with (
+        patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now),
+        patch("bernstein.core.orchestration.stalled_manager.time.strftime", return_value="20260516T120000"),
+    ):
+        diag = handle_stalled_manager(orch)
+
+    assert diag is not None
+
+    # Run was aborted cleanly: _running flipped to False.
+    assert orch._running is False
+    # Sticky flag prevents re-emission.
+    assert orch._stalled_manager_emitted is True
+    assert orch._stalled_manager_diagnostic is diag
+
+    # Console message surfaced.
+    captured = capsys.readouterr()
+    assert "Manager session" in captured.out
+    assert REMEDIATION_DOC in captured.out
+
+    # Bulletin was posted with the alert.
+    assert orch.bulletins == [("alert", f"stalled_manager: {diag.message()}")]
+
+    # Failure record was persisted under .sdd/runtime/failures/.
+    failures_dir = tmp_path / ".sdd" / "runtime" / "failures"
+    files = list(failures_dir.glob("manager-stalled-*.json"))
+    assert len(files) == 1
+    record = json.loads(files[0].read_text(encoding="utf-8"))
+    assert record["kind"] == "stalled_manager"
+    assert record["session_id"] == session.id
+    assert record["manager_task_id"] == "manager-task-1"
+    assert record["hook_event_count"] == 2
+    assert record["remediation"] == REMEDIATION_DOC
+    # Secrets redacted; non-secret tracked env retained; non-tracked dropped.
+    assert record["env_seen"]["BERNSTEIN_AUTH_TOKEN"] == "<redacted>"
+    assert record["env_seen"]["ANTHROPIC_API_KEY"] == "<redacted>"
+    assert record["env_seen"]["BERNSTEIN_SERVER_URL"] == "http://127.0.0.1:8052"
+    assert "HOME" not in record["env_seen"]
+
+    # Orchestrator log line written.
+    log_path = tmp_path / ".sdd" / "runtime" / "orchestrator.log"
+    assert log_path.exists()
+    log_contents = log_path.read_text(encoding="utf-8")
+    assert "stalled_manager" in log_contents
+    assert REMEDIATION_DOC in log_contents
+
+
+def test_handle_is_idempotent_across_ticks(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 200.0)
+    orch = _build_orch(tmp_path, session=session)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        first = handle_stalled_manager(orch)
+        second = handle_stalled_manager(orch)
+    assert first is not None
+    assert second is None  # already emitted; do not re-fire
+
+
+def test_handle_returns_none_when_no_stall(tmp_path: Path) -> None:
+    now = 1_000.0
+    session = _manager_session(spawn_ts=now - 10.0)
+    orch = _build_orch(tmp_path, session=session)
+    with patch("bernstein.core.orchestration.stalled_manager.time.time", return_value=now):
+        assert handle_stalled_manager(orch) is None
+    assert orch._running is True
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic message + helpers
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostic_message_includes_actionable_pointer() -> None:
+    diag = StalledManagerDiagnostic(
+        session_id="manager-deadbeef",
+        manager_task_id="task-1",
+        runtime_s=125.0,
+        hook_event_count=18,
+    )
+    msg = diag.message()
+    assert "manager-deadbeef" in msg
+    assert "125s" in msg
+    assert "18 hook event" in msg
+    assert REMEDIATION_DOC in msg
+    assert "authenticate" in msg.lower()
+
+
+def test_redact_env_handles_secret_substrings() -> None:
+    out = _redact_env(
+        {
+            "BERNSTEIN_AUTH_TOKEN": "abc",
+            "BERNSTEIN_HOOK_SECRET": "xyz",
+            "BERNSTEIN_BIND_HOST": "127.0.0.1",
+            "OPENROUTER_API_KEY": "sk-or-...",
+            "PATH": "/usr/bin",
+        }
+    )
+    assert out["BERNSTEIN_AUTH_TOKEN"] == "<redacted>"
+    assert out["BERNSTEIN_HOOK_SECRET"] == "<redacted>"
+    assert out["BERNSTEIN_BIND_HOST"] == "127.0.0.1"
+    assert out["OPENROUTER_API_KEY"] == "<redacted>"
+    assert "PATH" not in out
+
+
+def test_build_diagnostic_picks_last_five_bash_commands(tmp_path: Path) -> None:
+    session = _manager_session(spawn_ts=time.time() - 100.0)
+    events = [{"event": "PostToolUse", "tool_name": "Bash", "tool_input": f"cmd-{i}"} for i in range(8)]
+    _write_hook_events(tmp_path, session.id, events)
+    diag = build_diagnostic(tmp_path, session, now=time.time())
+    assert diag.last_bash_commands == ["cmd-3", "cmd-4", "cmd-5", "cmd-6", "cmd-7"]
+    assert diag.hook_event_count == 8


### PR DESCRIPTION
## Summary

Adds a dedicated "stalled-manager" detector so operators see the actual failure mode (manager alive but never POSTs `/tasks`) instead of the misleading `Server unresponsive for 60s` kill that the supervisor emits ~3 minutes later. Closes the UX side of #1261.

- New module `src/bernstein/core/orchestration/stalled_manager.py`:
  - Trips when a `role=manager` session has been alive `>= 90s` AND only the manager's own seed task exists on the server (no children).
  - Writes a structured failure record to `.sdd/runtime/failures/manager-stalled-<ts>-<sid>.json` with session id, hook event count, last 5 Bash commands from `runtime/hooks/<sid>.jsonl`, redacted env, and the remediation pointer `docs/architecture/manager-auth.md`.
  - Appends a single line to `.sdd/runtime/orchestrator.log` and prints the actionable message to stdout.
  - Posts a bulletin and clears `_running` so the existing drain path takes over — no generic-watchdog kill.
- Hook in `Orchestrator.tick()` (right after the existing watchdog sync) so the detector fires before the supervisor's 60s window expires.
- `orchestrator_run.run()` propagates `SystemExit(2)` after a clean drain when the stall fired, so `bernstein run` exits non-zero.
- 11 new unit tests in `tests/unit/test_stalled_manager.py`.

The auth-flow fix itself is out of scope (parallel agent on `fix/1261-auth-flow`).

## Test plan

- [x] `uv run pytest tests/unit/test_stalled_manager.py tests/unit/test_watchdog.py tests/unit/test_orchestrator.py -x -q` green
- [x] `uv run ruff check` clean on changed files
- [x] `uv run ruff format --check` clean on changed files
- [ ] CI green
