### PR TITLE
feat(communication): directed 1:1 channels with @mention wakeups (closes #1221)

### DIFF
--- a/src/bernstein/core/communication/direct.py
+++ b/src/bernstein/core/communication/direct.py
@@ -1,0 +1,283 @@
+"""Directed 1:1 channels between agent sessions.
+
+A minimal file-backed primitive for one-to-one messaging between running
+agent sessions. Each receiver has its own inbox directory under
+``.sdd/runtime/channels/<to_session>/``; messages are individual JSON files
+named by message id (sortable by timestamp prefix). The receiver polls for
+new messages, optionally filtering by an opaque cursor (the last seen
+``MessageId``).
+
+Mention support: the message body is scanned for ``@<session-id>`` tokens.
+Callers (typically the spawn/orchestration loop) can use
+:func:`mentions_session` to decide whether a wakeup signal should be raised
+for an idle session.
+
+Out of scope (intentionally deferred):
+    * TUI inbox rendering
+    * retention / expiry policies
+    * read receipts / acks
+    * broadcast variants
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A monotonically-comparable opaque token for "I have seen messages up to
+# here." Implemented as the message file stem (``<ts_ns>-<rand>``) so plain
+# lexicographic sort matches arrival order.
+MessageId = str
+
+# ``@`` followed by a session-id-like token (alnum, ``-``, ``_``).
+# Anchored on ``\B@`` so emails (``user@host``) do not match.
+_MENTION_RE = re.compile(r"(?<![A-Za-z0-9_])@([A-Za-z0-9][A-Za-z0-9_\-]*)")
+
+
+@dataclass(frozen=True)
+class Message:
+    """A single directed message between two agent sessions.
+
+    Attributes:
+        id: Sortable opaque identifier (also the filename stem on disk).
+        from_session: Sender session id.
+        to_session: Receiver session id.
+        body: Free-text payload; may contain ``@<session-id>`` mentions.
+        timestamp: Unix epoch seconds when the message was created.
+    """
+
+    id: MessageId
+    from_session: str
+    to_session: str
+    body: str
+    timestamp: float
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialise to a JSON-safe dict."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, object]) -> Message:
+        """Deserialise from a dict produced by :meth:`to_dict`."""
+        return cls(
+            id=str(d.get("id", "")),
+            from_session=str(d.get("from_session", "")),
+            to_session=str(d.get("to_session", "")),
+            body=str(d.get("body", "")),
+            timestamp=float(d.get("timestamp", 0.0) or 0.0),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _channels_root(workdir: Path) -> Path:
+    """Return the channels root directory (``<workdir>/.sdd/runtime/channels``)."""
+    return workdir / ".sdd" / "runtime" / "channels"
+
+
+def _inbox_dir(workdir: Path, to_session: str) -> Path:
+    """Return the inbox directory for *to_session*, creating it on demand."""
+    d = _channels_root(workdir) / to_session
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _new_message_id(now_s: float | None = None) -> MessageId:
+    """Generate a sortable opaque message id.
+
+    Format: ``<ts_ns>-<rand12>``. Lexicographic sort matches arrival order
+    even across processes since the nanosecond prefix is monotonically
+    advancing for any single sender.
+    """
+    ts_ns = int((now_s if now_s is not None else time.time()) * 1e9)
+    return f"{ts_ns:020d}-{uuid.uuid4().hex[:12]}"
+
+
+# ---------------------------------------------------------------------------
+# Send / receive
+# ---------------------------------------------------------------------------
+
+
+def send(
+    from_session: str,
+    to_session: str,
+    message: str,
+    workdir: Path,
+) -> MessageId:
+    """Deliver *message* from one session to another via a file-backed inbox.
+
+    The message is written to ``<workdir>/.sdd/runtime/channels/<to_session>/<msg_id>.json``.
+    The inbox directory is created if it does not exist.
+
+    Args:
+        from_session: Sender session id.
+        to_session: Receiver session id.
+        message: Free-text message body. May contain ``@<session-id>`` tokens.
+        workdir: Project root (parent of ``.sdd/``).
+
+    Returns:
+        The newly-created :data:`MessageId`.
+
+    Raises:
+        ValueError: If either session id is empty.
+    """
+    if not from_session or not to_session:
+        raise ValueError("from_session and to_session must be non-empty")
+
+    now = time.time()
+    msg_id = _new_message_id(now)
+    msg = Message(
+        id=msg_id,
+        from_session=from_session,
+        to_session=to_session,
+        body=message,
+        timestamp=now,
+    )
+
+    inbox = _inbox_dir(workdir, to_session)
+    target = inbox / f"{msg_id}.json"
+    # Atomic-ish write via tmp + rename so a polling reader never sees a
+    # partial JSON file.
+    tmp = inbox / f".{msg_id}.json.tmp"
+    tmp.write_text(json.dumps(msg.to_dict()), encoding="utf-8")
+    tmp.replace(target)
+    return msg_id
+
+
+def receive(
+    session: str,
+    workdir: Path,
+    since: MessageId | None = None,
+) -> list[Message]:
+    """Poll the inbox for *session* and return messages newer than *since*.
+
+    Messages are returned in arrival order (oldest first). If *since* is
+    ``None``, every message currently in the inbox is returned.
+
+    Args:
+        session: Receiver session id (the inbox owner).
+        workdir: Project root (parent of ``.sdd/``).
+        since: Opaque cursor returned by a previous call (the id of the
+            last seen message). Strictly exclusive lower bound.
+
+    Returns:
+        Ordered list of :class:`Message` objects.
+    """
+    inbox = _channels_root(workdir) / session
+    if not inbox.exists():
+        return []
+
+    messages: list[Message] = []
+    for path in sorted(inbox.glob("*.json")):
+        if path.name.startswith("."):
+            continue
+        msg_id = path.stem
+        if since is not None and msg_id <= since:
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # Skip half-written or corrupt files; the next poll will retry
+            # if the writer eventually completes.
+            continue
+        messages.append(Message.from_dict(data))
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Mention parsing / wakeup helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_mentions(body: str) -> list[str]:
+    """Extract ``@<session-id>`` tokens from *body* in left-to-right order.
+
+    Mentions inside email-like substrings (``user@host``) are ignored.
+    Duplicates are preserved so callers can count multiple references.
+
+    Args:
+        body: Free-text message content.
+
+    Returns:
+        List of session ids (without the leading ``@``).
+    """
+    if not body:
+        return []
+    return _MENTION_RE.findall(body)
+
+
+def mentions_session(body: str, session: str) -> bool:
+    """Return ``True`` iff *body* contains ``@<session>`` as a mention.
+
+    Args:
+        body: Free-text message content.
+        session: Session id to test for.
+    """
+    if not session:
+        return False
+    return session in parse_mentions(body)
+
+
+@dataclass(frozen=True)
+class WakeupSignal:
+    """Flag emitted when *session* has unread messages mentioning it.
+
+    Attributes:
+        session: Session that should be woken.
+        triggering_messages: Inbox messages that contain the mention.
+    """
+
+    session: str
+    triggering_messages: tuple[Message, ...] = field(default_factory=tuple)
+
+    @property
+    def should_wake(self) -> bool:
+        """True iff at least one mentioning message is queued."""
+        return bool(self.triggering_messages)
+
+
+def detect_wakeup(
+    session: str,
+    workdir: Path,
+    since: MessageId | None = None,
+) -> WakeupSignal:
+    """Inspect *session*'s inbox and emit a wakeup if it is mentioned.
+
+    The orchestrator's spawn loop calls this per idle session. The returned
+    :class:`WakeupSignal` exposes a single ``should_wake`` flag plus the
+    triggering messages so the caller can include them in the next prompt.
+
+    Args:
+        session: Receiver session id.
+        workdir: Project root (parent of ``.sdd/``).
+        since: Optional cursor; only newer messages are considered.
+
+    Returns:
+        A :class:`WakeupSignal`. ``should_wake`` is False when the inbox is
+        empty or contains only non-mentioning messages.
+    """
+    new_messages = receive(session, workdir, since=since)
+    triggering = tuple(m for m in new_messages if mentions_session(m.body, session))
+    return WakeupSignal(session=session, triggering_messages=triggering)
+
+
+__all__ = [
+    "Message",
+    "MessageId",
+    "WakeupSignal",
+    "detect_wakeup",
+    "mentions_session",
+    "parse_mentions",
+    "receive",
+    "send",
+]

--- a/src/bernstein/core/communication/direct.py
+++ b/src/bernstein/core/communication/direct.py
@@ -66,12 +66,23 @@ class Message:
     @classmethod
     def from_dict(cls, d: dict[str, object]) -> Message:
         """Deserialise from a dict produced by :meth:`to_dict`."""
+        raw_ts = d.get("timestamp", 0.0)
+        ts: float
+        if isinstance(raw_ts, (int, float)):
+            ts = float(raw_ts)
+        elif isinstance(raw_ts, str) and raw_ts:
+            try:
+                ts = float(raw_ts)
+            except ValueError:
+                ts = 0.0
+        else:
+            ts = 0.0
         return cls(
             id=str(d.get("id", "")),
             from_session=str(d.get("from_session", "")),
             to_session=str(d.get("to_session", "")),
             body=str(d.get("body", "")),
-            timestamp=float(d.get("timestamp", 0.0) or 0.0),
+            timestamp=ts,
         )
 
 

--- a/tests/unit/test_direct_channels.py
+++ b/tests/unit/test_direct_channels.py
@@ -1,0 +1,157 @@
+"""Unit tests for directed 1:1 channels and @mention wakeup detection."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from bernstein.core.communication.direct import (
+    Message,
+    detect_wakeup,
+    mentions_session,
+    parse_mentions,
+    receive,
+    send,
+)
+
+# ---------------------------------------------------------------------------
+# send / receive round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_send_receive_round_trip(tmp_path: Path) -> None:
+    """A sent message lands in the receiver's inbox and round-trips intact."""
+    msg_id = send(
+        from_session="worker-1",
+        to_session="worker-2",
+        message="ping",
+        workdir=tmp_path,
+    )
+    assert msg_id
+
+    inbox = receive(session="worker-2", workdir=tmp_path)
+    assert len(inbox) == 1
+    msg = inbox[0]
+    assert isinstance(msg, Message)
+    assert msg.id == msg_id
+    assert msg.from_session == "worker-1"
+    assert msg.to_session == "worker-2"
+    assert msg.body == "ping"
+    assert msg.timestamp > 0
+
+
+def test_receive_isolates_per_session(tmp_path: Path) -> None:
+    """Messages addressed to A do not leak into B's inbox."""
+    send("a", "b", "hello b", workdir=tmp_path)
+    send("a", "c", "hello c", workdir=tmp_path)
+
+    inbox_b = receive("b", workdir=tmp_path)
+    inbox_c = receive("c", workdir=tmp_path)
+    inbox_d = receive("d", workdir=tmp_path)
+
+    assert [m.body for m in inbox_b] == ["hello b"]
+    assert [m.body for m in inbox_c] == ["hello c"]
+    assert inbox_d == []
+
+
+def test_receive_since_cursor_filters_seen_messages(tmp_path: Path) -> None:
+    """Passing the last-seen id excludes it and earlier messages."""
+    first = send("a", "b", "one", workdir=tmp_path)
+    # Tiny sleep so the second id sorts strictly higher even if the system
+    # clock has very low resolution on some platforms.
+    time.sleep(0.001)
+    second = send("a", "b", "two", workdir=tmp_path)
+
+    after_first = receive("b", workdir=tmp_path, since=first)
+    assert [m.id for m in after_first] == [second]
+
+    after_second = receive("b", workdir=tmp_path, since=second)
+    assert after_second == []
+
+
+def test_receive_returns_arrival_order(tmp_path: Path) -> None:
+    """Messages come back oldest-first regardless of disk listing order."""
+    ids = []
+    for i in range(5):
+        ids.append(send("a", "b", f"msg-{i}", workdir=tmp_path))
+        time.sleep(0.001)
+
+    inbox = receive("b", workdir=tmp_path)
+    assert [m.id for m in inbox] == ids
+
+
+def test_send_rejects_empty_session_ids(tmp_path: Path) -> None:
+    """Empty sender/receiver ids raise rather than corrupt the layout."""
+    import pytest
+
+    with pytest.raises(ValueError, match="non-empty"):
+        send("", "b", "x", workdir=tmp_path)
+    with pytest.raises(ValueError, match="non-empty"):
+        send("a", "", "x", workdir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# mention parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_mentions_extracts_session_ids() -> None:
+    """All ``@<id>`` tokens are captured in left-to-right order."""
+    body = "@worker-2 please retry, then ping @worker-3 (cc @worker-2)"
+    assert parse_mentions(body) == ["worker-2", "worker-3", "worker-2"]
+
+
+def test_parse_mentions_ignores_email_addresses() -> None:
+    """``user@host`` patterns must not be treated as mentions."""
+    assert parse_mentions("contact me at user@example.com") == []
+
+
+def test_parse_mentions_handles_empty_input() -> None:
+    """Empty/None-equivalent inputs return an empty list."""
+    assert parse_mentions("") == []
+    assert parse_mentions("no mentions here") == []
+
+
+def test_mentions_session_matches_exact_token() -> None:
+    """Only an exact ``@session`` match counts as a mention."""
+    assert mentions_session("hi @worker-2", "worker-2")
+    assert not mentions_session("hi @worker-22", "worker-2")
+    assert not mentions_session("hi worker-2", "worker-2")
+
+
+# ---------------------------------------------------------------------------
+# wakeup detection (mention-detection flag flip)
+# ---------------------------------------------------------------------------
+
+
+def test_detect_wakeup_flips_on_mention(tmp_path: Path) -> None:
+    """A mentioning message in the inbox flips ``should_wake`` to True."""
+    # Baseline: empty inbox → no wakeup.
+    initial = detect_wakeup("worker-2", workdir=tmp_path)
+    assert initial.should_wake is False
+    assert initial.triggering_messages == ()
+
+    # Non-mentioning message → still no wakeup.
+    send("worker-1", "worker-2", "fyi the deploy is done", workdir=tmp_path)
+    quiet = detect_wakeup("worker-2", workdir=tmp_path)
+    assert quiet.should_wake is False
+
+    # Mentioning message → wakeup flag flips.
+    send("worker-1", "worker-2", "@worker-2 please retry", workdir=tmp_path)
+    woken = detect_wakeup("worker-2", workdir=tmp_path)
+    assert woken.should_wake is True
+    assert len(woken.triggering_messages) == 1
+    assert woken.triggering_messages[0].body == "@worker-2 please retry"
+
+
+def test_detect_wakeup_respects_since_cursor(tmp_path: Path) -> None:
+    """A cursor past the mention suppresses the wakeup on the next poll."""
+    seen = send("worker-1", "worker-2", "@worker-2 ping", workdir=tmp_path)
+
+    # Without cursor: triggers wakeup.
+    first = detect_wakeup("worker-2", workdir=tmp_path)
+    assert first.should_wake is True
+
+    # After acknowledging the message via cursor: no further wakeup.
+    second = detect_wakeup("worker-2", workdir=tmp_path, since=seen)
+    assert second.should_wake is False


### PR DESCRIPTION
## Summary

- Adds `src/bernstein/core/communication/direct.py`: file-backed 1:1 channels with per-receiver inbox under `.sdd/runtime/channels/<to_session>/`, atomic `tmp + rename` writes, sortable nanosecond message ids, and an opaque `since` cursor for incremental polls.
- Adds `@mention` parsing (`parse_mentions`, `mentions_session`) anchored to ignore `user@host` emails, plus `detect_wakeup` returning a `WakeupSignal` so the orchestrator can wake idle peers without polluting the bulletin broadcast feed.
- Adds `tests/unit/test_direct_channels.py` (11 tests) covering send/receive round-trip, per-session isolation, cursor filtering, arrival order, empty-id validation, mention extraction edge cases (email, duplicates, empty), and wakeup flip on mention + cursor suppression.

This is the minimal substrate the issue describes; CLI surface, dashboard tab, and notifier wiring will follow in separate PRs against the same module so this change stays reviewable.

## Test plan

- [x] `pytest tests/unit/test_direct_channels.py -v` (11 passed locally)
- [x] `ruff check` clean on touched files
- [x] `ruff format --check` clean on touched files
- [x] `mypy src/bernstein/core/communication/direct.py` clean (the unrelated `core/__init__.py` ModuleSpec warning is pre-existing on `main`)

Closes #1221.