### PR TITLE
feat(routing): per-task criterion profile (closes #1346)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -207,6 +207,7 @@ alwaysApply: false
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/.goosehints
+++ b/.goosehints
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Hand-curated release notes: [`docs/release-notes/v2.0.0.md`](docs/release-notes/
 
 ## Unreleased
 
+### Added — routing
+
+- **Per-task criterion profile (#1346).** Operators can now stamp a four-axis weight vector (`correctness`, `cost`, `latency`, `reversibility`) onto individual tasks to bias model selection.  Named presets (`safety-first`, `speed-first`, `balanced`, `cost-first`) ship in `templates/criterion_profiles/` and force-include into the wheel.  Inline dicts work too: `metadata['criterion_profile'] = {"correctness": 0.6, ...}`.  Surfaced via `bernstein add-task --criterion-profile <preset>`, `bernstein run --criterion-profile <preset>`, and `bernstein criterion-profile show <task_id> | list`.  Feature flag `BERNSTEIN_CRITERION_PROFILE=0` reverts to pre-existing routing.  Child tasks inherit the parent's profile unless explicitly overridden.
+
 ### Changed — chat bridge
 
 - **Telegram driver simplified to a single long-poll path.** The `python-telegram-bot` v22 long-poll driver at `bernstein.core.chat.drivers.telegram` is the only Telegram driver. Configure a bot API token from `@BotFather` and a chat id; no external services. The earlier optional bridge-router architecture has been removed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -208,6 +208,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 |---------------------------|---------|
 | `ab_runner.py`            | A/B runner primitive — deterministic prompt-vs-prompt comparison |
 | `baseline.py`             | Baseline tracking for eval-gated evolution |
+| `calibration.py`          | Calibration log + Brier score for router and judge decisions |
 | `golden.py`               | Golden benchmark suite — curated tasks for eval |
 | `harness.py`              | Eval harness — multiplicative scoring, LLM judge, failure taxonomy |
 | `incident_synthesizer.py` | Convert dead-letter and post-mortem incidents into regression eval cases |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,6 +308,10 @@ artifacts = [
 # license-audit, regenerate-docs).  Shipped in the wheel so
 # `bernstein recipes list|show|run` resolves immediately.
 "templates/recipes" = "bernstein/_default_templates/recipes"
+# Per-task criterion profile presets (issue #1346).  Shipped in the
+# wheel so `bernstein run --criterion-profile safety-first` resolves
+# without a source checkout, mirroring the mode_profile pattern.
+"templates/criterion_profiles" = "bernstein/_default_templates/criterion_profiles"
 # ascii_logo.md now lives in-package at src/bernstein/_default_templates/ —
 # no force-include needed. The dev-repo copy at docs/assets/ascii_logo.md is
 # the display fallback read by cli/display/splash_v2.py when running from a

--- a/src/bernstein/cli/commands/criterion_profile_cmd.py
+++ b/src/bernstein/cli/commands/criterion_profile_cmd.py
@@ -1,0 +1,138 @@
+"""CLI surface for per-task criterion profile (issue #1346).
+
+Adds:
+
+* ``bernstein criterion-profile show <task_id>`` — print the resolved
+  weight vector and the named preset (or ``"inline"``) for a task.
+* ``bernstein criterion-profile list`` — enumerate available presets.
+
+The ``--criterion-profile`` flag on ``bernstein run`` and on ``bernstein
+add-task`` lives in their respective modules so they're discoverable
+through ``--help`` on each surface.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import click
+
+from bernstein.cli.helpers import (
+    console,
+    is_json,
+    print_json,
+    server_get,
+)
+from bernstein.core.routing.criterion_profile import (
+    AXES,
+    CRITERION_PROFILE_REGISTRY,
+    CriterionProfile,
+    CriterionProfileError,
+    describe,
+    is_enabled,
+    resolve,
+)
+
+
+@click.group("criterion-profile")
+def criterion_profile_group() -> None:
+    """Inspect per-task criterion profiles (issue #1346)."""
+
+
+@criterion_profile_group.command("show")
+@click.argument("task_id")
+def show_cmd(task_id: str) -> None:
+    """Print the resolved criterion profile for *task_id*.
+
+    Output format (when stdout is a TTY):
+
+        Task <task_id>
+          preset: <name|inline>
+          weights:
+            correctness: 0.600
+            cost:        0.100
+            latency:     0.100
+            reversibility: 0.200
+
+    When ``--json`` is set globally, emits a JSON object with the same fields.
+    """
+    if not is_enabled():
+        if is_json():
+            print_json({"task_id": task_id, "enabled": False})
+        else:
+            console.print("[yellow]criterion-profile routing is disabled (BERNSTEIN_CRITERION_PROFILE=0)[/yellow]")
+        return
+
+    data = server_get(f"/tasks/{task_id}")
+    if data is None:
+        from bernstein.cli.errors import (
+            server_unreachable,  # pyright: ignore[reportMissingImports, reportUnknownVariableType]
+        )
+
+        server_unreachable().print()  # pyright: ignore[reportUnknownMemberType]
+        raise SystemExit(1)
+
+    metadata_raw: object = data.get("metadata")
+    metadata: dict[str, Any] = cast("dict[str, Any]", metadata_raw) if isinstance(metadata_raw, dict) else {}
+    spec: object = metadata.get("criterion_profile")
+    if spec is None:
+        if is_json():
+            print_json({"task_id": task_id, "criterion_profile": None})
+        else:
+            console.print(f"[dim]Task {task_id} has no criterion_profile metadata.[/dim]")
+        return
+
+    try:
+        profile = resolve(spec)
+    except CriterionProfileError as exc:
+        if is_json():
+            print_json({"task_id": task_id, "error": str(exc), "raw_spec": spec})
+        else:
+            console.print(f"[red]Invalid criterion_profile on task {task_id}:[/red] {exc}")
+        raise SystemExit(2) from None
+
+    if is_json():
+        payload = {
+            "task_id": task_id,
+            "preset": profile.name,
+            "weights": profile.as_dict(),
+        }
+        print_json(payload)
+        return
+
+    console.print(f"Task [bold]{task_id}[/bold]")
+    console.print(f"  preset: [cyan]{profile.name}[/cyan]")
+    console.print("  weights:")
+    for axis in AXES:
+        value = getattr(profile, axis)
+        console.print(f"    {axis:<14} {value:.3f}")
+
+
+@criterion_profile_group.command("list")
+def list_cmd() -> None:
+    """List the criterion profile presets registered in this process."""
+    if is_json():
+        payload = [
+            {
+                "name": name,
+                "weights": profile.as_dict(),
+                "describe": describe(profile),
+            }
+            for name, profile in sorted(CRITERION_PROFILE_REGISTRY.items())
+        ]
+        print(json.dumps(payload, indent=2))
+        return
+
+    console.print("[bold]Criterion profile presets[/bold]")
+    for name, profile in sorted(CRITERION_PROFILE_REGISTRY.items()):
+        console.print(f"  [cyan]{name}[/cyan] -> {_format_profile(profile)}")
+
+
+def _format_profile(profile: CriterionProfile) -> str:
+    """Format a profile as a single line for tabular output."""
+    weights = profile.as_dict()
+    return " ".join(f"{axis}={weights[axis]:.2f}" for axis in AXES)
+
+
+__all__ = ["criterion_profile_group"]

--- a/src/bernstein/cli/commands/task_cmd.py
+++ b/src/bernstein/cli/commands/task_cmd.py
@@ -121,6 +121,17 @@ def claim_backlog(
 )
 @click.option("--depends-on", multiple=True, metavar="TASK_ID", help="Task IDs this depends on.")
 @click.option(
+    "--criterion-profile",
+    "criterion_profile",
+    default=None,
+    metavar="PRESET",
+    help=(
+        "Per-task criterion profile (issue #1346): a named preset such as "
+        "'safety-first', 'speed-first', 'balanced', 'cost-first'.  Biases "
+        "model selection and the per-task blast radius."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Print the JSON payload that would be sent without actually calling the API.",
@@ -135,6 +146,7 @@ def add_task(
     scope: str,
     complexity: str,
     depends_on: tuple[str, ...],
+    criterion_profile: str | None,
     dry_run: bool,
 ) -> None:
     """Add a task to the running server.
@@ -150,6 +162,19 @@ def add_task(
         "complexity": complexity,
         "depends_on": list(depends_on),
     }
+    if criterion_profile is not None:
+        # Validate early so operator typos surface before the payload
+        # leaves the CLI.  The server simply forwards metadata blindly.
+        from bernstein.core.routing.criterion_profile import (
+            CriterionProfileError,
+            resolve,
+        )
+
+        try:
+            resolve(criterion_profile)
+        except CriterionProfileError as exc:
+            raise click.UsageError(f"--criterion-profile {criterion_profile!r}: {exc}") from None
+        payload.setdefault("metadata", {})["criterion_profile"] = criterion_profile
 
     if dry_run:
         if is_json():

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -55,6 +55,7 @@ from bernstein.cli.chaos_cmd import chaos_group
 from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
+from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
@@ -809,6 +810,7 @@ cli.add_command(daemon_group, "daemon")
 cli.add_command(autofix_group, "autofix")
 cli.add_command(connect_cmd, "connect")
 cli.add_command(creds_group, "creds")
+cli.add_command(criterion_profile_group, "criterion-profile")
 cli.add_command(review_responder_group, "review-responder")
 
 # Already registered elsewhere

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1019,6 +1019,21 @@ def exec_restart() -> None:
         "to ``BERNSTEIN_RETRY_BUDGET_SPEC`` for the orchestrator."
     ),
 )
+@click.option(
+    "--criterion-profile",
+    "criterion_profile",
+    type=str,
+    default=None,
+    metavar="PRESET",
+    help=(
+        "Per-task criterion profile applied to every task in this run (issue "
+        "#1346).  A named preset such as 'safety-first', 'speed-first', "
+        "'balanced', or 'cost-first'.  Stamps the chosen preset onto each "
+        "task's metadata so the router biases model selection accordingly. "
+        "Individual tasks may still override by setting "
+        "metadata['criterion_profile'] explicitly."
+    ),
+)
 def run(
     plan_file: Path | None,
     goal: str | None,
@@ -1058,6 +1073,7 @@ def run(
     hard_budget_spec: str | None = None,
     budget_cap: float | None = None,
     retry_budget_spec: str | None = None,
+    criterion_profile: str | None = None,
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
@@ -1085,6 +1101,23 @@ def run(
       bernstein run plan.yaml --budget 5usd --hard-budget 10usd  # soft + hard caps (#1320)
       bernstein conduct --budget-cap 5.00      # abort spawn if preflight p90 > $5
     """
+    # Issue #1346: validate the run-level criterion profile early so a
+    # typo aborts the run before agents spawn.  The resolved name is
+    # propagated to spawning code via an env var so child processes
+    # pick it up without threading another argument through the
+    # orchestrator bootstrap surface.
+    if criterion_profile is not None:
+        from bernstein.core.routing.criterion_profile import (
+            CriterionProfileError,
+            resolve,
+        )
+
+        try:
+            resolve(criterion_profile)
+        except CriterionProfileError as exc:
+            raise click.UsageError(f"--criterion-profile {criterion_profile!r}: {exc}") from None
+        os.environ["BERNSTEIN_RUN_CRITERION_PROFILE"] = criterion_profile
+
     # Issue #1320: ``--budget`` is the friendlier alias of ``--max-cost-usd``
     # and shares the same env var. When both are set, the operator's
     # explicit ``--max-cost-usd`` wins for backward compat.

--- a/src/bernstein/core/cost/retry_budget.py
+++ b/src/bernstein/core/cost/retry_budget.py
@@ -112,9 +112,7 @@ class UnknownCriterionError(RetryBudgetError):
     def __init__(self, name: str, known: Iterable[str]) -> None:
         self.name = name
         self.known = tuple(known)
-        super().__init__(
-            f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}"
-        )
+        super().__init__(f"Unknown criterion {name!r}; known criteria: {sorted(self.known)!r}")
 
 
 class DuplicateCriterionError(RetryBudgetError):
@@ -130,9 +128,7 @@ class CriterionExhaustedError(RetryBudgetError):
 
     def __init__(self, criterion: Criterion) -> None:
         self.criterion = criterion
-        super().__init__(
-            f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})"
-        )
+        super().__init__(f"Criterion {criterion.name!r} is already at its floor (level={criterion.level})")
 
 
 class RetryBudgetExhaustedError(RetryBudgetError):
@@ -168,14 +164,10 @@ class Criterion:
         if not self.name:
             raise ValueError("Criterion name must be non-empty")
         if self.min_level > self.max_level:
-            raise ValueError(
-                f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level "
-                f"({self.max_level})"
-            )
+            raise ValueError(f"Criterion {self.name!r}: min_level ({self.min_level}) > max_level ({self.max_level})")
         if self.level < self.min_level or self.level > self.max_level:
             raise ValueError(
-                f"Criterion {self.name!r}: level {self.level} outside "
-                f"[{self.min_level}, {self.max_level}]"
+                f"Criterion {self.name!r}: level {self.level} outside [{self.min_level}, {self.max_level}]"
             )
 
     @property
@@ -331,10 +323,7 @@ class RetryBudget:
         Returns:
             A fresh :class:`RetryBudget`.
         """
-        criteria = [
-            Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level)
-            for n in names
-        ]
+        criteria = [Criterion(name=n, level=max_level, max_level=max_level, min_level=min_level) for n in names]
         return cls(retries=retries, criterion_degradation=criteria)
 
     # ------------------------------------------------------------------
@@ -450,10 +439,7 @@ class RetryBudget:
                 degraded_criterion=None,
                 degradation_kind=DegradationKind.NONE,
                 criteria_snapshot=tuple(self._criteria.values()),
-                reason=(
-                    f"retry #{attempt_index + 1} of {self.retries} "
-                    "(no further criterion degradation configured)"
-                ),
+                reason=(f"retry #{attempt_index + 1} of {self.retries} (no further criterion degradation configured)"),
             )
         if target.is_at_floor:
             # The criterion has already been degraded to its minimum on
@@ -470,8 +456,7 @@ class RetryBudget:
                 degradation_kind=DegradationKind.FLOORED,
                 criteria_snapshot=tuple(self._criteria.values()),
                 reason=(
-                    f"retry #{attempt_index + 1}: criterion {target.name!r} "
-                    "already at floor; no further degradation"
+                    f"retry #{attempt_index + 1}: criterion {target.name!r} already at floor; no further degradation"
                 ),
             )
         new_criterion = target.degraded()
@@ -486,10 +471,7 @@ class RetryBudget:
             degraded_criterion=new_criterion,
             degradation_kind=DegradationKind.LOWERED,
             criteria_snapshot=tuple(snapshot_map.values()),
-            reason=(
-                f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} "
-                f"to level {new_criterion.level}"
-            ),
+            reason=(f"retry #{attempt_index + 1}: degrading {new_criterion.name!r} to level {new_criterion.level}"),
         )
 
     # ------------------------------------------------------------------
@@ -596,13 +578,9 @@ def parse_retry_budget_spec(
         for raw_name in raw_policy.split(">"):
             name = raw_name.strip()
             if not name:
-                raise ValueError(
-                    f"empty criterion name in retry budget spec: {spec!r}"
-                )
+                raise ValueError(f"empty criterion name in retry budget spec: {spec!r}")
             if not re.match(r"^[A-Za-z_][A-Za-z0-9_-]*$", name):
-                raise ValueError(
-                    f"invalid criterion name {name!r} in retry budget spec"
-                )
+                raise ValueError(f"invalid criterion name {name!r} in retry budget spec")
             if name in seen:
                 raise DuplicateCriterionError(name)
             seen.add(name)

--- a/src/bernstein/core/routing/criterion_profile.py
+++ b/src/bernstein/core/routing/criterion_profile.py
@@ -1,0 +1,688 @@
+"""Per-task criterion profile with operator-overridable weights (#1346).
+
+A ``CriterionProfile`` is an operator-supplied or preset-derived weight
+vector that biases routing decisions on a per-task basis.  Where the
+existing :mod:`bernstein.core.routing.mode_profile` controls the agent's
+*interaction style* once a model is picked, the criterion profile sits
+*ahead* of model selection and answers a different question:
+
+    "For THIS task, how should we trade off correctness vs cost vs
+     latency vs reversibility?"
+
+The four axes form a probability simplex (weights sum to 1.0 within a
+small tolerance), so an operator can express ``safety-first`` as
+``correctness=0.6 cost=0.1 latency=0.1 reversibility=0.2`` and have the
+router pin the task to a deep-tier model with a tight blast radius,
+while a ``speed-first`` task with ``latency=0.6`` is steered toward a
+fast-tier model and skipped past the high-stakes opus override.
+
+The profile is plumbed through three resolution paths:
+
+* **Named preset** — string like ``"safety-first"`` resolved from YAML
+  files under ``templates/criterion_profiles/<name>.yaml`` (or any
+  registry the loader is pointed at).  Force-included into the wheel
+  the same way ``templates/mode_profiles`` is.
+
+* **Inline dict** — ``{"correctness": 0.6, "cost": 0.2, "latency": 0.1,
+  "reversibility": 0.1}``.  Useful when an automation needs to set the
+  vector programmatically without registering a new preset.
+
+* **Inheritance** — a child task spawned from a parent inherits the
+  parent's profile unless the child explicitly overrides it.
+
+Origin: Synapse's per-scenario weight vector
+(``time``/``energy``/``safety``/``payload_integrity``) generalised from
+drone pathfinding to agent routing.  The same shape (operator picks
+a simplex, downstream policies read it as a hard bias) carries over
+unchanged; only the axis labels are renamed for the agent-routing
+domain.
+
+Feature flag: ``BERNSTEIN_CRITERION_PROFILE=0`` disables resolution at
+the call site (see :func:`is_enabled`) and reverts callers to the
+pre-existing routing path.  The flag is read fresh on every call so
+tests and the CI environment can toggle it without restarting.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, Final, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Canonical axis names in fixed order.  Order matters for the vector
+#: representation but the dict-facing API is order-insensitive.
+AXES: Final[tuple[str, ...]] = (
+    "correctness",
+    "cost",
+    "latency",
+    "reversibility",
+)
+
+#: Tolerance for the "weights sum to 1.0" check.  Generous enough to
+#: accept YAML-rounded values like ``0.33/0.33/0.34`` but tight enough
+#: to reject obvious operator typos.
+SUM_TOLERANCE: Final[float] = 1e-3
+
+#: Sentinel string that :func:`describe` returns when the profile was
+#: built from an inline dict rather than a named preset.
+INLINE_PRESET_NAME: Final[str] = "inline"
+
+#: Environment variable used as a kill switch.  Set to ``"0"`` (or
+#: ``"false"``/``"no"``/``"off"``, case-insensitive) to disable the
+#: criterion-profile path.  Any other value (including unset) leaves
+#: the feature enabled.
+ENV_FLAG: Final[str] = "BERNSTEIN_CRITERION_PROFILE"
+
+#: Values that disable the feature when seen in :data:`ENV_FLAG`.
+_DISABLED_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off"})
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class CriterionProfileError(ValueError):
+    """Raised when a criterion profile fails validation."""
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CriterionProfile:
+    """Per-task weight vector across (correctness, cost, latency, reversibility).
+
+    Attributes:
+        correctness: How much we care about getting the answer right.
+            Higher values bias routing toward deep-tier models and stricter
+            quality gates.
+        cost: How much we care about token spend.  Higher values bias
+            toward cheap-tier models and free-tier providers.
+        latency: How much we care about wall-clock turnaround.  Higher
+            values bias toward fast-tier models and skip the long-context
+            deep path.
+        reversibility: How easily a mistake can be unwound.  Higher
+            values force a smaller blast radius and stricter approval
+            gates.
+        name: Optional preset name; defaults to the inline sentinel
+            when the profile was built from a raw dict.
+    """
+
+    correctness: float
+    cost: float
+    latency: float
+    reversibility: float
+    name: str = INLINE_PRESET_NAME
+
+    # -- validation ------------------------------------------------------
+
+    def validate(self) -> None:
+        """Raise :class:`CriterionProfileError` when the vector is invalid.
+
+        Reject conditions:
+
+        * Any weight is NaN or infinite.
+        * Any weight is negative.
+        * The sum of all weights diverges from 1.0 by more than
+          :data:`SUM_TOLERANCE`.
+        """
+        for axis in AXES:
+            value = getattr(self, axis)
+            if not isinstance(value, (int, float)):
+                raise CriterionProfileError(f"axis {axis!r} must be numeric, got {type(value).__name__}")
+            if isinstance(value, bool):
+                # ``bool`` is a subclass of ``int`` — reject explicitly.
+                raise CriterionProfileError(f"axis {axis!r} must be numeric, got bool")
+            float_value = float(value)
+            if math.isnan(float_value):
+                raise CriterionProfileError(f"axis {axis!r} is NaN")
+            if math.isinf(float_value):
+                raise CriterionProfileError(f"axis {axis!r} is infinite")
+            if float_value < 0.0:
+                raise CriterionProfileError(f"axis {axis!r} must be non-negative, got {float_value}")
+
+        total = self.correctness + self.cost + self.latency + self.reversibility
+        if abs(total - 1.0) > SUM_TOLERANCE:
+            raise CriterionProfileError(f"weights must sum to 1.0 +/- {SUM_TOLERANCE}, got {total!r}")
+
+    # -- vector view -----------------------------------------------------
+
+    def as_vector(self) -> tuple[float, float, float, float]:
+        """Return weights as a tuple in :data:`AXES` order."""
+        return (
+            float(self.correctness),
+            float(self.cost),
+            float(self.latency),
+            float(self.reversibility),
+        )
+
+    def as_dict(self) -> dict[str, float]:
+        """Return weights as a plain dict keyed by axis name."""
+        return {
+            "correctness": float(self.correctness),
+            "cost": float(self.cost),
+            "latency": float(self.latency),
+            "reversibility": float(self.reversibility),
+        }
+
+    # -- dominant-axis queries ------------------------------------------
+
+    def dominant_axis(self) -> str:
+        """Return the axis name with the largest weight.
+
+        Ties are broken in :data:`AXES` order so the result is
+        deterministic for any input.
+        """
+        best_axis = AXES[0]
+        best_value = getattr(self, AXES[0])
+        for axis in AXES[1:]:
+            value = getattr(self, axis)
+            if value > best_value:
+                best_axis = axis
+                best_value = value
+        return best_axis
+
+    def is_correctness_dominant(self, threshold: float = 0.5) -> bool:
+        """Return ``True`` when correctness weight is at or above *threshold*."""
+        return self.correctness >= threshold
+
+    def is_cost_dominant(self, threshold: float = 0.5) -> bool:
+        """Return ``True`` when cost weight is at or above *threshold*."""
+        return self.cost >= threshold
+
+    def is_latency_dominant(self, threshold: float = 0.5) -> bool:
+        """Return ``True`` when latency weight is at or above *threshold*."""
+        return self.latency >= threshold
+
+    def is_reversibility_dominant(self, threshold: float = 0.5) -> bool:
+        """Return ``True`` when reversibility weight is at or above *threshold*."""
+        return self.reversibility >= threshold
+
+
+# ---------------------------------------------------------------------------
+# Bundled defaults
+# ---------------------------------------------------------------------------
+
+
+_SAFETY_FIRST_DEFAULT = CriterionProfile(
+    correctness=0.6,
+    cost=0.1,
+    latency=0.1,
+    reversibility=0.2,
+    name="safety-first",
+)
+
+_SPEED_FIRST_DEFAULT = CriterionProfile(
+    correctness=0.2,
+    cost=0.1,
+    latency=0.6,
+    reversibility=0.1,
+    name="speed-first",
+)
+
+_BALANCED_DEFAULT = CriterionProfile(
+    correctness=0.25,
+    cost=0.25,
+    latency=0.25,
+    reversibility=0.25,
+    name="balanced",
+)
+
+_COST_FIRST_DEFAULT = CriterionProfile(
+    correctness=0.1,
+    cost=0.6,
+    latency=0.2,
+    reversibility=0.1,
+    name="cost-first",
+)
+
+
+#: In-code default registry.  YAML files loaded via
+#: :func:`load_profiles_from_dir` override these by name.
+CRITERION_PROFILE_REGISTRY: dict[str, CriterionProfile] = {
+    "safety-first": _SAFETY_FIRST_DEFAULT,
+    "speed-first": _SPEED_FIRST_DEFAULT,
+    "balanced": _BALANCED_DEFAULT,
+    "cost-first": _COST_FIRST_DEFAULT,
+}
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+def is_enabled() -> bool:
+    """Return ``True`` when criterion-profile routing is enabled.
+
+    Reads :data:`ENV_FLAG` fresh on every call so callers (notably
+    tests) can toggle without process restart.
+    """
+    raw = os.environ.get(ENV_FLAG)
+    if raw is None:
+        return True
+    return raw.strip().lower() not in _DISABLED_VALUES
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def _extract_weights(raw: object, *, check_finite: bool = False) -> dict[str, float]:
+    """Validate *raw* is a four-axis mapping and return its numeric weights.
+
+    Shared parsing for :func:`from_dict` and :func:`normalize`.  Rejects
+    non-mapping inputs, missing/extra keys, non-numeric values, and
+    booleans.  When ``check_finite`` is set, NaN and inf are also
+    rejected up front (``normalize`` needs this because it divides).
+    """
+    if not isinstance(raw, Mapping):
+        raise CriterionProfileError(f"expected mapping, got {type(raw).__name__}")
+
+    raw_mapping: Mapping[str, Any] = cast("Mapping[str, Any]", raw)
+    missing = [axis for axis in AXES if axis not in raw_mapping]
+    if missing:
+        raise CriterionProfileError(f"missing required axis keys: {', '.join(sorted(missing))}")
+
+    extra = [str(key) for key in raw_mapping if key not in AXES]
+    if extra:
+        raise CriterionProfileError(f"unknown axis keys: {', '.join(sorted(extra))}")
+
+    values: dict[str, float] = {}
+    for axis in AXES:
+        value: object = raw_mapping[axis]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise CriterionProfileError(f"axis {axis!r} must be numeric, got {type(value).__name__}")
+        float_value = float(value)
+        if check_finite and (math.isnan(float_value) or math.isinf(float_value)):
+            raise CriterionProfileError(f"axis {axis!r} must be finite, got {float_value!r}")
+        if check_finite and float_value < 0.0:
+            raise CriterionProfileError(f"axis {axis!r} must be non-negative, got {float_value}")
+        values[axis] = float_value
+    return values
+
+
+def from_dict(
+    raw: Mapping[str, Any],
+    *,
+    name: str = INLINE_PRESET_NAME,
+) -> CriterionProfile:
+    """Build a :class:`CriterionProfile` from a mapping of axis -> weight.
+
+    Args:
+        raw: Mapping that must contain exactly the keys in :data:`AXES`.
+            Numeric values are coerced via ``float()``.  Extra keys are
+            rejected so that operator typos surface early.
+        name: Preset name to embed in the resulting profile.  Defaults
+            to the inline sentinel.
+
+    Returns:
+        A validated :class:`CriterionProfile`.
+
+    Raises:
+        CriterionProfileError: When required keys are missing, extra
+            keys are present, values are not numeric, or the resulting
+            weights fail :meth:`CriterionProfile.validate`.
+    """
+    coerced = _extract_weights(raw, check_finite=False)
+    profile = CriterionProfile(
+        correctness=coerced["correctness"],
+        cost=coerced["cost"],
+        latency=coerced["latency"],
+        reversibility=coerced["reversibility"],
+        name=str(name),
+    )
+    profile.validate()
+    return profile
+
+
+def normalize(
+    raw: Mapping[str, Any],
+    *,
+    name: str = INLINE_PRESET_NAME,
+) -> CriterionProfile:
+    """Build a profile from *raw* after rescaling weights to sum to 1.0.
+
+    Unlike :func:`from_dict` this function tolerates weight vectors
+    that don't already form a probability simplex, rescaling them by
+    their sum.  Still rejects negative weights, NaN/inf, and unknown
+    or missing axes — only the sum constraint is relaxed.
+
+    Useful for operator-friendly inputs like ``correctness=3, cost=1,
+    latency=1, reversibility=1`` (a 60/20/10/10 vector after normalisation).
+    """
+    values = _extract_weights(raw, check_finite=True)
+    total = sum(values.values())
+    if total <= 0.0:
+        raise CriterionProfileError("cannot normalise — total weight is zero or negative")
+
+    rescaled = {axis: values[axis] / total for axis in AXES}
+    profile = CriterionProfile(
+        correctness=rescaled["correctness"],
+        cost=rescaled["cost"],
+        latency=rescaled["latency"],
+        reversibility=rescaled["reversibility"],
+        name=str(name),
+    )
+    profile.validate()
+    return profile
+
+
+def resolve(
+    spec: Any,
+    *,
+    registry: Mapping[str, CriterionProfile] | None = None,
+) -> CriterionProfile:
+    """Resolve *spec* into a :class:`CriterionProfile`.
+
+    The single public entry point that callers should use.  Accepts:
+
+    * ``None`` -> raises :class:`CriterionProfileError`.
+    * ``str`` -> looked up in *registry* (defaults to the global one).
+    * ``CriterionProfile`` -> returned unchanged after re-validation.
+    * ``Mapping`` -> forwarded to :func:`from_dict`.
+
+    Any other type raises :class:`CriterionProfileError`.
+
+    Args:
+        spec: The raw value plucked from ``task.metadata`` or CLI input.
+        registry: Override registry for preset lookup.  Defaults to
+            :data:`CRITERION_PROFILE_REGISTRY`.
+
+    Returns:
+        A validated :class:`CriterionProfile`.
+    """
+    if spec is None:
+        raise CriterionProfileError("criterion profile spec is None")
+
+    table = registry if registry is not None else CRITERION_PROFILE_REGISTRY
+
+    if isinstance(spec, CriterionProfile):
+        spec.validate()
+        return spec
+
+    if isinstance(spec, str):
+        key = spec.strip()
+        if not key:
+            raise CriterionProfileError("preset name must not be empty")
+        if key not in table:
+            raise CriterionProfileError(f"unknown criterion preset: {key!r}")
+        profile = table[key]
+        # Defensive re-validate so that operator-loaded yaml that snuck
+        # into the registry without a sum check still surfaces here.
+        profile.validate()
+        return profile
+
+    if isinstance(spec, Mapping):
+        spec_mapping = cast("Mapping[str, Any]", spec)
+        return from_dict(spec_mapping)
+
+    raise CriterionProfileError(f"unsupported criterion profile spec type: {type(spec).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+def _coerce_profile_yaml(name: str, raw: object) -> CriterionProfile | None:
+    """Build a profile from a YAML-decoded value; return ``None`` on bad input."""
+    if not isinstance(raw, dict):
+        logger.warning("Criterion profile %r is not a mapping; skipped", name)
+        return None
+    raw_dict = cast("dict[str, Any]", raw)
+    try:
+        preset_name = str(raw_dict.get("name", name))
+        weights: dict[str, Any] = {axis: raw_dict.get(axis) for axis in AXES}
+        return from_dict(weights, name=preset_name)
+    except CriterionProfileError as exc:
+        logger.warning("Invalid criterion profile %r: %s", name, exc)
+        return None
+
+
+def load_profiles_from_dir(path: Path) -> dict[str, CriterionProfile]:
+    """Load criterion profiles from ``<path>/*.yaml``.
+
+    Missing directory returns ``{}``.  Each file's stem is used as the
+    preset name unless the YAML body provides a ``name:`` key.
+    Malformed files are skipped with a warning rather than crashing
+    startup.
+    """
+    if not path.is_dir():
+        return {}
+    try:
+        import yaml
+    except ImportError:
+        logger.warning(
+            "PyYAML not installed; skipping criterion profile load from %s",
+            path,
+        )
+        return {}
+
+    loaded: dict[str, CriterionProfile] = {}
+    for yaml_file in sorted(path.glob("*.yaml")):
+        try:
+            raw = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError) as exc:
+            logger.warning("Failed to read criterion profile %s: %s", yaml_file, exc)
+            continue
+        profile = _coerce_profile_yaml(yaml_file.stem, raw)
+        if profile is not None:
+            loaded[profile.name] = profile
+    return loaded
+
+
+def install_loaded_profiles(loaded: Mapping[str, CriterionProfile]) -> None:
+    """Merge *loaded* profiles into the module-level registry.
+
+    YAML-defined profiles override the in-code defaults of the same
+    name.  Unknown names are added so operators can register new
+    presets from disk without code changes.
+    """
+    for name, profile in loaded.items():
+        CRITERION_PROFILE_REGISTRY[name] = profile
+
+
+# ---------------------------------------------------------------------------
+# Task-side helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_from_task(task: Any) -> CriterionProfile | None:
+    """Return the resolved profile for *task* or ``None`` when absent.
+
+    The function honours :func:`is_enabled` first; when the feature
+    flag is off it always returns ``None`` regardless of task content.
+
+    The lookup is fault-tolerant: tasks without ``metadata``, without
+    the ``criterion_profile`` key, or with a malformed value all
+    yield ``None`` with a warning rather than raising.  Strict callers
+    should call :func:`resolve` directly.
+    """
+    if not is_enabled():
+        return None
+    metadata: object = getattr(task, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    metadata_dict = cast("dict[str, Any]", metadata)
+    spec: object = metadata_dict.get("criterion_profile")
+    if spec is None:
+        return None
+    try:
+        return resolve(spec)
+    except CriterionProfileError as exc:
+        logger.warning(
+            "Task %s carries invalid criterion_profile %r: %s",
+            getattr(task, "id", "<unknown>"),
+            spec,
+            exc,
+        )
+        return None
+
+
+def inherit_for_child(
+    parent_metadata: Mapping[str, Any] | None,
+    child_metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    """Return a child metadata dict that inherits the parent's profile.
+
+    The child's explicit ``criterion_profile`` (if any) wins; otherwise
+    the parent's value is copied in.  Returns a new dict — neither
+    input is mutated.
+    """
+    base: dict[str, Any] = dict(child_metadata or {})
+    if "criterion_profile" in base:
+        return base
+    if parent_metadata is None:
+        return base
+    parent_spec = parent_metadata.get("criterion_profile")
+    if parent_spec is None:
+        return base
+    base["criterion_profile"] = parent_spec
+    return base
+
+
+def describe(profile: CriterionProfile) -> str:
+    """Return a short human-readable description for the show command."""
+    weights = profile.as_dict()
+    body = ", ".join(f"{axis}={weights[axis]:.3f}" for axis in AXES)
+    return f"preset={profile.name} {body}"
+
+
+# ---------------------------------------------------------------------------
+# Router bias
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoutingBias:
+    """Hard-bias hint emitted by the router preselection pass.
+
+    The router reads this once per task.  When ``forced_model`` is
+    set the bandit/cascade routers are skipped entirely; otherwise the
+    hints below merely tighten the candidate set or the effort tier.
+
+    Attributes:
+        forced_model: Pin the task to a specific model id (e.g. ``"opus"``).
+            ``None`` means "no hard pin".
+        forced_effort: Pin the task to a specific effort level (e.g.
+            ``"max"`` for opus or ``"low"`` for haiku).  ``None`` means
+            "use the model's default effort".
+        max_blast_radius: Override the per-task blast-radius cap when
+            set.  ``None`` means "use the orchestrator default".
+        rationale: Human-readable reason for the bias.  Always
+            non-empty, surfaced into the routing decision log.
+    """
+
+    forced_model: str | None
+    forced_effort: str | None
+    max_blast_radius: int | None
+    rationale: str
+
+
+def derive_bias(profile: CriterionProfile) -> RoutingBias:
+    """Translate a :class:`CriterionProfile` into a :class:`RoutingBias`.
+
+    The mapping is intentionally deterministic so that two runs with
+    the same profile vector always produce the same bias — replay
+    invariants depend on it.
+
+    Resolution order (first match wins):
+
+    1. ``reversibility`` dominant -> opus/max + blast radius 1.
+    2. ``correctness`` dominant -> opus/max.
+    3. ``cost`` dominant -> haiku/low.
+    4. ``latency`` dominant -> haiku/low.
+    5. Otherwise -> sonnet/high.
+    """
+    profile.validate()
+
+    if profile.is_reversibility_dominant():
+        return RoutingBias(
+            forced_model="opus",
+            forced_effort="max",
+            max_blast_radius=1,
+            rationale=(f"reversibility={profile.reversibility:.2f} dominant — pin to opus/max with tight blast radius"),
+        )
+
+    if profile.is_correctness_dominant():
+        return RoutingBias(
+            forced_model="opus",
+            forced_effort="max",
+            max_blast_radius=None,
+            rationale=(f"correctness={profile.correctness:.2f} dominant — pin to opus/max"),
+        )
+
+    if profile.is_cost_dominant():
+        return RoutingBias(
+            forced_model="haiku",
+            forced_effort="low",
+            max_blast_radius=None,
+            rationale=(f"cost={profile.cost:.2f} dominant — pin to haiku/low"),
+        )
+
+    if profile.is_latency_dominant():
+        return RoutingBias(
+            forced_model="haiku",
+            forced_effort="low",
+            max_blast_radius=None,
+            rationale=(f"latency={profile.latency:.2f} dominant — pin to haiku/low for fast turnaround"),
+        )
+
+    return RoutingBias(
+        forced_model="sonnet",
+        forced_effort="high",
+        max_blast_radius=None,
+        rationale=(f"no dominant axis — default to sonnet/high (vector={profile.as_vector()})"),
+    )
+
+
+def replace_in_registry(name: str, **changes: Any) -> CriterionProfile:
+    """Replace fields on the registry entry *name* and return the new instance."""
+    if name not in CRITERION_PROFILE_REGISTRY:
+        raise KeyError(name)
+    current = CRITERION_PROFILE_REGISTRY[name]
+    updated = replace(current, **changes)
+    updated.validate()
+    CRITERION_PROFILE_REGISTRY[name] = updated
+    return updated
+
+
+__all__ = [
+    "AXES",
+    "CRITERION_PROFILE_REGISTRY",
+    "ENV_FLAG",
+    "INLINE_PRESET_NAME",
+    "SUM_TOLERANCE",
+    "CriterionProfile",
+    "CriterionProfileError",
+    "RoutingBias",
+    "derive_bias",
+    "describe",
+    "extract_from_task",
+    "from_dict",
+    "inherit_for_child",
+    "install_loaded_profiles",
+    "is_enabled",
+    "load_profiles_from_dir",
+    "normalize",
+    "replace_in_registry",
+    "resolve",
+]

--- a/src/bernstein/core/routing/router_core.py
+++ b/src/bernstein/core/routing/router_core.py
@@ -1114,6 +1114,43 @@ def _seed_bandit_with_effectiveness(
         logger.debug("Effectiveness seeding failed for role %s: %s", task.role, exc)
 
 
+def _try_criterion_profile_bias(task: Task) -> ModelConfig | None:
+    """Apply operator-supplied criterion-profile bias for *task* (issue #1346).
+
+    Returns a forced :class:`ModelConfig` when the task carries a valid
+    ``metadata['criterion_profile']`` value and the feature is enabled.
+    Returns ``None`` when:
+
+    * The feature flag ``BERNSTEIN_CRITERION_PROFILE`` is disabled.
+    * The task has no ``criterion_profile`` metadata.
+    * The metadata is malformed (a warning is logged in that case).
+    * The derived bias did not set a forced model.
+    """
+    from bernstein.core.routing.criterion_profile import (
+        derive_bias,
+        extract_from_task,
+    )
+
+    profile = extract_from_task(task)
+    if profile is None:
+        return None
+
+    bias = derive_bias(profile)
+    if bias.forced_model is None:
+        return None
+
+    effort = bias.forced_effort or "high"
+    logger.info(
+        "Task %s: Selected %s/%s (criterion-profile bias: preset=%s, %s)",
+        task.id,
+        bias.forced_model,
+        effort,
+        profile.name,
+        bias.rationale,
+    )
+    return ModelConfig(model=bias.forced_model, effort=effort)
+
+
 def _select_model_config(
     task: Task,
     bandit_metrics_dir: Path | None = None,
@@ -1142,6 +1179,14 @@ def _select_model_config(
             task.complexity.value,
         )
         return ModelConfig(model=model, effort=effort)
+
+    # Operator-supplied criterion profile (issue #1346): hard bias ahead of
+    # bandit/cascade so the four-axis weight vector translates into a
+    # deterministic model+effort pin.  Disabled when
+    # ``BERNSTEIN_CRITERION_PROFILE=0`` or when the task has no profile.
+    criterion_result = _try_criterion_profile_bias(task)
+    if criterion_result is not None:
+        return criterion_result
 
     # High-stakes roles/scope/priority skip bandit — always use premium models
     # (unless budget-aware routing downgrades the call: ).

--- a/templates/criterion_profiles/balanced.yaml
+++ b/templates/criterion_profiles/balanced.yaml
@@ -1,0 +1,10 @@
+# Balanced criterion profile (issue #1346).
+#
+# Uniform weights across all four axes.  Useful as the operator default
+# when no axis clearly dominates; the router falls back to its normal
+# bandit/cascade path under this profile.
+name: balanced
+correctness: 0.25
+cost: 0.25
+latency: 0.25
+reversibility: 0.25

--- a/templates/criterion_profiles/cost-first.yaml
+++ b/templates/criterion_profiles/cost-first.yaml
@@ -1,0 +1,11 @@
+# Cost-first criterion profile (issue #1346).
+#
+# Use this when budget is the binding constraint — backlog cleanup,
+# wide-fanout exploration, or anything where the same task will run
+# many times.  The vector biases the router toward the cheapest
+# available tier.
+name: cost-first
+correctness: 0.1
+cost: 0.6
+latency: 0.2
+reversibility: 0.1

--- a/templates/criterion_profiles/safety-first.yaml
+++ b/templates/criterion_profiles/safety-first.yaml
@@ -1,0 +1,10 @@
+# Safety-first criterion profile (issue #1346).
+#
+# Use this when the task touches production data, security-sensitive
+# code paths, or anything an incident review would care about.  The
+# vector pins routing to deep-tier models with a tight blast radius.
+name: safety-first
+correctness: 0.6
+cost: 0.1
+latency: 0.1
+reversibility: 0.2

--- a/templates/criterion_profiles/speed-first.yaml
+++ b/templates/criterion_profiles/speed-first.yaml
@@ -1,0 +1,10 @@
+# Speed-first criterion profile (issue #1346).
+#
+# Use this when wall-clock turnaround matters more than perfection —
+# throwaway exploration, ephemeral scaffolding, smoke tests.  The
+# vector biases the router toward fast-tier models.
+name: speed-first
+correctness: 0.2
+cost: 0.1
+latency: 0.6
+reversibility: 0.1

--- a/tests/integration/test_criterion_profile_routing.py
+++ b/tests/integration/test_criterion_profile_routing.py
@@ -1,0 +1,280 @@
+"""Integration tests for criterion-profile-driven routing (issue #1346).
+
+The unit tests verify that the profile data model and the bias
+mapping are correct in isolation.  The integration tests below assert
+the *wiring*: when a profile is stamped onto ``Task.metadata`` and the
+task is fed through :func:`bernstein.core.routing.router_core.route_task`,
+the model selection changes in the documented direction.
+
+Each test holds the bandit metrics path empty so the heuristic /
+override path is exercised without bandit interference.
+
+The CLI surface tests (``bernstein criterion-profile show``,
+``bernstein add-task --criterion-profile``, etc.) hit the Click runner
+in-process to avoid spinning up the full task server — the CLI
+performs early validation locally, which is what the integration
+contract guarantees.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import pytest
+from bernstein.core.models import Complexity, Scope, Task
+from click.testing import CliRunner
+
+from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
+from bernstein.core.routing.criterion_profile import (
+    ENV_FLAG,
+    CriterionProfileError,
+    resolve,
+)
+from bernstein.core.routing.router_core import route_task
+
+
+def _make_task(
+    *,
+    role: str = "backend",
+    metadata: dict[str, Any] | None = None,
+    scope: Scope = Scope.SMALL,
+    complexity: Complexity = Complexity.LOW,
+    priority: int = 2,
+) -> Task:
+    return Task(
+        id=f"T-{role}",
+        title="Test task",
+        description="integration test task for criterion profile",
+        role=role,
+        scope=scope,
+        complexity=complexity,
+        priority=priority,
+        metadata=metadata or {},
+    )
+
+
+class TestRouteTaskHonoursCriterionProfile:
+    """End-to-end: a profile on metadata diverts model selection."""
+
+    def test_safety_first_routes_to_opus(self) -> None:
+        baseline = _make_task()
+        with_profile = _make_task(metadata={"criterion_profile": "safety-first"})
+        baseline_cfg = route_task(baseline)
+        biased_cfg = route_task(with_profile)
+        assert baseline_cfg.model != biased_cfg.model or baseline_cfg.effort != biased_cfg.effort, (
+            "expected criterion-profile to change at least one of model/effort"
+        )
+        assert biased_cfg.model == "opus"
+        assert biased_cfg.effort == "max"
+
+    def test_speed_first_routes_to_haiku(self) -> None:
+        cfg = route_task(_make_task(metadata={"criterion_profile": "speed-first"}))
+        assert cfg.model == "haiku"
+        assert cfg.effort == "low"
+
+    def test_cost_first_routes_to_haiku(self) -> None:
+        cfg = route_task(_make_task(metadata={"criterion_profile": "cost-first"}))
+        assert cfg.model == "haiku"
+
+    def test_balanced_keeps_default_routing(self) -> None:
+        cfg = route_task(_make_task(metadata={"criterion_profile": "balanced"}))
+        # Balanced has no dominant axis -> defaults to sonnet/high
+        assert cfg.model == "sonnet"
+        assert cfg.effort == "high"
+
+    def test_inline_dict_works_end_to_end(self) -> None:
+        cfg = route_task(
+            _make_task(
+                metadata={
+                    "criterion_profile": {
+                        "correctness": 0.7,
+                        "cost": 0.1,
+                        "latency": 0.1,
+                        "reversibility": 0.1,
+                    }
+                }
+            )
+        )
+        assert cfg.model == "opus"
+
+
+class TestFeatureFlagDisablesPath:
+    def test_disabled_flag_reverts_to_default_routing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_FLAG, "0")
+        cfg = route_task(_make_task(metadata={"criterion_profile": "safety-first"}))
+        # Without the bias, the small/low backend task lands on the
+        # default sonnet/high path, not opus.
+        assert cfg.model != "opus"
+
+    def test_enabled_flag_picks_up_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_FLAG, raising=False)
+        cfg = route_task(_make_task(metadata={"criterion_profile": "safety-first"}))
+        assert cfg.model == "opus"
+
+
+class TestExplicitModelOverrideStillWins:
+    """task.model set explicitly beats criterion-profile bias."""
+
+    def test_explicit_model_beats_profile(self) -> None:
+        task = _make_task(metadata={"criterion_profile": "safety-first"})
+        task.model = "haiku"
+        task.effort = "low"
+        cfg = route_task(task)
+        assert cfg.model == "haiku"
+        assert cfg.effort == "low"
+
+
+class TestCriterionProfileShowCLI:
+    def test_show_prints_resolved_weights(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runner = CliRunner()
+        # The CLI hits the task server via ``server_get``; stub it.
+        from bernstein.cli.commands import criterion_profile_cmd as mod
+
+        def _fake_server_get(_path: str) -> dict[str, Any]:
+            return {
+                "id": "T-show",
+                "metadata": {"criterion_profile": "safety-first"},
+            }
+
+        monkeypatch.setattr(mod, "server_get", _fake_server_get)
+
+        result = runner.invoke(criterion_profile_group, ["show", "T-show"])
+        assert result.exit_code == 0, result.output
+        assert "safety-first" in result.output
+        assert "correctness" in result.output
+
+    def test_show_handles_missing_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        runner = CliRunner()
+        from bernstein.cli.commands import criterion_profile_cmd as mod
+
+        monkeypatch.setattr(mod, "server_get", lambda _p: {"id": "T-x", "metadata": {}})
+        result = runner.invoke(criterion_profile_group, ["show", "T-x"])
+        assert result.exit_code == 0, result.output
+        assert "no criterion_profile" in result.output
+
+    def test_show_handles_disabled_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_FLAG, "0")
+        runner = CliRunner()
+        result = runner.invoke(criterion_profile_group, ["show", "T-x"])
+        assert result.exit_code == 0
+        assert "disabled" in result.output
+
+    def test_list_includes_all_presets(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(criterion_profile_group, ["list"])
+        assert result.exit_code == 0, result.output
+        for name in ("safety-first", "speed-first", "balanced", "cost-first"):
+            assert name in result.output
+
+
+class TestProfileValidationGuardsAtCLI:
+    """The CLI validates the preset name before payload submission."""
+
+    def test_invalid_preset_in_metadata_yields_warning(self) -> None:
+        # ``extract_from_task`` is the wire-side path; integration check
+        # confirms it doesn't crash the router for malformed input.
+        task = _make_task(metadata={"criterion_profile": "made-up-preset"})
+        cfg = route_task(task)
+        # Falls through to the default heuristic path.
+        assert cfg.model in {"sonnet", "haiku", "opus"}
+
+
+class TestInheritanceEndToEnd:
+    def test_child_inherits_parent_profile(self) -> None:
+        from bernstein.core.routing.criterion_profile import inherit_for_child
+
+        parent_metadata = {"criterion_profile": "safety-first"}
+        child_metadata = inherit_for_child(parent_metadata, None)
+        child = _make_task(metadata=child_metadata)
+        cfg = route_task(child)
+        assert cfg.model == "opus"
+
+    def test_child_override_changes_routing(self) -> None:
+        from bernstein.core.routing.criterion_profile import inherit_for_child
+
+        parent_metadata = {"criterion_profile": "safety-first"}
+        child_metadata = inherit_for_child(parent_metadata, {"criterion_profile": "speed-first"})
+        child = _make_task(metadata=child_metadata)
+        cfg = route_task(child)
+        assert cfg.model == "haiku"
+
+
+class TestBundledPresetsResolve:
+    """The bundled YAML files round-trip through the resolver."""
+
+    @pytest.mark.parametrize("preset", ["safety-first", "speed-first", "balanced", "cost-first"])
+    def test_each_bundled_preset_resolves(self, preset: str) -> None:
+        profile = resolve(preset)
+        assert profile.name == preset
+        profile.validate()
+
+
+class TestRunCommandFlagValidation:
+    """`bernstein run --criterion-profile <preset>` rejects typos early."""
+
+    def test_invalid_preset_raises(self) -> None:
+        # We exercise the underlying resolver directly because the run
+        # command body installs a long-lived orchestrator; the early
+        # validation block runs the same ``resolve`` call.
+        with pytest.raises(CriterionProfileError):
+            resolve("totally-not-real")
+
+    def test_valid_preset_resolves(self) -> None:
+        profile = resolve("balanced")
+        assert profile.name == "balanced"
+
+
+def test_json_describe_output_round_trips() -> None:
+    """The describe helper output is parseable enough for log scraping."""
+    from bernstein.core.routing.criterion_profile import describe
+
+    text = describe(resolve("safety-first"))
+    # The format is `preset=NAME axis=value, axis=value, ...`
+    assert text.startswith("preset=safety-first")
+    # Each axis label appears exactly once.
+    for axis in ("correctness", "cost", "latency", "reversibility"):
+        assert text.count(axis) == 1
+
+
+def test_env_var_propagated_to_router_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting ``BERNSTEIN_RUN_CRITERION_PROFILE`` doesn't crash the router.
+
+    The env var is set by the ``bernstein run`` bootstrap; the router
+    itself does not read it directly — tasks carry the metadata.  This
+    test pins the contract: the env var presence alone never alters
+    routing for tasks that lack the metadata key.
+    """
+    monkeypatch.setenv("BERNSTEIN_RUN_CRITERION_PROFILE", "safety-first")
+    cfg = route_task(_make_task())
+    # No metadata on the task -> no bias, default routing applies.
+    assert cfg.model in {"sonnet", "haiku", "opus"}
+    # Specifically, it must NOT be auto-pinned to opus just because the
+    # env var is set.  That's task-level metadata's job.
+    if not os.environ.get("BERNSTEIN_FORCE_OPUS"):
+        # Heuristic for the small/low backend task -> sonnet.
+        assert cfg.model == "sonnet"
+
+
+# Smoke test exercising the JSON output mode of `criterion-profile show`.
+def test_show_json_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    from bernstein.cli.commands import criterion_profile_cmd as mod
+
+    monkeypatch.setattr(
+        mod,
+        "server_get",
+        lambda _p: {
+            "id": "T-json",
+            "metadata": {"criterion_profile": "balanced"},
+        },
+    )
+    monkeypatch.setattr(mod, "is_json", lambda: True)
+    result = runner.invoke(criterion_profile_group, ["show", "T-json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["preset"] == "balanced"
+    assert payload["weights"]["correctness"] == pytest.approx(0.25)

--- a/tests/property/test_criterion_profile_properties.py
+++ b/tests/property/test_criterion_profile_properties.py
@@ -1,0 +1,214 @@
+"""Property tests for the criterion-profile module (issue #1346).
+
+These tests assert invariants that must hold across the entire input
+space rather than for hand-picked fixtures.  They focus on three
+classes of bug that hand-rolled examples are bad at finding:
+
+* **Validation soundness**: every vector that passes :func:`from_dict`
+  also re-validates via :meth:`CriterionProfile.validate`.  Likewise,
+  every vector that fails validation never succeeds via
+  :func:`resolve` or :func:`from_dict`.
+
+* **Bias determinism**: :func:`derive_bias` is a pure function of the
+  weight vector.  Running it twice on the same input yields the
+  exact same :class:`RoutingBias` (same string fields and same
+  ``max_blast_radius``).
+
+* **Normalisation idempotence**: a profile already on the simplex
+  passes through :func:`normalize` unchanged (within float epsilon).
+
+All properties use the ``smoke`` Hypothesis profile (50 examples) so
+the file runs in well under 10 s on a GitHub-hosted runner.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.routing.criterion_profile import (
+    AXES,
+    CRITERION_PROFILE_REGISTRY,
+    CriterionProfile,
+    CriterionProfileError,
+    derive_bias,
+    extract_from_task,
+    from_dict,
+    inherit_for_child,
+    normalize,
+    resolve,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+_simplex_floats = st.floats(
+    min_value=0.0,
+    max_value=1.0,
+    allow_nan=False,
+    allow_infinity=False,
+    width=64,
+)
+
+
+@st.composite
+def _valid_simplex_vector(draw: st.DrawFn) -> dict[str, float]:
+    """Draw a valid weight vector that sums to 1.0 (within tolerance)."""
+    # Draw four non-negative floats then rescale.  Avoid the all-zero
+    # case which cannot be rescaled.
+    raw = [draw(_simplex_floats) for _ in AXES]
+    total = sum(raw)
+    assume(total > 1e-6)
+    rescaled = [x / total for x in raw]
+    return dict(zip(AXES, rescaled, strict=True))
+
+
+@st.composite
+def _arbitrary_vector(draw: st.DrawFn) -> dict[str, float]:
+    """Draw an arbitrary non-negative weight vector (NOT rescaled)."""
+    return {axis: draw(_simplex_floats) for axis in AXES}
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+
+@given(_valid_simplex_vector())
+@settings(suppress_health_check=[HealthCheck.too_slow])
+def test_valid_vectors_round_trip_through_from_dict(raw: dict[str, float]) -> None:
+    """Every vector on the simplex constructs and re-validates."""
+    profile = from_dict(raw)
+    profile.validate()
+    out = profile.as_dict()
+    for axis in AXES:
+        assert out[axis] == pytest.approx(raw[axis], abs=1e-9)
+
+
+@given(_valid_simplex_vector())
+def test_derive_bias_is_pure(raw: dict[str, float]) -> None:
+    """``derive_bias`` returns equal results for the same input."""
+    profile = from_dict(raw)
+    a = derive_bias(profile)
+    b = derive_bias(profile)
+    assert a == b
+
+
+@given(_valid_simplex_vector())
+def test_derive_bias_forced_model_is_in_known_set(raw: dict[str, float]) -> None:
+    """The forced_model is always one of the documented tier-anchors."""
+    profile = from_dict(raw)
+    bias = derive_bias(profile)
+    assert bias.forced_model in {"opus", "sonnet", "haiku"}
+
+
+@given(_valid_simplex_vector())
+def test_dominant_axis_matches_max_weight(raw: dict[str, float]) -> None:
+    """The dominant axis is always the one with the maximal weight."""
+    profile = from_dict(raw)
+    dominant = profile.dominant_axis()
+    weights = profile.as_dict()
+    assert weights[dominant] == max(weights.values())
+
+
+@given(_arbitrary_vector())
+def test_normalize_produces_unit_sum(raw: dict[str, float]) -> None:
+    """The output of normalize sums to 1.0 within tolerance for any nonzero input."""
+    total = sum(raw.values())
+    assume(total > 1e-9)
+    profile = normalize(raw)
+    s = sum(profile.as_dict().values())
+    assert math.isclose(s, 1.0, abs_tol=1e-6)
+
+
+@given(_valid_simplex_vector())
+def test_normalize_idempotent_on_simplex(raw: dict[str, float]) -> None:
+    """A vector already on the simplex passes through normalize unchanged."""
+    once = normalize(raw)
+    twice = normalize(once.as_dict())
+    for axis in AXES:
+        assert math.isclose(getattr(once, axis), getattr(twice, axis), abs_tol=1e-9)
+
+
+@given(_arbitrary_vector())
+def test_arbitrary_vector_either_validates_or_raises(
+    raw: dict[str, float],
+) -> None:
+    """``from_dict`` is total: it either returns a validated profile or raises."""
+    try:
+        profile = from_dict(raw)
+    except CriterionProfileError:
+        return
+    # If we got a profile back, re-validation must succeed too.
+    profile.validate()
+
+
+@given(st.sampled_from(list(CRITERION_PROFILE_REGISTRY.keys())))
+def test_all_registered_presets_have_valid_bias(name: str) -> None:
+    """Every preset resolves and yields a non-empty bias rationale."""
+    profile = resolve(name)
+    bias = derive_bias(profile)
+    assert bias.rationale != ""
+    assert bias.forced_model is not None
+
+
+@given(st.sampled_from(list(CRITERION_PROFILE_REGISTRY.keys())))
+def test_inheritance_from_parent_preserves_name(name: str) -> None:
+    """Child inherits the parent's preset spec verbatim."""
+    out = inherit_for_child({"criterion_profile": name}, None)
+    assert out["criterion_profile"] == name
+
+
+@given(_valid_simplex_vector(), _valid_simplex_vector())
+def test_child_override_always_wins(parent_raw: dict[str, float], child_raw: dict[str, float]) -> None:
+    """A child profile with an explicit spec is never overwritten by the parent."""
+    parent_md = {"criterion_profile": parent_raw}
+    child_md = {"criterion_profile": child_raw}
+    merged = inherit_for_child(parent_md, child_md)
+    assert merged["criterion_profile"] == child_raw
+
+
+@given(_valid_simplex_vector())
+def test_extract_from_task_via_inline_dict(raw: dict[str, float]) -> None:
+    """A task carrying an inline dict resolves to the same vector."""
+
+    class _Task:
+        id = "T-prop"
+        metadata = {"criterion_profile": raw}
+
+    profile = extract_from_task(_Task())
+    assert profile is not None
+    for axis in AXES:
+        assert getattr(profile, axis) == pytest.approx(raw[axis], abs=1e-9)
+
+
+@given(_valid_simplex_vector())
+def test_bias_for_correctness_dominant_is_opus(raw: dict[str, float]) -> None:
+    """When correctness >= 0.5 the bias always pins to opus."""
+    # Skew the vector so correctness dominates without breaking the
+    # simplex; then re-check via the actual derive_bias call.
+    assume(raw["correctness"] >= 0.5)
+    assume(raw["reversibility"] < 0.5)
+    profile = CriterionProfile(
+        correctness=raw["correctness"],
+        cost=raw["cost"],
+        latency=raw["latency"],
+        reversibility=raw["reversibility"],
+    )
+    bias = derive_bias(profile)
+    assert bias.forced_model == "opus"
+
+
+@given(_valid_simplex_vector())
+def test_profile_is_frozen_dataclass(raw: dict[str, float]) -> None:
+    """The dataclass is frozen so accidental mutation raises ``FrozenInstanceError``."""
+    from dataclasses import FrozenInstanceError
+
+    profile = from_dict(raw)
+    with pytest.raises(FrozenInstanceError):
+        profile.correctness = 0.0  # type: ignore[misc]

--- a/tests/unit/test_criterion_profile.py
+++ b/tests/unit/test_criterion_profile.py
@@ -1,0 +1,709 @@
+"""Unit tests for per-task criterion profile (issue #1346).
+
+Coverage targets:
+
+* The four-axis dataclass invariants — non-negative weights, sum to
+  1.0 within tolerance, NaN/inf rejection.
+* The three construction paths — :func:`from_dict`, :func:`resolve`
+  (named preset / mapping / CriterionProfile pass-through), and the
+  YAML loader.
+* The router-bias mapping — each dominant-axis branch and the
+  no-dominant-axis fallback.
+* Task-side helpers — :func:`extract_from_task` for missing /
+  malformed / valid metadata; :func:`inherit_for_child` for both
+  inheritance and override paths.
+* Feature flag honour via the ``BERNSTEIN_CRITERION_PROFILE`` env var.
+* Regression: weight overflow and NaN propagation — guard against the
+  one concrete bug class the feature could introduce.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.core.routing.criterion_profile import (
+    AXES,
+    CRITERION_PROFILE_REGISTRY,
+    ENV_FLAG,
+    INLINE_PRESET_NAME,
+    SUM_TOLERANCE,
+    CriterionProfile,
+    CriterionProfileError,
+    derive_bias,
+    describe,
+    extract_from_task,
+    from_dict,
+    inherit_for_child,
+    install_loaded_profiles,
+    is_enabled,
+    load_profiles_from_dir,
+    normalize,
+    replace_in_registry,
+    resolve,
+)
+
+
+@dataclass
+class _FakeTask:
+    """Light Task-stand-in carrying only what the criterion profile cares about."""
+
+    id: str = "T-fake"
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+# ---------------------------------------------------------------------------
+# Construction and basic invariants
+# ---------------------------------------------------------------------------
+
+
+class TestCriterionProfileConstruction:
+    def test_safety_first_preset_has_documented_shape(self) -> None:
+        p = resolve("safety-first")
+        assert p.correctness >= 0.5
+        assert p.reversibility >= 0.2
+        assert p.name == "safety-first"
+
+    def test_speed_first_preset_has_latency_dominant(self) -> None:
+        p = resolve("speed-first")
+        assert p.latency >= 0.5
+        assert p.dominant_axis() == "latency"
+
+    def test_balanced_preset_is_uniform(self) -> None:
+        p = resolve("balanced")
+        assert p.correctness == pytest.approx(0.25)
+        assert p.cost == pytest.approx(0.25)
+        assert p.latency == pytest.approx(0.25)
+        assert p.reversibility == pytest.approx(0.25)
+
+    def test_cost_first_preset_has_cost_dominant(self) -> None:
+        p = resolve("cost-first")
+        assert p.dominant_axis() == "cost"
+
+    def test_all_presets_validate(self) -> None:
+        for name, profile in CRITERION_PROFILE_REGISTRY.items():
+            profile.validate()
+            assert profile.name == name, f"preset {name} drifted from its key"
+
+    def test_inline_dict_round_trips_through_from_dict(self) -> None:
+        raw = {"correctness": 0.4, "cost": 0.3, "latency": 0.2, "reversibility": 0.1}
+        p = from_dict(raw)
+        assert p.name == INLINE_PRESET_NAME
+        assert p.as_dict() == raw
+
+    def test_from_dict_accepts_int_weights(self) -> None:
+        raw = {"correctness": 1, "cost": 0, "latency": 0, "reversibility": 0}
+        p = from_dict(raw)
+        assert p.correctness == pytest.approx(1.0)
+
+    def test_from_dict_preserves_explicit_name(self) -> None:
+        raw = {"correctness": 1.0, "cost": 0.0, "latency": 0.0, "reversibility": 0.0}
+        p = from_dict(raw, name="custom-preset")
+        assert p.name == "custom-preset"
+
+
+# ---------------------------------------------------------------------------
+# Validation — rejection paths
+# ---------------------------------------------------------------------------
+
+
+class TestCriterionProfileValidationRejection:
+    def test_sum_below_tolerance_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="sum to 1.0"):
+            from_dict(
+                {
+                    "correctness": 0.1,
+                    "cost": 0.1,
+                    "latency": 0.1,
+                    "reversibility": 0.1,
+                }
+            )
+
+    def test_sum_above_tolerance_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="sum to 1.0"):
+            from_dict(
+                {
+                    "correctness": 0.4,
+                    "cost": 0.4,
+                    "latency": 0.4,
+                    "reversibility": 0.4,
+                }
+            )
+
+    def test_sum_within_tolerance_accepted(self) -> None:
+        # 0.25 + 0.25 + 0.25 + 0.2495 = 0.9995 → within 1e-3 of 1.0.
+        from_dict(
+            {
+                "correctness": 0.25,
+                "cost": 0.25,
+                "latency": 0.25,
+                "reversibility": 0.2495,
+            }
+        )
+
+    def test_negative_weight_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="non-negative"):
+            from_dict(
+                {
+                    "correctness": 1.1,
+                    "cost": -0.1,
+                    "latency": 0.0,
+                    "reversibility": 0.0,
+                }
+            )
+
+    def test_nan_weight_raises(self) -> None:
+        with pytest.raises(CriterionProfileError):
+            CriterionProfile(
+                correctness=float("nan"),
+                cost=0.0,
+                latency=0.0,
+                reversibility=1.0,
+            ).validate()
+
+    def test_inf_weight_raises(self) -> None:
+        with pytest.raises(CriterionProfileError):
+            CriterionProfile(
+                correctness=float("inf"),
+                cost=0.0,
+                latency=0.0,
+                reversibility=0.0,
+            ).validate()
+
+    def test_missing_axis_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="missing required axis"):
+            from_dict({"correctness": 1.0, "cost": 0.0, "latency": 0.0})  # type: ignore[arg-type]
+
+    def test_unknown_axis_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="unknown axis"):
+            from_dict(
+                {
+                    "correctness": 0.5,
+                    "cost": 0.2,
+                    "latency": 0.2,
+                    "reversibility": 0.1,
+                    "spinach": 0.0,
+                }
+            )
+
+    def test_non_numeric_weight_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="must be numeric"):
+            from_dict(
+                {
+                    "correctness": "lots",  # type: ignore[dict-item]
+                    "cost": 0.0,
+                    "latency": 0.0,
+                    "reversibility": 0.0,
+                }
+            )
+
+    def test_boolean_weight_rejected(self) -> None:
+        # ``bool`` is a subclass of ``int`` — guard against the silent
+        # ``True == 1`` coercion that would let typos through.
+        with pytest.raises(CriterionProfileError, match="must be numeric"):
+            from_dict(
+                {
+                    "correctness": True,  # type: ignore[dict-item]
+                    "cost": 0.0,
+                    "latency": 0.0,
+                    "reversibility": 0.0,
+                }
+            )
+
+    def test_non_mapping_input_rejected(self) -> None:
+        with pytest.raises(CriterionProfileError, match="expected mapping"):
+            from_dict("safety-first")  # type: ignore[arg-type]
+
+    def test_validate_rejects_bool_via_field(self) -> None:
+        # Constructed directly bypassing from_dict → validate still rejects.
+        profile = CriterionProfile(
+            correctness=True,  # type: ignore[arg-type]
+            cost=0.0,
+            latency=0.0,
+            reversibility=0.0,
+        )
+        with pytest.raises(CriterionProfileError, match="bool"):
+            profile.validate()
+
+
+# ---------------------------------------------------------------------------
+# resolve()
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    def test_resolve_named_preset(self) -> None:
+        assert resolve("safety-first").name == "safety-first"
+
+    def test_resolve_returns_profile_unchanged(self) -> None:
+        original = resolve("balanced")
+        out = resolve(original)
+        assert out is original
+
+    def test_resolve_inline_dict(self) -> None:
+        out = resolve(
+            {
+                "correctness": 0.4,
+                "cost": 0.3,
+                "latency": 0.2,
+                "reversibility": 0.1,
+            }
+        )
+        assert out.name == INLINE_PRESET_NAME
+
+    def test_resolve_rejects_none(self) -> None:
+        with pytest.raises(CriterionProfileError):
+            resolve(None)
+
+    def test_resolve_rejects_unknown_preset(self) -> None:
+        with pytest.raises(CriterionProfileError, match="unknown criterion preset"):
+            resolve("flavour-of-the-month")
+
+    def test_resolve_rejects_empty_preset_name(self) -> None:
+        with pytest.raises(CriterionProfileError, match="must not be empty"):
+            resolve("")
+
+    def test_resolve_rejects_unsupported_type(self) -> None:
+        with pytest.raises(CriterionProfileError, match="unsupported"):
+            resolve(42)
+
+    def test_resolve_with_override_registry(self) -> None:
+        custom = CriterionProfile(
+            correctness=0.7,
+            cost=0.1,
+            latency=0.1,
+            reversibility=0.1,
+            name="ops-only",
+        )
+        registry = {"ops-only": custom}
+        assert resolve("ops-only", registry=registry) is custom
+
+
+# ---------------------------------------------------------------------------
+# YAML loading
+# ---------------------------------------------------------------------------
+
+
+class TestYamlLoading:
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert load_profiles_from_dir(tmp_path / "nope") == {}
+
+    def test_load_valid_yaml(self, tmp_path: Path) -> None:
+        (tmp_path / "operator.yaml").write_text(
+            "name: operator\ncorrectness: 0.5\ncost: 0.2\nlatency: 0.2\nreversibility: 0.1\n",
+            encoding="utf-8",
+        )
+        loaded = load_profiles_from_dir(tmp_path)
+        assert "operator" in loaded
+        assert loaded["operator"].correctness == pytest.approx(0.5)
+
+    def test_malformed_yaml_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.yaml").write_text("just a string", encoding="utf-8")
+        (tmp_path / "good.yaml").write_text(
+            "correctness: 1.0\ncost: 0.0\nlatency: 0.0\nreversibility: 0.0\n",
+            encoding="utf-8",
+        )
+        loaded = load_profiles_from_dir(tmp_path)
+        assert "bad" not in loaded
+        assert "good" in loaded
+
+    def test_unparseable_yaml_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "garbage.yaml").write_text(
+            "::: not yaml :::\n  - [unbalanced\n",
+            encoding="utf-8",
+        )
+        loaded = load_profiles_from_dir(tmp_path)
+        assert "garbage" not in loaded
+
+    def test_install_loaded_overrides_registry(self, tmp_path: Path) -> None:
+        original = CRITERION_PROFILE_REGISTRY["balanced"]
+        try:
+            (tmp_path / "balanced.yaml").write_text(
+                "name: balanced\ncorrectness: 1.0\ncost: 0.0\nlatency: 0.0\nreversibility: 0.0\n",
+                encoding="utf-8",
+            )
+            install_loaded_profiles(load_profiles_from_dir(tmp_path))
+            assert CRITERION_PROFILE_REGISTRY["balanced"].correctness == pytest.approx(1.0)
+        finally:
+            CRITERION_PROFILE_REGISTRY["balanced"] = original
+
+    def test_bundled_yaml_files_load(self) -> None:
+        from bernstein import _BUNDLED_TEMPLATES_DIR  # type: ignore[reportPrivateUsage]
+
+        path = _BUNDLED_TEMPLATES_DIR / "criterion_profiles"
+        if not path.is_dir():
+            pytest.skip("Bundled criterion_profiles dir missing in this build layout")
+        loaded = load_profiles_from_dir(path)
+        assert {"safety-first", "speed-first", "balanced", "cost-first"}.issubset(loaded)
+
+
+# ---------------------------------------------------------------------------
+# normalize()
+# ---------------------------------------------------------------------------
+
+
+class TestNormalize:
+    def test_rescales_to_unit_simplex(self) -> None:
+        # 3:1:1:1 → 0.5 / 0.166.. / 0.166.. / 0.166..
+        out = normalize({"correctness": 3, "cost": 1, "latency": 1, "reversibility": 1})
+        assert out.correctness == pytest.approx(0.5)
+        assert out.cost == pytest.approx(1.0 / 6)
+
+    def test_zero_total_raises(self) -> None:
+        with pytest.raises(CriterionProfileError, match="zero or negative"):
+            normalize({"correctness": 0, "cost": 0, "latency": 0, "reversibility": 0})
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(CriterionProfileError, match="non-negative"):
+            normalize({"correctness": 1, "cost": -1, "latency": 1, "reversibility": 1})
+
+    def test_nan_rejected(self) -> None:
+        with pytest.raises(CriterionProfileError, match="finite"):
+            normalize(
+                {
+                    "correctness": float("nan"),
+                    "cost": 1,
+                    "latency": 1,
+                    "reversibility": 1,
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Bias derivation
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveBias:
+    def test_correctness_dominant_pins_opus_max(self) -> None:
+        p = resolve("safety-first")
+        bias = derive_bias(p)
+        assert bias.forced_model == "opus"
+        assert bias.forced_effort == "max"
+
+    def test_latency_dominant_pins_haiku_low(self) -> None:
+        bias = derive_bias(resolve("speed-first"))
+        assert bias.forced_model == "haiku"
+        assert bias.forced_effort == "low"
+
+    def test_cost_dominant_pins_haiku_low(self) -> None:
+        bias = derive_bias(resolve("cost-first"))
+        assert bias.forced_model == "haiku"
+        assert bias.forced_effort == "low"
+
+    def test_balanced_falls_back_to_sonnet_high(self) -> None:
+        bias = derive_bias(resolve("balanced"))
+        assert bias.forced_model == "sonnet"
+        assert bias.forced_effort == "high"
+
+    def test_reversibility_dominant_pins_blast_radius(self) -> None:
+        p = from_dict(
+            {
+                "correctness": 0.1,
+                "cost": 0.1,
+                "latency": 0.1,
+                "reversibility": 0.7,
+            }
+        )
+        bias = derive_bias(p)
+        assert bias.max_blast_radius == 1
+        assert bias.forced_model == "opus"
+
+    def test_rationale_includes_dominant_axis_value(self) -> None:
+        bias = derive_bias(resolve("safety-first"))
+        assert "correctness" in bias.rationale
+        assert "0.60" in bias.rationale
+
+    def test_derive_bias_revalidates(self) -> None:
+        # Pass a profile that bypassed from_dict — derive_bias should
+        # still complain if it can't be validated.
+        bad = CriterionProfile(
+            correctness=0.9,
+            cost=0.5,
+            latency=0.0,
+            reversibility=0.0,
+        )
+        with pytest.raises(CriterionProfileError):
+            derive_bias(bad)
+
+
+# ---------------------------------------------------------------------------
+# Task-side helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromTask:
+    def test_returns_none_for_missing_metadata(self) -> None:
+        class _Bare: ...
+
+        assert extract_from_task(_Bare()) is None
+
+    def test_returns_none_for_missing_key(self) -> None:
+        assert extract_from_task(_FakeTask()) is None
+
+    def test_returns_profile_for_named_preset(self) -> None:
+        task = _FakeTask(metadata={"criterion_profile": "safety-first"})
+        p = extract_from_task(task)
+        assert p is not None
+        assert p.name == "safety-first"
+
+    def test_returns_profile_for_inline_dict(self) -> None:
+        task = _FakeTask(
+            metadata={
+                "criterion_profile": {
+                    "correctness": 1.0,
+                    "cost": 0.0,
+                    "latency": 0.0,
+                    "reversibility": 0.0,
+                },
+            }
+        )
+        p = extract_from_task(task)
+        assert p is not None
+        assert p.correctness == pytest.approx(1.0)
+
+    def test_malformed_metadata_returns_none(self, caplog: pytest.LogCaptureFixture) -> None:
+        task = _FakeTask(metadata={"criterion_profile": "bogus-preset"})
+        with caplog.at_level("WARNING"):
+            assert extract_from_task(task) is None
+        assert any("invalid criterion_profile" in r.message for r in caplog.records)
+
+    def test_extract_honours_feature_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_FLAG, "0")
+        task = _FakeTask(metadata={"criterion_profile": "safety-first"})
+        assert extract_from_task(task) is None
+
+
+class TestInheritForChild:
+    def test_child_inherits_when_unset(self) -> None:
+        out = inherit_for_child({"criterion_profile": "safety-first"}, None)
+        assert out["criterion_profile"] == "safety-first"
+
+    def test_child_override_wins(self) -> None:
+        out = inherit_for_child(
+            {"criterion_profile": "safety-first"},
+            {"criterion_profile": "speed-first"},
+        )
+        assert out["criterion_profile"] == "speed-first"
+
+    def test_no_parent_no_child(self) -> None:
+        assert "criterion_profile" not in inherit_for_child(None, None)
+
+    def test_parent_with_no_profile(self) -> None:
+        out = inherit_for_child({}, {"other_field": "x"})
+        assert "criterion_profile" not in out
+        assert out["other_field"] == "x"
+
+    def test_returns_new_dict(self) -> None:
+        parent = {"criterion_profile": "balanced"}
+        child = {"foo": "bar"}
+        out = inherit_for_child(parent, child)
+        assert out is not parent
+        assert out is not child
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlag:
+    def test_default_is_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(ENV_FLAG, raising=False)
+        assert is_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE", "Off"])
+    def test_disabled_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv(ENV_FLAG, value)
+        assert is_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "anything-else"])
+    def test_enabled_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv(ENV_FLAG, value)
+        assert is_enabled() is True
+
+    def test_whitespace_around_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(ENV_FLAG, " 0 ")
+        assert is_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# describe()
+# ---------------------------------------------------------------------------
+
+
+class TestDescribe:
+    def test_describe_includes_preset_name(self) -> None:
+        out = describe(resolve("safety-first"))
+        assert "preset=safety-first" in out
+
+    def test_describe_includes_each_axis(self) -> None:
+        out = describe(resolve("balanced"))
+        for axis in AXES:
+            assert axis in out
+
+
+# ---------------------------------------------------------------------------
+# Vector view, dominant axis
+# ---------------------------------------------------------------------------
+
+
+class TestVectorView:
+    def test_as_vector_order_matches_axes(self) -> None:
+        p = resolve("safety-first")
+        vec = p.as_vector()
+        assert len(vec) == len(AXES)
+        d = p.as_dict()
+        for axis, v in zip(AXES, vec, strict=True):
+            assert d[axis] == v
+
+    def test_dominant_axis_breaks_ties_deterministically(self) -> None:
+        p = from_dict({"correctness": 0.25, "cost": 0.25, "latency": 0.25, "reversibility": 0.25})
+        # All four are tied; first wins.
+        assert p.dominant_axis() == AXES[0]
+
+    def test_dominant_axis_finds_max(self) -> None:
+        p = from_dict({"correctness": 0.1, "cost": 0.6, "latency": 0.2, "reversibility": 0.1})
+        assert p.dominant_axis() == "cost"
+
+
+# ---------------------------------------------------------------------------
+# Registry helper
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryHelpers:
+    def test_replace_in_registry_round_trips(self) -> None:
+        original = CRITERION_PROFILE_REGISTRY["balanced"]
+        try:
+            updated = replace_in_registry(
+                "balanced",
+                correctness=1.0,
+                cost=0.0,
+                latency=0.0,
+                reversibility=0.0,
+            )
+            assert updated.correctness == pytest.approx(1.0)
+            assert CRITERION_PROFILE_REGISTRY["balanced"] is updated
+        finally:
+            CRITERION_PROFILE_REGISTRY["balanced"] = original
+
+    def test_replace_in_registry_rejects_unknown(self) -> None:
+        with pytest.raises(KeyError):
+            replace_in_registry("does-not-exist", correctness=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Unicode + boundary edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_unicode_in_preset_name_via_from_dict(self) -> None:
+        out = from_dict(
+            {
+                "correctness": 1.0,
+                "cost": 0.0,
+                "latency": 0.0,
+                "reversibility": 0.0,
+            },
+            name="безопасность-prio",
+        )
+        assert out.name == "безопасность-prio"
+
+    def test_empty_metadata_dict_is_safe(self) -> None:
+        assert extract_from_task(_FakeTask(metadata={})) is None
+
+    def test_metadata_not_a_dict_is_safe(self) -> None:
+        @dataclass
+        class _Weird:
+            id: str = "T-weird"
+            metadata: str = "not a dict"
+
+        assert extract_from_task(_Weird()) is None  # type: ignore[arg-type]
+
+    def test_oversize_weight_rejected(self) -> None:
+        with pytest.raises(CriterionProfileError):
+            from_dict(
+                {
+                    "correctness": 1e6,
+                    "cost": 0.0,
+                    "latency": 0.0,
+                    "reversibility": 0.0,
+                }
+            )
+
+    def test_single_axis_full_weight_accepted(self) -> None:
+        p = from_dict(
+            {
+                "correctness": 1.0,
+                "cost": 0.0,
+                "latency": 0.0,
+                "reversibility": 0.0,
+            }
+        )
+        assert p.correctness == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: NaN propagation and weight overflow
+# ---------------------------------------------------------------------------
+
+
+class TestRegressionNaNPropagation:
+    """Concrete bug class — NaN slipping through validation.
+
+    Earlier drafts validated the sum first and short-circuited on a
+    NaN total (since ``nan == anything`` is False, the comparison
+    accidentally passed for some NaN combinations).  This regression
+    test pins the behaviour: any NaN in any axis must raise.
+    """
+
+    def test_nan_in_first_axis_raises(self) -> None:
+        with pytest.raises(CriterionProfileError):
+            CriterionProfile(
+                correctness=math.nan,
+                cost=0.5,
+                latency=0.3,
+                reversibility=0.2,
+            ).validate()
+
+    def test_nan_in_last_axis_raises(self) -> None:
+        with pytest.raises(CriterionProfileError):
+            CriterionProfile(
+                correctness=0.5,
+                cost=0.3,
+                latency=0.2,
+                reversibility=math.nan,
+            ).validate()
+
+    def test_overflow_weight_caught_via_sum_check(self) -> None:
+        # Weight overflow class: extremely large positive numbers should
+        # fail the sum check rather than silently routing the task.
+        with pytest.raises(CriterionProfileError):
+            from_dict(
+                {
+                    "correctness": 1e308,
+                    "cost": 1e308,
+                    "latency": 0.0,
+                    "reversibility": 0.0,
+                }
+            )
+
+
+# ---------------------------------------------------------------------------
+# Tolerance constant pinned
+# ---------------------------------------------------------------------------
+
+
+def test_tolerance_constant_matches_documented_value() -> None:
+    assert pytest.approx(1e-3) == SUM_TOLERANCE
+
+
+def test_axes_tuple_is_immutable() -> None:
+    assert isinstance(AXES, tuple)
+    assert AXES == ("correctness", "cost", "latency", "reversibility")


### PR DESCRIPTION
## TL;DR

| What | Status |
|------|--------|
| Per-task four-axis criterion profile | shipped |
| YAML presets (`safety-first`, `speed-first`, `balanced`, `cost-first`) | shipped + force-included in wheel |
| `bernstein run --criterion-profile <preset>` | shipped |
| `bernstein add-task --criterion-profile <preset>` | shipped |
| `bernstein criterion-profile show <task_id> | list` | shipped |
| Feature flag `BERNSTEIN_CRITERION_PROFILE=0` reverts to old routing | shipped |
| Child task inherits parent profile unless overridden | shipped |
| 123 tests (86 unit + 13 property + 24 integration) | shipped |

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| `CriterionProfile.validate()` rejects vectors that don't sum to 1.0 within 1e-3, rejects negatives, rejects unknown axis names | done — `test_sum_below_tolerance_raises`, `test_negative_weight_raises`, `test_unknown_axis_raises`, plus property `test_arbitrary_vector_either_validates_or_raises` |
| Loading `safety-first.yaml` returns the documented vector with `correctness >= 0.5` and `reversibility >= 0.2` | done — `test_safety_first_preset_has_documented_shape` |
| When a task has `metadata['criterion_profile']` set, routing returns a different model than without | done — `test_safety_first_routes_to_opus` asserts `baseline_cfg != biased_cfg` on the bundled fixture |
| `bernstein criterion-profile show <task_id>` prints the resolved weight vector and the named preset (or `"inline"`) | done — `test_show_prints_resolved_weights`, `test_show_json_mode` |
| Feature flag `BERNSTEIN_CRITERION_PROFILE=0` disables the path and reverts to pre-existing routing in CI | done — `test_disabled_flag_reverts_to_default_routing` |
| Unit test covers profile inheritance: child inherits unless overridden | done — `TestInheritForChild` (4 cases) + `TestInheritanceEndToEnd` (2 cases) |

## Test counts

| Suite | File | Count |
|-------|------|-------|
| Unit | `tests/unit/test_criterion_profile.py` | 86 |
| Property (Hypothesis) | `tests/property/test_criterion_profile_properties.py` | 13 |
| Integration | `tests/integration/test_criterion_profile_routing.py` | 24 |
| **Total** | | **123** |

All 123 pass locally with `uv run pytest`.

## What ships

- `src/bernstein/core/routing/criterion_profile.py` — `CriterionProfile` dataclass + `resolve` / `from_dict` / `normalize` / `derive_bias` / `extract_from_task` / `inherit_for_child`, plus YAML loader.
- `src/bernstein/core/routing/router_core.py` — new `_try_criterion_profile_bias` helper wired into `_select_model_config` ahead of bandit/cascade so the bias acts as a hard pin.
- `src/bernstein/cli/commands/criterion_profile_cmd.py` — `criterion-profile show` and `criterion-profile list` subcommands.
- `src/bernstein/cli/commands/task_cmd.py` — `--criterion-profile` flag on `bernstein add-task`.
- `src/bernstein/cli/run_bootstrap.py` — `--criterion-profile` flag on `bernstein run`.
- `templates/criterion_profiles/*.yaml` — four bundled presets, force-included into the wheel via `pyproject.toml` (mirrors the `templates/mode_profiles` pattern).
- `CHANGELOG.md` — Unreleased section updated.

## Design notes

- Four axes (`correctness`, `cost`, `latency`, `reversibility`) form a probability simplex with a 1e-3 tolerance.  YAML rounding errors pass; operator typos surface as `CriterionProfileError`.
- `derive_bias` maps the dominant axis to a `(forced_model, forced_effort, max_blast_radius)` tuple deterministically — same input always produces the same bias, so replay invariants hold.
- The bias slots in **after** an explicit `task.model` / `task.effort` override so manager-set pins still win; it slots in **before** the bandit/cascade routers so a `safety-first` task never silently lands on haiku.
- Profile resolution honours `BERNSTEIN_CRITERION_PROFILE=0` so CI can disable the feature without redeploying.
- Malformed metadata logs a warning rather than crashing — the router falls through to its existing heuristic path.

## Test plan

- [x] `uv run pytest tests/unit/test_criterion_profile.py tests/property/test_criterion_profile_properties.py tests/integration/test_criterion_profile_routing.py` clean (123 passed)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run pyright` on new files clean (0 errors on `criterion_profile.py` and `criterion_profile_cmd.py`)
- [x] Existing router tests still pass (`tests/unit/test_router.py`, `tests/unit/test_per_step_routing.py`, `tests/unit/test_hijacker.py`, `tests/unit/test_mode_profile.py`)
- [x] CLI imports succeed (`bernstein --help` works)