### PR TITLE
feat(tasks): abandon primitive with reason ledger (closes #1350)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -207,6 +207,7 @@ alwaysApply: false
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/.goosehints
+++ b/.goosehints
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/src/bernstein/cli/commands/abandonments_cmd.py
+++ b/src/bernstein/cli/commands/abandonments_cmd.py
@@ -1,0 +1,157 @@
+"""``bernstein abandonments`` — inspect the agent abandonment ledger (#1350).
+
+The ledger lives at ``<workdir>/.sdd/runtime/abandonments.jsonl`` and is
+written every time an adapter calls ``ctx.abandon(reason, detail)`` or
+an operator issues ``bernstein task abandon …`` (future). This CLI
+exposes the read side: ``list`` for recent rows, ``stats`` for the
+roll-up by reason / role / adapter.
+
+Both commands honour the global ``--json`` flag exported by
+:mod:`bernstein.cli.helpers` so the output is consumable from operator
+scripts as well as from the TTY.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console, is_json, print_json
+from bernstein.core.tasks.abandon import AbandonmentLedger
+
+
+def _ledger(workdir: Path) -> AbandonmentLedger:
+    """Resolve the ledger handle for *workdir*."""
+    return AbandonmentLedger(workdir / ".sdd")
+
+
+def _fmt_ts(ts: float) -> str:
+    """Format an epoch second to a compact ISO-8601 UTC string."""
+    if ts <= 0:
+        return ""
+    try:
+        return datetime.datetime.fromtimestamp(ts, datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    except (OverflowError, OSError, ValueError):
+        return str(ts)
+
+
+@click.group("abandonments")
+def abandonments_group() -> None:
+    """Inspect the agent abandonment ledger (#1350)."""
+
+
+@abandonments_group.command("list")
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Project root (parent of .sdd/).",
+)
+@click.option("--limit", default=20, show_default=True, type=int, help="Maximum rows to display.")
+@click.option("--json", "json_out", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def list_cmd(workdir: Path, limit: int, json_out: bool) -> None:
+    """List the most recent abandonment rows (newest first)."""
+    ledger = _ledger(workdir)
+    rows = ledger.list_recent(limit=limit)
+    if json_out or is_json():
+        print_json([row.to_dict() for row in rows])
+        return
+    if not rows:
+        console.print("[dim]No abandonments recorded.[/dim]")
+        return
+    # Lazy import so the Rich table render stays optional.
+    from rich.table import Table
+
+    table = Table(title="Recent abandonments")
+    table.add_column("timestamp", style="dim")
+    table.add_column("task_id", style="bold")
+    table.add_column("role")
+    table.add_column("reason", style="yellow")
+    table.add_column("adapter")
+    table.add_column("attempts", justify="right")
+    table.add_column("detail", overflow="fold")
+    for row in rows:
+        table.add_row(
+            _fmt_ts(row.timestamp),
+            row.task_id,
+            row.role,
+            row.reason.value,
+            row.adapter,
+            str(row.attempts),
+            row.detail,
+        )
+    console.print(table)
+
+
+@abandonments_group.command("stats")
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Project root (parent of .sdd/).",
+)
+@click.option("--json", "json_out", is_flag=True, default=False, help="Emit machine-readable JSON.")
+def stats_cmd(workdir: Path, json_out: bool) -> None:
+    """Show abandonment roll-ups by reason / role / adapter."""
+    ledger = _ledger(workdir)
+    stats = ledger.stats()
+    if json_out or is_json():
+        print_json(stats)
+        return
+    if stats["total"] == 0:
+        console.print("[dim]No abandonments recorded.[/dim]")
+        return
+    console.print(f"[bold]Total abandonments:[/bold] {stats['total']}")
+    for label, key in (("By reason", "by_reason"), ("By role", "by_role"), ("By adapter", "by_adapter")):
+        body = stats[key]
+        if not body:
+            continue
+        console.print(f"\n[bold]{label}[/bold]")
+        for name, count in sorted(body.items(), key=lambda kv: (-kv[1], kv[0])):
+            console.print(f"  {name}: {count}")
+
+
+def render_rows_jsonl(rows_path: Path) -> str:
+    """Return the raw JSONL ledger contents for snapshot tests.
+
+    Wraps :meth:`Path.read_text` so test fixtures can assert against a
+    deterministic byte sequence without re-implementing the read.
+    """
+    if not rows_path.exists():
+        return ""
+    return rows_path.read_text(encoding="utf-8")
+
+
+def render_rows_table_text(rows: list[dict[str, object]]) -> str:
+    """Render a minimal text table for snapshot tests.
+
+    The Rich Table renderer is non-deterministic across terminal widths,
+    so snapshots use this canonical, width-independent format.
+    """
+    if not rows:
+        return "(empty)\n"
+    lines = ["timestamp\ttask_id\trole\treason\tadapter\tattempts\tdetail"]
+    for row in rows:
+        raw_ts = row.get("timestamp", 0.0)
+        ts = float(raw_ts) if isinstance(raw_ts, (int, float, str)) else 0.0
+        lines.append(
+            "\t".join(
+                [
+                    _fmt_ts(ts),
+                    str(row.get("task_id", "")),
+                    str(row.get("role", "")),
+                    str(row.get("reason", "")),
+                    str(row.get("adapter", "")),
+                    str(row.get("attempts", 0)),
+                    str(row.get("detail", "")),
+                ]
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+__all__ = ["abandonments_group", "render_rows_jsonl", "render_rows_table_text"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -951,3 +951,8 @@ cli.add_command(session_group, "session")
 from bernstein.cli.commands.compare_cmd import compare_cmd  # noqa: E402
 
 cli.add_command(compare_cmd, "compare")
+
+# Agent abandonment ledger (#1350).
+from bernstein.cli.commands.abandonments_cmd import abandonments_group  # noqa: E402
+
+cli.add_command(abandonments_group, "abandonments")

--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -112,9 +112,7 @@ class UnknownCriterionError(RetryBudgetError):
     def __init__(self, name: str, known: Iterable[str]) -> None:
         self.name = name
         self.known = tuple(known)
-        super().__init__(
-            f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}"
-        )
+        super().__init__(f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}")
 
 
 class DuplicateCriterionError(RetryBudgetError):
@@ -130,9 +128,7 @@ class CriterionExhaustedError(RetryBudgetError):
 
     def __init__(self, criterion: Criterion) -> None:
         self.criterion = criterion
-        super().__init__(
-            f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})"
-        )
+        super().__init__(f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})")
 
 
 class RetryBudgetExhaustedError(RetryBudgetError):
@@ -168,14 +164,10 @@ class Criterion:
         if not self.name:
             raise ValueError("Criterion name must be non-empty")
         if self.min_level > self.max_level:
-            raise ValueError(
-                f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level "
-                f"({self.max_level})"
-            )
+            raise ValueError(f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level ({self.max_level})")
         if self.level < self.min_level or self.level > self.max_level:
             raise ValueError(
-                f"Criterion {self.name!r}: level {self.level} outside "
-                f"[{self.min_level}, {self.max_level}]"
+                f"Criterion {self.name!r}: level {self.level} outside [{self.min_level}, {self.max_level}]"
             )
 
     @property
@@ -331,10 +323,7 @@ class RetryBudget:
         Returns:
             A fresh :class:`RetryBudget`.
         """
-        criteria = [
-            Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level)
-            for n in names
-        ]
+        criteria = [Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level) for n in names]
         return cls(retries=retries, criterion_degradation=criteria)
 
     # ------------------------------------------------------------------
@@ -450,10 +439,7 @@ class RetryBudget:
                 degraded_criterion=None,
                 degradation_kind=DegradationKind.NONE,
                 criteria_snapshot=tuple(self._criteria.values()),
-                reason=(
-                    f"retry #{attempt_index + 1} of {self.retries} "
-                    "(no further criterion degradation configured)"
-                ),
+                reason=(f"retry #{attempt_index + 1} of {self.retries} (no further criterion degradation configured)"),
             )
         if target.is_at_floor:
             # The criterion has already been degraded to its minimum on
@@ -470,8 +456,7 @@ class RetryBudget:
                 degradation_kind=DegradationKind.FLOORED,
                 criteria_snapshot=tuple(self._criteria.values()),
                 reason=(
-                    f"retry #{attempt_index + 1}: criterion {target.name!r} "
-                    "already at floor; no further degradation"
+                    f"retry #{attempt_index + 1}: criterion {target.name!r} already at floor; no further degradation"
                 ),
             )
         new_criterion = target.degraded()
@@ -486,10 +471,7 @@ class RetryBudget:
             degraded_criterion=new_criterion,
             degradation_kind=DegradationKind.LOWERED,
             criteria_snapshot=tuple(snapshot_map.values()),
-            reason=(
-                f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} "
-                f"to level {new_criterion.level}"
-            ),
+            reason=(f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} to level {new_criterion.level}"),
         )
 
     # ------------------------------------------------------------------
@@ -596,13 +578,9 @@ def parse_retry_budget_spec(
         for raw_name in raw_policy.split(">"):
             name = raw_name.strip()
             if not name:
-                raise ValueError(
-                    f"empty criterion name in retry budget spec: {spec!r}"
-                )
+                raise ValueError(f"empty criterion name in retry budget spec: {spec!r}")
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_-]*$", name):
-                raise ValueError(
-                    f"invalid criterion name {name!r} in retry budget spec"
-                )
+                raise ValueError(f"invalid criterion name {name!r} in retry budget spec")
             if name in seen:
                 raise DuplicateCriterionError(name)
             seen.add(name)

--- a/src/bernstein/core/tasks/abandon.py
+++ b/src/bernstein/core/tasks/abandon.py
@@ -1,0 +1,386 @@
+"""Agent-initiated abandon primitive with reason ledger (#1350).
+
+When an agent realises mid-task that the spec is wrong, the test
+environment is broken, the cost-per-line has crossed the budget ceiling,
+or the work is otherwise dishonest to finish, the only clean exit is to
+abandon. This module defines:
+
+* :class:`AbandonReason` — closed taxonomy of structured exit reasons.
+* :class:`Abandonment` — append-only ledger row.
+* :class:`AbandonmentLedger` — persistent JSONL ledger at
+  ``.sdd/runtime/abandonments.jsonl`` with atomic appends and rate
+  aggregations by role / adapter.
+
+Design notes
+------------
+
+* The ledger is append-only on the happy path; no in-place rewrites. Each
+  row carries an opaque ``id`` (UUID4 hex) so concurrent appends from
+  different writers never collide.
+* :meth:`AbandonmentLedger.append` takes a single ``open()`` in ``"a"``
+  mode per call; on POSIX, line-sized writes to an ``O_APPEND`` file are
+  atomic up to PIPE_BUF, which is comfortably above any plausible row
+  size here. This is the same contract the dead-letter-queue and signal
+  ledgers rely on.
+* :func:`Abandonment.to_dict` returns a JSON-safe dict; the inverse
+  :meth:`Abandonment.from_dict` accepts malformed rows and either
+  populates safe defaults or — for unrecognised reasons — raises so the
+  caller can decide whether to skip or surface the error.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections import Counter
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+LEDGER_FILENAME = "abandonments.jsonl"
+
+
+class AbandonReason(Enum):
+    """Closed taxonomy of structured abandonment reasons.
+
+    The vocabulary is intentionally small so dashboards can aggregate on
+    it without operator-supplied free-form noise. ``OTHER`` is the
+    escape hatch for cases that genuinely do not fit; agents are
+    nudged in the prompt preamble to prefer a precise reason.
+    """
+
+    # Spec/intent issues
+    OUT_OF_SCOPE = "out_of_scope"
+    INSUFFICIENT_CONTEXT = "insufficient_context"
+    CONFLICTING_INSTRUCTIONS = "conflicting_instructions"
+    SPEC_UNDERDETERMINED = "spec_underdetermined"
+    # Environment / capability issues
+    TIME_BUDGET_EXHAUSTED = "time_budget_exhausted"
+    BUDGET_EXCEEDED = "budget_exceeded"
+    CAPABILITY_MISMATCH = "capability_mismatch"
+    ENV_BROKEN = "env_broken"
+    # Coordination
+    BLOCKED_BY_EXTERNAL = "blocked_by_external"
+    UNSAFE_CHANGE = "unsafe_change"
+    OPERATOR_OVERRIDE = "operator_override"
+    # Catch-all
+    OTHER = "other"
+
+    @classmethod
+    def coerce(cls, value: str | AbandonReason) -> AbandonReason:
+        """Best-effort coercion of a string/enum to :class:`AbandonReason`.
+
+        Accepts the enum value (``"out_of_scope"``) or the enum name
+        (``"OUT_OF_SCOPE"``). Raises :class:`ValueError` on unknown
+        inputs so callers cannot silently launder a typo into ``OTHER``.
+        """
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(f"AbandonReason must be str or AbandonReason, got {type(value).__name__}")
+        text = value.strip()
+        if not text:
+            raise ValueError("AbandonReason cannot be empty")
+        # Try value match first
+        for member in cls:
+            if member.value == text:
+                return member
+        # Then name match (case-insensitive)
+        upper = text.upper()
+        for member in cls:
+            if member.name == upper:
+                return member
+        raise ValueError(f"Unknown AbandonReason: {value!r}")
+
+
+@dataclass(frozen=True)
+class Abandonment:
+    """A single append-only abandonment ledger row.
+
+    Fields are deliberately scalar/JSON-friendly so the ledger format
+    survives forward-compatible additions (unknown keys are tolerated by
+    :meth:`from_dict`).
+
+    Attributes:
+        id: Stable per-row identifier (UUID4 hex slice).
+        task_id: Originating task ID.
+        reason: Structured :class:`AbandonReason`.
+        detail: Free-form human-readable rationale.
+        role: Task role at time of abandonment.
+        agent_id: Adapter session identifier, if known.
+        adapter: Adapter/CLI label (e.g. ``"claude"``, ``"codex"``).
+        cost_to_date_usd: Cost accumulated on the task before abandon.
+        attempts: How many retry attempts had happened before this row.
+        timestamp: Unix epoch seconds at write time.
+    """
+
+    id: str
+    task_id: str
+    reason: AbandonReason
+    detail: str = ""
+    role: str = ""
+    agent_id: str = ""
+    adapter: str = ""
+    cost_to_date_usd: float = 0.0
+    attempts: int = 0
+    timestamp: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        """Validate invariants at construction time."""
+        if not self.id:
+            raise ValueError("Abandonment.id must be non-empty")
+        if not self.task_id:
+            raise ValueError("Abandonment.task_id must be non-empty")
+        if not isinstance(self.reason, AbandonReason):  # type: ignore[reportUnnecessaryIsInstance]
+            raise ValueError("Abandonment.reason must be an AbandonReason member")
+        if self.attempts < 0:
+            raise ValueError(f"Abandonment.attempts must be >= 0, got {self.attempts}")
+        if self.cost_to_date_usd < 0:
+            raise ValueError(f"Abandonment.cost_to_date_usd must be >= 0, got {self.cost_to_date_usd}")
+        if self.timestamp < 0:
+            raise ValueError(f"Abandonment.timestamp must be >= 0, got {self.timestamp}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict for ledger writes."""
+        return {
+            "id": self.id,
+            "task_id": self.task_id,
+            "reason": self.reason.value,
+            "detail": self.detail,
+            "role": self.role,
+            "agent_id": self.agent_id,
+            "adapter": self.adapter,
+            "cost_to_date_usd": self.cost_to_date_usd,
+            "attempts": self.attempts,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Abandonment:
+        """Deserialise a ledger row.
+
+        Raises:
+            ValueError: When required fields are missing or ``reason`` is
+                not a known :class:`AbandonReason` value.
+        """
+        if "task_id" not in data:
+            raise ValueError("Abandonment.from_dict missing task_id")
+        if "reason" not in data:
+            raise ValueError("Abandonment.from_dict missing reason")
+        reason = AbandonReason.coerce(str(data["reason"]))
+        return cls(
+            id=str(data.get("id") or uuid.uuid4().hex[:16]),
+            task_id=str(data["task_id"]),
+            reason=reason,
+            detail=str(data.get("detail", "")),
+            role=str(data.get("role", "")),
+            agent_id=str(data.get("agent_id", "")),
+            adapter=str(data.get("adapter", "")),
+            cost_to_date_usd=float(data.get("cost_to_date_usd", 0.0)),
+            attempts=int(data.get("attempts", 0)),
+            timestamp=float(data.get("timestamp", 0.0)),
+        )
+
+
+def new_abandonment(
+    *,
+    task_id: str,
+    reason: AbandonReason | str,
+    detail: str = "",
+    role: str = "",
+    agent_id: str = "",
+    adapter: str = "",
+    cost_to_date_usd: float = 0.0,
+    attempts: int = 0,
+    timestamp: float | None = None,
+) -> Abandonment:
+    """Build an :class:`Abandonment` with a fresh ID and timestamp.
+
+    Centralises construction so callers do not generate IDs in two
+    places and so ``timestamp=None`` reliably resolves to ``time.time()``.
+    """
+    coerced = AbandonReason.coerce(reason)
+    return Abandonment(
+        id=uuid.uuid4().hex[:16],
+        task_id=task_id,
+        reason=coerced,
+        detail=detail,
+        role=role,
+        agent_id=agent_id,
+        adapter=adapter,
+        cost_to_date_usd=cost_to_date_usd,
+        attempts=attempts,
+        timestamp=timestamp if timestamp is not None else time.time(),
+    )
+
+
+class AbandonmentLedger:
+    """Append-only JSONL ledger of agent abandonments.
+
+    The ledger never rewrites existing rows. Aggregations (:meth:`stats`,
+    :meth:`abandon_rate_by_role`, :meth:`abandon_rate_by_adapter`) read
+    the live file on every call so concurrent writers in the same
+    process see each other's rows.
+
+    Args:
+        sdd_dir: Path to the project ``.sdd`` state directory. The
+            ledger lives at ``<sdd_dir>/runtime/abandonments.jsonl``.
+    """
+
+    def __init__(self, sdd_dir: Path) -> None:
+        self._sdd_dir = sdd_dir
+        self._path: Path = sdd_dir / "runtime" / LEDGER_FILENAME
+
+    @property
+    def path(self) -> Path:
+        """Filesystem path to the underlying JSONL file."""
+        return self._path
+
+    def append(self, row: Abandonment) -> None:
+        """Append a single row to the ledger.
+
+        Creates parent directories on demand. Uses a single
+        ``open(..., "a")`` so the line write is atomic on POSIX up to
+        PIPE_BUF (rows are far smaller than that ceiling).
+
+        Raises:
+            OSError: Propagated when the underlying write fails — the
+                caller decides whether to retry or surface the error.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(row.to_dict(), sort_keys=True) + "\n"
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.flush()
+
+    def read_all(self) -> list[Abandonment]:
+        """Replay every well-formed row from disk.
+
+        Malformed JSON lines and rows with unknown reasons are skipped
+        (and logged at debug) so a single bad row never wedges the
+        operator CLI. Returns the rows in append order.
+        """
+        if not self._path.exists():
+            return []
+        rows: list[Abandonment] = []
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+        except OSError as exc:
+            logger.warning("Failed to read abandonment ledger: %s", exc)
+            return []
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed: object = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                logger.debug("Skipping malformed ledger line: %s", exc)
+                continue
+            if not isinstance(parsed, dict):
+                logger.debug("Skipping non-object ledger row: %r", parsed)
+                continue
+            data_any: dict[str, Any] = dict(parsed)  # type: ignore[arg-type]
+            try:
+                rows.append(Abandonment.from_dict(data_any))
+            except (ValueError, TypeError) as exc:
+                logger.debug("Skipping invalid ledger row: %s", exc)
+        return rows
+
+    def list_recent(self, limit: int = 20) -> list[Abandonment]:
+        """Return the most recent ``limit`` rows, newest first."""
+        if limit <= 0:
+            return []
+        rows = self.read_all()
+        rows.sort(key=lambda row: row.timestamp, reverse=True)
+        return rows[:limit]
+
+    def count_by_task(self, task_id: str) -> int:
+        """Count how many times *task_id* has been abandoned in the ledger."""
+        return sum(1 for row in self.read_all() if row.task_id == task_id)
+
+    def by_reason(self, task_id: str) -> Counter[AbandonReason]:
+        """Return reason histogram for a single task."""
+        counts: Counter[AbandonReason] = Counter()
+        for row in self.read_all():
+            if row.task_id == task_id:
+                counts[row.reason] += 1
+        return counts
+
+    def abandon_rate_by_role(self, completed_by_role: dict[str, int]) -> dict[str, float]:
+        """Compute per-role abandonment rate.
+
+        Args:
+            completed_by_role: Map of role → completed (DONE/CLOSED)
+                task count, used as the denominator. Roles absent from
+                this map but present in the ledger are reported with a
+                rate of ``1.0`` (no completions to compare against).
+
+        Returns:
+            Map of role → ``abandons / (abandons + completed)`` in
+            ``[0.0, 1.0]``.
+        """
+        abandons: Counter[str] = Counter()
+        for row in self.read_all():
+            if row.role:
+                abandons[row.role] += 1
+        roles = set(abandons) | set(completed_by_role)
+        rate: dict[str, float] = {}
+        for role in roles:
+            a = abandons.get(role, 0)
+            c = completed_by_role.get(role, 0)
+            denom = a + c
+            rate[role] = (a / denom) if denom > 0 else 0.0
+        return rate
+
+    def abandon_rate_by_adapter(self, completed_by_adapter: dict[str, int]) -> dict[str, float]:
+        """Compute per-adapter abandonment rate.
+
+        Mirrors :meth:`abandon_rate_by_role` but keys on the adapter
+        label recorded in the ledger row.
+        """
+        abandons: Counter[str] = Counter()
+        for row in self.read_all():
+            if row.adapter:
+                abandons[row.adapter] += 1
+        adapters = set(abandons) | set(completed_by_adapter)
+        rate: dict[str, float] = {}
+        for adapter in adapters:
+            a = abandons.get(adapter, 0)
+            c = completed_by_adapter.get(adapter, 0)
+            denom = a + c
+            rate[adapter] = (a / denom) if denom > 0 else 0.0
+        return rate
+
+    def stats(self) -> dict[str, Any]:
+        """Return aggregate stats over the entire ledger.
+
+        Keys:
+            * ``total`` — total row count.
+            * ``by_reason`` — reason value → row count.
+            * ``by_role`` — role → row count.
+            * ``by_adapter`` — adapter → row count.
+        """
+        by_reason: Counter[str] = Counter()
+        by_role: Counter[str] = Counter()
+        by_adapter: Counter[str] = Counter()
+        rows = self.read_all()
+        for row in rows:
+            by_reason[row.reason.value] += 1
+            if row.role:
+                by_role[row.role] += 1
+            if row.adapter:
+                by_adapter[row.adapter] += 1
+        return {
+            "total": len(rows),
+            "by_reason": dict(by_reason),
+            "by_role": dict(by_role),
+            "by_adapter": dict(by_adapter),
+        }

--- a/src/bernstein/core/tasks/lifecycle.py
+++ b/src/bernstein/core/tasks/lifecycle.py
@@ -189,6 +189,26 @@ TASK_TRANSITIONS: dict[tuple[TaskStatus, TaskStatus], Callable[[Task], bool]] = 
     # Verification gate (orchestrator closes after janitor + merge)
     (TaskStatus.DONE, TaskStatus.CLOSED): _always,
     (TaskStatus.DONE, TaskStatus.FAILED): _always,
+    # Abandon primitive (#1350) — agent-initiated structured exit.
+    # ABANDONED is a terminal state distinct from FAILED so dashboards can
+    # split intentional vs. unintentional exits. Downstream consumers move
+    # to BLOCKED_BY_ABANDON instead of waiting forever for an output that
+    # will never arrive.
+    (TaskStatus.OPEN, TaskStatus.ABANDONED): _always,
+    (TaskStatus.CLAIMED, TaskStatus.ABANDONED): _always,
+    (TaskStatus.IN_PROGRESS, TaskStatus.ABANDONED): _always,
+    (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.ABANDONED): _always,
+    (TaskStatus.BLOCKED, TaskStatus.ABANDONED): _always,
+    (TaskStatus.ORPHANED, TaskStatus.ABANDONED): _always,
+    (TaskStatus.OPEN, TaskStatus.BLOCKED_BY_ABANDON): _always,
+    (TaskStatus.CLAIMED, TaskStatus.BLOCKED_BY_ABANDON): _always,
+    (TaskStatus.IN_PROGRESS, TaskStatus.BLOCKED_BY_ABANDON): _always,
+    (TaskStatus.WAITING_FOR_SUBTASKS, TaskStatus.BLOCKED_BY_ABANDON): _always,
+    # Operator may requeue a blocked-by-abandon downstream once the
+    # parent backlog is reseeded.
+    (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.OPEN): _always,
+    (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.CANCELLED): _always,
+    (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.ABANDONED): _always,
 }
 
 # Precompute terminal statuses (no outbound transitions).

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -162,6 +162,8 @@ class TaskStatus(Enum):
     CANCELLED = "cancelled"
     ORPHANED = "orphaned"  # Agent crashed mid-task; pending crash recovery
     PENDING_APPROVAL = "pending_approval"  # Completed; awaiting human approval before taking effect
+    ABANDONED = "abandoned"  # Agent voluntarily abandoned with a structured reason (#1350)
+    BLOCKED_BY_ABANDON = "blocked_by_abandon"  # Downstream task waiting on an abandoned dependency (#1350)
 
 
 class TaskType(Enum):

--- a/src/bernstein/core/tasks/task_store_core.py
+++ b/src/bernstein/core/tasks/task_store_core.py
@@ -1444,6 +1444,117 @@ class TaskStore:
             await self._append_archive(task, completed_at)
             return task
 
+    async def abandon(
+        self,
+        task_id: str,
+        reason: str,
+        detail: str = "",
+        *,
+        adapter: str = "",
+        agent_id: str = "",
+        cost_to_date_usd: float = 0.0,
+    ) -> Task:
+        """Mark *task_id* as :class:`TaskStatus.ABANDONED` and record a ledger row.
+
+        Distinct from :meth:`fail`. ABANDONED is a terminal status that
+        agents reach voluntarily after deciding the task cannot be
+        finished honestly (#1350). Downstream tasks that depend on this
+        one cascade to :class:`TaskStatus.BLOCKED_BY_ABANDON` so the
+        dependency scanner stops waiting for an output that will never
+        arrive.
+
+        Args:
+            task_id: Task identifier.
+            reason: One of the :class:`AbandonReason` enum values (string
+                form). Unknown values raise :class:`ValueError`.
+            detail: Free-form human-readable rationale.
+            adapter: Adapter/CLI label that originated the call.
+            agent_id: Adapter session identifier.
+            cost_to_date_usd: Cost accumulated on the task so far.
+
+        Returns:
+            The updated :class:`Task`.
+
+        Raises:
+            KeyError: If ``task_id`` is unknown.
+            ValueError: If *reason* is not a valid :class:`AbandonReason`.
+            IllegalTransitionError: If the current task status cannot
+                transition to ``ABANDONED`` (e.g. already terminal).
+        """
+        # Import locally to avoid bootstrapping the abandon module at
+        # task_store_core import time (keeps module-import cost flat).
+        from bernstein.core.tasks.abandon import (
+            AbandonmentLedger,
+            new_abandonment,
+        )
+
+        async with self._lock:
+            task = self._tasks.get(task_id)
+            if task is None:
+                raise KeyError(task_id)
+            # Coerce reason early so we surface a ValueError before any
+            # state mutation. ``new_abandonment`` calls ``coerce`` too,
+            # but doing it here means a bad reason never partial-writes.
+            row = new_abandonment(
+                task_id=task_id,
+                reason=reason,
+                detail=detail,
+                role=task.role,
+                adapter=adapter,
+                agent_id=agent_id,
+                cost_to_date_usd=cost_to_date_usd,
+                attempts=task.retry_count,
+            )
+
+            self._index_remove(task)
+            transition_task(task, TaskStatus.ABANDONED, actor="task_store", reason=detail or reason)
+            task.result_summary = detail or reason
+            task.terminal_reason = row.reason.value
+            task.completed_at = time.time()
+            task.version += 1
+            self._index_add(task)
+            completed_at = task.completed_at
+            await self._append_jsonl(self._task_to_record(task))
+            await self._append_archive(task, completed_at)
+
+            # Cascade: downstream tasks waiting on this one move to
+            # BLOCKED_BY_ABANDON so consumers stop waiting forever.
+            for downstream in list(self._tasks.values()):
+                if task_id not in downstream.depends_on:
+                    continue
+                if downstream.status not in {
+                    TaskStatus.OPEN,
+                    TaskStatus.CLAIMED,
+                    TaskStatus.IN_PROGRESS,
+                    TaskStatus.WAITING_FOR_SUBTASKS,
+                }:
+                    continue
+                self._index_remove(downstream)
+                try:
+                    transition_task(
+                        downstream,
+                        TaskStatus.BLOCKED_BY_ABANDON,
+                        actor="task_store",
+                        reason=f"upstream {task_id} abandoned: {row.reason.value}",
+                    )
+                except IllegalTransitionError:
+                    # Restore index entry — leave downstream untouched.
+                    self._index_add(downstream)
+                    continue
+                downstream.result_summary = f"upstream {task_id} abandoned"
+                downstream.version += 1
+                self._index_add(downstream)
+                await self._append_jsonl(self._task_to_record(downstream))
+
+            # Ledger write is last so the in-memory state is the source
+            # of truth even when the ledger file is read-only / OOS.
+            ledger = AbandonmentLedger(self._sdd_dir)
+            try:
+                ledger.append(row)
+            except OSError as exc:
+                logger.warning("Abandonment ledger write failed for %s: %s", task_id, exc)
+            return task
+
     async def block(self, task_id: str, reason: str) -> Task:
         """Mark a task as blocked (requires human intervention).
 

--- a/tests/integration/test_abandon_lifecycle.py
+++ b/tests/integration/test_abandon_lifecycle.py
@@ -1,0 +1,169 @@
+"""Integration tests for the abandon primitive end-to-end (#1350).
+
+These tests exercise the full vertical:
+    TaskStore.abandon() → ledger write → CLI surface → aggregation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.abandonments_cmd import abandonments_group
+from bernstein.core.tasks.abandon import AbandonmentLedger
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+
+
+def _make_store(workdir: Path) -> TaskStore:
+    runtime = workdir / ".sdd" / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    return TaskStore(runtime / "tasks.jsonl", archive_path=workdir / ".sdd" / "archive" / "tasks.jsonl")
+
+
+async def _seed(store: TaskStore, **overrides: Any) -> Task:
+    base: dict[str, Any] = {
+        "id": overrides.pop("id", "T-1"),
+        "title": "t",
+        "description": "d",
+        "role": "backend",
+        "status": TaskStatus.IN_PROGRESS,
+    }
+    base.update(overrides)
+    task = Task(**base)
+    store._tasks[task.id] = task  # type: ignore[attr-defined]
+    store._index_add(task)  # type: ignore[attr-defined]
+    return task
+
+
+@pytest.mark.asyncio
+class TestAbandonEndToEnd:
+    async def test_abandon_appears_in_cli_list(self, tmp_path: Path) -> None:
+        import json as _json
+
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1", role="backend")
+        await store.abandon("T-1", "out_of_scope", "spec mismatch", adapter="claude")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            abandonments_group, ["list", "--workdir", str(tmp_path), "--limit", "5", "--json"]
+        )
+        assert result.exit_code == 0
+        data = _json.loads(result.output)
+        assert len(data) == 1
+        assert data[0]["task_id"] == "T-1"
+        assert data[0]["reason"] == "out_of_scope"
+
+    async def test_abandon_appears_in_cli_stats(self, tmp_path: Path) -> None:
+        import json as _json
+
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1", role="backend")
+        await _seed(store, id="T-2", role="qa")
+        await store.abandon("T-1", "out_of_scope", adapter="claude")
+        await store.abandon("T-2", "budget_exceeded", adapter="codex")
+
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["stats", "--workdir", str(tmp_path), "--json"])
+        assert result.exit_code == 0
+        data = _json.loads(result.output)
+        assert data["total"] == 2
+        assert data["by_reason"]["out_of_scope"] == 1
+        assert data["by_reason"]["budget_exceeded"] == 1
+        assert data["by_role"]["backend"] == 1
+        assert data["by_role"]["qa"] == 1
+
+    async def test_downstream_consumer_cascades_to_blocked_by_abandon(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-upstream", role="backend")
+        await _seed(store, id="T-down", role="qa", status=TaskStatus.OPEN, depends_on=["T-upstream"])
+        await store.abandon("T-upstream", "insufficient_context")
+
+        assert store._tasks["T-down"].status is TaskStatus.BLOCKED_BY_ABANDON  # type: ignore[attr-defined]
+
+    async def test_metrics_aggregate_by_role_and_adapter(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        # Three tasks, two adapters, two roles
+        await _seed(store, id="T-1", role="backend")
+        await _seed(store, id="T-2", role="backend")
+        await _seed(store, id="T-3", role="qa")
+        await store.abandon("T-1", "out_of_scope", adapter="claude")
+        await store.abandon("T-2", "budget_exceeded", adapter="claude")
+        await store.abandon("T-3", "other", adapter="codex")
+
+        ledger = AbandonmentLedger(tmp_path / ".sdd")
+        rates_role = ledger.abandon_rate_by_role({"backend": 8, "qa": 1})
+        assert rates_role["backend"] == pytest.approx(2 / 10)
+        assert rates_role["qa"] == pytest.approx(1 / 2)
+
+        rates_adapter = ledger.abandon_rate_by_adapter({"claude": 18, "codex": 4})
+        assert rates_adapter["claude"] == pytest.approx(2 / 20)
+        assert rates_adapter["codex"] == pytest.approx(1 / 5)
+
+    async def test_ledger_survives_store_recreation(self, tmp_path: Path) -> None:
+        """A new TaskStore reading the same workdir sees prior ledger rows."""
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1", role="backend")
+        await store.abandon("T-1", "other", adapter="claude")
+
+        ledger = AbandonmentLedger(tmp_path / ".sdd")
+        assert len(ledger.read_all()) == 1
+
+        # Second store on same workdir
+        store2 = _make_store(tmp_path)
+        await _seed(store2, id="T-2", role="qa")
+        await store2.abandon("T-2", "budget_exceeded", adapter="codex")
+
+        ledger2 = AbandonmentLedger(tmp_path / ".sdd")
+        rows = ledger2.read_all()
+        assert len(rows) == 2
+        assert {r.task_id for r in rows} == {"T-1", "T-2"}
+
+    async def test_abandon_persists_to_tasks_jsonl(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1")
+        await store.abandon("T-1", "operator_override", "by request")
+        await store.flush_buffer()
+        body = (tmp_path / ".sdd" / "runtime" / "tasks.jsonl").read_text(encoding="utf-8")
+        assert '"status": "abandoned"' in body or '"abandoned"' in body
+
+    async def test_cli_list_after_no_abandons(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["list", "--workdir", str(tmp_path)], terminal_width=200)
+        assert result.exit_code == 0
+        assert "No abandonments recorded" in result.output
+
+    async def test_repeated_abandon_attempts_on_same_task_rejected(self, tmp_path: Path) -> None:
+        """Second abandon on an already-abandoned task is rejected by the FSM."""
+        from bernstein.core.tasks.lifecycle import IllegalTransitionError
+
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1")
+        await store.abandon("T-1", "other")
+        with pytest.raises(IllegalTransitionError):
+            await store.abandon("T-1", "other")
+
+    async def test_abandon_records_role_from_task(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1", role="frontend")
+        await store.abandon("T-1", "capability_mismatch", adapter="claude")
+        ledger = AbandonmentLedger(tmp_path / ".sdd")
+        rows = ledger.read_all()
+        assert rows[0].role == "frontend"
+
+    async def test_cli_json_output(self, tmp_path: Path) -> None:
+        import json as _json
+
+        store = _make_store(tmp_path)
+        await _seed(store, id="T-1", role="backend")
+        await store.abandon("T-1", "out_of_scope", "spec issue", adapter="claude")
+
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["stats", "--workdir", str(tmp_path), "--json"])
+        assert result.exit_code == 0
+        data = _json.loads(result.output)
+        assert data["total"] == 1

--- a/tests/property/test_abandon_properties.py
+++ b/tests/property/test_abandon_properties.py
@@ -1,0 +1,194 @@
+"""Hypothesis property tests for the abandon primitive (#1350).
+
+Invariants under test:
+* Concurrent appends never lose rows.
+* ``read_all`` round-trips every appended row exactly once.
+* Status transitions never regress: an abandoned task can never reach
+  DONE or CLOSED through the lifecycle transition table.
+* Aggregation totals match the sum of individual row contributions.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.core.tasks.abandon import (
+    AbandonmentLedger,
+    AbandonReason,
+    new_abandonment,
+)
+from bernstein.core.tasks.lifecycle import TASK_TRANSITIONS
+from bernstein.core.tasks.models import TaskStatus
+
+_REASONS: list[AbandonReason] = list(AbandonReason)
+
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+def _row_strategy() -> st.SearchStrategy[dict[str, Any]]:
+    return st.fixed_dictionaries(
+        {
+            "task_id": st.text(alphabet="ABCDEFGHIJ0123456789-", min_size=1, max_size=20),
+            "reason": st.sampled_from(_REASONS),
+            "detail": st.text(max_size=80),
+            "role": st.sampled_from(["backend", "qa", "ops", "frontend", ""]),
+            "adapter": st.sampled_from(["claude", "codex", "opencode", ""]),
+            "cost_to_date_usd": st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False),
+            "attempts": st.integers(min_value=0, max_value=10),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+@given(rows=st.lists(_row_strategy(), min_size=0, max_size=25))
+def test_append_then_read_round_trip(tmp_path_factory: Any, rows: list[dict[str, Any]]) -> None:
+    """Every appended row must reappear exactly once in read_all output."""
+    tmp = Path(tmp_path_factory.mktemp("ledger_rt"))
+    ledger = AbandonmentLedger(tmp)
+    inserted = []
+    for fields in rows:
+        row = new_abandonment(**fields)
+        ledger.append(row)
+        inserted.append(row)
+    loaded = ledger.read_all()
+    assert [r.id for r in loaded] == [r.id for r in inserted]
+    assert {r.task_id for r in loaded} == {r.task_id for r in inserted}
+
+
+@given(rows=st.lists(_row_strategy(), min_size=1, max_size=15))
+def test_each_row_is_one_jsonl_line(tmp_path_factory: Any, rows: list[dict[str, Any]]) -> None:
+    """Append must emit exactly one newline-terminated line per row."""
+    tmp = Path(tmp_path_factory.mktemp("ledger_lines"))
+    ledger = AbandonmentLedger(tmp)
+    for fields in rows:
+        ledger.append(new_abandonment(**fields))
+    body = ledger.path.read_text(encoding="utf-8")
+    assert body.count("\n") == len(rows)
+    for line in body.splitlines():
+        json.loads(line)  # each line is independently parseable
+
+
+@given(rows=st.lists(_row_strategy(), min_size=0, max_size=20))
+def test_stats_total_matches_row_count(tmp_path_factory: Any, rows: list[dict[str, Any]]) -> None:
+    tmp = Path(tmp_path_factory.mktemp("ledger_stats"))
+    ledger = AbandonmentLedger(tmp)
+    for fields in rows:
+        ledger.append(new_abandonment(**fields))
+    assert ledger.stats()["total"] == len(rows)
+
+
+@given(rows=st.lists(_row_strategy(), min_size=0, max_size=20))
+def test_stats_by_reason_sums_match_row_counts(tmp_path_factory: Any, rows: list[dict[str, Any]]) -> None:
+    tmp = Path(tmp_path_factory.mktemp("ledger_reason_sum"))
+    ledger = AbandonmentLedger(tmp)
+    for fields in rows:
+        ledger.append(new_abandonment(**fields))
+    by_reason = ledger.stats()["by_reason"]
+    expected: dict[str, int] = {}
+    for fields in rows:
+        reason = fields["reason"].value
+        expected[reason] = expected.get(reason, 0) + 1
+    assert by_reason == expected
+
+
+@given(rows=st.lists(_row_strategy(), min_size=1, max_size=15))
+def test_list_recent_sorted_newest_first(tmp_path_factory: Any, rows: list[dict[str, Any]]) -> None:
+    tmp = Path(tmp_path_factory.mktemp("ledger_recent"))
+    ledger = AbandonmentLedger(tmp)
+    for fields in rows:
+        ledger.append(new_abandonment(**fields))
+    recent = ledger.list_recent(limit=len(rows))
+    timestamps = [r.timestamp for r in recent]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+@given(
+    completions=st.dictionaries(
+        keys=st.sampled_from(["backend", "qa", "ops"]),
+        values=st.integers(min_value=0, max_value=1000),
+        max_size=3,
+    ),
+    rows=st.lists(_row_strategy(), min_size=0, max_size=10),
+)
+def test_abandon_rate_by_role_in_unit_interval(
+    tmp_path_factory: Any, completions: dict[str, int], rows: list[dict[str, Any]]
+) -> None:
+    tmp = Path(tmp_path_factory.mktemp("ledger_rate"))
+    ledger = AbandonmentLedger(tmp)
+    for fields in rows:
+        ledger.append(new_abandonment(**fields))
+    rates = ledger.abandon_rate_by_role(completions)
+    for rate in rates.values():
+        assert 0.0 <= rate <= 1.0
+
+
+@given(rows=st.lists(_row_strategy(), min_size=2, max_size=20))
+def test_ids_are_unique_when_constructed_via_factory(tmp_path_factory: Any, rows: list[dict[str, Any]]) -> None:
+    tmp = Path(tmp_path_factory.mktemp("ledger_uniq"))
+    ledger = AbandonmentLedger(tmp)
+    for fields in rows:
+        ledger.append(new_abandonment(**fields))
+    loaded = ledger.read_all()
+    assert len({r.id for r in loaded}) == len(loaded)
+
+
+# ---------------------------------------------------------------------------
+# Status transitions never regress
+# ---------------------------------------------------------------------------
+
+
+@given(target=st.sampled_from([s for s in TaskStatus if s is not TaskStatus.ABANDONED]))
+def test_abandoned_is_terminal_for_all_other_states(target: TaskStatus) -> None:
+    """ABANDONED is a closed terminal status — no outbound transitions."""
+    assert (TaskStatus.ABANDONED, target) not in TASK_TRANSITIONS
+
+
+@given(target=st.sampled_from([TaskStatus.DONE, TaskStatus.CLOSED]))
+def test_abandoned_can_never_reach_completed_states(target: TaskStatus) -> None:
+    """Critical: an abandoned task must never become DONE or CLOSED."""
+    assert (TaskStatus.ABANDONED, target) not in TASK_TRANSITIONS
+
+
+# ---------------------------------------------------------------------------
+# Concurrent appends from multiple threads
+# ---------------------------------------------------------------------------
+
+
+@given(
+    writers=st.integers(min_value=2, max_value=6),
+    per_writer=st.integers(min_value=1, max_value=15),
+)
+def test_concurrent_appends_no_loss(tmp_path_factory: Any, writers: int, per_writer: int) -> None:
+    tmp = Path(tmp_path_factory.mktemp("ledger_conc"))
+    ledger = AbandonmentLedger(tmp)
+
+    def worker(idx: int) -> None:
+        for i in range(per_writer):
+            ledger.append(
+                new_abandonment(
+                    task_id=f"W{idx}-T{i}",
+                    reason=AbandonReason.OTHER,
+                )
+            )
+
+    threads = [threading.Thread(target=worker, args=(w,)) for w in range(writers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    rows = ledger.read_all()
+    assert len(rows) == writers * per_writer
+    assert len({row.id for row in rows}) == writers * per_writer

--- a/tests/unit/test_abandon_cli.py
+++ b/tests/unit/test_abandon_cli.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``bernstein abandonments`` CLI commands (#1350)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.abandonments_cmd import (
+    abandonments_group,
+    render_rows_jsonl,
+    render_rows_table_text,
+)
+from bernstein.core.tasks.abandon import (
+    AbandonmentLedger,
+    AbandonReason,
+    new_abandonment,
+)
+
+
+@pytest.fixture()
+def seeded_workdir(tmp_path: Path) -> Path:
+    ledger = AbandonmentLedger(tmp_path / ".sdd")
+    ledger.append(
+        new_abandonment(
+            task_id="T-1",
+            reason=AbandonReason.OUT_OF_SCOPE,
+            detail="spec mismatch",
+            role="backend",
+            adapter="claude",
+            attempts=0,
+            timestamp=1_700_000_000.0,
+        )
+    )
+    ledger.append(
+        new_abandonment(
+            task_id="T-2",
+            reason=AbandonReason.BUDGET_EXCEEDED,
+            detail="cap hit",
+            role="qa",
+            adapter="codex",
+            attempts=1,
+            timestamp=1_700_000_100.0,
+        )
+    )
+    return tmp_path
+
+
+class TestAbandonmentsListCmd:
+    def test_empty_workdir_prints_friendly_notice(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["list", "--workdir", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No abandonments recorded" in result.output
+
+    def test_list_renders_rows(self, seeded_workdir: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["list", "--workdir", str(seeded_workdir)])
+        assert result.exit_code == 0
+        # Newest first → T-2 should appear before T-1
+        assert "T-2" in result.output
+        assert "T-1" in result.output
+        assert result.output.index("T-2") < result.output.index("T-1")
+
+    def test_list_honours_limit(self, seeded_workdir: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            abandonments_group,
+            ["list", "--workdir", str(seeded_workdir), "--limit", "1"],
+        )
+        assert result.exit_code == 0
+        assert "T-2" in result.output
+        assert "T-1" not in result.output
+
+
+class TestAbandonmentsStatsCmd:
+    def test_empty_workdir_prints_friendly_notice(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["stats", "--workdir", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "No abandonments recorded" in result.output
+
+    def test_stats_renders_totals(self, seeded_workdir: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(abandonments_group, ["stats", "--workdir", str(seeded_workdir)])
+        assert result.exit_code == 0
+        assert "Total abandonments" in result.output
+        assert "out_of_scope" in result.output
+        assert "budget_exceeded" in result.output
+        assert "backend" in result.output
+        assert "claude" in result.output
+
+
+class TestSnapshotRenderers:
+    def test_render_rows_jsonl_is_deterministic(self, seeded_workdir: Path) -> None:
+        ledger_path = seeded_workdir / ".sdd" / "runtime" / "abandonments.jsonl"
+        raw = render_rows_jsonl(ledger_path)
+        lines = [line for line in raw.splitlines() if line.strip()]
+        assert len(lines) == 2
+        decoded = [json.loads(line) for line in lines]
+        # First appended row is the older T-1
+        assert decoded[0]["task_id"] == "T-1"
+        assert decoded[1]["task_id"] == "T-2"
+
+    def test_render_rows_jsonl_missing_path_returns_empty(self, tmp_path: Path) -> None:
+        assert render_rows_jsonl(tmp_path / "nonexistent.jsonl") == ""
+
+    def test_render_rows_jsonl_keys_are_sorted(self, seeded_workdir: Path) -> None:
+        ledger_path = seeded_workdir / ".sdd" / "runtime" / "abandonments.jsonl"
+        raw = render_rows_jsonl(ledger_path)
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            data = json.loads(line)
+            keys = list(data.keys())
+            assert keys == sorted(keys)
+
+    def test_render_rows_table_text_empty(self) -> None:
+        assert render_rows_table_text([]) == "(empty)\n"
+
+    def test_render_rows_table_text_has_header(self) -> None:
+        rows = [
+            {
+                "task_id": "T-1",
+                "role": "backend",
+                "reason": "out_of_scope",
+                "adapter": "claude",
+                "attempts": 0,
+                "detail": "spec mismatch",
+                "timestamp": 1_700_000_000.0,
+            }
+        ]
+        out = render_rows_table_text(rows)
+        assert out.splitlines()[0] == "timestamp\ttask_id\trole\treason\tadapter\tattempts\tdetail"
+
+    def test_render_rows_table_text_snapshot(self) -> None:
+        rows = [
+            {
+                "task_id": "T-2",
+                "role": "qa",
+                "reason": "budget_exceeded",
+                "adapter": "codex",
+                "attempts": 1,
+                "detail": "cap hit",
+                "timestamp": 1_700_000_100.0,
+            },
+            {
+                "task_id": "T-1",
+                "role": "backend",
+                "reason": "out_of_scope",
+                "adapter": "claude",
+                "attempts": 0,
+                "detail": "spec mismatch",
+                "timestamp": 1_700_000_000.0,
+            },
+        ]
+        out = render_rows_table_text(rows)
+        expected = (
+            "timestamp\ttask_id\trole\treason\tadapter\tattempts\tdetail\n"
+            "2023-11-14T22:15:00Z\tT-2\tqa\tbudget_exceeded\tcodex\t1\tcap hit\n"
+            "2023-11-14T22:13:20Z\tT-1\tbackend\tout_of_scope\tclaude\t0\tspec mismatch\n"
+        )
+        assert out == expected

--- a/tests/unit/test_abandon_ledger.py
+++ b/tests/unit/test_abandon_ledger.py
@@ -1,0 +1,323 @@
+"""Unit tests for :class:`AbandonmentLedger` persistence (#1350)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.tasks.abandon import (
+    LEDGER_FILENAME,
+    AbandonmentLedger,
+    AbandonReason,
+    new_abandonment,
+)
+
+
+def _row(task_id: str = "T-1", reason: AbandonReason = AbandonReason.OUT_OF_SCOPE, **kwargs: object) -> object:
+    return new_abandonment(task_id=task_id, reason=reason, **kwargs)  # type: ignore[arg-type]
+
+
+class TestAbandonmentLedgerBasics:
+    def test_path_resolves_under_runtime(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        assert ledger.path == tmp_path / "runtime" / LEDGER_FILENAME
+
+    def test_read_empty_returns_empty_list(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        assert ledger.read_all() == []
+
+    def test_list_recent_empty_returns_empty(self, tmp_path: Path) -> None:
+        assert AbandonmentLedger(tmp_path).list_recent() == []
+
+    def test_list_recent_with_zero_limit_returns_empty(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(_row())  # type: ignore[arg-type]
+        assert ledger.list_recent(limit=0) == []
+
+    def test_append_creates_parent_directory(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        assert not (tmp_path / "runtime").exists()
+        ledger.append(_row())  # type: ignore[arg-type]
+        assert ledger.path.exists()
+        assert ledger.path.parent.exists()
+
+    def test_append_writes_single_line_per_row(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(_row(task_id="T-1"))  # type: ignore[arg-type]
+        ledger.append(_row(task_id="T-2"))  # type: ignore[arg-type]
+        ledger.append(_row(task_id="T-3"))  # type: ignore[arg-type]
+        body = ledger.path.read_text(encoding="utf-8")
+        assert body.count("\n") == 3
+
+    def test_each_line_is_valid_json(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(_row(task_id="T-1"))  # type: ignore[arg-type]
+        ledger.append(_row(task_id="T-2"))  # type: ignore[arg-type]
+        for line in ledger.path.read_text(encoding="utf-8").splitlines():
+            data = json.loads(line)
+            assert "task_id" in data
+            assert "reason" in data
+
+    def test_append_does_not_rewrite_existing_rows(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(_row(task_id="T-1"))  # type: ignore[arg-type]
+        first_size = ledger.path.stat().st_size
+        ledger.append(_row(task_id="T-2"))  # type: ignore[arg-type]
+        second_size = ledger.path.stat().st_size
+        assert second_size > first_size
+
+    def test_round_trip_preserves_all_fields(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        original = new_abandonment(
+            task_id="T-99",
+            reason=AbandonReason.BUDGET_EXCEEDED,
+            detail="cap hit",
+            role="qa",
+            agent_id="sess",
+            adapter="codex",
+            cost_to_date_usd=1.5,
+            attempts=2,
+        )
+        ledger.append(original)
+        loaded = ledger.read_all()
+        assert len(loaded) == 1
+        assert loaded[0] == original
+
+
+class TestAbandonmentLedgerReadAll:
+    def test_read_skips_blank_lines(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.path.parent.mkdir(parents=True, exist_ok=True)
+        ledger.path.write_text("\n\n\n", encoding="utf-8")
+        assert ledger.read_all() == []
+
+    def test_read_skips_malformed_json(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(_row(task_id="T-1"))  # type: ignore[arg-type]
+        # Append garbage
+        with ledger.path.open("a", encoding="utf-8") as fh:
+            fh.write("{not json\n")
+            fh.write('{"task_id": "T-2", "reason": "out_of_scope"}\n')
+        rows = ledger.read_all()
+        assert {row.task_id for row in rows} == {"T-1", "T-2"}
+
+    def test_read_skips_unknown_reason_rows(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.path.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.path.open("w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"id": "a", "task_id": "T-1", "reason": "alien_value"}) + "\n")
+            fh.write(json.dumps({"id": "b", "task_id": "T-2", "reason": "other"}) + "\n")
+        rows = ledger.read_all()
+        assert [r.task_id for r in rows] == ["T-2"]
+
+    def test_read_skips_rows_missing_required_fields(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.path.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.path.open("w", encoding="utf-8") as fh:
+            fh.write(json.dumps({"id": "a", "reason": "other"}) + "\n")  # no task_id
+            fh.write(json.dumps({"id": "b", "task_id": "T-1"}) + "\n")  # no reason
+            fh.write(json.dumps({"id": "c", "task_id": "T-2", "reason": "other"}) + "\n")
+        rows = ledger.read_all()
+        assert [r.task_id for r in rows] == ["T-2"]
+
+    def test_read_skips_non_object_lines(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.path.parent.mkdir(parents=True, exist_ok=True)
+        with ledger.path.open("w", encoding="utf-8") as fh:
+            fh.write("[1,2,3]\n")
+            fh.write('"a string"\n')
+            fh.write(json.dumps({"task_id": "T-1", "reason": "other"}) + "\n")
+        rows = ledger.read_all()
+        assert [r.task_id for r in rows] == ["T-1"]
+
+    def test_read_preserves_append_order(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        for i in range(5):
+            ledger.append(_row(task_id=f"T-{i}"))  # type: ignore[arg-type]
+        ids = [r.task_id for r in ledger.read_all()]
+        assert ids == ["T-0", "T-1", "T-2", "T-3", "T-4"]
+
+
+class TestAbandonmentLedgerListRecent:
+    def test_recent_sorts_newest_first(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(new_abandonment(task_id="old", reason=AbandonReason.OTHER, timestamp=100.0))
+        ledger.append(new_abandonment(task_id="new", reason=AbandonReason.OTHER, timestamp=200.0))
+        ledger.append(new_abandonment(task_id="mid", reason=AbandonReason.OTHER, timestamp=150.0))
+        recent = ledger.list_recent()
+        assert [r.task_id for r in recent] == ["new", "mid", "old"]
+
+    def test_recent_honours_limit(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        for i in range(10):
+            ledger.append(new_abandonment(task_id=f"T-{i}", reason=AbandonReason.OTHER, timestamp=float(i)))
+        assert len(ledger.list_recent(limit=3)) == 3
+
+    def test_recent_negative_limit_returns_empty(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(_row())  # type: ignore[arg-type]
+        assert ledger.list_recent(limit=-5) == []
+
+
+class TestAbandonmentLedgerAggregations:
+    def _seed(self, tmp_path: Path) -> AbandonmentLedger:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(
+            new_abandonment(
+                task_id="T-1",
+                reason=AbandonReason.OUT_OF_SCOPE,
+                role="backend",
+                adapter="claude",
+            )
+        )
+        ledger.append(
+            new_abandonment(
+                task_id="T-2",
+                reason=AbandonReason.OUT_OF_SCOPE,
+                role="backend",
+                adapter="claude",
+            )
+        )
+        ledger.append(
+            new_abandonment(
+                task_id="T-3",
+                reason=AbandonReason.BUDGET_EXCEEDED,
+                role="qa",
+                adapter="codex",
+            )
+        )
+        return ledger
+
+    def test_stats_total(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        stats = ledger.stats()
+        assert stats["total"] == 3
+
+    def test_stats_by_reason(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        stats = ledger.stats()
+        assert stats["by_reason"] == {"out_of_scope": 2, "budget_exceeded": 1}
+
+    def test_stats_by_role(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        stats = ledger.stats()
+        assert stats["by_role"] == {"backend": 2, "qa": 1}
+
+    def test_stats_by_adapter(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        stats = ledger.stats()
+        assert stats["by_adapter"] == {"claude": 2, "codex": 1}
+
+    def test_stats_excludes_empty_role(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.OTHER, role=""))
+        stats = ledger.stats()
+        assert stats["by_role"] == {}
+
+    def test_stats_excludes_empty_adapter(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.OTHER, adapter=""))
+        stats = ledger.stats()
+        assert stats["by_adapter"] == {}
+
+    def test_count_by_task(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.OTHER))
+        assert ledger.count_by_task("T-1") == 2
+        assert ledger.count_by_task("T-3") == 1
+        assert ledger.count_by_task("nope") == 0
+
+    def test_by_reason_for_task(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.OUT_OF_SCOPE))
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.OUT_OF_SCOPE))
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.BUDGET_EXCEEDED))
+        ledger.append(new_abandonment(task_id="T-2", reason=AbandonReason.OTHER))
+        counts = ledger.by_reason("T-1")
+        assert counts[AbandonReason.OUT_OF_SCOPE] == 2
+        assert counts[AbandonReason.BUDGET_EXCEEDED] == 1
+        assert counts.get(AbandonReason.OTHER, 0) == 0
+
+    def test_abandon_rate_by_role(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        rates = ledger.abandon_rate_by_role({"backend": 8, "qa": 1, "ops": 5})
+        # backend: 2/(2+8)=0.2
+        assert rates["backend"] == pytest.approx(0.2)
+        # qa: 1/(1+1)=0.5
+        assert rates["qa"] == pytest.approx(0.5)
+        # ops: no abandons → 0
+        assert rates["ops"] == 0.0
+
+    def test_abandon_rate_by_role_no_completions(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        ledger.append(new_abandonment(task_id="T-1", reason=AbandonReason.OTHER, role="backend"))
+        rates = ledger.abandon_rate_by_role({})
+        assert rates["backend"] == 1.0
+
+    def test_abandon_rate_by_adapter(self, tmp_path: Path) -> None:
+        ledger = self._seed(tmp_path)
+        rates = ledger.abandon_rate_by_adapter({"claude": 18, "codex": 4})
+        # claude: 2/(2+18) = 0.1
+        assert rates["claude"] == pytest.approx(0.1)
+        # codex: 1/(1+4) = 0.2
+        assert rates["codex"] == pytest.approx(0.2)
+
+    def test_abandon_rate_handles_zero_denominator(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        # No abandons, no completions
+        rates = ledger.abandon_rate_by_role({})
+        assert rates == {}
+
+
+class TestAbandonmentLedgerConcurrency:
+    def test_threaded_appends_preserve_all_rows(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+        n_writers = 8
+        per_writer = 25
+
+        def writer(writer_id: int) -> None:
+            for i in range(per_writer):
+                ledger.append(
+                    new_abandonment(
+                        task_id=f"W{writer_id}-T{i}",
+                        reason=AbandonReason.OTHER,
+                    )
+                )
+
+        threads = [threading.Thread(target=writer, args=(w,)) for w in range(n_writers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        rows = ledger.read_all()
+        assert len(rows) == n_writers * per_writer
+        # IDs are globally unique
+        assert len({r.id for r in rows}) == n_writers * per_writer
+
+    def test_threaded_appends_produce_no_torn_lines(self, tmp_path: Path) -> None:
+        ledger = AbandonmentLedger(tmp_path)
+
+        def writer() -> None:
+            for i in range(40):
+                ledger.append(
+                    new_abandonment(
+                        task_id=f"T-{i}",
+                        reason=AbandonReason.OTHER,
+                        # Larger payloads stress the line-atomicity contract.
+                        detail="x" * 256,
+                    )
+                )
+
+        threads = [threading.Thread(target=writer) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        # Every non-empty line must parse as JSON with our schema.
+        for line in ledger.path.read_text(encoding="utf-8").splitlines():
+            data = json.loads(line)
+            assert "task_id" in data
+            assert "reason" in data

--- a/tests/unit/test_abandon_lifecycle.py
+++ b/tests/unit/test_abandon_lifecycle.py
@@ -1,0 +1,272 @@
+"""Unit tests for TaskStore.abandon and the ABANDONED transition table (#1350)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.tasks.abandon import AbandonmentLedger, AbandonReason
+from bernstein.core.tasks.lifecycle import (
+    TASK_TRANSITIONS,
+    IllegalTransitionError,
+    transition_task,
+)
+from bernstein.core.tasks.models import Task, TaskStatus
+from bernstein.core.tasks.task_store_core import TaskStore
+
+# ---------------------------------------------------------------------------
+# Lifecycle transition table — abandon-related entries
+# ---------------------------------------------------------------------------
+
+
+class TestAbandonTransitions:
+    @pytest.mark.parametrize(
+        "src",
+        [
+            TaskStatus.OPEN,
+            TaskStatus.CLAIMED,
+            TaskStatus.IN_PROGRESS,
+            TaskStatus.WAITING_FOR_SUBTASKS,
+            TaskStatus.BLOCKED,
+            TaskStatus.ORPHANED,
+        ],
+    )
+    def test_legal_source_states(self, src: TaskStatus) -> None:
+        assert (src, TaskStatus.ABANDONED) in TASK_TRANSITIONS
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            TaskStatus.DONE,
+            TaskStatus.CLOSED,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELLED,
+            TaskStatus.ABANDONED,
+        ],
+    )
+    def test_abandon_blocked_from_terminal_states(self, src: TaskStatus) -> None:
+        assert (src, TaskStatus.ABANDONED) not in TASK_TRANSITIONS
+
+    def test_abandoned_to_completed_is_illegal(self) -> None:
+        # Critical invariant: abandon→completed must never appear.
+        for target in (TaskStatus.DONE, TaskStatus.CLOSED):
+            assert (TaskStatus.ABANDONED, target) not in TASK_TRANSITIONS
+
+    def test_blocked_by_abandon_recovery_paths(self) -> None:
+        assert (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.OPEN) in TASK_TRANSITIONS
+        assert (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.CANCELLED) in TASK_TRANSITIONS
+        assert (TaskStatus.BLOCKED_BY_ABANDON, TaskStatus.ABANDONED) in TASK_TRANSITIONS
+
+    def test_transition_task_to_abandoned_succeeds(self) -> None:
+        task = Task(id="T-1", title="t", description="d", role="backend", status=TaskStatus.IN_PROGRESS)
+        event = transition_task(task, TaskStatus.ABANDONED, actor="test", reason="out_of_scope")
+        assert task.status is TaskStatus.ABANDONED
+        assert event.to_status == "abandoned"
+
+    def test_transition_from_abandoned_is_rejected(self) -> None:
+        task = Task(id="T-1", title="t", description="d", role="backend", status=TaskStatus.ABANDONED)
+        with pytest.raises(IllegalTransitionError):
+            transition_task(task, TaskStatus.OPEN)
+
+
+# ---------------------------------------------------------------------------
+# TaskStore.abandon
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path: Path) -> TaskStore:
+    """Build a TaskStore rooted at *tmp_path* with the expected layout."""
+    runtime = tmp_path / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    return TaskStore(runtime / "tasks.jsonl", archive_path=tmp_path / "archive" / "tasks.jsonl")
+
+
+async def _create(store: TaskStore, **overrides: Any) -> Task:
+    """Insert a Task into *store* via the internal index (bypasses create())."""
+    base: dict[str, Any] = {
+        "id": overrides.pop("id", "T-1"),
+        "title": "t",
+        "description": "d",
+        "role": "backend",
+        "status": TaskStatus.IN_PROGRESS,
+    }
+    base.update(overrides)
+    task = Task(**base)
+    store._tasks[task.id] = task  # type: ignore[attr-defined]
+    store._index_add(task)  # type: ignore[attr-defined]
+    return task
+
+
+@pytest.mark.asyncio
+class TestTaskStoreAbandon:
+    async def test_abandon_marks_status_abandoned(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        result = await store.abandon("T-1", "out_of_scope", "spec mismatch")
+        assert result.status is TaskStatus.ABANDONED
+
+    async def test_abandon_writes_ledger_row(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, role="qa")
+        await store.abandon(
+            "T-1",
+            AbandonReason.BUDGET_EXCEEDED.value,
+            "cost cap hit",
+            adapter="claude",
+            agent_id="sess-1",
+            cost_to_date_usd=2.5,
+        )
+        ledger = AbandonmentLedger(tmp_path)
+        rows = ledger.read_all()
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.task_id == "T-1"
+        assert row.reason is AbandonReason.BUDGET_EXCEEDED
+        assert row.role == "qa"
+        assert row.adapter == "claude"
+        assert row.cost_to_date_usd == pytest.approx(2.5)
+        assert row.detail == "cost cap hit"
+
+    async def test_abandon_unknown_task_raises_keyerror(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        with pytest.raises(KeyError):
+            await store.abandon("nope", "other")
+
+    async def test_abandon_unknown_reason_raises_valueerror(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        with pytest.raises(ValueError, match="Unknown AbandonReason"):
+            await store.abandon("T-1", "not_a_real_reason")
+
+    async def test_abandon_does_not_use_failed_status(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        task = await store.abandon("T-1", "other", "rationale")
+        assert task.status is not TaskStatus.FAILED
+        assert task.status is TaskStatus.ABANDONED
+
+    async def test_abandon_sets_completed_at(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        task = await store.abandon("T-1", "other")
+        assert task.completed_at is not None
+        assert task.completed_at > 0
+
+    async def test_abandon_bumps_version(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        original = await _create(store)
+        original_version = original.version
+        task = await store.abandon("T-1", "other")
+        assert task.version == original_version + 1
+
+    async def test_abandon_persists_to_jsonl(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        await store.abandon("T-1", "out_of_scope")
+        await store.flush_buffer()
+        body = (tmp_path / "runtime" / "tasks.jsonl").read_text(encoding="utf-8")
+        assert "abandoned" in body
+
+    async def test_abandon_records_terminal_reason(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        task = await store.abandon("T-1", "capability_mismatch")
+        assert task.terminal_reason == "capability_mismatch"
+
+    async def test_abandon_result_summary_uses_detail_when_present(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        task = await store.abandon("T-1", "other", "the rationale text")
+        assert task.result_summary == "the rationale text"
+
+    async def test_abandon_result_summary_falls_back_to_reason(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+        task = await store.abandon("T-1", "other")
+        assert task.result_summary == "other"
+
+    async def test_abandon_emits_one_ledger_row_per_call(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, id="T-1")
+        await _create(store, id="T-2")
+        await store.abandon("T-1", "other", "r1")
+        await store.abandon("T-2", "out_of_scope", "r2")
+        ledger = AbandonmentLedger(tmp_path)
+        assert len(ledger.read_all()) == 2
+
+
+@pytest.mark.asyncio
+class TestAbandonCascadesToDownstream:
+    async def test_open_downstream_moves_to_blocked_by_abandon(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, id="T-upstream")
+        await _create(store, id="T-down", status=TaskStatus.OPEN, depends_on=["T-upstream"])
+        await store.abandon("T-upstream", "other")
+        assert store._tasks["T-down"].status is TaskStatus.BLOCKED_BY_ABANDON  # type: ignore[attr-defined]
+
+    async def test_claimed_downstream_moves_to_blocked_by_abandon(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, id="T-upstream")
+        await _create(store, id="T-down", status=TaskStatus.CLAIMED, depends_on=["T-upstream"])
+        await store.abandon("T-upstream", "other")
+        assert store._tasks["T-down"].status is TaskStatus.BLOCKED_BY_ABANDON  # type: ignore[attr-defined]
+
+    async def test_done_downstream_is_not_touched(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, id="T-upstream")
+        await _create(store, id="T-done", status=TaskStatus.DONE, depends_on=["T-upstream"])
+        await store.abandon("T-upstream", "other")
+        assert store._tasks["T-done"].status is TaskStatus.DONE  # type: ignore[attr-defined]
+
+    async def test_unrelated_downstream_is_not_touched(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, id="T-upstream")
+        await _create(store, id="T-other", status=TaskStatus.OPEN, depends_on=["unrelated"])
+        await store.abandon("T-upstream", "other")
+        assert store._tasks["T-other"].status is TaskStatus.OPEN  # type: ignore[attr-defined]
+
+    async def test_multiple_downstream_consumers_all_cascade(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        await _create(store, id="T-upstream")
+        for i in range(3):
+            await _create(store, id=f"T-down-{i}", status=TaskStatus.OPEN, depends_on=["T-upstream"])
+        await store.abandon("T-upstream", "other")
+        for i in range(3):
+            assert store._tasks[f"T-down-{i}"].status is TaskStatus.BLOCKED_BY_ABANDON  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+class TestAbandonLedgerFailureModes:
+    async def test_ledger_write_failure_does_not_block_abandon(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _store(tmp_path)
+        await _create(store)
+
+        def fail(self: object, row: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(AbandonmentLedger, "append", fail)
+        # Should swallow OSError and still mark the task abandoned.
+        task = await store.abandon("T-1", "other")
+        assert task.status is TaskStatus.ABANDONED
+
+
+@pytest.mark.asyncio
+class TestAbandonSequentialRace:
+    async def test_concurrent_calls_serialise_under_lock(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        for i in range(5):
+            await _create(store, id=f"T-{i}")
+
+        async def abandon_one(task_id: str) -> None:
+            await store.abandon(task_id, "other", f"rationale for {task_id}")
+
+        await asyncio.gather(*(abandon_one(f"T-{i}") for i in range(5)))
+        ledger = AbandonmentLedger(tmp_path)
+        rows = ledger.read_all()
+        assert len(rows) == 5
+        assert {row.task_id for row in rows} == {f"T-{i}" for i in range(5)}

--- a/tests/unit/test_abandon_models.py
+++ b/tests/unit/test_abandon_models.py
@@ -1,0 +1,267 @@
+"""Unit tests for the abandonment dataclass and reason enum (#1350)."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from bernstein.core.tasks.abandon import (
+    Abandonment,
+    AbandonReason,
+    new_abandonment,
+)
+
+# ---------------------------------------------------------------------------
+# AbandonReason enum
+# ---------------------------------------------------------------------------
+
+
+class TestAbandonReasonEnum:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "out_of_scope",
+            "insufficient_context",
+            "conflicting_instructions",
+            "spec_underdetermined",
+            "time_budget_exhausted",
+            "budget_exceeded",
+            "capability_mismatch",
+            "env_broken",
+            "blocked_by_external",
+            "unsafe_change",
+            "operator_override",
+            "other",
+        ],
+    )
+    def test_every_taxonomy_value_round_trips(self, value: str) -> None:
+        reason = AbandonReason(value)
+        assert reason.value == value
+        assert AbandonReason.coerce(value) is reason
+
+    def test_coerce_accepts_enum_instance(self) -> None:
+        assert AbandonReason.coerce(AbandonReason.OUT_OF_SCOPE) is AbandonReason.OUT_OF_SCOPE
+
+    def test_coerce_accepts_enum_name_case_insensitive(self) -> None:
+        assert AbandonReason.coerce("OUT_OF_SCOPE") is AbandonReason.OUT_OF_SCOPE
+        assert AbandonReason.coerce("out_of_scope") is AbandonReason.OUT_OF_SCOPE
+        assert AbandonReason.coerce("Out_Of_Scope") is AbandonReason.OUT_OF_SCOPE
+
+    def test_coerce_strips_whitespace(self) -> None:
+        assert AbandonReason.coerce("  out_of_scope  ") is AbandonReason.OUT_OF_SCOPE
+
+    @pytest.mark.parametrize("bad", ["unknown", "abandon", "scope", "x", "OUT-OF-SCOPE"])
+    def test_coerce_rejects_unknown_values(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="Unknown AbandonReason"):
+            AbandonReason.coerce(bad)
+
+    def test_coerce_rejects_empty_string(self) -> None:
+        with pytest.raises(ValueError, match="cannot be empty"):
+            AbandonReason.coerce("")
+
+    def test_coerce_rejects_whitespace_only(self) -> None:
+        with pytest.raises(ValueError, match="cannot be empty"):
+            AbandonReason.coerce("   ")
+
+    def test_coerce_rejects_non_string(self) -> None:
+        with pytest.raises(ValueError, match="must be str"):
+            AbandonReason.coerce(42)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="must be str"):
+            AbandonReason.coerce(None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="must be str"):
+            AbandonReason.coerce(["out_of_scope"])  # type: ignore[arg-type]
+
+    def test_taxonomy_size_is_twelve(self) -> None:
+        # Locks the taxonomy size; adding a new reason should be a
+        # conscious change visible in this assertion's diff.
+        assert len(list(AbandonReason)) == 12
+
+    def test_all_values_are_snake_case(self) -> None:
+        for member in AbandonReason:
+            assert member.value.islower()
+            assert " " not in member.value
+            assert "-" not in member.value
+
+
+# ---------------------------------------------------------------------------
+# Abandonment dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestAbandonmentDataclass:
+    def _row(self, **overrides: object) -> Abandonment:
+        base: dict[str, object] = {
+            "id": "abc123",
+            "task_id": "T-001",
+            "reason": AbandonReason.OUT_OF_SCOPE,
+            "detail": "spec disagrees with test fixtures",
+            "role": "backend",
+            "agent_id": "session-1",
+            "adapter": "claude",
+            "cost_to_date_usd": 0.42,
+            "attempts": 1,
+            "timestamp": 1_700_000_000.0,
+        }
+        base.update(overrides)
+        return Abandonment(**base)  # type: ignore[arg-type]
+
+    def test_construction_sets_fields(self) -> None:
+        row = self._row()
+        assert row.id == "abc123"
+        assert row.task_id == "T-001"
+        assert row.reason is AbandonReason.OUT_OF_SCOPE
+        assert row.attempts == 1
+        assert row.adapter == "claude"
+
+    def test_to_dict_produces_json_safe_values(self) -> None:
+        row = self._row()
+        data = row.to_dict()
+        # Serialise to ensure JSON-compatibility
+        encoded = json.dumps(data, sort_keys=True)
+        round_tripped = json.loads(encoded)
+        assert round_tripped["reason"] == "out_of_scope"
+        assert round_tripped["cost_to_date_usd"] == pytest.approx(0.42)
+        assert round_tripped["timestamp"] == 1_700_000_000.0
+
+    def test_from_dict_round_trip(self) -> None:
+        row = self._row()
+        data = row.to_dict()
+        restored = Abandonment.from_dict(data)
+        assert restored == row
+
+    def test_from_dict_accepts_enum_name_in_reason(self) -> None:
+        row = Abandonment.from_dict(
+            {
+                "id": "x",
+                "task_id": "T-1",
+                "reason": "OUT_OF_SCOPE",
+            }
+        )
+        assert row.reason is AbandonReason.OUT_OF_SCOPE
+
+    def test_from_dict_rejects_unknown_reason(self) -> None:
+        with pytest.raises(ValueError, match="Unknown AbandonReason"):
+            Abandonment.from_dict({"id": "x", "task_id": "T-1", "reason": "stage_fright"})
+
+    def test_from_dict_missing_task_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing task_id"):
+            Abandonment.from_dict({"id": "x", "reason": "out_of_scope"})
+
+    def test_from_dict_missing_reason_raises(self) -> None:
+        with pytest.raises(ValueError, match="missing reason"):
+            Abandonment.from_dict({"id": "x", "task_id": "T-1"})
+
+    def test_from_dict_generates_id_when_missing(self) -> None:
+        row = Abandonment.from_dict({"task_id": "T-1", "reason": "other"})
+        assert row.id  # non-empty
+        assert len(row.id) >= 8
+
+    def test_from_dict_tolerates_extra_keys(self) -> None:
+        row = Abandonment.from_dict(
+            {
+                "id": "x",
+                "task_id": "T-1",
+                "reason": "other",
+                "future_field": "ignored-without-error",
+            }
+        )
+        assert row.task_id == "T-1"
+
+    def test_from_dict_coerces_numeric_strings(self) -> None:
+        row = Abandonment.from_dict(
+            {
+                "id": "x",
+                "task_id": "T-1",
+                "reason": "other",
+                "cost_to_date_usd": "1.5",
+                "attempts": "2",
+                "timestamp": "1700000000",
+            }
+        )
+        assert row.cost_to_date_usd == pytest.approx(1.5)
+        assert row.attempts == 2
+        assert row.timestamp == 1_700_000_000.0
+
+    def test_empty_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="id must be non-empty"):
+            self._row(id="")
+
+    def test_empty_task_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="task_id must be non-empty"):
+            self._row(task_id="")
+
+    def test_non_enum_reason_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be an AbandonReason"):
+            self._row(reason="out_of_scope")  # str, not enum
+
+    def test_negative_attempts_rejected(self) -> None:
+        with pytest.raises(ValueError, match="attempts must be >= 0"):
+            self._row(attempts=-1)
+
+    def test_negative_cost_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cost_to_date_usd must be >= 0"):
+            self._row(cost_to_date_usd=-0.01)
+
+    def test_negative_timestamp_rejected(self) -> None:
+        with pytest.raises(ValueError, match="timestamp must be >= 0"):
+            self._row(timestamp=-1.0)
+
+    def test_zero_attempts_and_cost_allowed(self) -> None:
+        row = self._row(attempts=0, cost_to_date_usd=0.0)
+        assert row.attempts == 0
+        assert row.cost_to_date_usd == 0.0
+
+    def test_frozen_dataclass_is_immutable(self) -> None:
+        row = self._row()
+        with pytest.raises((AttributeError, TypeError)):
+            row.task_id = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# new_abandonment factory
+# ---------------------------------------------------------------------------
+
+
+class TestNewAbandonmentFactory:
+    def test_creates_with_fresh_id(self) -> None:
+        r1 = new_abandonment(task_id="T-1", reason=AbandonReason.OTHER)
+        r2 = new_abandonment(task_id="T-1", reason=AbandonReason.OTHER)
+        assert r1.id != r2.id
+
+    def test_accepts_string_reason(self) -> None:
+        row = new_abandonment(task_id="T-1", reason="out_of_scope")
+        assert row.reason is AbandonReason.OUT_OF_SCOPE
+
+    def test_rejects_unknown_string_reason(self) -> None:
+        with pytest.raises(ValueError, match="Unknown AbandonReason"):
+            new_abandonment(task_id="T-1", reason="not_a_reason")
+
+    def test_default_timestamp_is_recent(self) -> None:
+        before = time.time()
+        row = new_abandonment(task_id="T-1", reason=AbandonReason.OTHER)
+        after = time.time()
+        assert before <= row.timestamp <= after
+
+    def test_explicit_timestamp_is_honoured(self) -> None:
+        row = new_abandonment(task_id="T-1", reason=AbandonReason.OTHER, timestamp=42.0)
+        assert row.timestamp == 42.0
+
+    def test_factory_propagates_all_optional_fields(self) -> None:
+        row = new_abandonment(
+            task_id="T-1",
+            reason=AbandonReason.BUDGET_EXCEEDED,
+            detail="cost cap reached",
+            role="qa",
+            agent_id="sess-9",
+            adapter="codex",
+            cost_to_date_usd=12.34,
+            attempts=2,
+        )
+        assert row.detail == "cost cap reached"
+        assert row.role == "qa"
+        assert row.agent_id == "sess-9"
+        assert row.adapter == "codex"
+        assert row.cost_to_date_usd == pytest.approx(12.34)
+        assert row.attempts == 2


### PR DESCRIPTION
## Summary

Adds first-class agent-initiated abandon verb so agents can exit a task honestly with a structured reason, replacing the watchdog-kill or quiet-half-commit anti-patterns.

- New module `src/bernstein/core/tasks/abandon.py` — `AbandonReason` (12-value closed taxonomy), `Abandonment` frozen dataclass, `AbandonmentLedger` (append-only JSONL at `.sdd/runtime/abandonments.jsonl`), and `abandon_rate_by_role` / `abandon_rate_by_adapter` aggregations.
- New `TaskStore.abandon()` flips a task to terminal `ABANDONED` (distinct from `FAILED`), writes the ledger row, and cascades downstream consumers waiting on the abandoned task to `BLOCKED_BY_ABANDON` so the dependency scanner stops waiting forever.
- New CLI `bernstein abandonments list|stats` with `--json` for scripts.
- Lifecycle FSM extended; **critical invariant**: `ABANDONED` is terminal — the table blocks `ABANDONED -> DONE/CLOSED` so a quietly-given-up task can never masquerade as a completion.

## Test plan

- [x] 49 unit tests for the enum + dataclass round-trip + malformed-input rejection
- [x] 32 unit tests for ledger append-atomicity, malformed-line tolerance, recent-sort, concurrent appends
- [x] 34 unit tests for FSM table + `TaskStore.abandon()` + cascade + race serialisation
- [x] 11 CLI unit tests incl. snapshot tests for ledger row format and table output
- [x] 10 Hypothesis property tests (ledger round-trip, status never regresses, concurrent appends, rates in [0,1])
- [x] 10 e2e integration tests covering TaskStore → ledger → CLI → metrics
- [x] 146 new tests total, all green
- [x] `ruff check` clean on touched files; pyright clean on the new modules