### PR TITLE
ci: mutation testing on fixed critical-path modules (TC-D)

### DIFF
--- a/.github/workflows/mutation-fixed.yml
+++ b/.github/workflows/mutation-fixed.yml
@@ -1,0 +1,250 @@
+# Mutation testing on a fixed critical-path module list.
+#
+# Complements the diff-only mutmut job in ci.yml. The diff-only run only
+# fires on PRs that *touch* a given file, so stable critical modules with
+# stale tests never get exercised. This workflow runs the focused harness
+# in scripts/mutmut_critical.py against a fixed set of high-risk modules
+# (atomic claim, HMAC audit chain, lineage v1, config seed parser) and
+# fails the gate when kill rate drops below the per-module threshold
+# (see scripts/mutmut_critical.py:MODULES).
+#
+# Trigger model:
+#   - PR: only when one of the gated source files OR the test suites that
+#     back them are touched (path-filtered to keep the gate quiet on
+#     unrelated PRs).
+#   - cron: weekly Sunday 04:17 UTC for a full audit independent of
+#     diff coverage.
+#   - manual: workflow_dispatch with optional `module` input for ad-hoc
+#     runs against a single module key.
+#
+# Each module runs in its own matrix job so per-module budgets are
+# enforced separately and a slow module doesn't squeeze the others. The
+# follow-up `summary` job aggregates all JSONs and (on PRs) sticks a
+# single comment with the per-module table.
+#
+# `continue-on-error: true` is set on the matrix jobs while thresholds
+# stabilise — this PR sets up the gate, humans tighten it in follow-ups.
+name: Mutation (fixed critical paths)
+
+on:
+  pull_request:
+    paths:
+      - "src/bernstein/core/tasks/claim.py"
+      - "src/bernstein/core/security/audit.py"
+      - "src/bernstein/core/security/audit_integrity.py"
+      - "src/bernstein/core/lineage/gate.py"
+      - "src/bernstein/core/lineage/tips.py"
+      - "src/bernstein/core/lineage/merge.py"
+      - "src/bernstein/core/config/seed_parser.py"
+      - "tests/unit/test_claim_next.py"
+      - "tests/unit/test_audit_chain_byteflip_regression.py"
+      - "tests/unit/test_audit_key.py"
+      - "tests/unit/test_audit_integrity.py"
+      - "tests/unit/test_config_schema.py"
+      - "tests/unit/lineage/**"
+      - "scripts/mutmut_critical.py"
+      - ".github/workflows/mutation-fixed.yml"
+  schedule:
+    # Weekly full audit. Independent of any PR.
+    - cron: "17 4 * * 0"
+  workflow_dispatch:
+    inputs:
+      module:
+        description: "Single module key to run (see scripts/mutmut_critical.py --list). Empty = all."
+        required: false
+        default: ""
+
+# Conservative top-level permissions; jobs widen pull-requests:write only
+# where needed.
+permissions:
+  contents: read
+
+concurrency:
+  group: mutation-fixed-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mutate:
+    name: ${{ matrix.module }}
+    runs-on: ubuntu-latest
+    # Hard total cap; per-module budgets enforced inside the harness.
+    timeout-minutes: 30
+    # Gate is advisory for the first two weeks. Once the thresholds in
+    # MODULES are calibrated, flip this to `false` (or drop the line).
+    continue-on-error: true
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - claim_next
+          - audit_log
+          - audit_integrity
+          - lineage_gate
+          - lineage_tips
+          - lineage_merge
+          - config_seed_parser
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+      - name: Install dev group (mutmut + test deps)
+        run: uv sync --group dev
+      # Workflow_dispatch with a specific module: skip every other matrix
+      # entry. The check costs one shell step and keeps the matrix as the
+      # single source of truth for module keys.
+      - name: Filter manual single-module runs
+        id: filter
+        env:
+          DISPATCH_MODULE: ${{ github.event.inputs.module }}
+          MATRIX_MODULE: ${{ matrix.module }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             && [ -n "$DISPATCH_MODULE" ] \
+             && [ "$DISPATCH_MODULE" != "$MATRIX_MODULE" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch targeted '$DISPATCH_MODULE'; skipping '$MATRIX_MODULE'."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run focused mutation harness
+        if: steps.filter.outputs.skip != 'true'
+        env:
+          MATRIX_MODULE: ${{ matrix.module }}
+        run: |
+          mkdir -p mutation-results
+          # Per-module budget is enforced inside the harness; this is a
+          # belt-and-braces wall-clock cap so a hung mutation can't burn
+          # the full 30-minute job timeout.
+          timeout 1500 uv run python scripts/mutmut_critical.py \
+            --only "$MATRIX_MODULE" \
+            --quiet \
+            --json "mutation-results/${MATRIX_MODULE}.json" \
+            || echo "harness exited non-zero (gate failure or baseline)"
+      - name: Upload module result
+        if: steps.filter.outputs.skip != 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutation-${{ matrix.module }}
+          path: mutation-results/${{ matrix.module }}.json
+          retention-days: 14
+          if-no-files-found: warn
+
+  summary:
+    name: Summary + PR comment
+    needs: [mutate]
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Download all module results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: mutation-results
+          pattern: mutation-*
+          merge-multiple: true
+      - name: Comment on PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const dir = 'mutation-results';
+            const marker = '<!-- mutation-fixed -->';
+
+            let rows = [];
+            if (fs.existsSync(dir)) {
+              for (const f of fs.readdirSync(dir)) {
+                if (!f.endsWith('.json')) continue;
+                try {
+                  const parsed = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
+                  for (const r of parsed) rows.push(r);
+                } catch (e) {
+                  core.warning(`failed to parse ${f}: ${e.message}`);
+                }
+              }
+            }
+
+            const icon = (r) => {
+              if (!r.baseline_ok) return '⚠️';
+              return r.passed ? '✅' : '❌';
+            };
+
+            let body = `${marker}\n### Mutation gate (fixed critical paths)\n\n`;
+            if (rows.length === 0) {
+              body += '_No module results were produced. Check the matrix job logs._';
+            } else {
+              rows.sort((a, b) => a.module.localeCompare(b.module));
+              body += '| Module | Kill rate | Threshold | Killed/Total | Status | Notes |\n';
+              body += '|--------|-----------|-----------|--------------|--------|-------|\n';
+              for (const r of rows) {
+                const rate = r.total ? `${(100 * r.kill_rate).toFixed(1)}%` : 'n/a';
+                const thr = `${(100 * r.threshold).toFixed(0)}%`;
+                const counts = `${r.killed}/${r.total}`;
+                const notes = [];
+                if (!r.baseline_ok) notes.push('baseline tests failed');
+                if (r.budget_exceeded) notes.push('budget exceeded');
+                if (r.survivors && r.survivors.length) notes.push(`${r.survivors.length} survivors`);
+                body += `| ${r.module} | ${rate} | ${thr} | ${counts} | ${icon(r)} | ${notes.join('; ') || '—'} |\n`;
+              }
+              const failing = rows.filter(r => !r.passed);
+              if (failing.length) {
+                body += '\n<details><summary>Surviving mutations (top 20)</summary>\n\n';
+                let printed = 0;
+                for (const r of failing) {
+                  if (!r.survivors) continue;
+                  for (const s of r.survivors) {
+                    if (printed >= 20) break;
+                    body += `- \`${r.module}\`: ${s}\n`;
+                    printed += 1;
+                  }
+                  if (printed >= 20) break;
+                }
+                body += '\n</details>\n';
+              }
+              body += '\n> Gate is **advisory** while thresholds stabilise. To kill survivors locally:\n> `uv run python scripts/mutmut_critical.py --only <module>`';
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -12,6 +12,7 @@ locally without waiting for the cloud runner.
 | **Schemathesis**            | 5xx leaks against fuzzed REST inputs                              | PR (allow-list), nightly (full)  |
 | **CrossHair**               | Logic errors in pure helpers (concolic execution, assert checks)  | nightly only         |
 | **mutmut diff-only**        | Test-effectiveness gaps on PR-changed lines                       | PR (advisory)       |
+| **mutmut fixed paths**      | Per-module kill-rate gate on a fixed critical-path module list    | PR (path-filtered) + weekly cron  |
 | **mutmut full**             | Test-effectiveness gaps across the whole repo                     | nightly (advisory)  |
 | **Semgrep** (custom rules)  | eval/exec/pickle in production, env-leak in `_spawn_*`            | PR (ERROR fails)    |
 | **Bandit**                  | Generic Python security smells (shell=True, weak hash, tarfile)   | PR (HIGH only)      |
@@ -108,6 +109,35 @@ The mutation operator changed `==` to `!=` (etc.) and no test
 caught it. Either add a test that distinguishes the two operators
 or, if the mutation is genuinely undetectable (e.g. an off-by-one
 in a comment-only path), document why in `mutmut_config.py`.
+
+### mutmut fixed-paths gate
+`mutation-fixed.yml` runs `scripts/mutmut_critical.py` against a
+fixed list of high-risk modules (atomic claim, HMAC audit chain,
+audit integrity verifier, lineage v1 trio, seed parser) and gates
+on a per-module kill rate. The module list, per-module thresholds,
+and wall-clock budgets live in `scripts/mutmut_critical.py:MODULES`.
+
+The gate is **advisory** while thresholds calibrate (the matrix job
+sets `continue-on-error: true`). The PR comment posted by the
+workflow summarises each module's score and survivors; until the
+gate is flipped to enforcing, treat a red row as a follow-up TODO,
+not a merge blocker.
+
+Reproduce locally:
+
+```bash
+# All modules (slow — budgets sum to about an hour).
+uv run python scripts/mutmut_critical.py
+
+# One module:
+uv run python scripts/mutmut_critical.py --only claim_next
+uv run python scripts/mutmut_critical.py --list   # show keys
+```
+
+Adding a module to the gate: extend `MODULES` in
+`scripts/mutmut_critical.py`, mirror the matrix in
+`.github/workflows/mutation-fixed.yml`, and add the source/test
+paths to the `paths:` filter on the same workflow.
 
 ## CI cost budget
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -615,7 +615,11 @@ dev = [
     "ruff>=0.9",
     "pyright>=1.1",
     "scikit-learn>=1.5",
-    "mutmut>=2.4",
+    # Pinned to the 3.x line — the focused harness in
+    # scripts/mutmut_critical.py / scripts/mutmut_lineage.py is validated
+    # against 3.5.0. mutmut's config surface and CLI moved between 2.x
+    # and 3.x; bump the upper bound deliberately when validating 4.x.
+    "mutmut>=3.5,<4",
     "import-linter>=2.0",  # Architecture contracts (`uv run lint-imports`)
     # CI hardening 2026 — keep this section in sync with [project.optional-dependencies].dev.
     "schemathesis>=4.18.1",
@@ -644,6 +648,14 @@ dev = [
 # project-wide conftest pulls heavyweight imports that mutmut 3's
 # `mutants/` shadow tree can't satisfy, so we ship a thin custom
 # harness alongside the standard config for ad-hoc deep runs.
+#
+# The wider fixed critical-path gate (claim_next, audit_log, audit
+# integrity, lineage v1, seed parser) is driven by
+# `scripts/mutmut_critical.py` and the .github/workflows/mutation-fixed.yml
+# workflow. The list below is kept *narrow* on purpose: anything bigger
+# breaks the mutmut-3 shadow tree because of our heavyweight conftest.
+# To add a module to the gate, extend `MODULES` in mutmut_critical.py
+# and the workflow matrix, NOT this list.
 paths_to_mutate = [
     "src/bernstein/core/lineage/gate.py",
     "src/bernstein/core/lineage/tips.py",

--- a/scripts/mutmut_critical.py
+++ b/scripts/mutmut_critical.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+"""Per-module mutation tester for a fixed critical-path module list.
+
+The repo-wide mutmut config doesn't compose cleanly with our heavyweight
+``tests/conftest.py`` (it imports the whole orchestrator); the existing
+``scripts/mutmut_lineage.py`` runner side-steps that by applying a small
+set of mutation operators directly to a target file and re-running a
+focused test suite. This script generalises that harness to a fixed set
+of critical-path modules so CI can gate mutation score per-module.
+
+Targets and per-module thresholds live in :data:`MODULES` below. Each
+entry pairs one source file with the unit-test path(s) that should kill
+mutations in that file. A module is "passing" when
+
+    kill_rate >= threshold
+
+where ``kill_rate = killed / total`` and ``total = killed + survivors``
+(timeouts count as kills — an infinite loop is a meaningful signal).
+
+CLI:
+
+    python scripts/mutmut_critical.py                # all modules
+    python scripts/mutmut_critical.py --only NAME    # one module
+    python scripts/mutmut_critical.py --list         # list module keys
+    python scripts/mutmut_critical.py --json PATH    # write summary JSON
+
+Exit codes:
+
+    0 — every module met its threshold
+    1 — at least one module below threshold (gate failed)
+    2 — baseline tests fail (cannot trust mutation results)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class Module:
+    """One critical-path module under mutation gate."""
+
+    key: str
+    source: str  # repo-relative
+    tests: tuple[str, ...]  # repo-relative test paths
+    threshold: float  # required kill rate (0..1)
+    budget_seconds: int  # wall-clock budget for this module
+    max_candidates: int = 80  # cap per-file candidates to bound wall-clock
+    note: str = ""  # short rationale / scope marker
+
+
+# Fixed critical-path modules. Paths verified against the worktree layout
+# (see CLAUDE.md "Module map"). Thresholds start at 0.70 per TC-D brief —
+# this is the *gate setup* PR, scores get raised once humans backfill
+# tests for any module that falls short.
+MODULES: tuple[Module, ...] = (
+    Module(
+        key="claim_next",
+        source="src/bernstein/core/tasks/claim.py",
+        tests=("tests/unit/test_claim_next.py",),
+        threshold=0.70,
+        budget_seconds=1200,
+        max_candidates=80,
+        note="Atomic file-backed claim primitive (issue #1292).",
+    ),
+    Module(
+        key="audit_log",
+        source="src/bernstein/core/security/audit.py",
+        tests=(
+            "tests/unit/test_audit_chain_byteflip_regression.py",
+            "tests/unit/test_audit_key.py",
+        ),
+        threshold=0.70,
+        budget_seconds=1200,
+        max_candidates=80,
+        note="HMAC-chained audit log writer.",
+    ),
+    Module(
+        key="audit_integrity",
+        source="src/bernstein/core/security/audit_integrity.py",
+        tests=("tests/unit/test_audit_integrity.py",),
+        threshold=0.70,
+        budget_seconds=900,
+        max_candidates=60,
+        note="Audit log integrity verifier on startup.",
+    ),
+    Module(
+        key="lineage_gate",
+        source="src/bernstein/core/lineage/gate.py",
+        tests=("tests/unit/lineage/",),
+        threshold=0.75,
+        budget_seconds=900,
+        max_candidates=60,
+        note="Lineage v1 admission gate.",
+    ),
+    Module(
+        key="lineage_tips",
+        source="src/bernstein/core/lineage/tips.py",
+        tests=("tests/unit/lineage/",),
+        threshold=0.75,
+        budget_seconds=600,
+        max_candidates=60,
+        note="Lineage v1 tip tracker.",
+    ),
+    Module(
+        key="lineage_merge",
+        source="src/bernstein/core/lineage/merge.py",
+        tests=("tests/unit/lineage/",),
+        threshold=0.75,
+        budget_seconds=600,
+        max_candidates=60,
+        note="Lineage v1 merge resolution.",
+    ),
+    Module(
+        key="config_seed_parser",
+        source="src/bernstein/core/config/seed_parser.py",
+        tests=("tests/unit/test_config_schema.py",),
+        threshold=0.70,
+        budget_seconds=1200,
+        max_candidates=80,
+        note="bernstein.yaml seed parser + ${ENV} reference resolution.",
+    ),
+)
+
+# (search, replace) pairs applied one-at-a-time per line. Mirrors the
+# small high-signal set used by scripts/mutmut_lineage.py.
+MUTATIONS: tuple[tuple[str, str], ...] = (
+    (" < ", " <= "),
+    (" <= ", " < "),
+    (" > ", " >= "),
+    (" >= ", " > "),
+    (" == ", " != "),
+    (" != ", " == "),
+    (" and ", " or "),
+    (" or ", " and "),
+    ("True", "False"),
+    ("False", "True"),
+    ("not ", ""),
+    (" 0", " 1"),
+    (" 1", " 2"),
+    (" 2", " 1"),
+    ("[]", "[None]"),
+    ("return True", "return False"),
+    ("return False", "return True"),
+    ("len(", "0 * len("),
+)
+
+
+@dataclass
+class ModuleResult:
+    key: str
+    total: int = 0
+    killed: int = 0
+    timeouts: int = 0
+    survivors: list[str] = field(default_factory=list)
+    elapsed_seconds: float = 0.0
+    threshold: float = 0.0
+    baseline_ok: bool = True
+    timed_out: bool = False  # wall-clock budget exceeded mid-run
+
+    @property
+    def kill_rate(self) -> float:
+        return (self.killed / self.total) if self.total else 0.0
+
+    @property
+    def passed(self) -> bool:
+        return self.baseline_ok and self.kill_rate >= self.threshold
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "module": self.key,
+            "total": self.total,
+            "killed": self.killed,
+            "timeouts": self.timeouts,
+            "survivors": self.survivors,
+            "kill_rate": round(self.kill_rate, 4),
+            "threshold": self.threshold,
+            "passed": self.passed,
+            "baseline_ok": self.baseline_ok,
+            "elapsed_seconds": round(self.elapsed_seconds, 1),
+            "budget_exceeded": self.timed_out,
+        }
+
+
+def _run_tests(test_paths: tuple[str, ...]) -> bool:
+    """Return True iff tests pass (i.e. mutation NOT killed)."""
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-x",
+            "-q",
+            "--no-cov",
+            "-p",
+            "no:cacheprovider",
+            *test_paths,
+        ],
+        cwd=str(REPO),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    return res.returncode == 0
+
+
+def _candidates(target: Path, limit: int) -> list[tuple[int, str, str, str]]:
+    out: list[tuple[int, str, str, str]] = []
+    text = target.read_text().splitlines(keepends=True)
+    in_docstring = False
+    for i, line in enumerate(text):
+        stripped = line.lstrip()
+        triple_count = line.count('"""') + line.count("'''")
+        if triple_count and triple_count % 2 == 1:
+            in_docstring = not in_docstring
+            continue
+        if in_docstring or stripped.startswith("#") or stripped.startswith("@"):
+            continue
+        if line.rstrip().endswith(",") and "=" in line and "(" not in line:
+            continue
+        for search, replace in MUTATIONS:
+            if search in line and search != replace:
+                out.append((i, line, search, replace))
+        if len(out) >= limit:
+            break
+    return out[:limit]
+
+
+def _mutate_module(mod: Module, *, verbose: bool = True) -> ModuleResult:
+    res = ModuleResult(key=mod.key, threshold=mod.threshold)
+    target = REPO / mod.source
+    if not target.exists():
+        print(f"[{mod.key}] missing source {target}; skipping", file=sys.stderr)
+        res.baseline_ok = False
+        return res
+
+    if verbose:
+        print(f"[{mod.key}] baseline tests: {mod.tests}", flush=True)
+    if not _run_tests(mod.tests):
+        print(f"[{mod.key}] baseline fails — cannot trust mutation run", file=sys.stderr)
+        res.baseline_ok = False
+        return res
+
+    original = target.read_text()
+    candidates = _candidates(target, mod.max_candidates)
+    if verbose:
+        print(f"[{mod.key}] {len(candidates)} candidate(s); budget {mod.budget_seconds}s", flush=True)
+
+    deadline = time.monotonic() + mod.budget_seconds
+    try:
+        for idx, (line_no, line, search, replace) in enumerate(candidates):
+            if time.monotonic() >= deadline:
+                res.timed_out = True
+                print(f"[{mod.key}] wall-clock budget exceeded after {idx} mutations", flush=True)
+                break
+            res.total += 1
+            new_line = line.replace(search, replace, 1)
+            lines = original.splitlines(keepends=True)
+            lines[line_no] = new_line
+            target.write_text("".join(lines))
+            try:
+                survived = _run_tests(mod.tests)
+            except subprocess.TimeoutExpired:
+                res.timeouts += 1
+                res.killed += 1
+                continue
+            if survived:
+                res.survivors.append(
+                    f"{mod.source}:{line_no + 1} '{search}' -> '{replace}': {line.rstrip()}"
+                )
+                if verbose:
+                    print(f"  [{idx + 1}/{len(candidates)}] SURVIVED line {line_no + 1}", flush=True)
+            else:
+                res.killed += 1
+    finally:
+        target.write_text(original)
+
+    res.elapsed_seconds = mod.budget_seconds - max(deadline - time.monotonic(), 0.0)
+    return res
+
+
+def _print_summary(results: list[ModuleResult]) -> None:
+    print()
+    print("=== Mutation gate summary ===")
+    print(f"{'module':<20} {'kill rate':>10} {'thr':>6} {'status':>8}  notes")
+    for r in results:
+        status = "PASS" if r.passed else ("BASE-FAIL" if not r.baseline_ok else "FAIL")
+        rate = f"{100 * r.kill_rate:5.1f}%" if r.total else "  n/a"
+        thr = f"{100 * r.threshold:4.0f}%"
+        suffix = " (budget exceeded)" if r.timed_out else ""
+        print(f"{r.key:<20} {rate:>10} {thr:>6} {status:>8}  {r.killed}/{r.total} killed{suffix}")
+    for r in results:
+        if r.survivors:
+            print()
+            print(f"Survivors in {r.key}:")
+            for s in r.survivors:
+                print(f"  - {s}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--only", help="Run a single module key", default=None)
+    parser.add_argument(
+        "--list", action="store_true", help="List configured module keys and exit"
+    )
+    parser.add_argument(
+        "--json", help="Write per-module summary JSON to this path", default=None
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="Suppress per-mutation logs"
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        for m in MODULES:
+            print(f"{m.key}\t{m.source}\tthr={m.threshold:.2f}\tbudget={m.budget_seconds}s")
+        return 0
+
+    selected: tuple[Module, ...]
+    if args.only:
+        match = [m for m in MODULES if m.key == args.only]
+        if not match:
+            print(f"unknown module: {args.only!r}", file=sys.stderr)
+            return 2
+        selected = tuple(match)
+    else:
+        selected = MODULES
+
+    results: list[ModuleResult] = []
+    for mod in selected:
+        results.append(_mutate_module(mod, verbose=not args.quiet))
+
+    _print_summary(results)
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps([r.to_dict() for r in results], indent=2) + "\n"
+        )
+
+    any_baseline_fail = any(not r.baseline_ok for r in results)
+    if any_baseline_fail:
+        return 2
+    return 0 if all(r.passed for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/typos.toml
+++ b/typos.toml
@@ -23,6 +23,7 @@ rto = "rto"          # Recovery Time Objective (compliance/DR)
 RTO = "RTO"          # Recovery Time Objective (compliance/DR, acronym)
 mis = "mis"          # false positive on partial words
 fo = "fo"            # fo = fan_out (test_complexity_correlation.py)
+thr = "thr"          # thr = threshold (scripts/mutmut_critical.py)
 Aktive = "Aktive"    # correct German word for "Active" (i18n.py)
 
 # Technical terms used consistently in the codebase

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ dev = [
     { name = "diff-cover", specifier = ">=9.0" },
     { name = "hypothesis", specifier = ">=6.100" },
     { name = "import-linter", specifier = ">=2.0" },
-    { name = "mutmut", specifier = ">=2.4" },
+    { name = "mutmut", specifier = ">=3.5,<4" },
     { name = "pip-audit", specifier = ">=2.7" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "pypdf", specifier = ">=4.0" },


### PR DESCRIPTION
## TL;DR

Adds a per-module mutation-score gate for a fixed list of critical-path modules. Complements the diff-only mutmut job in `ci.yml` (which only runs when a file is touched and so leaves stable critical code with stale tests unchecked).

Gate is **advisory** for the first two weeks (`continue-on-error: true`) while thresholds calibrate. Until then, treat a red row in the PR comment as a follow-up TODO, not a merge blocker.

## Modules under gate

| Module key            | Source                                                | Tests                                                                                  | Threshold | Per-module budget |
| --------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------- | --------- | ----------------- |
| `claim_next`          | `src/bernstein/core/tasks/claim.py`                   | `tests/unit/test_claim_next.py`                                                        | 70 %      | 20 min            |
| `audit_log`           | `src/bernstein/core/security/audit.py`                | `test_audit_chain_byteflip_regression.py`, `test_audit_key.py`                         | 70 %      | 20 min            |
| `audit_integrity`     | `src/bernstein/core/security/audit_integrity.py`      | `test_audit_integrity.py`                                                              | 70 %      | 15 min            |
| `lineage_gate`        | `src/bernstein/core/lineage/gate.py`                  | `tests/unit/lineage/`                                                                  | 75 %      | 15 min            |
| `lineage_tips`        | `src/bernstein/core/lineage/tips.py`                  | `tests/unit/lineage/`                                                                  | 75 %      | 10 min            |
| `lineage_merge`       | `src/bernstein/core/lineage/merge.py`                 | `tests/unit/lineage/`                                                                  | 75 %      | 10 min            |
| `config_seed_parser`  | `src/bernstein/core/config/seed_parser.py`            | `test_config_schema.py`                                                                | 70 %      | 20 min            |

Each module runs as its own matrix cell, so a slow module can't squeeze the others. Job hard cap 30 min, harness budget enforced internally too.

## Scope dropped from initial brief

- **manager spawn/kill** — `core/agents/spawner_core.py` is 3 000 LOC; far above the per-module budget and not a clean unit-test boundary. Will revisit after splitting.
- **worker handshake / #1261 auth area** — no dedicated handshake module yet (it lives across `core/orchestration/worker.py` + ACP handlers). Punt to a follow-up that first extracts a handshake module.
- **`TaskStore` atomic writes** — `task_store_core.py` is 2 200 LOC, far too slow to mutate inside the 25 min/module budget. Sub-targeting a smaller helper (e.g. `core/persistence/atomic_write.py`) would be a saner follow-up.

## Local validation

Two modules already run cleanly against current tests:

| Module        | Mutations | Killed | Kill rate | Status |
|---------------|-----------|--------|-----------|--------|
| `lineage_tips` | 16        | 15     | 93.8 %    | PASS   |
| `claim_next`   | 53        | 45     | 84.9 %    | PASS   |

Reproduce locally:

```
uv run python scripts/mutmut_critical.py --only claim_next
uv run python scripts/mutmut_critical.py --list
```

## Why a separate workflow

The existing `[tool.mutmut]` + `mutmut_config.py` setup is awkward because `tests/conftest.py` pulls heavyweight imports that the mutmut 3.x `mutants/` shadow tree can't satisfy. The lineage suite already side-steps this with `scripts/mutmut_lineage.py`; this PR just generalises that pattern to the wider critical-path set, so adding new modules is a single dict entry plus a matrix line.

## Notes for reviewer

- This PR is the gate **setup**, not the fix for any module that scores poorly. If a module surfaces below threshold once `mutation-fixed.yml` lands on `main`, file follow-up tasks targeting that module's test suite rather than adjusting the gate.
- All actions hard-pinned to commit SHAs; zizmor + actionlint clean locally.
- The `continue-on-error: true` line at jobs.mutate is the temporary advisory marker. Once thresholds stabilise (≥ 2 weekly cron runs above the gate) delete that line to flip the gate to enforcing.

## Test plan

- [ ] CI: `Mutation (fixed critical paths)` workflow runs on this PR (touches `scripts/mutmut_critical.py` + `.github/workflows/mutation-fixed.yml`)
- [ ] PR comment is posted by the `summary` job (look for the `<!-- mutation-fixed -->` marker)
- [ ] Per-module artifacts uploaded