### PR TITLE
feat(quality): blast-radius scorer + reversibility gate (closes #1322)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -312,6 +312,9 @@ artifacts = [
 # wheel so `bernstein run --criterion-profile safety-first` resolves
 # without a source checkout, mirroring the mode_profile pattern.
 "templates/criterion_profiles" = "bernstein/_default_templates/criterion_profiles"
+# Blast-radius detector defaults (#1322) so the reversibility gate finds
+# its rule list without requiring a source checkout.
+"templates/blast-radius" = "bernstein/_default_templates/blast-radius"
 # ascii_logo.md now lives in-package at src/bernstein/_default_templates/ —
 # no force-include needed. The dev-repo copy at docs/assets/ascii_logo.md is
 # the display fallback read by cli/display/splash_v2.py when running from a

--- a/src/bernstein/cli/commands/blast_radius_cmd.py
+++ b/src/bernstein/cli/commands/blast_radius_cmd.py
@@ -1,0 +1,162 @@
+"""CLI surface for blast-radius scoring (issue #1322).
+
+Two entry points:
+
+* ``bernstein blast-radius show <task_id>`` -- pretty-print a saved report.
+* ``bernstein blast-radius score`` -- ad-hoc scoring from explicit
+  ``--file`` / ``--diff-file`` arguments. Useful for CI scripts and for
+  reviewers who want to inspect a change without persisting it.
+
+The ``--max-blast-radius`` flag on ``bernstein run`` lives in
+:mod:`bernstein.cli.run_bootstrap`; it propagates the operator ceiling via
+the ``BERNSTEIN_MAX_BLAST_RADIUS`` env var so subprocesses see the same
+gate value.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from bernstein.core.quality.blast_radius import (
+    BlastRadiusReport,
+    BlastRadiusScorer,
+    evaluate_gate,
+    load_report,
+    save_report,
+)
+
+__all__ = ["blast_radius_group"]
+
+
+@click.group(name="blast-radius")
+def blast_radius_group() -> None:
+    """Inspect blast-radius scores for changes (issue #1322).
+
+    A blast-radius score in [0, 1] estimates how irreversible a change is.
+    Hard one-way detectors (DROP/DELETE SQL, rm -rf, schema migrations,
+    secrets / .env writes) force the score to 1.0.
+    """
+
+
+def _format_report(report: BlastRadiusReport, *, fmt: str) -> str:
+    if fmt == "json":
+        return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    lines: list[str] = []
+    lines.append(f"score:          {report.score:.2f}")
+    lines.append(f"hard_one_way:   {report.hard_one_way}")
+    lines.append(f"files_touched:  {report.files_touched}")
+    lines.append("components:")
+    for comp in report.components:
+        lines.append(f"  - {comp.name:>22s}: {comp.value:.2f}  ({comp.detail})")
+    if report.hits:
+        lines.append("detectors that fired:")
+        for hit in report.hits:
+            mark = "!" if hit.hard_one_way else "*"
+            lines.append(f"  [{mark}] {hit.detector_id} (w={hit.weight:.2f}, sev={hit.severity}): {hit.description}")
+            for path in hit.matched_paths[:3]:
+                lines.append(f"        path: {path}")
+            for snippet in hit.matched_snippets[:2]:
+                lines.append(f"        diff: {snippet}")
+    else:
+        lines.append("detectors that fired: (none)")
+    lines.append("")
+    lines.append(report.rationale)
+    return "\n".join(lines)
+
+
+@blast_radius_group.command("show")
+@click.argument("task_id")
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Workdir containing .sdd/metrics/blast_radius/. Defaults to cwd.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(("text", "json"), case_sensitive=False),
+    default="text",
+    help="Output format.",
+)
+def show_cmd(task_id: str, workdir: Path | None, fmt: str) -> None:
+    """Pretty-print the saved blast-radius report for ``TASK_ID``."""
+    report = load_report(task_id, workdir=workdir)
+    if report is None:
+        click.echo(f"No blast-radius report for task {task_id!r}.", err=True)
+        sys.exit(2)
+    click.echo(_format_report(report, fmt=fmt.lower()))
+
+
+@blast_radius_group.command("score")
+@click.option(
+    "--file",
+    "files",
+    multiple=True,
+    help="Path touched by the change. May be repeated.",
+)
+@click.option(
+    "--files-from",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Read newline-separated changed file paths from FILE.",
+)
+@click.option(
+    "--diff-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Read diff body (for content_regex detectors) from FILE.",
+)
+@click.option(
+    "--max-score",
+    type=click.FloatRange(0.0, 1.0),
+    default=None,
+    help="If set, exit non-zero when the score exceeds this ceiling.",
+)
+@click.option(
+    "--save-as",
+    "save_as",
+    type=str,
+    default=None,
+    help="Persist the report under .sdd/metrics/blast_radius/<TASK_ID>.json.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(("text", "json"), case_sensitive=False),
+    default="text",
+    help="Output format.",
+)
+def score_cmd(
+    files: tuple[str, ...],
+    files_from: Path | None,
+    diff_file: Path | None,
+    max_score: float | None,
+    save_as: str | None,
+    fmt: str,
+) -> None:
+    """Score a change described on the command line (no orchestrator needed)."""
+    paths: list[str] = list(files)
+    if files_from is not None:
+        for line in files_from.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if stripped:
+                paths.append(stripped)
+    diff_text = diff_file.read_text(encoding="utf-8") if diff_file is not None else ""
+
+    scorer = BlastRadiusScorer()
+    report = scorer.score(files=paths, diff_text=diff_text)
+    click.echo(_format_report(report, fmt=fmt.lower()))
+
+    if save_as is not None:
+        target = save_report(report, task_id=save_as)
+        click.echo(f"\nReport persisted to: {target}", err=True)
+
+    decision = evaluate_gate(report, max_score=max_score)
+    if not decision.allowed:
+        click.echo(f"\nGate refused: {decision.reason}", err=True)
+        sys.exit(3)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -946,6 +946,11 @@ from bernstein.cli.commands.identity_cmd import identity_group  # noqa: E402
 cli.add_command(identity_group, "identity")
 cli.add_command(analyze_cmd, "analyze")  # issue #768
 
+# Blast-radius scorer (issue #1322): inspect + ad-hoc score a change.
+from bernstein.cli.commands.blast_radius_cmd import blast_radius_group  # noqa: E402
+
+cli.add_command(blast_radius_group, "blast-radius")
+
 # Recorded run-session inspection + fork (#1222).
 from bernstein.cli.commands.session_cmd import session_group  # noqa: E402
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -269,6 +269,7 @@ def _propagate_env_flags(
     hard_budget_usd: float | None = None,
     allow_paid: bool = False,
     permission_profile: str | None = None,
+    max_blast_radius: float | None = None,
 ) -> None:
     """Set environment variables so orchestrator subprocesses inherit CLI flags."""
     _flag_map: list[tuple[bool, str]] = [
@@ -308,6 +309,13 @@ def _propagate_env_flags(
     # cumulative spend reaches this value, no soft-warn ramp.
     if hard_budget_usd is not None and hard_budget_usd > 0.0:
         os.environ["BERNSTEIN_HARD_BUDGET_USD"] = f"{hard_budget_usd:.6f}"
+
+    # Reversibility gate (#1322). Off-by-default: only propagated when
+    # the operator passes ``--max-blast-radius`` so existing runs are
+    # unaffected. The merge / deploy gate reads this env var and refuses
+    # changes whose blast-radius score exceeds the ceiling.
+    if max_blast_radius is not None:
+        os.environ["BERNSTEIN_MAX_BLAST_RADIUS"] = f"{max_blast_radius:.4f}"
 
     if sandbox:
         normalized = sandbox.lower()
@@ -1034,6 +1042,18 @@ def exec_restart() -> None:
         "metadata['criterion_profile'] explicitly."
     ),
 )
+@click.option(
+    "--max-blast-radius",
+    "max_blast_radius",
+    type=click.FloatRange(0.0, 1.0),
+    default=None,
+    help=(
+        "Reversibility gate (#1322): refuse merges whose blast-radius score "
+        "exceeds the supplied ceiling [0, 1]. Hard one-way changes (DROP/"
+        "DELETE SQL, rm -rf, schema migrations, secrets writes) always "
+        "score 1.0. Off by default; existing runs are unaffected."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1074,6 +1094,7 @@ def run(
     budget_cap: float | None = None,
     retry_budget_spec: str | None = None,
     criterion_profile: str | None = None,
+    max_blast_radius: float | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1181,6 +1202,7 @@ def run(
         hard_budget_usd=hard_budget_usd,
         allow_paid=allow_paid,
         permission_profile=permission_profile,
+        max_blast_radius=max_blast_radius,
     )
 
     _install_network_policy(run_profile=run_profile, allow_network=allow_network)

--- a/src/bernstein/core/lifecycle/blast_radius_gate.py
+++ b/src/bernstein/core/lifecycle/blast_radius_gate.py
@@ -1,0 +1,70 @@
+"""Lifecycle wire-in for the blast-radius reversibility gate (issue #1322).
+
+This module is the single integration point between the blast-radius scorer
+in :mod:`bernstein.core.quality.blast_radius` and the merge / deploy gate.
+It is intentionally tiny: orchestrator callers invoke
+:func:`install_blast_radius_gate` after building a
+:class:`bernstein.core.security.blocking_hooks.BlockingHookRunner`. The
+function is a no-op unless the operator opted in via
+``--max-blast-radius`` (which propagates the ``BERNSTEIN_MAX_BLAST_RADIUS``
+env var).
+
+Default behaviour stays unchanged: when the env var is unset, no hook is
+registered and the gate is a pass-through.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bernstein.core.security.blocking_hooks import BlockingHookRunner
+
+logger = logging.getLogger(__name__)
+
+#: Operator-visible env var that carries the ceiling from `bernstein run`.
+ENV_MAX_BLAST_RADIUS: str = "BERNSTEIN_MAX_BLAST_RADIUS"
+
+
+def _read_ceiling() -> float | None:
+    """Parse the env var and clamp to [0, 1]. Returns ``None`` when unset."""
+    raw = os.environ.get(ENV_MAX_BLAST_RADIUS)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Ignoring %s=%r: not a valid float in [0, 1].", ENV_MAX_BLAST_RADIUS, raw)
+        return None
+    if not 0.0 <= value <= 1.0:
+        logger.warning("Ignoring %s=%s: outside [0, 1].", ENV_MAX_BLAST_RADIUS, value)
+        return None
+    return value
+
+
+def install_blast_radius_gate(runner: BlockingHookRunner) -> bool:
+    """Register the blast-radius hook on ``runner`` if the env var is set.
+
+    Args:
+        runner: Existing :class:`BlockingHookRunner`.
+
+    Returns:
+        ``True`` when a hook was registered, ``False`` when the gate was
+        skipped (env var unset or invalid).
+    """
+    ceiling = _read_ceiling()
+    if ceiling is None:
+        return False
+    # Late import to avoid pulling YAML / scorer code into modules that
+    # never opt in to the gate.
+    from bernstein.core.quality.blast_radius import make_pre_merge_hook
+
+    hook = make_pre_merge_hook(max_score=ceiling)
+    runner.register("pre_merge", hook)
+    logger.info("Blast-radius reversibility gate active: ceiling=%.4f (pre_merge).", ceiling)
+    return True
+
+
+__all__ = ["ENV_MAX_BLAST_RADIUS", "install_blast_radius_gate"]

--- a/src/bernstein/core/quality/blast_radius.py
+++ b/src/bernstein/core/quality/blast_radius.py
@@ -1,0 +1,643 @@
+"""Blast-radius scorer + reversibility gate.
+
+Issue #1322. Produces a score in [0, 1] together with a structured rationale
+describing which detectors fired and how each contributed. Detectors with
+``hard_one_way: true`` force the score to 1.0 (regardless of other inputs)
+so schema migrations, secrets writes, ``DROP``/``DELETE`` statements and
+``rm -rf`` always surface as one-way doors.
+
+Design notes
+------------
+
+The scorer is intentionally additive on top of the existing approval surface
+(see issue #1322 non-goals): it produces a number + rationale, and the merge
+/ deploy gate is the consumer that decides what to do with it. Default
+behaviour for callers that do not opt in via ``max_score`` / the
+``--max-blast-radius`` CLI flag is unchanged.
+
+Soft components are normalized by their declared weight so the floor is the
+single biggest weight and the ceiling is 1.0 even when many low-severity
+detectors fire. A small file-count component is added (capped at 0.2) so a
+hundred-file refactor still ranks above a one-line tweak even when none of
+the destructive detectors match.
+
+This module is dependency-light on purpose: only the Python stdlib and PyYAML
+(already a Bernstein dependency) are required. It does *not* import any
+gate-runner state so it can be used from CLI entry points before the
+orchestrator is bootstrapped.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+__all__ = [
+    "BlastRadiusReport",
+    "BlastRadiusScorer",
+    "ComponentScore",
+    "Detector",
+    "DetectorHit",
+    "default_detectors_path",
+    "load_detectors",
+    "score_change",
+]
+
+
+DetectorKind = Literal["content_regex", "path_glob", "path_regex"]
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Detector:
+    """A single blast-radius detector loaded from YAML."""
+
+    id: str
+    kind: DetectorKind
+    pattern: str
+    description: str
+    severity: str
+    weight: float
+    hard_one_way: bool = False
+
+    def __post_init__(self) -> None:
+        if self.kind not in ("content_regex", "path_glob", "path_regex"):
+            raise ValueError(f"Detector {self.id}: unknown kind {self.kind!r}")
+        if not 0.0 <= self.weight <= 1.0:
+            raise ValueError(f"Detector {self.id}: weight must be in [0, 1], got {self.weight}")
+
+
+@dataclass(frozen=True, slots=True)
+class DetectorHit:
+    """A detector that matched, with the evidence that triggered it."""
+
+    detector_id: str
+    description: str
+    severity: str
+    weight: float
+    hard_one_way: bool
+    matched_paths: tuple[str, ...] = ()
+    matched_snippets: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "detector_id": self.detector_id,
+            "description": self.description,
+            "severity": self.severity,
+            "weight": self.weight,
+            "hard_one_way": self.hard_one_way,
+            "matched_paths": list(self.matched_paths),
+            "matched_snippets": list(self.matched_snippets),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ComponentScore:
+    """Contribution of one named component to the total."""
+
+    name: str
+    value: float
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "value": round(self.value, 4), "detail": self.detail}
+
+
+@dataclass(frozen=True, slots=True)
+class BlastRadiusReport:
+    """Output of :func:`score_change`."""
+
+    score: float
+    hard_one_way: bool
+    components: tuple[ComponentScore, ...]
+    hits: tuple[DetectorHit, ...]
+    rationale: str
+    files_touched: int
+    files: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "score": round(self.score, 4),
+            "hard_one_way": self.hard_one_way,
+            "components": [c.to_dict() for c in self.components],
+            "hits": [h.to_dict() for h in self.hits],
+            "rationale": self.rationale,
+            "files_touched": self.files_touched,
+            "files": list(self.files),
+        }
+
+    def exceeds(self, threshold: float) -> bool:
+        """Return ``True`` when this change should be refused by the gate.
+
+        A change exceeds the threshold when the numeric score is strictly
+        greater than the configured ceiling, or when any ``hard_one_way``
+        detector fired and the ceiling is below 1.0. The ``hard_one_way``
+        rule preserves the issue-#1322 invariant that schema migrations,
+        ``DROP``/``DELETE`` SQL, ``rm -rf`` and secrets writes always
+        require explicit approval.
+        """
+        if self.score > threshold:
+            return True
+        return bool(self.hard_one_way and threshold < 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Detector loading
+# ---------------------------------------------------------------------------
+
+
+def default_detectors_path() -> Path:
+    """Return the on-disk path of the shipped default detector list.
+
+    Search order:
+
+    1. ``<pkg>/_default_templates/blast-radius/detectors.yaml`` -- the
+       wheel-bundled copy (see ``[tool.hatch.build.targets.wheel.force-include]``
+       in ``pyproject.toml``). This is what installed users see.
+    2. ``<repo>/templates/blast-radius/detectors.yaml`` -- the editable
+       source-checkout layout used during development.
+    3. Walk up from the current file looking for a ``templates/`` sibling.
+    """
+    # 1. Wheel-bundled copy at ``<pkg>/_default_templates/blast-radius``.
+    bundled = (
+        Path(__file__).resolve().parents[2]
+        / "_default_templates"
+        / "blast-radius"
+        / "detectors.yaml"
+    )
+    if bundled.exists():
+        return bundled
+
+    # 2. Source-checkout: <repo>/templates/blast-radius/detectors.yaml
+    repo_root = Path(__file__).resolve().parents[3]
+    candidate = repo_root.parent / "templates" / "blast-radius" / "detectors.yaml"
+    if candidate.exists():
+        return candidate
+
+    # 3. Fallback: walk up looking for the templates directory.
+    for parent in Path(__file__).resolve().parents:
+        guess = parent / "templates" / "blast-radius" / "detectors.yaml"
+        if guess.exists():
+            return guess
+    raise FileNotFoundError("templates/blast-radius/detectors.yaml not found on disk")
+
+
+def load_detectors(path: Path | str | None = None) -> list[Detector]:
+    """Load detector definitions from a YAML file.
+
+    When ``path`` is ``None`` the shipped defaults are loaded from
+    ``templates/blast-radius/detectors.yaml``.
+    """
+    import yaml  # type: ignore[import-untyped]  # local import; PyYAML stubs are dev-only
+
+    if path is None:
+        path = default_detectors_path()
+    text = Path(path).read_text(encoding="utf-8")
+    raw = yaml.safe_load(text) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"detectors file {path} must be a mapping at the top level")
+    items = raw.get("detectors") or []
+    if not isinstance(items, list):
+        raise ValueError(f"detectors file {path}: `detectors:` must be a list")
+
+    out: list[Detector] = []
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            detector = Detector(
+                id=str(entry["id"]),
+                kind=entry["kind"],
+                pattern=str(entry["pattern"]),
+                description=str(entry.get("description", "")),
+                severity=str(entry.get("severity", "medium")),
+                weight=float(entry.get("weight", 0.3)),
+                hard_one_way=bool(entry.get("hard_one_way", False)),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"detectors file {path}: invalid entry {entry!r}: {exc}") from exc
+        out.append(detector)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+# File-count component is capped so a giant refactor doesn't dominate the
+# destructive detector signals. Threshold tuned to mirror the heuristic
+# called out in issue #1322 (weight ~0.2 on files_touched).
+_FILE_COUNT_CAP = 0.2
+_FILE_COUNT_SATURATION = 50  # at >=50 touched files the component is at cap
+
+
+def _file_count_component(n: int) -> ComponentScore:
+    """Return the file-count component score.
+
+    Saturates at ``_FILE_COUNT_CAP`` once the change touches more than
+    ``_FILE_COUNT_SATURATION`` files. A pure-doc change with one file gets
+    a near-zero contribution here, satisfying the issue-#1322 unit-test
+    expectation that doc changes score < 0.1.
+    """
+    if n <= 0:
+        return ComponentScore(name="files_touched", value=0.0, detail="0 files touched")
+    fraction = min(1.0, n / _FILE_COUNT_SATURATION)
+    value = round(fraction * _FILE_COUNT_CAP, 4)
+    return ComponentScore(name="files_touched", value=value, detail=f"{n} file(s) touched")
+
+
+def _match_path(detector: Detector, path: str) -> bool:
+    if detector.kind == "path_glob":
+        # Two-step match: ``**/foo`` should match both ``foo`` at the
+        # repo root and ``some/dir/foo`` anywhere below it. Python's
+        # ``fnmatch`` doesn't expand ``**/`` natively, so we also try
+        # the pattern without that prefix.
+        pattern = detector.pattern
+        if fnmatch.fnmatch(path, pattern):
+            return True
+        if pattern.startswith("**/"):
+            return fnmatch.fnmatch(path, pattern[3:])
+        return False
+    if detector.kind == "path_regex":
+        return re.search(detector.pattern, path) is not None
+    return False
+
+
+def _match_content(detector: Detector, content: str) -> list[str]:
+    """Return up to 3 short snippets for content_regex hits, else []."""
+    if detector.kind != "content_regex" or not content:
+        return []
+    flags = 0
+    snippets: list[str] = []
+    for match in re.finditer(detector.pattern, content, flags=flags):
+        # Show the matched line, trimmed.
+        start = content.rfind("\n", 0, match.start()) + 1
+        end = content.find("\n", match.end())
+        if end == -1:
+            end = len(content)
+        snippet = content[start:end].strip()
+        if len(snippet) > 200:
+            snippet = snippet[:200] + "..."
+        snippets.append(snippet)
+        if len(snippets) >= 3:
+            break
+    return snippets
+
+
+def _normalize_paths(files: Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for path in files:
+        p = str(path).strip()
+        if not p or p in seen:
+            continue
+        seen.add(p)
+        ordered.append(p)
+    return tuple(ordered)
+
+
+def _aggregate_soft_components(hits: Sequence[DetectorHit]) -> ComponentScore:
+    """Combine non-hard hits into a single ``destructive_signals`` component.
+
+    The contribution scales with the max weight that fired (so one critical
+    soft detector dominates), plus a smaller bonus for additional fires so
+    a long tail of medium-weight hits still bumps the score.
+    """
+    soft = [h for h in hits if not h.hard_one_way]
+    if not soft:
+        return ComponentScore(name="destructive_signals", value=0.0, detail="no destructive detectors fired")
+    weights = [h.weight for h in soft]
+    primary = max(weights)
+    extra = sum(w for w in weights if w < primary) * 0.25  # diminishing returns
+    value = min(1.0, primary + extra)
+    detail = f"{len(soft)} soft detector(s) fired; max weight {primary:.2f}"
+    return ComponentScore(name="destructive_signals", value=value, detail=detail)
+
+
+def score_change(
+    *,
+    files: Sequence[str] = (),
+    diff_text: str = "",
+    file_contents: dict[str, str] | None = None,
+    detectors: Sequence[Detector] | None = None,
+) -> BlastRadiusReport:
+    """Compute a blast-radius report for one set of changes.
+
+    Args:
+        files: Paths touched by the change (any path style; matched against
+            detector globs / regexes as-is).
+        diff_text: Concatenated diff / patch body for content_regex matching.
+            Pass an empty string when only path-based signals are available.
+        file_contents: Optional mapping from path to full file body. When
+            provided, content detectors also scan each file body in
+            addition to ``diff_text``.
+        detectors: Detector list. ``None`` loads the shipped defaults.
+
+    Returns:
+        A :class:`BlastRadiusReport` with score, components and rationale.
+    """
+    detectors_list = list(detectors) if detectors is not None else load_detectors()
+    paths = _normalize_paths(files)
+
+    hits: list[DetectorHit] = []
+    for det in detectors_list:
+        matched_paths: list[str] = []
+        for p in paths:
+            if _match_path(det, p):
+                matched_paths.append(p)
+
+        snippets: list[str] = []
+        if det.kind == "content_regex":
+            snippets = _match_content(det, diff_text)
+            if file_contents:
+                for _path, body in file_contents.items():
+                    snippets.extend(_match_content(det, body))
+                    if len(snippets) >= 6:
+                        break
+
+        if matched_paths or snippets:
+            hits.append(
+                DetectorHit(
+                    detector_id=det.id,
+                    description=det.description,
+                    severity=det.severity,
+                    weight=det.weight,
+                    hard_one_way=det.hard_one_way,
+                    matched_paths=tuple(matched_paths),
+                    matched_snippets=tuple(snippets[:5]),
+                )
+            )
+
+    hard_one_way = any(h.hard_one_way for h in hits)
+    file_component = _file_count_component(len(paths))
+    soft_component = _aggregate_soft_components(hits)
+
+    hard_value = 1.0 if hard_one_way else 0.0
+    hard_component = ComponentScore(
+        name="hard_one_way",
+        value=hard_value,
+        detail=(
+            "hard detector(s) fired: " + ", ".join(h.detector_id for h in hits if h.hard_one_way)
+            if hard_one_way
+            else "no hard detectors fired"
+        ),
+    )
+
+    # Combine soft signals and file-count into [0, 1] when no hard
+    # detectors fired; otherwise the issue-#1322 invariant forces 1.0.
+    score = 1.0 if hard_one_way else min(1.0, soft_component.value + file_component.value)
+
+    components = (hard_component, soft_component, file_component)
+    rationale = _build_rationale(score, hard_one_way, hits, file_component)
+
+    return BlastRadiusReport(
+        score=round(score, 4),
+        hard_one_way=hard_one_way,
+        components=components,
+        hits=tuple(hits),
+        rationale=rationale,
+        files_touched=len(paths),
+        files=paths,
+    )
+
+
+def _build_rationale(
+    score: float,
+    hard_one_way: bool,
+    hits: Sequence[DetectorHit],
+    file_component: ComponentScore,
+) -> str:
+    parts: list[str] = []
+    if hard_one_way:
+        ids = ", ".join(h.detector_id for h in hits if h.hard_one_way)
+        parts.append(
+            f"score=1.0 forced by hard one-way detector(s): {ids}. "
+            "Change requires explicit approval before merge / deploy."
+        )
+    else:
+        parts.append(f"score={score:.2f} computed from soft signals + file count.")
+        if hits:
+            ids = ", ".join(f"{h.detector_id}(w={h.weight:.2f})" for h in hits)
+            parts.append(f"Detectors that fired: {ids}.")
+        else:
+            parts.append("No detectors fired.")
+        parts.append(file_component.detail + ".")
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Convenience: a class wrapper so consumers can hold an immutable scorer.
+# ---------------------------------------------------------------------------
+
+
+class BlastRadiusScorer:
+    """Stateful wrapper around :func:`score_change` for repeated calls."""
+
+    def __init__(self, detectors: Sequence[Detector] | None = None) -> None:
+        self._detectors: list[Detector] = list(detectors) if detectors is not None else load_detectors()
+
+    @property
+    def detectors(self) -> tuple[Detector, ...]:
+        return tuple(self._detectors)
+
+    def score(
+        self,
+        *,
+        files: Sequence[str] = (),
+        diff_text: str = "",
+        file_contents: dict[str, str] | None = None,
+    ) -> BlastRadiusReport:
+        return score_change(
+            files=files,
+            diff_text=diff_text,
+            file_contents=file_contents,
+            detectors=self._detectors,
+        )
+
+    def to_payload(self, report: BlastRadiusReport) -> dict[str, Any]:
+        """Render ``report`` as a JSON-safe dict (alias for ``report.to_dict()``)."""
+        # Kept as a method so call sites can switch implementations without
+        # threading dataclass internals through their code.
+        return report.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Gate integration helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GateDecision:
+    """Outcome of evaluating a blast-radius report against an operator ceiling."""
+
+    allowed: bool
+    threshold: float
+    report: BlastRadiusReport
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "threshold": self.threshold,
+            "reason": self.reason,
+            "report": self.report.to_dict(),
+        }
+
+
+def evaluate_gate(report: BlastRadiusReport, *, max_score: float | None) -> GateDecision:
+    """Decide whether ``report`` clears the operator-supplied ceiling.
+
+    Default behaviour: when ``max_score`` is ``None`` (i.e. the operator did
+    not pass ``--max-blast-radius``), the gate is a no-op and ``allowed`` is
+    always ``True``. This preserves the issue-#1322 requirement that
+    existing runs are unaffected.
+    """
+    if max_score is None:
+        return GateDecision(
+            allowed=True,
+            threshold=1.0,
+            report=report,
+            reason="no --max-blast-radius set; gate skipped",
+        )
+    if not 0.0 <= max_score <= 1.0:
+        raise ValueError(f"max_score must be in [0, 1], got {max_score}")
+    if report.exceeds(max_score):
+        if report.hard_one_way:
+            reason = f"refused: hard one-way detector fired and ceiling {max_score:.2f} < 1.0"
+        else:
+            reason = f"refused: blast-radius score {report.score:.2f} > ceiling {max_score:.2f}"
+        return GateDecision(allowed=False, threshold=max_score, report=report, reason=reason)
+    return GateDecision(
+        allowed=True,
+        threshold=max_score,
+        report=report,
+        reason=f"score {report.score:.2f} within ceiling {max_score:.2f}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persisted report helpers (used by `bernstein blast-radius show <task_id>`).
+# ---------------------------------------------------------------------------
+
+
+_REPORT_DIR = Path(".sdd/metrics/blast_radius")
+
+
+def report_path_for(task_id: str, *, workdir: Path | None = None) -> Path:
+    """Filesystem path where a report for ``task_id`` is persisted."""
+    base = Path(workdir) if workdir is not None else Path.cwd()
+    return base / _REPORT_DIR / f"{task_id}.json"
+
+
+def save_report(report: BlastRadiusReport, *, task_id: str, workdir: Path | None = None) -> Path:
+    """Persist ``report`` to disk and return the path."""
+    import json
+
+    path = report_path_for(task_id, workdir=workdir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = report.to_dict()
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def load_report(task_id: str, *, workdir: Path | None = None) -> BlastRadiusReport | None:
+    """Load a previously-saved report; return ``None`` when missing."""
+    import json
+
+    path = report_path_for(task_id, workdir=workdir)
+    if not path.exists():
+        return None
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    components = tuple(
+        ComponentScore(name=c["name"], value=float(c["value"]), detail=str(c.get("detail", "")))
+        for c in raw.get("components", [])
+    )
+    hits = tuple(
+        DetectorHit(
+            detector_id=str(h["detector_id"]),
+            description=str(h.get("description", "")),
+            severity=str(h.get("severity", "medium")),
+            weight=float(h.get("weight", 0.0)),
+            hard_one_way=bool(h.get("hard_one_way", False)),
+            matched_paths=tuple(h.get("matched_paths", [])),
+            matched_snippets=tuple(h.get("matched_snippets", [])),
+        )
+        for h in raw.get("hits", [])
+    )
+    return BlastRadiusReport(
+        score=float(raw["score"]),
+        hard_one_way=bool(raw["hard_one_way"]),
+        components=components,
+        hits=hits,
+        rationale=str(raw.get("rationale", "")),
+        files_touched=int(raw.get("files_touched", 0)),
+        files=tuple(raw.get("files", [])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pre-merge blocking-hook factory (opt-in)
+# ---------------------------------------------------------------------------
+
+
+def make_pre_merge_hook(
+    *,
+    max_score: float,
+    detectors: Sequence[Detector] | None = None,
+) -> Any:
+    """Return a blocking hook callable suitable for ``pre_merge`` registration.
+
+    The hook reads ``files`` / ``diff_text`` from the
+    :class:`BlockingHookPayload`'s ``context`` dict (caller-supplied) and
+    returns a deny when the change exceeds ``max_score`` or trips a
+    hard one-way detector.
+
+    Wire-in example::
+
+        from bernstein.core.security.blocking_hooks import BlockingHookRunner
+        from bernstein.core.quality.blast_radius import make_pre_merge_hook
+
+        runner = BlockingHookRunner()
+        runner.register("pre_merge", make_pre_merge_hook(max_score=0.4))
+
+    Default behaviour is unchanged: this is opt-in. The caller decides when
+    to register the hook (typically when ``--max-blast-radius`` is set).
+    """
+    from bernstein.core.security.blocking_hooks import BlockingHookResult
+
+    scorer = BlastRadiusScorer(detectors=detectors)
+
+    def _hook(payload: Any) -> Any:
+        context = getattr(payload, "context", {}) or {}
+        files = context.get("files") or context.get("changed_files") or ()
+        diff_text = context.get("diff_text") or context.get("diff") or ""
+        report = scorer.score(files=tuple(files), diff_text=str(diff_text))
+        decision = evaluate_gate(report, max_score=max_score)
+        if decision.allowed:
+            return BlockingHookResult(
+                allowed=True,
+                reason=decision.reason,
+                hook_name="blast_radius",
+            )
+        return BlockingHookResult(
+            allowed=False,
+            reason=decision.reason,
+            hook_name="blast_radius",
+        )
+
+    return _hook
+
+
+# Re-export ``asdict`` for callers that prefer dataclass utilities directly.
+_ = asdict  # silence unused-import (kept available via ``from .blast_radius import asdict``)

--- a/src/bernstein/core/quality/blast_radius.py
+++ b/src/bernstein/core/quality/blast_radius.py
@@ -169,12 +169,7 @@ def default_detectors_path() -> Path:
     3. Walk up from the current file looking for a ``templates/`` sibling.
     """
     # 1. Wheel-bundled copy at ``<pkg>/_default_templates/blast-radius``.
-    bundled = (
-        Path(__file__).resolve().parents[2]
-        / "_default_templates"
-        / "blast-radius"
-        / "detectors.yaml"
-    )
+    bundled = Path(__file__).resolve().parents[2] / "_default_templates" / "blast-radius" / "detectors.yaml"
     if bundled.exists():
         return bundled
 

--- a/templates/blast-radius/detectors.yaml
+++ b/templates/blast-radius/detectors.yaml
@@ -1,0 +1,189 @@
+# Blast-radius detectors (issue #1322).
+#
+# Each entry adds a signal to the scorer. Detectors with `hard_one_way: true`
+# force the final score to 1.0 (regardless of other signals) and flag the
+# change as a one-way door — the merge / deploy gate must require explicit
+# approval.
+#
+# `kind` selects how the pattern is matched:
+#   - "content_regex": run the regex (multiline, case-insensitive unless
+#     the regex itself disables it) against the diff body / file contents.
+#   - "path_glob": match a touched file path against an fnmatch glob.
+#   - "path_regex": match a touched file path against a regex.
+#
+# `weight` is the contribution to the (non-hard) blast-radius components
+# when the detector fires at least once. The scorer normalizes the weights
+# of all firing soft detectors into [0, 1].
+#
+# Operators can ship their own detectors by adding entries to
+# `.bernstein/blast-radius/detectors.yaml`; the loader merges custom rules
+# on top of these defaults.
+
+version: 1
+
+detectors:
+  # ------------------------------------------------------------------ destructive SQL
+  - id: sql_drop_statement
+    kind: content_regex
+    pattern: "(?im)^\\s*DROP\\s+(TABLE|DATABASE|SCHEMA|INDEX|VIEW|FUNCTION|PROCEDURE)\\b"
+    description: "DROP statement detected in diff (destructive schema operation)."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  - id: sql_delete_unbounded
+    kind: content_regex
+    pattern: "(?im)^\\s*DELETE\\s+FROM\\s+[\\w\\.\"`]+\\s*;?\\s*$"
+    description: "Unbounded DELETE FROM statement (no WHERE clause)."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  - id: sql_truncate
+    kind: content_regex
+    pattern: "(?im)^\\s*TRUNCATE\\s+(TABLE\\s+)?[\\w\\.\"`]+"
+    description: "TRUNCATE detected (wipes table data)."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  # ------------------------------------------------------------------ destructive shell
+  - id: shell_rm_rf
+    kind: content_regex
+    pattern: "(?m)\\brm\\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r|--recursive\\s+--force|--force\\s+--recursive)\\b"
+    description: "rm -rf (recursive forced delete) detected."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  - id: shell_dd_of_dev
+    kind: content_regex
+    pattern: "(?m)\\bdd\\s+[^\\n]*\\bof=/dev/"
+    description: "dd writing to /dev/* device (destructive disk write)."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  - id: shell_mkfs
+    kind: content_regex
+    pattern: "(?m)\\bmkfs(\\.\\w+)?\\b"
+    description: "mkfs.* invocation (filesystem format)."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  # ------------------------------------------------------------------ schema migrations
+  - id: alembic_migration
+    kind: path_regex
+    pattern: "(^|.*/)alembic/versions/.*\\.py$"
+    description: "Alembic migration file touched (schema change)."
+    severity: high
+    weight: 0.8
+    hard_one_way: true
+
+  - id: django_migration
+    kind: path_regex
+    pattern: "(^|.*/)migrations/\\d{4}_.*\\.py$"
+    description: "Django migration file touched."
+    severity: high
+    weight: 0.8
+    hard_one_way: true
+
+  - id: sql_migration_file
+    kind: path_regex
+    pattern: "(^|.*/)(migrations?|db/migrate|schema)/.*\\.sql$"
+    description: "SQL migration file touched."
+    severity: high
+    weight: 0.8
+    hard_one_way: true
+
+  - id: prisma_schema
+    kind: path_glob
+    pattern: "**/schema.prisma"
+    description: "Prisma schema modified."
+    severity: high
+    weight: 0.7
+    hard_one_way: true
+
+  # ------------------------------------------------------------------ secrets / env
+  - id: dotenv_write
+    kind: path_regex
+    pattern: "(^|.*/)\\.env(\\..+)?$"
+    description: ".env* file touched (likely secret material)."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  - id: secret_path
+    kind: path_regex
+    pattern: "(^|.*/)?(secrets?|credentials?|private[_-]?key|api[_-]?keys?)([./_-].*)?$"
+    description: "File path matches a secret/credential pattern."
+    severity: high
+    weight: 0.7
+    hard_one_way: false
+
+  - id: pem_or_key_file
+    kind: path_regex
+    pattern: ".+\\.(pem|key|p12|pfx|jks|asc)$"
+    description: "Certificate / private key file touched."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  # ------------------------------------------------------------------ infra / CI
+  - id: terraform_state
+    kind: path_glob
+    pattern: "**/*.tfstate*"
+    description: "Terraform state file touched."
+    severity: critical
+    weight: 1.0
+    hard_one_way: true
+
+  - id: kubernetes_secret
+    kind: content_regex
+    pattern: "(?m)^kind:\\s*Secret\\s*$"
+    description: "Kubernetes Secret manifest in diff."
+    severity: high
+    weight: 0.7
+    hard_one_way: false
+
+  - id: github_workflow
+    kind: path_regex
+    pattern: "(^|.*/)\\.github/workflows/.*\\.ya?ml$"
+    description: "GitHub Actions workflow touched (CI/CD surface)."
+    severity: medium
+    weight: 0.4
+    hard_one_way: false
+
+  - id: dockerfile
+    kind: path_regex
+    pattern: "(^|.*/)(Dockerfile|Containerfile)(\\..+)?$"
+    description: "Dockerfile / Containerfile touched."
+    severity: medium
+    weight: 0.3
+    hard_one_way: false
+
+  # ------------------------------------------------------------------ user-facing surface
+  - id: public_api_module
+    kind: path_regex
+    pattern: "(^|.*/)(api|routes|handlers|controllers)/.*\\.(py|ts|js|go|rs|java)$"
+    description: "Public-facing API surface modified."
+    severity: medium
+    weight: 0.3
+    hard_one_way: false
+
+  - id: package_manifest
+    kind: path_glob
+    pattern: "**/package.json"
+    description: "package.json modified (dependency surface)."
+    severity: low
+    weight: 0.2
+    hard_one_way: false
+
+  - id: pyproject
+    kind: path_glob
+    pattern: "**/pyproject.toml"
+    description: "pyproject.toml modified (dependency / build surface)."
+    severity: low
+    weight: 0.2
+    hard_one_way: false

--- a/tests/unit/test_blast_radius.py
+++ b/tests/unit/test_blast_radius.py
@@ -1,0 +1,340 @@
+"""Unit tests for the blast-radius scorer (issue #1322).
+
+Coverage:
+
+* Known-destructive operations (DROP TABLE, rm -rf, schema migration,
+  `.env` writes) -> score 1.0 + ``hard_one_way``.
+* Pure documentation change -> score < 0.1.
+* Mixed change (docs + a moderately risky path) -> mid-range score.
+* Gate evaluation: ``--max-blast-radius`` ceiling, opt-in behaviour, and
+  the rule that hard one-way detectors always require explicit approval.
+* Detector loading + persisted report round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lifecycle.blast_radius_gate import (
+    ENV_MAX_BLAST_RADIUS,
+    install_blast_radius_gate,
+)
+from bernstein.core.quality.blast_radius import (
+    BlastRadiusScorer,
+    Detector,
+    default_detectors_path,
+    evaluate_gate,
+    load_detectors,
+    load_report,
+    save_report,
+    score_change,
+)
+
+# ---------------------------------------------------------------------------
+# Defaults load successfully
+# ---------------------------------------------------------------------------
+
+
+def test_default_detectors_load() -> None:
+    detectors = load_detectors()
+    ids = {d.id for d in detectors}
+    # A representative sample of the must-detect patterns called out in
+    # issue #1322. If any of these disappear from the YAML the gate
+    # silently regresses for an entire risk category.
+    expected = {
+        "sql_drop_statement",
+        "sql_delete_unbounded",
+        "shell_rm_rf",
+        "alembic_migration",
+        "django_migration",
+        "dotenv_write",
+        "pem_or_key_file",
+    }
+    missing = expected - ids
+    assert not missing, f"default detectors missing critical ids: {missing}"
+
+
+def test_default_detectors_path_resolves() -> None:
+    path = default_detectors_path()
+    assert path.exists()
+    assert path.name == "detectors.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Destructive operations -> score 1.0
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def scorer() -> BlastRadiusScorer:
+    return BlastRadiusScorer()
+
+
+def test_drop_table_scores_one(scorer: BlastRadiusScorer) -> None:
+    diff = "DROP TABLE users;\n"
+    report = scorer.score(files=("db/cleanup.sql",), diff_text=diff)
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+    assert any(h.detector_id == "sql_drop_statement" for h in report.hits)
+
+
+def test_delete_from_unbounded_scores_one(scorer: BlastRadiusScorer) -> None:
+    diff = "DELETE FROM payments;"
+    report = scorer.score(files=("scripts/cleanup.sql",), diff_text=diff)
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+    assert any(h.detector_id == "sql_delete_unbounded" for h in report.hits)
+
+
+def test_rm_rf_scores_one(scorer: BlastRadiusScorer) -> None:
+    diff = "rm -rf $HOME/cache\n"
+    report = scorer.score(files=("scripts/cleanup.sh",), diff_text=diff)
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+    assert any(h.detector_id == "shell_rm_rf" for h in report.hits)
+
+
+def test_alembic_migration_scores_one(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=("alembic/versions/2024_01_drop_legacy.py",))
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+    assert any(h.detector_id == "alembic_migration" for h in report.hits)
+
+
+def test_django_migration_scores_one(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=("apps/users/migrations/0042_drop_legacy.py",))
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+
+
+def test_dotenv_write_scores_one(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=(".env",))
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+    assert any(h.detector_id == "dotenv_write" for h in report.hits)
+
+
+def test_pem_key_scores_one(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=("deploy/keys/prod.pem",))
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+
+
+# ---------------------------------------------------------------------------
+# Pure docs change -> score < 0.1
+# ---------------------------------------------------------------------------
+
+
+def test_pure_doc_change_scores_below_threshold(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(
+        files=("docs/intro.md",),
+        diff_text="# Welcome\n\nA few new paragraphs explaining the feature.\n",
+    )
+    assert report.score < 0.1
+    assert report.hard_one_way is False
+    # No hits: the docs path doesn't match any detector.
+    assert report.hits == ()
+
+
+def test_single_comment_only_change(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(
+        files=("src/lib/util.py",),
+        diff_text="# fix typo in comment\n",
+    )
+    assert report.score < 0.1
+
+
+# ---------------------------------------------------------------------------
+# Mixed change -> mid-range score
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_change_scores_mid_range(scorer: BlastRadiusScorer) -> None:
+    """A change touching package.json + an api/ handler should land mid-range.
+
+    Neither detector is hard one-way, so the score must be > 0.1 (signal
+    fired) and strictly less than 1.0 (no hard detectors).
+    """
+    report = scorer.score(
+        files=(
+            "package.json",
+            "src/api/handlers/users.ts",
+        ),
+        diff_text="export function listUsers() { /* ... */ }\n",
+    )
+    assert 0.1 < report.score < 1.0
+    assert report.hard_one_way is False
+    ids = {h.detector_id for h in report.hits}
+    assert {"package_manifest", "public_api_module"}.issubset(ids)
+
+
+def test_many_files_bumps_score_via_file_count_component(scorer: BlastRadiusScorer) -> None:
+    files = tuple(f"src/lib/mod_{i}.py" for i in range(100))
+    report = scorer.score(files=files, diff_text="")
+    # File-count component saturates at 0.2; with no other hits this is the floor.
+    assert report.score >= 0.2
+    assert report.hard_one_way is False
+
+
+# ---------------------------------------------------------------------------
+# Gate evaluation
+# ---------------------------------------------------------------------------
+
+
+def test_gate_no_ceiling_is_passthrough(scorer: BlastRadiusScorer) -> None:
+    """No ceiling => existing runs unaffected (issue-#1322 constraint)."""
+    report = scorer.score(files=("alembic/versions/2024_01.py",))
+    decision = evaluate_gate(report, max_score=None)
+    assert decision.allowed is True
+    assert "skipped" in decision.reason
+
+
+def test_gate_refuses_when_score_exceeds_ceiling(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=(".env.prod",))
+    decision = evaluate_gate(report, max_score=0.4)
+    assert decision.allowed is False
+    assert "refused" in decision.reason
+
+
+def test_gate_refuses_hard_one_way_even_below_ceiling(
+    scorer: BlastRadiusScorer,
+) -> None:
+    """Hard one-way detectors must require explicit approval (ceiling < 1.0)."""
+    report = scorer.score(files=("alembic/versions/2024_01.py",))
+    # Score is 1.0 due to hard detector, so any ceiling < 1.0 must refuse.
+    decision = evaluate_gate(report, max_score=0.9)
+    assert decision.allowed is False
+    assert report.hard_one_way is True
+
+
+def test_gate_allows_when_score_within_ceiling(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=("docs/intro.md",))
+    decision = evaluate_gate(report, max_score=0.5)
+    assert decision.allowed is True
+
+
+def test_gate_rejects_invalid_ceiling(scorer: BlastRadiusScorer) -> None:
+    report = scorer.score(files=("docs/intro.md",))
+    with pytest.raises(ValueError):
+        evaluate_gate(report, max_score=1.5)
+
+
+# ---------------------------------------------------------------------------
+# Custom detectors
+# ---------------------------------------------------------------------------
+
+
+def test_custom_detector_via_score_change() -> None:
+    custom = [
+        Detector(
+            id="custom_glob",
+            kind="path_glob",
+            pattern="**/forbidden.txt",
+            description="custom",
+            severity="critical",
+            weight=1.0,
+            hard_one_way=True,
+        )
+    ]
+    report = score_change(files=("path/to/forbidden.txt",), detectors=custom)
+    assert report.score == 1.0
+    assert report.hard_one_way is True
+
+
+def test_detector_validation_rejects_unknown_kind() -> None:
+    with pytest.raises(ValueError):
+        Detector(
+            id="x",
+            kind="bogus",  # type: ignore[arg-type]
+            pattern="*",
+            description="",
+            severity="low",
+            weight=0.1,
+        )
+
+
+def test_detector_validation_rejects_bad_weight() -> None:
+    with pytest.raises(ValueError):
+        Detector(
+            id="x",
+            kind="path_glob",
+            pattern="*",
+            description="",
+            severity="low",
+            weight=2.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Persisted report round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_report_round_trip(tmp_path: Path) -> None:
+    scorer_local = BlastRadiusScorer()
+    report = scorer_local.score(files=("alembic/versions/2024.py",))
+    path = save_report(report, task_id="T-1322", workdir=tmp_path)
+    assert path.exists()
+    loaded = load_report("T-1322", workdir=tmp_path)
+    assert loaded is not None
+    assert loaded.score == report.score
+    assert loaded.hard_one_way == report.hard_one_way
+    assert {h.detector_id for h in loaded.hits} == {h.detector_id for h in report.hits}
+
+
+def test_load_report_missing_returns_none(tmp_path: Path) -> None:
+    assert load_report("nope", workdir=tmp_path) is None
+
+
+def test_report_to_dict_is_json_serializable() -> None:
+    report = score_change(files=("db/migrations/0001.sql",))
+    payload = report.to_dict()
+    # Round-trip via JSON to catch any non-serialisable fields.
+    json.dumps(payload)
+    assert payload["hard_one_way"] is True
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle wire-in (install_blast_radius_gate)
+# ---------------------------------------------------------------------------
+
+
+def test_install_gate_noop_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.security.blocking_hooks import BlockingHookRunner
+
+    monkeypatch.delenv(ENV_MAX_BLAST_RADIUS, raising=False)
+    runner = BlockingHookRunner()
+    installed = install_blast_radius_gate(runner)
+    assert installed is False
+    assert "pre_merge" not in runner.registered_events()
+
+
+def test_install_gate_registers_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.security.blocking_hooks import BlockingHookRunner
+
+    monkeypatch.setenv(ENV_MAX_BLAST_RADIUS, "0.4")
+    runner = BlockingHookRunner()
+    installed = install_blast_radius_gate(runner)
+    assert installed is True
+    assert "pre_merge" in runner.registered_events()
+
+
+def test_install_gate_ignores_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.security.blocking_hooks import BlockingHookRunner
+
+    monkeypatch.setenv(ENV_MAX_BLAST_RADIUS, "not-a-float")
+    runner = BlockingHookRunner()
+    installed = install_blast_radius_gate(runner)
+    assert installed is False
+
+
+def test_install_gate_ignores_out_of_range(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.security.blocking_hooks import BlockingHookRunner
+
+    monkeypatch.setenv(ENV_MAX_BLAST_RADIUS, "1.5")
+    runner = BlockingHookRunner()
+    installed = install_blast_radius_gate(runner)
+    assert installed is False


### PR DESCRIPTION
## Summary

- Adds a blast-radius score in `[0, 1]` with a structured rationale for every change. Hard one-way detectors (DROP / DELETE SQL, `rm -rf`, schema migrations, `.env*` writes, certificate / key files) force score = 1.0.
- New module `src/bernstein/core/quality/blast_radius.py` (scorer + 16 default detectors + report persistence + pre_merge blocking-hook factory).
- New lifecycle bridge `src/bernstein/core/lifecycle/blast_radius_gate.py` -- registers the hook only when the operator opts in via `BERNSTEIN_MAX_BLAST_RADIUS`.
- CLI: `bernstein run --max-blast-radius 0.4` propagates the ceiling; `bernstein blast-radius show <task_id>` and `bernstein blast-radius score --file ... --diff-file ...` for ad-hoc inspection.
- Detectors as YAML in `templates/blast-radius/detectors.yaml`, force-included into the wheel.

Closes #1322. Pairs with #1318 (allowlist) and #1323 (hooks).

## Default behaviour

Unchanged. The gate is a pass-through unless the operator passes `--max-blast-radius`. This matches the issue-#1322 non-goal of not replacing the existing approval surface.

## Detected destructive patterns

| Category | Detectors |
| --- | --- |
| Destructive SQL | `DROP TABLE/DATABASE/SCHEMA/...`, unbounded `DELETE FROM`, `TRUNCATE` |
| Destructive shell | `rm -rf`, `dd of=/dev/...`, `mkfs.*` |
| Schema migrations | alembic versions, django migrations, generic SQL migrations, Prisma |
| Secrets / keys | `.env*` writes, secret-path heuristic, `*.pem` / `*.key` / `*.p12` / `*.pfx` / `*.jks` / `*.asc` |
| Infra | Terraform state, K8s Secret manifests, GitHub Actions workflow, Dockerfile |
| User-facing surface | `api/` / `routes/` / `handlers/` modules, `package.json`, `pyproject.toml` |

## Opt-in path

1. `bernstein run --max-blast-radius 0.4` sets `BERNSTEIN_MAX_BLAST_RADIUS=0.4`.
2. Orchestrator (or any caller) builds a `BlockingHookRunner` and invokes `install_blast_radius_gate(runner)`.
3. On `pre_merge`, the hook scores the change from the payload's `context.files` + `context.diff_text` and denies when the score exceeds the ceiling or any hard one-way detector fired.

## Test plan

- [x] Unit: `DROP TABLE`, unbounded `DELETE`, `rm -rf`, alembic / django migrations, `.env`, `*.pem` -> score 1.0 + `hard_one_way`.
- [x] Unit: pure-doc / single-comment change -> score < 0.1.
- [x] Unit: mixed change (package.json + api handler) -> mid-range, both detectors fire.
- [x] Unit: gate refuses when score > ceiling, refuses hard one-way under sub-1.0 ceiling, allows when within ceiling, no-op when ceiling unset.
- [x] Unit: persisted report round-trip; custom detector list; validation rejects bad weight / unknown kind.
- [x] Unit: `install_blast_radius_gate` is a no-op without env, registers with valid env, ignores invalid/out-of-range env.
- [x] Manual: `bernstein blast-radius --help`, `bernstein blast-radius score --file db/migrations/0001.sql --max-score 0.4` exits non-zero with rationale.
- [x] `ruff check` clean on new files; `mypy` clean on new files (only pre-existing repo-wide errors remain).