### PR TITLE
feat(observability): OTLP exporter with GenAI semantic conventions

### DIFF
--- a/bernstein.yaml
+++ b/bernstein.yaml
@@ -41,3 +41,12 @@ context_files:
 - CLAUDE.md
 agency:
   path: ${BERNSTEIN_AGENCY_PATH:-./external/agency-agents}  # replace with your agency-agents clone path
+# OTLP exporter with OpenTelemetry GenAI semantic conventions.
+# Spans are emitted only when ``endpoint`` is set (or the BERNSTEIN_OTEL_ENDPOINT
+# env var is exported); otherwise Bernstein keeps writing local JSONL traces.
+# Install the optional extras with: pip install 'bernstein[otel]'.
+observability:
+  otlp:
+    endpoint: ${BERNSTEIN_OTEL_ENDPOINT:-}        # e.g. http://otel-collector:4317
+    service_name: ${BERNSTEIN_OTEL_SERVICE_NAME:-bernstein}
+    insecure: true                                # skip TLS verify on local collectors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,14 @@ eval = ["datasets>=4.8.5", "huggingface-hub>=0.24"]
 #   pip install 'bernstein[gui]'
 # then: bernstein gui serve
 gui = ["sse-starlette>=2.1.0"]
+# OpenTelemetry OTLP/gRPC exporter for GenAI semantic conventions
+# (src/bernstein/core/observability/otlp_exporter.py). The exporter is a
+# no-op when this extra is absent or BERNSTEIN_OTEL_ENDPOINT is unset, so
+# minimal installs do not pay the gRPC import cost. Enable with:
+#   pip install 'bernstein[otel]'
+otel = [
+    "opentelemetry-exporter-otlp-proto-grpc>=1.41.1",
+]
 
 [project.scripts]
 bernstein = "bernstein.cli.main:cli"

--- a/src/bernstein/core/observability/otlp_exporter.py
+++ b/src/bernstein/core/observability/otlp_exporter.py
@@ -1,0 +1,379 @@
+"""OTLP exporter with OpenTelemetry GenAI semantic conventions.
+
+Operators running Bernstein at scale already have an observability stack
+(Datadog, Honeycomb, Grafana / Tempo, Elastic, ...).  The default JSONL
+writer under ``.sdd/traces/`` is great for local debugging but invisible
+to existing dashboards.
+
+This module emits spans over OTLP/gRPC using the OpenTelemetry GenAI
+semantic conventions so operator tooling can recognise Bernstein traffic
+without bespoke parsing.  When the ``BERNSTEIN_OTEL_ENDPOINT`` env var is
+unset (or the optional ``opentelemetry-exporter-otlp-proto-grpc`` package
+is not installed) every method becomes a no-op -- the local JSONL store
+remains the default destination.
+
+Usage::
+
+    from bernstein.core.observability.otlp_exporter import (
+        GenAIOTLPExporter,
+        get_default_exporter,
+    )
+
+    exporter = get_default_exporter()
+    with exporter.start_genai_span(
+        operation="chat",
+        system="anthropic",
+        model="claude-sonnet-4-6",
+    ) as span:
+        ...  # call the model
+        exporter.record_usage(span, prompt_tokens=128, completion_tokens=64)
+
+Pin points:
+
+* Environment variable: ``BERNSTEIN_OTEL_ENDPOINT`` (e.g. ``http://otel-collector:4317``)
+* Optional service-name override: ``BERNSTEIN_OTEL_SERVICE_NAME`` (default ``bernstein``)
+* Optional install extra: ``pip install 'bernstein[otel]'``
+
+Semantic conventions covered (`OTel GenAI <https://opentelemetry.io/docs/specs/semconv/gen-ai/>`__):
+
+* ``gen_ai.system``
+* ``gen_ai.request.model``
+* ``gen_ai.operation.name``
+* ``gen_ai.usage.prompt_tokens``
+* ``gen_ai.usage.completion_tokens``
+* ``gen_ai.tool.name``
+* ``gen_ai.tool.call.id``
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+
+#: Environment variable that toggles the OTLP exporter on.  When unset, the
+#: exporter is a no-op so default installs do not require the optional
+#: ``opentelemetry-exporter-otlp-proto-grpc`` package.
+OTEL_ENDPOINT_ENV = "BERNSTEIN_OTEL_ENDPOINT"
+
+#: Optional override for the ``service.name`` resource attribute.
+OTEL_SERVICE_NAME_ENV = "BERNSTEIN_OTEL_SERVICE_NAME"
+
+#: Default service name applied to every emitted span when no override is set.
+DEFAULT_SERVICE_NAME = "bernstein"
+
+#: Default GenAI operation name -- ``chat`` covers most adapter calls.
+DEFAULT_OPERATION = "chat"
+
+# GenAI semantic-convention attribute names.  Re-exported as module-level
+# constants so adapters can apply them without a hard dep on the OTel SDK.
+ATTR_GEN_AI_SYSTEM = "gen_ai.system"
+ATTR_GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+ATTR_GEN_AI_OPERATION_NAME = "gen_ai.operation.name"
+ATTR_GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
+ATTR_GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
+ATTR_GEN_AI_TOOL_NAME = "gen_ai.tool.name"
+ATTR_GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OTLPExporterConfig:
+    """Static configuration for :class:`GenAIOTLPExporter`.
+
+    Attributes:
+        endpoint: OTLP/gRPC collector URL (e.g. ``http://otel-collector:4317``).
+            ``None`` disables export entirely.
+        service_name: ``service.name`` resource attribute.
+        insecure: Skip TLS verification on gRPC channel.
+        headers: Extra gRPC metadata forwarded to the collector.
+        resource_attributes: Static resource attributes merged with the
+            default ``service.name``.
+    """
+
+    endpoint: str | None
+    service_name: str = DEFAULT_SERVICE_NAME
+    insecure: bool = True
+    headers: dict[str, str] = field(default_factory=dict[str, str])
+    resource_attributes: dict[str, str] = field(default_factory=dict[str, str])
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> OTLPExporterConfig:
+        """Build a config from environment variables.
+
+        Args:
+            env: Mapping to read from.  Defaults to ``os.environ``.
+
+        Returns:
+            A new :class:`OTLPExporterConfig`.  ``endpoint`` will be ``None``
+            (i.e. exporter disabled) when ``BERNSTEIN_OTEL_ENDPOINT`` is not
+            set or is empty.
+        """
+        source = env if env is not None else os.environ
+        raw_endpoint = source.get(OTEL_ENDPOINT_ENV) or None
+        service_name = source.get(OTEL_SERVICE_NAME_ENV) or DEFAULT_SERVICE_NAME
+        return cls(endpoint=raw_endpoint, service_name=service_name)
+
+
+# ---------------------------------------------------------------------------
+# Exporter
+# ---------------------------------------------------------------------------
+
+
+class GenAIOTLPExporter:
+    """OTLP/gRPC exporter that tags spans with GenAI semantic conventions.
+
+    The exporter is fail-safe: when ``config.endpoint`` is ``None`` or the
+    optional ``opentelemetry-exporter-otlp-proto-grpc`` package is missing,
+    every public method is a no-op.  Callers do not need to special-case
+    "telemetry disabled" -- they can always invoke ``start_genai_span``
+    and friends.
+
+    Args:
+        config: Static configuration.  Use :meth:`OTLPExporterConfig.from_env`
+            for the standard ``BERNSTEIN_OTEL_ENDPOINT`` flow.
+        tracer_provider: Optional pre-built tracer provider.  When supplied,
+            the exporter wires its span processor onto this provider instead
+            of creating a new one.  Used by the InMemorySpanExporter test
+            harness.
+    """
+
+    def __init__(
+        self,
+        config: OTLPExporterConfig | None = None,
+        *,
+        tracer_provider: Any | None = None,
+    ) -> None:
+        self._config = config or OTLPExporterConfig.from_env()
+        self._tracer: Any | None = None
+        self._provider: Any | None = tracer_provider
+        self._enabled = False
+
+        if self._config.endpoint is None and tracer_provider is None:
+            # Disabled — keep everything as None so calls become no-ops.
+            return
+
+        self._enabled = self._init_tracer()
+
+    # ------------------------------------------------------------------ API
+
+    @property
+    def enabled(self) -> bool:
+        """Whether the exporter has an active OTLP destination."""
+        return self._enabled
+
+    @property
+    def config(self) -> OTLPExporterConfig:
+        """Effective configuration (after env-var resolution)."""
+        return self._config
+
+    @contextlib.contextmanager
+    def start_genai_span(
+        self,
+        *,
+        operation: str = DEFAULT_OPERATION,
+        system: str,
+        model: str,
+        tool_name: str | None = None,
+        tool_call_id: str | None = None,
+        extra_attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[Any]:
+        """Open a span tagged with the GenAI semantic conventions.
+
+        Args:
+            operation: ``gen_ai.operation.name``.  Defaults to ``"chat"``.
+            system: ``gen_ai.system`` (e.g. ``"anthropic"``, ``"openai"``).
+            model: ``gen_ai.request.model`` (e.g. ``"claude-sonnet-4-6"``).
+            tool_name: Optional ``gen_ai.tool.name`` when the span covers
+                a tool invocation.
+            tool_call_id: Optional ``gen_ai.tool.call.id``.
+            extra_attributes: Additional attributes merged on top of the
+                semantic-convention ones.  Useful for ``task.id`` and other
+                Bernstein-specific tags.
+
+        Yields:
+            The underlying OTel span object, or ``None`` when the exporter
+            is disabled.  Tests should not depend on the concrete span type.
+        """
+        if not self._enabled or self._tracer is None:
+            yield None
+            return
+
+        attributes: dict[str, Any] = {
+            ATTR_GEN_AI_OPERATION_NAME: operation,
+            ATTR_GEN_AI_SYSTEM: system,
+            ATTR_GEN_AI_REQUEST_MODEL: model,
+        }
+        if tool_name is not None:
+            attributes[ATTR_GEN_AI_TOOL_NAME] = tool_name
+        if tool_call_id is not None:
+            attributes[ATTR_GEN_AI_TOOL_CALL_ID] = tool_call_id
+        if extra_attributes:
+            attributes.update(extra_attributes)
+
+        span_name = f"gen_ai.{operation}"
+        with self._tracer.start_as_current_span(span_name, attributes=attributes) as span:
+            yield span
+
+    def record_usage(
+        self,
+        span: Any,
+        *,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+    ) -> None:
+        """Attach token usage attributes to ``span``.
+
+        Args:
+            span: Span returned by :meth:`start_genai_span`.  ``None`` is
+                tolerated (exporter disabled path).
+            prompt_tokens: ``gen_ai.usage.prompt_tokens``.
+            completion_tokens: ``gen_ai.usage.completion_tokens``.
+        """
+        if span is None:
+            return
+        if prompt_tokens is not None:
+            span.set_attribute(ATTR_GEN_AI_USAGE_PROMPT_TOKENS, int(prompt_tokens))
+        if completion_tokens is not None:
+            span.set_attribute(ATTR_GEN_AI_USAGE_COMPLETION_TOKENS, int(completion_tokens))
+
+    def shutdown(self) -> None:
+        """Flush any in-flight spans and tear the provider down.
+
+        Safe to call on a disabled exporter.
+        """
+        provider = self._provider
+        if provider is None:
+            return
+        try:
+            provider.shutdown()
+        except Exception as exc:
+            logger.warning("OTLP exporter shutdown failed: %s", exc)
+
+    # ----------------------------------------------------------- Internals
+
+    def _init_tracer(self) -> bool:
+        """Wire the OTLP span processor onto a tracer provider.
+
+        Returns ``True`` when the tracer is ready and spans will be exported,
+        ``False`` when the optional OTel exporter dep is missing or
+        initialisation raises.  All failure paths log a single warning and
+        leave the exporter in a disabled-but-callable state.
+        """
+        try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.resources import Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        except ImportError:
+            logger.warning(
+                "OTLP exporter disabled — install 'bernstein[otel]' for "
+                "opentelemetry-sdk + opentelemetry-exporter-otlp-proto-grpc",
+            )
+            return False
+
+        try:
+            if self._provider is None:
+                resource_attrs: dict[str, str] = {"service.name": self._config.service_name}
+                resource_attrs.update(self._config.resource_attributes)
+                self._provider = TracerProvider(resource=Resource.create(resource_attrs))
+                # Register globally only when we created the provider ourselves.
+                # When the caller supplied one (tests), they own the lifecycle.
+                trace.set_tracer_provider(self._provider)
+
+            # gRPC OTLP exporter is the optional extra.  When a tracer_provider
+            # was supplied by the caller and endpoint is unset (in-memory test
+            # path), skip the gRPC processor entirely.
+            if self._config.endpoint is not None:
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                    OTLPSpanExporter,
+                )
+
+                span_exporter = OTLPSpanExporter(
+                    endpoint=self._config.endpoint,
+                    insecure=self._config.insecure,
+                    headers=tuple(self._config.headers.items()) or None,
+                )
+                self._provider.add_span_processor(BatchSpanProcessor(span_exporter))
+
+            self._tracer = trace.get_tracer(self._config.service_name, tracer_provider=self._provider)
+        except ImportError:
+            logger.warning(
+                "OTLP gRPC exporter missing — install 'bernstein[otel]' to enable",
+            )
+            return False
+        except Exception as exc:
+            logger.warning("OTLP exporter init failed: %s", exc)
+            return False
+
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience
+# ---------------------------------------------------------------------------
+
+
+_default_exporter: GenAIOTLPExporter | None = None
+
+
+def get_default_exporter() -> GenAIOTLPExporter:
+    """Return the process-wide :class:`GenAIOTLPExporter`.
+
+    Lazily constructed from the environment on first call.  Operators who
+    need a custom config should instantiate :class:`GenAIOTLPExporter`
+    directly instead of mutating the default.
+
+    Returns:
+        The shared exporter instance.  Always callable; may be a no-op when
+        ``BERNSTEIN_OTEL_ENDPOINT`` is unset.
+    """
+    global _default_exporter
+    if _default_exporter is None:
+        _default_exporter = GenAIOTLPExporter()
+    return _default_exporter
+
+
+def reset_default_exporter() -> None:
+    """Drop the cached default exporter (test helper)."""
+    global _default_exporter
+    if _default_exporter is not None:
+        with contextlib.suppress(Exception):
+            _default_exporter.shutdown()
+    _default_exporter = None
+
+
+__all__ = [
+    "ATTR_GEN_AI_OPERATION_NAME",
+    "ATTR_GEN_AI_REQUEST_MODEL",
+    "ATTR_GEN_AI_SYSTEM",
+    "ATTR_GEN_AI_TOOL_CALL_ID",
+    "ATTR_GEN_AI_TOOL_NAME",
+    "ATTR_GEN_AI_USAGE_COMPLETION_TOKENS",
+    "ATTR_GEN_AI_USAGE_PROMPT_TOKENS",
+    "DEFAULT_OPERATION",
+    "DEFAULT_SERVICE_NAME",
+    "OTEL_ENDPOINT_ENV",
+    "OTEL_SERVICE_NAME_ENV",
+    "GenAIOTLPExporter",
+    "OTLPExporterConfig",
+    "get_default_exporter",
+    "reset_default_exporter",
+]

--- a/tests/unit/test_otlp_exporter.py
+++ b/tests/unit/test_otlp_exporter.py
@@ -1,0 +1,223 @@
+"""Tests for the OTLP exporter with GenAI semantic conventions.
+
+These tests use ``opentelemetry-sdk``'s :class:`InMemorySpanExporter` so
+they never touch the network.  The optional ``opentelemetry-exporter-otlp-
+proto-grpc`` package is exercised only via the env-var path, which is
+covered by patching the importable symbol.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from bernstein.core.observability.otlp_exporter import (
+    ATTR_GEN_AI_OPERATION_NAME,
+    ATTR_GEN_AI_REQUEST_MODEL,
+    ATTR_GEN_AI_SYSTEM,
+    ATTR_GEN_AI_TOOL_CALL_ID,
+    ATTR_GEN_AI_TOOL_NAME,
+    ATTR_GEN_AI_USAGE_COMPLETION_TOKENS,
+    ATTR_GEN_AI_USAGE_PROMPT_TOKENS,
+    DEFAULT_SERVICE_NAME,
+    OTEL_ENDPOINT_ENV,
+    OTEL_SERVICE_NAME_ENV,
+    GenAIOTLPExporter,
+    OTLPExporterConfig,
+    get_default_exporter,
+    reset_default_exporter,
+)
+
+
+@pytest.fixture
+def in_memory_provider() -> Iterator[tuple[TracerProvider, InMemorySpanExporter]]:
+    """Provide a fresh tracer provider wired to an in-memory exporter."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    try:
+        yield provider, exporter
+    finally:
+        provider.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def _clear_default_exporter() -> Iterator[None]:
+    """Ensure the singleton default exporter does not leak between tests."""
+    reset_default_exporter()
+    try:
+        yield
+    finally:
+        reset_default_exporter()
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_config_from_env_empty_returns_disabled() -> None:
+    """No env var means the config is disabled (endpoint is None)."""
+    cfg = OTLPExporterConfig.from_env({})
+    assert cfg.endpoint is None
+    assert cfg.service_name == DEFAULT_SERVICE_NAME
+
+
+def test_config_from_env_reads_endpoint_and_service_name() -> None:
+    cfg = OTLPExporterConfig.from_env(
+        {
+            OTEL_ENDPOINT_ENV: "http://otel-collector:4317",
+            OTEL_SERVICE_NAME_ENV: "bernstein-prod",
+        },
+    )
+    assert cfg.endpoint == "http://otel-collector:4317"
+    assert cfg.service_name == "bernstein-prod"
+
+
+def test_config_from_env_blank_endpoint_treated_as_unset() -> None:
+    """Empty string is intentionally treated as 'not configured'."""
+    cfg = OTLPExporterConfig.from_env({OTEL_ENDPOINT_ENV: ""})
+    assert cfg.endpoint is None
+
+
+# ---------------------------------------------------------------------------
+# No-op behaviour when endpoint is unset
+# ---------------------------------------------------------------------------
+
+
+def test_exporter_disabled_when_no_endpoint() -> None:
+    exporter = GenAIOTLPExporter(OTLPExporterConfig(endpoint=None))
+    assert exporter.enabled is False
+
+    # Disabled exporter must still be safe to call.
+    with exporter.start_genai_span(system="anthropic", model="claude-sonnet-4-6") as span:
+        assert span is None
+        exporter.record_usage(span, prompt_tokens=10, completion_tokens=5)
+    exporter.shutdown()  # idempotent on disabled
+
+
+def test_get_default_exporter_no_env_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OTEL_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv(OTEL_SERVICE_NAME_ENV, raising=False)
+    exporter = get_default_exporter()
+    assert exporter.enabled is False
+    # Same instance returned on subsequent calls.
+    assert get_default_exporter() is exporter
+
+
+# ---------------------------------------------------------------------------
+# GenAI semantic conventions on emitted spans
+# ---------------------------------------------------------------------------
+
+
+def test_span_contains_gen_ai_semantic_conventions(
+    in_memory_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    provider, exporter = in_memory_provider
+    otlp = GenAIOTLPExporter(
+        OTLPExporterConfig(endpoint=None, service_name="bernstein-test"),
+        tracer_provider=provider,
+    )
+    assert otlp.enabled is True
+
+    with otlp.start_genai_span(
+        operation="chat",
+        system="anthropic",
+        model="claude-sonnet-4-6",
+        tool_name="repo.search",
+        tool_call_id="call-123",
+        extra_attributes={"task.id": "task-007"},
+    ) as span:
+        assert span is not None
+        otlp.record_usage(span, prompt_tokens=128, completion_tokens=64)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    finished = spans[0]
+    assert finished.name == "gen_ai.chat"
+
+    attrs = dict(finished.attributes or {})
+    assert attrs[ATTR_GEN_AI_SYSTEM] == "anthropic"
+    assert attrs[ATTR_GEN_AI_REQUEST_MODEL] == "claude-sonnet-4-6"
+    assert attrs[ATTR_GEN_AI_OPERATION_NAME] == "chat"
+    assert attrs[ATTR_GEN_AI_TOOL_NAME] == "repo.search"
+    assert attrs[ATTR_GEN_AI_TOOL_CALL_ID] == "call-123"
+    assert attrs[ATTR_GEN_AI_USAGE_PROMPT_TOKENS] == 128
+    assert attrs[ATTR_GEN_AI_USAGE_COMPLETION_TOKENS] == 64
+    assert attrs["task.id"] == "task-007"
+
+
+def test_span_without_tool_attrs_omits_them(
+    in_memory_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    provider, exporter = in_memory_provider
+    otlp = GenAIOTLPExporter(
+        OTLPExporterConfig(endpoint=None),
+        tracer_provider=provider,
+    )
+    with otlp.start_genai_span(system="openai", model="gpt-4o-mini") as span:
+        assert span is not None
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = dict(spans[0].attributes or {})
+    assert ATTR_GEN_AI_TOOL_NAME not in attrs
+    assert ATTR_GEN_AI_TOOL_CALL_ID not in attrs
+    assert ATTR_GEN_AI_USAGE_PROMPT_TOKENS not in attrs
+
+
+def test_record_usage_with_only_prompt_tokens(
+    in_memory_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    """Recording one half of usage must not invent the other."""
+    provider, exporter = in_memory_provider
+    otlp = GenAIOTLPExporter(
+        OTLPExporterConfig(endpoint=None),
+        tracer_provider=provider,
+    )
+    with otlp.start_genai_span(system="anthropic", model="claude") as span:
+        otlp.record_usage(span, prompt_tokens=10)
+
+    attrs = dict(exporter.get_finished_spans()[0].attributes or {})
+    assert attrs[ATTR_GEN_AI_USAGE_PROMPT_TOKENS] == 10
+    assert ATTR_GEN_AI_USAGE_COMPLETION_TOKENS not in attrs
+
+
+def test_default_operation_is_chat(
+    in_memory_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    provider, exporter = in_memory_provider
+    otlp = GenAIOTLPExporter(OTLPExporterConfig(endpoint=None), tracer_provider=provider)
+    with otlp.start_genai_span(system="anthropic", model="claude"):
+        pass
+    attrs = dict(exporter.get_finished_spans()[0].attributes or {})
+    assert attrs[ATTR_GEN_AI_OPERATION_NAME] == "chat"
+
+
+# ---------------------------------------------------------------------------
+# Optional-dep guard
+# ---------------------------------------------------------------------------
+
+
+def test_missing_optional_grpc_extra_disables_exporter() -> None:
+    """When the gRPC OTLP package is missing, exporter falls back to no-op."""
+    import sys
+
+    real_module_name = "opentelemetry.exporter.otlp.proto.grpc.trace_exporter"
+    # Hide the gRPC OTLP module from a fresh import.
+    with patch.dict(sys.modules, {real_module_name: None}):
+        exporter = GenAIOTLPExporter(
+            OTLPExporterConfig(endpoint="http://collector:4317"),
+        )
+        # Even with an endpoint configured, the exporter must NOT raise --
+        # it should degrade to disabled.
+        assert exporter.enabled is False
+
+        # And remain callable.
+        with exporter.start_genai_span(system="anthropic", model="claude") as span:
+            assert span is None

--- a/uv.lock
+++ b/uv.lock
@@ -315,6 +315,9 @@ modal = [
 openai = [
     { name = "openai-agents" },
 ]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+]
 r2 = [
     { name = "boto3" },
 ]
@@ -383,6 +386,7 @@ requires-dist = [
     { name = "openai-agents", marker = "extra == 'openai'", specifier = ">=0.4.0" },
     { name = "opentelemetry-api", specifier = ">=1.41.1" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.41.1" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.41.1" },
     { name = "opentelemetry-sdk", specifier = ">=1.41.1" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
@@ -417,7 +421,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=4.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
-provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2", "telegram", "eval", "gui"]
+provides-extras = ["dev", "grpc", "k8s", "ml", "graphics", "openai", "docker", "e2b", "modal", "s3", "gcs", "azure", "r2", "telegram", "eval", "gui", "otel"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- New `src/bernstein/core/observability/otlp_exporter.py` ships a GenAI-aware OTLP/gRPC exporter that tags spans with the OpenTelemetry GenAI semantic conventions (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.operation.name`, `gen_ai.usage.prompt_tokens`, `gen_ai.usage.completion_tokens`, `gen_ai.tool.name`, `gen_ai.tool.call.id`).
- Fires when `BERNSTEIN_OTEL_ENDPOINT` is set (or `observability.otlp.endpoint` in `bernstein.yaml`); no-op otherwise -- the local `.sdd/traces/` JSONL writer stays the default destination.
- gRPC OTLP package is an optional extra (`pip install 'bernstein[otel]'`); a missing import degrades to disabled-but-callable instead of raising, so existing installs keep working.
- `bernstein.yaml` gains a small `observability.otlp` block documenting the env-var-driven config surface.

## Test plan

- [x] `uv run pytest tests/unit/test_otlp_exporter.py -x -q` (10 passed) -- uses `InMemorySpanExporter`, no network.
- [x] `uv run pytest tests/unit/test_telemetry.py -x -q` (15 passed) -- guard against regressions in the existing telemetry module.
- [x] `uv run ruff check src/ tests/unit/test_otlp_exporter.py` -- clean.
- [x] `uv run pyright src/bernstein/core/observability/otlp_exporter.py` -- 0 errors.

## Docs hooks

- Env var to advertise: `BERNSTEIN_OTEL_ENDPOINT` (optional `BERNSTEIN_OTEL_SERVICE_NAME`).
- Install extra: `pip install 'bernstein[otel]'`.

Closes #1317