### PR TITLE
ci: narrow merge window — split PR/main concurrency + auto-heal allowlist (#1273)

### DIFF
--- a/.github/workflows/bernstein-ci-fix.yml
+++ b/.github/workflows/bernstein-ci-fix.yml
@@ -127,7 +127,19 @@ jobs:
           #   - Workflow lint                  (actionlint via reviewdog)
           #   - Repo hygiene                   (.sdd not tracked, no merge markers, etc.)
           #   - Dead code (Vulture)            (unused vars/imports)
-          ALLOWED='^(Lint|Spelling \(typos\)|Workflow lint|Repo hygiene|Dead code \(Vulture\))$'
+          #   - Test (...)                     (contract-drift fixtures only,
+          #                                     guarded by a strict max-LOC cap
+          #                                     downstream — see #1273.)
+          #
+          # `Test (...)` matrix legs were added so trivial contract drift
+          # (e.g. "expected gui in DOCUMENTED_COMMANDS",
+          # "_INFRASTRUCTURE_PATHS missing /ui", "idle param not forwarded")
+          # can be auto-PR'd instead of escalated to a manual issue. The
+          # downstream max-LOC guard (see "Enforce small-diff cap" step in
+          # job `fix`) refuses to open a PR if the Gemini diff exceeds 50
+          # lines added+removed, which keeps the model away from anything
+          # that isn't a one-shot fixture edit.
+          ALLOWED='^(Lint|Spelling \(typos\)|Workflow lint|Repo hygiene|Dead code \(Vulture\)|Test \()'
 
           FAILED=$(gh run view "$RUN_ID" \
             --repo "${{ github.repository }}" \
@@ -178,7 +190,10 @@ jobs:
     outputs:
       pr_url: ${{ steps.open-pr.outputs.pr_url }}
       pr_number: ${{ steps.open-pr.outputs.pr_number }}
-      result: ${{ steps.open-pr.outputs.result }}
+      # Surface whichever sub-step actually set a result. open-pr only fires
+      # when the diff is small and non-empty; otherwise no-changes-result
+      # or oversized-result wins.
+      result: ${{ steps.open-pr.outputs.result || steps.oversized-result.outputs.result || steps.no-changes-result.outputs.result }}
     steps:
       - name: Checkout failing commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -245,9 +260,36 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Enforce small-diff cap (max 50 LOC)
+        id: size-check
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          # Auto-heal is only safe for trivial deterministic fixes. We cap
+          # the diff at 50 LOC added+removed (excluding the diff header) so
+          # the Test allowlist entry can't turn into an open invitation for
+          # the model to rewrite production code. Anything larger drops to
+          # the fallback-issue path for human triage. See #1273.
+          MAX_LOC=50
+          # Sum the added + removed columns. Binary files report '-' for
+          # both columns; treat those as oversized to force human review.
+          if git diff HEAD --numstat | awk '{ if ($1 == "-" || $2 == "-") { exit 2 } added+=$1; removed+=$2 } END { exit (added+removed > '"$MAX_LOC"') ? 1 : 0 }'; then
+            TOTAL=$(git diff HEAD --numstat | awk '{ added+=$1; removed+=$2 } END { print added+removed }')
+            echo "::notice::Auto-heal diff is ${TOTAL} LOC (cap ${MAX_LOC}) — within cap."
+            echo "within_cap=true" >> "$GITHUB_OUTPUT"
+          else
+            STATUS=$?
+            if [ "$STATUS" = "2" ]; then
+              echo "::warning::Auto-heal diff contains binary changes — refusing to auto-PR."
+            else
+              TOTAL=$(git diff HEAD --numstat | awk '{ added+=$1; removed+=$2 } END { print added+removed }')
+              echo "::warning::Auto-heal diff is ${TOTAL} LOC, exceeds cap ${MAX_LOC} — escalating to fallback issue."
+            fi
+            echo "within_cap=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Push auto-heal branch and open PR
         id: open-pr
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_changes == 'true' && steps.size-check.outputs.within_cap == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTO_HEAL_BRANCH: ${{ needs.triage.outputs.auto_heal_branch }}
@@ -301,6 +343,11 @@ jobs:
         if: steps.diff.outputs.has_changes != 'true'
         run: echo "result=no_changes" >> "$GITHUB_OUTPUT"
 
+      - name: Mark oversized-diff outcome
+        id: oversized-result
+        if: steps.diff.outputs.has_changes == 'true' && steps.size-check.outputs.within_cap != 'true'
+        run: echo "result=oversized_diff" >> "$GITHUB_OUTPUT"
+
   fallback-issue:
     name: Open ci-fix issue (fallback)
     needs: [triage, fix]
@@ -310,7 +357,8 @@ jobs:
       (needs.triage.outputs.safe_for_gemini != 'true' ||
        needs.fix.result == 'failure' ||
        needs.fix.result == 'skipped' ||
-       needs.fix.outputs.result == 'no_changes')
+       needs.fix.outputs.result == 'no_changes' ||
+       needs.fix.outputs.result == 'oversized_diff')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -330,6 +378,8 @@ jobs:
           REASON="Bernstein auto-heal could not produce a fix in 3 iterations within \$5 budget."
           if [ "$OUTCOME" = "no_changes" ]; then
             REASON="Bernstein auto-heal ran but produced no diff (likely a transient/infrastructural failure or out-of-scope error)."
+          elif [ "$OUTCOME" = "oversized_diff" ]; then
+            REASON="Bernstein auto-heal produced a diff larger than the 50 LOC safety cap. Refusing to auto-PR; human review required (see #1273 for the cap rationale)."
           fi
           BODY=$(cat <<EOF
           CI failure on commit \`${HEAD_SHA}\`. Run: $RUN_URL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,26 @@ on:
       - "scripts/gen_roadmap_*.py"
       - "scripts/generate_benchmark_docs.py"
 
-# On branch pushes (incl. main after PR merges): cancel the old run so only
-# the latest commit's CI matters. auto-release.yml depends on success on the
-# final commit; keeping older runs alive delays or skips the release.
-# On pull_request: also cancel — reviewers only care about the latest push.
+# Concurrency policy (split PR vs main pushes — see #1273):
+#
+#   - Pull requests: per-PR group (keyed off pull_request.number, stable
+#     across pushes to the same PR), cancel-in-progress=true. New commits
+#     on the same PR cancel older CI runs so reviewers only ever wait on
+#     the latest push and we don't burn minutes on stale SHAs.
+#
+#   - Pushes to main (incl. squash-merges from auto/bump-* PRs): per-SHA
+#     group, cancel-in-progress=false. Each merged commit gets its own
+#     un-cancellable CI run so the `workflow_run` listener in
+#     auto-release.yml always observes a real success/failure conclusion
+#     for that SHA — never `cancelled`-by-newer-push. This is the v2-merge
+#     unblocker: a tag/publish race that previously dropped the release
+#     when two merges landed in quick succession.
+#
+# The conditional in `group:` selects the right key per event type, and
+# `cancel-in-progress` only fires for pull_request events.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('sha-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ─── Fast checks (never cancelled, <2 min each) ───────────────────────


### PR DESCRIPTION
## TL;DR

Three changes to narrow the post-merge window that broke v2:

| # | Change | File | Status |
|---|--------|------|--------|
| 1 | Split CI concurrency: PR cancel / main queue | `.github/workflows/ci.yml` | in this PR |
| 2 | Add `Test (` to auto-heal allowlist + 50 LOC cap | `.github/workflows/bernstein-ci-fix.yml` | in this PR |
| 3 | Branch-protection tightening | repo settings | **operator-only — commands below** |

Tracking: #1273. Sibling PR for `CI gate` aggregate check: see #1273 step B.

## 1. `ci.yml` concurrency split

Before: single block, `cancel-in-progress: true` on every event. A
second push to main (or a fast squash-merge) cancelled the still-running
CI on the earlier SHA, and `auto-release.yml`'s `workflow_run` listener
only fires on `success`. `cancelled` silently dropped the release — that
is the v2 tag/publish failure mode.

After:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('sha-{0}', github.sha) }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- PR events: group key `pr-<n>` (stable across pushes to the PR), cancel old runs.
- Push events: group key `sha-<sha>` (unique per commit), no cancellation.

Net effect: every merged commit gets its own un-cancellable CI run, so
`auto-release` always observes a real `success` / `failure` for that SHA.

## 2. `bernstein-ci-fix.yml` allowlist + size cap

- Allowlist regex now: `^(Lint|Spelling \(typos\)|Workflow lint|Repo hygiene|Dead code \(Vulture\)|Test \()`. Matches `Test (…)` matrix legs (the shape that drifted in v2: `DOCUMENTED_COMMANDS`, `_INFRASTRUCTURE_PATHS`, idle-param forwarding).
- New `Enforce small-diff cap` step: refuses to open an auto-heal PR if added+removed > 50 LOC, or if any file in the diff is binary. Oversized diffs fall through to the existing `fallback-issue` job. Real contract-drift fixes are 1-3 lines.
- New `oversized_diff` outcome flows into the job-level `result` output and the fallback-issue body explains the cap escalation.

Recursion guard, cost guard, idempotency check, and `actions: write` denial are all preserved.

## 3. Branch-protection commands (operator runs these)

NOT applied by this PR. Review and run from a maintainer terminal:

\`\`\`bash
# Replace REPO with sipyourdrink-ltd/bernstein
REPO=sipyourdrink-ltd/bernstein

# Require PR to be up-to-date with base before merge (strict status checks)
# AND scope required contexts to the single `CI gate` aggregate from CI-B
# (sibling PR — see #1273 step B; do NOT run this until CI gate exists).
gh api -X PATCH "/repos/$REPO/branches/main/protection/required_status_checks" \
  -f strict=true \
  -F 'contexts[]=CI gate'

# Linear history (no merge commits on main)
gh api -X PATCH "/repos/$REPO/branches/main/protection" \
  -F required_linear_history.enabled=true

# Last-push approval (re-approval required after each push to the PR)
gh api -X PATCH "/repos/$REPO/branches/main/protection/required_pull_request_reviews" \
  -F require_last_push_approval=true
\`\`\`

Also consider: enable GitHub merge queue (free for org-owned public repos in 2026) — it complements `strict=true` by batching merges and re-running CI on each batch instead of forcing a manual rebase per PR.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`: OK
- `actionlint .github/workflows/bernstein-ci-fix.yml`: clean
- `actionlint .github/workflows/ci.yml`: only pre-existing `if: false` on line 781 (not touched)
- Local awk LOC check: validated with 10-line diff (within cap) and 60-line diff (oversized)

## Hard constraints honoured

- No force-push, no `--no-verify`, no AI attribution, no secrets in commit.
- All work done in worktree `/Users/sasha/IdeaProjects/personal_projects/bernstein-wt-ci-c`.

Refs #1273.