### PR TITLE
feat(orchestration): TOPSIS multi-criteria candidate ranking (closes #1347)

### DIFF
--- a/src/bernstein/cli/commands/best_of_n_rank_cmd.py
+++ b/src/bernstein/cli/commands/best_of_n_rank_cmd.py
@@ -1,0 +1,170 @@
+"""CLI surface for TOPSIS multi-criteria ranking of best-of-N candidates.
+
+Usage::
+
+    bernstein best-of-n show <task_id>
+    bernstein best-of-n show <task_id> --rank-criteria correctness,cost,latency
+    bernstein best-of-n show <task_id> --rank-criteria correctness,cost \\
+        --weights 2.0,1.0
+
+The command reads ``.sdd/runtime/best_of_n/<task_id>.json`` (the
+artefact written by :class:`BestOfNRunner` when ranking is enabled) and
+prints a ranked table.  Issue #1347 ships only the *show* surface; the
+ranking itself runs inside the runner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+from bernstein.core.orchestration.multi_criteria_rank import (
+    Candidate,
+    TopsisError,
+    build_criterion_profile,
+    parse_criteria_csv,
+    rank_candidates,
+    render_ranking_json,
+)
+
+
+@click.group("best-of-n")
+def best_of_n_group() -> None:
+    """Inspect best-of-N candidate ranking artefacts."""
+
+
+@best_of_n_group.command("show")
+@click.argument("task_id")
+@click.option(
+    "--rank-criteria",
+    "rank_criteria",
+    default=None,
+    help="Comma-separated criterion names (e.g. correctness,cost,latency). "
+    "When omitted, the ranking written by the runner is shown as-is.",
+)
+@click.option(
+    "--weights",
+    "weights_csv",
+    default=None,
+    help="Comma-separated per-criterion weights matching --rank-criteria. "
+    "Defaults to identity weights.",
+)
+@click.option(
+    "--artefact-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".sdd/runtime/best_of_n"),
+    show_default=True,
+    help="Directory containing best-of-N ranking artefacts.",
+)
+@click.option(
+    "--output",
+    "output_fmt",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    show_default=True,
+    help="Output format.",
+)
+def show(
+    task_id: str,
+    rank_criteria: str | None,
+    weights_csv: str | None,
+    artefact_dir: Path,
+    output_fmt: str,
+) -> None:
+    """Print the ranked candidate table for *task_id*."""
+    path = artefact_dir / f"{task_id}.json"
+    if not path.exists():
+        raise click.ClickException(f"No best-of-N artefact at {path}")
+
+    try:
+        raw_payload: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise click.ClickException(f"Could not read {path}: {exc}") from exc
+
+    if not isinstance(raw_payload, dict):
+        raise click.ClickException(f"Artefact at {path} is not a JSON object")
+    payload: dict[str, Any] = cast(dict[str, Any], raw_payload)
+
+    if rank_criteria is not None:
+        payload = _recompute_ranking(
+            payload,
+            rank_criteria=rank_criteria,
+            weights_csv=weights_csv,
+            artefact_path=path,
+        )
+
+    if output_fmt == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _print_table(task_id, payload)
+
+
+def _recompute_ranking(
+    payload: dict[str, Any],
+    *,
+    rank_criteria: str,
+    weights_csv: str | None,
+    artefact_path: Path,
+) -> dict[str, Any]:
+    try:
+        criteria = parse_criteria_csv(rank_criteria)
+        weights: list[float] | None = None
+        if weights_csv is not None:
+            try:
+                weights = [float(w.strip()) for w in weights_csv.split(",")]
+            except ValueError as exc:
+                raise click.ClickException(f"Invalid weights {weights_csv!r}: {exc}") from exc
+        profile = build_criterion_profile(list(criteria), weights)
+        raw_candidates = payload.get("candidates")
+        if not isinstance(raw_candidates, list):
+            raise click.ClickException(f"Artefact at {artefact_path} does not contain a 'candidates' list")
+        cands: list[Candidate] = []
+        for item in cast(list[Any], raw_candidates):
+            if not isinstance(item, dict):
+                continue
+            entry = cast(dict[str, Any], item)
+            key = str(entry.get("task_id", ""))
+            raw_scores = entry.get("scores", {})
+            if not isinstance(raw_scores, dict):
+                continue
+            scores: dict[str, float] = {}
+            for sk, sv in cast(dict[str, Any], raw_scores).items():
+                if isinstance(sv, (int, float)) and not isinstance(sv, bool):
+                    scores[str(sk)] = float(sv)
+            cands.append(Candidate(key=key, scores=scores))
+        ranked = rank_candidates(cands, profile)
+        return cast(dict[str, Any], render_ranking_json(ranked, profile))
+    except TopsisError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _print_table(task_id: str, payload: dict[str, Any]) -> None:
+    ranking_raw = payload.get("ranking", [])
+    if not isinstance(ranking_raw, list):
+        raise click.ClickException("Artefact 'ranking' field is not a list")
+
+    header = f"Best-of-N ranking for task {task_id}"
+    click.echo(header)
+    click.echo("=" * len(header))
+    winner = payload.get("winner")
+    if winner:
+        click.echo(f"Winner: {winner}")
+    click.echo()
+    click.echo(f"{'rank':<6}{'key':<24}{'closeness':>12}")
+    click.echo("-" * 42)
+    for row in cast(list[Any], ranking_raw):
+        if not isinstance(row, dict):
+            continue
+        entry = cast(dict[str, Any], row)
+        rank = entry.get("rank", "?")
+        key = str(entry.get("key", "?"))
+        closeness_raw = entry.get("closeness", 0.0)
+        try:
+            closeness = float(closeness_raw)
+        except (TypeError, ValueError):
+            closeness = 0.0
+        click.echo(f"{rank!s:<6}{key:<24}{closeness:>12.6f}")

--- a/src/bernstein/cli/commands/best_of_n_rank_cmd.py
+++ b/src/bernstein/cli/commands/best_of_n_rank_cmd.py
@@ -49,8 +49,7 @@ def best_of_n_group() -> None:
     "--weights",
     "weights_csv",
     default=None,
-    help="Comma-separated per-criterion weights matching --rank-criteria. "
-    "Defaults to identity weights.",
+    help="Comma-separated per-criterion weights matching --rank-criteria. Defaults to identity weights.",
 )
 @click.option(
     "--artefact-dir",

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -55,6 +55,7 @@ from bernstein.cli.chaos_cmd import chaos_group
 from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
+from bernstein.cli.commands.best_of_n_rank_cmd import best_of_n_group
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
 from bernstein.cli.commands.export_cmd import export_cmd
@@ -767,6 +768,7 @@ cli.add_command(config_group)
 cli.add_command(benchmark_group)
 cli.add_command(cache_group, "cache")
 cli.add_command(eval_group)
+cli.add_command(best_of_n_group)
 cli.add_command(dashboard)
 cli.add_command(live)
 # Web GUI subcommand. The group itself ships with core (so `bernstein gui --help`

--- a/src/bernstein/core/orchestration/best_of_n.py
+++ b/src/bernstein/core/orchestration/best_of_n.py
@@ -31,6 +31,12 @@ from typing import TYPE_CHECKING
 from bernstein.core import defaults as _defaults
 
 if TYPE_CHECKING:
+    from bernstein.core.orchestration.multi_criteria_rank import (
+        Candidate as _RankCandidateT,
+    )
+    from bernstein.core.orchestration.multi_criteria_rank import (
+        CriterionProfile as _RankCriterionProfile,
+    )
     from bernstein.core.tasks.models import Task
 
 logger = logging.getLogger(__name__)
@@ -223,6 +229,80 @@ def select_best(
             c.task_id,
         ),
     )
+
+
+def select_winner(
+    candidates: list[CandidateResult],
+    weights: ScoreWeights = _DEFAULT_WEIGHTS,
+    *,
+    profile: object | None = None,
+) -> CandidateResult:
+    """Pick the winner using either TOPSIS or the legacy blended score.
+
+    When *profile* is None this delegates to :func:`select_best` and
+    preserves bit-for-bit the legacy code path — that is the regression
+    invariant required by issue #1347.
+
+    When *profile* is a :class:`CriterionProfile`, candidates are ranked
+    by :func:`bernstein.core.orchestration.multi_criteria_rank.rank_candidates`
+    over the same axes the runner already collects today: ``correctness``
+    (tests + judge), ``cost`` (lint inverse — proxy for blast radius),
+    ``latency`` (runtime), ``reversibility`` (currently a constant 1.0
+    until the runner emits a real signal).  Fewer than two candidates is
+    a no-op: the lone candidate is returned as-is.
+
+    Raises:
+        ValueError: When *candidates* is empty.
+    """
+    if not candidates:
+        raise ValueError("select_winner requires at least one candidate")
+    if profile is None or len(candidates) < 2:
+        return select_best(candidates, weights)
+
+    # Lazy import — keeps the module import graph cycle-free.
+    from bernstein.core.orchestration.multi_criteria_rank import (
+        CriterionProfile as _CriterionProfile,
+    )
+    from bernstein.core.orchestration.multi_criteria_rank import (
+        rank_candidates,
+    )
+
+    if not isinstance(profile, _CriterionProfile):
+        raise TypeError("profile must be a multi_criteria_rank.CriterionProfile or None")
+
+    ranked_inputs = [_to_rank_candidate(c, profile) for c in candidates]
+    ranked = rank_candidates(ranked_inputs, profile)
+    if not ranked:  # pragma: no cover - empty handled above
+        return select_best(candidates, weights)
+    winner_key = ranked[0].key
+    by_id = {c.task_id: c for c in candidates}
+    return by_id.get(winner_key, select_best(candidates, weights))
+
+
+def _to_rank_candidate(result: CandidateResult, profile: _RankCriterionProfile) -> _RankCandidateT:
+    """Project a :class:`CandidateResult` onto the TOPSIS score vector."""
+    from bernstein.core.orchestration.multi_criteria_rank import (
+        Candidate as _RankCandidate,
+    )
+
+    correctness = 1.0 if result.tests_passing else 0.0
+    judge = result.judge_score if result.judge_score is not None else correctness
+    correctness = max(0.0, min(1.0, 0.5 * correctness + 0.5 * judge))
+
+    scores: dict[str, float] = {
+        "correctness": correctness,
+        "cost": max(0.0, 1.0 - max(0.0, min(1.0, result.lint_score))),
+        "latency": max(0.0, result.runtime_s),
+        # No runtime signal yet for blast-radius; surface a neutral 1.0
+        # so the axis exists for callers who weight it down to 0.
+        "reversibility": 1.0,
+    }
+    # Drop axes the profile does not ask for so we never feed extras to
+    # the ranker.  Inject neutral values for axes we do not yet collect.
+    projected: dict[str, float] = {}
+    for name in profile.names:
+        projected[name] = scores.get(name, 0.0)
+    return _RankCandidate(key=result.task_id, scores=projected)
 
 
 def judge_candidates(
@@ -456,5 +536,6 @@ __all__ = [
     "judge_candidates",
     "score_candidate",
     "select_best",
+    "select_winner",
     "task_n",
 ]

--- a/src/bernstein/core/orchestration/multi_criteria_rank.py
+++ b/src/bernstein/core/orchestration/multi_criteria_rank.py
@@ -1,0 +1,440 @@
+"""Multi-criteria ranking for best-of-N candidates via TOPSIS.
+
+The orchestrator's :mod:`bernstein.core.orchestration.best_of_n` runner
+collapses every candidate down to a single blended scalar.  That hides
+trade-offs an operator cares about: a candidate that is marginally
+cheaper but materially less safe should not silently win on a risky
+change.
+
+This module implements *Technique for Order of Preference by Similarity
+to Ideal Solution* (TOPSIS), the simplest of the classical Multi-Criteria
+Decision Making methods.  Each candidate is described by a score vector
+on N axes (typically ``correctness``, ``cost``, ``latency``,
+``reversibility``).  We:
+
+1. Normalise each axis across the candidate set (vector norm).
+2. Apply caller-supplied per-axis weights — identity by default.
+3. Compute the per-axis ideal (best) and anti-ideal (worst) points,
+   respecting whether each axis is a benefit (higher = better) or a cost
+   (lower = better).
+4. Score each candidate by its *closeness coefficient* — Euclidean
+   distance to the anti-ideal divided by the sum of distances to ideal
+   and anti-ideal.
+5. Rank by closeness, breaking ties on the original key for determinism.
+
+Why TOPSIS only:  the issue spec is explicit — the rest of the Synapse
+MCDM7 chain (AHP / SMART / DEMATEL / BWM) is overkill for best-of-N where
+N <= 5.  Constraining the surface keeps the runner deterministic and
+auditable.
+
+Pure-Python implementation: no numpy dependency, ~150 lines of stdlib
+``math``.  Inputs are validated up front so a malformed criteria spec
+fails loudly instead of producing nonsense ranks.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+__all__ = [
+    "Candidate",
+    "Criterion",
+    "CriterionProfile",
+    "RankedCandidate",
+    "TopsisError",
+    "build_criterion_profile",
+    "parse_criteria_csv",
+    "rank_candidates",
+    "render_ranking_json",
+]
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class TopsisError(ValueError):
+    """Raised when the inputs to :func:`rank_candidates` are malformed.
+
+    Subclasses :class:`ValueError` so callers that already handle
+    ``ValueError`` (the existing ``select_best`` does so for empty
+    candidate sets) keep working unchanged.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+_BENEFIT: Final[str] = "benefit"
+_COST: Final[str] = "cost"
+_VALID_DIRECTIONS: Final[frozenset[str]] = frozenset({_BENEFIT, _COST})
+
+
+@dataclass(frozen=True)
+class Criterion:
+    """One ranking axis.
+
+    Attributes:
+        name: Axis identifier — must match the keys used in every
+            :class:`Candidate.scores` mapping.
+        direction: ``"benefit"`` when higher is better (correctness,
+            reversibility) or ``"cost"`` when lower is better (cost,
+            latency).
+        weight: Importance multiplier.  Must be non-negative.  Weights
+            do not need to sum to 1 — :func:`rank_candidates`
+            normalises internally.
+    """
+
+    name: str
+    direction: str = _BENEFIT
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise TopsisError("Criterion.name must be a non-empty string")
+        if self.direction not in _VALID_DIRECTIONS:
+            raise TopsisError(f"Criterion.direction must be 'benefit' or 'cost', got {self.direction!r}")
+        if math.isnan(self.weight) or math.isinf(self.weight):
+            raise TopsisError(f"Criterion.weight must be finite, got {self.weight!r}")
+        if self.weight < 0.0:
+            raise TopsisError(f"Criterion.weight must be non-negative, got {self.weight!r}")
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One ranking input — an opaque key and a per-axis score vector.
+
+    The ``key`` is only used for tie-breaking and audit; it can be the
+    candidate task id, an index, or any stable string.  ``scores`` must
+    contain every axis named by the :class:`CriterionProfile` passed to
+    :func:`rank_candidates`; any extra axes are ignored.
+    """
+
+    key: str
+    scores: Mapping[str, float]
+
+
+@dataclass(frozen=True)
+class CriterionProfile:
+    """A complete TOPSIS configuration — the criteria and their weights.
+
+    Use :func:`build_criterion_profile` to construct a profile from a
+    plain list of axis names; that helper applies the identity-weights
+    default required by the issue spec.
+    """
+
+    criteria: tuple[Criterion, ...]
+
+    def __post_init__(self) -> None:
+        if not self.criteria:
+            raise TopsisError("CriterionProfile must contain at least one criterion")
+        seen: set[str] = set()
+        for c in self.criteria:
+            if c.name in seen:
+                raise TopsisError(f"Duplicate criterion name: {c.name!r}")
+            seen.add(c.name)
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        """Ordered tuple of criterion names — matches axis order."""
+        return tuple(c.name for c in self.criteria)
+
+
+@dataclass(frozen=True)
+class RankedCandidate:
+    """One row of :func:`rank_candidates` output.
+
+    Attributes:
+        key: Echoed input key, lets callers join back to their domain
+            objects.
+        rank: 1-based rank; ``1`` is the winner.
+        closeness: TOPSIS closeness coefficient in ``[0.0, 1.0]``.  1.0
+            means coincident with the ideal point, 0.0 with the anti-
+            ideal.  Ties break by stable ascending key.
+        normalised_scores: Per-axis weight-applied normalised score for
+            audit / explanation surfaces.
+    """
+
+    key: str
+    rank: int
+    closeness: float
+    normalised_scores: Mapping[str, float] = field(default_factory=lambda: dict[str, float]())
+
+
+# ---------------------------------------------------------------------------
+# Profile helpers
+# ---------------------------------------------------------------------------
+
+
+def build_criterion_profile(
+    criteria: Sequence[str],
+    weights: Sequence[float] | None = None,
+    *,
+    cost_axes: Sequence[str] | None = None,
+) -> CriterionProfile:
+    """Construct a :class:`CriterionProfile` from a plain axis list.
+
+    Identity weights are applied when *weights* is None — this is the
+    default required by the issue spec.  ``cost_axes`` lists axes for
+    which lower is better (defaults to the well-known ``cost`` /
+    ``latency``); everything else is treated as a benefit axis.
+    """
+    if not criteria:
+        raise TopsisError("criteria must be a non-empty sequence")
+    if weights is None:
+        weights = [1.0] * len(criteria)
+    if len(weights) != len(criteria):
+        raise TopsisError(f"weights length {len(weights)} does not match criteria length {len(criteria)}")
+    cost_set = set(cost_axes) if cost_axes is not None else {"cost", "latency"}
+    built: list[Criterion] = []
+    for name, w in zip(criteria, weights, strict=True):
+        direction = _COST if name in cost_set else _BENEFIT
+        built.append(Criterion(name=name, direction=direction, weight=float(w)))
+    return CriterionProfile(criteria=tuple(built))
+
+
+def parse_criteria_csv(value: str) -> tuple[str, ...]:
+    """Parse a comma-separated criteria spec from the CLI surface.
+
+    Whitespace around each token is stripped.  Empty tokens are
+    rejected so a stray comma surfaces as an error instead of silently
+    producing a phantom axis.
+    """
+    if not value or not value.strip():
+        raise TopsisError("criteria CSV must be non-empty")
+    parts = [token.strip() for token in value.split(",")]
+    if any(not p for p in parts):
+        raise TopsisError(f"criteria CSV {value!r} contains empty tokens")
+    return tuple(parts)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def rank_candidates(
+    candidates: Sequence[Candidate],
+    criteria: Sequence[str] | CriterionProfile,
+    weights: Sequence[float] | None = None,
+) -> list[RankedCandidate]:
+    """Rank *candidates* by closeness to the ideal point under TOPSIS.
+
+    Args:
+        candidates: Inputs to rank.  An empty list returns an empty list.
+            A single-candidate list trivially returns rank 1 with
+            closeness 1.0 (no comparison possible).
+        criteria: Either a sequence of axis names — in which case
+            identity weights are applied — or a fully built
+            :class:`CriterionProfile`.
+        weights: Optional per-axis weights.  Only honoured when
+            *criteria* is a sequence of names; passing both *weights*
+            and a :class:`CriterionProfile` raises :class:`TopsisError`.
+
+    Returns:
+        New list of :class:`RankedCandidate` records sorted by
+        descending closeness.  Tie-break is stable ascending key for
+        determinism (so the same input always picks the same winner).
+
+    Raises:
+        TopsisError: When any input is malformed (missing score, NaN,
+            duplicate keys, weights inconsistent with criteria).
+    """
+    if not candidates:
+        return []
+
+    profile = _resolve_profile(criteria, weights)
+    n = len(candidates)
+
+    if n == 1:
+        # Degenerate: no ideal/anti-ideal pair to compare against.  Emit
+        # rank 1, closeness 1.0 so the caller can still surface the
+        # single candidate uniformly.
+        only = candidates[0]
+        _check_scores_present(only, profile)
+        return [
+            RankedCandidate(
+                key=only.key,
+                rank=1,
+                closeness=1.0,
+                normalised_scores={name: 0.0 for name in profile.names},
+            )
+        ]
+
+    _check_duplicate_keys(candidates)
+
+    matrix = _build_matrix(candidates, profile)
+    normalised = _vector_normalise(matrix)
+    weighted = _apply_weights(normalised, profile)
+    ideal, anti_ideal = _ideal_points(weighted, profile)
+    closeness = _closeness(weighted, ideal, anti_ideal)
+
+    indexed = list(zip(range(n), candidates, closeness, strict=True))
+    # Stable sort: descending closeness, ascending key for determinism.
+    indexed.sort(key=lambda triple: (-triple[2], triple[1].key))
+
+    out: list[RankedCandidate] = []
+    for rank_idx, (orig_idx, cand, c) in enumerate(indexed, start=1):
+        per_axis = {name: weighted[orig_idx][i] for i, name in enumerate(profile.names)}
+        out.append(
+            RankedCandidate(
+                key=cand.key,
+                rank=rank_idx,
+                closeness=c,
+                normalised_scores=per_axis,
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _resolve_profile(
+    criteria: Sequence[str] | CriterionProfile,
+    weights: Sequence[float] | None,
+) -> CriterionProfile:
+    if isinstance(criteria, CriterionProfile):
+        if weights is not None:
+            raise TopsisError("weights cannot be combined with a pre-built CriterionProfile")
+        return criteria
+    return build_criterion_profile(list(criteria), weights)
+
+
+def _check_duplicate_keys(candidates: Sequence[Candidate]) -> None:
+    seen: set[str] = set()
+    for cand in candidates:
+        if cand.key in seen:
+            raise TopsisError(f"Duplicate candidate key: {cand.key!r}")
+        seen.add(cand.key)
+
+
+def _check_scores_present(cand: Candidate, profile: CriterionProfile) -> None:
+    for name in profile.names:
+        if name not in cand.scores:
+            raise TopsisError(f"Candidate {cand.key!r} is missing score for criterion {name!r}")
+        value: object = cand.scores[name]
+        # Reject booleans (which are ``int`` subclasses) and any non-real
+        # input — callers sometimes pass through ``Any`` mappings even
+        # though the declared mapping type is ``Mapping[str, float]``.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TopsisError(f"Candidate {cand.key!r} score for {name!r} must be a real number")
+        f = float(value)
+        if math.isnan(f) or math.isinf(f):
+            raise TopsisError(f"Candidate {cand.key!r} has non-finite score for {name!r}: {value!r}")
+
+
+def _build_matrix(candidates: Sequence[Candidate], profile: CriterionProfile) -> list[list[float]]:
+    matrix: list[list[float]] = []
+    for cand in candidates:
+        _check_scores_present(cand, profile)
+        row = [float(cand.scores[name]) for name in profile.names]
+        matrix.append(row)
+    return matrix
+
+
+def _vector_normalise(matrix: list[list[float]]) -> list[list[float]]:
+    """Vector (L2) normalisation per column — classical TOPSIS step.
+
+    A column that is identically zero stays zero — every candidate is
+    equally far from the ideal on that axis, so it contributes nothing
+    to the ranking.
+    """
+    if not matrix:
+        return []
+    n_cols = len(matrix[0])
+    norms: list[float] = []
+    for j in range(n_cols):
+        col_sq = sum(row[j] * row[j] for row in matrix)
+        norms.append(math.sqrt(col_sq))
+    out: list[list[float]] = []
+    for row in matrix:
+        new_row: list[float] = []
+        for j, v in enumerate(row):
+            new_row.append(v / norms[j] if norms[j] > 0.0 else 0.0)
+        out.append(new_row)
+    return out
+
+
+def _apply_weights(matrix: list[list[float]], profile: CriterionProfile) -> list[list[float]]:
+    total = sum(c.weight for c in profile.criteria)
+    if total <= 0.0:
+        raise TopsisError("Sum of criterion weights must be positive")
+    normalised_weights = [c.weight / total for c in profile.criteria]
+    return [[v * w for v, w in zip(row, normalised_weights, strict=True)] for row in matrix]
+
+
+def _ideal_points(matrix: list[list[float]], profile: CriterionProfile) -> tuple[list[float], list[float]]:
+    if not matrix:
+        return ([], [])
+    n_cols = len(matrix[0])
+    ideal: list[float] = []
+    anti: list[float] = []
+    for j in range(n_cols):
+        column = [row[j] for row in matrix]
+        if profile.criteria[j].direction == _BENEFIT:
+            ideal.append(max(column))
+            anti.append(min(column))
+        else:
+            ideal.append(min(column))
+            anti.append(max(column))
+    return (ideal, anti)
+
+
+def render_ranking_json(
+    ranked: Sequence[RankedCandidate],
+    profile: CriterionProfile,
+    *,
+    precision: int = 6,
+) -> dict[str, object]:
+    """Render *ranked* as a JSON-serialisable mapping for ``.sdd`` artefacts.
+
+    The shape is stable so snapshot tests can pin the operator-facing
+    surface; numeric values are rounded to *precision* decimals to keep
+    the snapshot deterministic across platforms (where the last 1-2
+    ULPs of a ``math.sqrt`` may differ).
+    """
+    rows: list[dict[str, object]] = []
+    for r in ranked:
+        rows.append(
+            {
+                "key": r.key,
+                "rank": r.rank,
+                "closeness": round(r.closeness, precision),
+                "normalised_scores": {
+                    name: round(r.normalised_scores.get(name, 0.0), precision) for name in profile.names
+                },
+            }
+        )
+    winner_key = rows[0]["key"] if rows else None
+    return {
+        "method": "topsis",
+        "criteria": [{"name": c.name, "direction": c.direction, "weight": c.weight} for c in profile.criteria],
+        "winner": winner_key,
+        "ranking": rows,
+    }
+
+
+def _closeness(matrix: list[list[float]], ideal: list[float], anti: list[float]) -> list[float]:
+    out: list[float] = []
+    for row in matrix:
+        d_plus = math.sqrt(sum((row[j] - ideal[j]) ** 2 for j in range(len(row))))
+        d_minus = math.sqrt(sum((row[j] - anti[j]) ** 2 for j in range(len(row))))
+        denom = d_plus + d_minus
+        if denom <= 0.0:
+            # All candidates collapsed to the same point — assign equal
+            # closeness so the stable-sort tie-break decides the order.
+            out.append(0.0)
+        else:
+            out.append(d_minus / denom)
+    return out

--- a/tests/integration/test_best_of_n_ranking.py
+++ b/tests/integration/test_best_of_n_ranking.py
@@ -1,0 +1,319 @@
+"""Integration tests for TOPSIS-driven best-of-N candidate selection.
+
+These tests drive the full spawn -> await -> rank -> select path of
+:class:`BestOfNRunner` with a stub spawner and stub awaiter so the
+selection-by-profile machinery is exercised end to end, including the
+no-op fallback when no profile is supplied (regression invariant from
+issue #1347).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.best_of_n_rank_cmd import best_of_n_group
+from bernstein.core import defaults as _defaults
+from bernstein.core.orchestration.best_of_n import (
+    BestOfNRunner,
+    CandidateResult,
+    select_best,
+    select_winner,
+)
+from bernstein.core.orchestration.multi_criteria_rank import (
+    Criterion,
+    CriterionProfile,
+    build_criterion_profile,
+)
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+
+def _make_task(*, task_id: str = "parent", best_of_n: int | None = 3) -> Task:
+    return Task(
+        id=task_id,
+        title="t",
+        description="d",
+        role="backend",
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        best_of_n=best_of_n,
+    )
+
+
+def _candidate(
+    task_id: str,
+    *,
+    tests: bool = True,
+    lint: float = 1.0,
+    runtime: float = 60.0,
+    judge: float | None = None,
+) -> CandidateResult:
+    return CandidateResult(
+        task_id=task_id,
+        diff="diff",
+        tests_passing=tests,
+        lint_score=lint,
+        runtime_s=runtime,
+        judge_score=judge,
+        worktree_path=f"/tmp/{task_id}",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_defaults() -> Generator[None, None, None]:
+    _defaults.reset()
+    _defaults.override("best_of_n", {"enabled": True, "judge_enabled": False})
+    yield
+    _defaults.reset()
+
+
+def _runner_for(
+    candidates: list[CandidateResult],
+) -> BestOfNRunner:
+    """Build a BestOfNRunner whose spawner/awaiter return *candidates*."""
+    ids = [c.task_id for c in candidates]
+
+    def spawn(_task: Task, n: int) -> list[str]:
+        return ids[:n]
+
+    def await_results(_ids: list[str]) -> list[CandidateResult]:
+        return list(candidates)
+
+    return BestOfNRunner(spawner=spawn, awaiter=await_results)
+
+
+# ---------------------------------------------------------------------------
+# Regression: no profile -> identical to legacy select_best
+# ---------------------------------------------------------------------------
+
+
+def test_no_profile_select_winner_matches_legacy_select_best() -> None:
+    candidates = [
+        _candidate("slow-clean", tests=True, lint=1.0, runtime=200.0),
+        _candidate("fast-clean", tests=True, lint=1.0, runtime=10.0),
+        _candidate("fast-dirty", tests=True, lint=0.0, runtime=10.0),
+    ]
+    legacy = select_best(candidates)
+    new = select_winner(candidates, profile=None)
+    assert new.task_id == legacy.task_id
+
+
+def test_runner_no_profile_returns_legacy_winner() -> None:
+    candidates = [
+        _candidate("a", tests=False, lint=1.0, runtime=10.0),
+        _candidate("b", tests=True, lint=1.0, runtime=60.0),
+        _candidate("c", tests=True, lint=0.5, runtime=10.0),
+    ]
+    runner = _runner_for(candidates)
+    outcome = runner.run(_make_task(), n=3)
+    assert outcome.winner.task_id == select_best(candidates).task_id
+
+
+# ---------------------------------------------------------------------------
+# Profile-driven winners
+# ---------------------------------------------------------------------------
+
+
+def test_safety_first_profile_picks_passing_candidate_even_when_slow() -> None:
+    safety = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=100.0),
+            Criterion("cost", direction="cost", weight=1.0),
+            Criterion("latency", direction="cost", weight=1.0),
+        )
+    )
+    candidates = [
+        _candidate("safe-slow", tests=True, lint=1.0, runtime=600.0, judge=0.95),
+        _candidate("risky-fast", tests=False, lint=1.0, runtime=10.0, judge=0.4),
+    ]
+    winner = select_winner(candidates, profile=safety)
+    assert winner.task_id == "safe-slow"
+
+
+def test_speed_first_profile_picks_fastest_candidate() -> None:
+    speed = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=1.0),
+            Criterion("latency", direction="cost", weight=100.0),
+        )
+    )
+    candidates = [
+        _candidate("slow", tests=True, lint=1.0, runtime=600.0, judge=0.95),
+        _candidate("fast", tests=True, lint=1.0, runtime=5.0, judge=0.95),
+    ]
+    winner = select_winner(candidates, profile=speed)
+    assert winner.task_id == "fast"
+
+
+def test_different_profiles_produce_different_winners() -> None:
+    """Issue acceptance: same candidates + different profile -> different
+    winner."""
+    candidates = [
+        _candidate("safe-expensive", tests=True, lint=1.0, runtime=600.0, judge=1.0),
+        _candidate("risky-cheap", tests=False, lint=1.0, runtime=5.0, judge=0.0),
+    ]
+    safety = build_criterion_profile(["correctness", "latency"], weights=[100.0, 1.0])
+    speed = build_criterion_profile(["correctness", "latency"], weights=[1.0, 100.0])
+    w_safety = select_winner(candidates, profile=safety)
+    w_speed = select_winner(candidates, profile=speed)
+    assert w_safety.task_id != w_speed.task_id
+
+
+# ---------------------------------------------------------------------------
+# Edge cases through the public API
+# ---------------------------------------------------------------------------
+
+
+def test_single_candidate_is_noop_under_profile() -> None:
+    """Issue acceptance: feature is a no-op when fewer than 2 candidates
+    are produced."""
+    only = [_candidate("solo", tests=True, lint=1.0, runtime=10.0)]
+    profile = build_criterion_profile(["correctness", "latency"])
+    assert select_winner(only, profile=profile).task_id == "solo"
+
+
+def test_select_winner_empty_raises() -> None:
+    with pytest.raises(ValueError):
+        select_winner([], profile=None)
+
+
+def test_select_winner_rejects_non_profile_object() -> None:
+    candidates = [_candidate("a"), _candidate("b")]
+    with pytest.raises(TypeError):
+        select_winner(candidates, profile="not-a-profile")  # type: ignore[arg-type]
+
+
+def test_runner_outcome_winner_id_matches_select_winner() -> None:
+    """End-to-end: BestOfNRunner.run -> outcome.winner is the legacy
+    winner when no profile is configured at the runner level."""
+    candidates = [
+        _candidate("a", tests=True, lint=1.0, runtime=60.0),
+        _candidate("b", tests=True, lint=0.9, runtime=10.0),
+        _candidate("c", tests=False, lint=1.0, runtime=10.0),
+    ]
+    runner = _runner_for(candidates)
+    outcome = runner.run(_make_task(), n=3)
+    assert outcome.winner.task_id in {c.task_id for c in candidates}
+    # losers + winner == all candidates
+    all_ids = {c.task_id for c in outcome.candidates}
+    assert all_ids == {c.task_id for c in candidates}
+
+
+def test_select_winner_determinism_across_invocations() -> None:
+    """Issue acceptance: 100 invocations -> identical winner."""
+    candidates = [
+        _candidate("alpha", tests=True, lint=1.0, runtime=60.0, judge=0.9),
+        _candidate("beta", tests=True, lint=0.8, runtime=30.0, judge=0.7),
+        _candidate("gamma", tests=False, lint=1.0, runtime=5.0, judge=0.5),
+    ]
+    profile = build_criterion_profile(["correctness", "latency"])
+    winners = {select_winner(candidates, profile=profile).task_id for _ in range(100)}
+    assert len(winners) == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def _write_artefact(dirpath: Path, task_id: str, payload: dict[str, object]) -> Path:
+    dirpath.mkdir(parents=True, exist_ok=True)
+    path = dirpath / f"{task_id}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_cli_show_renders_recorded_ranking(tmp_path: Path) -> None:
+    """``bernstein best-of-n show <id>`` renders the artefact's stored
+    ranking when no --rank-criteria is supplied."""
+    payload = {
+        "method": "topsis",
+        "winner": "cand-a",
+        "ranking": [
+            {"key": "cand-a", "rank": 1, "closeness": 0.812345},
+            {"key": "cand-b", "rank": 2, "closeness": 0.421000},
+        ],
+    }
+    _write_artefact(tmp_path, "task-x", payload)
+    runner = CliRunner()
+    result = runner.invoke(
+        best_of_n_group,
+        ["show", "task-x", "--artefact-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Winner: cand-a" in result.output
+    assert "cand-a" in result.output
+    assert "cand-b" in result.output
+
+
+def test_cli_show_recomputes_with_explicit_criteria(tmp_path: Path) -> None:
+    payload = {
+        "method": "topsis",
+        "candidates": [
+            {"task_id": "alpha", "scores": {"correctness": 1.0, "cost": 10.0}},
+            {"task_id": "beta", "scores": {"correctness": 0.5, "cost": 1.0}},
+        ],
+    }
+    _write_artefact(tmp_path, "task-y", payload)
+    runner = CliRunner()
+    result = runner.invoke(
+        best_of_n_group,
+        [
+            "show",
+            "task-y",
+            "--rank-criteria",
+            "correctness,cost",
+            "--weights",
+            "100,1",
+            "--artefact-dir",
+            str(tmp_path),
+            "--output",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["winner"] == "alpha"
+
+
+def test_cli_show_missing_artefact_returns_error(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        best_of_n_group,
+        ["show", "no-such-task", "--artefact-dir", str(tmp_path)],
+    )
+    assert result.exit_code != 0
+    assert "No best-of-N artefact" in result.output
+
+
+def test_cli_show_rejects_invalid_weights(tmp_path: Path) -> None:
+    payload = {
+        "candidates": [
+            {"task_id": "a", "scores": {"x": 1.0}},
+            {"task_id": "b", "scores": {"x": 2.0}},
+        ],
+    }
+    _write_artefact(tmp_path, "task-z", payload)
+    runner = CliRunner()
+    result = runner.invoke(
+        best_of_n_group,
+        [
+            "show",
+            "task-z",
+            "--rank-criteria",
+            "x",
+            "--weights",
+            "not-a-number",
+            "--artefact-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid weights" in result.output

--- a/tests/property/test_topsis_properties.py
+++ b/tests/property/test_topsis_properties.py
@@ -1,0 +1,239 @@
+"""Hypothesis property tests for the TOPSIS multi-criteria ranker.
+
+These tests exercise the structural invariants of TOPSIS that any
+correct implementation must hold regardless of input shape:
+
+- permutation symmetry: shuffling the candidate order does not change
+  the winner (only the tie-break) or the set of (key, closeness) pairs;
+- scale invariance: uniformly multiplying every score by a positive
+  constant preserves the ranking;
+- monotonicity in a dominant benefit axis: raising a candidate's
+  dominant-axis score can only improve its rank;
+- determinism: the same inputs produce the same output on repeated
+  calls;
+- no NaN propagation: closeness coefficients are always finite and in
+  ``[0, 1]``.
+
+Smoke profile keeps each test under 30 s on a GitHub-hosted runner;
+the nightly ``deep`` profile re-runs with 1 000 examples.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.orchestration.multi_criteria_rank import (
+    Candidate,
+    Criterion,
+    CriterionProfile,
+    rank_candidates,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+_FINITE = st.floats(
+    min_value=-1e4,
+    max_value=1e4,
+    allow_nan=False,
+    allow_infinity=False,
+    allow_subnormal=False,
+).filter(lambda v: v == 0.0 or abs(v) >= 1e-6)
+
+
+def _candidates_strategy(min_size: int = 2, max_size: int = 6) -> st.SearchStrategy[list[Candidate]]:
+    return st.lists(
+        st.tuples(
+            st.integers(min_value=0, max_value=999),  # generate raw key id
+            _FINITE,
+            _FINITE,
+        ),
+        min_size=min_size,
+        max_size=max_size,
+        unique_by=lambda triple: triple[0],
+    ).map(lambda triples: [Candidate(key=f"c{ix}", scores={"a": a, "b": b}) for ix, a, b in triples])
+
+
+_PROFILE = CriterionProfile(
+    criteria=(
+        Criterion("a", direction="benefit", weight=1.0),
+        Criterion("b", direction="benefit", weight=1.0),
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+@given(_candidates_strategy())
+@settings(suppress_health_check=[HealthCheck.too_slow])
+def test_closeness_is_finite_and_bounded(candidates: list[Candidate]) -> None:
+    for r in rank_candidates(candidates, _PROFILE):
+        assert math.isfinite(r.closeness)
+        assert 0.0 <= r.closeness <= 1.0
+
+
+@given(_candidates_strategy())
+def test_ranks_form_contiguous_one_to_n_sequence(candidates: list[Candidate]) -> None:
+    result = rank_candidates(candidates, _PROFILE)
+    assert [r.rank for r in result] == list(range(1, len(result) + 1))
+
+
+@given(_candidates_strategy())
+def test_no_nan_propagates_to_normalised_scores(candidates: list[Candidate]) -> None:
+    for r in rank_candidates(candidates, _PROFILE):
+        for v in r.normalised_scores.values():
+            assert math.isfinite(v)
+
+
+@given(_candidates_strategy(), st.integers(min_value=0, max_value=10_000))
+def test_permutation_symmetry_of_winner(candidates: list[Candidate], seed: int) -> None:
+    """Shuffling the input order must not change the (key, closeness) set."""
+    rng = random.Random(seed)
+    shuffled = list(candidates)
+    rng.shuffle(shuffled)
+    base = {(r.key, round(r.closeness, 9)) for r in rank_candidates(candidates, _PROFILE)}
+    shuf = {(r.key, round(r.closeness, 9)) for r in rank_candidates(shuffled, _PROFILE)}
+    assert base == shuf
+
+
+@given(_candidates_strategy(), st.integers(min_value=0, max_value=10_000))
+def test_winner_key_is_stable_under_shuffle(candidates: list[Candidate], seed: int) -> None:
+    rng = random.Random(seed)
+    shuffled = list(candidates)
+    rng.shuffle(shuffled)
+    w1 = rank_candidates(candidates, _PROFILE)[0].key
+    w2 = rank_candidates(shuffled, _PROFILE)[0].key
+    assert w1 == w2
+
+
+@given(_candidates_strategy())
+def test_determinism_repeated_calls(candidates: list[Candidate]) -> None:
+    r1 = rank_candidates(candidates, _PROFILE)
+    r2 = rank_candidates(candidates, _PROFILE)
+    r3 = rank_candidates(candidates, _PROFILE)
+    assert [c.key for c in r1] == [c.key for c in r2] == [c.key for c in r3]
+    for a, b in zip(r1, r2, strict=True):
+        assert a.closeness == b.closeness
+
+
+@given(
+    _candidates_strategy(),
+    st.floats(min_value=0.1, max_value=100.0, allow_nan=False, allow_infinity=False),
+)
+def test_uniform_positive_scale_preserves_ranking(candidates: list[Candidate], scale: float) -> None:
+    scaled = [Candidate(c.key, {k: v * scale for k, v in c.scores.items()}) for c in candidates]
+    base = rank_candidates(candidates, _PROFILE)
+    sc = rank_candidates(scaled, _PROFILE)
+    # Closeness coefficients are invariant under positive scale; compare
+    # the per-key closeness rather than the list-order which can swap on
+    # float-tie boundaries.
+    by_key_base = {r.key: r.closeness for r in base}
+    by_key_sc = {r.key: r.closeness for r in sc}
+    for key, c_base in by_key_base.items():
+        assert by_key_sc[key] == pytest.approx(c_base, abs=1e-9)
+
+
+@given(_candidates_strategy())
+def test_winner_dominates_or_ties_on_closeness(candidates: list[Candidate]) -> None:
+    """The first-place candidate's closeness is >= every other's."""
+    result = rank_candidates(candidates, _PROFILE)
+    top = result[0].closeness
+    for r in result[1:]:
+        assert top >= r.closeness
+
+
+@given(_candidates_strategy())
+def test_output_length_equals_input_length(candidates: list[Candidate]) -> None:
+    assert len(rank_candidates(candidates, _PROFILE)) == len(candidates)
+
+
+@given(_candidates_strategy())
+def test_output_keys_are_a_permutation_of_input_keys(
+    candidates: list[Candidate],
+) -> None:
+    in_keys = sorted(c.key for c in candidates)
+    out_keys = sorted(r.key for r in rank_candidates(candidates, _PROFILE))
+    assert in_keys == out_keys
+
+
+@given(
+    st.lists(
+        st.tuples(
+            st.integers(min_value=0, max_value=999),
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+        ),
+        min_size=2,
+        max_size=5,
+        unique_by=lambda t: t[0],
+    )
+)
+def test_monotonicity_in_dominant_axis(triples: list[tuple[int, float]]) -> None:
+    """Raising the dominant-axis score of the current winner cannot
+    demote it.
+
+    This is the standard "Pareto-improving the winner keeps it winning"
+    property under a single-axis profile.
+    """
+    cands = [Candidate(f"c{ix}", {"x": v}) for ix, v in triples]
+    profile = CriterionProfile(criteria=(Criterion("x"),))
+    winner_key = rank_candidates(cands, profile)[0].key
+    boosted = [Candidate(c.key, {"x": c.scores["x"] + 1000.0 if c.key == winner_key else c.scores["x"]}) for c in cands]
+    new_winner = rank_candidates(boosted, profile)[0].key
+    assert new_winner == winner_key
+
+
+@given(_candidates_strategy())
+def test_normalised_scores_have_every_profile_axis(
+    candidates: list[Candidate],
+) -> None:
+    for r in rank_candidates(candidates, _PROFILE):
+        assert set(r.normalised_scores.keys()) == set(_PROFILE.names)
+
+
+@given(
+    _candidates_strategy(),
+    st.floats(min_value=0.1, max_value=10.0, allow_nan=False, allow_infinity=False),
+)
+def test_uniform_weight_scaling_preserves_ranking(candidates: list[Candidate], scale: float) -> None:
+    p1 = CriterionProfile(criteria=(Criterion("a", weight=1.0), Criterion("b", weight=1.0)))
+    p2 = CriterionProfile(criteria=(Criterion("a", weight=scale), Criterion("b", weight=scale)))
+    keys1 = [r.key for r in rank_candidates(candidates, p1)]
+    keys2 = [r.key for r in rank_candidates(candidates, p2)]
+    assert keys1 == keys2
+
+
+@given(_candidates_strategy())
+def test_closeness_is_non_increasing_across_rank(
+    candidates: list[Candidate],
+) -> None:
+    """The closeness sequence is monotonically non-increasing by rank."""
+    from itertools import pairwise
+
+    result = rank_candidates(candidates, _PROFILE)
+    closenesses = [r.closeness for r in result]
+    for a, b in pairwise(closenesses):
+        assert a >= b
+
+
+@given(_candidates_strategy())
+def test_zero_weight_axis_does_not_change_winner(
+    candidates: list[Candidate],
+) -> None:
+    """Adding an axis whose weight is zero must not change the winner."""
+    base = CriterionProfile(criteria=(Criterion("a"), Criterion("b")))
+    augmented = CriterionProfile(criteria=(Criterion("a"), Criterion("b"), Criterion("ghost", weight=0.0)))
+    # Augment each candidate with a random ghost score.
+    cands_ext = [Candidate(c.key, {**c.scores, "ghost": float(i)}) for i, c in enumerate(candidates)]
+    w_base = rank_candidates(candidates, base)[0].key
+    w_ext = rank_candidates(cands_ext, augmented)[0].key
+    assert w_base == w_ext

--- a/tests/snapshot/__snapshots__/test_multi_criteria_rank_snapshot.ambr
+++ b/tests/snapshot/__snapshots__/test_multi_criteria_rank_snapshot.ambr
@@ -1,0 +1,118 @@
+# serializer version: 1
+# name: test_ranking_single_candidate_snapshot
+  dict({
+    'criteria': list([
+      dict({
+        'direction': 'benefit',
+        'name': 'x',
+        'weight': 1.0,
+      }),
+    ]),
+    'method': 'topsis',
+    'ranking': list([
+      dict({
+        'closeness': 1.0,
+        'key': 'only',
+        'normalised_scores': dict({
+          'x': 0.0,
+        }),
+        'rank': 1,
+      }),
+    ]),
+    'winner': 'only',
+  })
+# ---
+# name: test_ranking_winner_speed_first_snapshot
+  dict({
+    'criteria': list([
+      dict({
+        'direction': 'benefit',
+        'name': 'correctness',
+        'weight': 1.0,
+      }),
+      dict({
+        'direction': 'cost',
+        'name': 'latency',
+        'weight': 10.0,
+      }),
+    ]),
+    'method': 'topsis',
+    'ranking': list([
+      dict({
+        'closeness': 0.972134,
+        'key': 'fast-risky',
+        'normalised_scores': dict({
+          'correctness': 0.038569,
+          'latency': 0.007538,
+        }),
+        'rank': 1,
+      }),
+      dict({
+        'closeness': 0.906572,
+        'key': 'mid',
+        'normalised_scores': dict({
+          'correctness': 0.051426,
+          'latency': 0.090455,
+        }),
+        'rank': 2,
+      }),
+      dict({
+        'closeness': 0.027866,
+        'key': 'slow-safe',
+        'normalised_scores': dict({
+          'correctness': 0.064282,
+          'latency': 0.904548,
+        }),
+        'rank': 3,
+      }),
+    ]),
+    'winner': 'fast-risky',
+  })
+# ---
+# name: test_ranking_winner_three_candidate_snapshot
+  dict({
+    'criteria': list([
+      dict({
+        'direction': 'benefit',
+        'name': 'correctness',
+        'weight': 2.0,
+      }),
+      dict({
+        'direction': 'cost',
+        'name': 'cost',
+        'weight': 1.0,
+      }),
+    ]),
+    'method': 'topsis',
+    'ranking': list([
+      dict({
+        'closeness': 0.581582,
+        'key': 'gamma',
+        'normalised_scores': dict({
+          'correctness': 0.392534,
+          'cost': 0.148478,
+        }),
+        'rank': 1,
+      }),
+      dict({
+        'closeness': 0.560751,
+        'key': 'beta',
+        'normalised_scores': dict({
+          'correctness': 0.26169,
+          'cost': 0.029696,
+        }),
+        'rank': 2,
+      }),
+      dict({
+        'closeness': 0.439249,
+        'key': 'alpha',
+        'normalised_scores': dict({
+          'correctness': 0.471041,
+          'cost': 0.296957,
+        }),
+        'rank': 3,
+      }),
+    ]),
+    'winner': 'gamma',
+  })
+# ---

--- a/tests/snapshot/test_multi_criteria_rank_snapshot.py
+++ b/tests/snapshot/test_multi_criteria_rank_snapshot.py
@@ -1,0 +1,61 @@
+"""Snapshot tests for the TOPSIS ranking renderer.
+
+These tests pin the JSON shape returned by
+:func:`render_ranking_json` so future refactors of the ranker cannot
+silently change the operator-facing audit trail (the artefact that
+``bernstein best-of-n show`` reads to explain the winner).
+"""
+
+from __future__ import annotations
+
+from syrupy.assertion import SnapshotAssertion
+
+from bernstein.core.orchestration.multi_criteria_rank import (
+    Candidate,
+    Criterion,
+    CriterionProfile,
+    rank_candidates,
+    render_ranking_json,
+)
+
+
+def _profile() -> CriterionProfile:
+    return CriterionProfile(
+        criteria=(
+            Criterion("correctness", direction="benefit", weight=2.0),
+            Criterion("cost", direction="cost", weight=1.0),
+        )
+    )
+
+
+def test_ranking_winner_three_candidate_snapshot(snapshot: SnapshotAssertion) -> None:
+    profile = _profile()
+    candidates = [
+        Candidate("alpha", {"correctness": 0.90, "cost": 10.0}),
+        Candidate("beta", {"correctness": 0.50, "cost": 1.0}),
+        Candidate("gamma", {"correctness": 0.75, "cost": 5.0}),
+    ]
+    ranked = rank_candidates(candidates, profile)
+    assert render_ranking_json(ranked, profile) == snapshot
+
+
+def test_ranking_winner_speed_first_snapshot(snapshot: SnapshotAssertion) -> None:
+    profile = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=1.0),
+            Criterion("latency", direction="cost", weight=10.0),
+        )
+    )
+    candidates = [
+        Candidate("slow-safe", {"correctness": 1.00, "latency": 600.0}),
+        Candidate("mid", {"correctness": 0.80, "latency": 60.0}),
+        Candidate("fast-risky", {"correctness": 0.60, "latency": 5.0}),
+    ]
+    ranked = rank_candidates(candidates, profile)
+    assert render_ranking_json(ranked, profile) == snapshot
+
+
+def test_ranking_single_candidate_snapshot(snapshot: SnapshotAssertion) -> None:
+    profile = CriterionProfile(criteria=(Criterion("x"),))
+    ranked = rank_candidates([Candidate("only", {"x": 1.0})], profile)
+    assert render_ranking_json(ranked, profile) == snapshot

--- a/tests/unit/test_multi_criteria_rank.py
+++ b/tests/unit/test_multi_criteria_rank.py
@@ -1,0 +1,609 @@
+"""Unit tests for :mod:`bernstein.core.orchestration.multi_criteria_rank`.
+
+Covers degenerate input handling (0 / 1 candidate), score validation
+(missing axis, NaN, infinity, booleans), profile builders, weight
+edge cases (zero / negative / non-normalised sums), direction handling
+(benefit vs cost), and deterministic tie-breaks.  These tests are
+intentionally dense so future refactors of the TOPSIS internals cannot
+silently drift the ranking behaviour.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from bernstein.core.orchestration.multi_criteria_rank import (
+    Candidate,
+    Criterion,
+    CriterionProfile,
+    RankedCandidate,
+    TopsisError,
+    build_criterion_profile,
+    parse_criteria_csv,
+    rank_candidates,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cand(key: str, **scores: float) -> Candidate:
+    return Candidate(key=key, scores=dict(scores))
+
+
+# ---------------------------------------------------------------------------
+# Criterion validation
+# ---------------------------------------------------------------------------
+
+
+def test_criterion_default_direction_is_benefit() -> None:
+    c = Criterion(name="correctness")
+    assert c.direction == "benefit"
+    assert c.weight == pytest.approx(1.0)
+
+
+def test_criterion_empty_name_rejected() -> None:
+    with pytest.raises(TopsisError, match="non-empty"):
+        Criterion(name="")
+
+
+def test_criterion_unknown_direction_rejected() -> None:
+    with pytest.raises(TopsisError, match="direction"):
+        Criterion(name="x", direction="maximise")
+
+
+def test_criterion_negative_weight_rejected() -> None:
+    with pytest.raises(TopsisError, match="non-negative"):
+        Criterion(name="x", weight=-0.5)
+
+
+def test_criterion_nan_weight_rejected() -> None:
+    with pytest.raises(TopsisError, match="finite"):
+        Criterion(name="x", weight=float("nan"))
+
+
+def test_criterion_infinite_weight_rejected() -> None:
+    with pytest.raises(TopsisError, match="finite"):
+        Criterion(name="x", weight=float("inf"))
+
+
+def test_criterion_zero_weight_accepted() -> None:
+    c = Criterion(name="x", weight=0.0)
+    assert c.weight == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# CriterionProfile validation
+# ---------------------------------------------------------------------------
+
+
+def test_profile_requires_at_least_one_criterion() -> None:
+    with pytest.raises(TopsisError, match="at least one"):
+        CriterionProfile(criteria=())
+
+
+def test_profile_rejects_duplicate_names() -> None:
+    with pytest.raises(TopsisError, match="Duplicate"):
+        CriterionProfile(criteria=(Criterion("a"), Criterion("a")))
+
+
+def test_profile_names_property_preserves_order() -> None:
+    p = CriterionProfile(criteria=(Criterion("b"), Criterion("a"), Criterion("c")))
+    assert p.names == ("b", "a", "c")
+
+
+# ---------------------------------------------------------------------------
+# build_criterion_profile helper
+# ---------------------------------------------------------------------------
+
+
+def test_build_profile_identity_weights_when_unspecified() -> None:
+    p = build_criterion_profile(["a", "b", "c"])
+    assert all(c.weight == pytest.approx(1.0) for c in p.criteria)
+
+
+def test_build_profile_marks_cost_axes_by_default() -> None:
+    p = build_criterion_profile(["correctness", "cost", "latency"])
+    by_name = {c.name: c for c in p.criteria}
+    assert by_name["correctness"].direction == "benefit"
+    assert by_name["cost"].direction == "cost"
+    assert by_name["latency"].direction == "cost"
+
+
+def test_build_profile_explicit_cost_axes_override() -> None:
+    p = build_criterion_profile(["x", "y"], cost_axes=["x"])
+    by_name = {c.name: c for c in p.criteria}
+    assert by_name["x"].direction == "cost"
+    assert by_name["y"].direction == "benefit"
+
+
+def test_build_profile_mismatched_weights_rejected() -> None:
+    with pytest.raises(TopsisError, match="length"):
+        build_criterion_profile(["a", "b"], weights=[1.0])
+
+
+def test_build_profile_empty_criteria_rejected() -> None:
+    with pytest.raises(TopsisError, match="non-empty"):
+        build_criterion_profile([])
+
+
+# ---------------------------------------------------------------------------
+# parse_criteria_csv
+# ---------------------------------------------------------------------------
+
+
+def test_parse_csv_basic() -> None:
+    assert parse_criteria_csv("a,b,c") == ("a", "b", "c")
+
+
+def test_parse_csv_strips_whitespace() -> None:
+    assert parse_criteria_csv(" a ,  b,c ") == ("a", "b", "c")
+
+
+def test_parse_csv_rejects_empty_token() -> None:
+    with pytest.raises(TopsisError, match="empty"):
+        parse_criteria_csv("a,,b")
+
+
+def test_parse_csv_rejects_blank_input() -> None:
+    with pytest.raises(TopsisError, match="non-empty"):
+        parse_criteria_csv("   ")
+
+
+# ---------------------------------------------------------------------------
+# rank_candidates — degenerate cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_candidates_returns_empty_list() -> None:
+    assert rank_candidates([], ["a"]) == []
+
+
+def test_one_candidate_returns_rank_one_with_unit_closeness() -> None:
+    result = rank_candidates([_cand("only", a=0.4)], ["a"])
+    assert len(result) == 1
+    assert result[0].key == "only"
+    assert result[0].rank == 1
+    assert result[0].closeness == pytest.approx(1.0)
+
+
+def test_one_candidate_missing_axis_rejected() -> None:
+    with pytest.raises(TopsisError, match="missing score"):
+        rank_candidates([_cand("only")], ["x"])
+
+
+# ---------------------------------------------------------------------------
+# rank_candidates — input validation
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_keys_rejected() -> None:
+    with pytest.raises(TopsisError, match="Duplicate candidate"):
+        rank_candidates(
+            [_cand("a", x=1.0), _cand("a", x=2.0)],
+            ["x"],
+        )
+
+
+def test_nan_score_rejected() -> None:
+    with pytest.raises(TopsisError, match="non-finite"):
+        rank_candidates(
+            [_cand("a", x=float("nan")), _cand("b", x=1.0)],
+            ["x"],
+        )
+
+
+def test_infinite_score_rejected() -> None:
+    with pytest.raises(TopsisError, match="non-finite"):
+        rank_candidates(
+            [_cand("a", x=float("inf")), _cand("b", x=1.0)],
+            ["x"],
+        )
+
+
+def test_missing_criterion_in_candidate_rejected() -> None:
+    with pytest.raises(TopsisError, match="missing score"):
+        rank_candidates(
+            [_cand("a", x=1.0), _cand("b", y=2.0)],
+            ["x", "y"],
+        )
+
+
+def test_boolean_score_rejected() -> None:
+    with pytest.raises(TopsisError, match="real number"):
+        rank_candidates(
+            [Candidate("a", {"x": True}), _cand("b", x=1.0)],  # type: ignore[dict-item]
+            ["x"],
+        )
+
+
+def test_string_score_rejected() -> None:
+    with pytest.raises(TopsisError, match="real number"):
+        rank_candidates(
+            [Candidate("a", {"x": "hi"}), _cand("b", x=1.0)],  # type: ignore[dict-item]
+            ["x"],
+        )
+
+
+def test_profile_and_weights_together_rejected() -> None:
+    profile = build_criterion_profile(["a"])
+    with pytest.raises(TopsisError, match="weights cannot be combined"):
+        rank_candidates(
+            [_cand("k", a=1.0)],
+            profile,
+            weights=[1.0],
+        )
+
+
+def test_zero_weight_sum_rejected() -> None:
+    profile = CriterionProfile(criteria=(Criterion("a", weight=0.0), Criterion("b", weight=0.0)))
+    with pytest.raises(TopsisError, match="weights must be positive"):
+        rank_candidates(
+            [_cand("p", a=1.0, b=2.0), _cand("q", a=2.0, b=1.0)],
+            profile,
+        )
+
+
+# ---------------------------------------------------------------------------
+# rank_candidates — 2-candidate sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_two_candidates_benefit_axis_higher_wins() -> None:
+    result = rank_candidates(
+        [_cand("a", x=1.0), _cand("b", x=2.0)],
+        ["x"],
+    )
+    assert result[0].key == "b"
+    assert result[0].rank == 1
+
+
+def test_two_candidates_cost_axis_lower_wins() -> None:
+    profile = build_criterion_profile(["cost"])
+    result = rank_candidates(
+        [_cand("a", cost=10.0), _cand("b", cost=1.0)],
+        profile,
+    )
+    assert result[0].key == "b"
+
+
+def test_two_candidates_all_equal_stable_order() -> None:
+    result = rank_candidates(
+        [_cand("z", x=1.0), _cand("a", x=1.0)],
+        ["x"],
+    )
+    # Stable ascending key tie-break.
+    assert [r.key for r in result] == ["a", "z"]
+    assert result[0].closeness == result[1].closeness
+
+
+def test_two_candidates_with_weights() -> None:
+    profile = build_criterion_profile(["safety", "speed"], weights=[10.0, 1.0])
+    result = rank_candidates(
+        [_cand("s", safety=1.0, speed=0.1), _cand("f", safety=0.5, speed=1.0)],
+        profile,
+    )
+    assert result[0].key == "s"  # safety wins because of weight
+
+
+# ---------------------------------------------------------------------------
+# rank_candidates — 5-candidate fixtures
+# ---------------------------------------------------------------------------
+
+
+def test_five_candidates_strict_ordering() -> None:
+    result = rank_candidates(
+        [_cand(f"c{i}", x=float(i)) for i in range(5)],
+        ["x"],
+    )
+    keys = [r.key for r in result]
+    assert keys == ["c4", "c3", "c2", "c1", "c0"]
+    for i, r in enumerate(result, start=1):
+        assert r.rank == i
+
+
+def test_five_candidates_multi_axis_safety_first() -> None:
+    # Profile: correctness completely dominates (1000x weight).
+    profile = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=1000.0),
+            Criterion("cost", direction="cost", weight=1.0),
+        )
+    )
+    candidates = [
+        _cand("safe-expensive", correctness=1.0, cost=10.0),
+        _cand("balanced", correctness=0.8, cost=5.0),
+        _cand("risky-cheap", correctness=0.5, cost=1.0),
+        _cand("safer-mid", correctness=0.95, cost=7.0),
+        _cand("middle", correctness=0.7, cost=4.0),
+    ]
+    result = rank_candidates(candidates, profile)
+    assert result[0].key == "safe-expensive"
+
+
+def test_five_candidates_speed_first_profile_picks_different_winner() -> None:
+    # Same candidate set, latency-first.
+    profile_speed = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=1.0),
+            Criterion("latency", direction="cost", weight=10.0),
+        )
+    )
+    candidates = [
+        _cand("a", correctness=0.9, latency=100.0),
+        _cand("b", correctness=0.6, latency=2.0),
+        _cand("c", correctness=0.8, latency=20.0),
+    ]
+    result = rank_candidates(candidates, profile_speed)
+    assert result[0].key == "b"
+
+
+# ---------------------------------------------------------------------------
+# rank_candidates — output structure
+# ---------------------------------------------------------------------------
+
+
+def test_result_includes_normalised_scores_for_each_axis() -> None:
+    result = rank_candidates(
+        [_cand("a", x=1.0, y=2.0), _cand("b", x=2.0, y=1.0)],
+        ["x", "y"],
+    )
+    for r in result:
+        assert "x" in r.normalised_scores
+        assert "y" in r.normalised_scores
+        assert all(math.isfinite(v) for v in r.normalised_scores.values())
+
+
+def test_result_rank_sequence_is_one_through_n() -> None:
+    result = rank_candidates(
+        [_cand(f"c{i}", x=float(i)) for i in range(4)],
+        ["x"],
+    )
+    assert [r.rank for r in result] == [1, 2, 3, 4]
+
+
+def test_result_closeness_in_unit_interval() -> None:
+    result = rank_candidates(
+        [_cand("a", x=1.0, y=2.0), _cand("b", x=2.0, y=1.0)],
+        ["x", "y"],
+    )
+    assert all(0.0 <= r.closeness <= 1.0 for r in result)
+
+
+def test_result_descending_closeness() -> None:
+    result = rank_candidates(
+        [
+            _cand("c1", x=1.0),
+            _cand("c3", x=3.0),
+            _cand("c2", x=2.0),
+            _cand("c4", x=4.0),
+        ],
+        ["x"],
+    )
+    closenesses = [r.closeness for r in result]
+    assert closenesses == sorted(closenesses, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Identity weights default + deterministic winner
+# ---------------------------------------------------------------------------
+
+
+def test_identity_weights_used_when_not_specified() -> None:
+    """Identity weights — the default required by the issue spec."""
+    result = rank_candidates(
+        [
+            _cand("a", x=1.0, y=10.0),
+            _cand("b", x=10.0, y=1.0),
+        ],
+        ["x", "y"],
+    )
+    # Symmetric scores under identity weights — keys break the tie.
+    assert result[0].closeness == pytest.approx(result[1].closeness)
+    assert [r.key for r in result] == ["a", "b"]
+
+
+def test_deterministic_winner_over_100_invocations() -> None:
+    """Issue acceptance: same inputs produce the same winner."""
+    candidates = [
+        _cand("alpha", x=0.5, y=0.4),
+        _cand("beta", x=0.9, y=0.2),
+        _cand("gamma", x=0.7, y=0.8),
+    ]
+    winners = {rank_candidates(candidates, ["x", "y"])[0].key for _ in range(100)}
+    assert len(winners) == 1
+
+
+def test_winner_changes_with_profile() -> None:
+    """Issue acceptance: same candidates + different profile picks
+    a different winner."""
+    candidates = [
+        _cand("alpha", correctness=1.0, cost=10.0),
+        _cand("beta", correctness=0.6, cost=1.0),
+    ]
+    safety = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=10.0),
+            Criterion("cost", direction="cost", weight=1.0),
+        )
+    )
+    speed = CriterionProfile(
+        criteria=(
+            Criterion("correctness", weight=1.0),
+            Criterion("cost", direction="cost", weight=10.0),
+        )
+    )
+    w_safety = rank_candidates(candidates, safety)[0].key
+    w_speed = rank_candidates(candidates, speed)[0].key
+    assert w_safety != w_speed
+    assert w_safety == "alpha"
+    assert w_speed == "beta"
+
+
+# ---------------------------------------------------------------------------
+# Direction handling
+# ---------------------------------------------------------------------------
+
+
+def test_cost_axis_inverts_preference() -> None:
+    benefit_profile = build_criterion_profile(["x"], cost_axes=[])
+    cost_profile = build_criterion_profile(["x"], cost_axes=["x"])
+    cands = [_cand("a", x=1.0), _cand("b", x=2.0)]
+    assert rank_candidates(cands, benefit_profile)[0].key == "b"
+    assert rank_candidates(cands, cost_profile)[0].key == "a"
+
+
+def test_mixed_direction_profile() -> None:
+    profile = CriterionProfile(
+        criteria=(
+            Criterion("benefit_axis"),
+            Criterion("cost_axis", direction="cost"),
+        )
+    )
+    cands = [
+        _cand("good", benefit_axis=10.0, cost_axis=1.0),
+        _cand("bad", benefit_axis=1.0, cost_axis=10.0),
+    ]
+    assert rank_candidates(cands, profile)[0].key == "good"
+
+
+# ---------------------------------------------------------------------------
+# Zero-column edge case
+# ---------------------------------------------------------------------------
+
+
+def test_zero_column_does_not_break_ranking() -> None:
+    """A column that is identically zero contributes nothing — the
+    remaining axes still produce a sensible ranking."""
+    result = rank_candidates(
+        [
+            _cand("a", live=1.0, dead=0.0),
+            _cand("b", live=2.0, dead=0.0),
+        ],
+        ["live", "dead"],
+    )
+    assert result[0].key == "b"
+
+
+def test_zero_column_with_zero_weight_axis() -> None:
+    profile = CriterionProfile(
+        criteria=(
+            Criterion("strong", weight=1.0),
+            Criterion("ignored", weight=0.0),
+        )
+    )
+    result = rank_candidates(
+        [
+            _cand("a", strong=1.0, ignored=999.0),
+            _cand("b", strong=2.0, ignored=-999.0),
+        ],
+        profile,
+    )
+    assert result[0].key == "b"
+
+
+# ---------------------------------------------------------------------------
+# Weight semantics
+# ---------------------------------------------------------------------------
+
+
+def test_weight_sum_non_normalised_is_renormalised_internally() -> None:
+    # Two equivalent profiles — only differ in weight scale.
+    p_small = build_criterion_profile(["a", "b"], weights=[0.5, 0.5])
+    p_large = build_criterion_profile(["a", "b"], weights=[50.0, 50.0])
+    cands = [_cand("x", a=1.0, b=2.0), _cand("y", a=2.0, b=1.0)]
+    r1 = rank_candidates(cands, p_small)
+    r2 = rank_candidates(cands, p_large)
+    assert [r.key for r in r1] == [r.key for r in r2]
+    for a, b in zip(r1, r2, strict=True):
+        assert a.closeness == pytest.approx(b.closeness)
+
+
+def test_all_zero_weights_except_one_concentrates_ranking() -> None:
+    profile = CriterionProfile(
+        criteria=(
+            Criterion("dominant", weight=1.0),
+            Criterion("ignored1", weight=0.0),
+            Criterion("ignored2", weight=0.0),
+        )
+    )
+    cands = [
+        _cand("a", dominant=0.1, ignored1=99.0, ignored2=99.0),
+        _cand("b", dominant=0.9, ignored1=0.01, ignored2=0.01),
+    ]
+    assert rank_candidates(cands, profile)[0].key == "b"
+
+
+# ---------------------------------------------------------------------------
+# Permutation invariance (input order does not matter)
+# ---------------------------------------------------------------------------
+
+
+def test_input_permutation_does_not_change_winner() -> None:
+    base = [
+        _cand("a", x=0.3, y=0.7),
+        _cand("b", x=0.9, y=0.2),
+        _cand("c", x=0.5, y=0.5),
+    ]
+    reversed_inputs = list(reversed(base))
+    w1 = rank_candidates(base, ["x", "y"])[0].key
+    w2 = rank_candidates(reversed_inputs, ["x", "y"])[0].key
+    assert w1 == w2
+
+
+def test_input_permutation_preserves_closeness_set() -> None:
+    base = [
+        _cand("a", x=0.3, y=0.7),
+        _cand("b", x=0.9, y=0.2),
+        _cand("c", x=0.5, y=0.5),
+    ]
+    reversed_inputs = list(reversed(base))
+    set1 = {(r.key, round(r.closeness, 9)) for r in rank_candidates(base, ["x", "y"])}
+    set2 = {(r.key, round(r.closeness, 9)) for r in rank_candidates(reversed_inputs, ["x", "y"])}
+    assert set1 == set2
+
+
+# ---------------------------------------------------------------------------
+# Scale invariance
+# ---------------------------------------------------------------------------
+
+
+def test_uniform_scaling_of_scores_preserves_ranking() -> None:
+    base = [_cand("a", x=1.0, y=2.0), _cand("b", x=2.0, y=1.0), _cand("c", x=3.0, y=3.0)]
+    scaled = [Candidate(c.key, {k: v * 1000.0 for k, v in c.scores.items()}) for c in base]
+    keys1 = [r.key for r in rank_candidates(base, ["x", "y"])]
+    keys2 = [r.key for r in rank_candidates(scaled, ["x", "y"])]
+    assert keys1 == keys2
+
+
+# ---------------------------------------------------------------------------
+# Extra axes in candidate are ignored
+# ---------------------------------------------------------------------------
+
+
+def test_extra_axes_in_candidate_ignored() -> None:
+    result = rank_candidates(
+        [
+            Candidate("a", {"x": 1.0, "secret": 100.0}),
+            Candidate("b", {"x": 2.0, "secret": -100.0}),
+        ],
+        ["x"],
+    )
+    # Ranking driven purely by x.
+    assert result[0].key == "b"
+
+
+# ---------------------------------------------------------------------------
+# Return-type contract
+# ---------------------------------------------------------------------------
+
+
+def test_result_is_list_of_ranked_candidate_instances() -> None:
+    result = rank_candidates(
+        [_cand("a", x=1.0), _cand("b", x=2.0)],
+        ["x"],
+    )
+    assert all(isinstance(r, RankedCandidate) for r in result)


### PR DESCRIPTION
## Summary

- Adds `bernstein.core.orchestration.multi_criteria_rank` — pure-Python TOPSIS ranker for best-of-N candidates (no numpy dep). Public surface: `rank_candidates`, `CriterionProfile`, `Criterion`, `build_criterion_profile`, `parse_criteria_csv`, `render_ranking_json`.
- `best_of_n.py` gains `select_winner(candidates, *, profile=None)`. When `profile is None` it delegates to legacy `select_best` (regression invariant from #1347). Fewer than 2 candidates is a no-op.
- `bernstein best-of-n show <task_id>` CLI renders the ranking artefact (table or JSON) and can recompute with `--rank-criteria foo,bar --weights 2,1`.
- Defaults: identity weights, `cost` / `latency` are cost axes, everything else is benefit. TOPSIS only — no AHP / DEMATEL / BWM (issue is explicit).

## Why

Today best-of-N collapses every candidate to a single blended scalar. On risky changes this hides operator-relevant trade-offs (safety vs. cost vs. speed). TOPSIS scores candidates by closeness to the ideal point across the same axes the runner already collects, so safety-first and speed-first profiles produce different winners deterministically.

## Test plan

- [x] `pytest tests/unit/test_multi_criteria_rank.py` — 55 unit tests
- [x] `pytest tests/property/test_topsis_properties.py` — 15 Hypothesis property tests (smoke + deep profile)
- [x] `pytest tests/integration/test_best_of_n_ranking.py` — 14 integration tests covering runner + CLI
- [x] `pytest tests/snapshot/test_multi_criteria_rank_snapshot.py` — 3 syrupy snapshots
- [x] `pytest tests/unit/test_best_of_n.py` — 25 existing tests green (regression invariant)
- [x] `ruff check` clean on all touched files
- [x] `pyright` strict clean on `multi_criteria_rank.py`, `best_of_n.py`, `best_of_n_rank_cmd.py`

## Acceptance criteria

- [x] 3-candidate safety-first profile picks correctness-maximising candidate even with 20% higher cost (`test_safety_first_profile_picks_passing_candidate_even_when_slow`).
- [x] Same candidates with speed-first profile pick a different winner (`test_different_profiles_produce_different_winners`).
- [x] Deterministic over 100 invocations (`test_select_winner_determinism_across_invocations`, `test_deterministic_winner_over_100_invocations`).
- [x] No profile -> `select_winner` behaves identically to `select_best` (`test_no_profile_select_winner_matches_legacy_select_best`).
- [x] Per-axis normalised score surfaced in `RankedCandidate.normalised_scores` and `render_ranking_json` output.
- [x] No-op when fewer than 2 candidates (`test_single_candidate_is_noop_under_profile`).