### PR TITLE
feat(ci): aggregator gate-job — single required check that treats cancelled as failure (closes #1273 partial)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -940,3 +940,96 @@ jobs:
                 body,
               });
             }
+
+  # ─── Aggregator gate (closes #1273) ────────────────────────────────────
+  #
+  # SINGLE required status check for branch protection.
+  #
+  # Why this exists:
+  #   * `ci.yml` has 20+ jobs (incl. an OS x Python matrix that fans out
+  #     `test (ubuntu-latest, 3.12)` etc.) — listing every contextual name
+  #     in branch-protection is fragile because matrix names drift with
+  #     each matrix change.
+  #   * A `skipped` job auto-passes branch protection. So does a job that
+  #     was never enqueued because an upstream `needs:` was `cancelled`.
+  #     Either condition can let a red commit reach `main`.
+  #
+  # This job fails on ANY non-success result — including `cancelled`,
+  # `timed_out`, `action_required`, or a job that never ran. `skipped` is
+  # treated as a pass because several jobs here are intentionally gated
+  # on `if: github.event_name == 'pull_request'` or `if: false`.
+  #
+  # Operator: after this PR merges, replace every required check in
+  # branch protection with this single context (name shown in UI:
+  # ``CI gate``). The exact `gh api` invocation is in PR #1273's body.
+  #
+  # Excluded from `needs:`:
+  #   * `autofix`        — runs only on push to main, mutates the tree
+  #   * `pr-summary`     — cosmetic PR comment, must not gate merges
+  #   * `ci-gate` itself — would deadlock the dependency graph
+  ci-gate:
+    name: CI gate
+    runs-on: ubuntu-latest
+    # `always()` ensures the gate fires even when an upstream job is
+    # `cancelled`. `!cancelled()` lets the gate itself be cancelled when
+    # the user cancels the whole workflow run (so we don't try to
+    # report "cancelled" on a manually aborted run).
+    if: always() && !cancelled()
+    needs:
+      - repo-hygiene
+      - lint
+      - spelling
+      - actionlint
+      - lineage-gate
+      - typecheck
+      - dead-code
+      - dist-size
+      - property-tests
+      - snapshot-tests
+      - schemathesis-smoke
+      - semgrep
+      - bandit
+      - pip-audit
+      - beartype
+      - mutmut-diff
+      - diff-coverage
+      - pyright-strict-zone
+      - adapter-integration
+      - test
+      - sonarcloud
+      - close-ci-issues
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - id: roll-up
+        name: Roll up needs.*.result
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          # Write the JSON to disk so the python heredoc can read it
+          # without worrying about shell quoting on multiline content.
+          printf '%s' "$NEEDS_JSON" > results.json
+          python3 - <<'PY'
+          import json, sys
+          data = json.load(open("results.json"))
+          # `skipped` is intentionally tolerated: some jobs only run on
+          # PRs (`mutmut-diff`, `pr-summary`), some only on push-to-main
+          # (`close-ci-issues`), and `sonarcloud` is gated `if: false`
+          # until SonarCloud rehoming. A real regression in any of those
+          # surfaces as a non-skipped failure elsewhere.
+          bad = [
+              name
+              for name, info in data.items()
+              if info.get("result") not in ("success", "skipped")
+          ]
+          if bad:
+              print("::error::CI gate FAILED — these jobs were not success:")
+              for n in bad:
+                  info = data[n]
+                  print(f"  - {n}: result={info.get('result')}")
+              sys.exit(1)
+          print("CI gate: all required jobs passed.")
+          for n, info in sorted(data.items()):
+              print(f"  {n}: {info.get('result')}")
+          PY


### PR DESCRIPTION
## Summary

Adds a single aggregator `ci-gate` job at the end of `.github/workflows/ci.yml` that fans into every other job and fails if any of them is not `success`/`skipped`. This is meant to be the **only** required status check in branch protection once landed.

Refs #1273.

## Why

- Branch protection currently lists 13 individual contexts. Several are matrix names like `Test (ubuntu-latest, Python 3.12)`. Matrix labels drift with every OS/Python change, silently de-listing required checks.
- `skipped` auto-passes branch protection. A downstream job whose `needs:` was `cancelled` is reported as `skipped` — that path can let a red commit reach `main`.
- One aggregator job is canonical: list it once in branch protection, never touch it again.

## What the gate does

- `if: always() && !cancelled()` — fires even when matrix jobs are cancelled, but allows manual run cancellation.
- `needs:` every job in the workflow except `autofix` (push-to-main mutator), `pr-summary` (cosmetic comment), and itself. 22 jobs total.
- Reads `toJSON(needs)`, checks each `result`, emits `::error::` lines listing offenders, exits 1.
- Tolerates `skipped` because:
  - `mutmut-diff` runs only on PRs
  - `close-ci-issues` runs only on push-to-main
  - `sonarcloud` is currently `if: false` (free-tier LOC cap)

UI name: **CI gate** (set via `name:` key — exact context string for branch protection).

## Jobs listed in `needs:`

```
repo-hygiene, lint, spelling, actionlint, lineage-gate, typecheck, dead-code,
dist-size, property-tests, snapshot-tests, schemathesis-smoke, semgrep,
bandit, pip-audit, beartype, mutmut-diff, diff-coverage, pyright-strict-zone,
adapter-integration, test, sonarcloud, close-ci-issues
```

## Operator follow-up (do AFTER this PR lands and is green on `main`)

This PR does **not** touch branch protection. Once the gate is green on `main`, run:

```sh
gh api -X PUT repos/sipyourdrink-ltd/bernstein/branches/main/protection \
  --input - <<'JSON'
{
  "required_status_checks": {
    "strict": true,
    "contexts": ["CI gate"]
  },
  "enforce_admins": false,
  "required_pull_request_reviews": null,
  "restrictions": null,
  "required_linear_history": false,
  "allow_force_pushes": true,
  "allow_deletions": false,
  "block_creations": false,
  "required_conversation_resolution": false,
  "lock_branch": false,
  "allow_fork_syncing": false
}
JSON
```

The existing 13 contexts are preserved in the run output below for reference; this command replaces them with the single `CI gate` context.

Current required contexts (for the record, pre-change):

```
Lint, Type check, Test (ubuntu-latest, Python 3.13), Test (macos-latest, Python 3.13),
Test (ubuntu-latest, Python 3.12), CodeQL, Test (windows-latest, Python 3.13),
CodeQL (python), Repo hygiene, Workflow lint, Dead code (Vulture),
Spelling (typos), Package size check
```

## Test plan

- [ ] On this PR, the new `CI gate` check appears in the Checks tab.
- [ ] If all other required checks are green, `CI gate` is green.
- [ ] If any non-skipped job goes red, `CI gate` fails and its log lists the offending job(s).
- [ ] After merging to `main`, run the `gh api` command above; only `CI gate` remains as a required context.
- [ ] Subsequent PRs cannot merge while `CI gate` is failing.

## Notes for reviewer

- The `ci-gate` job itself will only become green on this PR after every other required check on this PR's HEAD commit is green/skipped. If any pre-existing job is flaky, that's a separate bug to fix in a follow-up — do not work around it inside the gate.
- Two jobs in the workflow have job-level `continue-on-error: true`: `sonarcloud` (line 764) and `autofix` (line 794). Both are intentional (Sonar is disabled with `if: false`, autofix mutates the tree on push-to-main). `autofix` is excluded from `needs:`; `sonarcloud` is included but always `skipped` so the gate isn't fooled.