### PR TITLE
feat(planner): enforce vertical slicing — reject horizontally-phased plans

### DIFF
--- a/src/bernstein/cli/commands/plan_generate_cmd.py
+++ b/src/bernstein/cli/commands/plan_generate_cmd.py
@@ -228,6 +228,91 @@ def _slug(text: str, max_len: int = 40) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Vertical-slice shape check on YAML plans
+# ---------------------------------------------------------------------------
+
+
+def _yaml_steps_to_pseudo_tasks(plan_data: dict[str, Any]) -> list[Any]:
+    """Convert YAML plan steps into lightweight pseudo-Task objects.
+
+    The shape checker reads ``title``, ``owned_files``, and ``scope``.
+    We provide a minimal stand-in so ``plan generate`` can reuse the
+    same checker without importing the full Task dataclass.
+    """
+    from dataclasses import dataclass
+
+    @dataclass
+    class _PseudoScope:
+        value: str
+
+    @dataclass
+    class _PseudoTask:
+        title: str
+        owned_files: list[str]
+        scope: _PseudoScope
+
+    pseudo: list[Any] = []
+    for stage in plan_data.get("stages", []) or []:
+        for step in stage.get("steps", []) or []:
+            pseudo.append(
+                _PseudoTask(
+                    title=str(step.get("title", "")),
+                    owned_files=list(step.get("owned_files", []) or []),
+                    scope=_PseudoScope(value=str(step.get("scope", "medium"))),
+                )
+            )
+    return pseudo
+
+
+def _shape_check_yaml_plan(
+    plan_data: dict[str, Any],
+    *,
+    max_loc: int | None,
+    max_files: int | None,
+) -> None:
+    """Run the vertical-slice shape checker against a YAML plan.
+
+    Prints violations to the console for operator visibility.  Does not
+    raise — the YAML is still written so the operator can edit it; the
+    diagnostics make the issues obvious.
+    """
+    from bernstein.core.planning.vertical_slice import (
+        ShapeConfig,
+        check_plan,
+        load_shape_config,
+    )
+
+    base = load_shape_config(Path("."))
+    cfg = ShapeConfig(
+        enforce_vertical=True,
+        max_loc_hard=max_loc if max_loc is not None else base.max_loc_hard,
+        max_loc_ideal=base.max_loc_ideal,
+        max_files=max_files if max_files is not None else base.max_files,
+        max_modules=base.max_modules,
+    )
+    pseudo = _yaml_steps_to_pseudo_tasks(plan_data)
+    if not pseudo:
+        return
+    violations = check_plan(pseudo, cfg)
+    if not violations:
+        console.print("[dim]Vertical-slice shape check passed.[/dim]")
+        return
+    errors = [v for v in violations if v.severity == "error"]
+    warns = [v for v in violations if v.severity == "warn"]
+    if errors:
+        console.print(f"[red]Vertical-slice shape check found {len(errors)} error(s):[/red]")
+        for v in errors:
+            console.print(f"  - [{v.rule}] {v.message}")
+        console.print(
+            "[dim]Re-run with --no-enforce-vertical to bypass, or edit the YAML to split oversized stages.[/dim]"
+        )
+    if warns:
+        console.print(f"[yellow]{len(warns)} shape warning(s):[/yellow]")
+        for v in warns:
+            console.print(f"  - [{v.rule}] {v.message}")
+
+
+# ---------------------------------------------------------------------------
 # Click command
 # ---------------------------------------------------------------------------
 
@@ -265,6 +350,30 @@ def _slug(text: str, max_len: int = 40) -> str:
     type=click.Path(exists=True, file_okay=False, path_type=Path),
     help="Project root directory to analyse.",
 )
+@click.option(
+    "--enforce-vertical/--no-enforce-vertical",
+    default=True,
+    show_default=True,
+    help=(
+        "Enforce vertical-slice shape checks on the generated plan "
+        "(issue #1321). Default on in the 2.x line; use "
+        "``--no-enforce-vertical`` to opt out."
+    ),
+)
+@click.option(
+    "--max-loc",
+    "max_loc",
+    type=int,
+    default=None,
+    help="Hard LOC cap per slice. Overrides bernstein.yaml [plan].max_loc.",
+)
+@click.option(
+    "--max-files",
+    "max_files",
+    type=int,
+    default=None,
+    help="Max files per slice. Overrides bernstein.yaml [plan].max_files.",
+)
 def plan_generate(
     description: str,
     output: str | None,
@@ -272,6 +381,9 @@ def plan_generate(
     provider: str,
     dry_run: bool,
     workdir: Path,
+    enforce_vertical: bool,
+    max_loc: int | None,
+    max_files: int | None,
 ) -> None:
     """Generate a multi-stage YAML plan from a natural language description.
 
@@ -318,6 +430,13 @@ def plan_generate(
         plan_data["name"] = description[:60]
     if not plan_data.get("description"):
         plan_data["description"] = description
+
+    # Vertical-slice shape check (issue #1321).  Operates on the YAML
+    # steps directly; reports violations but does not abort by default
+    # — the LLM-generated YAML is then surfaced to the operator who can
+    # re-run with ``--no-enforce-vertical`` if appropriate.
+    if enforce_vertical:
+        _shape_check_yaml_plan(plan_data, max_loc=max_loc, max_files=max_files)
 
     step_count, estimated_usd = _estimate_cost(plan_data)
     stage_count = len(plan_data.get("stages", []))

--- a/src/bernstein/core/orchestration/manager.py
+++ b/src/bernstein/core/orchestration/manager.py
@@ -220,12 +220,18 @@ class ManagerAgent:
         templates_dir: Path,
         model: str = "nvidia/nemotron-3-super-120b-a12b",
         provider: str = "openrouter_free",
+        *,
+        enforce_vertical: bool | None = None,
     ) -> None:
         self._server_url = server_url
         self._workdir = workdir
         self._templates_dir = templates_dir
         self._model = model
         self._provider = provider
+        # ``None`` defers to ``bernstein.yaml`` ``[plan].enforce_vertical``;
+        # explicit ``True``/``False`` overrides the repo-level value.
+        # Default-on in the 2.x line per issue #1321.
+        self._enforce_vertical = enforce_vertical
 
     async def plan(self, goal: str) -> list[Task]:
         """Decompose a goal into tasks using the LLM.
@@ -330,6 +336,47 @@ class ManagerAgent:
             if not tasks:
                 logger.warning("LLM returned no valid tasks")
                 return []
+
+            # 6.5 Vertical-slice shape check (issue #1321).
+            from bernstein.core.planning.vertical_slice import (
+                ShapeConfig,
+                check_plan,
+                format_violations_for_reprompt,
+                load_shape_config,
+                summarise_slice,
+            )
+
+            shape_cfg = load_shape_config(self._workdir)
+            if self._enforce_vertical is not None:
+                shape_cfg = ShapeConfig(
+                    enforce_vertical=self._enforce_vertical,
+                    max_loc_hard=shape_cfg.max_loc_hard,
+                    max_loc_ideal=shape_cfg.max_loc_ideal,
+                    max_files=shape_cfg.max_files,
+                    max_modules=shape_cfg.max_modules,
+                )
+
+            if shape_cfg.enforce_vertical:
+                violations = check_plan(tasks, shape_cfg)
+                error_violations = [v for v in violations if v.severity == "error"]
+                if error_violations:
+                    logger.warning(
+                        "Plan rejected by vertical-slice shape check (%d error(s)); re-prompting",
+                        len(error_violations),
+                    )
+                    correction = format_violations_for_reprompt(violations)
+                    retry_prompt = f"{prompt}\n\n---\n\n{correction}"
+                    try:
+                        retry_raw = await call_llm(retry_prompt, model=self._model, provider=self._provider)
+                        retry_parsed = parse_tasks_response(retry_raw)
+                        retry_tasks = raw_dicts_to_tasks(retry_parsed)
+                        if retry_tasks:
+                            tasks = retry_tasks
+                    except Exception as exc:
+                        logger.error("Vertical-slice re-prompt failed: %s", exc)
+
+            for idx, task in enumerate(tasks, start=1):
+                logger.info("slice %d: %s · %s", idx, task.title, summarise_slice(task))
 
             # 7. Resolve dependency titles to IDs
             _resolve_depends_on(tasks)

--- a/src/bernstein/core/planning/planner.py
+++ b/src/bernstein/core/planning/planner.py
@@ -25,6 +25,13 @@ from bernstein.core.manager_parsing import (
 from bernstein.core.manager_prompts import render_plan_prompt
 from bernstein.core.metrics import get_collector
 from bernstein.core.models import Complexity, Scope, Task, TaskStatus, TaskType
+from bernstein.core.planning.vertical_slice import (
+    ShapeConfig,
+    check_plan,
+    format_violations_for_reprompt,
+    load_shape_config,
+    summarise_slice,
+)
 from bernstein.core.semantic_cache import SemanticCacheManager
 
 if TYPE_CHECKING:
@@ -155,6 +162,68 @@ async def _fetch_existing_tasks(
     return tasks
 
 
+async def _run_shape_check_with_retry(
+    *,
+    tasks: list[Task],
+    prompt: str,
+    model: str,
+    provider: str,
+    shape_config: ShapeConfig,
+) -> list[Task]:
+    """Apply :func:`check_plan`; re-prompt the LLM once on violations.
+
+    The retry is best-effort: if the second LLM call fails to parse, or
+    still produces an invalid plan, we fall back to the original tasks
+    and log the violations as warnings.  This keeps existing plans from
+    breaking hard when the LLM cannot satisfy the new constraints —
+    operators still have the ``--no-enforce-vertical`` escape valve.
+    """
+    violations = check_plan(tasks, shape_config)
+    error_violations = [v for v in violations if v.severity == "error"]
+    if not error_violations:
+        for warn in violations:
+            logger.warning("plan shape warning [%s]: %s", warn.rule, warn.message)
+        return tasks
+
+    logger.warning(
+        "Plan rejected by vertical-slice shape check (%d violation(s)); re-prompting LLM",
+        len(error_violations),
+    )
+    for v in error_violations:
+        logger.warning("  [%s] %s", v.rule, v.message)
+
+    correction = format_violations_for_reprompt(violations)
+    retry_prompt = f"{prompt}\n\n---\n\n{correction}"
+    try:
+        retry_response = await call_llm(retry_prompt, model=model, provider=provider)
+    except Exception as exc:
+        logger.error("Re-prompt for vertical-slice correction failed: %s", exc)
+        return tasks
+
+    try:
+        retry_raw = parse_tasks_response(retry_response)
+        retry_tasks = raw_dicts_to_tasks(retry_raw)
+    except Exception as exc:
+        logger.error("Re-prompt response could not be parsed: %s", exc)
+        return tasks
+
+    if not retry_tasks:
+        logger.warning("Re-prompt returned no usable tasks; keeping original plan")
+        return tasks
+
+    retry_violations = [v for v in check_plan(retry_tasks, shape_config) if v.severity == "error"]
+    if retry_violations:
+        logger.warning(
+            "Re-prompt still violates vertical-slice caps (%d issue(s)); accepting with warnings",
+            len(retry_violations),
+        )
+        for v in retry_violations:
+            logger.warning("  [%s] %s", v.rule, v.message)
+    else:
+        logger.info("Re-prompt produced a vertical-sliced plan with %d task(s)", len(retry_tasks))
+    return retry_tasks
+
+
 async def plan(
     goal: str,
     server_url: str,
@@ -162,6 +231,9 @@ async def plan(
     templates_dir: Path,
     model: str,
     provider: str,
+    *,
+    enforce_vertical: bool | None = None,
+    shape_config: ShapeConfig | None = None,
 ) -> list[Task]:
     """Decompose a goal into tasks using the LLM.
 
@@ -172,8 +244,10 @@ async def plan(
         4. Build prompt with goal + context + roles + existing tasks
         5. Call Claude via CLI subprocess
         6. Parse JSON response into Task objects
-        7. Resolve dependency titles to IDs
-        8. POST each task to the server
+        7. Run the vertical-slice shape checker; re-prompt once if the
+           plan violates the configured caps (issue #1321).
+        8. Resolve dependency titles to IDs
+        9. POST each task to the server
 
     Args:
         goal: Free-text project goal to decompose.
@@ -182,6 +256,15 @@ async def plan(
         templates_dir: Root templates/ directory (contains roles/ and prompts/).
         model: LLM model to use for planning.
         provider: LLM provider.
+        enforce_vertical: When set, override the repo-level
+            ``[plan].enforce_vertical`` from ``bernstein.yaml``.  ``True``
+            forces the shape-check pass on, ``False`` disables it
+            (operator opt-out for plans that legitimately do not fit the
+            vertical-slice mould).  When ``None``, the repo config wins.
+        shape_config: Explicit :class:`ShapeConfig` override; mostly used
+            by tests.  When provided it short-circuits both the
+            ``enforce_vertical`` argument and the ``bernstein.yaml``
+            lookup.
 
     Returns:
         List of created Task objects (with server-assigned IDs).
@@ -190,6 +273,17 @@ async def plan(
         RuntimeError: If the LLM call fails.
         ValueError: If the LLM response cannot be parsed.
     """
+    # Resolve shape config: explicit > CLI/API flag > bernstein.yaml > defaults.
+    if shape_config is None:
+        shape_config = load_shape_config(workdir)
+    if enforce_vertical is not None:
+        shape_config = ShapeConfig(
+            enforce_vertical=enforce_vertical,
+            max_loc_hard=shape_config.max_loc_hard,
+            max_loc_ideal=shape_config.max_loc_ideal,
+            max_files=shape_config.max_files,
+            max_modules=shape_config.max_modules,
+        )
     # 0. Semantic cache — skip LLM if we've planned a similar goal before
     sem_cache = SemanticCacheManager(workdir)
 
@@ -294,6 +388,23 @@ async def plan(
             logger.warning("LLM returned no valid tasks")
             return []
 
+        # 6.5 Vertical-slice shape check (issue #1321).  When enabled,
+        # reject plans that violate the LOC / file / module caps or that
+        # are horizontally phased.  Retry once with a corrective prompt
+        # before giving up and accepting the original plan with a warning.
+        if shape_config.enforce_vertical:
+            tasks = await _run_shape_check_with_retry(
+                tasks=tasks,
+                prompt=prompt,
+                model=model,
+                provider=provider,
+                shape_config=shape_config,
+            )
+
+        # Log a one-line shape summary per slice for operator visibility.
+        for idx, task in enumerate(tasks, start=1):
+            logger.info("slice %d: %s · %s", idx, task.title, summarise_slice(task))
+
         # 7. Resolve dependency titles to IDs
         _resolve_depends_on(tasks)
 
@@ -319,6 +430,8 @@ async def replan(
     templates_dir: Path,
     model: str,
     provider: str,
+    *,
+    enforce_vertical: bool | None = None,
 ) -> list[Task]:
     """Adjust the plan based on progress.
 
@@ -351,4 +464,12 @@ async def replan(
         "Create only the NEW tasks needed to get back on track. "
         "Do not duplicate remaining tasks."
     )
-    return await plan(progress, server_url, workdir, templates_dir, model, provider)
+    return await plan(
+        progress,
+        server_url,
+        workdir,
+        templates_dir,
+        model,
+        provider,
+        enforce_vertical=enforce_vertical,
+    )

--- a/src/bernstein/core/planning/vertical_slice.py
+++ b/src/bernstein/core/planning/vertical_slice.py
@@ -1,0 +1,439 @@
+"""Vertical-slice shape checker for LLM-emitted plans.
+
+Issue #1321: enforce vertical slicing so the planner refuses plans where
+each task lives in only one architectural layer ("DB → DB → DB"), or
+where a single task is large enough that it cannot be reviewed in one
+pass.  The shape-checker runs *after* the LLM emits a plan and either
+accepts it or returns a structured violation report which the planner
+uses to re-prompt the LLM with a "your previous plan was too coarse"
+correction.
+
+Public API:
+    - ``ShapeConfig``: thresholds (LOC, files, modules) — loaded from
+      ``bernstein.yaml`` ``[plan]`` table when present.
+    - ``ShapeViolation``: a single rule failure attached to a task or to
+      a pair of consecutive tasks.
+    - ``check_plan(tasks, config)``: returns a list of violations.  An
+      empty list means the plan is accepted.
+    - ``summarise_slice(task)``: one-line shape summary, used for
+      operator-visible plan output ("slice 1: routes/ + tests/ + UI ·
+      ~180 LOC").
+    - ``load_shape_config(workdir)``: parse the optional ``[plan]`` table
+      from ``bernstein.yaml`` for repo-level threshold overrides.
+
+The module is deliberately I/O-light and side-effect free so it is easy
+to unit-test and to call from the planner's retry loop.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# Per issue #1321: ideal ≤200 LOC, hard ≤400 LOC, ≤10 files, ≤2 modules.
+DEFAULT_MAX_LOC_HARD = 400
+DEFAULT_MAX_LOC_IDEAL = 200
+DEFAULT_MAX_FILES = 10
+DEFAULT_MAX_MODULES = 2
+
+# Heuristic LOC estimate when the LLM does not state one explicitly.
+# Each owned file is assumed to grow by this many lines.
+_LOC_PER_FILE_ESTIMATE = 40
+
+# Recognised layer markers in owned-files paths.  A vertical slice should
+# touch at least two of these layers (or any of them plus tests/UI).
+_LAYER_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "tests": ("tests/", "/test_", "_test.", "spec/", "/__tests__/"),
+    "ui": (
+        "ui/",
+        "frontend/",
+        "components/",
+        "pages/",
+        "templates/",
+        ".tsx",
+        ".jsx",
+        ".vue",
+        ".svelte",
+        ".html",
+    ),
+    "api": ("routes/", "api/", "handlers/", "controllers/", "endpoints/", "views/"),
+    "domain": ("models/", "domain/", "services/", "core/"),
+    "db": ("migrations/", "schema/", "db/", "alembic/", "repositories/"),
+    "infra": ("infra/", "deploy/", "terraform/", "k8s/", "ops/"),
+    "docs": ("docs/", "README", ".md"),
+}
+
+
+@dataclass(frozen=True)
+class ShapeConfig:
+    """Thresholds for the shape checker.
+
+    Defaults match the issue spec.  All numeric thresholds may be
+    overridden via ``bernstein.yaml`` ``[plan]`` table, e.g.
+
+        plan:
+          max_loc: 400
+          max_loc_ideal: 200
+          max_files: 10
+          max_modules: 2
+          enforce_vertical: true
+    """
+
+    enforce_vertical: bool = True
+    max_loc_hard: int = DEFAULT_MAX_LOC_HARD
+    max_loc_ideal: int = DEFAULT_MAX_LOC_IDEAL
+    max_files: int = DEFAULT_MAX_FILES
+    max_modules: int = DEFAULT_MAX_MODULES
+
+
+@dataclass(frozen=True)
+class ShapeViolation:
+    """A single shape rule failure.
+
+    Attributes:
+        rule: Short rule identifier (e.g. ``"max_loc_hard"``).
+        message: Human-readable explanation, suitable for the re-prompt.
+        task_index: Index of the offending task in the original list, or
+            ``-1`` if the violation spans multiple tasks.
+        task_title: Title of the offending task, for log/UX clarity.
+        severity: ``"error"`` (rejects the plan) or ``"warn"`` (surfaced
+            but does not trigger a re-prompt).
+    """
+
+    rule: str
+    message: str
+    task_index: int = -1
+    task_title: str = ""
+    severity: str = "error"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _layers_for_path(path: str) -> set[str]:
+    """Return the set of layer labels that *path* belongs to."""
+    lowered = path.lower()
+    layers: set[str] = set()
+    for layer, markers in _LAYER_KEYWORDS.items():
+        for marker in markers:
+            if marker.lower() in lowered:
+                layers.add(layer)
+                break
+    return layers
+
+
+def _layers_for_task(task: Task) -> set[str]:
+    """Aggregate layer labels for every owned file on a task."""
+    layers: set[str] = set()
+    for path in task.owned_files:
+        layers.update(_layers_for_path(path))
+    return layers
+
+
+def _module_roots(task: Task) -> set[str]:
+    """Extract distinct top-level "modules" (first 2-3 path segments).
+
+    A "module" here is a coarse subpackage marker — e.g.
+    ``src/bernstein/core/planning/`` and
+    ``src/bernstein/core/planning/foo/`` collapse to the same module.
+    """
+    roots: set[str] = set()
+    for path in task.owned_files:
+        # Normalise and split.
+        parts = [seg for seg in path.replace("\\", "/").split("/") if seg]
+        if not parts:
+            continue
+        # Use the first three segments to give "src/<pkg>/<subpkg>"
+        # granularity which matches Python project layout in practice.
+        depth = min(3, len(parts))
+        roots.add("/".join(parts[:depth]))
+    return roots
+
+
+def _estimate_loc(task: Task) -> int:
+    """Best-effort LOC estimate for a task.
+
+    Looks at task ``scope`` first (small/medium/large), then falls back
+    to ``len(owned_files) * _LOC_PER_FILE_ESTIMATE``.
+    """
+    # ``scope`` is an enum; coerce to its value safely.
+    scope_value = getattr(task.scope, "value", str(task.scope)).lower()
+    scope_loc = {
+        "small": 80,
+        "medium": 200,
+        "large": 500,
+    }
+    base = scope_loc.get(scope_value, 200)
+
+    file_estimate = len(task.owned_files) * _LOC_PER_FILE_ESTIMATE
+    return max(base, file_estimate)
+
+
+def _same_module_tree(task_a: Task, task_b: Task) -> bool:
+    """Heuristic: do *task_a* and *task_b* live in the same subpackage tree?
+
+    True when at least one module root from *task_a* is a prefix of (or
+    equal to) one from *task_b* and neither task touches tests/UI.
+    """
+    roots_a = _module_roots(task_a)
+    roots_b = _module_roots(task_b)
+    if not roots_a or not roots_b:
+        return False
+    for a in roots_a:
+        for b in roots_b:
+            if a == b or a.startswith(b + "/") or b.startswith(a + "/"):
+                return True
+    return False
+
+
+def _is_horizontal(task: Task) -> bool:
+    """A task is "horizontal" when it touches only one architectural
+    layer and that layer is *not* tests or UI.
+    """
+    layers = _layers_for_task(task)
+    if not layers:
+        # If we cannot tell from owned_files, treat as horizontal only
+        # when the task explicitly belongs to a single backend role with
+        # no test/UI markers — be lenient here to avoid false positives.
+        return False
+    if "tests" in layers or "ui" in layers:
+        return False
+    return len(layers) == 1
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def summarise_slice(task: Task) -> str:
+    """One-line operator-friendly shape summary for *task*.
+
+    Example output::
+
+        routes/ + tests/ + UI · ~180 LOC
+
+    Args:
+        task: The task to summarise.
+
+    Returns:
+        Short label suitable for printing alongside a plan listing.
+    """
+    layers = sorted(_layers_for_task(task))
+    layer_str = "no-files" if not layers else " + ".join(layers)
+    return f"{layer_str} · ~{_estimate_loc(task)} LOC"
+
+
+def check_plan(tasks: list[Task], config: ShapeConfig | None = None) -> list[ShapeViolation]:
+    """Run the shape-check pass over an LLM-emitted plan.
+
+    Args:
+        tasks: Tasks parsed from the LLM response.
+        config: Threshold overrides; defaults are used when ``None``.
+
+    Returns:
+        List of :class:`ShapeViolation`.  Empty list means the plan
+        passed; the caller may still log ``severity="warn"`` entries.
+    """
+    cfg = config or ShapeConfig()
+    if not cfg.enforce_vertical:
+        return []
+
+    violations: list[ShapeViolation] = []
+
+    for idx, task in enumerate(tasks):
+        loc = _estimate_loc(task)
+        files = len(task.owned_files)
+        modules = len(_module_roots(task))
+
+        if loc > cfg.max_loc_hard:
+            violations.append(
+                ShapeViolation(
+                    rule="max_loc_hard",
+                    message=(
+                        f"Task {idx + 1} '{task.title}' is too large "
+                        f"(~{loc} LOC > {cfg.max_loc_hard} hard cap). "
+                        "Split it into multiple vertical slices."
+                    ),
+                    task_index=idx,
+                    task_title=task.title,
+                )
+            )
+        elif loc > cfg.max_loc_ideal:
+            violations.append(
+                ShapeViolation(
+                    rule="max_loc_ideal",
+                    message=(
+                        f"Task {idx + 1} '{task.title}' is above the ideal LOC budget (~{loc} > {cfg.max_loc_ideal})."
+                    ),
+                    task_index=idx,
+                    task_title=task.title,
+                    severity="warn",
+                )
+            )
+
+        if files > cfg.max_files:
+            violations.append(
+                ShapeViolation(
+                    rule="max_files",
+                    message=(f"Task {idx + 1} '{task.title}' touches {files} files (> {cfg.max_files} cap)."),
+                    task_index=idx,
+                    task_title=task.title,
+                )
+            )
+
+        if modules > cfg.max_modules:
+            violations.append(
+                ShapeViolation(
+                    rule="max_modules",
+                    message=(f"Task {idx + 1} '{task.title}' touches {modules} modules (> {cfg.max_modules} cap)."),
+                    task_index=idx,
+                    task_title=task.title,
+                )
+            )
+
+    # Horizontal-phasing check: two consecutive tasks that both live in
+    # only one layer, same subpackage tree, and neither touches tests/UI.
+    for i in range(len(tasks) - 1):
+        a, b = tasks[i], tasks[i + 1]
+        if _is_horizontal(a) and _is_horizontal(b) and _same_module_tree(a, b):
+            layers_a = sorted(_layers_for_task(a))
+            layers_b = sorted(_layers_for_task(b))
+            violations.append(
+                ShapeViolation(
+                    rule="horizontally_phased",
+                    message=(
+                        f"Tasks {i + 1} '{a.title}' and {i + 2} '{b.title}' "
+                        f"are horizontally phased — both stay inside the "
+                        f"{layers_a}/{layers_b} layer without crossing into "
+                        "tests or UI. Re-shape into vertical slices that "
+                        "cross every layer per task."
+                    ),
+                    task_index=i,
+                    task_title=a.title,
+                )
+            )
+
+    return violations
+
+
+def format_violations_for_reprompt(violations: list[ShapeViolation]) -> str:
+    """Render *violations* into a re-prompt body for the LLM.
+
+    Only ``severity="error"`` violations drive the re-prompt; warnings
+    are skipped here because we don't want to over-correct the LLM.
+
+    Args:
+        violations: The list returned by :func:`check_plan`.
+
+    Returns:
+        Multi-line string suitable to inline into a follow-up prompt.
+    """
+    errors = [v for v in violations if v.severity == "error"]
+    if not errors:
+        return ""
+    lines = [
+        "Your previous plan was too coarse. Specifically:",
+        "",
+    ]
+    lines.extend(f"- {v.message}" for v in errors)
+    lines.extend(
+        [
+            "",
+            "Re-emit the plan as vertical slices. Each slice must:",
+            "  - Stay under 400 LOC (ideal 200 LOC).",
+            "  - Touch ≤10 files and ≤2 modules.",
+            "  - Cross at least two layers (e.g. routes + tests, or "
+            "domain + UI). One user-visible behaviour per slice.",
+            "Output ONLY the corrected JSON array.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+
+
+def load_shape_config(workdir: Path | None) -> ShapeConfig:
+    """Load shape thresholds from ``bernstein.yaml`` ``[plan]`` table.
+
+    Missing file, missing table, or parse errors fall back to defaults
+    silently — the planner stays opinionated by default but never blows
+    up on a malformed repo.
+
+    Args:
+        workdir: Project root.  ``None`` returns defaults.
+
+    Returns:
+        Validated :class:`ShapeConfig` instance.
+    """
+    if workdir is None:
+        return ShapeConfig()
+    path = workdir / "bernstein.yaml"
+    if not path.is_file():
+        return ShapeConfig()
+    try:
+        import yaml
+
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Failed to parse bernstein.yaml for [plan] overrides: %s", exc)
+        return ShapeConfig()
+
+    block = raw.get("plan") if isinstance(raw, dict) else None
+    if not isinstance(block, dict):
+        return ShapeConfig()
+
+    def _int(key: str, default: int) -> int:
+        value = block.get(key, default)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _bool(key: str, default: bool) -> bool:
+        value = block.get(key, default)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return default
+
+    return ShapeConfig(
+        enforce_vertical=_bool("enforce_vertical", True),
+        max_loc_hard=_int("max_loc", DEFAULT_MAX_LOC_HARD),
+        max_loc_ideal=_int("max_loc_ideal", DEFAULT_MAX_LOC_IDEAL),
+        max_files=_int("max_files", DEFAULT_MAX_FILES),
+        max_modules=_int("max_modules", DEFAULT_MAX_MODULES),
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_FILES",
+    "DEFAULT_MAX_LOC_HARD",
+    "DEFAULT_MAX_LOC_IDEAL",
+    "DEFAULT_MAX_MODULES",
+    "ShapeConfig",
+    "ShapeViolation",
+    "check_plan",
+    "format_violations_for_reprompt",
+    "load_shape_config",
+    "summarise_slice",
+]

--- a/templates/prompts/plan.md
+++ b/templates/prompts/plan.md
@@ -22,14 +22,30 @@ You are the Manager of a multi-agent coding team. Your job is to decompose the g
 
 Break the goal into tasks. Each task should be completable by a single agent in 30-120 minutes.
 
+Shape every task as a **vertical slice** that crosses every layer it
+needs in one shippable unit (issue #1321). Horizontally-phased plans
+("DB → DB → DB → API → API → tests at the end") are rejected by the
+shape-checker and will be sent back to you for re-planning.
+
+Hard caps per task — exceed them and your plan will be rejected:
+- ≤200 LOC ideal, ≤400 LOC absolute hard cap
+- ≤10 files touched
+- ≤2 modules (top-level subpackages) touched
+- Each slice should include the route/handler **and** the test **and**
+  any UI hook it needs — one user-visible behaviour per slice.
+
 Rules:
 1. Never assign two tasks to the same files — prevent merge conflicts.
-2. Include test-writing in implementation tasks or as separate QA tasks.
+2. Include test-writing **inside** the same task as the production code
+   it covers, not as a separate phase at the end.
 3. Order tasks by dependency — foundational work first.
 4. Use the most appropriate role for each task.
-5. Keep tasks focused: one concern per task.
+5. Keep tasks focused: one user-visible behaviour per task.
 6. If existing tasks already cover part of the goal, do not duplicate them.
 7. Every task must have at least one completion signal so the janitor can verify it.
+8. No two consecutive tasks should live entirely in the same layer of
+   the same subpackage tree with no tests/UI work — that is the
+   "horizontally phased" anti-pattern.
 
 Output a JSON array of tasks. Each task object must have exactly these fields:
 

--- a/tests/unit/planning/test_vertical_slice.py
+++ b/tests/unit/planning/test_vertical_slice.py
@@ -1,0 +1,305 @@
+"""Unit tests for the vertical-slice shape checker (issue #1321)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.planning.vertical_slice import (
+    DEFAULT_MAX_FILES,
+    ShapeConfig,
+    ShapeViolation,
+    check_plan,
+    format_violations_for_reprompt,
+    load_shape_config,
+    summarise_slice,
+)
+from bernstein.core.tasks.models import Complexity, Scope, Task
+
+
+def _make_task(
+    title: str,
+    *,
+    owned_files: list[str] | None = None,
+    scope: Scope = Scope.MEDIUM,
+    role: str = "backend",
+) -> Task:
+    return Task(
+        id=f"t-{title}",
+        title=title,
+        description=f"impl {title}",
+        role=role,
+        scope=scope,
+        complexity=Complexity.MEDIUM,
+        owned_files=owned_files or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defaults & disabled mode
+# ---------------------------------------------------------------------------
+
+
+def test_shape_config_defaults_match_issue_spec() -> None:
+    cfg = ShapeConfig()
+    assert cfg.enforce_vertical is True
+    assert cfg.max_loc_hard == 400
+    assert cfg.max_loc_ideal == 200
+    assert cfg.max_files == 10
+    assert cfg.max_modules == 2
+
+
+def test_disabled_config_returns_no_violations_even_for_terrible_plan() -> None:
+    tasks = [
+        _make_task("db schema", owned_files=["src/app/db/schema.py"]),
+        _make_task("db migration", owned_files=["src/app/db/migration.py"]),
+        _make_task(
+            "huge task",
+            owned_files=[f"src/app/core/x{i}.py" for i in range(50)],
+            scope=Scope.LARGE,
+        ),
+    ]
+    cfg = ShapeConfig(enforce_vertical=False)
+    assert check_plan(tasks, cfg) == []
+
+
+# ---------------------------------------------------------------------------
+# Oversized slice detection
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_task_is_rejected_by_loc_cap() -> None:
+    task = _make_task(
+        "huge slice",
+        # 20 files * 40 LOC = 800 LOC, well above the 400 hard cap.
+        owned_files=[f"src/pkg/a{i}.py" for i in range(20)],
+        scope=Scope.LARGE,
+    )
+    violations = check_plan([task])
+    rules = {v.rule for v in violations}
+    assert "max_loc_hard" in rules
+    assert any(v.severity == "error" for v in violations)
+
+
+def test_too_many_files_is_rejected() -> None:
+    task = _make_task(
+        "too many files",
+        owned_files=[f"src/pkg/file{i}.py" for i in range(DEFAULT_MAX_FILES + 5)],
+        scope=Scope.SMALL,
+    )
+    violations = check_plan([task])
+    assert any(v.rule == "max_files" for v in violations)
+
+
+def test_too_many_modules_is_rejected() -> None:
+    task = _make_task(
+        "spread across modules",
+        owned_files=[
+            "src/pkgA/x.py",
+            "src/pkgB/y.py",
+            "src/pkgC/z.py",
+        ],
+    )
+    violations = check_plan([task])
+    assert any(v.rule == "max_modules" for v in violations)
+
+
+def test_ideal_loc_warning_only() -> None:
+    task = _make_task(
+        "slightly large slice",
+        # 7 files * 40 = 280 LOC: above ideal 200 but under hard 400.
+        owned_files=[f"src/pkg/a{i}.py" for i in range(7)],
+        scope=Scope.SMALL,
+    )
+    violations = check_plan([task])
+    rule_severities = {(v.rule, v.severity) for v in violations}
+    assert ("max_loc_ideal", "warn") in rule_severities
+    assert not any(v.severity == "error" and v.rule == "max_loc_hard" for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Horizontally-phased detection
+# ---------------------------------------------------------------------------
+
+
+def test_horizontally_phased_pair_is_flagged() -> None:
+    tasks = [
+        _make_task("db schema", owned_files=["src/app/db/schema.py"]),
+        _make_task("db migration", owned_files=["src/app/db/migration.py"]),
+    ]
+    violations = check_plan(tasks)
+    assert any(v.rule == "horizontally_phased" for v in violations)
+
+
+def test_vertical_pair_with_tests_is_accepted() -> None:
+    tasks = [
+        _make_task(
+            "feature A",
+            owned_files=[
+                "src/app/api/handler.py",
+                "tests/test_handler.py",
+            ],
+        ),
+        _make_task(
+            "feature B",
+            owned_files=[
+                "src/app/api/other.py",
+                "tests/test_other.py",
+            ],
+        ),
+    ]
+    errors = [v for v in check_plan(tasks) if v.severity == "error"]
+    assert errors == []
+
+
+def test_pair_in_different_modules_is_not_horizontally_phased() -> None:
+    tasks = [
+        _make_task("db work", owned_files=["src/pkgA/db/schema.py"]),
+        _make_task("api work", owned_files=["src/pkgB/api/handler.py"]),
+    ]
+    errors = [v for v in check_plan(tasks) if v.severity == "error"]
+    assert not any(v.rule == "horizontally_phased" for v in errors)
+
+
+# ---------------------------------------------------------------------------
+# Re-prompt body formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_violations_for_reprompt_empty_returns_empty() -> None:
+    assert format_violations_for_reprompt([]) == ""
+    only_warn = [ShapeViolation(rule="x", message="m", severity="warn")]
+    assert format_violations_for_reprompt(only_warn) == ""
+
+
+def test_format_violations_for_reprompt_includes_errors() -> None:
+    violations = [
+        ShapeViolation(rule="max_loc_hard", message="too big", severity="error"),
+        ShapeViolation(rule="ignored", message="warn only", severity="warn"),
+    ]
+    text = format_violations_for_reprompt(violations)
+    assert "too big" in text
+    assert "warn only" not in text
+    assert "Re-emit" in text
+    assert "vertical slices" in text
+
+
+# ---------------------------------------------------------------------------
+# Summary line
+# ---------------------------------------------------------------------------
+
+
+def test_summarise_slice_includes_layers_and_loc() -> None:
+    task = _make_task(
+        "feature",
+        owned_files=["src/app/api/handler.py", "tests/test_handler.py"],
+    )
+    summary = summarise_slice(task)
+    assert "api" in summary
+    assert "tests" in summary
+    assert "LOC" in summary
+
+
+def test_summarise_slice_handles_no_owned_files() -> None:
+    task = _make_task("free-form")
+    summary = summarise_slice(task)
+    assert "no-files" in summary
+    assert "LOC" in summary
+
+
+# ---------------------------------------------------------------------------
+# bernstein.yaml [plan] overrides
+# ---------------------------------------------------------------------------
+
+
+def test_load_shape_config_no_file_returns_defaults(tmp_path: Path) -> None:
+    cfg = load_shape_config(tmp_path)
+    assert cfg == ShapeConfig()
+
+
+def test_load_shape_config_with_overrides(tmp_path: Path) -> None:
+    (tmp_path / "bernstein.yaml").write_text(
+        "plan:\n  enforce_vertical: false\n  max_loc: 250\n  max_loc_ideal: 150\n  max_files: 5\n  max_modules: 1\n",
+        encoding="utf-8",
+    )
+    cfg = load_shape_config(tmp_path)
+    assert cfg.enforce_vertical is False
+    assert cfg.max_loc_hard == 250
+    assert cfg.max_loc_ideal == 150
+    assert cfg.max_files == 5
+    assert cfg.max_modules == 1
+
+
+def test_load_shape_config_missing_plan_block_returns_defaults(tmp_path: Path) -> None:
+    (tmp_path / "bernstein.yaml").write_text(
+        "goal: 'do things'\nmax_agents: 4\n",
+        encoding="utf-8",
+    )
+    cfg = load_shape_config(tmp_path)
+    assert cfg == ShapeConfig()
+
+
+def test_load_shape_config_string_bool_accepted(tmp_path: Path) -> None:
+    (tmp_path / "bernstein.yaml").write_text(
+        "plan:\n  enforce_vertical: 'no'\n",
+        encoding="utf-8",
+    )
+    cfg = load_shape_config(tmp_path)
+    assert cfg.enforce_vertical is False
+
+
+# ---------------------------------------------------------------------------
+# Integration-ish scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_horizontally_phased_full_plan_known_oversized_split_target() -> None:
+    """Known horizontally-phased plan should be rejected and the
+    re-prompt body should mention how to split.
+    """
+    tasks = [
+        _make_task(
+            "design db schema",
+            owned_files=["src/svc/db/users.py", "src/svc/db/posts.py"],
+        ),
+        _make_task(
+            "write db migrations",
+            owned_files=["src/svc/db/migrations/001.py"],
+        ),
+        _make_task(
+            "implement api endpoints",
+            owned_files=[
+                "src/svc/api/users.py",
+                "src/svc/api/posts.py",
+                "src/svc/api/comments.py",
+            ],
+        ),
+    ]
+    violations = check_plan(tasks)
+    errors = [v for v in violations if v.severity == "error"]
+    assert errors, "expected at least one error on a phased plan"
+    body = format_violations_for_reprompt(violations)
+    assert "Re-emit" in body
+    assert "vertical slices" in body
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("1", True),
+        ("false", False),
+        ("0", False),
+        ("off", False),
+    ],
+)
+def test_load_shape_config_string_bool_variants(tmp_path: Path, value: str, expected: bool) -> None:
+    (tmp_path / "bernstein.yaml").write_text(
+        f"plan:\n  enforce_vertical: '{value}'\n",
+        encoding="utf-8",
+    )
+    cfg = load_shape_config(tmp_path)
+    assert cfg.enforce_vertical is expected


### PR DESCRIPTION
Closes #1321

## Summary

- New shape-check pass after the LLM emits a plan: rejects slices that exceed 400 LOC hard / 200 LOC ideal, touch >10 files, or span >2 modules.
- Detects horizontally-phased plans (two consecutive tasks stuck in one layer of one subpackage tree, no tests/UI).
- Auto-split via single re-prompt: "your previous plan was too coarse" with a structured violation list. Falls back to the original plan if the retry still fails, so existing plans don't break hard.
- `[plan]` table in `bernstein.yaml` tunes the caps repo-wide (`enforce_vertical`, `max_loc`, `max_loc_ideal`, `max_files`, `max_modules`).
- `bernstein plan generate --enforce-vertical` (default on in 2.x) / `--no-enforce-vertical` opt-out. `--max-loc` and `--max-files` per-invocation overrides.
- Planner prompt template (`templates/prompts/plan.md`) bakes the vertical-slice contract into the LLM instructions and explicitly lists the caps.
- Operator-visible one-line shape summary per slice in planner logs: `slice 1: api + tests · ~180 LOC`.

## Test plan

- [x] Unit: oversized plan rejected (LOC, files, modules caps).
- [x] Unit: horizontally-phased pair flagged; vertical pair with tests accepted; pair in different modules not flagged.
- [x] Unit: re-prompt body formatting (errors only, warnings filtered out).
- [x] Unit: `summarise_slice` includes layer labels + LOC.
- [x] Unit: `load_shape_config` parses `[plan]` table, handles missing file / block, accepts string bool values.
- [x] Smoke: planner imports still resolve via redirect (`bernstein.core.planner`).
- [x] Existing planner + plan tests still pass (260 tests across planning surface).

## Default thresholds

| Knob              | Default | Override                       |
|-------------------|---------|--------------------------------|
| max LOC (hard)    | 400     | `[plan].max_loc` / `--max-loc` |
| max LOC (ideal)   | 200     | `[plan].max_loc_ideal`         |
| max files         | 10      | `[plan].max_files` / `--max-files` |
| max modules       | 2       | `[plan].max_modules`           |
| enforce_vertical  | true    | `[plan].enforce_vertical` / `--no-enforce-vertical` |

## Opt-out

- CLI: `bernstein plan generate ... --no-enforce-vertical`
- Config: `plan: {enforce_vertical: false}` in `bernstein.yaml`
- API: `ManagerAgent(..., enforce_vertical=False)` / `plan(..., enforce_vertical=False)`