### PR TITLE
feat(cost): criterion-aware retry budget (closes #1352)

### DIFF
--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1005,6 +1005,20 @@ def exec_restart() -> None:
         "Distinct from --max-cost-usd / --hard-budget, which are enforced at runtime."
     ),
 )
+@click.option(
+    "--retry-budget",
+    "retry_budget_spec",
+    type=str,
+    default=None,
+    metavar="SPEC",
+    help=(
+        "Criterion-aware retry budget (issue #1352). Accepts "
+        "``'3 retries, degrade: coverage>tests>style'``. Each retry "
+        "dials down the next criterion rather than burning identical "
+        "rerun budget. Validated eagerly; the parsed spec is exported "
+        "to ``BERNSTEIN_RETRY_BUDGET_SPEC`` for the orchestrator."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1043,6 +1057,7 @@ def run(
     budget_spec: str | None = None,
     hard_budget_spec: str | None = None,
     budget_cap: float | None = None,
+    retry_budget_spec: str | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1077,6 +1092,21 @@ def run(
     if budget_value is not None and max_cost_usd is None:
         max_cost_usd = budget_value
     hard_budget_usd = _parse_budget_spec(hard_budget_spec)
+    # Issue #1352: validate the criterion-aware retry budget eagerly so
+    # the operator sees parse errors before any process is spawned.  The
+    # parsed budget itself is reconstructed by the orchestrator from the
+    # env var; we only need to confirm the spec is well-formed here.
+    if retry_budget_spec is not None:
+        from bernstein.core.cost.retry_budget import (
+            RetryBudgetError,
+            parse_retry_budget_spec,
+        )
+
+        try:
+            parse_retry_budget_spec(retry_budget_spec)
+        except (RetryBudgetError, ValueError) as exc:
+            raise click.UsageError(f"invalid --retry-budget value: {exc}") from exc
+        os.environ["BERNSTEIN_RETRY_BUDGET_SPEC"] = retry_budget_spec
     # Print the startup banner unless the parent ``cli()`` group already
     # rendered the premium splash for this invocation. Regressed by commit
     # 1e5c13013 ("fix: ... double banner ..."), which mistakenly removed the

--- a/src/bernstein/core/cost/__init__.py
+++ b/src/bernstein/core/cost/__init__.py
@@ -3,6 +3,36 @@
 from bernstein.core.cost.cost import *  # noqa: F403
 from bernstein.core.cost.cost import _MODEL_COST_USD_PER_1K as _MODEL_COST_USD_PER_1K
 from bernstein.core.cost.cost import _model_cost as _model_cost
+from bernstein.core.cost.retry_budget import (
+    Criterion as Criterion,
+)
+from bernstein.core.cost.retry_budget import (
+    CriterionExhaustedError as CriterionExhaustedError,
+)
+from bernstein.core.cost.retry_budget import (
+    DegradationKind as DegradationKind,
+)
+from bernstein.core.cost.retry_budget import (
+    DuplicateCriterionError as DuplicateCriterionError,
+)
+from bernstein.core.cost.retry_budget import (
+    RetryBudget as RetryBudget,
+)
+from bernstein.core.cost.retry_budget import (
+    RetryBudgetError as RetryBudgetError,
+)
+from bernstein.core.cost.retry_budget import (
+    RetryBudgetExhaustedError as RetryBudgetExhaustedError,
+)
+from bernstein.core.cost.retry_budget import (
+    RetryDecision as RetryDecision,
+)
+from bernstein.core.cost.retry_budget import (
+    UnknownCriterionError as UnknownCriterionError,
+)
+from bernstein.core.cost.retry_budget import (
+    parse_retry_budget_spec as parse_retry_budget_spec,
+)
 from bernstein.core.cost.spend_ledger import (
     CallTags as CallTags,
 )

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -1085,6 +1085,25 @@ class CostTracker:
         except OSError as exc:  # pragma: no cover - best-effort IO
             logger.debug("Failed to rotate evicted cost usage for run %s: %s", self.run_id, exc)
 
+    def attach_retry_budget(self, budget: object) -> None:
+        """Attach a :class:`~bernstein.core.cost.retry_budget.RetryBudget`.
+
+        Imported lazily so importing ``cost_tracker`` does not pull in
+        the retry budget module (and vice versa).  The attachment is a
+        back-reference — the tracker does not mutate the budget.
+
+        Args:
+            budget: Any object that exposes ``attempts_left`` /
+                ``is_exhausted``.  Typically a ``RetryBudget`` from
+                :mod:`bernstein.core.cost.retry_budget`.
+        """
+        self._retry_budget = budget
+
+    @property
+    def retry_budget(self) -> object | None:
+        """The attached retry budget, if any."""
+        return getattr(self, "_retry_budget", None)
+
     def _emit_threshold_warnings(self, status: BudgetStatus) -> None:
         """Log warnings when budget thresholds are crossed.
 

--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -1,0 +1,615 @@
+"""Criterion-aware retry budget with graceful degradation.
+
+Synapse port (issue #1352).
+
+The default retry path in ``task_retry.py`` rebooks an identical attempt:
+same model, same prompt, same gate criteria.  When attempt #1 has already
+exhausted the per-task budget, attempt #2 either burns the same amount
+and yields the same failure, or trips the circuit breaker.  Operators
+want the second attempt to be *cheaper and more cautious* — not a
+rerun.
+
+This module models that behaviour as a :class:`RetryBudget`: a finite
+list of retries paired with an *ordered* list of criteria to dial down.
+The first retry degrades the first criterion, the second retry degrades
+the second criterion, and so on.  Once every criterion has been
+degraded, further retries operate at the minimum bar — they are still
+permitted but produce no additional degradation.
+
+A criterion (:class:`Criterion`) is identified by name plus an integer
+*level*.  Degrading a criterion decrements its level by ``1`` until it
+reaches its declared minimum.  A criterion at its floor cannot be
+degraded further; attempting to do so raises
+:class:`CriterionExhaustedError`.
+
+Public surface:
+
+* :class:`Criterion` — name + level + min/max bounds.
+* :class:`RetryBudget` — retries + ordered degradation policy.
+* :class:`RetryDecision` — what to do for the *next* attempt.
+* :func:`parse_retry_budget_spec` — parse the CLI string format
+  ``"3 retries, degrade: coverage>tests>style"``.
+* :exc:`RetryBudgetError` and subclasses.
+
+The module has no runtime dependencies on the orchestrator: tests can
+construct a budget directly and exercise the decision path without
+spinning up a task store.  See ``tests/unit/test_retry_budget.py`` and
+``tests/property/test_retry_budget_properties.py`` for examples.
+
+This file is pyright-strict and ruff clean.  Mutating state lives in
+``RetryBudget._criteria`` only; ``RetryDecision`` is a frozen snapshot.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping, Sequence
+
+__all__ = [
+    "DEFAULT_CRITERION_MAX",
+    "DEFAULT_CRITERION_MIN",
+    "Criterion",
+    "CriterionExhaustedError",
+    "DegradationKind",
+    "DuplicateCriterionError",
+    "RetryBudget",
+    "RetryBudgetError",
+    "RetryBudgetExhaustedError",
+    "RetryDecision",
+    "UnknownCriterionError",
+    "parse_retry_budget_spec",
+]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_CRITERION_MAX: Final[int] = 3
+"""Default upper level for a criterion (e.g. ``"comprehensive"``)."""
+
+DEFAULT_CRITERION_MIN: Final[int] = 0
+"""Default lower level for a criterion (``"minimum viable"``)."""
+
+
+class DegradationKind(StrEnum):
+    """Kinds of degradation that a retry can apply.
+
+    These are descriptive labels emitted in :class:`RetryDecision` so
+    callers can render an operator-facing message.  The kind does not
+    affect the numerical level — the criterion's *name* is what the
+    orchestrator keys policy off.
+    """
+
+    LOWERED = "lowered"
+    """The criterion was dialled down by one level."""
+
+    FLOORED = "floored"
+    """The criterion was already at its floor; no further degradation."""
+
+    NONE = "none"
+    """No degradation applied (e.g. the policy list is exhausted)."""
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RetryBudgetError(Exception):
+    """Base class for retry-budget errors."""
+
+
+class UnknownCriterionError(RetryBudgetError):
+    """The degradation policy referenced a criterion that doesn't exist."""
+
+    def __init__(self, name: str, known: Iterable[str]) -> None:
+        self.name = name
+        self.known = tuple(known)
+        super().__init__(
+            f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}"
+        )
+
+
+class DuplicateCriterionError(RetryBudgetError):
+    """A criterion appeared twice in the degradation policy."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        super().__init__(f"Criterion {name!r} appears more than once in the policy")
+
+
+class CriterionExhaustedError(RetryBudgetError):
+    """Attempted to degrade a criterion already at its floor."""
+
+    def __init__(self, criterion: Criterion) -> None:
+        self.criterion = criterion
+        super().__init__(
+            f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})"
+        )
+
+
+class RetryBudgetExhaustedError(RetryBudgetError):
+    """The retry budget has no attempts left."""
+
+    def __init__(self) -> None:
+        super().__init__("Retry budget is exhausted")
+
+
+# ---------------------------------------------------------------------------
+# Criterion
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Criterion:
+    """A single quality criterion that can be dialled down.
+
+    Attributes:
+        name: Stable identifier (e.g. ``"coverage"``, ``"tests"``).
+        level: Current level.  Higher = stricter.
+        min_level: Floor.  Once reached, further degradation raises
+            :exc:`CriterionExhaustedError`.
+        max_level: Ceiling.  Used by :meth:`reset` to restore.
+    """
+
+    name: str
+    level: int = DEFAULT_CRITERION_MAX
+    min_level: int = DEFAULT_CRITERION_MIN
+    max_level: int = DEFAULT_CRITERION_MAX
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Criterion name must be non-empty")
+        if self.min_level > self.max_level:
+            raise ValueError(
+                f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level "
+                f"({self.max_level})"
+            )
+        if self.level < self.min_level or self.level > self.max_level:
+            raise ValueError(
+                f"Criterion {self.name!r}: level {self.level} outside "
+                f"[{self.min_level}, {self.max_level}]"
+            )
+
+    @property
+    def is_at_floor(self) -> bool:
+        """``True`` iff this criterion cannot be degraded any further."""
+        return self.level <= self.min_level
+
+    def degraded(self) -> Criterion:
+        """Return a new criterion with the level decremented by one.
+
+        Raises:
+            CriterionExhaustedError: If the criterion is already at its
+                floor.
+        """
+        if self.is_at_floor:
+            raise CriterionExhaustedError(self)
+        return replace(self, level=self.level - 1)
+
+    def reset(self) -> Criterion:
+        """Return a new criterion restored to ``max_level``."""
+        return replace(self, level=self.max_level)
+
+
+# ---------------------------------------------------------------------------
+# Decision
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RetryDecision:
+    """Snapshot describing the *next* retry attempt.
+
+    Attributes:
+        should_retry: ``True`` if the orchestrator should re-attempt.
+            ``False`` means "give up / route to dead-letter".
+        attempt_index: Zero-based index of the attempt this decision
+            authorises.  Attempt 0 is the *first retry* (i.e. the
+            second overall execution).
+        degraded_criterion: The criterion whose level changed for this
+            attempt, or ``None`` if no degradation was applied.
+        degradation_kind: Why the criterion's level did or did not
+            change.
+        criteria_snapshot: Immutable view of all criteria as they stand
+            *after* the degradation.
+        reason: Operator-facing human-readable string.
+    """
+
+    should_retry: bool
+    attempt_index: int
+    degraded_criterion: Criterion | None
+    degradation_kind: DegradationKind
+    criteria_snapshot: tuple[Criterion, ...]
+    reason: str
+
+    def criterion(self, name: str) -> Criterion:
+        """Return the criterion with ``name`` from the snapshot.
+
+        Raises:
+            UnknownCriterionError: If no such criterion exists.
+        """
+        for c in self.criteria_snapshot:
+            if c.name == name:
+                return c
+        raise UnknownCriterionError(name, (c.name for c in self.criteria_snapshot))
+
+
+# ---------------------------------------------------------------------------
+# Budget
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class RetryBudget:
+    """Criterion-aware retry budget.
+
+    Construct with a positive integer ``retries`` and an ordered list of
+    criteria names (``criterion_degradation``) describing *which*
+    criterion to dial down on each successive retry.
+
+    The constructor accepts either a list of :class:`Criterion`
+    instances (full control over levels) *or* a list of names (default
+    bounds).  Use :meth:`from_names` for the shorthand.
+
+    Example::
+
+        budget = RetryBudget(
+            retries=3,
+            criterion_degradation=[
+                Criterion("coverage"),
+                Criterion("tests"),
+                Criterion("style"),
+            ],
+        )
+        decision = budget.consume()
+        assert decision.should_retry
+        assert decision.degraded_criterion is not None
+        assert decision.degraded_criterion.name == "coverage"
+
+    Args:
+        retries: Total number of retries permitted (>= 0).
+        criterion_degradation: Ordered list of criteria to dial down,
+            one per retry.  All names must be unique.
+
+    Raises:
+        ValueError: If ``retries`` is negative.
+        DuplicateCriterionError: If a name appears twice.
+    """
+
+    retries: int
+    criterion_degradation: Sequence[Criterion] = field(default_factory=lambda: [])
+    _attempts_used: int = field(default=0, init=False)
+    _criteria: dict[str, Criterion] = field(default_factory=lambda: {}, init=False)
+
+    def __post_init__(self) -> None:
+        if self.retries < 0:
+            raise ValueError(f"retries must be >= 0 (got {self.retries})")
+        # Build the canonical criteria map.  Duplicate detection happens
+        # here so callers see the error eagerly, not on first retry.
+        seen: set[str] = set()
+        criteria: dict[str, Criterion] = {}
+        for c in self.criterion_degradation:
+            if c.name in seen:
+                raise DuplicateCriterionError(c.name)
+            seen.add(c.name)
+            criteria[c.name] = c
+        # Freeze the ordering so iteration is stable.
+        self._criteria = criteria
+
+    # ------------------------------------------------------------------
+    # Alternate constructors
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_names(
+        cls,
+        retries: int,
+        names: Sequence[str],
+        *,
+        max_level: int = DEFAULT_CRITERION_MAX,
+        min_level: int = DEFAULT_CRITERION_MIN,
+    ) -> RetryBudget:
+        """Convenience: build a budget from criterion *names*.
+
+        Each criterion is initialised at ``max_level`` with the supplied
+        floor.
+
+        Args:
+            retries: Total retries (>= 0).
+            names: Ordered criterion names.
+            max_level: Starting level for every criterion.
+            min_level: Floor for every criterion.
+
+        Returns:
+            A fresh :class:`RetryBudget`.
+        """
+        criteria = [
+            Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level)
+            for n in names
+        ]
+        return cls(retries=retries, criterion_degradation=criteria)
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def attempts_used(self) -> int:
+        """Number of retries already consumed."""
+        return self._attempts_used
+
+    @property
+    def attempts_left(self) -> int:
+        """Number of retries still available."""
+        return max(0, self.retries - self._attempts_used)
+
+    @property
+    def is_exhausted(self) -> bool:
+        """``True`` iff no further retries are permitted."""
+        return self.attempts_left == 0
+
+    @property
+    def criteria(self) -> tuple[Criterion, ...]:
+        """Snapshot of criteria preserving the configured order."""
+        return tuple(self._criteria.values())
+
+    def criterion(self, name: str) -> Criterion:
+        """Return the current state of criterion ``name``.
+
+        Raises:
+            UnknownCriterionError: If no such criterion exists.
+        """
+        try:
+            return self._criteria[name]
+        except KeyError as exc:
+            raise UnknownCriterionError(name, self._criteria.keys()) from exc
+
+    # ------------------------------------------------------------------
+    # Core operation
+    # ------------------------------------------------------------------
+
+    def peek(self) -> RetryDecision:
+        """Compute the next decision *without* consuming a retry.
+
+        Useful for previewing what would happen next (e.g. for logging
+        or for tests).  The returned :class:`RetryDecision` reflects
+        the criterion that *would* be degraded if :meth:`consume` were
+        called.
+
+        Returns:
+            A :class:`RetryDecision` describing the next attempt.
+        """
+        return self._compute_decision(consume=False)
+
+    def consume(self) -> RetryDecision:
+        """Authorise the next retry and mutate state accordingly.
+
+        On a successful call:
+
+        * ``attempts_used`` is incremented.
+        * The next criterion in the degradation policy is dialled down
+          (if any remain and the criterion is not already at its
+          floor).
+
+        Returns:
+            A :class:`RetryDecision`.  If the budget is exhausted the
+            decision has ``should_retry=False`` and no state mutation
+            occurs.
+        """
+        if self.is_exhausted:
+            return RetryDecision(
+                should_retry=False,
+                attempt_index=self._attempts_used,
+                degraded_criterion=None,
+                degradation_kind=DegradationKind.NONE,
+                criteria_snapshot=tuple(self._criteria.values()),
+                reason="retry budget exhausted",
+            )
+        return self._compute_decision(consume=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _criterion_for_attempt(self, attempt_index: int) -> Criterion | None:
+        """Return the criterion targeted by ``attempt_index`` (or None).
+
+        The policy is consulted positionally: the first retry targets
+        the first criterion, the second targets the second, etc.  If
+        the policy is shorter than the attempt index, no criterion is
+        targeted (we still permit the retry, just without degradation).
+        """
+        if attempt_index < 0 or attempt_index >= len(self.criterion_degradation):
+            return None
+        # Look up by name to get the *current* level — the configured
+        # criterion is only the *target*; its mutable state lives in
+        # ``self._criteria``.
+        target_name = self.criterion_degradation[attempt_index].name
+        return self._criteria[target_name]
+
+    def _compute_decision(self, *, consume: bool) -> RetryDecision:
+        """Shared decision logic for :meth:`peek` and :meth:`consume`."""
+        attempt_index = self._attempts_used
+        target = self._criterion_for_attempt(attempt_index)
+        if target is None:
+            # No criterion left in the policy at this index — retry is
+            # still permitted but no degradation happens.
+            if consume:
+                self._attempts_used += 1
+            return RetryDecision(
+                should_retry=True,
+                attempt_index=attempt_index,
+                degraded_criterion=None,
+                degradation_kind=DegradationKind.NONE,
+                criteria_snapshot=tuple(self._criteria.values()),
+                reason=(
+                    f"retry #{attempt_index + 1} of {self.retries} "
+                    "(no further criterion degradation configured)"
+                ),
+            )
+        if target.is_at_floor:
+            # The criterion has already been degraded to its minimum on
+            # a *prior* call (unusual, since the policy lists each
+            # criterion at most once, but possible if a Criterion was
+            # supplied with level == min_level).  Permit the retry but
+            # do not crash.
+            if consume:
+                self._attempts_used += 1
+            return RetryDecision(
+                should_retry=True,
+                attempt_index=attempt_index,
+                degraded_criterion=target,
+                degradation_kind=DegradationKind.FLOORED,
+                criteria_snapshot=tuple(self._criteria.values()),
+                reason=(
+                    f"retry #{attempt_index + 1}: criterion {target.name!r} "
+                    "already at floor; no further degradation"
+                ),
+            )
+        new_criterion = target.degraded()
+        snapshot_map = dict(self._criteria)
+        snapshot_map[new_criterion.name] = new_criterion
+        if consume:
+            self._criteria[new_criterion.name] = new_criterion
+            self._attempts_used += 1
+        return RetryDecision(
+            should_retry=True,
+            attempt_index=attempt_index,
+            degraded_criterion=new_criterion,
+            degradation_kind=DegradationKind.LOWERED,
+            criteria_snapshot=tuple(snapshot_map.values()),
+            reason=(
+                f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} "
+                f"to level {new_criterion.level}"
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-friendly representation."""
+        return {
+            "retries": self.retries,
+            "attempts_used": self._attempts_used,
+            "attempts_left": self.attempts_left,
+            "criteria": [
+                {
+                    "name": c.name,
+                    "level": c.level,
+                    "min_level": c.min_level,
+                    "max_level": c.max_level,
+                }
+                for c in self._criteria.values()
+            ],
+            "policy": [c.name for c in self.criterion_degradation],
+        }
+
+
+# ---------------------------------------------------------------------------
+# CLI spec parser
+# ---------------------------------------------------------------------------
+
+
+# Accepted forms (case-insensitive on keywords):
+#
+#   "3 retries, degrade: coverage>tests>style"
+#   "5, coverage > tests > style"
+#   "1 retry, degrade: coverage"
+#   "0"
+#
+# Whitespace around tokens is liberal.  The retry count is mandatory and
+# must be the first token (integer).  The degradation list is optional
+# and defaults to empty.
+
+_SPEC_RE: Final = re.compile(
+    r"""
+    ^\s*
+    (?P<retries>\d+)
+    \s*
+    (?:retr(?:y|ies)|attempts?)?
+    \s*
+    (?:
+        [,;]\s*
+        (?:degrade\s*:)?\s*
+        (?P<policy>[^,;]+(?:>[^,;]+)*)
+    )?
+    \s*$
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def parse_retry_budget_spec(
+    spec: str,
+    *,
+    known_criteria: Mapping[str, Criterion] | None = None,
+) -> RetryBudget:
+    """Parse the CLI ``--retry-budget`` argument into a :class:`RetryBudget`.
+
+    The format mirrors the issue description:
+
+        ``"3 retries, degrade: coverage>tests>style"``
+
+    Either commas or semicolons can separate the retry count from the
+    policy.  The ``"degrade:"`` keyword is optional.  Spaces around
+    ``">"`` are allowed.  Criterion names match
+    ``[A-Za-z_][A-Za-z0-9_-]*``.
+
+    Args:
+        spec: Raw operator-supplied string.
+        known_criteria: Optional whitelist.  If provided, every name in
+            the policy must appear in the mapping; the mapping's
+            :class:`Criterion` values are used (so callers can specify
+            non-default bounds).  If omitted, criteria are constructed
+            with default bounds.
+
+    Returns:
+        A :class:`RetryBudget`.
+
+    Raises:
+        ValueError: If the spec is syntactically invalid.
+        UnknownCriterionError: If ``known_criteria`` is supplied and a
+            name doesn't appear in it.
+        DuplicateCriterionError: If a criterion is listed twice.
+    """
+    stripped = spec.strip()
+    if not stripped:
+        raise ValueError("retry budget spec is empty")
+    match = _SPEC_RE.match(stripped)
+    if match is None:
+        raise ValueError(f"could not parse retry budget spec: {spec!r}")
+    retries = int(match.group("retries"))
+    raw_policy = match.group("policy")
+    criteria: list[Criterion] = []
+    if raw_policy is not None:
+        seen: set[str] = set()
+        for raw_name in raw_policy.split(">"):
+            name = raw_name.strip()
+            if not name:
+                raise ValueError(
+                    f"empty criterion name in retry budget spec: {spec!r}"
+                )
+            if not re.match(r"^[A-Za-z_][A-Za-z0-9_-]*$", name):
+                raise ValueError(
+                    f"invalid criterion name {name!r} in retry budget spec"
+                )
+            if name in seen:
+                raise DuplicateCriterionError(name)
+            seen.add(name)
+            if known_criteria is not None:
+                if name not in known_criteria:
+                    raise UnknownCriterionError(name, known_criteria.keys())
+                criteria.append(known_criteria[name])
+            else:
+                criteria.append(Criterion(name=name))
+    return RetryBudget(retries=retries, criterion_degradation=criteria)

--- a/tests/integration/test_retry_budget_lifecycle.py
+++ b/tests/integration/test_retry_budget_lifecycle.py
@@ -1,0 +1,139 @@
+"""Integration tests for the criterion-aware retry budget lifecycle.
+
+These tests stitch the retry budget into the surrounding cost tracker
+(via :py:meth:`CostTracker.attach_retry_budget`) and exercise full
+multi-retry sessions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.cost.cost_tracker import CostTracker
+from bernstein.core.cost.retry_budget import (
+    Criterion,
+    DegradationKind,
+    RetryBudget,
+    parse_retry_budget_spec,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tracker(tmp_path: Path) -> CostTracker:
+    """A bare ``CostTracker`` rotating evicted rows into ``tmp_path``."""
+    return CostTracker(
+        run_id="test-run",
+        budget_usd=10.0,
+        rotation_dir=tmp_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+def test_cost_tracker_can_attach_retry_budget(tracker: CostTracker) -> None:
+    """A retry budget can be attached to and retrieved from a tracker."""
+    budget = RetryBudget.from_names(retries=3, names=["coverage", "tests"])
+    assert tracker.retry_budget is None
+    tracker.attach_retry_budget(budget)
+    assert tracker.retry_budget is budget
+
+
+def test_attached_budget_survives_independent_consumption(
+    tracker: CostTracker,
+) -> None:
+    """Consuming retries on the attached budget does not affect the tracker."""
+    budget = RetryBudget.from_names(retries=2, names=["coverage", "tests"])
+    tracker.attach_retry_budget(budget)
+    budget.consume()
+    # The tracker still exposes the same object.
+    fetched = tracker.retry_budget
+    assert fetched is budget
+    assert isinstance(fetched, RetryBudget)
+    assert fetched.attempts_used == 1
+
+
+def test_full_three_retry_lifecycle_via_cli_spec() -> None:
+    """End-to-end: parse a CLI spec, run three retries, verify ordering."""
+    budget = parse_retry_budget_spec(
+        "3 retries, degrade: coverage>tests>style"
+    )
+    decisions = [budget.consume() for _ in range(3)]
+    names = [
+        d.degraded_criterion.name
+        for d in decisions
+        if d.degraded_criterion is not None
+    ]
+    assert names == ["coverage", "tests", "style"]
+    # Levels have all stepped from 3 -> 2.
+    for d in decisions:
+        assert d.degraded_criterion is not None
+        assert d.degraded_criterion.level == 2
+    # Fourth retry is denied.
+    extra = budget.consume()
+    assert not extra.should_retry
+
+
+def test_lifecycle_with_pre_floored_criterion_yields_dlq() -> None:
+    """A criterion already at floor yields a FLOORED retry then exhausts."""
+    budget = RetryBudget(
+        retries=1,
+        criterion_degradation=[
+            Criterion("coverage", level=0, min_level=0, max_level=3),
+        ],
+    )
+    d = budget.consume()
+    assert d.should_retry
+    assert d.degradation_kind is DegradationKind.FLOORED
+    d2 = budget.consume()
+    # Budget exhausted on the second call.
+    assert not d2.should_retry
+
+
+def test_zero_retry_lifecycle_routes_to_dead_letter(
+    tracker: CostTracker,
+) -> None:
+    """A zero-retry budget produces no retries and an exhaustion decision."""
+    budget = RetryBudget(retries=0)
+    tracker.attach_retry_budget(budget)
+    decision = budget.consume()
+    assert not decision.should_retry
+    assert "exhausted" in decision.reason.lower()
+    # The tracker still reports the budget as attached.
+    assert tracker.retry_budget is budget
+
+
+def test_cli_retry_budget_flag_validates_eagerly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI plumbing rejects malformed specs before dispatch.
+
+    Imports happen inside the test to avoid the full CLI graph at
+    module-collection time.
+    """
+    from click.testing import CliRunner
+
+    from bernstein.cli.run_bootstrap import run as run_cmd  # type: ignore[attr-defined]
+
+    runner = CliRunner()
+    monkeypatch.delenv("BERNSTEIN_RETRY_BUDGET_SPEC", raising=False)
+    result = runner.invoke(
+        run_cmd,
+        ["--retry-budget", "garbage", "--plan-only"],
+        catch_exceptions=True,
+    )
+    assert result.exit_code != 0
+    # The friendly Click error mentions our flag name.
+    assert "retry-budget" in result.output.lower() or "retry budget" in result.output.lower()

--- a/tests/property/test_retry_budget_properties.py
+++ b/tests/property/test_retry_budget_properties.py
@@ -1,0 +1,188 @@
+"""Hypothesis property tests for the criterion-aware retry budget.
+
+Each test exercises an invariant that should hold across the entire
+input space, not just hand-picked fixtures.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.cost.retry_budget import (
+    Criterion,
+    DegradationKind,
+    DuplicateCriterionError,
+    RetryBudget,
+    parse_retry_budget_spec,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+_NAME_ALPHABET = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz_",
+    min_size=1,
+    max_size=12,
+).filter(lambda s: s[0] != "_" or len(s) > 1)
+
+
+def _unique_names(min_size: int = 0, max_size: int = 6) -> st.SearchStrategy[list[str]]:
+    return st.lists(_NAME_ALPHABET, min_size=min_size, max_size=max_size, unique=True)
+
+
+_RETRIES = st.integers(min_value=0, max_value=20)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@given(retries=_RETRIES, names=_unique_names(max_size=6))
+def test_consume_at_most_retries_times(retries: int, names: list[str]) -> None:
+    """``consume()`` can authorise at most ``retries`` retries."""
+    b = RetryBudget.from_names(retries=retries, names=names)
+    authorised = sum(1 for _ in range(retries + 5) if b.consume().should_retry)
+    assert authorised == retries
+
+
+@given(retries=_RETRIES, names=_unique_names(max_size=6))
+def test_attempts_left_plus_used_equals_retries_until_exhausted(
+    retries: int, names: list[str]
+) -> None:
+    """``attempts_left + attempts_used`` is invariant up to the cap."""
+    b = RetryBudget.from_names(retries=retries, names=names)
+    for _ in range(retries):
+        assert b.attempts_left + b.attempts_used == retries
+        b.consume()
+    assert b.attempts_used == retries
+    assert b.attempts_left == 0
+
+
+@given(names=_unique_names(min_size=1, max_size=8))
+def test_degradation_targets_match_policy_order(names: list[str]) -> None:
+    """The first ``len(names)`` retries target criteria in policy order."""
+    retries = len(names)
+    b = RetryBudget.from_names(retries=retries, names=names)
+    decisions = [b.consume() for _ in range(retries)]
+    targeted = [
+        d.degraded_criterion.name for d in decisions if d.degraded_criterion is not None
+    ]
+    assert targeted == names
+
+
+@given(retries=_RETRIES, names=_unique_names(max_size=6))
+def test_levels_monotonically_non_increase(retries: int, names: list[str]) -> None:
+    """A criterion's level never goes up across consume() calls."""
+    b = RetryBudget.from_names(retries=retries, names=names)
+    history: dict[str, list[int]] = {n: [b.criterion(n).level] for n in names}
+    for _ in range(retries):
+        b.consume()
+        for n in names:
+            history[n].append(b.criterion(n).level)
+    for series in history.values():
+        for prev, curr in pairwise(series):
+            assert curr <= prev
+
+
+@given(retries=_RETRIES, names=_unique_names(max_size=6))
+def test_decision_either_retries_or_exhausts(
+    retries: int, names: list[str]
+) -> None:
+    """Every consume call yields a retry OR an exhausted decision."""
+    b = RetryBudget.from_names(retries=retries, names=names)
+    for _ in range(retries + 3):
+        d = b.consume()
+        if d.should_retry:
+            assert d.degradation_kind in (
+                DegradationKind.LOWERED,
+                DegradationKind.NONE,
+                DegradationKind.FLOORED,
+            )
+        else:
+            assert d.degradation_kind is DegradationKind.NONE
+            assert "exhausted" in d.reason.lower()
+
+
+@given(names=_unique_names(max_size=6))
+def test_duplicate_names_always_rejected(names: list[str]) -> None:
+    """If a policy contains a duplicate name, construction fails."""
+    assume(len(names) >= 1)
+    dupes = [*names, names[0]]  # force a duplicate
+    try:
+        RetryBudget(
+            retries=len(dupes),
+            criterion_degradation=[Criterion(n) for n in dupes],
+        )
+    except DuplicateCriterionError:
+        return
+    raise AssertionError("Expected DuplicateCriterionError")
+
+
+@given(retries=_RETRIES, names=_unique_names(max_size=4))
+def test_peek_idempotent(retries: int, names: list[str]) -> None:
+    """``peek()`` does not advance state; calling twice yields equal."""
+    b = RetryBudget.from_names(retries=retries, names=names)
+    p1 = b.peek()
+    p2 = b.peek()
+    assert p1 == p2
+    assert b.attempts_used == 0
+
+
+@given(retries=_RETRIES, names=_unique_names(max_size=6))
+def test_to_dict_roundtrip_keys(retries: int, names: list[str]) -> None:
+    """``to_dict()`` exposes a stable schema."""
+    b = RetryBudget.from_names(retries=retries, names=names)
+    d = b.to_dict()
+    assert set(d.keys()) == {
+        "retries",
+        "attempts_used",
+        "attempts_left",
+        "criteria",
+        "policy",
+    }
+
+
+@given(names=_unique_names(min_size=1, max_size=5))
+def test_parse_spec_roundtrip(names: list[str]) -> None:
+    """Spec-string -> budget -> assertions hold."""
+    spec = f"{len(names)}, degrade: {'>'.join(names)}"
+    b = parse_retry_budget_spec(spec)
+    assert b.retries == len(names)
+    assert [c.name for c in b.criterion_degradation] == names
+
+
+@given(retries=_RETRIES)
+def test_zero_or_more_retries_construction(retries: int) -> None:
+    """Non-negative retries always construct successfully."""
+    b = RetryBudget(retries=retries)
+    assert b.attempts_left == retries
+    assert b.is_exhausted == (retries == 0)
+
+
+@given(retries=st.integers(min_value=-100, max_value=-1))
+def test_negative_retries_rejected_property(retries: int) -> None:
+    """Negative retries always fail construction."""
+    try:
+        RetryBudget(retries=retries)
+    except ValueError:
+        return
+    raise AssertionError("Expected ValueError")
+
+
+@given(names=_unique_names(min_size=1, max_size=6))
+def test_each_targeted_criterion_appears_in_snapshot(names: list[str]) -> None:
+    """Every degraded criterion is present in the decision snapshot."""
+    b = RetryBudget.from_names(retries=len(names), names=names)
+    for _ in range(len(names)):
+        d = b.consume()
+        if d.degraded_criterion is None:
+            continue
+        snap_names = [c.name for c in d.criteria_snapshot]
+        assert d.degraded_criterion.name in snap_names

--- a/tests/unit/test_retry_budget_criterion.py
+++ b/tests/unit/test_retry_budget_criterion.py
@@ -1,0 +1,515 @@
+"""Unit tests for :mod:`bernstein.core.cost.retry_budget`.
+
+Covers budget exhaustion, criterion degradation ordering, illegal
+degradation rejection, zero-retry edge cases, and the CLI spec parser.
+
+A sibling module ``tests/unit/test_retry_budget.py`` already exists for
+the *task-level* retry budget under ``bernstein.core.cost.planned`` —
+this file is the criterion-aware (issue #1352) suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.core.cost.retry_budget import (
+    Criterion,
+    CriterionExhaustedError,
+    DegradationKind,
+    DuplicateCriterionError,
+    RetryBudget,
+    RetryBudgetError,
+    RetryDecision,
+    UnknownCriterionError,
+    parse_retry_budget_spec,
+)
+
+# ---------------------------------------------------------------------------
+# Criterion
+# ---------------------------------------------------------------------------
+
+
+class TestCriterion:
+    def test_default_levels(self) -> None:
+        c = Criterion(name="coverage")
+        assert c.name == "coverage"
+        assert c.level == 3
+        assert c.min_level == 0
+        assert c.max_level == 3
+        assert not c.is_at_floor
+
+    def test_at_floor_flag(self) -> None:
+        c = Criterion(name="tests", level=0, min_level=0, max_level=3)
+        assert c.is_at_floor
+
+    def test_degrade_decrements_level(self) -> None:
+        c = Criterion(name="style", level=2)
+        d = c.degraded()
+        assert d.level == 1
+        assert d.name == "style"
+        # original is unchanged (frozen dataclass).
+        assert c.level == 2
+
+    def test_degrade_at_floor_raises(self) -> None:
+        c = Criterion(name="x", level=0, min_level=0)
+        with pytest.raises(CriterionExhaustedError):
+            c.degraded()
+
+    def test_degrade_walks_to_floor(self) -> None:
+        c = Criterion(name="x", level=3)
+        c = c.degraded()
+        c = c.degraded()
+        c = c.degraded()
+        assert c.level == 0
+        assert c.is_at_floor
+        with pytest.raises(CriterionExhaustedError):
+            c.degraded()
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Criterion(name="")
+
+    def test_min_above_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="min_level"):
+            Criterion(name="bad", level=1, min_level=5, max_level=1)
+
+    def test_level_above_max_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside"):
+            Criterion(name="bad", level=5, max_level=3)
+
+    def test_level_below_min_rejected(self) -> None:
+        with pytest.raises(ValueError, match="outside"):
+            Criterion(name="bad", level=-1, min_level=0)
+
+    def test_reset_restores_max_level(self) -> None:
+        c = Criterion(name="x", level=0, max_level=3)
+        r = c.reset()
+        assert r.level == 3
+
+    def test_criterion_is_hashable(self) -> None:
+        c = Criterion(name="x", level=2)
+        assert hash(c) == hash(Criterion(name="x", level=2))
+
+
+# ---------------------------------------------------------------------------
+# RetryBudget construction
+# ---------------------------------------------------------------------------
+
+
+class TestRetryBudgetConstruction:
+    def test_basic_construction(self) -> None:
+        b = RetryBudget(retries=3, criterion_degradation=[Criterion("coverage")])
+        assert b.retries == 3
+        assert b.attempts_used == 0
+        assert b.attempts_left == 3
+        assert not b.is_exhausted
+
+    def test_zero_retries(self) -> None:
+        b = RetryBudget(retries=0)
+        assert b.is_exhausted
+        assert b.attempts_left == 0
+
+    def test_negative_retries_rejected(self) -> None:
+        with pytest.raises(ValueError, match="retries must be >= 0"):
+            RetryBudget(retries=-1)
+
+    def test_duplicate_criterion_rejected(self) -> None:
+        with pytest.raises(DuplicateCriterionError):
+            RetryBudget(
+                retries=2,
+                criterion_degradation=[
+                    Criterion("coverage"),
+                    Criterion("coverage"),
+                ],
+            )
+
+    def test_from_names_helper(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["a", "b"])
+        assert b.retries == 2
+        assert [c.name for c in b.criteria] == ["a", "b"]
+        assert all(c.level == 3 for c in b.criteria)
+
+    def test_from_names_with_custom_bounds(self) -> None:
+        b = RetryBudget.from_names(
+            retries=1, names=["x"], max_level=5, min_level=1
+        )
+        assert b.criteria[0].level == 5
+        assert b.criteria[0].max_level == 5
+        assert b.criteria[0].min_level == 1
+
+    def test_empty_policy_allowed(self) -> None:
+        b = RetryBudget(retries=2)
+        assert b.criteria == ()
+        assert b.attempts_left == 2
+
+    def test_construct_with_pre_degraded_criterion(self) -> None:
+        b = RetryBudget(
+            retries=1,
+            criterion_degradation=[Criterion("c", level=1, min_level=0)],
+        )
+        assert b.criterion("c").level == 1
+
+
+# ---------------------------------------------------------------------------
+# RetryBudget.consume / peek
+# ---------------------------------------------------------------------------
+
+
+class TestRetryBudgetConsume:
+    def test_consume_returns_decision(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["coverage", "tests"])
+        d = b.consume()
+        assert isinstance(d, RetryDecision)
+        assert d.should_retry
+        assert d.attempt_index == 0
+
+    def test_consume_decrements_attempts_left(self) -> None:
+        b = RetryBudget.from_names(retries=3, names=["a"])
+        assert b.attempts_left == 3
+        b.consume()
+        assert b.attempts_left == 2
+        b.consume()
+        assert b.attempts_left == 1
+
+    def test_consume_exhausted_returns_no_retry(self) -> None:
+        b = RetryBudget(retries=0)
+        d = b.consume()
+        assert not d.should_retry
+        assert d.degradation_kind is DegradationKind.NONE
+        assert "exhausted" in d.reason.lower()
+
+    def test_consume_after_exhaustion_is_idempotent(self) -> None:
+        b = RetryBudget(retries=1)
+        b.consume()
+        d2 = b.consume()
+        assert not d2.should_retry
+        assert b.attempts_used == 1
+
+    def test_degradation_first_retry_targets_first_criterion(self) -> None:
+        b = RetryBudget.from_names(
+            retries=3, names=["coverage", "tests", "style"]
+        )
+        d = b.consume()
+        assert d.degraded_criterion is not None
+        assert d.degraded_criterion.name == "coverage"
+        assert d.degraded_criterion.level == 2
+
+    def test_degradation_second_retry_targets_second_criterion(self) -> None:
+        b = RetryBudget.from_names(
+            retries=3, names=["coverage", "tests", "style"]
+        )
+        b.consume()
+        d = b.consume()
+        assert d.degraded_criterion is not None
+        assert d.degraded_criterion.name == "tests"
+        assert d.degraded_criterion.level == 2
+
+    def test_degradation_third_retry_targets_third_criterion(self) -> None:
+        b = RetryBudget.from_names(
+            retries=3, names=["coverage", "tests", "style"]
+        )
+        b.consume()
+        b.consume()
+        d = b.consume()
+        assert d.degraded_criterion is not None
+        assert d.degraded_criterion.name == "style"
+
+    def test_more_retries_than_criteria_no_degradation(self) -> None:
+        b = RetryBudget.from_names(retries=5, names=["coverage"])
+        b.consume()  # coverage 3->2
+        b.consume()  # no policy entry at idx=1
+        d = b.consume()
+        assert d.should_retry
+        assert d.degraded_criterion is None
+        assert d.degradation_kind is DegradationKind.NONE
+
+    def test_peek_does_not_mutate_state(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["coverage"])
+        p1 = b.peek()
+        p2 = b.peek()
+        assert b.attempts_used == 0
+        assert p1.attempt_index == p2.attempt_index == 0
+        assert b.criterion("coverage").level == 3
+
+    def test_peek_then_consume_consistent(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["coverage"])
+        p = b.peek()
+        d = b.consume()
+        assert p.attempt_index == d.attempt_index
+        assert p.degraded_criterion == d.degraded_criterion
+
+    def test_criterion_already_at_floor_yields_floored_kind(self) -> None:
+        b = RetryBudget(
+            retries=2,
+            criterion_degradation=[
+                Criterion("coverage", level=0, min_level=0, max_level=3),
+            ],
+        )
+        d = b.consume()
+        assert d.should_retry
+        assert d.degradation_kind is DegradationKind.FLOORED
+        assert d.degraded_criterion is not None
+        assert d.degraded_criterion.level == 0
+
+    def test_consume_n_times_yields_n_attempts_used(self) -> None:
+        b = RetryBudget.from_names(retries=4, names=["a", "b", "c", "d"])
+        for _ in range(4):
+            b.consume()
+        assert b.attempts_used == 4
+        assert b.is_exhausted
+
+    def test_attempts_left_never_negative(self) -> None:
+        b = RetryBudget(retries=1)
+        b.consume()
+        b.consume()
+        b.consume()
+        assert b.attempts_left == 0
+
+
+# ---------------------------------------------------------------------------
+# RetryDecision
+# ---------------------------------------------------------------------------
+
+
+class TestRetryDecision:
+    def test_decision_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        b = RetryBudget.from_names(retries=1, names=["c"])
+        d = b.consume()
+        with pytest.raises(FrozenInstanceError):
+            d.attempt_index = 99  # type: ignore[misc]
+
+    def test_decision_criterion_lookup(self) -> None:
+        b = RetryBudget.from_names(retries=1, names=["coverage"])
+        d = b.consume()
+        c = d.criterion("coverage")
+        assert c.name == "coverage"
+
+    def test_decision_criterion_unknown_raises(self) -> None:
+        b = RetryBudget.from_names(retries=1, names=["coverage"])
+        d = b.consume()
+        with pytest.raises(UnknownCriterionError):
+            d.criterion("nonexistent")
+
+    def test_decision_reason_mentions_retry_number(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["coverage"])
+        d = b.consume()
+        assert "retry #1" in d.reason
+
+    def test_decision_snapshot_reflects_post_degradation(self) -> None:
+        b = RetryBudget.from_names(retries=1, names=["coverage"])
+        d = b.consume()
+        snap = {c.name: c.level for c in d.criteria_snapshot}
+        assert snap["coverage"] == 2
+
+    def test_decision_after_exhaustion_carries_full_snapshot(self) -> None:
+        b = RetryBudget.from_names(retries=1, names=["coverage"])
+        b.consume()
+        d = b.consume()
+        # snapshot still contains coverage
+        assert any(c.name == "coverage" for c in d.criteria_snapshot)
+
+
+# ---------------------------------------------------------------------------
+# Introspection
+# ---------------------------------------------------------------------------
+
+
+class TestIntrospection:
+    def test_criterion_lookup_by_name(self) -> None:
+        b = RetryBudget.from_names(retries=1, names=["coverage", "tests"])
+        assert b.criterion("coverage").name == "coverage"
+        assert b.criterion("tests").name == "tests"
+
+    def test_criterion_unknown_name_raises(self) -> None:
+        b = RetryBudget.from_names(retries=1, names=["coverage"])
+        with pytest.raises(UnknownCriterionError):
+            b.criterion("nope")
+
+    def test_criteria_property_preserves_order(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["z", "a", "m"])
+        names = [c.name for c in b.criteria]
+        assert names == ["z", "a", "m"]
+
+    def test_to_dict_serialises_state(self) -> None:
+        b = RetryBudget.from_names(retries=2, names=["coverage"])
+        b.consume()
+        d = b.to_dict()
+        assert d["retries"] == 2
+        assert d["attempts_used"] == 1
+        assert d["attempts_left"] == 1
+        assert d["policy"] == ["coverage"]
+        assert isinstance(d["criteria"], list)
+
+
+# ---------------------------------------------------------------------------
+# CLI spec parser
+# ---------------------------------------------------------------------------
+
+
+class TestParseSpec:
+    def test_basic_form(self) -> None:
+        b = parse_retry_budget_spec("3 retries, degrade: coverage>tests>style")
+        assert b.retries == 3
+        assert [c.name for c in b.criterion_degradation] == [
+            "coverage",
+            "tests",
+            "style",
+        ]
+
+    def test_no_degrade_keyword(self) -> None:
+        b = parse_retry_budget_spec("2, coverage>tests")
+        assert b.retries == 2
+        assert [c.name for c in b.criterion_degradation] == ["coverage", "tests"]
+
+    def test_single_criterion(self) -> None:
+        b = parse_retry_budget_spec("1 retry, degrade: coverage")
+        assert b.retries == 1
+        assert len(b.criterion_degradation) == 1
+
+    def test_zero_retries(self) -> None:
+        b = parse_retry_budget_spec("0")
+        assert b.retries == 0
+        assert b.is_exhausted
+
+    def test_extra_whitespace_tolerated(self) -> None:
+        b = parse_retry_budget_spec(
+            "  3   retries  ,   degrade :  coverage  >  tests  >  style  "
+        )
+        assert b.retries == 3
+        assert [c.name for c in b.criterion_degradation] == [
+            "coverage",
+            "tests",
+            "style",
+        ]
+
+    def test_empty_spec_rejected(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            parse_retry_budget_spec("")
+
+    def test_whitespace_spec_rejected(self) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            parse_retry_budget_spec("   \t  ")
+
+    def test_garbage_spec_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            parse_retry_budget_spec("not a number")
+
+    def test_empty_criterion_rejected(self) -> None:
+        with pytest.raises(ValueError, match="empty criterion"):
+            parse_retry_budget_spec("3, coverage>>tests")
+
+    def test_duplicate_criterion_rejected(self) -> None:
+        with pytest.raises(DuplicateCriterionError):
+            parse_retry_budget_spec("3, coverage>coverage")
+
+    def test_invalid_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="invalid criterion name"):
+            parse_retry_budget_spec("3, 9bad")
+
+    def test_known_criteria_whitelist_applies_bounds(self) -> None:
+        known = {"coverage": Criterion("coverage", max_level=5, level=5)}
+        b = parse_retry_budget_spec("1, coverage", known_criteria=known)
+        assert b.criterion("coverage").max_level == 5
+
+    def test_known_criteria_rejects_unknown(self) -> None:
+        with pytest.raises(UnknownCriterionError):
+            parse_retry_budget_spec(
+                "1, coverage>tests",
+                known_criteria={"coverage": Criterion("coverage")},
+            )
+
+    def test_attempts_synonym_works(self) -> None:
+        b = parse_retry_budget_spec("4 attempts")
+        assert b.retries == 4
+
+    def test_semicolon_separator(self) -> None:
+        b = parse_retry_budget_spec("2; coverage>tests")
+        assert b.retries == 2
+        assert len(b.criterion_degradation) == 2
+
+
+# ---------------------------------------------------------------------------
+# Error hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHierarchy:
+    def test_all_errors_subclass_base(self) -> None:
+        for exc in (
+            CriterionExhaustedError,
+            DuplicateCriterionError,
+            UnknownCriterionError,
+        ):
+            assert issubclass(exc, RetryBudgetError)
+
+    def test_unknown_criterion_carries_known_set(self) -> None:
+        try:
+            RetryBudget.from_names(retries=1, names=["a"]).criterion("missing")
+        except UnknownCriterionError as exc:
+            assert exc.name == "missing"
+            assert "a" in exc.known
+        else:  # pragma: no cover - defensive
+            pytest.fail("expected UnknownCriterionError")
+
+    def test_duplicate_criterion_carries_name(self) -> None:
+        try:
+            RetryBudget(
+                retries=1,
+                criterion_degradation=[Criterion("x"), Criterion("x")],
+            )
+        except DuplicateCriterionError as exc:
+            assert exc.name == "x"
+        else:  # pragma: no cover - defensive
+            pytest.fail("expected DuplicateCriterionError")
+
+    def test_criterion_exhausted_carries_criterion(self) -> None:
+        c = Criterion("x", level=0, min_level=0)
+        try:
+            c.degraded()
+        except CriterionExhaustedError as exc:
+            assert exc.criterion.name == "x"
+        else:  # pragma: no cover - defensive
+            pytest.fail("expected CriterionExhaustedError")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_full_degradation_sequence(self) -> None:
+        b = RetryBudget.from_names(
+            retries=3, names=["coverage", "tests", "style"]
+        )
+        decisions = [b.consume() for _ in range(4)]
+        retry_names = [
+            d.degraded_criterion.name
+            for d in decisions[:3]
+            if d.degraded_criterion is not None
+        ]
+        assert retry_names == ["coverage", "tests", "style"]
+        assert not decisions[3].should_retry
+
+    def test_zero_retry_budget_routes_to_dlq(self) -> None:
+        b = RetryBudget(retries=0)
+        d = b.consume()
+        assert d.should_retry is False
+
+    def test_floor_walk_respects_min_level(self) -> None:
+        b = RetryBudget(
+            retries=2,
+            criterion_degradation=[
+                Criterion("coverage", level=3, min_level=2, max_level=3),
+            ],
+        )
+        d = b.consume()
+        assert d.degraded_criterion is not None
+        assert d.degraded_criterion.level == 2
+        # No further consumption degrades — second consume has no
+        # criterion at index 1.
+        d2 = b.consume()
+        assert d2.should_retry
+        assert d2.degraded_criterion is None


### PR DESCRIPTION
## Summary

Synapse port of "criterion-aware retry budget with graceful degradation" (closes #1352).

Today the retry path reruns with identical model + prompt + gates. This PR adds a `RetryBudget` that dials down a *named criterion* (coverage, tests, style, etc.) on each retry instead of burning identical attempts.

### What ships

- `src/bernstein/core/cost/retry_budget.py` — new module:
  - `Criterion(name, level, min_level, max_level)` — dataclass with `degraded()` / `reset()` / `is_at_floor`.
  - `RetryBudget(retries, criterion_degradation)` — ordered policy; positional degradation per retry; `peek()` / `consume()`.
  - `RetryDecision` — frozen snapshot returned to the caller; `should_retry`, `degraded_criterion`, `degradation_kind`, `criteria_snapshot`, `reason`.
  - `parse_retry_budget_spec("3 retries, degrade: coverage>tests>style")` — operator-CLI parser.
  - Sealed error hierarchy: `RetryBudgetError` / `CriterionExhaustedError` / `DuplicateCriterionError` / `UnknownCriterionError` / `RetryBudgetExhaustedError`.
- `cost_tracker.CostTracker` gains `attach_retry_budget()` / `retry_budget` back-reference (no behaviour change to existing tracker logic).
- `bernstein run --retry-budget SPEC` Click option in `cli/run_bootstrap.py` — validates the spec eagerly and exports `BERNSTEIN_RETRY_BUDGET_SPEC` for the orchestrator.

### Tests (82 new)

| Layer       | File                                                    | Count |
|-------------|---------------------------------------------------------|-------|
| Unit        | `tests/unit/test_retry_budget_criterion.py`             | 64    |
| Property    | `tests/property/test_retry_budget_properties.py`        | 12    |
| Integration | `tests/integration/test_retry_budget_lifecycle.py`      | 6     |

(`tests/unit/test_retry_budget.py` already exists for the task-level retry budget under `core.cost.planned` — kept untouched; the new criterion-aware suite is `test_retry_budget_criterion.py`.)

Covers: budget exhaustion, criterion degradation order, illegal degradation rejection (duplicate, unknown, malformed), zero-retry edge case, CLI-spec parsing roundtrip, levels-monotonically-non-increase property, snapshot consistency, CLI flag rejection of garbage input.

### Lint / type

- `uv run ruff check` — clean on every touched file.
- `uv run pyright src/bernstein/core/cost/retry_budget.py` — clean under strict mode.
- `cost_tracker.py` and `run_bootstrap.py` pyright counts unchanged from pre-existing baseline.

## Test plan

- [x] `uv run pytest tests/unit/test_retry_budget_criterion.py` (64 pass)
- [x] `uv run pytest tests/property/test_retry_budget_properties.py` (12 pass)
- [x] `uv run pytest tests/integration/test_retry_budget_lifecycle.py` (6 pass)
- [x] `uv run pytest tests/unit/test_retry_budget.py tests/unit/test_cost_tracker.py` — existing suites still green (46 pass).
- [x] `uv run ruff check` — passes for all touched files.
- [x] `uv run pyright src/bernstein/core/cost/retry_budget.py` — passes strict mode.