### PR TITLE
fix(ci): gate release-please + Scorecard until operator one-time setup

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,11 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Disabled until the operator enables "Allow GitHub Actions to create
+    # and approve pull requests" under Repo Settings → Actions, OR provides
+    # a fine-grained PAT via ``secrets.RELEASE_PLEASE_PAT`` and swaps the
+    # token below. See docs/maintainers/ci-apps.md.
+    if: false
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,9 +9,13 @@ name: OSSF Scorecard
 # Ref: #1273
 
 on:
+  # Scorecard scores rolling repo posture (signed releases, branch protection,
+  # pinned actions, fuzzing, etc.) — designed for weekly tracking, not
+  # per-commit gating. Triggering on every push-to-main produces noisy
+  # "failures" when individual high-severity findings exist (expected during
+  # first-time setup). Restricted to schedule + dispatch + branch-protection
+  # changes per https://github.com/ossf/scorecard-action#installation.
   branch_protection_rule:
-  push:
-    branches: [main]
   schedule:
     - cron: "11 5 * * 1"  # Weekly, Monday 05:11 UTC
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Two workflows added in the v2.0.1 hardening rollout are reporting `failure` on every main push:

| Workflow | Reason | Fix |
|---|---|---|
| `release-please.yml` | `GitHub Actions is not permitted to create or approve pull requests` at the org level | Gated `if: false`. Operator one-time setting flip in Repo → Settings → Actions → "Allow GitHub Actions to create and approve pull requests". Then drop the gate. |
| `scorecard.yml` | Per-push trigger surfaces "failure" when SARIF report has high-severity findings (expected first-time, before signed-releases + branch-protection-rule are in place) | Restricted to weekly cron + `branch_protection_rule` + `workflow_dispatch` per the action's own README. No more per-push noise. |

Both fixes are non-functional: release-please will resume on next push once the operator flips the setting and the gate is removed; Scorecard will run weekly + on dispatch with full output uploaded to Code Scanning.

References:
- Operator playbook: `docs/maintainers/ci-apps.md` (already documents the toggle path)
- Tracking: #1273