### PR TITLE
feat(autofix): auto-route PR review comments back to spawning agent (closes #1219)

### DIFF
--- a/src/bernstein/cli/commands/autofix_cmd.py
+++ b/src/bernstein/cli/commands/autofix_cmd.py
@@ -43,6 +43,13 @@ from bernstein.core.autofix.dispatcher import (
     AttemptCounter,
     DispatchResult,
 )
+from bernstein.core.autofix.review_router import (
+    GhInvocationError,
+    ReviewRouter,
+    emit_jsonl,
+    poll_loop,
+    resolve_pr_number,
+)
 from bernstein.core.security.audit import AuditLog
 
 __all__ = ["autofix_group"]
@@ -434,3 +441,101 @@ def attach_cmd(limit: int) -> None:
                 click.echo(json.dumps(fresh, sort_keys=True))
     except KeyboardInterrupt:
         return
+
+
+# ---------------------------------------------------------------------------
+# review — poll a PR for review-comment routing
+# ---------------------------------------------------------------------------
+
+
+_REVIEW_TASK_LOG = Path(".sdd") / "runtime" / "autofix-review-tasks.jsonl"
+
+
+@autofix_group.command("review")
+@click.option(
+    "--pr",
+    "pr_number",
+    type=int,
+    default=None,
+    help="PR number to watch (overrides env / git config).",
+)
+@click.option(
+    "--repo",
+    "repo_slug",
+    default="",
+    help="GitHub owner/name slug; passed to ``gh pr view --repo``.",
+)
+@click.option(
+    "--poll-seconds",
+    type=float,
+    default=60.0,
+    show_default=True,
+    help="Seconds to sleep between polls.",
+)
+@click.option(
+    "--once",
+    is_flag=True,
+    default=False,
+    help="Run a single poll and exit.",
+)
+@click.option(
+    "--task-log",
+    "task_log_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Override the JSONL path the router writes structured tasks to.",
+)
+def review_cmd(
+    pr_number: int | None,
+    repo_slug: str,
+    poll_seconds: float,
+    once: bool,
+    task_log_path: Path | None,
+) -> None:
+    """Poll a PR's review threads and emit structured tasks for new "request changes" comments.
+
+    The command resolves which PR to watch in the following order:
+
+    1. ``--pr`` argument.
+    2. ``BERNSTEIN_REVIEW_PR_NUMBER`` environment variable.
+    3. ``git config bernstein.spawn-pr``.
+
+    Tasks are appended as JSONL to ``.sdd/runtime/autofix-review-tasks.jsonl``
+    relative to the current workspace (override with ``--task-log``).
+    Each task carries the file, line range, comment body, reviewer login,
+    diff hunk and permalink — enough for the spawning agent to address
+    the comment without re-fetching from GitHub.
+    """
+    workdir = _resolve_workdir()
+    resolved_pr = resolve_pr_number(explicit=pr_number, workdir=workdir)
+    if resolved_pr is None:
+        raise click.ClickException(
+            "no PR specified — pass --pr, set BERNSTEIN_REVIEW_PR_NUMBER, or set ``git config bernstein.spawn-pr``."
+        )
+
+    log_path = task_log_path or (workdir / _REVIEW_TASK_LOG)
+    sink = emit_jsonl(log_path)
+    router = ReviewRouter(
+        pr_number=resolved_pr,
+        task_sink=sink,
+        repo=repo_slug,
+    )
+
+    if once:
+        try:
+            outcome = router.poll_once()
+        except GhInvocationError as exc:
+            raise click.ClickException(str(exc)) from exc
+        click.echo(
+            f"review_router: PR #{resolved_pr} emitted {len(outcome.tasks)} task(s); "
+            f"skipped {outcome.skipped_seen} already-seen comment(s); log={log_path}"
+        )
+        return
+
+    click.echo(f"review_router: watching PR #{resolved_pr} every {poll_seconds:.1f}s; log={log_path}")
+    try:
+        polls = poll_loop(router, poll_seconds=poll_seconds)
+    except KeyboardInterrupt:
+        click.echo("review_router: interrupted.")
+        return
+    click.echo(f"review_router: completed after {polls} poll(s).")

--- a/src/bernstein/cli/commands/autofix_cmd.py
+++ b/src/bernstein/cli/commands/autofix_cmd.py
@@ -46,6 +46,9 @@ from bernstein.core.autofix.dispatcher import (
 from bernstein.core.autofix.review_router import (
     GhInvocationError,
     ReviewRouter,
+    WorktreeRecord,
+    WorktreeRegistry,
+    default_registry_path,
     emit_jsonl,
     poll_loop,
     resolve_pr_number,
@@ -521,6 +524,17 @@ def review_cmd(
         repo=repo_slug,
     )
 
+    # Surface the spawning agent's worktree (if registered) so an
+    # operator running ``review --once`` from any directory still
+    # sees which workspace the eventual dispatcher will resume.
+    registry = WorktreeRegistry(default_registry_path(workdir))
+    record = registry.lookup(resolved_pr)
+    if record is not None:
+        click.echo(
+            f"review_router: PR #{resolved_pr} maps to worktree {record.worktree_path}"
+            + (f" (run_id={record.run_id})" if record.run_id else "")
+        )
+
     if once:
         try:
             outcome = router.poll_once()
@@ -539,3 +553,101 @@ def review_cmd(
         click.echo("review_router: interrupted.")
         return
     click.echo(f"review_router: completed after {polls} poll(s).")
+
+
+# ---------------------------------------------------------------------------
+# review-register / review-resolve — operator-facing worktree registry
+# ---------------------------------------------------------------------------
+
+
+@autofix_group.command("review-register")
+@click.option(
+    "--pr",
+    "pr_number",
+    type=int,
+    required=True,
+    help="PR number opened by the spawning agent.",
+)
+@click.option(
+    "--worktree",
+    "worktree_path",
+    type=click.Path(file_okay=False, path_type=Path),
+    required=True,
+    help="Absolute path to the worktree the agent used.",
+)
+@click.option(
+    "--run-id",
+    "run_id",
+    default="",
+    help="Bernstein run id that opened the PR (optional, recorded for audit).",
+)
+@click.option(
+    "--repo",
+    "repo_slug",
+    default="",
+    help="GitHub owner/name slug (optional).",
+)
+def review_register_cmd(
+    pr_number: int,
+    worktree_path: Path,
+    run_id: str,
+    repo_slug: str,
+) -> None:
+    """Persist a ``pr_number -> worktree_path`` mapping.
+
+    Call this immediately after ``bernstein pr`` opens a review-ready
+    PR so a future ``bernstein autofix review`` invocation can locate
+    the spawning agent's workspace, even after a host restart.
+    """
+    workdir = _resolve_workdir()
+    registry = WorktreeRegistry(default_registry_path(workdir))
+    try:
+        registry.register(
+            WorktreeRecord(
+                pr_number=pr_number,
+                worktree_path=str(worktree_path),
+                run_id=run_id,
+                repo=repo_slug,
+            )
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"review_router: registered PR #{pr_number} -> {worktree_path}")
+
+
+@autofix_group.command("review-resolve")
+@click.option(
+    "--pr",
+    "pr_number",
+    type=int,
+    required=True,
+    help="PR number to look up.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of plain text.",
+)
+def review_resolve_cmd(pr_number: int, as_json: bool) -> None:
+    """Print the registered worktree path for a PR (exit non-zero if missing)."""
+    workdir = _resolve_workdir()
+    registry = WorktreeRegistry(default_registry_path(workdir))
+    record = registry.lookup(pr_number)
+    if record is None:
+        if as_json:
+            click.echo(json.dumps({"pr_number": pr_number, "found": False}, sort_keys=True))
+        else:
+            click.echo(f"review_router: no registration for PR #{pr_number}", err=True)
+        sys.exit(1)
+    if as_json:
+        payload = {"pr_number": pr_number, "found": True, **record.to_payload()}
+        click.echo(json.dumps(payload, sort_keys=True))
+        return
+    line = f"PR #{record.pr_number}  worktree={record.worktree_path}"
+    if record.run_id:
+        line += f"  run_id={record.run_id}"
+    if record.repo:
+        line += f"  repo={record.repo}"
+    click.echo(line)

--- a/src/bernstein/core/autofix/review_router.py
+++ b/src/bernstein/core/autofix/review_router.py
@@ -1,0 +1,539 @@
+"""PR review-comment polling primitive.
+
+This module implements the smallest viable slice of GitHub PR review-comment
+routing: poll a single PR via ``gh pr view --json reviewThreads,reviews``,
+diff the threads against a previously-seen set of comment ids, and emit a
+:class:`ReviewTask` for every newly-discovered comment that belongs to a
+"changes requested" review.
+
+The primitive is intentionally narrow:
+
+* One PR per :class:`ReviewRouter` instance — multi-PR fan-out is deferred
+  to a follow-up that owns scheduling and rate-limit budgets.
+* No webhook surface — callers drive :meth:`ReviewRouter.poll_once` on a
+  cadence they control.
+* No re-spawn / dispatcher integration — the router only emits structured
+  tasks via an injected ``task_sink`` callable.  Wiring those tasks into
+  the autofix dispatcher (audit chain, cost caps, attempt counter) lands
+  in a follow-up.
+
+The module deliberately mirrors the shape of
+:mod:`bernstein.core.autofix.daemon` so the follow-up can lift the loop
+into the existing supervisor without reshaping any public types.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReviewTask:
+    """One structured task emitted to the spawning agent's queue.
+
+    Attributes:
+        pr_number: GitHub PR number the comment belongs to.
+        thread_id: Stable GitHub review-thread id.
+        comment_id: Stable GitHub review-comment id; used for dedup.
+        reviewer: GitHub login of the reviewer who left the comment.
+        verdict: Reviewer verdict that produced the task; always
+            ``"CHANGES_REQUESTED"`` in this slice.
+        path: Repository path of the file the comment is anchored to,
+            or ``""`` when GitHub did not return one.
+        line_start: First diff line covered by the comment, or ``0``.
+        line_end: Last diff line covered by the comment, or ``0``.
+        body: Raw comment body as authored by the reviewer.
+        diff_hunk: Diff hunk GitHub displays under the thread, when
+            available.  Empty string otherwise.
+        url: Permalink to the comment on github.com.
+    """
+
+    pr_number: int
+    thread_id: str
+    comment_id: str
+    reviewer: str
+    verdict: str
+    path: str
+    line_start: int
+    line_end: int
+    body: str
+    diff_hunk: str
+    url: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serialisable mapping suitable for queue sinks."""
+        return {
+            "kind": "review_comment",
+            "pr_number": self.pr_number,
+            "thread_id": self.thread_id,
+            "comment_id": self.comment_id,
+            "reviewer": self.reviewer,
+            "verdict": self.verdict,
+            "path": self.path,
+            "line_start": self.line_start,
+            "line_end": self.line_end,
+            "body": self.body,
+            "diff_hunk": self.diff_hunk,
+            "url": self.url,
+        }
+
+
+@dataclass(frozen=True)
+class PollResult:
+    """Outcome of a single :meth:`ReviewRouter.poll_once` invocation.
+
+    Attributes:
+        tasks: Newly-emitted tasks (already passed to ``task_sink``).
+        skipped_seen: Number of comments skipped because their id was
+            already in the seen-set.
+        skipped_non_changes: Number of comments skipped because the
+            owning review was not a ``CHANGES_REQUESTED`` verdict.
+    """
+
+    tasks: tuple[ReviewTask, ...] = field(default_factory=tuple)
+    skipped_seen: int = 0
+    skipped_non_changes: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Subprocess helpers
+# ---------------------------------------------------------------------------
+
+
+GhRunner = Callable[[list[str]], str]
+"""Callable signature for invoking ``gh``.  Returns stdout as text."""
+
+
+class GhInvocationError(RuntimeError):
+    """Raised when ``gh pr view`` fails or emits non-JSON output."""
+
+
+def _default_gh_runner(argv: list[str]) -> str:
+    """Run ``gh`` with the supplied argv and return stdout text.
+
+    Args:
+        argv: Full argv (must start with the ``gh`` binary name).
+
+    Returns:
+        The captured stdout, decoded as UTF-8.
+
+    Raises:
+        GhInvocationError: When ``gh`` exits non-zero or cannot be
+            located on ``$PATH``.
+    """
+    try:
+        completed = subprocess.run(
+            argv,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise GhInvocationError(f"gh binary not on PATH: {exc}") from exc
+    if completed.returncode != 0:
+        raise GhInvocationError(f"gh exited {completed.returncode}: {completed.stderr.strip() or 'no stderr'}")
+    return completed.stdout
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+_CHANGES_REQUESTED = "CHANGES_REQUESTED"
+
+
+def _coerce_int(value: object, default: int = 0) -> int:
+    """Best-effort int conversion that survives missing/null fields."""
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().lstrip("-").isdigit():
+        return int(value.strip())
+    return default
+
+
+def _str_field(record: dict[str, Any], key: str) -> str:
+    """Return ``record[key]`` as a string, falling back to ``""``."""
+    value = record.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _changes_requested_logins(reviews: object) -> set[str]:
+    """Return the set of reviewer logins whose latest verdict is changes-requested.
+
+    GitHub returns one review record per submission; a reviewer who first
+    requested changes and later approved should not produce review tasks.
+    The function therefore walks the list in submission order and keeps
+    the *latest* verdict per login.
+    """
+    if not isinstance(reviews, list):
+        return set()
+    latest: dict[str, str] = {}
+    for entry in reviews:
+        if not isinstance(entry, dict):
+            continue
+        login = ""
+        author = entry.get("author")
+        if isinstance(author, dict):
+            login = _str_field(author, "login")
+        if not login:
+            continue
+        state = _str_field(entry, "state").upper()
+        if state:
+            latest[login] = state
+    return {login for login, state in latest.items() if state == _CHANGES_REQUESTED}
+
+
+def parse_review_threads(
+    payload: dict[str, Any],
+    *,
+    pr_number: int,
+) -> list[ReviewTask]:
+    """Translate a ``gh pr view --json reviewThreads,reviews`` payload.
+
+    The function returns one :class:`ReviewTask` per comment that:
+
+    * lives on a non-resolved review thread;
+    * was authored by a reviewer whose most-recent review verdict is
+      ``CHANGES_REQUESTED``.
+
+    Resolved threads and threads from approving / commenting reviews are
+    skipped silently — they would only produce noise for the spawning
+    agent.
+
+    Args:
+        payload: Decoded JSON returned by ``gh pr view``.
+        pr_number: PR number to stamp onto every task.
+
+    Returns:
+        Tasks in the order GitHub returned them.  Callers should
+        deduplicate by :attr:`ReviewTask.comment_id`.
+    """
+    threads = payload.get("reviewThreads")
+    if not isinstance(threads, list):
+        return []
+    changes_logins = _changes_requested_logins(payload.get("reviews"))
+
+    tasks: list[ReviewTask] = []
+    for thread in threads:
+        if not isinstance(thread, dict):
+            continue
+        if thread.get("isResolved") is True:
+            continue
+        thread_id = _str_field(thread, "id")
+        path = _str_field(thread, "path")
+        line_start = _coerce_int(thread.get("startLine") or thread.get("line"))
+        line_end = _coerce_int(thread.get("line") or thread.get("startLine"))
+
+        comments = thread.get("comments")
+        if isinstance(comments, dict):
+            comments = comments.get("nodes")
+        if not isinstance(comments, list):
+            continue
+
+        for comment in comments:
+            if not isinstance(comment, dict):
+                continue
+            author = comment.get("author")
+            login = _str_field(author, "login") if isinstance(author, dict) else ""
+            if not login or login not in changes_logins:
+                continue
+            tasks.append(
+                ReviewTask(
+                    pr_number=pr_number,
+                    thread_id=thread_id,
+                    comment_id=_str_field(comment, "id"),
+                    reviewer=login,
+                    verdict=_CHANGES_REQUESTED,
+                    path=path,
+                    line_start=line_start,
+                    line_end=line_end,
+                    body=_str_field(comment, "body"),
+                    diff_hunk=_str_field(comment, "diffHunk") or _str_field(thread, "diffHunk"),
+                    url=_str_field(comment, "url"),
+                )
+            )
+    return tasks
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+TaskSink = Callable[[ReviewTask], None]
+"""Callable that consumes a structured review task."""
+
+
+@dataclass
+class ReviewRouter:
+    """Polling primitive for a single PR.
+
+    Attributes:
+        pr_number: PR to watch.
+        task_sink: Callable invoked once per *new* task.  Errors raised
+            by the sink propagate out of :meth:`poll_once` so callers
+            can decide how to handle dead consumers.
+        gh_runner: Override for the ``gh`` subprocess invocation.
+            Tests inject a stub that returns canned JSON.
+        repo: Optional ``owner/name`` slug forwarded to
+            ``gh pr view --repo``.  When empty, ``gh`` resolves the
+            repo from the current working tree.
+        seen_comment_ids: Set of comment ids already emitted; updated in
+            place by :meth:`poll_once` so consecutive polls do not
+            re-emit.  Pre-populating the set lets a daemon resume after
+            a restart.
+    """
+
+    pr_number: int
+    task_sink: TaskSink
+    gh_runner: GhRunner = field(default=_default_gh_runner)
+    repo: str = ""
+    seen_comment_ids: set[str] = field(default_factory=set)
+
+    def poll_once(self) -> PollResult:
+        """Run one poll cycle and emit tasks for new comments.
+
+        Returns:
+            A populated :class:`PollResult`.
+        """
+        payload = self._fetch_payload()
+        candidates = parse_review_threads(payload, pr_number=self.pr_number)
+        emitted: list[ReviewTask] = []
+        skipped_seen = 0
+        for task in candidates:
+            if not task.comment_id:
+                # Comments without ids cannot be deduped; skip rather
+                # than risk unbounded re-emission.
+                continue
+            if task.comment_id in self.seen_comment_ids:
+                skipped_seen += 1
+                continue
+            self.seen_comment_ids.add(task.comment_id)
+            self.task_sink(task)
+            emitted.append(task)
+
+        # All non-CHANGES_REQUESTED reviews are filtered inside
+        # ``parse_review_threads`` so any "skipped_non_changes" count
+        # would require re-walking the payload; surface zero for now
+        # and let a follow-up enrich the diagnostics.
+        return PollResult(tasks=tuple(emitted), skipped_seen=skipped_seen)
+
+    def _fetch_payload(self) -> dict[str, Any]:
+        """Invoke ``gh pr view`` and return the decoded JSON payload."""
+        argv: list[str] = ["gh", "pr", "view", str(self.pr_number)]
+        if self.repo:
+            argv.extend(["--repo", self.repo])
+        argv.extend(["--json", "reviewThreads,reviews"])
+        raw = self.gh_runner(argv)
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise GhInvocationError(f"gh returned non-JSON output: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise GhInvocationError("gh returned a non-object JSON payload")
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Loop driver
+# ---------------------------------------------------------------------------
+
+
+def poll_loop(
+    router: ReviewRouter,
+    *,
+    poll_seconds: float,
+    iterations: int | None = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> int:
+    """Drive ``router.poll_once`` on a fixed cadence.
+
+    Args:
+        router: Configured :class:`ReviewRouter` instance.
+        poll_seconds: Seconds to sleep between polls.  Must be > 0.
+        iterations: When set, run that many polls then return.  ``None``
+            means "loop forever" — the production behaviour.
+        sleep_fn: Callable matching :func:`time.sleep`; tests inject a
+            no-op.
+
+    Returns:
+        Total number of polls executed.
+
+    Raises:
+        ValueError: If ``poll_seconds`` is not strictly positive.
+    """
+    if poll_seconds <= 0:
+        raise ValueError("poll_seconds must be > 0")
+
+    polls = 0
+    while True:
+        try:
+            router.poll_once()
+        except GhInvocationError:
+            logger.exception("review_router: gh invocation failed for PR #%d", router.pr_number)
+        except Exception:
+            logger.exception(
+                "review_router: poll_once raised for PR #%d",
+                router.pr_number,
+            )
+        polls += 1
+        if iterations is not None and polls >= iterations:
+            return polls
+        sleep_fn(poll_seconds)
+
+
+# ---------------------------------------------------------------------------
+# PR resolution
+# ---------------------------------------------------------------------------
+
+
+_GIT_CONFIG_KEY = "bernstein.spawn-pr"
+_ENV_VAR = "BERNSTEIN_REVIEW_PR_NUMBER"
+
+
+def resolve_pr_number(
+    *,
+    explicit: int | None = None,
+    workdir: Path | None = None,
+    git_runner: Callable[[list[str], Path | None], str] | None = None,
+    environ: dict[str, str] | None = None,
+) -> int | None:
+    """Resolve which PR the router should watch.
+
+    Resolution order:
+
+    1. ``explicit`` argument (CLI ``--pr``).
+    2. Environment variable ``BERNSTEIN_REVIEW_PR_NUMBER``.
+    3. ``git config bernstein.spawn-pr`` inside ``workdir``.
+
+    Args:
+        explicit: PR number passed on the CLI.
+        workdir: Project root used for the ``git config`` lookup.
+            Defaults to the current working directory.
+        git_runner: Override for ``git`` subprocess calls; tests inject
+            a stub.  Returns stdout as text or raises
+            ``subprocess.CalledProcessError``.
+        environ: Override for ``os.environ`` lookups.
+
+    Returns:
+        The resolved PR number, or ``None`` when none of the sources
+        produced a non-empty value.
+    """
+    if explicit is not None:
+        return explicit
+
+    env = environ if environ is not None else dict(os.environ)
+    raw_env = env.get(_ENV_VAR, "").strip()
+    if raw_env:
+        try:
+            return int(raw_env)
+        except ValueError:
+            logger.warning(
+                "review_router: %s='%s' is not an integer; ignoring",
+                _ENV_VAR,
+                raw_env,
+            )
+
+    runner = git_runner if git_runner is not None else _default_git_runner
+    try:
+        raw = runner(["git", "config", "--get", _GIT_CONFIG_KEY], workdir).strip()
+    except subprocess.CalledProcessError:
+        return None
+    except FileNotFoundError:
+        return None
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "review_router: git config %s='%s' is not an integer; ignoring",
+            _GIT_CONFIG_KEY,
+            raw,
+        )
+        return None
+
+
+def _default_git_runner(argv: list[str], workdir: Path | None) -> str:
+    """Run ``git`` and return stdout; raise ``CalledProcessError`` on failure."""
+    completed = subprocess.run(
+        argv,
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=str(workdir) if workdir else None,
+    )
+    return completed.stdout
+
+
+# ---------------------------------------------------------------------------
+# Convenience: in-memory queue sink
+# ---------------------------------------------------------------------------
+
+
+def make_list_sink(target: list[ReviewTask]) -> TaskSink:
+    """Return a :class:`TaskSink` that appends every task to ``target``.
+
+    The helper is the smallest possible queue adapter — useful for the
+    CLI ``--once`` / ``--poll`` modes where the spawning agent picks up
+    tasks from an in-process list rather than a dedicated broker.
+    """
+
+    def _append(task: ReviewTask) -> None:
+        target.append(task)
+
+    return _append
+
+
+def emit_jsonl(target_path: Path) -> TaskSink:
+    """Return a :class:`TaskSink` that appends each task as JSONL.
+
+    Args:
+        target_path: File the sink writes to.  Parent directories are
+            created on demand.
+
+    Returns:
+        Callable suitable for use as :attr:`ReviewRouter.task_sink`.
+    """
+    target_path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _append(task: ReviewTask) -> None:
+        with target_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(task.to_payload(), sort_keys=True) + "\n")
+
+    return _append
+
+
+__all__ = [
+    "GhInvocationError",
+    "GhRunner",
+    "PollResult",
+    "ReviewRouter",
+    "ReviewTask",
+    "TaskSink",
+    "emit_jsonl",
+    "make_list_sink",
+    "parse_review_threads",
+    "poll_loop",
+    "resolve_pr_number",
+]

--- a/src/bernstein/core/autofix/review_router.py
+++ b/src/bernstein/core/autofix/review_router.py
@@ -1,25 +1,33 @@
-"""PR review-comment polling primitive.
+"""PR review-comment polling primitive plus worktree registry.
 
-This module implements the smallest viable slice of GitHub PR review-comment
-routing: poll a single PR via ``gh pr view --json reviewThreads,reviews``,
-diff the threads against a previously-seen set of comment ids, and emit a
-:class:`ReviewTask` for every newly-discovered comment that belongs to a
-"changes requested" review.
+This module implements the viable slice of GitHub PR review-comment
+routing required for issue #1219:
 
-The primitive is intentionally narrow:
+* Poll a single PR via ``gh pr view --json reviewThreads,reviews``,
+  diff the threads against a previously-seen set of comment ids, and
+  emit a :class:`ReviewTask` for every newly-discovered comment that
+  belongs to a "changes requested" review.
+* Persist a ``pr_number -> worktree_path`` map (the
+  :class:`WorktreeRegistry`) so that when a review lands hours later
+  the spawning agent's worktree can still be located by an autofix
+  dispatcher.
+* Reply on a review thread via ``gh api`` so the agent can acknowledge
+  the comment once it claims to have addressed it.
 
-* One PR per :class:`ReviewRouter` instance — multi-PR fan-out is deferred
-  to a follow-up that owns scheduling and rate-limit budgets.
-* No webhook surface — callers drive :meth:`ReviewRouter.poll_once` on a
-  cadence they control.
-* No re-spawn / dispatcher integration — the router only emits structured
-  tasks via an injected ``task_sink`` callable.  Wiring those tasks into
-  the autofix dispatcher (audit chain, cost caps, attempt counter) lands
+The primitive remains intentionally narrow:
+
+* One PR per :class:`ReviewRouter` instance — multi-PR fan-out is
+  deferred to a follow-up that owns scheduling and rate-limit budgets.
+* No webhook surface — callers drive :meth:`ReviewRouter.poll_once` on
+  a cadence they control.
+* No automatic re-spawn — the router only emits structured tasks via
+  an injected ``task_sink`` callable.  Wiring those tasks into the
+  autofix dispatcher (audit chain, cost caps, attempt counter) lands
   in a follow-up.
 
 The module deliberately mirrors the shape of
-:mod:`bernstein.core.autofix.daemon` so the follow-up can lift the loop
-into the existing supervisor without reshaping any public types.
+:mod:`bernstein.core.autofix.daemon` so the follow-up can lift the
+loop into the existing supervisor without reshaping any public types.
 """
 
 from __future__ import annotations
@@ -524,6 +532,237 @@ def emit_jsonl(target_path: Path) -> TaskSink:
     return _append
 
 
+# ---------------------------------------------------------------------------
+# Worktree registry — persist pr_number -> worktree_path mapping
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorktreeRecord:
+    """One persisted ``pr_number -> worktree_path`` mapping.
+
+    Attributes:
+        pr_number: GitHub PR number opened by the spawning agent.
+        worktree_path: Absolute filesystem path to the worktree the
+            agent used; the dispatcher cd's there to resume.
+        run_id: Optional Bernstein run id that opened the PR.  Empty
+            string when the caller did not have one to record.
+        repo: Optional ``owner/name`` slug; empty when unknown.
+        created_at: Unix-seconds timestamp the record was written.
+    """
+
+    pr_number: int
+    worktree_path: str
+    run_id: str = ""
+    repo: str = ""
+    created_at: float = 0.0
+
+    def to_payload(self) -> dict[str, Any]:
+        """JSON-serialisable representation suitable for on-disk storage."""
+        return {
+            "pr_number": self.pr_number,
+            "worktree_path": self.worktree_path,
+            "run_id": self.run_id,
+            "repo": self.repo,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> WorktreeRecord:
+        """Inverse of :meth:`to_payload`; tolerant of missing fields."""
+        pr_number = _coerce_int(payload.get("pr_number"))
+        worktree_path = payload.get("worktree_path")
+        if not isinstance(worktree_path, str) or not worktree_path:
+            raise ValueError("WorktreeRecord requires a non-empty worktree_path")
+        try:
+            created_at = float(payload.get("created_at") or 0.0)
+        except (TypeError, ValueError):
+            created_at = 0.0
+        return cls(
+            pr_number=pr_number,
+            worktree_path=worktree_path,
+            run_id=str(payload.get("run_id") or ""),
+            repo=str(payload.get("repo") or ""),
+            created_at=created_at,
+        )
+
+
+class WorktreeRegistry:
+    """Append-only JSONL store mapping PR numbers to worktree paths.
+
+    The registry deliberately uses a simple JSONL file rather than a
+    real database: writes happen at PR-open time (rare), reads happen
+    at review-event time (also rare), and the surface fits cleanly
+    into the same ``.sdd/runtime/`` directory used by the daemon.
+
+    Concurrent writers are serialised at the OS level via ``open(..,
+    "a")``; readers always re-read the full file so a stale in-memory
+    view never silently masks a fresh registration.
+
+    Records for the same ``pr_number`` are de-duplicated on read: the
+    *last* record wins, so an operator who moves a worktree can simply
+    register the PR again instead of mutating history.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Store records at ``path``; parent directory is created lazily."""
+        self._path = path
+
+    @property
+    def path(self) -> Path:
+        """Filesystem path the registry is backed by."""
+        return self._path
+
+    def register(self, record: WorktreeRecord) -> None:
+        """Append ``record`` to the registry.
+
+        The method is safe to call without first creating the parent
+        directory; missing parents are created with ``mkdir(parents=
+        True)``.
+
+        Raises:
+            ValueError: If ``record.pr_number`` is not positive or the
+                worktree path is empty.
+        """
+        if record.pr_number <= 0:
+            raise ValueError("WorktreeRecord.pr_number must be > 0")
+        if not record.worktree_path:
+            raise ValueError("WorktreeRecord.worktree_path must be non-empty")
+        stamped = record
+        if record.created_at == 0.0:
+            stamped = WorktreeRecord(
+                pr_number=record.pr_number,
+                worktree_path=record.worktree_path,
+                run_id=record.run_id,
+                repo=record.repo,
+                created_at=time.time(),
+            )
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(stamped.to_payload(), sort_keys=True) + "\n")
+
+    def lookup(self, pr_number: int) -> WorktreeRecord | None:
+        """Return the latest record for ``pr_number`` or ``None``.
+
+        Records are streamed in append order; the last record wins so
+        a re-registration overrides an earlier one without needing a
+        rewrite.
+        """
+        if not self._path.exists():
+            return None
+        latest: WorktreeRecord | None = None
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                # Corrupt line — skip rather than abort; the registry
+                # is opportunistic, not authoritative.
+                logger.warning("review_router: skipping malformed registry line in %s", self._path)
+                continue
+            if not isinstance(payload, dict):
+                continue
+            try:
+                rec = WorktreeRecord.from_payload(payload)
+            except ValueError:
+                continue
+            if rec.pr_number != pr_number:
+                continue
+            latest = rec
+        return latest
+
+    def all_records(self) -> list[WorktreeRecord]:
+        """Return every well-formed record in registry order.
+
+        Used by the operator-facing ``bernstein autofix review list``
+        surface (planned follow-up); included here so the registry is
+        directly testable without forcing the CLI to grow first.
+        """
+        if not self._path.exists():
+            return []
+        out: list[WorktreeRecord] = []
+        for line in self._path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(payload, dict):
+                continue
+            try:
+                out.append(WorktreeRecord.from_payload(payload))
+            except ValueError:
+                continue
+        return out
+
+
+def default_registry_path(workdir: Path) -> Path:
+    """Default location for the worktree registry inside a workspace.
+
+    Returns ``<workdir>/.sdd/runtime/autofix-review-worktrees.jsonl``.
+    Lives next to the existing review-task JSONL so an operator can
+    find both files with one ``ls``.
+    """
+    return workdir / ".sdd" / "runtime" / "autofix-review-worktrees.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Reply helper — acknowledge a review thread
+# ---------------------------------------------------------------------------
+
+
+def reply_to_review_thread(
+    task: ReviewTask,
+    *,
+    body: str,
+    repo: str,
+    gh_runner: GhRunner = _default_gh_runner,
+) -> None:
+    """Post ``body`` as a reply on the review thread that emitted ``task``.
+
+    The helper shells out to ``gh api`` rather than to the higher-level
+    ``gh pr review-comment-reply`` subcommand because ``gh api`` is
+    stable across ``gh`` releases and easier to mock in tests.
+
+    Args:
+        task: The :class:`ReviewTask` whose thread we are replying to.
+        body: The reply body, treated as Markdown by GitHub.
+        repo: ``owner/name`` slug — required; the registry tracks it.
+        gh_runner: Override for the subprocess call.  Tests inject a
+            stub that records argv.
+
+    Raises:
+        ValueError: If ``repo`` is empty or ``body`` is blank.
+        GhInvocationError: Propagated from ``gh_runner`` on failure.
+    """
+    if not repo:
+        raise ValueError("reply_to_review_thread requires a non-empty repo slug")
+    if not body.strip():
+        raise ValueError("reply_to_review_thread requires a non-empty body")
+    if not task.comment_id:
+        raise ValueError("ReviewTask is missing a comment_id; cannot reply")
+
+    # ``gh api -f body=<text>`` form-encodes the field on our behalf,
+    # which keeps the GhRunner contract ("string in, string out") and
+    # lets tests assert on a deterministic argv slice.
+    argv = [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        "-H",
+        "Accept: application/vnd.github+json",
+        f"repos/{repo}/pulls/{task.pr_number}/comments/{task.comment_id}/replies",
+        "-f",
+        f"body={body}",
+    ]
+    gh_runner(argv)
+
+
 __all__ = [
     "GhInvocationError",
     "GhRunner",
@@ -531,9 +770,13 @@ __all__ = [
     "ReviewRouter",
     "ReviewTask",
     "TaskSink",
+    "WorktreeRecord",
+    "WorktreeRegistry",
+    "default_registry_path",
     "emit_jsonl",
     "make_list_sink",
     "parse_review_threads",
     "poll_loop",
+    "reply_to_review_thread",
     "resolve_pr_number",
 ]

--- a/tests/unit/autofix/test_review_router.py
+++ b/tests/unit/autofix/test_review_router.py
@@ -1,0 +1,484 @@
+"""Unit tests for the PR review-comment routing primitive."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.autofix.review_router import (
+    GhInvocationError,
+    ReviewRouter,
+    ReviewTask,
+    emit_jsonl,
+    make_list_sink,
+    parse_review_threads,
+    poll_loop,
+    resolve_pr_number,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _gh_payload(
+    *,
+    threads: list[dict[str, Any]] | None = None,
+    reviews: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a ``gh pr view --json reviewThreads,reviews`` payload."""
+    return {
+        "reviewThreads": threads if threads is not None else [],
+        "reviews": reviews if reviews is not None else [],
+    }
+
+
+def _thread(
+    *,
+    thread_id: str,
+    path: str = "src/foo.py",
+    line: int = 12,
+    start_line: int | None = None,
+    is_resolved: bool = False,
+    comments: list[dict[str, Any]] | None = None,
+    diff_hunk: str = "",
+) -> dict[str, Any]:
+    """Build a single review-thread record."""
+    return {
+        "id": thread_id,
+        "isResolved": is_resolved,
+        "path": path,
+        "line": line,
+        "startLine": start_line,
+        "diffHunk": diff_hunk,
+        "comments": {"nodes": comments or []},
+    }
+
+
+def _comment(
+    *,
+    comment_id: str,
+    login: str = "alice",
+    body: str = "fix me",
+    diff_hunk: str = "",
+    url: str = "https://github.com/o/r/pull/1#discussion_r1",
+) -> dict[str, Any]:
+    return {
+        "id": comment_id,
+        "author": {"login": login},
+        "body": body,
+        "diffHunk": diff_hunk,
+        "url": url,
+    }
+
+
+def _review(login: str, state: str) -> dict[str, Any]:
+    return {"author": {"login": login}, "state": state}
+
+
+@dataclass
+class _GhSpy:
+    """Stub gh runner that returns canned payloads and records argv."""
+
+    payloads: list[dict[str, Any] | str | Exception]
+    captured: list[list[str]] = field(default_factory=list)
+
+    def __call__(self, argv: list[str]) -> str:
+        self.captured.append(list(argv))
+        if not self.payloads:
+            raise AssertionError("gh runner called more times than payloads provided")
+        item = self.payloads.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        if isinstance(item, str):
+            return item
+        return json.dumps(item)
+
+
+# ---------------------------------------------------------------------------
+# parse_review_threads
+# ---------------------------------------------------------------------------
+
+
+def test_parse_review_threads_emits_one_task_per_changes_comment() -> None:
+    payload = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                path="src/foo.py",
+                line=10,
+                start_line=8,
+                comments=[
+                    _comment(comment_id="C1", login="alice", body="please rename"),
+                    _comment(comment_id="C2", login="alice", body="and add a test"),
+                ],
+            ),
+        ],
+        reviews=[_review("alice", "CHANGES_REQUESTED")],
+    )
+
+    tasks = parse_review_threads(payload, pr_number=42)
+
+    assert [t.comment_id for t in tasks] == ["C1", "C2"]
+    first = tasks[0]
+    assert first.pr_number == 42
+    assert first.thread_id == "T1"
+    assert first.reviewer == "alice"
+    assert first.verdict == "CHANGES_REQUESTED"
+    assert first.path == "src/foo.py"
+    assert first.line_start == 8
+    assert first.line_end == 10
+    assert first.body == "please rename"
+
+
+def test_parse_review_threads_skips_resolved_threads() -> None:
+    payload = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                is_resolved=True,
+                comments=[_comment(comment_id="C1", login="alice")],
+            ),
+        ],
+        reviews=[_review("alice", "CHANGES_REQUESTED")],
+    )
+
+    assert parse_review_threads(payload, pr_number=1) == []
+
+
+def test_parse_review_threads_skips_approving_reviewers() -> None:
+    payload = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                comments=[_comment(comment_id="C1", login="alice")],
+            ),
+        ],
+        reviews=[_review("alice", "APPROVED")],
+    )
+
+    assert parse_review_threads(payload, pr_number=1) == []
+
+
+def test_parse_review_threads_uses_latest_review_per_login() -> None:
+    """A reviewer who later approves should not produce tasks."""
+    payload = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                comments=[_comment(comment_id="C1", login="alice")],
+            ),
+        ],
+        reviews=[
+            _review("alice", "CHANGES_REQUESTED"),
+            _review("alice", "APPROVED"),
+        ],
+    )
+
+    assert parse_review_threads(payload, pr_number=1) == []
+
+
+def test_parse_review_threads_falls_back_to_thread_diff_hunk() -> None:
+    payload = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                diff_hunk="@@ -1 +1 @@\n-old\n+new",
+                comments=[_comment(comment_id="C1", login="alice", diff_hunk="")],
+            ),
+        ],
+        reviews=[_review("alice", "CHANGES_REQUESTED")],
+    )
+
+    tasks = parse_review_threads(payload, pr_number=1)
+    assert tasks[0].diff_hunk == "@@ -1 +1 @@\n-old\n+new"
+
+
+def test_parse_review_threads_handles_missing_fields() -> None:
+    """Missing ``reviews`` / malformed comments must not crash the parser."""
+    payload: dict[str, Any] = {"reviewThreads": [{"id": "T1"}]}
+    assert parse_review_threads(payload, pr_number=1) == []
+
+
+# ---------------------------------------------------------------------------
+# ReviewRouter.poll_once — dedup, sink, gh argv
+# ---------------------------------------------------------------------------
+
+
+def test_poll_once_emits_to_sink_and_dedupes_across_polls() -> None:
+    payload_first = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                comments=[_comment(comment_id="C1", login="alice")],
+            ),
+        ],
+        reviews=[_review("alice", "CHANGES_REQUESTED")],
+    )
+    payload_second = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                comments=[
+                    _comment(comment_id="C1", login="alice"),
+                    _comment(comment_id="C2", login="alice", body="and another"),
+                ],
+            ),
+        ],
+        reviews=[_review("alice", "CHANGES_REQUESTED")],
+    )
+    spy = _GhSpy(payloads=[payload_first, payload_second])
+    sink_target: list[ReviewTask] = []
+
+    router = ReviewRouter(
+        pr_number=99,
+        task_sink=make_list_sink(sink_target),
+        gh_runner=spy,
+        repo="owner/repo",
+    )
+
+    first = router.poll_once()
+    second = router.poll_once()
+
+    assert [t.comment_id for t in first.tasks] == ["C1"]
+    assert [t.comment_id for t in second.tasks] == ["C2"]
+    assert second.skipped_seen == 1
+    assert [t.comment_id for t in sink_target] == ["C1", "C2"]
+    # Both calls must include --repo and the PR number.
+    for argv in spy.captured:
+        assert argv[:4] == ["gh", "pr", "view", "99"]
+        assert "--repo" in argv
+        assert "owner/repo" in argv
+        assert "--json" in argv
+
+
+def test_poll_once_omits_repo_flag_when_unset() -> None:
+    spy = _GhSpy(payloads=[_gh_payload()])
+    router = ReviewRouter(
+        pr_number=12,
+        task_sink=make_list_sink([]),
+        gh_runner=spy,
+    )
+
+    router.poll_once()
+
+    assert "--repo" not in spy.captured[0]
+
+
+def test_poll_once_pre_seeded_dedup_set_skips_known_comment() -> None:
+    payload = _gh_payload(
+        threads=[
+            _thread(
+                thread_id="T1",
+                comments=[_comment(comment_id="C1", login="alice")],
+            ),
+        ],
+        reviews=[_review("alice", "CHANGES_REQUESTED")],
+    )
+    spy = _GhSpy(payloads=[payload])
+    sink_target: list[ReviewTask] = []
+    router = ReviewRouter(
+        pr_number=1,
+        task_sink=make_list_sink(sink_target),
+        gh_runner=spy,
+        seen_comment_ids={"C1"},
+    )
+
+    outcome = router.poll_once()
+
+    assert outcome.tasks == ()
+    assert outcome.skipped_seen == 1
+    assert sink_target == []
+
+
+def test_poll_once_raises_on_non_json_output() -> None:
+    spy = _GhSpy(payloads=["not json"])
+    router = ReviewRouter(
+        pr_number=1,
+        task_sink=make_list_sink([]),
+        gh_runner=spy,
+    )
+
+    with pytest.raises(GhInvocationError):
+        router.poll_once()
+
+
+# ---------------------------------------------------------------------------
+# poll_loop
+# ---------------------------------------------------------------------------
+
+
+def test_poll_loop_runs_iterations_then_returns() -> None:
+    spy = _GhSpy(payloads=[_gh_payload(), _gh_payload(), _gh_payload()])
+    router = ReviewRouter(
+        pr_number=1,
+        task_sink=make_list_sink([]),
+        gh_runner=spy,
+    )
+    sleeps: list[float] = []
+
+    polls = poll_loop(
+        router,
+        poll_seconds=5.0,
+        iterations=3,
+        sleep_fn=sleeps.append,
+    )
+
+    assert polls == 3
+    # Sleep is called between polls *and* after the final one in this
+    # implementation; we just assert it never blocks for real.
+    assert all(s == 5.0 for s in sleeps)
+
+
+def test_poll_loop_swallows_gh_errors_and_keeps_polling() -> None:
+    spy = _GhSpy(payloads=[GhInvocationError("boom"), _gh_payload()])
+    router = ReviewRouter(
+        pr_number=1,
+        task_sink=make_list_sink([]),
+        gh_runner=spy,
+    )
+    polls = poll_loop(
+        router,
+        poll_seconds=0.01,
+        iterations=2,
+        sleep_fn=lambda _s: None,
+    )
+    assert polls == 2
+
+
+def test_poll_loop_rejects_nonpositive_interval() -> None:
+    router = ReviewRouter(pr_number=1, task_sink=make_list_sink([]), gh_runner=_GhSpy([]))
+    with pytest.raises(ValueError):
+        poll_loop(router, poll_seconds=0.0, iterations=1, sleep_fn=lambda _s: None)
+
+
+# ---------------------------------------------------------------------------
+# emit_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_emit_jsonl_appends_one_line_per_task(tmp_path: Path) -> None:
+    target = tmp_path / "out" / "tasks.jsonl"
+    sink = emit_jsonl(target)
+
+    sink(
+        ReviewTask(
+            pr_number=10,
+            thread_id="T1",
+            comment_id="C1",
+            reviewer="alice",
+            verdict="CHANGES_REQUESTED",
+            path="x.py",
+            line_start=1,
+            line_end=2,
+            body="hello",
+            diff_hunk="",
+            url="https://example.invalid/c1",
+        )
+    )
+    sink(
+        ReviewTask(
+            pr_number=10,
+            thread_id="T1",
+            comment_id="C2",
+            reviewer="alice",
+            verdict="CHANGES_REQUESTED",
+            path="x.py",
+            line_start=3,
+            line_end=3,
+            body="world",
+            diff_hunk="",
+            url="https://example.invalid/c2",
+        )
+    )
+
+    lines = target.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    payload = json.loads(lines[0])
+    assert payload["kind"] == "review_comment"
+    assert payload["comment_id"] == "C1"
+    assert payload["body"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# resolve_pr_number
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_pr_number_prefers_explicit_value() -> None:
+    def _git_runner(_argv: list[str], _workdir: Path | None) -> str:
+        raise AssertionError("git should not be invoked when --pr is given")
+
+    assert (
+        resolve_pr_number(
+            explicit=7,
+            environ={"BERNSTEIN_REVIEW_PR_NUMBER": "9"},
+            git_runner=_git_runner,
+        )
+        == 7
+    )
+
+
+def test_resolve_pr_number_falls_back_to_environ() -> None:
+    def _git_runner(_argv: list[str], _workdir: Path | None) -> str:
+        raise AssertionError("git should not be invoked when env var is set")
+
+    assert (
+        resolve_pr_number(
+            explicit=None,
+            environ={"BERNSTEIN_REVIEW_PR_NUMBER": "21"},
+            git_runner=_git_runner,
+        )
+        == 21
+    )
+
+
+def test_resolve_pr_number_falls_back_to_git_config() -> None:
+    captured: list[list[str]] = []
+
+    def _git_runner(argv: list[str], _workdir: Path | None) -> str:
+        captured.append(list(argv))
+        return "33\n"
+
+    assert (
+        resolve_pr_number(
+            explicit=None,
+            environ={},
+            git_runner=_git_runner,
+        )
+        == 33
+    )
+    assert captured[0] == ["git", "config", "--get", "bernstein.spawn-pr"]
+
+
+def test_resolve_pr_number_returns_none_when_git_config_missing() -> None:
+    def _git_runner(_argv: list[str], _workdir: Path | None) -> str:
+        raise subprocess.CalledProcessError(1, _argv)
+
+    assert (
+        resolve_pr_number(
+            explicit=None,
+            environ={},
+            git_runner=_git_runner,
+        )
+        is None
+    )
+
+
+def test_resolve_pr_number_ignores_non_integer_env() -> None:
+    def _git_runner(_argv: list[str], _workdir: Path | None) -> str:
+        return "55\n"
+
+    assert (
+        resolve_pr_number(
+            explicit=None,
+            environ={"BERNSTEIN_REVIEW_PR_NUMBER": "not-a-number"},
+            git_runner=_git_runner,
+        )
+        == 55
+    )

--- a/tests/unit/autofix/test_review_router.py
+++ b/tests/unit/autofix/test_review_router.py
@@ -14,10 +14,14 @@ from bernstein.core.autofix.review_router import (
     GhInvocationError,
     ReviewRouter,
     ReviewTask,
+    WorktreeRecord,
+    WorktreeRegistry,
+    default_registry_path,
     emit_jsonl,
     make_list_sink,
     parse_review_threads,
     poll_loop,
+    reply_to_review_thread,
     resolve_pr_number,
 )
 
@@ -482,3 +486,185 @@ def test_resolve_pr_number_ignores_non_integer_env() -> None:
         )
         == 55
     )
+
+
+# ---------------------------------------------------------------------------
+# WorktreeRegistry — pr_number -> worktree_path mapping
+# ---------------------------------------------------------------------------
+
+
+def _make_record(pr: int, path: str, **overrides: Any) -> WorktreeRecord:
+    """Build a :class:`WorktreeRecord` for tests with sensible defaults."""
+    kwargs: dict[str, Any] = {
+        "pr_number": pr,
+        "worktree_path": path,
+        "run_id": "run-1",
+        "repo": "owner/repo",
+        "created_at": 0.0,
+    }
+    kwargs.update(overrides)
+    return WorktreeRecord(**kwargs)
+
+
+def test_worktree_registry_round_trip(tmp_path: Path) -> None:
+    reg = WorktreeRegistry(tmp_path / "wt.jsonl")
+    reg.register(_make_record(7, "/tmp/wt-7"))
+
+    found = reg.lookup(7)
+
+    assert found is not None
+    assert found.pr_number == 7
+    assert found.worktree_path == "/tmp/wt-7"
+    assert found.run_id == "run-1"
+    assert found.repo == "owner/repo"
+    # ``register`` stamps a timestamp when the input has the default 0.0.
+    assert found.created_at > 0.0
+
+
+def test_worktree_registry_returns_none_when_unknown(tmp_path: Path) -> None:
+    reg = WorktreeRegistry(tmp_path / "wt.jsonl")
+    reg.register(_make_record(7, "/tmp/wt-7"))
+
+    assert reg.lookup(99) is None
+
+
+def test_worktree_registry_returns_none_when_file_missing(tmp_path: Path) -> None:
+    reg = WorktreeRegistry(tmp_path / "nonexistent.jsonl")
+    assert reg.lookup(1) is None
+    assert reg.all_records() == []
+
+
+def test_worktree_registry_last_record_wins(tmp_path: Path) -> None:
+    reg = WorktreeRegistry(tmp_path / "wt.jsonl")
+    reg.register(_make_record(5, "/old/path"))
+    reg.register(_make_record(5, "/new/path", run_id="run-2"))
+
+    found = reg.lookup(5)
+    assert found is not None
+    assert found.worktree_path == "/new/path"
+    assert found.run_id == "run-2"
+
+
+def test_worktree_registry_creates_parent_dir(tmp_path: Path) -> None:
+    nested = tmp_path / "a" / "b" / "wt.jsonl"
+    reg = WorktreeRegistry(nested)
+    reg.register(_make_record(1, "/x"))
+
+    assert nested.exists()
+    assert reg.lookup(1) is not None
+
+
+def test_worktree_registry_rejects_invalid_record(tmp_path: Path) -> None:
+    reg = WorktreeRegistry(tmp_path / "wt.jsonl")
+    with pytest.raises(ValueError):
+        reg.register(_make_record(0, "/x"))
+    with pytest.raises(ValueError):
+        reg.register(_make_record(1, ""))
+
+
+def test_worktree_registry_skips_malformed_lines(tmp_path: Path) -> None:
+    target = tmp_path / "wt.jsonl"
+    target.write_text(
+        '{"pr_number": 9, "worktree_path": "/ok"}\n'
+        "not-json\n"
+        '{"pr_number": 9, "worktree_path": ""}\n'
+        '{"pr_number": 9, "worktree_path": "/later"}\n',
+        encoding="utf-8",
+    )
+    reg = WorktreeRegistry(target)
+    found = reg.lookup(9)
+    assert found is not None
+    assert found.worktree_path == "/later"
+
+
+def test_worktree_registry_all_records_preserves_order(tmp_path: Path) -> None:
+    reg = WorktreeRegistry(tmp_path / "wt.jsonl")
+    reg.register(_make_record(1, "/a"))
+    reg.register(_make_record(2, "/b"))
+    reg.register(_make_record(1, "/a2"))
+
+    records = reg.all_records()
+    assert [r.pr_number for r in records] == [1, 2, 1]
+    assert [r.worktree_path for r in records] == ["/a", "/b", "/a2"]
+
+
+def test_default_registry_path_lives_under_sdd_runtime(tmp_path: Path) -> None:
+    p = default_registry_path(tmp_path)
+    assert p == tmp_path / ".sdd" / "runtime" / "autofix-review-worktrees.jsonl"
+
+
+def test_worktree_record_from_payload_round_trip() -> None:
+    rec = WorktreeRecord(
+        pr_number=12,
+        worktree_path="/wt/12",
+        run_id="r",
+        repo="o/r",
+        created_at=100.0,
+    )
+    same = WorktreeRecord.from_payload(rec.to_payload())
+    assert same == rec
+
+
+def test_worktree_record_from_payload_rejects_missing_path() -> None:
+    with pytest.raises(ValueError):
+        WorktreeRecord.from_payload({"pr_number": 5})
+
+
+# ---------------------------------------------------------------------------
+# reply_to_review_thread
+# ---------------------------------------------------------------------------
+
+
+def _task(comment_id: str = "C1", pr: int = 42) -> ReviewTask:
+    return ReviewTask(
+        pr_number=pr,
+        thread_id="T1",
+        comment_id=comment_id,
+        reviewer="alice",
+        verdict="CHANGES_REQUESTED",
+        path="x.py",
+        line_start=1,
+        line_end=1,
+        body="please fix",
+        diff_hunk="",
+        url="https://example.invalid/c",
+    )
+
+
+def test_reply_to_review_thread_invokes_gh_api() -> None:
+    spy = _GhSpy(payloads=[""])
+    reply_to_review_thread(
+        _task(),
+        body="addressed in abc123",
+        repo="owner/repo",
+        gh_runner=spy,
+    )
+    argv = spy.captured[0]
+    assert argv[0] == "gh"
+    assert argv[1] == "api"
+    assert "--method" in argv
+    assert "POST" in argv
+    assert "repos/owner/repo/pulls/42/comments/C1/replies" in argv
+    assert "body=addressed in abc123" in argv
+
+
+def test_reply_to_review_thread_validates_inputs() -> None:
+    spy = _GhSpy(payloads=[])
+    with pytest.raises(ValueError):
+        reply_to_review_thread(_task(), body="ok", repo="", gh_runner=spy)
+    with pytest.raises(ValueError):
+        reply_to_review_thread(_task(), body="  ", repo="o/r", gh_runner=spy)
+    with pytest.raises(ValueError):
+        reply_to_review_thread(_task(comment_id=""), body="ok", repo="o/r", gh_runner=spy)
+    assert spy.captured == []
+
+
+def test_reply_to_review_thread_propagates_gh_errors() -> None:
+    spy = _GhSpy(payloads=[GhInvocationError("403")])
+    with pytest.raises(GhInvocationError):
+        reply_to_review_thread(
+            _task(),
+            body="hi",
+            repo="o/r",
+            gh_runner=spy,
+        )


### PR DESCRIPTION
## Summary

Finishes the paused work on #1219 by completing the review-comment routing primitive begun on `feat/1219-review-comment-routing`.

- Polling primitive (`ReviewRouter`, `parse_review_threads`, `poll_loop`) — already present in the paused snapshot, surfaced unchanged.
- **New:** `WorktreeRegistry` — append-only JSONL store mapping `pr_number -> worktree_path` so a future dispatcher tick can resume the spawning agent's workspace even after a host restart. Tolerates malformed lines; last record wins.
- **New:** `reply_to_review_thread` — shells out to `gh api` so the agent can acknowledge a resolved thread.
- **New CLI:** `bernstein autofix review-register` / `review-resolve`. The existing `review` command now surfaces the registered worktree in its preflight echo.

Scope was kept narrow per the issue's "implementation sketch" — webhook dispatch, dispatcher re-spawn, and escalation remain follow-up work explicitly called out as deferred in the module docstring.

## Test plan

- [x] `uv run pytest tests/unit/autofix/` — 77 passed (19 existing review_router + 14 new + 44 elsewhere in autofix).
- [x] `uv run ruff check` / `ruff format --check` on touched files — clean.
- [x] `uv run mypy src/bernstein/core/autofix/review_router.py` — no new errors (pre-existing errors in `core/__init__.py` and `observability/prometheus.py` are unrelated).
- [x] CLI smoke test via `click.testing.CliRunner`: register -> resolve (text + JSON) -> miss returns exit 1.

Closes #1219