### PR TITLE
feat(evolution): predicted-delta gate + oscillation guard (closes #1348)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -177,29 +177,31 @@ alwaysApply: false
 
 ### `src/bernstein/evolution/` — self-evolution engine
 
-| File                  | Purpose |
-|-----------------------|---------|
-| `_shared.py`          | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`       | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`       | Change applicator — execute upgrades via file modification |
-| `benchmark.py`        | Tiered benchmark runner for evolution validation |
-| `circuit.py`          | CircuitBreaker — halt evolution when safety conditions are violated |
-| `creative.py`         | Creative evolution pipeline — visionary → analyst → production gate |
-| `cycle_helpers.py`    | Evolution cycle helper logic — community, creative, and GitHub sync |
-| `cycle_runner.py`     | Evolution cycle execution engine |
-| `data_collector.py`   | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`         | Opportunity detection from aggregated metrics |
-| `gate.py`             | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
-| `governance.py`       | Adaptive governance for the evolution system |
-| `invariants.py`       | InvariantsGuard — hash-lock safety-critical files |
-| `loop.py`             | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
-| `proposal_scorer.py`  | Proposal risk scoring and routing classification |
-| `proposals.py`        | Upgrade proposal generation |
-| `report.py`           | Evolution observability — history table and static report generation |
-| `report_generator.py` | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`             | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`          | SandboxValidator — isolated testing of evolution proposals |
-| `types.py`            | Shared types for the evolution system |
+| File                   | Purpose |
+|------------------------|---------|
+| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`        | Change applicator — execute upgrades via file modification |
+| `benchmark.py`         | Tiered benchmark runner for evolution validation |
+| `circuit.py`           | CircuitBreaker — halt evolution when safety conditions are violated |
+| `creative.py`          | Creative evolution pipeline — visionary → analyst → production gate |
+| `cycle_helpers.py`     | Evolution cycle helper logic — community, creative, and GitHub sync |
+| `cycle_runner.py`      | Evolution cycle execution engine |
+| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`          | Opportunity detection from aggregated metrics |
+| `gate.py`              | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
+| `governance.py`        | Adaptive governance for the evolution system |
+| `invariants.py`        | InvariantsGuard — hash-lock safety-critical files |
+| `loop.py`              | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
+| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
+| `proposals.py`         | Upgrade proposal generation |
+| `report.py`            | Evolution observability — history table and static report generation |
+| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`           | SandboxValidator — isolated testing of evolution proposals |
+| `types.py`             | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` — evaluation harness
 

--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -209,6 +209,7 @@ alwaysApply: false
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/.goosehints
+++ b/.goosehints
@@ -178,29 +178,31 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` — self-evolution engine
 
-| File                  | Purpose |
-|-----------------------|---------|
-| `_shared.py`          | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`       | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`       | Change applicator — execute upgrades via file modification |
-| `benchmark.py`        | Tiered benchmark runner for evolution validation |
-| `circuit.py`          | CircuitBreaker — halt evolution when safety conditions are violated |
-| `creative.py`         | Creative evolution pipeline — visionary → analyst → production gate |
-| `cycle_helpers.py`    | Evolution cycle helper logic — community, creative, and GitHub sync |
-| `cycle_runner.py`     | Evolution cycle execution engine |
-| `data_collector.py`   | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`         | Opportunity detection from aggregated metrics |
-| `gate.py`             | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
-| `governance.py`       | Adaptive governance for the evolution system |
-| `invariants.py`       | InvariantsGuard — hash-lock safety-critical files |
-| `loop.py`             | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
-| `proposal_scorer.py`  | Proposal risk scoring and routing classification |
-| `proposals.py`        | Upgrade proposal generation |
-| `report.py`           | Evolution observability — history table and static report generation |
-| `report_generator.py` | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`             | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`          | SandboxValidator — isolated testing of evolution proposals |
-| `types.py`            | Shared types for the evolution system |
+| File                   | Purpose |
+|------------------------|---------|
+| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`        | Change applicator — execute upgrades via file modification |
+| `benchmark.py`         | Tiered benchmark runner for evolution validation |
+| `circuit.py`           | CircuitBreaker — halt evolution when safety conditions are violated |
+| `creative.py`          | Creative evolution pipeline — visionary → analyst → production gate |
+| `cycle_helpers.py`     | Evolution cycle helper logic — community, creative, and GitHub sync |
+| `cycle_runner.py`      | Evolution cycle execution engine |
+| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`          | Opportunity detection from aggregated metrics |
+| `gate.py`              | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
+| `governance.py`        | Adaptive governance for the evolution system |
+| `invariants.py`        | InvariantsGuard — hash-lock safety-critical files |
+| `loop.py`              | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
+| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
+| `proposals.py`         | Upgrade proposal generation |
+| `report.py`            | Evolution observability — history table and static report generation |
+| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`           | SandboxValidator — isolated testing of evolution proposals |
+| `types.py`             | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` — evaluation harness
 

--- a/.goosehints
+++ b/.goosehints
@@ -210,6 +210,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,29 +178,31 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` — self-evolution engine
 
-| File                  | Purpose |
-|-----------------------|---------|
-| `_shared.py`          | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`       | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`       | Change applicator — execute upgrades via file modification |
-| `benchmark.py`        | Tiered benchmark runner for evolution validation |
-| `circuit.py`          | CircuitBreaker — halt evolution when safety conditions are violated |
-| `creative.py`         | Creative evolution pipeline — visionary → analyst → production gate |
-| `cycle_helpers.py`    | Evolution cycle helper logic — community, creative, and GitHub sync |
-| `cycle_runner.py`     | Evolution cycle execution engine |
-| `data_collector.py`   | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`         | Opportunity detection from aggregated metrics |
-| `gate.py`             | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
-| `governance.py`       | Adaptive governance for the evolution system |
-| `invariants.py`       | InvariantsGuard — hash-lock safety-critical files |
-| `loop.py`             | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
-| `proposal_scorer.py`  | Proposal risk scoring and routing classification |
-| `proposals.py`        | Upgrade proposal generation |
-| `report.py`           | Evolution observability — history table and static report generation |
-| `report_generator.py` | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`             | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`          | SandboxValidator — isolated testing of evolution proposals |
-| `types.py`            | Shared types for the evolution system |
+| File                   | Purpose |
+|------------------------|---------|
+| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`        | Change applicator — execute upgrades via file modification |
+| `benchmark.py`         | Tiered benchmark runner for evolution validation |
+| `circuit.py`           | CircuitBreaker — halt evolution when safety conditions are violated |
+| `creative.py`          | Creative evolution pipeline — visionary → analyst → production gate |
+| `cycle_helpers.py`     | Evolution cycle helper logic — community, creative, and GitHub sync |
+| `cycle_runner.py`      | Evolution cycle execution engine |
+| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`          | Opportunity detection from aggregated metrics |
+| `gate.py`              | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
+| `governance.py`        | Adaptive governance for the evolution system |
+| `invariants.py`        | InvariantsGuard — hash-lock safety-critical files |
+| `loop.py`              | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
+| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
+| `proposals.py`         | Upgrade proposal generation |
+| `report.py`            | Evolution observability — history table and static report generation |
+| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`           | SandboxValidator — isolated testing of evolution proposals |
+| `types.py`             | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` — evaluation harness
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,29 +178,31 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` — self-evolution engine
 
-| File                  | Purpose |
-|-----------------------|---------|
-| `_shared.py`          | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`       | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`       | Change applicator — execute upgrades via file modification |
-| `benchmark.py`        | Tiered benchmark runner for evolution validation |
-| `circuit.py`          | CircuitBreaker — halt evolution when safety conditions are violated |
-| `creative.py`         | Creative evolution pipeline — visionary → analyst → production gate |
-| `cycle_helpers.py`    | Evolution cycle helper logic — community, creative, and GitHub sync |
-| `cycle_runner.py`     | Evolution cycle execution engine |
-| `data_collector.py`   | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`         | Opportunity detection from aggregated metrics |
-| `gate.py`             | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
-| `governance.py`       | Adaptive governance for the evolution system |
-| `invariants.py`       | InvariantsGuard — hash-lock safety-critical files |
-| `loop.py`             | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
-| `proposal_scorer.py`  | Proposal risk scoring and routing classification |
-| `proposals.py`        | Upgrade proposal generation |
-| `report.py`           | Evolution observability — history table and static report generation |
-| `report_generator.py` | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`             | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`          | SandboxValidator — isolated testing of evolution proposals |
-| `types.py`            | Shared types for the evolution system |
+| File                   | Purpose |
+|------------------------|---------|
+| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`        | Change applicator — execute upgrades via file modification |
+| `benchmark.py`         | Tiered benchmark runner for evolution validation |
+| `circuit.py`           | CircuitBreaker — halt evolution when safety conditions are violated |
+| `creative.py`          | Creative evolution pipeline — visionary → analyst → production gate |
+| `cycle_helpers.py`     | Evolution cycle helper logic — community, creative, and GitHub sync |
+| `cycle_runner.py`      | Evolution cycle execution engine |
+| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`          | Opportunity detection from aggregated metrics |
+| `gate.py`              | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
+| `governance.py`        | Adaptive governance for the evolution system |
+| `invariants.py`        | InvariantsGuard — hash-lock safety-critical files |
+| `loop.py`              | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
+| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
+| `proposals.py`         | Upgrade proposal generation |
+| `report.py`            | Evolution observability — history table and static report generation |
+| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`           | SandboxValidator — isolated testing of evolution proposals |
+| `types.py`             | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` — evaluation harness
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -178,29 +178,31 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 ### `src/bernstein/evolution/` — self-evolution engine
 
-| File                  | Purpose |
-|-----------------------|---------|
-| `_shared.py`          | Shared constants, data classes, and helpers for the evolution loop modules |
-| `aggregator.py`       | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
-| `applicator.py`       | Change applicator — execute upgrades via file modification |
-| `benchmark.py`        | Tiered benchmark runner for evolution validation |
-| `circuit.py`          | CircuitBreaker — halt evolution when safety conditions are violated |
-| `creative.py`         | Creative evolution pipeline — visionary → analyst → production gate |
-| `cycle_helpers.py`    | Evolution cycle helper logic — community, creative, and GitHub sync |
-| `cycle_runner.py`     | Evolution cycle execution engine |
-| `data_collector.py`   | Metric record types and file-based metrics collection for the evolution system |
-| `detector.py`         | Opportunity detection from aggregated metrics |
-| `gate.py`             | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
-| `governance.py`       | Adaptive governance for the evolution system |
-| `invariants.py`       | InvariantsGuard — hash-lock safety-critical files |
-| `loop.py`             | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
-| `proposal_scorer.py`  | Proposal risk scoring and routing classification |
-| `proposals.py`        | Upgrade proposal generation |
-| `report.py`           | Evolution observability — history table and static report generation |
-| `report_generator.py` | Analysis result types, statistical helpers, and Goodhart's Law defenses |
-| `risk.py`             | Strategic Risk Score (SRS) computation for evolution proposals |
-| `sandbox.py`          | SandboxValidator — isolated testing of evolution proposals |
-| `types.py`            | Shared types for the evolution system |
+| File                   | Purpose |
+|------------------------|---------|
+| `_shared.py`           | Shared constants, data classes, and helpers for the evolution loop modules |
+| `aggregator.py`        | Metrics aggregation with EWMA, CUSUM, BOCPD, and Goodhart defenses |
+| `applicator.py`        | Change applicator — execute upgrades via file modification |
+| `benchmark.py`         | Tiered benchmark runner for evolution validation |
+| `circuit.py`           | CircuitBreaker — halt evolution when safety conditions are violated |
+| `creative.py`          | Creative evolution pipeline — visionary → analyst → production gate |
+| `cycle_helpers.py`     | Evolution cycle helper logic — community, creative, and GitHub sync |
+| `cycle_runner.py`      | Evolution cycle execution engine |
+| `data_collector.py`    | Metric record types and file-based metrics collection for the evolution system |
+| `detector.py`          | Opportunity detection from aggregated metrics |
+| `gate.py`              | ApprovalGate and EvalGate — risk-stratified routing for evolution proposals |
+| `governance.py`        | Adaptive governance for the evolution system |
+| `invariants.py`        | InvariantsGuard — hash-lock safety-critical files |
+| `loop.py`              | Autoresearch evolution loop — continuous self-improvement via experiment cycles |
+| `oscillation_guard.py` | Oscillation guard for prompt-evolution proposals |
+| `predicted_delta.py`   | Predicted-delta gate for prompt-evolution proposals |
+| `proposal_scorer.py`   | Proposal risk scoring and routing classification |
+| `proposals.py`         | Upgrade proposal generation |
+| `report.py`            | Evolution observability — history table and static report generation |
+| `report_generator.py`  | Analysis result types, statistical helpers, and Goodhart's Law defenses |
+| `risk.py`              | Strategic Risk Score (SRS) computation for evolution proposals |
+| `sandbox.py`           | SandboxValidator — isolated testing of evolution proposals |
+| `types.py`             | Shared types for the evolution system |
 
 ### `src/bernstein/eval/` — evaluation harness
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -210,6 +210,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -112,9 +112,7 @@ class UnknownCriterionError(RetryBudgetError):
     def __init__(self, name: str, known: Iterable[str]) -> None:
         self.name = name
         self.known = tuple(known)
-        super().__init__(
-            f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}"
-        )
+        super().__init__(f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}")
 
 
 class DuplicateCriterionError(RetryBudgetError):
@@ -130,9 +128,7 @@ class CriterionExhaustedError(RetryBudgetError):
 
     def __init__(self, criterion: Criterion) -> None:
         self.criterion = criterion
-        super().__init__(
-            f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})"
-        )
+        super().__init__(f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})")
 
 
 class RetryBudgetExhaustedError(RetryBudgetError):
@@ -168,14 +164,10 @@ class Criterion:
         if not self.name:
             raise ValueError("Criterion name must be non-empty")
         if self.min_level > self.max_level:
-            raise ValueError(
-                f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level "
-                f"({self.max_level})"
-            )
+            raise ValueError(f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level ({self.max_level})")
         if self.level < self.min_level or self.level > self.max_level:
             raise ValueError(
-                f"Criterion {self.name!r}: level {self.level} outside "
-                f"[{self.min_level}, {self.max_level}]"
+                f"Criterion {self.name!r}: level {self.level} outside [{self.min_level}, {self.max_level}]"
             )
 
     @property
@@ -331,10 +323,7 @@ class RetryBudget:
         Returns:
             A fresh :class:`RetryBudget`.
         """
-        criteria = [
-            Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level)
-            for n in names
-        ]
+        criteria = [Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level) for n in names]
         return cls(retries=retries, criterion_degradation=criteria)
 
     # ------------------------------------------------------------------
@@ -450,10 +439,7 @@ class RetryBudget:
                 degraded_criterion=None,
                 degradation_kind=DegradationKind.NONE,
                 criteria_snapshot=tuple(self._criteria.values()),
-                reason=(
-                    f"retry #{attempt_index + 1} of {self.retries} "
-                    "(no further criterion degradation configured)"
-                ),
+                reason=(f"retry #{attempt_index + 1} of {self.retries} (no further criterion degradation configured)"),
             )
         if target.is_at_floor:
             # The criterion has already been degraded to its minimum on
@@ -470,8 +456,7 @@ class RetryBudget:
                 degradation_kind=DegradationKind.FLOORED,
                 criteria_snapshot=tuple(self._criteria.values()),
                 reason=(
-                    f"retry #{attempt_index + 1}: criterion {target.name!r} "
-                    "already at floor; no further degradation"
+                    f"retry #{attempt_index + 1}: criterion {target.name!r} already at floor; no further degradation"
                 ),
             )
         new_criterion = target.degraded()
@@ -486,10 +471,7 @@ class RetryBudget:
             degraded_criterion=new_criterion,
             degradation_kind=DegradationKind.LOWERED,
             criteria_snapshot=tuple(snapshot_map.values()),
-            reason=(
-                f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} "
-                f"to level {new_criterion.level}"
-            ),
+            reason=(f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} to level {new_criterion.level}"),
         )
 
     # ------------------------------------------------------------------
@@ -596,13 +578,9 @@ def parse_retry_budget_spec(
         for raw_name in raw_policy.split(">"):
             name = raw_name.strip()
             if not name:
-                raise ValueError(
-                    f"empty criterion name in retry budget spec: {spec!r}"
-                )
+                raise ValueError(f"empty criterion name in retry budget spec: {spec!r}")
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_-]*$", name):
-                raise ValueError(
-                    f"invalid criterion name {name!r} in retry budget spec"
-                )
+                raise ValueError(f"invalid criterion name {name!r} in retry budget spec")
             if name in seen:
                 raise DuplicateCriterionError(name)
             seen.add(name)

--- a/src/bernstein/evolution/__init__.py
+++ b/src/bernstein/evolution/__init__.py
@@ -47,7 +47,12 @@ from bernstein.evolution.detector import (
     OpportunityDetector,
     UpgradeCategory,
 )
-from bernstein.evolution.gate import ApprovalGate
+from bernstein.evolution.gate import (
+    ApprovalGate,
+    PromptPatchDecision,
+    PromptPatchGate,
+    PromptPatchOutcome,
+)
 from bernstein.evolution.invariants import (
     check_proposal_targets,
     compute_invariants,
@@ -55,6 +60,19 @@ from bernstein.evolution.invariants import (
     write_lockfile,
 )
 from bernstein.evolution.loop import EvolutionLoop, ExperimentResult
+from bernstein.evolution.oscillation_guard import (
+    OscillationGuard,
+    OscillationResult,
+    OscillationVerdict,
+)
+from bernstein.evolution.predicted_delta import (
+    DeltaPredictor,
+    HeuristicDeltaPredictor,
+    PatchProposal,
+    PatchVerdict,
+    PredictedDeltaGate,
+    PredictedDeltaResult,
+)
 from bernstein.evolution.proposals import (
     AnalysisTrigger,
     ApprovalMode,
@@ -92,6 +110,7 @@ __all__ = [
     "CircuitState",
     "CostMetrics",
     "CreativePipeline",
+    "DeltaPredictor",
     "EvolutionCoordinator",
     "EvolutionLoop",
     "ExperimentResult",
@@ -100,13 +119,24 @@ __all__ = [
     "FailureRecord",
     "FileMetricsCollector",
     "FileUpgradeExecutor",
+    "HeuristicDeltaPredictor",
     "ImprovementOpportunity",
     "MetricRecord",
     "MetricsAggregator",
     "MetricsCollector",
     "MetricsRecord",
     "OpportunityDetector",
+    "OscillationGuard",
+    "OscillationResult",
+    "OscillationVerdict",
+    "PatchProposal",
+    "PatchVerdict",
     "PipelineResult",
+    "PredictedDeltaGate",
+    "PredictedDeltaResult",
+    "PromptPatchDecision",
+    "PromptPatchGate",
+    "PromptPatchOutcome",
     "ProposalGenerator",
     "ProposalRiskScore",
     "ProposalStatus",

--- a/src/bernstein/evolution/gate.py
+++ b/src/bernstein/evolution/gate.py
@@ -31,6 +31,17 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
 
+from bernstein.evolution.oscillation_guard import (
+    OscillationGuard,
+    OscillationResult,
+    OscillationVerdict,
+)
+from bernstein.evolution.predicted_delta import (
+    PatchProposal,
+    PatchVerdict,
+    PredictedDeltaGate,
+    PredictedDeltaResult,
+)
 from bernstein.evolution.types import RiskLevel, UpgradeProposal
 
 logger = logging.getLogger(__name__)
@@ -707,3 +718,262 @@ def eval_gate(
         promotion_threshold=promotion_threshold,
     )
     return gate.evaluate(proposal, risk_level, sandbox_dir=sandbox_dir)
+
+
+# ======================================================================
+# PromptPatchGate — predicted-delta + oscillation guard wiring
+# ======================================================================
+
+# Veto message format. Pinned so the snapshot test can detect regressions.
+_VETO_MESSAGE_TEMPLATE: str = (
+    "[prompt-patch-gate] prompt={prompt} proposal_id={proposal_id} verdict={verdict} reason={reason}"
+)
+
+
+class PromptPatchOutcome(Enum):
+    """Top-level outcome of a :class:`PromptPatchGate` evaluation."""
+
+    APPLIED = "applied"
+    """Both sub-gates approved and the patch is queued for application."""
+
+    PENDING = "pending_confirmation"
+    """Oscillation guard wants one more consecutive cycle."""
+
+    REJECTED_DELTA = "below_threshold"
+    """Predicted delta did not clear the threshold."""
+
+    REJECTED_OSCILLATION = "flip_back"
+    """Patch would oscillate against a recent applied change."""
+
+    REJECTED_SESSION_CAP = "session_cap"
+    """Per-session accepted-patch cap reached."""
+
+    REJECTED_INVALID_DELTA = "invalid_delta"
+    """``predicted_delta`` was not finite and the predictor could not fix it."""
+
+
+@dataclass
+class PromptPatchDecision:
+    """Composite verdict of :class:`PromptPatchGate`.
+
+    Attributes:
+        proposal_id: ID of the evaluated patch proposal.
+        outcome: Top-level outcome.
+        applied: True iff this decision results in the patch being applied.
+        delta_result: Underlying predicted-delta verdict.
+        oscillation_result: Underlying oscillation verdict
+            (``None`` if the delta gate vetoed first).
+        veto_message: Standardised veto message (empty if accepted).
+        decided_at: Unix timestamp of the decision.
+    """
+
+    proposal_id: str
+    outcome: PromptPatchOutcome
+    applied: bool
+    delta_result: PredictedDeltaResult
+    oscillation_result: OscillationResult | None
+    veto_message: str
+    decided_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for the per-cycle audit row."""
+        return {
+            "proposal_id": self.proposal_id,
+            "outcome": self.outcome.value,
+            "applied": self.applied,
+            "delta": {
+                "verdict": self.delta_result.verdict.value,
+                "predicted_delta": self.delta_result.predicted_delta,
+                "threshold": self.delta_result.threshold,
+                "reason": self.delta_result.reason,
+            },
+            "oscillation": (
+                {
+                    "verdict": self.oscillation_result.verdict.value,
+                    "confirmations": self.oscillation_result.confirmations,
+                    "applied_count": self.oscillation_result.applied_count,
+                    "reason": self.oscillation_result.reason,
+                }
+                if self.oscillation_result is not None
+                else None
+            ),
+            "veto_message": self.veto_message,
+            "decided_at": self.decided_at,
+        }
+
+
+class PromptPatchGate:
+    """Combined predicted-delta + oscillation gate for prompt patches.
+
+    This is the wiring point requested by issue #1348. It owns two
+    sub-gates and an optional JSONL audit log under
+    ``<audit_dir>/<session>.jsonl``. Decision flow:
+
+    1. Run :class:`PredictedDeltaGate`. If the patch fails, write an
+       audit row and short-circuit with
+       :attr:`PromptPatchOutcome.REJECTED_DELTA` or
+       :attr:`PromptPatchOutcome.REJECTED_INVALID_DELTA`.
+    2. Run :class:`OscillationGuard`. Translate its verdict into a
+       :class:`PromptPatchOutcome`. Audit-log the result.
+    3. On :attr:`PromptPatchOutcome.APPLIED`, the caller is expected
+       to invoke :meth:`mark_applied` once the patch has actually
+       been written.
+
+    Args:
+        delta_gate: Override the predicted-delta gate.
+        oscillation_guard: Override the oscillation guard.
+        audit_dir: Optional directory for the per-cycle audit JSONL.
+            When ``None``, no audit file is written.
+        session_id: Stable id used for the audit filename. Defaults
+            to ``"default"``.
+    """
+
+    def __init__(
+        self,
+        delta_gate: PredictedDeltaGate | None = None,
+        oscillation_guard: OscillationGuard | None = None,
+        audit_dir: Path | None = None,
+        session_id: str = "default",
+    ) -> None:
+        self._delta_gate = delta_gate or PredictedDeltaGate()
+        self._oscillation = oscillation_guard or OscillationGuard()
+        self._audit_dir = audit_dir
+        self._session_id = session_id
+        if self._audit_dir is not None:
+            self._audit_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def delta_gate(self) -> PredictedDeltaGate:
+        return self._delta_gate
+
+    @property
+    def oscillation_guard(self) -> OscillationGuard:
+        return self._oscillation
+
+    @property
+    def audit_path(self) -> Path | None:
+        if self._audit_dir is None:
+            return None
+        return self._audit_dir / f"{self._session_id}.jsonl"
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate(self, proposal: PatchProposal) -> PromptPatchDecision:
+        """Evaluate ``proposal`` through both sub-gates.
+
+        Returns:
+            :class:`PromptPatchDecision` describing the combined verdict.
+            Audit-logged exactly once.
+        """
+        delta_result = self._delta_gate.evaluate(proposal)
+        if delta_result.verdict == PatchVerdict.REJECTED_BELOW_THRESHOLD:
+            decision = PromptPatchDecision(
+                proposal_id=proposal.proposal_id,
+                outcome=PromptPatchOutcome.REJECTED_DELTA,
+                applied=False,
+                delta_result=delta_result,
+                oscillation_result=None,
+                veto_message=self._format_veto(
+                    prompt=proposal.prompt_name,
+                    proposal_id=proposal.proposal_id,
+                    outcome=PromptPatchOutcome.REJECTED_DELTA,
+                    reason=delta_result.reason,
+                ),
+            )
+            self._log_decision(decision)
+            return decision
+
+        if delta_result.verdict == PatchVerdict.REJECTED_INVALID_DELTA:
+            decision = PromptPatchDecision(
+                proposal_id=proposal.proposal_id,
+                outcome=PromptPatchOutcome.REJECTED_INVALID_DELTA,
+                applied=False,
+                delta_result=delta_result,
+                oscillation_result=None,
+                veto_message=self._format_veto(
+                    prompt=proposal.prompt_name,
+                    proposal_id=proposal.proposal_id,
+                    outcome=PromptPatchOutcome.REJECTED_INVALID_DELTA,
+                    reason=delta_result.reason,
+                ),
+            )
+            self._log_decision(decision)
+            return decision
+
+        # Delta passed — run the oscillation guard.
+        osc_result = self._oscillation.evaluate(proposal)
+        outcome = _oscillation_to_outcome(osc_result.verdict)
+        applied = outcome == PromptPatchOutcome.APPLIED
+        veto = (
+            ""
+            if applied
+            else self._format_veto(
+                prompt=proposal.prompt_name,
+                proposal_id=proposal.proposal_id,
+                outcome=outcome,
+                reason=osc_result.reason,
+            )
+        )
+        decision = PromptPatchDecision(
+            proposal_id=proposal.proposal_id,
+            outcome=outcome,
+            applied=applied,
+            delta_result=delta_result,
+            oscillation_result=osc_result,
+            veto_message=veto,
+        )
+        self._log_decision(decision)
+        return decision
+
+    def mark_applied(self, proposal: PatchProposal) -> None:
+        """Mark ``proposal`` as applied. Forwards to the oscillation guard."""
+        self._oscillation.record_applied(proposal)
+
+    def reset_session(self) -> None:
+        """Reset the per-session counters on the oscillation guard."""
+        self._oscillation.reset_session()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_veto(
+        *,
+        prompt: str,
+        proposal_id: str,
+        outcome: PromptPatchOutcome,
+        reason: str,
+    ) -> str:
+        return _VETO_MESSAGE_TEMPLATE.format(
+            prompt=prompt,
+            proposal_id=proposal_id,
+            verdict=outcome.value,
+            reason=reason,
+        )
+
+    def _log_decision(self, decision: PromptPatchDecision) -> None:
+        path = self.audit_path
+        if path is None:
+            return
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(decision.to_dict()) + "\n")
+
+
+def _oscillation_to_outcome(verdict: OscillationVerdict) -> PromptPatchOutcome:
+    """Translate an :class:`OscillationVerdict` to a :class:`PromptPatchOutcome`."""
+    match verdict:
+        case OscillationVerdict.ACCEPTED:
+            return PromptPatchOutcome.APPLIED
+        case OscillationVerdict.PENDING_CONFIRMATION:
+            return PromptPatchOutcome.PENDING
+        case OscillationVerdict.REJECTED_FLIP_BACK:
+            return PromptPatchOutcome.REJECTED_OSCILLATION
+        case OscillationVerdict.REJECTED_SESSION_CAP:
+            return PromptPatchOutcome.REJECTED_SESSION_CAP

--- a/src/bernstein/evolution/oscillation_guard.py
+++ b/src/bernstein/evolution/oscillation_guard.py
@@ -1,0 +1,385 @@
+"""Oscillation guard for prompt-evolution proposals.
+
+Synapse port of the patch-engine *2-consecutive-cycle* rule.
+
+Problem
+-------
+The evolution loop can flip a prompt back and forth across cycles
+(A → B → A → B), wasting compute and leaving the operator without a
+signal about whether each change was net-positive.
+
+Defense
+-------
+Two checks operate on a sliding window of accepted patches keyed by
+content hash:
+
+1. **Two-cycle confirmation** — a patch must be *proposed* in two
+   consecutive cycles (same content hash, same target ``prompt_name``)
+   before it is applied. Single-cycle proposals are stored as
+   "pending" and not applied yet.
+
+2. **Flip-back veto** — if the proposed content hash equals a content
+   hash that was *applied* within the last ``window_size`` patches
+   *and* a different content hash was applied between, the proposal is
+   vetoed as an oscillation (A → B → A).
+
+Session cap
+-----------
+At most ``max_patches_per_session`` patches may be accepted in a single
+session. The 4th accepted patch in a session of cap 3 is rejected with
+``session_cap``.
+
+State
+-----
+The guard is in-memory by default; callers can persist the history
+themselves by serialising :meth:`OscillationGuard.snapshot` to JSON.
+A dedicated audit file is *not* written by this module — the wiring
+into :class:`bernstein.evolution.gate.ApprovalGate` owns audit-row
+emission.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.evolution.predicted_delta import PatchProposal
+
+logger = logging.getLogger(__name__)
+
+# Tunables. The defaults mirror the issue acceptance criteria.
+DEFAULT_WINDOW_SIZE: int = 4
+DEFAULT_MAX_PATCHES_PER_SESSION: int = 3
+DEFAULT_MIN_CONFIRMATIONS: int = 2  # consecutive-cycle requirement
+
+
+class OscillationVerdict(Enum):
+    """Possible outcomes of an oscillation-guard evaluation."""
+
+    ACCEPTED = "accepted"
+    """Patch cleared the oscillation guard and may be applied."""
+
+    PENDING_CONFIRMATION = "pending_confirmation"
+    """First sighting of this patch — not yet applied."""
+
+    REJECTED_FLIP_BACK = "flip_back"
+    """Patch would revert a recent change (A → B → A)."""
+
+    REJECTED_SESSION_CAP = "session_cap"
+    """Session already has ``max_patches_per_session`` accepted patches."""
+
+
+@dataclass(frozen=True)
+class OscillationResult:
+    """Verdict from :class:`OscillationGuard`.
+
+    Attributes:
+        verdict: Outcome of the check.
+        proposal_id: Proposal that was evaluated.
+        content_hash: Content hash of the candidate patch.
+        confirmations: How many *consecutive* cycles this patch hash has
+            been proposed (including the current one).
+        applied_count: How many patches have been *applied* in the
+            current session.
+        reason: Human-readable explanation suitable for an audit row.
+    """
+
+    verdict: OscillationVerdict
+    proposal_id: str
+    content_hash: str
+    confirmations: int
+    applied_count: int
+    reason: str
+
+    @property
+    def accepted(self) -> bool:
+        """True iff the proposal cleared the guard and may apply."""
+        return self.verdict == OscillationVerdict.ACCEPTED
+
+
+@dataclass
+class _AppliedRecord:
+    """Internal record for the recent-applied ring buffer."""
+
+    prompt_name: str
+    content_hash: str
+    proposal_id: str
+    applied_at: float = field(default_factory=time.time)
+
+
+@dataclass
+class _PendingRecord:
+    """Internal record for a single-cycle pending proposal."""
+
+    prompt_name: str
+    content_hash: str
+    proposal_id: str
+    consecutive_cycles: int = 1
+    first_seen_at: float = field(default_factory=time.time)
+
+
+def resolve_max_patches_per_session(default: int = DEFAULT_MAX_PATCHES_PER_SESSION) -> int:
+    """Resolve the per-session patch cap from the environment."""
+    raw = os.environ.get("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION")
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION=%r — falling back to %s",
+            raw,
+            default,
+        )
+        return default
+    return max(parsed, 0)
+
+
+class OscillationGuard:
+    """In-memory oscillation guard for prompt patches.
+
+    Args:
+        window_size: Number of recent *applied* patches retained per
+            prompt for the flip-back check. Defaults to
+            :data:`DEFAULT_WINDOW_SIZE`.
+        min_confirmations: How many consecutive cycles a content hash
+            must appear in before it may be applied. Defaults to
+            :data:`DEFAULT_MIN_CONFIRMATIONS` (the 2-cycle rule).
+        max_patches_per_session: Per-session accepted-patch cap. ``0``
+            disables the cap.
+    """
+
+    def __init__(
+        self,
+        window_size: int | None = None,
+        min_confirmations: int | None = None,
+        max_patches_per_session: int | None = None,
+    ) -> None:
+        self.window_size: int = max(window_size if window_size is not None else DEFAULT_WINDOW_SIZE, 1)
+        self.min_confirmations: int = max(
+            min_confirmations if min_confirmations is not None else DEFAULT_MIN_CONFIRMATIONS,
+            1,
+        )
+        self.max_patches_per_session: int = (
+            max_patches_per_session if max_patches_per_session is not None else resolve_max_patches_per_session()
+        )
+        # Recent applied patches, keyed by prompt_name. Maintained as a
+        # ring buffer so the flip-back check is O(window_size).
+        self._applied: dict[str, deque[_AppliedRecord]] = {}
+        # Pending (single-cycle) proposals, keyed by (prompt_name, content_hash).
+        self._pending: dict[tuple[str, str], _PendingRecord] = {}
+        # Total applied count for the session cap.
+        self._session_applied_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def evaluate(self, proposal: PatchProposal) -> OscillationResult:
+        """Check whether ``proposal`` may be applied without oscillating.
+
+        The method is *non-mutating with respect to applied state* — it
+        records the sighting for the consecutive-cycle counter but does
+        not mark the patch as applied. Callers must invoke
+        :meth:`record_applied` once the patch has actually been written.
+        That split matches the two-stage flow of
+        :class:`bernstein.evolution.gate.ApprovalGate`: route → apply.
+
+        Args:
+            proposal: The candidate patch.
+
+        Returns:
+            :class:`OscillationResult` describing the verdict.
+        """
+        key = (proposal.prompt_name, proposal.content_hash)
+
+        if self._is_flip_back(proposal):
+            self._pending.pop(key, None)
+            return OscillationResult(
+                verdict=OscillationVerdict.REJECTED_FLIP_BACK,
+                proposal_id=proposal.proposal_id,
+                content_hash=proposal.content_hash,
+                confirmations=0,
+                applied_count=self._session_applied_count,
+                reason=(
+                    f"flip_back: content_hash={proposal.content_hash[:12]} "
+                    f"would revert a recent change to prompt={proposal.prompt_name!r}"
+                ),
+            )
+
+        if self.max_patches_per_session > 0 and self._session_applied_count >= self.max_patches_per_session:
+            return OscillationResult(
+                verdict=OscillationVerdict.REJECTED_SESSION_CAP,
+                proposal_id=proposal.proposal_id,
+                content_hash=proposal.content_hash,
+                confirmations=0,
+                applied_count=self._session_applied_count,
+                reason=(
+                    f"session_cap: already applied {self._session_applied_count} of "
+                    f"{self.max_patches_per_session} allowed patches this session"
+                ),
+            )
+
+        # Consecutive-cycle confirmation logic.
+        existing = self._pending.get(key)
+        if existing is None:
+            self._pending[key] = _PendingRecord(
+                prompt_name=proposal.prompt_name,
+                content_hash=proposal.content_hash,
+                proposal_id=proposal.proposal_id,
+            )
+            if self.min_confirmations <= 1:
+                return OscillationResult(
+                    verdict=OscillationVerdict.ACCEPTED,
+                    proposal_id=proposal.proposal_id,
+                    content_hash=proposal.content_hash,
+                    confirmations=1,
+                    applied_count=self._session_applied_count,
+                    reason="accepted: min_confirmations=1, single sighting is sufficient",
+                )
+            return OscillationResult(
+                verdict=OscillationVerdict.PENDING_CONFIRMATION,
+                proposal_id=proposal.proposal_id,
+                content_hash=proposal.content_hash,
+                confirmations=1,
+                applied_count=self._session_applied_count,
+                reason=(f"pending_confirmation: 1/{self.min_confirmations} consecutive cycles seen"),
+            )
+
+        # Re-sighting — bump the consecutive counter.
+        existing.consecutive_cycles += 1
+        if existing.consecutive_cycles >= self.min_confirmations:
+            return OscillationResult(
+                verdict=OscillationVerdict.ACCEPTED,
+                proposal_id=proposal.proposal_id,
+                content_hash=proposal.content_hash,
+                confirmations=existing.consecutive_cycles,
+                applied_count=self._session_applied_count,
+                reason=(
+                    f"accepted: confirmed {existing.consecutive_cycles}/{self.min_confirmations} consecutive cycles"
+                ),
+            )
+
+        return OscillationResult(
+            verdict=OscillationVerdict.PENDING_CONFIRMATION,
+            proposal_id=proposal.proposal_id,
+            content_hash=proposal.content_hash,
+            confirmations=existing.consecutive_cycles,
+            applied_count=self._session_applied_count,
+            reason=(
+                f"pending_confirmation: {existing.consecutive_cycles}/{self.min_confirmations} consecutive cycles seen"
+            ),
+        )
+
+    def record_applied(self, proposal: PatchProposal) -> None:
+        """Mark ``proposal`` as applied. Updates the recent-applied window.
+
+        Idempotent against repeated calls for the same proposal id — a
+        proposal whose content_hash matches the most recent applied
+        record for that prompt is treated as a no-op so callers can
+        safely call this in a finally clause.
+        """
+        bucket = self._applied.setdefault(proposal.prompt_name, deque(maxlen=self.window_size))
+        if bucket and bucket[-1].content_hash == proposal.content_hash:
+            # Same content as the last applied — nothing to do.
+            return
+        bucket.append(
+            _AppliedRecord(
+                prompt_name=proposal.prompt_name,
+                content_hash=proposal.content_hash,
+                proposal_id=proposal.proposal_id,
+            )
+        )
+        self._session_applied_count += 1
+        # Clear pending state for this hash now that it's applied.
+        self._pending.pop((proposal.prompt_name, proposal.content_hash), None)
+
+    def reset_session(self) -> None:
+        """Reset the per-session counters but keep the applied window.
+
+        Useful when starting a new operator-managed session inside the
+        same process (e.g. interactive CLI flow).
+        """
+        self._session_applied_count = 0
+        self._pending.clear()
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def session_applied_count(self) -> int:
+        """How many patches have been applied in the current session."""
+        return self._session_applied_count
+
+    def recent_applied_hashes(self, prompt_name: str) -> list[str]:
+        """Return the recent-applied content hashes for ``prompt_name``."""
+        bucket = self._applied.get(prompt_name)
+        if bucket is None:
+            return []
+        return [r.content_hash for r in bucket]
+
+    def pending_count(self) -> int:
+        """How many proposals are currently in the "pending confirmation" state."""
+        return len(self._pending)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot of the guard's state."""
+        return {
+            "session_applied_count": self._session_applied_count,
+            "window_size": self.window_size,
+            "min_confirmations": self.min_confirmations,
+            "max_patches_per_session": self.max_patches_per_session,
+            "applied": {
+                prompt: [
+                    {
+                        "content_hash": r.content_hash,
+                        "proposal_id": r.proposal_id,
+                        "applied_at": r.applied_at,
+                    }
+                    for r in bucket
+                ]
+                for prompt, bucket in self._applied.items()
+            },
+            "pending": [
+                {
+                    "prompt_name": r.prompt_name,
+                    "content_hash": r.content_hash,
+                    "proposal_id": r.proposal_id,
+                    "consecutive_cycles": r.consecutive_cycles,
+                    "first_seen_at": r.first_seen_at,
+                }
+                for r in self._pending.values()
+            ],
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _is_flip_back(self, proposal: PatchProposal) -> bool:
+        """Detect A → B → A within the recent-applied window.
+
+        A flip-back is when the proposed content_hash equals an
+        applied content_hash *and* there is at least one different
+        applied content_hash *after* it in the window. The plain "same
+        content as last applied" case is NOT a flip-back — it's a re-
+        application or noop.
+        """
+        bucket = self._applied.get(proposal.prompt_name)
+        if bucket is None or len(bucket) < 2:
+            return False
+        # Find the position of the proposed hash in the window.
+        hashes = [r.content_hash for r in bucket]
+        try:
+            idx = hashes.index(proposal.content_hash)
+        except ValueError:
+            return False
+        # Anything after idx that differs constitutes the "B" in A→B→A.
+        return any(h != proposal.content_hash for h in hashes[idx + 1 :])

--- a/src/bernstein/evolution/predicted_delta.py
+++ b/src/bernstein/evolution/predicted_delta.py
@@ -1,0 +1,316 @@
+"""Predicted-delta gate for prompt-evolution proposals.
+
+Origin: Synapse port — the agent_refinement_cycle.md patch-engine section.
+Today the evolution loop accepts any proposed prompt patch. This gate
+adds an *epsilon* check: a patch must declare a predicted win-rate
+improvement at or above ``BERNSTEIN_PROMPT_MIN_DELTA`` (default
+``0.05``) before it is allowed to proceed.
+
+Design notes
+------------
+- Computing ``predicted_delta`` is the proposer's job. This module only
+  gates on the value the proposer claims. A pluggable
+  :class:`DeltaPredictor` protocol exists so an LLM-judge or heuristic
+  scorer can fill the value in when the proposer leaves it blank.
+- The default :class:`HeuristicDeltaPredictor` is fully deterministic
+  (no LLM calls, no network) — it derives a small synthetic score
+  from proposal features so unit tests stay hermetic.
+- The gate hooks ``pre_prompt_patch_apply``; if rejected, the proposal
+  is logged with reason ``below_threshold`` and the version is not
+  bumped. See :class:`bernstein.evolution.gate.ApprovalGate` for the
+  wiring point.
+
+Hard contracts (acceptance criteria for #1348)
+----------------------------------------------
+- ``predicted_delta = 0.02`` with threshold ``0.05`` → rejected
+  (``below_threshold``).
+- Threshold = 0 → delta check is disabled (every numeric delta passes).
+- Identical content proposals (same content hash) never produce a
+  *false reject*: they get the same verdict given the same threshold.
+- NaN / inf deltas are treated as ``predicted_delta = -inf`` and
+  rejected.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Default minimum predicted delta for a patch to be applied. Overridable
+# via the ``BERNSTEIN_PROMPT_MIN_DELTA`` environment variable per the
+# issue spec.
+DEFAULT_MIN_DELTA: float = 0.05
+
+# Valid range for predicted_delta values. Anything outside [-1, 1] is
+# clamped before threshold comparison so a buggy predictor cannot
+# bypass the gate by returning an absurdly large number.
+DELTA_MIN: float = -1.0
+DELTA_MAX: float = 1.0
+
+
+class PatchVerdict(Enum):
+    """Possible outcomes of a predicted-delta evaluation."""
+
+    ACCEPTED = "accepted"
+    REJECTED_BELOW_THRESHOLD = "below_threshold"
+    REJECTED_INVALID_DELTA = "invalid_delta"
+
+
+@dataclass(frozen=True)
+class PatchProposal:
+    """A proposed mutation to a versioned prompt template.
+
+    Carries everything the gates need: the originating version id, the
+    candidate content, the proposer's rationale, and the numeric
+    ``predicted_delta`` (estimated win-rate improvement,
+    range ``[-1.0, 1.0]``).
+
+    The proposal is frozen so the *same* proposal object can be re-routed
+    through different gates without one mutating it under another.
+
+    Attributes:
+        prompt_name: Identifier of the prompt being patched (e.g. ``"judge"``).
+        from_version_id: Version id this patch is derived from.
+        to_content: Candidate prompt body.
+        rationale: Why the proposer believes this patch is an improvement.
+        predicted_delta: Proposer-claimed win-rate delta in ``[-1.0, 1.0]``.
+        proposal_id: Stable id used in audit rows. Defaults to a hash of
+            ``(prompt_name, from_version_id, content_hash)``.
+        created_at: Unix timestamp.
+    """
+
+    prompt_name: str
+    from_version_id: str
+    to_content: str
+    rationale: str
+    predicted_delta: float
+    proposal_id: str = ""
+    created_at: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        if not self.proposal_id:
+            seed = f"{self.prompt_name}|{self.from_version_id}|{self.content_hash}"
+            # Use object.__setattr__ because the dataclass is frozen.
+            object.__setattr__(
+                self,
+                "proposal_id",
+                hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16],
+            )
+
+    @property
+    def content_hash(self) -> str:
+        """Stable SHA-256 hex digest of the candidate content.
+
+        Used by the oscillation guard to detect A → B → A flips and by
+        the audit log to de-duplicate identical proposals.
+        """
+        return hashlib.sha256(self.to_content.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class PredictedDeltaResult:
+    """Verdict from :class:`PredictedDeltaGate`.
+
+    Attributes:
+        verdict: Outcome of the evaluation.
+        proposal_id: Proposal that was evaluated.
+        predicted_delta: The numeric value used for the threshold check
+            (post-clamp / sanitisation).
+        threshold: The threshold that was applied.
+        reason: Human-readable explanation suitable for an audit row.
+        accepted: Convenience alias of ``verdict == ACCEPTED``.
+    """
+
+    verdict: PatchVerdict
+    proposal_id: str
+    predicted_delta: float
+    threshold: float
+    reason: str
+
+    @property
+    def accepted(self) -> bool:
+        """True iff the proposal cleared the predicted-delta gate."""
+        return self.verdict == PatchVerdict.ACCEPTED
+
+
+@runtime_checkable
+class DeltaPredictor(Protocol):
+    """Pluggable scorer for ``predicted_delta``.
+
+    Implementations may use a heuristic, a local model, or an LLM judge.
+    The default implementation (:class:`HeuristicDeltaPredictor`) is
+    deterministic and hermetic so unit tests do not need network or
+    secret access.
+    """
+
+    def predict(self, proposal: PatchProposal) -> float:  # pragma: no cover - protocol
+        """Return a predicted win-rate delta in ``[-1.0, 1.0]``."""
+        ...
+
+
+class HeuristicDeltaPredictor:
+    """Tiny deterministic predictor used when the proposer omits a delta.
+
+    Strategy
+    --------
+    - If the proposal already carries a finite ``predicted_delta``,
+      return it unchanged (after clamping). The proposer is the
+      authority; this predictor only fills gaps.
+    - Otherwise, derive a synthetic score from cheap content features:
+      shorter rationale or empty content → lower delta; longer, more
+      detailed proposals → slightly higher delta. Bounded into
+      ``[-0.1, 0.1]`` so a heuristic guess never alone unlocks a
+      contested patch.
+
+    The exact formula is intentionally simple — it exists to keep the
+    pipeline moving when ``predicted_delta`` is not yet wired up, NOT to
+    be a real predictor.
+    """
+
+    SYNTHETIC_BOUND: float = 0.10
+
+    def predict(self, proposal: PatchProposal) -> float:
+        """Return the proposer's delta if finite, else a heuristic guess."""
+        d = proposal.predicted_delta
+        if math.isfinite(d):
+            return _clamp(d, DELTA_MIN, DELTA_MAX)
+
+        # Heuristic guess: scale rationale length into [-0.1, 0.1].
+        # Empty rationale → -0.1, well-argued (>= 200 chars) → +0.1.
+        rationale_len = len(proposal.rationale or "")
+        if rationale_len == 0:
+            return -self.SYNTHETIC_BOUND
+        ratio = min(rationale_len, 200) / 200.0  # 0..1
+        return _clamp(
+            (ratio - 0.5) * 2.0 * self.SYNTHETIC_BOUND,
+            -self.SYNTHETIC_BOUND,
+            self.SYNTHETIC_BOUND,
+        )
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp ``value`` to the closed interval ``[lo, hi]``."""
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value
+
+
+def resolve_min_delta(default: float = DEFAULT_MIN_DELTA) -> float:
+    """Resolve the active minimum delta from the environment.
+
+    Returns ``default`` when ``BERNSTEIN_PROMPT_MIN_DELTA`` is unset,
+    empty, or unparseable. Values below 0 are clamped to 0 — a negative
+    threshold has no useful semantics for this gate.
+    """
+    raw = os.environ.get("BERNSTEIN_PROMPT_MIN_DELTA")
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        parsed = float(raw)
+    except ValueError:
+        logger.warning("Invalid BERNSTEIN_PROMPT_MIN_DELTA=%r — falling back to %s", raw, default)
+        return default
+    if not math.isfinite(parsed):
+        logger.warning("Non-finite BERNSTEIN_PROMPT_MIN_DELTA=%r — falling back to %s", raw, default)
+        return default
+    return max(parsed, 0.0)
+
+
+class PredictedDeltaGate:
+    """Reject prompt patches whose predicted delta is below the threshold.
+
+    Args:
+        min_delta: Threshold. Patches with
+            ``predicted_delta < min_delta`` are rejected. ``min_delta``
+            is clamped to ``>= 0`` because a negative threshold has no
+            useful meaning here (every numeric delta would pass).
+        predictor: Optional predictor that fills in
+            ``predicted_delta`` when the proposer leaves it as NaN.
+
+    Example:
+        >>> gate = PredictedDeltaGate(min_delta=0.05)
+        >>> proposal = PatchProposal(
+        ...     prompt_name="judge",
+        ...     from_version_id="v1",
+        ...     to_content="...",
+        ...     rationale="tighter rubric",
+        ...     predicted_delta=0.02,
+        ... )
+        >>> gate.evaluate(proposal).accepted
+        False
+    """
+
+    def __init__(
+        self,
+        min_delta: float | None = None,
+        predictor: DeltaPredictor | None = None,
+    ) -> None:
+        resolved = min_delta if min_delta is not None else resolve_min_delta()
+        self.min_delta: float = max(resolved, 0.0)
+        self._predictor: DeltaPredictor = predictor or HeuristicDeltaPredictor()
+
+    def evaluate(self, proposal: PatchProposal) -> PredictedDeltaResult:
+        """Evaluate ``proposal`` against the predicted-delta threshold.
+
+        Decision flow:
+        1. Resolve the effective delta (proposer's value, falling back to
+           the predictor when the proposer's value is NaN / inf).
+        2. Reject with ``invalid_delta`` if the effective delta is still
+           not finite.
+        3. Clamp into ``[-1, 1]``.
+        4. Compare against ``self.min_delta``. ``>=`` accepts.
+
+        Returns:
+            :class:`PredictedDeltaResult` describing the verdict.
+        """
+        proposer_delta = proposal.predicted_delta
+        if math.isfinite(proposer_delta):
+            effective = _clamp(proposer_delta, DELTA_MIN, DELTA_MAX)
+            source = "proposer"
+        else:
+            predicted = self._predictor.predict(proposal)
+            if not math.isfinite(predicted):
+                reason = (
+                    f"invalid_delta: predicted_delta={proposer_delta!r}, "
+                    f"predictor returned non-finite value {predicted!r}"
+                )
+                return PredictedDeltaResult(
+                    verdict=PatchVerdict.REJECTED_INVALID_DELTA,
+                    proposal_id=proposal.proposal_id,
+                    predicted_delta=float("nan"),
+                    threshold=self.min_delta,
+                    reason=reason,
+                )
+            effective = _clamp(predicted, DELTA_MIN, DELTA_MAX)
+            source = "predictor"
+
+        if effective >= self.min_delta:
+            return PredictedDeltaResult(
+                verdict=PatchVerdict.ACCEPTED,
+                proposal_id=proposal.proposal_id,
+                predicted_delta=effective,
+                threshold=self.min_delta,
+                reason=(
+                    f"accepted: predicted_delta={effective:.4f} >= threshold={self.min_delta:.4f} (source={source})"
+                ),
+            )
+
+        return PredictedDeltaResult(
+            verdict=PatchVerdict.REJECTED_BELOW_THRESHOLD,
+            proposal_id=proposal.proposal_id,
+            predicted_delta=effective,
+            threshold=self.min_delta,
+            reason=(
+                f"below_threshold: predicted_delta={effective:.4f} < threshold={self.min_delta:.4f} (source={source})"
+            ),
+        )

--- a/tests/integration/test_evolution_gate_loop.py
+++ b/tests/integration/test_evolution_gate_loop.py
@@ -1,0 +1,209 @@
+"""End-to-end integration tests for the prompt-patch evolution gate.
+
+These tests exercise the full evolution-cycle wiring with the
+:class:`PromptPatchGate` enabled vs disabled. They are kept lightweight
+(no real LLM calls, no real prompt template files) — the goal is to
+verify the gate's effect on the proposal stream, audit log, and applied
+patches, not to re-test individual evolution components.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from bernstein.evolution.gate import (
+    PromptPatchGate,
+    PromptPatchOutcome,
+)
+from bernstein.evolution.oscillation_guard import OscillationGuard
+from bernstein.evolution.predicted_delta import (
+    PatchProposal,
+    PredictedDeltaGate,
+)
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory evolution-cycle harness
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakePromptStore:
+    """Records *applied* prompts so the tests can assert on final state."""
+
+    history: list[tuple[str, str, str]] = field(default_factory=list)
+
+    def apply(self, prompt_name: str, from_version_id: str, content: str) -> None:
+        self.history.append((prompt_name, from_version_id, content))
+
+    def current(self, prompt_name: str) -> str | None:
+        for name, _, content in reversed(self.history):
+            if name == prompt_name:
+                return content
+        return None
+
+
+@dataclass
+class FakeEvolutionLoop:
+    """A toy evolution loop that submits one proposal per cycle.
+
+    With ``gate`` provided, each proposal goes through the predicted-delta
+    + oscillation guards. With ``gate=None``, every proposal is applied
+    unconditionally — mirroring the *pre-#1348* behaviour.
+    """
+
+    store: FakePromptStore
+    gate: PromptPatchGate | None
+    applied: list[PatchProposal] = field(default_factory=list)
+    decisions: list[object] = field(default_factory=list)
+
+    def run_cycle(self, proposal: PatchProposal) -> None:
+        if self.gate is None:
+            self._apply(proposal)
+            return
+        decision = self.gate.evaluate(proposal)
+        self.decisions.append(decision)
+        if decision.outcome == PromptPatchOutcome.APPLIED:
+            self._apply(proposal)
+            self.gate.mark_applied(proposal)
+
+    def _apply(self, proposal: PatchProposal) -> None:
+        self.applied.append(proposal)
+        self.store.apply(
+            proposal.prompt_name,
+            proposal.from_version_id,
+            proposal.to_content,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.delenv("BERNSTEIN_PROMPT_MIN_DELTA", raising=False)
+    monkeypatch.delenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", raising=False)
+    yield
+
+
+def _proposal(
+    *,
+    to_content: str,
+    predicted_delta: float = 0.10,
+    prompt_name: str = "judge",
+    from_version_id: str = "v1",
+    rationale: str = "tighter",
+) -> PatchProposal:
+    return PatchProposal(
+        prompt_name=prompt_name,
+        from_version_id=from_version_id,
+        to_content=to_content,
+        rationale=rationale,
+        predicted_delta=predicted_delta,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvolutionLoopWithGate:
+    def test_gate_disabled_applies_everything(self) -> None:
+        """Baseline: without the gate, every proposal is applied (legacy behaviour)."""
+        store = FakePromptStore()
+        loop = FakeEvolutionLoop(store=store, gate=None)
+        for c in "ABCDEFG":
+            loop.run_cycle(_proposal(to_content=c))
+        # All 7 proposals applied, no decisions recorded.
+        assert len(loop.applied) == 7
+        assert loop.decisions == []
+        # Final state is the last applied content.
+        assert store.current("judge") == "G"
+
+    def test_gate_enabled_blocks_low_delta(self, tmp_path: Path) -> None:
+        store = FakePromptStore()
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+            session_id="lowdelta",
+        )
+        loop = FakeEvolutionLoop(store=store, gate=gate)
+        loop.run_cycle(_proposal(to_content="bad", predicted_delta=0.01))
+        loop.run_cycle(_proposal(to_content="good", predicted_delta=0.10))
+        assert len(loop.applied) == 1
+        assert loop.applied[0].to_content == "good"
+
+        # Audit log captures the rejected proposal.
+        log = tmp_path / "lowdelta.jsonl"
+        rows = [json.loads(line) for line in log.read_text().splitlines()]
+        assert rows[0]["outcome"] == "below_threshold"
+        assert rows[1]["outcome"] == "applied"
+
+    def test_gate_enabled_blocks_flip_back(self, tmp_path: Path) -> None:
+        store = FakePromptStore()
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+        )
+        loop = FakeEvolutionLoop(store=store, gate=gate)
+        loop.run_cycle(_proposal(to_content="A"))
+        loop.run_cycle(_proposal(to_content="B"))
+        # A → B → A should be vetoed by the oscillation guard.
+        loop.run_cycle(_proposal(to_content="A"))
+        contents = [p.to_content for p in loop.applied]
+        assert contents == ["A", "B"]
+        assert store.current("judge") == "B"
+
+    def test_gate_enabled_enforces_session_cap(self, tmp_path: Path) -> None:
+        store = FakePromptStore()
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(min_confirmations=1, max_patches_per_session=3),
+            audit_dir=tmp_path,
+        )
+        loop = FakeEvolutionLoop(store=store, gate=gate)
+        for c in "ABCDE":
+            loop.run_cycle(_proposal(to_content=c, predicted_delta=0.10))
+        # Only 3 applied because of the cap.
+        assert len(loop.applied) == 3
+        assert [p.to_content for p in loop.applied] == ["A", "B", "C"]
+
+    def test_two_consecutive_cycle_confirmation(self, tmp_path: Path) -> None:
+        """AC: same patch hash in two consecutive cycles is accepted on cycle N+1."""
+        store = FakePromptStore()
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=2),
+            audit_dir=tmp_path,
+        )
+        loop = FakeEvolutionLoop(store=store, gate=gate)
+        # Cycle N: same proposal, predicted_delta clears threshold.
+        loop.run_cycle(_proposal(to_content="A", predicted_delta=0.10))
+        assert len(loop.applied) == 0  # pending
+        # Cycle N+1: same proposal again — confirmed and applied.
+        loop.run_cycle(_proposal(to_content="A", predicted_delta=0.10))
+        assert len(loop.applied) == 1
+        assert store.current("judge") == "A"
+
+
+class TestZeroThresholdSemantics:
+    def test_zero_threshold_disables_only_delta_check(self, tmp_path: Path) -> None:
+        """AC: BERNSTEIN_PROMPT_MIN_DELTA=0 disables delta check; oscillation guard still applies."""
+        store = FakePromptStore()
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+        )
+        loop = FakeEvolutionLoop(store=store, gate=gate)
+        loop.run_cycle(_proposal(to_content="A", predicted_delta=0.0))
+        loop.run_cycle(_proposal(to_content="B", predicted_delta=0.0))
+        # Both applied, oscillation guard sees them.
+        loop.run_cycle(_proposal(to_content="A", predicted_delta=0.0))
+        # Third should be flip-back-vetoed.
+        contents = [p.to_content for p in loop.applied]
+        assert contents == ["A", "B"]

--- a/tests/property/test_evolution_gate_properties.py
+++ b/tests/property/test_evolution_gate_properties.py
@@ -1,0 +1,334 @@
+"""Property tests for the prompt-patch evolution gate.
+
+Invariants under test
+---------------------
+
+* **Idempotence** — running the predicted-delta gate twice on the same
+  proposal yields the same verdict, predicted_delta, and threshold.
+
+* **Monotonicity in threshold** — for any fixed proposal, raising the
+  threshold can only keep the verdict the same or flip it from
+  *accepted* to *below_threshold* (never the reverse).
+
+* **No false-veto on identical-content proposals** — two proposals
+  with the same content_hash receive the same delta-gate verdict and,
+  for the oscillation guard, identical handling order (second sighting
+  is always accepted or pending depending on min_confirmations, never
+  flipped to "flip_back" out of nowhere).
+
+* **Session-cap monotone** — total accepted patches in a session never
+  exceed ``max_patches_per_session`` (when > 0), regardless of the
+  sequence of proposals.
+
+* **Oscillation random sequences <= 20** — the audit row count equals
+  the number of proposals submitted, and ``session_applied_count`` is
+  bounded by the cap.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from bernstein.evolution.gate import (
+    PromptPatchGate,
+    PromptPatchOutcome,
+)
+from bernstein.evolution.oscillation_guard import OscillationGuard, OscillationVerdict
+from bernstein.evolution.predicted_delta import (
+    PatchProposal,
+    PatchVerdict,
+    PredictedDeltaGate,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+finite_deltas = st.floats(
+    min_value=-1.0,
+    max_value=1.0,
+    allow_nan=False,
+    allow_infinity=False,
+    width=64,
+)
+thresholds = st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
+content_letters = st.sampled_from(["A", "B", "C", "D"])
+prompt_names = st.sampled_from(["judge", "manager", "qa"])
+
+
+def _proposal(
+    *,
+    to_content: str = "A",
+    predicted_delta: float = 0.10,
+    prompt_name: str = "judge",
+    from_version_id: str = "v1",
+) -> PatchProposal:
+    return PatchProposal(
+        prompt_name=prompt_name,
+        from_version_id=from_version_id,
+        to_content=to_content,
+        rationale="r",
+        predicted_delta=predicted_delta,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaGateIdempotence:
+    @given(delta=finite_deltas, threshold=thresholds)
+    def test_evaluate_twice_same_verdict(self, delta: float, threshold: float) -> None:
+        gate = PredictedDeltaGate(min_delta=threshold)
+        proposal = _proposal(predicted_delta=delta)
+        r1 = gate.evaluate(proposal)
+        r2 = gate.evaluate(proposal)
+        assert r1.verdict == r2.verdict
+        assert r1.threshold == r2.threshold
+        assert r1.predicted_delta == r2.predicted_delta
+
+    @given(delta=finite_deltas, threshold=thresholds)
+    def test_two_proposals_same_hash_same_verdict(self, delta: float, threshold: float) -> None:
+        gate = PredictedDeltaGate(min_delta=threshold)
+        a = _proposal(to_content="same", predicted_delta=delta)
+        b = _proposal(to_content="same", predicted_delta=delta)
+        r1 = gate.evaluate(a)
+        r2 = gate.evaluate(b)
+        assert r1.verdict == r2.verdict
+        assert r1.predicted_delta == r2.predicted_delta
+
+
+# ---------------------------------------------------------------------------
+# Monotonicity in threshold
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdMonotonicity:
+    @given(delta=finite_deltas, low=thresholds, high=thresholds)
+    def test_raising_threshold_never_flips_to_accept(self, delta: float, low: float, high: float) -> None:
+        assume(low <= high)
+        proposal = _proposal(predicted_delta=delta)
+        low_result = PredictedDeltaGate(min_delta=low).evaluate(proposal)
+        high_result = PredictedDeltaGate(min_delta=high).evaluate(proposal)
+        # If low rejects, high MUST also reject (monotone in threshold).
+        if low_result.verdict == PatchVerdict.REJECTED_BELOW_THRESHOLD:
+            assert high_result.verdict == PatchVerdict.REJECTED_BELOW_THRESHOLD
+
+    @given(delta=finite_deltas, t=thresholds)
+    def test_threshold_zero_accepts_all_non_negative_deltas(self, delta: float, t: float) -> None:
+        assume(delta >= 0)
+        result = PredictedDeltaGate(min_delta=0.0).evaluate(_proposal(predicted_delta=delta))
+        assert result.verdict == PatchVerdict.ACCEPTED
+
+
+# ---------------------------------------------------------------------------
+# Identical-content proposals receive identical handling
+# ---------------------------------------------------------------------------
+
+
+class TestIdenticalContentHandling:
+    @given(delta=finite_deltas, threshold=thresholds)
+    def test_no_false_veto_for_identical_content(self, delta: float, threshold: float) -> None:
+        """The delta gate never vetoes one of two identical proposals while accepting the other."""
+        gate = PredictedDeltaGate(min_delta=threshold)
+        a = _proposal(to_content="x", predicted_delta=delta)
+        b = _proposal(to_content="x", predicted_delta=delta)
+        assert gate.evaluate(a).verdict == gate.evaluate(b).verdict
+
+    @given(delta=finite_deltas)
+    def test_oscillation_guard_handles_identical_back_to_back(self, delta: float) -> None:
+        guard = OscillationGuard(min_confirmations=2)
+        proposal = _proposal(predicted_delta=delta, to_content="A")
+        r1 = guard.evaluate(proposal)
+        r2 = guard.evaluate(proposal)
+        # Sighting #2 must accept (no flip-back possible without an applied B).
+        assert r1.verdict == OscillationVerdict.PENDING_CONFIRMATION
+        assert r2.verdict == OscillationVerdict.ACCEPTED
+
+
+# ---------------------------------------------------------------------------
+# Session cap is monotone
+# ---------------------------------------------------------------------------
+
+
+class TestSessionCapMonotone:
+    @given(
+        sequence=st.lists(content_letters, min_size=0, max_size=20),
+        cap=st.integers(min_value=1, max_value=10),
+    )
+    @settings(deadline=None)
+    def test_session_applied_never_exceeds_cap(self, sequence: list[str], cap: int) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(min_confirmations=1, max_patches_per_session=cap),
+        )
+        for c in sequence:
+            decision = gate.evaluate(_proposal(to_content=c))
+            if decision.outcome == PromptPatchOutcome.APPLIED:
+                gate.mark_applied(_proposal(to_content=c))
+        assert gate.oscillation_guard.session_applied_count <= cap
+
+
+# ---------------------------------------------------------------------------
+# Random sequences <= 20 — oscillation guard invariants
+# ---------------------------------------------------------------------------
+
+
+class TestRandomOscillationSequences:
+    @given(
+        sequence=st.lists(content_letters, min_size=0, max_size=20),
+    )
+    @settings(deadline=None)
+    def test_audit_row_per_proposal(self, sequence: list[str], tmp_path_factory: pytest.TempPathFactory) -> None:
+        import json
+
+        tmp_dir = tmp_path_factory.mktemp("audit")
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(min_confirmations=1, max_patches_per_session=0),
+            audit_dir=tmp_dir,
+            session_id="prop",
+        )
+        for c in sequence:
+            decision = gate.evaluate(_proposal(to_content=c))
+            if decision.outcome == PromptPatchOutcome.APPLIED:
+                gate.mark_applied(_proposal(to_content=c))
+        log = tmp_dir / "prop.jsonl"
+        if not sequence:
+            assert not log.exists() or log.read_text() == ""
+            return
+        rows = [json.loads(line) for line in log.read_text().splitlines()]
+        assert len(rows) == len(sequence)
+
+    @given(
+        sequence=st.lists(content_letters, min_size=0, max_size=20),
+        min_conf=st.integers(min_value=1, max_value=3),
+    )
+    @settings(deadline=None)
+    def test_applied_count_bounded_by_unique_with_min_confirmations_one(
+        self, sequence: list[str], min_conf: int
+    ) -> None:
+        guard = OscillationGuard(min_confirmations=min_conf, max_patches_per_session=0, window_size=10)
+        for c in sequence:
+            r = guard.evaluate(_proposal(to_content=c))
+            if r.verdict == OscillationVerdict.ACCEPTED:
+                guard.record_applied(_proposal(to_content=c))
+        # Applied count can't exceed total proposals.
+        assert guard.session_applied_count <= len(sequence)
+
+
+# ---------------------------------------------------------------------------
+# Pluggable predictor — return value range
+# ---------------------------------------------------------------------------
+
+
+class TestPredictorRange:
+    @given(value=st.floats(min_value=-100, max_value=100, allow_nan=False, allow_infinity=False))
+    def test_predicted_delta_clamped(self, value: float) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        result = gate.evaluate(_proposal(predicted_delta=value))
+        assert -1.0 <= result.predicted_delta <= 1.0
+        assert math.isfinite(result.predicted_delta)
+
+
+# ---------------------------------------------------------------------------
+# Combined gate — symmetric input/output guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedGate:
+    @given(delta=finite_deltas, threshold=thresholds)
+    def test_below_threshold_short_circuits_oscillation(self, delta: float, threshold: float) -> None:
+        assume(threshold > 0)
+        assume(delta < threshold)
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=threshold),
+            oscillation_guard=OscillationGuard(),
+        )
+        decision = gate.evaluate(_proposal(predicted_delta=delta))
+        assert decision.outcome == PromptPatchOutcome.REJECTED_DELTA
+        assert decision.oscillation_result is None
+
+    @given(delta=finite_deltas)
+    def test_passing_delta_runs_oscillation(self, delta: float) -> None:
+        assume(delta >= 0.0)  # threshold = 0
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(),
+        )
+        decision = gate.evaluate(_proposal(predicted_delta=delta))
+        assert decision.oscillation_result is not None
+
+
+# ---------------------------------------------------------------------------
+# Additional invariants
+# ---------------------------------------------------------------------------
+
+
+class TestAdditionalInvariants:
+    @given(sequence=st.lists(content_letters, min_size=1, max_size=20))
+    @settings(deadline=None)
+    def test_recent_applied_window_bounded_by_size(self, sequence: list[str]) -> None:
+        guard = OscillationGuard(window_size=3, max_patches_per_session=0, min_confirmations=1)
+        for c in sequence:
+            r = guard.evaluate(_proposal(to_content=c))
+            if r.verdict == OscillationVerdict.ACCEPTED:
+                guard.record_applied(_proposal(to_content=c))
+        assert len(guard.recent_applied_hashes("judge")) <= 3
+
+    @given(
+        sequence=st.lists(content_letters, min_size=0, max_size=20),
+        cap=st.integers(min_value=1, max_value=5),
+    )
+    @settings(deadline=None)
+    def test_after_cap_all_remaining_rejected_with_cap(self, sequence: list[str], cap: int) -> None:
+        guard = OscillationGuard(min_confirmations=1, max_patches_per_session=cap, window_size=20)
+        for c in sequence:
+            r = guard.evaluate(_proposal(to_content=c))
+            if r.verdict == OscillationVerdict.ACCEPTED:
+                guard.record_applied(_proposal(to_content=c))
+            elif r.verdict == OscillationVerdict.REJECTED_SESSION_CAP:
+                # Once cap is hit, applied_count should already equal cap.
+                assert guard.session_applied_count == cap
+
+    @given(prompt_a=prompt_names, prompt_b=prompt_names)
+    def test_different_prompts_independent_pending(self, prompt_a: str, prompt_b: str) -> None:
+        assume(prompt_a != prompt_b)
+        guard = OscillationGuard(min_confirmations=2)
+        r_a = guard.evaluate(_proposal(prompt_name=prompt_a, to_content="X"))
+        r_b = guard.evaluate(_proposal(prompt_name=prompt_b, to_content="X"))
+        assert r_a.verdict == OscillationVerdict.PENDING_CONFIRMATION
+        assert r_b.verdict == OscillationVerdict.PENDING_CONFIRMATION
+
+    @given(delta=finite_deltas, threshold=thresholds)
+    def test_result_threshold_matches_gate_threshold(self, delta: float, threshold: float) -> None:
+        gate = PredictedDeltaGate(min_delta=threshold)
+        result = gate.evaluate(_proposal(predicted_delta=delta))
+        assert result.threshold == max(threshold, 0.0)
+
+    @given(content=st.text(min_size=0, max_size=64))
+    def test_content_hash_is_stable(self, content: str) -> None:
+        h1 = _proposal(to_content=content).content_hash
+        h2 = _proposal(to_content=content).content_hash
+        assert h1 == h2
+        assert len(h1) == 64  # sha256 hex digest length
+
+    @given(content_a=st.text(min_size=0, max_size=32), content_b=st.text(min_size=0, max_size=32))
+    def test_different_content_different_hash(self, content_a: str, content_b: str) -> None:
+        assume(content_a != content_b)
+        h_a = _proposal(to_content=content_a).content_hash
+        h_b = _proposal(to_content=content_b).content_hash
+        assert h_a != h_b
+
+    @given(delta=finite_deltas, threshold=thresholds)
+    def test_accepted_means_positive_delta_post_clamp(self, delta: float, threshold: float) -> None:
+        gate = PredictedDeltaGate(min_delta=threshold)
+        result = gate.evaluate(_proposal(predicted_delta=delta))
+        if result.verdict == PatchVerdict.ACCEPTED:
+            assert result.predicted_delta >= result.threshold

--- a/tests/unit/test_oscillation_guard.py
+++ b/tests/unit/test_oscillation_guard.py
@@ -1,0 +1,539 @@
+"""Unit tests for the oscillation guard.
+
+Covers the acceptance criteria from issue #1348:
+- Single-cycle proposals stay pending.
+- Two consecutive same-hash proposals confirm and accept.
+- Different hashes between cycles do not confirm.
+- Flip-back (A → B → A) is vetoed.
+- Per-session cap is enforced.
+- Audit row format from :class:`PromptPatchGate` matches the spec.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bernstein.evolution.gate import (
+    PromptPatchDecision,
+    PromptPatchGate,
+    PromptPatchOutcome,
+)
+from bernstein.evolution.oscillation_guard import (
+    DEFAULT_MAX_PATCHES_PER_SESSION,
+    DEFAULT_WINDOW_SIZE,
+    OscillationGuard,
+    OscillationVerdict,
+    resolve_max_patches_per_session,
+)
+from bernstein.evolution.predicted_delta import (
+    PatchProposal,
+    PredictedDeltaGate,
+)
+
+
+def _make(
+    *,
+    prompt_name: str = "judge",
+    from_version_id: str = "v1",
+    to_content: str = "A",
+    rationale: str = "tighter rubric",
+    predicted_delta: float = 0.10,
+) -> PatchProposal:
+    return PatchProposal(
+        prompt_name=prompt_name,
+        from_version_id=from_version_id,
+        to_content=to_content,
+        rationale=rationale,
+        predicted_delta=predicted_delta,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.delenv("BERNSTEIN_PROMPT_MIN_DELTA", raising=False)
+    monkeypatch.delenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# resolve_max_patches_per_session
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMax:
+    def test_default(self) -> None:
+        assert resolve_max_patches_per_session() == DEFAULT_MAX_PATCHES_PER_SESSION
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", "10")
+        assert resolve_max_patches_per_session() == 10
+
+    def test_env_garbage_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", "abc")
+        assert resolve_max_patches_per_session() == DEFAULT_MAX_PATCHES_PER_SESSION
+
+    def test_env_zero_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", "0")
+        assert resolve_max_patches_per_session() == 0
+
+    def test_env_negative_clamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", "-3")
+        assert resolve_max_patches_per_session() == 0
+
+
+# ---------------------------------------------------------------------------
+# OscillationGuard — consecutive-cycle confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestConsecutiveCycleConfirmation:
+    def test_first_cycle_pending(self) -> None:
+        guard = OscillationGuard()
+        result = guard.evaluate(_make(to_content="A"))
+        assert result.verdict == OscillationVerdict.PENDING_CONFIRMATION
+        assert result.confirmations == 1
+
+    def test_second_cycle_accepts(self) -> None:
+        guard = OscillationGuard()
+        guard.evaluate(_make(to_content="A"))
+        result = guard.evaluate(_make(to_content="A"))
+        assert result.verdict == OscillationVerdict.ACCEPTED
+        assert result.confirmations == 2
+
+    def test_different_content_resets_confirmation(self) -> None:
+        guard = OscillationGuard()
+        guard.evaluate(_make(to_content="A"))
+        # Different content — new pending track.
+        result_b = guard.evaluate(_make(to_content="B"))
+        assert result_b.verdict == OscillationVerdict.PENDING_CONFIRMATION
+        # A's pending state has not advanced.
+        result_a2 = guard.evaluate(_make(to_content="A"))
+        assert result_a2.verdict == OscillationVerdict.ACCEPTED
+
+    def test_min_confirmations_one_accepts_immediately(self) -> None:
+        guard = OscillationGuard(min_confirmations=1)
+        result = guard.evaluate(_make(to_content="A"))
+        assert result.verdict == OscillationVerdict.ACCEPTED
+
+    def test_min_confirmations_three(self) -> None:
+        guard = OscillationGuard(min_confirmations=3)
+        r1 = guard.evaluate(_make(to_content="A"))
+        r2 = guard.evaluate(_make(to_content="A"))
+        r3 = guard.evaluate(_make(to_content="A"))
+        assert r1.verdict == OscillationVerdict.PENDING_CONFIRMATION
+        assert r2.verdict == OscillationVerdict.PENDING_CONFIRMATION
+        assert r3.verdict == OscillationVerdict.ACCEPTED
+
+    def test_pending_per_prompt_independent(self) -> None:
+        guard = OscillationGuard()
+        guard.evaluate(_make(prompt_name="judge", to_content="A"))
+        result = guard.evaluate(_make(prompt_name="manager", to_content="A"))
+        # Different prompts, same content — manager is fresh pending.
+        assert result.verdict == OscillationVerdict.PENDING_CONFIRMATION
+
+    def test_pending_count_tracked(self) -> None:
+        guard = OscillationGuard()
+        assert guard.pending_count() == 0
+        guard.evaluate(_make(to_content="A"))
+        guard.evaluate(_make(to_content="B"))
+        assert guard.pending_count() == 2
+
+    def test_pending_cleared_on_apply(self) -> None:
+        guard = OscillationGuard()
+        guard.evaluate(_make(to_content="A"))
+        guard.evaluate(_make(to_content="A"))
+        guard.record_applied(_make(to_content="A"))
+        # The (prompt_name, content_hash) entry should be gone.
+        assert guard.pending_count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Flip-back detection
+# ---------------------------------------------------------------------------
+
+
+class TestFlipBack:
+    def test_simple_a_b_a_is_flip_back(self) -> None:
+        guard = OscillationGuard()
+        guard.record_applied(_make(to_content="A"))
+        guard.record_applied(_make(to_content="B"))
+        result = guard.evaluate(_make(to_content="A"))
+        assert result.verdict == OscillationVerdict.REJECTED_FLIP_BACK
+        assert "flip_back" in result.reason
+
+    def test_a_b_c_b_a_is_flip_back_for_a(self) -> None:
+        guard = OscillationGuard(window_size=5)
+        for c in ("A", "B", "C", "B"):
+            guard.record_applied(_make(to_content=c))
+        result = guard.evaluate(_make(to_content="A"))
+        assert result.verdict == OscillationVerdict.REJECTED_FLIP_BACK
+
+    def test_re_apply_same_content_is_not_flip_back(self) -> None:
+        guard = OscillationGuard()
+        guard.record_applied(_make(to_content="A"))
+        # Proposing A again with no B in between is a re-apply / no-op.
+        result = guard.evaluate(_make(to_content="A"))
+        assert result.verdict != OscillationVerdict.REJECTED_FLIP_BACK
+
+    def test_flip_back_only_within_window(self) -> None:
+        guard = OscillationGuard(window_size=2)
+        guard.record_applied(_make(to_content="A"))
+        guard.record_applied(_make(to_content="B"))
+        guard.record_applied(_make(to_content="C"))  # evicts A
+        result = guard.evaluate(_make(to_content="A"))
+        # A is no longer in the window — A→B→C→A is not a "flip back to A"
+        # because A's history was forgotten.
+        assert result.verdict != OscillationVerdict.REJECTED_FLIP_BACK
+
+    def test_flip_back_clears_pending(self) -> None:
+        guard = OscillationGuard()
+        guard.record_applied(_make(to_content="A"))
+        guard.record_applied(_make(to_content="B"))
+        guard.evaluate(_make(to_content="A"))
+        # After veto, no pending entry should linger.
+        assert guard.pending_count() == 0
+
+    def test_flip_back_only_within_same_prompt(self) -> None:
+        guard = OscillationGuard()
+        guard.record_applied(_make(prompt_name="judge", to_content="A"))
+        guard.record_applied(_make(prompt_name="judge", to_content="B"))
+        # Same content but different prompt — not a flip-back.
+        result = guard.evaluate(_make(prompt_name="manager", to_content="A"))
+        assert result.verdict != OscillationVerdict.REJECTED_FLIP_BACK
+
+
+# ---------------------------------------------------------------------------
+# Session cap
+# ---------------------------------------------------------------------------
+
+
+class TestSessionCap:
+    def test_default_cap_three(self) -> None:
+        guard = OscillationGuard(min_confirmations=1)
+        for i, c in enumerate(("A", "B", "C")):
+            r = guard.evaluate(_make(to_content=c))
+            assert r.verdict == OscillationVerdict.ACCEPTED, f"#{i}"
+            guard.record_applied(_make(to_content=c))
+        # 4th — capped.
+        r4 = guard.evaluate(_make(to_content="D"))
+        assert r4.verdict == OscillationVerdict.REJECTED_SESSION_CAP
+        assert "session_cap" in r4.reason
+
+    def test_session_cap_zero_disables(self) -> None:
+        guard = OscillationGuard(min_confirmations=1, max_patches_per_session=0)
+        for c in "ABCDE":
+            r = guard.evaluate(_make(to_content=c))
+            assert r.verdict == OscillationVerdict.ACCEPTED
+            guard.record_applied(_make(to_content=c))
+
+    def test_session_cap_custom(self) -> None:
+        guard = OscillationGuard(min_confirmations=1, max_patches_per_session=2)
+        for c in "AB":
+            guard.evaluate(_make(to_content=c))
+            guard.record_applied(_make(to_content=c))
+        r = guard.evaluate(_make(to_content="C"))
+        assert r.verdict == OscillationVerdict.REJECTED_SESSION_CAP
+
+    def test_session_cap_resolved_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", "5")
+        guard = OscillationGuard(min_confirmations=1)
+        assert guard.max_patches_per_session == 5
+
+    def test_session_reset(self) -> None:
+        guard = OscillationGuard(min_confirmations=1)
+        for c in "ABC":
+            guard.evaluate(_make(to_content=c))
+            guard.record_applied(_make(to_content=c))
+        assert guard.session_applied_count == 3
+        guard.reset_session()
+        assert guard.session_applied_count == 0
+        # New patch after reset works.
+        r = guard.evaluate(_make(to_content="D"))
+        assert r.verdict == OscillationVerdict.ACCEPTED
+
+
+# ---------------------------------------------------------------------------
+# record_applied
+# ---------------------------------------------------------------------------
+
+
+class TestRecordApplied:
+    def test_idempotent_for_same_content(self) -> None:
+        guard = OscillationGuard()
+        guard.record_applied(_make(to_content="A"))
+        guard.record_applied(_make(to_content="A"))
+        assert guard.session_applied_count == 1
+
+    def test_increments_for_different_content(self) -> None:
+        guard = OscillationGuard()
+        guard.record_applied(_make(to_content="A"))
+        guard.record_applied(_make(to_content="B"))
+        assert guard.session_applied_count == 2
+
+    def test_recent_applied_hashes(self) -> None:
+        guard = OscillationGuard(window_size=3)
+        for c in "ABCD":
+            guard.record_applied(_make(to_content=c))
+        hashes = guard.recent_applied_hashes("judge")
+        # window size 3 → only last 3 retained.
+        assert len(hashes) == 3
+
+    def test_window_size_one_keeps_only_latest(self) -> None:
+        guard = OscillationGuard(window_size=1)
+        for c in "ABCD":
+            guard.record_applied(_make(to_content=c))
+        hashes = guard.recent_applied_hashes("judge")
+        assert len(hashes) == 1
+
+    def test_recent_hashes_empty_for_unknown_prompt(self) -> None:
+        guard = OscillationGuard()
+        assert guard.recent_applied_hashes("nonexistent") == []
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_snapshot_round_trip_serialisable(self) -> None:
+        import json
+
+        guard = OscillationGuard()
+        guard.evaluate(_make(to_content="A"))
+        guard.record_applied(_make(to_content="B"))
+        snap = guard.snapshot()
+        # Must be JSON-serialisable.
+        encoded = json.dumps(snap)
+        assert "session_applied_count" in encoded
+        assert "applied" in snap
+        assert "pending" in snap
+
+    def test_snapshot_records_window(self) -> None:
+        guard = OscillationGuard(window_size=5)
+        snap = guard.snapshot()
+        assert snap["window_size"] == 5
+
+    def test_default_window_size(self) -> None:
+        guard = OscillationGuard()
+        assert guard.window_size == DEFAULT_WINDOW_SIZE
+
+
+# ---------------------------------------------------------------------------
+# PromptPatchGate wiring (combines delta + oscillation)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptPatchGate:
+    def test_delta_failure_short_circuits(self, tmp_path: Path) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+            session_id="s1",
+        )
+        decision = gate.evaluate(_make(predicted_delta=0.02))
+        assert decision.outcome == PromptPatchOutcome.REJECTED_DELTA
+        assert not decision.applied
+        assert decision.oscillation_result is None
+        assert "below_threshold" in decision.veto_message
+
+    def test_oscillation_pending_after_delta_pass(self, tmp_path: Path) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(),
+            audit_dir=tmp_path,
+        )
+        decision = gate.evaluate(_make(predicted_delta=0.10))
+        assert decision.outcome == PromptPatchOutcome.PENDING
+        assert not decision.applied
+        assert decision.oscillation_result is not None
+
+    def test_two_cycles_applied(self, tmp_path: Path) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(),
+            audit_dir=tmp_path,
+        )
+        gate.evaluate(_make(predicted_delta=0.10))
+        decision = gate.evaluate(_make(predicted_delta=0.10))
+        assert decision.outcome == PromptPatchOutcome.APPLIED
+        assert decision.applied
+
+    def test_session_cap_after_three(self, tmp_path: Path) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+        )
+        for c in "ABC":
+            d = gate.evaluate(_make(to_content=c, predicted_delta=0.10))
+            assert d.outcome == PromptPatchOutcome.APPLIED
+            gate.mark_applied(_make(to_content=c, predicted_delta=0.10))
+        d4 = gate.evaluate(_make(to_content="D", predicted_delta=0.10))
+        assert d4.outcome == PromptPatchOutcome.REJECTED_SESSION_CAP
+        assert "session_cap" in d4.veto_message
+
+    def test_flip_back_through_combined_gate(self, tmp_path: Path) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+        )
+        gate.evaluate(_make(to_content="A", predicted_delta=0.10))
+        gate.mark_applied(_make(to_content="A", predicted_delta=0.10))
+        gate.evaluate(_make(to_content="B", predicted_delta=0.10))
+        gate.mark_applied(_make(to_content="B", predicted_delta=0.10))
+        decision = gate.evaluate(_make(to_content="A", predicted_delta=0.10))
+        assert decision.outcome == PromptPatchOutcome.REJECTED_OSCILLATION
+
+    def test_delta_zero_disables_only_delta_check(self, tmp_path: Path) -> None:
+        """AC: BERNSTEIN_PROMPT_MIN_DELTA=0 disables only the delta check; oscillation still applies."""
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.0),
+            oscillation_guard=OscillationGuard(),
+            audit_dir=tmp_path,
+        )
+        # Even with delta = 0 (or slightly positive), oscillation guard
+        # demands a second confirmation.
+        d1 = gate.evaluate(_make(predicted_delta=0.0))
+        assert d1.outcome == PromptPatchOutcome.PENDING
+
+    def test_audit_row_is_written(self, tmp_path: Path) -> None:
+        import json
+
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+            session_id="audit-test",
+        )
+        gate.evaluate(_make(predicted_delta=0.02))
+        gate.evaluate(_make(to_content="B", predicted_delta=0.10))
+        log_path = tmp_path / "audit-test.jsonl"
+        assert log_path.exists()
+        rows = [json.loads(line) for line in log_path.read_text().splitlines()]
+        assert len(rows) == 2
+        assert rows[0]["outcome"] == "below_threshold"
+        assert rows[0]["applied"] is False
+        assert rows[1]["outcome"] == "applied"
+        assert rows[1]["applied"] is True
+
+    def test_audit_skipped_when_no_dir(self) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+        )
+        gate.evaluate(_make(predicted_delta=0.10))
+        assert gate.audit_path is None
+
+    def test_audit_row_carries_full_payload(self, tmp_path: Path) -> None:
+        import json
+
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+        )
+        gate.evaluate(_make(predicted_delta=0.10))
+        rows = [json.loads(line) for line in (tmp_path / "default.jsonl").read_text().splitlines()]
+        row = rows[0]
+        assert "delta" in row
+        assert "oscillation" in row
+        assert "veto_message" in row
+        assert row["delta"]["threshold"] == 0.05
+        assert row["delta"]["verdict"] == "accepted"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot test of the veto message format
+# ---------------------------------------------------------------------------
+
+
+class TestVetoMessageSnapshot:
+    def test_below_threshold_format(self) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+        )
+        proposal = PatchProposal(
+            prompt_name="judge",
+            from_version_id="v1",
+            to_content="content",
+            rationale="r",
+            predicted_delta=0.01,
+            proposal_id="abc123",
+        )
+        decision = gate.evaluate(proposal)
+        assert decision.veto_message == (
+            "[prompt-patch-gate] prompt=judge proposal_id=abc123 "
+            "verdict=below_threshold reason=below_threshold: "
+            "predicted_delta=0.0100 < threshold=0.0500 (source=proposer)"
+        )
+
+    def test_flip_back_format(self) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+        )
+        a = PatchProposal(
+            prompt_name="judge",
+            from_version_id="v1",
+            to_content="A",
+            rationale="r",
+            predicted_delta=0.10,
+            proposal_id="aaa",
+        )
+        b = PatchProposal(
+            prompt_name="judge",
+            from_version_id="v1",
+            to_content="B",
+            rationale="r",
+            predicted_delta=0.10,
+            proposal_id="bbb",
+        )
+        gate.evaluate(a)
+        gate.mark_applied(a)
+        gate.evaluate(b)
+        gate.mark_applied(b)
+        flip = gate.evaluate(a)
+        assert flip.veto_message.startswith("[prompt-patch-gate] prompt=judge proposal_id=aaa verdict=flip_back")
+
+    def test_session_cap_format(self) -> None:
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1, max_patches_per_session=1),
+        )
+        a = _make(to_content="A", predicted_delta=0.10)
+        b = _make(to_content="B", predicted_delta=0.10)
+        gate.evaluate(a)
+        gate.mark_applied(a)
+        decision = gate.evaluate(b)
+        assert decision.outcome == PromptPatchOutcome.REJECTED_SESSION_CAP
+        assert "verdict=session_cap" in decision.veto_message
+        assert "already applied 1 of 1 allowed patches" in decision.veto_message
+
+
+# ---------------------------------------------------------------------------
+# Decision serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestPromptPatchDecisionSerialisation:
+    def test_to_dict_round_trips_via_json(self, tmp_path: Path) -> None:
+        import json
+
+        gate = PromptPatchGate(
+            delta_gate=PredictedDeltaGate(min_delta=0.05),
+            oscillation_guard=OscillationGuard(min_confirmations=1),
+            audit_dir=tmp_path,
+        )
+        decision: PromptPatchDecision = gate.evaluate(_make(predicted_delta=0.10))
+        encoded = json.dumps(decision.to_dict())
+        decoded = json.loads(encoded)
+        assert decoded["proposal_id"] == decision.proposal_id
+        assert decoded["outcome"] == "applied"
+        assert decoded["applied"] is True

--- a/tests/unit/test_predicted_delta_gate.py
+++ b/tests/unit/test_predicted_delta_gate.py
@@ -1,0 +1,365 @@
+"""Unit tests for the predicted-delta gate.
+
+Covers the acceptance criteria from issue #1348:
+- ``predicted_delta = 0.02`` rejected with ``below_threshold``.
+- ``BERNSTEIN_PROMPT_MIN_DELTA = 0`` disables the delta check.
+- NaN / inf deltas trip the ``invalid_delta`` verdict.
+- Pluggable predictor / heuristic fallback.
+- Audit payload format matches the issue spec.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+
+import pytest
+
+from bernstein.evolution.predicted_delta import (
+    DEFAULT_MIN_DELTA,
+    DELTA_MAX,
+    DELTA_MIN,
+    HeuristicDeltaPredictor,
+    PatchProposal,
+    PatchVerdict,
+    PredictedDeltaGate,
+    PredictedDeltaResult,
+    resolve_min_delta,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make(
+    *,
+    prompt_name: str = "judge",
+    from_version_id: str = "v1",
+    to_content: str = "you are a strict judge",
+    rationale: str = "tighter rubric",
+    predicted_delta: float = 0.10,
+) -> PatchProposal:
+    return PatchProposal(
+        prompt_name=prompt_name,
+        from_version_id=from_version_id,
+        to_content=to_content,
+        rationale=rationale,
+        predicted_delta=predicted_delta,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.delenv("BERNSTEIN_PROMPT_MIN_DELTA", raising=False)
+    monkeypatch.delenv("BERNSTEIN_PROMPT_MAX_PATCHES_PER_SESSION", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# PatchProposal
+# ---------------------------------------------------------------------------
+
+
+class TestPatchProposal:
+    def test_content_hash_is_deterministic(self) -> None:
+        p1 = _make(to_content="hello world")
+        p2 = _make(to_content="hello world")
+        assert p1.content_hash == p2.content_hash
+
+    def test_content_hash_changes_with_content(self) -> None:
+        p1 = _make(to_content="A")
+        p2 = _make(to_content="B")
+        assert p1.content_hash != p2.content_hash
+
+    def test_proposal_id_is_deterministic(self) -> None:
+        p1 = _make()
+        p2 = _make()
+        assert p1.proposal_id == p2.proposal_id
+
+    def test_explicit_proposal_id_is_preserved(self) -> None:
+        p = PatchProposal(
+            prompt_name="judge",
+            from_version_id="v1",
+            to_content="x",
+            rationale="r",
+            predicted_delta=0.1,
+            proposal_id="custom-id",
+        )
+        assert p.proposal_id == "custom-id"
+
+    def test_proposal_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        p = _make()
+        with pytest.raises(FrozenInstanceError):
+            p.predicted_delta = 0.5  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# resolve_min_delta
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMinDelta:
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_PROMPT_MIN_DELTA", raising=False)
+        assert resolve_min_delta() == DEFAULT_MIN_DELTA
+
+    def test_custom_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_PROMPT_MIN_DELTA", raising=False)
+        assert resolve_min_delta(default=0.2) == 0.2
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "0.1")
+        assert resolve_min_delta() == 0.1
+
+    def test_env_empty_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "")
+        assert resolve_min_delta() == DEFAULT_MIN_DELTA
+
+    def test_env_garbage_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "abc")
+        assert resolve_min_delta() == DEFAULT_MIN_DELTA
+
+    def test_env_negative_clamped_to_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "-0.5")
+        assert resolve_min_delta() == 0.0
+
+    def test_env_zero_disables_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "0")
+        assert resolve_min_delta() == 0.0
+
+    def test_env_inf_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "inf")
+        assert resolve_min_delta() == DEFAULT_MIN_DELTA
+
+
+# ---------------------------------------------------------------------------
+# HeuristicDeltaPredictor
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicDeltaPredictor:
+    def test_returns_proposer_value_when_finite(self) -> None:
+        p = HeuristicDeltaPredictor()
+        proposal = _make(predicted_delta=0.07)
+        assert p.predict(proposal) == 0.07
+
+    def test_clamps_proposer_value_above_one(self) -> None:
+        p = HeuristicDeltaPredictor()
+        proposal = _make(predicted_delta=5.0)
+        assert p.predict(proposal) == DELTA_MAX
+
+    def test_clamps_proposer_value_below_minus_one(self) -> None:
+        p = HeuristicDeltaPredictor()
+        proposal = _make(predicted_delta=-5.0)
+        assert p.predict(proposal) == DELTA_MIN
+
+    def test_falls_back_for_nan(self) -> None:
+        p = HeuristicDeltaPredictor()
+        proposal = _make(predicted_delta=float("nan"), rationale="a" * 200)
+        assert p.predict(proposal) == pytest.approx(HeuristicDeltaPredictor.SYNTHETIC_BOUND)
+
+    def test_falls_back_for_empty_rationale(self) -> None:
+        p = HeuristicDeltaPredictor()
+        proposal = _make(predicted_delta=float("nan"), rationale="")
+        assert p.predict(proposal) == pytest.approx(-HeuristicDeltaPredictor.SYNTHETIC_BOUND)
+
+    def test_heuristic_bounded(self) -> None:
+        p = HeuristicDeltaPredictor()
+        for rl in ("", "x", "xx", "x" * 50, "x" * 500, "x" * 5000):
+            proposal = _make(predicted_delta=float("inf"), rationale=rl)
+            v = p.predict(proposal)
+            assert -HeuristicDeltaPredictor.SYNTHETIC_BOUND <= v <= HeuristicDeltaPredictor.SYNTHETIC_BOUND
+
+
+# ---------------------------------------------------------------------------
+# PredictedDeltaGate — core behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPredictedDeltaGate:
+    def test_accept_when_delta_above_threshold(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=0.10)
+        result = gate.evaluate(proposal)
+        assert result.accepted
+        assert result.verdict == PatchVerdict.ACCEPTED
+        assert "accepted" in result.reason
+
+    def test_accept_when_delta_equals_threshold(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=0.05)
+        result = gate.evaluate(proposal)
+        assert result.accepted
+
+    def test_reject_when_below_threshold(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=0.02)
+        result = gate.evaluate(proposal)
+        assert not result.accepted
+        assert result.verdict == PatchVerdict.REJECTED_BELOW_THRESHOLD
+        assert "below_threshold" in result.reason
+
+    def test_reject_exactly_one_epsilon_below(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=0.0499)
+        result = gate.evaluate(proposal)
+        assert not result.accepted
+
+    def test_zero_threshold_disables_check(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.0)
+        # Even tiny negative deltas (-0.001) are not accepted at threshold 0
+        # because the rule is strict >= threshold. Issue says "delta check
+        # is disabled" — interpret as: every non-negative delta passes.
+        assert gate.evaluate(_make(predicted_delta=0.0)).accepted
+        assert gate.evaluate(_make(predicted_delta=0.001)).accepted
+
+    def test_negative_threshold_clamped_to_zero(self) -> None:
+        gate = PredictedDeltaGate(min_delta=-0.5)
+        assert gate.min_delta == 0.0
+
+    def test_threshold_resolved_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "0.20")
+        gate = PredictedDeltaGate()
+        assert gate.min_delta == 0.20
+
+    def test_explicit_threshold_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_PROMPT_MIN_DELTA", "0.20")
+        gate = PredictedDeltaGate(min_delta=0.01)
+        assert gate.min_delta == 0.01
+
+    def test_clamps_delta_above_one(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        result = gate.evaluate(_make(predicted_delta=5.0))
+        assert result.predicted_delta == DELTA_MAX
+        assert result.accepted
+
+    def test_clamps_delta_below_minus_one(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        result = gate.evaluate(_make(predicted_delta=-5.0))
+        assert result.predicted_delta == DELTA_MIN
+        assert not result.accepted
+
+    def test_nan_delta_falls_back_to_predictor(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=float("nan"), rationale="a" * 200)
+        result = gate.evaluate(proposal)
+        # Heuristic at max length returns +0.10 → accepted
+        assert result.accepted
+
+    def test_nan_delta_with_short_rationale_rejected(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=float("nan"), rationale="")
+        result = gate.evaluate(proposal)
+        # Heuristic returns -0.10 → rejected
+        assert not result.accepted
+        assert result.verdict == PatchVerdict.REJECTED_BELOW_THRESHOLD
+
+    def test_pos_inf_delta_falls_back(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=float("inf"), rationale="x" * 200)
+        result = gate.evaluate(proposal)
+        assert math.isfinite(result.predicted_delta)
+        assert result.accepted
+
+    def test_neg_inf_delta_falls_back(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=float("-inf"), rationale="x" * 200)
+        result = gate.evaluate(proposal)
+        # Predictor still returns its heuristic guess, which is +0.1 for long rationale.
+        assert math.isfinite(result.predicted_delta)
+
+    def test_invalid_delta_when_predictor_also_broken(self) -> None:
+        class BrokenPredictor:
+            def predict(self, proposal: PatchProposal) -> float:
+                return float("nan")
+
+        gate = PredictedDeltaGate(min_delta=0.05, predictor=BrokenPredictor())
+        proposal = _make(predicted_delta=float("nan"))
+        result = gate.evaluate(proposal)
+        assert result.verdict == PatchVerdict.REJECTED_INVALID_DELTA
+        assert "invalid_delta" in result.reason
+        assert math.isnan(result.predicted_delta)
+
+    def test_custom_predictor_used_only_when_proposer_invalid(self) -> None:
+        calls: list[PatchProposal] = []
+
+        class TrackingPredictor:
+            def predict(self, proposal: PatchProposal) -> float:
+                calls.append(proposal)
+                return 1.0
+
+        gate = PredictedDeltaGate(min_delta=0.05, predictor=TrackingPredictor())
+        gate.evaluate(_make(predicted_delta=0.07))
+        assert calls == []  # finite proposer value short-circuits predictor.
+
+        gate.evaluate(_make(predicted_delta=float("nan")))
+        assert len(calls) == 1
+
+    def test_result_reason_includes_threshold(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        result = gate.evaluate(_make(predicted_delta=0.02))
+        assert "0.0500" in result.reason
+        assert "0.0200" in result.reason
+
+    def test_result_carries_proposal_id(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make()
+        result = gate.evaluate(proposal)
+        assert result.proposal_id == proposal.proposal_id
+
+
+# ---------------------------------------------------------------------------
+# Determinism / idempotence
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_identical_proposals_get_identical_verdict(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        p1 = _make(predicted_delta=0.02)
+        p2 = _make(predicted_delta=0.02)
+        r1 = gate.evaluate(p1)
+        r2 = gate.evaluate(p2)
+        assert r1.verdict == r2.verdict
+        assert r1.predicted_delta == r2.predicted_delta
+        assert r1.threshold == r2.threshold
+
+    def test_evaluate_does_not_mutate_proposal(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=0.02)
+        before = (
+            proposal.predicted_delta,
+            proposal.rationale,
+            proposal.to_content,
+            proposal.from_version_id,
+            proposal.prompt_name,
+        )
+        gate.evaluate(proposal)
+        after = (
+            proposal.predicted_delta,
+            proposal.rationale,
+            proposal.to_content,
+            proposal.from_version_id,
+            proposal.prompt_name,
+        )
+        assert before == after
+
+    def test_evaluate_is_pure_for_same_input(self) -> None:
+        gate = PredictedDeltaGate(min_delta=0.05)
+        proposal = _make(predicted_delta=0.02)
+        r1 = gate.evaluate(proposal)
+        r2 = gate.evaluate(proposal)
+        assert r1.verdict == r2.verdict
+        assert r1.threshold == r2.threshold
+
+    def test_result_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        gate = PredictedDeltaGate(min_delta=0.05)
+        result = gate.evaluate(_make())
+        assert isinstance(result, PredictedDeltaResult)
+        with pytest.raises(FrozenInstanceError):
+            result.verdict = PatchVerdict.ACCEPTED  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Synapse port — gate prompt-evolution proposals on **predicted delta** and **oscillation**.

- `PredictedDeltaGate` rejects patches with `predicted_delta < BERNSTEIN_PROMPT_MIN_DELTA` (default `0.05`).
- `OscillationGuard` enforces the 2-consecutive-cycle confirmation rule, vetoes A→B→A flip-backs in a sliding window, and caps accepted patches per session (default 3).
- `PromptPatchGate` composes both sub-gates, emits a standardised veto message, and writes a per-cycle audit JSONL.

## Files

| File | Purpose |
|------|---------|
| `src/bernstein/evolution/predicted_delta.py` | `PatchProposal`, `PredictedDeltaGate`, pluggable `DeltaPredictor` + heuristic fallback |
| `src/bernstein/evolution/oscillation_guard.py` | `OscillationGuard` — 2-cycle confirmation, flip-back ring buffer, session cap |
| `src/bernstein/evolution/gate.py` | New `PromptPatchGate` wiring + standardised veto message |
| `tests/unit/test_predicted_delta_gate.py` | 41 unit tests |
| `tests/unit/test_oscillation_guard.py` | 45 unit tests (includes 3 veto-message snapshot tests) |
| `tests/property/test_evolution_gate_properties.py` | 19 Hypothesis tests — idempotence, threshold monotonicity, identical-content no-false-veto, session-cap monotone, content-hash stability |
| `tests/integration/test_evolution_gate_loop.py` | 6 end-to-end tests — gate enabled vs disabled |

## Acceptance criteria

- [x] `predicted_delta = 0.02` rejected with reason `below_threshold`; audit row records the rejection
- [x] Same patch hash in cycle N+1 is accepted; different hashes in N and N+1 stay pending
- [x] 4th accepted patch in a session of cap 3 is rejected with reason `session_cap`
- [x] `BERNSTEIN_PROMPT_MIN_DELTA=0` disables only the delta check; oscillation guard still applies
- [x] Random patch sequences of length ≤ 20 covered by Hypothesis

## Test plan

- [x] `uv run pytest tests/unit/test_predicted_delta_gate.py tests/unit/test_oscillation_guard.py` — 86 passed
- [x] `uv run pytest tests/property/test_evolution_gate_properties.py` — 19 passed
- [x] `uv run pytest tests/integration/test_evolution_gate_loop.py` — 6 passed
- [x] `uv run ruff check src/bernstein/evolution tests/{unit,property,integration}` — clean
- [x] `uv run pyright -p pyrightconfig.strict.json` — 0 errors
- [x] `uv run pytest tests/unit/test_approval_gate.py tests/unit/test_evolution_loop.py` — no regressions (141 passed)

Closes #1348.