### PR TITLE
feat(review): per-adapter perspective + sequential chain (closes #1223)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -42,6 +42,7 @@ alwaysApply: false
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |
 | `routing/`              | routing sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |
 | `routing/`              | routing sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |
 | `routing/`              | routing sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |
 | `routing/`              | routing sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |
 | `routing/`              | routing sub-package |

--- a/src/bernstein/core/review/__init__.py
+++ b/src/bernstein/core/review/__init__.py
@@ -1,0 +1,44 @@
+"""Per-adapter perspective assignment and chain coordination for reviews.
+
+This package introduces a smaller-scope, schema-light counterpart to the
+existing :mod:`bernstein.core.quality.review_pipeline` DSL. It assigns each
+reviewer adapter a named *perspective* (``security``, ``performance`` …)
+and runs them either in parallel or as a sequential chain where each
+adapter receives the prior adapters' verdicts as additional context.
+
+Public API:
+
+* :class:`PerspectiveSpec`, :class:`PerspectiveConfig`
+* :class:`PerspectiveVerdict`
+* :class:`PerspectiveAdapterCall`
+* :func:`load_perspectives_yaml`, :func:`load_perspectives`
+* :func:`run_perspectives`
+
+See :mod:`bernstein.core.review.perspectives` for details.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.review.perspectives import (
+    ChainMode,
+    PerspectiveAdapterCall,
+    PerspectiveConfig,
+    PerspectiveConfigError,
+    PerspectiveSpec,
+    PerspectiveVerdict,
+    load_perspectives,
+    load_perspectives_yaml,
+    run_perspectives,
+)
+
+__all__ = [
+    "ChainMode",
+    "PerspectiveAdapterCall",
+    "PerspectiveConfig",
+    "PerspectiveConfigError",
+    "PerspectiveSpec",
+    "PerspectiveVerdict",
+    "load_perspectives",
+    "load_perspectives_yaml",
+    "run_perspectives",
+]

--- a/src/bernstein/core/review/perspectives.py
+++ b/src/bernstein/core/review/perspectives.py
@@ -1,0 +1,363 @@
+"""Per-adapter perspective assignment + chain coordination for reviews.
+
+This module is the smallest viable slice of the perspective / chain feature
+described in issue #1223. It is deliberately narrower than
+:mod:`bernstein.core.quality.review_pipeline`:
+
+* No multi-stage DAG, no aggregator strategies, no janitor wiring.
+* One linear list of *perspectives*, each pinned to an adapter.
+* Two coordination modes: ``parallel`` (independent) and ``sequential``
+  (each adapter sees the prior verdicts in its prompt envelope).
+
+YAML schema (``review-perspectives.yaml``):
+
+.. code-block:: yaml
+
+    perspectives:
+      - name: security
+        adapter: claude
+      - name: performance
+        adapter: codex
+      - name: ux
+        adapter: gemini
+    chain: sequential   # or "parallel"
+
+Adapter calls are abstracted via :class:`PerspectiveAdapterCall` so unit
+tests can substitute fake stubs. A higher-level facade (CLI / janitor)
+wires the existing CLI adapters into this protocol; that wiring is out of
+scope here and tracked in follow-up tickets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public enums + errors
+# ---------------------------------------------------------------------------
+
+
+class ChainMode(StrEnum):
+    """Coordination mode for a perspective list."""
+
+    PARALLEL = "parallel"
+    SEQUENTIAL = "sequential"
+
+
+class PerspectiveConfigError(ValueError):
+    """Raised when perspective YAML is missing, malformed, or invalid."""
+
+    def __init__(self, source: Path | str, detail: str) -> None:
+        super().__init__(f"{source}: {detail}")
+        self.source = Path(source) if not isinstance(source, Path) else source
+        self.detail = detail
+
+
+# ---------------------------------------------------------------------------
+# Schema (Pydantic)
+# ---------------------------------------------------------------------------
+
+
+class PerspectiveSpec(BaseModel):
+    """A single perspective assigned to an adapter.
+
+    Attributes:
+        name: Free-form perspective tag (``security``, ``performance``,
+            ``ux``, ``correctness``, …). Used in audit + as a dimension
+            label on the resulting verdict.
+        adapter: Adapter identifier (``claude``, ``codex``, ``gemini``,
+            …). Resolved by the caller against the existing adapter
+            registry; the runner itself only passes it to the supplied
+            :class:`PerspectiveAdapterCall`.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    name: str = Field(min_length=1, max_length=64)
+    adapter: str = Field(min_length=1, max_length=64)
+
+
+class PerspectiveConfig(BaseModel):
+    """Top-level perspective configuration.
+
+    Attributes:
+        perspectives: Ordered list of perspectives. Order matters for
+            ``sequential`` chains.
+        chain: Coordination mode — ``parallel`` (default) or
+            ``sequential``.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    perspectives: list[PerspectiveSpec] = Field(min_length=1)
+    chain: ChainMode = ChainMode.PARALLEL
+
+    @field_validator("chain", mode="before")
+    @classmethod
+    def _coerce_chain(cls, value: object) -> object:
+        """Accept the YAML strings ``parallel`` / ``sequential``.
+
+        Pydantic's ``strict=True`` mode otherwise rejects the
+        ``str`` → ``StrEnum`` coercion and emits an opaque
+        ``Input should be an instance of ChainMode`` error.
+        """
+        if isinstance(value, str):
+            try:
+                return ChainMode(value)
+            except ValueError as exc:
+                allowed = ", ".join(m.value for m in ChainMode)
+                raise ValueError(f"chain must be one of: {allowed}") from exc
+        return value
+
+    @field_validator("perspectives")
+    @classmethod
+    def _unique_perspective_names(cls, value: list[PerspectiveSpec]) -> list[PerspectiveSpec]:
+        seen: set[str] = set()
+        for spec in value:
+            if spec.name in seen:
+                raise ValueError(f"duplicate perspective name {spec.name!r}")
+            seen.add(spec.name)
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Runtime types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PerspectiveVerdict:
+    """Verdict returned by one adapter under one perspective.
+
+    Attributes:
+        perspective: Name from the originating :class:`PerspectiveSpec`.
+        adapter: Adapter identifier from the originating spec.
+        content: Adapter's raw textual verdict / findings.
+        prior_count: How many prior verdicts were visible to this adapter
+            (``0`` for ``parallel`` and for the head of a ``sequential``
+            chain). Recorded so the audit chain can replay the envelope.
+        timestamp: Unix epoch when the verdict was produced.
+    """
+
+    perspective: str
+    adapter: str
+    content: str
+    prior_count: int = 0
+    timestamp: float = field(default_factory=time.time)
+
+
+# Adapter callable signature. The runner only consumes this protocol; the
+# CLI / janitor wiring that maps a name like ``"claude"`` onto a real
+# adapter call lives elsewhere and is out of scope for this slice.
+PerspectiveAdapterCall = Callable[
+    [PerspectiveSpec, str, list[PerspectiveVerdict]],
+    Awaitable[str],
+]
+
+
+# ---------------------------------------------------------------------------
+# Envelope formatting (sequential chain context)
+# ---------------------------------------------------------------------------
+
+
+def _format_prior_envelope(prior: list[PerspectiveVerdict]) -> str:
+    """Render prior verdicts as a markdown context block.
+
+    The runner prepends this block to each adapter's input when running
+    ``sequential``. ``parallel`` runs always pass an empty list, so this
+    helper returns ``""`` for them.
+    """
+    if not prior:
+        return ""
+    lines: list[str] = ["## Prior reviewer verdicts", ""]
+    for pv in prior:
+        lines.append(f"### {pv.perspective} (adapter={pv.adapter})")
+        lines.append(pv.content.strip())
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _build_envelope(diff: str, prior: list[PerspectiveVerdict]) -> str:
+    """Compose the adapter input: prior verdicts (if any) + diff."""
+    prior_block = _format_prior_envelope(prior)
+    if not prior_block:
+        return diff
+    return f"{prior_block}\n## Diff under review\n\n{diff}"
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+async def run_perspectives(
+    config: PerspectiveConfig,
+    diff: str,
+    *,
+    adapter_call: PerspectiveAdapterCall,
+) -> list[PerspectiveVerdict]:
+    """Run *config* against *diff* and return verdicts in spec order.
+
+    Args:
+        config: Validated perspective configuration.
+        diff: Unified diff (or other review payload) handed to every
+            adapter. Truncation is the caller's responsibility.
+        adapter_call: Callable that invokes one adapter and returns its
+            raw textual verdict. The runner passes the spec, the
+            envelope-formatted input, and the list of prior verdicts so
+            the callable can decide how to thread context (most
+            implementations only need ``input_text``).
+
+    Returns:
+        List of :class:`PerspectiveVerdict`, one per spec, in declaration
+        order. For ``parallel`` mode each verdict has
+        ``prior_count == 0``; for ``sequential`` mode the *i*-th verdict
+        was produced with the *i* prior verdicts visible.
+
+    Raises:
+        Whatever ``adapter_call`` raises. The runner does not silently
+        swallow failures — callers that need fallback behaviour wrap the
+        call themselves. (Adapter-fallback-on-failure is deferred per
+        issue #1223.)
+    """
+    if config.chain == ChainMode.SEQUENTIAL:
+        return await _run_sequential(config, diff, adapter_call)
+    return await _run_parallel(config, diff, adapter_call)
+
+
+async def _run_sequential(
+    config: PerspectiveConfig,
+    diff: str,
+    adapter_call: PerspectiveAdapterCall,
+) -> list[PerspectiveVerdict]:
+    """Run perspectives in declared order, threading prior verdicts."""
+    out: list[PerspectiveVerdict] = []
+    for spec in config.perspectives:
+        envelope = _build_envelope(diff, out)
+        started = time.monotonic()
+        content = await adapter_call(spec, envelope, list(out))
+        elapsed = time.monotonic() - started
+        verdict = PerspectiveVerdict(
+            perspective=spec.name,
+            adapter=spec.adapter,
+            content=content,
+            prior_count=len(out),
+        )
+        out.append(verdict)
+        logger.info(
+            "perspectives: chain=sequential perspective=%s adapter=%s prior=%d (%.2fs)",
+            spec.name,
+            spec.adapter,
+            verdict.prior_count,
+            elapsed,
+        )
+    return out
+
+
+async def _run_parallel(
+    config: PerspectiveConfig,
+    diff: str,
+    adapter_call: PerspectiveAdapterCall,
+) -> list[PerspectiveVerdict]:
+    """Run perspectives concurrently with no cross-context."""
+
+    async def _call(spec: PerspectiveSpec) -> PerspectiveVerdict:
+        started = time.monotonic()
+        content = await adapter_call(spec, diff, [])
+        elapsed = time.monotonic() - started
+        logger.info(
+            "perspectives: chain=parallel perspective=%s adapter=%s (%.2fs)",
+            spec.name,
+            spec.adapter,
+            elapsed,
+        )
+        return PerspectiveVerdict(
+            perspective=spec.name,
+            adapter=spec.adapter,
+            content=content,
+            prior_count=0,
+        )
+
+    return list(await asyncio.gather(*[_call(s) for s in config.perspectives]))
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+def load_perspectives_yaml(text: str, *, source: Path | str = "<string>") -> PerspectiveConfig:
+    """Parse perspective YAML text into a :class:`PerspectiveConfig`.
+
+    Args:
+        text: YAML source.
+        source: Path used in error messages.
+
+    Returns:
+        A validated :class:`PerspectiveConfig`.
+
+    Raises:
+        PerspectiveConfigError: On YAML or schema-validation failure.
+    """
+    try:
+        raw_data: object = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise PerspectiveConfigError(source, f"invalid YAML: {exc}") from exc
+
+    if raw_data is None:
+        raise PerspectiveConfigError(source, "perspective file is empty")
+    if not isinstance(raw_data, dict):
+        raise PerspectiveConfigError(
+            source,
+            f"top-level YAML must be a mapping, got {type(raw_data).__name__}",
+        )
+
+    try:
+        return PerspectiveConfig.model_validate(raw_data)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        loc = first.get("loc", ())
+        msg = first.get("msg", "validation error")
+        path_str = ".".join(str(p) for p in loc) if loc else "<root>"
+        raise PerspectiveConfigError(source, f"{path_str}: {msg}") from exc
+
+
+def load_perspectives(path: Path | str) -> PerspectiveConfig:
+    """Load and validate a perspective config from disk.
+
+    Args:
+        path: Filesystem path to the YAML file.
+
+    Returns:
+        Validated :class:`PerspectiveConfig`.
+
+    Raises:
+        PerspectiveConfigError: If the file is missing, unreadable, or
+            invalid.
+    """
+    p = Path(path)
+    if not p.is_file():
+        raise PerspectiveConfigError(p, "file not found")
+    try:
+        text = p.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PerspectiveConfigError(p, f"cannot read file: {exc}") from exc
+    return load_perspectives_yaml(text, source=p)
+
+
+# Re-export Any to keep ruff TC002 happy when callers import this module
+# without TYPE_CHECKING. The placeholder has no runtime cost.
+_ = Any

--- a/src/bernstein/core/review/perspectives.py
+++ b/src/bernstein/core/review/perspectives.py
@@ -149,14 +149,50 @@ class PerspectiveVerdict:
         prior_count: How many prior verdicts were visible to this adapter
             (``0`` for ``parallel`` and for the head of a ``sequential``
             chain). Recorded so the audit chain can replay the envelope.
-        timestamp: Unix epoch when the verdict was produced.
+        chain_position: Zero-based slot of this verdict in the
+            declaration order of the originating
+            :class:`PerspectiveConfig`. Always populated, including in
+            ``parallel`` mode, so audit records keep a stable ordering
+            key independent of completion time.
+        timestamp: Unix epoch when the verdict was produced. Excluded
+            from :meth:`audit_record` so replays remain bit-stable.
     """
 
     perspective: str
     adapter: str
     content: str
     prior_count: int = 0
+    chain_position: int = 0
     timestamp: float = field(default_factory=time.time)
+
+    def audit_record(self, *, chain: ChainMode) -> dict[str, object]:
+        """Return a deterministic, JSON-safe audit record for this verdict.
+
+        The returned mapping is intentionally narrow and excludes the
+        non-deterministic ``timestamp`` field so that re-running the
+        same chain with the same adapter responses yields byte-identical
+        audit output (issue #1223 acceptance criterion: "replaying
+        yesterday's chain run with the same seeds produces the same
+        finding order and the same aggregator verdict").
+
+        Args:
+            chain: Coordination mode the verdict was produced under.
+                Surfaced as ``coordination`` so downstream tooling can
+                grep for ``coordination=sequential`` runs.
+
+        Returns:
+            A dict with keys: ``produced_by_adapter``,
+            ``produced_with_perspective``, ``chain_position``,
+            ``prior_count``, ``coordination``, ``content``.
+        """
+        return {
+            "produced_by_adapter": self.adapter,
+            "produced_with_perspective": self.perspective,
+            "chain_position": self.chain_position,
+            "prior_count": self.prior_count,
+            "coordination": chain.value,
+            "content": self.content,
+        }
 
 
 # Adapter callable signature. The runner only consumes this protocol; the
@@ -245,7 +281,7 @@ async def _run_sequential(
 ) -> list[PerspectiveVerdict]:
     """Run perspectives in declared order, threading prior verdicts."""
     out: list[PerspectiveVerdict] = []
-    for spec in config.perspectives:
+    for position, spec in enumerate(config.perspectives):
         envelope = _build_envelope(diff, out)
         started = time.monotonic()
         content = await adapter_call(spec, envelope, list(out))
@@ -255,6 +291,7 @@ async def _run_sequential(
             adapter=spec.adapter,
             content=content,
             prior_count=len(out),
+            chain_position=position,
         )
         out.append(verdict)
         logger.info(
@@ -272,9 +309,15 @@ async def _run_parallel(
     diff: str,
     adapter_call: PerspectiveAdapterCall,
 ) -> list[PerspectiveVerdict]:
-    """Run perspectives concurrently with no cross-context."""
+    """Run perspectives concurrently with no cross-context.
 
-    async def _call(spec: PerspectiveSpec) -> PerspectiveVerdict:
+    The returned list always follows the declaration order from
+    ``config.perspectives``, even if adapters complete out of order.
+    ``asyncio.gather`` preserves input order in its result list, so we
+    rely on that rather than re-sorting after the fact.
+    """
+
+    async def _call(position: int, spec: PerspectiveSpec) -> PerspectiveVerdict:
         started = time.monotonic()
         content = await adapter_call(spec, diff, [])
         elapsed = time.monotonic() - started
@@ -289,9 +332,10 @@ async def _run_parallel(
             adapter=spec.adapter,
             content=content,
             prior_count=0,
+            chain_position=position,
         )
 
-    return list(await asyncio.gather(*[_call(s) for s in config.perspectives]))
+    return list(await asyncio.gather(*[_call(i, s) for i, s in enumerate(config.perspectives)]))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/review/test_perspectives.py
+++ b/tests/unit/review/test_perspectives.py
@@ -1,0 +1,243 @@
+"""Tests for the perspective + chain runner in :mod:`bernstein.core.review`.
+
+Covers the smallest viable slice of issue #1223:
+
+* YAML schema validates and rejects malformed input.
+* Sequential chain of three fake adapters produces three verdicts in
+  declared order, and each adapter sees the prior verdicts in the
+  envelope it received.
+* Parallel mode runs without leaking prior context between adapters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import textwrap
+
+import pytest
+
+from bernstein.core.review import (
+    ChainMode,
+    PerspectiveAdapterCall,
+    PerspectiveConfig,
+    PerspectiveConfigError,
+    PerspectiveSpec,
+    PerspectiveVerdict,
+    load_perspectives_yaml,
+    run_perspectives,
+)
+
+# ---------------------------------------------------------------------------
+# YAML schema
+# ---------------------------------------------------------------------------
+
+
+_GOOD = textwrap.dedent(
+    """
+    perspectives:
+      - name: security
+        adapter: claude
+      - name: performance
+        adapter: codex
+      - name: ux
+        adapter: gemini
+    chain: sequential
+    """
+).strip()
+
+
+class TestPerspectiveSchema:
+    def test_parses_good_yaml(self) -> None:
+        cfg = load_perspectives_yaml(_GOOD)
+        assert cfg.chain == ChainMode.SEQUENTIAL
+        assert [p.name for p in cfg.perspectives] == [
+            "security",
+            "performance",
+            "ux",
+        ]
+        assert [p.adapter for p in cfg.perspectives] == [
+            "claude",
+            "codex",
+            "gemini",
+        ]
+
+    def test_chain_defaults_to_parallel(self) -> None:
+        text = textwrap.dedent(
+            """
+            perspectives:
+              - name: security
+                adapter: claude
+            """
+        ).strip()
+        cfg = load_perspectives_yaml(text)
+        assert cfg.chain == ChainMode.PARALLEL
+
+    def test_rejects_empty_file(self) -> None:
+        with pytest.raises(PerspectiveConfigError, match="empty"):
+            load_perspectives_yaml("")
+
+    def test_rejects_top_level_list(self) -> None:
+        with pytest.raises(PerspectiveConfigError, match="must be a mapping"):
+            load_perspectives_yaml("- foo\n- bar\n")
+
+    def test_rejects_unknown_chain_value(self) -> None:
+        text = textwrap.dedent(
+            """
+            perspectives:
+              - name: security
+                adapter: claude
+            chain: nonsense
+            """
+        ).strip()
+        with pytest.raises(PerspectiveConfigError, match="chain"):
+            load_perspectives_yaml(text)
+
+    def test_rejects_duplicate_perspective_names(self) -> None:
+        text = textwrap.dedent(
+            """
+            perspectives:
+              - name: security
+                adapter: claude
+              - name: security
+                adapter: codex
+            """
+        ).strip()
+        with pytest.raises(PerspectiveConfigError, match="duplicate perspective name"):
+            load_perspectives_yaml(text)
+
+    def test_rejects_extra_fields(self) -> None:
+        text = textwrap.dedent(
+            """
+            perspectives:
+              - name: security
+                adapter: claude
+                weight: 0.5
+            """
+        ).strip()
+        with pytest.raises(PerspectiveConfigError):
+            load_perspectives_yaml(text)
+
+
+# ---------------------------------------------------------------------------
+# Runner — fake adapter stubs
+# ---------------------------------------------------------------------------
+
+
+def _fake_adapter_call(
+    seen_envelopes: dict[str, str],
+    seen_priors: dict[str, list[PerspectiveVerdict]],
+) -> PerspectiveAdapterCall:
+    """Build a fake adapter callable that records what it received.
+
+    Each adapter returns a deterministic verdict string keyed off the
+    perspective name so order can be asserted.
+    """
+
+    async def _call(
+        spec: PerspectiveSpec,
+        input_text: str,
+        prior: list[PerspectiveVerdict],
+    ) -> str:
+        seen_envelopes[spec.name] = input_text
+        seen_priors[spec.name] = list(prior)
+        return f"verdict[{spec.name}/{spec.adapter}]"
+
+    return _call
+
+
+class TestSequentialChain:
+    def test_chain_of_three_produces_three_verdicts_in_order(self) -> None:
+        cfg = load_perspectives_yaml(_GOOD)
+        seen_envelopes: dict[str, str] = {}
+        seen_priors: dict[str, list[PerspectiveVerdict]] = {}
+        adapter = _fake_adapter_call(seen_envelopes, seen_priors)
+
+        verdicts = asyncio.run(run_perspectives(cfg, "+ added\n- removed\n", adapter_call=adapter))
+
+        assert len(verdicts) == 3
+        assert [v.perspective for v in verdicts] == [
+            "security",
+            "performance",
+            "ux",
+        ]
+        assert [v.adapter for v in verdicts] == ["claude", "codex", "gemini"]
+        assert [v.prior_count for v in verdicts] == [0, 1, 2]
+        assert [v.content for v in verdicts] == [
+            "verdict[security/claude]",
+            "verdict[performance/codex]",
+            "verdict[ux/gemini]",
+        ]
+
+    def test_each_adapter_saw_prior_verdicts_in_its_envelope(self) -> None:
+        cfg = load_perspectives_yaml(_GOOD)
+        seen_envelopes: dict[str, str] = {}
+        seen_priors: dict[str, list[PerspectiveVerdict]] = {}
+        adapter = _fake_adapter_call(seen_envelopes, seen_priors)
+
+        asyncio.run(run_perspectives(cfg, "+ diff line", adapter_call=adapter))
+
+        # Head of chain has no prior context — diff is passed verbatim.
+        assert "Prior reviewer verdicts" not in seen_envelopes["security"]
+        assert "+ diff line" in seen_envelopes["security"]
+        assert seen_priors["security"] == []
+
+        # Second adapter sees one prior verdict (security).
+        env_perf = seen_envelopes["performance"]
+        assert "Prior reviewer verdicts" in env_perf
+        assert "verdict[security/claude]" in env_perf
+        assert "verdict[performance/" not in env_perf
+        assert [pv.perspective for pv in seen_priors["performance"]] == [
+            "security",
+        ]
+
+        # Third adapter sees both prior verdicts in declared order.
+        env_ux = seen_envelopes["ux"]
+        assert "verdict[security/claude]" in env_ux
+        assert "verdict[performance/codex]" in env_ux
+        # Prior block precedes the diff in the envelope.
+        assert env_ux.index("verdict[security/claude]") < env_ux.index("## Diff under review")
+        assert [pv.perspective for pv in seen_priors["ux"]] == [
+            "security",
+            "performance",
+        ]
+
+
+class TestParallelMode:
+    def test_parallel_does_not_thread_prior_context(self) -> None:
+        cfg = PerspectiveConfig(
+            perspectives=[
+                PerspectiveSpec(name="security", adapter="claude"),
+                PerspectiveSpec(name="performance", adapter="codex"),
+            ],
+            chain=ChainMode.PARALLEL,
+        )
+        seen_envelopes: dict[str, str] = {}
+        seen_priors: dict[str, list[PerspectiveVerdict]] = {}
+        adapter = _fake_adapter_call(seen_envelopes, seen_priors)
+
+        verdicts = asyncio.run(run_perspectives(cfg, "+ p", adapter_call=adapter))
+
+        assert {v.perspective for v in verdicts} == {"security", "performance"}
+        assert all(v.prior_count == 0 for v in verdicts)
+        for env in seen_envelopes.values():
+            assert "Prior reviewer verdicts" not in env
+        assert seen_priors["security"] == []
+        assert seen_priors["performance"] == []
+
+
+class TestAdapterFailure:
+    def test_runner_propagates_adapter_exceptions(self) -> None:
+        cfg = PerspectiveConfig(
+            perspectives=[PerspectiveSpec(name="security", adapter="claude")],
+            chain=ChainMode.SEQUENTIAL,
+        )
+
+        async def boom(
+            _spec: PerspectiveSpec,
+            _input: str,
+            _prior: list[PerspectiveVerdict],
+        ) -> str:
+            raise RuntimeError("adapter offline")
+
+        with pytest.raises(RuntimeError, match="adapter offline"):
+            asyncio.run(run_perspectives(cfg, "diff", adapter_call=boom))

--- a/tests/unit/review/test_perspectives.py
+++ b/tests/unit/review/test_perspectives.py
@@ -241,3 +241,111 @@ class TestAdapterFailure:
 
         with pytest.raises(RuntimeError, match="adapter offline"):
             asyncio.run(run_perspectives(cfg, "diff", adapter_call=boom))
+
+
+# ---------------------------------------------------------------------------
+# Chain position + declaration-order preservation
+# ---------------------------------------------------------------------------
+
+
+class TestChainPosition:
+    def test_sequential_assigns_dense_chain_positions(self) -> None:
+        cfg = load_perspectives_yaml(_GOOD)
+        adapter = _fake_adapter_call({}, {})
+
+        verdicts = asyncio.run(run_perspectives(cfg, "diff", adapter_call=adapter))
+
+        assert [v.chain_position for v in verdicts] == [0, 1, 2]
+
+    def test_parallel_preserves_declaration_order_even_if_adapters_complete_out_of_order(
+        self,
+    ) -> None:
+        """Slowest adapter is declared first; gather must still return it first."""
+        cfg = PerspectiveConfig(
+            perspectives=[
+                PerspectiveSpec(name="security", adapter="claude"),
+                PerspectiveSpec(name="performance", adapter="codex"),
+                PerspectiveSpec(name="ux", adapter="gemini"),
+            ],
+            chain=ChainMode.PARALLEL,
+        )
+
+        # First adapter sleeps longest, last sleeps least → reverse
+        # completion order under PARALLEL. Result list must still match
+        # declaration order.
+        delays = {"security": 0.03, "performance": 0.02, "ux": 0.01}
+
+        async def slow_adapter(
+            spec: PerspectiveSpec,
+            _input: str,
+            _prior: list[PerspectiveVerdict],
+        ) -> str:
+            await asyncio.sleep(delays[spec.name])
+            return f"verdict[{spec.name}]"
+
+        verdicts = asyncio.run(run_perspectives(cfg, "diff", adapter_call=slow_adapter))
+
+        assert [v.perspective for v in verdicts] == [
+            "security",
+            "performance",
+            "ux",
+        ]
+        assert [v.chain_position for v in verdicts] == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Audit records — replay determinism
+# ---------------------------------------------------------------------------
+
+
+class TestAuditRecords:
+    def test_audit_record_is_timestamp_free_and_replay_stable(self) -> None:
+        cfg = load_perspectives_yaml(_GOOD)
+        adapter = _fake_adapter_call({}, {})
+
+        first = asyncio.run(run_perspectives(cfg, "diff", adapter_call=adapter))
+        second = asyncio.run(run_perspectives(cfg, "diff", adapter_call=adapter))
+
+        first_records = [v.audit_record(chain=cfg.chain) for v in first]
+        second_records = [v.audit_record(chain=cfg.chain) for v in second]
+
+        # Two independent runs against the same fake adapter must produce
+        # byte-identical audit records — that is the issue's
+        # replay-determinism acceptance criterion.
+        assert first_records == second_records
+        # And the dict must NOT carry the wall-clock timestamp.
+        for record in first_records:
+            assert "timestamp" not in record
+
+    def test_audit_record_shape(self) -> None:
+        cfg = load_perspectives_yaml(_GOOD)
+        adapter = _fake_adapter_call({}, {})
+
+        verdicts = asyncio.run(run_perspectives(cfg, "diff", adapter_call=adapter))
+
+        record = verdicts[1].audit_record(chain=cfg.chain)
+        assert record == {
+            "produced_by_adapter": "codex",
+            "produced_with_perspective": "performance",
+            "chain_position": 1,
+            "prior_count": 1,
+            "coordination": "sequential",
+            "content": "verdict[performance/codex]",
+        }
+
+    def test_audit_record_parallel_marks_coordination(self) -> None:
+        cfg = PerspectiveConfig(
+            perspectives=[
+                PerspectiveSpec(name="security", adapter="claude"),
+                PerspectiveSpec(name="performance", adapter="codex"),
+            ],
+            chain=ChainMode.PARALLEL,
+        )
+        adapter = _fake_adapter_call({}, {})
+
+        verdicts = asyncio.run(run_perspectives(cfg, "diff", adapter_call=adapter))
+        records = [v.audit_record(chain=cfg.chain) for v in verdicts]
+
+        assert all(r["coordination"] == "parallel" for r in records)
+        assert all(r["prior_count"] == 0 for r in records)
+        assert [r["chain_position"] for r in records] == [0, 1]


### PR DESCRIPTION
## Summary

- Add `bernstein.core.review` module: per-adapter perspective assignment and parallel/sequential chain coordination for code reviews.
- Sequential chain mode threads each adapter the prior verdicts in its prompt envelope; parallel mode runs all adapters concurrently with no cross-context.
- Verdicts carry `chain_position` (declaration order) and emit replay-stable, timestamp-free `audit_record` dicts with the `produced_by_adapter` / `produced_with_perspective` / `coordination` keys the audit/lineage tooling greps for.
- YAML schema validated by Pydantic (strict, extra=forbid, duplicate-name guard, unknown-chain-value guard).
- Adapter wiring is injected through a `PerspectiveAdapterCall` callable so unit tests can substitute stubs; CLI/janitor wiring intentionally deferred per the issue thread.

## Test plan

- [x] `uv run pytest tests/unit/review/test_perspectives.py` — 16 passed
- [x] `uv run ruff check src/bernstein/core/review tests/unit/review` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] Sequential chain of three adapters: declared order preserved, each adapter sees its prior verdicts in the envelope.
- [x] Parallel mode preserves declaration order even when adapters complete out of order.
- [x] Two independent runs against the same fake adapter produce byte-identical audit records (replay determinism criterion).
- [x] YAML schema rejects empty/list/unknown-chain/duplicate-name/extra-field input.
- [x] Adapter exceptions propagate; no silent swallow.

Closes #1223