### PR TITLE
feat(security): per-tool allowlist + fail-closed policy + read-only profile

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -239,6 +239,7 @@ def _propagate_env_flags(
     audit: bool,
     max_cost_usd: float | None = None,
     allow_paid: bool = False,
+    permission_profile: str | None = None,
 ) -> None:
     """Set environment variables so orchestrator subprocesses inherit CLI flags."""
     _flag_map: list[tuple[bool, str]] = [
@@ -260,6 +261,7 @@ def _propagate_env_flags(
         (container_image, "BERNSTEIN_CONTAINER_IMAGE"),
         (task_filter, "BERNSTEIN_TASK_FILTER"),
         (activity_log_path, "BERNSTEIN_ACTIVITY_LOG"),
+        (permission_profile, "BERNSTEIN_PERMISSION_PROFILE"),
     ]
     for val, key in _str_map:
         if val:
@@ -885,6 +887,21 @@ def exec_restart() -> None:
     ),
 )
 @click.option(
+    "--permission-profile",
+    "permission_profile",
+    default=None,
+    type=click.Choice(
+        ["read-only", "builder", "reviewer", "custom"],
+        case_sensitive=False,
+    ),
+    help=(
+        "Per-tool permission profile (roadmap #1318). 'read-only' = review/explore "
+        "agents only; 'builder' = write + shell on an allowlist; 'reviewer' = "
+        "read + diff only; 'custom' = honour [permissions.custom] in "
+        "bernstein.yaml/bernstein.toml. Off by default to preserve existing behaviour."
+    ),
+)
+@click.option(
     "--task",
     "-t",
     "task_filter",
@@ -947,6 +964,7 @@ def run(
     cprofile: bool = False,
     run_profile: str | None = None,
     allow_network: tuple[str, ...] = (),
+    permission_profile: str | None = None,
     task_filter: str | None = None,
     auto_pr: bool = False,
     activity_log_path: str | None = None,
@@ -1015,6 +1033,7 @@ def run(
         audit=audit,
         max_cost_usd=max_cost_usd,
         allow_paid=allow_paid,
+        permission_profile=permission_profile,
     )
 
     _install_network_policy(run_profile=run_profile, allow_network=allow_network)

--- a/src/bernstein/core/approval/gate.py
+++ b/src/bernstein/core/approval/gate.py
@@ -35,6 +35,13 @@ from bernstein.core.security.always_allow import (
     load_always_allow_rules,
 )
 from bernstein.core.security.guardrails import check_always_allow_tool
+from bernstein.core.security.permission_policy import (
+    PermissionProfile,
+    PolicyChecker,
+    ToolCall,
+    resolve_profile,
+)
+from bernstein.core.security.policy_engine import DecisionType
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +99,48 @@ def _always_allow_hit(
     return check_always_allow_tool(tool_name, tool_args, engine).matched
 
 
+def _policy_reject(
+    *,
+    session_id: str,
+    agent_role: str,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    workdir: Path | None,
+    profile: PermissionProfile | None = None,
+) -> ResolvedApproval | None:
+    """Run the per-tool permission policy ahead of the approval queue.
+
+    Returns a synthetic :class:`ResolvedApproval` carrying
+    :class:`ApprovalDecision.REJECT` when the active profile denies the
+    invocation. Returns ``None`` when there is no profile or when the
+    profile allows the call (i.e. continue with the legacy approval
+    flow). Denials are logged to the audit trail by
+    :class:`PolicyChecker`.
+    """
+    effective = profile if profile is not None else resolve_profile(workdir=workdir)
+    if effective is None:
+        return None
+
+    checker = PolicyChecker(effective)
+    call = ToolCall(
+        tool=tool_name,
+        path=tool_args.get("path") or tool_args.get("file_path"),
+        host=tool_args.get("host") or tool_args.get("url_host"),
+        shell_cmd=tool_args.get("command") or tool_args.get("shell_cmd"),
+        session_id=session_id,
+        actor=agent_role,
+        extra={"tool_args_keys": sorted(tool_args.keys())},
+    )
+    decision = checker.check_and_record(call, workdir=workdir)
+    if decision.type == DecisionType.DENY:
+        return ResolvedApproval(
+            approval_id=f"policy-deny:{effective.name}",
+            decision=ApprovalDecision.REJECT,
+            reason=decision.reason,
+        )
+    return None
+
+
 async def await_tool_call(
     *,
     session_id: str,
@@ -114,6 +163,19 @@ async def await_tool_call(
         ApprovalTimeoutError: When the TTL expires without an operator
             decision. The caller MUST treat this as a rejection.
     """
+    # Per-tool permission policy runs first — it must apply regardless
+    # of whether the interactive approval queue is on, so a fail-closed
+    # profile cannot be bypassed by disabling approvals.
+    policy_decision = _policy_reject(
+        session_id=session_id,
+        agent_role=agent_role,
+        tool_name=tool_name,
+        tool_args=tool_args,
+        workdir=workdir,
+    )
+    if policy_decision is not None:
+        return policy_decision
+
     cfg = config if config is not None else load_approval_config(workdir)
     if not cfg.interactive:
         return None

--- a/src/bernstein/core/security/permission_policy.py
+++ b/src/bernstein/core/security/permission_policy.py
@@ -1,0 +1,599 @@
+"""Per-tool allowlist + fail-closed permission policy (roadmap #1318).
+
+This module owns the *single* policy-checker for tool dispatch. Every
+adapter and approval gate call should funnel through :func:`check_tool_call`
+(or :class:`PolicyChecker` for callers that hold their own profile) so that
+denials surface consistently and land in the audit chain.
+
+The policy is configured declaratively under the ``permissions:`` block of
+``bernstein.yaml`` (or ``[permissions]`` / ``[permissions.<name>]`` in
+``bernstein.toml``). The operator picks a profile (``read-only``,
+``builder``, ``reviewer``, ``custom``) and the checker enforces a
+fail-closed default for that profile.
+
+Design notes
+------------
+
+* **Fail-closed by default.** Built-in profiles default to ``deny``; an
+  empty allow_tools list means *nothing* is allowed.
+* **No global side-effects unless opted in.** When no profile is
+  configured (the historical default) the checker returns ``ALLOW`` so
+  existing runs are unaffected.
+* **One policy, one denial path.** Denials are emitted as
+  :class:`PermissionDecision` objects of type :class:`DecisionType.DENY`
+  so they compose cleanly with :class:`DecisionGraph`.
+* **Auditability.** :meth:`PolicyChecker.check_and_record` writes a
+  ``{tool, path/host, profile, reason}`` record to the daily audit chain
+  *and* to a lightweight JSONL trail under
+  ``.sdd/runtime/permission_denials.jsonl`` so dashboards can tail it.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from bernstein.core.security.policy_engine import (
+    DecisionType,
+    PermissionDecision,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+logger = logging.getLogger(__name__)
+
+# Environment variable consumed by orchestrator subprocesses so the
+# operator's ``--permission-profile`` selection survives across spawn.
+ENV_PROFILE = "BERNSTEIN_PERMISSION_PROFILE"
+
+#: Profile name reserved for the inline ``[permissions.<name>]`` section.
+PROFILE_CUSTOM = "custom"
+PROFILE_READ_ONLY = "read-only"
+PROFILE_BUILDER = "builder"
+PROFILE_REVIEWER = "reviewer"
+
+BUILTIN_PROFILE_NAMES: tuple[str, ...] = (
+    PROFILE_READ_ONLY,
+    PROFILE_BUILDER,
+    PROFILE_REVIEWER,
+    PROFILE_CUSTOM,
+)
+
+
+# ---------------------------------------------------------------------------
+# Profile dataclass + built-in presets
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PermissionProfile:
+    """Declarative permission rules for a named profile.
+
+    Attributes:
+        name: Profile identifier (matches the operator-visible name).
+        default: Default decision when nothing matches the allowlist.
+            ``"deny"`` makes the profile fail-closed; ``"allow"`` makes
+            it advisory only.
+        allow_tools: Tool identifiers (e.g. ``fs.read``, ``shell.run``)
+            permitted under this profile. ``"*"`` matches anything.
+        allow_paths: Glob patterns of filesystem paths that read/write
+            tools may touch.
+        deny_paths: Glob patterns that always lose, regardless of
+            ``allow_paths`` or wildcard tool grants.
+        allow_hosts: Hostnames (exact match, or ``"*.example.com"``
+            suffix glob) that network tools may dial.
+        shell_allowlist: First-token allowlist for ``shell.run``-style
+            tools. ``("uv", "git")`` permits ``uv pip install``,
+            ``git status`` etc. Empty means every command passes the
+            shell check (path/tool rules still apply).
+    """
+
+    name: str
+    default: str = "deny"
+    allow_tools: tuple[str, ...] = ()
+    allow_paths: tuple[str, ...] = ()
+    deny_paths: tuple[str, ...] = ()
+    allow_hosts: tuple[str, ...] = ()
+    shell_allowlist: tuple[str, ...] = ()
+
+    @property
+    def is_fail_closed(self) -> bool:
+        """True when an unmatched call should be denied."""
+        return self.default.lower() != "allow"
+
+
+def _read_only_profile() -> PermissionProfile:
+    """Read-only profile: review / explore agents, zero side-effects."""
+    return PermissionProfile(
+        name=PROFILE_READ_ONLY,
+        default="deny",
+        allow_tools=("fs.read", "fs.stat", "fs.list", "git.diff", "git.log", "git.status"),
+        allow_paths=("**",),
+        deny_paths=(".env*", "**/.git/objects/**", "**/.sdd/runtime/**", "**/secrets/**"),
+        allow_hosts=(),
+        shell_allowlist=(),
+    )
+
+
+def _builder_profile() -> PermissionProfile:
+    """Builder profile: write + shell, but on an allowlist."""
+    return PermissionProfile(
+        name=PROFILE_BUILDER,
+        default="deny",
+        allow_tools=(
+            "fs.read",
+            "fs.stat",
+            "fs.list",
+            "fs.write",
+            "fs.mkdir",
+            "shell.run",
+            "git.diff",
+            "git.log",
+            "git.status",
+            "git.add",
+            "git.commit",
+        ),
+        allow_paths=("src/**", "tests/**", "docs/**", "scripts/**", "*.md", "*.toml", "*.yaml", "*.yml"),
+        deny_paths=(".env*", "**/.git/**", "**/.sdd/runtime/**", "**/secrets/**", "**/credentials*"),
+        allow_hosts=("api.anthropic.com", "api.openai.com", "api.github.com"),
+        shell_allowlist=("uv", "pytest", "ruff", "git", "python", "python3", "node", "npm", "pnpm"),
+    )
+
+
+def _reviewer_profile() -> PermissionProfile:
+    """Reviewer profile: read + diff only, nothing else."""
+    return PermissionProfile(
+        name=PROFILE_REVIEWER,
+        default="deny",
+        allow_tools=("fs.read", "fs.stat", "fs.list", "git.diff", "git.log", "git.status", "git.show"),
+        allow_paths=("**",),
+        deny_paths=(".env*", "**/.git/objects/**", "**/.sdd/runtime/**", "**/secrets/**"),
+        allow_hosts=(),
+        shell_allowlist=(),
+    )
+
+
+def _custom_profile_skeleton() -> PermissionProfile:
+    """Fully operator-defined: empty allowlists, fail-closed."""
+    return PermissionProfile(
+        name=PROFILE_CUSTOM,
+        default="deny",
+        allow_tools=(),
+        allow_paths=(),
+        deny_paths=(),
+        allow_hosts=(),
+        shell_allowlist=(),
+    )
+
+
+_BUILTIN_FACTORIES: dict[str, Any] = {
+    PROFILE_READ_ONLY: _read_only_profile,
+    PROFILE_BUILDER: _builder_profile,
+    PROFILE_REVIEWER: _reviewer_profile,
+    PROFILE_CUSTOM: _custom_profile_skeleton,
+}
+
+
+def get_builtin_profile(name: str) -> PermissionProfile | None:
+    """Return a built-in profile by name, or ``None`` if unknown."""
+    factory = _BUILTIN_FACTORIES.get(name.lower())
+    if factory is None:
+        return None
+    return factory()
+
+
+def list_builtin_profiles() -> tuple[PermissionProfile, ...]:
+    """Return all built-in profiles in deterministic order."""
+    return tuple(factory() for factory in _BUILTIN_FACTORIES.values())
+
+
+# ---------------------------------------------------------------------------
+# Profile loading from config + env
+# ---------------------------------------------------------------------------
+
+
+def _coerce_str_tuple(value: Any) -> tuple[str, ...]:
+    """Normalize a YAML/TOML list-of-strings into ``tuple[str, ...]``."""
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item) for item in value if item is not None)
+    if isinstance(value, str):
+        return (value,)
+    return ()
+
+
+def _merge_overrides(base: PermissionProfile, overrides: Mapping[str, Any]) -> PermissionProfile:
+    """Return a new profile with operator overrides layered on top of *base*."""
+    return PermissionProfile(
+        name=str(overrides.get("name", base.name)),
+        default=str(overrides.get("default", base.default)),
+        allow_tools=_coerce_str_tuple(overrides.get("allow_tools", base.allow_tools)),
+        allow_paths=_coerce_str_tuple(overrides.get("allow_paths", base.allow_paths)),
+        deny_paths=_coerce_str_tuple(overrides.get("deny_paths", base.deny_paths)),
+        allow_hosts=_coerce_str_tuple(overrides.get("allow_hosts", base.allow_hosts)),
+        shell_allowlist=_coerce_str_tuple(overrides.get("shell_allowlist", base.shell_allowlist)),
+    )
+
+
+def _load_yaml_permissions(workdir: Path) -> Mapping[str, Any] | None:
+    """Return the ``permissions:`` block from ``bernstein.yaml`` (if any)."""
+    path = workdir / "bernstein.yaml"
+    if not path.exists():
+        return None
+    try:
+        import yaml
+
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Could not read bernstein.yaml for permissions: %s", exc)
+        return None
+    if not isinstance(raw, dict):
+        return None
+    section = raw.get("permissions")
+    if not isinstance(section, dict):
+        return None
+    return section
+
+
+def _load_toml_permissions(workdir: Path) -> Mapping[str, Any] | None:
+    """Return the ``[permissions]`` table from ``bernstein.toml`` (if any)."""
+    path = workdir / "bernstein.toml"
+    if not path.exists():
+        return None
+    try:
+        import tomllib
+
+        raw = tomllib.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Could not read bernstein.toml for permissions: %s", exc)
+        return None
+    section = raw.get("permissions")
+    if not isinstance(section, dict):
+        return None
+    return section
+
+
+def load_permissions_config(workdir: Path | None = None) -> Mapping[str, Any] | None:
+    """Load the ``permissions`` block, preferring TOML when both exist."""
+    root = workdir if workdir is not None else Path.cwd()
+    toml_section = _load_toml_permissions(root)
+    if toml_section is not None:
+        return toml_section
+    return _load_yaml_permissions(root)
+
+
+def resolve_profile(
+    *,
+    workdir: Path | None = None,
+    cli_override: str | None = None,
+) -> PermissionProfile | None:
+    """Resolve the effective profile for a run.
+
+    Priority (high → low):
+        1. ``cli_override`` (``--permission-profile``)
+        2. ``BERNSTEIN_PERMISSION_PROFILE`` env var
+        3. ``permissions.profile`` in ``bernstein.toml`` / ``bernstein.yaml``
+
+    Returns ``None`` when nothing is configured — callers MUST treat that
+    as "no policy installed" and preserve current default behaviour.
+    """
+    section = load_permissions_config(workdir) or {}
+
+    chosen = cli_override or os.environ.get(ENV_PROFILE) or section.get("profile")
+    if not chosen:
+        return None
+
+    chosen_norm = str(chosen).strip().lower()
+    base = get_builtin_profile(chosen_norm)
+    if base is None:
+        # Unknown profile name — fail closed by returning a deny-all
+        # skeleton named after what the operator asked for so the
+        # audit trail shows the typo verbatim.
+        logger.warning("Unknown permission profile %r; falling back to deny-all", chosen)
+        base = PermissionProfile(name=str(chosen_norm), default="deny")
+
+    overrides = section.get(chosen_norm)
+    if isinstance(overrides, dict):
+        return _merge_overrides(base, overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# PolicyChecker — the one and only dispatch hook
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """Inputs to the policy check.
+
+    Attributes:
+        tool: Canonical tool name (``fs.read``, ``shell.run`` …).
+        path: Optional filesystem path the tool will touch.
+        host: Optional network host the tool will dial.
+        shell_cmd: Optional shell command (first token is checked).
+        session_id: Caller session for denial tracking / audit.
+        actor: Human-readable actor (agent role) for audit records.
+        extra: Free-form metadata that lands in the deny record.
+    """
+
+    tool: str
+    path: str | None = None
+    host: str | None = None
+    shell_cmd: str | None = None
+    session_id: str = "unknown"
+    actor: str = "agent"
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+def _match_glob(value: str, patterns: tuple[str, ...]) -> bool:
+    """True when *value* matches any glob in *patterns*."""
+    if not patterns:
+        return False
+    return any(fnmatch.fnmatchcase(value, pat) for pat in patterns)
+
+
+def _match_host(host: str, patterns: tuple[str, ...]) -> bool:
+    """Match host against exact names or ``*.suffix`` patterns."""
+    if not patterns:
+        return False
+    host_norm = host.lower()
+    for pat in patterns:
+        pat_norm = pat.lower()
+        if pat_norm == host_norm:
+            return True
+        if pat_norm.startswith("*.") and host_norm.endswith(pat_norm[1:]):
+            return True
+        if pat_norm == "*":
+            return True
+    return False
+
+
+def _first_shell_token(cmd: str) -> str:
+    """Return the first whitespace-separated token (without env prefix)."""
+    # Strip leading ``ENV=val`` style prefixes (``KEY=value foo``) so the
+    # binary identity is what we match on. Be deliberately conservative.
+    tokens = re.split(r"\s+", cmd.strip())
+    for tok in tokens:
+        if "=" in tok and not tok.startswith("-"):
+            # env-var assignment, skip
+            continue
+        return tok
+    return ""
+
+
+class PolicyChecker:
+    """Stateless evaluator backed by a :class:`PermissionProfile`."""
+
+    def __init__(self, profile: PermissionProfile) -> None:
+        self._profile = profile
+
+    @property
+    def profile(self) -> PermissionProfile:
+        return self._profile
+
+    def check(self, call: ToolCall) -> PermissionDecision:
+        """Return the policy decision for *call*.
+
+        ALLOW means the dispatch may proceed. Anything else means the
+        caller MUST block the dispatch and surface the reason.
+        """
+        prof = self._profile
+
+        # Deny paths always lose — even when the tool is broadly allowed.
+        if call.path is not None and _match_glob(call.path, prof.deny_paths):
+            return PermissionDecision(
+                type=DecisionType.DENY,
+                reason=f"path {call.path!r} matches deny_paths under profile {prof.name!r}",
+                bypass_immune=True,
+            )
+
+        # Tool allowlist.
+        tool_matches = _match_glob(call.tool, prof.allow_tools) or "*" in prof.allow_tools
+        if not tool_matches and prof.is_fail_closed:
+            return PermissionDecision(
+                type=DecisionType.DENY,
+                reason=f"tool {call.tool!r} not in allow_tools for profile {prof.name!r}",
+            )
+
+        # Path allowlist (only when the call carries a path).
+        if (
+            call.path is not None
+            and prof.allow_paths
+            and not _match_glob(call.path, prof.allow_paths)
+            and prof.is_fail_closed
+        ):
+            return PermissionDecision(
+                type=DecisionType.DENY,
+                reason=f"path {call.path!r} not in allow_paths for profile {prof.name!r}",
+            )
+
+        # Host allowlist (network tools).
+        if (
+            call.host is not None
+            and not _match_host(call.host, prof.allow_hosts)
+            and prof.is_fail_closed
+        ):
+            return PermissionDecision(
+                type=DecisionType.DENY,
+                reason=f"host {call.host!r} not in allow_hosts for profile {prof.name!r}",
+            )
+
+        # Shell allowlist (first token must match).
+        if call.shell_cmd is not None and prof.shell_allowlist:
+            token = _first_shell_token(call.shell_cmd)
+            if token not in prof.shell_allowlist:
+                return PermissionDecision(
+                    type=DecisionType.DENY,
+                    reason=(
+                        f"shell command {token!r} not in shell_allowlist "
+                        f"for profile {prof.name!r}"
+                    ),
+                )
+
+        return PermissionDecision(
+            type=DecisionType.ALLOW,
+            reason=f"profile {prof.name!r} permits {call.tool!r}",
+        )
+
+    def check_and_record(
+        self,
+        call: ToolCall,
+        *,
+        workdir: Path | None = None,
+    ) -> PermissionDecision:
+        """:meth:`check` + audit-trail side-effect on DENY."""
+        decision = self.check(call)
+        if decision.type == DecisionType.DENY:
+            _record_denial(call=call, profile=self._profile, decision=decision, workdir=workdir)
+        return decision
+
+
+# ---------------------------------------------------------------------------
+# Audit / denial trail
+# ---------------------------------------------------------------------------
+
+
+def _denial_log_path(workdir: Path | None = None) -> Path:
+    root = workdir if workdir is not None else Path.cwd()
+    return root / ".sdd" / "runtime" / "permission_denials.jsonl"
+
+
+def _record_denial(
+    *,
+    call: ToolCall,
+    profile: PermissionProfile,
+    decision: PermissionDecision,
+    workdir: Path | None = None,
+) -> None:
+    """Append a JSONL denial record + log a structured warning."""
+    record: dict[str, Any] = {
+        "timestamp": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "tool": call.tool,
+        "path": call.path,
+        "host": call.host,
+        "shell_cmd": call.shell_cmd,
+        "profile": profile.name,
+        "reason": decision.reason,
+        "session_id": call.session_id,
+        "actor": call.actor,
+    }
+    if call.extra:
+        record["extra"] = dict(call.extra)
+
+    logger.warning(
+        "Permission denial: tool=%s profile=%s reason=%s",
+        call.tool,
+        profile.name,
+        decision.reason,
+    )
+
+    try:
+        path = _denial_log_path(workdir)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, sort_keys=True) + "\n")
+    except OSError as exc:  # pragma: no cover - filesystem permissions
+        logger.warning("Could not persist denial record: %s", exc)
+
+    # Best-effort propagation into the in-process denial tracker so the
+    # over-threshold alert path fires consistently. Imported lazily to
+    # keep the dependency one-way.
+    try:
+        tracker = _default_tracker()
+        if tracker is not None:
+            tracker.record_denial(
+                session_id=call.session_id,
+                command_or_path=call.shell_cmd or call.path or call.host or call.tool,
+                reason=f"[{profile.name}] {decision.reason}",
+            )
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+
+_TRACKER_SINGLETON: Any = None
+
+
+def _default_tracker() -> Any:
+    """Singleton DenialTracker for opt-in callers (best effort)."""
+    global _TRACKER_SINGLETON
+    if _TRACKER_SINGLETON is None:
+        try:
+            from bernstein.core.security.denial_tracker import DenialTracker
+
+            _TRACKER_SINGLETON = DenialTracker()
+        except Exception:  # pragma: no cover - defensive
+            return None
+    return _TRACKER_SINGLETON
+
+
+# ---------------------------------------------------------------------------
+# Top-level convenience
+# ---------------------------------------------------------------------------
+
+
+def check_tool_call(
+    *,
+    tool: str,
+    path: str | None = None,
+    host: str | None = None,
+    shell_cmd: str | None = None,
+    session_id: str = "unknown",
+    actor: str = "agent",
+    workdir: Path | None = None,
+    profile: PermissionProfile | None = None,
+    extra: dict[str, Any] | None = None,
+) -> PermissionDecision:
+    """One-shot policy check used by adapters and the approval gate.
+
+    When *profile* is omitted the active profile is resolved via
+    :func:`resolve_profile`. If no profile is configured at all the
+    returned decision is :class:`DecisionType.ALLOW` with a reason that
+    flags the no-op path — callers can rely on the same return type in
+    both modes.
+    """
+    effective = profile if profile is not None else resolve_profile(workdir=workdir)
+    if effective is None:
+        return PermissionDecision(
+            type=DecisionType.ALLOW,
+            reason="no permission profile configured (legacy default)",
+        )
+
+    checker = PolicyChecker(effective)
+    call = ToolCall(
+        tool=tool,
+        path=path,
+        host=host,
+        shell_cmd=shell_cmd,
+        session_id=session_id,
+        actor=actor,
+        extra=extra or {},
+    )
+    return checker.check_and_record(call, workdir=workdir)
+
+
+__all__ = [
+    "BUILTIN_PROFILE_NAMES",
+    "ENV_PROFILE",
+    "PROFILE_BUILDER",
+    "PROFILE_CUSTOM",
+    "PROFILE_READ_ONLY",
+    "PROFILE_REVIEWER",
+    "PermissionProfile",
+    "PolicyChecker",
+    "ToolCall",
+    "check_tool_call",
+    "get_builtin_profile",
+    "list_builtin_profiles",
+    "load_permissions_config",
+    "resolve_profile",
+]

--- a/src/bernstein/core/security/permission_policy.py
+++ b/src/bernstein/core/security/permission_policy.py
@@ -418,11 +418,7 @@ class PolicyChecker:
             )
 
         # Host allowlist (network tools).
-        if (
-            call.host is not None
-            and not _match_host(call.host, prof.allow_hosts)
-            and prof.is_fail_closed
-        ):
+        if call.host is not None and not _match_host(call.host, prof.allow_hosts) and prof.is_fail_closed:
             return PermissionDecision(
                 type=DecisionType.DENY,
                 reason=f"host {call.host!r} not in allow_hosts for profile {prof.name!r}",
@@ -434,10 +430,7 @@ class PolicyChecker:
             if token not in prof.shell_allowlist:
                 return PermissionDecision(
                     type=DecisionType.DENY,
-                    reason=(
-                        f"shell command {token!r} not in shell_allowlist "
-                        f"for profile {prof.name!r}"
-                    ),
+                    reason=(f"shell command {token!r} not in shell_allowlist for profile {prof.name!r}"),
                 )
 
         return PermissionDecision(

--- a/tests/unit/test_permission_policy.py
+++ b/tests/unit/test_permission_policy.py
@@ -1,0 +1,355 @@
+"""Unit tests for the per-tool permission policy (roadmap #1318).
+
+Covers each built-in profile, the fail-closed default, custom-profile
+overrides loaded from ``bernstein.yaml``/``bernstein.toml``, and the
+denial audit-trail side-effect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.security.permission_policy import (
+    BUILTIN_PROFILE_NAMES,
+    ENV_PROFILE,
+    PROFILE_BUILDER,
+    PROFILE_CUSTOM,
+    PROFILE_READ_ONLY,
+    PROFILE_REVIEWER,
+    PermissionProfile,
+    PolicyChecker,
+    ToolCall,
+    check_tool_call,
+    get_builtin_profile,
+    list_builtin_profiles,
+    resolve_profile,
+)
+from bernstein.core.security.policy_engine import DecisionType
+
+# ---------------------------------------------------------------------------
+# Built-in profile shape
+# ---------------------------------------------------------------------------
+
+
+class TestBuiltinProfiles:
+    """Every built-in profile is registered, fail-closed, and well-formed."""
+
+    def test_all_builtin_names_resolvable(self) -> None:
+        for name in BUILTIN_PROFILE_NAMES:
+            profile = get_builtin_profile(name)
+            assert profile is not None, name
+            assert profile.name == name
+
+    def test_unknown_profile_returns_none(self) -> None:
+        assert get_builtin_profile("does-not-exist") is None
+
+    def test_list_returns_all_in_order(self) -> None:
+        names = tuple(p.name for p in list_builtin_profiles())
+        assert names == BUILTIN_PROFILE_NAMES
+
+    def test_all_builtin_profiles_fail_closed(self) -> None:
+        for profile in list_builtin_profiles():
+            assert profile.is_fail_closed, f"{profile.name} must default to deny"
+
+
+# ---------------------------------------------------------------------------
+# read-only profile
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnlyProfile:
+    """``read-only`` allows reads, denies writes/shell/network."""
+
+    @pytest.fixture
+    def checker(self) -> PolicyChecker:
+        profile = get_builtin_profile(PROFILE_READ_ONLY)
+        assert profile is not None
+        return PolicyChecker(profile)
+
+    def test_fs_read_allowed(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.read", path="src/foo.py"))
+        assert decision.type == DecisionType.ALLOW
+
+    def test_fs_write_denied(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.write", path="src/foo.py"))
+        assert decision.type == DecisionType.DENY
+        assert "allow_tools" in decision.reason
+
+    def test_shell_run_denied(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="shell.run", shell_cmd="ls"))
+        assert decision.type == DecisionType.DENY
+
+    def test_secrets_path_denied_even_for_fs_read(self, checker: PolicyChecker) -> None:
+        # deny_paths takes precedence over allow_tools.
+        decision = checker.check(ToolCall(tool="fs.read", path=".env"))
+        assert decision.type == DecisionType.DENY
+        assert "deny_paths" in decision.reason
+
+    def test_sdd_runtime_blocked(self, checker: PolicyChecker) -> None:
+        decision = checker.check(
+            ToolCall(tool="fs.read", path="project/.sdd/runtime/state.json"),
+        )
+        assert decision.type == DecisionType.DENY
+
+
+# ---------------------------------------------------------------------------
+# builder profile
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderProfile:
+    """``builder`` allows write/shell on an allowlist."""
+
+    @pytest.fixture
+    def checker(self) -> PolicyChecker:
+        profile = get_builtin_profile(PROFILE_BUILDER)
+        assert profile is not None
+        return PolicyChecker(profile)
+
+    def test_fs_write_in_src_allowed(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.write", path="src/foo.py"))
+        assert decision.type == DecisionType.ALLOW
+
+    def test_fs_write_outside_allowlist_denied(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.write", path="weird/place.bin"))
+        assert decision.type == DecisionType.DENY
+        assert "allow_paths" in decision.reason
+
+    def test_shell_allowlist_first_token(self, checker: PolicyChecker) -> None:
+        ok = checker.check(ToolCall(tool="shell.run", shell_cmd="uv pip install foo"))
+        assert ok.type == DecisionType.ALLOW
+
+        bad = checker.check(ToolCall(tool="shell.run", shell_cmd="curl evil.example.com"))
+        assert bad.type == DecisionType.DENY
+        assert "shell_allowlist" in bad.reason
+
+    def test_known_host_allowed_under_explicit_profile(self) -> None:
+        # Build a synthetic profile that includes a hypothetical net tool
+        # so we can isolate the host-allowlist check from the tool check.
+        profile = PermissionProfile(
+            name="net-builder",
+            default="deny",
+            allow_tools=("net.http",),
+            allow_paths=("**",),
+            allow_hosts=("api.anthropic.com", "*.openai.com"),
+        )
+        checker = PolicyChecker(profile)
+        ok = checker.check(ToolCall(tool="net.http", host="api.anthropic.com"))
+        assert ok.type == DecisionType.ALLOW
+        wildcard = checker.check(ToolCall(tool="net.http", host="api.openai.com"))
+        assert wildcard.type == DecisionType.ALLOW
+        bad = checker.check(ToolCall(tool="net.http", host="exfil.example.com"))
+        assert bad.type == DecisionType.DENY
+        assert "allow_hosts" in bad.reason
+
+    def test_dotenv_denied(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.write", path=".env.production"))
+        assert decision.type == DecisionType.DENY
+        assert "deny_paths" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# reviewer profile
+# ---------------------------------------------------------------------------
+
+
+class TestReviewerProfile:
+    """``reviewer`` is read+diff only; everything else is denied."""
+
+    @pytest.fixture
+    def checker(self) -> PolicyChecker:
+        profile = get_builtin_profile(PROFILE_REVIEWER)
+        assert profile is not None
+        return PolicyChecker(profile)
+
+    def test_git_diff_allowed(self, checker: PolicyChecker) -> None:
+        assert checker.check(ToolCall(tool="git.diff")).type == DecisionType.ALLOW
+
+    def test_fs_read_allowed(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.read", path="docs/x.md"))
+        assert decision.type == DecisionType.ALLOW
+
+    def test_shell_denied(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="shell.run", shell_cmd="ls"))
+        assert decision.type == DecisionType.DENY
+
+    def test_fs_write_denied(self, checker: PolicyChecker) -> None:
+        decision = checker.check(ToolCall(tool="fs.write", path="src/foo.py"))
+        assert decision.type == DecisionType.DENY
+
+
+# ---------------------------------------------------------------------------
+# custom profile
+# ---------------------------------------------------------------------------
+
+
+class TestCustomProfile:
+    """``custom`` starts deny-all and is populated from config."""
+
+    def test_skeleton_denies_everything(self) -> None:
+        profile = get_builtin_profile(PROFILE_CUSTOM)
+        assert profile is not None
+        checker = PolicyChecker(profile)
+        decision = checker.check(ToolCall(tool="fs.read", path="anything"))
+        assert decision.type == DecisionType.DENY
+
+    def test_overrides_loaded_from_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "bernstein.yaml").write_text(
+            """\
+permissions:
+  profile: custom
+  custom:
+    default: deny
+    allow_tools: ["fs.read", "fs.write"]
+    allow_paths: ["notes/**"]
+""",
+        )
+        profile = resolve_profile(workdir=tmp_path)
+        assert profile is not None
+        assert profile.name == "custom"
+        assert "fs.read" in profile.allow_tools
+        checker = PolicyChecker(profile)
+        ok = checker.check(ToolCall(tool="fs.write", path="notes/today.md"))
+        assert ok.type == DecisionType.ALLOW
+        bad = checker.check(ToolCall(tool="fs.write", path="src/foo.py"))
+        assert bad.type == DecisionType.DENY
+
+
+# ---------------------------------------------------------------------------
+# resolve_profile precedence
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProfile:
+    """CLI override > env > config file."""
+
+    def test_returns_none_when_no_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_PROFILE, raising=False)
+        assert resolve_profile(workdir=tmp_path) is None
+
+    def test_cli_override_wins(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_PROFILE, PROFILE_BUILDER)
+        (tmp_path / "bernstein.yaml").write_text("permissions:\n  profile: read-only\n")
+        profile = resolve_profile(workdir=tmp_path, cli_override=PROFILE_REVIEWER)
+        assert profile is not None
+        assert profile.name == PROFILE_REVIEWER
+
+    def test_env_overrides_config(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_PROFILE, PROFILE_BUILDER)
+        (tmp_path / "bernstein.yaml").write_text("permissions:\n  profile: read-only\n")
+        profile = resolve_profile(workdir=tmp_path)
+        assert profile is not None
+        assert profile.name == PROFILE_BUILDER
+
+    def test_config_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_PROFILE, raising=False)
+        (tmp_path / "bernstein.yaml").write_text("permissions:\n  profile: reviewer\n")
+        profile = resolve_profile(workdir=tmp_path)
+        assert profile is not None
+        assert profile.name == PROFILE_REVIEWER
+
+    def test_unknown_profile_yields_deny_all(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(ENV_PROFILE, raising=False)
+        profile = resolve_profile(workdir=tmp_path, cli_override="banana")
+        assert profile is not None
+        assert profile.name == "banana"
+        # No allow_tools — every check fails.
+        decision = PolicyChecker(profile).check(ToolCall(tool="fs.read"))
+        assert decision.type == DecisionType.DENY
+
+
+# ---------------------------------------------------------------------------
+# Audit / denial side-effect
+# ---------------------------------------------------------------------------
+
+
+class TestDenialAudit:
+    """Denials write a JSONL audit record under .sdd/runtime/."""
+
+    def test_denial_is_persisted(self, tmp_path: Path) -> None:
+        profile = get_builtin_profile(PROFILE_READ_ONLY)
+        assert profile is not None
+        checker = PolicyChecker(profile)
+        decision = checker.check_and_record(
+            ToolCall(
+                tool="fs.write",
+                path="src/foo.py",
+                session_id="session-abc",
+                actor="backend",
+            ),
+            workdir=tmp_path,
+        )
+        assert decision.type == DecisionType.DENY
+
+        trail = tmp_path / ".sdd" / "runtime" / "permission_denials.jsonl"
+        assert trail.exists(), "denial trail must be written"
+        record = json.loads(trail.read_text().strip())
+        assert record["tool"] == "fs.write"
+        assert record["profile"] == PROFILE_READ_ONLY
+        assert record["session_id"] == "session-abc"
+        assert record["actor"] == "backend"
+        assert "reason" in record
+
+    def test_allow_does_not_write_trail(self, tmp_path: Path) -> None:
+        profile = get_builtin_profile(PROFILE_BUILDER)
+        assert profile is not None
+        checker = PolicyChecker(profile)
+        decision = checker.check_and_record(
+            ToolCall(tool="fs.read", path="src/foo.py"),
+            workdir=tmp_path,
+        )
+        assert decision.type == DecisionType.ALLOW
+        trail = tmp_path / ".sdd" / "runtime" / "permission_denials.jsonl"
+        assert not trail.exists()
+
+
+# ---------------------------------------------------------------------------
+# check_tool_call convenience
+# ---------------------------------------------------------------------------
+
+
+class TestCheckToolCall:
+    """Top-level helper behaves like a no-op when nothing is configured."""
+
+    def test_no_profile_returns_allow(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv(ENV_PROFILE, raising=False)
+        decision = check_tool_call(
+            tool="fs.write",
+            path="src/foo.py",
+            workdir=tmp_path,
+        )
+        assert decision.type == DecisionType.ALLOW
+        assert "legacy default" in decision.reason
+
+    def test_active_profile_enforced(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(ENV_PROFILE, PROFILE_READ_ONLY)
+        decision = check_tool_call(
+            tool="shell.run",
+            shell_cmd="rm -rf /",
+            workdir=tmp_path,
+        )
+        assert decision.type == DecisionType.DENY
+
+    def test_explicit_profile_used(self, tmp_path: Path) -> None:
+        profile = PermissionProfile(
+            name="strict",
+            default="deny",
+            allow_tools=("fs.read",),
+            allow_paths=("**",),
+        )
+        decision = check_tool_call(
+            tool="fs.write",
+            path="src/foo.py",
+            workdir=tmp_path,
+            profile=profile,
+        )
+        assert decision.type == DecisionType.DENY

--- a/tests/unit/test_permission_policy.py
+++ b/tests/unit/test_permission_policy.py
@@ -252,7 +252,9 @@ class TestResolveProfile:
         assert profile.name == PROFILE_REVIEWER
 
     def test_unknown_profile_yields_deny_all(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv(ENV_PROFILE, raising=False)
         profile = resolve_profile(workdir=tmp_path, cli_override="banana")
@@ -317,7 +319,9 @@ class TestCheckToolCall:
     """Top-level helper behaves like a no-op when nothing is configured."""
 
     def test_no_profile_returns_allow(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.delenv(ENV_PROFILE, raising=False)
         decision = check_tool_call(
@@ -329,7 +333,9 @@ class TestCheckToolCall:
         assert "legacy default" in decision.reason
 
     def test_active_profile_enforced(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv(ENV_PROFILE, PROFILE_READ_ONLY)
         decision = check_tool_call(


### PR DESCRIPTION
## Summary

- New `PolicyChecker` in `src/bernstein/core/security/permission_policy.py` is the single hook every tool dispatch funnels through. Built-in profiles (`read-only`, `builder`, `reviewer`, `custom`) all default to deny; the checker emits structured `PermissionDecision(DENY, ...)` and writes `{tool, path/host, profile, reason}` to `.sdd/runtime/permission_denials.jsonl` so dashboards and the compliance evidence pack (#1316) can consume the trail.
- Hooked into `bernstein.core.approval.gate.await_tool_call` ahead of the interactive queue so a fail-closed profile applies even when interactive approvals are disabled; denials surface as `ResolvedApproval(decision=REJECT, reason=…)`.
- CLI: `bernstein run --permission-profile {read-only|builder|reviewer|custom}` propagates via `BERNSTEIN_PERMISSION_PROFILE` so orchestrator subprocesses inherit. Operators may also pin `permissions.profile: builder` plus per-profile overrides in `bernstein.yaml` or `[permissions]` in `bernstein.toml`.
- Backward compatibility preserved: when no profile is configured the checker is a no-op (returns ALLOW with a legacy-default reason) so existing runs are unaffected.

## Profiles shipped

| Profile     | Tools                                    | Paths                          | Shell                                  | Hosts                      |
|-------------|------------------------------------------|--------------------------------|----------------------------------------|----------------------------|
| `read-only` | `fs.read`, `fs.stat`, `git.diff` …       | `**` minus `.env*`, `.sdd/runtime/**` | (none)                                 | (none)                     |
| `builder`   | `fs.read`/`fs.write`, `shell.run`, `git.*` | `src/**`, `tests/**`, `docs/**` minus `.env*`, `.git/**` | `uv`, `pytest`, `ruff`, `git`, `python`, `npm` … | `api.anthropic.com`, `api.openai.com`, `api.github.com` |
| `reviewer`  | `fs.read`, `git.diff`/`log`/`show`/`status` | `**` minus secret-ish patterns | (none)                                 | (none)                     |
| `custom`    | (operator-defined)                       | (operator-defined)             | (operator-defined)                     | (operator-defined)         |

## How operators opt in

```bash
bernstein run --permission-profile read-only
```

or in `bernstein.yaml`:

```yaml
permissions:
  profile: builder
  builder:
    allow_paths: [\"src/**\", \"docs/**\"]
    shell_allowlist: [\"uv\", \"pytest\", \"ruff\", \"git\"]
```

## Test plan

- [x] `uv run pytest tests/unit/test_permission_policy.py` (30 tests; each built-in profile + deny_paths precedence + shell allowlist + host wildcards + profile resolution precedence + denial-trail side-effect)
- [x] `uv run pytest tests/unit/test_approval_gate.py tests/unit/test_approval_hook.py tests/unit/test_approval.py tests/unit/test_denial_tracker.py` (no regressions, 46 passed)
- [x] `uv run ruff check src/bernstein/core/security/permission_policy.py src/bernstein/core/approval/gate.py src/bernstein/cli/run_bootstrap.py tests/unit/test_permission_policy.py`

Closes #1318