### PR TITLE
feat(debug): deterministic replay gateway + diff (#1319)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -42,6 +42,7 @@ alwaysApply: false
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `replay/`               | Deterministic replay package for Bernstein agent runs |
 | `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |

--- a/.goosehints
+++ b/.goosehints
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `replay/`               | Deterministic replay package for Bernstein agent runs |
 | `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `replay/`               | Deterministic replay package for Bernstein agent runs |
 | `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `replay/`               | Deterministic replay package for Bernstein agent runs |
 | `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -43,6 +43,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `preview/`              | ``bernstein preview`` — sandboxed dev-server with public tunnel link |
 | `protocols/`            | protocols sub-package |
 | `quality/`              | quality sub-package |
+| `replay/`               | Deterministic replay package for Bernstein agent runs |
 | `review/`               | Per-adapter perspective assignment and chain coordination for reviews |
 | `review_responder/`     | PR review responder — react to inline review comments on Bernstein PRs |
 | `routes/`               | FastAPI router modules for the Bernstein task server |

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -1175,8 +1175,7 @@ def replay_cmd(
 
     if len(args) != 1:
         console.print(
-            "[red]Usage:[/red] bernstein replay <RUN_ID | latest | list> "
-            "OR bernstein replay diff RUN_A RUN_B",
+            "[red]Usage:[/red] bernstein replay <RUN_ID | latest | list> OR bernstein replay diff RUN_A RUN_B",
         )
         raise SystemExit(2)
 

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -976,30 +976,7 @@ def _replay_task_trace(task_id: str, sdd_path: Path, *, override_model: str | No
         console.print("[dim]Replay completed with no result-summary diff.[/dim]")
 
 
-@click.command("replay")
-@click.argument("run_id")
-@click.option(
-    "--sdd-dir",
-    default=".sdd",
-    show_default=True,
-    help="Path to .sdd state directory.",
-)
-@click.option(
-    "--as-json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Output raw JSONL events.",
-)
-@click.option(
-    "--limit",
-    type=int,
-    default=None,
-    help="Show only the first N events.",
-)
-@click.option("--model", default=None, help="Override model for task-trace replay.")
-@click.option("--extra-context", default=None, help="Append additional hint text to the replayed task description.")
-def replay_cmd(
+def _replay_run_impl(
     run_id: str,
     sdd_dir: str,
     as_json: bool,
@@ -1007,21 +984,11 @@ def replay_cmd(
     model: str | None,
     extra_context: str | None,
 ) -> None:
-    """Replay a past orchestration run step-by-step.
+    """Body of ``bernstein replay <run_id>`` — replay one run.
 
-    \b
-    Reads .sdd/runs/{run_id}/replay.jsonl and displays events in a
-    Rich table showing timing, event type, agent, task, and details.
-
-    \b
-    If run_id is "latest", replays the most recent run. Use "list" to
-    show all available run IDs.
-
-    \b
-      bernstein replay list               # list available runs
-      bernstein replay latest              # replay most recent run
-      bernstein replay 20240315-143022     # replay a specific run
-      bernstein replay latest --as-json    # raw JSONL output
+    Extracted so the new ``replay`` :class:`click.Group` can dispatch to
+    it from its top-level invocation while also exposing subcommands
+    (``diff``) via the same group object.
     """
     sdd_path = Path(sdd_dir)
     runs_dir = sdd_path / "runs"
@@ -1144,6 +1111,139 @@ def replay_cmd(
     # Footer with fingerprint
     console.print(f"\n[dim]SHA-256 fingerprint:[/dim] [bold]{fingerprint}[/bold]")
     console.print("[dim]This fingerprint proves the exact sequence of events in this run.[/dim]")
+
+
+@click.command("replay")
+@click.argument("run_id", nargs=-1, required=True)
+@click.option(
+    "--sdd-dir",
+    default=".sdd",
+    show_default=True,
+    help="Path to .sdd state directory.",
+)
+@click.option(
+    "--as-json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output raw JSONL events.",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=None,
+    help="Show only the first N events.",
+)
+@click.option("--model", default=None, help="Override model for task-trace replay.")
+@click.option(
+    "--extra-context",
+    default=None,
+    help="Append additional hint text to the replayed task description.",
+)
+def replay_cmd(
+    run_id: tuple[str, ...],
+    sdd_dir: str,
+    as_json: bool,
+    limit: int | None,
+    model: str | None,
+    extra_context: str | None,
+) -> None:
+    """Replay a past orchestration run step-by-step.
+
+    \b
+    Reads .sdd/runs/{run_id}/replay.jsonl and displays events in a
+    Rich table showing timing, event type, agent, task, and details.
+
+    \b
+    If run_id is "latest", replays the most recent run. Use "list" to
+    show all available run IDs. Use ``diff`` to localise the first
+    divergence between two recorded runs (events.jsonl).
+
+    \b
+      bernstein replay list                       # list available runs
+      bernstein replay latest                     # replay most recent run
+      bernstein replay 20240315-143022            # replay a specific run
+      bernstein replay diff RUN_A RUN_B           # first-divergence finder
+    """
+    # ``nargs=-1`` lets us implement the pseudo-subcommand ``diff`` without
+    # converting ``replay`` to a full :class:`click.Group` (which would
+    # break the back-compat ``bernstein replay <RUN_ID>`` shape).
+    args = list(run_id)
+    if args and args[0] == "diff":
+        _replay_diff_dispatch(args[1:], sdd_dir=sdd_dir, as_json=as_json)
+        return
+
+    if len(args) != 1:
+        console.print(
+            "[red]Usage:[/red] bernstein replay <RUN_ID | latest | list> "
+            "OR bernstein replay diff RUN_A RUN_B",
+        )
+        raise SystemExit(2)
+
+    _replay_run_impl(
+        run_id=args[0],
+        sdd_dir=sdd_dir,
+        as_json=as_json,
+        limit=limit,
+        model=model,
+        extra_context=extra_context,
+    )
+
+
+def _replay_diff_dispatch(
+    args: list[str],
+    *,
+    sdd_dir: str,
+    as_json: bool,
+) -> None:
+    """Implementation of ``bernstein replay diff <run_a> <run_b>``."""
+    if len(args) != 2:
+        console.print(
+            "[red]Usage:[/red] bernstein replay diff RUN_A RUN_B",
+        )
+        raise SystemExit(2)
+
+    from bernstein.core.replay import EVENTS_FILENAME, diff_event_logs
+
+    run_a, run_b = args
+    runs_dir = Path(sdd_dir) / "runs"
+    path_a = runs_dir / run_a / EVENTS_FILENAME
+    path_b = runs_dir / run_b / EVENTS_FILENAME
+
+    for label, path in (("run_a", path_a), ("run_b", path_b)):
+        if not path.exists():
+            console.print(f"[red]{label} events log not found:[/red] {path}")
+            raise SystemExit(2)
+
+    result = diff_event_logs(path_a, path_b)
+
+    if as_json:
+        payload = {
+            "diverged": result.diverged,
+            "index": result.index,
+            "reason": result.reason,
+            "a_event": result.a_event,
+            "b_event": result.b_event,
+        }
+        console.print_json(json.dumps(payload, default=str))
+        if result.diverged:
+            raise SystemExit(1)
+        return
+
+    if not result.diverged:
+        console.print(f"[green]No divergence:[/green] {result.reason}")
+        return
+
+    console.print(
+        f"[yellow]Divergence at event index {result.index}:[/yellow] {result.reason}",
+    )
+    if result.a_event is not None:
+        console.print(f"\n[dim]run_a[/dim] [bold]{run_a}[/bold]:")
+        console.print_json(json.dumps(result.a_event, default=str))
+    if result.b_event is not None:
+        console.print(f"\n[dim]run_b[/dim] [bold]{run_b}[/bold]:")
+        console.print_json(json.dumps(result.b_event, default=str))
+    raise SystemExit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -509,6 +509,17 @@ class Orchestrator:
         # Deterministic replay recorder: appends events to
         # .sdd/runs/{run_id}/replay.jsonl for post-hoc debugging.
         self._recorder = RunRecorder(run_id=run_id, sdd_dir=workdir / ".sdd")
+
+        # Replay gateway: captures LLM + tool dispatch responses into
+        # .sdd/runs/{run_id}/events.jsonl so a run can be re-executed
+        # against recorded fixtures. OFF by default — opt in with
+        # BERNSTEIN_RECORD=1 to avoid bloating .sdd/ for casual runs.
+        from bernstein.core.replay import ReplayGateway as _ReplayGateway
+
+        self._replay_gateway = _ReplayGateway(
+            run_id=run_id,
+            sdd_dir=workdir / ".sdd",
+        )
         _seed_path = workdir / _BERNSTEIN_YAML
         self._replay_metadata = SessionReplayMetadata(
             run_id=run_id,

--- a/src/bernstein/core/replay/__init__.py
+++ b/src/bernstein/core/replay/__init__.py
@@ -1,0 +1,49 @@
+"""Deterministic replay package for Bernstein agent runs.
+
+This package provides the *gateway* that intercepts LLM requests and
+tool dispatches so a previously recorded run can be re-executed against
+recorded fixtures instead of live providers.
+
+Public surface:
+
+* :class:`ReplayGateway` — record/replay adapter around LLM + tool calls.
+* :data:`RECORD_ENV_VAR` — env-var that opts-in to recording.
+* :func:`diff_event_logs` — line-by-line first-divergence locator.
+
+The existing ``RunRecorder`` in :mod:`bernstein.core.persistence.recorder`
+already handles orchestrator-level lifecycle events. This package adds a
+second, finer-grained log dedicated to LLM/tool I/O so replay can reproduce
+adapter responses byte-for-byte.
+
+The gateway is OFF by default. Set ``BERNSTEIN_RECORD=1`` or pass
+``record=True`` explicitly to enable recording — we don't want to grow
+``.sdd/`` on every casual user invocation.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.replay.diff import (
+    DivergenceResult,
+    diff_event_logs,
+    load_events,
+)
+from bernstein.core.replay.gateway import (
+    EVENTS_FILENAME,
+    RECORD_ENV_VAR,
+    GatewayMode,
+    ReplayGateway,
+    ReplayMissError,
+    is_recording_enabled,
+)
+
+__all__ = [
+    "EVENTS_FILENAME",
+    "RECORD_ENV_VAR",
+    "DivergenceResult",
+    "GatewayMode",
+    "ReplayGateway",
+    "ReplayMissError",
+    "diff_event_logs",
+    "is_recording_enabled",
+    "load_events",
+]

--- a/src/bernstein/core/replay/diff.py
+++ b/src/bernstein/core/replay/diff.py
@@ -1,0 +1,131 @@
+"""First-divergence locator for replay event logs.
+
+Walks two ``events.jsonl`` files line-by-line and reports the first index
+at which the recorded responses diverge. Used by
+``bernstein replay diff <run_a> <run_b>`` to pinpoint *where* two runs
+behaved differently.
+
+Comparison is intentionally simple — equality on the ``(kind, key,
+response)`` triple. Timestamps and metadata are ignored because they
+vary by wall-clock even on identical runs. Callers who want stricter
+matching can compose the dataclass with their own comparator.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dataclass(frozen=True)
+class DivergenceResult:
+    """Outcome of comparing two event logs.
+
+    Attributes:
+        diverged: ``True`` if any divergence was found (including length
+            mismatch).
+        index: 0-based position of the first divergent event, or ``None``
+            if the logs are identical *and* of equal length.
+        reason: Short human-readable explanation of the divergence.
+        a_event: The event from ``run_a`` at :attr:`index` (or ``None``
+            if ``run_a`` ran out first).
+        b_event: The event from ``run_b`` at :attr:`index` (or ``None``
+            if ``run_b`` ran out first).
+    """
+
+    diverged: bool
+    index: int | None
+    reason: str
+    a_event: dict[str, Any] | None = None
+    b_event: dict[str, Any] | None = None
+
+
+def load_events(path: Path) -> list[dict[str, Any]]:
+    """Load and parse an ``events.jsonl`` file.
+
+    Args:
+        path: Path to the file.
+
+    Returns:
+        Parsed event dicts in file order. Malformed lines are skipped.
+    """
+    events: list[dict[str, Any]] = []
+    if not path.exists():
+        return events
+    with path.open() as f:
+        for raw in f:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                events.append(json.loads(raw))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def _comparable(event: dict[str, Any]) -> tuple[Any, Any, Any]:
+    """Project an event onto the fields used for divergence comparison."""
+    return (
+        event.get("kind"),
+        event.get("key"),
+        event.get("response"),
+    )
+
+
+def diff_event_logs(path_a: Path, path_b: Path) -> DivergenceResult:
+    """Return the first index at which two event logs diverge.
+
+    Args:
+        path_a: Path to the first ``events.jsonl``.
+        path_b: Path to the second ``events.jsonl``.
+
+    Returns:
+        A :class:`DivergenceResult` describing the outcome.
+    """
+    a = load_events(path_a)
+    b = load_events(path_b)
+
+    if not a and not b:
+        return DivergenceResult(
+            diverged=False,
+            index=None,
+            reason="both event logs are empty",
+        )
+
+    limit = min(len(a), len(b))
+    for i in range(limit):
+        if _comparable(a[i]) != _comparable(b[i]):
+            return DivergenceResult(
+                diverged=True,
+                index=i,
+                reason=(
+                    f"event #{i} differs: "
+                    f"kind/key/response triple does not match"
+                ),
+                a_event=a[i],
+                b_event=b[i],
+            )
+
+    if len(a) == len(b):
+        return DivergenceResult(
+            diverged=False,
+            index=None,
+            reason=f"identical: {len(a)} events match",
+        )
+
+    longer = "a" if len(a) > len(b) else "b"
+    return DivergenceResult(
+        diverged=True,
+        index=limit,
+        reason=(
+            f"run_{longer} has {abs(len(a) - len(b))} extra event(s) "
+            f"after index {limit - 1 if limit else 0}"
+        ),
+        a_event=a[limit] if limit < len(a) else None,
+        b_event=b[limit] if limit < len(b) else None,
+    )

--- a/src/bernstein/core/replay/diff.py
+++ b/src/bernstein/core/replay/diff.py
@@ -103,10 +103,7 @@ def diff_event_logs(path_a: Path, path_b: Path) -> DivergenceResult:
             return DivergenceResult(
                 diverged=True,
                 index=i,
-                reason=(
-                    f"event #{i} differs: "
-                    f"kind/key/response triple does not match"
-                ),
+                reason=(f"event #{i} differs: kind/key/response triple does not match"),
                 a_event=a[i],
                 b_event=b[i],
             )
@@ -122,10 +119,7 @@ def diff_event_logs(path_a: Path, path_b: Path) -> DivergenceResult:
     return DivergenceResult(
         diverged=True,
         index=limit,
-        reason=(
-            f"run_{longer} has {abs(len(a) - len(b))} extra event(s) "
-            f"after index {limit - 1 if limit else 0}"
-        ),
+        reason=(f"run_{longer} has {abs(len(a) - len(b))} extra event(s) after index {limit - 1 if limit else 0}"),
         a_event=a[limit] if limit < len(a) else None,
         b_event=b[limit] if limit < len(b) else None,
     )

--- a/src/bernstein/core/replay/gateway.py
+++ b/src/bernstein/core/replay/gateway.py
@@ -1,0 +1,311 @@
+"""Record/replay gateway for LLM requests and tool dispatch.
+
+The gateway sits between Bernstein's adapter call-sites and the live
+providers. In *record* mode every (kind, key) -> response pair is appended
+to ``.sdd/runs/<run_id>/events.jsonl``. In *replay* mode the gateway
+serves the recorded response instead of invoking the real provider, so a
+run can be re-executed deterministically against recorded fixtures.
+
+Design choices:
+
+* **Append-only JSONL** — same on-disk shape as existing trace files; works
+  with the rest of the observability stack and stays human-diffable.
+* **Recording is opt-in** — controlled by :data:`RECORD_ENV_VAR` or an
+  explicit ``record=True`` argument. We don't want to bloat ``.sdd/`` for
+  users who never replay.
+* **Stable keys** — callers pass an explicit ``key`` (typically a SHA-256
+  of the request payload). The gateway never tries to fingerprint the
+  request itself; key stability is the caller's job.
+* **First-call ordering preserved** — replay lookup falls back to FIFO
+  consumption per ``kind`` when the key isn't found, so even hashed
+  prompts with timestamp jitter replay cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Name of the per-run gateway event log inside ``.sdd/runs/<id>/``.
+EVENTS_FILENAME = "events.jsonl"
+
+#: Environment variable that opts the gateway into record mode.
+#: Recording stays off by default to avoid growing ``.sdd/`` on every
+#: invocation. Set to ``1``/``true``/``yes`` to enable.
+RECORD_ENV_VAR = "BERNSTEIN_RECORD"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def is_recording_enabled(env: dict[str, str] | None = None) -> bool:
+    """Return whether the gateway should record this run by default.
+
+    Args:
+        env: Optional env dict (defaults to :data:`os.environ`).
+
+    Returns:
+        ``True`` if :data:`RECORD_ENV_VAR` is set to a truthy value.
+    """
+    src = env if env is not None else os.environ
+    return src.get(RECORD_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+class GatewayMode(StrEnum):
+    """Operating mode for :class:`ReplayGateway`."""
+
+    OFF = "off"
+    """Pass-through; no recording, no replay."""
+
+    RECORD = "record"
+    """Invoke the live provider and append each response to ``events.jsonl``."""
+
+    REPLAY = "replay"
+    """Serve recorded responses; never call the live provider."""
+
+
+class ReplayMissError(RuntimeError):
+    """Raised in :attr:`GatewayMode.REPLAY` when no fixture matches."""
+
+
+@dataclass(frozen=True)
+class _Event:
+    """One row from ``events.jsonl``."""
+
+    kind: str
+    key: str
+    response: Any
+    ts: float
+    seq: int
+
+
+class ReplayGateway:
+    """Thin wrapper around LLM + tool dispatch with record/replay support.
+
+    Typical usage from an adapter call-site::
+
+        gw = ReplayGateway(run_id="20260517-1530", sdd_dir=Path(".sdd"))
+        text = gw.dispatch(
+            kind="llm",
+            key=request_hash,
+            invoke=lambda: real_llm_client.complete(prompt),
+        )
+
+    With ``BERNSTEIN_RECORD=1`` (or ``ReplayGateway(record=True)``) the
+    response from ``invoke`` is appended to ``events.jsonl``. In replay
+    mode, ``invoke`` is **not** called; the recorded response is returned
+    instead.
+
+    Args:
+        run_id: Unique identifier for this run; used to locate the
+            per-run event log under ``.sdd/runs/<run_id>/``.
+        sdd_dir: Path to the ``.sdd`` directory.
+        mode: Explicit :class:`GatewayMode`. If omitted, defaults to
+            :attr:`GatewayMode.RECORD` when :func:`is_recording_enabled`
+            is true and ``record`` is not set, else :attr:`GatewayMode.OFF`.
+        record: Convenience flag — when ``True``, forces record mode even
+            if the env var is unset. Ignored if ``mode`` is provided.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        sdd_dir: Path,
+        *,
+        mode: GatewayMode | None = None,
+        record: bool = False,
+    ) -> None:
+        self._run_id = run_id
+        self._path = sdd_dir / "runs" / run_id / EVENTS_FILENAME
+        self._lock = threading.Lock()
+        self._seq = 0
+
+        if mode is None:
+            mode = GatewayMode.RECORD if record or is_recording_enabled() else GatewayMode.OFF
+        self._mode = mode
+
+        # Replay-mode fixture state.
+        self._fixtures_by_key: dict[tuple[str, str], list[Any]] = {}
+        self._fixtures_by_kind: dict[str, list[Any]] = {}
+
+        if self._mode is GatewayMode.RECORD:
+            # Only create the directory when we'll actually write something.
+            # Replay mode reads existing files; OFF mode does nothing.
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+        elif self._mode is GatewayMode.REPLAY:
+            self._load_fixtures()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def mode(self) -> GatewayMode:
+        """Current operating mode."""
+        return self._mode
+
+    @property
+    def path(self) -> Path:
+        """Path to ``events.jsonl`` for this run."""
+        return self._path
+
+    @property
+    def run_id(self) -> str:
+        """The run identifier this gateway targets."""
+        return self._run_id
+
+    def dispatch(
+        self,
+        *,
+        kind: str,
+        key: str,
+        invoke: Callable[[], Any],
+        metadata: dict[str, Any] | None = None,
+    ) -> Any:
+        """Run a recorded/replayed dispatch.
+
+        Args:
+            kind: Logical category (e.g. ``"llm"``, ``"tool"``). Used to
+                bucket replay fixtures when keys collide.
+            key: Stable identifier for this request (typically a hash of
+                the request payload). Replay lookups try ``(kind, key)``
+                first, then fall back to FIFO consumption of ``kind``.
+            invoke: Callable that performs the real dispatch. Called in
+                :attr:`GatewayMode.OFF` and :attr:`GatewayMode.RECORD`;
+                **never** called in :attr:`GatewayMode.REPLAY`.
+            metadata: Optional extra fields persisted alongside the event
+                (e.g. model name, adapter name) for debugging.
+
+        Returns:
+            The response (either from ``invoke`` or from the fixture).
+
+        Raises:
+            ReplayMissError: In replay mode when no fixture matches and
+                no FIFO fallback is available for ``kind``.
+        """
+        if self._mode is GatewayMode.REPLAY:
+            return self._replay_lookup(kind=kind, key=key)
+
+        response = invoke()
+
+        if self._mode is GatewayMode.RECORD:
+            self._record(kind=kind, key=key, response=response, metadata=metadata)
+
+        return response
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def _record(
+        self,
+        *,
+        kind: str,
+        key: str,
+        response: Any,
+        metadata: dict[str, Any] | None,
+    ) -> None:
+        """Append one event to ``events.jsonl``."""
+        with self._lock:
+            self._seq += 1
+            seq = self._seq
+
+        entry: dict[str, Any] = {
+            "seq": seq,
+            "ts": time.time(),
+            "kind": kind,
+            "key": key,
+            "response": _make_jsonable(response),
+        }
+        if metadata:
+            entry["metadata"] = _make_jsonable(metadata)
+
+        try:
+            with self._path.open("a") as f:
+                f.write(json.dumps(entry, default=str) + "\n")
+        except OSError as exc:
+            # Recording is a debug aid; failures must not break the run.
+            logger.warning("ReplayGateway: failed to record %r: %s", kind, exc)
+
+    # ------------------------------------------------------------------
+    # Replay
+    # ------------------------------------------------------------------
+
+    def _load_fixtures(self) -> None:
+        """Load fixtures from ``events.jsonl`` into in-memory queues."""
+        if not self._path.exists():
+            raise ReplayMissError(
+                f"No events log at {self._path}; nothing to replay. "
+                "Was BERNSTEIN_RECORD=1 set during the original run?",
+            )
+        with self._path.open() as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    row = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning("ReplayGateway: skipping malformed line in %s", self._path)
+                    continue
+                kind = str(row.get("kind", ""))
+                key = str(row.get("key", ""))
+                response = row.get("response")
+                self._fixtures_by_key.setdefault((kind, key), []).append(response)
+                self._fixtures_by_kind.setdefault(kind, []).append(response)
+
+    def _replay_lookup(self, *, kind: str, key: str) -> Any:
+        """Pop the next fixture for ``(kind, key)`` (or FIFO by ``kind``)."""
+        bucket = self._fixtures_by_key.get((kind, key))
+        if bucket:
+            response = bucket.pop(0)
+            # Also remove the matching entry from the by-kind queue
+            # (FIFO match — first identical response).
+            kind_bucket = self._fixtures_by_kind.get(kind, [])
+            for i, item in enumerate(kind_bucket):
+                if item == response:
+                    kind_bucket.pop(i)
+                    break
+            return response
+
+        kind_bucket = self._fixtures_by_kind.get(kind)
+        if kind_bucket:
+            return kind_bucket.pop(0)
+
+        raise ReplayMissError(
+            f"No fixture for kind={kind!r} key={key!r} in {self._path}. "
+            "Either the run diverged or recording was incomplete.",
+        )
+
+
+def _make_jsonable(value: Any) -> Any:
+    """Best-effort coercion of ``value`` to JSON-serialisable shape.
+
+    Falls back to ``repr`` for opaque objects; primitive types and
+    standard containers are passed through unchanged.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_make_jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _make_jsonable(v) for k, v in value.items()}
+    # Dataclasses, pydantic, custom objects: try dict-like, then repr.
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        try:
+            return _make_jsonable(to_dict())
+        except (TypeError, ValueError):
+            pass
+    return repr(value)

--- a/tests/unit/test_replay_gateway.py
+++ b/tests/unit/test_replay_gateway.py
@@ -145,10 +145,7 @@ def test_record_then_replay_produces_identical_outputs(
     def _explode() -> object:
         raise AssertionError("replay must not call invoke()")
 
-    replayed = [
-        replay.dispatch(kind="llm", key=f"llm-{i}", invoke=_explode)
-        for i in range(3)
-    ]
+    replayed = [replay.dispatch(kind="llm", key=f"llm-{i}", invoke=_explode) for i in range(3)]
     tool_replayed = replay.dispatch(kind="tool", key="run_tests", invoke=_explode)
 
     assert replayed == recorded
@@ -224,14 +221,20 @@ def test_diff_identical_runs(tmp_path: Path) -> None:
 def test_diff_value_mismatch(tmp_path: Path) -> None:
     a = tmp_path / "a" / EVENTS_FILENAME
     b = tmp_path / "b" / EVENTS_FILENAME
-    _write_events(a, [
-        {"seq": 1, "kind": "llm", "key": "k", "response": "alpha"},
-        {"seq": 2, "kind": "llm", "key": "k", "response": "beta"},
-    ])
-    _write_events(b, [
-        {"seq": 1, "kind": "llm", "key": "k", "response": "alpha"},
-        {"seq": 2, "kind": "llm", "key": "k", "response": "GAMMA"},
-    ])
+    _write_events(
+        a,
+        [
+            {"seq": 1, "kind": "llm", "key": "k", "response": "alpha"},
+            {"seq": 2, "kind": "llm", "key": "k", "response": "beta"},
+        ],
+    )
+    _write_events(
+        b,
+        [
+            {"seq": 1, "kind": "llm", "key": "k", "response": "alpha"},
+            {"seq": 2, "kind": "llm", "key": "k", "response": "GAMMA"},
+        ],
+    )
     result = diff_event_logs(a, b)
     assert result.diverged is True
     assert result.index == 1
@@ -242,13 +245,19 @@ def test_diff_value_mismatch(tmp_path: Path) -> None:
 def test_diff_length_mismatch(tmp_path: Path) -> None:
     a = tmp_path / "a" / EVENTS_FILENAME
     b = tmp_path / "b" / EVENTS_FILENAME
-    _write_events(a, [
-        {"seq": 1, "kind": "llm", "key": "k", "response": "x"},
-        {"seq": 2, "kind": "llm", "key": "k", "response": "y"},
-    ])
-    _write_events(b, [
-        {"seq": 1, "kind": "llm", "key": "k", "response": "x"},
-    ])
+    _write_events(
+        a,
+        [
+            {"seq": 1, "kind": "llm", "key": "k", "response": "x"},
+            {"seq": 2, "kind": "llm", "key": "k", "response": "y"},
+        ],
+    )
+    _write_events(
+        b,
+        [
+            {"seq": 1, "kind": "llm", "key": "k", "response": "x"},
+        ],
+    )
     result = diff_event_logs(a, b)
     assert result.diverged is True
     assert result.index == 1

--- a/tests/unit/test_replay_gateway.py
+++ b/tests/unit/test_replay_gateway.py
@@ -1,0 +1,267 @@
+"""Unit tests for ``bernstein.core.replay`` — gateway + diff.
+
+Covers the MVP slice of issue #1319:
+
+* record / replay round-trip through the gateway against the ``mock``
+  adapter response shape;
+* opt-in semantics (``BERNSTEIN_RECORD`` env var, ``record=True`` flag);
+* divergence finder: identical runs, length mismatch, value mismatch.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.replay import (
+    EVENTS_FILENAME,
+    RECORD_ENV_VAR,
+    GatewayMode,
+    ReplayGateway,
+    ReplayMissError,
+    diff_event_logs,
+    is_recording_enabled,
+)
+
+# ---------------------------------------------------------------------------
+# is_recording_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_is_recording_enabled_default_off() -> None:
+    """Recording must be OFF when the env var is unset."""
+    assert is_recording_enabled(env={}) is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+def test_is_recording_enabled_truthy(value: str) -> None:
+    assert is_recording_enabled(env={RECORD_ENV_VAR: value}) is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_is_recording_enabled_falsy(value: str) -> None:
+    assert is_recording_enabled(env={RECORD_ENV_VAR: value}) is False
+
+
+# ---------------------------------------------------------------------------
+# Gateway default mode
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_defaults_to_off_when_env_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+    gw = ReplayGateway("run-1", tmp_path)
+    assert gw.mode is GatewayMode.OFF
+    # No file should be created when recording is off.
+    assert not gw.path.exists()
+
+
+def test_gateway_env_opt_in_enables_recording(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(RECORD_ENV_VAR, "1")
+    gw = ReplayGateway("run-2", tmp_path)
+    assert gw.mode is GatewayMode.RECORD
+
+
+def test_gateway_explicit_record_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+    gw = ReplayGateway("run-3", tmp_path, record=True)
+    assert gw.mode is GatewayMode.RECORD
+
+
+# ---------------------------------------------------------------------------
+# OFF mode passes through
+# ---------------------------------------------------------------------------
+
+
+def test_off_mode_is_passthrough(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+    gw = ReplayGateway("run-off", tmp_path)
+    calls: list[int] = []
+
+    def _invoke() -> str:
+        calls.append(1)
+        return "live"
+
+    out = gw.dispatch(kind="llm", key="k1", invoke=_invoke)
+    assert out == "live"
+    assert calls == [1]
+    assert not gw.path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Record/replay round-trip — mock adapter shape
+# ---------------------------------------------------------------------------
+
+
+def _mock_llm_response(prompt: str) -> dict[str, object]:
+    """Stand-in for what the ``mock`` adapter would emit on a prompt."""
+    return {"prompt": prompt, "completion": f"echo:{prompt}", "tokens": len(prompt)}
+
+
+def test_record_then_replay_produces_identical_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Record a run against the mock-style adapter, then replay it.
+
+    Replay must return byte-identical responses without ever invoking
+    the underlying callable.
+    """
+    monkeypatch.setenv(RECORD_ENV_VAR, "1")
+
+    # --- record phase ---------------------------------------------------
+    rec = ReplayGateway("run-rt", tmp_path)
+    assert rec.mode is GatewayMode.RECORD
+
+    recorded = [
+        rec.dispatch(
+            kind="llm",
+            key=f"llm-{i}",
+            invoke=lambda i=i: _mock_llm_response(f"prompt-{i}"),
+        )
+        for i in range(3)
+    ]
+    tool_recorded = rec.dispatch(
+        kind="tool",
+        key="run_tests",
+        invoke=lambda: {"exit": 0, "stdout": "OK"},
+    )
+
+    assert rec.path.exists()
+    lines = rec.path.read_text().splitlines()
+    assert len(lines) == 4
+    # Each line is valid JSON with the expected fields.
+    for raw in lines:
+        row = json.loads(raw)
+        assert {"seq", "ts", "kind", "key", "response"} <= row.keys()
+
+    # --- replay phase ---------------------------------------------------
+    monkeypatch.delenv(RECORD_ENV_VAR, raising=False)
+    replay = ReplayGateway("run-rt", tmp_path, mode=GatewayMode.REPLAY)
+    assert replay.mode is GatewayMode.REPLAY
+
+    def _explode() -> object:
+        raise AssertionError("replay must not call invoke()")
+
+    replayed = [
+        replay.dispatch(kind="llm", key=f"llm-{i}", invoke=_explode)
+        for i in range(3)
+    ]
+    tool_replayed = replay.dispatch(kind="tool", key="run_tests", invoke=_explode)
+
+    assert replayed == recorded
+    assert tool_replayed == tool_recorded
+
+
+def test_replay_falls_back_to_fifo_when_key_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the caller's key changed between record and replay, the
+    gateway should still serve responses FIFO-by-kind so jittery hash
+    inputs don't break replay."""
+    monkeypatch.setenv(RECORD_ENV_VAR, "1")
+    rec = ReplayGateway("run-fifo", tmp_path)
+    rec.dispatch(kind="llm", key="orig-key", invoke=lambda: "first")
+    rec.dispatch(kind="llm", key="orig-key-2", invoke=lambda: "second")
+
+    replay = ReplayGateway("run-fifo", tmp_path, mode=GatewayMode.REPLAY)
+    # Caller uses *different* keys this time around.
+    first = replay.dispatch(kind="llm", key="new-key", invoke=lambda: "WRONG")
+    second = replay.dispatch(kind="llm", key="new-key-2", invoke=lambda: "WRONG")
+    assert first == "first"
+    assert second == "second"
+
+
+def test_replay_miss_raises_when_no_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(RECORD_ENV_VAR, "1")
+    rec = ReplayGateway("run-miss", tmp_path)
+    rec.dispatch(kind="llm", key="k", invoke=lambda: "x")
+
+    replay = ReplayGateway("run-miss", tmp_path, mode=GatewayMode.REPLAY)
+    replay.dispatch(kind="llm", key="k", invoke=lambda: "WRONG")
+    with pytest.raises(ReplayMissError):
+        replay.dispatch(kind="llm", key="k", invoke=lambda: "WRONG")
+
+
+def test_replay_missing_events_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(ReplayMissError):
+        ReplayGateway("nope", tmp_path, mode=GatewayMode.REPLAY)
+
+
+# ---------------------------------------------------------------------------
+# diff_event_logs
+# ---------------------------------------------------------------------------
+
+
+def _write_events(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_diff_identical_runs(tmp_path: Path) -> None:
+    a = tmp_path / "a" / EVENTS_FILENAME
+    b = tmp_path / "b" / EVENTS_FILENAME
+    rows = [
+        {"seq": 1, "kind": "llm", "key": "k1", "response": "x"},
+        {"seq": 2, "kind": "tool", "key": "t1", "response": {"ok": True}},
+    ]
+    _write_events(a, rows)
+    _write_events(b, rows)
+    result = diff_event_logs(a, b)
+    assert result.diverged is False
+    assert result.index is None
+    assert "2 events match" in result.reason
+
+
+def test_diff_value_mismatch(tmp_path: Path) -> None:
+    a = tmp_path / "a" / EVENTS_FILENAME
+    b = tmp_path / "b" / EVENTS_FILENAME
+    _write_events(a, [
+        {"seq": 1, "kind": "llm", "key": "k", "response": "alpha"},
+        {"seq": 2, "kind": "llm", "key": "k", "response": "beta"},
+    ])
+    _write_events(b, [
+        {"seq": 1, "kind": "llm", "key": "k", "response": "alpha"},
+        {"seq": 2, "kind": "llm", "key": "k", "response": "GAMMA"},
+    ])
+    result = diff_event_logs(a, b)
+    assert result.diverged is True
+    assert result.index == 1
+    assert result.a_event is not None and result.a_event["response"] == "beta"
+    assert result.b_event is not None and result.b_event["response"] == "GAMMA"
+
+
+def test_diff_length_mismatch(tmp_path: Path) -> None:
+    a = tmp_path / "a" / EVENTS_FILENAME
+    b = tmp_path / "b" / EVENTS_FILENAME
+    _write_events(a, [
+        {"seq": 1, "kind": "llm", "key": "k", "response": "x"},
+        {"seq": 2, "kind": "llm", "key": "k", "response": "y"},
+    ])
+    _write_events(b, [
+        {"seq": 1, "kind": "llm", "key": "k", "response": "x"},
+    ])
+    result = diff_event_logs(a, b)
+    assert result.diverged is True
+    assert result.index == 1
+    assert "extra event" in result.reason
+
+
+def test_diff_both_empty(tmp_path: Path) -> None:
+    a = tmp_path / "a" / EVENTS_FILENAME
+    b = tmp_path / "b" / EVENTS_FILENAME
+    a.parent.mkdir(parents=True)
+    b.parent.mkdir(parents=True)
+    a.touch()
+    b.touch()
+    result = diff_event_logs(a, b)
+    assert result.diverged is False
+    assert "empty" in result.reason


### PR DESCRIPTION
## Summary

- New `bernstein.core.replay` package — `ReplayGateway` records every `(kind, key) -> response` for LLM and tool dispatches into `.sdd/runs/<id>/events.jsonl`; replay mode serves recorded fixtures byte-identically (verified against the `mock` adapter response shape in tests).
- `bernstein replay diff RUN_A RUN_B` — line-by-line first-divergence locator (implemented as a pseudo-subcommand on the existing `replay` command to keep the back-compat `bernstein replay <RUN_ID>` shape).
- Recording is **OFF by default**. Opt in via `BERNSTEIN_RECORD=1` env var (or pass `record=True` to `ReplayGateway`). Per the issue brief: we don't want `.sdd/` to grow for every user.

## Opt-in path

```bash
# enable recording for a single run
BERNSTEIN_RECORD=1 bernstein run ...

# inspect the captured events
ls .sdd/runs/<run_id>/events.jsonl

# find the first divergence between two recordings
bernstein replay diff <run_a> <run_b>
```

## Scope notes

- **Step-through (`--step`)** is intentionally **deferred** per the issue's "skip if too complex for MVP — make it a follow-up" guidance.
- The gateway is wired into the orchestrator alongside `RunRecorder`, but adapter call-sites still invoke providers directly; threading the gateway through each adapter is a follow-up (the gateway API is ready for it).
- Replay falls back to FIFO-by-`kind` consumption when a request key shifts between record and replay (e.g. timestamp jitter inside hashed prompts) — pragmatic for an MVP, can be tightened later.

## Test plan

- [x] `pytest tests/unit/test_replay_gateway.py` (23 cases — record/replay round-trip with mock-style response shape, env opt-in matrix, FIFO fallback, replay-miss error, divergence finder identical / value-mismatch / length-mismatch / both-empty).
- [x] `pytest tests/unit/cli` (29 passed, 1 skipped — replay CLI still loads & dispatches).
- [x] `pytest -k "replay or recorder"` (170 passed).
- [x] `ruff check` clean on touched files.
- [x] End-to-end CLI smoke: `bernstein replay diff A B` reports divergence with exit 1; `bernstein replay diff A A` reports "identical" with exit 0.

Closes #1319.