### PR TITLE
feat: bernstein worktrees — inspect & reap orphans

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -57,6 +57,7 @@ alwaysApply: false
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
 | `workflows/`            | Archon-inspired YAML workflow manifests |
+| `worktrees/`            | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/.goosehints
+++ b/.goosehints
@@ -58,6 +58,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
 | `workflows/`            | Archon-inspired YAML workflow manifests |
+| `worktrees/`            | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
 | `workflows/`            | Archon-inspired YAML workflow manifests |
+| `worktrees/`            | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
 | `workflows/`            | Archon-inspired YAML workflow manifests |
+| `worktrees/`            | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -58,6 +58,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `trigger_sources/`      | Trigger source adapters — normalize raw events into TriggerEvent |
 | `tunnels/`              | Tunnel provider abstraction and registry |
 | `workflows/`            | Archon-inspired YAML workflow manifests |
+| `worktrees/`            | Worktree inventory and garbage-collection helpers |
 
 ### `src/bernstein/adapters/` — CLI agent adapters
 

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -129,6 +129,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "worker_cmd": "bernstein.cli.commands.worker_cmd",
     "workflow_cmd": "bernstein.cli.commands.workflow_cmd",
     "workspace_cmd": "bernstein.cli.commands.workspace_cmd",
+    "worktrees_cmd": "bernstein.cli.commands.worktrees_cmd",
     "wrap_up_cmd": "bernstein.cli.commands.wrap_up_cmd",
 }
 

--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -136,7 +136,7 @@ def lock_gc(repo_root: Path):  # type: ignore[no-untyped-def]
     lock_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
     except FileExistsError as exc:
         raise GcLockError(f"another worktree GC is already running ({lock_path})") from exc
 

--- a/src/bernstein/cli/commands/worktrees_cmd.py
+++ b/src/bernstein/cli/commands/worktrees_cmd.py
@@ -1,0 +1,332 @@
+"""``bernstein worktrees`` — inspect and reap orphan worktrees.
+
+Two subcommands::
+
+    bernstein worktrees list           # tabular dump of every worktree
+    bernstein worktrees gc [--yes] [--dry]
+
+The classifier in :mod:`bernstein.core.worktrees.classifier` is the
+source of truth for state. This module only handles I/O: rendering the
+table, holding the GC lock, prompting the operator, and emitting the
+``worktree.gc`` lifecycle event for plugins.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from bernstein.core.worktrees.classifier import (
+    GC_LOCK_RELPATH,
+    WORKTREE_GC_LIFECYCLE_EVENT,
+    ClassifiedWorktree,
+    WorktreeState,
+    classify_worktrees,
+    format_size,
+    reap_worktree,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["format_age", "lock_gc", "render_worktrees_table", "worktrees_group"]
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+_STATE_STYLE: dict[WorktreeState, str] = {
+    WorktreeState.ACTIVE: "green",
+    WorktreeState.ORPHAN: "yellow",
+    WorktreeState.STALE: "red",
+    WorktreeState.CORRUPT: "magenta",
+}
+
+
+def format_age(seconds: float) -> str:
+    """Render a wall-clock duration as ``"3d 04h"`` / ``"5m"`` / ``"42s"``."""
+    secs = max(0, int(seconds))
+    if secs < 60:
+        return f"{secs}s"
+    if secs < 3600:
+        return f"{secs // 60}m"
+    if secs < 86_400:
+        hours = secs // 3600
+        mins = (secs % 3600) // 60
+        return f"{hours}h {mins:02d}m"
+    days = secs // 86_400
+    hours = (secs % 86_400) // 3600
+    return f"{days}d {hours:02d}h"
+
+
+def render_worktrees_table(rows: Iterable[ClassifiedWorktree]) -> Table:
+    """Build a Rich table for ``bernstein worktrees list``."""
+    table = Table(title="Bernstein worktrees", header_style="bold cyan")
+    table.add_column("Path", overflow="fold", no_wrap=False)
+    table.add_column("Task")
+    table.add_column("State")
+    table.add_column("Age", justify="right")
+    table.add_column("Size", justify="right")
+    table.add_column("PID", justify="right")
+
+    for row in rows:
+        style = _STATE_STYLE.get(row.state, "white")
+        task_display = row.task_id[:12] if row.task_id else "—"
+        pid_display = "—" if row.pid is None else (f"{row.pid}" + ("" if row.pid_alive else "✗"))
+        table.add_row(
+            str(row.path),
+            task_display,
+            f"[{style}]{row.state.value}[/{style}]",
+            format_age(row.age_seconds),
+            format_size(row.size_bytes),
+            pid_display,
+        )
+    return table
+
+
+def _rows_to_json(rows: Iterable[ClassifiedWorktree]) -> list[dict[str, object]]:
+    return [
+        {
+            "path": str(r.path),
+            "session_id": r.session_id,
+            "task_id": r.task_id,
+            "state": r.state.value,
+            "age_seconds": int(r.age_seconds),
+            "size_bytes": r.size_bytes,
+            "pid": r.pid,
+            "pid_alive": r.pid_alive,
+            "last_trace_mtime": r.last_trace_mtime,
+            "reapable": r.is_reapable,
+        }
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Lock
+# ---------------------------------------------------------------------------
+
+
+class GcLockError(RuntimeError):
+    """Raised when the GC lock cannot be acquired."""
+
+
+@contextlib.contextmanager
+def lock_gc(repo_root: Path):  # type: ignore[no-untyped-def]
+    """Acquire :data:`GC_LOCK_RELPATH` exclusively, yielding the lock path.
+
+    The lock file is created with ``O_EXCL``; a concurrent invocation
+    sees the file and raises :class:`GcLockError`. The lock is removed
+    on context exit even when the body raises.
+    """
+    lock_path = repo_root / GC_LOCK_RELPATH
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError as exc:
+        raise GcLockError(f"another worktree GC is already running ({lock_path})") from exc
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            payload = {"pid": os.getpid(), "started_at": time.time()}
+            fh.write(json.dumps(payload))
+        yield lock_path
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError:
+            logger.debug("lock release: %s already removed", lock_path)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle event helper
+# ---------------------------------------------------------------------------
+
+
+def _emit_worktree_gc(repo_root: Path, row: ClassifiedWorktree, dry_run: bool) -> None:
+    """Notify plugins that ``row`` was reaped.
+
+    We import lazily so importing this CLI module never drags in pluggy
+    when the operator only ran ``--help``.
+    """
+    try:
+        from bernstein.core.lifecycle.hooks import HookRegistry, LifecycleContext, LifecycleEvent
+    except Exception:
+        return
+
+    registry = _shared_registry()
+    if registry is None:
+        return
+
+    # ``LifecycleEvent`` is a closed StrEnum and we deliberately do not
+    # add a new entry to avoid rippling through the notify bridge. We
+    # piggyback on ``POST_ARCHIVE`` semantically (lifecycle-end) and pass
+    # the canonical event id via the ``env`` payload.
+    ctx = LifecycleContext(
+        event=LifecycleEvent.POST_ARCHIVE,
+        task=row.task_id,
+        session_id=row.session_id,
+        workdir=repo_root,
+        env={
+            "BERNSTEIN_WORKTREE_GC_EVENT": WORKTREE_GC_LIFECYCLE_EVENT,
+            "BERNSTEIN_WORKTREE_GC_STATE": row.state.value,
+            "BERNSTEIN_WORKTREE_GC_PATH": str(row.path),
+            "BERNSTEIN_WORKTREE_GC_DRY_RUN": "1" if dry_run else "0",
+        },
+    )
+    try:
+        # ``HookRegistry`` may not implement an event-name-string overload;
+        # the shared registry uses canonical enum events. We call the
+        # standard fire path so any plugin that subscribes to
+        # ``post_archive`` sees the env payload above and can filter by
+        # ``BERNSTEIN_WORKTREE_GC_EVENT``.
+        registry.run(LifecycleEvent.POST_ARCHIVE, ctx)
+    except Exception as exc:
+        logger.debug("lifecycle emit failed: %s", exc)
+    _ = HookRegistry  # silence unused import warning when registry is None
+
+
+def _shared_registry():  # type: ignore[no-untyped-def]
+    """Return the process-wide :class:`HookRegistry`, if one is installed.
+
+    Bernstein bootstrap stashes a singleton on a module-level attribute.
+    The lookup is intentionally defensive — running the CLI as a
+    standalone script should not require the orchestrator to be alive.
+    """
+    try:
+        from bernstein.core.lifecycle import hooks as _hooks_mod
+    except Exception:
+        return None
+    return getattr(_hooks_mod, "GLOBAL_REGISTRY", None)
+
+
+# ---------------------------------------------------------------------------
+# Subcommands
+# ---------------------------------------------------------------------------
+
+
+@click.group("worktrees")
+def worktrees_group() -> None:
+    """Inspect and reap Bernstein agent worktrees."""
+
+
+@worktrees_group.command("list")
+@click.option(
+    "--workdir",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=Path("."),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option("--json", "as_json", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def list_cmd(workdir: Path, as_json: bool) -> None:
+    """List every Bernstein worktree and its state."""
+    repo_root = workdir.resolve()
+    rows = classify_worktrees(repo_root)
+    if as_json:
+        click.echo(json.dumps(_rows_to_json(rows), indent=2, default=str))
+        return
+
+    console = Console()
+    if not rows:
+        console.print(f"[dim]No Bernstein worktrees found under {repo_root}/.sdd/.[/dim]")
+        return
+    console.print(render_worktrees_table(rows))
+    reapable = sum(1 for r in rows if r.is_reapable)
+    if reapable:
+        console.print(
+            f"[yellow]{reapable} worktree(s) reapable — run [bold]bernstein worktrees gc[/bold] to clean up.[/yellow]"
+        )
+
+
+@worktrees_group.command("gc")
+@click.option(
+    "--workdir",
+    type=click.Path(path_type=Path, file_okay=False),
+    default=Path("."),
+    show_default=True,
+    help="Project root containing .sdd/.",
+)
+@click.option("--yes", is_flag=True, default=False, help="Skip the confirmation prompt.")
+@click.option(
+    "--dry",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Print what would be deleted without touching disk.",
+)
+def gc_cmd(workdir: Path, yes: bool, dry_run: bool) -> None:
+    """Delete orphan, stale, and corrupt worktrees."""
+    repo_root = workdir.resolve()
+    rows = classify_worktrees(repo_root)
+    reapable = [r for r in rows if r.is_reapable]
+
+    console = Console()
+    if not reapable:
+        console.print("[green]No reapable worktrees — nothing to do.[/green]")
+        return
+
+    console.print(render_worktrees_table(reapable))
+    if not yes and not dry_run and not click.confirm(f"Reap {len(reapable)} worktree(s)?", default=False):
+        click.echo("Aborted.")
+        raise SystemExit(1)
+
+    try:
+        run_gc(
+            repo_root,
+            reapable,
+            dry_run=dry_run,
+            on_progress=lambda row, removed: _print_reap_progress(console, row, removed, dry_run=dry_run),
+        )
+    except GcLockError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(2) from exc
+
+
+def _print_reap_progress(
+    console: Console,
+    row: ClassifiedWorktree,
+    removed: bool,
+    *,
+    dry_run: bool,
+) -> None:
+    verb = "Would remove" if dry_run else ("Removed" if removed else "Skipped")
+    console.print(f"[dim]{verb}[/dim] {row.path} ({row.state.value})")
+
+
+def run_gc(
+    repo_root: Path,
+    rows: list[ClassifiedWorktree],
+    *,
+    dry_run: bool,
+    on_progress: Callable[[ClassifiedWorktree, bool], None] | None = None,
+) -> int:
+    """Reap ``rows`` under the GC lock and emit lifecycle events.
+
+    Returns the number of worktrees actually removed (always 0 in
+    ``--dry`` mode after the lock work completes).
+    """
+    removed_count = 0
+    with lock_gc(repo_root):
+        for row in rows:
+            removed = reap_worktree(repo_root, row, dry_run=dry_run)
+            if on_progress is not None:
+                on_progress(row, removed)
+            if removed and not dry_run:
+                removed_count += 1
+            _emit_worktree_gc(repo_root, row, dry_run)
+    return removed_count

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -122,6 +122,7 @@ from bernstein.cli.wiki_cmd import wiki_group
 from bernstein.cli.worker_cmd import worker
 from bernstein.cli.workflow_cmd import workflow_group
 from bernstein.cli.workspace_cmd import config_group, workspace_group
+from bernstein.cli.worktrees_cmd import worktrees_group
 from bernstein.cli.wrap_up_cmd import wrap_up
 from bernstein.core.json_logging import setup_json_logging
 
@@ -218,6 +219,7 @@ __all__ = [
     "wiki_group",
     "worker",
     "workspace_group",
+    "worktrees_group",
     "wrap_up",
     "write_pid",
     "write_shutdown_signals",
@@ -850,6 +852,7 @@ cli.add_command(listen_cmd, "listen")
 cli.add_command(self_update_cmd, "self-update")
 cli.add_command(undo_cmd, "undo")
 cli.add_command(worker, "worker")
+cli.add_command(worktrees_group, "worktrees")
 cli.add_command(diff_cmd, "diff")
 cli.add_command(merge_cmd, "merge")
 cli.add_command(migrate_cmd, "migrate")

--- a/src/bernstein/core/worktrees/__init__.py
+++ b/src/bernstein/core/worktrees/__init__.py
@@ -1,0 +1,35 @@
+"""Worktree inventory and garbage-collection helpers.
+
+This subpackage hosts the classifier used by ``bernstein worktrees`` and the
+TUI list pane to inspect every directory under ``.sdd/runtime/worktrees/``
+(or, on older layouts, ``.sdd/worktrees/``), assign each worktree a
+deterministic state, and reap the non-active ones.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.worktrees.classifier import (
+    GC_LOCK_RELPATH,
+    STALE_TRACE_AGE_S,
+    WORKTREE_GC_LIFECYCLE_EVENT,
+    ClassifiedWorktree,
+    WorktreeState,
+    classify_worktrees,
+    format_size,
+    iter_worktree_dirs,
+    reap_worktree,
+    worktrees_root,
+)
+
+__all__ = [
+    "GC_LOCK_RELPATH",
+    "STALE_TRACE_AGE_S",
+    "WORKTREE_GC_LIFECYCLE_EVENT",
+    "ClassifiedWorktree",
+    "WorktreeState",
+    "classify_worktrees",
+    "format_size",
+    "iter_worktree_dirs",
+    "reap_worktree",
+    "worktrees_root",
+]

--- a/src/bernstein/core/worktrees/classifier.py
+++ b/src/bernstein/core/worktrees/classifier.py
@@ -1,0 +1,469 @@
+"""Classify Bernstein worktrees as active / orphan / stale / corrupt.
+
+The classifier is the single source of truth shared by
+
+* the ``bernstein worktrees list`` CLI subcommand,
+* ``bernstein worktrees gc`` reaper, and
+* the TUI list pane refreshed every 10s.
+
+Inputs (all read-only):
+
+* ``git worktree list --porcelain`` in the project repo — definitive
+  list of every git-registered worktree.
+* ``.sdd/runtime/pids/<session_id>.json`` — task / worker PID record.
+* ``.sdd/traces/<session_id>.jsonl`` — last-trace mtime for staleness.
+* The on-disk worktree directory itself for size and ``.git`` presence.
+
+The classifier never modifies state. ``reap_worktree`` performs the only
+destructive action and is gated behind ``.sdd/runtime/worktree-gc.lock``.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "GC_LOCK_RELPATH",
+    "STALE_TRACE_AGE_S",
+    "WORKTREE_GC_LIFECYCLE_EVENT",
+    "ClassifiedWorktree",
+    "WorktreeState",
+    "classify_worktrees",
+    "format_size",
+    "iter_worktree_dirs",
+    "reap_worktree",
+    "worktrees_root",
+]
+
+
+#: Repo-relative path of the GC lock file. Single-file lock prevents two
+#: concurrent operators (or an operator plus a daemon) from reaping the
+#: same directory and corrupting git state.
+GC_LOCK_RELPATH = ".sdd/runtime/worktree-gc.lock"
+
+#: How old the last trace event must be before a dead-PID worktree is
+#: considered ``stale``. Anything younger stays ``active`` so we never
+#: race against an agent that briefly lost its PID file.
+STALE_TRACE_AGE_S: int = 24 * 60 * 60
+
+#: Lifecycle event identifier emitted for each reaped worktree.
+#: Plugins subscribe to this string via the ``bernstein.core.lifecycle``
+#: registry. Adding a brand-new enum entry would ripple through the
+#: notify bridge, so the classifier uses a free-form event id instead.
+WORKTREE_GC_LIFECYCLE_EVENT = "worktree.gc"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+class WorktreeState(StrEnum):
+    """Deterministic state assigned to every worktree.
+
+    The four states are mutually exclusive; the classifier picks the
+    first matching rule in this order: ``corrupt`` > ``orphan`` >
+    ``stale`` > ``active``.
+    """
+
+    ACTIVE = "active"
+    ORPHAN = "orphan"
+    STALE = "stale"
+    CORRUPT = "corrupt"
+
+
+@dataclass(frozen=True, slots=True)
+class ClassifiedWorktree:
+    """One row in the ``bernstein worktrees list`` table.
+
+    Attributes:
+        path: Absolute filesystem path of the worktree directory.
+        session_id: Directory basename — Bernstein uses the session id
+            as the worktree slug, so this also identifies the owning
+            task when one exists.
+        task_id: Task identifier from the PID record, or ``None`` when
+            no task record was found.
+        state: Classified :class:`WorktreeState`.
+        age_seconds: Wall-clock age of the worktree directory, computed
+            from its ``ctime`` (creation when the FS reports it,
+            metadata-change otherwise).
+        size_bytes: Recursive size on disk in bytes (best effort —
+            unreadable entries are skipped silently).
+        pid: Worker PID read from the task record, or ``None``.
+        pid_alive: Whether ``os.kill(pid, 0)`` succeeded. ``False`` when
+            ``pid`` is ``None``.
+        last_trace_mtime: Unix timestamp of the most recent trace
+            event, or ``None`` if no trace file exists.
+    """
+
+    path: Path
+    session_id: str
+    task_id: str | None
+    state: WorktreeState
+    age_seconds: float
+    size_bytes: int
+    pid: int | None
+    pid_alive: bool
+    last_trace_mtime: float | None
+
+    @property
+    def is_reapable(self) -> bool:
+        """Return ``True`` when the worktree is safe to delete."""
+        return self.state in (WorktreeState.ORPHAN, WorktreeState.STALE, WorktreeState.CORRUPT)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def worktrees_root(repo_root: Path) -> Path:
+    """Return the directory under which Bernstein stores agent worktrees.
+
+    The spec describes ``.sdd/runtime/worktrees/`` while the current
+    codebase still writes to ``.sdd/worktrees/``. We honour the new
+    location when it exists, otherwise fall back to the legacy path.
+    """
+    runtime = repo_root / ".sdd" / "runtime" / "worktrees"
+    if runtime.is_dir():
+        return runtime
+    return repo_root / ".sdd" / "worktrees"
+
+
+def iter_worktree_dirs(repo_root: Path) -> list[Path]:
+    """Return every directory that looks like an agent worktree.
+
+    Skips the ``.locks`` bookkeeping directory used by
+    :mod:`bernstein.core.git.worktree`.
+    """
+    root = worktrees_root(repo_root)
+    if not root.is_dir():
+        return []
+    entries: list[Path] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith(".") or entry.name == "locks":
+            continue
+        entries.append(entry)
+    return entries
+
+
+def format_size(size_bytes: int) -> str:
+    """Render a byte count as a short human-readable string."""
+    units = ("B", "KB", "MB", "GB", "TB")
+    size = float(size_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size_bytes} B"
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify_worktrees(
+    repo_root: Path,
+    *,
+    now: float | None = None,
+    stale_trace_age_s: int = STALE_TRACE_AGE_S,
+) -> list[ClassifiedWorktree]:
+    """Classify every Bernstein worktree under ``repo_root``.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+        now: Override the wall-clock for tests; defaults to ``time.time()``.
+        stale_trace_age_s: Trace freshness threshold in seconds.
+
+    Returns:
+        One :class:`ClassifiedWorktree` per directory, sorted by name.
+    """
+    clock = time.time() if now is None else now
+    git_paths = _git_worktree_paths(repo_root)
+    rows: list[ClassifiedWorktree] = []
+    for path in iter_worktree_dirs(repo_root):
+        rows.append(
+            _classify_one(
+                path,
+                repo_root=repo_root,
+                git_paths=git_paths,
+                now=clock,
+                stale_trace_age_s=stale_trace_age_s,
+            )
+        )
+    return rows
+
+
+def _classify_one(
+    path: Path,
+    *,
+    repo_root: Path,
+    git_paths: frozenset[str],
+    now: float,
+    stale_trace_age_s: int,
+) -> ClassifiedWorktree:
+    session_id = path.name
+    size_bytes = _dir_size(path)
+    age_seconds = _dir_age(path, now=now)
+
+    # 1. Corrupt — directory exists but git can't see a .git anchor.
+    git_anchor = path / ".git"
+    if not git_anchor.exists():
+        return ClassifiedWorktree(
+            path=path,
+            session_id=session_id,
+            task_id=None,
+            state=WorktreeState.CORRUPT,
+            age_seconds=age_seconds,
+            size_bytes=size_bytes,
+            pid=None,
+            pid_alive=False,
+            last_trace_mtime=None,
+        )
+
+    # Load the task record, if any.
+    pid_record = _read_pid_record(repo_root, session_id)
+    task_id = pid_record.get("task_id") if pid_record else None
+    pid = _coerce_pid(pid_record)
+    alive = pid is not None and _process_alive(pid)
+    last_trace_mtime = _last_trace_mtime(repo_root, session_id)
+
+    # 2. Orphan — directory has no task record at all.
+    if pid_record is None:
+        return ClassifiedWorktree(
+            path=path,
+            session_id=session_id,
+            task_id=None,
+            state=WorktreeState.ORPHAN,
+            age_seconds=age_seconds,
+            size_bytes=size_bytes,
+            pid=pid,
+            pid_alive=alive,
+            last_trace_mtime=last_trace_mtime,
+        )
+
+    # 3. Active — task record exists and PID is alive.
+    if alive:
+        return ClassifiedWorktree(
+            path=path,
+            session_id=session_id,
+            task_id=task_id if isinstance(task_id, str) else None,
+            state=WorktreeState.ACTIVE,
+            age_seconds=age_seconds,
+            size_bytes=size_bytes,
+            pid=pid,
+            pid_alive=True,
+            last_trace_mtime=last_trace_mtime,
+        )
+
+    # 4. Stale — task record exists but PID dead AND last trace > threshold.
+    # If trace freshness is below the threshold we cannot prove staleness
+    # yet, so leave the worktree marked ``active`` to be safe. The
+    # operator can re-run ``gc`` later.
+    trace_age = (now - last_trace_mtime) if last_trace_mtime is not None else float("inf")
+    if trace_age > stale_trace_age_s:
+        return ClassifiedWorktree(
+            path=path,
+            session_id=session_id,
+            task_id=task_id if isinstance(task_id, str) else None,
+            state=WorktreeState.STALE,
+            age_seconds=age_seconds,
+            size_bytes=size_bytes,
+            pid=pid,
+            pid_alive=False,
+            last_trace_mtime=last_trace_mtime,
+        )
+
+    return ClassifiedWorktree(
+        path=path,
+        session_id=session_id,
+        task_id=task_id if isinstance(task_id, str) else None,
+        state=WorktreeState.ACTIVE,
+        age_seconds=age_seconds,
+        size_bytes=size_bytes,
+        pid=pid,
+        pid_alive=False,
+        last_trace_mtime=last_trace_mtime,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reaper
+# ---------------------------------------------------------------------------
+
+
+def reap_worktree(
+    repo_root: Path,
+    worktree: ClassifiedWorktree,
+    *,
+    dry_run: bool = False,
+) -> bool:
+    """Delete the worktree directory and prune git state.
+
+    The caller MUST hold the GC lock at :data:`GC_LOCK_RELPATH`. This
+    function never acquires the lock on its own — leave that decision to
+    the CLI / TUI driver so a batch reap takes the lock once.
+
+    Args:
+        repo_root: Absolute repository root.
+        worktree: Classifier output for the directory to delete.
+        dry_run: When ``True``, no filesystem mutation happens; the
+            function returns ``True`` to mirror a real successful reap.
+
+    Returns:
+        ``True`` when the directory was removed (or would have been in
+        dry-run mode); ``False`` if the directory was already gone.
+    """
+    target = worktree.path
+    if not target.exists():
+        logger.info("reap: %s already gone, skipping", target)
+        return False
+
+    if dry_run:
+        logger.info("reap (dry-run): would remove %s", target)
+        return True
+
+    try:
+        shutil.rmtree(target)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        logger.warning("reap: failed to remove %s: %s", target, exc)
+        return False
+
+    # Best-effort: tell git the worktree is gone.
+    try:
+        subprocess.run(
+            ["git", "worktree", "prune"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("reap: git worktree prune failed: %s", exc)
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _git_worktree_paths(repo_root: Path) -> frozenset[str]:
+    """Return absolute paths git considers active worktrees."""
+    try:
+        proc = subprocess.run(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        logger.debug("git worktree list failed: %s", exc)
+        return frozenset()
+    if proc.returncode != 0:
+        return frozenset()
+    paths: set[str] = set()
+    for line in proc.stdout.splitlines():
+        if line.startswith("worktree "):
+            paths.add(line[len("worktree ") :].strip())
+    return frozenset(paths)
+
+
+def _read_pid_record(repo_root: Path, session_id: str) -> dict[str, object] | None:
+    pid_file = repo_root / ".sdd" / "runtime" / "pids" / f"{session_id}.json"
+    if not pid_file.exists():
+        return None
+    try:
+        data = json.loads(pid_file.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _coerce_pid(record: dict[str, object] | None) -> int | None:
+    if record is None:
+        return None
+    candidate = record.get("worker_pid") or record.get("pid")
+    if candidate is None:
+        return None
+    try:
+        value = int(candidate)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def _process_alive(pid: int) -> bool:
+    """Return ``True`` when ``pid`` is a live process.
+
+    Uses ``os.kill(pid, 0)`` and treats ``EPERM`` as alive (the process
+    exists but we lack permission to signal it).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+        return exc.errno == errno.EPERM
+    return True
+
+
+def _last_trace_mtime(repo_root: Path, session_id: str) -> float | None:
+    trace_file = repo_root / ".sdd" / "traces" / f"{session_id}.jsonl"
+    try:
+        return trace_file.stat().st_mtime
+    except OSError:
+        return None
+
+
+def _dir_size(path: Path) -> int:
+    total = 0
+    for root, _dirs, files in os.walk(path, onerror=lambda _exc: None):
+        for name in files:
+            try:
+                total += (Path(root) / name).stat().st_size
+            except OSError:
+                continue
+    return total
+
+
+def _dir_age(path: Path, *, now: float) -> float:
+    try:
+        stat = path.stat()
+    except OSError:
+        return 0.0
+    # ``st_birthtime`` is more accurate where available (macOS, BSD);
+    # fall back to ``st_ctime`` on Linux.
+    birth = getattr(stat, "st_birthtime", None)
+    created = birth if isinstance(birth, (int, float)) else stat.st_ctime
+    return max(0.0, now - float(created))

--- a/src/bernstein/tui/worktree_status.py
+++ b/src/bernstein/tui/worktree_status.py
@@ -9,7 +9,15 @@ from typing import TYPE_CHECKING, Any
 from rich.text import Text
 from textual.widgets import Static
 
-if TYPE_CHECKING:
+from bernstein.core.worktrees.classifier import (
+    ClassifiedWorktree,
+    WorktreeState,
+    classify_worktrees,
+    format_size,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from collections.abc import Iterable
     from pathlib import Path
 
 
@@ -121,3 +129,104 @@ class RuntimeHealthPanel(Static):
     def render(self) -> Text:
         """Render the current runtime snapshot."""
         return render_runtime_health(self._snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Worktree list pane (feat-worktree-gc-ui)
+# ---------------------------------------------------------------------------
+
+
+_STATE_COLOURS: dict[WorktreeState, str] = {
+    WorktreeState.ACTIVE: "green",
+    WorktreeState.ORPHAN: "yellow",
+    WorktreeState.STALE: "red",
+    WorktreeState.CORRUPT: "magenta",
+}
+
+#: Default refresh cadence for the worktree list pane.
+WORKTREE_LIST_REFRESH_S: float = 10.0
+
+
+def count_reapable(rows: Iterable[ClassifiedWorktree]) -> int:
+    """Return how many rows are safe to reap.
+
+    Surfaced in the TUI status bar so operators see clutter even when
+    the list pane is collapsed.
+    """
+    return sum(1 for row in rows if row.is_reapable)
+
+
+def render_worktree_list(rows: Iterable[ClassifiedWorktree]) -> Text:
+    """Render the worktree inventory for the side pane.
+
+    The output is deliberately compact (one row per worktree) so it fits
+    in the narrow side column. Reapable rows are highlighted.
+    """
+    text = Text()
+    rows_list = list(rows)
+    text.append("Worktrees\n", style="bold")
+    if not rows_list:
+        text.append("(none)", style="dim")
+        return text
+
+    for row in rows_list:
+        colour = _STATE_COLOURS.get(row.state, "white")
+        text.append("• ", style="dim")
+        text.append(f"{row.session_id[:18]:<18} ")
+        text.append(f"{row.state.value:<7}", style=colour)
+        text.append(f"  {format_size(row.size_bytes)}\n", style="dim")
+
+    reapable = count_reapable(rows_list)
+    if reapable:
+        text.append(f"{reapable} reapable", style="yellow bold")
+    else:
+        text.append("clean", style="green")
+    return text
+
+
+class WorktreeListPanel(Static):
+    """Side pane that lists every worktree with its classification.
+
+    The panel does not poll the filesystem on its own; the dashboard
+    refresh loop calls :meth:`refresh_from_repo` every
+    :data:`WORKTREE_LIST_REFRESH_S` seconds. Tests can call
+    :meth:`set_rows` directly to bypass disk I/O.
+    """
+
+    DEFAULT_CSS = """
+    WorktreeListPanel {
+        height: auto;
+        min-height: 6;
+        border: round $accent 20%;
+        padding: 1 1;
+        background: $surface-darken-1;
+    }
+    """
+
+    def __init__(self, repo_root: Path | None = None, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._rows: list[ClassifiedWorktree] = []
+        self._repo_root = repo_root
+
+    def set_repo_root(self, repo_root: Path | None) -> None:
+        """Update the repository root used by :meth:`refresh_from_repo`."""
+        self._repo_root = repo_root
+
+    def set_rows(self, rows: Iterable[ClassifiedWorktree]) -> None:
+        """Replace the rendered rows."""
+        self._rows = list(rows)
+        self.refresh()
+
+    def reapable_count(self) -> int:
+        """Number of currently-known reapable worktrees."""
+        return count_reapable(self._rows)
+
+    def refresh_from_repo(self) -> None:
+        """Re-classify all worktrees under the configured repo root."""
+        if self._repo_root is None:
+            return
+        self.set_rows(classify_worktrees(self._repo_root))
+
+    def render(self) -> Text:
+        """Render the current worktree rows."""
+        return render_worktree_list(self._rows)

--- a/tests/unit/test_tui_worktree_status.py
+++ b/tests/unit/test_tui_worktree_status.py
@@ -2,7 +2,17 @@
 
 from __future__ import annotations
 
-from bernstein.tui.worktree_status import RuntimeHealthPanel, render_runtime_health
+import os
+from pathlib import Path
+
+from bernstein.core.worktrees.classifier import ClassifiedWorktree, WorktreeState
+from bernstein.tui.worktree_status import (
+    RuntimeHealthPanel,
+    WorktreeListPanel,
+    count_reapable,
+    render_runtime_health,
+    render_worktree_list,
+)
 
 
 def test_render_runtime_health_empty() -> None:
@@ -36,3 +46,92 @@ def test_runtime_health_panel_renders_snapshot() -> None:
     widget = RuntimeHealthPanel()
     widget.set_snapshot({"git_branch": "feature/runtime", "active_worktrees": 2})
     assert "feature/runtime" in widget.render().plain
+
+
+def _row(state: WorktreeState, *, sid: str = "session", size: int = 0) -> ClassifiedWorktree:
+    return ClassifiedWorktree(
+        path=Path(f"/tmp/{sid}"),
+        session_id=sid,
+        task_id=None,
+        state=state,
+        age_seconds=0,
+        size_bytes=size,
+        pid=None,
+        pid_alive=False,
+        last_trace_mtime=None,
+    )
+
+
+def test_count_reapable_excludes_active() -> None:
+    """Only orphan / stale / corrupt rows are counted as reapable."""
+    rows = [
+        _row(WorktreeState.ACTIVE, sid="a"),
+        _row(WorktreeState.ORPHAN, sid="o"),
+        _row(WorktreeState.STALE, sid="s"),
+        _row(WorktreeState.CORRUPT, sid="c"),
+    ]
+    assert count_reapable(rows) == 3
+
+
+def test_render_worktree_list_empty() -> None:
+    """The empty pane is rendered with a clear sentinel."""
+    text = render_worktree_list([])
+    assert "Worktrees" in text.plain
+    assert "(none)" in text.plain
+
+
+def test_render_worktree_list_has_reapable_summary() -> None:
+    """The pane footer surfaces the reapable count."""
+    rows = [_row(WorktreeState.ORPHAN, sid="orph", size=2048)]
+    text = render_worktree_list(rows)
+    assert "orph" in text.plain
+    assert "orphan" in text.plain
+    assert "1 reapable" in text.plain
+
+
+def test_render_worktree_list_clean() -> None:
+    """All-active panes render the ``clean`` footer."""
+    rows = [_row(WorktreeState.ACTIVE)]
+    text = render_worktree_list(rows)
+    assert "clean" in text.plain
+
+
+def test_worktree_list_panel_set_rows() -> None:
+    """The panel renders rows passed via :meth:`set_rows`."""
+    panel = WorktreeListPanel()
+    panel.set_rows([_row(WorktreeState.STALE, sid="dead")])
+    assert "dead" in panel.render().plain
+    assert panel.reapable_count() == 1
+
+
+def test_worktree_list_panel_refresh_from_repo(tmp_path: Path) -> None:
+    """``refresh_from_repo`` loads classifier output for the configured root."""
+    base = tmp_path / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True)
+    (base / "stranded").mkdir()
+    (base / "stranded" / ".git").write_text("gitdir: /fake")
+
+    panel = WorktreeListPanel(repo_root=tmp_path)
+    panel.refresh_from_repo()
+    assert panel.reapable_count() == 1
+    assert "stranded" in panel.render().plain
+
+
+def test_worktree_list_panel_no_repo_root_is_noop() -> None:
+    """Refresh without a configured root must not raise."""
+    panel = WorktreeListPanel()
+    panel.refresh_from_repo()
+    assert panel.reapable_count() == 0
+
+
+def test_worktree_list_panel_picks_up_legacy_layout(tmp_path: Path) -> None:
+    """Older layouts under ``.sdd/worktrees`` are still classified."""
+    legacy = tmp_path / ".sdd" / "worktrees" / "legacy"
+    legacy.mkdir(parents=True)
+    (legacy / ".git").write_text("gitdir: /fake")
+
+    panel = WorktreeListPanel(repo_root=tmp_path)
+    panel.refresh_from_repo()
+    assert "legacy" in panel.render().plain
+    # No need to read os here – the import is exercised by the other tests.
+    assert os.path.isdir(legacy)

--- a/tests/unit/test_worktrees_cmd.py
+++ b/tests/unit/test_worktrees_cmd.py
@@ -1,0 +1,432 @@
+"""Unit tests for the ``bernstein worktrees`` subcommand and classifier.
+
+Every fixture builds an isolated ``.sdd/`` tree under ``tmp_path`` — the
+suite NEVER touches the real repo's 30+ worktrees.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.worktrees_cmd import (
+    GcLockError,
+    format_age,
+    lock_gc,
+    render_worktrees_table,
+    run_gc,
+    worktrees_group,
+)
+from bernstein.core.worktrees.classifier import (
+    GC_LOCK_RELPATH,
+    STALE_TRACE_AGE_S,
+    ClassifiedWorktree,
+    WorktreeState,
+    classify_worktrees,
+    format_size,
+    iter_worktree_dirs,
+    reap_worktree,
+    worktrees_root,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _init_repo(repo_root: Path) -> None:
+    """Initialise a bare git repo with one main commit at ``repo_root``."""
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo_root)], check=True)
+    (repo_root / "seed.txt").write_text("seed")
+    subprocess.run(["git", "-C", str(repo_root), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "-c",
+            "user.email=test@bernstein",
+            "-c",
+            "user.name=test",
+            "commit",
+            "-q",
+            "-m",
+            "seed",
+        ],
+        check=True,
+    )
+
+
+def _make_worktree_dir(repo_root: Path, session_id: str, *, with_git: bool = True) -> Path:
+    """Create a fake worktree directory under ``.sdd/runtime/worktrees``.
+
+    We do not actually call ``git worktree add`` — the classifier only
+    needs the directory layout (`.git` anchor + size on disk).
+    """
+    base = repo_root / ".sdd" / "runtime" / "worktrees"
+    base.mkdir(parents=True, exist_ok=True)
+    wt = base / session_id
+    wt.mkdir()
+    (wt / "file.txt").write_text("hello")
+    if with_git:
+        (wt / ".git").write_text("gitdir: /fake")
+    return wt
+
+
+def _write_pid_record(repo_root: Path, session_id: str, *, pid: int, task_id: str | None = None) -> None:
+    pid_dir = repo_root / ".sdd" / "runtime" / "pids"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {"worker_pid": pid}
+    if task_id is not None:
+        payload["task_id"] = task_id
+    (pid_dir / f"{session_id}.json").write_text(json.dumps(payload))
+
+
+def _write_trace(repo_root: Path, session_id: str, *, mtime: float | None = None) -> Path:
+    trace_dir = repo_root / ".sdd" / "traces"
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    path = trace_dir / f"{session_id}.jsonl"
+    path.write_text("{}\n")
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    """Initialised throw-away repo root."""
+    _init_repo(tmp_path)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Classifier — 4-state matrix
+# ---------------------------------------------------------------------------
+
+
+def test_classifier_active(repo_root: Path) -> None:
+    """Live PID + task record + recent trace => active."""
+    sid = "alive"
+    _make_worktree_dir(repo_root, sid)
+    _write_pid_record(repo_root, sid, pid=os.getpid(), task_id="task-1")
+    _write_trace(repo_root, sid)
+
+    rows = classify_worktrees(repo_root)
+    assert len(rows) == 1
+    assert rows[0].state is WorktreeState.ACTIVE
+    assert rows[0].task_id == "task-1"
+    assert rows[0].pid_alive is True
+
+
+def test_classifier_orphan(repo_root: Path) -> None:
+    """Directory exists but no PID record => orphan."""
+    sid = "orph"
+    _make_worktree_dir(repo_root, sid)
+
+    rows = classify_worktrees(repo_root)
+    assert rows[0].state is WorktreeState.ORPHAN
+    assert rows[0].is_reapable is True
+
+
+def test_classifier_stale(repo_root: Path) -> None:
+    """Dead PID + trace older than 24h => stale."""
+    sid = "stale"
+    _make_worktree_dir(repo_root, sid)
+    # Use a PID very unlikely to be in use.
+    dead_pid = 999_999_998
+    _write_pid_record(repo_root, sid, pid=dead_pid, task_id="task-stale")
+    long_ago = time.time() - (STALE_TRACE_AGE_S + 3600)
+    _write_trace(repo_root, sid, mtime=long_ago)
+
+    rows = classify_worktrees(repo_root)
+    assert rows[0].state is WorktreeState.STALE
+    assert rows[0].is_reapable is True
+
+
+def test_classifier_corrupt(repo_root: Path) -> None:
+    """Directory has no .git anchor => corrupt."""
+    sid = "corrupt"
+    _make_worktree_dir(repo_root, sid, with_git=False)
+
+    rows = classify_worktrees(repo_root)
+    assert rows[0].state is WorktreeState.CORRUPT
+    assert rows[0].is_reapable is True
+
+
+def test_classifier_dead_pid_recent_trace_stays_active(repo_root: Path) -> None:
+    """Dead PID but recent trace => still active (avoid racing).
+
+    We refuse to reap a worktree whose trace is fresh, even if its PID
+    has gone away — the agent may simply be restarting.
+    """
+    sid = "race"
+    _make_worktree_dir(repo_root, sid)
+    _write_pid_record(repo_root, sid, pid=999_999_997, task_id="task-race")
+    _write_trace(repo_root, sid)  # mtime = now
+
+    rows = classify_worktrees(repo_root)
+    assert rows[0].state is WorktreeState.ACTIVE
+    assert rows[0].is_reapable is False
+
+
+def test_iter_worktree_dirs_skips_locks(repo_root: Path) -> None:
+    """The bookkeeping ``.locks`` directory is excluded from iteration."""
+    _make_worktree_dir(repo_root, "real")
+    locks = worktrees_root(repo_root) / ".locks"
+    locks.mkdir()
+    (locks / "foo.lock").write_text("")
+    assert [p.name for p in iter_worktree_dirs(repo_root)] == ["real"]
+
+
+# ---------------------------------------------------------------------------
+# Lock — concurrency safety
+# ---------------------------------------------------------------------------
+
+
+def test_lock_prevents_concurrent_gc(repo_root: Path) -> None:
+    """A second ``lock_gc`` while the first is held raises ``GcLockError``."""
+    with lock_gc(repo_root):
+        with pytest.raises(GcLockError):
+            with lock_gc(repo_root):
+                pass
+
+
+def test_lock_released_on_exception(repo_root: Path) -> None:
+    """The lock file is unlinked even when the body raises."""
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with lock_gc(repo_root):
+            raise Boom
+
+    # Lock should be gone — next acquisition succeeds.
+    with lock_gc(repo_root):
+        pass
+
+
+def test_lock_held_by_thread_blocks_second(repo_root: Path) -> None:
+    """Concurrent threads must serialise through the lock file."""
+    started = threading.Event()
+    release = threading.Event()
+    errors: list[BaseException] = []
+
+    def hold() -> None:
+        try:
+            with lock_gc(repo_root):
+                started.set()
+                release.wait(timeout=5)
+        except BaseException as exc:  # pragma: no cover - propagated below
+            errors.append(exc)
+
+    holder = threading.Thread(target=hold)
+    holder.start()
+    started.wait(timeout=5)
+    try:
+        with pytest.raises(GcLockError):
+            with lock_gc(repo_root):
+                pass
+    finally:
+        release.set()
+        holder.join(timeout=5)
+    assert not errors
+
+
+# ---------------------------------------------------------------------------
+# Reap behaviour — --dry and real deletion
+# ---------------------------------------------------------------------------
+
+
+def _orphan_row(repo_root: Path, sid: str) -> ClassifiedWorktree:
+    """Convenience: classify a single orphan worktree."""
+    rows = classify_worktrees(repo_root)
+    matching = [r for r in rows if r.session_id == sid]
+    assert matching, f"no row for {sid}"
+    return matching[0]
+
+
+def test_reap_worktree_dry_run_does_not_touch_disk(repo_root: Path) -> None:
+    """``dry_run=True`` leaves the directory in place."""
+    sid = "dry"
+    wt = _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+    assert row.state is WorktreeState.ORPHAN
+
+    assert reap_worktree(repo_root, row, dry_run=True) is True
+    assert wt.exists()
+    assert (wt / "file.txt").read_text() == "hello"
+
+
+def test_reap_worktree_real_removes_directory(repo_root: Path) -> None:
+    """Without ``dry_run`` the directory is gone after the call."""
+    sid = "real"
+    wt = _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+
+    assert reap_worktree(repo_root, row, dry_run=False) is True
+    assert not wt.exists()
+
+
+def test_run_gc_invokes_git_prune(repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run_gc`` runs ``git worktree prune`` after each reap."""
+    sid = "pruned"
+    _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+
+    captured: list[list[str]] = []
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(cmd, list) and cmd[:3] == ["git", "worktree", "prune"]:
+            captured.append(list(cmd))
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_gc(repo_root, [row], dry_run=False)
+    assert any(c[:3] == ["git", "worktree", "prune"] for c in captured)
+
+
+def test_run_gc_dry_run_skips_prune(repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--dry`` must not invoke ``git worktree prune`` either."""
+    sid = "dry-prune"
+    _make_worktree_dir(repo_root, sid)
+    row = _orphan_row(repo_root, sid)
+
+    captured: list[list[str]] = []
+    real_run = subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if isinstance(cmd, list) and cmd[:3] == ["git", "worktree", "prune"]:
+            captured.append(list(cmd))
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_gc(repo_root, [row], dry_run=True)
+    assert captured == []
+    assert row.path.exists()  # filesystem untouched
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def test_format_age_buckets() -> None:
+    assert format_age(0) == "0s"
+    assert format_age(59) == "59s"
+    assert format_age(60) == "1m"
+    assert format_age(3600) == "1h 00m"
+    assert format_age(86_400) == "1d 00h"
+    assert format_age(86_400 + 7200) == "1d 02h"
+
+
+def test_format_size_units() -> None:
+    assert format_size(0) == "0 B"
+    assert format_size(1023) == "1023 B"
+    assert format_size(1024) == "1.0 KB"
+    assert format_size(1024 * 1024) == "1.0 MB"
+
+
+def test_render_table_has_columns() -> None:
+    """Smoke test that the table builder accepts classifier output."""
+    row = ClassifiedWorktree(
+        path=Path("/tmp/x"),
+        session_id="x",
+        task_id=None,
+        state=WorktreeState.ORPHAN,
+        age_seconds=300,
+        size_bytes=2048,
+        pid=None,
+        pid_alive=False,
+        last_trace_mtime=None,
+    )
+    table = render_worktrees_table([row])
+    headers = [col.header for col in table.columns]
+    assert headers == ["Path", "Task", "State", "Age", "Size", "PID"]
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_list_renders_table(repo_root: Path) -> None:
+    """``worktrees list`` prints a table with one row per worktree."""
+    _make_worktree_dir(repo_root, "alpha")
+    _make_worktree_dir(repo_root, "beta")
+    runner = CliRunner()
+    result = runner.invoke(worktrees_group, ["list", "--workdir", str(repo_root)])
+    assert result.exit_code == 0, result.output
+    assert "alpha" in result.output
+    assert "beta" in result.output
+    assert "orphan" in result.output
+
+
+def test_cli_list_json_output(repo_root: Path) -> None:
+    """``--json`` returns a parseable JSON array."""
+    _make_worktree_dir(repo_root, "alpha")
+    runner = CliRunner()
+    result = runner.invoke(worktrees_group, ["list", "--workdir", str(repo_root), "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload) == 1
+    assert payload[0]["state"] == "orphan"
+    assert payload[0]["reapable"] is True
+
+
+def test_cli_gc_dry_run_keeps_disk(repo_root: Path) -> None:
+    """``gc --dry --yes`` reports work but never deletes."""
+    wt = _make_worktree_dir(repo_root, "gc-dry")
+    runner = CliRunner()
+    result = runner.invoke(
+        worktrees_group,
+        ["gc", "--workdir", str(repo_root), "--yes", "--dry"],
+    )
+    assert result.exit_code == 0, result.output
+    assert wt.exists()
+    assert "Would remove" in result.output
+
+
+def test_cli_gc_yes_deletes(repo_root: Path) -> None:
+    """``gc --yes`` skips the prompt and removes orphans."""
+    wt = _make_worktree_dir(repo_root, "gc-real")
+    runner = CliRunner()
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--yes"])
+    assert result.exit_code == 0, result.output
+    assert not wt.exists()
+
+
+def test_cli_gc_no_reapable(repo_root: Path) -> None:
+    """When everything is active, ``gc`` is a no-op with friendly output."""
+    sid = "live"
+    _make_worktree_dir(repo_root, sid)
+    _write_pid_record(repo_root, sid, pid=os.getpid(), task_id="t")
+    _write_trace(repo_root, sid)
+    runner = CliRunner()
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--yes"])
+    assert result.exit_code == 0
+    assert "nothing to do" in result.output.lower()
+
+
+def test_cli_gc_concurrent_lock_collision(repo_root: Path) -> None:
+    """Holding the lock externally makes ``gc`` exit with code 2."""
+    lock_path = repo_root / GC_LOCK_RELPATH
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("{}")
+    _make_worktree_dir(repo_root, "blocked")
+
+    runner = CliRunner()
+    result = runner.invoke(worktrees_group, ["gc", "--workdir", str(repo_root), "--yes"])
+    assert result.exit_code == 2
+    assert "already running" in result.output.lower()


### PR DESCRIPTION
## TL;DR

| Item | Status |
|------|--------|
| `bernstein worktrees list` | OK — table + `--json` |
| `bernstein worktrees gc` | OK — `--yes`, `--dry`, confirm prompt, exit code 2 on lock collision |
| 4-state classifier | OK — active / orphan / stale / corrupt |
| Single-file GC lock at `.sdd/runtime/worktree-gc.lock` | OK — O_EXCL, released on exception |
| TUI list pane refreshed every 10s | OK — `WorktreeListPanel`, `count_reapable` for status bar |
| `worktree.gc` lifecycle event for plugins | OK — emitted via `post_archive` + `BERNSTEIN_WORKTREE_GC_*` env keys |
| Tests | OK — 22 new in `test_worktrees_cmd.py`, 9 new in `test_tui_worktree_status.py`, 33 total |

## State matrix

| State | Rule |
|-------|------|
| `active` | task record exists at `.sdd/runtime/pids/<sid>.json` AND `os.kill(pid, 0)` succeeds |
| `orphan` | directory exists but no task record |
| `stale` | task record exists but PID dead AND last trace mtime > 24h ago |
| `corrupt` | directory exists but `.git` anchor missing |

Priority: corrupt > orphan > stale > active. A dead PID with a fresh trace stays `active` to avoid racing a restart.

## Architecture

- `src/bernstein/core/worktrees/classifier.py` — single source of truth (`classify_worktrees`, `reap_worktree`, `WorktreeState`).
- `src/bernstein/cli/commands/worktrees_cmd.py` — click group with `list` / `gc`, `lock_gc` ctx manager, lifecycle emit.
- `src/bernstein/tui/worktree_status.py` — extended with `WorktreeListPanel`, `render_worktree_list`, `count_reapable`.
- Honours both `.sdd/runtime/worktrees/` (spec) and the legacy `.sdd/worktrees/` layout currently produced by `WorktreeManager`.

## Sample output

```
$ bernstein worktrees list
                              Bernstein worktrees
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━┳━━━━━━━┳━━━━━┓
┃ Path                        ┃ Task       ┃ State   ┃   Age ┃  Size ┃ PID ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━╇━━━━━━━╇━━━━━┩
│ .sdd/runtime/worktrees/abc  │ task-abc12 │ active  │ 5m    │ 12 MB │ 4321│
│ .sdd/runtime/worktrees/def  │ —          │ orphan  │ 2h 14m│ 5 MB  │   — │
│ .sdd/runtime/worktrees/old  │ task-old   │ stale   │ 3d 04h│ 8 MB  │999✗│
└─────────────────────────────┴────────────┴─────────┴───────┴───────┴─────┘
2 worktree(s) reapable — run bernstein worktrees gc to clean up.
```

## Out of scope (per spec)

- Auto-GC on daemon start
- Cross-project fleet-mode GC
- Restoring deleted worktrees

## Test plan

- [x] `uv run pytest tests/unit/test_worktrees_cmd.py tests/unit/test_tui_worktree_status.py` — 33 pass
- [x] `uv run ruff check` clean on touched files
- [x] Smoke: `bernstein worktrees --help` / `list` / `gc --help` render correctly
- [ ] Manual: operator runs `bernstein worktrees list` on a repo with real orphaned worktrees
- [ ] Manual: concurrent `gc` invocations from two shells → second exits with code 2