### PR TITLE
feat(orchestration): agent-side watchdog for stuck prompts + pre-approved confirmations (closes #1224)

### DIFF
--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -1555,6 +1555,12 @@ class Orchestrator:
         if _run_slow:
             self._watchdog.sync(collect_watchdog_findings(self))
 
+        # 4d-ii.7 Self-healing liveness watchdog (#1224): periodic check for
+        # stuck adapter sessions on pre-approved safety prompts. Off by
+        # default; opt-in via BERNSTEIN_WATCHDOG_ENABLED=1.
+        if _run_slow:
+            self._run_liveness_watchdog()
+
         # 4d-iii. Cost anomaly detection: burn rate projection, stop on budget overrun
         # Gated behind _run_slow — anomaly detection doesn't need every-tick granularity.
         if _run_slow:
@@ -2598,6 +2604,84 @@ class Orchestrator:
             self._stop_spawning = True
         else:
             logger.info("Anomaly [%s]: %s", signal.rule, signal.message)
+
+    def _run_liveness_watchdog(self) -> None:
+        """Run one liveness-watchdog pass over current adapter sessions.
+
+        Off by default; the watchdog short-circuits when
+        ``BERNSTEIN_WATCHDOG_ENABLED`` is not set. Failures are logged
+        and swallowed so a watchdog bug never breaks the tick loop.
+        """
+        from bernstein.core.orchestration.watchdog import (
+            SessionSnapshot,
+        )
+        from bernstein.core.orchestration.watchdog import (
+            is_enabled as _watchdog_enabled,
+        )
+        from bernstein.core.orchestration.watchdog import (
+            tick as _watchdog_tick,
+        )
+
+        if not _watchdog_enabled():
+            return
+
+        snapshots: list[SessionSnapshot] = []
+        for session in self._agents.values():
+            if getattr(session, "status", "") == "dead":
+                continue
+            session_id = str(getattr(session, "id", ""))
+            if not session_id:
+                continue
+            recent_output = str(getattr(session, "last_output_tail", "") or "")
+            is_paused = bool(getattr(session, "awaiting_prompt", False))
+            approved = frozenset(getattr(session, "approved_prompt_classes", frozenset()))
+            snapshots.append(
+                SessionSnapshot(
+                    session_id=session_id,
+                    recent_output=recent_output,
+                    is_paused=is_paused,
+                    approved_prompt_classes=approved,
+                )
+            )
+        if not snapshots:
+            return
+
+        spawner = self._spawner
+
+        def _respond(session_id: str, keystroke: str) -> bool:
+            send = getattr(spawner, "send_keystroke", None)
+            if send is None:
+                return False
+            try:
+                return bool(send(session_id, keystroke))
+            except Exception as exc:  # spawner failures must not break tick
+                logger.warning("watchdog respond failed for %s: %s", session_id, exc)
+                return False
+
+        audit_path = self._workdir / ".sdd" / "audit" / "watchdog_recoveries.jsonl"
+        try:
+            result = _watchdog_tick(snapshots, _respond, audit_path)
+        except Exception as exc:  # tick-level safety net
+            logger.warning("liveness watchdog tick raised: %s", exc)
+            return
+
+        if result.recoveries:
+            logger.info(
+                "Liveness watchdog applied %d recovery action(s): %s",
+                len(result.recoveries),
+                ", ".join(r.session_id for r in result.recoveries),
+            )
+        if result.skipped_model_questions and self._notify is not None:
+            for session_id in result.skipped_model_questions:
+                with contextlib.suppress(Exception):
+                    self._notify(
+                        "approval.needed",
+                        "Watchdog escalation",
+                        f"Model question awaiting operator on session {session_id}",
+                        severity="medium",
+                        source="prompt_waiting",
+                        session_id=session_id,
+                    )
 
     def _record_live_costs(self) -> None:
         """Update live cost tracker from active agent token usage."""

--- a/src/bernstein/core/orchestration/watchdog.py
+++ b/src/bernstein/core/orchestration/watchdog.py
@@ -1,0 +1,367 @@
+"""Periodic liveness watchdog for live adapter sessions.
+
+This is the smallest-viable slice of the self-healing watchdog (#1224):
+one tick-driven loop that scans each running adapter session for a
+single liveness signal and applies a single recovery action when it
+fires.
+
+Slice scope
+-----------
+The slice handles **pre-approved confirmation prompts**: when the
+operator opted into yolo-mode for a class of safety prompts (e.g.
+``Continue? [y/N]``) and the agent stalls on one of those prompts, the
+watchdog answers ``y`` once and emits an audit event. Prompts that look
+like the model asking the operator a clarifying question are explicitly
+*not* auto-answered — those escalate.
+
+Out of slice (deferred)
+-----------------------
+- Context-pressure ``/compact`` recovery.
+- ``redacted_thinking`` corruption restart-with-replay.
+- Stuck-class ML classifier.
+- Dashboard surfacing / per-session recovery counters in
+  ``bernstein run report``.
+
+The module exposes :func:`tick` so the orchestrator can call it once
+per tick under the existing slow-tick gate, and :func:`is_enabled` so
+the call site can short-circuit before importing tick state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Final, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DEFAULT_SAFETY_PROMPT_PATTERNS",
+    "FEATURE_FLAG_ENV",
+    "PromptKind",
+    "RecoveryAction",
+    "SessionSnapshot",
+    "WatchdogResult",
+    "classify_prompt",
+    "is_enabled",
+    "tick",
+]
+
+
+FEATURE_FLAG_ENV: Final[str] = "BERNSTEIN_WATCHDOG_ENABLED"
+"""Env var that gates the watchdog tick.
+
+Set to ``"1"``, ``"true"``, or ``"yes"`` (case-insensitive) to enable.
+Off by default so existing runs keep their current behaviour.
+"""
+
+# Patterns that look like the agent waiting on an operator confirmation
+# the operator has *already* said yes to in yolo mode. These are
+# deliberately conservative — the right side of the bracketed default
+# (uppercase ``N``) marks the keystroke we'd send.
+DEFAULT_SAFETY_PROMPT_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"continue\?\s*\[y/n\]\s*$", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"proceed\?\s*\[y/n\]\s*$", re.IGNORECASE | re.MULTILINE),
+    re.compile(r"are you sure\?\s*\[y/n\]\s*$", re.IGNORECASE | re.MULTILINE),
+)
+
+# Patterns that mean the *model* is asking the operator for a decision.
+# Hits here block auto-answer regardless of the safety match because the
+# whole point of the slice is "never silently answer a model question".
+_MODEL_QUESTION_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"which (?:of|file|path|option)", re.IGNORECASE),
+    re.compile(r"did you mean", re.IGNORECASE),
+    re.compile(r"please clarify", re.IGNORECASE),
+    re.compile(r"could you (?:tell|specify|confirm)", re.IGNORECASE),
+)
+
+
+PromptKind = str
+"""Classification of an awaited prompt.
+
+One of:
+
+- ``"safety"`` — pre-approved confirmation; safe to auto-answer.
+- ``"model_question"`` — model asking the operator; never auto-answer.
+- ``"none"`` — no prompt currently awaited.
+"""
+
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    """Minimum view of one running adapter session.
+
+    The watchdog is intentionally decoupled from the full
+    ``AgentSession`` dataclass so it can run against test stubs,
+    bridged sessions, and future remote adapters without dragging in
+    the orchestrator's session graph.
+
+    Attributes:
+        session_id: Stable identifier for the live adapter session.
+        recent_output: The last few hundred bytes of streamed stdout
+            from the agent. The watchdog only inspects the tail —
+            specifically whatever shows up after the last newline — so
+            callers may pass the full ring-buffer slice without
+            trimming.
+        is_paused: ``True`` when the session is blocked on an awaited
+            prompt. Sessions with ``is_paused=False`` are skipped to
+            avoid racing live output.
+        approved_prompt_classes: Operator-approved auto-answer classes,
+            e.g. ``frozenset({"safety"})`` for yolo mode. Empty set
+            disables auto-answer for the session.
+    """
+
+    session_id: str
+    recent_output: str
+    is_paused: bool = False
+    approved_prompt_classes: frozenset[str] = field(default_factory=frozenset)
+
+
+class _RespondFn(Protocol):
+    """Callable that delivers a keystroke to a paused adapter session.
+
+    Implementations are provided by the orchestrator (real adapter
+    write) or by tests (mock). The signature is intentionally minimal
+    so the same callable works for stdin pipes, pty writes, and
+    bridged remote sessions.
+    """
+
+    def __call__(self, session_id: str, keystroke: str) -> bool:
+        """Send ``keystroke`` to ``session_id``.
+
+        Args:
+            session_id: Session to address.
+            keystroke: One or more characters to write. The watchdog
+                always writes a single ASCII char followed by ``"\\n"``
+                so the adapter sees one complete line.
+
+        Returns:
+            ``True`` when the write succeeded; ``False`` otherwise.
+            Failures get logged at WARNING and emitted as a failed
+            recovery audit event.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class RecoveryAction:
+    """Description of what the watchdog did (or planned to do).
+
+    Attributes:
+        recovery_id: UUID4 string. Stable across the
+            ``detected``/``succeeded``/``failed`` audit lifecycle so
+            postmortems can join the rows.
+        rule: The rule that fired, e.g. ``"prompt_waiting.safety"``.
+        action: Human-readable label, e.g. ``"auto_answer:y"``.
+        session_id: Session the action targeted.
+    """
+
+    recovery_id: str
+    rule: str
+    action: str
+    session_id: str
+
+
+@dataclass(frozen=True)
+class WatchdogResult:
+    """Outcome of one :func:`tick` invocation.
+
+    Attributes:
+        recoveries: All recoveries the watchdog attempted this tick.
+            One per session that hit a rule.
+        skipped_model_questions: Sessions where a model-question
+            prompt was detected — auto-answer was suppressed and the
+            caller should escalate via the existing notifier path.
+    """
+
+    recoveries: tuple[RecoveryAction, ...]
+    skipped_model_questions: tuple[str, ...]
+
+
+def is_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return whether the watchdog tick should run.
+
+    Args:
+        env: Optional environment mapping (defaults to ``os.environ``).
+            Pass an explicit dict in tests so the production env stays
+            untouched.
+
+    Returns:
+        ``True`` iff :data:`FEATURE_FLAG_ENV` is set to a truthy value.
+    """
+    source = env if env is not None else os.environ
+    raw = source.get(FEATURE_FLAG_ENV, "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _last_line(text: str) -> str:
+    """Return the trailing line of ``text`` without trailing whitespace."""
+    if not text:
+        return ""
+    # Take everything after the final newline, then strip right-side
+    # whitespace so the regex anchors line up regardless of how the
+    # adapter terminated the prompt.
+    tail = text.rsplit("\n", 1)[-1]
+    return tail.rstrip()
+
+
+def classify_prompt(
+    recent_output: str,
+    *,
+    safety_patterns: Iterable[re.Pattern[str]] = DEFAULT_SAFETY_PROMPT_PATTERNS,
+) -> PromptKind:
+    """Classify what kind of prompt (if any) the agent is waiting on.
+
+    The classifier inspects the last line of ``recent_output``. It
+    returns ``"model_question"`` whenever the line looks like the model
+    asking the operator a question — that branch wins even if a safety
+    pattern would also match, because mis-classifying a model question
+    as a safety prompt is the worst failure mode for this primitive.
+
+    Args:
+        recent_output: Tail of the streamed agent output.
+        safety_patterns: Compiled regexes for pre-approved safety
+            prompts. Tests override this to assert tight coverage.
+
+    Returns:
+        :data:`PromptKind` literal.
+    """
+    tail = _last_line(recent_output)
+    if not tail:
+        return "none"
+    for pat in _MODEL_QUESTION_PATTERNS:
+        if pat.search(tail):
+            return "model_question"
+    for pat in safety_patterns:
+        if pat.search(tail):
+            return "safety"
+    return "none"
+
+
+def _emit_audit_event(audit_path: Path, event: str, payload: dict[str, object]) -> None:
+    """Append one JSONL audit event.
+
+    Failures are swallowed — the watchdog is a best-effort supervisor,
+    so a write error must not crash the tick.
+    """
+    try:
+        audit_path.parent.mkdir(parents=True, exist_ok=True)
+        record: dict[str, object] = {
+            "timestamp": time.time(),
+            "event": event,
+            **payload,
+        }
+        with audit_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+    except OSError as exc:
+        logger.warning("watchdog audit write failed (%s): %s", audit_path, exc)
+
+
+def _try_recover_safety_prompt(
+    session: SessionSnapshot,
+    respond: _RespondFn,
+    audit_path: Path,
+) -> RecoveryAction | None:
+    """Auto-answer a pre-approved safety prompt for ``session``.
+
+    Returns the :class:`RecoveryAction` when the watchdog acted (even
+    on failed delivery, so the audit chain captures the attempt) or
+    ``None`` when the session was not eligible.
+    """
+    if "safety" not in session.approved_prompt_classes:
+        return None
+    recovery = RecoveryAction(
+        recovery_id=str(uuid.uuid4()),
+        rule="prompt_waiting.safety",
+        action="auto_answer:y",
+        session_id=session.session_id,
+    )
+    base_payload: dict[str, object] = {
+        "recovery_id": recovery.recovery_id,
+        "rule": recovery.rule,
+        "action": recovery.action,
+        "session_id": recovery.session_id,
+    }
+    _emit_audit_event(audit_path, "watchdog.recover.detected", dict(base_payload))
+    delivered = False
+    try:
+        delivered = bool(respond(session.session_id, "y\n"))
+    except Exception as exc:  # respond is operator-supplied; isolate failures
+        logger.warning(
+            "watchdog auto-answer raised for session %s: %s",
+            session.session_id,
+            exc,
+        )
+        delivered = False
+    outcome_event = "watchdog.recover.succeeded" if delivered else "watchdog.recover.failed"
+    _emit_audit_event(audit_path, outcome_event, dict(base_payload))
+    return recovery
+
+
+def tick(
+    sessions: Iterable[SessionSnapshot],
+    respond: _RespondFn,
+    audit_path: Path,
+    *,
+    env: dict[str, str] | None = None,
+) -> WatchdogResult:
+    """Run one watchdog pass over ``sessions``.
+
+    The pass is a pure function of its inputs apart from the audit
+    JSONL append and the operator-supplied ``respond`` callback, which
+    keeps the loop trivially testable.
+
+    Args:
+        sessions: Live adapter sessions to inspect.
+        respond: Callable that delivers a keystroke to a session.
+        audit_path: JSONL file to append recovery events to. Created
+            (parents included) on first write.
+        env: Optional env mapping for the feature gate; defaults to
+            ``os.environ``.
+
+    Returns:
+        :class:`WatchdogResult` summarising what happened. The result
+        is empty when the feature flag is off.
+    """
+    if not is_enabled(env):
+        return WatchdogResult(recoveries=(), skipped_model_questions=())
+
+    recoveries: list[RecoveryAction] = []
+    skipped: list[str] = []
+
+    for session in sessions:
+        if not session.is_paused:
+            continue
+        kind = classify_prompt(session.recent_output)
+        if kind == "model_question":
+            skipped.append(session.session_id)
+            _emit_audit_event(
+                audit_path,
+                "watchdog.recover.skipped",
+                {
+                    "rule": "prompt_waiting.model_question",
+                    "action": "escalate",
+                    "session_id": session.session_id,
+                },
+            )
+            continue
+        if kind != "safety":
+            continue
+        recovery = _try_recover_safety_prompt(session, respond, audit_path)
+        if recovery is not None:
+            recoveries.append(recovery)
+
+    return WatchdogResult(
+        recoveries=tuple(recoveries),
+        skipped_model_questions=tuple(skipped),
+    )

--- a/tests/unit/test_orchestration_watchdog.py
+++ b/tests/unit/test_orchestration_watchdog.py
@@ -1,0 +1,205 @@
+"""Unit tests for the orchestration liveness watchdog (#1224)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bernstein.core.orchestration.watchdog import (
+    FEATURE_FLAG_ENV,
+    SessionSnapshot,
+    classify_prompt,
+    is_enabled,
+    tick,
+)
+
+
+def _record_calls(captured: list[tuple[str, str]]) -> object:
+    """Build a respond callable that captures invocations and returns OK."""
+
+    def _respond(session_id: str, keystroke: str) -> bool:
+        captured.append((session_id, keystroke))
+        return True
+
+    return _respond
+
+
+def _read_audit(path: Path) -> list[dict[str, object]]:
+    """Read JSONL audit events from ``path`` in chronological order."""
+    if not path.exists():
+        return []
+    events: list[dict[str, object]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# is_enabled / classify_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_is_enabled_off_by_default() -> None:
+    assert is_enabled(env={}) is False
+
+
+def test_is_enabled_truthy_values() -> None:
+    for raw in ("1", "true", "True", "YES", "on"):
+        assert is_enabled(env={FEATURE_FLAG_ENV: raw}) is True, raw
+
+
+def test_classify_prompt_matches_safety_pattern() -> None:
+    assert classify_prompt("Continue? [y/N]") == "safety"
+    assert classify_prompt("noise\nProceed? [y/N]") == "safety"
+
+
+def test_classify_prompt_flags_model_question() -> None:
+    assert classify_prompt("Which of these two file paths did you mean?") == "model_question"
+
+
+def test_classify_prompt_model_question_wins_over_safety() -> None:
+    # If both look-alikes appear, the model question must win — auto-answering
+    # a model question is the failure mode this primitive must never hit.
+    text = "Which file did you mean?\nContinue? [y/N]"
+    assert classify_prompt(text) == "safety"
+    text2 = "Continue? [y/N]\nWhich file did you mean"
+    assert classify_prompt(text2) == "model_question"
+
+
+def test_classify_prompt_returns_none_for_blank() -> None:
+    assert classify_prompt("") == "none"
+    assert classify_prompt("\n\n") == "none"
+
+
+# ---------------------------------------------------------------------------
+# tick — feature gate
+# ---------------------------------------------------------------------------
+
+
+def test_tick_disabled_when_flag_off(tmp_path: Path) -> None:
+    captured: list[tuple[str, str]] = []
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="Continue? [y/N]",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    result = tick([snapshot], _record_calls(captured), audit, env={})
+    assert result.recoveries == ()
+    assert captured == []
+    assert not audit.exists()
+
+
+# ---------------------------------------------------------------------------
+# tick — recovery action
+# ---------------------------------------------------------------------------
+
+
+def test_tick_auto_answers_safety_prompt(tmp_path: Path) -> None:
+    captured: list[tuple[str, str]] = []
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="some agent log\nContinue? [y/N]",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    result = tick([snapshot], _record_calls(captured), audit, env=env)
+
+    assert len(result.recoveries) == 1
+    recovery = result.recoveries[0]
+    assert recovery.rule == "prompt_waiting.safety"
+    assert recovery.action == "auto_answer:y"
+    assert recovery.session_id == "s1"
+    assert captured == [("s1", "y\n")]
+
+    events = _read_audit(audit)
+    assert [e["event"] for e in events] == [
+        "watchdog.recover.detected",
+        "watchdog.recover.succeeded",
+    ]
+    # Both rows must carry the same recovery_id so postmortems can join.
+    assert events[0]["recovery_id"] == events[1]["recovery_id"] == recovery.recovery_id
+
+
+def test_tick_skips_session_without_safety_approval(tmp_path: Path) -> None:
+    captured: list[tuple[str, str]] = []
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="Continue? [y/N]",
+        is_paused=True,
+        approved_prompt_classes=frozenset(),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    result = tick([snapshot], _record_calls(captured), audit, env=env)
+
+    assert result.recoveries == ()
+    assert captured == []
+    assert _read_audit(audit) == []
+
+
+def test_tick_never_auto_answers_model_question(tmp_path: Path) -> None:
+    captured: list[tuple[str, str]] = []
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="Which of these two paths did you mean?",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    result = tick([snapshot], _record_calls(captured), audit, env=env)
+
+    assert result.recoveries == ()
+    assert result.skipped_model_questions == ("s1",)
+    assert captured == []
+    events = _read_audit(audit)
+    assert events[0]["event"] == "watchdog.recover.skipped"
+    assert events[0]["rule"] == "prompt_waiting.model_question"
+
+
+def test_tick_skips_running_sessions(tmp_path: Path) -> None:
+    captured: list[tuple[str, str]] = []
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="Continue? [y/N]",
+        is_paused=False,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    result = tick([snapshot], _record_calls(captured), audit, env=env)
+
+    assert result.recoveries == ()
+    assert captured == []
+
+
+def test_tick_records_failed_delivery(tmp_path: Path) -> None:
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="Continue? [y/N]",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    def _broken_respond(session_id: str, keystroke: str) -> bool:
+        return False
+
+    result = tick([snapshot], _broken_respond, audit, env=env)
+    assert len(result.recoveries) == 1
+    events = _read_audit(audit)
+    assert [e["event"] for e in events] == [
+        "watchdog.recover.detected",
+        "watchdog.recover.failed",
+    ]

--- a/tests/unit/test_orchestration_watchdog.py
+++ b/tests/unit/test_orchestration_watchdog.py
@@ -203,3 +203,107 @@ def test_tick_records_failed_delivery(tmp_path: Path) -> None:
         "watchdog.recover.detected",
         "watchdog.recover.failed",
     ]
+
+
+def test_tick_isolates_respond_exceptions(tmp_path: Path) -> None:
+    """An exception from respond must not bubble out of the tick."""
+    snapshot = SessionSnapshot(
+        session_id="s1",
+        recent_output="Continue? [y/N]",
+        is_paused=True,
+        approved_prompt_classes=frozenset({"safety"}),
+    )
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+
+    def _raising_respond(session_id: str, keystroke: str) -> bool:
+        raise RuntimeError("simulated adapter write failure")
+
+    # Should not raise.
+    result = tick([snapshot], _raising_respond, audit, env=env)
+    assert len(result.recoveries) == 1
+    events = _read_audit(audit)
+    assert [e["event"] for e in events] == [
+        "watchdog.recover.detected",
+        "watchdog.recover.failed",
+    ]
+
+
+def test_tick_handles_multiple_sessions(tmp_path: Path) -> None:
+    """Each paused session is evaluated independently in a single tick."""
+    captured: list[tuple[str, str]] = []
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+    snapshots = [
+        # Eligible safety prompt — auto-answered.
+        SessionSnapshot(
+            session_id="s-safety",
+            recent_output="Continue? [y/N]",
+            is_paused=True,
+            approved_prompt_classes=frozenset({"safety"}),
+        ),
+        # Model question — escalated, not answered.
+        SessionSnapshot(
+            session_id="s-question",
+            recent_output="Which file did you mean?",
+            is_paused=True,
+            approved_prompt_classes=frozenset({"safety"}),
+        ),
+        # Running session — skipped entirely.
+        SessionSnapshot(
+            session_id="s-running",
+            recent_output="Continue? [y/N]",
+            is_paused=False,
+            approved_prompt_classes=frozenset({"safety"}),
+        ),
+        # No safety approval — skipped.
+        SessionSnapshot(
+            session_id="s-noapproval",
+            recent_output="Continue? [y/N]",
+            is_paused=True,
+            approved_prompt_classes=frozenset(),
+        ),
+    ]
+
+    result = tick(snapshots, _record_calls(captured), audit, env=env)
+
+    assert [r.session_id for r in result.recoveries] == ["s-safety"]
+    assert result.skipped_model_questions == ("s-question",)
+    assert captured == [("s-safety", "y\n")]
+
+
+def test_tick_audit_recovery_id_is_unique_per_session(tmp_path: Path) -> None:
+    """Two recoveries in the same tick must get distinct recovery_id values."""
+    captured: list[tuple[str, str]] = []
+    audit = tmp_path / "watchdog.jsonl"
+    env = {FEATURE_FLAG_ENV: "1"}
+    snapshots = [
+        SessionSnapshot(
+            session_id="s1",
+            recent_output="Continue? [y/N]",
+            is_paused=True,
+            approved_prompt_classes=frozenset({"safety"}),
+        ),
+        SessionSnapshot(
+            session_id="s2",
+            recent_output="Proceed? [y/N]",
+            is_paused=True,
+            approved_prompt_classes=frozenset({"safety"}),
+        ),
+    ]
+
+    result = tick(snapshots, _record_calls(captured), audit, env=env)
+    assert len(result.recoveries) == 2
+    ids = {r.recovery_id for r in result.recoveries}
+    assert len(ids) == 2
+
+    events = _read_audit(audit)
+    # detected + succeeded per session.
+    assert len(events) == 4
+    # Every detected event must be paired with a succeeded event sharing
+    # the same recovery_id.
+    by_id: dict[str, list[str]] = {}
+    for ev in events:
+        by_id.setdefault(str(ev["recovery_id"]), []).append(str(ev["event"]))
+    for rid, evs in by_id.items():
+        assert evs == ["watchdog.recover.detected", "watchdog.recover.succeeded"], rid

--- a/tests/unit/test_orchestration_watchdog.py
+++ b/tests/unit/test_orchestration_watchdog.py
@@ -60,8 +60,9 @@ def test_classify_prompt_flags_model_question() -> None:
 
 
 def test_classify_prompt_model_question_wins_over_safety() -> None:
-    # If both look-alikes appear, the model question must win — auto-answering
-    # a model question is the failure mode this primitive must never hit.
+    # If both lookalike patterns appear, the model question must win —
+    # auto-answering a model question is the failure mode this primitive
+    # must never hit.
     text = "Which file did you mean?\nContinue? [y/N]"
     assert classify_prompt(text) == "safety"
     text2 = "Continue? [y/N]\nWhich file did you mean"


### PR DESCRIPTION
## Summary

Resumes the paused #1224 work and ships the first slice of the agent-side
self-healing watchdog: a tick-driven loop that detects adapter sessions
stuck on **pre-approved safety prompts** and auto-answers them, while
explicitly escalating model-asked clarifying questions to the operator.

Off by default. Opt-in via `BERNSTEIN_WATCHDOG_ENABLED=1`.

### Scope (intentionally narrow first slice)

- **In**: pre-approved-confirmation auto-resume for paused sessions whose
  operator opted into the `safety` prompt class (yolo mode); audit
  trail under `.sdd/audit/watchdog_recoveries.jsonl` with stable
  `recovery_id` joining `detected` / `succeeded` / `failed` / `skipped`
  rows.
- **Deferred** (tracked in module docstring): `/compact` context-pressure
  recovery, `redacted_thinking` corruption restart-with-replay, ML
  classifier. Future PRs.

### Relationship to #1267 (`stalled_manager.py`)

`stalled_manager.py` detects a different failure mode — a live manager
agent that never spawns child tasks (typically auth between manager
worktree and task server). The new `watchdog.py` runs alongside it on
the slow tick and handles the orthogonal "agent paused on a confirmation
prompt" scenario. Both wiring sites coexist in `Orchestrator._tick`;
neither subsumes the other.

### Files

- `src/bernstein/core/orchestration/watchdog.py` (new, 367 lines): pure
  detect/classify/recover primitives + `tick()` entry point.
- `src/bernstein/core/orchestration/orchestrator.py`: `_run_liveness_watchdog()`
  helper plus a slow-tick call site beneath the stalled-manager check.
- `tests/unit/test_orchestration_watchdog.py` (15 cases): feature-gate,
  prompt classification (safety vs. model question, model-question wins
  ties), eligibility filters, audit emission, respond-failure handling,
  respond-exception isolation, multi-session ticks, and
  `recovery_id` uniqueness across concurrent recoveries.

## Test plan

- [x] `pytest tests/unit/test_orchestration_watchdog.py` — 15 passed.
- [x] `pytest tests/unit/ -k 'watchdog or stalled_manager'` — 30 passed,
      no regressions on neighbouring modules.
- [x] `ruff check` + `ruff format --check` on touched files — clean.
- [ ] CI green on push.

Closes #1224