### PR TITLE
chore(ci): retire COPR / RPM channel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -274,27 +274,3 @@ jobs:
             echo "::warning::npm publish failed — continuing release. Likely cause: NPM_TOKEN needs to be re-issued with publish rights for bernstein-orchestrator."
           fi
 
-  # COPR RPM rebuild — triggers a new build from the updated PyPI release.
-  trigger-copr:
-    name: Trigger COPR rebuild
-    runs-on: ubuntu-latest
-    needs: build
-    timeout-minutes: 10
-    permissions: {}
-    steps:
-      - name: Harden runner (audit mode)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-      - name: Trigger COPR build
-        run: |
-          pip install copr-cli
-          mkdir -p ~/.config
-          cat > ~/.config/copr << EOF
-          [copr-cli]
-          login = ${{ secrets.COPR_LOGIN }}
-          username = alexchernysh
-          token = ${{ secrets.COPR_TOKEN }}
-          copr_url = https://copr.fedorainfracloud.org
-          EOF
-          copr-cli buildpypi --packagename bernstein alexchernysh/bernstein --nowait


### PR DESCRIPTION
## Summary

Drops the \`trigger-copr\` job from \`publish.yml\`. COPR builds have been failing since March 2026 (Fedora chroots can't resolve transitive Python deps); fix path requires those deps to land in EPEL, historically 6+ months.

\`pipx install bernstein\` and \`uv tool install bernstein\` work natively on Fedora 41/42 and are the upstream Python recommendation, so users keep a working install path.

Full rationale in \`docs/maintainers/ci-apps.md\` §10 (landed in #1297).

## Operator follow-ups (optional, separate)

- Delete repo secrets \`COPR_LOGIN\`, \`COPR_TOKEN\`, \`COPR_WEBHOOK_URL\` via Settings → Secrets.
- Archive the COPR project at copr.fedorainfracloud.org/coprs/alexchernysh/bernstein.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next \`publish.yml\` run no longer attempts COPR upload