### PR TITLE
fix(ci): repair main after #1360 merge (lint + hygiene)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -207,6 +207,7 @@ alwaysApply: false
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/.goosehints
+++ b/.goosehints
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -112,9 +112,7 @@ class UnknownCriterionError(RetryBudgetError):
     def __init__(self, name: str, known: Iterable[str]) -> None:
         self.name = name
         self.known = tuple(known)
-        super().__init__(
-            f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}"
-        )
+        super().__init__(f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}")
 
 
 class DuplicateCriterionError(RetryBudgetError):
@@ -130,9 +128,7 @@ class CriterionExhaustedError(RetryBudgetError):
 
     def __init__(self, criterion: Criterion) -> None:
         self.criterion = criterion
-        super().__init__(
-            f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})"
-        )
+        super().__init__(f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})")
 
 
 class RetryBudgetExhaustedError(RetryBudgetError):
@@ -168,14 +164,10 @@ class Criterion:
         if not self.name:
             raise ValueError("Criterion name must be non-empty")
         if self.min_level > self.max_level:
-            raise ValueError(
-                f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level "
-                f"({self.max_level})"
-            )
+            raise ValueError(f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level ({self.max_level})")
         if self.level < self.min_level or self.level > self.max_level:
             raise ValueError(
-                f"Criterion {self.name!r}: level {self.level} outside "
-                f"[{self.min_level}, {self.max_level}]"
+                f"Criterion {self.name!r}: level {self.level} outside [{self.min_level}, {self.max_level}]"
             )
 
     @property
@@ -331,10 +323,7 @@ class RetryBudget:
         Returns:
             A fresh :class:`RetryBudget`.
         """
-        criteria = [
-            Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level)
-            for n in names
-        ]
+        criteria = [Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level) for n in names]
         return cls(retries=retries, criterion_degradation=criteria)
 
     # ------------------------------------------------------------------
@@ -450,10 +439,7 @@ class RetryBudget:
                 degraded_criterion=None,
                 degradation_kind=DegradationKind.NONE,
                 criteria_snapshot=tuple(self._criteria.values()),
-                reason=(
-                    f"retry #{attempt_index + 1} of {self.retries} "
-                    "(no further criterion degradation configured)"
-                ),
+                reason=(f"retry #{attempt_index + 1} of {self.retries} (no further criterion degradation configured)"),
             )
         if target.is_at_floor:
             # The criterion has already been degraded to its minimum on
@@ -470,8 +456,7 @@ class RetryBudget:
                 degradation_kind=DegradationKind.FLOORED,
                 criteria_snapshot=tuple(self._criteria.values()),
                 reason=(
-                    f"retry #{attempt_index + 1}: criterion {target.name!r} "
-                    "already at floor; no further degradation"
+                    f"retry #{attempt_index + 1}: criterion {target.name!r} already at floor; no further degradation"
                 ),
             )
         new_criterion = target.degraded()
@@ -486,10 +471,7 @@ class RetryBudget:
             degraded_criterion=new_criterion,
             degradation_kind=DegradationKind.LOWERED,
             criteria_snapshot=tuple(snapshot_map.values()),
-            reason=(
-                f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} "
-                f"to level {new_criterion.level}"
-            ),
+            reason=(f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} to level {new_criterion.level}"),
         )
 
     # ------------------------------------------------------------------
@@ -596,13 +578,9 @@ def parse_retry_budget_spec(
         for raw_name in raw_policy.split(">"):
             name = raw_name.strip()
             if not name:
-                raise ValueError(
-                    f"empty criterion name in retry budget spec: {spec!r}"
-                )
+                raise ValueError(f"empty criterion name in retry budget spec: {spec!r}")
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_-]*$", name):
-                raise ValueError(
-                    f"invalid criterion name {name!r} in retry budget spec"
-                )
+                raise ValueError(f"invalid criterion name {name!r} in retry budget spec")
             if name in seen:
                 raise DuplicateCriterionError(name)
             seen.add(name)


### PR DESCRIPTION
## Summary
- ruff format collapsed long-line breaks in `src/bernstein/core/cost/retry_budget.py` (left over from #1355).
- `bernstein agents-md sync` added missing `calibration.py` module-map row to AGENTS.md / CLAUDE.md / CONVENTIONS.md / .goosehints / .cursor/rules/module-map.mdc (left over from #1359).
- Fixes red main on commit `3c23cf1` (CI run 25993132985 — Lint + Repo hygiene + CI gate failing).

## Test plan
- [x] `uv run ruff check src/` passes
- [x] `uv run ruff format --check src/` passes
- [x] `uv run lint-imports` passes (3 contracts kept)
- [x] `uv run bernstein agents-md verify --workdir .` reports `OK all 12 file(s) in sync`
- [ ] CI green on PR