### PR TITLE
feat: calibrated p50/p90 cost preflight band

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -994,6 +994,17 @@ def exec_restart() -> None:
         "agent is spawned, no retry."
     ),
 )
+@click.option(
+    "--budget-cap",
+    "budget_cap",
+    type=float,
+    default=None,
+    help=(
+        "Preflight budget cap in USD. Aborts spawn before the orchestrator "
+        "starts when the calibrated p90 of the cost band exceeds the cap. "
+        "Distinct from --max-cost-usd / --hard-budget, which are enforced at runtime."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1031,6 +1042,7 @@ def run(
     max_cost_usd: float | None = None,
     budget_spec: str | None = None,
     hard_budget_spec: str | None = None,
+    budget_cap: float | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1056,6 +1068,7 @@ def run(
       bernstein conduct --audit                # SOC 2 audit mode (HMAC-chained log + Merkle seal)
       bernstein conduct --max-cost-usd 1.50    # hard cap total run spend at $1.50
       bernstein run plan.yaml --budget 5usd --hard-budget 10usd  # soft + hard caps (#1320)
+      bernstein conduct --budget-cap 5.00      # abort spawn if preflight p90 > $5
     """
     # Issue #1320: ``--budget`` is the friendlier alias of ``--max-cost-usd``
     # and shares the same env var. When both are set, the operator's
@@ -1158,6 +1171,7 @@ def run(
             auto_approve=auto_approve,
             quiet=quiet,
             plan_approval_follows=not auto_approve,
+            budget_cap=budget_cap,
         )
 
     # --plan_file: loadable YAML plan (stages + steps)

--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -21,6 +21,7 @@ from bernstein.cli.helpers import (
 from bernstein.cli.run import render_run_summary_from_dict
 from bernstein.cli.ui import make_console
 from bernstein.core.cost import estimate_run_cost
+from bernstein.core.cost.preflight import CostBand, compute_band, format_band
 from bernstein.core.plan_loader import load_plan_from_yaml
 from bernstein.core.runtime_state import directory_size_bytes
 
@@ -78,12 +79,22 @@ def _drain_completed_backlog_files() -> None:
 
 @dataclass(frozen=True)
 class RunCostEstimate:
-    """Preflight cost estimate for a pending run."""
+    """Preflight cost estimate for a pending run.
+
+    Attributes:
+        task_count: Number of tasks the run will spawn.
+        model: Display label for the model (``"adapter/model"`` or model).
+        low_usd: Legacy single-point low estimate (kept for back-compat).
+        high_usd: Legacy single-point high estimate (kept for back-compat).
+        band: Optional calibrated p50/p90 band. Populated for new callers;
+            legacy callers can leave it unset.
+    """
 
     task_count: int
     model: str
     low_usd: float
     high_usd: float
+    band: CostBand | None = None
 
 
 def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None) -> int:
@@ -105,16 +116,25 @@ def _estimate_task_count(workdir: Path, plan_file: Path | None, goal: str | None
     return max(1, count)
 
 
-def _resolve_model_and_cli(seed_file: str | None, model_override: str | None) -> tuple[str, str]:
-    """Resolve model and CLI adapter from seed file or defaults."""
+def _resolve_model_and_cli(
+    seed_file: str | None,
+    model_override: str | None,
+) -> tuple[str, str, str]:
+    """Resolve model, CLI adapter, and dominant role from seed or defaults.
+
+    Returns:
+        Tuple of ``(model, cli, role)``. ``role`` defaults to ``"backend"``
+        when the seed does not specify a role policy.
+    """
     est_model = model_override or "sonnet"
     est_cli = "claude"
+    est_role = "backend"
     if model_override is not None:
-        return est_model, est_cli
+        return est_model, est_cli, est_role
 
     seed_path = Path(seed_file) if seed_file is not None else find_seed_file()
     if seed_path is None or not seed_path.exists():
-        return est_model, est_cli
+        return est_model, est_cli, est_role
 
     try:
         from bernstein.core.seed import parse_seed
@@ -124,6 +144,8 @@ def _resolve_model_and_cli(seed_file: str | None, model_override: str | None) ->
             est_model = seed.model
         if seed.role_model_policy:
             for _role, _policy in seed.role_model_policy.items():
+                if isinstance(_role, str):
+                    est_role = _role
                 if "cli" in _policy:
                     est_cli = _policy["cli"]
                 if "model" in _policy:
@@ -133,7 +155,7 @@ def _resolve_model_and_cli(seed_file: str | None, model_override: str | None) ->
             est_cli = seed.cli
     except Exception:
         est_model = "sonnet"
-    return est_model, est_cli
+    return est_model, est_cli, est_role
 
 
 _FREE_ADAPTERS = frozenset(("qwen", "gemini", "ollama"))
@@ -149,6 +171,13 @@ def _estimate_run_preview(
 ) -> RunCostEstimate:
     """Estimate run cost before bootstrapping the orchestrator.
 
+    Computes both the legacy single-point heuristic (``low_usd``/``high_usd``,
+    kept for back-compat) and the calibrated ``CostBand`` (``band``).
+    The calibrated band reads the last 50 records of the same
+    ``(role, adapter)`` pair from ``.sdd/metrics/cost.jsonl``; cold-start
+    falls back to the legacy heuristic and the band is flagged
+    ``cold_start=True``.
+
     Args:
         workdir: Repository root.
         plan_file: Optional explicit YAML plan file.
@@ -160,18 +189,35 @@ def _estimate_run_preview(
         Cost estimate using the best available task count and model hint.
     """
     est_task_count = _estimate_task_count(workdir, plan_file, goal)
-    est_model, est_cli = _resolve_model_and_cli(seed_file, model_override)
+    est_model, est_cli, est_role = _resolve_model_and_cli(seed_file, model_override)
 
     if est_cli in _FREE_ADAPTERS:
         low_usd, high_usd = 0.0, 0.0
+        band = CostBand(
+            p50=0.0,
+            p90=0.0,
+            samples=0,
+            cold_start=False,
+            role=est_role,
+            adapter=est_cli,
+            model=est_model,
+        )
     else:
         low_usd, high_usd = estimate_run_cost(est_task_count, est_model)
+        band = compute_band(
+            role=est_role,
+            adapter=est_cli,
+            model=est_model,
+            task_count=est_task_count,
+            metrics_dir=workdir / ".sdd" / "metrics",
+        )
     display_model = f"{est_cli}/{est_model}" if est_cli != "claude" else est_model
     return RunCostEstimate(
         task_count=est_task_count,
         model=display_model,
         low_usd=low_usd,
         high_usd=high_usd,
+        band=band,
     )
 
 
@@ -182,6 +228,7 @@ def _emit_preflight_runtime_warnings(
     auto_approve: bool,
     quiet: bool,
     plan_approval_follows: bool = False,
+    budget_cap: float | None = None,
 ) -> None:
     """Show startup cost and disk-usage warnings before execution.
 
@@ -190,24 +237,53 @@ def _emit_preflight_runtime_warnings(
         estimate: Cost estimate computed from local context.
         auto_approve: Whether confirmation prompts are disabled.
         quiet: Whether normal startup output is suppressed.
+        plan_approval_follows: When True, a plan-approval prompt that
+            already shows cost will follow, so we skip the duplicate
+            confirmation here.
+        budget_cap: Optional preflight ceiling in USD. When the p90 of the
+            calibrated band exceeds this value, the spawn is aborted with
+            ``SystemExit(1)``. ``None`` (default) disables the check.
 
     Raises:
-        SystemExit: When the operator declines a high-cost run.
+        SystemExit: When the operator declines a high-cost run or when
+            ``budget_cap`` is exceeded.
     """
     sdd_dir = workdir / ".sdd"
     disk_usage_gb = directory_size_bytes(sdd_dir) / (1024**3)
+    band = estimate.band
     if not quiet:
-        console.print(
-            "[bold yellow]Estimated cost:[/bold yellow] "
-            f"${estimate.low_usd:.2f}-${estimate.high_usd:.2f} "
-            f"based on {estimate.task_count} task(s) at {estimate.model} pricing"
-        )
+        if band is not None:
+            console.print(f"[bold yellow]{format_band(band)}[/bold yellow]")
+            samples_note = (
+                f"{band.samples} historical sample(s)" if not band.cold_start else "no history yet — using heuristic"
+            )
+            console.print(
+                f"[dim]based on {estimate.task_count} task(s) at {estimate.model} pricing, {samples_note}[/dim]"
+            )
+        else:
+            console.print(
+                "[bold yellow]Estimated cost:[/bold yellow] "
+                f"${estimate.low_usd:.2f}-${estimate.high_usd:.2f} "
+                f"based on {estimate.task_count} task(s) at {estimate.model} pricing"
+            )
         if disk_usage_gb >= 1.0:
             console.print(
                 "[yellow]Warning:[/yellow] "
                 f".sdd/ is using {disk_usage_gb:.2f} GB. "
                 "Run [bold]bernstein cleanup[/bold] if stale worktrees or logs are accumulating."
             )
+
+    # --budget-cap: abort before spawn when p90 exceeds the operator's
+    # ceiling.  Honours auto-approve so CI can opt out of the prompt;
+    # when no band is available (e.g. legacy callers) we compare against
+    # ``high_usd`` so the contract still holds.
+    if budget_cap is not None and budget_cap > 0.0:
+        p90 = band.p90 if band is not None else estimate.high_usd
+        if p90 > budget_cap:
+            console.print(
+                f"[bold red]Budget cap exceeded:[/bold red] p90 ${p90:.2f} > cap ${budget_cap:.2f}. Aborting spawn."
+            )
+            raise SystemExit(1)
 
     # Cost confirmation is skipped when the plan approval prompt follows
     # (it already shows cost and asks Y/N — no need to ask twice).

--- a/src/bernstein/core/cost/preflight.py
+++ b/src/bernstein/core/cost/preflight.py
@@ -181,7 +181,8 @@ def load_history(
         if not isinstance(parsed, dict):
             continue
         record: dict[str, object] = {
-            str(k): v for k, v in parsed.items()  # type: ignore[reportUnknownVariableType]
+            str(k): v
+            for k, v in parsed.items()  # type: ignore[reportUnknownVariableType]
         }
         if not _matches(record, role_norm, adapter_norm):
             continue

--- a/src/bernstein/core/cost/preflight.py
+++ b/src/bernstein/core/cost/preflight.py
@@ -1,0 +1,318 @@
+"""Calibrated p50/p90 cost preflight band.
+
+Replaces the single-point heuristic with a percentile band computed from
+the last ``N`` runs of the same ``(role, adapter)`` pair persisted to
+``.sdd/metrics/cost.jsonl``. Cold-start (no history) falls back to the
+legacy heuristic and the band is labelled ``(cold estimate)``.
+
+The estimator is intentionally additive and side-effect-free:
+
+* Read-only over the metrics store. No schema migration.
+* No NumPy dependency: uses :func:`statistics.quantiles`.
+* No live pricing fetch. Rate cards are sourced from
+  :mod:`bernstein.core.cost.rate_cards`.
+
+Schema (lenient parser):
+
+Each line of ``cost.jsonl`` is a JSON object. The estimator looks for the
+following fields and tolerates missing/extra keys:
+
+* ``role``        -- string, must match (case-insensitive) the queried role
+* ``adapter``     -- string adapter id (``"claude"``, ``"codex"``...). The
+  parser also accepts ``cli`` or ``model`` aliases when ``adapter`` is
+  absent.
+* ``cost_usd``    -- number, finite and ``>= 0``. Records failing this
+  check are skipped, never coerced to NaN/negative.
+
+Any other shape is silently skipped; a corrupt history file must never
+abort the preflight.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from bernstein.core.cost.rate_cards import lookup_rate_per_1k
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "DEFAULT_HISTORY_LIMIT",
+    "CostBand",
+    "compute_band",
+    "format_band",
+    "load_history",
+]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HISTORY_LIMIT: Final[int] = 50
+"""Last ``N`` records of the same (role, adapter) pair to consider."""
+
+_COLD_START_LABEL: Final[str] = "(cold estimate)"
+
+# Heuristic token band for the cold-start fallback. Matches the legacy
+# ``estimate_run_cost`` envelope (50k-150k tokens per task, expressed in
+# units of "1k tokens" so the multiplication against the per-1k rate is
+# direct).
+_HEURISTIC_TOKENS_PER_TASK_LOW: Final[float] = 50.0
+_HEURISTIC_TOKENS_PER_TASK_HIGH: Final[float] = 150.0
+
+
+@dataclass(frozen=True)
+class CostBand:
+    """Calibrated p50/p90 cost preflight band.
+
+    Attributes:
+        p50: Median estimated USD spend for the run.
+        p90: 90th-percentile estimated USD spend for the run.
+        samples: Number of historical samples backing the band. ``0`` for
+            cold-start.
+        cold_start: True when the band was produced by the heuristic
+            fallback rather than from history.
+        role: Queried role (e.g. ``"backend"``).
+        adapter: Queried adapter identifier (e.g. ``"claude"``).
+        model: Model used to drive the cold-start heuristic. Empty when
+            unknown / not provided.
+    """
+
+    p50: float
+    p90: float
+    samples: int
+    cold_start: bool
+    role: str
+    adapter: str
+    model: str
+
+    @property
+    def label(self) -> str:
+        """Suffix appended to the formatted band when cold-started."""
+        return _COLD_START_LABEL if self.cold_start else ""
+
+
+def _sanitize(value: float) -> float:
+    """Clamp a USD figure to a safe display value.
+
+    Negative values, NaNs and infinities are mapped to ``0.0``; everything
+    else is rounded to two decimals.
+    """
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if amount != amount:  # NaN
+        return 0.0
+    if amount < 0.0:
+        return 0.0
+    if amount == float("inf") or amount == float("-inf"):
+        return 0.0
+    return round(amount, 2)
+
+
+def _extract_adapter(record: dict[str, object]) -> str | None:
+    """Pull the adapter id from a record, accepting aliases."""
+    for key in ("adapter", "cli", "model"):
+        raw = record.get(key)
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().lower()
+    return None
+
+
+def _matches(
+    record: dict[str, object],
+    role: str,
+    adapter: str,
+) -> bool:
+    """Return True when ``record`` belongs to the queried (role, adapter)."""
+    record_role = record.get("role")
+    if not isinstance(record_role, str) or record_role.strip().lower() != role:
+        return False
+    record_adapter = _extract_adapter(record)
+    return record_adapter == adapter
+
+
+def load_history(
+    metrics_path: Path,
+    *,
+    role: str,
+    adapter: str,
+    limit: int = DEFAULT_HISTORY_LIMIT,
+) -> list[float]:
+    """Return the last ``limit`` USD costs for ``(role, adapter)``.
+
+    Args:
+        metrics_path: Path to ``.sdd/metrics/cost.jsonl``. A missing file or
+            unreadable file yields an empty list (cold-start).
+        role: Role to filter on, case-insensitive (e.g. ``"backend"``).
+        adapter: Adapter id to filter on, case-insensitive (e.g.
+            ``"claude"``).
+        limit: Maximum samples to retain (most recent records win).
+
+    Returns:
+        List of finite, non-negative USD figures, newest-last preserved
+        in file order. Empty when no history is available.
+    """
+    if limit <= 0 or not metrics_path.exists() or not metrics_path.is_file():
+        return []
+
+    role_norm = role.strip().lower()
+    adapter_norm = adapter.strip().lower()
+    matched: list[float] = []
+
+    try:
+        text = metrics_path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - defensive
+        logger.debug("preflight: cost history unreadable at %s: %s", metrics_path, exc)
+        return []
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        record: dict[str, object] = {
+            str(k): v for k, v in parsed.items()  # type: ignore[reportUnknownVariableType]
+        }
+        if not _matches(record, role_norm, adapter_norm):
+            continue
+        cost_raw = record.get("cost_usd")
+        try:
+            cost = float(cost_raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            continue
+        if cost != cost or cost < 0.0:  # NaN or negative
+            continue
+        if cost == float("inf"):
+            continue
+        matched.append(cost)
+
+    if len(matched) > limit:
+        matched = matched[-limit:]
+    return matched
+
+
+def _percentile(samples: list[float], q: float) -> float:
+    """Return the ``q``-th percentile of ``samples`` (``q`` in 0..1).
+
+    Uses :func:`statistics.quantiles` with the inclusive method, which
+    matches the canonical "linear interpolation between order statistics"
+    definition used by NumPy ``percentile`` for the same percentile.
+
+    For samples of length ``<= 1`` we degrade to the single value so we
+    never raise on micro-history.
+    """
+    if not samples:
+        return 0.0
+    if len(samples) == 1:
+        return samples[0]
+    # ``quantiles(n=100)`` returns the 99 cutpoints; index ``q*100 - 1``.
+    idx = round(q * 100) - 1
+    idx = max(0, min(98, idx))
+    cuts = statistics.quantiles(samples, n=100, method="inclusive")
+    return cuts[idx]
+
+
+def _heuristic_band(
+    *,
+    task_count: int,
+    model: str,
+) -> tuple[float, float]:
+    """Return the legacy single-point heuristic as a (p50, p90)-shaped band.
+
+    The legacy heuristic is a width-bounded range, not a true band; we
+    map ``low`` -> p50 and ``high`` -> p90 so the new caller sees a band
+    of the expected shape even on a fully cold workspace.
+    """
+    rate = lookup_rate_per_1k(model)
+    tasks = max(1, task_count)
+    p50 = tasks * _HEURISTIC_TOKENS_PER_TASK_LOW * rate
+    p90 = tasks * _HEURISTIC_TOKENS_PER_TASK_HIGH * rate
+    return (p50, p90)
+
+
+def compute_band(
+    *,
+    role: str,
+    adapter: str,
+    model: str,
+    task_count: int,
+    metrics_dir: Path,
+    history_limit: int = DEFAULT_HISTORY_LIMIT,
+) -> CostBand:
+    """Compute the calibrated p50/p90 preflight band.
+
+    Args:
+        role: Role driving the planned run (e.g. ``"backend"``).
+        adapter: Adapter id (e.g. ``"claude"``, ``"codex"``).
+        model: Model name used by the cold-start heuristic.
+        task_count: Number of tasks planned. Multiplies the heuristic but
+            does not affect historical samples (those already reflect
+            per-run totals).
+        metrics_dir: Path to ``.sdd/metrics``. ``cost.jsonl`` is the only
+            file consulted.
+        history_limit: Max samples to retain from history (newest wins).
+
+    Returns:
+        :class:`CostBand` with rounded, non-negative ``p50`` and ``p90``.
+    """
+    role_norm = role.strip().lower()
+    adapter_norm = adapter.strip().lower()
+    history_path = metrics_dir / "cost.jsonl"
+
+    samples = load_history(
+        history_path,
+        role=role_norm,
+        adapter=adapter_norm,
+        limit=history_limit,
+    )
+
+    if samples:
+        p50_raw = _percentile(samples, 0.5)
+        p90_raw = _percentile(samples, 0.9)
+        # Order invariant: p90 must never sit below p50, even with
+        # heavily-skewed micro-samples.
+        if p90_raw < p50_raw:
+            p90_raw = p50_raw
+        return CostBand(
+            p50=_sanitize(p50_raw),
+            p90=_sanitize(p90_raw),
+            samples=len(samples),
+            cold_start=False,
+            role=role_norm,
+            adapter=adapter_norm,
+            model=model,
+        )
+
+    p50_raw, p90_raw = _heuristic_band(task_count=task_count, model=model)
+    return CostBand(
+        p50=_sanitize(p50_raw),
+        p90=_sanitize(p90_raw),
+        samples=0,
+        cold_start=True,
+        role=role_norm,
+        adapter=adapter_norm,
+        model=model,
+    )
+
+
+def format_band(band: CostBand) -> str:
+    """Render a :class:`CostBand` for the preflight banner.
+
+    Returns a string of the form
+    ``"Estimated cost: p50 $X.XX, p90 $Y.YY"``, with ``" (cold estimate)"``
+    appended on the cold-start path.
+    """
+    base = f"Estimated cost: p50 ${band.p50:.2f}, p90 ${band.p90:.2f}"
+    if band.cold_start:
+        return f"{base} {_COLD_START_LABEL}"
+    return base

--- a/src/bernstein/core/cost/rate_cards.py
+++ b/src/bernstein/core/cost/rate_cards.py
@@ -1,0 +1,76 @@
+"""Model rate cards for cost preflight.
+
+This module is the single edit point for model pricing used by the
+preflight estimator (see :mod:`bernstein.core.cost.preflight`). Updating
+prices here must not require touching estimator code.
+
+Values are blended ``USD per 1k tokens`` (input + output averaged), which
+matches the granularity needed by the cold-start heuristic. Per-token-type
+breakdowns are intentionally out of scope; see the dashboard ticket.
+
+Rates are sourced from :data:`bernstein.core.cost.cost._MODEL_COST_USD_PER_1K`
+to avoid drift; that table remains the canonical pricing dump.  The wrapper
+here exists so callers don't reach into a private symbol and so we can swap
+the source out (e.g. a YAML override) without touching estimator code.
+"""
+
+from __future__ import annotations
+
+# ``_MODEL_COST_USD_PER_1K`` is the package-canonical rate dump; the leading
+# underscore signals "do not edit ad-hoc -- go through this module instead",
+# not "do not import". The cost sub-package ``__init__`` re-exports the name
+# explicitly for callers like this one.
+from bernstein.core.cost import _MODEL_COST_USD_PER_1K  # pyright: ignore[reportPrivateUsage]
+
+__all__ = [
+    "MissingRateCardError",
+    "lookup_rate_per_1k",
+    "rate_card",
+]
+
+
+class MissingRateCardError(KeyError):
+    """Raised when no rate card matches the requested model name."""
+
+    def __init__(self, model: str) -> None:
+        super().__init__(model)
+        self.model = model
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"no rate card for model {self.model!r}"
+
+
+def rate_card() -> dict[str, float]:
+    """Return a snapshot of the blended ``USD per 1k token`` rate card.
+
+    Returns:
+        Mapping of ``model substring -> blended USD/1k tokens``. The keys are
+        matched by left-to-right substring against the requested model name
+        in :func:`lookup_rate_per_1k`, so longer/more specific keys come
+        first in the source table.
+    """
+    return dict(_MODEL_COST_USD_PER_1K)
+
+
+def lookup_rate_per_1k(model: str, *, strict: bool = False) -> float:
+    """Return blended USD/1k tokens for ``model``.
+
+    Args:
+        model: Model identifier (e.g. ``"sonnet"``, ``"gpt-5-mini"``).
+        strict: When True, raise :class:`MissingRateCardError` on miss.
+            When False, return ``0.005`` (matches the legacy fallback in
+            :func:`bernstein.core.cost.cost._model_cost`).
+
+    Returns:
+        Blended cost per 1k tokens in USD.
+
+    Raises:
+        MissingRateCardError: When ``strict`` and no entry matches.
+    """
+    model_lower = model.lower()
+    for key, cost in _MODEL_COST_USD_PER_1K.items():
+        if key in model_lower:
+            return cost
+    if strict:
+        raise MissingRateCardError(model)
+    return 0.005

--- a/tests/unit/test_cost_preflight_v2.py
+++ b/tests/unit/test_cost_preflight_v2.py
@@ -1,0 +1,342 @@
+"""Tests for calibrated p50/p90 cost preflight band (feat-cost-preflight-v2)."""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.cost.preflight import (
+    DEFAULT_HISTORY_LIMIT,
+    CostBand,
+    compute_band,
+    format_band,
+    load_history,
+)
+from bernstein.core.cost.rate_cards import MissingRateCardError, lookup_rate_per_1k
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_history(path: Path, records: list[dict[str, object]]) -> None:
+    """Serialise a list of records as ``cost.jsonl`` newline-delimited JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture()
+def metrics_dir(tmp_path: Path) -> Path:
+    """Return a fresh ``.sdd/metrics`` directory for the test."""
+    target = tmp_path / ".sdd" / "metrics"
+    target.mkdir(parents=True)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# load_history
+# ---------------------------------------------------------------------------
+
+
+def test_load_history_missing_file_returns_empty(metrics_dir: Path) -> None:
+    """When ``cost.jsonl`` is absent, load_history returns ``[]``."""
+    samples = load_history(metrics_dir / "cost.jsonl", role="backend", adapter="claude")
+    assert samples == []
+
+
+def test_load_history_filters_by_role_and_adapter(metrics_dir: Path) -> None:
+    """Records for other (role, adapter) pairs must be excluded."""
+    history = metrics_dir / "cost.jsonl"
+    _write_history(
+        history,
+        [
+            {"role": "backend", "adapter": "claude", "cost_usd": 1.0},
+            {"role": "backend", "adapter": "codex", "cost_usd": 99.0},  # excluded
+            {"role": "qa", "adapter": "claude", "cost_usd": 99.0},  # excluded
+            {"role": "backend", "adapter": "claude", "cost_usd": 2.0},
+        ],
+    )
+
+    samples = load_history(history, role="backend", adapter="claude")
+    assert samples == [1.0, 2.0]
+
+
+def test_load_history_accepts_cli_and_model_aliases(metrics_dir: Path) -> None:
+    """Adapter id can be carried as ``cli`` or ``model`` when ``adapter`` missing."""
+    history = metrics_dir / "cost.jsonl"
+    _write_history(
+        history,
+        [
+            {"role": "backend", "cli": "claude", "cost_usd": 1.0},
+            {"role": "backend", "model": "claude", "cost_usd": 2.0},
+        ],
+    )
+
+    samples = load_history(history, role="backend", adapter="claude")
+    assert samples == [1.0, 2.0]
+
+
+def test_load_history_skips_invalid_records(metrics_dir: Path) -> None:
+    """Corrupt lines, negative/NaN/non-numeric costs must be silently skipped."""
+    history = metrics_dir / "cost.jsonl"
+    history.write_text(
+        "\n".join(
+            [
+                "not-json",
+                json.dumps({"role": "backend", "adapter": "claude", "cost_usd": -1.0}),
+                json.dumps({"role": "backend", "adapter": "claude", "cost_usd": "NaN"}),
+                json.dumps({"role": "backend", "adapter": "claude", "cost_usd": "oops"}),
+                json.dumps({"role": "backend", "adapter": "claude", "cost_usd": 1.5}),
+                "",
+                json.dumps(["array-not-dict"]),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    samples = load_history(history, role="backend", adapter="claude")
+    assert samples == [1.5]
+
+
+def test_load_history_keeps_only_last_n(metrics_dir: Path) -> None:
+    """When more than ``limit`` samples match, only the tail is kept."""
+    history = metrics_dir / "cost.jsonl"
+    records: list[dict[str, object]] = [
+        {"role": "backend", "adapter": "claude", "cost_usd": float(i)} for i in range(120)
+    ]
+    _write_history(history, records)
+
+    samples = load_history(history, role="backend", adapter="claude", limit=50)
+    assert len(samples) == 50
+    # Newest records win — the last 50 should be 70..119.
+    assert samples[0] == 70.0
+    assert samples[-1] == 119.0
+
+
+# ---------------------------------------------------------------------------
+# compute_band — cold-start
+# ---------------------------------------------------------------------------
+
+
+def test_compute_band_cold_start_falls_back_to_heuristic(metrics_dir: Path) -> None:
+    """No history -> ``cold_start=True`` and the band derives from rate card."""
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+        task_count=4,
+        metrics_dir=metrics_dir,
+    )
+
+    assert band.cold_start is True
+    assert band.samples == 0
+    assert band.p50 > 0.0
+    assert band.p90 >= band.p50
+    # Sonnet at blended $0.009/1k * (4 tasks * 50k tokens) = $1.80
+    assert band.p50 == pytest.approx(1.80, abs=0.01)
+    # 4 * 150 * 0.009 = $5.40
+    assert band.p90 == pytest.approx(5.40, abs=0.01)
+
+
+def test_compute_band_cold_start_label_in_format(metrics_dir: Path) -> None:
+    """``format_band`` appends the cold-start label only when applicable."""
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+        task_count=1,
+        metrics_dir=metrics_dir,
+    )
+    assert "(cold estimate)" in format_band(band)
+
+
+# ---------------------------------------------------------------------------
+# compute_band — mature pair
+# ---------------------------------------------------------------------------
+
+
+def test_compute_band_mature_pair_uses_history(metrics_dir: Path) -> None:
+    """With > 50 samples we sample the percentiles from history, not heuristics."""
+    history = metrics_dir / "cost.jsonl"
+    # 100 deterministic samples 0.01..1.00 -- p50 ~= 0.50, p90 ~= 0.90.
+    records: list[dict[str, object]] = [
+        {"role": "backend", "adapter": "claude", "cost_usd": (i + 1) / 100.0} for i in range(100)
+    ]
+    _write_history(history, records)
+
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+        task_count=99,  # heuristic would dominate; ensure history wins
+        metrics_dir=metrics_dir,
+    )
+
+    assert band.cold_start is False
+    assert band.samples == DEFAULT_HISTORY_LIMIT  # tail of 50
+    # Tail-sampling keeps records 51..100 (cost 0.51..1.00); p50 ~= 0.75,
+    # p90 ~= 0.95.  Round to two decimals as the API contract requires.
+    assert band.p50 == pytest.approx(0.75, abs=0.02)
+    assert band.p90 == pytest.approx(0.95, abs=0.02)
+    assert band.p90 >= band.p50
+
+
+def test_compute_band_p90_never_below_p50(metrics_dir: Path) -> None:
+    """Even with two-sample history, p90 is clamped >= p50."""
+    history = metrics_dir / "cost.jsonl"
+    _write_history(
+        history,
+        [
+            {"role": "backend", "adapter": "claude", "cost_usd": 5.0},
+            {"role": "backend", "adapter": "claude", "cost_usd": 5.0},
+        ],
+    )
+
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+        task_count=1,
+        metrics_dir=metrics_dir,
+    )
+    assert band.p50 == pytest.approx(5.0)
+    assert band.p90 == pytest.approx(5.0)
+    assert band.p90 >= band.p50
+
+
+def test_compute_band_rounds_to_two_decimals(metrics_dir: Path) -> None:
+    """``p50`` and ``p90`` are rounded to two decimal places."""
+    history = metrics_dir / "cost.jsonl"
+    _write_history(
+        history,
+        [{"role": "backend", "adapter": "claude", "cost_usd": 1.23456789} for _ in range(10)],
+    )
+
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+        task_count=1,
+        metrics_dir=metrics_dir,
+    )
+    assert band.p50 == 1.23
+    assert band.p90 == 1.23
+
+
+# ---------------------------------------------------------------------------
+# compute_band — mixed pair
+# ---------------------------------------------------------------------------
+
+
+def test_compute_band_mixed_pair_ignores_other_pairs(metrics_dir: Path) -> None:
+    """A file that mixes pairs only consumes records matching the query."""
+    history = metrics_dir / "cost.jsonl"
+    records: list[dict[str, object]] = []
+    # Heavy noise for the wrong pair.
+    for _ in range(60):
+        records.append({"role": "qa", "adapter": "codex", "cost_usd": 99.0})
+    # Only three matching records — small history, but still > 0 samples.
+    records.extend(
+        [
+            {"role": "backend", "adapter": "claude", "cost_usd": 0.10},
+            {"role": "backend", "adapter": "claude", "cost_usd": 0.20},
+            {"role": "backend", "adapter": "claude", "cost_usd": 0.30},
+        ]
+    )
+    _write_history(history, records)
+
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+        task_count=10,
+        metrics_dir=metrics_dir,
+    )
+
+    assert band.cold_start is False
+    assert band.samples == 3
+    # 99.0 noise must not bleed in.
+    assert band.p90 < 1.0
+    assert band.p50 == pytest.approx(0.20, abs=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Rate card
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_rate_per_1k_known_models() -> None:
+    """Known model identifiers resolve to a positive blended cost."""
+    assert lookup_rate_per_1k("sonnet") > 0.0
+    assert lookup_rate_per_1k("opus") > lookup_rate_per_1k("sonnet")
+
+
+def test_lookup_rate_per_1k_strict_raises_for_unknown() -> None:
+    """``strict=True`` raises :class:`MissingRateCardError` on unknown models."""
+    with pytest.raises(MissingRateCardError):
+        lookup_rate_per_1k("not-a-real-model-2099", strict=True)
+
+
+def test_lookup_rate_per_1k_non_strict_falls_back() -> None:
+    """``strict=False`` (default) returns a safe positive fallback."""
+    rate = lookup_rate_per_1k("not-a-real-model-2099")
+    assert rate > 0.0
+
+
+def test_compute_band_unknown_model_uses_fallback_rate(metrics_dir: Path) -> None:
+    """An unknown model still produces a finite, non-negative band."""
+    band = compute_band(
+        role="backend",
+        adapter="claude",
+        model="some-future-frontier-model",
+        task_count=1,
+        metrics_dir=metrics_dir,
+    )
+    assert band.cold_start is True
+    assert band.p50 >= 0.0
+    assert band.p90 >= band.p50
+
+
+# ---------------------------------------------------------------------------
+# CostBand / format_band shape
+# ---------------------------------------------------------------------------
+
+
+def test_cost_band_is_frozen() -> None:
+    """``CostBand`` is a frozen dataclass."""
+    band = CostBand(
+        p50=1.0,
+        p90=2.0,
+        samples=5,
+        cold_start=False,
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+    )
+    with pytest.raises(AttributeError):
+        band.p50 = 9.0  # type: ignore[misc]
+
+
+def test_format_band_warm_has_no_cold_label() -> None:
+    """Warm band format omits the ``(cold estimate)`` suffix."""
+    band = CostBand(
+        p50=1.0,
+        p90=2.0,
+        samples=5,
+        cold_start=False,
+        role="backend",
+        adapter="claude",
+        model="sonnet",
+    )
+    text = format_band(band)
+    assert "(cold estimate)" not in text
+    assert "p50 $1.00" in text
+    assert "p90 $2.00" in text


### PR DESCRIPTION
## TL;DR

Replaces the single-point preflight cost estimate with a calibrated p50/p90 band sourced from `.sdd/metrics/cost.jsonl` history per `(role, adapter)` pair. Cold-start falls back to the legacy heuristic and is labelled `(cold estimate)`.

## Before / after output

Before:
```
Estimated cost: $1.80-$5.40 based on 4 task(s) at sonnet pricing
```

After (warm pair, 50+ samples):
```
Estimated cost: p50 $0.75, p90 $0.95
based on 4 task(s) at sonnet pricing, 50 historical sample(s)
```

After (cold start):
```
Estimated cost: p50 $1.80, p90 $5.40 (cold estimate)
based on 4 task(s) at sonnet pricing, no history yet -- using heuristic
```

## Changes

- `core/cost/preflight.py` (new): owns the band logic -- `compute_band`, `load_history`, `format_band`, `CostBand`.
- `core/cost/rate_cards.py` (new): single edit point for model pricing; `lookup_rate_per_1k` is the public API used by the cold-start heuristic. Updating prices does not require touching estimator code.
- `cli/run_preflight.py`: thin caller; `RunCostEstimate` gains an optional `band` field for back-compat.
- `cli/run_bootstrap.py`: new `--budget-cap $X` option aborts spawn when preflight p90 > X. Distinct from `--max-cost-usd` (runtime cap).

## Edge cases covered

| Case | Behavior |
|------|----------|
| No `cost.jsonl` | Cold-start, heuristic band, `(cold estimate)` label |
| Missing rate card | Safe fallback ($0.005/1k) or strict `MissingRateCardError` |
| Negative / NaN / non-numeric `cost_usd` | Record skipped |
| Corrupt JSON line | Line skipped |
| Adapter id absent | Accepts `cli` or `model` aliases |
| > 50 matching samples | Tail-sampled (newest wins) |
| Mixed pairs in one file | Only matching pair consumed |
| Two-sample history | `p90` clamped >= `p50` |
| Free adapters (qwen/gemini/ollama) | Zero band, no history read |

## Opt-in: `--budget-cap`

```
bernstein conduct --budget-cap 5.00      # aborts if preflight p90 > $5
```

Off by default. Honours `--auto-approve`. Falls back to `high_usd` when no band is available.

## Test plan

- [x] `uv run pytest tests/unit/test_cost_preflight_v2.py -x` -- 17/17 pass
- [x] `uv run pytest tests/unit/test_run_cmd_track_b.py tests/unit/test_preflight.py` -- back-compat unchanged
- [x] `uv run ruff check` -- clean on touched files
- [x] Pyright -- no new errors on `core/cost/{preflight,rate_cards}.py`; same baseline count on `run_preflight.py`
- [x] Pre-push hooks pass (lint + import-linter + typecheck advisory)

## Constraints honoured

- Pure Python `statistics.quantiles` (no NumPy)
- Round to 2 decimals; never NaN/negative
- Read-only over `.sdd/metrics/cost.jsonl`; no schema migration
- No live API pricing fetch

Closes spec `2026-05-17-feat-cost-preflight-v2` (moved to `.sdd/backlog/done/`).