### PR TITLE
chore(ci): pre-commit config + Telegram fanout for nightly workflows

### DIFF
--- a/.github/workflows/notify-other-failures.yml
+++ b/.github/workflows/notify-other-failures.yml
@@ -1,0 +1,81 @@
+name: Telegram nightly-fanout notifications
+
+# Fan-out failure notifications for nightly / weekly workflows that previously
+# failed silently. Triggered on `workflow_run` completion so a single job
+# covers every workflow in the list — keeps the diff in each workflow zero.
+#
+# Reuses the same TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID secrets as
+# `telegram-notify.yml`. No new secret required.
+#
+# Refs: #1273.
+
+on:
+  workflow_run:
+    workflows:
+      - "Nightly deep tests"
+      - "eval-nightly"
+      - "soc2-evidence-nightly"
+      - "Adversarial Pen-Test Suite"
+    types: [completed]
+
+concurrency:
+  group: notify-other-${{ github.event.workflow_run.name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  notify:
+    # Notify on anything that isn't a clean pass or an explicit skip. This
+    # catches `failure`, `cancelled`, `timed_out`, `action_required`, and
+    # `startup_failure` — every operator-actionable outcome.
+    if: >-
+      github.event.workflow_run.conclusion != 'success' &&
+      github.event.workflow_run.conclusion != 'skipped' &&
+      github.event.workflow_run.conclusion != 'neutral'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Send Telegram notification for nightly failure
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          STATUS: ${{ github.event.workflow_run.conclusion }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          HTML_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          EVENT: ${{ github.event.workflow_run.event }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
+            echo "Telegram not configured; skipping."
+            exit 0
+          fi
+
+          SHORT_SHA="${SHA:0:7}"
+          case "${STATUS}" in
+            failure) ICON="❌" ;;
+            cancelled) ICON="🚫" ;;
+            timed_out) ICON="⏱️" ;;
+            action_required) ICON="⚠️" ;;
+            startup_failure) ICON="💥" ;;
+            *) ICON="⚠️" ;;
+          esac
+
+          TITLE="${ICON} ${WORKFLOW_NAME}: ${STATUS} (${EVENT})"
+          TEXT="${TITLE}
+          Branch: ${BRANCH:-?}
+          Commit: ${SHORT_SHA}
+          ${HTML_URL}"
+
+          KEYBOARD='{"inline_keyboard":[[{"text":"🔄 View Run","url":"'"${HTML_URL}"'"},{"text":"📋 Rerun","url":"https://github.com/'"${REPO}"'/actions/runs/'"${RUN_ID}"'/rerun"}]]}'
+
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            -H "Content-Type: application/json" \
+            -d "{\"chat_id\":\"${TELEGRAM_CHAT_ID}\",\"text\":\"${TEXT}\",\"reply_markup\":${KEYBOARD}}" \
+            || echo "Telegram notification failed"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,52 @@
+# Pre-commit hooks for Bernstein.
+#
+# Local: `pre-commit install && pre-commit run --all-files`.
+# In CI: pre-commit.ci (https://pre-commit.ci/) auto-fixes formatting / lint
+# drift on PRs by pushing follow-up commits. No new repo secret required.
+# Heavy checks (mypy / pyright / pytest) stay in GitHub Actions on purpose.
+#
+# Refs: #1273.
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in sync with `ruff>=0.9` pinned in pyproject.toml.
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        # Some workflow files use GitHub Actions tag expressions (`!!`) that
+        # break strict YAML parsing; rely on actionlint elsewhere.
+        args: [--allow-multiple-documents]
+        exclude: ^\.github/workflows/
+      - id: check-toml
+      - id: check-json
+        exclude: |
+          (?x)^(
+            \.bandit-baseline\.json|
+            \.vscode/.*\.json|
+            .*\.ipynb
+          )$
+      - id: end-of-file-fixer
+        exclude: |
+          (?x)^(
+            \.bandit-baseline\.json|
+            .*\.svg|
+            .*\.snap
+          )$
+      - id: trailing-whitespace
+        # Markdown uses two trailing spaces for a soft line break.
+        args: [--markdown-linebreak-ext=md]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+ci:
+  autofix_commit_msg: |
+    style: pre-commit auto-fix
+  autofix_prs: true
+  autoupdate_schedule: weekly


### PR DESCRIPTION
## Summary

Plugs two silent-failure gaps tracked in #1273:

- **`.pre-commit-config.yaml`** (new) — ruff (lint + format, pinned in sync with `ruff>=0.9` in `pyproject.toml`), `check-yaml`/`check-toml`/`check-json`, `end-of-file-fixer`, `trailing-whitespace` (with markdown linebreak exception), `mixed-line-ending`. **No** `mypy` / `pyright` — those stay in CI as today. Adds a `ci:` block so [pre-commit.ci](https://pre-commit.ci/) can auto-fix style drift on PRs.
- **`.github/workflows/notify-other-failures.yml`** (new) — `workflow_run` listener that fans out Telegram alerts when `Nightly deep tests`, `eval-nightly`, `soc2-evidence-nightly`, or `Adversarial Pen-Test Suite` finish with anything other than `success` / `skipped` / `neutral`. Reuses the existing `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` secrets — **no new secret required**. Kept as a single workflow so the diff to each nightly file is zero.

Refs #1273.

## Operator follow-up — enable pre-commit.ci (one-time, ~30 sec)

1. Visit https://pre-commit.ci/
2. Sign in with GitHub
3. Click "Add new repository" and install on `sipyourdrink-ltd/bernstein` (free for open-source)
4. Done — the next push triggers it; it will auto-commit `style: pre-commit auto-fix` if hooks change anything

Free tier. No repo secret. No GitHub Actions minutes spent.

## What stays the same

- `continue-on-error: true` on nightly-deep-tests jobs is left in place by design — the fanout workflow watches the **workflow** conclusion, which surfaces when the whole workflow fails (e.g. setup, OOM, infra). For job-level visibility we already have the artefact uploads.
- `bernstein-ci-fix` and the existing `telegram-notify.yml` for CI on `main` are untouched.

## Test plan

- [ ] PR CI green
- [ ] Operator installs pre-commit.ci per instructions above
- [ ] Next nightly run of `eval-nightly` / `soc2-evidence-nightly` / `nightly-deep-tests` is gated as before (no spurious notifications on `skipped`)
- [ ] Manually `workflow_dispatch` one of the nightly workflows with a forced failure to verify Telegram delivery (optional smoke)