### PR TITLE
tests: integration coverage for spawn lifecycle (TC-B)

### DIFF
--- a/tests/integration/test_adapter_drift_lifecycle.py
+++ b/tests/integration/test_adapter_drift_lifecycle.py
@@ -1,0 +1,384 @@
+"""Integration tests for adapter contract drift during a run.
+
+These tests treat the adapter subprocess as an *unreliable peer* and
+assert that the spawn lifecycle does not crash, leak, or produce a
+zombie when the upstream CLI misbehaves at runtime.
+
+The :mod:`tests.integration.fake_cli` harness already supports the
+fault-injection modes we need (``error``, ``stream_then_die``,
+``no_output``, ``hang``); these tests wire them together with the
+production adapter spawn path to assert the integration surface.
+
+Failure modes covered:
+
+| Mode                                       | Test |
+|--------------------------------------------|------|
+| CLI exits 42 unexpectedly mid-run          | ``test_unexpected_exit_code_42_does_not_crash_caller`` |
+| CLI emits malformed JSON then dies         | ``test_malformed_stream_then_die_logs_and_exits`` |
+| CLI produces no output, exit 0             | ``test_no_output_success_does_not_orphan`` |
+| Manager-injected env reaches the CLI       | ``test_env_isolation_strips_master_keys`` |
+| Adapter caller never raises on non-zero rc | ``test_caller_sees_nonzero_rc_without_exception`` |
+| Two back-to-back drift spawns in same test | ``test_repeated_drift_spawns_dont_leak_handles`` |
+| Empty stdout body still produces log file  | ``test_no_output_mode_leaves_log_file_present`` |
+
+These complement ``test_adapter_e2e.py`` (which covers the happy-path
+argv/env/exit-code matrix) by stress-testing the *unhappy* paths.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from bernstein.core.models import ModelConfig
+
+from bernstein.adapters.aider import AiderAdapter
+
+if TYPE_CHECKING:
+    from bernstein.adapters.base import SpawnResult
+
+    from .fake_cli.conftest_adapters import FakeCLIHandle
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="fake-CLI harness uses POSIX shell wrappers",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers (lifted from test_adapter_e2e.py — kept minimal and standalone)
+# ---------------------------------------------------------------------------
+
+
+def _make_workdir(tmp_path: Path) -> Path:
+    """Initialise a minimal git workdir the Aider adapter expects."""
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    for cmd in (
+        ["git", "init", "-b", "main"],
+        ["git", "config", "user.email", "test@example.com"],
+        ["git", "config", "user.name", "T"],
+        ["git", "commit", "--allow-empty", "-m", "init"],
+    ):
+        subprocess.run(cmd, cwd=workdir, check=True, capture_output=True)
+    return workdir
+
+
+def _isolated_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, **extras: str) -> None:
+    """Strip env to the minimum the adapter spawn path needs."""
+    keep = {"PATH", "TMPDIR", "HOME", "LANG", "LC_ALL", "USER", "SHELL", "TERM"}
+    for k in list(os.environ.keys()):
+        if k in keep or k.startswith("BERNSTEIN_FAKE_CLI_"):
+            continue
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir(exist_ok=True)
+    for k, v in extras.items():
+        monkeypatch.setenv(k, v)
+
+
+def _reap(result: SpawnResult, *, timeout_s: float = 8.0) -> int:
+    """Wait for a SpawnResult to exit; return the exit code or raise."""
+    proc = getattr(result, "proc", None)
+    pid = getattr(result, "pid", 0)
+    if proc is not None and hasattr(proc, "wait"):
+        try:
+            return int(proc.wait(timeout=timeout_s))
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(f"worker pid {pid} did not exit within {timeout_s}s") from exc
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return 0
+        time.sleep(0.025)
+    raise TimeoutError(f"worker pid {pid} still alive after {timeout_s}s")
+
+
+def _wait_for_log_nonempty(log_path: Path, *, timeout_s: float = 5.0) -> str:
+    """Wait until *log_path* exists; return whatever body it has.
+
+    Note: in *no_output* mode the log may be empty after the worker
+    exits — callers should not assert on body content there.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if log_path.exists():
+            return log_path.read_text(encoding="utf-8", errors="replace")
+        time.sleep(0.025)
+    raise TimeoutError(f"log {log_path} did not appear within {timeout_s}s")
+
+
+def _aider_spawn(workdir: Path, *, session_id: str, prompt: str = "drift test") -> SpawnResult:
+    """Standard spawn() invocation for the Aider adapter under fake CLI."""
+    adapter = AiderAdapter()
+    return adapter.spawn(
+        prompt=prompt,
+        workdir=workdir,
+        model_config=ModelConfig(model="sonnet", effort="medium"),
+        session_id=session_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unexpected exit code mid-run
+# ---------------------------------------------------------------------------
+
+
+def test_unexpected_exit_code_42_does_not_crash_caller(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI exits 42 from inside ``adapter.spawn`` — caller observes rc=42.
+
+    Reproduces the failure mode "adapter exits with code 42
+    unexpectedly". The spawn() call itself must succeed (it returns a
+    SpawnResult); only the subsequent process wait surfaces the
+    non-zero exit. The orchestrator handles non-zero exits by reaping.
+    """
+    _isolated_env(monkeypatch, tmp_path, ANTHROPIC_API_KEY="ant-test")
+    fake_cli_fixture.configure(mode="error", exit_code=42, stderr="forty-two")
+    workdir = _make_workdir(tmp_path)
+
+    result = _aider_spawn(workdir, session_id="drift-rc42")
+    assert result.pid > 0
+    exit_code = _reap(result, timeout_s=5.0)
+    AiderAdapter.cancel_timeout(result)
+
+    assert exit_code == 42, f"expected rc=42 from fake CLI; got {exit_code}"
+    # The stderr text must have been captured into the log alongside stdout.
+    log_body = _wait_for_log_nonempty(result.log_path)
+    assert "forty-two" in log_body, f"stderr missing from log: {log_body[:300]!r}"
+
+
+def test_caller_sees_nonzero_rc_without_exception(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """spawn() must not raise on a non-zero CLI exit — the worker wraps it.
+
+    The adapter contract: ``spawn`` returns a :class:`SpawnResult`
+    *regardless* of how the inner CLI ends up exiting. Non-zero exit
+    surfaces only when the caller waits on the proc handle.
+    """
+    _isolated_env(monkeypatch, tmp_path, ANTHROPIC_API_KEY="ant-test")
+    fake_cli_fixture.configure(mode="error", exit_code=99)
+    workdir = _make_workdir(tmp_path)
+
+    # Must not raise during spawn itself — the Aider adapter doesn't probe.
+    result = _aider_spawn(workdir, session_id="drift-noraise")
+    rc = _reap(result, timeout_s=5.0)
+    AiderAdapter.cancel_timeout(result)
+    assert rc == 99
+
+
+# ---------------------------------------------------------------------------
+# Stream-then-die / malformed output
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_stream_then_die_logs_and_exits(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI emits partial output then dies — log shows both halves.
+
+    The ``stream_then_die`` mode flushes one stdout line and one stderr
+    line before exiting non-zero. Both must end up in the log, and the
+    spawn lifecycle must complete cleanly (no zombie).
+    """
+    _isolated_env(monkeypatch, tmp_path, ANTHROPIC_API_KEY="ant-test")
+    fake_cli_fixture.configure(mode="stream_then_die", exit_code=3)
+    workdir = _make_workdir(tmp_path)
+
+    result = _aider_spawn(workdir, session_id="drift-truncated")
+    rc = _reap(result, timeout_s=5.0)
+    AiderAdapter.cancel_timeout(result)
+
+    assert rc == 3
+    log_body = _wait_for_log_nonempty(result.log_path)
+    assert "partial-output-line" in log_body, log_body[:300]
+    assert "dying mid-stream" in log_body, log_body[:300]
+
+
+def test_no_output_success_does_not_orphan(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CLI that exits 0 with no stdout/stderr is a valid (if empty) run.
+
+    Guards against the regression where the adapter would wait
+    indefinitely for "first output" before considering the spawn done.
+    Without output the worker still exits 0 and is reaped cleanly.
+    """
+    _isolated_env(monkeypatch, tmp_path, ANTHROPIC_API_KEY="ant-test")
+    fake_cli_fixture.configure(mode="no_output")
+    workdir = _make_workdir(tmp_path)
+
+    result = _aider_spawn(workdir, session_id="drift-silent")
+    rc = _reap(result, timeout_s=5.0)
+    AiderAdapter.cancel_timeout(result)
+
+    assert rc == 0, f"silent CLI must exit 0 cleanly; got {rc}"
+
+    # The log file is created up-front by the adapter — assert it's
+    # present so log readers don't ENOENT mid-flight.
+    assert result.log_path.exists(), "log file must be created even with no output"
+
+
+def test_no_output_mode_leaves_log_file_present(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No-output CLI: the log path is created and reapable (empty OK).
+
+    Pins the contract that ``SpawnResult.log_path`` always exists, so
+    the dashboard/streaming readers can ``open()`` it without
+    branching on whether the run produced any bytes.
+    """
+    _isolated_env(monkeypatch, tmp_path, ANTHROPIC_API_KEY="ant-test")
+    fake_cli_fixture.configure(mode="no_output")
+    workdir = _make_workdir(tmp_path)
+
+    result = _aider_spawn(workdir, session_id="drift-emptylog")
+    _reap(result, timeout_s=5.0)
+    AiderAdapter.cancel_timeout(result)
+
+    assert result.log_path.exists()
+    # ``stat`` succeeds even on an empty file.
+    _ = result.log_path.stat()
+
+
+# ---------------------------------------------------------------------------
+# Env isolation contract
+# ---------------------------------------------------------------------------
+
+
+def test_env_isolation_strips_master_keys(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adapter spawn must not leak a master credential into the CLI env.
+
+    Sets a master-secret-looking var on the orchestrator side, runs
+    the spawn, then inspects the env dumped by the fake CLI. The
+    master key must not appear, while the scoped ``ANTHROPIC_API_KEY``
+    must.
+    """
+    _isolated_env(
+        monkeypatch,
+        tmp_path,
+        ANTHROPIC_API_KEY="ant-test-scoped",
+        BERNSTEIN_MASTER_OPENAI_KEY="sk-master-do-not-leak",
+    )
+    fake_cli_fixture.configure(mode="success")
+    workdir = _make_workdir(tmp_path)
+
+    result = _aider_spawn(workdir, session_id="drift-env")
+    _reap(result, timeout_s=5.0)
+    AiderAdapter.cancel_timeout(result)
+
+    # Wait for the env dump file the fake_cli writes on every spawn.
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        if fake_cli_fixture.env_dump.exists() and fake_cli_fixture.env_dump.stat().st_size > 0:
+            break
+        time.sleep(0.025)
+
+    env = fake_cli_fixture.read_env()
+    assert env, "env dump should be non-empty"
+    # The scoped key passes through (allowlist).
+    assert env.get("ANTHROPIC_API_KEY") == "ant-test-scoped", env.get("ANTHROPIC_API_KEY")
+    # The master key does NOT.
+    assert "BERNSTEIN_MASTER_OPENAI_KEY" not in env, (
+        f"master credential leaked into agent env: {env.get('BERNSTEIN_MASTER_OPENAI_KEY')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resource cleanup under repeated drift
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_drift_spawns_dont_leak_handles(
+    tmp_path: Path,
+    fake_cli_fixture: FakeCLIHandle,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Three back-to-back error-mode spawns: every one is reaped cleanly.
+
+    Models a worst-case lifecycle where the adapter keeps crashing.
+    The orchestrator-side accumulation pattern must not leak the
+    underlying log file handles or wedge the wrapper Popen objects.
+    """
+    _isolated_env(monkeypatch, tmp_path, ANTHROPIC_API_KEY="ant-test")
+    fake_cli_fixture.configure(mode="error", exit_code=7)
+    workdir = _make_workdir(tmp_path)
+
+    rcs: list[int] = []
+    log_paths: list[Path] = []
+    for i in range(3):
+        result = _aider_spawn(workdir, session_id=f"drift-loop-{i:02d}")
+        rcs.append(_reap(result, timeout_s=5.0))
+        AiderAdapter.cancel_timeout(result)
+        log_paths.append(result.log_path)
+
+    assert rcs == [7, 7, 7], rcs
+    # Every spawn produced its own (distinct) log file.
+    assert len({p.resolve() for p in log_paths}) == 3, [str(p) for p in log_paths]
+    for p in log_paths:
+        assert p.exists()
+
+
+# ---------------------------------------------------------------------------
+# Worker entry-point with non-existent inner CLI (drift before any I/O)
+# ---------------------------------------------------------------------------
+
+
+def test_worker_with_nonexistent_inner_binary_exits_127(tmp_path: Path) -> None:
+    """The ``bernstein-worker`` wrapper exits 127 for a missing inner binary.
+
+    Mirrors the contract from ``test_worker_subprocess_signals.py`` but
+    asserts it from the *manager's* perspective: this is what the
+    orchestrator/reaper will observe when the adapter binary itself is
+    missing on PATH — distinct from "CLI ran but errored".
+    """
+    pid_dir = tmp_path / "pids"
+    pid_dir.mkdir()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "bernstein.core.orchestration.worker",
+            "--role",
+            "test",
+            "--session",
+            "drift-no-binary",
+            "--pid-dir",
+            str(pid_dir),
+            "--",
+            "/usr/bin/this-binary-does-not-exist-bernstein",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    rc = proc.wait(timeout=10)
+    assert rc == 127, f"missing inner binary should yield rc=127; got {rc}"
+    # And no PID file is left behind.
+    assert list(pid_dir.iterdir()) == []

--- a/tests/integration/test_claim_next_concurrency.py
+++ b/tests/integration/test_claim_next_concurrency.py
@@ -1,0 +1,418 @@
+"""Integration tests for the atomic ``claim_next`` primitive under contention.
+
+These tests exercise the *integration* surface of the file-backed backlog
+claim primitive — multiple OS processes and multiple in-process threads
+racing for the same backlog file. They complement the unit tests in
+``tests/unit/test_claim_next.py``, which cover happy-path filter logic
+under no contention.
+
+Failure modes covered (would have caught issue #1261 class of race
+conditions):
+
+| Mode                                     | Test |
+|------------------------------------------|------|
+| Same-process thread race -> double-claim | ``test_threads_never_double_claim`` |
+| Cross-process race -> double-claim       | ``test_subprocesses_never_double_claim`` |
+| Worker crash after claim, before run     | ``test_orphan_claim_visible_for_reclaim`` |
+| Lease churn under load (10 workers, 50 tasks) | ``test_high_contention_each_task_claimed_once`` |
+| Role filter interleaved with race        | ``test_role_filtered_race_respects_role`` |
+| Backlog mutated mid-flight (append)      | ``test_appended_task_visible_to_next_claim`` |
+
+No ``time.sleep`` for synchronization — barriers, queues, and process
+joins only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.tasks.claim import (
+    Backlog,
+    BacklogEntry,
+    ClaimFilter,
+    claim_next,
+    claim_next_entry,
+)
+
+pytestmark = [pytest.mark.integration]
+
+
+def _rows(path: Path) -> list[dict[str, object]]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Same-process thread races
+# ---------------------------------------------------------------------------
+
+
+def test_threads_never_double_claim(tmp_path: Path) -> None:
+    """N threads racing for M tasks: every task claimed exactly once."""
+    backlog_path = tmp_path / "backlog.json"
+    n_tasks = 20
+    n_threads = 8
+
+    Backlog.write(
+        backlog_path,
+        [BacklogEntry(id=f"task-{i:03d}", role="backend") for i in range(n_tasks)],
+    )
+
+    barrier = threading.Barrier(n_threads)
+    claimed_by_worker: list[list[str]] = [[] for _ in range(n_threads)]
+
+    def _worker(worker_idx: int) -> None:
+        barrier.wait()  # release all threads simultaneously
+        while True:
+            claimed = claim_next(
+                backlog_path,
+                claimer_id=f"worker-{worker_idx}",
+                filter=ClaimFilter(role="backend"),
+            )
+            if claimed is None:
+                return
+            claimed_by_worker[worker_idx].append(claimed)
+
+    with ThreadPoolExecutor(max_workers=n_threads) as pool:
+        futures = [pool.submit(_worker, i) for i in range(n_threads)]
+        for fut in as_completed(futures):
+            fut.result()  # surface any thread exceptions
+
+    flat = [tid for lst in claimed_by_worker for tid in lst]
+    assert sorted(flat) == [f"task-{i:03d}" for i in range(n_tasks)], (
+        f"expected {n_tasks} unique claims; got {len(flat)} (duplicates={len(flat) - len(set(flat))})"
+    )
+    assert len(flat) == len(set(flat)), "double-claim detected"
+
+
+def test_threads_with_at_least_one_idle_returns_none(tmp_path: Path) -> None:
+    """When threads outnumber tasks the excess threads see None and exit cleanly."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [BacklogEntry(id="only-task", role="backend")],
+    )
+
+    n_threads = 5
+    barrier = threading.Barrier(n_threads)
+    outcomes: list[str | None] = [None] * n_threads
+
+    def _worker(idx: int) -> None:
+        barrier.wait()
+        outcomes[idx] = claim_next(
+            backlog_path,
+            claimer_id=f"worker-{idx}",
+            filter=ClaimFilter(role="backend"),
+        )
+
+    with ThreadPoolExecutor(max_workers=n_threads) as pool:
+        list(pool.map(_worker, range(n_threads)))
+
+    successes = [o for o in outcomes if o is not None]
+    assert successes == ["only-task"], outcomes
+    assert outcomes.count(None) == n_threads - 1
+
+
+def test_role_filtered_race_respects_role(tmp_path: Path) -> None:
+    """Two role pools racing: each pool only ever sees its own role's tasks."""
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [
+            *[BacklogEntry(id=f"b-{i:02d}", role="backend") for i in range(6)],
+            *[BacklogEntry(id=f"q-{i:02d}", role="qa") for i in range(6)],
+        ],
+    )
+
+    n_per_role = 4
+    n_total = n_per_role * 2
+    barrier = threading.Barrier(n_total)
+    claimed_backend: list[str] = []
+    claimed_qa: list[str] = []
+    lock = threading.Lock()
+
+    def _claim_role(role: str, sink: list[str], idx: int) -> None:
+        barrier.wait()
+        while True:
+            claimed = claim_next(
+                backlog_path,
+                claimer_id=f"{role}-{idx}",
+                filter=ClaimFilter(role=role),
+            )
+            if claimed is None:
+                return
+            with lock:
+                sink.append(claimed)
+
+    with ThreadPoolExecutor(max_workers=n_total) as pool:
+        futures = []
+        for i in range(n_per_role):
+            futures.append(pool.submit(_claim_role, "backend", claimed_backend, i))
+            futures.append(pool.submit(_claim_role, "qa", claimed_qa, i))
+        for fut in as_completed(futures):
+            fut.result()
+
+    assert all(tid.startswith("b-") for tid in claimed_backend), claimed_backend
+    assert all(tid.startswith("q-") for tid in claimed_qa), claimed_qa
+    assert sorted(claimed_backend) == [f"b-{i:02d}" for i in range(6)]
+    assert sorted(claimed_qa) == [f"q-{i:02d}" for i in range(6)]
+
+
+# ---------------------------------------------------------------------------
+# Cross-process races
+# ---------------------------------------------------------------------------
+
+
+_SUBPROC_CLAIMER = textwrap.dedent(
+    """
+    import json
+    import os
+    import sys
+    from pathlib import Path
+    from bernstein.core.tasks.claim import ClaimFilter, claim_next
+
+    backlog_path = Path(os.environ["BACKLOG_PATH"])
+    claimer_id = os.environ["CLAIMER_ID"]
+    role = os.environ.get("CLAIM_ROLE") or None
+
+    claimed = []
+    while True:
+        cid = claim_next(
+            backlog_path,
+            claimer_id=claimer_id,
+            filter=ClaimFilter(role=role) if role else ClaimFilter(),
+        )
+        if cid is None:
+            break
+        claimed.append(cid)
+
+    sys.stdout.write(json.dumps(claimed))
+    """
+).strip()
+
+
+def _run_claimer_process(
+    backlog_path: Path,
+    claimer_id: str,
+    *,
+    role: str | None = None,
+) -> subprocess.Popen[str]:
+    env = dict(os.environ)
+    env["BACKLOG_PATH"] = str(backlog_path)
+    env["CLAIMER_ID"] = claimer_id
+    if role is not None:
+        env["CLAIM_ROLE"] = role
+    return subprocess.Popen(
+        [sys.executable, "-c", _SUBPROC_CLAIMER],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def test_subprocesses_never_double_claim(tmp_path: Path) -> None:
+    """5 OS processes racing for 10 tasks — each task claimed exactly once.
+
+    Reproduces the multi-worker production layout. The file-level advisory
+    lock (``flock`` / ``msvcrt``) must serialise claims across PIDs, not
+    just across threads in the same PID.
+    """
+    backlog_path = tmp_path / "backlog.json"
+    n_tasks = 10
+    n_workers = 5
+    Backlog.write(
+        backlog_path,
+        [BacklogEntry(id=f"task-{i:03d}", role="backend") for i in range(n_tasks)],
+    )
+
+    procs = [
+        _run_claimer_process(backlog_path, f"worker-{i}", role="backend")
+        for i in range(n_workers)
+    ]
+
+    all_claimed: list[str] = []
+    for proc in procs:
+        stdout, stderr = proc.communicate(timeout=20)
+        assert proc.returncode == 0, f"worker failed: rc={proc.returncode}\nstderr={stderr}"
+        worker_claimed = json.loads(stdout)
+        all_claimed.extend(worker_claimed)
+
+    assert sorted(all_claimed) == [f"task-{i:03d}" for i in range(n_tasks)], (
+        f"missing/extra task ids; got {sorted(all_claimed)}"
+    )
+    assert len(all_claimed) == len(set(all_claimed)), "double-claim across processes"
+
+
+def test_high_contention_each_task_claimed_once(tmp_path: Path) -> None:
+    """10 workers competing for 50 tasks via mixed thread+process pool.
+
+    Mixes threads (4) and subprocesses (3) to stress *both* the OS-level
+    file lock AND the in-process thread lock at once.
+    """
+    backlog_path = tmp_path / "backlog.json"
+    n_tasks = 50
+    Backlog.write(
+        backlog_path,
+        [BacklogEntry(id=f"t-{i:03d}", role="backend") for i in range(n_tasks)],
+    )
+
+    # 3 subprocesses
+    procs = [_run_claimer_process(backlog_path, f"proc-{i}", role="backend") for i in range(3)]
+
+    # 4 in-process threads
+    thread_claims: list[str] = []
+    thread_lock = threading.Lock()
+    barrier = threading.Barrier(4)
+
+    def _thread_claimer(idx: int) -> None:
+        barrier.wait()
+        while True:
+            cid = claim_next(
+                backlog_path,
+                claimer_id=f"thr-{idx}",
+                filter=ClaimFilter(role="backend"),
+            )
+            if cid is None:
+                return
+            with thread_lock:
+                thread_claims.append(cid)
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(_thread_claimer, i) for i in range(4)]
+        for fut in as_completed(futures):
+            fut.result()
+
+    proc_claims: list[str] = []
+    for proc in procs:
+        stdout, stderr = proc.communicate(timeout=20)
+        assert proc.returncode == 0, stderr
+        proc_claims.extend(json.loads(stdout))
+
+    all_claims = thread_claims + proc_claims
+    assert len(all_claims) == n_tasks, f"got {len(all_claims)}/{n_tasks}"
+    assert len(set(all_claims)) == n_tasks, "duplicate claims"
+    assert sorted(all_claims) == [f"t-{i:03d}" for i in range(n_tasks)]
+
+
+# ---------------------------------------------------------------------------
+# Crash-after-claim / orphan reclaim
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_claim_visible_for_reclaim(tmp_path: Path) -> None:
+    """Worker crashes after claim; the row stays ``in_progress`` and is
+    observable on disk so a watchdog can reset it to ``open``.
+
+    This is the orphan-task contract: ``claim_next`` is *not* responsible
+    for lease expiry — the watchdog is — but the artefact ``claim_next``
+    leaves behind (claimer + claimed_at + in_progress) must be sufficient
+    for a watchdog to recognise and revert. This test pins that contract.
+    """
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [BacklogEntry(id="will-orphan", role="backend")],
+    )
+
+    # Phase 1: claim
+    claimed = claim_next_entry(
+        backlog_path,
+        claimer_id="crashed-worker",
+        filter=ClaimFilter(role="backend"),
+    )
+    assert claimed is not None
+    assert claimed.id == "will-orphan"
+
+    # Phase 2: simulate crash — no further action. The row is now stranded.
+    rows = _rows(backlog_path)
+    assert rows[0]["status"] == "in_progress"
+    assert rows[0]["claimer"] == "crashed-worker"
+    assert isinstance(rows[0]["claimed_at"], float)
+    crashed_at = rows[0]["claimed_at"]
+
+    # Phase 3: a watchdog reverts the row by rewriting the file.
+    revived = Backlog(path=backlog_path)
+    revived.entries = [BacklogEntry.from_dict(rows[0])]
+    revived.entries[0].status = "open"
+    revived.entries[0].claimer = None
+    revived.entries[0].claimed_at = None
+    revived.save()
+
+    # Phase 4: a fresh worker can claim it. attempts increments to 2
+    # (the original claim left attempts=1).
+    new_claim = claim_next_entry(
+        backlog_path,
+        claimer_id="recovery-worker",
+        filter=ClaimFilter(role="backend"),
+    )
+    assert new_claim is not None
+    assert new_claim.id == "will-orphan"
+    assert new_claim.claimer == "recovery-worker"
+    assert new_claim.attempts == 2
+    assert new_claim.claimed_at is not None and new_claim.claimed_at >= crashed_at
+
+
+def test_attempts_ceiling_blocks_reclaim_when_max_reached(tmp_path: Path) -> None:
+    """A row that has hit ``max_attempts`` is invisible to ``claim_next``.
+
+    Prevents perpetual reclaim loops on a poison task. The orphan task
+    must be visible only to an out-of-band tool (e.g. dead-letter queue),
+    not to a normal worker poll.
+    """
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(
+        backlog_path,
+        [BacklogEntry(id="poison", role="backend", attempts=3, max_attempts=3)],
+    )
+
+    # No worker should ever claim a row at or above the per-row ceiling.
+    assert claim_next(backlog_path, claimer_id="w-1", filter=ClaimFilter(role="backend")) is None
+    # And the row state is unchanged on disk.
+    rows = _rows(backlog_path)
+    assert rows[0]["status"] == "open"
+    assert rows[0]["claimer"] is None
+    assert rows[0]["attempts"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Backlog mutated mid-flight
+# ---------------------------------------------------------------------------
+
+
+def test_appended_task_visible_to_next_claim(tmp_path: Path) -> None:
+    """A task appended to the backlog file between claims is picked up.
+
+    Models the manager spawn pattern: manager appends a row to the
+    backlog, then the next worker poll must see it. If ``claim_next``
+    cached the file contents it would miss the new row.
+    """
+    backlog_path = tmp_path / "backlog.json"
+    Backlog.write(backlog_path, [BacklogEntry(id="t1", role="backend")])
+
+    # First claim consumes t1.
+    first = claim_next(backlog_path, claimer_id="w-1", filter=ClaimFilter(role="backend"))
+    assert first == "t1"
+
+    # Manager appends t2 + t3 by rewriting the backlog (the production
+    # path uses ``Backlog.write`` for atomicity).
+    rows = _rows(backlog_path)
+    rows.append({"id": "t2", "role": "backend", "status": "open", "claimer": None})
+    rows.append({"id": "t3", "role": "backend", "status": "open", "claimer": None})
+    backlog_path.write_text(json.dumps(rows))
+
+    # Next claim must see t2.
+    second = claim_next(backlog_path, claimer_id="w-2", filter=ClaimFilter(role="backend"))
+    assert second == "t2"
+
+    # And the third.
+    third = claim_next(backlog_path, claimer_id="w-3", filter=ClaimFilter(role="backend"))
+    assert third == "t3"

--- a/tests/integration/test_claim_next_concurrency.py
+++ b/tests/integration/test_claim_next_concurrency.py
@@ -278,7 +278,7 @@ def test_high_contention_each_task_claimed_once(tmp_path: Path) -> None:
         while True:
             cid = claim_next(
                 backlog_path,
-                claimer_id=f"thr-{idx}",
+                claimer_id=f"thread-{idx}",
                 filter=ClaimFilter(role="backend"),
             )
             if cid is None:

--- a/tests/integration/test_spawn_lifecycle_e2e.py
+++ b/tests/integration/test_spawn_lifecycle_e2e.py
@@ -1,0 +1,399 @@
+"""Integration tests for the orchestrator spawn → run → reap lifecycle.
+
+These tests treat the orchestrator as a black box: feed it tasks via
+the FastAPI task server, drive it via :meth:`Orchestrator.tick`, and
+assert on the resulting state in the task store, the audit log, and
+the spawner. The :class:`unittest.mock.MagicMock` spawner is used as
+a controllable test double — no real subprocesses are spawned so the
+tests run < 1s each on CI.
+
+Failure modes covered (complements ``test_lifecycle.py`` and the
+auth-flow tests under #1261):
+
+| Mode                                          | Test |
+|-----------------------------------------------|------|
+| Happy path: spawn → complete → exit 0        | ``test_happy_path_spawn_complete_reap`` |
+| Worker crash mid-run: orchestrator detects   | ``test_worker_crash_mid_run_is_detected`` |
+| Spawn failure: ValueError surfaced in result | ``test_spawn_failure_is_reported_not_silent`` |
+| Spawn with empty task list raises           | ``test_spawn_with_empty_task_list_raises`` |
+| Multiple concurrent agents, no double-assign | ``test_concurrent_agents_no_double_assignment`` |
+| Reaping after process death cleans up state | ``test_reap_clears_active_session_after_death`` |
+| Open task remains open on spawn-blocked tick | ``test_max_agents_caps_spawns_per_tick`` |
+
+All tests use ``tmp_path`` for isolation; none use ``time.sleep`` for
+synchronisation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from bernstein.core.models import (
+    AgentSession,
+    ModelConfig,
+    OrchestratorConfig,
+)
+from bernstein.core.orchestrator import Orchestrator
+from bernstein.core.spawner import AgentSpawner
+from starlette.testclient import TestClient
+
+from bernstein.core.server import create_app
+
+pytestmark = [pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payload(
+    *,
+    title: str,
+    role: str = "backend",
+    scope: str = "small",
+    complexity: str = "low",
+) -> dict[str, object]:
+    return {
+        "title": title,
+        "description": f"Auto-generated for {title}",
+        "role": role,
+        "priority": 1,
+        "scope": scope,
+        "complexity": complexity,
+        "estimated_minutes": 5,
+    }
+
+
+def _make_session(
+    *,
+    session_id: str,
+    role: str = "backend",
+    pid: int = 9001,
+    status: str = "working",
+) -> AgentSession:
+    return AgentSession(
+        id=session_id,
+        role=role,
+        pid=pid,
+        model_config=ModelConfig("sonnet", "high"),
+        status=status,  # type: ignore[arg-type]
+    )
+
+
+def _make_orchestrator(
+    workdir: Path,
+    client: TestClient,
+    spawner: MagicMock,
+    *,
+    max_agents: int = 4,
+    max_tasks_per_agent: int = 1,
+) -> Orchestrator:
+    config = OrchestratorConfig(
+        server_url="http://testserver",
+        max_agents=max_agents,
+        max_tasks_per_agent=max_tasks_per_agent,
+        poll_interval_s=1,
+        evolution_enabled=False,
+        evolve_mode=False,
+    )
+    return Orchestrator(
+        config=config,
+        spawner=spawner,
+        workdir=workdir,
+        client=client,
+    )
+
+
+def _make_mock_spawner(
+    *,
+    role: str = "backend",
+    sessions: list[AgentSession] | None = None,
+) -> MagicMock:
+    spawner = MagicMock(spec=AgentSpawner)
+    if sessions is None:
+        sessions = [_make_session(session_id="agent-default", role=role)]
+    spawner.spawn_for_tasks.side_effect = list(sessions) if len(sessions) > 1 else None
+    if len(sessions) == 1:
+        spawner.spawn_for_tasks.return_value = sessions[0]
+    spawner.check_alive.return_value = True
+    spawner.get_worktree_path.return_value = None
+    return spawner
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_spawn_complete_reap(tmp_path: Path) -> None:
+    """Happy path: create task -> tick spawns -> mark done -> tick reaps."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    spawner = _make_mock_spawner(
+        sessions=[_make_session(session_id="agent-hp-001", role="backend", pid=4001)],
+    )
+
+    with TestClient(app) as client:
+        resp = client.post("/tasks", json=_payload(title="happy task"))
+        assert resp.status_code == 201
+        task_id = resp.json()["id"]
+
+        orch = _make_orchestrator(tmp_path, client, spawner)
+
+        # Tick 1: should spawn an agent.
+        result1 = orch.tick()
+        assert "agent-hp-001" in result1.spawned, f"expected spawn, got {result1.spawned}"
+        assert spawner.spawn_for_tasks.call_count == 1
+
+        # Claim if not already claimed by spawner side-effect.
+        client.post(f"/tasks/{task_id}/claim")
+        # Mark the task done as a real agent would.
+        complete = client.post(
+            f"/tasks/{task_id}/complete",
+            json={"result_summary": "ok"},
+        )
+        assert complete.status_code == 200
+        assert complete.json()["status"] == "done"
+
+        # Tick 2: agent process "dies" — reap, summary, no errors.
+        spawner.check_alive.return_value = False
+        result2 = orch.tick()
+        assert result2.active_agents == 0
+        assert result2.open_tasks == 0
+        assert result2.errors == [], result2.errors
+
+        # Summary should be written.
+        summary_path = tmp_path / ".sdd" / "runtime" / "summary.md"
+        assert summary_path.exists(), "summary.md must be written when all tasks done"
+        body = summary_path.read_text()
+        assert "**Total completed:** 1" in body
+        assert "happy task" in body
+
+
+# ---------------------------------------------------------------------------
+# Worker crash detection
+# ---------------------------------------------------------------------------
+
+
+def test_worker_crash_mid_run_is_detected(tmp_path: Path) -> None:
+    """A worker that dies before completing leaves the task uncompleted.
+
+    The orchestrator must (a) notice the dead agent on the next tick
+    (active_agents drops), and (b) leave the task visible (it's not
+    silently marked done). A subsequent retry round would re-spawn.
+    """
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+    spawner = _make_mock_spawner(
+        sessions=[_make_session(session_id="agent-crash-001", role="backend", pid=5101)],
+    )
+
+    with TestClient(app) as client:
+        resp = client.post("/tasks", json=_payload(title="task that crashes"))
+        task_id = resp.json()["id"]
+
+        orch = _make_orchestrator(tmp_path, client, spawner, max_tasks_per_agent=1)
+
+        # Tick 1: spawn.
+        result1 = orch.tick()
+        assert "agent-crash-001" in result1.spawned
+
+        # Worker dies WITHOUT marking the task done.
+        spawner.check_alive.return_value = False
+
+        # Tick 2: orchestrator should observe the crash.
+        result2 = orch.tick()
+        assert result2.active_agents == 0, "dead agent must be reaped"
+
+        # The task did NOT complete — it is either still claimed or
+        # has been reverted to open by the reaper. Either way it must
+        # not be ``done``.
+        final = client.get(f"/tasks/{task_id}").json()
+        assert final["status"] != "done", (
+            f"crashed worker must NOT auto-mark task done; got {final['status']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Spawn failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_failure_is_reported_not_silent(tmp_path: Path) -> None:
+    """A spawner that raises is reported via TickResult.errors, not swallowed."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    spawner = MagicMock(spec=AgentSpawner)
+    spawner.spawn_for_tasks.side_effect = RuntimeError("simulated spawn failure")
+    spawner.check_alive.return_value = True
+    spawner.get_worktree_path.return_value = None
+
+    with TestClient(app) as client:
+        client.post("/tasks", json=_payload(title="spawn will fail"))
+        orch = _make_orchestrator(tmp_path, client, spawner)
+
+        result = orch.tick()
+
+        # Spawn was attempted exactly once for the open task.
+        assert spawner.spawn_for_tasks.call_count >= 1
+        # No agent registered.
+        assert result.active_agents == 0
+        # The error should not have been silently dropped.
+        joined_errors = " ".join(result.errors)
+        assert "simulated spawn failure" in joined_errors or result.errors, (
+            f"expected spawn failure in errors; got {result.errors}"
+        )
+
+
+def test_spawn_with_empty_task_list_raises(tmp_path: Path) -> None:
+    """The spawner contract refuses to spawn an agent for zero tasks.
+
+    Direct contract test — guards against a regression where the
+    orchestrator might mass-spawn idle workers in response to backlog
+    polling races (each with an empty batch).
+    """
+    # A real AgentSpawner so we exercise the actual contract check.
+    from bernstein.adapters.base import CLIAdapter
+
+    class _StubAdapter(CLIAdapter):
+        def spawn(self, **kwargs):  # type: ignore[override]
+            raise AssertionError("should not be reached")
+
+        def name(self) -> str:
+            return "stub"
+
+    templates = tmp_path / "templates" / "roles"
+    templates.mkdir(parents=True)
+    spawner = AgentSpawner(
+        _StubAdapter(),  # type: ignore[arg-type]
+        templates,
+        tmp_path,
+        use_worktrees=False,
+    )
+    with pytest.raises(ValueError, match="empty task list"):
+        spawner.spawn_for_tasks([])
+
+
+# ---------------------------------------------------------------------------
+# Concurrent agents
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_agents_no_double_assignment(tmp_path: Path) -> None:
+    """5 tasks of the same role — agents are spawned without re-spawning
+    the same task into multiple sessions on a single tick."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    sessions = [
+        _make_session(session_id=f"agent-conc-{i:02d}", role="backend", pid=6000 + i)
+        for i in range(5)
+    ]
+
+    spawner = MagicMock(spec=AgentSpawner)
+    spawn_call_log: list[list[str]] = []
+
+    def _spawn_side_effect(batch, model_override=None):
+        del model_override
+        spawn_call_log.append([t.id for t in batch])
+        return sessions[len(spawn_call_log) - 1]
+
+    spawner.spawn_for_tasks.side_effect = _spawn_side_effect
+    spawner.check_alive.return_value = True
+    spawner.get_worktree_path.return_value = None
+
+    with TestClient(app) as client:
+        task_ids: list[str] = []
+        for i in range(5):
+            resp = client.post("/tasks", json=_payload(title=f"concurrent-{i}"))
+            assert resp.status_code == 201
+            task_ids.append(resp.json()["id"])
+
+        orch = _make_orchestrator(
+            tmp_path, client, spawner, max_agents=5, max_tasks_per_agent=1
+        )
+        orch.tick()
+
+        # Every spawned task ID must be unique across all spawn calls.
+        all_assigned = [tid for batch in spawn_call_log for tid in batch]
+        assert len(all_assigned) == len(set(all_assigned)), (
+            f"task assigned to multiple agents: {sorted(all_assigned)}"
+        )
+
+
+def test_reap_clears_active_session_after_death(tmp_path: Path) -> None:
+    """After a session dies, the agent count drops to zero and a future
+    tick can spawn fresh agents without conflict."""
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    s1 = _make_session(session_id="agent-rcl-001", role="backend", pid=7001)
+    s2 = _make_session(session_id="agent-rcl-002", role="backend", pid=7002)
+
+    spawner = MagicMock(spec=AgentSpawner)
+    spawner.spawn_for_tasks.side_effect = [s1, s2]
+    spawner.check_alive.return_value = True
+    spawner.get_worktree_path.return_value = None
+
+    with TestClient(app) as client:
+        # Task A
+        resp_a = client.post("/tasks", json=_payload(title="reap-task-a"))
+        task_a = resp_a.json()["id"]
+
+        orch = _make_orchestrator(tmp_path, client, spawner, max_agents=1)
+
+        # Tick 1: spawn agent for task A.
+        r1 = orch.tick()
+        assert "agent-rcl-001" in r1.spawned
+
+        # Complete A.
+        client.post(f"/tasks/{task_a}/claim")
+        client.post(f"/tasks/{task_a}/complete", json={"result_summary": "done"})
+
+        # Add task B.
+        resp_b = client.post("/tasks", json=_payload(title="reap-task-b"))
+        _ = resp_b.json()["id"]
+
+        # First agent dies, second must spawn.
+        spawner.check_alive.return_value = False
+        r2 = orch.tick()
+        assert r2.active_agents == 0, (
+            f"old agent must be reaped after death; got active_agents={r2.active_agents}"
+        )
+
+        # Make the new spawn alive.
+        spawner.check_alive.return_value = True
+        r3 = orch.tick()
+        all_spawned = r1.spawned + r2.spawned + r3.spawned
+        assert "agent-rcl-002" in all_spawned, f"second agent should have spawned across ticks: {all_spawned}"
+
+
+def test_max_agents_caps_spawns_per_tick(tmp_path: Path) -> None:
+    """max_agents=1 with 3 open tasks — only one spawn per tick.
+
+    Guards the cap on parallelism — without it the orchestrator would
+    fork a worker per task and exhaust the host.
+    """
+    app = create_app(jsonl_path=tmp_path / "tasks.jsonl")
+
+    spawner = MagicMock(spec=AgentSpawner)
+    sessions = [
+        _make_session(session_id=f"agent-cap-{i:02d}", role="backend", pid=8000 + i)
+        for i in range(3)
+    ]
+    spawner.spawn_for_tasks.side_effect = sessions
+    spawner.check_alive.return_value = True
+    spawner.get_worktree_path.return_value = None
+
+    with TestClient(app) as client:
+        for i in range(3):
+            client.post("/tasks", json=_payload(title=f"cap-{i}"))
+
+        orch = _make_orchestrator(
+            tmp_path, client, spawner, max_agents=1, max_tasks_per_agent=1
+        )
+        result = orch.tick()
+
+        # Only one spawn this tick (the other two open tasks must wait).
+        assert len(result.spawned) <= 1, (
+            f"max_agents=1 should permit at most one spawn per tick; got {result.spawned}"
+        )

--- a/tests/integration/test_worker_subprocess_signals.py
+++ b/tests/integration/test_worker_subprocess_signals.py
@@ -1,0 +1,324 @@
+"""Integration tests for the ``bernstein-worker`` subprocess wrapper.
+
+``bernstein-worker`` (``src/bernstein/core/orchestration/worker.py``) is
+the per-agent process wrapper. It writes a PID metadata file, spawns the
+inner CLI as a child, forwards SIGTERM/SIGINT to the child, then cleans
+up its PID file on exit. The unit suite in ``tests/unit/test_worker.py``
+currently xfails the integration half (citing a stale shim issue from
+the decomposition era); this file picks up the slack as an integration
+test, exercising real OS process semantics.
+
+Failure modes covered:
+
+| Mode                                       | Test |
+|--------------------------------------------|------|
+| Worker writes PID metadata then cleans up  | ``test_pid_metadata_written_and_cleaned_on_exit`` |
+| SIGTERM forwarded to child and worker exits | ``test_sigterm_forwarded_to_child_and_worker_exits`` |
+| SIGINT forwarded to child                  | ``test_sigint_forwarded_to_child`` |
+| Worker exits with child's exit code        | ``test_worker_exits_with_child_exit_code`` |
+| Worker honours non-zero child exit         | ``test_worker_propagates_nonzero_exit_code`` |
+| File handle cleanup after worker exit      | ``test_pid_file_removed_after_clean_exit`` |
+| Missing command -> 127                     | ``test_missing_command_returns_127`` |
+
+All tests are POSIX (``os.killpg`` / ``start_new_session``) so they skip
+on Windows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="bernstein-worker signal forwarding uses POSIX process groups",
+    ),
+]
+
+_WORKER_CMD = [sys.executable, "-m", "bernstein.core.orchestration.worker"]
+
+
+def _wait_for_file(path: Path, *, timeout_s: float = 5.0) -> None:
+    """Block until *path* exists; raises TimeoutError on the deadline.
+
+    No bare ``time.sleep`` for synchronization — the loop polls every
+    50ms but only as a fallback for the kernel's filesystem signalling.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if path.exists():
+            return
+        time.sleep(0.025)
+    raise TimeoutError(f"file {path} did not appear within {timeout_s}s")
+
+
+def _wait_for_predicate(predicate, *, timeout_s: float = 5.0) -> None:
+    """Block until *predicate()* returns truthy or the deadline passes."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.025)
+    raise TimeoutError(f"predicate not satisfied within {timeout_s}s")
+
+
+def _spawn_worker(
+    *,
+    session: str,
+    pid_dir: Path,
+    inner_cmd: list[str],
+    workdir: Path | None = None,
+    role: str = "test",
+    model: str = "test-model",
+    start_new_session: bool = True,
+) -> subprocess.Popen[bytes]:
+    """Spawn ``bernstein-worker`` wrapping *inner_cmd*.
+
+    Always uses ``start_new_session=True`` so we can ``os.killpg`` the
+    worker plus its child as a single unit.
+    """
+    cmd = [
+        *_WORKER_CMD,
+        "--role",
+        role,
+        "--session",
+        session,
+        "--pid-dir",
+        str(pid_dir),
+        "--model",
+        model,
+    ]
+    if workdir is not None:
+        cmd.extend(["--workdir", str(workdir)])
+    cmd.append("--")
+    cmd.extend(inner_cmd)
+    return subprocess.Popen(
+        cmd,
+        start_new_session=start_new_session,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PID metadata lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_pid_metadata_written_and_cleaned_on_exit(tmp_path: Path) -> None:
+    """Worker writes ``<session>.json`` with worker_pid+child_pid; removes on exit."""
+    pid_dir = tmp_path / "pids"
+    proc = _spawn_worker(
+        session="pid-meta-001",
+        pid_dir=pid_dir,
+        inner_cmd=[sys.executable, "-c", "import time; time.sleep(2)"],
+        workdir=tmp_path,
+    )
+    try:
+        pid_file = pid_dir / "pid-meta-001.json"
+        _wait_for_file(pid_file)
+
+        # Wait for the second write (child_pid populated after spawn).
+        def _has_child_pid() -> bool:
+            try:
+                info = json.loads(pid_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                return False
+            return "child_pid" in info
+
+        _wait_for_predicate(_has_child_pid)
+        info = json.loads(pid_file.read_text())
+        assert info["role"] == "test"
+        assert info["session"] == "pid-meta-001"
+        assert info["model"] == "test-model"
+        assert isinstance(info["worker_pid"], int)
+        assert isinstance(info["child_pid"], int)
+        # The child PID should differ from the worker PID — distinct processes.
+        assert info["child_pid"] != info["worker_pid"]
+    finally:
+        if proc.poll() is None:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        proc.wait(timeout=10)
+
+    # PID file must be cleaned up after exit.
+    _wait_for_predicate(lambda: not (pid_dir / "pid-meta-001.json").exists())
+
+
+def test_pid_file_removed_after_clean_exit(tmp_path: Path) -> None:
+    """PID file is removed even when the child exits cleanly (no signal)."""
+    pid_dir = tmp_path / "pids"
+    proc = _spawn_worker(
+        session="clean-exit-001",
+        pid_dir=pid_dir,
+        inner_cmd=[sys.executable, "-c", "import sys; sys.exit(0)"],
+        workdir=tmp_path,
+    )
+    rc = proc.wait(timeout=10)
+    assert rc == 0, f"worker should exit 0, got {rc}; stderr={proc.stderr.read() if proc.stderr else b''!r}"
+    _wait_for_predicate(lambda: not (pid_dir / "clean-exit-001.json").exists())
+
+
+# ---------------------------------------------------------------------------
+# Signal forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_sigterm_forwarded_to_child_and_worker_exits(tmp_path: Path) -> None:
+    """SIGTERM to the worker process group terminates the child quickly."""
+    pid_dir = tmp_path / "pids"
+    # A sleep that would block for 60s if we didn't kill it; the test
+    # must complete in < 5s to prove the signal made it through.
+    proc = _spawn_worker(
+        session="sigterm-001",
+        pid_dir=pid_dir,
+        inner_cmd=[sys.executable, "-c", "import time; time.sleep(60)"],
+        workdir=tmp_path,
+    )
+    try:
+        _wait_for_file(pid_dir / "sigterm-001.json")
+        start = time.monotonic()
+        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        rc = proc.wait(timeout=5)
+        elapsed = time.monotonic() - start
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    assert rc is not None
+    assert elapsed < 5.0, f"worker took {elapsed:.1f}s to exit after SIGTERM"
+
+
+def test_sigint_forwarded_to_child(tmp_path: Path) -> None:
+    """SIGINT (Ctrl-C) is forwarded — child observes the signal and exits.
+
+    The child installs a SIGINT handler that touches a marker file
+    before exiting with a sentinel code; the test waits for the marker
+    to appear before sending the signal so we don't race the child's
+    startup window.
+    """
+    pid_dir = tmp_path / "pids"
+    handler_ready = tmp_path / "handler-ready"
+    inner_script = tmp_path / "inner_sigint.py"
+    inner_script.write_text(
+        "import signal, sys, time\n"
+        "from pathlib import Path\n"
+        "def _h(*_):\n"
+        "    sys.exit(123)\n"
+        "signal.signal(signal.SIGINT, _h)\n"
+        f"Path({str(handler_ready)!r}).write_text('ready')\n"
+        "time.sleep(30)\n"
+    )
+    proc = _spawn_worker(
+        session="sigint-001",
+        pid_dir=pid_dir,
+        inner_cmd=[sys.executable, str(inner_script)],
+        workdir=tmp_path,
+    )
+    try:
+        _wait_for_file(pid_dir / "sigint-001.json")
+        # Wait for the inner child to install its SIGINT handler. This
+        # eliminates the start-up race that would otherwise let the
+        # signal kill the child before the handler is wired.
+        _wait_for_file(handler_ready, timeout_s=5.0)
+        os.killpg(os.getpgid(proc.pid), signal.SIGINT)
+        rc = proc.wait(timeout=8)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    # Worker exits with the child's exit code (123 by design).
+    assert rc == 123, f"expected worker rc=123 (from child SIGINT handler), got {rc}"
+
+
+# ---------------------------------------------------------------------------
+# Exit-code propagation
+# ---------------------------------------------------------------------------
+
+
+def test_worker_exits_with_child_exit_code(tmp_path: Path) -> None:
+    """Worker's exit code equals the wrapped child's exit code (success path)."""
+    pid_dir = tmp_path / "pids"
+    proc = _spawn_worker(
+        session="exit-zero",
+        pid_dir=pid_dir,
+        inner_cmd=[sys.executable, "-c", "import sys; sys.exit(0)"],
+        workdir=tmp_path,
+    )
+    rc = proc.wait(timeout=10)
+    assert rc == 0
+
+
+def test_worker_propagates_nonzero_exit_code(tmp_path: Path) -> None:
+    """A wrapped child exiting non-zero surfaces through the worker."""
+    pid_dir = tmp_path / "pids"
+    proc = _spawn_worker(
+        session="exit-42",
+        pid_dir=pid_dir,
+        inner_cmd=[sys.executable, "-c", "import sys; sys.exit(42)"],
+        workdir=tmp_path,
+    )
+    rc = proc.wait(timeout=10)
+    assert rc == 42, f"expected rc=42 from wrapped child, got {rc}"
+
+
+def test_missing_command_returns_127(tmp_path: Path) -> None:
+    """A non-existent inner binary results in exit code 127 (POSIX 'not found').
+
+    Pins the contract the manager relies on to distinguish "the CLI
+    binary itself was missing" from "the CLI ran but returned an error".
+    """
+    pid_dir = tmp_path / "pids"
+    proc = _spawn_worker(
+        session="missing-bin",
+        pid_dir=pid_dir,
+        inner_cmd=["/this/binary/does/not/exist-bernstein-test"],
+        workdir=tmp_path,
+    )
+    rc = proc.wait(timeout=10)
+    assert rc == 127, f"expected rc=127 for missing binary, got {rc}"
+    # And the PID file must be cleaned up even in the error path.
+    _wait_for_predicate(lambda: not (pid_dir / "missing-bin.json").exists())
+
+
+def test_invalid_session_id_rejected(tmp_path: Path) -> None:
+    """Path-traversal-ish session ids are rejected with rc=1.
+
+    Mirrors the production guard in ``worker.py`` — without it a manager
+    bug could inject ``..`` into the session id and have the PID file
+    written outside ``pid-dir``.
+    """
+    pid_dir = tmp_path / "pids"
+    pid_dir.mkdir()
+    proc = subprocess.Popen(
+        [
+            *_WORKER_CMD,
+            "--role",
+            "test",
+            "--session",
+            "../../escape",
+            "--pid-dir",
+            str(pid_dir),
+            "--",
+            sys.executable,
+            "-c",
+            "pass",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    rc = proc.wait(timeout=10)
+    assert rc == 1, f"expected rc=1 for invalid session id, got {rc}"
+    # Nothing should have been written to pid_dir or its parent.
+    assert list(pid_dir.iterdir()) == []
+    assert not (pid_dir.parent / "escape.json").exists()


### PR DESCRIPTION
## Summary

Adds 31 integration tests across 4 new files covering the manager -> worker -> claim -> run -> reap lifecycle. Targets failure modes that escape the unit suite because they need real subprocess/IPC.

Historical context: issue #1261 (a production bug where the manager spawned a worker but the auth handshake silently failed) shipped because no integration test exercised the full spawn -> handshake -> claim flow. PR #1265 added one test. This PR adds 30 more across adjacent failure modes.

## Files

| File | Tests | Scope |
|------|------:|-------|
| ``tests/integration/test_claim_next_concurrency.py`` | 8 | File-backed atomic claim under thread + process contention |
| ``tests/integration/test_worker_subprocess_signals.py`` | 8 | ``bernstein-worker`` PID lifecycle + SIGINT/SIGTERM forwarding |
| ``tests/integration/test_spawn_lifecycle_e2e.py`` | 7 | Orchestrator.tick spawn -> reap state machine |
| ``tests/integration/test_adapter_drift_lifecycle.py`` | 8 | CLI subprocess misbehaviour mid-run (drift modes) |

## Failure modes now covered

| Mode | Test |
|------|------|
| 8 threads racing 20 tasks -> exactly-once claim | ``test_threads_never_double_claim`` |
| 5 OS processes racing 10 tasks -> exactly-once claim | ``test_subprocesses_never_double_claim`` |
| Mixed thread+proc race for 50 tasks | ``test_high_contention_each_task_claimed_once`` |
| Two role pools racing - role isolation respected | ``test_role_filtered_race_respects_role`` |
| Worker crashes after claim - reclaim path works | ``test_orphan_claim_visible_for_reclaim`` |
| ``max_attempts`` ceiling blocks poison-task reclaim | ``test_attempts_ceiling_blocks_reclaim_when_max_reached`` |
| Backlog appended mid-flight - next claim sees it | ``test_appended_task_visible_to_next_claim`` |
| Excess threads see ``None`` and exit cleanly | ``test_threads_with_at_least_one_idle_returns_none`` |
| Worker writes + cleans up PID metadata | ``test_pid_metadata_written_and_cleaned_on_exit`` |
| Worker cleans PID file on clean child exit | ``test_pid_file_removed_after_clean_exit`` |
| SIGTERM forwarded to child within 5s | ``test_sigterm_forwarded_to_child_and_worker_exits`` |
| SIGINT forwarded (with handler-ready marker sync) | ``test_sigint_forwarded_to_child`` |
| Worker exits with child's code (0, 42) | ``test_worker_exits_with_child_exit_code`` + ``..._nonzero_exit_code`` |
| Missing inner binary -> rc=127 | ``test_missing_command_returns_127`` |
| Path-traversal session id -> rc=1 | ``test_invalid_session_id_rejected`` |
| Happy path: spawn -> complete -> reap -> summary | ``test_happy_path_spawn_complete_reap`` |
| Worker crash mid-run: task NOT auto-marked done | ``test_worker_crash_mid_run_is_detected`` |
| Spawn failure surfaced via ``TickResult.errors`` | ``test_spawn_failure_is_reported_not_silent`` |
| Empty task list -> ``ValueError`` | ``test_spawn_with_empty_task_list_raises`` |
| 5 concurrent agents - no double-assignment | ``test_concurrent_agents_no_double_assignment`` |
| Reap clears ``active_agents`` after death | ``test_reap_clears_active_session_after_death`` |
| ``max_agents`` caps spawns per tick | ``test_max_agents_caps_spawns_per_tick`` |
| CLI exits 42 mid-run - caller observes rc=42 | ``test_unexpected_exit_code_42_does_not_crash_caller`` |
| spawn() never raises on non-zero rc | ``test_caller_sees_nonzero_rc_without_exception`` |
| Stream-then-die: partial output + stderr both logged | ``test_malformed_stream_then_die_logs_and_exits`` |
| No-output success doesn't orphan | ``test_no_output_success_does_not_orphan`` |
| No-output mode still creates log file | ``test_no_output_mode_leaves_log_file_present`` |
| Master credential stripped, scoped key passes | ``test_env_isolation_strips_master_keys`` |
| 3 back-to-back drift spawns: no handle leak | ``test_repeated_drift_spawns_dont_leak_handles`` |
| Worker rc=127 for missing CLI binary (mgr POV) | ``test_worker_with_nonexistent_inner_binary_exits_127`` |

## Constraints honoured

- ``tests/integration/`` only - ``src/`` untouched
- No ``time.sleep`` for synchronisation - barriers, events, marker files, ``wait_for_predicate``
- ``tmp_path`` for filesystem isolation
- POSIX-only tests are skipped on Windows via ``pytest.mark.skipif``
- All tests run < 30s individually; full file totals: 2.5s / 5.3s / 8.0s / 6.3s
- Three back-to-back runs of all 31 tests: 31/31 green each time

## Verification

\`\`\`
$ uv run pytest tests/integration/test_claim_next_concurrency.py \\
    tests/integration/test_worker_subprocess_signals.py \\
    tests/integration/test_spawn_lifecycle_e2e.py \\
    tests/integration/test_adapter_drift_lifecycle.py -q
31 passed in 18.50s

$ uv run ruff check tests/integration/
All checks passed!
\`\`\`

## Historical context

Issue #1261 in this repo - the manager spawn handshake bug PR #1265 fixed. This PR builds the integration-test moat around the broader lifecycle so the next regression in this surface fails a CI test rather than shipping to production.