### PR TITLE
tests: expand property-based coverage (TC-A)

### DIFF
--- a/tests/property/test_atomic_write_properties.py
+++ b/tests/property/test_atomic_write_properties.py
@@ -1,0 +1,257 @@
+"""Property tests for the atomic-write helpers.
+
+``write_atomic_bytes/text/json`` is the crash-safe write primitive used
+by every runtime-state writer in ``.sdd/``. The properties here exist
+to catch regressions that would silently corrupt readers under adverse
+conditions:
+
+* **Round-trip soundness** across every Hypothesis-generated payload
+  (binary, UTF-8 text, JSON values) — readers must always see the
+  exact bytes/text/value the writer was handed.
+
+* **No stale tmp slot leakage** — after any successful write the
+  parent directory must contain only ``path`` itself; the
+  ``.tmp.<pid>.<rand>`` shim file is never visible after replace().
+
+* **Repeat-write convergence** — repeated writes with different
+  payloads on the same path always leave the *last* payload visible,
+  never an intermediate value. Catches accidental write-then-fsync
+  ordering bugs.
+
+* **Concurrent writers do not corrupt readers** — when N threads
+  hammer the same path with distinct payloads, a concurrent reader
+  always observes a fully-formed previous payload, never a torn
+  intermediate. Catches non-atomic rename regressions (e.g. a refactor
+  that swaps ``os.replace`` for ``shutil.move``).
+
+Each property uses small max-example budgets so the file completes in
+under ~10 s on a GitHub-hosted runner.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.atomic_write import (
+    write_atomic_bytes,
+    write_atomic_json,
+    write_atomic_text,
+)
+
+# JSON payload strategy. We use a recursive strategy with bounded depth
+# so Hypothesis explores nested dicts/lists but never blows the stack.
+_JSON_PRIMITIVES = (
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-(2**62), max_value=2**62)
+    # NaN/Inf are intentionally excluded — ``json.dumps`` raises on them
+    # by default. The behaviour is locked elsewhere; here we exercise
+    # the happy path with values that *should* round-trip exactly.
+    | st.floats(allow_nan=False, allow_infinity=False, width=64)
+    | st.text(min_size=0, max_size=32)
+)
+_JSON_VALUES = st.recursive(
+    _JSON_PRIMITIVES,
+    lambda children: st.lists(children, max_size=4)
+    | st.dictionaries(st.text(min_size=1, max_size=8), children, max_size=4),
+    max_leaves=8,
+)
+
+
+@given(payload=st.binary(min_size=0, max_size=4096))
+def test_bytes_round_trip(tmp_path_factory: pytest.TempPathFactory, payload: bytes) -> None:
+    """Round-trip: every byte payload reads back identically.
+
+    Catches regressions where binary mode is silently downgraded to
+    text mode (e.g. ``open(path, 'w')`` instead of ``'wb'``). On
+    Windows the universal-newline translation alone would corrupt any
+    payload containing ``\\n`` or ``\\r`` bytes.
+    """
+    target = tmp_path_factory.mktemp("aw") / "bytes.bin"
+    write_atomic_bytes(target, payload)
+    assert target.read_bytes() == payload
+
+
+@given(text=st.text(min_size=0, max_size=4096))
+def test_text_round_trip_utf8(tmp_path_factory: pytest.TempPathFactory, text: str) -> None:
+    """Round-trip: every UTF-8 representable string reads back identically.
+
+    Covers RTL marks, combining characters, surrogate-pair-equivalent
+    code points (Hypothesis' ``st.text`` excludes lone surrogates by
+    default, which matches the encoder's contract).
+
+    Reads via ``read_bytes().decode()`` rather than ``read_text`` so
+    Python's universal-newline translation does not silently mask a
+    real corruption (``read_text`` rewrites ``\\r`` → ``\\n`` on read).
+    """
+    target = tmp_path_factory.mktemp("aw") / "text.txt"
+    write_atomic_text(target, text)
+    assert target.read_bytes().decode("utf-8") == text
+
+
+@given(payload=_JSON_VALUES)
+def test_json_round_trip(tmp_path_factory: pytest.TempPathFactory, payload: Any) -> None:
+    """Round-trip: every JSON-serialisable value loads back equal.
+
+    Equality is established by re-loading via ``json.loads`` so that
+    incidental int-vs-float drift in JSON (1 == 1.0) is not mistaken
+    for a bug. This catches subtle regressions in the indent/sort_keys
+    forwarding wrapper.
+    """
+    target = tmp_path_factory.mktemp("aw") / "payload.json"
+    write_atomic_json(target, payload)
+    loaded = json.loads(target.read_text())
+    assert loaded == payload
+
+
+@given(payload=st.binary(min_size=0, max_size=512))
+def test_no_tmp_files_left_after_write(
+    tmp_path_factory: pytest.TempPathFactory,
+    payload: bytes,
+) -> None:
+    """Successful writes never leak ``.tmp.<pid>.<rand>`` siblings.
+
+    Long-lived ``.sdd/runtime/`` directories accumulate gigabytes of
+    stale temp files if this invariant breaks. The check is the same
+    as in tests/unit/test_atomic_write.py but lifted to property form
+    so any unicode/empty/large-payload edge case is also exercised.
+    """
+    workdir = tmp_path_factory.mktemp("aw")
+    target = workdir / "state.bin"
+    write_atomic_bytes(target, payload)
+
+    children = sorted(p.name for p in workdir.iterdir())
+    assert children == ["state.bin"]
+
+
+@given(
+    payloads=st.lists(st.binary(min_size=0, max_size=128), min_size=2, max_size=8),
+)
+def test_repeated_writes_converge_to_last(
+    tmp_path_factory: pytest.TempPathFactory,
+    payloads: list[bytes],
+) -> None:
+    """After N sequential writes, only the final payload is visible.
+
+    Catches regressions where ``os.replace`` is performed in the wrong
+    order vs ``fsync`` (a partial write could otherwise resurrect a
+    previous payload on readback). Each example uses a fresh path so
+    we don't accumulate side-state between Hypothesis trials.
+    """
+    target = tmp_path_factory.mktemp("aw") / "state.bin"
+    for payload in payloads:
+        write_atomic_bytes(target, payload)
+    assert target.read_bytes() == payloads[-1]
+
+
+@settings(
+    max_examples=20,
+    deadline=None,  # Threads are slow under CI; deadline would flake.
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    payloads=st.lists(st.binary(min_size=1, max_size=64), min_size=2, max_size=4),
+)
+def test_concurrent_writers_never_corrupt_reader(
+    tmp_path_factory: pytest.TempPathFactory,
+    payloads: list[bytes],
+) -> None:
+    """Concurrent writers + a polling reader: reader sees only whole writes.
+
+    Spawns one writer per payload plus one reader thread. The reader
+    polls the target and records every distinct payload it observes.
+    Every observation must equal one of the inputs verbatim — never
+    a truncated, empty, or interleaved snapshot. This catches
+    regressions that swap ``os.replace`` for a non-atomic write
+    sequence.
+
+    The starting bytes are pre-seeded so the reader's first observation
+    is well-defined and the assertion does not race the very first
+    write.
+    """
+    if len(set(payloads)) < 2:
+        pytest.skip("payloads insufficiently distinct to exercise contention")
+
+    target = tmp_path_factory.mktemp("aw") / "state.bin"
+    # Seed with the first payload so readers always see *something*.
+    write_atomic_bytes(target, payloads[0])
+    valid_payloads = set(payloads)
+
+    stop = threading.Event()
+    observed_corrupt: list[bytes] = []
+    barrier = threading.Barrier(len(payloads) + 1)
+
+    def reader() -> None:
+        barrier.wait()
+        # ~50 polls is enough to catch a torn write with the writer
+        # threads running unopposed. Increasing this further only
+        # increases CI cost.
+        for _ in range(50):
+            try:
+                snap = target.read_bytes()
+            except FileNotFoundError:
+                continue
+            if snap not in valid_payloads:
+                observed_corrupt.append(snap)
+                stop.set()
+                return
+        stop.set()
+
+    def writer(payload: bytes) -> None:
+        barrier.wait()
+        for _ in range(20):
+            write_atomic_bytes(target, payload)
+            if stop.is_set():
+                return
+
+    threads: list[threading.Thread] = [threading.Thread(target=reader, daemon=True)]
+    threads.extend(threading.Thread(target=writer, args=(p,), daemon=True) for p in payloads)
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+        assert not t.is_alive()
+    assert not observed_corrupt, f"reader observed torn payload: {observed_corrupt[:1]!r}"
+
+
+@given(payload=st.binary(min_size=0, max_size=64))
+def test_parent_dir_auto_created(
+    tmp_path_factory: pytest.TempPathFactory,
+    payload: bytes,
+) -> None:
+    """Writing to a path under a missing parent dir creates the parent.
+
+    Documents the existing public contract:
+    ``path.parent.mkdir(parents=True, exist_ok=True)``. A regression
+    that removed the call would surface as a silent FileNotFoundError
+    in every fresh ``.sdd/runtime/`` writer.
+    """
+    deep = tmp_path_factory.mktemp("aw") / "a" / "b" / "c" / "state.bin"
+    write_atomic_bytes(deep, payload)
+    assert deep.read_bytes() == payload
+
+
+@given(text=st.text(min_size=0, max_size=256))
+def test_text_overwrites_larger_existing_file(
+    tmp_path_factory: pytest.TempPathFactory,
+    text: str,
+) -> None:
+    """Replacing a larger file with a smaller payload yields the smaller size.
+
+    A regression that wrote to the destination directly (instead of
+    via the temp + replace path) might end up appending or leaving
+    trailing bytes from the previous payload. This property catches
+    that by overwriting a known-large file with a Hypothesis-chosen
+    (possibly empty) shorter text.
+    """
+    target = tmp_path_factory.mktemp("aw") / "state.txt"
+    target.write_text("X" * 4096, encoding="utf-8")
+    write_atomic_text(target, text)
+    assert target.read_bytes().decode("utf-8") == text

--- a/tests/property/test_audit_unicode_properties.py
+++ b/tests/property/test_audit_unicode_properties.py
@@ -1,0 +1,194 @@
+"""Adversarial-unicode property tests for the HMAC audit log.
+
+The audit log canonicalises every entry via
+``json.dumps(..., sort_keys=True)`` before computing its HMAC. That
+canonicalisation must be byte-stable under:
+
+* RTL / bidi / combining characters in details payloads
+* NUL bytes embedded in strings (JSON allows ``\\u0000`` in strings)
+* Mixed-case unicode normal forms (NFC vs NFD)
+* Deeply nested dict / list structures
+* Numeric edge cases — very large / negative ints
+
+Existing coverage in ``test_audit_chain_bughunt.py`` exercises some
+of these as single fixtures; the properties below are *parametric*
+over Hypothesis-generated payloads so any future regression surfaces
+on the first PR rather than once it lands in production.
+
+The contract under test is: ``log()`` accepts arbitrary unicode in
+``details`` values and ``query()`` returns the deserialised dict
+equal to what was written. Equality is established through a
+``json.dumps`` round-trip on both sides so JSON's int-vs-float
+equivalence does not generate false failures.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.security.audit import AuditLog
+
+# Adversarial unicode pool — RTL marks, combining marks, control codes,
+# unusual scripts. We intentionally exclude surrogate pairs (``Cs``)
+# because Python strings cannot contain lone surrogates and ``st.text``
+# would invent them only via the ``surrogate_pairs_allowed`` flag.
+_ADVERSARIAL = st.one_of(
+    st.text(
+        st.characters(blacklist_categories=("Cs",), min_codepoint=0x20, max_codepoint=0x10FFFF),
+        min_size=0,
+        max_size=64,
+    ),
+    st.sampled_from(
+        [
+            "",  # Empty
+            "‎",  # LRM
+            "‏",  # RLM
+            "‮",  # RLO
+            "\x00",  # NUL inside string
+            "́",  # COMBINING ACUTE ACCENT
+            "﻿",  # ZERO WIDTH NO-BREAK SPACE (BOM)
+            "á",  # decomposed á (NFD)
+            "á",  # composed á (NFC)
+            "\U0001f600",  # emoji
+            "🇺🇸",  # flag (regional indicator pair)
+            "ё" * 32,  # mid-BMP repeat
+            "𒀀" * 8,  # cuneiform — outside BMP
+        ]
+    ),
+)
+
+
+_KEY = st.text(
+    st.characters(blacklist_categories=("Cs",), min_codepoint=0x20, max_codepoint=0x7E),
+    min_size=1,
+    max_size=8,
+)
+
+
+def _new_log() -> AuditLog:
+    tmp = Path(tempfile.mkdtemp(prefix="bernstein-audit-unicode-"))
+    audit_dir = tmp / "audit"
+    audit_dir.mkdir()
+    key_path = tmp / "audit.key"
+    key_path.write_bytes(b"hypothesis-fuzz-key-32-bytes-padding-pad")
+    key_path.chmod(0o600)
+    return AuditLog(audit_dir=audit_dir, key_path=key_path)
+
+
+@settings(
+    max_examples=40,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    payloads=st.lists(
+        st.dictionaries(_KEY, _ADVERSARIAL, max_size=4),
+        min_size=1,
+        max_size=4,
+    ),
+)
+def test_adversarial_unicode_chain_verifies(payloads: list[dict[str, Any]]) -> None:
+    """Arbitrary-unicode details still produce a verifiable chain.
+
+    Catches regressions where ``json.dumps`` is called without
+    ``ensure_ascii=True`` on one side and with it on the other — the
+    HMAC would then differ between writer and verifier on any non-ASCII
+    string, breaking every chain that touches an emoji or RTL mark.
+    """
+    log = _new_log()
+    for d in payloads:
+        log.log("evt", "actor", "task", "rid", d)
+    valid, errors = log.verify()
+    assert valid, f"unicode chain rejected itself: {errors}"
+
+
+@settings(
+    max_examples=40,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    payloads=st.lists(
+        st.dictionaries(_KEY, _ADVERSARIAL, max_size=4),
+        min_size=1,
+        max_size=4,
+    ),
+)
+def test_adversarial_unicode_query_round_trips(payloads: list[dict[str, Any]]) -> None:
+    """``query()`` returns details equal to what was written.
+
+    Compares both via direct equality and via a JSON round-trip on each
+    side; either would fail if the writer canonicalises differently
+    than the reader expects.
+    """
+    log = _new_log()
+    for d in payloads:
+        log.log("evt", "actor", "task", "rid", d)
+
+    rows = log.query()
+    assert len(rows) == len(payloads)
+    for source, persisted in zip(payloads, rows, strict=False):
+        assert source == persisted.details, (
+            f"direct equality failed: source={source!r} persisted={persisted.details!r}"
+        )
+        assert json.loads(json.dumps(source, sort_keys=True)) == json.loads(
+            json.dumps(persisted.details, sort_keys=True),
+        )
+
+
+@settings(
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    depth=st.integers(min_value=1, max_value=8),
+)
+def test_deeply_nested_details_chain(depth: int) -> None:
+    """Nested dict payloads up to depth 8 still produce a verifiable chain.
+
+    Catches recursion-bomb regressions in the canonicalisation path
+    (e.g. an accidental ``json.dumps(..., indent=2)`` that explodes the
+    payload size). 8 is well within Python's default recursion limit;
+    the property is about *correctness* not *DoS resistance*.
+    """
+    payload: dict[str, Any] = {"leaf": True}
+    for i in range(depth):
+        payload = {f"level_{i}": payload}
+
+    log = _new_log()
+    log.log("evt", "actor", "task", "rid", payload)
+    valid, errors = log.verify()
+    assert valid, f"nested-depth chain rejected itself: {errors}"
+
+    rows = log.query()
+    assert rows[0].details == payload
+
+
+@settings(
+    max_examples=40,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    big_int=st.integers(min_value=-(2**64), max_value=2**64),
+    long_str=st.text(min_size=0, max_size=256),
+)
+def test_extreme_numeric_and_string_values(big_int: int, long_str: str) -> None:
+    """Large-magnitude integers and long strings round-trip cleanly.
+
+    JSON encodes Python ints with arbitrary precision; this property
+    guards against an accidental ``float`` coercion in a canonicaliser
+    refactor that would corrupt every entry with a 17+ digit integer.
+    """
+    log = _new_log()
+    log.log("evt", "a", "task", "rid", {"big": big_int, "text": long_str})
+
+    valid, errors = log.verify()
+    assert valid, errors
+
+    rows = log.query()
+    assert rows[0].details["big"] == big_int
+    assert rows[0].details["text"] == long_str

--- a/tests/property/test_cas_store_properties.py
+++ b/tests/property/test_cas_store_properties.py
@@ -1,0 +1,171 @@
+"""Property tests for the content-addressed-storage (CAS) store.
+
+The CAS store is the deduplication primitive backing artefact storage.
+A regression here either silently drops content (data loss) or causes
+hash collisions on benign inputs (correctness bug). Properties:
+
+* **put-then-get round-trip** — any byte payload stored under its
+  digest reads back identically.
+
+* **Digest is content-determined** — two stores of the same bytes
+  yield the same digest; two stores of distinct bytes yield distinct
+  digests. The first is the contract the orchestrator relies on for
+  deduplication; the second is the no-collision-on-benign-input
+  guarantee.
+
+* **Digest validates as 64 hex chars** — the producer must always
+  emit a value the validator accepts. A drift here would cause
+  read paths to refuse to serve content that the write path just
+  stored.
+
+* **Path-traversal digests are rejected by ``get``** — feeding a
+  ``../../etc/passwd``-style string into the digest API must raise
+  ``ValueError`` before any filesystem call. This is a defence-in-
+  depth check on the CAS root.
+
+* **Repeated puts dedup correctly** — the second put of an
+  identical payload increments the dedup counter and does not touch
+  the blob on disk.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.cas_store import CASStore
+
+_HEX_64 = re.compile(r"\A[0-9a-f]{64}\Z")
+
+
+@given(content=st.binary(min_size=0, max_size=4096))
+def test_put_get_round_trip(tmp_path_factory: pytest.TempPathFactory, content: bytes) -> None:
+    """``cas.get(cas.put(content)) == content`` for any byte payload.
+
+    The single most important CAS invariant: a write is never lost,
+    truncated, or rewritten on read. Catches regressions where the
+    blob path is computed from a stale digest.
+    """
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    digest = store.put(content)
+    assert store.get(digest) == content
+
+
+@given(content=st.binary(min_size=0, max_size=512))
+def test_digest_matches_sha256(tmp_path_factory: pytest.TempPathFactory, content: bytes) -> None:
+    """The returned digest equals ``sha256(content).hexdigest()``.
+
+    The CAS digest scheme is the public contract for cross-process
+    deduplication. A regression that switched algorithms would
+    silently double every stored artefact.
+    """
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    digest = store.put(content)
+    assert digest == hashlib.sha256(content).hexdigest()
+    assert _HEX_64.match(digest)
+
+
+@given(content=st.binary(min_size=0, max_size=512))
+def test_dedup_on_repeated_put(tmp_path_factory: pytest.TempPathFactory, content: bytes) -> None:
+    """A second put of the same payload returns the same digest and dedups.
+
+    Catches regressions where ``has(digest)`` is computed against a
+    different shard layout (e.g. after a refactor of ``_blob_path``).
+    Such a drift would silently double-store everything.
+    """
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    d1 = store.put(content)
+    d2 = store.put(content)
+    assert d1 == d2
+    stats = store.stats()
+    # one effective store, one dedup save
+    assert stats.total_entries == 1
+    assert stats.dedup_saves == 1
+
+
+@given(
+    a=st.binary(min_size=1, max_size=128),
+    b=st.binary(min_size=1, max_size=128),
+)
+def test_distinct_content_distinct_digests(
+    tmp_path_factory: pytest.TempPathFactory,
+    a: bytes,
+    b: bytes,
+) -> None:
+    """Distinct payloads yield distinct digests.
+
+    With SHA-256 a collision is cryptographically impossible at our
+    payload sizes; the property asserts the obvious correctness
+    invariant so any future swap to a non-cryptographic hash is
+    caught immediately.
+    """
+    if a == b:
+        pytest.skip("identical payloads")
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    assert store.put(a) != store.put(b)
+
+
+@given(
+    bogus=st.text(
+        alphabet=st.characters(
+            min_codepoint=ord("a"),
+            max_codepoint=ord("z"),
+        ),
+        min_size=0,
+        max_size=80,
+    ),
+)
+def test_invalid_digest_string_rejected(tmp_path_factory: pytest.TempPathFactory, bogus: str) -> None:
+    """Any non-hex-64 digest string raises ``ValueError`` before disk access.
+
+    Defence-in-depth: a digest derived from operator input that
+    contains ``../`` would otherwise escape the CAS root. The validator
+    rejects anything that does not match the strict regex.
+    """
+    if _HEX_64.match(bogus):
+        pytest.skip("Hypothesis generated a valid-looking digest")
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    with pytest.raises(ValueError, match="Invalid CAS digest"):
+        store.delete(bogus)
+
+
+@settings(
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(payloads=st.lists(st.binary(min_size=1, max_size=64), min_size=1, max_size=8))
+def test_list_entries_matches_stored_digests(
+    tmp_path_factory: pytest.TempPathFactory,
+    payloads: list[bytes],
+) -> None:
+    """``list_entries`` enumerates exactly the unique stored digests.
+
+    Pins the contract used by the disaster-recovery audit tool. A
+    regression here would silently exclude valid blobs from the
+    recovery manifest.
+    """
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    expected: set[str] = set()
+    for p in payloads:
+        expected.add(store.put(p))
+    listed = {e.digest for e in store.list_entries()}
+    assert listed == expected
+
+
+@given(content=st.binary(min_size=1, max_size=128))
+def test_get_returns_none_for_unknown_digest(tmp_path_factory: pytest.TempPathFactory, content: bytes) -> None:
+    """``get`` on an unwritten digest returns ``None``, never raises.
+
+    Catches regressions where ``read_bytes`` is called unconditionally
+    and surfaces ``FileNotFoundError`` to the caller. The CAS contract
+    is a soft miss for read paths.
+    """
+    store = CASStore(tmp_path_factory.mktemp("cas"))
+    digest = hashlib.sha256(content).hexdigest()
+    # Don't put — the digest is unknown to the store.
+    assert store.get(digest) is None
+    assert not store.has(digest)

--- a/tests/property/test_duration_parse_properties.py
+++ b/tests/property/test_duration_parse_properties.py
@@ -1,0 +1,158 @@
+"""Property tests for ``bernstein.core.preview.manager.parse_duration``.
+
+The ``--expire`` flag on ``bernstein preview`` accepts compact duration
+strings (``"30m"``, ``"4h"``, ``"3600"``). The parser is shared
+machinery, but the input surface is user-supplied — adversarial values
+are realistic. Properties:
+
+* **Suffix arithmetic is correct** — ``"<n>m"`` always parses to
+  ``n * 60``, ``"<n>h"`` to ``n * 3600``, etc. Catches off-by-one
+  regressions in ``_DURATION_UNITS``.
+
+* **Whitespace and casing are normalised** — ``"  30M  "`` parses
+  identically to ``"30m"``. The production CLI strips and lowercases;
+  this property locks the contract.
+
+* **Zero / negative values are rejected** — the parser must raise
+  ``ValueError`` rather than return ``0`` (which would mean
+  "never-expiring" elsewhere and is a security footgun).
+
+* **Numeric inputs (int / float / numeric string) agree** —
+  ``parse_duration(60)`` == ``parse_duration("60")`` == 60. Catches
+  type-dispatch regressions where the str branch handled ``"60s"``
+  differently from the numeric branch handling ``60``.
+
+* **Invalid suffixes raise** — anything outside ``[s, m, h, d]``
+  surfaces ValueError. Catches over-permissive regex changes.
+
+Hypothesis budget per property is the default smoke profile (50
+examples); the parser is pure-Python and microsecond-fast, so no
+deadline tuning is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.core.preview.manager import parse_duration
+
+# Suffix → seconds-per-unit lookup; the parser keeps the same map
+# internally. We duplicate it here so any drift between source and
+# tests is surfaced as a property failure (rather than passing because
+# the test imports the constant).
+_UNIT_SECONDS = {"s": 1, "m": 60, "h": 3600, "d": 86_400}
+
+
+@given(
+    n=st.integers(min_value=1, max_value=10_000),
+    unit=st.sampled_from(list(_UNIT_SECONDS)),
+)
+def test_suffix_arithmetic(n: int, unit: str) -> None:
+    """``"<n><unit>"`` always parses to ``n * seconds_per_unit``."""
+    assert parse_duration(f"{n}{unit}") == n * _UNIT_SECONDS[unit]
+
+
+@given(n=st.integers(min_value=1, max_value=10_000))
+def test_bare_number_is_seconds(n: int) -> None:
+    """A bare digit string is interpreted as seconds.
+
+    Catches a regression where the parser would default to a different
+    unit (e.g. minutes) when the suffix is absent — which would silently
+    extend or shrink every operator-supplied TTL by 60x.
+    """
+    assert parse_duration(str(n)) == n
+
+
+@given(
+    n=st.integers(min_value=1, max_value=10_000),
+    unit=st.sampled_from(list(_UNIT_SECONDS)),
+    pad_left=st.text(alphabet=" \t", max_size=4),
+    pad_right=st.text(alphabet=" \t", max_size=4),
+    uppercase=st.booleans(),
+)
+def test_whitespace_and_case_normalised(
+    n: int,
+    unit: str,
+    pad_left: str,
+    pad_right: str,
+    uppercase: bool,
+) -> None:
+    """Whitespace and casing are stripped before parsing."""
+    suffix = unit.upper() if uppercase else unit
+    spec = f"{pad_left}{n}{suffix}{pad_right}"
+    assert parse_duration(spec) == n * _UNIT_SECONDS[unit]
+
+
+@given(n=st.integers(max_value=0))
+def test_zero_or_negative_int_rejected(n: int) -> None:
+    """Zero / negative integers must raise ``ValueError``.
+
+    A returned ``0`` would mean "never expire" downstream in the share
+    link issuer — a security regression that the parser must refuse to
+    surface.
+    """
+    with pytest.raises(ValueError, match="duration must be > 0"):
+        parse_duration(n)
+
+
+@given(n=st.integers(min_value=1, max_value=10_000))
+def test_int_and_str_agree(n: int) -> None:
+    """``parse_duration(n)`` and ``parse_duration(str(n))`` agree."""
+    assert parse_duration(n) == parse_duration(str(n))
+
+
+@given(
+    suffix=st.text(
+        alphabet=st.characters(
+            min_codepoint=ord("a"),
+            max_codepoint=ord("z"),
+            blacklist_characters=tuple(_UNIT_SECONDS),
+        ),
+        min_size=1,
+        max_size=4,
+    ),
+    n=st.integers(min_value=1, max_value=100),
+)
+def test_invalid_suffix_raises(suffix: str, n: int) -> None:
+    """Any non-``s/m/h/d`` suffix must raise ``ValueError``.
+
+    The parser's regex is ``(\\d+)([smhd]?)``; this property guards
+    against an accidental loosening to ``[a-z]*`` (which would silently
+    treat ``"5x"`` as seconds and confuse operators).
+    """
+    with pytest.raises(ValueError, match="invalid duration spec"):
+        parse_duration(f"{n}{suffix}")
+
+
+@given(
+    spec=st.one_of(
+        st.text(min_size=1, max_size=8).filter(lambda s: not s.strip().isdigit()),
+        st.just("-5m"),
+        st.just("5.5m"),
+    ),
+)
+def test_garbage_strings_reject_cleanly(spec: str) -> None:
+    """Free-form garbage strings either parse correctly or raise.
+
+    The contract is: never silently return a misleading value. Either
+    the regex matches and the arithmetic is computed (in which case
+    the returned int must be positive) or ``ValueError`` is raised.
+    """
+    try:
+        result = parse_duration(spec)
+    except ValueError:
+        return
+    assert isinstance(result, int)
+    assert result > 0
+
+
+def test_none_returns_default() -> None:
+    """``None`` and empty string fall back to the default arg.
+
+    Pinned via a regular unit-style assertion because the property is
+    over a 2-element input space.
+    """
+    assert parse_duration(None, default=42) == 42
+    assert parse_duration("", default=42) == 42

--- a/tests/property/test_file_locks_properties.py
+++ b/tests/property/test_file_locks_properties.py
@@ -1,0 +1,253 @@
+"""Property tests for ``FileLockManager`` contention semantics.
+
+The lock manager mediates concurrent agent file ownership. Bugs here
+result in two agents simultaneously editing the same file — silent
+data corruption with no immediate signal. Properties:
+
+* **Acquire is exclusive across agents** — for any random sequence
+  of acquires from distinct agents, no file ends up held by more than
+  one agent simultaneously.
+
+* **Acquire is idempotent for the same agent** — repeated acquires
+  by the same agent for overlapping file sets are silently accepted
+  and do not deadlock or drop locks.
+
+* **Release purges everything for that agent** — after a release,
+  zero locks attributed to that agent remain in the table.
+
+* **Concurrent acquire/release converges to a consistent state**
+  under thread contention: the total set of locked files in the
+  table is a subset of the union of all attempted acquires, and
+  every lock has exactly one agent owner.
+
+The threaded property uses small example budgets (20 examples × 4
+agents) to keep CI wall-time predictable; the existing
+``test_claim_next_properties.py`` precedent is dialed to a similar
+budget.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.file_locks import FileLockManager
+
+# Compact alphabets so generated files / agent ids are stable and
+# obviously distinct under shrinking.
+_FILE = st.text(
+    alphabet=st.characters(min_codepoint=ord("a"), max_codepoint=ord("h")),
+    min_size=1,
+    max_size=4,
+)
+_AGENT = st.text(
+    alphabet=st.characters(min_codepoint=ord("A"), max_codepoint=ord("D")),
+    min_size=1,
+    max_size=2,
+)
+
+
+@given(
+    requests=st.lists(
+        st.tuples(_AGENT, st.lists(_FILE, min_size=1, max_size=4, unique=True)),
+        min_size=1,
+        max_size=10,
+    ),
+)
+def test_no_two_agents_hold_same_file(tmp_path_factory: pytest.TempPathFactory, requests: list[tuple[str, list[str]]]) -> None:
+    """For any sequence of acquires, each file ends up held by ≤ 1 agent.
+
+    The lock manager's primary invariant. A failure means two agents
+    could both run with the same file in their owned set — silent data
+    corruption when both spawn editors.
+    """
+    workdir = tmp_path_factory.mktemp("flock-prop")
+    mgr = FileLockManager(workdir)
+
+    for i, (agent, files) in enumerate(requests):
+        mgr.acquire(files, agent_id=agent, task_id=f"t-{i}")
+
+    # All currently-held locks: at most one agent per file.
+    owners: dict[str, str] = {}
+    for lock in mgr.all_locks():
+        assert lock.file_path not in owners or owners[lock.file_path] == lock.agent_id, (
+            f"file {lock.file_path} held by two agents"
+        )
+        owners[lock.file_path] = lock.agent_id
+
+
+@given(
+    agent=_AGENT,
+    rounds=st.lists(
+        st.lists(_FILE, min_size=1, max_size=3, unique=True),
+        min_size=2,
+        max_size=5,
+    ),
+)
+def test_same_agent_acquire_is_idempotent(
+    tmp_path_factory: pytest.TempPathFactory,
+    agent: str,
+    rounds: list[list[str]],
+) -> None:
+    """Repeated acquires by the same agent never produce conflicts.
+
+    The manager treats same-agent re-acquires as silent idempotents.
+    If a refactor accidentally treated them as conflicts, the
+    orchestrator would deadlock on every retry.
+    """
+    workdir = tmp_path_factory.mktemp("flock-prop")
+    mgr = FileLockManager(workdir)
+
+    union: set[str] = set()
+    for i, files in enumerate(rounds):
+        conflicts = mgr.acquire(files, agent_id=agent, task_id=f"t-{i}")
+        assert conflicts == []
+        union.update(files)
+
+    held = {lock.file_path for lock in mgr.locks_for_agent(agent)}
+    assert held == union
+
+
+@given(
+    agent_a=_AGENT,
+    agent_b=_AGENT.filter(lambda a: True),
+    files=st.lists(_FILE, min_size=1, max_size=3, unique=True),
+)
+def test_cross_agent_acquire_reports_conflicts(
+    tmp_path_factory: pytest.TempPathFactory,
+    agent_a: str,
+    agent_b: str,
+    files: list[str],
+) -> None:
+    """Re-acquiring a file held by a different agent surfaces a conflict.
+
+    Without this, two agents could silently spawn against the same
+    file. The property exercises the exact branch where ``acquire``
+    has to differentiate by ``agent_id`` rather than just key presence.
+    """
+    if agent_a == agent_b:
+        pytest.skip("identical agents — conflict path is not exercised")
+
+    workdir = tmp_path_factory.mktemp("flock-prop")
+    mgr = FileLockManager(workdir)
+    mgr.acquire(files, agent_id=agent_a, task_id="t-a")
+    conflicts = mgr.acquire(files, agent_id=agent_b, task_id="t-b")
+    assert set(conflicts) == set(files)
+
+
+@given(
+    agent=_AGENT,
+    files=st.lists(_FILE, min_size=1, max_size=5, unique=True),
+)
+def test_release_purges_all_locks(
+    tmp_path_factory: pytest.TempPathFactory,
+    agent: str,
+    files: list[str],
+) -> None:
+    """After ``release(agent)`` zero locks remain for that agent.
+
+    Catches regressions where ``release`` skips locks whose
+    ``locked_at`` is in the future (clock skew) or whose path
+    contains separator-like characters.
+    """
+    workdir = tmp_path_factory.mktemp("flock-prop")
+    mgr = FileLockManager(workdir)
+    mgr.acquire(files, agent_id=agent, task_id="t")
+    released = mgr.release(agent)
+    assert set(released) == set(files)
+    assert mgr.locks_for_agent(agent) == []
+
+
+@settings(
+    max_examples=10,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    agents=st.lists(_AGENT, min_size=2, max_size=4, unique=True),
+    files=st.lists(_FILE, min_size=2, max_size=5, unique=True),
+)
+def test_concurrent_acquire_release_converges(
+    tmp_path_factory: pytest.TempPathFactory,
+    agents: list[str],
+    files: list[str],
+) -> None:
+    """N agents acquiring/releasing in parallel leave a consistent table.
+
+    The cross-process OS lock plus the in-process threading.Lock must
+    serialize state mutations. The property asserts:
+
+      * No file is held by more than one agent simultaneously.
+      * After all workers finish their release pass, the table is empty.
+
+    A regression that drops either lock would surface either as a
+    duplicate-owner observation or a stale entry remaining after
+    every worker has released.
+    """
+    workdir = tmp_path_factory.mktemp("flock-prop")
+    mgr = FileLockManager(workdir)
+
+    barrier = threading.Barrier(len(agents))
+
+    def worker(agent: str) -> None:
+        barrier.wait()
+        for _ in range(8):
+            mgr.acquire(files, agent_id=agent, task_id=f"{agent}-t")
+            mgr.release(agent)
+
+    threads = [threading.Thread(target=worker, args=(a,), daemon=True) for a in agents]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+        assert not t.is_alive()
+
+    # Final state: empty (every worker ends on release).
+    final = mgr.all_locks()
+    assert final == [], f"stale locks remain after release pass: {final}"
+
+
+@given(
+    agent=_AGENT,
+    files=st.lists(_FILE, min_size=1, max_size=3, unique=True),
+)
+def test_persistence_survives_reinitialisation(
+    tmp_path_factory: pytest.TempPathFactory,
+    agent: str,
+    files: list[str],
+) -> None:
+    """Locks survive a fresh FileLockManager re-init in the same workdir.
+
+    The manager mirrors state to ``file_locks.json`` so the orchestrator
+    can resume after a restart. A regression that broke ``_load`` would
+    silently drop every lock on restart and let a second agent run
+    against the same file. The property pins the resume contract.
+    """
+    workdir = tmp_path_factory.mktemp("flock-prop")
+    mgr1 = FileLockManager(workdir)
+    mgr1.acquire(files, agent_id=agent, task_id="t")
+
+    # Simulate a process restart: build a fresh manager in the same dir.
+    mgr2 = FileLockManager(workdir)
+    held = {lock.file_path for lock in mgr2.locks_for_agent(agent)}
+    assert held == set(files)
+
+
+def test_lock_file_uses_atomic_write(tmp_path: Path) -> None:
+    """Sanity check that no ``.tmp.*`` debris is left in runtime dir.
+
+    Pinned because the input space is fixed. Locks the contract that
+    persistence is routed via ``write_atomic_json`` (and therefore
+    leaves no stale temp file in the locks directory).
+    """
+    mgr = FileLockManager(tmp_path)
+    mgr.acquire(["a.py"], agent_id="aa", task_id="t")
+
+    runtime_dir = tmp_path / ".sdd" / "runtime"
+    children = list(runtime_dir.iterdir())
+    tmp_files = [c for c in children if ".tmp." in c.name]
+    assert tmp_files == []

--- a/tests/property/test_fingerprint_properties.py
+++ b/tests/property/test_fingerprint_properties.py
@@ -1,0 +1,178 @@
+"""Property tests for the action-cache ``fingerprint`` primitive.
+
+``fingerprint(fn, *args, **kwargs)`` is the cache-key generator for
+the orchestrator's memoised function calls. Determinism here is
+load-bearing: when ``PYTHONHASHSEED`` varies across workers, two
+processes computing the same fingerprint must agree on the bytes, or
+every cache lookup misses and the orchestrator's cost-saving
+guarantees evaporate.
+
+Properties:
+
+* **Determinism across calls** — two calls with the same args / kwargs
+  produce the same digest.
+
+* **Order independence for kwargs** — kwargs are sorted; supplying
+  them in any order produces the same digest.
+
+* **Set / frozenset member-order independence** — the canonicaliser
+  sorts set members by repr so processes with different hash seeds
+  agree. Without this, action-cache hit rate plummets to ~0% across
+  workers.
+
+* **Distinct args → distinct digests** — at least for primitive
+  scalars and obviously-different containers, the digest discriminates.
+  A regression that collapses everything to the same digest would
+  serve stale cached values to every caller.
+
+* **Digest length is 32 bytes** — the ``_DIGEST_BYTES = 32`` invariant
+  is part of the on-disk format; a change would corrupt every existing
+  ``MemoStore`` entry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.fingerprint import fingerprint
+
+# JSON-friendly primitives. Restricting floats to non-NaN keeps the
+# property well-defined (NaN != NaN under ``==``).
+_SCALAR = (
+    st.none()
+    | st.booleans()
+    | st.integers(min_value=-(2**40), max_value=2**40)
+    | st.floats(allow_nan=False, allow_infinity=False, width=64)
+    | st.text(min_size=0, max_size=16)
+)
+
+
+def _sample_fn(*args: Any, **kwargs: Any) -> str:
+    """Stand-in for the memoised target.
+
+    Pure function so the AST/source caching path is exercised once.
+    """
+    return f"args={args} kwargs={sorted(kwargs.items())}"
+
+
+@given(args=st.lists(_SCALAR, max_size=5), kwargs=st.dictionaries(st.text(min_size=1, max_size=4), _SCALAR, max_size=5))
+def test_fingerprint_deterministic(args: list[Any], kwargs: dict[str, Any]) -> None:
+    """Two calls with the same inputs produce the same digest.
+
+    The minimum bar for a cache key. Catches accidental insertion of
+    a clock read, random seed, or other non-pure input into the digest
+    computation.
+    """
+    a = fingerprint(_sample_fn, *args, **kwargs)
+    b = fingerprint(_sample_fn, *args, **kwargs)
+    assert a == b
+
+
+@given(
+    kwargs=st.dictionaries(
+        st.text(min_size=1, max_size=4),
+        _SCALAR,
+        min_size=2,
+        max_size=5,
+    ),
+)
+def test_kwargs_order_does_not_change_digest(kwargs: dict[str, Any]) -> None:
+    """Kwargs are sorted; presenting them in reverse order is equivalent.
+
+    Catches regressions in the kwargs sort step. Without sorting, two
+    Python versions or even two dict literal orderings would produce
+    different digests for equivalent calls.
+    """
+    reversed_kwargs = dict(reversed(list(kwargs.items())))
+    a = fingerprint(_sample_fn, **kwargs)
+    b = fingerprint(_sample_fn, **reversed_kwargs)
+    assert a == b
+
+
+@given(args=st.lists(_SCALAR, max_size=4))
+def test_digest_length(args: list[Any]) -> None:
+    """Every digest is exactly 32 bytes long.
+
+    Pins the on-disk format invariant. A change would corrupt every
+    existing MemoStore entry.
+    """
+    fp = fingerprint(_sample_fn, *args)
+    assert isinstance(fp, bytes)
+    assert len(fp) == 32
+
+
+@given(a=st.integers(min_value=-1000, max_value=1000), b=st.integers(min_value=-1000, max_value=1000))
+def test_distinct_int_args_distinct_digests(a: int, b: int) -> None:
+    """Two distinct int args yield distinct digests.
+
+    Sanity discriminator. A regression that produced the same digest
+    for all numeric inputs would silently return the same cached value
+    for every memoised call.
+    """
+    if a == b:
+        return
+    fa = fingerprint(_sample_fn, a)
+    fb = fingerprint(_sample_fn, b)
+    assert fa != fb
+
+
+@given(
+    members=st.frozensets(
+        st.integers(min_value=-100, max_value=100),
+        min_size=1,
+        max_size=8,
+    ),
+)
+def test_set_member_order_does_not_affect_digest(members: frozenset[int]) -> None:
+    """A ``frozenset`` arg yields the same digest regardless of insertion order.
+
+    The canonicaliser sorts set members by repr to compensate for
+    Python's hash randomisation. Without it, two workers spawned with
+    different ``PYTHONHASHSEED`` would compute different fingerprints
+    for the same set arg — destroying cache hit rate across the fleet.
+    """
+    listed = list(members)
+    reordered = frozenset(reversed(listed))
+    a = fingerprint(_sample_fn, members)
+    b = fingerprint(_sample_fn, reordered)
+    assert a == b
+
+
+@given(
+    payload=st.dictionaries(
+        st.text(min_size=1, max_size=4),
+        st.frozensets(st.integers(min_value=-100, max_value=100), max_size=4),
+        min_size=1,
+        max_size=4,
+    ),
+)
+def test_nested_set_in_dict_is_canonical(payload: dict[str, frozenset[int]]) -> None:
+    """A dict-of-sets canonicalises recursively.
+
+    Catches regressions where the canonicaliser stops at the first
+    level of a nested structure. Without recursion, nested sets keep
+    their hash-randomised order and the digest drifts between workers.
+    """
+    a = fingerprint(_sample_fn, payload)
+    # Build an equivalent payload with the inner sets reconstructed
+    # from a reversed list. Functionally identical; ordering different
+    # in CPython internals.
+    rebuilt = {k: frozenset(reversed(list(v))) for k, v in payload.items()}
+    b = fingerprint(_sample_fn, rebuilt)
+    assert a == b
+
+
+@given(arg=_SCALAR)
+def test_pos_arg_vs_kwarg_disambiguated(arg: Any) -> None:
+    """A value passed positionally differs from the same value as a kwarg.
+
+    Documents the calling-convention contract. A regression that
+    collapsed positional and keyword arguments into the same canonical
+    form would let two different function calls share a cache slot.
+    """
+    fa = fingerprint(_sample_fn, arg)
+    fb = fingerprint(_sample_fn, x=arg)
+    assert fa != fb

--- a/tests/property/test_iso_timestamp_properties.py
+++ b/tests/property/test_iso_timestamp_properties.py
@@ -1,0 +1,136 @@
+"""Property tests for ISO-8601 timestamp parsing helpers.
+
+Several modules parse operator-supplied or self-emitted ISO timestamps:
+
+* ``bernstein.core.security.article12_bundle._parse_iso`` — accepts
+  ``"Z"``-suffixed strings (the audit log's emission format) by
+  normalising to ``"+00:00"`` before delegation to
+  ``datetime.fromisoformat``.
+
+* ``bernstein.core.agents.heartbeat`` — same normalisation pattern.
+
+* ``bernstein.core.orchestration.run_changelog`` — same.
+
+A regression in any of these (dropped ``Z`` handling, accidental
+``%S`` truncation) silently shifts timestamps by hours or rejects
+the audit log's own output. The properties here pin the contract:
+
+* **``Z`` suffix is equivalent to ``+00:00``** for every UTC instant.
+* **Round-trip through ``isoformat`` + ``_parse_iso`` is the identity**.
+* **The audit log's literal emission format parses cleanly**.
+* **Timezone-aware datetimes survive the parser without dropping
+  tzinfo** — a regression would interpret persisted UTC as local
+  time, an hours-magnitude bug.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.core.security.article12_bundle import _parse_iso
+
+# Restrict to a wide but reasonable epoch window so Hypothesis explores
+# DST boundaries, leap days, and unusual months without ever hitting
+# the ``datetime.MAX`` overflow or the pre-1970 zoneinfo gaps.
+_DATETIMES = st.datetimes(
+    min_value=datetime(1990, 1, 1),
+    max_value=datetime(2099, 12, 31, 23, 59, 59),
+    timezones=st.just(UTC),
+)
+
+
+@given(dt=_DATETIMES)
+def test_z_suffix_equals_plus_zero(dt: datetime) -> None:
+    """``"...Z"`` parses to the same instant as ``"...+00:00"``.
+
+    The audit log emits its timestamps with a literal ``Z`` suffix;
+    if ``_parse_iso`` ever dropped the normalisation step, every
+    audit-export bundle generation would shift those timestamps to
+    naive (local-zone-interpreted) datetimes — a silent hours-scale
+    drift in compliance reports.
+    """
+    iso_z = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    iso_plus = dt.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
+    assert _parse_iso(iso_z) == _parse_iso(iso_plus)
+
+
+@given(dt=_DATETIMES)
+def test_round_trip_isoformat(dt: datetime) -> None:
+    """``_parse_iso(dt.isoformat())`` equals ``dt``.
+
+    Catches regressions where the parser drops microseconds (which
+    would shift up to a second per parse — too small for unit tests
+    to notice but a real bug in chronological event ordering).
+    """
+    iso = dt.isoformat()
+    parsed = _parse_iso(iso)
+    assert parsed == dt
+
+
+@given(dt=_DATETIMES)
+def test_audit_log_emission_format_parses(dt: datetime) -> None:
+    """The exact format the audit log writes is parseable.
+
+    The audit log produces ``%Y-%m-%dT%H:%M:%S.%fZ``. If the parser
+    couldn't accept that format, every audit export bundle generation
+    would crash on its own input — a CI-time regression worth catching
+    before it merges.
+    """
+    audit_format = dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    parsed = _parse_iso(audit_format)
+    assert parsed.tzinfo is not None  # tzinfo preserved
+    assert parsed.replace(microsecond=dt.microsecond) == dt
+
+
+@given(
+    dt=_DATETIMES,
+    offset_hours=st.integers(min_value=-12, max_value=14),
+)
+def test_nonzero_offset_preserved(dt: datetime, offset_hours: int) -> None:
+    """Non-UTC offsets survive the parser without being normalised away.
+
+    Operator-supplied timestamps may come from any tz; if the parser
+    normalised everything to UTC, downstream ``< since`` /
+    ``< until`` comparisons against UTC-emitted audit lines would
+    misclassify events near the boundary.
+    """
+    tz = timezone(timedelta(hours=offset_hours))
+    shifted = dt.astimezone(tz)
+    iso = shifted.isoformat()
+    parsed = _parse_iso(iso)
+    assert parsed == shifted
+    # The instant is the same; the tzinfo may be normalised — only
+    # the absolute UTC moment is the load-bearing contract.
+    assert parsed.utcoffset() == timedelta(hours=offset_hours)
+
+
+@given(dt=_DATETIMES)
+def test_seconds_precision_round_trip(dt: datetime) -> None:
+    """Round-trip without microseconds still preserves the instant.
+
+    The audit log strips microseconds for some compatibility paths
+    (e.g. archive subdir naming). The parser must accept that shorter
+    format cleanly.
+    """
+    truncated = dt.replace(microsecond=0)
+    iso = truncated.strftime("%Y-%m-%dT%H:%M:%SZ")
+    parsed = _parse_iso(iso)
+    assert parsed == truncated
+
+
+@given(dt=_DATETIMES)
+def test_two_calls_idempotent(dt: datetime) -> None:
+    """Parsing the same value twice yields equal datetimes.
+
+    Trivially true for ``datetime.fromisoformat`` but a regression
+    that introduced mutable state (e.g. a memoised parser) could
+    surface here on a second call returning a wrapped or
+    cache-corrupted value.
+    """
+    iso = dt.isoformat()
+    a = _parse_iso(iso)
+    b = _parse_iso(iso)
+    assert a == b

--- a/tests/property/test_json_adversarial_properties.py
+++ b/tests/property/test_json_adversarial_properties.py
@@ -1,0 +1,215 @@
+"""Adversarial-JSON property tests for the atomic-write JSON path.
+
+``write_atomic_json`` is used everywhere a structured runtime state
+file is persisted (session.json, file_locks.json, supervisor_state.json,
+merkle seal). Subtle JSON serialisation behaviours can creep in here:
+
+* **NaN / +Inf / -Inf** — Python's ``json.dumps`` emits non-standard
+  ``NaN`` / ``Infinity`` tokens by default. The audit / runtime
+  consumers expect strict JSON; the writer's contract is to either
+  emit valid JSON or refuse to write. The property here asserts the
+  current behaviour: if a non-finite float reaches the writer, the
+  resulting bytes parse back via ``json.loads`` (whose default
+  permissive flag matches the dump default). This locks the current
+  contract so any future tightening (``allow_nan=False``) is a
+  deliberate change.
+
+* **Dict key order does not affect ``sort_keys`` round-trip** — the
+  ``sort_keys=True`` argument is intended to produce a canonical
+  byte form. The property asserts that two semantically-equivalent
+  dicts (different insertion order) write the same bytes.
+
+* **Large numeric payloads** — ``json.dumps`` happily round-trips
+  Python's arbitrary-precision ints. The property catches a
+  regression that would coerce to float and lose precision on values
+  beyond 2^53.
+
+* **Unicode keys / values do not corrupt the JSON byte form** — the
+  default Python ``json.dumps`` emits ``\\uXXXX`` escapes; the
+  bytes on disk are pure ASCII regardless of the input character set.
+  Catches regressions that flip ``ensure_ascii=False`` and produce
+  payloads downstream tools cannot parse.
+
+Each property uses the smoke profile and is microsecond-fast.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+
+@given(payload=st.dictionaries(st.text(min_size=1, max_size=8), st.integers(), max_size=4))
+def test_sort_keys_makes_writes_canonical(
+    tmp_path_factory: pytest.TempPathFactory,
+    payload: dict[str, int],
+) -> None:
+    """Writing the same dict twice produces identical bytes (``sort_keys=True``).
+
+    Catches regressions where ``sort_keys`` is accidentally dropped
+    from the wrapper. Without it, two writers with different insertion
+    orders would produce diff-noisy commits / drift across runs.
+    """
+    a = tmp_path_factory.mktemp("aw-json") / "a.json"
+    b = tmp_path_factory.mktemp("aw-json") / "b.json"
+
+    write_atomic_json(a, payload, sort_keys=True)
+    # Build a reversed-order copy.
+    reordered = dict(reversed(list(payload.items())))
+    write_atomic_json(b, reordered, sort_keys=True)
+
+    assert a.read_bytes() == b.read_bytes()
+
+
+@given(
+    big_int=st.integers(
+        min_value=-(2**80),
+        max_value=2**80,
+    ),
+)
+def test_arbitrary_precision_int_round_trips(
+    tmp_path_factory: pytest.TempPathFactory,
+    big_int: int,
+) -> None:
+    """Arbitrary-precision ints survive a JSON round-trip without precision loss.
+
+    JSON's default Python encoder preserves int width. A regression
+    that swapped ``json.dumps`` for a float-coercing encoder would
+    silently corrupt every >2^53 quantity persisted to runtime state.
+    """
+    target = tmp_path_factory.mktemp("aw-json") / "big.json"
+    write_atomic_json(target, {"n": big_int})
+    loaded = json.loads(target.read_text())
+    assert loaded["n"] == big_int
+    assert isinstance(loaded["n"], int)
+
+
+@given(
+    text=st.text(
+        st.characters(min_codepoint=0x80, max_codepoint=0xFFFF, blacklist_categories=("Cs",)),
+        min_size=1,
+        max_size=16,
+    ),
+)
+def test_unicode_value_emits_ascii_escapes(
+    tmp_path_factory: pytest.TempPathFactory,
+    text: str,
+) -> None:
+    """High-codepoint values are escaped as ``\\uXXXX`` (ASCII bytes on disk).
+
+    Default ``json.dumps`` emits ``ensure_ascii=True``; the produced
+    bytes contain only ASCII. Catches a refactor that flips the flag
+    and produces multi-byte UTF-8 sequences that downstream consumers
+    (legacy parsers, regex-scanners) cannot handle.
+
+    Equality is established via ``json.loads`` rather than raw byte
+    inspection — the loader expands escapes back to the original
+    code point regardless of how the writer stored them.
+    """
+    target = tmp_path_factory.mktemp("aw-json") / "u.json"
+    write_atomic_json(target, {"k": text})
+    raw = target.read_bytes()
+    # Every byte is ASCII (no leak of multi-byte UTF-8).
+    assert all(b < 0x80 for b in raw)
+    loaded = json.loads(raw)
+    assert loaded["k"] == text
+
+
+@settings(
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(depth=st.integers(min_value=1, max_value=16))
+def test_deeply_nested_dict_round_trips(
+    tmp_path_factory: pytest.TempPathFactory,
+    depth: int,
+) -> None:
+    """A nested-dict payload up to depth 16 round-trips exactly.
+
+    Catches recursion-related regressions in the JSON layer (Python's
+    default recursion limit is 1000; depth 16 leaves enormous head-
+    room but exercises the code path that any future custom encoder
+    would have to honour).
+    """
+    payload: Any = {"leaf": 42}
+    for i in range(depth):
+        payload = {f"k_{i}": payload}
+
+    target = tmp_path_factory.mktemp("aw-json") / "deep.json"
+    write_atomic_json(target, payload)
+    loaded = json.loads(target.read_text())
+    assert loaded == payload
+
+
+def test_nan_emits_non_strict_token(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """``NaN`` payload writes the non-standard ``NaN`` token (status quo).
+
+    Pinned (single-value space). Documents the current behaviour: the
+    writer does *not* pass ``allow_nan=False``, so a NaN in payload
+    produces bytes that Python's ``json.loads`` can read back but any
+    strict parser (JS, Rust, Go) will refuse. Any change to this
+    behaviour should be deliberate and visible as a property failure.
+    """
+    target = tmp_path_factory.mktemp("aw-json") / "nan.json"
+    write_atomic_json(target, {"x": math.nan})
+    text = target.read_text()
+    assert "NaN" in text
+
+
+@given(
+    payload=st.dictionaries(
+        st.text(min_size=1, max_size=4),
+        st.one_of(
+            st.integers(),
+            st.text(min_size=0, max_size=8),
+            st.lists(st.integers(min_value=-100, max_value=100), max_size=4),
+        ),
+        min_size=0,
+        max_size=4,
+    ),
+)
+def test_round_trip_arbitrary_payloads(
+    tmp_path_factory: pytest.TempPathFactory,
+    payload: dict[str, Any],
+) -> None:
+    """Arbitrary mixed-type payloads survive write-then-read.
+
+    Composite property: combines the int-precision, key-order, and
+    container-flat-vs-nested cases into one Hypothesis sweep.
+    """
+    target = tmp_path_factory.mktemp("aw-json") / "mix.json"
+    write_atomic_json(target, payload)
+    loaded = json.loads(target.read_text())
+    assert loaded == payload
+
+
+@given(
+    payload=st.recursive(
+        st.integers() | st.text(max_size=4) | st.booleans(),
+        lambda children: st.lists(children, max_size=3)
+        | st.dictionaries(st.text(min_size=1, max_size=4), children, max_size=3),
+        max_leaves=10,
+    ),
+)
+def test_indent_does_not_change_semantic_value(
+    tmp_path_factory: pytest.TempPathFactory,
+    payload: Any,
+) -> None:
+    """``indent=2`` and ``indent=None`` yield bytes that parse to the same value.
+
+    The indent kwarg only affects whitespace. Catches a regression
+    where indent forwarding accidentally toggled ``sort_keys`` as a
+    side-effect (the wrapper accepts both — they must be independent).
+    """
+    a = tmp_path_factory.mktemp("aw-json") / "a.json"
+    b = tmp_path_factory.mktemp("aw-json") / "b.json"
+    write_atomic_json(a, payload, indent=None, sort_keys=True)
+    write_atomic_json(b, payload, indent=2, sort_keys=True)
+    assert json.loads(a.read_text()) == json.loads(b.read_text())

--- a/tests/property/test_merkle_seal_properties.py
+++ b/tests/property/test_merkle_seal_properties.py
@@ -117,13 +117,42 @@ def test_leaf_swap_changes_root(pairs: list[tuple[str, str]]) -> None:
     assert root_a != root_b
 
 
+def _last_line_is_hmac_json(raw: bytes) -> bool:
+    """True iff the last newline-separated chunk parses as a JSON dict with ``hmac``.
+
+    ``file_leaf_hash`` short-circuits to the embedded ``hmac`` value
+    in that case, so a byte flip *outside* the last line is invisible
+    to the Merkle leaf — a real but separate property (the HMAC chain
+    itself catches it). To keep this property well-defined we filter
+    those files out and stick to the whole-file content-hash branch.
+    """
+    if not raw.strip():
+        return False
+    last = raw.rstrip(b"\n").split(b"\n")[-1]
+    try:
+        entry = json.loads(last)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(entry, dict) and "hmac" in entry
+
+
 @settings(
     max_examples=40,
     suppress_health_check=[HealthCheck.function_scoped_fixture],
 )
 @given(
     files=st.lists(
-        st.tuples(_DAY_NAMES, st.binary(min_size=1, max_size=64)),
+        st.tuples(
+            _DAY_NAMES,
+            # Restrict to printable ASCII that is highly unlikely to
+            # parse as a JSON dict with an ``hmac`` field — keeps us
+            # in the content-hash branch of ``file_leaf_hash``.
+            st.text(
+                alphabet=st.characters(min_codepoint=0x41, max_codepoint=0x5A),
+                min_size=4,
+                max_size=64,
+            ).map(lambda s: s.encode()),
+        ),
         min_size=1,
         max_size=4,
         unique_by=lambda t: t[0],
@@ -135,17 +164,21 @@ def test_single_byte_flip_in_sealed_file_detected(
     files: list[tuple[str, bytes]],
     flip_target: int,
 ) -> None:
-    """Flipping a byte in any sealed file must produce a TAMPERED error.
+    """Flipping a byte in any sealed (non-JSONL) file must produce a TAMPERED error.
 
-    This is the file-granularity counterpart to the audit log's
-    per-line single-byte property. The Merkle seal hashes either the
-    last HMAC line (if JSONL) or the whole file (otherwise). Either
-    branch must propagate a byte flip to the seal's leaf hash.
+    The Merkle seal hashes either the last HMAC line (if JSONL) or
+    the whole file (otherwise). The per-line HMAC chain catches the
+    first branch; this property pins the second branch — non-JSONL
+    contents must be content-hashed end-to-end.
     """
     tmp = tmp_path_factory.mktemp("merkle-flip")
     audit = tmp / "audit"
     merkle = tmp / "merkle"
     _write_audit_files(audit, files)
+
+    # Skip if any file accidentally landed in the HMAC-JSONL branch.
+    if any(_last_line_is_hmac_json(payload) for _, payload in files):
+        pytest.skip("file would short-circuit to embedded hmac field")
 
     _, seal = compute_seal(audit)
     merkle.mkdir(parents=True, exist_ok=True)
@@ -312,7 +345,11 @@ def _build_canonical_seal(audit: Path) -> dict[str, Any]:
 )
 @given(
     payloads=st.lists(
-        st.binary(min_size=1, max_size=64),
+        st.text(
+            alphabet=st.characters(min_codepoint=0x41, max_codepoint=0x5A),
+            min_size=4,
+            max_size=64,
+        ).map(lambda s: s.encode()),
         min_size=2,
         max_size=4,
     ),
@@ -326,6 +363,10 @@ def test_swapping_two_file_contents_detected(
     Both files remain present, so DELETED/INSERTED won't fire. The
     only signal is per-file hash mismatch via TAMPERED. The property
     documents that file-name-to-hash binding is enforced.
+
+    Restricts to non-JSONL ASCII payloads so we stay in the content-
+    hash branch of ``file_leaf_hash`` (the HMAC-JSONL branch's swap
+    invariants are covered by the per-line audit chain property).
     """
     if len({p for p in payloads}) < 2:
         pytest.skip("payloads too uniform to swap")

--- a/tests/property/test_merkle_seal_properties.py
+++ b/tests/property/test_merkle_seal_properties.py
@@ -1,0 +1,354 @@
+"""Property tests for the Merkle-tree integrity seal.
+
+The Merkle seal is the second-layer integrity check on top of the HMAC
+audit chain. Per-line tamper-evidence is provided by the HMAC chain
+itself; the Merkle seal catches tampering that touches *files* —
+deleting a daily log, inserting a forged log, or swapping file
+contents wholesale. These properties encode the invariants we rely on:
+
+* **Build determinism** — feeding the same ``(name, hash)`` pairs in
+  the same order always yields the same root.
+
+* **Single-byte tamper-evidence at file granularity** — flipping any
+  byte of any sealed log file must surface a TAMPERED error from
+  :func:`verify_merkle`. This catches regressions in
+  :func:`file_leaf_hash` (e.g. accidental ``str.strip`` that hides
+  trailing-byte mutations).
+
+* **Insertion / deletion detection** — adding or removing a JSONL
+  file after the seal must surface an INSERTED or DELETED error.
+
+* **Order sensitivity of the root** — permuting the leaf order
+  (without the seal recording the permutation) must change the root
+  hash. Without this property an attacker could swap two days of logs
+  and re-seal with the same root.
+
+Smoke profile: ~50 examples each. Each example builds an in-memory or
+on-disk audit dir of <= 6 small files, so wall-time per example is
+sub-100 ms.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.persistence.merkle import (
+    build_merkle_tree,
+    compute_seal,
+    file_leaf_hash,
+    verify_merkle,
+)
+
+# File names of the form ``YYYY-MM-DD.jsonl`` so sorted() ordering is
+# stable and the seal layout matches the production writer.
+_DAY_NAMES = st.builds(
+    lambda i: f"2026-01-{i:02d}.jsonl",
+    st.integers(min_value=1, max_value=28),
+)
+
+_LEAF_HASHES = st.text(
+    alphabet=st.characters(min_codepoint=0x30, max_codepoint=0x39)
+    | st.characters(min_codepoint=0x61, max_codepoint=0x66),
+    min_size=64,
+    max_size=64,
+)
+
+
+def _write_audit_files(audit_dir: Path, contents: list[tuple[str, bytes]]) -> None:
+    """Write a deterministic set of ``YYYY-MM-DD.jsonl`` files."""
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    for name, payload in contents:
+        (audit_dir / name).write_bytes(payload)
+
+
+@given(
+    pairs=st.lists(
+        st.tuples(_DAY_NAMES, _LEAF_HASHES),
+        min_size=1,
+        max_size=8,
+        unique_by=lambda t: t[0],
+    ),
+)
+def test_build_is_deterministic(pairs: list[tuple[str, str]]) -> None:
+    """Identical input pairs in identical order yield identical roots.
+
+    Catches regressions where ``build_merkle_tree`` accepts hashable
+    inputs but introduces non-determinism (e.g. ``dict`` iteration,
+    ``set`` flattening). A non-deterministic root would silently break
+    re-verification on a different machine even when nothing on disk
+    changed.
+    """
+    pairs_sorted = sorted(pairs)
+    tree_a = build_merkle_tree(pairs_sorted)
+    tree_b = build_merkle_tree(pairs_sorted)
+    assert tree_a.root.hash == tree_b.root.hash
+
+
+@given(
+    pairs=st.lists(
+        st.tuples(_DAY_NAMES, _LEAF_HASHES),
+        min_size=2,
+        max_size=8,
+        unique_by=lambda t: t[0],
+    ),
+)
+def test_leaf_swap_changes_root(pairs: list[tuple[str, str]]) -> None:
+    """Permuting two distinct leaf hashes must change the root.
+
+    The Merkle tree is order-sensitive by construction (left/right
+    siblings combine with ``f"merkle:{left}:{right}"``); a swap of
+    distinct hashes therefore must propagate to the root. This catches
+    accidental commutative-combine regressions
+    (e.g. ``sha256(left + right)`` vs ``sha256(sorted([left, right]))``).
+    """
+    pairs_sorted = sorted(pairs)
+    if pairs_sorted[0][1] == pairs_sorted[1][1]:
+        pytest.skip("identical leaf hashes — swap is a no-op")
+    swapped = list(pairs_sorted)
+    swapped[0], swapped[1] = swapped[1], swapped[0]
+    root_a = build_merkle_tree(pairs_sorted).root.hash
+    root_b = build_merkle_tree(swapped).root.hash
+    assert root_a != root_b
+
+
+@settings(
+    max_examples=40,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    files=st.lists(
+        st.tuples(_DAY_NAMES, st.binary(min_size=1, max_size=64)),
+        min_size=1,
+        max_size=4,
+        unique_by=lambda t: t[0],
+    ),
+    flip_target=st.integers(min_value=0, max_value=2**16 - 1),
+)
+def test_single_byte_flip_in_sealed_file_detected(
+    tmp_path_factory: pytest.TempPathFactory,
+    files: list[tuple[str, bytes]],
+    flip_target: int,
+) -> None:
+    """Flipping a byte in any sealed file must produce a TAMPERED error.
+
+    This is the file-granularity counterpart to the audit log's
+    per-line single-byte property. The Merkle seal hashes either the
+    last HMAC line (if JSONL) or the whole file (otherwise). Either
+    branch must propagate a byte flip to the seal's leaf hash.
+    """
+    tmp = tmp_path_factory.mktemp("merkle-flip")
+    audit = tmp / "audit"
+    merkle = tmp / "merkle"
+    _write_audit_files(audit, files)
+
+    _, seal = compute_seal(audit)
+    merkle.mkdir(parents=True, exist_ok=True)
+    (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
+
+    # Pick a file to mutate. flip_target is wrapped so it always lands
+    # in-range regardless of generated file sizes.
+    target_idx = flip_target % len(files)
+    target_name = sorted(name for name, _ in files)[target_idx]
+    target_path = audit / target_name
+    raw = target_path.read_bytes()
+    if not raw:
+        pytest.skip("empty file — nothing to flip")
+    pos = flip_target % len(raw)
+    mutated = bytearray(raw)
+    mutated[pos] ^= 0x01
+    if bytes(mutated) == raw:
+        pytest.skip("XOR with 0x01 produced identical bytes")
+    target_path.write_bytes(bytes(mutated))
+
+    result = verify_merkle(audit, merkle)
+    assert not result.valid, "byte flip in sealed file went undetected"
+    assert any("TAMPERED" in e for e in result.errors)
+
+
+@settings(
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    files=st.lists(
+        st.tuples(_DAY_NAMES, st.binary(min_size=1, max_size=32)),
+        min_size=2,
+        max_size=4,
+        unique_by=lambda t: t[0],
+    ),
+)
+def test_file_deletion_detected(
+    tmp_path_factory: pytest.TempPathFactory,
+    files: list[tuple[str, bytes]],
+) -> None:
+    """Deleting any sealed file must produce a DELETED error.
+
+    Catches regressions in ``_check_deleted_files`` where the seal
+    leaf list is read but the on-disk set is computed wrong (e.g.
+    iterating over the seal twice instead of the audit dir).
+    """
+    tmp = tmp_path_factory.mktemp("merkle-del")
+    audit = tmp / "audit"
+    merkle = tmp / "merkle"
+    _write_audit_files(audit, files)
+
+    _, seal = compute_seal(audit)
+    merkle.mkdir(parents=True, exist_ok=True)
+    (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
+
+    # Delete the first file (alphabetically) from the sealed set.
+    victim = sorted(audit.glob("*.jsonl"))[0]
+    victim.unlink()
+
+    result = verify_merkle(audit, merkle)
+    assert not result.valid
+    assert any("DELETED" in e for e in result.errors)
+
+
+@settings(
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    files=st.lists(
+        st.tuples(_DAY_NAMES, st.binary(min_size=1, max_size=32)),
+        min_size=1,
+        max_size=3,
+        unique_by=lambda t: t[0],
+    ),
+    intruder_payload=st.binary(min_size=1, max_size=64),
+)
+def test_file_insertion_detected(
+    tmp_path_factory: pytest.TempPathFactory,
+    files: list[tuple[str, bytes]],
+    intruder_payload: bytes,
+) -> None:
+    """Adding a post-seal file must produce an INSERTED error.
+
+    An attacker forging a fresh day's log after the seal would slip
+    past verification if ``_check_inserted_files`` reads only the
+    sealed list. The property forces the verifier to compare against
+    the on-disk set.
+    """
+    tmp = tmp_path_factory.mktemp("merkle-ins")
+    audit = tmp / "audit"
+    merkle = tmp / "merkle"
+    _write_audit_files(audit, files)
+
+    _, seal = compute_seal(audit)
+    merkle.mkdir(parents=True, exist_ok=True)
+    (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
+
+    # Pick a date that's guaranteed not in the sealed set.
+    existing = {name for name, _ in files}
+    intruder_name = next(
+        f"2026-02-{i:02d}.jsonl" for i in range(1, 28) if f"2026-02-{i:02d}.jsonl" not in existing
+    )
+    (audit / intruder_name).write_bytes(intruder_payload)
+
+    result = verify_merkle(audit, merkle)
+    assert not result.valid
+    assert any("INSERTED" in e for e in result.errors)
+
+
+@given(payload=st.binary(min_size=0, max_size=1024))
+def test_file_leaf_hash_is_pure(tmp_path_factory: pytest.TempPathFactory, payload: bytes) -> None:
+    """Computing the leaf hash twice on the same file yields the same value.
+
+    Catches regressions where ``file_leaf_hash`` accidentally consumes
+    a stateful resource (e.g. an open file handle that's reused). A
+    drift between two consecutive calls would also surface as flaky
+    seal verification in CI.
+    """
+    tmp = tmp_path_factory.mktemp("merkle-pure")
+    path = tmp / "f.jsonl"
+    path.write_bytes(payload)
+    assert file_leaf_hash(path) == file_leaf_hash(path)
+
+
+@given(
+    leaves=st.lists(
+        _LEAF_HASHES,
+        min_size=1,
+        max_size=8,
+    ),
+)
+def test_duplicate_leaf_does_not_collapse_tree(leaves: list[str]) -> None:
+    """Adding a duplicate leaf hash with a *different* name changes the root.
+
+    The Merkle layer must distinguish two files with identical contents
+    but different names (the file name is part of the seal). Otherwise
+    an attacker could swap one daily file for a copy of another and
+    leave the root unchanged.
+    """
+    if len(leaves) < 2 or leaves[0] != leaves[1]:
+        # Force a duplicate to expose the property.
+        leaves = [leaves[0], leaves[0], *leaves[1:]]
+    pairs_a = [(f"2026-01-{i + 1:02d}.jsonl", h) for i, h in enumerate(leaves)]
+    pairs_b = [(f"2026-02-{i + 1:02d}.jsonl", h) for i, h in enumerate(leaves)]
+    root_a = build_merkle_tree(sorted(pairs_a)).root.hash
+    root_b = build_merkle_tree(sorted(pairs_b)).root.hash
+    # Both lists encode the same leaf hashes in the same order — the
+    # tree hashes only the leaf hashes, not the names. So roots must
+    # match; this documents the current contract and will catch any
+    # regression that surreptitiously folds names into the leaf.
+    assert root_a == root_b
+
+
+def _build_canonical_seal(audit: Path) -> dict[str, Any]:
+    _, seal = compute_seal(audit)
+    return seal
+
+
+@settings(
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(
+    payloads=st.lists(
+        st.binary(min_size=1, max_size=64),
+        min_size=2,
+        max_size=4,
+    ),
+)
+def test_swapping_two_file_contents_detected(
+    tmp_path_factory: pytest.TempPathFactory,
+    payloads: list[bytes],
+) -> None:
+    """Swapping the *contents* of two sealed files trips verification.
+
+    Both files remain present, so DELETED/INSERTED won't fire. The
+    only signal is per-file hash mismatch via TAMPERED. The property
+    documents that file-name-to-hash binding is enforced.
+    """
+    if len({p for p in payloads}) < 2:
+        pytest.skip("payloads too uniform to swap")
+
+    tmp = tmp_path_factory.mktemp("merkle-swap")
+    audit = tmp / "audit"
+    merkle = tmp / "merkle"
+    files = [(f"2026-01-{i + 1:02d}.jsonl", payloads[i]) for i in range(len(payloads))]
+    _write_audit_files(audit, files)
+
+    seal = _build_canonical_seal(audit)
+    merkle.mkdir(parents=True, exist_ok=True)
+    (merkle / "seal-20260101T000000Z.json").write_text(json.dumps(seal))
+
+    # Swap the two file contents.
+    a = audit / files[0][0]
+    b = audit / files[1][0]
+    if a.read_bytes() == b.read_bytes():
+        pytest.skip("files identical — swap is a no-op")
+    a_bytes, b_bytes = a.read_bytes(), b.read_bytes()
+    a.write_bytes(b_bytes)
+    b.write_bytes(a_bytes)
+
+    result = verify_merkle(audit, merkle)
+    assert not result.valid
+    assert any("TAMPERED" in e for e in result.errors)

--- a/tests/property/test_normalize_path_properties.py
+++ b/tests/property/test_normalize_path_properties.py
@@ -1,0 +1,159 @@
+"""Property tests for path normalisation and traversal safety.
+
+Bernstein has two related path safety surfaces:
+
+1. ``bernstein.core.config.platform_compat.normalize_path`` — used to
+   canonicalise operator-supplied paths before they hit subprocess
+   args, gitignore patterns, etc. Bugs here surface as broken path
+   matching on either platform.
+
+2. ``bernstein.core.lineage.recorder._is_unsafe_path`` — the
+   defence-in-depth check that rejects absolute and traversal
+   artefact paths before they reach disk. A regression here is a
+   direct path-traversal vulnerability (the recorder could write
+   outside the lineage store).
+
+Properties:
+
+* **``normalize_path`` is idempotent** — running it twice yields the
+  same string. Catches regressions where the normaliser leaves a
+  trailing separator on some inputs that a second pass would strip.
+
+* **``normalize_path`` collapses ``"./"`` segments** — the contract
+  that downstream gitignore-style matchers depend on.
+
+* **``_is_unsafe_path`` rejects every traversal segment** — for any
+  segment count and position, ``..`` anywhere in the path is
+  detected.
+
+* **Trusted relative paths are accepted** — pure-relative paths
+  without traversal segments must pass cleanly; otherwise the
+  recorder would refuse legitimate writes.
+
+The lineage path-safety check is a pure function; the property runs
+50 examples in well under a second.
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from bernstein.core.config.platform_compat import normalize_path
+from bernstein.core.lineage.recorder import _is_unsafe_path
+
+_SAFE_SEG = st.text(
+    alphabet=st.characters(
+        min_codepoint=0x61,
+        max_codepoint=0x7A,  # lowercase ascii — boring, safe segments
+    ),
+    min_size=1,
+    max_size=8,
+)
+
+
+@given(
+    segments=st.lists(_SAFE_SEG, min_size=1, max_size=6),
+    use_forward=st.booleans(),
+)
+def test_normalize_path_idempotent(segments: list[str], use_forward: bool) -> None:
+    """``normalize_path(normalize_path(p)) == normalize_path(p)``.
+
+    The normaliser is supposed to converge on a canonical form. A
+    drift between two calls would surface as flaky gitignore matching
+    in the dependency-scan plugin (and elsewhere).
+    """
+    sep = "/" if use_forward else "\\"
+    raw = sep.join(segments)
+    once = normalize_path(raw)
+    twice = normalize_path(once)
+    assert once == twice
+
+
+@given(segments=st.lists(_SAFE_SEG, min_size=1, max_size=6))
+def test_normalize_collapses_dot_segments(segments: list[str]) -> None:
+    """``./`` segments are collapsed by normalisation.
+
+    Catches regressions where the normaliser stops short of removing
+    explicit ``.`` components (which causes Match-vs-Compare drift
+    against any path that the writer canonicalised differently).
+    """
+    raw = "./" + "/".join(segments)
+    normalised = normalize_path(raw)
+    # ``./a/b`` → ``a/b``; the normaliser produces no leading ``./``.
+    assert not normalised.startswith("./")
+
+
+@given(
+    prefix=st.lists(_SAFE_SEG, max_size=3),
+    suffix=st.lists(_SAFE_SEG, max_size=3),
+)
+def test_traversal_segment_anywhere_is_unsafe(prefix: list[str], suffix: list[str]) -> None:
+    """``..`` segment anywhere in the path is rejected.
+
+    The recorder uses ``_is_unsafe_path`` as its only line of defence
+    against path traversal; this property checks that the segment is
+    detected regardless of position.
+    """
+    segments = [*prefix, "..", *suffix]
+    raw = "/".join(segments)
+    reason = _is_unsafe_path(raw)
+    assert reason is not None
+    assert "path traversal" in reason
+
+
+@given(segments=st.lists(_SAFE_SEG, min_size=1, max_size=5))
+def test_safe_relative_path_accepted(segments: list[str]) -> None:
+    """Relative path with no ``..`` and no leading ``/`` is accepted.
+
+    The complement of the previous property: legitimate paths must not
+    be rejected. Catches over-broad regexes (e.g. matching ``."`` or
+    ``..foo``).
+    """
+    # Filter out segments that themselves equal ``..`` (Hypothesis
+    # respects the alphabet but ``..`` is a literal value that
+    # ``_SAFE_SEG`` cannot generate; defensive ``assume`` anyway).
+    assume(all(s != ".." for s in segments))
+    raw = "/".join(segments)
+    assert _is_unsafe_path(raw) is None
+
+
+@given(path=_SAFE_SEG)
+def test_absolute_paths_rejected(path: str) -> None:
+    """Any leading-slash path is rejected by the recorder.
+
+    Lineage paths are repo-relative POSIX strings; the recorder must
+    refuse an absolute path or it would write outside the store.
+    """
+    raw = "/" + path
+    reason = _is_unsafe_path(raw)
+    assert reason is not None
+    assert "absolute" in reason
+
+
+def test_empty_path_rejected() -> None:
+    """The empty path is rejected.
+
+    Pinned (input space is a single value). Documents the contract
+    so a future refactor cannot accidentally accept ``""``.
+    """
+    reason = _is_unsafe_path("")
+    assert reason is not None
+    assert "empty" in reason
+
+
+@given(
+    drive=st.sampled_from(["C", "D", "Z"]),
+    rest=_SAFE_SEG,
+)
+def test_windows_absolute_paths_rejected(drive: str, rest: str) -> None:
+    """Windows-style ``X:\\...`` paths are rejected on every platform.
+
+    The recorder writes POSIX-style paths; a Windows-shaped value
+    leaking through would either confuse the path resolver or
+    (worse) be interpreted as ``X:`` plus a relative path on POSIX
+    and silently land in the wrong directory.
+    """
+    raw = f"{drive}:\\{rest}"
+    reason = _is_unsafe_path(raw)
+    assert reason is not None

--- a/tests/property/test_shell_quote_properties.py
+++ b/tests/property/test_shell_quote_properties.py
@@ -1,0 +1,193 @@
+"""Property tests for shell quoting and shlex round-trips.
+
+Bernstein assembles subprocess commands from operator-supplied strings
+(``benchmark_command``, ``coverage_command``, ``auto_format_*``, etc.)
+and pipes them through ``shlex.split`` / ``shlex.quote`` /
+``shlex.join``. A malformed quoting helper here translates directly to
+command injection on the runner.
+
+Properties:
+
+* **``shlex.split(shlex.join(parts))`` round-trips for arbitrary
+  argv** — the canonical invariant for safe command construction.
+  Catches regressions where a refactor introduces ``" ".join(args)``
+  on a path that previously called ``shlex.join``.
+
+* **``shell_quote`` produces single-argv tokens** — feeding
+  ``shell_quote(s)`` back through ``shlex.split`` always yields
+  ``[s]`` (modulo whitespace-only edge cases). This is the contract
+  the production CLI relies on for ``ssh_backend.write_file`` and
+  similar shell-spliced calls.
+
+* **Injection metacharacters are not exposed** — strings containing
+  ``;``, ``$(...)``, backticks, ``|``, and ``&&`` survive a
+  ``shell_quote`` → ``shlex.split`` round-trip as a single argv
+  token. This is the security guarantee: if it ever splits into
+  multiple tokens, an attacker controls subsequent shell tokens.
+
+* **Empty / whitespace-only strings round-trip safely** — ``""`` →
+  ``"''"`` → ``[""]``. Catches regressions that drop the explicit
+  empty quoting branch and accidentally collapse to ``[]``.
+
+Each property uses the smoke profile (50 examples) — these are
+microsecond operations and there's no IO to slow them down.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+
+import pytest
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from bernstein.core.config.platform_compat import shell_quote
+from bernstein.core.workflows.workflow_runner import shell_join
+
+# Characters that survive shlex round-trip without ambiguity. We exclude
+# code points that shlex's POSIX mode treats specially as line
+# terminators inside a quoted token (the only one that matters in
+# practice is the literal newline; shlex.split with posix=True will
+# happily split on ``\n`` inside ``$'...'`` constructs we don't use).
+_TOKEN_ALPHABET = st.characters(
+    blacklist_categories=("Cs", "Cc"),
+    min_codepoint=0x20,
+    max_codepoint=0x7E,
+) | st.sampled_from([" ", "\t"])
+
+# Characters known to be hostile to shells. The point of the property
+# is to confirm shlex still produces a single token when the input
+# embeds them verbatim.
+_INJECTION_CHARS = st.sampled_from(
+    [";", "&", "|", "$", "`", "(", ")", "<", ">", "\\", '"', "'"]
+)
+
+
+def _argv_strategy() -> st.SearchStrategy[list[str]]:
+    return st.lists(
+        st.text(_TOKEN_ALPHABET, min_size=1, max_size=16),
+        min_size=1,
+        max_size=6,
+    )
+
+
+@given(argv=_argv_strategy())
+def test_split_join_round_trip(argv: list[str]) -> None:
+    """``shlex.split(shell_join(argv)) == argv`` for arbitrary argv.
+
+    The single critical invariant for safe command construction. A
+    failure here means any caller that builds a command via
+    ``shell_join`` and later re-parses with ``shlex.split`` will get
+    the wrong argument boundary — the root cause of every shell
+    injection bug we've ever closed.
+    """
+    joined = shell_join(argv)
+    assert shlex.split(joined) == argv
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shlex semantics")
+@given(token=st.text(_TOKEN_ALPHABET, min_size=0, max_size=32))
+def test_shell_quote_produces_single_token(token: str) -> None:
+    """``shlex.split(shell_quote(s))`` always yields ``[s]`` on POSIX.
+
+    Empty strings are explicitly part of the contract: ``shell_quote("")``
+    must produce ``"''"`` so the empty argv is preserved. Without this,
+    callers building ``f"foo {shell_quote(x)} bar"`` would silently
+    swallow blank arguments.
+    """
+    quoted = shell_quote(token)
+    parts = shlex.split(quoted)
+    assert parts == [token]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shlex semantics")
+@given(
+    prefix=st.text(_TOKEN_ALPHABET, min_size=0, max_size=8),
+    injection=_INJECTION_CHARS,
+    suffix=st.text(_TOKEN_ALPHABET, min_size=0, max_size=8),
+)
+def test_injection_chars_do_not_escape_quoting(
+    prefix: str,
+    injection: str,
+    suffix: str,
+) -> None:
+    """Hostile shell metacharacters survive quoting as part of one token.
+
+    If ``shell_quote("foo; rm -rf /")`` ever produced two
+    ``shlex.split`` tokens, the attacker controls subsequent shell
+    state. The property forces a single-token result regardless of how
+    Hypothesis interleaves the metacharacter with benign text.
+    """
+    payload = f"{prefix}{injection}{suffix}"
+    parts = shlex.split(shell_quote(payload))
+    assert parts == [payload], (
+        f"injection char {injection!r} escaped quoting: "
+        f"shlex.split({shell_quote(payload)!r}) = {parts!r}"
+    )
+
+
+@given(argv=_argv_strategy())
+def test_join_idempotent_under_round_trip(argv: list[str]) -> None:
+    """``shell_join`` is canonical: re-joining after a round-trip is stable.
+
+    ``shell_join(shlex.split(shell_join(argv))) == shell_join(argv)``.
+    Without this, a value that flows through a chain of quote-unquote
+    operations would drift (e.g. a benchmark-command string read from
+    config, parsed, then re-joined to log).
+    """
+    once = shell_join(argv)
+    twice = shell_join(shlex.split(once))
+    assert once == twice
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shlex semantics")
+@given(
+    argv=st.lists(
+        st.text(_TOKEN_ALPHABET, min_size=1, max_size=8)
+        | st.builds(
+            lambda a, b, c: f"{a}{b}{c}",
+            st.text(_TOKEN_ALPHABET, max_size=4),
+            _INJECTION_CHARS,
+            st.text(_TOKEN_ALPHABET, max_size=4),
+        ),
+        min_size=1,
+        max_size=4,
+    ),
+)
+def test_argv_with_injection_chars_round_trips(argv: list[str]) -> None:
+    """argv carrying metacharacters survives a full join+split.
+
+    Composite of the two prior properties at the argv level: a
+    Hypothesis-generated mix of benign tokens and injection-laden
+    tokens must reassemble to the original argv.
+    """
+    # shlex collapses whitespace-only tokens; skip those to keep the
+    # invariant well-defined.
+    assume(all(tok.strip() != "" or tok == "" for tok in argv))
+    joined = shell_join(argv)
+    assert shlex.split(joined) == argv
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shlex semantics")
+def test_empty_string_explicit_quoting() -> None:
+    """``shell_quote("")`` produces ``"''"`` (not empty).
+
+    Pinned because the input space is a single value. Documents the
+    contract for callers like ``ssh_backend.write_file`` that splice
+    quoted tokens directly into a shell line.
+    """
+    quoted = shell_quote("")
+    assert quoted == "''"
+    assert shlex.split(quoted) == [""]
+
+
+@given(token=st.text(min_size=0, max_size=128))
+def test_shell_quote_never_returns_empty(token: str) -> None:
+    """``shell_quote`` never returns ``""``.
+
+    A returned empty string would silently disappear in shell line
+    splicing. The function's contract is to always return at least
+    one character of quoting/data.
+    """
+    assert shell_quote(token) != ""


### PR DESCRIPTION
## TL;DR

| Module under test | New property file | # props | Bug class caught |
|---|---|---|---|
| `core.persistence.merkle` | `test_merkle_seal_properties.py` | 7 | build determinism / file-set tamper-evidence (DELETED, INSERTED, TAMPERED, swap) |
| `core.persistence.atomic_write` | `test_atomic_write_properties.py` | 8 | byte/text/JSON roundtrip, tmp-leak, torn concurrent read |
| `core.preview.parse_duration` | `test_duration_parse_properties.py` | 8 | suffix arithmetic, ws/case normalisation, zero/negative reject |
| `shlex + shell_quote` | `test_shell_quote_properties.py` | 7 | shell-injection metacharacter escapes |
| `normalize_path + lineage._is_unsafe_path` | `test_normalize_path_properties.py` | 7 | idempotence, `..`/absolute traversal reject |
| `core.persistence.file_locks` | `test_file_locks_properties.py` | 7 | cross-agent exclusivity, threaded convergence, restart persistence |
| audit `details` unicode | `test_audit_unicode_properties.py` | 4 | RTL/NUL/BOM/emoji/deep-nest HMAC drift |
| `core.persistence.cas_store` | `test_cas_store_properties.py` | 7 | put/get roundtrip, dedup, traversal in digest |
| `core.persistence.fingerprint` | `test_fingerprint_properties.py` | 7 | hash-seed-stable canonical args |
| `write_atomic_json` | `test_json_adversarial_properties.py` | 7 | sort_keys canonicality, int precision, ASCII-escape on disk |
| ISO-8601 timestamp parsers | `test_iso_timestamp_properties.py` | 6 | `Z` vs `+00:00` drift, microsecond loss |

Total: **75 new property tests** across **11 files**.

## Scope (per TC-A brief)

- JSON / TOML / YAML serialization adversarial inputs - covered (JSON adversarial + audit unicode)
- Path handling, atomic-write atomicity, path traversal - covered
- HMAC audit chain integrity beyond existing coverage - covered via Merkle layer + adversarial unicode
- Time / duration parsing - covered (parse_duration + ISO timestamp)
- Command-arg escaping / shlex - covered

## Constraints respected

- src/ untouched. Tests only.
- CI workflows untouched.
- Smoke profile (50 ex) for fast paths; tighter budgets (20-40 ex) for IO/thread-heavy properties.
- `uv run pytest tests/property/ --no-header -q` -> 330 passed, 9 skipped, 35 xfailed (1m13s on local).
- `uv run ruff check tests/property/` clean.

## Test plan

- [x] Each new property runs solo (`uv run pytest tests/property/<file>`)
- [x] Full property suite green after both commits
- [x] No flake when re-run with cleared `.hypothesis/` (one initial flake exposed a real over-broad scope in the merkle test; fixed in commit 2)
- [x] Lint clean