### PR TITLE
feat(ci): restore Docker / GHCR publish workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -180,8 +180,11 @@ jobs:
     if: needs.gate.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Distribution (PyPI, npm, GHCR Docker) is owned by `publish.yml`,
-    # which runs on the tag push emitted by the `Tag` step below.
+    # Distribution is split across two workflows that both fire from this job:
+    #   - `publish.yml`        — runs on tag push; owns PyPI, npm, GitHub Release
+    #   - `publish-docker.yml` — runs on `release: published`; owns GHCR image
+    # The tag push emitted by the `Tag` step below triggers `publish.yml`,
+    # which then creates the GitHub Release that triggers `publish-docker.yml`.
     # This job's responsibility is now narrowed to:
     #   1. Decide whether to tag (gate already passed),
     #   2. Push the tag,
@@ -261,8 +264,9 @@ jobs:
           fi
 
       # Push the tag. `publish.yml` is triggered by `push: tags: v*` and
-      # owns the Build / Sigstore attestation / PyPI / npm / GHCR steps
-      # from here.
+      # owns Build / Sigstore attestation / PyPI / npm / GitHub Release.
+      # GHCR Docker is owned by `publish-docker.yml`, which fires on the
+      # `release: published` event emitted by `publish.yml::github-release`.
       - name: Tag
         if: steps.final.outputs.deferred != 'true'
         run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,114 @@
+name: Publish Docker Image
+
+# Build and push the Bernstein container image to GitHub Container Registry
+# (GHCR) on every GitHub Release publish event. `workflow_dispatch` is kept
+# so an operator can manually republish a tag (e.g. when a release predates
+# this workflow, or to retry after a transient failure).
+#
+# Image: ghcr.io/sipyourdrink-ltd/bernstein
+# Tags : vX.Y.Z, X.Y.Z, X.Y, X, latest (the last only for stable releases)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build (e.g. v2.0.1). Defaults to the workflow ref."
+        required: false
+
+permissions: {}
+
+jobs:
+  publish:
+    name: Build and push image to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Resolve build ref
+        id: ref
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            REF="$INPUT_TAG"
+          elif [ -n "$RELEASE_TAG" ]; then
+            REF="$RELEASE_TAG"
+          else
+            REF="${GITHUB_REF_NAME}"
+          fi
+          # Strip leading "v" if present so downstream consumers get a clean
+          # semantic version they can substitute into pip/uv/Docker tags.
+          VERSION="${REF#v}"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Building image for ref=$REF (version=$VERSION)"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+          persist-credentials: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/bernstein
+          # Tag matrix:
+          #   - v2.0.1, 2.0.1, 2.0, 2  (full semver + truncations)
+          #   - latest                  (only for stable, non-prerelease tags)
+          # `value=` is used to pass the explicit ref/version through both
+          # the `release` and `workflow_dispatch` triggers so this workflow
+          # behaves identically whether GitHub fired it or an operator did.
+          tags: |
+            type=semver,pattern={{raw}},value=${{ steps.ref.outputs.ref }}
+            type=semver,pattern={{version}},value=${{ steps.ref.outputs.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ref.outputs.ref }}
+            type=semver,pattern={{major}},value=${{ steps.ref.outputs.ref }}
+            type=raw,value=latest,enable=${{ !contains(steps.ref.outputs.version, '-') }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      # Sigstore keyless build-provenance attestation for the image, mirroring
+      # the PyPI wheel/sdist attestation in publish.yml. Verifiable via:
+      #   gh attestation verify oci://ghcr.io/sipyourdrink-ltd/bernstein:<tag> \
+      #     --owner sipyourdrink-ltd
+      - name: Attest build provenance (Sigstore)
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/bernstein
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-docker.yml` to rebuild and push the Bernstein container image to `ghcr.io/sipyourdrink-ltd/bernstein` on every GitHub Release publish event (plus `workflow_dispatch` for manual republishes).
- Uses `docker/metadata-action` to emit the full semver tag matrix (`vX.Y.Z`, `X.Y.Z`, `X.Y`, `X`) and only assigns `latest` to stable, non-prerelease tags.
- Pushes to `ghcr.io/${{ github.repository_owner }}/bernstein` so the image path tracks repo ownership instead of being hard-coded.
- Generates a Sigstore keyless build-provenance attestation for the image digest, matching the SLSA-3 attestation `publish.yml` already produces for the PyPI wheel/sdist.
- SHA-pins every third-party action and runs `step-security/harden-runner` in audit mode.
- Fixes two outdated comments in `auto-release.yml` that still claimed `publish.yml` owns the GHCR step.

## Why

The previous `publish-docker.yml` was removed in `1d8107e8c` (workflow cleanup, 2026-04-13) and no replacement was added. The container image at `ghcr.io/sipyourdrink-ltd/bernstein` has therefore been frozen at `1.11.0` while v2.0.0 and v2.0.1 shipped through every other channel. Landing-page (bernstein.run) advertises `docker` as one of four install channels, so this is operator-visible.

## Tag matrix produced

| Trigger | Example tag | Resulting image tags |
|---|---|---|
| `release: published` for `v2.0.1` | `v2.0.1` | `v2.0.1`, `2.0.1`, `2.0`, `2`, `latest` |
| `workflow_dispatch` with `tag=v2.0.1` | `v2.0.1` | same as above |
| Prerelease tag (e.g. `v2.1.0-rc1`) | `v2.1.0-rc1` | semver tags only, **no** `latest` |

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses the workflow.
- [x] `zizmor` reports no findings on the new file.
- [ ] After merge: workflow run for `v2.0.1` (via `gh workflow run publish-docker.yml --ref v2.0.1`) lands `ghcr.io/sipyourdrink-ltd/bernstein:2.0.1` and re-points `:latest`.
- [ ] `docker manifest inspect ghcr.io/sipyourdrink-ltd/bernstein:2.0.1` returns a valid manifest.
- [ ] Next `auto-release` cycle (or manual tag) publishes a new image without operator intervention.