### PR TITLE
test(ci): fix stale base_ref assertion on main

### DIFF
--- a/tests/unit/test_cross_platform_ci.py
+++ b/tests/unit/test_cross_platform_ci.py
@@ -125,7 +125,13 @@ class TestCIWorkflowExists:
         assert len(fetch_steps) == 1
         fetch_step = fetch_steps[0]
         assert fetch_step.get("if") == "github.event_name == 'pull_request' && runner.os != 'Windows'"
-        assert "refs/heads/${{ github.base_ref }}" in fetch_step.get("run", "")
+        env = fetch_step.get("env") or {}
+        assert env.get("BASE_REF") == "${{ github.base_ref }}", (
+            "BASE_REF must be bound via env: to avoid template injection (zizmor)"
+        )
+        run_script = fetch_step.get("run", "")
+        assert "refs/heads/${BASE_REF}" in run_script
+        assert "refs/remotes/origin/${BASE_REF}" in run_script
 
     def test_pull_request_test_job_uses_affected_runner_with_fallback(self) -> None:
         data = _load_ci_workflow()
@@ -135,9 +141,13 @@ class TestCIWorkflowExists:
         # The Linux/macOS variant carries the --affected fallback logic.
         unix_steps = [step for step in run_steps if "Linux/macOS" in (step.get("name") or "")]
         assert len(unix_steps) == 1
+        env = unix_steps[0].get("env") or {}
+        assert env.get("BASE_REF") == "${{ github.base_ref }}", (
+            "BASE_REF must be bound via env: to avoid template injection (zizmor)"
+        )
         run_script = unix_steps[0].get("run", "")
         assert "--affected" in run_script
-        assert "refs/remotes/origin/${{ github.base_ref }}" in run_script
+        assert "refs/remotes/origin/${BASE_REF}" in run_script
         assert "uv run python scripts/run_tests.py" in run_script
         assert "--parallel 4" in run_script
 


### PR DESCRIPTION
## TL;DR

| | |
|---|---|
| File | `tests/unit/test_cross_platform_ci.py` |
| Problem | Test asserted literal `${{ github.base_ref }}` in the `run:` block, but the zizmor security pass moved it into `env: BASE_REF: ...` and now uses `${BASE_REF}` in shell |
| Result | main CI red on every commit since the security hardening landed |

## What changes

- `test_pull_request_test_job_fetches_base_ref_for_impacted_tests` now asserts `env.BASE_REF == "${{ github.base_ref }}"` plus the presence of `${BASE_REF}` in the run script
- `test_pull_request_test_job_uses_affected_runner_with_fallback` updated the same way for the unix Run steps

## Test plan

- [x] `uv run pytest tests/unit/test_cross_platform_ci.py -v` → 19/19 pass locally
- [x] `uv run ruff check` clean