### PR TITLE
feat: bernstein recipes — first-class workflow library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,10 @@ packages = ["src/bernstein"]
 # override path .sdd/eval/golden/<tier>/*.md is still consulted first.
 artifacts = [
     "src/bernstein/eval/golden_data/**/*.md",
+    # Recipe golden traces — YAML fixtures that pin the resolved
+    # workflow shape for each bundled recipe.  Loaded by the eval
+    # harness to catch drift after refactors.
+    "src/bernstein/eval/golden_data/**/*.yaml",
     # Web GUI built assets — Vite output committed to the package tree so
     # the wheel ships pre-built. Rebuild with: cd web && npm run build.
     "src/bernstein/gui/static/**/*",
@@ -286,6 +290,11 @@ artifacts = [
 # `bernstein workflow list` / `... run <name>` resolve immediately
 # without requiring a source checkout.
 "templates/workflows" = "bernstein/_default_templates/workflows"
+# First-class recipe library — parameterised workflows for common
+# operator tasks (refactor-glob, bump-dependency, add-tests-for-module,
+# license-audit, regenerate-docs).  Shipped in the wheel so
+# `bernstein recipes list|show|run` resolves immediately.
+"templates/recipes" = "bernstein/_default_templates/recipes"
 # ascii_logo.md now lives in-package at src/bernstein/_default_templates/ —
 # no force-include needed. The dev-repo copy at docs/assets/ascii_logo.md is
 # the display fallback read by cli/display/splash_v2.py when running from a

--- a/src/bernstein/cli/__init__.py
+++ b/src/bernstein/cli/__init__.py
@@ -94,6 +94,7 @@ _CLI_REDIRECT_MAP: dict[str, str] = {
     "prompts_cmd": "bernstein.cli.commands.prompts_cmd",
     "quickstart_cmd": "bernstein.cli.commands.quickstart_cmd",
     "quickstart_templates": "bernstein.cli.commands.quickstart_templates",
+    "recipes_cmd": "bernstein.cli.commands.recipes_cmd",
     "replay_filter_cmd": "bernstein.cli.commands.replay_filter_cmd",
     "report_cmd": "bernstein.cli.commands.report_cmd",
     "role_adapter_policy_cmd": "bernstein.cli.commands.role_adapter_policy_cmd",

--- a/src/bernstein/cli/commands/recipes_cmd.py
+++ b/src/bernstein/cli/commands/recipes_cmd.py
@@ -1,0 +1,406 @@
+"""CLI commands for the first-class recipe library.
+
+A *recipe* is a parameterised workflow.  Each manifest lives under
+``templates/recipes/*.yaml`` and reuses
+:class:`bernstein.core.workflows.workflow_spec.WorkflowSpec` for the
+node body; a top-level ``params:`` block adds operator-facing typed
+inputs.  The CLI validates parameters, applies defaults, and renders
+placeholders before handing the resulting :class:`WorkflowSpec` to the
+existing :class:`bernstein.core.workflows.workflow_runner.WorkflowRunner`.
+
+Surface:
+
+* ``bernstein recipes list`` — bundled recipes + one-line descriptions.
+* ``bernstein recipes show <name>`` — manifest details: params, nodes,
+  dependency order.
+* ``bernstein recipes run <name> --param key=value ...`` — execute the
+  recipe end-to-end.  ``--dry-run`` prints the resolved workflow plan
+  without spawning agents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+
+if TYPE_CHECKING:  # pragma: no cover — typing only
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_spec import RecipeSpec
+
+
+# ---------------------------------------------------------------------------
+# Top-level group
+# ---------------------------------------------------------------------------
+
+
+@click.group("recipes")
+def recipes_group() -> None:
+    """First-class recipe library — parameterised workflows for common tasks.
+
+    \b
+    Examples:
+      bernstein recipes list
+      bernstein recipes show bump-dependency
+      bernstein recipes run bump-dependency --param package=httpx --param version=0.27.0
+      bernstein recipes run refactor-glob --param pattern=foo_ --param replacement=bar_ --dry-run
+    """
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+@recipes_group.command("list")
+@click.option(
+    "--bundled-only",
+    is_flag=True,
+    default=False,
+    help="Skip user directories; list only recipes shipped with the wheel.",
+)
+def list_cmd(bundled_only: bool) -> None:
+    """List every reachable recipe with a one-line description.
+
+    \b
+    Lookup order:
+      1. <workdir>/.bernstein/recipes/
+      2. ~/.bernstein/recipes/
+      3. templates/recipes/ (bundled)
+
+    First match wins on name collisions.
+    """
+    from rich.console import Console
+    from rich.table import Table
+
+    from bernstein.core.workflows.recipe_spec import (
+        RecipeSpecError,
+        discover_recipes,
+        load_recipe_spec,
+    )
+
+    console = Console()
+    table = Table(title="Recipes")
+    table.add_column("Name", style="bold")
+    table.add_column("Description")
+    table.add_column("Params", justify="right")
+    table.add_column("Nodes", justify="right")
+    table.add_column("Source")
+
+    workdir = Path.cwd()
+    found = 0
+    for _name, path in discover_recipes(
+        workdir=workdir,
+        include_bundled=True,
+        include_user=not bundled_only,
+    ):
+        try:
+            spec = load_recipe_spec(path)
+            table.add_row(
+                spec.name,
+                spec.description,
+                str(len(spec.params)),
+                str(len(spec.nodes)),
+                path.parent.as_posix(),
+            )
+            found += 1
+        except RecipeSpecError as exc:
+            table.add_row(path.stem, f"[red]error: {exc}[/red]", "-", "-", path.parent.as_posix())
+            found += 1
+
+    if found == 0:
+        console.print("[dim]No recipes found.[/dim]")
+        return
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+@recipes_group.command("show")
+@click.argument("name")
+def show_cmd(name: str) -> None:
+    """Print the manifest for ``name`` — params, nodes, dependency layers.
+
+    \b
+    Example:
+      bernstein recipes show bump-dependency
+    """
+    from rich.console import Console
+    from rich.panel import Panel
+
+    from bernstein.core.workflows.recipe_spec import (
+        RecipeSpecError,
+        resolve_recipe,
+    )
+
+    console = Console()
+    try:
+        path, spec = resolve_recipe(name, workdir=Path.cwd())
+    except RecipeSpecError as exc:
+        console.print(f"[bold red]Failed to load recipe:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+
+    console.print(
+        Panel(
+            f"[bold]{spec.name}[/bold] v{spec.version}\n[dim]{spec.description}[/dim]\n[dim]Source: {path}[/dim]",
+            expand=False,
+        ),
+    )
+
+    _render_params_table(spec, console)
+    _render_nodes_table(spec, console)
+    _render_layer_plan(spec, console)
+
+
+def _render_params_table(spec: RecipeSpec, console: Console) -> None:
+    """Render the ``params`` block as a Rich table."""
+    from rich.table import Table
+
+    if not spec.params:
+        console.print("[dim]No parameters declared.[/dim]")
+        return
+    params_table = Table(title="Parameters", show_lines=False)
+    params_table.add_column("Name", style="bold")
+    params_table.add_column("Type")
+    params_table.add_column("Required")
+    params_table.add_column("Default")
+    params_table.add_column("Choices")
+    params_table.add_column("Help")
+    for param in spec.params:
+        params_table.add_row(
+            param.name,
+            param.type,
+            "yes" if param.required else "no",
+            "-" if param.default is None else str(param.default),
+            ", ".join(param.choices) if param.choices else "-",
+            param.help,
+        )
+    console.print(params_table)
+
+
+def _render_nodes_table(spec: RecipeSpec, console: Console) -> None:
+    """Render the raw node list (pre-substitution) as a Rich table."""
+    from rich.table import Table
+
+    nodes_table = Table(title="Nodes", show_lines=False)
+    nodes_table.add_column("Id", style="bold")
+    nodes_table.add_column("Kind")
+    nodes_table.add_column("Depends on")
+    nodes_table.add_column("Body")
+    for node in spec.nodes:
+        node_id = str(node.get("id", "?"))
+        depends = ", ".join(node.get("depends_on", []) or []) or "-"
+        if "agent" in node:
+            kind = f"agent ({node['agent']})"
+            body = _truncate(str(node.get("prompt", "")), 80)
+        else:
+            kind = "command"
+            body = _truncate(str(node.get("command", "")), 80)
+        nodes_table.add_row(node_id, kind, depends, body)
+    console.print(nodes_table)
+
+
+def _render_layer_plan(spec: RecipeSpec, console: Console) -> None:
+    """Print the execution layer plan derived from a defaults-only render."""
+    from bernstein.core.workflows.recipe_spec import RecipeParamError, RecipeSpecError
+
+    # Render with defaults if possible.  If a required param has no
+    # default we just show the raw node list; the operator can still
+    # read the manifest above.
+    try:
+        defaults = spec.resolve_params({})
+    except RecipeParamError:
+        console.print(
+            "[dim]Execution plan unavailable: recipe has required params with no defaults.[/dim]",
+        )
+        return
+    try:
+        workflow = spec.to_workflow_spec(param_values=defaults)
+    except RecipeSpecError as exc:
+        console.print(f"[yellow]Execution plan unavailable: {exc}[/yellow]")
+        return
+    layers = workflow.topological_order()
+    console.print("[bold]Execution order:[/bold]")
+    for index, layer in enumerate(layers, start=1):
+        ids = ", ".join(node.id for node in layer)
+        console.print(f"  Layer {index}: {ids}")
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Compress multi-line bodies to one line capped at ``limit`` chars."""
+    flattened = " ".join(text.split())
+    if len(flattened) <= limit:
+        return flattened
+    return flattened[: limit - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+@recipes_group.command("run")
+@click.argument("name")
+@click.option(
+    "--param",
+    "params",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Set a recipe parameter.  May be repeated.",
+)
+@click.option(
+    "-g",
+    "--goal",
+    default="",
+    help="Free-text goal substituted into {goal} placeholders in prompts.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Resolve params + render the workflow without spawning agents.",
+)
+def run_cmd(
+    name: str,
+    params: tuple[str, ...],
+    goal: str,
+    dry_run: bool,
+) -> None:
+    """Execute a recipe end-to-end.
+
+    \b
+    Resolves ``name`` against bundled + user-installed recipe dirs, or
+    treats it as a filesystem path when it looks like one.  Validates
+    --param values against the manifest's declared types, applies
+    defaults for omitted params, then hands the rendered workflow to
+    the standard WorkflowRunner.
+
+    \b
+    Examples:
+      bernstein recipes run refactor-glob \\
+        --param pattern=foo_ --param replacement=bar_
+      bernstein recipes run bump-dependency \\
+        --param package=httpx --param version=0.27.0 --dry-run
+    """
+    from rich.console import Console
+
+    from bernstein.core.workflows.recipe_spec import (
+        RecipeParamError,
+        RecipeSpecError,
+        parse_param_overrides,
+        resolve_recipe,
+    )
+
+    console = Console()
+
+    # --- resolve manifest ---------------------------------------------------
+    try:
+        path, spec = resolve_recipe(name, workdir=Path.cwd())
+    except RecipeSpecError as exc:
+        console.print(f"[bold red]Recipe load failed:[/bold red] {exc}")
+        # Exit code 2: manifest problem (vs operator-input problem at 1).
+        raise SystemExit(2) from exc
+
+    # --- parse + validate operator params -----------------------------------
+    try:
+        overrides = parse_param_overrides(params)
+        resolved = spec.resolve_params(overrides)
+    except RecipeParamError as exc:
+        console.print(f"[bold red]Invalid --param:[/bold red] {exc}")
+        raise SystemExit(1) from exc
+
+    # --- render workflow ----------------------------------------------------
+    try:
+        workflow = spec.to_workflow_spec(param_values=resolved)
+    except RecipeSpecError as exc:
+        console.print(f"[bold red]Recipe render failed:[/bold red] {exc}")
+        raise SystemExit(2) from exc
+
+    console.print(f"[bold]Recipe:[/bold] {spec.name} v{spec.version}  [dim]({path})[/dim]")
+    console.print(f"[dim]{spec.description}[/dim]")
+    if resolved:
+        for key in sorted(resolved):
+            console.print(f"  [cyan]{key}[/cyan] = {resolved[key]!r}")
+    else:
+        console.print("[dim]No parameters supplied.[/dim]")
+
+    if dry_run:
+        _print_dry_run(workflow, console)
+        return
+
+    # --- execute ------------------------------------------------------------
+    _execute(workflow, goal=goal, console=console)
+
+
+def _print_dry_run(workflow: Any, console: Console) -> None:
+    """Print the resolved execution plan."""
+    from rich.table import Table
+
+    from bernstein.core.workflows.workflow_spec import dump_spec_yaml
+
+    console.print("\n[bold]Resolved workflow:[/bold]")
+    console.print(dump_spec_yaml(workflow))
+
+    plan = Table(title="Execution plan")
+    plan.add_column("Layer", justify="right")
+    plan.add_column("Nodes")
+    for index, layer in enumerate(workflow.topological_order(), start=1):
+        plan.add_row(str(index), ", ".join(node.id for node in layer))
+    console.print(plan)
+    console.print("[dim]Dry-run only — no agents were spawned.[/dim]")
+
+
+def _execute(
+    workflow: Any,
+    *,
+    goal: str,
+    console: Console,
+) -> None:
+    """Hand ``workflow`` to the standard WorkflowRunner and print results.
+
+    The runner is constructed without a spawner — recipes are operator-
+    facing, so the orchestrator bootstrap path (which wires a real
+    spawner from CLI flags) is the right entry point for production
+    runs.  CLI-direct ``recipes run`` is best for command-only flows
+    and dry-runs; agent-typed nodes surface as FAILED with a clear
+    "no spawner wired" message so the operator can see the gap.
+    """
+    from rich.table import Table
+
+    from bernstein.core.workflows import NodeStatus, WorkflowRunner
+
+    runner = WorkflowRunner(workdir=Path.cwd())
+    execution = runner.run(workflow, goal=goal)
+
+    table = Table(title=f"Run {execution.run_id}")
+    table.add_column("Node")
+    table.add_column("Status")
+    table.add_column("Iters", justify="right")
+    table.add_column("Exit", justify="right")
+    table.add_column("Wall (s)", justify="right")
+    table.add_column("Note")
+    for node_exec in execution.nodes:
+        colour = (
+            "green"
+            if node_exec.status == NodeStatus.SUCCESS
+            else ("red" if node_exec.status == NodeStatus.FAILED else "yellow")
+        )
+        table.add_row(
+            node_exec.node_id,
+            f"[{colour}]{node_exec.status.value}[/{colour}]",
+            str(node_exec.iterations),
+            "-" if node_exec.exit_code is None else str(node_exec.exit_code),
+            f"{node_exec.wall_time_seconds:.2f}",
+            node_exec.error or "",
+        )
+    console.print(table)
+    if not execution.succeeded:
+        raise SystemExit(1)
+
+
+__all__ = ["recipes_group"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -93,6 +93,7 @@ from bernstein.cli.postmortem_cmd import postmortem_cmd
 from bernstein.cli.profile_cmd import profile_cmd
 from bernstein.cli.prompts_cmd import prompts_group
 from bernstein.cli.quickstart_cmd import quickstart_cmd
+from bernstein.cli.recipes_cmd import recipes_group
 from bernstein.cli.report_cmd import report_cmd
 from bernstein.cli.run_changelog_cmd import run_changelog_cmd
 from bernstein.cli.scaffold_cmd import scaffold_cmd
@@ -842,6 +843,7 @@ cli.add_command(postmortem_cmd, "postmortem")
 cli.add_command(slo_cmd, "slo")
 cli.add_command(man_pages_cmd, "man-pages")
 cli.add_command(workflow_group, "workflow")
+cli.add_command(recipes_group, "recipes")
 cli.add_command(quickstart_cmd, "quickstart")
 cli.add_command(scaffold_cmd, "scaffold")
 cli.add_command(watch_cmd, "watch")

--- a/src/bernstein/core/workflows/__init__.py
+++ b/src/bernstein/core/workflows/__init__.py
@@ -16,6 +16,17 @@ Public surface:
 
 from __future__ import annotations
 
+from bernstein.core.workflows.recipe_spec import (
+    RecipeParam,
+    RecipeParamError,
+    RecipeSpec,
+    RecipeSpecError,
+    discover_recipes,
+    load_recipe_spec,
+    load_recipe_spec_from_text,
+    parse_param_overrides,
+    resolve_recipe,
+)
 from bernstein.core.workflows.workflow_runner import (
     NodeExecution,
     NodeStatus,
@@ -37,13 +48,22 @@ __all__ = [
     "LoopSpec",
     "NodeExecution",
     "NodeStatus",
+    "RecipeParam",
+    "RecipeParamError",
+    "RecipeSpec",
+    "RecipeSpecError",
     "WorkflowExecution",
     "WorkflowNode",
     "WorkflowRunError",
     "WorkflowRunner",
     "WorkflowSpec",
     "WorkflowSpecError",
+    "discover_recipes",
     "discover_workflows",
+    "load_recipe_spec",
+    "load_recipe_spec_from_text",
     "load_workflow_spec",
     "load_workflow_spec_from_text",
+    "parse_param_overrides",
+    "resolve_recipe",
 ]

--- a/src/bernstein/core/workflows/recipe_spec.py
+++ b/src/bernstein/core/workflows/recipe_spec.py
@@ -1,0 +1,561 @@
+"""Recipe manifest schema — parameterised workflows for operators.
+
+A recipe is a thin wrapper around :class:`WorkflowSpec` that adds an
+operator-facing ``params`` block.  Each parameter declares a name, type
+hint, default value, required flag, and a one-line help string.  When the
+operator launches a recipe with ``--param key=value`` arguments the CLI
+validates the inputs, applies defaults, and renders all ``{param}``
+placeholders in prompts and commands before handing a finished
+:class:`WorkflowSpec` to the existing :class:`WorkflowRunner`.
+
+Example manifest::
+
+    name: bump-dependency
+    description: "Upgrade a Python dependency and fix test breakage."
+    version: "1.0.0"
+    params:
+      - name: package
+        type: string
+        required: true
+        help: "Distribution name on PyPI (e.g. 'httpx')."
+      - name: version
+        type: string
+        required: true
+        help: "Target version specifier (e.g. '0.27.0')."
+      - name: run_tests
+        type: bool
+        default: true
+        help: "Run pytest after the bump."
+    nodes:
+      - id: bump
+        agent: backend
+        prompt: "Upgrade {package} to {version} in pyproject.toml. Goal: {goal}"
+      - id: tests
+        depends_on: [bump]
+        command: "pytest -x"
+
+The recipe layer is intentionally additive: a manifest without a
+``params`` block parses as a recipe with zero params and behaves exactly
+like a vanilla workflow.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+from bernstein.core.workflows.workflow_spec import (
+    WorkflowSpec,
+    WorkflowSpecError,
+    load_workflow_spec_from_text,
+)
+
+# ---------------------------------------------------------------------------
+# Parameter declaration
+# ---------------------------------------------------------------------------
+
+# Parameter names mirror node id constraints — slug-shaped so they round
+# trip through YAML keys and CLI flags without escaping.
+_PARAM_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# The set of supported scalar types.  Kept small on purpose: recipes are
+# operator-facing, not a general-purpose templating engine.
+ParamType = Literal["string", "int", "float", "bool"]
+
+
+class RecipeParam(BaseModel):
+    """One operator-facing recipe parameter.
+
+    Attributes:
+        name: Slug-shaped parameter name.  Referenced as ``{name}`` in
+            prompt / command bodies.
+        type: One of ``string``, ``int``, ``float``, ``bool``.
+        default: Optional default value applied when the operator omits
+            the parameter at launch.  Stored as the declared type.
+        required: When ``True``, missing values produce a clean exit-1
+            instead of falling back to ``default`` / empty string.
+        help: One-line operator-facing description.
+        choices: Optional whitelist for ``string`` params.  Values
+            outside the list are rejected at validation time.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1, max_length=64)
+    type: ParamType = "string"
+    default: str | int | float | bool | None = None
+    required: bool = False
+    help: str = Field(default="", max_length=256)
+    choices: list[str] | None = None
+
+    @field_validator("name")
+    @classmethod
+    def _check_name(cls, value: str) -> str:
+        """Reject names that are not slug-shaped."""
+        if not _PARAM_NAME_PATTERN.match(value):
+            raise ValueError(
+                f"param name {value!r} must match {_PARAM_NAME_PATTERN.pattern}",
+            )
+        if value == "goal":
+            # ``goal`` is reserved — it's substituted by the WorkflowRunner
+            # itself from the CLI ``--goal`` option, not by the recipe
+            # layer.  Collisions silently shadow operator input.
+            raise ValueError("param name 'goal' is reserved")
+        return value
+
+    @model_validator(mode="after")
+    def _check_default_matches_type(self) -> RecipeParam:
+        """Default value (when present) must coerce; choices stay string-only."""
+        if self.choices is not None and self.type != "string":
+            raise ValueError(
+                f"param {self.name!r} declares choices but type is {self.type!r}; "
+                "choices only apply to 'string' params",
+            )
+        if self.default is None:
+            return self
+        try:
+            _coerce_value(str(self.default), self.type)
+        except RecipeParamError as exc:
+            raise ValueError(f"default for {self.name!r}: {exc}") from exc
+        if self.choices is not None and str(self.default) not in self.choices:
+            raise ValueError(
+                f"default {self.default!r} for {self.name!r} not in choices {self.choices!r}",
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class RecipeSpecError(ValueError):
+    """Raised when a recipe manifest is malformed or fails schema validation."""
+
+
+class RecipeParamError(ValueError):
+    """Raised when operator-provided parameter values fail validation.
+
+    Distinct from :class:`RecipeSpecError` so the CLI can map manifest
+    errors to one exit code (2 — bad recipe on disk) and operator input
+    errors to a different one (1 — bad ``--param`` value).
+    """
+
+
+# ---------------------------------------------------------------------------
+# Coercion
+# ---------------------------------------------------------------------------
+
+
+def _coerce_value(raw: str, type_: ParamType) -> str | int | float | bool:
+    """Coerce a raw CLI string into the parameter's declared scalar type.
+
+    Args:
+        raw: Raw string value as it appeared on the command line.
+        type_: Declared parameter type.
+
+    Returns:
+        The coerced Python value.
+
+    Raises:
+        RecipeParamError: When ``raw`` does not parse as the declared
+            type.  Bool accepts the usual truthy / falsy spellings.
+    """
+    if type_ == "string":
+        return raw
+    if type_ == "int":
+        try:
+            return int(raw)
+        except ValueError as exc:
+            raise RecipeParamError(f"expected int, got {raw!r}") from exc
+    if type_ == "float":
+        try:
+            return float(raw)
+        except ValueError as exc:
+            raise RecipeParamError(f"expected float, got {raw!r}") from exc
+    if type_ == "bool":
+        lowered = raw.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "off"}:
+            return False
+        raise RecipeParamError(f"expected bool, got {raw!r}")
+    raise RecipeParamError(f"unsupported type {type_!r}")  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Recipe spec
+# ---------------------------------------------------------------------------
+
+
+class RecipeSpec(BaseModel):
+    """Top-level recipe manifest model.
+
+    A recipe is a workflow plus a typed ``params`` block.  The recipe
+    body is exactly the same shape as :class:`WorkflowSpec` so the same
+    runner can execute it once parameters are substituted.
+
+    Attributes:
+        name: Slug-shaped recipe name.  Also the file stem on disk.
+        description: One-line human-readable description.
+        version: Semver-ish version string.
+        params: Operator-facing parameters.  Order is preserved for
+            display purposes (``recipes show`` renders the table in
+            declaration order).
+        nodes: Raw node mappings forwarded to :class:`WorkflowSpec`
+            after parameter substitution.  Kept as ``list[dict]`` here
+            so unresolved ``{param}`` placeholders don't trip the
+            workflow validator at recipe-load time.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(min_length=1, max_length=64)
+    description: str = Field(min_length=1, max_length=512)
+    version: str = Field(default="1.0.0")
+    params: list[RecipeParam] = Field(default_factory=lambda: [])
+    nodes: list[dict[str, Any]] = Field(min_length=1)
+
+    @field_validator("params")
+    @classmethod
+    def _check_unique_param_names(cls, value: list[RecipeParam]) -> list[RecipeParam]:
+        """Param names must be unique within a recipe."""
+        seen: set[str] = set()
+        for param in value:
+            if param.name in seen:
+                raise ValueError(f"duplicate param name {param.name!r}")
+            seen.add(param.name)
+        return value
+
+    def param_by_name(self, name: str) -> RecipeParam:
+        """Return the param with ``name`` or raise :class:`KeyError`."""
+        for param in self.params:
+            if param.name == name:
+                return param
+        raise KeyError(name)
+
+    def resolve_params(self, overrides: dict[str, str]) -> dict[str, str | int | float | bool]:
+        """Apply defaults to ``overrides`` and validate the result.
+
+        Args:
+            overrides: Raw operator-supplied values keyed by param name.
+                Values arrive as strings from the CLI; this method
+                coerces them to the declared type.
+
+        Returns:
+            Mapping from parameter name to coerced value.  Includes
+            defaulted entries for params the operator omitted.
+
+        Raises:
+            RecipeParamError: When required params are missing, unknown
+                param names appear in ``overrides``, choices are
+                violated, or a value fails coercion.
+        """
+        declared = {p.name for p in self.params}
+        unknown = sorted(set(overrides) - declared)
+        if unknown:
+            raise RecipeParamError(
+                f"unknown param(s): {', '.join(unknown)}; declared: {sorted(declared) or '(none)'}",
+            )
+        resolved: dict[str, str | int | float | bool] = {}
+        missing: list[str] = []
+        for param in self.params:
+            if param.name in overrides:
+                value = _coerce_value(overrides[param.name], param.type)
+                if param.choices is not None and value not in param.choices:
+                    raise RecipeParamError(
+                        f"{param.name}={value!r} not in choices {param.choices!r}",
+                    )
+                resolved[param.name] = value
+                continue
+            if param.default is not None:
+                resolved[param.name] = param.default
+                continue
+            if param.required:
+                missing.append(param.name)
+        if missing:
+            raise RecipeParamError(
+                f"missing required param(s): {', '.join(missing)}",
+            )
+        return resolved
+
+    def to_workflow_spec(
+        self,
+        *,
+        param_values: dict[str, str | int | float | bool] | None = None,
+    ) -> WorkflowSpec:
+        """Render the recipe into a runnable :class:`WorkflowSpec`.
+
+        Args:
+            param_values: Result of :meth:`resolve_params`.  When
+                ``None``, all params must have defaults — otherwise
+                :class:`RecipeParamError` is raised through the resolver.
+
+        Returns:
+            A validated :class:`WorkflowSpec` with all ``{param}``
+            placeholders substituted in agent prompts and command
+            bodies.  The ``{goal}`` placeholder is left intact so the
+            runner can still substitute the operator-supplied goal.
+
+        Raises:
+            RecipeSpecError: When the rendered workflow body fails the
+                downstream :class:`WorkflowSpec` validator (e.g. cyclic
+                ``depends_on`` graph that was not detectable from raw
+                node dicts at recipe-load time).
+        """
+        if param_values is None:
+            param_values = self.resolve_params({})
+
+        rendered_nodes = [_substitute_node(node, param_values) for node in self.nodes]
+        body: dict[str, Any] = {
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "nodes": rendered_nodes,
+        }
+        try:
+            return WorkflowSpec.model_validate(body)
+        except ValidationError as exc:
+            raise RecipeSpecError(
+                f"recipe {self.name!r} produced an invalid workflow: {exc}",
+            ) from exc
+        except WorkflowSpecError as exc:  # pragma: no cover — defensive
+            raise RecipeSpecError(str(exc)) from exc
+
+
+def _substitute_node(node: dict[str, Any], values: dict[str, str | int | float | bool]) -> dict[str, Any]:
+    """Return a copy of ``node`` with ``{param}`` placeholders rendered.
+
+    Substitution targets the two free-text fields (``prompt`` and
+    ``command``) plus the loop predicate.  Other fields pass through
+    unchanged — substituting into ``id`` or ``depends_on`` would let a
+    recipe rewire its own DAG at launch, which the spec deliberately
+    forbids.
+    """
+    out: dict[str, Any] = dict(node)
+    for key in ("prompt", "command"):
+        raw = out.get(key)
+        if isinstance(raw, str):
+            out[key] = _format_template(raw, values)
+    loop = out.get("loop")
+    if isinstance(loop, dict):
+        # ``isinstance`` narrows to ``dict[Unknown, Unknown]`` under
+        # strict pyright; cast to a typed shape before mutating.
+        loop_dict: dict[str, Any] = dict(loop)  # type: ignore[arg-type]
+        until_raw = loop_dict.get("until")
+        if isinstance(until_raw, str):
+            loop_dict["until"] = _format_template(until_raw, values)
+            out["loop"] = loop_dict
+    return out
+
+
+def _format_template(template: str, values: dict[str, str | int | float | bool]) -> str:
+    """Substitute ``{name}`` placeholders that match declared params.
+
+    Keeps unrelated placeholders (notably ``{goal}``) intact so the
+    workflow runner can substitute them downstream.  Implemented with a
+    regex sweep instead of :meth:`str.format_map` because the latter
+    would choke on any brace pair that doesn't match a known key.
+    """
+    if not values:
+        return template
+    pattern = re.compile(r"\{([a-z][a-z0-9_]*)\}")
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key in values:
+            return str(values[key])
+        return match.group(0)
+
+    return pattern.sub(_replace, template)
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+def load_recipe_spec_from_text(text: str) -> RecipeSpec:
+    """Parse ``text`` as a YAML recipe manifest.
+
+    Args:
+        text: Raw manifest body.
+
+    Returns:
+        A validated :class:`RecipeSpec`.  Note: the node DAG is not
+        validated here — placeholders may still be unresolved, so the
+        downstream :class:`WorkflowSpec` validator runs only inside
+        :meth:`RecipeSpec.to_workflow_spec`.
+
+    Raises:
+        RecipeSpecError: On YAML parse failure or schema violation.
+    """
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise RecipeSpecError(f"malformed YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RecipeSpecError("recipe manifest must be a mapping at the top level")
+    try:
+        return RecipeSpec.model_validate(data)
+    except ValidationError as exc:
+        raise RecipeSpecError(str(exc)) from exc
+
+
+def load_recipe_spec(path: Path) -> RecipeSpec:
+    """Load a recipe manifest from disk."""
+    if not path.is_file():
+        raise RecipeSpecError(f"recipe manifest not found: {path}")
+    return load_recipe_spec_from_text(path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+
+def _bundled_recipes_dir() -> Path:
+    """Return the bundled stock-recipes directory.
+
+    Resolves the wheel-installed ``_default_templates/recipes`` or the
+    dev-checkout ``templates/recipes``.
+    """
+    from bernstein import _BUNDLED_TEMPLATES_DIR
+
+    return _BUNDLED_TEMPLATES_DIR / "recipes"
+
+
+def _user_recipes_dirs(workdir: Path | None = None) -> list[Path]:
+    """Return user-installed recipe directories, in lookup order.
+
+    Project-local ``<workdir>/.bernstein/recipes/`` wins over
+    ``~/.bernstein/recipes/`` so a checked-in recipe shadows a
+    home-directory copy.
+    """
+    candidates: list[Path] = []
+    if workdir is not None:
+        candidates.append(workdir / ".bernstein" / "recipes")
+    candidates.append(Path.home() / ".bernstein" / "recipes")
+    return candidates
+
+
+def discover_recipes(
+    *,
+    workdir: Path | None = None,
+    include_bundled: bool = True,
+    include_user: bool = True,
+) -> Iterator[tuple[str, Path]]:
+    """Yield ``(name, path)`` pairs for every reachable recipe manifest.
+
+    Lookup order matches :func:`discover_workflows`: project-local,
+    user-home, then bundled.  Names are deduplicated across sources —
+    the first occurrence wins.
+    """
+    seen: set[str] = set()
+    dirs: list[Path] = []
+    if include_user:
+        dirs.extend(_user_recipes_dirs(workdir))
+    if include_bundled:
+        dirs.append(_bundled_recipes_dir())
+    for directory in dirs:
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.yaml")) + sorted(directory.glob("*.yml")):
+            name = path.stem
+            if name in seen:
+                continue
+            seen.add(name)
+            yield name, path
+
+
+def resolve_recipe(
+    name_or_path: str,
+    *,
+    workdir: Path | None = None,
+) -> tuple[Path, RecipeSpec]:
+    """Resolve a name or filesystem path to a loaded :class:`RecipeSpec`.
+
+    Args:
+        name_or_path: Either a path on disk or a bare recipe name.
+        workdir: Project root for project-local discovery.
+
+    Returns:
+        ``(path, spec)`` for the resolved manifest.
+
+    Raises:
+        RecipeSpecError: When the recipe can't be located or fails
+            validation.
+    """
+    candidate = Path(name_or_path)
+    if candidate.suffix in {".yaml", ".yml"} or candidate.exists():
+        return candidate.resolve(), load_recipe_spec(candidate)
+    for name, path in discover_recipes(workdir=workdir):
+        if name == name_or_path:
+            return path.resolve(), load_recipe_spec(path)
+    raise RecipeSpecError(
+        f"recipe {name_or_path!r} not found; "
+        "pass a path or place a YAML in templates/recipes/, "
+        ".bernstein/recipes/, or ~/.bernstein/recipes/",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_param_overrides(raw: tuple[str, ...] | list[str]) -> dict[str, str]:
+    """Parse ``--param key=value`` arguments into a raw string mapping.
+
+    Args:
+        raw: Sequence of ``key=value`` strings as collected by Click.
+
+    Returns:
+        Dict from key to raw string value.
+
+    Raises:
+        RecipeParamError: When an entry lacks an ``=`` separator or
+            specifies the same key twice.
+    """
+    out: dict[str, str] = {}
+    for entry in raw:
+        if "=" not in entry:
+            raise RecipeParamError(
+                f"invalid --param {entry!r}; expected key=value",
+            )
+        key, _, value = entry.partition("=")
+        key = key.strip()
+        if not key:
+            raise RecipeParamError(
+                f"invalid --param {entry!r}; missing key",
+            )
+        if key in out:
+            raise RecipeParamError(
+                f"duplicate --param {key!r}",
+            )
+        out[key] = value
+    return out
+
+
+# Re-export the workflow loader for downstream consumers that want a
+# uniform import surface.  Keeps test modules from reaching into the
+# workflow_spec module directly.
+__all__ = [
+    "RecipeParam",
+    "RecipeParamError",
+    "RecipeSpec",
+    "RecipeSpecError",
+    "discover_recipes",
+    "load_recipe_spec",
+    "load_recipe_spec_from_text",
+    "load_workflow_spec_from_text",
+    "parse_param_overrides",
+    "resolve_recipe",
+]

--- a/src/bernstein/eval/golden_data/recipes/__init__.py
+++ b/src/bernstein/eval/golden_data/recipes/__init__.py
@@ -1,0 +1,14 @@
+"""Golden trace fixtures for the bundled recipe library.
+
+Each ``<recipe-name>.trace.yaml`` captures the expected per-node
+execution order and node kinds (agent role / command body) after
+parameter substitution.  The eval harness loads these fixtures and
+re-renders the recipe against the canned parameters; any drift in the
+resolved workflow shape produces a regression failure.
+
+The fixtures intentionally pin only the *shape* of the resolved
+workflow — node ids, kinds, agent roles, and command templates with
+parameters substituted in.  They do not pin the full prompt body
+because prompt wording is allowed to evolve without breaking the
+recipe contract.
+"""

--- a/src/bernstein/eval/golden_data/recipes/add-tests-for-module.trace.yaml
+++ b/src/bernstein/eval/golden_data/recipes/add-tests-for-module.trace.yaml
@@ -1,0 +1,25 @@
+recipe: add-tests-for-module
+params:
+  module: bernstein.core.cost.estimator
+  target_coverage: 85
+  test_dir: tests/unit
+  test_command: "pytest -x -q"
+expected_workflow:
+  name: add-tests-for-module
+  layers:
+    - [survey]
+    - [write-tests]
+    - [tests]
+  nodes:
+    - id: survey
+      kind: agent
+      agent: qa
+    - id: write-tests
+      kind: agent
+      agent: qa
+      depends_on: [survey]
+      fresh_context: true
+    - id: tests
+      kind: command
+      depends_on: [write-tests]
+      command: "pytest -x -q"

--- a/src/bernstein/eval/golden_data/recipes/bump-dependency.trace.yaml
+++ b/src/bernstein/eval/golden_data/recipes/bump-dependency.trace.yaml
@@ -1,0 +1,30 @@
+recipe: bump-dependency
+params:
+  package: httpx
+  version: "0.27.0"
+  lockfile: uv.lock
+  test_command: "pytest -x -q"
+expected_workflow:
+  name: bump-dependency
+  layers:
+    - [bump]
+    - [tests]
+    - [fix-breakage]
+    - [tests-after-fix]
+  nodes:
+    - id: bump
+      kind: agent
+      agent: backend
+    - id: tests
+      kind: command
+      depends_on: [bump]
+      command: "pytest -x -q"
+    - id: fix-breakage
+      kind: agent
+      agent: backend
+      depends_on: [tests]
+      fresh_context: true
+    - id: tests-after-fix
+      kind: command
+      depends_on: [fix-breakage]
+      command: "pytest -x -q"

--- a/src/bernstein/eval/golden_data/recipes/license-audit.trace.yaml
+++ b/src/bernstein/eval/golden_data/recipes/license-audit.trace.yaml
@@ -1,0 +1,27 @@
+recipe: license-audit
+params:
+  project_license: MIT
+  scope: runtime
+  fail_on_incompatible: true
+  report_path: ".bernstein/license-audit.md"
+expected_workflow:
+  name: license-audit
+  layers:
+    - [collect]
+    - [analyse]
+    - [report]
+    - [gate]
+  nodes:
+    - id: collect
+      kind: command
+    - id: analyse
+      kind: agent
+      agent: security
+      depends_on: [collect]
+    - id: report
+      kind: agent
+      agent: docs
+      depends_on: [analyse]
+    - id: gate
+      kind: command
+      depends_on: [report]

--- a/src/bernstein/eval/golden_data/recipes/refactor-glob.trace.yaml
+++ b/src/bernstein/eval/golden_data/recipes/refactor-glob.trace.yaml
@@ -1,0 +1,31 @@
+# Golden trace for the refactor-glob recipe.
+#
+# Loaded by the eval harness with the canned params below; the resolved
+# workflow shape must match `expected_workflow`.  Drift in node ids,
+# kinds, agent roles, or command templates after parameter substitution
+# is treated as a regression.
+recipe: refactor-glob
+params:
+  pattern: foo_
+  replacement: bar_
+  path: src
+  test_command: "pytest -x"
+expected_workflow:
+  name: refactor-glob
+  layers:
+    - [locate]
+    - [refactor]
+    - [tests]
+  nodes:
+    - id: locate
+      kind: agent
+      agent: analyst
+    - id: refactor
+      kind: agent
+      agent: backend
+      depends_on: [locate]
+      fresh_context: true
+    - id: tests
+      kind: command
+      depends_on: [refactor]
+      command: "pytest -x"

--- a/src/bernstein/eval/golden_data/recipes/regenerate-docs.trace.yaml
+++ b/src/bernstein/eval/golden_data/recipes/regenerate-docs.trace.yaml
@@ -1,0 +1,31 @@
+recipe: regenerate-docs
+params:
+  package: bernstein
+  doc_root: docs
+  module_map_path: CLAUDE.md
+  build_command: "mkdocs build --strict"
+  lint_command: "ruff check docs"
+expected_workflow:
+  name: regenerate-docs
+  layers:
+    - [module-map]
+    - [api-docs]
+    - [build]
+    - [lint]
+  nodes:
+    - id: module-map
+      kind: agent
+      agent: docs
+    - id: api-docs
+      kind: agent
+      agent: docs
+      depends_on: [module-map]
+      fresh_context: true
+    - id: build
+      kind: command
+      depends_on: [api-docs]
+      command: "mkdocs build --strict"
+    - id: lint
+      kind: command
+      depends_on: [build]
+      command: "ruff check docs"

--- a/templates/recipes/add-tests-for-module.yaml
+++ b/templates/recipes/add-tests-for-module.yaml
@@ -1,0 +1,49 @@
+name: add-tests-for-module
+description: "Backfill pytest coverage for a single Python module that currently has low coverage."
+version: "1.0.0"
+params:
+  - name: module
+    type: string
+    required: true
+    help: "Importable module path (e.g. 'bernstein.core.cost.estimator')."
+  - name: target_coverage
+    type: int
+    default: 85
+    help: "Target line-coverage percentage for the module."
+  - name: test_dir
+    type: string
+    default: "tests/unit"
+    help: "Directory where the new test module is written."
+  - name: test_command
+    type: string
+    default: "pytest -x -q"
+    help: "Test command run after the backfill."
+nodes:
+  - id: survey
+    agent: qa
+    prompt: |
+      Survey the public surface of `{module}`. List every function,
+      class, and class method, and for each one note (1) whether tests
+      already exist, (2) the obvious happy-path inputs, and (3) any
+      branches that are hard to reach without fixtures.
+
+      Goal context (optional): {goal}
+
+  - id: write-tests
+    depends_on: [survey]
+    agent: qa
+    prompt: |
+      Write pytest tests for `{module}` based on the survey. Target at
+      least {target_coverage}% line coverage. Place tests under
+      `{test_dir}/` following the naming convention used by the rest of
+      the suite. Cover happy paths first, then add one or two negative
+      cases per public callable. Do not modify the production module
+      itself unless a behaviour change is required to make the code
+      testable, and call that out explicitly in the commit message.
+    fresh_context: true
+    timeout_seconds: 3600
+
+  - id: tests
+    depends_on: [write-tests]
+    command: "{test_command}"
+    timeout_seconds: 1800

--- a/templates/recipes/bump-dependency.yaml
+++ b/templates/recipes/bump-dependency.yaml
@@ -1,0 +1,49 @@
+name: bump-dependency
+description: "Upgrade a Python dependency to a target version and fix any test breakage."
+version: "1.0.0"
+params:
+  - name: package
+    type: string
+    required: true
+    help: "Distribution name on PyPI (e.g. 'httpx', 'pydantic')."
+  - name: version
+    type: string
+    required: true
+    help: "Target version specifier (e.g. '0.27.0' or '^2.5')."
+  - name: lockfile
+    type: string
+    default: "uv.lock"
+    help: "Lock file to refresh alongside pyproject.toml."
+  - name: test_command
+    type: string
+    default: "pytest -x -q"
+    help: "Test command run after the bump."
+nodes:
+  - id: bump
+    agent: backend
+    prompt: |
+      Upgrade `{package}` to `{version}` in `pyproject.toml`. Refresh
+      `{lockfile}` if it exists. Do not change other dependency pins.
+
+      Goal context (optional, may be blank): {goal}
+
+  - id: tests
+    depends_on: [bump]
+    command: "{test_command}"
+    timeout_seconds: 1800
+
+  - id: fix-breakage
+    depends_on: [tests]
+    agent: backend
+    prompt: |
+      Tests broke after upgrading `{package}` to `{version}`. Read the
+      failures, classify each one (API change, deprecation, edge case,
+      unrelated flake), and land the minimum fixes. Keep the bump itself
+      intact — do not pin back.
+    fresh_context: true
+    timeout_seconds: 3600
+
+  - id: tests-after-fix
+    depends_on: [fix-breakage]
+    command: "{test_command}"
+    timeout_seconds: 1800

--- a/templates/recipes/license-audit.yaml
+++ b/templates/recipes/license-audit.yaml
@@ -1,0 +1,54 @@
+name: license-audit
+description: "Scan project dependencies for licenses incompatible with the declared project license."
+version: "1.0.0"
+params:
+  - name: project_license
+    type: string
+    default: "MIT"
+    help: "License declared by the project (used as the compatibility baseline)."
+  - name: scope
+    type: string
+    default: "runtime"
+    choices: ["runtime", "dev", "all"]
+    help: "Dependency scope to scan."
+  - name: fail_on_incompatible
+    type: bool
+    default: true
+    help: "Exit non-zero if any incompatible license is found."
+  - name: report_path
+    type: string
+    default: ".bernstein/license-audit.md"
+    help: "Markdown report destination."
+nodes:
+  - id: collect
+    command: "pip-licenses --format=json --output-file=.bernstein/licenses.json --with-urls --with-license-file --no-license-path"
+    timeout_seconds: 600
+
+  - id: analyse
+    depends_on: [collect]
+    agent: security
+    prompt: |
+      Analyse the dependency licenses captured in
+      `.bernstein/licenses.json` against the project license
+      `{project_license}` (scope: `{scope}`). For each dependency,
+      classify the license as compatible, copyleft (incompatible),
+      ambiguous, or proprietary.  Surface every incompatible or
+      ambiguous case as a one-line bullet with the dependency name,
+      license SPDX id, and a one-sentence justification.
+
+      Goal context (optional): {goal}
+
+  - id: report
+    depends_on: [analyse]
+    agent: docs
+    prompt: |
+      Produce a markdown report at `{report_path}` that summarises the
+      audit. Sections: Summary (counts by category), Incompatible
+      licenses (table with dependency, version, license, justification),
+      Ambiguous cases, Action items. Keep it operator-scannable: no
+      marketing prose, no padding.
+
+  - id: gate
+    depends_on: [report]
+    command: "test \"{fail_on_incompatible}\" = \"True\" && ! grep -q '^| .* | .* | [Cc]opyleft' '{report_path}' || ! test \"{fail_on_incompatible}\" = \"True\""
+    timeout_seconds: 60

--- a/templates/recipes/refactor-glob.yaml
+++ b/templates/recipes/refactor-glob.yaml
@@ -1,0 +1,46 @@
+name: refactor-glob
+description: "Rename a glob of identifiers across a path, then run tests to catch regressions."
+version: "1.0.0"
+params:
+  - name: pattern
+    type: string
+    required: true
+    help: "Source identifier pattern (e.g. 'foo_*' or 'OldName')."
+  - name: replacement
+    type: string
+    required: true
+    help: "Replacement identifier (e.g. 'bar_*' or 'NewName')."
+  - name: path
+    type: string
+    default: "src"
+    help: "Filesystem root to search under."
+  - name: test_command
+    type: string
+    default: "pytest -x"
+    help: "Test command run after the refactor."
+nodes:
+  - id: locate
+    agent: analyst
+    prompt: |
+      Locate every occurrence of the identifier pattern `{pattern}` under
+      `{path}`. Produce a precise list of files and call sites that will
+      need to change to `{replacement}`. Flag any tricky cases (string
+      literals, doc strings, generated code) that need a manual call.
+
+      Goal context: {goal}
+
+  - id: refactor
+    depends_on: [locate]
+    agent: backend
+    prompt: |
+      Rename `{pattern}` to `{replacement}` across `{path}` based on the
+      site list from the locate step. Preserve casing conventions, do not
+      touch unrelated identifiers, and keep each commit logically small.
+      Update any documentation or call sites that the analyst flagged.
+    fresh_context: true
+    timeout_seconds: 3600
+
+  - id: tests
+    depends_on: [refactor]
+    command: "{test_command}"
+    timeout_seconds: 1800

--- a/templates/recipes/regenerate-docs.yaml
+++ b/templates/recipes/regenerate-docs.yaml
@@ -1,0 +1,56 @@
+name: regenerate-docs
+description: "Rebuild API docs and module map from current source."
+version: "1.0.0"
+params:
+  - name: package
+    type: string
+    default: "bernstein"
+    help: "Top-level package name to regenerate docs for."
+  - name: doc_root
+    type: string
+    default: "docs"
+    help: "Documentation root directory."
+  - name: module_map_path
+    type: string
+    default: "CLAUDE.md"
+    help: "Path to the module map document."
+  - name: build_command
+    type: string
+    default: "mkdocs build --strict"
+    help: "Documentation build command."
+  - name: lint_command
+    type: string
+    default: "ruff check docs"
+    help: "Lint command run against the rebuilt docs."
+nodes:
+  - id: module-map
+    agent: docs
+    prompt: |
+      Walk `src/{package}/` and refresh the module map at
+      `{module_map_path}`. For each subpackage, regenerate the table of
+      file → one-line purpose lines. Keep the existing section order and
+      headings; do not invent new top-level sections.
+
+      Goal context (optional): {goal}
+
+  - id: api-docs
+    depends_on: [module-map]
+    agent: docs
+    prompt: |
+      Regenerate the API reference pages under `{doc_root}/` from the
+      current source of `{package}`. Use the project's existing
+      conventions (autodoc directives, headings, cross-references).
+      Surface any public symbols that lack a docstring as a one-line
+      bullet list in the commit message rather than silently skipping.
+    fresh_context: true
+    timeout_seconds: 3600
+
+  - id: build
+    depends_on: [api-docs]
+    command: "{build_command}"
+    timeout_seconds: 1800
+
+  - id: lint
+    depends_on: [build]
+    command: "{lint_command}"
+    timeout_seconds: 600

--- a/tests/unit/test_recipes_cmd.py
+++ b/tests/unit/test_recipes_cmd.py
@@ -1,0 +1,567 @@
+"""Unit tests for the ``bernstein recipes`` command surface.
+
+Covers:
+
+* Recipe manifest schema (params block, type coercion, defaults, required
+  validation, choices whitelist, reserved names).
+* Parameter substitution into prompts / commands without touching ids
+  or depends_on graphs.
+* CLI behaviour for ``list``, ``show``, ``run`` (including ``--dry-run``,
+  unknown/missing params, command-only execution).
+* All five bundled seed recipes load, render with their advertised
+  defaults (or operator-provided required values), and produce valid
+  :class:`WorkflowSpec` instances.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.recipes_cmd import recipes_group
+from bernstein.core.workflows.recipe_spec import (
+    RecipeParam,
+    RecipeParamError,
+    RecipeSpec,
+    RecipeSpecError,
+    discover_recipes,
+    load_recipe_spec,
+    load_recipe_spec_from_text,
+    parse_param_overrides,
+    resolve_recipe,
+)
+
+# Required-param values needed to render each seed recipe.  Anything not
+# listed here is satisfied by manifest-declared defaults.
+_SEED_REQUIRED_PARAMS: dict[str, dict[str, str]] = {
+    "refactor-glob": {"pattern": "foo_", "replacement": "bar_"},
+    "bump-dependency": {"package": "httpx", "version": "0.27.0"},
+    "add-tests-for-module": {"module": "bernstein.core.cost.estimator"},
+    "license-audit": {},
+    "regenerate-docs": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_workdir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Run tests in a clean working directory so user-recipe dirs don't leak.
+
+    Sets HOME to a temp dir as well so ``~/.bernstein/recipes/`` cannot
+    influence ``discover_recipes`` results.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    (tmp_path / "home").mkdir(parents=True, exist_ok=True)
+    old_cwd = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(old_cwd)
+
+
+# ---------------------------------------------------------------------------
+# Schema: parameter types and defaults
+# ---------------------------------------------------------------------------
+
+
+_MINIMAL_YAML = """\
+name: hello
+description: "Echoes hello."
+version: "1.0.0"
+nodes:
+  - id: greet
+    command: "echo hello"
+"""
+
+
+def test_minimal_recipe_parses_without_params() -> None:
+    """A recipe without a params block still parses and renders."""
+    spec = load_recipe_spec_from_text(_MINIMAL_YAML)
+    assert spec.name == "hello"
+    assert spec.params == []
+    workflow = spec.to_workflow_spec()
+    assert workflow.name == "hello"
+    assert workflow.nodes[0].command == "echo hello"
+
+
+def test_unknown_param_raises_clean_error() -> None:
+    """Operator-supplied params not declared in the manifest are rejected."""
+    spec = load_recipe_spec_from_text(_MINIMAL_YAML)
+    with pytest.raises(RecipeParamError) as excinfo:
+        spec.resolve_params({"surprise": "x"})
+    assert "unknown param" in str(excinfo.value)
+
+
+def test_missing_required_param_lists_every_gap() -> None:
+    """All missing required names appear in the single error message."""
+    yaml = """\
+name: two-required
+description: "Recipe with two required params."
+version: "1.0.0"
+params:
+  - {name: alpha, type: string, required: true}
+  - {name: beta, type: string, required: true}
+nodes:
+  - id: noop
+    command: "echo {alpha} {beta}"
+"""
+    spec = load_recipe_spec_from_text(yaml)
+    with pytest.raises(RecipeParamError) as excinfo:
+        spec.resolve_params({})
+    msg = str(excinfo.value)
+    assert "alpha" in msg
+    assert "beta" in msg
+
+
+def test_type_coercion_for_int_float_bool() -> None:
+    """CLI strings coerce to the declared scalar type."""
+    yaml = """\
+name: typed
+description: "Typed params."
+version: "1.0.0"
+params:
+  - {name: count, type: int, default: 3}
+  - {name: ratio, type: float, default: 0.5}
+  - {name: dry, type: bool, default: true}
+nodes:
+  - id: noop
+    command: "echo {count} {ratio} {dry}"
+"""
+    spec = load_recipe_spec_from_text(yaml)
+    resolved = spec.resolve_params({"count": "7", "ratio": "1.25", "dry": "no"})
+    assert resolved == {"count": 7, "ratio": 1.25, "dry": False}
+
+
+def test_bad_type_value_raises_with_context() -> None:
+    """A non-int CLI value for an int param produces a clean error."""
+    yaml = """\
+name: typed
+description: "Typed params."
+version: "1.0.0"
+params:
+  - {name: count, type: int, default: 3}
+nodes:
+  - id: noop
+    command: "echo {count}"
+"""
+    spec = load_recipe_spec_from_text(yaml)
+    with pytest.raises(RecipeParamError) as excinfo:
+        spec.resolve_params({"count": "not-a-number"})
+    assert "int" in str(excinfo.value)
+
+
+def test_choices_whitelist_rejects_off_list_value() -> None:
+    """``choices`` restricts string params to a closed set."""
+    yaml = """\
+name: choices
+description: "Choices param."
+version: "1.0.0"
+params:
+  - name: mode
+    type: string
+    default: "fast"
+    choices: ["fast", "thorough"]
+nodes:
+  - id: noop
+    command: "echo {mode}"
+"""
+    spec = load_recipe_spec_from_text(yaml)
+    spec.resolve_params({"mode": "thorough"})  # ok
+    with pytest.raises(RecipeParamError):
+        spec.resolve_params({"mode": "sloppy"})
+
+
+def test_reserved_name_goal_is_rejected() -> None:
+    """``goal`` is reserved — collisions would silently shadow CLI input."""
+    yaml = """\
+name: reserved
+description: "Param named goal."
+version: "1.0.0"
+params:
+  - {name: goal, type: string}
+nodes:
+  - id: noop
+    command: "echo {goal}"
+"""
+    with pytest.raises(RecipeSpecError):
+        load_recipe_spec_from_text(yaml)
+
+
+def test_duplicate_param_name_is_rejected() -> None:
+    """Two params with the same name fail validation at load time."""
+    yaml = """\
+name: dup
+description: "Duplicated param name."
+version: "1.0.0"
+params:
+  - {name: alpha, type: string}
+  - {name: alpha, type: int}
+nodes:
+  - id: noop
+    command: "echo {alpha}"
+"""
+    with pytest.raises(RecipeSpecError):
+        load_recipe_spec_from_text(yaml)
+
+
+def test_default_must_match_declared_type() -> None:
+    """A default value that cannot coerce to ``type`` fails at load time."""
+    yaml = """\
+name: bad-default
+description: "Default does not match declared type."
+version: "1.0.0"
+params:
+  - {name: count, type: int, default: "not-a-number"}
+nodes:
+  - id: noop
+    command: "echo {count}"
+"""
+    with pytest.raises(RecipeSpecError):
+        load_recipe_spec_from_text(yaml)
+
+
+# ---------------------------------------------------------------------------
+# Substitution
+# ---------------------------------------------------------------------------
+
+
+def test_substitution_renders_prompt_and_command_bodies() -> None:
+    """{param} placeholders fill in prompts and commands; {goal} is preserved."""
+    yaml = """\
+name: subst
+description: "Substitution test."
+version: "1.0.0"
+params:
+  - {name: pkg, type: string, required: true}
+nodes:
+  - id: think
+    agent: backend
+    prompt: "Upgrade {pkg} for goal {goal}"
+  - id: tests
+    depends_on: [think]
+    command: "pytest -k {pkg}"
+"""
+    spec = load_recipe_spec_from_text(yaml)
+    resolved = spec.resolve_params({"pkg": "httpx"})
+    workflow = spec.to_workflow_spec(param_values=resolved)
+    assert workflow.nodes[0].prompt == "Upgrade httpx for goal {goal}"
+    assert workflow.nodes[1].command == "pytest -k httpx"
+
+
+def test_unknown_placeholder_is_left_intact() -> None:
+    """Unknown placeholders pass through untouched (for goal/runner subst)."""
+    yaml = """\
+name: passthrough
+description: "Unknown placeholders pass through."
+version: "1.0.0"
+nodes:
+  - id: noop
+    command: "echo {goal} {something_else}"
+"""
+    spec = load_recipe_spec_from_text(yaml)
+    workflow = spec.to_workflow_spec()
+    assert workflow.nodes[0].command == "echo {goal} {something_else}"
+
+
+# ---------------------------------------------------------------------------
+# parse_param_overrides
+# ---------------------------------------------------------------------------
+
+
+def test_parse_param_overrides_rejects_entry_without_equals() -> None:
+    """An entry without ``=`` is rejected with a clean message."""
+    with pytest.raises(RecipeParamError):
+        parse_param_overrides(["no-equals-here"])
+
+
+def test_parse_param_overrides_rejects_duplicate_key() -> None:
+    """Two ``--param k=...`` entries for the same key are rejected."""
+    with pytest.raises(RecipeParamError):
+        parse_param_overrides(["k=1", "k=2"])
+
+
+# ---------------------------------------------------------------------------
+# CLI: list
+# ---------------------------------------------------------------------------
+
+
+def test_cli_list_includes_every_seed_recipe(isolated_workdir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``recipes list`` surfaces all five bundled seed recipes by name."""
+    _ = isolated_workdir
+    # Rich truncates table cells based on terminal width; force a wide
+    # terminal so the full recipe names appear in the captured output.
+    monkeypatch.setenv("COLUMNS", "200")
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, ["list", "--bundled-only"])
+    assert result.exit_code == 0, result.output
+    for name in _SEED_REQUIRED_PARAMS:
+        assert name in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: show
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("recipe_name", sorted(_SEED_REQUIRED_PARAMS))
+def test_cli_show_renders_for_every_seed(recipe_name: str, isolated_workdir: Path) -> None:
+    """``recipes show <name>`` succeeds for every seed recipe."""
+    _ = isolated_workdir
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, ["show", recipe_name])
+    assert result.exit_code == 0, result.output
+    assert recipe_name in result.output
+
+
+def test_cli_show_unknown_recipe_exits_nonzero(isolated_workdir: Path) -> None:
+    """Unknown recipe name exits with code 1 and a clear message."""
+    _ = isolated_workdir
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, ["show", "does-not-exist"])
+    assert result.exit_code == 1
+    assert "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI: run --dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_cli_run_unknown_param_exits_1(isolated_workdir: Path) -> None:
+    """An unknown ``--param`` produces operator-input exit code (1)."""
+    _ = isolated_workdir
+    runner = CliRunner()
+    result = runner.invoke(
+        recipes_group,
+        ["run", "bump-dependency", "--param", "what=ever"],
+    )
+    assert result.exit_code == 1
+    assert "unknown" in result.output.lower()
+
+
+def test_cli_run_missing_required_exits_1(isolated_workdir: Path) -> None:
+    """Missing required params exit with code 1 and list every gap."""
+    _ = isolated_workdir
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, ["run", "bump-dependency"])
+    assert result.exit_code == 1
+    assert "package" in result.output
+    assert "version" in result.output
+
+
+def test_cli_run_unknown_recipe_exits_2(isolated_workdir: Path) -> None:
+    """A bad recipe name produces the manifest-error exit code (2)."""
+    _ = isolated_workdir
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, ["run", "does-not-exist", "--dry-run"])
+    assert result.exit_code == 2
+
+
+@pytest.mark.parametrize("recipe_name", sorted(_SEED_REQUIRED_PARAMS))
+def test_cli_run_dry_run_for_every_seed(recipe_name: str, isolated_workdir: Path) -> None:
+    """Every seed recipe renders cleanly under ``--dry-run``."""
+    _ = isolated_workdir
+    args = ["run", recipe_name, "--dry-run"]
+    for key, value in _SEED_REQUIRED_PARAMS[recipe_name].items():
+        args.extend(["--param", f"{key}={value}"])
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, args)
+    assert result.exit_code == 0, result.output
+    assert "Resolved workflow" in result.output
+    assert "Execution plan" in result.output
+
+
+# ---------------------------------------------------------------------------
+# CLI: run (command-only, no agents) — mock-adapter-equivalent smoke
+# ---------------------------------------------------------------------------
+
+
+def test_cli_run_command_only_recipe_executes(isolated_workdir: Path) -> None:
+    """A command-only recipe runs end-to-end via the standard runner.
+
+    This is the CI smoke equivalent of "mock adapter": no agent-typed
+    nodes, no API keys, no network — proves the run path is wired
+    correctly from param resolution through WorkflowRunner.run().
+    """
+    # Place a project-local recipe and let `recipes run` find it by name.
+    local_dir = isolated_workdir / ".bernstein" / "recipes"
+    local_dir.mkdir(parents=True)
+    (local_dir / "cmd-only.yaml").write_text(
+        """\
+name: cmd-only
+description: "Two-step command-only smoke recipe."
+version: "1.0.0"
+params:
+  - {name: marker, type: string, default: "smoke"}
+nodes:
+  - id: write
+    command: "echo {marker} > out.txt"
+  - id: verify
+    depends_on: [write]
+    command: "grep {marker} out.txt"
+""",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(recipes_group, ["run", "cmd-only"])
+    assert result.exit_code == 0, result.output
+    assert (isolated_workdir / "out.txt").read_text().startswith("smoke")
+
+
+def test_cli_run_command_only_recipe_with_param_override(isolated_workdir: Path) -> None:
+    """``--param`` overrides flow through to command bodies at runtime."""
+    local_dir = isolated_workdir / ".bernstein" / "recipes"
+    local_dir.mkdir(parents=True)
+    (local_dir / "cmd-only.yaml").write_text(
+        """\
+name: cmd-only
+description: "Two-step command-only recipe."
+version: "1.0.0"
+params:
+  - {name: marker, type: string, default: "smoke"}
+nodes:
+  - id: write
+    command: "echo {marker} > out.txt"
+""",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        recipes_group,
+        ["run", "cmd-only", "--param", "marker=override"],
+    )
+    assert result.exit_code == 0, result.output
+    assert (isolated_workdir / "out.txt").read_text().startswith("override")
+
+
+# ---------------------------------------------------------------------------
+# Seed recipe inventory
+# ---------------------------------------------------------------------------
+
+
+def test_all_seed_recipes_load_and_render() -> None:
+    """The bundled directory exposes exactly the five advertised seeds."""
+    bundled: dict[str, Path] = {}
+    for name, path in discover_recipes(workdir=Path.cwd(), include_user=False):
+        bundled[name] = path
+
+    for name in _SEED_REQUIRED_PARAMS:
+        assert name in bundled, f"missing seed recipe: {name}"
+
+    for name, overrides in _SEED_REQUIRED_PARAMS.items():
+        spec = load_recipe_spec(bundled[name])
+        resolved = spec.resolve_params(overrides)
+        workflow = spec.to_workflow_spec(param_values=resolved)
+        assert workflow.name == name
+        # Every recipe must produce at least one node and at least one
+        # command node so it can run without an agent spawner in CI.
+        kinds = {node.kind for node in workflow.nodes}
+        assert kinds, f"{name}: empty workflow"
+
+
+def test_seed_recipes_carry_descriptions() -> None:
+    """Every seed recipe carries a non-empty operator-facing description."""
+    bundled: dict[str, Path] = dict(discover_recipes(workdir=Path.cwd(), include_user=False))
+    for name in _SEED_REQUIRED_PARAMS:
+        spec = load_recipe_spec(bundled[name])
+        assert spec.description.strip(), f"{name}: empty description"
+        assert len(spec.description) <= 160, f"{name}: description too long"
+
+
+# ---------------------------------------------------------------------------
+# resolve_recipe by path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_recipe_accepts_filesystem_path(tmp_path: Path) -> None:
+    """A path-shaped argument is loaded directly without discovery."""
+    path = tmp_path / "local.yaml"
+    path.write_text(_MINIMAL_YAML, encoding="utf-8")
+    resolved_path, spec = resolve_recipe(str(path))
+    assert resolved_path == path.resolve()
+    assert isinstance(spec, RecipeSpec)
+    assert spec.name == "hello"
+
+
+def test_resolve_recipe_missing_path_raises_clean() -> None:
+    """Unknown name + non-existent path raises :class:`RecipeSpecError`."""
+    with pytest.raises(RecipeSpecError):
+        resolve_recipe("definitely-not-a-recipe-xyz")
+
+
+# ---------------------------------------------------------------------------
+# Golden traces — pin recipe shape against drift
+# ---------------------------------------------------------------------------
+
+
+def _golden_traces_dir() -> Path:
+    """Locate the packaged golden trace directory for recipes."""
+    import bernstein.eval.golden_data.recipes as recipes_pkg
+
+    pkg_file = recipes_pkg.__file__
+    assert pkg_file is not None
+    return Path(pkg_file).parent
+
+
+@pytest.mark.parametrize("recipe_name", sorted(_SEED_REQUIRED_PARAMS))
+def test_golden_trace_matches_resolved_workflow_shape(recipe_name: str) -> None:
+    """Rendered workflow shape matches the pinned golden trace.
+
+    Catches accidental drift in node order, kinds, agent roles, or
+    command bodies after a refactor.  Prompt wording is intentionally
+    not pinned — that's expected to evolve.
+    """
+    import yaml
+
+    trace_path = _golden_traces_dir() / f"{recipe_name}.trace.yaml"
+    assert trace_path.is_file(), f"missing golden trace: {trace_path}"
+    trace = yaml.safe_load(trace_path.read_text(encoding="utf-8"))
+
+    bundled = dict(discover_recipes(workdir=Path.cwd(), include_user=False))
+    spec = load_recipe_spec(bundled[recipe_name])
+    raw_params: dict[str, str] = {k: str(v) for k, v in trace["params"].items()}
+    workflow = spec.to_workflow_spec(param_values=spec.resolve_params(raw_params))
+
+    expected = trace["expected_workflow"]
+    assert workflow.name == expected["name"]
+
+    # Layer plan
+    layers = workflow.topological_order()
+    layer_ids = [[node.id for node in layer] for layer in layers]
+    assert layer_ids == expected["layers"]
+
+    # Per-node shape (kind, agent role, command body, depends_on, fresh_context)
+    by_id = {node.id: node for node in workflow.nodes}
+    for node_spec in expected["nodes"]:
+        node = by_id[node_spec["id"]]
+        assert node.kind == node_spec["kind"], f"{recipe_name}/{node.id}: kind drift"
+        if "agent" in node_spec:
+            assert node.agent == node_spec["agent"]
+        if "command" in node_spec:
+            assert node.command == node_spec["command"]
+        if "depends_on" in node_spec:
+            assert node.depends_on == node_spec["depends_on"]
+        if node_spec.get("fresh_context"):
+            assert node.fresh_context is True
+
+
+# ---------------------------------------------------------------------------
+# RecipeParam model sanity
+# ---------------------------------------------------------------------------
+
+
+def test_recipe_param_rejects_choices_for_non_string() -> None:
+    """``choices`` only makes sense for ``string`` params."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        RecipeParam(name="x", type="int", choices=["1", "2"])


### PR DESCRIPTION
## Summary

Promote ``cook`` into a discoverable recipe surface.  ``bernstein
recipes list|show|run`` operates over ``templates/recipes/*.yaml`` —
each manifest is a workflow with a typed ``params`` block.  Operator
inputs are validated and coerced before the resolved workflow goes to
the existing ``WorkflowRunner``; ``--dry-run`` prints the rendered plan
without spawning agents.

## Recipes shipped

| Name | What it does |
| --- | --- |
| `refactor-glob` | Rename an identifier pattern across a path, then run tests. |
| `bump-dependency` | Upgrade a Python dependency, run tests, fix breakage, re-run tests. |
| `add-tests-for-module` | Survey a module's public surface and backfill pytest coverage. |
| `license-audit` | Scan deps for licenses incompatible with the project license, write report. |
| `regenerate-docs` | Refresh module map + API docs, then build and lint the docs site. |

## Surface

```
bernstein recipes list
bernstein recipes show <name>
bernstein recipes run <name> --param key=value [--dry-run] [-g GOAL]
```

Each manifest declares typed params (``string``/``int``/``float``/``bool``)
with defaults, required flags, choices whitelists, and help strings.  Bad
input → exit 1 with operator-readable error.  Bad manifest → exit 2.

## Sample `recipes show` output (excerpt)

```
╭─────────────────────────────────────────────────────────────────────╮
│ bump-dependency v1.0.0                                              │
│ Upgrade a Python dependency to a target version and fix any test    │
│ breakage.                                                           │
╰─────────────────────────────────────────────────────────────────────╯
                              Parameters
┏━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┓
┃ Name         ┃ Type   ┃ Required ┃ Default      ┃ Help               ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━┩
│ package      │ string │ yes      │ -            │ Distribution name… │
│ version      │ string │ yes      │ -            │ Target version sp… │
│ lockfile     │ string │ no       │ uv.lock      │ Lock file to refr… │
│ test_command │ string │ no       │ pytest -x -q │ Test command run … │
└──────────────┴────────┴──────────┴──────────────┴────────────────────┘

Execution order:
  Layer 1: bump
  Layer 2: tests
  Layer 3: fix-breakage
  Layer 4: tests-after-fix
```

## Implementation notes

- Schema lives in ``src/bernstein/core/workflows/recipe_spec.py``; reuses
  ``WorkflowSpec`` for the node body via ``RecipeSpec.to_workflow_spec``.
- New ``recipes`` subcommand at ``src/bernstein/cli/commands/recipes_cmd.py``;
  thin wrapper around the standard ``WorkflowRunner``.
- Manifests force-included in the wheel via ``[tool.hatch.build.targets.wheel.force-include]``.
- Golden trace fixtures at ``src/bernstein/eval/golden_data/recipes/`` pin
  the resolved workflow shape (node ids, kinds, agent roles, command
  templates) against drift.

## Test plan

- [x] `pytest tests/unit/test_recipes_cmd.py` — 40 tests pass (schema,
  type coercion, substitution, CLI list/show/run, golden traces,
  command-only end-to-end smoke).
- [x] `pytest tests/unit/test_workflow_spec.py` — 28 existing workflow
  tests still green.
- [x] `ruff check` clean on new files.
- [x] `ruff format --check` clean on new files.
- [x] `lint-imports` clean (Adapters/Core/CLI layering preserved).
- [x] `pyright --strict` clean apart from one pre-existing baseline
  error (`_BUNDLED_TEMPLATES_DIR` private-usage warning that also
  exists in `workflow_spec.py`).