### PR TITLE
feat(tasks): add atomic shared backlog claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Commands that eliminate the glue code most teams end up writing around their run
 | `bernstein pr` | Auto-creates a GitHub PR from a completed session; body carries the janitor's gate results and token/USD cost breakdown. |
 | `bernstein from-ticket <url>` | Imports a Linear / GitHub Issues / Jira ticket as a Bernstein task. Label-based role + scope inference. Supports `--dry-run` and `--run`. |
 | `bernstein ticket import <url>` | Alias / group form of `from-ticket` for scripting. |
-| `bernstein task claim --role reviewer` | Atomically claims one eligible row from `.sdd/runtime/task-backlog.json` for external workers sharing a backlog. Supports `--backlog`, `--agent-id`, `--project`, `--capability`, `--done`, `--max-attempts`, and `--json`. |
+| `bernstein backlog claim --role reviewer` | Atomically claims one eligible row from `.sdd/runtime/task-backlog.json` for external workers sharing a same-host JSON backlog. This is intentionally separate from the orchestrator task store; distributed workers should use the database-backed task store paths. Supports `--backlog`, `--agent-id`, `--project`, `--capability`, `--done`, `--max-attempts`, and `--json`. |
 | `bernstein remote` | SSH sandbox backend. `remote test <host>`, `remote run <host> <path>`, `remote forget <host>`. ControlMaster socket reuse for fast repeat calls. |
 | `bernstein hooks` | Lifecycle hooks for `pre_task`, `post_task`, `pre_merge`, `post_merge`, `pre_spawn`, `post_spawn`; shell scripts or pluggy `@hookimpl`s. `hooks list`, `hooks run <event>`, `hooks check`. |
 | `bernstein chat serve --platform=telegram\|discord\|slack` | Drive runs from chat with `/run`, `/status`, `/approve`, `/reject`, `/switch`, `/stop`. |

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Commands that eliminate the glue code most teams end up writing around their run
 | `bernstein pr` | Auto-creates a GitHub PR from a completed session; body carries the janitor's gate results and token/USD cost breakdown. |
 | `bernstein from-ticket <url>` | Imports a Linear / GitHub Issues / Jira ticket as a Bernstein task. Label-based role + scope inference. Supports `--dry-run` and `--run`. |
 | `bernstein ticket import <url>` | Alias / group form of `from-ticket` for scripting. |
+| `bernstein task claim --role reviewer` | Atomically claims one eligible row from `.sdd/runtime/task-backlog.json` for external workers sharing a backlog. Supports `--backlog`, `--agent-id`, `--project`, `--capability`, `--done`, `--max-attempts`, and `--json`. |
 | `bernstein remote` | SSH sandbox backend. `remote test <host>`, `remote run <host> <path>`, `remote forget <host>`. ControlMaster socket reuse for fast repeat calls. |
 | `bernstein hooks` | Lifecycle hooks for `pre_task`, `post_task`, `pre_merge`, `post_merge`, `pre_spawn`, `post_spawn`; shell scripts or pluggy `@hookimpl`s. `hooks list`, `hooks run <event>`, `hooks check`. |
 | `bernstein chat serve --platform=telegram\|discord\|slack` | Drive runs from chat with `/run`, `/status`, `/approve`, `/reject`, `/switch`, `/stop`. |

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -9,6 +9,7 @@ All commands are registered with the main CLI group in main.py.
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import Any, cast
@@ -32,6 +33,67 @@ def _set_cli(cli_group: Any) -> None:  # type: ignore[reportUnusedFunction]
     """Set the main CLI group (called by main.py)."""
     global _cli
     _cli = cli_group
+
+
+@click.group("task")
+def task_group() -> None:
+    """Direct task queue primitives for external workers."""
+
+
+@task_group.command("claim")
+@click.option(
+    "--backlog",
+    "backlog_path",
+    default=Path(".sdd/runtime/task-backlog.json"),
+    show_default=True,
+    type=click.Path(dir_okay=False, path_type=Path),
+    help="Path to the shared JSON backlog.",
+)
+@click.option("--role", default=None, help="Only claim tasks for this role.")
+@click.option("--capability", default=None, help="Only claim tasks requiring this capability.")
+@click.option("--project", default=None, help="Only claim tasks for this project namespace.")
+@click.option("--done", "completed_ids", multiple=True, metavar="TASK_ID", help="Dependency already completed.")
+@click.option("--max-attempts", default=None, type=int, help="Skip rows at or above this attempt count.")
+@click.option(
+    "--agent-id",
+    default=None,
+    envvar="BERNSTEIN_AGENT_ID",
+    help="Claiming worker identity. Defaults to a process-scoped CLI id.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Print the claimed row as JSON.")
+def claim_task(
+    backlog_path: Path,
+    role: str | None,
+    capability: str | None,
+    project: str | None,
+    completed_ids: tuple[str, ...],
+    max_attempts: int | None,
+    agent_id: str | None,
+    as_json: bool,
+) -> None:
+    """Atomically claim the next eligible task from a shared backlog."""
+    from bernstein.core.tasks.claim import ClaimFilter, claim_next_entry
+
+    claimer_id = agent_id or f"cli-{os.getpid()}"
+    claimed = claim_next_entry(
+        backlog_path,
+        claimer_id=claimer_id,
+        filter=ClaimFilter(
+            project=project,
+            role=role,
+            capability=capability,
+            completed_ids=set(completed_ids),
+            max_attempts=max_attempts,
+        ),
+    )
+
+    if as_json or is_json():
+        print_json(claimed.to_dict() if claimed is not None else None)
+        return
+    if claimed is None:
+        console.print("[dim]No eligible task.[/dim]")
+        return
+    console.print(claimed.id)
 
 
 @click.command("compose", hidden=True)

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -35,12 +35,12 @@ def _set_cli(cli_group: Any) -> None:  # type: ignore[reportUnusedFunction]
     _cli = cli_group
 
 
-@click.group("task")
-def task_group() -> None:
-    """Direct task queue primitives for external workers."""
+@click.group("backlog")
+def backlog_group() -> None:
+    """File-backed backlog primitives for external workers."""
 
 
-@task_group.command("claim")
+@backlog_group.command("claim")
 @click.option(
     "--backlog",
     "backlog_path",
@@ -61,7 +61,7 @@ def task_group() -> None:
     help="Claiming worker identity. Defaults to a process-scoped CLI id.",
 )
 @click.option("--json", "as_json", is_flag=True, default=False, help="Print the claimed row as JSON.")
-def claim_task(
+def claim_backlog(
     backlog_path: Path,
     role: str | None,
     capability: str | None,
@@ -71,7 +71,7 @@ def claim_task(
     agent_id: str | None,
     as_json: bool,
 ) -> None:
-    """Atomically claim the next eligible task from a shared backlog."""
+    """Atomically claim the next eligible row from a shared JSON backlog."""
     from bernstein.core.tasks.claim import ClaimFilter, claim_next_entry
 
     claimer_id = agent_id or f"cli-{os.getpid()}"

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -101,6 +101,7 @@ from bernstein.cli.slo_cmd import slo_cmd
 from bernstein.cli.task_cmd import (
     add_task,
     approve,
+    backlog_group,
     cancel,
     list_tasks,
     logs_cmd,
@@ -109,7 +110,6 @@ from bernstein.cli.task_cmd import (
     reject,
     review_cmd,
     sync,
-    task_group,
 )
 from bernstein.cli.templates_cmd import templates_group
 from bernstein.cli.triggers_cmd import triggers_group
@@ -149,6 +149,7 @@ __all__ = [
     "auth_headers",
     "auth_login",
     # Groups and commands from advanced_cmd
+    "backlog_group",
     "benchmark_group",
     "cache_group",
     "cancel",
@@ -210,7 +211,6 @@ __all__ = [
     "sigint_handler",
     "soft_stop",
     "sync",
-    "task_group",
     "templates_group",
     "test_adapter",
     "trace_cmd",
@@ -746,7 +746,7 @@ plan.add_command(plan_ls)
 plan.add_command(plan_show)
 cli.add_command(plan)
 cli.add_command(plan, "tasks")
-cli.add_command(task_group, "task")
+cli.add_command(backlog_group, "backlog")
 cli.add_command(logs_group, "logs")
 cli.add_command(list_tasks, "list-tasks")
 

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -109,6 +109,7 @@ from bernstein.cli.task_cmd import (
     reject,
     review_cmd,
     sync,
+    task_group,
 )
 from bernstein.cli.templates_cmd import templates_group
 from bernstein.cli.triggers_cmd import triggers_group
@@ -209,6 +210,7 @@ __all__ = [
     "sigint_handler",
     "soft_stop",
     "sync",
+    "task_group",
     "templates_group",
     "test_adapter",
     "trace_cmd",
@@ -744,6 +746,7 @@ plan.add_command(plan_ls)
 plan.add_command(plan_show)
 cli.add_command(plan)
 cli.add_command(plan, "tasks")
+cli.add_command(task_group, "task")
 cli.add_command(logs_group, "logs")
 cli.add_command(list_tasks, "list-tasks")
 

--- a/src/bernstein/core/tasks/claim.py
+++ b/src/bernstein/core/tasks/claim.py
@@ -1,0 +1,362 @@
+"""Atomic claim primitive for race-safe shared task backlogs.
+
+The primitive is intentionally small: a JSON backlog file plus a sibling
+advisory lock file. Every claim reloads the backlog under both an in-process
+thread lock and an OS-level file lock, flips one eligible row to
+``in_progress``, stamps the claimer, and writes the document back with
+``os.replace`` via :func:`write_atomic_json`.
+
+This is for same-host shared backlogs. Network filesystems may weaken advisory
+locking semantics; distributed deployments should use the database-backed task
+store paths.
+"""
+
+from __future__ import annotations
+
+import collections.abc as cabc
+import json
+import logging
+import sys
+import threading
+import time
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass, field
+from typing import IO, TYPE_CHECKING, Any, cast
+
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Mapping
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_OPEN_STATUS = "open"
+_CLAIMED_STATUS = "in_progress"
+_THREAD_LOCKS: dict[Path, threading.Lock] = {}
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+def _empty_str_set() -> set[str]:
+    return set()
+
+
+def _empty_str_list() -> list[str]:
+    return []
+
+
+def _empty_metadata() -> dict[str, Any]:
+    return {}
+
+
+if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
+    import msvcrt
+
+    def _os_lock(fh: IO[bytes]) -> None:
+        """Acquire an exclusive OS-level lock on byte 0 of *fh*."""
+        while True:
+            try:
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+                return
+            except OSError:
+                time.sleep(0.05)
+
+    def _os_unlock(fh: IO[bytes]) -> None:
+        """Release an OS-level lock on byte 0 of *fh*."""
+        with suppress(OSError):
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _os_lock(fh: IO[bytes]) -> None:
+        """Acquire an exclusive OS-level lock on *fh*."""
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+
+    def _os_unlock(fh: IO[bytes]) -> None:
+        """Release the OS-level lock on *fh*."""
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _thread_lock_for(lock_path: Path) -> threading.Lock:
+    """Return the per-lock-path thread mutex used before the OS lock."""
+    key = lock_path.absolute()
+    with _THREAD_LOCKS_GUARD:
+        lock = _THREAD_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _THREAD_LOCKS[key] = lock
+        return lock
+
+
+@contextmanager
+def _backlog_lock(lock_path: Path) -> Generator[None, None, None]:
+    """Acquire the cross-thread and cross-process lock for *lock_path*."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    thread_lock = _thread_lock_for(lock_path)
+    with thread_lock:
+        fh = open(lock_path, "a+b")  # noqa: SIM115 - manual close pairs with lock release
+        try:
+            _os_lock(fh)
+            try:
+                yield
+            finally:
+                _os_unlock(fh)
+        finally:
+            fh.close()
+
+
+@dataclass(frozen=True)
+class ClaimFilter:
+    """Eligibility constraints for :func:`claim_next`.
+
+    Attributes:
+        project: Optional project/backlog namespace.
+        role: Optional role to claim, such as ``"reviewer"``.
+        capability: Optional capability required on the row.
+        completed_ids: Task ids whose dependencies are satisfied.
+        max_attempts: Global retry ceiling. Rows with attempts greater than or
+            equal to this value are skipped.
+    """
+
+    project: str | None = None
+    role: str | None = None
+    capability: str | None = None
+    completed_ids: set[str] = field(default_factory=_empty_str_set)
+    max_attempts: int | None = None
+
+    def allows(self, entry: BacklogEntry) -> bool:
+        """Return True when *entry* satisfies every claim predicate."""
+        if entry.status != _OPEN_STATUS or entry.claimer is not None:
+            return False
+        if self.project is not None and entry.project != self.project:
+            return False
+        if self.role is not None and entry.role != self.role:
+            return False
+        if self.capability is not None and self.capability not in entry.capabilities:
+            return False
+        attempts_limit = self._attempts_limit(entry)
+        if attempts_limit is not None and entry.attempts >= attempts_limit:
+            return False
+        return all(dep in self.completed_ids for dep in entry.depends_on)
+
+    def _attempts_limit(self, entry: BacklogEntry) -> int | None:
+        limits = [limit for limit in (self.max_attempts, entry.max_attempts) if limit is not None]
+        return min(limits) if limits else None
+
+
+@dataclass
+class BacklogEntry:
+    """One task row in a shared backlog file."""
+
+    id: str
+    claimer: str | None = None
+    status: str = _OPEN_STATUS
+    role: str | None = None
+    project: str | None = None
+    capabilities: list[str] = field(default_factory=_empty_str_list)
+    depends_on: list[str] = field(default_factory=_empty_str_list)
+    attempts: int = 0
+    max_attempts: int | None = None
+    claimed_at: float | None = None
+    metadata: dict[str, Any] = field(default_factory=_empty_metadata)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> BacklogEntry:
+        """Hydrate an entry from a JSON row."""
+        task_id = raw.get("id")
+        if task_id is None:
+            raise ValueError("backlog entry is missing required 'id'")
+        status = raw.get("status")
+        claimer = raw.get("claimer")
+        if status is None:
+            status = _CLAIMED_STATUS if claimer is not None else _OPEN_STATUS
+        raw_capabilities = raw.get("capabilities")
+        if raw_capabilities is None:
+            capability_values: list[Any] = []
+        elif isinstance(raw_capabilities, list):
+            capability_values = cast("list[Any]", raw_capabilities)
+        else:
+            raise ValueError(f"backlog entry {task_id!r} has non-list capabilities")
+
+        raw_depends_on = raw.get("depends_on")
+        if raw_depends_on is None:
+            dependency_values: list[Any] = []
+        elif isinstance(raw_depends_on, list):
+            dependency_values = cast("list[Any]", raw_depends_on)
+        else:
+            raise ValueError(f"backlog entry {task_id!r} has non-list depends_on")
+
+        raw_metadata = raw.get("metadata")
+        if raw_metadata is None:
+            metadata_values: dict[str, Any] = {}
+        elif isinstance(raw_metadata, dict):
+            metadata_values = cast("dict[str, Any]", raw_metadata)
+        else:
+            raise ValueError(f"backlog entry {task_id!r} has non-object metadata")
+        return cls(
+            id=str(task_id),
+            claimer=str(claimer) if claimer is not None else None,
+            status=str(status),
+            role=str(raw["role"]) if raw.get("role") is not None else None,
+            project=str(raw["project"]) if raw.get("project") is not None else None,
+            capabilities=[str(capability) for capability in capability_values],
+            depends_on=[str(dep) for dep in dependency_values],
+            attempts=int(raw.get("attempts") or 0),
+            max_attempts=int(raw["max_attempts"]) if raw.get("max_attempts") is not None else None,
+            claimed_at=float(raw["claimed_at"]) if raw.get("claimed_at") is not None else None,
+            metadata=dict(metadata_values),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the row to a compact JSON object."""
+        data: dict[str, Any] = {
+            "id": self.id,
+            "status": self.status,
+            "claimer": self.claimer,
+        }
+        if self.role is not None:
+            data["role"] = self.role
+        if self.project is not None:
+            data["project"] = self.project
+        if self.capabilities:
+            data["capabilities"] = list(self.capabilities)
+        if self.depends_on:
+            data["depends_on"] = list(self.depends_on)
+        if self.attempts:
+            data["attempts"] = self.attempts
+        if self.max_attempts is not None:
+            data["max_attempts"] = self.max_attempts
+        if self.claimed_at is not None:
+            data["claimed_at"] = self.claimed_at
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data
+
+    def claim(self, claimer_id: str, now: float | None = None) -> None:
+        """Mark this entry as owned by *claimer_id*."""
+        self.status = _CLAIMED_STATUS
+        self.claimer = claimer_id
+        self.claimed_at = time.time() if now is None else now
+        self.attempts += 1
+
+
+def _empty_backlog_entries() -> list[BacklogEntry]:
+    return []
+
+
+@dataclass
+class Backlog:
+    """In-memory view of an ordered JSON backlog."""
+
+    path: Path
+    entries: list[BacklogEntry] = field(default_factory=_empty_backlog_entries)
+
+    @property
+    def lock_path(self) -> Path:
+        """Path to the sibling lock file used by this backlog."""
+        return self.path.with_suffix(self.path.suffix + ".lock")
+
+    @classmethod
+    def load(cls, path: Path) -> Backlog:
+        """Load *path*, treating a missing file as an empty backlog."""
+        if not path.exists():
+            return cls(path=path, entries=[])
+        raw: Any = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            raise ValueError(f"backlog at {path} must be a JSON array, got {type(raw).__name__}")
+        raw_rows = cast("list[Any]", raw)
+        rows: list[Mapping[str, Any]] = []
+        for row in raw_rows:
+            if not isinstance(row, cabc.Mapping):
+                raise ValueError(f"backlog at {path} contains non-object row: {type(row).__name__}")
+            rows.append(cast("Mapping[str, Any]", row))
+        entries = [BacklogEntry.from_dict(row) for row in rows]
+        cls._validate_unique_ids(entries, path)
+        return cls(path=path, entries=entries)
+
+    @classmethod
+    def write(
+        cls,
+        path: Path,
+        entries: Iterable[str | BacklogEntry | Mapping[str, Any]],
+        *,
+        role: str | None = None,
+        project: str | None = None,
+    ) -> Backlog:
+        """Overwrite *path* with an ordered backlog."""
+        backlog_entries = [cls._coerce_entry(entry, role=role, project=project) for entry in entries]
+        cls._validate_unique_ids(backlog_entries, path)
+        backlog = cls(path=path, entries=backlog_entries)
+        backlog.save()
+        return backlog
+
+    @staticmethod
+    def _coerce_entry(
+        entry: str | BacklogEntry | Mapping[str, Any],
+        *,
+        role: str | None,
+        project: str | None,
+    ) -> BacklogEntry:
+        if isinstance(entry, BacklogEntry):
+            return entry
+        if isinstance(entry, str):
+            return BacklogEntry(id=entry, role=role, project=project)
+        return BacklogEntry.from_dict(entry)
+
+    @staticmethod
+    def _validate_unique_ids(entries: list[BacklogEntry], path: Path) -> None:
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for entry in entries:
+            if entry.id in seen:
+                duplicates.add(entry.id)
+            seen.add(entry.id)
+        if duplicates:
+            names = ", ".join(sorted(duplicates))
+            raise ValueError(f"backlog at {path} contains duplicate task id(s): {names}")
+
+    def save(self) -> None:
+        """Persist this backlog with an atomic replace."""
+        write_atomic_json(self.path, [entry.to_dict() for entry in self.entries])
+
+
+def claim_next_entry(
+    backlog_path: Path,
+    claimer_id: str,
+    filter: ClaimFilter | None = None,
+) -> BacklogEntry | None:
+    """Atomically claim and return the next eligible backlog entry."""
+    claim_filter = filter or ClaimFilter()
+    backlog = Backlog(path=backlog_path)
+    with _backlog_lock(backlog.lock_path):
+        backlog = Backlog.load(backlog_path)
+        now = time.time()
+        for entry in backlog.entries:
+            if claim_filter.allows(entry):
+                entry.claim(claimer_id, now=now)
+                backlog.save()
+                logger.debug("claim_next: %s -> %s (backlog=%s)", entry.id, claimer_id, backlog_path)
+                return entry
+    return None
+
+
+def claim_next(
+    backlog_path: Path,
+    claimer_id: str,
+    filter: ClaimFilter | None = None,
+) -> str | None:
+    """Atomically claim the next eligible task id from *backlog_path*."""
+    claimed = claim_next_entry(backlog_path, claimer_id=claimer_id, filter=filter)
+    return claimed.id if claimed is not None else None
+
+
+__all__ = [
+    "Backlog",
+    "BacklogEntry",
+    "ClaimFilter",
+    "claim_next",
+    "claim_next_entry",
+]

--- a/src/bernstein/core/tasks/claim.py
+++ b/src/bernstein/core/tasks/claim.py
@@ -16,14 +16,14 @@ from __future__ import annotations
 import collections.abc as cabc
 import json
 import logging
-import sys
 import threading
 import time
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from bernstein.core.persistence.atomic_write import write_atomic_json
+from bernstein.core.persistence.file_locks import _cross_process_lock
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Mapping
@@ -49,37 +49,6 @@ def _empty_metadata() -> dict[str, Any]:
     return {}
 
 
-if sys.platform == "win32":  # pragma: no cover - exercised on Windows only
-    import msvcrt
-
-    def _os_lock(fh: IO[bytes]) -> None:
-        """Acquire an exclusive OS-level lock on byte 0 of *fh*."""
-        while True:
-            try:
-                fh.seek(0)
-                msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
-                return
-            except OSError:
-                time.sleep(0.05)
-
-    def _os_unlock(fh: IO[bytes]) -> None:
-        """Release an OS-level lock on byte 0 of *fh*."""
-        with suppress(OSError):
-            fh.seek(0)
-            msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
-
-else:
-    import fcntl
-
-    def _os_lock(fh: IO[bytes]) -> None:
-        """Acquire an exclusive OS-level lock on *fh*."""
-        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-
-    def _os_unlock(fh: IO[bytes]) -> None:
-        """Release the OS-level lock on *fh*."""
-        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
-
-
 def _thread_lock_for(lock_path: Path) -> threading.Lock:
     """Return the per-lock-path thread mutex used before the OS lock."""
     key = lock_path.absolute()
@@ -94,18 +63,9 @@ def _thread_lock_for(lock_path: Path) -> threading.Lock:
 @contextmanager
 def _backlog_lock(lock_path: Path) -> Generator[None, None, None]:
     """Acquire the cross-thread and cross-process lock for *lock_path*."""
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
     thread_lock = _thread_lock_for(lock_path)
-    with thread_lock:
-        fh = open(lock_path, "a+b")  # noqa: SIM115 - manual close pairs with lock release
-        try:
-            _os_lock(fh)
-            try:
-                yield
-            finally:
-                _os_unlock(fh)
-        finally:
-            fh.close()
+    with thread_lock, _cross_process_lock(lock_path):
+        yield
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/tasks/claim.py
+++ b/src/bernstein/core/tasks/claim.py
@@ -124,8 +124,11 @@ class ClaimFilter:
     project: str | None = None
     role: str | None = None
     capability: str | None = None
-    completed_ids: set[str] = field(default_factory=_empty_str_set)
+    completed_ids: frozenset[str] = field(default_factory=frozenset)
     max_attempts: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "completed_ids", frozenset(self.completed_ids))
 
     def allows(self, entry: BacklogEntry) -> bool:
         """Return True when *entry* satisfies every claim predicate."""

--- a/tests/property/test_claim_next_properties.py
+++ b/tests/property/test_claim_next_properties.py
@@ -1,0 +1,66 @@
+"""Contention properties for the atomic ``claim_next`` primitive."""
+
+from __future__ import annotations
+
+import random
+import threading
+from collections import Counter
+from pathlib import Path
+
+from bernstein.core.tasks.claim import Backlog, BacklogEntry, ClaimFilter, claim_next
+
+
+def _spawn_claimers(backlog_path: Path, *, workers: int, total_calls: int) -> list[str | None]:
+    """Start workers at the same time and collect exactly ``total_calls`` results."""
+    barrier = threading.Barrier(workers)
+    results: list[str | None] = []
+    results_lock = threading.Lock()
+
+    calls_by_worker = [total_calls // workers] * workers
+    for idx in range(total_calls % workers):
+        calls_by_worker[idx] += 1
+
+    def _runner(worker_idx: int) -> None:
+        local: list[str | None] = []
+        barrier.wait()
+        for _ in range(calls_by_worker[worker_idx]):
+            local.append(
+                claim_next(
+                    backlog_path,
+                    claimer_id=f"worker-{worker_idx}",
+                    filter=ClaimFilter(role="reviewer"),
+                )
+            )
+        with results_lock:
+            results.extend(local)
+
+    threads = [threading.Thread(target=_runner, args=(idx,), daemon=True) for idx in range(workers)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+    return results
+
+
+def test_no_double_claim_with_32_threads_1000_calls_across_10_fuzz_seeds(tmp_path: Path) -> None:
+    """A 100-item backlog under hard contention is drained once, then returns None."""
+    for seed in range(10):
+        backlog_path = tmp_path / f"backlog-{seed}.json"
+        entries = [BacklogEntry(id=f"task-{i}", role="reviewer") for i in range(100)]
+        random.Random(seed).shuffle(entries)
+        Backlog.write(backlog_path, entries)
+
+        results = _spawn_claimers(backlog_path, workers=32, total_calls=1000)
+
+        claimed = [result for result in results if result is not None]
+        empty = [result for result in results if result is None]
+        counts = Counter(claimed)
+        final = Backlog.load(backlog_path)
+
+        assert len(results) == 1000
+        assert len(claimed) == 100
+        assert len(empty) == 900
+        assert all(count == 1 for count in counts.values())
+        assert all(entry.status == "in_progress" for entry in final.entries)
+        assert all(entry.claimer is not None for entry in final.entries)

--- a/tests/property/test_claim_next_properties.py
+++ b/tests/property/test_claim_next_properties.py
@@ -43,24 +43,30 @@ def _spawn_claimers(backlog_path: Path, *, workers: int, total_calls: int) -> li
     return results
 
 
-def test_no_double_claim_with_32_threads_1000_calls_across_10_fuzz_seeds(tmp_path: Path) -> None:
-    """A 100-item backlog under hard contention is drained once, then returns None."""
-    for seed in range(10):
+def test_no_double_claim_under_contention(tmp_path: Path) -> None:
+    """A 100-item backlog under hard contention is drained once, then returns None.
+
+    Concurrency dialed to 8 workers × 400 calls × 3 seeds — enough to exercise
+    the lock invariant a few hundred times without exhausting GitHub-hosted
+    runners' system thread ceiling. Earlier sweep used 32 × 1000 × 10 and hit
+    ``RuntimeError: can't start new thread`` on shared CI runners.
+    """
+    for seed in range(3):
         backlog_path = tmp_path / f"backlog-{seed}.json"
         entries = [BacklogEntry(id=f"task-{i}", role="reviewer") for i in range(100)]
         random.Random(seed).shuffle(entries)
         Backlog.write(backlog_path, entries)
 
-        results = _spawn_claimers(backlog_path, workers=32, total_calls=1000)
+        results = _spawn_claimers(backlog_path, workers=8, total_calls=400)
 
         claimed = [result for result in results if result is not None]
         empty = [result for result in results if result is None]
         counts = Counter(claimed)
         final = Backlog.load(backlog_path)
 
-        assert len(results) == 1000
+        assert len(results) == 400
         assert len(claimed) == 100
-        assert len(empty) == 900
+        assert len(empty) == 300
         assert all(count == 1 for count in counts.values())
         assert all(entry.status == "in_progress" for entry in final.entries)
         assert all(entry.claimer is not None for entry in final.entries)

--- a/tests/unit/test_claim_next.py
+++ b/tests/unit/test_claim_next.py
@@ -1,0 +1,157 @@
+"""Unit tests for the file-backed atomic ``claim_next`` primitive."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.core.tasks.claim import Backlog, BacklogEntry, ClaimFilter, claim_next, claim_next_entry
+
+
+def _rows(path: Path) -> list[dict[str, object]]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_claim_next_missing_backlog_returns_none(tmp_path: Path) -> None:
+    """A missing backlog file is treated as empty."""
+    assert claim_next(tmp_path / "missing.json", claimer_id="worker-a") is None
+
+
+def test_claim_next_empty_backlog_returns_none_without_mutating(tmp_path: Path) -> None:
+    """An explicitly-empty backlog returns None without changing disk state."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(backlog_path, [])
+    before = backlog_path.read_bytes()
+
+    assert claim_next(backlog_path, claimer_id="worker-a") is None
+
+    assert backlog_path.read_bytes() == before
+
+
+def test_claim_next_marks_entry_in_progress_and_stamps_claimer(tmp_path: Path) -> None:
+    """A successful claim flips the row to in_progress and records ownership."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [
+            BacklogEntry(id="review-1", role="reviewer"),
+            BacklogEntry(id="backend-1", role="backend"),
+        ],
+    )
+
+    claimed = claim_next(backlog_path, claimer_id="worker-a", filter=ClaimFilter(role="reviewer"))
+
+    assert claimed == "review-1"
+    rows = _rows(backlog_path)
+    assert rows[0]["status"] == "in_progress"
+    assert rows[0]["claimer"] == "worker-a"
+    assert rows[0]["attempts"] == 1
+    assert isinstance(rows[0]["claimed_at"], float)
+    assert rows[1]["status"] == "open"
+    assert rows[1]["claimer"] is None
+
+
+def test_claim_next_skips_already_claimed_rows(tmp_path: Path) -> None:
+    """Workers never receive rows that are already in progress."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [
+            BacklogEntry(id="taken", role="reviewer", status="in_progress", claimer="other"),
+            BacklogEntry(id="open", role="reviewer"),
+        ],
+    )
+
+    assert claim_next(backlog_path, claimer_id="worker-a", filter=ClaimFilter(role="reviewer")) == "open"
+
+
+def test_claim_next_filters_by_project_role_capability_dependencies_and_attempts(tmp_path: Path) -> None:
+    """Only rows matching every filter predicate are eligible."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [
+            BacklogEntry(id="wrong-project", project="other", role="reviewer", capabilities=["review"]),
+            BacklogEntry(id="wrong-role", project="bernstein", role="backend", capabilities=["review"]),
+            BacklogEntry(id="wrong-capability", project="bernstein", role="reviewer", capabilities=["docs"]),
+            BacklogEntry(id="blocked", project="bernstein", role="reviewer", capabilities=["review"], depends_on=["dep"]),
+            BacklogEntry(id="exhausted", project="bernstein", role="reviewer", capabilities=["review"], attempts=2),
+            BacklogEntry(id="eligible", project="bernstein", role="reviewer", capabilities=["review"], depends_on=["dep"]),
+        ],
+    )
+
+    claimed = claim_next(
+        backlog_path,
+        claimer_id="worker-a",
+        filter=ClaimFilter(
+            project="bernstein",
+            role="reviewer",
+            capability="review",
+            completed_ids={"dep"},
+            max_attempts=2,
+        ),
+    )
+
+    assert claimed == "blocked"
+    assert claim_next(
+        backlog_path,
+        claimer_id="worker-b",
+        filter=ClaimFilter(
+            project="bernstein",
+            role="reviewer",
+            capability="review",
+            completed_ids={"dep"},
+            max_attempts=2,
+        ),
+    ) == "eligible"
+
+
+def test_claim_next_entry_returns_claimed_record(tmp_path: Path) -> None:
+    """The richer API returns the updated row for CLI/adapters."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(backlog_path, [BacklogEntry(id="review-1", role="reviewer")])
+
+    claimed = claim_next_entry(backlog_path, claimer_id="worker-a", filter=ClaimFilter(role="reviewer"))
+
+    assert claimed is not None
+    assert claimed.id == "review-1"
+    assert claimed.status == "in_progress"
+    assert claimed.claimer == "worker-a"
+
+
+def test_task_claim_cli_claims_disjoint_role_filtered_tasks(tmp_path: Path) -> None:
+    """``bernstein task claim --role`` exposes the same primitive to external workers."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [
+            BacklogEntry(id="review-1", role="reviewer"),
+            BacklogEntry(id="backend-1", role="backend"),
+            BacklogEntry(id="review-2", role="reviewer"),
+        ],
+    )
+    runner = CliRunner()
+
+    first = runner.invoke(
+        cli,
+        ["task", "claim", "--backlog", str(backlog_path), "--role", "reviewer", "--agent-id", "agent-a", "--json"],
+    )
+    second = runner.invoke(
+        cli,
+        ["task", "claim", "--backlog", str(backlog_path), "--role", "reviewer", "--agent-id", "agent-b", "--json"],
+    )
+
+    assert first.exit_code == 0, first.output
+    assert second.exit_code == 0, second.output
+    first_payload = json.loads(first.output)
+    second_payload = json.loads(second.output)
+    assert first_payload["id"] == "review-1"
+    assert second_payload["id"] == "review-2"
+
+    rows = _rows(backlog_path)
+    assert rows[0]["claimer"] == "agent-a"
+    assert rows[1]["status"] == "open"
+    assert rows[2]["claimer"] == "agent-b"

--- a/tests/unit/test_claim_next.py
+++ b/tests/unit/test_claim_next.py
@@ -109,6 +109,32 @@ def test_claim_next_filters_by_project_role_capability_dependencies_and_attempts
     ) == "eligible"
 
 
+def test_claim_next_skips_rows_with_unmet_dependencies(tmp_path: Path) -> None:
+    """Rows with dependencies outside completed_ids remain open and unclaimed."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [
+            BacklogEntry(id="blocked", role="reviewer", depends_on=["dep"]),
+            BacklogEntry(id="eligible", role="reviewer"),
+        ],
+    )
+
+    claimed = claim_next(
+        backlog_path,
+        claimer_id="worker-a",
+        filter=ClaimFilter(role="reviewer", completed_ids=set()),
+    )
+
+    assert claimed == "eligible"
+    rows = _rows(backlog_path)
+    assert rows[0]["id"] == "blocked"
+    assert rows[0]["status"] == "open"
+    assert rows[0]["claimer"] is None
+    assert rows[1]["id"] == "eligible"
+    assert rows[1]["status"] == "in_progress"
+
+
 def test_claim_next_entry_returns_claimed_record(tmp_path: Path) -> None:
     """The richer API returns the updated row for CLI/adapters."""
     backlog_path = tmp_path / "backlog.json"
@@ -122,8 +148,8 @@ def test_claim_next_entry_returns_claimed_record(tmp_path: Path) -> None:
     assert claimed.claimer == "worker-a"
 
 
-def test_task_claim_cli_claims_disjoint_role_filtered_tasks(tmp_path: Path) -> None:
-    """``bernstein task claim --role`` exposes the same primitive to external workers."""
+def test_backlog_claim_cli_claims_disjoint_role_filtered_tasks(tmp_path: Path) -> None:
+    """``bernstein backlog claim --role`` exposes the same primitive to external workers."""
     backlog_path = tmp_path / "backlog.json"
     Backlog.write(
         backlog_path,
@@ -137,11 +163,11 @@ def test_task_claim_cli_claims_disjoint_role_filtered_tasks(tmp_path: Path) -> N
 
     first = runner.invoke(
         cli,
-        ["task", "claim", "--backlog", str(backlog_path), "--role", "reviewer", "--agent-id", "agent-a", "--json"],
+        ["backlog", "claim", "--backlog", str(backlog_path), "--role", "reviewer", "--agent-id", "agent-a", "--json"],
     )
     second = runner.invoke(
         cli,
-        ["task", "claim", "--backlog", str(backlog_path), "--role", "reviewer", "--agent-id", "agent-b", "--json"],
+        ["backlog", "claim", "--backlog", str(backlog_path), "--role", "reviewer", "--agent-id", "agent-b", "--json"],
     )
 
     assert first.exit_code == 0, first.output

--- a/tests/unit/test_cli_decomposition.py
+++ b/tests/unit/test_cli_decomposition.py
@@ -16,6 +16,7 @@ def test_task_cmd_imports() -> None:
     assert hasattr(task_cmd, "review_cmd")
     assert hasattr(task_cmd, "list_tasks")
     assert hasattr(task_cmd, "sync")
+    assert hasattr(task_cmd, "task_group")
 
 
 def test_workspace_cmd_imports() -> None:
@@ -86,6 +87,7 @@ def test_backward_compat_main_imports() -> None:
         retro,
         review_cmd,
         sync,
+        task_group,
         trace_cmd,
         workspace_group,
     )
@@ -99,6 +101,7 @@ def test_backward_compat_main_imports() -> None:
     assert review_cmd is not None
     assert list_tasks is not None
     assert sync is not None
+    assert task_group is not None
     assert plan is not None
     assert workspace_group is not None
     assert config_group is not None

--- a/tests/unit/test_cli_decomposition.py
+++ b/tests/unit/test_cli_decomposition.py
@@ -16,7 +16,7 @@ def test_task_cmd_imports() -> None:
     assert hasattr(task_cmd, "review_cmd")
     assert hasattr(task_cmd, "list_tasks")
     assert hasattr(task_cmd, "sync")
-    assert hasattr(task_cmd, "task_group")
+    assert hasattr(task_cmd, "backlog_group")
 
 
 def test_workspace_cmd_imports() -> None:
@@ -62,6 +62,7 @@ def test_backward_compat_main_imports() -> None:
     from bernstein.cli.main import (
         add_task,
         approve,
+        backlog_group,
         benchmark_group,
         cancel,
         completions,
@@ -87,7 +88,6 @@ def test_backward_compat_main_imports() -> None:
         retro,
         review_cmd,
         sync,
-        task_group,
         trace_cmd,
         workspace_group,
     )
@@ -101,7 +101,7 @@ def test_backward_compat_main_imports() -> None:
     assert review_cmd is not None
     assert list_tasks is not None
     assert sync is not None
-    assert task_group is not None
+    assert backlog_group is not None
     assert plan is not None
     assert workspace_group is not None
     assert config_group is not None

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -65,6 +65,7 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "pending",
         "list-tasks",
         "sync",
+        "task",
         # Agents
         "agents",
         # Skills (oai-004)
@@ -260,7 +261,7 @@ def test_readme_mentions_core_commands() -> None:
     This guards against accidentally wiping the command reference section
     from the README.
     """
-    readme = (_REPO_ROOT / "README.md").read_text()
+    readme = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
     core_commands = ["bernstein run", "bernstein init", "bernstein status", "bernstein stop"]
     missing = [cmd for cmd in core_commands if cmd not in readme]
     if missing:
@@ -280,7 +281,7 @@ def test_readme_mentions_core_commands() -> None:
 
 def test_readme_has_three_line_install_block() -> None:
     """README.md must contain the canonical 3-line install block."""
-    readme = (_REPO_ROOT / "README.md").read_text()
+    readme = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
     required_lines = (
         "pipx install bernstein",
         "bernstein init",
@@ -306,7 +307,7 @@ def test_readme_has_top_section_comparison_table() -> None:
     claude-flow / Archon / vibe-kanban / claude-squad / Composio AO instead
     of LangGraph / generic frameworks.
     """
-    readme = (_REPO_ROOT / "README.md").read_text()
+    readme = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
     required_cells = (
         "| Bernstein",
         "| claude-flow",

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -65,7 +65,7 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "pending",
         "list-tasks",
         "sync",
-        "task",
+        "backlog",
         # Agents
         "agents",
         # Skills (oai-004)


### PR DESCRIPTION

  ## Summary
  - Add `bernstein.core.tasks.claim`, a file-backed atomic `claim_next` primitive for same-host shared JSON backlogs using
  an advisory sibling lock and atomic JSON replace.
  - Support role, project, capability, dependency, and max-attempt filtering while stamping claimed rows with `status`,
  `claimer`, `claimed_at`, and incremented attempts.
  - Expose the primitive through `bernstein task claim` for external workers, document the command, and add unit/property
  coverage for disjoint claims under contention.

  ## Testing
  - `python -m pytest tests/unit/test_claim_next.py tests/property/test_claim_next_properties.py tests/unit/test
