### PR TITLE
chore(ci): pin remaining GHA references by SHA (zizmor unpinned-uses)

### DIFF
--- a/.github/workflows/a2a-federation-e2e.yml
+++ b/.github/workflows/a2a-federation-e2e.yml
@@ -45,10 +45,10 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/cluster-e2e.yml
+++ b/.github/workflows/cluster-e2e.yml
@@ -37,10 +37,10 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cluster-e2e-logs
           path: |

--- a/.github/workflows/cluster-tunnel-e2e.yml
+++ b/.github/workflows/cluster-tunnel-e2e.yml
@@ -51,12 +51,12 @@ jobs:
         with:
           egress-policy: audit
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: cluster-tunnel-e2e-logs
           path: |

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -74,10 +74,10 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -95,7 +95,7 @@ jobs:
             --badge .sdd/runtime/eval/badge.md
 
       - name: Upload smoke artefacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: eval-nightly-smoke
           path: |
@@ -120,10 +120,10 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -149,7 +149,7 @@ jobs:
             --badge .sdd/runtime/eval/badge.md
 
       - name: Upload leaderboard artefacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: eval-nightly-${{ github.run_id }}
           path: |

--- a/.github/workflows/soc2-evidence-nightly.yml
+++ b/.github/workflows/soc2-evidence-nightly.yml
@@ -70,10 +70,10 @@ jobs:
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
           egress-policy: audit
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -100,7 +100,7 @@ jobs:
             "${INCLUDE_FLAG[@]}"
 
       - name: Upload evidence pack
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: soc2-evidence-${{ github.run_id }}
           path: |

--- a/action.yml
+++ b/action.yml
@@ -60,12 +60,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
       with:
         enable-cache: true
 


### PR DESCRIPTION
## Summary

Replace floating major/minor tags with full commit SHAs plus version comments for the GitHub Actions still flagged by `zizmor/unpinned-uses` code-scanning alerts. Pinning by SHA prevents silent action-source changes if an upstream tag is moved.

## Pins applied

| Action | Pin |
|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0` |
| `astral-sh/setup-uv` | `37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0` |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7` |

## Files touched

- `action.yml`
- `.github/workflows/a2a-federation-e2e.yml`
- `.github/workflows/cluster-e2e.yml`
- `.github/workflows/cluster-tunnel-e2e.yml`
- `.github/workflows/eval-nightly.yml`
- `.github/workflows/soc2-evidence-nightly.yml`

## Resolves

Code-scanning alerts: #133, #134, #225, #226, #227, #229, #230, #231, #245, #246, #247, #248, #249, #250, #318, #319, #320, #322, #323 (19 total).

## Test plan

- [ ] Required CI checks pass on this PR.
- [ ] After merge, `zizmor/unpinned-uses` alerts above auto-close on the next code-scan run.