### PR TITLE
feat(sessions): fork a running session into sibling worktree (closes #1222)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -48,6 +48,7 @@ alwaysApply: false
 | `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
+| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -49,6 +49,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
+| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
+| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
+| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -49,6 +49,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `sandbox/`              | Pluggable sandbox backends for agent isolation (oai-002 phase 1) |
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
+| `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/src/bernstein/cli/commands/session_cmd.py
+++ b/src/bernstein/cli/commands/session_cmd.py
@@ -1,16 +1,21 @@
-"""Session command group — record and replay deterministic run sessions.
+"""Session command group — record, replay, and fork deterministic run sessions.
 
 Every ``bernstein run`` that completes task planning records a session to
 ``.sdd/runtime/sessions/<session_id>.json``.  The session captures the
 goal, a random seed, and the full task list so that the exact same run can
 be reproduced at any time.
 
+``bernstein session fork`` (#1222) clones a recorded session into a sibling
+git worktree branched from the parent's current commit so an operator can
+explore an alternate path without disturbing the parent.
+
 Usage::
 
     bernstein session list                        # list recorded sessions
     bernstein session show 20240101-120000-abc123 # inspect a session
     bernstein session replay 20240101-120000-abc123  # re-run a session
-    bernstein session replay --dry-run 20240101-120000-abc123  # preview
+    bernstein session replay --dry-run <session_id>  # preview
+    bernstein session fork <session_id> --label use-yaml  # sibling worktree
 """
 
 from __future__ import annotations
@@ -175,3 +180,57 @@ def session_replay(
         raise SystemExit(1) from exc
 
     console.print("[green]Replay complete.[/green]")
+
+
+@session_group.command("fork")
+@click.argument("session_id")
+@click.option(
+    "--label",
+    "fork_label",
+    default="",
+    show_default=False,
+    help="Short label baked into the fork branch / session id (a-z, 0-9, '.-_').",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit the fork descriptor as JSON instead of human-readable output.",
+)
+def session_fork(session_id: str, fork_label: str, as_json: bool) -> None:
+    """Fork a recorded session into a sibling git worktree.
+
+    Creates a new worktree under ``.sdd/worktrees/<fork_session_id>``
+    branched from the parent's current HEAD commit and writes a snapshot
+    of the parent's task state into the fork's sessions directory.  The
+    parent session is untouched.
+
+    Example::
+
+        bernstein session fork 20240101-120000-abc123 --label use-yaml
+    """
+    from bernstein.core.sessions.fork import SessionForkError, fork_session
+
+    workdir = Path.cwd()
+    try:
+        fork = fork_session(
+            parent_session_id=session_id,
+            fork_label=fork_label,
+            repo_root=workdir,
+        )
+    except SessionForkError as exc:
+        console.print(f"[red]Fork failed:[/red] {exc}")
+        raise SystemExit(1) from exc
+
+    if as_json:
+        click.echo(json.dumps(fork.to_dict(), indent=2, sort_keys=True))
+        return
+
+    console.print("[green]Forked session.[/green]")
+    console.print(f"  [bold]parent:[/bold]    {fork.parent_session_id}")
+    console.print(f"  [bold]fork:[/bold]      {fork.fork_session_id}")
+    console.print(f"  [bold]branch:[/bold]    {fork.fork_branch}")
+    console.print(f"  [bold]worktree:[/bold]  {fork.fork_worktree}")
+    console.print(f"  [bold]commit:[/bold]    {fork.fork_commit[:12]}")
+    console.print(f"  [bold]snapshot:[/bold]  {fork.snapshot_path}")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -927,3 +927,8 @@ from bernstein.cli.commands.identity_cmd import identity_group  # noqa: E402
 
 cli.add_command(identity_group, "identity")
 cli.add_command(analyze_cmd, "analyze")  # issue #768
+
+# Recorded run-session inspection + fork (#1222).
+from bernstein.cli.commands.session_cmd import session_group  # noqa: E402
+
+cli.add_command(session_group, "session")

--- a/src/bernstein/core/sessions/__init__.py
+++ b/src/bernstein/core/sessions/__init__.py
@@ -1,0 +1,20 @@
+"""Session-level orchestration primitives that span multiple subsystems.
+
+The :mod:`fork` submodule lets an operator clone a recorded session into a
+sibling git worktree to explore an alternate path without disturbing the
+parent.  See :func:`bernstein.core.sessions.fork.fork_session`.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.sessions.fork import (
+    SessionFork,
+    SessionForkError,
+    fork_session,
+)
+
+__all__ = [
+    "SessionFork",
+    "SessionForkError",
+    "fork_session",
+]

--- a/src/bernstein/core/sessions/fork.py
+++ b/src/bernstein/core/sessions/fork.py
@@ -1,0 +1,468 @@
+"""Fork a recorded session into a sibling git worktree (smallest viable slice).
+
+The ``fork_session`` function clones the *task-state* of a parent
+:class:`~bernstein.core.orchestration.run_session.RunSession` into a
+freshly-allocated session id, materialises a sibling git worktree
+branched from the parent's current commit, and writes the snapshot into
+the fork worktree's session directory.
+
+This is the snapshot-based slice of GH-1222.  It does **not** attempt to
+pause-and-fork a live agent process, replicate streaming conversation
+state, or auto-merge fork results — those are deferred follow-ups.
+
+Usage::
+
+    fork = fork_session(
+        parent_session_id="20260510-120000-abcdef",
+        fork_label="alternate-path",
+        repo_root=Path("/path/to/repo"),
+    )
+    print(fork.fork_worktree)
+    print(fork.fork_branch)
+
+Why ``repo_root`` is explicit: the function refuses to guess the
+repository when the caller is itself running inside a worktree, since
+nesting fork worktrees inside an agent worktree silently breaks
+isolation guarantees the rest of the codebase relies on (T481, T580).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import secrets
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bernstein.core.orchestration.run_session import RunSession, sessions_dir_for
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+# Worktree base directory (mirrors ``WorktreeManager._WORKTREE_BASE``).
+_WORKTREE_BASE_REL = Path(".sdd/worktrees")
+
+# Slugify pattern for the optional fork label — keep it tight so the
+# resulting branch and directory names stay shell- and git-safe.
+_LABEL_SLUG_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+_LABEL_MAX_LEN = 32
+
+# Branch convention for forks. Mirrors the lineage hint described in #1222
+# so operators can read parent → child relationships from ``git branch``.
+_FORK_BRANCH_PREFIX = "fork"
+
+
+class SessionForkError(Exception):
+    """Raised when a fork operation cannot complete safely."""
+
+
+@dataclass(frozen=True)
+class SessionFork:
+    """Result of a successful :func:`fork_session` call.
+
+    Attributes:
+        parent_session_id: Source session identifier.
+        fork_session_id: Newly-allocated session identifier for the fork.
+        parent_branch: Git branch of the parent session (best-effort —
+            may be empty when the parent was checked out in detached
+            HEAD or when ``git symbolic-ref`` fails).
+        fork_branch: Git branch created for the fork.
+        parent_worktree: Filesystem path of the parent worktree
+            (``repo_root`` when no per-session worktree exists).
+        fork_worktree: Filesystem path of the new sibling worktree.
+        snapshot_path: Path to the cloned session JSON inside
+            ``fork_worktree``.
+        fork_commit: Commit SHA the fork branched from.
+    """
+
+    parent_session_id: str
+    fork_session_id: str
+    parent_branch: str
+    fork_branch: str
+    parent_worktree: Path
+    fork_worktree: Path
+    snapshot_path: Path
+    fork_commit: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly representation (paths coerced to ``str``)."""
+        raw = asdict(self)
+        raw["parent_worktree"] = str(self.parent_worktree)
+        raw["fork_worktree"] = str(self.fork_worktree)
+        raw["snapshot_path"] = str(self.snapshot_path)
+        return raw
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slugify_label(label: str) -> str:
+    """Reduce *label* to a filesystem- and git-safe slug.
+
+    Args:
+        label: Free-text fork label provided by the caller.
+
+    Returns:
+        Slug containing only ``[a-zA-Z0-9._-]`` characters, trimmed of
+        leading/trailing separators and capped at ``_LABEL_MAX_LEN``
+        characters.
+    """
+    cleaned = _LABEL_SLUG_RE.sub("-", label).strip("-._")
+    return cleaned[:_LABEL_MAX_LEN]
+
+
+def _generate_fork_session_id(label_slug: str) -> str:
+    """Generate a fork-flavoured session id with timestamp + random suffix.
+
+    Args:
+        label_slug: Pre-slugified label (may be empty).
+
+    Returns:
+        Identifier shaped like ``fork-<ts>-<hex>`` or
+        ``fork-<label>-<ts>-<hex>``.
+    """
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    suffix = secrets.token_hex(3)
+    if label_slug:
+        return f"fork-{label_slug}-{ts}-{suffix}"
+    return f"fork-{ts}-{suffix}"
+
+
+def _resolve_session_worktree(
+    repo_root: Path,
+    parent_session_id: str,
+    worktrees_map: Mapping[str, Path] | None,
+) -> Path:
+    """Return the worktree directory associated with ``parent_session_id``.
+
+    The runtime convention (see :class:`WorktreeManager`) places per-session
+    worktrees at ``<repo_root>/.sdd/worktrees/<session_id>``.  When that
+    path exists we treat the parent as worktree-bound; otherwise we fall
+    back to the main repo checkout, which is the common case for
+    sessions recorded by ``bernstein run`` directly in the repo root.
+
+    Args:
+        repo_root: Absolute repository root.
+        parent_session_id: Source session identifier.
+        worktrees_map: Optional pre-resolved mapping of session id →
+            worktree path (used by tests; production resolves via the
+            filesystem convention).
+
+    Returns:
+        Existing directory for the parent worktree.
+    """
+    if worktrees_map and parent_session_id in worktrees_map:
+        return worktrees_map[parent_session_id]
+    candidate = repo_root / _WORKTREE_BASE_REL / parent_session_id
+    if candidate.is_dir():
+        return candidate
+    return repo_root
+
+
+def _git_head_in(path: Path) -> str:
+    """Return the HEAD commit SHA visible from ``path`` or empty on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("git rev-parse failed in %s: %s", path, exc)
+        return ""
+    if result.returncode != 0:
+        logger.debug("git rev-parse exited %d in %s: %s", result.returncode, path, result.stderr.strip())
+        return ""
+    return result.stdout.strip()
+
+
+def _git_current_branch(path: Path) -> str:
+    """Return the current branch of the worktree at ``path`` (empty on detached HEAD)."""
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            cwd=path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("git symbolic-ref failed in %s: %s", path, exc)
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _build_fork_branch_name(parent_branch: str, fork_session_id: str) -> str:
+    """Construct a git branch name for the fork.
+
+    The branch name encodes both lineage (parent suffix when available)
+    and the fork session id so it is greppable from ``git branch``.
+
+    Args:
+        parent_branch: Parent branch name (may be empty).
+        fork_session_id: Newly-generated fork session id.
+
+    Returns:
+        Git-safe branch name.
+    """
+    base = parent_branch.replace("/", "-") if parent_branch else "session"
+    return f"{_FORK_BRANCH_PREFIX}/{base}/{fork_session_id}"
+
+
+def _clone_session_snapshot(
+    parent_session: RunSession,
+    fork_session_id: str,
+    target_sessions_dir: Path,
+    *,
+    fork_label: str,
+    parent_session_id: str,
+    fork_branch: str,
+    fork_commit: str,
+) -> Path:
+    """Write the parent session snapshot into the fork worktree.
+
+    The snapshot keeps the *exact* task list (including ``status`` so
+    in-progress tasks remain in-progress in the fork) and stamps fork
+    lineage metadata under ``fork``.  We deliberately do **not** mutate
+    ``run_seed`` or ``goal`` — operators want the fork to start from
+    the same planning context.
+
+    Args:
+        parent_session: Loaded parent session.
+        fork_session_id: New session id for the fork.
+        target_sessions_dir: Sessions directory inside the fork
+            worktree.
+        fork_label: Original (unsanitised) label for audit purposes.
+        parent_session_id: Source session id (preserved for lineage).
+        fork_branch: Git branch the fork was created on.
+        fork_commit: Commit the fork branched from.
+
+    Returns:
+        Filesystem path of the written snapshot JSON.
+    """
+    target_sessions_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = target_sessions_dir / f"{fork_session_id}.json"
+
+    payload: dict[str, object] = {
+        "session_id": fork_session_id,
+        "goal": parent_session.goal,
+        "run_seed": parent_session.run_seed,
+        "tasks": parent_session.tasks,
+        "routing_decisions": parent_session.routing_decisions,
+        "git_sha": fork_commit or parent_session.git_sha,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "bernstein_version": parent_session.bernstein_version,
+        "fork": {
+            "parent_session_id": parent_session_id,
+            "label": fork_label,
+            "branch": fork_branch,
+            "branched_from_commit": fork_commit,
+        },
+    }
+    write_atomic_json(snapshot_path, payload, indent=2)
+    return snapshot_path
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def fork_session(
+    parent_session_id: str,
+    fork_label: str = "",
+    *,
+    repo_root: Path | None = None,
+    worktrees_map: Mapping[str, Path] | None = None,
+) -> SessionFork:
+    """Fork a recorded session into a sibling git worktree.
+
+    Steps:
+
+    1. Load the parent session JSON from ``<repo_root>/.sdd/runtime/sessions``.
+    2. Resolve the parent's worktree (per-session if it exists, otherwise
+       ``repo_root``) and capture its current commit + branch.
+    3. Allocate a fresh fork session id and a sibling worktree path under
+       ``<repo_root>/.sdd/worktrees/<fork_session_id>``.
+    4. Run ``git worktree add -b <fork_branch>`` so the fork starts from
+       the parent's current commit.
+    5. Clone the parent session JSON into the fork worktree's sessions
+       directory, preserving every task and its current ``status`` so
+       in-progress tasks remain in-progress in the fork.
+
+    The function fails fast (no partial state) when the parent session
+    cannot be loaded, the fork worktree path already exists, or the git
+    worktree command fails.  No cleanup of partial state is required
+    because the fork worktree is the only side-effect and it is created
+    as the very last step.
+
+    Args:
+        parent_session_id: Identifier of the source session.
+        fork_label: Optional human-readable label that becomes part of
+            the fork session id and branch name.
+        repo_root: Repository root.  Defaults to ``Path.cwd()``.
+        worktrees_map: Optional explicit mapping of session id →
+            worktree path.  Useful for tests; production discovers
+            worktrees via the filesystem convention.
+
+    Returns:
+        Populated :class:`SessionFork` describing the new fork.
+
+    Raises:
+        SessionForkError: When the parent session cannot be loaded or
+            the worktree creation fails.
+    """
+    if not parent_session_id:
+        raise SessionForkError("parent_session_id must not be empty")
+
+    repo_root = (repo_root or Path.cwd()).resolve()
+    if not repo_root.is_dir():
+        raise SessionForkError(f"repo_root does not exist: {repo_root}")
+
+    label_slug = _slugify_label(fork_label)
+    fork_session_id = _generate_fork_session_id(label_slug)
+
+    sessions_dir = sessions_dir_for(repo_root)
+    try:
+        parent_session = RunSession.load(sessions_dir, parent_session_id)
+    except FileNotFoundError as exc:
+        raise SessionForkError(f"parent session not found: {parent_session_id}") from exc
+    except ValueError as exc:
+        raise SessionForkError(f"parent session unreadable: {exc}") from exc
+
+    parent_worktree = _resolve_session_worktree(repo_root, parent_session_id, worktrees_map)
+    fork_commit = _git_head_in(parent_worktree)
+    if not fork_commit:
+        raise SessionForkError(
+            f"could not resolve git HEAD for parent worktree {parent_worktree}; "
+            "is this a git repository?"
+        )
+
+    parent_branch = _git_current_branch(parent_worktree)
+    fork_branch = _build_fork_branch_name(parent_branch, fork_session_id)
+
+    fork_worktree = repo_root / _WORKTREE_BASE_REL / fork_session_id
+    if fork_worktree.exists():
+        raise SessionForkError(f"fork worktree path already exists: {fork_worktree}")
+    fork_worktree.parent.mkdir(parents=True, exist_ok=True)
+
+    # Branch directly from the parent's current commit so the fork is
+    # bit-identical at creation time.  Using the commit SHA (rather than
+    # parent_branch) avoids race conditions with a still-running parent
+    # that could advance the branch between read and worktree-add.
+    result = worktree_add_from_commit(
+        repo_root=repo_root,
+        path=fork_worktree,
+        branch=fork_branch,
+        commit=fork_commit,
+    )
+    if not result.ok:
+        stderr = (result.stderr or "").strip()
+        raise SessionForkError(
+            f"git worktree add failed for fork '{fork_session_id}': {stderr or result.stdout!r}"
+        )
+
+    snapshot_path = _clone_session_snapshot(
+        parent_session=parent_session,
+        fork_session_id=fork_session_id,
+        target_sessions_dir=sessions_dir_for(fork_worktree),
+        fork_label=fork_label,
+        parent_session_id=parent_session_id,
+        fork_branch=fork_branch,
+        fork_commit=fork_commit,
+    )
+
+    fork = SessionFork(
+        parent_session_id=parent_session_id,
+        fork_session_id=fork_session_id,
+        parent_branch=parent_branch,
+        fork_branch=fork_branch,
+        parent_worktree=parent_worktree,
+        fork_worktree=fork_worktree,
+        snapshot_path=snapshot_path,
+        fork_commit=fork_commit,
+    )
+    logger.info(
+        "Forked session %s -> %s (branch=%s commit=%s)",
+        parent_session_id,
+        fork_session_id,
+        fork_branch,
+        fork_commit[:12],
+    )
+    return fork
+
+
+# ---------------------------------------------------------------------------
+# Thin git wrappers
+# ---------------------------------------------------------------------------
+
+
+def worktree_add_from_commit(
+    repo_root: Path,
+    path: Path,
+    branch: str,
+    commit: str,
+):  # type: ignore[no-untyped-def]  # GitResult typing kept lazy to avoid circular imports
+    """Create a worktree at ``path`` on a new branch starting from ``commit``.
+
+    The shared :func:`bernstein.core.git.git_pr.worktree_add` helper
+    starts the branch from the current HEAD; for fork semantics we need
+    to pin the start point to the parent's commit explicitly so a
+    racing parent cannot influence the fork's base.
+
+    Args:
+        repo_root: Repository root.
+        path: Filesystem path for the new worktree.
+        branch: New branch name.
+        commit: Start commit (full SHA preferred).
+
+    Returns:
+        ``GitResult`` from :func:`bernstein.core.git.git_basic.run_git`.
+    """
+    from bernstein.core.git.git_basic import run_git
+
+    return run_git(
+        ["worktree", "add", str(path), "-b", branch, commit],
+        repo_root,
+        timeout=30,
+    )
+
+
+def result_ok(result: object) -> bool:
+    """Return whether a ``GitResult``-like object has ``returncode == 0``.
+
+    Tests substitute a lightweight stub for ``run_git``; tolerating an
+    object with just ``returncode`` keeps the contract loose without
+    importing the concrete dataclass at module load time.
+    """
+    return bool(getattr(result, "ok", getattr(result, "returncode", 1) == 0))
+
+
+# Public re-exports — keep ``worktree_add`` referenced so the import is
+# not pruned by unused-import linters when only the helper is consumed
+# in production.
+_ = worktree_add
+
+__all__ = [
+    "SessionFork",
+    "SessionForkError",
+    "fork_session",
+    "worktree_add_from_commit",
+]

--- a/src/bernstein/core/sessions/fork.py
+++ b/src/bernstein/core/sessions/fork.py
@@ -28,7 +28,6 @@ isolation guarantees the rest of the codebase relies on (T481, T580).
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 import secrets
@@ -351,8 +350,7 @@ def fork_session(
     fork_commit = _git_head_in(parent_worktree)
     if not fork_commit:
         raise SessionForkError(
-            f"could not resolve git HEAD for parent worktree {parent_worktree}; "
-            "is this a git repository?"
+            f"could not resolve git HEAD for parent worktree {parent_worktree}; is this a git repository?"
         )
 
     parent_branch = _git_current_branch(parent_worktree)
@@ -375,9 +373,7 @@ def fork_session(
     )
     if not result.ok:
         stderr = (result.stderr or "").strip()
-        raise SessionForkError(
-            f"git worktree add failed for fork '{fork_session_id}': {stderr or result.stdout!r}"
-        )
+        raise SessionForkError(f"git worktree add failed for fork '{fork_session_id}': {stderr or result.stdout!r}")
 
     snapshot_path = _clone_session_snapshot(
         parent_session=parent_session,
@@ -444,21 +440,6 @@ def worktree_add_from_commit(
         timeout=30,
     )
 
-
-def result_ok(result: object) -> bool:
-    """Return whether a ``GitResult``-like object has ``returncode == 0``.
-
-    Tests substitute a lightweight stub for ``run_git``; tolerating an
-    object with just ``returncode`` keeps the contract loose without
-    importing the concrete dataclass at module load time.
-    """
-    return bool(getattr(result, "ok", getattr(result, "returncode", 1) == 0))
-
-
-# Public re-exports — keep ``worktree_add`` referenced so the import is
-# not pruned by unused-import linters when only the helper is consumed
-# in production.
-_ = worktree_add
 
 __all__ = [
     "SessionFork",

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -190,6 +190,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         # Bughunt 2026-05-13 release wave
         "adapters",
         "analyze",
+        # Recorded run-session inspection + fork (#1222)
+        "session",
     }
 )
 

--- a/tests/unit/test_session_fork.py
+++ b/tests/unit/test_session_fork.py
@@ -1,0 +1,296 @@
+"""Tests for ``bernstein.core.sessions.fork`` (#1222).
+
+These cover the snapshot-based fork primitive end-to-end against a real
+git repository created in ``tmp_path``.  We exercise:
+
+* successful fork → sibling worktree on a derived branch, snapshot written
+* fork-id and branch-name slugification with awkward labels
+* error paths: missing parent session, unknown id, non-git ``repo_root``,
+  and pre-existing fork worktree directory
+* CLI ``bernstein session fork`` happy path + JSON output
+
+The tests avoid mocking subprocess.  Initialising a small temp repo is
+cheaper than maintaining a fake-git layer and exercises the real worktree
+plumbing the production code relies on.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.session_cmd import session_group
+from bernstein.core.orchestration.run_session import RunSession, sessions_dir_for
+from bernstein.core.sessions.fork import (
+    SessionFork,
+    SessionForkError,
+    _build_fork_branch_name,
+    _slugify_label,
+    fork_session,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Initialise an empty git repository with one commit."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    (root / "README.md").write_text("# repo\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-q", "-m", "initial")
+    return root
+
+
+@pytest.fixture
+def parent_session(repo: Path) -> RunSession:
+    """Create + persist a parent run session inside *repo*."""
+    sdir = sessions_dir_for(repo)
+    sdir.mkdir(parents=True, exist_ok=True)
+    session = RunSession.create(goal="build a feature", run_seed=42)
+    session.tasks = [
+        {"id": "t-1", "role": "backend", "title": "implement", "status": "in_progress"},
+        {"id": "t-2", "role": "qa", "title": "verify", "status": "pending"},
+    ]
+    session.routing_decisions = {"t-1": "sonnet"}
+    session.save(sdir)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSlugify:
+    def test_keeps_safe_chars(self) -> None:
+        assert _slugify_label("use-yaml.v1_2") == "use-yaml.v1_2"
+
+    def test_replaces_unsafe_with_dash(self) -> None:
+        assert _slugify_label("try yaml not json!") == "try-yaml-not-json"
+
+    def test_truncates_long_labels(self) -> None:
+        out = _slugify_label("a" * 200)
+        assert len(out) == 32
+        assert set(out) == {"a"}
+
+    def test_strips_leading_trailing_separators(self) -> None:
+        assert _slugify_label("---foo---") == "foo"
+
+    def test_empty_string(self) -> None:
+        assert _slugify_label("") == ""
+
+
+class TestBranchNameBuilder:
+    def test_parent_branch_with_slash(self) -> None:
+        name = _build_fork_branch_name("feature/foo", "fork-x-20260101-aaa")
+        assert name == "fork/feature-foo/fork-x-20260101-aaa"
+
+    def test_detached_parent_falls_back_to_session(self) -> None:
+        name = _build_fork_branch_name("", "fork-20260101-bbb")
+        assert name == "fork/session/fork-20260101-bbb"
+
+
+# ---------------------------------------------------------------------------
+# fork_session — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestForkSessionHappyPath:
+    def test_creates_sibling_worktree_and_snapshot(self, repo: Path, parent_session: RunSession) -> None:
+        fork = fork_session(
+            parent_session_id=parent_session.session_id,
+            fork_label="use yaml",
+            repo_root=repo,
+        )
+        # Structural checks on the returned descriptor.
+        assert isinstance(fork, SessionFork)
+        assert fork.parent_session_id == parent_session.session_id
+        assert fork.fork_session_id.startswith("fork-use-yaml-")
+        assert fork.fork_branch.startswith("fork/main/")
+        assert fork.fork_worktree.is_dir()
+        assert fork.fork_worktree.parent.name == "worktrees"
+        # The fork worktree is on the new branch we asked for.
+        head_branch = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            cwd=fork.fork_worktree,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head_branch == fork.fork_branch
+        # And it branched from the parent's commit.
+        head_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=fork.fork_worktree,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert head_sha == fork.fork_commit
+        # Parent session file is preserved verbatim, fork snapshot lives
+        # inside the fork worktree's sessions directory.
+        assert fork.snapshot_path.is_file()
+        assert fork.snapshot_path.parent == sessions_dir_for(fork.fork_worktree)
+
+    def test_snapshot_preserves_tasks_and_lineage_metadata(self, repo: Path, parent_session: RunSession) -> None:
+        fork = fork_session(
+            parent_session_id=parent_session.session_id,
+            fork_label="alt",
+            repo_root=repo,
+        )
+        payload = json.loads(fork.snapshot_path.read_text(encoding="utf-8"))
+        assert payload["session_id"] == fork.fork_session_id
+        assert payload["goal"] == parent_session.goal
+        assert payload["run_seed"] == parent_session.run_seed
+        assert payload["tasks"] == parent_session.tasks
+        assert payload["routing_decisions"] == parent_session.routing_decisions
+        lineage = payload["fork"]
+        assert lineage["parent_session_id"] == parent_session.session_id
+        assert lineage["label"] == "alt"
+        assert lineage["branch"] == fork.fork_branch
+        assert lineage["branched_from_commit"] == fork.fork_commit
+
+    def test_to_dict_serialises_paths_as_strings(self, repo: Path, parent_session: RunSession) -> None:
+        fork = fork_session(
+            parent_session_id=parent_session.session_id,
+            repo_root=repo,
+        )
+        as_dict = fork.to_dict()
+        assert isinstance(as_dict["fork_worktree"], str)
+        assert isinstance(as_dict["parent_worktree"], str)
+        assert isinstance(as_dict["snapshot_path"], str)
+        # Round-trips through JSON.
+        json.dumps(as_dict)
+
+    def test_empty_label_omitted_from_id(self, repo: Path, parent_session: RunSession) -> None:
+        fork = fork_session(
+            parent_session_id=parent_session.session_id,
+            fork_label="",
+            repo_root=repo,
+        )
+        assert fork.fork_session_id.startswith("fork-")
+        assert "fork--" not in fork.fork_session_id
+
+    def test_parent_session_file_untouched(self, repo: Path, parent_session: RunSession) -> None:
+        parent_path = sessions_dir_for(repo) / f"{parent_session.session_id}.json"
+        before = parent_path.read_text(encoding="utf-8")
+        fork_session(
+            parent_session_id=parent_session.session_id,
+            repo_root=repo,
+        )
+        assert parent_path.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# fork_session — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestForkSessionErrors:
+    def test_empty_parent_id_rejected(self, repo: Path) -> None:
+        with pytest.raises(SessionForkError, match="parent_session_id"):
+            fork_session(parent_session_id="", repo_root=repo)
+
+    def test_unknown_parent_id_rejected(self, repo: Path) -> None:
+        with pytest.raises(SessionForkError, match="parent session not found"):
+            fork_session(parent_session_id="does-not-exist", repo_root=repo)
+
+    def test_non_git_repo_root_rejected(self, tmp_path: Path, parent_session: RunSession) -> None:
+        # Point at a fresh non-git tmp_path so the HEAD lookup fails even
+        # though the parent session JSON loads fine.
+        bare = tmp_path / "not-a-repo"
+        bare.mkdir()
+        parent_session.save(sessions_dir_for(bare))
+        with pytest.raises(SessionForkError, match="git HEAD"):
+            fork_session(parent_session_id=parent_session.session_id, repo_root=bare)
+
+    def test_missing_repo_root_rejected(self, tmp_path: Path) -> None:
+        with pytest.raises(SessionForkError, match="repo_root"):
+            fork_session(
+                parent_session_id="any",
+                repo_root=tmp_path / "missing",
+            )
+
+    def test_existing_fork_worktree_rejected(
+        self, repo: Path, parent_session: RunSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the fork worktree path to land somewhere we've pre-created
+        # by stubbing the id generator to a known value.
+        from bernstein.core.sessions import fork as fork_mod
+
+        monkeypatch.setattr(fork_mod, "_generate_fork_session_id", lambda _label: "fork-fixed")
+        target = repo / ".sdd" / "worktrees" / "fork-fixed"
+        target.mkdir(parents=True)
+        with pytest.raises(SessionForkError, match="worktree path already exists"):
+            fork_session(
+                parent_session_id=parent_session.session_id,
+                repo_root=repo,
+            )
+
+    def test_two_forks_get_distinct_branches(self, repo: Path, parent_session: RunSession) -> None:
+        a = fork_session(parent_session_id=parent_session.session_id, repo_root=repo)
+        b = fork_session(parent_session_id=parent_session.session_id, repo_root=repo)
+        assert a.fork_session_id != b.fork_session_id
+        assert a.fork_branch != b.fork_branch
+        assert a.fork_worktree != b.fork_worktree
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — ``bernstein session fork``
+# ---------------------------------------------------------------------------
+
+
+class TestSessionForkCLI:
+    def test_cli_happy_path_human(
+        self, repo: Path, parent_session: RunSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(repo)
+        runner = CliRunner()
+        result = runner.invoke(
+            session_group,
+            ["fork", parent_session.session_id, "--label", "alt-path"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Forked session" in result.output
+        assert parent_session.session_id in result.output
+
+    def test_cli_json_output(self, repo: Path, parent_session: RunSession, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(repo)
+        runner = CliRunner()
+        result = runner.invoke(
+            session_group,
+            ["fork", parent_session.session_id, "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["parent_session_id"] == parent_session.session_id
+        assert payload["fork_session_id"].startswith("fork-")
+        assert payload["fork_branch"].startswith("fork/")
+
+    def test_cli_unknown_parent_exits_nonzero(self, repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(repo)
+        runner = CliRunner()
+        result = runner.invoke(session_group, ["fork", "does-not-exist"])
+        assert result.exit_code == 1
+        assert "Fork failed" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

- Adds `bernstein session fork <session_id>` (#1222): clones a recorded run-session into a freshly-allocated session id on a sibling git worktree branched from the parent's HEAD commit. Parent stays untouched.
- Fixes a `NameError` import bug in the paused checkpoint (`fork.py` referenced an unimported `worktree_add` at module load) and wires the previously-orphaned `session` group into the top-level CLI.
- 21 new unit tests in `tests/unit/test_session_fork.py` exercise the primitive end-to-end against a real temp git repo plus the CLI surface.

## What ships

| Layer | Change |
|---|---|
| `src/bernstein/core/sessions/fork.py` | Drop dead `worktree_add` reference + `result_ok` helper. Snapshot-based fork primitive (was already in WIP). |
| `src/bernstein/cli/commands/session_cmd.py` | New `fork` subcommand with `--label` and `--json` flags. |
| `src/bernstein/cli/main.py` | Register `session_group` under `cli` (was previously unreachable). |
| `tests/unit/test_session_fork.py` | New: slugifier, branch builder, happy-path, error paths, CLI. |

## Scope notes

This lands the *snapshot-based* slice of #1222 (sibling worktree + cloned task state + lineage metadata). The deeper "pause a live agent, replicate streaming conversation, auto-merge winner" pieces are deferred — the primitive lets an operator hand-replay the fork via `bernstein session replay`. Branch convention `fork/<parent_branch>/<fork_session_id>` keeps lineage readable from `git branch`.

## Test plan

- [x] `uv run pytest tests/unit/test_session_fork.py` — 21 passed
- [x] `uv run pytest tests/unit/test_session*.py` — 73 passed (no regression in adjacent suites)
- [x] `uv run ruff check` on touched files — clean
- [x] `uv run ruff format --check` on touched files — clean
- [x] `bernstein session fork --help` reachable
- [ ] CI green on PR

Closes #1222