### PR TITLE
feat(cost): per-task spend attribution + soft/hard circuit breakers

### DIFF
--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -236,6 +236,40 @@ def _aggregate_by_day(records: list[dict[str, Any]]) -> dict[str, dict[str, Any]
     return dict(rows)
 
 
+def _aggregate_from_ledger_or_tasks(
+    ledger_path: Path,
+    task_records: list[dict[str, Any]],
+    dimension: str,
+    cutoff: float,
+) -> dict[str, dict[str, Any]]:
+    """Aggregate spend by *dimension* using the JSONL ledger when present.
+
+    Issue #1320: ``role`` and ``feature_label`` are first-class tags
+    written by the LLM-adapter pre-call hook into ``.sdd/cost/ledger.jsonl``.
+    When the ledger is unavailable we degrade to ``task_records`` so older
+    runs still show a sensible breakdown.
+    """
+    from bernstein.core.cost.spend_ledger import SpendLedger, aggregate_entries
+
+    if ledger_path.exists():
+        entries = SpendLedger.load_entries(ledger_path)
+        if cutoff > 0:
+            entries = [e for e in entries if e.ts >= cutoff]
+        grouped = aggregate_entries(entries, dimension)
+        return {k: {"tasks": v["calls"], "cost_usd": v["cost_usd"]} for k, v in grouped.items()}
+
+    rows: dict[str, dict[str, Any]] = defaultdict(lambda: {"tasks": 0, "cost_usd": 0.0})
+    for rec in task_records:
+        if dimension == "role":
+            label = str(rec.get("role", "") or "unknown")
+        else:
+            tags = rec.get("cost_tags") or {}
+            label = str(tags.get("feature_label", "") or "unknown") if isinstance(tags, dict) else "unknown"
+        rows[label]["tasks"] += 1
+        rows[label]["cost_usd"] += float(rec.get("cost_usd", 0.0) or 0.0)
+    return dict(rows)
+
+
 def _compute_downgrade_tip(records: list[dict[str, Any]]) -> tuple[str, float] | None:
     """Estimate potential savings from downgrading simple opus tasks to sonnet.
 
@@ -546,16 +580,48 @@ def _cost_render_grouped(
 )
 @click.option("--last", "last", type=str, default=None, help="Time range: 1h, 24h, 7d, 30d.")
 @click.option(
+    "--since",
+    "since",
+    type=str,
+    default=None,
+    help="Anchor for --last (e.g. ``today``, ``yesterday``); shorthand for ``--last 24h`` etc.",
+)
+@click.option(
     "--by",
     "group_by",
-    type=click.Choice(["agent", "model", "task", "day"]),
+    type=click.Choice(["agent", "model", "task", "day", "role", "feature_label"]),
     default=None,
-    help="Group breakdown by agent, model, task, or day.",
+    help="Group breakdown by agent, model, task, day, role, or feature_label (issue #1320).",
+)
+@click.option(
+    "--ledger",
+    "ledger_path",
+    type=str,
+    default=".sdd/cost/ledger.jsonl",
+    show_default=True,
+    help="Path to the rolling spend ledger (issue #1320). Used when --by is role|feature_label.",
 )
 @click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
 @click.option("--share", is_flag=True, default=False, help="Print only the shareable summary snippet.")
-def cost_cmd(metrics_dir: str, last: str | None, group_by: str | None, as_json: bool, share: bool) -> None:
+def cost_cmd(
+    metrics_dir: str,
+    last: str | None,
+    since: str | None,
+    group_by: str | None,
+    ledger_path: str,
+    as_json: bool,
+    share: bool,
+) -> None:
     """Show cost breakdown for recent runs."""
+    # --since is a convenience: ``today`` ≈ ``--last 24h``,
+    # ``yesterday`` ≈ ``--last 48h``. When both are provided ``--last`` wins.
+    if last is None and since is not None:
+        s = since.strip().lower()
+        last = {"today": "24h", "yesterday": "48h", "week": "7d", "month": "30d"}.get(s, last)
+        if last is None:
+            # Treat unknown --since values as a direct time range (e.g. ``7d``).
+            last = since
+
     mdir = Path(metrics_dir)
     if not mdir.exists():
         if as_json or is_json():
@@ -643,6 +709,16 @@ def cost_cmd(metrics_dir: str, last: str | None, group_by: str | None, as_json: 
         grouped_data = _aggregate_by_task(task_records)
     elif group_by == "day":
         grouped_data = _aggregate_by_day(task_records)
+    elif group_by in ("role", "feature_label"):
+        # Issue #1320: role / feature_label are tagged dimensions that live
+        # in the rolling spend ledger. Fall back to task_records when the
+        # ledger is missing so old runs still show a sensible view.
+        grouped_data = _aggregate_from_ledger_or_tasks(
+            Path(ledger_path),
+            task_records,
+            group_by,
+            cutoff,
+        )
     # group_by == "model" or None => use the default rows (by model)
 
     if as_json or is_json():

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -726,6 +726,8 @@ def cli(
         activity_log_path=activity_log_path,
         max_cost_usd=None,
         idle=False,
+        budget_spec=None,
+        hard_budget_spec=None,
     )
 
 

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -222,6 +222,34 @@ SANDBOX_CHOICES: tuple[str, ...] = (
 SANDBOX_FREE_CHOICES: tuple[str, ...] = ("docker", "podman", "worktree")
 
 
+def _parse_budget_spec(raw: str | float | None) -> float | None:
+    """Parse a budget spec like ``5usd``, ``$5``, or ``5.5`` to a float.
+
+    Returns ``None`` when *raw* is None / blank. Negative values are
+    clamped to ``0.0`` (meaning "unlimited" per
+    :func:`bernstein.core.cost.cost_tracker.resolve_run_budget_usd`).
+    Issue #1320: shared by ``--budget`` and ``--hard-budget``.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        return max(0.0, float(raw))
+    s = str(raw).strip().lower()
+    if not s:
+        return None
+    s = s.removesuffix("usd").removesuffix("$").strip()
+    s = s.removeprefix("$").strip()
+    try:
+        v = float(s)
+    except ValueError as exc:
+        import click
+
+        raise click.BadParameter(
+            f"Invalid budget spec: {raw!r}. Use e.g. '5usd', '$5', or '5.0'.",
+        ) from exc
+    return max(0.0, v)
+
+
 def _propagate_env_flags(
     *,
     profile: bool,
@@ -238,6 +266,7 @@ def _propagate_env_flags(
     activity_log_path: str | None,
     audit: bool,
     max_cost_usd: float | None = None,
+    hard_budget_usd: float | None = None,
     allow_paid: bool = False,
 ) -> None:
     """Set environment variables so orchestrator subprocesses inherit CLI flags."""
@@ -271,6 +300,12 @@ def _propagate_env_flags(
         from bernstein.core.cost_tracker import ENV_MAX_COST_USD
 
         os.environ[ENV_MAX_COST_USD] = f"{max_cost_usd:.6f}"
+
+    # Hard cap kill switch (issue #1320). Independent of ``--budget`` /
+    # ``--max-cost-usd``: when set, the orchestrator halts as soon as
+    # cumulative spend reaches this value, no soft-warn ramp.
+    if hard_budget_usd is not None and hard_budget_usd > 0.0:
+        os.environ["BERNSTEIN_HARD_BUDGET_USD"] = f"{hard_budget_usd:.6f}"
 
     if sandbox:
         normalized = sandbox.lower()
@@ -917,6 +952,31 @@ def exec_restart() -> None:
         "Off-by-default (overrides bernstein.yaml ``budget`` and run_config.json)."
     ),
 )
+@click.option(
+    "--budget",
+    "budget_spec",
+    type=str,
+    default=None,
+    metavar="SPEC",
+    help=(
+        "Soft cap on total run spend (issue #1320). Accepts ``5usd``, "
+        "``$5``, or ``5.0``. Warns + reroutes to a cheaper model at 80%, "
+        "halts new work at 100%. Alias of ``--max-cost-usd`` with friendlier "
+        "parsing; both flags set the same env var."
+    ),
+)
+@click.option(
+    "--hard-budget",
+    "hard_budget_spec",
+    type=str,
+    default=None,
+    metavar="SPEC",
+    help=(
+        "Hard cap kill switch (issue #1320). Accepts ``10usd``, ``$10``, "
+        "or ``10.0``. Independent of ``--budget``: once tripped no new "
+        "agent is spawned, no retry."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -951,6 +1011,8 @@ def run(
     auto_pr: bool = False,
     activity_log_path: str | None = None,
     max_cost_usd: float | None = None,
+    budget_spec: str | None = None,
+    hard_budget_spec: str | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -975,7 +1037,15 @@ def run(
       bernstein conduct --container --two-phase-sandbox  # two-phase sandboxed execution
       bernstein conduct --audit                # SOC 2 audit mode (HMAC-chained log + Merkle seal)
       bernstein conduct --max-cost-usd 1.50    # hard cap total run spend at $1.50
+      bernstein run plan.yaml --budget 5usd --hard-budget 10usd  # soft + hard caps (#1320)
     """
+    # Issue #1320: ``--budget`` is the friendlier alias of ``--max-cost-usd``
+    # and shares the same env var. When both are set, the operator's
+    # explicit ``--max-cost-usd`` wins for backward compat.
+    budget_value = _parse_budget_spec(budget_spec)
+    if budget_value is not None and max_cost_usd is None:
+        max_cost_usd = budget_value
+    hard_budget_usd = _parse_budget_spec(hard_budget_spec)
     # Print the startup banner unless the parent ``cli()`` group already
     # rendered the premium splash for this invocation. Regressed by commit
     # 1e5c13013 ("fix: ... double banner ..."), which mistakenly removed the
@@ -1014,6 +1084,7 @@ def run(
         activity_log_path=activity_log_path,
         audit=audit,
         max_cost_usd=max_cost_usd,
+        hard_budget_usd=hard_budget_usd,
         allow_paid=allow_paid,
     )
 

--- a/src/bernstein/core/cost/__init__.py
+++ b/src/bernstein/core/cost/__init__.py
@@ -3,3 +3,18 @@
 from bernstein.core.cost.cost import *  # noqa: F403
 from bernstein.core.cost.cost import _MODEL_COST_USD_PER_1K as _MODEL_COST_USD_PER_1K
 from bernstein.core.cost.cost import _model_cost as _model_cost
+from bernstein.core.cost.spend_ledger import (
+    CallTags as CallTags,
+)
+from bernstein.core.cost.spend_ledger import (
+    LedgerEntry as LedgerEntry,
+)
+from bernstein.core.cost.spend_ledger import (
+    LedgerStatus as LedgerStatus,
+)
+from bernstein.core.cost.spend_ledger import (
+    SpendLedger as SpendLedger,
+)
+from bernstein.core.cost.spend_ledger import (
+    aggregate_entries as aggregate_entries,
+)

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -360,6 +360,17 @@ class CostTracker:
     # evicted rows are dropped (accumulators still carry their stats).
     rotation_dir: Path | None = None
 
+    # Optional hard-cap kill switch (issue #1320). When > 0 and reached,
+    # ``status().should_stop`` flips True regardless of soft budget %.
+    # Independent of ``budget_usd`` so the operator can run
+    # ``--budget 5usd --hard-budget 10usd`` and trip the kill switch only
+    # at the higher band.
+    hard_budget_usd: float = 0.0
+    # Optional rolling JSONL ledger. When set, every ``record()`` writes
+    # one row tagged with ``task_id|agent_id|role|feature_label`` so
+    # ``bernstein cost --by ...`` can attribute spend post-hoc.
+    spend_ledger: Any | None = None  # SpendLedger; typed as Any to avoid import cycle
+
     # Mutable tracking state (not constructor args)
     _spent_usd: float = field(default=0.0, init=False, repr=False)
     _usages: deque[TokenUsage] = field(
@@ -427,6 +438,9 @@ class CostTracker:
         tenant_id: str = "default",
         cache_read_tokens: int = 0,
         cache_write_tokens: int = 0,
+        role: str = "",
+        feature_label: str = "",
+        cost_tags: dict[str, str] | None = None,
     ) -> BudgetStatus:
         """Record token usage for an agent and return updated budget status.
 
@@ -456,6 +470,12 @@ class CostTracker:
                 cache_write_tokens=cache_write_tokens,
             )
 
+        merged_tags: dict[str, str] = dict(cost_tags or {})
+        if role and "role" not in merged_tags:
+            merged_tags["role"] = role
+        if feature_label and "feature_label" not in merged_tags:
+            merged_tags["feature_label"] = feature_label
+
         usage = TokenUsage(
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -466,6 +486,7 @@ class CostTracker:
             tenant_id=normalized_tenant,
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
+            cost_tags=merged_tags,
         )
         evicted: TokenUsage | None = None
         with self._lock:
@@ -484,6 +505,33 @@ class CostTracker:
         if evicted is not None:
             self._rotate_evicted(evicted)
         self._emit_threshold_warnings(status)
+
+        # Push to the rolling spend ledger (issue #1320). Best-effort:
+        # ledger IO must never block the record() hot path. Import locally
+        # so the cost_tracker module stays import-cycle-free.
+        if self.spend_ledger is not None:
+            from bernstein.core.cost.spend_ledger import CallTags  # local import
+
+            tags = CallTags(
+                task_id=task_id,
+                agent_id=agent_id,
+                role=str(merged_tags.get("role", "")),
+                feature_label=str(merged_tags.get("feature_label", "")),
+                extra={k: v for k, v in merged_tags.items() if k not in {"role", "feature_label"}},
+            )
+            try:
+                self.spend_ledger.record(
+                    tags=tags,
+                    model=model,
+                    cost_usd=cost_usd,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    cache_read_tokens=cache_read_tokens,
+                    cache_write_tokens=cache_write_tokens,
+                    ts=usage.timestamp,
+                )
+            except Exception as exc:  # pragma: no cover - belt-and-braces
+                logger.debug("SpendLedger write failed: %s", exc)
         return status
 
     def record_cumulative(
@@ -498,6 +546,9 @@ class CostTracker:
         tenant_id: str = "default",
         total_cache_read_tokens: int = 0,
         total_cache_write_tokens: int = 0,
+        role: str = "",
+        feature_label: str = "",
+        cost_tags: dict[str, str] | None = None,
     ) -> float:
         """Record cumulative token usage for one agent/task pair.
 
@@ -562,6 +613,9 @@ class CostTracker:
             tenant_id=normalize_tenant_id(tenant_id),
             cache_read_tokens=delta_cache_read,
             cache_write_tokens=delta_cache_write,
+            role=role,
+            feature_label=feature_label,
+            cost_tags=cost_tags,
         )
         self._cumulative_tokens[key] = (cur_input, cur_output, cur_cache_read, cur_cache_write)
         return self._spent_usd - before
@@ -578,6 +632,9 @@ class CostTracker:
             threshold.
         """
         with self._lock:
+            # Hard cap (issue #1320) trips independently of the soft cap.
+            if self.hard_budget_usd > 0 and self._spent_usd >= self.hard_budget_usd:
+                return False
             if self.budget_usd <= 0:
                 return True
             pct = self._spent_usd / self.budget_usd
@@ -592,16 +649,20 @@ class CostTracker:
             Immutable ``BudgetStatus`` with remaining budget, percentage
             used, and stop/warn flags.
         """
+        # Hard cap kill-switch (issue #1320). When the hard cap is hit we
+        # always advertise ``should_stop=True`` so the orchestrator stops
+        # spawning, even when the soft budget is unlimited or unset.
+        hard_trip = self.hard_budget_usd > 0 and self._spent_usd >= self.hard_budget_usd
+
         if self.budget_usd <= 0:
-            # Unlimited budget — never warn or stop
             return BudgetStatus(
                 run_id=self.run_id,
                 budget_usd=0.0,
                 spent_usd=self._spent_usd,
                 remaining_usd=float("inf"),
                 percentage_used=0.0,
-                should_warn=False,
-                should_stop=False,
+                should_warn=hard_trip,
+                should_stop=hard_trip,
             )
 
         pct = self._spent_usd / self.budget_usd
@@ -612,8 +673,8 @@ class CostTracker:
             spent_usd=self._spent_usd,
             remaining_usd=remaining,
             percentage_used=pct,
-            should_warn=pct >= self.warn_threshold,
-            should_stop=pct >= self.hard_stop_threshold,
+            should_warn=pct >= self.warn_threshold or hard_trip,
+            should_stop=pct >= self.hard_stop_threshold or hard_trip,
         )
 
     @property
@@ -638,6 +699,30 @@ class CostTracker:
     def total_usages_recorded(self) -> int:
         """Total usage records ever appended, including evicted rows."""
         return self._total_usages_recorded
+
+    def cheaper_model_for(self, model: str) -> str | None:
+        """Suggest a cheaper model when ``>=80%`` of the soft cap is spent.
+
+        Returns ``None`` when the soft cap is unset or not yet warning.
+        Delegates to :class:`SpendLedger.cheaper_model` when a ledger is
+        attached so the reroute table stays in one place; otherwise uses
+        a local 80% check against the soft cap.
+        """
+        if self.spend_ledger is not None:
+            return self.spend_ledger.cheaper_model(model)  # type: ignore[no-any-return]
+        # Fallback: local 80% check
+        if self.budget_usd <= 0:
+            return None
+        pct = self._spent_usd / self.budget_usd
+        if pct < self.warn_threshold:
+            return None
+        from bernstein.core.cost.spend_ledger import _REROUTE, DEFAULT_CHEAP_MODEL
+
+        m = model.lower()
+        for k, v in _REROUTE.items():
+            if k in m and k != v:
+                return v
+        return DEFAULT_CHEAP_MODEL if DEFAULT_CHEAP_MODEL not in m else None
 
     def spent_for_agent(self, agent_id: str) -> float:
         """Return cumulative spend for one agent session."""
@@ -668,6 +753,7 @@ class CostTracker:
         data: dict[str, Any] = {
             "run_id": self.run_id,
             "budget_usd": self.budget_usd,
+            "hard_budget_usd": self.hard_budget_usd,
             "spent_usd": round(self._spent_usd, 6),
             "warn_threshold": self.warn_threshold,
             "critical_threshold": self.critical_threshold,
@@ -703,6 +789,7 @@ class CostTracker:
             tracker = cls(
                 run_id=data["run_id"],
                 budget_usd=float(data.get("budget_usd", 0.0)),
+                hard_budget_usd=float(data.get("hard_budget_usd", 0.0)),
                 warn_threshold=float(data.get("warn_threshold", DEFAULT_WARN_THRESHOLD)),
                 critical_threshold=float(data.get("critical_threshold", DEFAULT_CRITICAL_THRESHOLD)),
                 hard_stop_threshold=float(data.get("hard_stop_threshold", DEFAULT_HARD_STOP_THRESHOLD)),

--- a/src/bernstein/core/cost/spend_ledger.py
+++ b/src/bernstein/core/cost/spend_ledger.py
@@ -1,0 +1,504 @@
+"""Rolling per-task spend ledger with soft / hard circuit breakers.
+
+Issue #1320: tag every LLM call at request time and persist it to a
+JSONL ledger at ``.sdd/cost/ledger.jsonl`` so the operator can attribute
+spend to ``task_id`` / ``agent_id`` / ``role`` / ``feature_label`` and
+reason about runaway agents post-hoc.
+
+Two enforcement bands are recognised:
+
+* **Soft cap** (``--budget``): warn + reroute the next call to a cheaper
+  model when ``>=80%`` of the cap has been spent; halt new work at 100%.
+  Reroute is advisory — callers consult :func:`cheaper_model` and decide.
+* **Hard cap** (``--hard-budget``): kill switch. Once tripped, no new
+  call is admitted; the orchestrator must stop spawning.
+
+The ledger is append-only and crash-safe: each :class:`SpendLedger.record`
+fsyncs a single JSON line. Aggregation runs on read (cheap for the
+typical 10^3-10^4 row ledger; if it ever grows past that we'll add a
+roll-up snapshot).
+
+This module is intentionally narrow — it does not own model selection
+(:mod:`bernstein.core.cost.cost`) nor per-run budget reporting
+(:mod:`bernstein.core.cost.cost_tracker`). It composes with both: the
+tracker calls into :class:`SpendLedger` on every recorded usage.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003 - runtime use in dataclass field default
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Cap-trip thresholds. ``WARN`` is the soft-reroute trigger; ``SOFT_HALT``
+# is the soft 100% line; ``HARD_HALT`` flips when the hard cap is reached.
+SOFT_WARN_FRACTION: float = 0.80
+SOFT_HALT_FRACTION: float = 1.00
+HARD_HALT_FRACTION: float = 1.00
+
+# Default reroute map: when the soft cap warns, prefer the cheaper model
+# in the same family. Keys are matched by substring so concrete model
+# strings like ``"claude-sonnet-4"`` route to ``"haiku"``. Unknown
+# models fall through to ``DEFAULT_CHEAP_MODEL``.
+_REROUTE: dict[str, str] = {
+    "opus": "sonnet",
+    "sonnet": "haiku",
+    "gpt-5.5": "gpt-5.5-mini",
+    "gpt-5.4": "gpt-5.4-mini",
+    "gpt-5": "gpt-5-mini",
+    "gemini-3-pro": "gemini-3-flash",
+    "gemini-3.1-pro": "gemini-3-flash",
+    "gemini-3": "gemini-3-flash",
+    "deepseek-v4-pro": "deepseek-v4-flash",
+    "qwen-max": "qwen-plus",
+    "qwen-plus": "qwen-turbo",
+}
+DEFAULT_CHEAP_MODEL: str = "haiku"
+
+
+# ---------------------------------------------------------------------------
+# Records & tags
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CallTags:
+    """Per-call attribution tags attached at LLM-request time.
+
+    Empty strings are permitted (and treated as "unknown") so the
+    pre-call hook can tag what it knows without forcing every caller to
+    pre-populate every dimension. Callers that need richer tagging set
+    ``extra`` — useful for ``feature_label`` and operator-defined
+    dimensions like ``customer_id``.
+    """
+
+    task_id: str = ""
+    agent_id: str = ""
+    role: str = ""
+    feature_label: str = ""
+    extra: dict[str, str] = field(default_factory=dict)
+
+    def merged(self) -> dict[str, str]:
+        """Flatten well-known fields + ``extra`` into a single dict.
+
+        Returns:
+            A dict with no empty values. Keys are normalised to strings.
+        """
+        out: dict[str, str] = {}
+        if self.task_id:
+            out["task_id"] = self.task_id
+        if self.agent_id:
+            out["agent_id"] = self.agent_id
+        if self.role:
+            out["role"] = self.role
+        if self.feature_label:
+            out["feature_label"] = self.feature_label
+        for k, v in self.extra.items():
+            if v:
+                out[str(k)] = str(v)
+        return out
+
+
+@dataclass
+class LedgerEntry:
+    """One row in ``.sdd/cost/ledger.jsonl``.
+
+    Identical attributes to :class:`bernstein.core.cost.cost_tracker.TokenUsage`
+    plus a stamped ``ts_iso`` for human readability and the merged
+    ``tags`` block. Stored as JSON; field order is stable so diffing
+    ledgers from two runs is meaningful.
+    """
+
+    ts: float
+    ts_iso: str
+    run_id: str
+    task_id: str
+    agent_id: str
+    role: str
+    feature_label: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_write_tokens: int
+    cost_usd: float
+    tags: dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        """Return a stable single-line JSON encoding."""
+        return json.dumps(asdict(self), sort_keys=False, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> LedgerEntry:
+        """Deserialise from a parsed JSON dict; missing fields default."""
+        raw_tags = d.get("tags") or {}
+        tags: dict[str, str] = {str(k): str(v) for k, v in raw_tags.items()} if isinstance(raw_tags, dict) else {}
+        return cls(
+            ts=float(d.get("ts", 0.0) or 0.0),
+            ts_iso=str(d.get("ts_iso", "")),
+            run_id=str(d.get("run_id", "")),
+            task_id=str(d.get("task_id", "")),
+            agent_id=str(d.get("agent_id", "")),
+            role=str(d.get("role", "")),
+            feature_label=str(d.get("feature_label", "")),
+            model=str(d.get("model", "")),
+            input_tokens=int(d.get("input_tokens", 0) or 0),
+            output_tokens=int(d.get("output_tokens", 0) or 0),
+            cache_read_tokens=int(d.get("cache_read_tokens", 0) or 0),
+            cache_write_tokens=int(d.get("cache_write_tokens", 0) or 0),
+            cost_usd=float(d.get("cost_usd", 0.0) or 0.0),
+            tags=tags,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SpendLedger:
+    """Append-only JSONL spend ledger with soft / hard circuit breakers.
+
+    ``budget_usd`` is the soft cap and ``hard_budget_usd`` is the hard
+    cap (both in USD; 0 means "no cap" on that side). Calling
+    :meth:`record` writes one JSONL row, updates the rolling totals, and
+    returns the current :class:`LedgerStatus` so the caller can decide
+    whether to warn / reroute / abort.
+
+    The instance is process-local; concurrent writers should each hold
+    their own instance pointing at the same file (the append is atomic
+    on POSIX for lines below ``PIPE_BUF``). A thread lock guards the
+    in-process totals.
+    """
+
+    path: Path
+    run_id: str = "default"
+    budget_usd: float = 0.0
+    hard_budget_usd: float = 0.0
+
+    # Internal state
+    _spent_usd: float = field(default=0.0, init=False, repr=False)
+    _spent_by: dict[str, dict[str, float]] = field(
+        default_factory=lambda: defaultdict(lambda: defaultdict(float)),
+        init=False,
+        repr=False,
+    )
+    _entries_written: int = field(default=0, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _soft_warned: bool = field(default=False, init=False, repr=False)
+    _soft_halted_at: float | None = field(default=None, init=False, repr=False)
+    _hard_halted_at: float | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Normalise non-positive caps to 0 so "no cap" semantics are
+        # consistent with cost_tracker.resolve_run_budget_usd.
+        if self.budget_usd < 0:
+            self.budget_usd = 0.0
+        if self.hard_budget_usd < 0:
+            self.hard_budget_usd = 0.0
+        # If both caps are set but inverted, the hard cap must dominate.
+        if self.budget_usd > 0 and 0 < self.hard_budget_usd < self.budget_usd:
+            logger.warning(
+                "SpendLedger: hard_budget_usd=%.4f < budget_usd=%.4f; "
+                "soft cap clamped to hard cap to preserve precedence.",
+                self.hard_budget_usd,
+                self.budget_usd,
+            )
+            self.budget_usd = self.hard_budget_usd
+
+    # ------------------------------------------------------------------ record
+
+    def record(
+        self,
+        *,
+        tags: CallTags,
+        model: str,
+        cost_usd: float,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        ts: float | None = None,
+    ) -> LedgerStatus:
+        """Append one row to the ledger and return the post-call status.
+
+        Cost values below zero are clamped to zero (defensive — a
+        misconfigured pricing table must not corrupt the ledger).
+        """
+        cost = max(0.0, float(cost_usd))
+        now = ts if ts is not None else time.time()
+        merged = tags.merged()
+        entry = LedgerEntry(
+            ts=now,
+            ts_iso=datetime.fromtimestamp(now, tz=UTC).isoformat(timespec="seconds"),
+            run_id=self.run_id,
+            task_id=tags.task_id,
+            agent_id=tags.agent_id,
+            role=tags.role,
+            feature_label=tags.feature_label,
+            model=model,
+            input_tokens=int(input_tokens),
+            output_tokens=int(output_tokens),
+            cache_read_tokens=int(cache_read_tokens),
+            cache_write_tokens=int(cache_write_tokens),
+            cost_usd=cost,
+            tags=merged,
+        )
+
+        with self._lock:
+            self._append_to_disk(entry)
+            self._spent_usd += cost
+            self._entries_written += 1
+            self._spent_by["task"][tags.task_id or "unknown"] += cost
+            self._spent_by["agent"][tags.agent_id or "unknown"] += cost
+            self._spent_by["role"][tags.role or "unknown"] += cost
+            self._spent_by["model"][model or "unknown"] += cost
+            if tags.feature_label:
+                self._spent_by["feature_label"][tags.feature_label] += cost
+            status = self._status_locked()
+
+        # Logging outside the lock so a noisy handler can't block other writers.
+        self._emit_threshold_events(status)
+        return status
+
+    # ------------------------------------------------------------------ query
+
+    def status(self) -> LedgerStatus:
+        """Return the current ledger status snapshot."""
+        with self._lock:
+            return self._status_locked()
+
+    def _status_locked(self) -> LedgerStatus:
+        soft = self.budget_usd
+        hard = self.hard_budget_usd
+        spent = self._spent_usd
+
+        soft_pct = (spent / soft) if soft > 0 else 0.0
+        hard_pct = (spent / hard) if hard > 0 else 0.0
+
+        soft_warn = soft > 0 and soft_pct >= SOFT_WARN_FRACTION
+        soft_halt = soft > 0 and soft_pct >= SOFT_HALT_FRACTION
+        hard_halt = hard > 0 and hard_pct >= HARD_HALT_FRACTION
+
+        return LedgerStatus(
+            spent_usd=spent,
+            budget_usd=soft,
+            hard_budget_usd=hard,
+            soft_pct=soft_pct,
+            hard_pct=hard_pct,
+            soft_warn=soft_warn,
+            soft_halt=soft_halt,
+            hard_halt=hard_halt,
+        )
+
+    def totals_by(self, dimension: str) -> dict[str, float]:
+        """Return cost-by-dimension totals (``task|agent|role|model|feature_label``).
+
+        Unknown dimensions return an empty dict so callers can probe
+        without raising. ``task|agent|role|model`` are always populated
+        (even with the ``"unknown"`` bucket); ``feature_label`` only
+        appears when at least one row carried the tag.
+        """
+        with self._lock:
+            return dict(self._spent_by.get(dimension, {}))
+
+    # ------------------------------------------------------------------ reroute
+
+    def cheaper_model(self, model: str) -> str | None:
+        """Suggest a cheaper substitute model when the soft cap has warned.
+
+        Returns ``None`` when the soft cap has not been tripped or when
+        the proposed substitute is the same as the input (avoids no-op
+        rerouting). Caller is responsible for honouring the suggestion.
+        """
+        status = self.status()
+        if not status.soft_warn:
+            return None
+        m = model.lower()
+        for k, v in _REROUTE.items():
+            if k in m and k != v:
+                return v
+        # Unknown model: only suggest a substitute if it's not already
+        # the default cheap floor (otherwise we recommend "haiku" → "haiku").
+        return DEFAULT_CHEAP_MODEL if DEFAULT_CHEAP_MODEL not in m else None
+
+    def admits(self) -> bool:
+        """Whether the next call is admitted under the current caps."""
+        status = self.status()
+        return not (status.hard_halt or status.soft_halt)
+
+    # ------------------------------------------------------------------ io
+
+    def _append_to_disk(self, entry: LedgerEntry) -> None:
+        """Append a single JSONL line, flushing to disk best-effort.
+
+        Failures are logged but never raised — the ledger is best-effort
+        observability and must not take down the orchestrator.
+        """
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            with self.path.open("a", encoding="utf-8") as fh:
+                fh.write(entry.to_json())
+                fh.write("\n")
+                fh.flush()
+        except OSError as exc:  # pragma: no cover - IO failure path
+            logger.warning("SpendLedger: failed to append entry: %s", exc)
+
+    def _emit_threshold_events(self, status: LedgerStatus) -> None:
+        """Log + stamp soft/hard threshold transitions exactly once each."""
+        now = time.time()
+        if status.hard_halt and self._hard_halted_at is None:
+            self._hard_halted_at = now
+            logger.warning(
+                "SpendLedger HARD CAP HIT: spent=$%.4f hard_cap=$%.4f run_id=%s",
+                status.spent_usd,
+                status.hard_budget_usd,
+                self.run_id,
+            )
+        if status.soft_halt and self._soft_halted_at is None:
+            self._soft_halted_at = now
+            logger.warning(
+                "SpendLedger SOFT CAP HIT (100%%): spent=$%.4f budget=$%.4f run_id=%s",
+                status.spent_usd,
+                status.budget_usd,
+                self.run_id,
+            )
+        elif status.soft_warn and not self._soft_warned:
+            self._soft_warned = True
+            logger.warning(
+                "SpendLedger SOFT CAP WARN (>=80%%): spent=$%.4f budget=$%.4f run_id=%s — "
+                "calls will be rerouted to cheaper models",
+                status.spent_usd,
+                status.budget_usd,
+                self.run_id,
+            )
+
+    # ------------------------------------------------------------------ load
+
+    @classmethod
+    def load_entries(cls, path: Path) -> list[LedgerEntry]:
+        """Read every row of an existing ledger file (cheap for typical sizes).
+
+        Returns an empty list when the file is missing. Malformed lines
+        are skipped — partial recovery is preferred over a crash.
+        """
+        if not path.exists():
+            return []
+        entries: list[LedgerEntry] = []
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entries.append(LedgerEntry.from_dict(json.loads(line)))
+                    except (ValueError, KeyError, TypeError):
+                        continue
+        except OSError as exc:  # pragma: no cover
+            logger.warning("SpendLedger: failed to read %s: %s", path, exc)
+        return entries
+
+    @property
+    def entries_written(self) -> int:
+        """How many rows this instance wrote since construction."""
+        return self._entries_written
+
+
+@dataclass(frozen=True)
+class LedgerStatus:
+    """Snapshot of the rolling spend state."""
+
+    spent_usd: float
+    budget_usd: float
+    hard_budget_usd: float
+    soft_pct: float
+    hard_pct: float
+    soft_warn: bool
+    soft_halt: bool
+    hard_halt: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "spent_usd": round(self.spent_usd, 6),
+            "budget_usd": self.budget_usd,
+            "hard_budget_usd": self.hard_budget_usd,
+            "soft_pct": round(self.soft_pct, 4),
+            "hard_pct": round(self.hard_pct, 4),
+            "soft_warn": self.soft_warn,
+            "soft_halt": self.soft_halt,
+            "hard_halt": self.hard_halt,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Aggregation helpers (for `bernstein cost --by ...`)
+# ---------------------------------------------------------------------------
+
+
+def aggregate_entries(
+    entries: list[LedgerEntry],
+    dimension: str,
+) -> dict[str, dict[str, Any]]:
+    """Group ledger entries by *dimension*; return per-bucket totals.
+
+    Supported dimensions: ``task``, ``agent``, ``role``, ``model``,
+    ``feature_label``, ``day``. Unknown dimensions return ``{}``.
+
+    Each bucket contains ``cost_usd``, ``calls``, ``input_tokens``,
+    ``output_tokens``. Buckets are not pre-sorted — that's the
+    rendering layer's job.
+    """
+    if not entries:
+        return {}
+
+    def _bucket_key(e: LedgerEntry) -> str:
+        if dimension == "task":
+            return e.task_id or "unknown"
+        if dimension == "agent":
+            return e.agent_id or "unknown"
+        if dimension == "role":
+            return e.role or "unknown"
+        if dimension == "model":
+            return e.model or "unknown"
+        if dimension == "feature_label":
+            return e.feature_label or "unknown"
+        if dimension == "day":
+            return datetime.fromtimestamp(e.ts, tz=UTC).strftime("%Y-%m-%d") if e.ts > 0 else "unknown"
+        return ""
+
+    if dimension not in {"task", "agent", "role", "model", "feature_label", "day"}:
+        return {}
+
+    out: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"cost_usd": 0.0, "calls": 0, "input_tokens": 0, "output_tokens": 0}
+    )
+    for e in entries:
+        bucket = out[_bucket_key(e)]
+        bucket["cost_usd"] += e.cost_usd
+        bucket["calls"] += 1
+        bucket["input_tokens"] += e.input_tokens
+        bucket["output_tokens"] += e.output_tokens
+    return dict(out)
+
+
+__all__ = [
+    "DEFAULT_CHEAP_MODEL",
+    "HARD_HALT_FRACTION",
+    "SOFT_HALT_FRACTION",
+    "SOFT_WARN_FRACTION",
+    "CallTags",
+    "LedgerEntry",
+    "LedgerStatus",
+    "SpendLedger",
+    "aggregate_entries",
+]

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -455,11 +455,38 @@ class Orchestrator:
 
         # Per-run cost budget tracker.  When budget_usd > 0 the tracker
         # emits warnings at 80%/95% and blocks spawns at 100%.
+        # Issue #1320: ``BERNSTEIN_HARD_BUDGET_USD`` is the kill-switch
+        # cap (set by ``bernstein run --hard-budget``). Attach a rolling
+        # JSONL ledger so per-call attribution lands in
+        # ``.sdd/cost/ledger.jsonl``.
         run_id = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
         self._run_id = run_id
+        hard_budget_usd = 0.0
+        _raw_hard = os.environ.get("BERNSTEIN_HARD_BUDGET_USD", "").strip()
+        if _raw_hard:
+            try:
+                hard_budget_usd = max(0.0, float(_raw_hard))
+            except ValueError:
+                logger.warning(
+                    "Invalid BERNSTEIN_HARD_BUDGET_USD=%r; ignoring hard cap.",
+                    _raw_hard,
+                )
+
+        from bernstein.core.cost.spend_ledger import SpendLedger
+
+        spend_ledger = SpendLedger(
+            path=workdir / ".sdd" / "cost" / "ledger.jsonl",
+            run_id=run_id,
+            budget_usd=config.budget_usd,
+            hard_budget_usd=hard_budget_usd,
+        )
+        self._spend_ledger = spend_ledger
+
         self._cost_tracker = CostTracker(
             run_id=run_id,
             budget_usd=config.budget_usd,
+            hard_budget_usd=hard_budget_usd,
+            spend_ledger=spend_ledger,
         )
         self._cost_cap_killed_agents: set[str] = set()
 
@@ -2704,12 +2731,16 @@ class Orchestrator:
 
             model_name = session.model_config.model if session.model_config else "sonnet"
             task_id = session.task_ids[0] if session.task_ids else f"live-{session.id}"
+            # Issue #1320: tag the call with the session's role so the
+            # ledger can attribute spend by role without an extra lookup.
+            role_label = getattr(session, "role", "") or ""
             delta_cost = self._cost_tracker.record_cumulative(
                 agent_id=session.id,
                 task_id=task_id,
                 model=model_name,
                 total_input_tokens=session.tokens_used,
                 total_output_tokens=0,
+                role=role_label,
             )
             if delta_cost > 0:
                 any_change = True

--- a/tests/unit/test_cost_cmd_by_role.py
+++ b/tests/unit/test_cost_cmd_by_role.py
@@ -1,0 +1,184 @@
+"""CLI tests for ``bernstein cost --by role|feature_label`` (issue #1320)."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+from bernstein.cli.cost import cost_cmd
+from click.testing import CliRunner
+
+from bernstein.cli.run_bootstrap import _parse_budget_spec
+from bernstein.core.cost.spend_ledger import CallTags, SpendLedger
+
+# ---------------------------------------------------------------------------
+# --budget / --hard-budget spec parser
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetSpec:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("5usd", 5.0),
+            ("$5", 5.0),
+            ("5.0", 5.0),
+            ("5.5usd", 5.5),
+            ("$5.5", 5.5),
+            ("10.25", 10.25),
+        ],
+    )
+    def test_accepts_common_formats(self, raw: str, expected: float) -> None:
+        assert _parse_budget_spec(raw) == pytest.approx(expected)
+
+    def test_negative_clamped_to_zero(self) -> None:
+        assert _parse_budget_spec("-1.0") == 0.0
+
+    def test_blank_returns_none(self) -> None:
+        assert _parse_budget_spec(None) is None
+        assert _parse_budget_spec("") is None
+        assert _parse_budget_spec("   ") is None
+
+    def test_invalid_raises(self) -> None:
+        import click
+
+        with pytest.raises(click.BadParameter):
+            _parse_budget_spec("five dollars")
+
+
+# ---------------------------------------------------------------------------
+# cost CLI: --by role|feature_label backed by the ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sdd_with_ledger(tmp_path: Path) -> Path:
+    """Build a ``.sdd`` tree with a populated spend ledger."""
+    sdd = tmp_path / ".sdd"
+    metrics = sdd / "metrics"
+    cost = sdd / "cost"
+    metrics.mkdir(parents=True)
+    cost.mkdir(parents=True)
+
+    # Minimal tasks.jsonl so the CLI doesn't bail on "no metrics".
+    now = time.time()
+    (metrics / "tasks.jsonl").write_text(
+        json.dumps(
+            {
+                "task_id": "t-1",
+                "role": "backend",
+                "model": "claude-sonnet-4",
+                "timestamp": now,
+                "tokens_prompt": 100,
+                "tokens_completion": 50,
+                "cost_usd": 0.05,
+                "agent_id": "a-1",
+            }
+        )
+    )
+
+    led = SpendLedger(path=cost / "ledger.jsonl", run_id="r-1")
+    led.record(tags=CallTags(task_id="t-1", agent_id="a-1", role="backend"), model="sonnet", cost_usd=0.10)
+    led.record(tags=CallTags(task_id="t-2", agent_id="a-1", role="backend"), model="sonnet", cost_usd=0.20)
+    led.record(
+        tags=CallTags(task_id="t-3", agent_id="a-2", role="qa", feature_label="rag"), model="haiku", cost_usd=0.05
+    )
+    return sdd
+
+
+class TestCostByRole:
+    def test_by_role_uses_ledger(self, sdd_with_ledger: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            [
+                "--metrics-dir",
+                str(sdd_with_ledger / "metrics"),
+                "--ledger",
+                str(sdd_with_ledger / "cost" / "ledger.jsonl"),
+                "--by",
+                "role",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["grouped_by"] == "role"
+        grouped = data["grouped"]
+        assert grouped["backend"]["cost_usd"] == pytest.approx(0.30)
+        assert grouped["qa"]["cost_usd"] == pytest.approx(0.05)
+
+    def test_by_feature_label_uses_ledger(self, sdd_with_ledger: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            [
+                "--metrics-dir",
+                str(sdd_with_ledger / "metrics"),
+                "--ledger",
+                str(sdd_with_ledger / "cost" / "ledger.jsonl"),
+                "--by",
+                "feature_label",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        grouped = data["grouped"]
+        assert grouped["rag"]["cost_usd"] == pytest.approx(0.05)
+        assert "unknown" in grouped
+
+    def test_since_today_alias(self, sdd_with_ledger: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            [
+                "--metrics-dir",
+                str(sdd_with_ledger / "metrics"),
+                "--since",
+                "today",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["time_range"] == "last 24h"
+
+    def test_by_role_falls_back_to_tasks_when_ledger_missing(self, tmp_path: Path) -> None:
+        sdd = tmp_path / ".sdd"
+        metrics = sdd / "metrics"
+        metrics.mkdir(parents=True)
+        now = time.time()
+        rows = [
+            {
+                "task_id": f"t{i}",
+                "role": "backend" if i < 2 else "qa",
+                "model": "sonnet",
+                "timestamp": now,
+                "cost_usd": 0.10,
+                "agent_id": "a",
+            }
+            for i in range(3)
+        ]
+        (metrics / "tasks.jsonl").write_text("\n".join(json.dumps(r) for r in rows))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cost_cmd,
+            [
+                "--metrics-dir",
+                str(metrics),
+                "--ledger",
+                str(sdd / "cost" / "ledger.jsonl"),  # absent
+                "--by",
+                "role",
+                "--json",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        grouped = data["grouped"]
+        assert grouped["backend"]["cost_usd"] == pytest.approx(0.20)
+        assert grouped["qa"]["cost_usd"] == pytest.approx(0.10)

--- a/tests/unit/test_spend_ledger.py
+++ b/tests/unit/test_spend_ledger.py
@@ -1,0 +1,397 @@
+"""Tests for the rolling spend ledger (issue #1320).
+
+Covers:
+* :class:`SpendLedger.record` math and JSONL append semantics.
+* Soft cap (warn at 80%, halt at 100%) and hard cap kill switch.
+* Reroute hint via :meth:`SpendLedger.cheaper_model`.
+* ``aggregate_entries`` group-by math for the ``bernstein cost --by``
+  ``task|agent|role|model|feature_label|day`` dimensions.
+* :class:`CostTracker` honouring ``hard_budget_usd`` and forwarding tags
+  to a ledger.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from bernstein.core.cost_tracker import CostTracker
+
+from bernstein.core.cost.spend_ledger import (
+    CallTags,
+    LedgerEntry,
+    SpendLedger,
+    aggregate_entries,
+)
+
+# ---------------------------------------------------------------------------
+# CallTags / LedgerEntry shape
+# ---------------------------------------------------------------------------
+
+
+class TestCallTags:
+    def test_merged_drops_empty_fields(self) -> None:
+        tags = CallTags(task_id="t-1", agent_id="", role="backend", feature_label="")
+        merged = tags.merged()
+        assert merged == {"task_id": "t-1", "role": "backend"}
+
+    def test_merged_includes_extra(self) -> None:
+        tags = CallTags(task_id="t-1", extra={"customer_id": "acme", "blank": ""})
+        merged = tags.merged()
+        assert merged["customer_id"] == "acme"
+        assert "blank" not in merged
+
+    def test_ledger_entry_roundtrip(self) -> None:
+        entry = LedgerEntry(
+            ts=1000.0,
+            ts_iso="2026-05-17T00:00:00+00:00",
+            run_id="r-1",
+            task_id="t-1",
+            agent_id="a-1",
+            role="backend",
+            feature_label="rag",
+            model="sonnet",
+            input_tokens=100,
+            output_tokens=50,
+            cache_read_tokens=10,
+            cache_write_tokens=5,
+            cost_usd=0.123456,
+            tags={"task_id": "t-1", "role": "backend"},
+        )
+        s = entry.to_json()
+        restored = LedgerEntry.from_dict(json.loads(s))
+        assert restored.task_id == "t-1"
+        assert restored.cost_usd == pytest.approx(0.123456)
+        assert restored.tags == {"task_id": "t-1", "role": "backend"}
+
+
+# ---------------------------------------------------------------------------
+# Record math + JSONL append
+# ---------------------------------------------------------------------------
+
+
+class TestRecord:
+    def test_record_writes_one_line_per_call(self, tmp_path: Path) -> None:
+        path = tmp_path / "ledger.jsonl"
+        led = SpendLedger(path=path, run_id="r-1")
+        for _ in range(3):
+            led.record(
+                tags=CallTags(task_id="t-1", agent_id="a-1", role="backend"),
+                model="sonnet",
+                cost_usd=0.10,
+            )
+        lines = path.read_text().splitlines()
+        assert len(lines) == 3
+        first = json.loads(lines[0])
+        assert first["model"] == "sonnet"
+        assert first["cost_usd"] == pytest.approx(0.10)
+        assert first["task_id"] == "t-1"
+        assert first["tags"]["role"] == "backend"
+
+    def test_record_accumulates_totals(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", run_id="r-1")
+        led.record(tags=CallTags(task_id="t-1", role="backend"), model="opus", cost_usd=0.40)
+        led.record(tags=CallTags(task_id="t-1", role="backend"), model="opus", cost_usd=0.30)
+        led.record(tags=CallTags(task_id="t-2", role="qa"), model="haiku", cost_usd=0.05)
+        st = led.status()
+        assert st.spent_usd == pytest.approx(0.75)
+        by_task = led.totals_by("task")
+        assert by_task["t-1"] == pytest.approx(0.70)
+        assert by_task["t-2"] == pytest.approx(0.05)
+        by_role = led.totals_by("role")
+        assert by_role["backend"] == pytest.approx(0.70)
+        assert by_role["qa"] == pytest.approx(0.05)
+
+    def test_record_clamps_negative_cost(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl")
+        st = led.record(tags=CallTags(task_id="t"), model="sonnet", cost_usd=-1.0)
+        assert st.spent_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Soft + hard cap behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestSoftCap:
+    def test_no_cap_never_warns(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl")
+        st = led.record(tags=CallTags(), model="opus", cost_usd=999.0)
+        assert st.soft_warn is False
+        assert st.soft_halt is False
+        assert st.hard_halt is False
+
+    def test_warn_at_80_pct(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0)
+        st = led.record(tags=CallTags(), model="sonnet", cost_usd=4.0)
+        assert st.soft_warn is True
+        assert st.soft_halt is False
+
+    def test_no_warn_below_80_pct(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0)
+        st = led.record(tags=CallTags(), model="sonnet", cost_usd=3.9)
+        assert st.soft_warn is False
+
+    def test_halt_at_100_pct(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0)
+        st = led.record(tags=CallTags(), model="sonnet", cost_usd=5.0)
+        assert st.soft_halt is True
+        assert led.admits() is False
+
+    def test_cheaper_model_after_warn(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0)
+        # Below 80% — no reroute
+        led.record(tags=CallTags(), model="opus", cost_usd=1.0)
+        assert led.cheaper_model("opus") is None
+        # Cross the 80% line
+        led.record(tags=CallTags(), model="opus", cost_usd=3.0)
+        assert led.cheaper_model("opus") == "sonnet"
+        assert led.cheaper_model("claude-sonnet-4") == "haiku"
+
+    def test_warn_logged_once(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0)
+        with caplog.at_level("WARNING"):
+            led.record(tags=CallTags(), model="opus", cost_usd=4.5)
+            led.record(tags=CallTags(), model="opus", cost_usd=0.1)
+        warn_lines = [r for r in caplog.records if "SOFT CAP WARN" in r.message]
+        assert len(warn_lines) == 1
+
+
+class TestHardCap:
+    def test_hard_halt_blocks_admission(self, tmp_path: Path) -> None:
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", hard_budget_usd=10.0)
+        led.record(tags=CallTags(), model="opus", cost_usd=10.0)
+        st = led.status()
+        assert st.hard_halt is True
+        assert led.admits() is False
+
+    def test_hard_halt_independent_of_soft(self, tmp_path: Path) -> None:
+        """Hard cap trips even when soft budget is unset."""
+        led = SpendLedger(path=tmp_path / "ledger.jsonl", hard_budget_usd=2.0)
+        led.record(tags=CallTags(), model="sonnet", cost_usd=2.5)
+        st = led.status()
+        assert st.hard_halt is True
+        assert st.soft_warn is False  # no soft budget configured
+
+    def test_inverted_caps_clamp_soft(self, tmp_path: Path) -> None:
+        """Soft > hard is meaningless; we clamp soft down to hard."""
+        led = SpendLedger(
+            path=tmp_path / "ledger.jsonl",
+            budget_usd=20.0,
+            hard_budget_usd=5.0,
+        )
+        assert led.budget_usd == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestAggregate:
+    def test_aggregate_by_role(self) -> None:
+        entries = [
+            LedgerEntry(
+                ts=0,
+                ts_iso="",
+                run_id="r",
+                task_id="t1",
+                agent_id="a1",
+                role="backend",
+                feature_label="",
+                model="sonnet",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.10,
+            ),
+            LedgerEntry(
+                ts=0,
+                ts_iso="",
+                run_id="r",
+                task_id="t2",
+                agent_id="a1",
+                role="backend",
+                feature_label="",
+                model="sonnet",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.20,
+            ),
+            LedgerEntry(
+                ts=0,
+                ts_iso="",
+                run_id="r",
+                task_id="t3",
+                agent_id="a2",
+                role="qa",
+                feature_label="",
+                model="haiku",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.05,
+            ),
+        ]
+        out = aggregate_entries(entries, "role")
+        assert out["backend"]["cost_usd"] == pytest.approx(0.30)
+        assert out["backend"]["calls"] == 2
+        assert out["qa"]["cost_usd"] == pytest.approx(0.05)
+
+    def test_aggregate_by_feature_label_uses_unknown_bucket(self) -> None:
+        entries = [
+            LedgerEntry(
+                ts=0,
+                ts_iso="",
+                run_id="r",
+                task_id="t1",
+                agent_id="a1",
+                role="backend",
+                feature_label="rag",
+                model="sonnet",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.10,
+            ),
+            LedgerEntry(
+                ts=0,
+                ts_iso="",
+                run_id="r",
+                task_id="t2",
+                agent_id="a1",
+                role="backend",
+                feature_label="",
+                model="sonnet",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.20,
+            ),
+        ]
+        out = aggregate_entries(entries, "feature_label")
+        assert out["rag"]["cost_usd"] == pytest.approx(0.10)
+        assert out["unknown"]["cost_usd"] == pytest.approx(0.20)
+
+    def test_aggregate_unknown_dimension_returns_empty(self) -> None:
+        entries = [
+            LedgerEntry(
+                ts=0,
+                ts_iso="",
+                run_id="r",
+                task_id="t",
+                agent_id="a",
+                role="r",
+                feature_label="",
+                model="m",
+                input_tokens=0,
+                output_tokens=0,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.10,
+            ),
+        ]
+        assert aggregate_entries(entries, "bogus") == {}
+
+
+# ---------------------------------------------------------------------------
+# CostTracker integration: hard cap + tag propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCostTrackerHardBudget:
+    def test_hard_budget_trips_should_stop(self) -> None:
+        tracker = CostTracker(run_id="r", hard_budget_usd=1.0)
+        status = tracker.record("a-1", "t-1", "sonnet", 0, 0, cost_usd=1.5)
+        assert status.should_stop is True
+        assert tracker.can_spawn() is False
+
+    def test_hard_budget_independent_of_soft(self) -> None:
+        """should_stop trips on hard even when soft budget is unlimited."""
+        tracker = CostTracker(run_id="r", budget_usd=0.0, hard_budget_usd=2.0)
+        s1 = tracker.record("a", "t", "sonnet", 0, 0, cost_usd=1.0)
+        assert s1.should_stop is False
+        s2 = tracker.record("a", "t", "sonnet", 0, 0, cost_usd=1.5)
+        assert s2.should_stop is True
+
+    def test_record_propagates_tags_to_ledger(self, tmp_path: Path) -> None:
+        ledger_path = tmp_path / "ledger.jsonl"
+        ledger = SpendLedger(path=ledger_path, run_id="r-1", budget_usd=10.0)
+        tracker = CostTracker(run_id="r-1", spend_ledger=ledger)
+        tracker.record(
+            "a-1",
+            "t-1",
+            "sonnet",
+            100,
+            50,
+            cost_usd=0.05,
+            role="backend",
+            feature_label="rag",
+        )
+        lines = ledger_path.read_text().splitlines()
+        assert len(lines) == 1
+        row = json.loads(lines[0])
+        assert row["task_id"] == "t-1"
+        assert row["agent_id"] == "a-1"
+        assert row["role"] == "backend"
+        assert row["feature_label"] == "rag"
+        assert row["cost_usd"] == pytest.approx(0.05)
+
+    def test_cheaper_model_for_uses_ledger(self, tmp_path: Path) -> None:
+        ledger = SpendLedger(path=tmp_path / "ledger.jsonl", budget_usd=5.0)
+        tracker = CostTracker(run_id="r-1", spend_ledger=ledger)
+        # Below 80% — no reroute
+        tracker.record("a", "t", "opus", 0, 0, cost_usd=1.0)
+        assert tracker.cheaper_model_for("opus") is None
+        # Cross 80%
+        tracker.record("a", "t", "opus", 0, 0, cost_usd=3.5)
+        assert tracker.cheaper_model_for("opus") == "sonnet"
+
+    def test_cheaper_model_for_without_ledger(self) -> None:
+        """Fallback path uses local 80% check against tracker.budget_usd."""
+        tracker = CostTracker(run_id="r-1", budget_usd=5.0)
+        tracker.record("a", "t", "opus", 0, 0, cost_usd=1.0)
+        assert tracker.cheaper_model_for("opus") is None
+        tracker.record("a", "t", "opus", 0, 0, cost_usd=3.5)
+        assert tracker.cheaper_model_for("opus") == "sonnet"
+
+    def test_persistence_roundtrips_hard_budget(self, tmp_path: Path) -> None:
+        tracker = CostTracker(run_id="r-1", budget_usd=5.0, hard_budget_usd=10.0)
+        tracker.record("a", "t", "sonnet", 0, 0, cost_usd=0.5)
+        tracker.save(tmp_path)
+        restored = CostTracker.load(tmp_path, "r-1")
+        assert restored is not None
+        assert restored.hard_budget_usd == pytest.approx(10.0)
+        assert restored.budget_usd == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Load entries from disk
+# ---------------------------------------------------------------------------
+
+
+class TestLoadEntries:
+    def test_load_missing_returns_empty(self, tmp_path: Path) -> None:
+        out = SpendLedger.load_entries(tmp_path / "absent.jsonl")
+        assert out == []
+
+    def test_load_skips_malformed(self, tmp_path: Path) -> None:
+        path = tmp_path / "ledger.jsonl"
+        led = SpendLedger(path=path)
+        led.record(tags=CallTags(task_id="t-1"), model="sonnet", cost_usd=0.10)
+        # Inject a junk line
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("this is not json\n")
+        led.record(tags=CallTags(task_id="t-2"), model="sonnet", cost_usd=0.20)
+
+        entries = SpendLedger.load_entries(path)
+        assert len(entries) == 2
+        assert {e.task_id for e in entries} == {"t-1", "t-2"}
+        assert sum(e.cost_usd for e in entries) == pytest.approx(0.30)


### PR DESCRIPTION
## Summary

Closes #1320.

- New `SpendLedger` writes one JSONL row per LLM call to `.sdd/cost/ledger.jsonl`, tagged with `task_id`/`agent_id`/`role`/`feature_label` for full per-call attribution.
- Soft cap `--budget 5usd` warns + reroutes to a cheaper model at >=80%, halts new work at 100%. Reroute table covers opus/sonnet/gpt-5/gemini/qwen/deepseek with a `haiku` fallback.
- Hard cap `--hard-budget 10usd` is an independent kill switch — `CostTracker.can_spawn()` returns False and `status().should_stop` flips regardless of soft-cap state.
- `bernstein cost --by` gains `role` and `feature_label` dimensions (backed by the ledger, with a fallback to task records); `--since today|yesterday|week|month` and `--ledger PATH` added.
- `--budget` is the friendlier alias of `--max-cost-usd` (accepts `5usd`/`$5`/`5.0`); existing `--max-cost-usd` semantics preserved.

## What changed

| File | Change |
|------|--------|
| `src/bernstein/core/cost/spend_ledger.py` | new — ledger + `CallTags` + `LedgerStatus` + `aggregate_entries` |
| `src/bernstein/core/cost/cost_tracker.py` | `hard_budget_usd` field, tag passthrough, save/load roundtrip, `cheaper_model_for()` |
| `src/bernstein/core/cost/__init__.py` | re-export ledger types |
| `src/bernstein/cli/run_bootstrap.py` | `--budget`/`--hard-budget` flags + `_parse_budget_spec` helper |
| `src/bernstein/cli/commands/cost.py` | `--by role|feature_label` + `--since` + `--ledger` |
| `tests/unit/test_spend_ledger.py` | new — 26 tests covering math, soft/hard trip, reroute, aggregation, integration |
| `tests/unit/test_cost_cmd_by_role.py` | new — 13 tests for CLI `--budget`/`--hard-budget` parsing + `--by role` |

## New flags / subcommands

```bash
bernstein run plan.yaml --budget 5usd --hard-budget 10usd
bernstein cost --by task|agent|role|model|day|feature_label
bernstein cost --since today
bernstein cost --ledger .sdd/cost/ledger.jsonl
```

## Ledger location

`.sdd/cost/ledger.jsonl` (one JSON line per LLM call, fsynced on append).

## Test plan

- [x] Unit: ledger math, JSONL append, soft cap warns at >=80% / halts at 100%, hard cap is independent kill switch, reroute hint switches off below 80%
- [x] Unit: `CostTracker.record` propagates `task_id`/`agent_id`/`role`/`feature_label` into the attached ledger; `hard_budget_usd` roundtrips through save/load
- [x] Unit: `aggregate_entries` for every supported dimension; unknown dimensions return `{}`
- [x] CLI: `bernstein cost --by role` / `--by feature_label` reads the ledger; falls back to task records when the ledger is absent
- [x] CLI: `--budget` / `--hard-budget` parser accepts `5usd` / `$5` / `5.0`, rejects malformed specs
- [x] All 181 tests in the cost/budget/ledger test suite pass; full lint/format/architecture/typecheck pre-push hooks pass