### PR TITLE
fix(gui): mount gui-meta on root AND /api/v1 — bidirectional parity

### DIFF
--- a/src/bernstein/gui/__init__.py
+++ b/src/bernstein/gui/__init__.py
@@ -36,7 +36,11 @@ def mount(app: FastAPI) -> None:
             f"GUI static assets not found at {STATIC_DIR}. Build them with: `cd web && npm install && npm run build`"
         )
 
-    router = APIRouter(prefix="/api/v1", tags=["gui"])
+    # Bidirectional parity: register on BOTH the root app AND under /api/v1/.
+    # AUDIT-126's `test_every_v1_route_has_root_counterpart` asserts every
+    # versioned route has a root mirror — keeping the router prefix-less and
+    # mounting it twice satisfies both directions of the parity test.
+    router = APIRouter(tags=["gui"])
 
     # NB: ``from __future__ import annotations`` (top of this file) turns every
     # return annotation into a string. FastAPI's OpenAPI builder then tries to
@@ -57,6 +61,7 @@ def mount(app: FastAPI) -> None:
         )
 
     app.include_router(router)
+    app.include_router(router, prefix="/api/v1")
 
     assets_dir = STATIC_DIR / "assets"
     if assets_dir.exists():


### PR DESCRIPTION
## Bug

Main CI failing on `tests/unit/test_api_v1_routing.py::TestVersionedRoutesParity::test_every_v1_route_has_root_counterpart` with:

```
AssertionError: Routes exist only under /api/v1/* but not on the root app. Orphans: ['/gui-meta']
```

This is the **reverse direction** of the parity test that I already fixed in #1272 (which handled root → v1 with the `/ui` infrastructure path carve-out). The v1 → root direction has no carve-out — every versioned route must mirror a root route.

## Root cause

`src/bernstein/gui/__init__.py:39` creates `APIRouter(prefix="/api/v1", tags=["gui"])` — the router has a hardcoded `/api/v1` prefix, so it ONLY mounts at `/api/v1/gui-meta`, never at `/gui-meta` on the root. Every other Bernstein router has no prefix and is mounted twice by `server_app.create_app`'s dual-mount loop.

## Fix

Drop the router prefix. Mount the same router on both surfaces:

```python
router = APIRouter(tags=["gui"])
@router.get("/gui-meta", response_class=JSONResponse)
def gui_meta(): ...

app.include_router(router)                  # /gui-meta on root
app.include_router(router, prefix="/api/v1")  # /api/v1/gui-meta
```

## Test plan

- [x] `pytest tests/unit/test_api_v1_routing.py` → 9 passed locally
- [ ] Full CI matrix green
- [ ] Auto-release fires + v2.0.1 tag + PyPI publish

Closes the v2.0.1-blocker.