### PR TITLE
feat(eval): calibration log + Brier score (closes #1353)

### DIFF
--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -794,4 +794,88 @@ def eval_ab(
 
 
 # ---------------------------------------------------------------------------
+# eval calibration — Brier + ECE report over the on-disk calibration log
+# ---------------------------------------------------------------------------
+
+
+@eval_group.group("calibration")
+def calibration_group() -> None:
+    """Inspect calibration of router/judge probability outputs."""
+
+
+@calibration_group.command("report")
+@click.option(
+    "--since",
+    "since",
+    default=None,
+    help="Restrict to records within this duration (e.g. '7d', '30m', '24h').",
+)
+@click.option(
+    "--kind",
+    "decision_kind",
+    default=None,
+    help="Filter records by decision_kind (e.g. 'model_route').",
+)
+@click.option(
+    "--log-path",
+    "log_path",
+    default=None,
+    type=click.Path(dir_okay=False),
+    help="Override the calibration JSONL log path.",
+)
+@click.option(
+    "--bins",
+    "bin_count",
+    type=click.IntRange(min=1),
+    default=10,
+    show_default=True,
+    help="Number of reliability buckets.",
+)
+@click.option(
+    "--output",
+    "output_path",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Write report JSON to this file (stdout if omitted).",
+)
+def calibration_report(
+    since: str | None,
+    decision_kind: str | None,
+    log_path: str | None,
+    bin_count: int,
+    output_path: str | None,
+) -> None:
+    """Print a Brier + ECE + reliability report for the calibration log.
+
+    \b
+      bernstein eval calibration report --since 7d
+      bernstein eval calibration report --since 24h --kind model_route
+    """
+    import json as _json
+
+    from bernstein.eval.calibration import (
+        DEFAULT_LOG_PATH,
+        compute_report,
+        load_log,
+        parse_duration,
+    )
+
+    path = Path(log_path) if log_path else DEFAULT_LOG_PATH
+    since_seconds = parse_duration(since) if since else None
+    records = load_log(path, since_seconds=since_seconds, decision_kind=decision_kind)
+    report = compute_report(
+        records,
+        bin_count=bin_count,
+        decision_kind=decision_kind,
+        since=since,
+    )
+    payload = _json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    if output_path:
+        Path(output_path).write_text(payload + "\n", encoding="utf-8")
+        console.print(f"[green]wrote[/green] {output_path}  decisions={report.decisions}")
+    else:
+        click.echo(payload)
+
+
+# ---------------------------------------------------------------------------
 # workspace — multi-repo workspace management

--- a/src/bernstein/eval/__init__.py
+++ b/src/bernstein/eval/__init__.py
@@ -7,6 +7,20 @@ failure taxonomy, and golden benchmark task management.
 from __future__ import annotations
 
 from bernstein.eval.baseline import EvalBaseline, load_baseline, save_baseline
+from bernstein.eval.calibration import (
+    BrierScore,
+    CalibrationLogError,
+    CalibrationRecord,
+    CalibrationReport,
+    ReliabilityBucket,
+    compute_brier,
+    compute_report,
+    expected_calibration_error,
+    load_log,
+    log_decision,
+    parse_duration,
+    reliability_diagram_data,
+)
 from bernstein.eval.harness import EvalHarness, EvalResult, EvalTier
 from bernstein.eval.incident_synthesizer import (
     IncidentEvalCase,
@@ -16,6 +30,10 @@ from bernstein.eval.incident_synthesizer import (
 )
 
 __all__ = [
+    "BrierScore",
+    "CalibrationLogError",
+    "CalibrationRecord",
+    "CalibrationReport",
     "EvalBaseline",
     "EvalHarness",
     "EvalResult",
@@ -23,7 +41,15 @@ __all__ = [
     "IncidentEvalCase",
     "IncidentSyncResult",
     "IncidentSynthesizer",
+    "ReliabilityBucket",
+    "compute_brier",
+    "compute_report",
+    "expected_calibration_error",
     "load_baseline",
+    "load_log",
+    "log_decision",
+    "parse_duration",
+    "reliability_diagram_data",
     "run_incident_eval_gate",
     "save_baseline",
 ]

--- a/src/bernstein/eval/calibration.py
+++ b/src/bernstein/eval/calibration.py
@@ -1,0 +1,611 @@
+"""Calibration log + Brier score for router and judge decisions.
+
+This module measures the calibration quality of probability and confidence
+outputs from the bandit router, LLM judge, and any other Bernstein component
+that emits a probability paired with an eventually-observed binary outcome.
+
+Three core primitives are exported:
+
+* :func:`BrierScore` — mean squared error between predicted probability and
+  observed outcome. Lower is better; range is ``[0, 1]``.
+* :func:`expected_calibration_error` — weighted average bucket gap between
+  predicted-probability mean and observed-outcome mean (the classic 10-bin
+  ECE reference implementation).
+* :func:`reliability_diagram_data` — per-bucket data for a reliability plot
+  (predicted mean, observed mean, count, lower edge, upper edge).
+
+Additionally, helpers manage the on-disk JSONL log at
+``.sdd/metrics/calibration.jsonl`` and produce a structured report consumed
+by the ``bernstein eval calibration report`` CLI surface.
+
+The implementation is pure-Python with no external dependencies, type-checked
+under pyright strict, and ruff-clean. All numeric routines handle the
+zero-prediction, single-prediction, and perfectly-calibrated edge cases
+deterministically.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence
+
+__all__ = [
+    "DEFAULT_LOG_PATH",
+    "BrierScore",
+    "CalibrationLogError",
+    "CalibrationRecord",
+    "CalibrationReport",
+    "ReliabilityBucket",
+    "compute_brier",
+    "compute_report",
+    "expected_calibration_error",
+    "load_log",
+    "log_decision",
+    "parse_duration",
+    "reliability_diagram_data",
+]
+
+
+DEFAULT_LOG_PATH: Final[Path] = Path(".sdd/metrics/calibration.jsonl")
+"""Default on-disk location for the calibration JSONL log."""
+
+_DEFAULT_BIN_COUNT: Final[int] = 10
+"""Default number of reliability buckets — the standard 10-bin ECE config."""
+
+_DURATION_RE: Final[re.Pattern[str]] = re.compile(
+    r"^\s*(\d+)\s*(s|m|h|d|w)\s*$",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors and dataclasses
+# ---------------------------------------------------------------------------
+
+
+class CalibrationLogError(ValueError):
+    """Raised when the calibration log contains malformed or invalid data."""
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationRecord:
+    """One predicted-probability/observed-outcome pair.
+
+    Attributes:
+        timestamp: Unix epoch seconds at which the decision was logged.
+        decision_kind: A categorical label (e.g. ``"model_route"``, ``"judge"``).
+        policy_path: Optional path or identifier of the policy that emitted
+            the probability (e.g. ``"bandit/v3"``).
+        predicted_prob: Probability that the decision will be a win,
+            in the closed interval ``[0.0, 1.0]``.
+        observed_outcome: Binary outcome — ``True`` for win, ``False`` for loss.
+        decision_id: Optional identifier for joining with external logs.
+        metadata: Optional auxiliary fields preserved on round-trip.
+    """
+
+    timestamp: float
+    decision_kind: str
+    policy_path: str
+    predicted_prob: float
+    observed_outcome: bool
+    decision_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=lambda: cast("dict[str, Any]", {}))
+
+    def __post_init__(self) -> None:
+        """Validate the record at construction time."""
+        if math.isnan(self.predicted_prob):
+            msg = "predicted_prob must not be NaN"
+            raise CalibrationLogError(msg)
+        if math.isinf(self.predicted_prob):
+            msg = "predicted_prob must be finite"
+            raise CalibrationLogError(msg)
+        if not 0.0 <= self.predicted_prob <= 1.0:
+            msg = f"predicted_prob {self.predicted_prob!r} outside [0, 1]"
+            raise CalibrationLogError(msg)
+        # We *intentionally* keep this isinstance check despite the static
+        # type — callers reaching us from JSON deserialisation may slip in
+        # an ``int``; we want to reject that rather than silently coerce.
+        if type(self.observed_outcome) is not bool:
+            msg = "observed_outcome must be a bool"
+            raise CalibrationLogError(msg)
+        if not self.decision_kind:
+            msg = "decision_kind must be a non-empty string"
+            raise CalibrationLogError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class ReliabilityBucket:
+    """One bucket of a reliability diagram.
+
+    Attributes:
+        lower: Inclusive lower bound of the bucket on the predicted scale.
+        upper: Exclusive upper bound (inclusive only for the top bucket).
+        count: Number of predictions that landed in this bucket.
+        predicted_mean: Mean predicted probability of those predictions.
+        observed_mean: Empirical mean outcome (1.0 = perfect win-rate).
+    """
+
+    lower: float
+    upper: float
+    count: int
+    predicted_mean: float
+    observed_mean: float
+
+
+@dataclass(frozen=True, slots=True)
+class BrierScore:
+    """A Brier score paired with metadata for downstream reporting.
+
+    Attributes:
+        score: Mean squared error in ``[0, 1]`` between predicted probability
+            and observed outcome — lower is better.
+        sample_count: Number of predictions used to compute the score.
+    """
+
+    score: float
+    sample_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationReport:
+    """End-to-end calibration report for a window of decisions.
+
+    Attributes:
+        decisions: Total number of decisions considered.
+        brier: Brier score for the window — ``None`` when ``decisions == 0``.
+        ece: Expected calibration error — ``None`` when ``decisions == 0``.
+        buckets: Reliability diagram buckets (always returned, may be empty).
+        decision_kind: Optional filter that produced this report.
+        since: Optional duration that produced this report (e.g. ``"7d"``).
+    """
+
+    decisions: int
+    brier: float | None
+    ece: float | None
+    buckets: tuple[ReliabilityBucket, ...]
+    decision_kind: str | None = None
+    since: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the report."""
+        return {
+            "decisions": self.decisions,
+            "brier": self.brier,
+            "ece": self.ece,
+            "buckets": [asdict(b) for b in self.buckets],
+            "decision_kind": self.decision_kind,
+            "since": self.since,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Numeric primitives
+# ---------------------------------------------------------------------------
+
+
+def _check_pairs(predicted: Sequence[float], observed: Sequence[bool]) -> None:
+    """Validate paired probability/outcome inputs.
+
+    Args:
+        predicted: Sequence of probabilities in ``[0, 1]``.
+        observed: Sequence of booleans matching ``predicted`` in length.
+
+    Raises:
+        CalibrationLogError: If lengths mismatch, predictions are non-finite,
+            or predictions fall outside ``[0, 1]``.
+    """
+    if len(predicted) != len(observed):
+        msg = f"length mismatch: predicted={len(predicted)} observed={len(observed)}"
+        raise CalibrationLogError(msg)
+    for i, p in enumerate(predicted):
+        if math.isnan(p):
+            msg = f"predicted[{i}] is NaN"
+            raise CalibrationLogError(msg)
+        if math.isinf(p):
+            msg = f"predicted[{i}] is infinite"
+            raise CalibrationLogError(msg)
+        if not 0.0 <= p <= 1.0:
+            msg = f"predicted[{i}]={p!r} outside [0, 1]"
+            raise CalibrationLogError(msg)
+
+
+def compute_brier(predicted: Sequence[float], observed: Sequence[bool]) -> BrierScore:
+    """Compute the binary Brier score.
+
+    The Brier score is the mean squared error between each predicted
+    probability and the corresponding observed binary outcome (encoded as
+    ``1.0`` for ``True``, ``0.0`` for ``False``).
+
+    Args:
+        predicted: Predicted probabilities, each in ``[0, 1]``.
+        observed: Matching observed boolean outcomes.
+
+    Returns:
+        A :class:`BrierScore` with the mean squared error and sample count.
+
+    Raises:
+        CalibrationLogError: On length mismatch or invalid prediction value.
+    """
+    _check_pairs(predicted, observed)
+    if not predicted:
+        return BrierScore(score=0.0, sample_count=0)
+    total = 0.0
+    for p, o in zip(predicted, observed, strict=True):
+        target = 1.0 if o else 0.0
+        diff = p - target
+        total += diff * diff
+    return BrierScore(score=total / len(predicted), sample_count=len(predicted))
+
+
+def _bucket_index(prob: float, bin_count: int) -> int:
+    """Return the bucket index for ``prob`` given ``bin_count`` buckets.
+
+    The top edge (``prob == 1.0``) belongs to the last bucket to avoid an
+    off-by-one explosion.
+    """
+    if prob >= 1.0:
+        return bin_count - 1
+    if prob <= 0.0:
+        return 0
+    idx = int(prob * bin_count)
+    return min(idx, bin_count - 1)
+
+
+def reliability_diagram_data(
+    predicted: Sequence[float],
+    observed: Sequence[bool],
+    *,
+    bin_count: int = _DEFAULT_BIN_COUNT,
+) -> tuple[ReliabilityBucket, ...]:
+    """Compute per-bucket data for a reliability diagram.
+
+    Args:
+        predicted: Predicted probabilities, each in ``[0, 1]``.
+        observed: Matching observed boolean outcomes.
+        bin_count: Number of equal-width buckets across ``[0, 1]``.
+
+    Returns:
+        A tuple of :class:`ReliabilityBucket` entries — one per bucket,
+        in monotonically non-decreasing ``lower`` order. Empty buckets are
+        included with ``count=0``, ``predicted_mean=lower``,
+        ``observed_mean=0.0`` so the diagram retains its axis structure.
+
+    Raises:
+        CalibrationLogError: On length mismatch or invalid prediction value.
+        ValueError: If ``bin_count`` is not at least 1.
+    """
+    if bin_count < 1:
+        msg = f"bin_count must be >= 1, got {bin_count}"
+        raise ValueError(msg)
+    _check_pairs(predicted, observed)
+    sums_pred: list[float] = [0.0] * bin_count
+    sums_obs: list[float] = [0.0] * bin_count
+    counts: list[int] = [0] * bin_count
+    for p, o in zip(predicted, observed, strict=True):
+        idx = _bucket_index(p, bin_count)
+        sums_pred[idx] += p
+        sums_obs[idx] += 1.0 if o else 0.0
+        counts[idx] += 1
+    width = 1.0 / bin_count
+    out: list[ReliabilityBucket] = []
+    for i in range(bin_count):
+        lower = i * width
+        upper = 1.0 if i == bin_count - 1 else (i + 1) * width
+        if counts[i] == 0:
+            out.append(
+                ReliabilityBucket(
+                    lower=lower,
+                    upper=upper,
+                    count=0,
+                    predicted_mean=lower,
+                    observed_mean=0.0,
+                )
+            )
+        else:
+            out.append(
+                ReliabilityBucket(
+                    lower=lower,
+                    upper=upper,
+                    count=counts[i],
+                    predicted_mean=sums_pred[i] / counts[i],
+                    observed_mean=sums_obs[i] / counts[i],
+                )
+            )
+    return tuple(out)
+
+
+def expected_calibration_error(
+    predicted: Sequence[float],
+    observed: Sequence[bool],
+    *,
+    bin_count: int = _DEFAULT_BIN_COUNT,
+) -> float:
+    """Compute the Expected Calibration Error (ECE).
+
+    ECE is the count-weighted mean absolute gap between bucket-mean
+    predicted probability and bucket-mean observed outcome.
+
+    Args:
+        predicted: Predicted probabilities, each in ``[0, 1]``.
+        observed: Matching observed boolean outcomes.
+        bin_count: Number of equal-width buckets across ``[0, 1]``.
+
+    Returns:
+        A scalar in ``[0, 1]``. Returns ``0.0`` when no predictions are
+        supplied — there is no error to report.
+
+    Raises:
+        CalibrationLogError: On length mismatch or invalid prediction value.
+        ValueError: If ``bin_count`` is not at least 1.
+    """
+    buckets = reliability_diagram_data(predicted, observed, bin_count=bin_count)
+    total = sum(b.count for b in buckets)
+    if total == 0:
+        return 0.0
+    err = 0.0
+    for b in buckets:
+        if b.count == 0:
+            continue
+        err += (b.count / total) * abs(b.predicted_mean - b.observed_mean)
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Log I/O
+# ---------------------------------------------------------------------------
+
+
+def _record_to_json(record: CalibrationRecord) -> str:
+    """Serialize a record to a single JSONL line."""
+    payload: dict[str, Any] = {
+        "ts": record.timestamp,
+        "decision_kind": record.decision_kind,
+        "policy_path": record.policy_path,
+        "predicted_prob": record.predicted_prob,
+        "observed_outcome": record.observed_outcome,
+    }
+    if record.decision_id is not None:
+        payload["decision_id"] = record.decision_id
+    if record.metadata:
+        payload["metadata"] = record.metadata
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _record_from_json(line: str) -> CalibrationRecord:
+    """Parse one JSONL line into a record."""
+    try:
+        raw_any: object = json.loads(line)
+    except json.JSONDecodeError as exc:
+        msg = f"invalid JSON in calibration log: {exc.msg}"
+        raise CalibrationLogError(msg) from exc
+    if not isinstance(raw_any, dict):
+        msg = "calibration log entry must be a JSON object"
+        raise CalibrationLogError(msg)
+    raw = cast("dict[str, object]", raw_any)
+    try:
+        outcome_raw: object = raw["observed_outcome"]
+    except KeyError as exc:
+        msg = "calibration record missing 'observed_outcome'"
+        raise CalibrationLogError(msg) from exc
+    if not isinstance(outcome_raw, bool):
+        msg = "observed_outcome must be a JSON boolean"
+        raise CalibrationLogError(msg)
+    try:
+        ts = float(raw["ts"])  # type: ignore[arg-type]
+        kind = str(raw["decision_kind"])
+        policy = str(raw["policy_path"])
+        prob = float(raw["predicted_prob"])  # type: ignore[arg-type]
+    except (KeyError, TypeError, ValueError) as exc:
+        msg = f"calibration record missing or malformed required field: {exc}"
+        raise CalibrationLogError(msg) from exc
+    metadata_raw: object = raw.get("metadata") or {}
+    if not isinstance(metadata_raw, dict):
+        msg = "metadata must be a JSON object"
+        raise CalibrationLogError(msg)
+    metadata: dict[str, Any] = cast("dict[str, Any]", metadata_raw)
+    decision_id_raw: object = raw.get("decision_id")
+    decision_id = str(decision_id_raw) if decision_id_raw is not None else None
+    return CalibrationRecord(
+        timestamp=ts,
+        decision_kind=kind,
+        policy_path=policy,
+        predicted_prob=prob,
+        observed_outcome=outcome_raw,
+        decision_id=decision_id,
+        metadata=metadata,
+    )
+
+
+def log_decision(
+    *,
+    decision_kind: str,
+    policy_path: str,
+    predicted_prob: float,
+    observed_outcome: bool,
+    decision_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    log_path: Path | None = None,
+    timestamp: float | None = None,
+) -> CalibrationRecord:
+    """Append a calibration record to the on-disk JSONL log.
+
+    Args:
+        decision_kind: Categorical decision label, e.g. ``"model_route"``.
+        policy_path: Identifier of the policy that produced the probability.
+        predicted_prob: Probability in ``[0, 1]``.
+        observed_outcome: Eventual binary outcome (``True`` = win).
+        decision_id: Optional join key for external logs.
+        metadata: Optional auxiliary fields persisted verbatim.
+        log_path: Override for the JSONL log path. Defaults to
+            :data:`DEFAULT_LOG_PATH` relative to the current working directory.
+        timestamp: Override timestamp; defaults to :func:`time.time`.
+
+    Returns:
+        The persisted :class:`CalibrationRecord`.
+
+    Raises:
+        CalibrationLogError: If validation fails.
+    """
+    record = CalibrationRecord(
+        timestamp=time.time() if timestamp is None else timestamp,
+        decision_kind=decision_kind,
+        policy_path=policy_path,
+        predicted_prob=predicted_prob,
+        observed_outcome=observed_outcome,
+        decision_id=decision_id,
+        metadata=dict(metadata or {}),
+    )
+    path = log_path if log_path is not None else DEFAULT_LOG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = _record_to_json(record)
+    # Append-only; one JSON object per line; trailing newline preserved so
+    # readers can rely on iteration by line.
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.write(os.linesep if os.linesep == "\n" else "\n")
+    return record
+
+
+def load_log(
+    log_path: Path | None = None,
+    *,
+    since_seconds: float | None = None,
+    decision_kind: str | None = None,
+    now: float | None = None,
+) -> list[CalibrationRecord]:
+    """Read the calibration log from disk, applying optional filters.
+
+    Args:
+        log_path: Override path. Defaults to :data:`DEFAULT_LOG_PATH`.
+        since_seconds: Drop records older than ``now - since_seconds``. When
+            ``None`` (the default) all records are returned.
+        decision_kind: Restrict to records with this ``decision_kind``.
+        now: Override the reference time (defaults to :func:`time.time`).
+
+    Returns:
+        A list of records in file order. Missing or empty logs return ``[]``.
+
+    Raises:
+        CalibrationLogError: If any line is malformed.
+    """
+    path = log_path if log_path is not None else DEFAULT_LOG_PATH
+    if not path.exists():
+        return []
+    cutoff: float | None = None
+    if since_seconds is not None:
+        ref = time.time() if now is None else now
+        cutoff = ref - since_seconds
+    out: list[CalibrationRecord] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line:
+                continue
+            record = _record_from_json(line)
+            if cutoff is not None and record.timestamp < cutoff:
+                continue
+            if decision_kind is not None and record.decision_kind != decision_kind:
+                continue
+            out.append(record)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def parse_duration(spec: str) -> float:
+    """Parse a duration spec like ``"7d"`` or ``"30m"`` into seconds.
+
+    Supported suffixes: ``s`` (seconds), ``m`` (minutes), ``h`` (hours),
+    ``d`` (days), ``w`` (weeks). Case-insensitive.
+
+    Args:
+        spec: A non-empty duration spec.
+
+    Returns:
+        The duration in seconds as a float.
+
+    Raises:
+        ValueError: If ``spec`` is empty or malformed.
+    """
+    if not spec:
+        msg = "duration spec must be non-empty"
+        raise ValueError(msg)
+    match = _DURATION_RE.match(spec)
+    if match is None:
+        msg = f"cannot parse duration {spec!r}; use e.g. '7d', '30m', '24h'"
+        raise ValueError(msg)
+    value = int(match.group(1))
+    unit = match.group(2).lower()
+    factor = {"s": 1, "m": 60, "h": 3600, "d": 86_400, "w": 604_800}[unit]
+    return float(value * factor)
+
+
+def _records_to_arrays(
+    records: Iterable[CalibrationRecord],
+) -> tuple[list[float], list[bool]]:
+    """Split records into parallel ``predicted``/``observed`` lists."""
+    preds: list[float] = []
+    obs: list[bool] = []
+    for r in records:
+        preds.append(r.predicted_prob)
+        obs.append(r.observed_outcome)
+    return preds, obs
+
+
+def compute_report(
+    records: Sequence[CalibrationRecord],
+    *,
+    bin_count: int = _DEFAULT_BIN_COUNT,
+    decision_kind: str | None = None,
+    since: str | None = None,
+) -> CalibrationReport:
+    """Compute a :class:`CalibrationReport` from a sequence of records.
+
+    Args:
+        records: Calibration records to summarise.
+        bin_count: Number of reliability buckets.
+        decision_kind: Optional filter label persisted on the report.
+        since: Optional duration spec persisted on the report.
+
+    Returns:
+        A :class:`CalibrationReport`. When ``records`` is empty, ``brier``
+        and ``ece`` are ``None`` and ``buckets`` is empty — never raises.
+    """
+    if not records:
+        return CalibrationReport(
+            decisions=0,
+            brier=None,
+            ece=None,
+            buckets=(),
+            decision_kind=decision_kind,
+            since=since,
+        )
+    preds, obs = _records_to_arrays(records)
+    brier = compute_brier(preds, obs)
+    ece = expected_calibration_error(preds, obs, bin_count=bin_count)
+    buckets = reliability_diagram_data(preds, obs, bin_count=bin_count)
+    return CalibrationReport(
+        decisions=brier.sample_count,
+        brier=brier.score,
+        ece=ece,
+        buckets=buckets,
+        decision_kind=decision_kind,
+        since=since,
+    )
+
+
+def iter_records(records: Iterable[CalibrationRecord]) -> Iterator[CalibrationRecord]:
+    """Yield records lazily — used for streaming callers."""
+    yield from records

--- a/tests/integration/test_calibration_pipeline.py
+++ b/tests/integration/test_calibration_pipeline.py
@@ -1,0 +1,140 @@
+"""Integration tests for the calibration pipeline.
+
+Exercises the end-to-end flow: ``log_decision`` -> ``load_log`` -> CLI
+``bernstein eval calibration report``. Each test wires the production CLI
+through Click's test runner against a temporary log file to verify the
+operator-visible surface.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.eval_benchmark_cmd import eval_group
+from bernstein.eval.calibration import (
+    compute_report,
+    load_log,
+    log_decision,
+)
+
+
+def _log_batch(log_path: Path, *, n: int = 20) -> None:
+    """Seed the log with a deterministic batch of records."""
+    for i in range(n):
+        prob = (i + 0.5) / n
+        won = i >= (n // 2)
+        log_decision(
+            decision_kind="model_route" if i % 2 == 0 else "judge",
+            policy_path="bandit/v1",
+            predicted_prob=prob,
+            observed_outcome=won,
+            log_path=log_path,
+            timestamp=float(i),
+        )
+
+
+def test_pipeline_log_to_report_round_trip(tmp_path: Path) -> None:
+    """Logged decisions feed into ``compute_report`` without loss."""
+    log = tmp_path / "calibration.jsonl"
+    _log_batch(log, n=20)
+    records = load_log(log)
+    assert len(records) == 20
+    report = compute_report(records)
+    assert report.decisions == 20
+    assert report.brier is not None
+    assert report.ece is not None
+
+
+def test_cli_report_empty_log(tmp_path: Path) -> None:
+    """Running the CLI against an empty log returns null Brier/ECE — no crash."""
+    log = tmp_path / "calibration.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        ["calibration", "report", "--log-path", str(log), "--since", "7d"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["decisions"] == 0
+    assert payload["brier"] is None
+    assert payload["ece"] is None
+    assert payload["since"] == "7d"
+
+
+def test_cli_report_with_records(tmp_path: Path) -> None:
+    """The CLI reports correct decision counts and finite Brier/ECE."""
+    log = tmp_path / "calibration.jsonl"
+    _log_batch(log, n=20)
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        ["calibration", "report", "--log-path", str(log)],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["decisions"] == 20
+    assert 0.0 <= payload["brier"] <= 1.0
+    assert 0.0 <= payload["ece"] <= 1.0
+    assert len(payload["buckets"]) == 10
+
+
+def test_cli_report_filter_by_kind(tmp_path: Path) -> None:
+    """The CLI ``--kind`` filter restricts to a single decision_kind."""
+    log = tmp_path / "calibration.jsonl"
+    _log_batch(log, n=20)
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        ["calibration", "report", "--log-path", str(log), "--kind", "judge"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    # 20 records, every other is "judge" -> 10.
+    assert payload["decisions"] == 10
+    assert payload["decision_kind"] == "judge"
+
+
+def test_cli_report_writes_to_output_file(tmp_path: Path) -> None:
+    """The ``--output`` flag persists the report JSON to disk."""
+    log = tmp_path / "calibration.jsonl"
+    _log_batch(log, n=10)
+    out = tmp_path / "report.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        ["calibration", "report", "--log-path", str(log), "--output", str(out)],
+    )
+    assert result.exit_code == 0, result.output
+    assert out.exists()
+    parsed = json.loads(out.read_text())
+    assert parsed["decisions"] == 10
+
+
+def test_cli_report_rejects_invalid_duration(tmp_path: Path) -> None:
+    """An invalid duration spec surfaces a clear error and non-zero exit."""
+    log = tmp_path / "calibration.jsonl"
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        ["calibration", "report", "--log-path", str(log), "--since", "weasel"],
+    )
+    assert result.exit_code != 0
+    # The error message originates from ``parse_duration``.
+    assert "duration" in str(result.exception) or "duration" in result.output
+
+
+def test_cli_report_custom_bin_count(tmp_path: Path) -> None:
+    """The ``--bins`` option changes the number of reliability buckets."""
+    log = tmp_path / "calibration.jsonl"
+    _log_batch(log, n=20)
+    runner = CliRunner()
+    result = runner.invoke(
+        eval_group,
+        ["calibration", "report", "--log-path", str(log), "--bins", "5"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert len(payload["buckets"]) == 5

--- a/tests/property/test_calibration_properties.py
+++ b/tests/property/test_calibration_properties.py
@@ -1,0 +1,217 @@
+"""Property tests for ``bernstein.eval.calibration``.
+
+Each property check encodes an invariant the calibration primitives must
+hold for arbitrary valid inputs:
+
+* Brier score range is ``[0, 1]``.
+* Increasing the absolute prediction error never decreases the Brier score.
+* ECE is bounded above by 1 and is zero on perfectly-calibrated batches.
+* Reliability buckets sum to the input length with monotonic bounds.
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from bernstein.eval.calibration import (
+    compute_brier,
+    expected_calibration_error,
+    reliability_diagram_data,
+)
+
+_PROB = st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
+_BOOLS = st.booleans()
+
+
+@given(st.lists(_PROB, min_size=1, max_size=200), st.lists(_BOOLS, min_size=1, max_size=200))
+def test_brier_within_unit_interval(preds: list[float], obs: list[bool]) -> None:
+    """Brier score is always in ``[0, 1]`` regardless of inputs."""
+    n = min(len(preds), len(obs))
+    score = compute_brier(preds[:n], obs[:n]).score
+    assert 0.0 <= score <= 1.0
+
+
+@given(st.lists(_PROB, min_size=1, max_size=200), st.lists(_BOOLS, min_size=1, max_size=200))
+def test_brier_zero_iff_perfect_predictions(preds: list[float], obs: list[bool]) -> None:
+    """Score is zero exactly when every prediction equals its target."""
+    n = min(len(preds), len(obs))
+    preds, obs = preds[:n], obs[:n]
+    perfect = [1.0 if o else 0.0 for o in obs]
+    assert compute_brier(perfect, obs).score == 0.0
+
+
+@given(st.lists(_BOOLS, min_size=1, max_size=100))
+def test_brier_one_when_anticalibrated(obs: list[bool]) -> None:
+    """All-wrong deterministic predictions yield score == 1.0."""
+    anti = [0.0 if o else 1.0 for o in obs]
+    assert compute_brier(anti, obs).score == 1.0
+
+
+@given(st.lists(_PROB, min_size=2, max_size=50), st.lists(_BOOLS, min_size=2, max_size=50))
+def test_brier_monotonic_in_error(preds: list[float], obs: list[bool]) -> None:
+    """Pushing every prediction further from its target increases the Brier score.
+
+    For each prediction ``p`` paired with target ``t`` we construct ``q``
+    such that ``|q - t| >= |p - t|``; the resulting Brier score must not
+    decrease.
+    """
+    n = min(len(preds), len(obs))
+    preds, obs = preds[:n], obs[:n]
+    base = compute_brier(preds, obs).score
+    worse: list[float] = []
+    for p, o in zip(preds, obs, strict=True):
+        target = 1.0 if o else 0.0
+        # Move further from target while staying in [0, 1].
+        delta = target - p
+        # If p == target, perturb away — otherwise nudge further.
+        if delta == 0:
+            worse.append(0.0 if target == 1.0 else 1.0)
+        else:
+            worse.append(0.0 if target == 1.0 else 1.0)
+    worse_score = compute_brier(worse, obs).score
+    assert worse_score >= base - 1e-12
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=100),
+    st.lists(_BOOLS, min_size=1, max_size=100),
+    st.integers(min_value=1, max_value=20),
+)
+def test_ece_within_unit_interval(preds: list[float], obs: list[bool], bins: int) -> None:
+    """ECE lies in ``[0, 1]`` for any valid bin_count."""
+    n = min(len(preds), len(obs))
+    err = expected_calibration_error(preds[:n], obs[:n], bin_count=bins)
+    assert 0.0 <= err <= 1.0
+
+
+@given(st.lists(_BOOLS, min_size=1, max_size=50))
+def test_ece_zero_for_perfect_predictions(obs: list[bool]) -> None:
+    """Perfect predictions yield ECE == 0 in any bin count."""
+    perfect = [1.0 if o else 0.0 for o in obs]
+    assert expected_calibration_error(perfect, obs) == 0.0
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+    st.integers(min_value=1, max_value=20),
+)
+def test_reliability_bucket_count_invariant(preds: list[float], obs: list[bool], bins: int) -> None:
+    """Bucket counts sum to the input length, and bin count is exact."""
+    n = min(len(preds), len(obs))
+    buckets = reliability_diagram_data(preds[:n], obs[:n], bin_count=bins)
+    assert len(buckets) == bins
+    assert sum(b.count for b in buckets) == n
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+    st.integers(min_value=1, max_value=20),
+)
+def test_reliability_bounds_monotonic(preds: list[float], obs: list[bool], bins: int) -> None:
+    """Reliability bucket bounds are monotonically non-decreasing."""
+    from itertools import pairwise
+
+    n = min(len(preds), len(obs))
+    buckets = reliability_diagram_data(preds[:n], obs[:n], bin_count=bins)
+    for prev, curr in pairwise(buckets):
+        assert curr.lower >= prev.lower
+        assert curr.upper >= prev.upper
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+    st.integers(min_value=2, max_value=20),
+)
+def test_reliability_predicted_mean_within_bucket(preds: list[float], obs: list[bool], bins: int) -> None:
+    """For each non-empty bucket, predicted_mean lies inside [lower, upper]."""
+    n = min(len(preds), len(obs))
+    for b in reliability_diagram_data(preds[:n], obs[:n], bin_count=bins):
+        if b.count == 0:
+            continue
+        # Allow tiny float slack for the top bucket which is closed on both ends.
+        assert b.lower - 1e-12 <= b.predicted_mean <= b.upper + 1e-12
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+)
+def test_brier_symmetry_under_relabel(preds: list[float], obs: list[bool]) -> None:
+    """Brier(p, o) == Brier(1-p, not o)."""
+    n = min(len(preds), len(obs))
+    preds, obs = preds[:n], obs[:n]
+    flipped_preds = [1.0 - p for p in preds]
+    flipped_obs = [not o for o in obs]
+    a = compute_brier(preds, obs).score
+    b = compute_brier(flipped_preds, flipped_obs).score
+    # Float arithmetic with subnormals introduces ~1e-16 noise; compare with
+    # an absolute tolerance well within the unit interval.
+    assert abs(a - b) <= 1e-9
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+)
+def test_brier_is_finite(preds: list[float], obs: list[bool]) -> None:
+    """Brier score is finite for any valid input."""
+    import math
+
+    n = min(len(preds), len(obs))
+    score = compute_brier(preds[:n], obs[:n]).score
+    assert math.isfinite(score)
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+    st.integers(min_value=1, max_value=20),
+)
+def test_ece_is_finite(preds: list[float], obs: list[bool], bins: int) -> None:
+    """ECE is finite for any valid input."""
+    import math
+
+    n = min(len(preds), len(obs))
+    err = expected_calibration_error(preds[:n], obs[:n], bin_count=bins)
+    assert math.isfinite(err)
+
+
+@given(
+    st.lists(_PROB, min_size=2, max_size=80),
+    st.lists(_BOOLS, min_size=2, max_size=80),
+)
+def test_brier_does_not_change_under_pair_permutation(preds: list[float], obs: list[bool]) -> None:
+    """Brier score is invariant under joint reordering of pairs."""
+    n = min(len(preds), len(obs))
+    preds, obs = preds[:n], obs[:n]
+    assume(n >= 2)
+    direct = compute_brier(preds, obs).score
+    reverse = compute_brier(list(reversed(preds)), list(reversed(obs))).score
+    # Summation order can introduce ~1e-16 noise.
+    assert abs(direct - reverse) <= 1e-9
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=40),
+    st.lists(_BOOLS, min_size=1, max_size=40),
+)
+def test_reliability_default_buckets_is_ten(preds: list[float], obs: list[bool]) -> None:
+    """Default bin_count yields exactly ten buckets."""
+    n = min(len(preds), len(obs))
+    assert len(reliability_diagram_data(preds[:n], obs[:n])) == 10
+
+
+@given(
+    st.lists(_PROB, min_size=1, max_size=80),
+    st.lists(_BOOLS, min_size=1, max_size=80),
+    st.integers(min_value=1, max_value=10),
+)
+def test_reliability_observed_mean_in_unit_interval(preds: list[float], obs: list[bool], bins: int) -> None:
+    """observed_mean of every bucket lies in ``[0, 1]``."""
+    n = min(len(preds), len(obs))
+    for b in reliability_diagram_data(preds[:n], obs[:n], bin_count=bins):
+        assert 0.0 <= b.observed_mean <= 1.0

--- a/tests/unit/test_calibration.py
+++ b/tests/unit/test_calibration.py
@@ -1,0 +1,675 @@
+"""Unit tests for ``bernstein.eval.calibration``.
+
+This suite covers every documented edge case for the calibration primitives:
+single-prediction inputs, perfect calibration, perfectly miscalibrated
+inputs, NaN / Inf rejection, missing-outcome handling, malformed log lines,
+round-tripping, duration parsing, and reliability-diagram structure.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.eval.calibration import (
+    DEFAULT_LOG_PATH,
+    BrierScore,
+    CalibrationLogError,
+    CalibrationRecord,
+    CalibrationReport,
+    ReliabilityBucket,
+    compute_brier,
+    compute_report,
+    expected_calibration_error,
+    load_log,
+    log_decision,
+    parse_duration,
+    reliability_diagram_data,
+)
+
+# ---------------------------------------------------------------------------
+# BrierScore
+# ---------------------------------------------------------------------------
+
+
+def test_brier_empty_inputs() -> None:
+    """Empty predictions return a zero score with zero samples."""
+    result = compute_brier([], [])
+    assert result == BrierScore(score=0.0, sample_count=0)
+
+
+def test_brier_single_prediction_perfect() -> None:
+    """A single perfect prediction yields a Brier score of 0."""
+    result = compute_brier([1.0], [True])
+    assert result.score == 0.0
+    assert result.sample_count == 1
+
+
+def test_brier_single_prediction_perfectly_wrong() -> None:
+    """A single perfectly miscalibrated prediction yields the maximum 1.0."""
+    result = compute_brier([1.0], [False])
+    assert result.score == 1.0
+
+
+def test_brier_single_prediction_half() -> None:
+    """A 0.5 prediction yields a Brier score of 0.25 regardless of outcome."""
+    won = compute_brier([0.5], [True]).score
+    lost = compute_brier([0.5], [False]).score
+    assert won == pytest.approx(0.25)
+    assert lost == pytest.approx(0.25)
+
+
+def test_brier_perfectly_calibrated() -> None:
+    """All probabilities of 0 or 1 matching outcomes yield zero error."""
+    result = compute_brier([0.0, 1.0, 0.0, 1.0], [False, True, False, True])
+    assert result.score == 0.0
+    assert result.sample_count == 4
+
+
+def test_brier_perfectly_anticalibrated() -> None:
+    """All probabilities of 0 or 1 mismatched yield 1.0."""
+    result = compute_brier([0.0, 1.0, 0.0, 1.0], [True, False, True, False])
+    assert result.score == pytest.approx(1.0)
+
+
+def test_brier_mixed_known_reference() -> None:
+    """Reference computation: hand-checked against the textbook formula."""
+    preds = [0.9, 0.8, 0.3, 0.5]
+    obs = [True, True, False, True]
+    expected = ((0.9 - 1) ** 2 + (0.8 - 1) ** 2 + (0.3 - 0) ** 2 + (0.5 - 1) ** 2) / 4
+    assert compute_brier(preds, obs).score == pytest.approx(expected, abs=1e-12)
+
+
+def test_brier_range_within_unit_interval() -> None:
+    """Brier outputs are clamped to ``[0, 1]`` by construction."""
+    preds = [0.0, 0.25, 0.5, 0.75, 1.0]
+    obs = [True, True, False, False, True]
+    result = compute_brier(preds, obs)
+    assert 0.0 <= result.score <= 1.0
+
+
+def test_brier_length_mismatch_raises() -> None:
+    """Mismatched lengths raise ``CalibrationLogError``."""
+    with pytest.raises(CalibrationLogError):
+        compute_brier([0.5, 0.5], [True])
+
+
+def test_brier_rejects_nan_prediction() -> None:
+    """NaN predictions are rejected with a descriptive error."""
+    with pytest.raises(CalibrationLogError, match="NaN"):
+        compute_brier([math.nan], [True])
+
+
+def test_brier_rejects_inf_prediction() -> None:
+    """Infinite predictions are rejected."""
+    with pytest.raises(CalibrationLogError, match="infinite"):
+        compute_brier([math.inf], [True])
+
+
+def test_brier_rejects_negative_prediction() -> None:
+    """Probabilities outside ``[0, 1]`` are rejected."""
+    with pytest.raises(CalibrationLogError, match=r"outside \[0, 1\]"):
+        compute_brier([-0.1], [True])
+
+
+def test_brier_rejects_above_one_prediction() -> None:
+    """Probabilities above 1.0 are rejected."""
+    with pytest.raises(CalibrationLogError, match=r"outside \[0, 1\]"):
+        compute_brier([1.1], [False])
+
+
+def test_brier_accepts_n_equal_two_minimum() -> None:
+    """n=2 is the minimum non-trivial case and must be supported."""
+    assert compute_brier([0.0, 1.0], [False, True]).score == 0.0
+
+
+def test_brier_large_input_does_not_overflow() -> None:
+    """Large inputs (10_000 predictions) compute without overflow."""
+    n = 10_000
+    preds = [0.5] * n
+    obs = [True] * (n // 2) + [False] * (n // 2)
+    score = compute_brier(preds, obs).score
+    assert 0.0 <= score <= 1.0
+    assert score == pytest.approx(0.25, abs=1e-12)
+
+
+def test_brier_sample_count_matches_input() -> None:
+    """sample_count exactly equals the number of paired observations."""
+    result = compute_brier([0.1, 0.2, 0.3], [True, False, True])
+    assert result.sample_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Expected Calibration Error
+# ---------------------------------------------------------------------------
+
+
+def test_ece_empty_returns_zero() -> None:
+    """ECE on empty inputs returns 0.0 — there is no error to report."""
+    assert expected_calibration_error([], []) == 0.0
+
+
+def test_ece_perfect_calibration_yields_zero() -> None:
+    """When predictions match observed frequencies exactly, ECE == 0."""
+    # All predictions at 0.5; outcomes balanced -> bucket prediction mean
+    # (0.5) equals bucket observed mean (0.5).
+    preds = [0.5, 0.5, 0.5, 0.5]
+    obs = [True, False, True, False]
+    assert expected_calibration_error(preds, obs) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_ece_perfectly_anticalibrated_is_one() -> None:
+    """All predictions 0.0 with all wins yields ECE == 1.0."""
+    preds = [0.0, 0.0, 0.0, 0.0]
+    obs = [True, True, True, True]
+    assert expected_calibration_error(preds, obs) == pytest.approx(1.0, abs=1e-12)
+
+
+def test_ece_reference_calculation() -> None:
+    """Hand-computed ECE on a small fixture matches the implementation."""
+    # Bucket assignment for bin_count=2:
+    #  - [0.0, 0.5): preds 0.1 -> True, 0.3 -> False  (n=2; pred_mean=0.2; obs_mean=0.5)
+    #  - [0.5, 1.0]: preds 0.7 -> True, 0.9 -> True   (n=2; pred_mean=0.8; obs_mean=1.0)
+    # ECE = (2/4) * |0.2 - 0.5| + (2/4) * |0.8 - 1.0| = 0.15 + 0.10 = 0.25.
+    preds = [0.1, 0.3, 0.7, 0.9]
+    obs = [True, False, True, True]
+    assert expected_calibration_error(preds, obs, bin_count=2) == pytest.approx(0.25, abs=1e-12)
+
+
+def test_ece_invalid_bin_count_raises() -> None:
+    """ECE with bin_count < 1 raises ``ValueError``."""
+    with pytest.raises(ValueError, match="bin_count"):
+        expected_calibration_error([0.5], [True], bin_count=0)
+
+
+def test_ece_rejects_nan() -> None:
+    """NaN predictions are rejected by ECE too."""
+    with pytest.raises(CalibrationLogError):
+        expected_calibration_error([math.nan, 0.5], [True, False])
+
+
+def test_ece_length_mismatch() -> None:
+    """ECE length mismatch raises ``CalibrationLogError``."""
+    with pytest.raises(CalibrationLogError):
+        expected_calibration_error([0.5], [True, False])
+
+
+def test_ece_within_unit_interval() -> None:
+    """ECE outputs lie in ``[0, 1]``."""
+    preds = [0.1, 0.4, 0.7, 0.95]
+    obs = [True, False, True, True]
+    err = expected_calibration_error(preds, obs)
+    assert 0.0 <= err <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Reliability diagram data
+# ---------------------------------------------------------------------------
+
+
+def test_reliability_default_bin_count_returns_ten_buckets() -> None:
+    """Default bin_count is 10."""
+    buckets = reliability_diagram_data([0.5], [True])
+    assert len(buckets) == 10
+
+
+def test_reliability_buckets_have_monotonic_lower_bounds() -> None:
+    """Bucket lower bounds are monotonically non-decreasing."""
+    from itertools import pairwise
+
+    buckets = reliability_diagram_data([0.5], [True])
+    for prev, curr in pairwise(buckets):
+        assert curr.lower >= prev.lower
+
+
+def test_reliability_top_bucket_includes_one_point_zero() -> None:
+    """A prediction of exactly 1.0 maps to the last bucket."""
+    buckets = reliability_diagram_data([1.0], [True], bin_count=4)
+    last = buckets[-1]
+    assert last.count == 1
+    assert last.upper == 1.0
+
+
+def test_reliability_zero_lands_in_first_bucket() -> None:
+    """A prediction of exactly 0.0 maps to the first bucket."""
+    buckets = reliability_diagram_data([0.0], [False], bin_count=4)
+    assert buckets[0].count == 1
+
+
+def test_reliability_empty_buckets_preserve_axis_structure() -> None:
+    """Empty buckets are still emitted so plot axes line up."""
+    buckets = reliability_diagram_data([0.5], [True], bin_count=4)
+    assert len(buckets) == 4
+    assert sum(b.count for b in buckets) == 1
+
+
+def test_reliability_invalid_bin_count() -> None:
+    """bin_count < 1 raises ``ValueError``."""
+    with pytest.raises(ValueError, match="bin_count"):
+        reliability_diagram_data([0.5], [True], bin_count=0)
+
+
+def test_reliability_length_mismatch() -> None:
+    """Length mismatch is rejected by the reliability helper."""
+    with pytest.raises(CalibrationLogError):
+        reliability_diagram_data([0.5], [True, False])
+
+
+def test_reliability_bucket_count_sums_to_input_size() -> None:
+    """Total count across all buckets equals the input length."""
+    preds = [0.05, 0.15, 0.35, 0.55, 0.75, 0.95]
+    obs = [True, False, True, False, True, False]
+    buckets = reliability_diagram_data(preds, obs, bin_count=10)
+    assert sum(b.count for b in buckets) == len(preds)
+
+
+def test_reliability_single_bucket_collapses_all_inputs() -> None:
+    """With bin_count=1 every prediction lands in the only bucket."""
+    preds = [0.1, 0.5, 0.9]
+    obs = [True, False, True]
+    buckets = reliability_diagram_data(preds, obs, bin_count=1)
+    assert len(buckets) == 1
+    assert buckets[0].count == 3
+
+
+def test_reliability_predicted_mean_within_bucket_range() -> None:
+    """Each non-empty bucket has predicted_mean within its [lower, upper] range."""
+    preds = [0.05, 0.45, 0.85]
+    obs = [True, False, True]
+    for b in reliability_diagram_data(preds, obs, bin_count=10):
+        if b.count == 0:
+            continue
+        assert b.lower <= b.predicted_mean <= b.upper + 1e-12
+
+
+# ---------------------------------------------------------------------------
+# CalibrationRecord validation
+# ---------------------------------------------------------------------------
+
+
+def test_record_rejects_nan_probability() -> None:
+    """CalibrationRecord rejects NaN predicted_prob at construction."""
+    with pytest.raises(CalibrationLogError, match="NaN"):
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="model_route",
+            policy_path="p",
+            predicted_prob=math.nan,
+            observed_outcome=True,
+        )
+
+
+def test_record_rejects_inf_probability() -> None:
+    """CalibrationRecord rejects infinite predicted_prob."""
+    with pytest.raises(CalibrationLogError, match="finite"):
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="k",
+            policy_path="p",
+            predicted_prob=math.inf,
+            observed_outcome=False,
+        )
+
+
+def test_record_rejects_probability_below_zero() -> None:
+    """CalibrationRecord rejects probability below 0."""
+    with pytest.raises(CalibrationLogError, match=r"outside \[0, 1\]"):
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="k",
+            policy_path="p",
+            predicted_prob=-0.0001,
+            observed_outcome=True,
+        )
+
+
+def test_record_rejects_empty_decision_kind() -> None:
+    """An empty decision_kind is rejected."""
+    with pytest.raises(CalibrationLogError, match="decision_kind"):
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="",
+            policy_path="p",
+            predicted_prob=0.5,
+            observed_outcome=True,
+        )
+
+
+def test_record_rejects_non_bool_outcome() -> None:
+    """``observed_outcome`` must be a true ``bool``, not an ``int``."""
+    with pytest.raises(CalibrationLogError, match="observed_outcome"):
+        CalibrationRecord(  # type: ignore[arg-type]
+            timestamp=0.0,
+            decision_kind="k",
+            policy_path="p",
+            predicted_prob=0.5,
+            observed_outcome=1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Log I/O — round-trip and edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_log_append_creates_parent_dirs(tmp_path: Path) -> None:
+    """``log_decision`` creates the metrics directory if it is missing."""
+    log = tmp_path / "deep" / "nested" / "calibration.jsonl"
+    log_decision(
+        decision_kind="model_route",
+        policy_path="bandit/v1",
+        predicted_prob=0.7,
+        observed_outcome=True,
+        log_path=log,
+        timestamp=1_000.0,
+    )
+    assert log.exists()
+    assert log.parent.exists()
+
+
+def test_log_round_trip_preserves_values(tmp_path: Path) -> None:
+    """A logged record reads back with identical values."""
+    log = tmp_path / "calibration.jsonl"
+    record = log_decision(
+        decision_kind="judge",
+        policy_path="judge/v2",
+        predicted_prob=0.42,
+        observed_outcome=False,
+        decision_id="abc",
+        metadata={"slice": "router"},
+        log_path=log,
+        timestamp=42.0,
+    )
+    rows = load_log(log)
+    assert len(rows) == 1
+    assert rows[0] == record
+
+
+def test_log_missing_returns_empty(tmp_path: Path) -> None:
+    """A missing log file returns an empty list, not an error."""
+    assert load_log(tmp_path / "absent.jsonl") == []
+
+
+def test_log_blank_lines_are_skipped(tmp_path: Path) -> None:
+    """Blank lines inside the JSONL file are silently skipped."""
+    log = tmp_path / "calibration.jsonl"
+    log_decision(
+        decision_kind="k",
+        policy_path="p",
+        predicted_prob=0.5,
+        observed_outcome=True,
+        log_path=log,
+        timestamp=1.0,
+    )
+    log.write_text(log.read_text() + "\n\n", encoding="utf-8")
+    rows = load_log(log)
+    assert len(rows) == 1
+
+
+def test_log_rejects_invalid_json(tmp_path: Path) -> None:
+    """Malformed JSON in the log raises ``CalibrationLogError``."""
+    log = tmp_path / "calibration.jsonl"
+    log.write_text("not-json\n", encoding="utf-8")
+    with pytest.raises(CalibrationLogError, match="invalid JSON"):
+        load_log(log)
+
+
+def test_log_rejects_non_object(tmp_path: Path) -> None:
+    """Top-level non-object entries are rejected."""
+    log = tmp_path / "calibration.jsonl"
+    log.write_text(json.dumps([1, 2, 3]) + "\n", encoding="utf-8")
+    with pytest.raises(CalibrationLogError, match="must be a JSON object"):
+        load_log(log)
+
+
+def test_log_rejects_missing_outcome(tmp_path: Path) -> None:
+    """Records missing ``observed_outcome`` are flagged."""
+    log = tmp_path / "calibration.jsonl"
+    payload: dict[str, Any] = {
+        "ts": 0.0,
+        "decision_kind": "k",
+        "policy_path": "p",
+        "predicted_prob": 0.5,
+    }
+    log.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    with pytest.raises(CalibrationLogError, match="observed_outcome"):
+        load_log(log)
+
+
+def test_log_rejects_non_bool_outcome_in_json(tmp_path: Path) -> None:
+    """Outcomes stored as ints are rejected — bool only."""
+    log = tmp_path / "calibration.jsonl"
+    payload = {
+        "ts": 0.0,
+        "decision_kind": "k",
+        "policy_path": "p",
+        "predicted_prob": 0.5,
+        "observed_outcome": 1,
+    }
+    log.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    with pytest.raises(CalibrationLogError, match="observed_outcome"):
+        load_log(log)
+
+
+def test_log_filter_by_decision_kind(tmp_path: Path) -> None:
+    """``decision_kind`` filter restricts to matching records."""
+    log = tmp_path / "calibration.jsonl"
+    log_decision(
+        decision_kind="model_route",
+        policy_path="p",
+        predicted_prob=0.5,
+        observed_outcome=True,
+        log_path=log,
+        timestamp=1.0,
+    )
+    log_decision(
+        decision_kind="judge",
+        policy_path="p",
+        predicted_prob=0.5,
+        observed_outcome=False,
+        log_path=log,
+        timestamp=2.0,
+    )
+    rows = load_log(log, decision_kind="judge")
+    assert len(rows) == 1
+    assert rows[0].decision_kind == "judge"
+
+
+def test_log_filter_by_since_drops_old_records(tmp_path: Path) -> None:
+    """``since_seconds`` filter excludes older records."""
+    log = tmp_path / "calibration.jsonl"
+    log_decision(
+        decision_kind="k",
+        policy_path="p",
+        predicted_prob=0.5,
+        observed_outcome=True,
+        log_path=log,
+        timestamp=100.0,
+    )
+    log_decision(
+        decision_kind="k",
+        policy_path="p",
+        predicted_prob=0.5,
+        observed_outcome=False,
+        log_path=log,
+        timestamp=200.0,
+    )
+    rows = load_log(log, since_seconds=50.0, now=210.0)
+    assert len(rows) == 1
+    assert rows[0].timestamp == 200.0
+
+
+def test_log_default_path_constant_is_under_sdd_metrics() -> None:
+    """The default log path lives under .sdd/metrics — operator contract."""
+    assert Path(".sdd/metrics/calibration.jsonl") == DEFAULT_LOG_PATH
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def test_compute_report_empty_returns_nulls() -> None:
+    """Empty records produce a report with null Brier and ECE — no crash."""
+    report = compute_report([])
+    assert report.decisions == 0
+    assert report.brier is None
+    assert report.ece is None
+    assert report.buckets == ()
+
+
+def test_compute_report_carries_filter_metadata() -> None:
+    """``decision_kind`` and ``since`` are echoed on the report."""
+    report = compute_report([], decision_kind="judge", since="7d")
+    assert report.decision_kind == "judge"
+    assert report.since == "7d"
+
+
+def test_compute_report_with_records_sets_decisions() -> None:
+    """A non-empty input yields the matching decisions count."""
+    records = [
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="k",
+            policy_path="p",
+            predicted_prob=0.6,
+            observed_outcome=True,
+        ),
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="k",
+            policy_path="p",
+            predicted_prob=0.4,
+            observed_outcome=False,
+        ),
+    ]
+    report = compute_report(records)
+    assert report.decisions == 2
+    assert report.brier is not None and 0.0 <= report.brier <= 1.0
+    assert report.ece is not None and 0.0 <= report.ece <= 1.0
+
+
+def test_report_to_dict_is_json_serializable() -> None:
+    """The report dict can be serialised to JSON and back losslessly."""
+    records = [
+        CalibrationRecord(
+            timestamp=0.0,
+            decision_kind="k",
+            policy_path="p",
+            predicted_prob=0.5,
+            observed_outcome=True,
+        ),
+    ]
+    report = compute_report(records, decision_kind="k", since="1h")
+    blob = json.dumps(report.to_dict(), sort_keys=True)
+    parsed = json.loads(blob)
+    assert parsed["decisions"] == 1
+    assert parsed["since"] == "1h"
+
+
+def test_report_dataclass_is_frozen() -> None:
+    """``CalibrationReport`` is immutable."""
+    report = CalibrationReport(decisions=0, brier=None, ece=None, buckets=())
+    with pytest.raises((AttributeError, TypeError)):
+        report.decisions = 5  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Duration parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("1s", 1.0),
+        ("30s", 30.0),
+        ("5m", 300.0),
+        ("2h", 7_200.0),
+        ("1d", 86_400.0),
+        ("7d", 604_800.0),
+        ("2w", 1_209_600.0),
+        ("24H", 86_400.0),
+        (" 3d ", 259_200.0),
+    ],
+)
+def test_parse_duration_supported_forms(spec: str, expected: float) -> None:
+    """All documented duration suffixes round-trip to seconds."""
+    assert parse_duration(spec) == expected
+
+
+@pytest.mark.parametrize("spec", ["", "abc", "5y", "-1d", "1.5d", "d", "5"])
+def test_parse_duration_rejects_invalid_forms(spec: str) -> None:
+    """Empty, units-only, missing-unit, and unsupported suffixes raise."""
+    with pytest.raises(ValueError):
+        parse_duration(spec)
+
+
+# ---------------------------------------------------------------------------
+# Fixture-driven reference parity (issue acceptance criterion #1 & #2)
+# ---------------------------------------------------------------------------
+
+
+def test_hundred_sample_fixture_brier_matches_reference() -> None:
+    """50-win / 50-loss synthetic fixture parity check."""
+    # Construct a deterministic fixture: confidences increase linearly.
+    preds = [(i + 0.5) / 100 for i in range(100)]
+    # Outcomes: the second half always wins, the first half always loses.
+    obs = [i >= 50 for i in range(100)]
+    # Hand-rolled reference, matching the standard mean-squared-error formula.
+    reference = sum((p - (1.0 if o else 0.0)) ** 2 for p, o in zip(preds, obs, strict=True)) / 100
+    assert compute_brier(preds, obs).score == pytest.approx(reference, abs=1e-9)
+
+
+def test_hundred_sample_fixture_ece_matches_reference() -> None:
+    """ECE on the same fixture matches a hand-rolled 10-bin reference."""
+    preds = [(i + 0.5) / 100 for i in range(100)]
+    obs = [i >= 50 for i in range(100)]
+    # Reference: each of 10 buckets holds 10 predictions; compute by hand.
+    pred_sum = [0.0] * 10
+    obs_sum = [0.0] * 10
+    cnt = [0] * 10
+    for p, o in zip(preds, obs, strict=True):
+        idx = min(int(p * 10), 9)
+        pred_sum[idx] += p
+        obs_sum[idx] += 1.0 if o else 0.0
+        cnt[idx] += 1
+    total = sum(cnt)
+    expected = sum((cnt[i] / total) * abs(pred_sum[i] / cnt[i] - obs_sum[i] / cnt[i]) for i in range(10) if cnt[i] > 0)
+    assert expected_calibration_error(preds, obs) == pytest.approx(expected, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Defensive parity / typing
+# ---------------------------------------------------------------------------
+
+
+def test_record_is_hashable_and_frozen() -> None:
+    """CalibrationRecord is a frozen dataclass — hashable when metadata empty."""
+    record = CalibrationRecord(
+        timestamp=0.0,
+        decision_kind="k",
+        policy_path="p",
+        predicted_prob=0.5,
+        observed_outcome=True,
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        record.predicted_prob = 0.0  # type: ignore[misc]
+
+
+def test_brier_dataclass_is_frozen() -> None:
+    """BrierScore is a frozen dataclass."""
+    b = BrierScore(score=0.0, sample_count=0)
+    with pytest.raises((AttributeError, TypeError)):
+        b.score = 1.0  # type: ignore[misc]
+
+
+def test_reliability_bucket_dataclass_is_frozen() -> None:
+    """ReliabilityBucket is a frozen dataclass."""
+    bucket = ReliabilityBucket(lower=0.0, upper=0.1, count=0, predicted_mean=0.0, observed_mean=0.0)
+    with pytest.raises((AttributeError, TypeError)):
+        bucket.count = 5  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- New `src/bernstein/eval/calibration.py` module exporting `BrierScore`, `expected_calibration_error`, and `reliability_diagram_data` primitives plus on-disk JSONL log helpers (`log_decision`, `load_log`, `compute_report`) that read/write `.sdd/metrics/calibration.jsonl`.
- New `bernstein eval calibration report` CLI command supporting `--since`, `--kind`, `--bins`, `--log-path`, and `--output` flags. Returns `decisions: 0, brier: null` instead of crashing when the window is empty.
- Pure-Python, zero new runtime dependencies. Pyright strict clean. Ruff clean.

## Test plan

- [x] `tests/unit/test_calibration.py` — 76 unit tests covering NaN/Inf rejection, single-prediction edge cases, perfectly calibrated and anti-calibrated inputs, n=2 minimum, malformed log lines, missing-outcome handling, duration parsing, and parity against a hand-rolled 100-sample reference fixture.
- [x] `tests/property/test_calibration_properties.py` — 15 Hypothesis property tests verifying Brier ∈ [0, 1], symmetry under relabel, monotonicity in absolute error, finiteness, ECE bounds, and reliability bucket invariants (bucket count, monotonic bounds, predicted_mean ∈ bucket range).
- [x] `tests/integration/test_calibration_pipeline.py` — 7 integration tests exercising the end-to-end log → load → CLI report flow, including empty-log behaviour, kind filtering, JSON output round-trip, and invalid-duration handling.
- [x] `uv run ruff check` clean on all new/modified files.
- [x] `uv run pyright` (strict) clean on the new module.

Closes #1353.