### PR TITLE
feat(ci): self-PR autofix bot for contract-test drift (CI-E)

### DIFF
--- a/.github/workflows/contract-drift-autofix.yml
+++ b/.github/workflows/contract-drift-autofix.yml
@@ -1,0 +1,244 @@
+name: "Contract Drift Autofix"
+
+# Refs: #1273 — CI hardening, bucket CI-E.
+#
+# Why this workflow exists
+# ------------------------
+# Three contract tests in tests/unit/ act as drift detectors:
+#
+#   * test_readme_api_coverage.py::test_all_cli_commands_are_documented
+#     fails when a new top-level CLI command is registered but not added to
+#     DOCUMENTED_COMMANDS.
+#   * test_api_v1_routing.py::TestVersionedRoutesParity::test_every_root_route_has_v1_counterpart
+#     fails when a new root-mounted FastAPI route is added without either a
+#     /api/v1/* mirror or an entry in _INFRASTRUCTURE_PATHS.
+#   * test_cli_run_params.py::test_run_params_match_cli_call
+#     fails when run() gains a new parameter that the cli() click callback
+#     does not forward.
+#
+# Every one of these is a 1-2 line allow-list / forward-arg edit. They are
+# real signals (new public surface needs explicit acknowledgement) but the
+# fix is mechanical — perfectly suited for an autofix bot.
+#
+# This workflow watches the CI workflow_run for PRs, runs just these three
+# tests, and if any fail invokes scripts/regen_contract_drift.py to
+# regenerate the allow-list / forward-arg list, then opens a follow-up PR
+# via peter-evans/create-pull-request.
+#
+# Recursion guards
+# ----------------
+#   * Skips when the head branch is main (autofix only applies to PRs).
+#   * Skips when the PR author is the bot itself (no infinite loops).
+#   * Diff size capped at 30 LOC by the regen script; larger diffs imply
+#     a real change and are escalated by opening an issue instead.
+#   * No `actions: write` permission, so the autofix PR cannot recursively
+#     trigger more workflows in this file.
+#
+# Secret requirements
+# -------------------
+#   * BOT_PAT (optional, recommended): a fine-grained PAT with `contents:
+#     write` + `pull-requests: write` on this repo. When present, the
+#     autofix PR triggers CI runs (GITHUB_TOKEN-authored PRs are otherwise
+#     muted by GitHub's recursion protection). When absent, falls back to
+#     GITHUB_TOKEN — the bot PR opens but CI must be kicked manually by
+#     closing/reopening it.
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+concurrency:
+  group: contract-drift-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  autofix:
+    name: Detect and patch contract drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Recursion guard: don't run on PRs the bot itself opened. The matchers
+    # are intentionally broad (covers default GITHUB_TOKEN authorship via
+    # `github-actions[bot]` AND any of our bot identities used elsewhere).
+    if: >
+      github.event.pull_request.user.login != 'github-actions[bot]' &&
+      github.event.pull_request.user.login != 'bernstein[bot]' &&
+      github.event.pull_request.user.login != 'bernstein-orchestrator[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'bot/contract-drift-')
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+          # Use BOT_PAT if present so the eventual autofix PR can trigger
+          # CI. GITHUB_TOKEN-authored PRs are muted by GitHub.
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: astral-sh/setup-uv@00714ea9dc27830a1586fe47ef7ad28e4fd5db45 # v7
+
+      - name: Sync project (dev group)
+        run: uv sync --group dev
+
+      - name: Run drift tests (capture failures, don't fail the job)
+        id: drift
+        run: |
+          set +e
+          uv run pytest \
+            tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented \
+            tests/unit/test_api_v1_routing.py::TestVersionedRoutesParity::test_every_root_route_has_v1_counterpart \
+            tests/unit/test_cli_run_params.py::test_run_params_match_cli_call \
+            --tb=short
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -eq 0 ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No contract drift detected."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Contract drift detected — running regen."
+          fi
+          exit 0
+
+      - name: Regenerate drift fixtures
+        if: steps.drift.outputs.drift == 'true'
+        id: regen
+        run: |
+          set +e
+          uv run python scripts/regen_contract_drift.py --fixture all
+          # The regen script returns 0 only when at least one fixture was
+          # patched. Any non-zero exit means nothing was patched — either
+          # because the drift wasn't one of the three known patterns or
+          # because the diff exceeded the 30-LOC safety cap.
+          regen_status=$?
+          echo "regen_status=$regen_status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Verify regen produced something
+        if: steps.drift.outputs.drift == 'true'
+        id: verify
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Drift was detected but regen produced no diff. Likely an unhandled drift pattern or LOC-cap trip — opening tracking issue."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            # Compute a coarse summary of what was regenerated.
+            CHANGED_FILES=$(git diff --name-only | sort -u)
+            {
+              echo "changed_files<<EOF"
+              echo "$CHANGED_FILES"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            # Compute LOC delta (added+removed) for the safety report.
+            STAT=$(git diff --shortstat)
+            INS=$(echo "$STAT" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo "0")
+            DEL=$(echo "$STAT" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo "0")
+            LOC=$((INS + DEL))
+            echo "loc_delta=${LOC}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Regen produced ${LOC:-0} LOC of changes across:"
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              echo "  $f"
+            done <<< "$CHANGED_FILES"
+          fi
+
+      - name: Re-run drift tests to confirm regen fixed them
+        if: steps.drift.outputs.drift == 'true' && steps.verify.outputs.changed == 'true'
+        id: reverify
+        run: |
+          set +e
+          uv run pytest \
+            tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented \
+            tests/unit/test_api_v1_routing.py::TestVersionedRoutesParity::test_every_root_route_has_v1_counterpart \
+            tests/unit/test_cli_run_params.py::test_run_params_match_cli_call \
+            --tb=short
+          status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          if [ "$status" -ne 0 ]; then
+            echo "::warning::Regen ran but drift tests still fail. Bot will open an issue instead of a PR."
+          fi
+          exit 0
+
+      - name: Open autofix PR
+        if: >
+          steps.drift.outputs.drift == 'true' &&
+          steps.verify.outputs.changed == 'true' &&
+          steps.reverify.outputs.status == '0'
+        id: cpr
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
+        with:
+          token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
+          branch: bot/contract-drift-pr-${{ github.event.pull_request.number }}
+          base: ${{ github.event.pull_request.head.ref }}
+          commit-message: |
+            chore(ci): regenerate contract drift allow-lists
+
+            Drift detected on PR #${{ github.event.pull_request.number }}.
+            Regenerated via scripts/regen_contract_drift.py.
+            Refs #1273.
+          title: "bot(contract-drift): regenerate ${{ steps.verify.outputs.changed_files }}"
+          body: |
+            Auto-generated patch from `contract-drift-autofix.yml`.
+
+            Three contract tests act as drift detectors against the public CLI / API surface:
+
+            - `tests/unit/test_readme_api_coverage.py::test_all_cli_commands_are_documented`
+            - `tests/unit/test_api_v1_routing.py::TestVersionedRoutesParity::test_every_root_route_has_v1_counterpart`
+            - `tests/unit/test_cli_run_params.py::test_run_params_match_cli_call`
+
+            One or more failed on PR #${{ github.event.pull_request.number }}; this PR regenerates the
+            corresponding allow-list / forward-arg list via
+            `scripts/regen_contract_drift.py`.
+
+            **Files changed:**
+            ```
+            ${{ steps.verify.outputs.changed_files }}
+            ```
+            **LOC delta:** ${{ steps.verify.outputs.loc_delta }} (cap: 30)
+
+            **Source CI run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Refs #1273.
+
+            > [!NOTE]
+            > If the `BOT_PAT` secret is not configured, this PR was opened
+            > with the default `GITHUB_TOKEN`, which means CI workflows will
+            > NOT run automatically on it. Close and reopen the PR (or push
+            > an empty commit) to trigger CI manually.
+          delete-branch: true
+          labels: |
+            ci
+            contract-drift
+            bot
+
+      - name: Fall back to issue when regen could not fix the drift
+        if: >
+          steps.drift.outputs.drift == 'true' && (
+            steps.verify.outputs.changed != 'true' ||
+            steps.reverify.outputs.status != '0'
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Title is idempotent on PR number so re-runs don't spam issues.
+          TITLE="Contract drift on PR #${{ github.event.pull_request.number }} could not be auto-patched"
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number // ""')
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::Issue #$EXISTING already tracks this drift — skipping."
+            exit 0
+          fi
+          gh issue create \
+            --title "$TITLE" \
+            --label ci,contract-drift,bot \
+            --body "Contract drift was detected on PR #${{ github.event.pull_request.number }} but \`scripts/regen_contract_drift.py\` could not produce a clean patch.
+
+          Possible reasons:
+          - Drift exceeded the 30-LOC safety cap (real semantic change, not drift).
+          - Drift pattern is not one of the three the script handles.
+          - Regen ran but the targeted tests still fail (regen bug).
+
+          See workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details. Refs #1273."

--- a/scripts/regen_contract_drift.py
+++ b/scripts/regen_contract_drift.py
@@ -1,0 +1,373 @@
+"""Regenerate contract allow-lists / forwards when CI flags drift.
+
+Three contract tests in ``tests/unit/`` act as drift detectors against the
+shape of the public CLI / API / ``cli()`` callback. They fail loud when
+something new is added without updating a small allow-list. The fix in each
+case is a 1-2 line edit to a data structure -- this script does that edit
+automatically so the bot can open a follow-up PR.
+
+Fixtures handled
+----------------
+* ``DOCUMENTED_COMMANDS``  -- ``tests/unit/test_readme_api_coverage.py``
+* ``_INFRASTRUCTURE_PATHS`` -- ``tests/unit/test_api_v1_routing.py``
+* ``cli_run_callback``     -- forward-arg list in ``src/bernstein/cli/main.py``
+
+Usage
+-----
+::
+
+    python scripts/regen_contract_drift.py --fixture DOCUMENTED_COMMANDS
+    python scripts/regen_contract_drift.py --fixture _INFRASTRUCTURE_PATHS
+    python scripts/regen_contract_drift.py --fixture cli_run_callback
+    python scripts/regen_contract_drift.py --fixture all
+
+The script writes back to disk in-place. Run ``git diff`` afterwards to see
+what changed. Refuses to write if the resulting diff exceeds 30 LOC --
+larger drift is a real signal and deserves a human.
+
+References #1273.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Hard ceiling: drift fixes should be tiny. Anything bigger and we bail so a
+# human looks at the diff (the bot would mis-classify a real semantic change
+# as drift).
+MAX_LOC_DELTA = 30
+
+
+# ---------------------------------------------------------------------------
+# Common helpers
+# ---------------------------------------------------------------------------
+
+
+def _diff_loc(before: str, after: str) -> int:
+    """Return the number of changed lines (added + removed)."""
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+    # Cheap symmetric-diff line-count -- not a real diff algorithm but fine for
+    # the rough size gate (we only care about order-of-magnitude).
+    added = [ln for ln in after_lines if ln not in before_lines]
+    removed = [ln for ln in before_lines if ln not in after_lines]
+    return len(added) + len(removed)
+
+
+def _write_if_changed(path: Path, before: str, after: str) -> bool:
+    if before == after:
+        print(f"[regen] {path.name}: no changes")
+        return False
+    delta = _diff_loc(before, after)
+    if delta > MAX_LOC_DELTA:
+        print(
+            f"[regen] {path.name}: refusing to write, diff is {delta} LOC "
+            f"(cap {MAX_LOC_DELTA}). Real change suspected -- open an issue.",
+            file=sys.stderr,
+        )
+        return False
+    path.write_text(after)
+    print(f"[regen] {path.name}: wrote {delta} LOC of changes")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Fixture 1: DOCUMENTED_COMMANDS
+# ---------------------------------------------------------------------------
+
+
+def regen_documented_commands() -> bool:
+    """Add newly-registered CLI commands to the README allow-list."""
+    from bernstein.cli.main import cli
+
+    target = REPO_ROOT / "tests" / "unit" / "test_readme_api_coverage.py"
+    source = target.read_text()
+
+    # Extract the existing frozenset literal -- AST gives us the exact names
+    # without us having to teach a regex about Python syntax.
+    import ast
+
+    tree = ast.parse(source)
+    documented: set[str] = set()
+    for node in ast.walk(tree):
+        target_name: str | None = None
+        rhs: ast.AST | None = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            target_name = node.targets[0].id
+            rhs = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_name = node.target.id
+            rhs = node.value
+        if target_name == "DOCUMENTED_COMMANDS" and rhs is not None:
+            # Walk the right-hand-side and harvest every constant string.
+            for sub in ast.walk(rhs):
+                if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                    documented.add(sub.value)
+            break
+
+    registered = set(cli.commands.keys())
+    missing = sorted(registered - documented)
+    if not missing:
+        print("[regen] DOCUMENTED_COMMANDS: nothing to add")
+        return False
+
+    # Insert before the closing ``}`` of the frozenset({...}) literal.
+    # We anchor on ``_REPO_ROOT = Path`` which is the next top-level statement
+    # after the frozenset -- the closing ``}\n    )`` we want lives just above.
+    anchor = "\n# ---------------------------------------------------------------------------\n# Helpers"
+    if anchor not in source:
+        print("[regen] DOCUMENTED_COMMANDS: could not find anchor -- skipping", file=sys.stderr)
+        return False
+
+    # Build the insert block. Group new entries under a comment so the diff is
+    # self-explanatory.
+    bot_block_lines = ["        # Bot-added: drift autofix (regen_contract_drift.py)"]
+    for name in missing:
+        bot_block_lines.append(f'        "{name}",')
+    bot_block = "\n".join(bot_block_lines) + "\n"
+
+    # Walk the file forward to locate the ``    }\n)`` that closes the literal.
+    # Start search just before the anchor so we don't accidentally edit a
+    # different frozenset later in the file.
+    pre, _, _ = source.partition(anchor)
+    close_idx = pre.rfind("    }\n)")
+    if close_idx == -1:
+        print(
+            "[regen] DOCUMENTED_COMMANDS: could not locate frozenset close -- skipping",
+            file=sys.stderr,
+        )
+        return False
+    new_source = pre[:close_idx] + bot_block + pre[close_idx:] + source[len(pre) :]
+
+    return _write_if_changed(target, source, new_source)
+
+
+# ---------------------------------------------------------------------------
+# Fixture 2: _INFRASTRUCTURE_PATHS
+# ---------------------------------------------------------------------------
+
+
+def regen_infrastructure_paths() -> bool:
+    """Add new root-only FastAPI routes to the parity allow-list."""
+    from fastapi.routing import APIRoute, APIWebSocketRoute
+    from starlette.routing import WebSocketRoute
+
+    from bernstein.core.server import create_app
+
+    target = REPO_ROOT / "tests" / "unit" / "test_api_v1_routing.py"
+    source = target.read_text()
+
+    # Mirror the test's own path-collection logic so we know exactly which
+    # paths it would flag.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        jsonl_path = Path(tmpdir) / "tasks.jsonl"
+        app = create_app(jsonl_path=jsonl_path)
+        root_paths: set[str] = set()
+        v1_relative: set[str] = set()
+        for route in app.routes:
+            if not isinstance(route, APIRoute | APIWebSocketRoute | WebSocketRoute):
+                continue
+            path = route.path
+            if path.startswith("/api/v1/"):
+                v1_relative.add(path[len("/api/v1") :])
+            elif path == "/api/v1":
+                continue
+            else:
+                root_paths.add(path)
+
+    # Extract the existing _INFRASTRUCTURE_PATHS allow-list via AST.
+    import ast
+
+    tree = ast.parse(source)
+    documented: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "_INFRASTRUCTURE_PATHS"
+        ):
+            for sub in ast.walk(node.value or ast.Constant(None)):
+                if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                    documented.add(sub.value)
+            break
+
+    # A path qualifies as drift if it's root-mounted, has no /api/v1 mirror,
+    # and isn't already in _INFRASTRUCTURE_PATHS. The test treats such paths
+    # as failures.
+    missing_in_v1 = {p for p in root_paths if p not in documented and p not in v1_relative}
+    if not missing_in_v1:
+        print("[regen] _INFRASTRUCTURE_PATHS: nothing to add")
+        return False
+
+    # Same insertion strategy as DOCUMENTED_COMMANDS: anchor to the next
+    # top-level construct (an ``@pytest.fixture`` line in this file) and walk
+    # back to the closing brace.
+    anchor = "\n@pytest.fixture()"
+    if anchor not in source:
+        print("[regen] _INFRASTRUCTURE_PATHS: could not find anchor -- skipping", file=sys.stderr)
+        return False
+    pre, _, _ = source.partition(anchor)
+    close_idx = pre.rfind("    }\n)")
+    if close_idx == -1:
+        print(
+            "[regen] _INFRASTRUCTURE_PATHS: could not locate frozenset close -- skipping",
+            file=sys.stderr,
+        )
+        return False
+
+    bot_block_lines = ["        # Bot-added: drift autofix (regen_contract_drift.py)"]
+    for name in sorted(missing_in_v1):
+        bot_block_lines.append(f'        "{name}",')
+    bot_block = "\n".join(bot_block_lines) + "\n"
+
+    new_source = pre[:close_idx] + bot_block + pre[close_idx:] + source[len(pre) :]
+    return _write_if_changed(target, source, new_source)
+
+
+# ---------------------------------------------------------------------------
+# Fixture 3: cli() forward-arg list
+# ---------------------------------------------------------------------------
+
+
+def regen_cli_run_callback() -> bool:
+    """Add any new run() params as forwarded kwargs in the cli() callback."""
+    from bernstein.cli.main import run
+
+    callback = run.callback
+    assert callback is not None, "run command has no callback"
+    sig = inspect.signature(callback)
+    run_params = list(sig.parameters.keys())
+
+    target = REPO_ROOT / "src" / "bernstein" / "cli" / "main.py"
+    source = target.read_text()
+
+    # Locate the ``run.callback(`` call inside ``def cli(...)`` and find the
+    # kwargs that are already forwarded.
+    import ast
+
+    tree = ast.parse(source)
+    call_node: ast.Call | None = None
+    func_def_node: ast.FunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "cli":
+            func_def_node = node
+            for sub in ast.walk(node):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Attribute)
+                    and sub.func.attr == "callback"
+                    and isinstance(sub.func.value, ast.Name)
+                    and sub.func.value.id == "run"
+                ):
+                    call_node = sub
+                    break
+            break
+
+    if call_node is None or func_def_node is None:
+        print("[regen] cli_run_callback: could not locate run.callback() call", file=sys.stderr)
+        return False
+
+    forwarded = {kw.arg for kw in call_node.keywords if kw.arg is not None}
+    cli_params = {p.arg for p in func_def_node.args.args}
+    missing = [p for p in run_params if p not in forwarded]
+    if not missing:
+        print("[regen] cli_run_callback: nothing to add")
+        return False
+
+    # Build the lines to insert. For each missing param, pick a safe default:
+    #   - if cli() already has a same-named param, forward it (``foo=foo``)
+    #   - else if run() default is bool ``False``, pass ``False``
+    #   - else if run() default is ``None`` or required, pass ``None``
+    new_lines: list[str] = []
+    for name in missing:
+        if name in cli_params:
+            new_lines.append(f"        {name}={name},")
+            continue
+        default = sig.parameters[name].default
+        if default is False:
+            value_repr = "False"
+        elif default is True:
+            value_repr = "True"
+        elif default == ():
+            value_repr = "()"
+        else:
+            # Empty tuple, None, complex defaults all collapse to None -- this
+            # matches the existing pattern (max_cost_usd=None, etc.).
+            value_repr = "None"
+        new_lines.append(f"        {name}={value_repr},")
+
+    # Insert before the closing ``)`` of the call. The call ends on the line
+    # whose unindented end-col equals the call's end_col_offset. Easier: find
+    # the slice of source for the call and inject right before the final ``)``.
+    if call_node.end_lineno is None or call_node.end_col_offset is None:
+        print("[regen] cli_run_callback: AST has no end position", file=sys.stderr)
+        return False
+
+    src_lines = source.splitlines(keepends=True)
+    end_line_idx = call_node.end_lineno - 1  # 1-indexed -> 0-indexed
+    end_line = src_lines[end_line_idx]
+    # The end-col-offset points just past the ``)``. Re-find the ``)`` on that
+    # line to be robust to trailing whitespace.
+    paren_pos = end_line.rfind(")")
+    if paren_pos == -1:
+        print("[regen] cli_run_callback: could not find closing paren", file=sys.stderr)
+        return False
+
+    # Inject the bot-comment + new lines BEFORE the closing-paren line.
+    insert_block = "        # Bot-added: drift autofix (regen_contract_drift.py)\n"
+    insert_block += "\n".join(new_lines) + "\n"
+    src_lines.insert(end_line_idx, insert_block)
+    new_source = "".join(src_lines)
+    return _write_if_changed(target, source, new_source)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+FIXTURES = {
+    "DOCUMENTED_COMMANDS": regen_documented_commands,
+    "_INFRASTRUCTURE_PATHS": regen_infrastructure_paths,
+    "cli_run_callback": regen_cli_run_callback,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture",
+        required=True,
+        choices=[*FIXTURES.keys(), "all"],
+        help="Which contract fixture to regenerate.",
+    )
+    args = parser.parse_args(argv)
+
+    # Make sure we can import bernstein from the repo's src/ layout when
+    # invoked from a fresh checkout where the package isn't pip-installed.
+    src_dir = REPO_ROOT / "src"
+    if str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+    targets = list(FIXTURES.keys()) if args.fixture == "all" else [args.fixture]
+    any_changed = False
+    for name in targets:
+        print(f"[regen] running {name}")
+        try:
+            changed = FIXTURES[name]()
+        except Exception as exc:
+            print(f"[regen] {name}: FAILED ({exc.__class__.__name__}: {exc})", file=sys.stderr)
+            continue
+        any_changed = any_changed or changed
+
+    return 0 if any_changed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes the **CI-E** bucket of #1273. Three contract tests in `tests/unit/` act as drift detectors against the public CLI / API surface; all three bit us on the v2.0.0 cut (#1271). Each fix was 1-2 lines — perfect autofix shape.

This PR adds a self-PR bot that runs the three drift tests on every PR and, when they fail, regenerates the affected allow-lists / forward-arg list via a small Python helper, then opens a follow-up PR (or an issue, if the regen can't produce a clean patch).

### Drift patterns handled

| Test | Fixture | Regen strategy |
|---|---|---|
| `test_all_cli_commands_are_documented` | `DOCUMENTED_COMMANDS` (frozenset in `test_readme_api_coverage.py`) | Import `cli`, diff registered commands vs AST-extracted frozenset, append missing |
| `test_every_root_route_has_v1_counterpart` | `_INFRASTRUCTURE_PATHS` (frozenset in `test_api_v1_routing.py`) | Build tmp FastAPI app via `create_app()`, mirror the test's collection logic, append new root-only paths |
| `test_run_params_match_cli_call` | `run.callback(...)` call inside `cli()` (`src/bernstein/cli/main.py`) | `inspect.signature(run.callback)`, AST-locate the call, append missing kwargs (forward same-named cli param, else False/None/() matching run() defaults) |

**3 of 3 patterns implemented.** None skipped.

### Files

- `.github/workflows/contract-drift-autofix.yml` — `pull_request` trigger, recursion guard on bot authors and `bot/contract-drift-*` head refs, runs 3 tests, regen, re-tests, opens PR via `peter-evans/create-pull-request@v7`. Falls back to opening an issue when regen can't fix (LOC cap > 30 or untracked pattern).
- `scripts/regen_contract_drift.py` — AST-level edits (no regex on Python source). 30-LOC hard cap as a safety net.

### Safety net

- Skips PRs opened by `github-actions[bot]`, `bernstein[bot]`, `bernstein-orchestrator[bot]`, or any head branch starting with `bot/contract-drift-`.
- Regen refuses to write if its diff exceeds **30 LOC** — that's real drift, not a typo, and gets a human issue instead.
- The workflow has **no `actions: write` permission**, so the bot PR can't recursively trigger more autofix runs.
- After regen, the workflow **re-runs the same 3 tests** and only opens a PR if they're green.

### Secret requirements

- `BOT_PAT` (optional, recommended): fine-grained PAT with `contents: write` + `pull-requests: write`. With it, the autofix PR triggers CI on push. Without it, falls back to `GITHUB_TOKEN` — PR opens but CI doesn't run on it automatically (documented in the PR body the bot generates).

### Local verification

Reverted each of the three contract fixes from #1272 one at a time and ran the regen:

```
[regen] running DOCUMENTED_COMMANDS
[regen] test_readme_api_coverage.py: wrote 2 LOC of changes
[regen] running _INFRASTRUCTURE_PATHS
[regen] test_api_v1_routing.py: wrote 3 LOC of changes
[regen] running cli_run_callback
[regen] main.py: wrote 2 LOC of changes
```

All three targeted tests pass after regen.

## Test plan

- [x] Ruff lint + format passes on the new script
- [x] `actionlint` passes on the new workflow
- [x] Regen produces a 2-3 LOC diff for each of the three known drift patterns (matches the human fix from #1272 modulo a single `# Bot-added` marker comment)
- [x] On a clean tree, `regen_contract_drift.py --fixture all` exits 1 (no-op) and writes nothing
- [x] All three targeted tests pass after regen
- [ ] CI green on this PR (verifies the workflow YAML parses on GitHub)
- [ ] Manual smoke once merged: open a throwaway PR that adds a fake CLI command, observe the bot file a follow-up PR

Refs #1273.