### PR TITLE
feat(observability): bernstein simulate - digital-twin orchestration (closes #1374)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -51,6 +51,7 @@ alwaysApply: false
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
 | `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -52,6 +52,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
 | `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
 | `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
 | `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -52,6 +52,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `security/`             | security sub-package |
 | `server/`               | server sub-package — re-exports for backward compatibility |
 | `sessions/`             | Session-level orchestration primitives that span multiple subsystems |
+| `simulate/`             | Digital-twin orchestration simulator (issue #1374) |
 | `skills/`               | Progressive-disclosure skill packs (oai-004) |
 | `storage/`              | Pluggable artifact storage sinks (oai-003) |
 | `tasks/`                | tasks sub-package |

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Commands that eliminate the glue code most teams end up writing around their run
 | `bernstein wiki build` | Renders `WIKI.md` for the current repo from the AST symbol graph. Local, no LLM call, no cloud round-trip. |
 | `bernstein identity show` / `decode` / `verify` / `disable` | Operator-side helpers for the install-rev fingerprint embedded in shared yaml/trace/role-prompt artefacts. No network egress; discovery uses public `gh search code`. |
 | `bernstein security role-adapter-policy` | Inspects and edits the per-role adapter allow-list (deny-list enforcement at spawn time). |
+| `bernstein simulate <plan.yaml>` | Digital-twin dry-run: predicts cost band (p50/p90), wall-clock, abandonment probability, per-task blast-radius, and bottlenecks against historical `.sdd/traces/` + `.sdd/metrics/` without spawning a real agent or hitting the network. Supports `--from-traces N`, `--seed S`, `--budget-cap X`, `--out report.json\|report.md`. Exits non-zero when a `--budget-cap` is breached. |
 
 ### retrieval & caching: what's actually under the hood
 

--- a/src/bernstein/cli/commands/simulate_cmd.py
+++ b/src/bernstein/cli/commands/simulate_cmd.py
@@ -1,0 +1,159 @@
+"""CLI surface for ``bernstein simulate`` (issue #1374).
+
+Dry-runs a full multi-agent cycle on synthetic data with mock LLMs so
+operators see decision flow, costs, and abandonment-rate predictions
+BEFORE spending real tokens.
+
+Usage::
+
+    bernstein simulate <plan.yaml> [--from-traces N] [--seed S]
+                                   [--budget-cap X] [--out report.json|report.md]
+
+The command exits non-zero when the simulator cannot load the plan, or
+when a ``--budget-cap`` is supplied and the predicted p90 spend breaches
+it. Otherwise the human-readable Markdown summary is printed to stdout
+and (optionally) the structured JSON sidecar is written to ``--out``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import click
+
+from bernstein.core.simulate import (
+    SimulationError,
+    SimulationOptions,
+    render_json,
+    render_markdown,
+    simulate,
+)
+
+__all__ = ["simulate_cmd"]
+
+
+_DEFAULT_METRICS_DIR = Path(".sdd/metrics")
+_DEFAULT_TRACES_DIR = Path(".sdd/traces")
+
+
+def _resolve_dir(explicit: str | None, default: Path) -> str | None:
+    """Pick the dir to consult: explicit > default-if-exists > None."""
+    if explicit is not None:
+        return explicit
+    if default.exists() and default.is_dir():
+        return str(default)
+    return None
+
+
+@click.command("simulate")
+@click.argument(
+    "plan",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--from-traces",
+    "from_traces",
+    type=click.IntRange(min=1),
+    default=50,
+    show_default=True,
+    help="Maximum historical trace records to consult per (role, adapter).",
+)
+@click.option(
+    "--seed",
+    type=int,
+    default=42,
+    show_default=True,
+    help="Random seed. Same seed + same plan + same traces yields a byte-identical report.",
+)
+@click.option(
+    "--budget-cap",
+    "budget_cap",
+    type=click.FloatRange(min=0.0),
+    default=None,
+    help="USD ceiling for the run. Non-zero exit when the predicted p90 spend exceeds it.",
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Write report to this path (``.json`` or ``.md``). Stdout always shows the Markdown summary.",
+)
+@click.option(
+    "--metrics-dir",
+    "metrics_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Path to .sdd/metrics. Defaults to ./.sdd/metrics when present, else cold-start.",
+)
+@click.option(
+    "--traces-dir",
+    "traces_dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Path to .sdd/traces. Defaults to ./.sdd/traces when present, else cold-start.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(("md", "json"), case_sensitive=False),
+    default="md",
+    show_default=True,
+    help="Stdout format. Use ``--out`` for the sibling-format sidecar.",
+)
+def simulate_cmd(
+    plan: Path,
+    from_traces: int,
+    seed: int,
+    budget_cap: float | None,
+    out_path: Path | None,
+    metrics_dir: Path | None,
+    traces_dir: Path | None,
+    fmt: str,
+) -> None:
+    """Digital-twin simulation of a plan against historical traces (issue #1374).
+
+    PLAN is the YAML plan file to simulate. The simulator never spawns a
+    real agent or hits the network - it only reads ``.sdd/traces`` and
+    ``.sdd/metrics`` for calibration.
+    """
+    options = SimulationOptions(
+        seed=seed,
+        from_traces=from_traces,
+        budget_cap=budget_cap,
+        metrics_dir=_resolve_dir(str(metrics_dir) if metrics_dir else None, _DEFAULT_METRICS_DIR),
+        traces_dir=_resolve_dir(str(traces_dir) if traces_dir else None, _DEFAULT_TRACES_DIR),
+    )
+
+    try:
+        report = simulate(plan, options)
+    except SimulationError as exc:
+        click.echo(f"simulate: {exc}", err=True)
+        sys.exit(2)
+
+    if fmt.lower() == "json":
+        click.echo(render_json(report))
+    else:
+        click.echo(render_markdown(report))
+
+    if out_path is not None:
+        suffix = out_path.suffix.lower()
+        if suffix == ".json":
+            payload = render_json(report)
+        elif suffix in {".md", ".markdown"}:
+            payload = render_markdown(report)
+        else:
+            # Default sidecar is JSON when extension is unknown so the
+            # operator always gets a machine-readable artifact.
+            payload = render_json(report)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(payload + "\n", encoding="utf-8")
+        click.echo(f"\nReport written to {out_path}", err=True)
+
+    if report.aggregate.budget_breach:
+        click.echo(
+            f"\nbudget cap ${options.budget_cap:.2f} breached by predicted p90 ${report.aggregate.total_cost_p90:.2f}",
+            err=True,
+        )
+        sys.exit(3)

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -972,3 +972,8 @@ cli.add_command(compare_cmd, "compare")
 from bernstein.cli.commands.abandonments_cmd import abandonments_group  # noqa: E402
 
 cli.add_command(abandonments_group, "abandonments")
+
+# Digital-twin orchestration simulator (#1374).
+from bernstein.cli.commands.simulate_cmd import simulate_cmd  # noqa: E402
+
+cli.add_command(simulate_cmd, "simulate")

--- a/src/bernstein/core/simulate/__init__.py
+++ b/src/bernstein/core/simulate/__init__.py
@@ -1,0 +1,65 @@
+"""Digital-twin orchestration simulator (issue #1374).
+
+This subpackage provides a pure, side-effect-free simulator that runs a
+Bernstein plan against historical traces and mock LLM stubs to answer
+"what-if" questions before any real tokens are spent.
+
+Public surface:
+
+* :func:`simulate` - top-level entry point: ``simulate(plan, options)``
+  returns a :class:`SimulationReport`.
+* :class:`SimulationReport` - structured result with per-task predictions
+  and aggregate bands (cost, abandonment, blast-radius, bottlenecks).
+* :class:`SimulationOptions` - knobs (seed, budget cap, history depth).
+* :class:`TaskPrediction` - per-task forecast: cost band, abandon prob,
+  blast-radius score, latency estimate.
+
+The simulator is read-only: it consults ``.sdd/traces/`` and
+``.sdd/metrics/`` for calibration, never writes outside the operator-
+supplied ``--out`` path, and never spawns a real agent.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.simulate.predictor import (
+    DEFAULT_HISTORY_LIMIT,
+    AbandonmentPredictor,
+    BlastRadiusPredictor,
+    CostPredictor,
+    HistoricalTraces,
+    LatencyPredictor,
+    load_traces,
+)
+from bernstein.core.simulate.report import (
+    AggregateBands,
+    Bottleneck,
+    CriterionProfileBias,
+    DecisionEdge,
+    SimulationOptions,
+    SimulationReport,
+    TaskPrediction,
+    render_json,
+    render_markdown,
+)
+from bernstein.core.simulate.runner import SimulationError, simulate
+
+__all__ = [
+    "DEFAULT_HISTORY_LIMIT",
+    "AbandonmentPredictor",
+    "AggregateBands",
+    "BlastRadiusPredictor",
+    "Bottleneck",
+    "CostPredictor",
+    "CriterionProfileBias",
+    "DecisionEdge",
+    "HistoricalTraces",
+    "LatencyPredictor",
+    "SimulationError",
+    "SimulationOptions",
+    "SimulationReport",
+    "TaskPrediction",
+    "load_traces",
+    "render_json",
+    "render_markdown",
+    "simulate",
+]

--- a/src/bernstein/core/simulate/predictor.py
+++ b/src/bernstein/core/simulate/predictor.py
@@ -1,0 +1,413 @@
+"""Cost / latency / abandonment / blast-radius predictors.
+
+Each predictor is a small, pure object that consumes a task description
+plus an optional :class:`HistoricalTraces` view and returns a forecast.
+
+Design constraints (issue #1374):
+
+* Read-only: predictors only read from ``.sdd/traces`` and
+  ``.sdd/metrics``; never write.
+* Deterministic: a fixed seed produces a stable output for the same input.
+* Cold-start safe: missing history falls back to a documented heuristic.
+* No NumPy: ``statistics.quantiles`` covers everything we need.
+
+The cost predictor delegates to :mod:`bernstein.core.cost.preflight` when
+metrics history is available, so the simulator stays consistent with the
+preflight banner shown on real runs.
+
+The blast-radius predictor delegates to
+:func:`bernstein.core.quality.blast_radius.score_change`, scoring on the
+task's declared ``owned_files`` plus a synthetic diff body assembled from
+the task description. This keeps risk scoring honest without requiring a
+real diff.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from bernstein.core.cost.preflight import compute_band, load_history
+from bernstein.core.quality.blast_radius import BlastRadiusScorer
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.core.tasks.models import Task
+
+__all__ = [
+    "DEFAULT_HISTORY_LIMIT",
+    "AbandonmentPredictor",
+    "BlastRadiusPredictor",
+    "CostPredictor",
+    "HistoricalTraces",
+    "LatencyPredictor",
+    "load_traces",
+]
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_HISTORY_LIMIT: Final[int] = 50
+"""Newest-N records consulted per (role, adapter) key."""
+
+# Heuristic priors when no traces are available. These are calibrated to
+# match the cold-start envelope used in :mod:`bernstein.core.cost.preflight`
+# and the abandon-rate prior observed across the seed plans shipped with
+# Bernstein (~5% abandon, 60s minimum task wall-clock).
+_COLD_ABANDON_PRIOR: Final[float] = 0.05
+_COLD_LATENCY_P50: Final[float] = 60.0
+_COLD_LATENCY_P90: Final[float] = 180.0
+
+# Mapping from role to canonical criterion bucket. Used by the runner to
+# build the criterion-profile bias chart. Unknown roles fall back to
+# ``"quality"`` (most roles in the catalog are quality-leaning by default).
+_ROLE_CRITERION: Final[dict[str, str]] = {
+    "backend": "quality",
+    "frontend": "speed",
+    "qa": "quality",
+    "security": "safety",
+    "adversary": "safety",
+    "reviewer": "safety",
+    "ci-fixer": "speed",
+    "devops": "speed",
+    "docs": "cost",
+    "manager": "cost",
+    "architect": "quality",
+    "analyst": "quality",
+    "ml-engineer": "quality",
+    "prompt-engineer": "cost",
+    "retrieval": "speed",
+    "resolver": "safety",
+    "visionary": "cost",
+    "vp": "cost",
+}
+
+
+def role_criterion(role: str) -> str:
+    """Return the canonical criterion bucket for ``role``.
+
+    Falls back to ``"quality"`` for unknown roles.
+    """
+    return _ROLE_CRITERION.get(role.strip().lower(), "quality")
+
+
+# ---------------------------------------------------------------------------
+# Historical traces
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalTraces:
+    """In-memory view of historical agent traces.
+
+    Built from ``.sdd/traces/*.jsonl`` records. Only the fields the
+    simulator needs are extracted; everything else is ignored. The
+    structure is keyed by ``(role, adapter)`` so cold-start fallback can
+    be applied per dimension.
+
+    Attributes:
+        abandon_rates: Map from ``(role, adapter)`` to observed abandon
+            probability in [0, 1].
+        latency_samples: Map from ``(role, adapter)`` to a tuple of
+            wall-clock samples (seconds). Empty tuple means cold-start.
+        sample_count: Total number of trace records parsed across all
+            keys.
+    """
+
+    abandon_rates: dict[tuple[str, str], float] = field(default_factory=dict[tuple[str, str], float])
+    latency_samples: dict[tuple[str, str], tuple[float, ...]] = field(
+        default_factory=dict[tuple[str, str], tuple[float, ...]]
+    )
+    sample_count: int = 0
+
+    @property
+    def is_empty(self) -> bool:
+        return self.sample_count == 0
+
+
+def _coerce_str(raw: object) -> str:
+    if isinstance(raw, str):
+        return raw.strip().lower()
+    return ""
+
+
+def _coerce_float(raw: object) -> float | None:
+    try:
+        value = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if value != value or value < 0.0 or value == float("inf"):
+        return None
+    return value
+
+
+def load_traces(traces_dir: Path | None, *, limit: int = DEFAULT_HISTORY_LIMIT) -> HistoricalTraces:
+    """Load historical traces into a :class:`HistoricalTraces` view.
+
+    Reads every ``*.jsonl`` file under ``traces_dir``. Each line is
+    expected to be a JSON object with at minimum a ``role`` field; the
+    optional fields the simulator uses are:
+
+    * ``adapter`` / ``cli`` / ``model`` - adapter id
+    * ``abandoned`` - boolean
+    * ``status`` - ``"abandoned"`` / ``"completed"`` etc.
+    * ``latency_seconds`` / ``duration_s`` - wall-clock seconds
+
+    Missing or malformed records are skipped silently.
+    """
+    abandon_counters: dict[tuple[str, str], list[int]] = {}
+    latency_buckets: dict[tuple[str, str], list[float]] = {}
+    total = 0
+
+    if traces_dir is None or not traces_dir.exists() or not traces_dir.is_dir():
+        return HistoricalTraces()
+
+    for trace_file in sorted(traces_dir.glob("*.jsonl")):
+        try:
+            text = trace_file.read_text(encoding="utf-8")
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.debug("simulate: trace file unreadable: %s (%s)", trace_file, exc)
+            continue
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            record: dict[str, object] = {
+                str(k): v  # type: ignore[reportUnknownArgumentType, reportUnknownVariableType]
+                for k, v in parsed.items()  # type: ignore[reportUnknownVariableType]
+            }
+            role = _coerce_str(record.get("role"))
+            if not role:
+                continue
+            adapter = (
+                _coerce_str(record.get("adapter"))
+                or _coerce_str(record.get("cli"))
+                or _coerce_str(record.get("model"))
+                or "mock"
+            )
+            key = (role, adapter)
+            counters = abandon_counters.setdefault(key, [0, 0])  # [abandoned, total]
+            abandoned = bool(record.get("abandoned")) or _coerce_str(record.get("status")) == "abandoned"
+            counters[1] += 1
+            if abandoned:
+                counters[0] += 1
+            latency = _coerce_float(record.get("latency_seconds")) or _coerce_float(record.get("duration_s"))
+            if latency is not None:
+                bucket = latency_buckets.setdefault(key, [])
+                bucket.append(latency)
+            total += 1
+
+    abandon_rates: dict[tuple[str, str], float] = {}
+    for key, (bad, all_) in abandon_counters.items():
+        if all_ <= 0:
+            continue
+        abandon_rates[key] = bad / all_
+
+    latency_samples: dict[tuple[str, str], tuple[float, ...]] = {}
+    for key, samples in latency_buckets.items():
+        # Newest-last; trim to ``limit``.
+        trimmed = samples[-limit:] if len(samples) > limit else samples
+        latency_samples[key] = tuple(trimmed)
+
+    return HistoricalTraces(
+        abandon_rates=abandon_rates,
+        latency_samples=latency_samples,
+        sample_count=total,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cost predictor
+# ---------------------------------------------------------------------------
+
+
+def _percentile(samples: Sequence[float], q: float) -> float:
+    """Return ``q``-quantile (``q`` in [0, 1]) via stdlib only."""
+    if not samples:
+        return 0.0
+    if len(samples) == 1:
+        return float(samples[0])
+    idx = round(q * 100) - 1
+    idx = max(0, min(98, idx))
+    cuts = statistics.quantiles(list(samples), n=100, method="inclusive")
+    return cuts[idx]
+
+
+@dataclass(frozen=True, slots=True)
+class CostPredictor:
+    """Predict per-task cost band in USD.
+
+    Delegates to :mod:`bernstein.core.cost.preflight` so the simulation
+    stays consistent with the real preflight banner. Cold-start path uses
+    the same legacy heuristic, keyed off ``model``.
+
+    Attributes:
+        metrics_dir: Optional path to ``.sdd/metrics``. ``None`` forces
+            cold-start.
+        default_model: Model id used for the cold-start heuristic when a
+            task does not declare its own.
+        default_adapter: Adapter id used when a task does not declare
+            ``cli``.
+        history_limit: Max samples per (role, adapter) pair.
+    """
+
+    metrics_dir: Path | None = None
+    default_model: str = "claude-sonnet-4"
+    default_adapter: str = "mock"
+    history_limit: int = DEFAULT_HISTORY_LIMIT
+
+    def predict(self, task: Task) -> tuple[float, float, bool]:
+        """Return ``(p50, p90, cold_start)`` for ``task``."""
+        role = task.role or "backend"
+        adapter = (task.cli or self.default_adapter).strip().lower()
+        model = (task.model or self.default_model).strip()
+        if self.metrics_dir is None:
+            # Force the heuristic path without touching disk.
+            band = compute_band(
+                role=role,
+                adapter=adapter,
+                model=model,
+                task_count=1,
+                metrics_dir=Path("/__simulate_no_metrics__"),
+                history_limit=self.history_limit,
+            )
+            return (band.p50, band.p90, band.cold_start)
+        band = compute_band(
+            role=role,
+            adapter=adapter,
+            model=model,
+            task_count=1,
+            metrics_dir=self.metrics_dir,
+            history_limit=self.history_limit,
+        )
+        return (band.p50, band.p90, band.cold_start)
+
+    def history_count(self, *, role: str, adapter: str) -> int:
+        """Return the number of historical cost samples for ``(role, adapter)``."""
+        if self.metrics_dir is None:
+            return 0
+        return len(
+            load_history(
+                self.metrics_dir / "cost.jsonl",
+                role=role,
+                adapter=adapter,
+                limit=self.history_limit,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# Latency predictor
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LatencyPredictor:
+    """Predict per-task wall-clock latency (seconds).
+
+    History path: percentile over historical samples for ``(role, adapter)``.
+    Cold-start: uniform prior using the task's ``estimated_minutes``
+    field scaled into seconds, with a documented minimum.
+
+    Attributes:
+        traces: :class:`HistoricalTraces` view.
+        floor_p50: Minimum p50 seconds for cold-start.
+        floor_p90: Minimum p90 seconds for cold-start.
+    """
+
+    traces: HistoricalTraces = field(default_factory=HistoricalTraces)
+    floor_p50: float = _COLD_LATENCY_P50
+    floor_p90: float = _COLD_LATENCY_P90
+
+    def predict(self, task: Task, *, default_adapter: str = "mock") -> tuple[float, float]:
+        """Return ``(p50, p90)`` seconds for ``task``."""
+        role = (task.role or "backend").strip().lower()
+        adapter = (task.cli or default_adapter).strip().lower()
+        samples = self.traces.latency_samples.get((role, adapter), ())
+        if samples:
+            p50 = _percentile(samples, 0.5)
+            p90 = _percentile(samples, 0.9)
+            if p90 < p50:
+                p90 = p50
+            return (round(p50, 2), round(p90, 2))
+        # Cold-start: scale from estimated_minutes, floor at the prior.
+        minutes = float(max(1, getattr(task, "estimated_minutes", 30)))
+        base = minutes * 60.0
+        p50 = max(self.floor_p50, base * 0.6)
+        p90 = max(self.floor_p90, base * 1.2)
+        return (round(p50, 2), round(p90, 2))
+
+
+# ---------------------------------------------------------------------------
+# Abandonment predictor
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AbandonmentPredictor:
+    """Predict abandon probability for a task in [0, 1].
+
+    History path: fraction of past records for ``(role, adapter)`` that
+    ended in ``status == "abandoned"`` (or carried ``abandoned: true``).
+
+    Cold-start: returns ``_COLD_ABANDON_PRIOR``. The prior is intentionally
+    small but non-zero so a downstream consumer always sees a "this might
+    fail" signal even on green workspaces.
+
+    Attributes:
+        traces: :class:`HistoricalTraces` view.
+        cold_prior: Cold-start abandon probability.
+    """
+
+    traces: HistoricalTraces = field(default_factory=HistoricalTraces)
+    cold_prior: float = _COLD_ABANDON_PRIOR
+
+    def predict(self, task: Task, *, default_adapter: str = "mock") -> float:
+        """Return abandon probability for ``task`` in [0, 1]."""
+        role = (task.role or "backend").strip().lower()
+        adapter = (task.cli or default_adapter).strip().lower()
+        rate = self.traces.abandon_rates.get((role, adapter))
+        if rate is None:
+            return self.cold_prior
+        # Clamp defensively; corrupt traces could push the ratio out.
+        return max(0.0, min(1.0, rate))
+
+
+# ---------------------------------------------------------------------------
+# Blast-radius predictor
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BlastRadiusPredictor:
+    """Predict the blast-radius score for a task in [0, 1].
+
+    Reuses the production scorer so this estimate matches the gate that
+    would actually evaluate the change on a real run. We construct a
+    "synthetic" diff body from the task description so content detectors
+    still get a chance to fire on obvious destructive keywords
+    (``DROP TABLE``, ``rm -rf`` etc.).
+
+    Attributes:
+        scorer: Underlying production scorer.
+    """
+
+    scorer: BlastRadiusScorer = field(default_factory=BlastRadiusScorer)
+
+    def predict(self, task: Task) -> float:
+        """Return the blast-radius score for ``task`` in [0, 1]."""
+        files = tuple(task.owned_files or ())
+        diff_text = task.description or ""
+        report = self.scorer.score(files=files, diff_text=diff_text)
+        return float(report.score)

--- a/src/bernstein/core/simulate/report.py
+++ b/src/bernstein/core/simulate/report.py
@@ -1,0 +1,401 @@
+"""Structured simulation report types and rendering helpers.
+
+The report is the public contract of :func:`bernstein.core.simulate.simulate`.
+It is deliberately JSON-friendly (frozen dataclasses with ``to_dict``) so
+operators can persist it, diff it across runs, and pipe it into downstream
+dashboards without binding to internal types.
+
+Two renderers are provided:
+
+* :func:`render_json` - canonical JSON sidecar.
+* :func:`render_markdown` - human-readable summary with decision-tree
+  ASCII, criterion-profile bias chart, and bottleneck table.
+
+Both are pure functions: they accept a :class:`SimulationReport` and
+return a string. They do not touch the filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "AggregateBands",
+    "Bottleneck",
+    "CriterionProfileBias",
+    "DecisionEdge",
+    "SimulationOptions",
+    "SimulationReport",
+    "TaskPrediction",
+    "render_json",
+    "render_markdown",
+]
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationOptions:
+    """Knobs controlling a simulation run.
+
+    Attributes:
+        seed: Deterministic random seed. Same seed + same plan + same
+            traces yields byte-identical reports.
+        from_traces: Maximum historical trace records to consult per
+            (role, adapter) pair. Newest records win.
+        budget_cap: Optional USD ceiling. When set, the simulator marks
+            tasks whose predicted p90 cost would push the running aggregate
+            over the cap. ``None`` means no cap.
+        metrics_dir: Path to ``.sdd/metrics`` for cost history. ``None``
+            uses cold-start heuristics throughout.
+        traces_dir: Path to ``.sdd/traces`` for abandonment/latency
+            calibration. ``None`` uses uniform priors.
+    """
+
+    seed: int = 42
+    from_traces: int = 50
+    budget_cap: float | None = None
+    metrics_dir: str | None = None
+    traces_dir: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Per-task forecast
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TaskPrediction:
+    """Forecast for a single task in the plan.
+
+    Attributes:
+        task_id: Stable id from the plan loader (e.g. ``"plan-0-1"``).
+        title: Task title verbatim from the plan.
+        role: Agent role (``"backend"``, ``"qa"`` ...).
+        adapter: Adapter id used in the forecast (defaults to ``"mock"``).
+        cost_p50: Median predicted USD spend for this task.
+        cost_p90: 90th-percentile predicted USD spend for this task.
+        latency_p50: Median predicted wall-clock seconds.
+        latency_p90: 90th-percentile predicted wall-clock seconds.
+        abandon_probability: Probability in [0, 1] that the task is
+            abandoned (manager rejects or worker bails out).
+        blast_radius_score: Estimated blast-radius score in [0, 1].
+        depends_on: Task ids this task waits on (verbatim from plan).
+        cold_start: True when no historical samples backed the cost band
+            and the heuristic fallback was used.
+        budget_violation: True when the operator-supplied ``budget_cap``
+            is exceeded by this task's p90 contribution.
+    """
+
+    task_id: str
+    title: str
+    role: str
+    adapter: str
+    cost_p50: float
+    cost_p90: float
+    latency_p50: float
+    latency_p90: float
+    abandon_probability: float
+    blast_radius_score: float
+    depends_on: tuple[str, ...] = field(default_factory=tuple)
+    cold_start: bool = False
+    budget_violation: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "title": self.title,
+            "role": self.role,
+            "adapter": self.adapter,
+            "cost_p50": round(self.cost_p50, 4),
+            "cost_p90": round(self.cost_p90, 4),
+            "latency_p50": round(self.latency_p50, 2),
+            "latency_p90": round(self.latency_p90, 2),
+            "abandon_probability": round(self.abandon_probability, 4),
+            "blast_radius_score": round(self.blast_radius_score, 4),
+            "depends_on": list(self.depends_on),
+            "cold_start": self.cold_start,
+            "budget_violation": self.budget_violation,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Aggregate bands
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class AggregateBands:
+    """Roll-up bands across all tasks in the plan.
+
+    Attributes:
+        total_cost_p50: Sum of per-task ``cost_p50`` (USD).
+        total_cost_p90: Sum of per-task ``cost_p90`` (USD).
+        wall_clock_p50: Critical-path latency at p50 (seconds).
+        wall_clock_p90: Critical-path latency at p90 (seconds).
+        expected_abandonments: Sum of per-task ``abandon_probability``.
+        max_blast_radius: Highest per-task blast-radius score.
+        budget_cap: Operator-supplied USD ceiling (echoed). ``None`` when
+            unset.
+        budget_breach: True when ``total_cost_p90 > budget_cap`` and a cap
+            was supplied.
+    """
+
+    total_cost_p50: float
+    total_cost_p90: float
+    wall_clock_p50: float
+    wall_clock_p90: float
+    expected_abandonments: float
+    max_blast_radius: float
+    budget_cap: float | None = None
+    budget_breach: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_cost_p50": round(self.total_cost_p50, 4),
+            "total_cost_p90": round(self.total_cost_p90, 4),
+            "wall_clock_p50": round(self.wall_clock_p50, 2),
+            "wall_clock_p90": round(self.wall_clock_p90, 2),
+            "expected_abandonments": round(self.expected_abandonments, 4),
+            "max_blast_radius": round(self.max_blast_radius, 4),
+            "budget_cap": self.budget_cap,
+            "budget_breach": self.budget_breach,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Bottlenecks and decision edges
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Bottleneck:
+    """A task flagged as a bottleneck on the simulated critical path.
+
+    Attributes:
+        task_id: Task id of the bottleneck.
+        title: Human-readable task title.
+        reason: Short label (``"fan_out"``, ``"high_abandon"``,
+            ``"long_latency"``, ``"high_blast_radius"``).
+        score: Magnitude that justified the flag (larger == worse).
+    """
+
+    task_id: str
+    title: str
+    reason: str
+    score: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "title": self.title,
+            "reason": self.reason,
+            "score": round(self.score, 4),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionEdge:
+    """One directed edge in the simulated decision flow.
+
+    Attributes:
+        from_task: Predecessor task id (``"START"`` for plan entry).
+        to_task: Successor task id.
+        label: Short edge label (typically the predecessor's role).
+    """
+
+    from_task: str
+    to_task: str
+    label: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"from": self.from_task, "to": self.to_task, "label": self.label}
+
+
+@dataclass(frozen=True, slots=True)
+class CriterionProfileBias:
+    """Aggregate bias of the predicted decision flow per criterion.
+
+    Each task contributes its role weight to one of the four canonical
+    criterion buckets (``speed``, ``cost``, ``quality``, ``safety``).
+    Operators read this to spot lop-sided plans (e.g. 80% of work on
+    "speed" with no ``security`` review).
+
+    Attributes:
+        speed: Share in [0, 1] of work biased toward speed.
+        cost: Share in [0, 1] biased toward cost minimisation.
+        quality: Share in [0, 1] biased toward quality / verification.
+        safety: Share in [0, 1] biased toward safety / security review.
+    """
+
+    speed: float
+    cost: float
+    quality: float
+    safety: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "speed": round(self.speed, 4),
+            "cost": round(self.cost, 4),
+            "quality": round(self.quality, 4),
+            "safety": round(self.safety, 4),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Top-level report
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class SimulationReport:
+    """Structured output of a simulation run.
+
+    The report is JSON-stable across runs of the same plan with the same
+    seed and the same trace history. Operators diff it across plan edits
+    to spot regressions before paying real tokens.
+    """
+
+    plan_name: str
+    plan_path: str
+    seed: int
+    task_count: int
+    tasks: tuple[TaskPrediction, ...]
+    aggregate: AggregateBands
+    bottlenecks: tuple[Bottleneck, ...]
+    decision_edges: tuple[DecisionEdge, ...]
+    criterion_bias: CriterionProfileBias
+    history_samples: int
+    cold_start: bool
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plan_name": self.plan_name,
+            "plan_path": self.plan_path,
+            "seed": self.seed,
+            "task_count": self.task_count,
+            "tasks": [t.to_dict() for t in self.tasks],
+            "aggregate": self.aggregate.to_dict(),
+            "bottlenecks": [b.to_dict() for b in self.bottlenecks],
+            "decision_edges": [e.to_dict() for e in self.decision_edges],
+            "criterion_bias": self.criterion_bias.to_dict(),
+            "history_samples": self.history_samples,
+            "cold_start": self.cold_start,
+            "notes": list(self.notes),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def render_json(report: SimulationReport, *, indent: int = 2) -> str:
+    """Return a canonical JSON string for ``report``.
+
+    Sort keys for stability across runs.
+    """
+    return json.dumps(report.to_dict(), indent=indent, sort_keys=True)
+
+
+def _bar(value: float, width: int = 20) -> str:
+    """Render a bracketed unit-bar of ``width`` characters for ``value`` in [0, 1]."""
+    clamped = max(0.0, min(1.0, value))
+    filled = round(clamped * width)
+    return "[" + ("#" * filled) + ("-" * (width - filled)) + "]"
+
+
+def _format_usd(value: float) -> str:
+    return f"${value:.2f}"
+
+
+def render_markdown(report: SimulationReport) -> str:
+    """Return a human-readable Markdown summary.
+
+    Includes:
+
+    * TL;DR with cost band, wall-clock, abandonment, max blast-radius.
+    * Per-task table with cost/abandon/blast-radius columns.
+    * Bottleneck section.
+    * Criterion-profile bias chart (ASCII bars).
+    * Decision-flow as a Mermaid graph (operators can paste into docs).
+    """
+    agg = report.aggregate
+    bias = report.criterion_bias
+
+    lines: list[str] = []
+    lines.append(f"# Bernstein simulate - {report.plan_name}")
+    lines.append("")
+    lines.append(f"Plan: `{report.plan_path}` - seed `{report.seed}` - {report.task_count} task(s)")
+    lines.append("")
+    lines.append("## TL;DR")
+    lines.append("")
+    lines.append(f"- **Cost band**: {_format_usd(agg.total_cost_p50)} (p50) .. {_format_usd(agg.total_cost_p90)} (p90)")
+    lines.append(f"- **Wall-clock**: {agg.wall_clock_p50:.0f}s (p50) .. {agg.wall_clock_p90:.0f}s (p90)")
+    lines.append(f"- **Expected abandonments**: {agg.expected_abandonments:.2f}")
+    lines.append(f"- **Max blast-radius**: {agg.max_blast_radius:.2f}")
+    if agg.budget_cap is not None:
+        flag = " - BREACH" if agg.budget_breach else " - within cap"
+        lines.append(f"- **Budget cap**: {_format_usd(agg.budget_cap)}{flag}")
+    if report.cold_start:
+        lines.append("- *Note: cold-start, heuristic fallback used.*")
+    lines.append("")
+
+    lines.append("## Per-task predictions")
+    lines.append("")
+    lines.append("| Task | Role | Cost p50 | Cost p90 | Abandon | Blast |")
+    lines.append("|------|------|---------:|---------:|--------:|------:|")
+    for task in report.tasks:
+        warn = " !" if task.budget_violation else ""
+        lines.append(
+            f"| {task.task_id} {task.title}{warn} | {task.role} | "
+            f"{_format_usd(task.cost_p50)} | {_format_usd(task.cost_p90)} | "
+            f"{task.abandon_probability:.2f} | {task.blast_radius_score:.2f} |"
+        )
+    lines.append("")
+
+    lines.append("## Bottlenecks")
+    lines.append("")
+    if report.bottlenecks:
+        for bn in report.bottlenecks:
+            lines.append(f"- `{bn.task_id}` ({bn.reason}, score={bn.score:.2f}) - {bn.title}")
+    else:
+        lines.append("- None identified.")
+    lines.append("")
+
+    lines.append("## Criterion-profile bias")
+    lines.append("")
+    lines.append(f"- speed    {_bar(bias.speed)}  {bias.speed:.2f}")
+    lines.append(f"- cost     {_bar(bias.cost)}  {bias.cost:.2f}")
+    lines.append(f"- quality  {_bar(bias.quality)}  {bias.quality:.2f}")
+    lines.append(f"- safety   {_bar(bias.safety)}  {bias.safety:.2f}")
+    lines.append("")
+
+    lines.append("## Decision flow")
+    lines.append("")
+    lines.append("```mermaid")
+    lines.append("graph TD")
+    for edge in report.decision_edges:
+        label = f"|{edge.label}|" if edge.label else ""
+        # Mermaid node ids must be ascii-safe; the plan loader already
+        # produces ``plan-{stage}-{step}`` ids that satisfy this.
+        from_node = edge.from_task.replace("-", "_")
+        to_node = edge.to_task.replace("-", "_")
+        lines.append(f"  {from_node} -->{label} {to_node}")
+    lines.append("```")
+    lines.append("")
+
+    if report.notes:
+        lines.append("## Notes")
+        lines.append("")
+        for note in report.notes:
+            lines.append(f"- {note}")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/src/bernstein/core/simulate/runner.py
+++ b/src/bernstein/core/simulate/runner.py
@@ -1,0 +1,366 @@
+"""Digital-twin orchestration runner.
+
+The runner wires the four predictors together, walks the plan's task
+graph in topological order, and assembles a :class:`SimulationReport`
+without spawning a real agent or hitting the network.
+
+Determinism: the same ``(plan, options.seed, traces)`` triple always
+produces a byte-identical report.
+
+Cycle handling: tasks whose ``depends_on`` references are unresolvable
+(cycle, missing predecessor) are still simulated, but a note is appended
+to the report so the operator can investigate. We do not raise on cycles
+because the underlying plan loader currently accepts them; raising would
+be a behaviour change outside this issue's scope.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from bernstein.core.planning.plan_loader import PlanLoadError, load_plan  # type: ignore[reportUnknownVariableType]
+from bernstein.core.simulate.predictor import (
+    AbandonmentPredictor,
+    BlastRadiusPredictor,
+    CostPredictor,
+    HistoricalTraces,
+    LatencyPredictor,
+    load_traces,
+    role_criterion,
+)
+from bernstein.core.simulate.report import (
+    AggregateBands,
+    Bottleneck,
+    CriterionProfileBias,
+    DecisionEdge,
+    SimulationOptions,
+    SimulationReport,
+    TaskPrediction,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from bernstein.core.tasks.models import Task
+
+__all__ = ["SimulationError", "simulate"]
+
+
+class SimulationError(Exception):
+    """Raised when the plan cannot be loaded or simulated."""
+
+
+def _topological_order(tasks: Sequence[Task]) -> list[Task]:
+    """Return ``tasks`` in dependency order (Kahn's algorithm).
+
+    Tasks whose ``depends_on`` references cannot be resolved are appended
+    after the resolvable subgraph, in their original order, so the
+    simulator still produces a forecast on a malformed plan.
+    """
+    by_title: dict[str, Task] = {t.title: t for t in tasks}
+    by_id: dict[str, Task] = {t.id: t for t in tasks}
+    indegree: dict[str, int] = {t.id: 0 for t in tasks}
+    successors: dict[str, list[str]] = defaultdict(list)
+
+    for task in tasks:
+        for dep in task.depends_on:
+            dep_task = by_title.get(dep) or by_id.get(dep)
+            if dep_task is None:
+                continue
+            successors[dep_task.id].append(task.id)
+            indegree[task.id] += 1
+
+    # Process roots in original plan order so the output is stable.
+    queue: list[str] = [t.id for t in tasks if indegree[t.id] == 0]
+    visited: set[str] = set()
+    ordered_ids: list[str] = []
+    while queue:
+        current = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+        ordered_ids.append(current)
+        for succ in successors[current]:
+            indegree[succ] -= 1
+            if indegree[succ] <= 0:
+                queue.append(succ)
+
+    # Append any unresolved tasks (cycles / dangling deps) in plan order.
+    for task in tasks:
+        if task.id not in visited:
+            ordered_ids.append(task.id)
+
+    return [by_id[i] for i in ordered_ids]
+
+
+def _critical_path(
+    tasks: Sequence[TaskPrediction],
+    *,
+    use_p90: bool,
+) -> float:
+    """Return the critical-path wall-clock (seconds) over predictions.
+
+    Uses ``latency_p90`` when ``use_p90`` is True, otherwise ``latency_p50``.
+    """
+    by_id: dict[str, TaskPrediction] = {t.task_id: t for t in tasks}
+    longest: dict[str, float] = {}
+
+    # Original list order is already topologically sound (runner sorts).
+    for task in tasks:
+        own = task.latency_p90 if use_p90 else task.latency_p50
+        max_pred = 0.0
+        for dep_id in task.depends_on:
+            dep = by_id.get(dep_id)
+            if dep is None:
+                continue
+            max_pred = max(max_pred, longest.get(dep.task_id, 0.0))
+        longest[task.task_id] = max_pred + own
+
+    return max(longest.values(), default=0.0)
+
+
+def _fan_out(tasks: Sequence[TaskPrediction]) -> dict[str, int]:
+    """Return successor count per task id."""
+    count: dict[str, int] = {t.task_id: 0 for t in tasks}
+    by_id: dict[str, TaskPrediction] = {t.task_id: t for t in tasks}
+    for task in tasks:
+        for dep_id in task.depends_on:
+            if dep_id in by_id:
+                count[dep_id] = count.get(dep_id, 0) + 1
+    return count
+
+
+def _bottlenecks(predictions: Sequence[TaskPrediction]) -> tuple[Bottleneck, ...]:
+    """Identify bottleneck tasks across multiple heuristics.
+
+    A task is flagged when any of the following hold:
+
+    * Fan-out >= 2 (more than one task waits on it).
+    * Abandon probability >= 0.25.
+    * Blast-radius score >= 0.5.
+    * Latency p90 in the top 20% across the plan.
+    """
+    if not predictions:
+        return ()
+
+    out: list[Bottleneck] = []
+    fan = _fan_out(predictions)
+    latencies = sorted((t.latency_p90 for t in predictions), reverse=True)
+    cut = latencies[max(0, len(latencies) // 5 - 1)] if latencies else 0.0
+    seen: set[tuple[str, str]] = set()
+
+    def _emit(task: TaskPrediction, reason: str, score: float) -> None:
+        key = (task.task_id, reason)
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(Bottleneck(task_id=task.task_id, title=task.title, reason=reason, score=score))
+
+    for task in predictions:
+        fo = fan.get(task.task_id, 0)
+        if fo >= 2:
+            _emit(task, "fan_out", float(fo))
+        if task.abandon_probability >= 0.25:
+            _emit(task, "high_abandon", task.abandon_probability)
+        if task.blast_radius_score >= 0.5:
+            _emit(task, "high_blast_radius", task.blast_radius_score)
+        if cut > 0 and task.latency_p90 >= cut:
+            _emit(task, "long_latency", task.latency_p90)
+
+    # Sort by descending score so the top entries surface first.
+    out.sort(key=lambda b: -b.score)
+    return tuple(out)
+
+
+def _decision_edges(predictions: Sequence[TaskPrediction]) -> tuple[DecisionEdge, ...]:
+    """Build the simulated decision-flow graph.
+
+    Each task with no resolved predecessor receives an edge from a synthetic
+    ``START`` node so the resulting Mermaid graph has a single root.
+    """
+    ids = {t.task_id for t in predictions}
+    edges: list[DecisionEdge] = []
+    for task in predictions:
+        resolved = [dep for dep in task.depends_on if dep in ids]
+        if not resolved:
+            edges.append(DecisionEdge(from_task="START", to_task=task.task_id, label=task.role))
+            continue
+        for dep_id in resolved:
+            edges.append(DecisionEdge(from_task=dep_id, to_task=task.task_id, label=task.role))
+    return tuple(edges)
+
+
+def _criterion_bias(predictions: Sequence[TaskPrediction]) -> CriterionProfileBias:
+    """Compute the criterion-profile bias chart."""
+    buckets: dict[str, float] = {"speed": 0.0, "cost": 0.0, "quality": 0.0, "safety": 0.0}
+    total = float(len(predictions))
+    if total == 0:
+        return CriterionProfileBias(speed=0.0, cost=0.0, quality=0.0, safety=0.0)
+    for task in predictions:
+        bucket = role_criterion(task.role)
+        if bucket in buckets:
+            buckets[bucket] += 1.0
+        else:
+            buckets["quality"] += 1.0
+    return CriterionProfileBias(
+        speed=buckets["speed"] / total,
+        cost=buckets["cost"] / total,
+        quality=buckets["quality"] / total,
+        safety=buckets["safety"] / total,
+    )
+
+
+def _jitter(rng: random.Random, value: float, *, spread: float) -> float:
+    """Apply a deterministic multiplicative jitter to ``value``.
+
+    Used to differentiate identical-shape tasks under the same seed so
+    operators see a non-flat plot in the Markdown report. The spread is
+    intentionally tiny (default 5%) so the predicted bands stay close to
+    the underlying calibrated values.
+    """
+    factor = 1.0 + (rng.random() - 0.5) * spread
+    return max(0.0, value * factor)
+
+
+def simulate(
+    plan_path: Path | str,
+    options: SimulationOptions | None = None,
+) -> SimulationReport:
+    """Run a full simulation for ``plan_path`` and return the report.
+
+    Args:
+        plan_path: Path to a YAML plan file (same format as
+            ``bernstein run``).
+        options: :class:`SimulationOptions` knobs. ``None`` uses defaults
+            (seed=42, no budget cap, cold-start everywhere).
+
+    Returns:
+        :class:`SimulationReport` with per-task predictions and aggregate
+        bands.
+
+    Raises:
+        SimulationError: If the plan cannot be loaded.
+    """
+    opts = options or SimulationOptions()
+    path = Path(plan_path)
+
+    try:
+        loaded = load_plan(path)  # type: ignore[reportUnknownVariableType]
+    except PlanLoadError as exc:
+        raise SimulationError(f"failed to load plan {path}: {exc}") from exc
+    plan_config = loaded[0]
+    # ``Task`` lives in a module excluded from pyright strict; cast so the
+    # downstream loop has a concrete type to work against.
+    tasks: list[Task] = cast("list[Task]", loaded[1])
+
+    metrics_dir = Path(opts.metrics_dir) if opts.metrics_dir else None
+    traces_dir = Path(opts.traces_dir) if opts.traces_dir else None
+
+    traces: HistoricalTraces = load_traces(traces_dir, limit=opts.from_traces)
+    cost_pred = CostPredictor(metrics_dir=metrics_dir, history_limit=opts.from_traces)
+    latency_pred = LatencyPredictor(traces=traces)
+    abandon_pred = AbandonmentPredictor(traces=traces)
+    blast_pred = BlastRadiusPredictor()
+
+    rng = random.Random(opts.seed)
+    ordered = _topological_order(tasks)
+    title_to_id = {t.title: t.id for t in tasks}
+
+    notes: list[str] = []
+    if traces.is_empty:
+        notes.append("no trace history available; predictions use cold-start priors")
+    if metrics_dir is None:
+        notes.append("no metrics history available; cost band uses heuristic")
+
+    predictions: list[TaskPrediction] = []
+    running_p90 = 0.0
+    cold_any = False
+    for task in ordered:
+        cost_p50, cost_p90, cold = cost_pred.predict(task)
+        # Apply tiny deterministic jitter so two identical tasks don't
+        # collapse into the same row in the report.
+        cost_p50 = round(_jitter(rng, cost_p50, spread=0.04), 4)
+        cost_p90 = round(_jitter(rng, cost_p90, spread=0.04), 4)
+        latency_p50, latency_p90 = latency_pred.predict(task)
+        latency_p50 = round(_jitter(rng, latency_p50, spread=0.05), 2)
+        latency_p90 = round(_jitter(rng, latency_p90, spread=0.05), 2)
+        abandon_prob = abandon_pred.predict(task)
+        blast_score = blast_pred.predict(task)
+
+        # Resolve depends_on (titles) to task ids so the report carries
+        # a graph the consumer can render without rejoining tables.
+        resolved_deps: list[str] = []
+        for dep in task.depends_on:
+            dep_id = title_to_id.get(dep, dep)
+            resolved_deps.append(dep_id)
+
+        budget_violation = False
+        if opts.budget_cap is not None:
+            running_p90 += cost_p90
+            if running_p90 > opts.budget_cap:
+                budget_violation = True
+
+        cold_any = cold_any or cold
+        predictions.append(
+            TaskPrediction(
+                task_id=task.id,
+                title=task.title,
+                role=task.role,
+                adapter=(task.cli or "mock").strip().lower(),
+                cost_p50=cost_p50,
+                cost_p90=cost_p90,
+                latency_p50=latency_p50,
+                latency_p90=latency_p90,
+                abandon_probability=round(abandon_prob, 4),
+                blast_radius_score=round(blast_score, 4),
+                depends_on=tuple(resolved_deps),
+                cold_start=cold,
+                budget_violation=budget_violation,
+            )
+        )
+
+    total_p50 = sum(p.cost_p50 for p in predictions)
+    total_p90 = sum(p.cost_p90 for p in predictions)
+    wall_p50 = _critical_path(predictions, use_p90=False)
+    wall_p90 = _critical_path(predictions, use_p90=True)
+    expected_abandon = sum(p.abandon_probability for p in predictions)
+    max_blast = max((p.blast_radius_score for p in predictions), default=0.0)
+
+    budget_breach = False
+    if opts.budget_cap is not None and total_p90 > opts.budget_cap:
+        budget_breach = True
+
+    aggregate = AggregateBands(
+        total_cost_p50=round(total_p50, 4),
+        total_cost_p90=round(total_p90, 4),
+        wall_clock_p50=round(wall_p50, 2),
+        wall_clock_p90=round(wall_p90, 2),
+        expected_abandonments=round(expected_abandon, 4),
+        max_blast_radius=round(max_blast, 4),
+        budget_cap=opts.budget_cap,
+        budget_breach=budget_breach,
+    )
+
+    return SimulationReport(
+        plan_name=plan_config.name or path.stem,
+        plan_path=str(path),
+        seed=opts.seed,
+        task_count=len(predictions),
+        tasks=tuple(predictions),
+        aggregate=aggregate,
+        bottlenecks=_bottlenecks(predictions),
+        decision_edges=_decision_edges(predictions),
+        criterion_bias=_criterion_bias(predictions),
+        history_samples=traces.sample_count,
+        cold_start=cold_any,
+        notes=tuple(notes),
+    )
+
+
+# Silence pyflakes for ``replace`` (kept available for downstream callers
+# that want to derive variants of a frozen report without re-deriving).
+_ = replace

--- a/tests/integration/test_simulate_e2e.py
+++ b/tests/integration/test_simulate_e2e.py
@@ -1,0 +1,204 @@
+"""End-to-end integration tests for ``bernstein simulate`` (issue #1374).
+
+These tests exercise the full pipeline against real seed plans shipped
+in ``examples/plans/*.yaml`` plus synthesized large fixtures. They run
+without spawning a real agent or hitting the network - the simulator
+stays in-process.
+
+Coverage:
+
+* Each seed plan produces a non-empty report.
+* The simulator survives a generated 50-task plan.
+* JSON + Markdown sidecars on disk are syntactically valid.
+* The CLI invoked end-to-end matches the in-process API.
+* Trace-history calibration changes the abandon prediction.
+* Predicted band envelopes a tiny fake run (within tolerance).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from bernstein.cli.commands.simulate_cmd import simulate_cmd
+from bernstein.core.simulate import SimulationOptions, render_markdown, simulate
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLES = _REPO_ROOT / "examples" / "plans"
+
+
+def _seed_plans() -> list[Path]:
+    if not _EXAMPLES.exists():
+        return []
+    return sorted(_EXAMPLES.glob("*.yaml"))
+
+
+# ---------------------------------------------------------------------------
+# Seed plans render a non-empty report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("plan_path", _seed_plans())
+def test_each_seed_plan_simulates(plan_path: Path) -> None:
+    report = simulate(plan_path, SimulationOptions(seed=1))
+    assert report.task_count > 0
+    # Cost band is always non-negative.
+    assert report.aggregate.total_cost_p50 >= 0.0
+    assert report.aggregate.total_cost_p90 >= report.aggregate.total_cost_p50
+    # Wall-clock band ordered.
+    assert report.aggregate.wall_clock_p90 >= report.aggregate.wall_clock_p50
+
+
+@pytest.mark.parametrize("plan_path", _seed_plans())
+def test_each_seed_plan_renders_markdown(plan_path: Path) -> None:
+    report = simulate(plan_path, SimulationOptions(seed=1))
+    md = render_markdown(report)
+    assert "# Bernstein simulate" in md
+    assert "## TL;DR" in md
+
+
+# ---------------------------------------------------------------------------
+# Large synthesized plan
+# ---------------------------------------------------------------------------
+
+
+def _large_plan(tmp_path: Path, *, task_count: int = 50) -> Path:
+    stages: list[dict[str, Any]] = []
+    # 5 sequential stages of N/5 tasks each.
+    per_stage = max(1, task_count // 5)
+    for stage_idx in range(5):
+        steps = [{"title": f"task-{stage_idx}-{i}", "role": "backend"} for i in range(per_stage)]
+        stage: dict[str, Any] = {"name": f"Stage{stage_idx}", "steps": steps}
+        if stage_idx > 0:
+            stage["depends_on"] = [f"Stage{stage_idx - 1}"]
+        stages.append(stage)
+    plan = {"name": "Large", "stages": stages}
+    target = tmp_path / "large.yaml"
+    target.write_text(yaml.safe_dump(plan), encoding="utf-8")
+    return target
+
+
+def test_simulate_large_plan_runs(tmp_path: Path) -> None:
+    plan = _large_plan(tmp_path, task_count=50)
+    report = simulate(plan, SimulationOptions(seed=1))
+    assert report.task_count >= 45
+
+
+def test_simulate_large_plan_critical_path_smaller_than_sum(tmp_path: Path) -> None:
+    plan = _large_plan(tmp_path, task_count=50)
+    report = simulate(plan, SimulationOptions(seed=1))
+    sum_p50 = sum(t.latency_p50 for t in report.tasks)
+    # With parallel tasks per stage, the critical path must be shorter
+    # than the sum of all per-task latencies.
+    assert report.aggregate.wall_clock_p50 < sum_p50
+
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end on a seed plan
+# ---------------------------------------------------------------------------
+
+
+def test_cli_end_to_end_on_seed_plan(tmp_path: Path) -> None:
+    plans = _seed_plans()
+    if not plans:
+        pytest.skip("no seed plans found")
+    plan = plans[0]
+    out_path = tmp_path / "report.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        simulate_cmd,
+        [str(plan), "--format", "json", "--out", str(out_path), "--seed", "3"],
+    )
+    assert result.exit_code == 0, result.output
+    sidecar = json.loads(out_path.read_text(encoding="utf-8"))
+    # Sanity: sidecar mirrors the in-process simulate() result.
+    via_api = simulate(plan, SimulationOptions(seed=3))
+    assert sidecar == via_api.to_dict()
+
+
+def test_cli_markdown_sidecar_matches_render(tmp_path: Path) -> None:
+    plans = _seed_plans()
+    if not plans:
+        pytest.skip("no seed plans found")
+    plan = plans[0]
+    out_path = tmp_path / "report.md"
+    runner = CliRunner()
+    result = runner.invoke(
+        simulate_cmd,
+        [str(plan), "--out", str(out_path), "--seed", "1"],
+    )
+    assert result.exit_code == 0, result.output
+    body = out_path.read_text(encoding="utf-8")
+    assert "## Per-task predictions" in body
+
+
+# ---------------------------------------------------------------------------
+# Trace calibration changes prediction
+# ---------------------------------------------------------------------------
+
+
+def test_trace_calibration_changes_abandon_prediction(tmp_path: Path) -> None:
+    plan_dict: dict[str, Any] = {
+        "name": "Calibration",
+        "stages": [{"name": "Only", "steps": [{"title": "Single task", "role": "backend"}]}],
+    }
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan_dict), encoding="utf-8")
+
+    traces_dir = tmp_path / "traces"
+    traces_dir.mkdir()
+    # 8 of 10 abandoned (80%).
+    lines: list[str] = []
+    for i in range(10):
+        status = "abandoned" if i < 8 else "completed"
+        lines.append('{"role": "backend", "adapter": "mock", "status": "' + status + '"}')
+    (traces_dir / "t.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    cold = simulate(plan_path, SimulationOptions(seed=1))
+    hot = simulate(plan_path, SimulationOptions(seed=1, traces_dir=str(traces_dir)))
+    assert cold.tasks[0].abandon_probability < hot.tasks[0].abandon_probability
+    assert hot.tasks[0].abandon_probability == pytest.approx(0.8)
+
+
+# ---------------------------------------------------------------------------
+# Fake-cli comparison: predicted vs actual on a 1-task run
+# ---------------------------------------------------------------------------
+
+
+def test_predicted_cost_band_envelopes_a_single_known_sample(tmp_path: Path) -> None:
+    """When a single historical sample of $0.50 exists, the band should bracket it."""
+    plan_dict: dict[str, Any] = {
+        "name": "Compare",
+        "stages": [{"name": "Only", "steps": [{"title": "Task", "role": "backend"}]}],
+    }
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan_dict), encoding="utf-8")
+
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir()
+    body_lines = ['{"role": "backend", "adapter": "mock", "cost_usd": 0.50}' for _ in range(20)]
+    (metrics_dir / "cost.jsonl").write_text("\n".join(body_lines) + "\n", encoding="utf-8")
+
+    report = simulate(plan_path, SimulationOptions(seed=1, metrics_dir=str(metrics_dir)))
+    task = report.tasks[0]
+    # Tolerance allows for the deterministic jitter the runner applies.
+    assert task.cost_p50 == pytest.approx(0.5, rel=0.1)
+    assert task.cost_p90 == pytest.approx(0.5, rel=0.1)
+
+
+def test_cold_start_report_flags_cold_start(tmp_path: Path) -> None:
+    plan_dict: dict[str, Any] = {
+        "name": "Cold",
+        "stages": [{"name": "Only", "steps": [{"title": "Task", "role": "backend"}]}],
+    }
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan_dict), encoding="utf-8")
+
+    report = simulate(plan_path, SimulationOptions(seed=1))
+    assert report.cold_start is True
+    assert any("cold-start" in n or "heuristic" in n for n in report.notes)

--- a/tests/property/test_simulate_properties.py
+++ b/tests/property/test_simulate_properties.py
@@ -1,0 +1,298 @@
+"""Hypothesis property tests for ``bernstein simulate`` (issue #1374).
+
+Invariants under test:
+
+* Determinism: same plan + same seed -> byte-identical report.
+* Monotonicity in budget cap: a stricter cap never widens the no-breach
+  region; a relaxed cap never shrinks it.
+* No negative cost / latency predictions for any task.
+* Cost p90 >= cost p50 for every task.
+* Latency p90 >= latency p50 for every task.
+* Abandon probability always in [0, 1].
+* Blast-radius score always in [0, 1].
+* Criterion-profile bias sums to ~1.0 for non-empty plans.
+* Aggregate totals are the sum of per-task contributions.
+* All decision edges reference tasks that exist (no dangling ids).
+* Trace history makes the abandon prediction match the observed rate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.simulate import SimulationOptions, simulate
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+_KNOWN_ROLES: list[str] = [
+    "backend",
+    "frontend",
+    "qa",
+    "security",
+    "docs",
+    "devops",
+    "architect",
+]
+
+
+_step_strategy = st.fixed_dictionaries(
+    {
+        "title": st.text(alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")), min_size=1, max_size=15),
+        "role": st.sampled_from(_KNOWN_ROLES),
+    }
+)
+
+
+_stage_strategy = st.fixed_dictionaries(
+    {
+        "name": st.text(alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")), min_size=1, max_size=10),
+        "steps": st.lists(_step_strategy, min_size=1, max_size=4, unique_by=lambda s: s["title"]),
+    }
+)
+
+
+_plan_strategy = st.fixed_dictionaries(
+    {
+        "name": st.text(min_size=1, max_size=20),
+        "stages": st.lists(_stage_strategy, min_size=1, max_size=3, unique_by=lambda s: s["name"]),
+    }
+)
+
+
+_SETTINGS = settings(
+    max_examples=30,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.function_scoped_fixture],
+)
+
+
+def _write_plan(tmp_path: Path, plan: dict[str, Any]) -> Path:
+    target = tmp_path / "plan.yaml"
+    target.write_text(yaml.safe_dump(plan), encoding="utf-8")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+@given(plan=_plan_strategy, seed=st.integers(min_value=0, max_value=2**16 - 1))
+@_SETTINGS
+def test_determinism_same_seed_same_report(
+    tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any], seed: int
+) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    a = simulate(plan_path, SimulationOptions(seed=seed))
+    b = simulate(plan_path, SimulationOptions(seed=seed))
+    assert a.to_dict() == b.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Non-negativity
+# ---------------------------------------------------------------------------
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_costs_are_non_negative(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    for task in report.tasks:
+        assert task.cost_p50 >= 0.0
+        assert task.cost_p90 >= 0.0
+        assert task.latency_p50 >= 0.0
+        assert task.latency_p90 >= 0.0
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_p90_at_least_p50(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    for task in report.tasks:
+        assert task.cost_p90 >= task.cost_p50
+        assert task.latency_p90 >= task.latency_p50
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_abandon_probability_in_unit_range(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    for task in report.tasks:
+        assert 0.0 <= task.abandon_probability <= 1.0
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_blast_radius_in_unit_range(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    for task in report.tasks:
+        assert 0.0 <= task.blast_radius_score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Aggregate invariants
+# ---------------------------------------------------------------------------
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_aggregate_cost_matches_sum(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    expected_p50 = sum(t.cost_p50 for t in report.tasks)
+    expected_p90 = sum(t.cost_p90 for t in report.tasks)
+    assert report.aggregate.total_cost_p50 == pytest.approx(expected_p50)
+    assert report.aggregate.total_cost_p90 == pytest.approx(expected_p90)
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_aggregate_max_blast_radius_correct(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    expected = max((t.blast_radius_score for t in report.tasks), default=0.0)
+    assert report.aggregate.max_blast_radius == pytest.approx(expected)
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_criterion_bias_sums_to_one(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    bias = report.criterion_bias
+    total = bias.speed + bias.cost + bias.quality + bias.safety
+    if report.task_count > 0:
+        assert total == pytest.approx(1.0)
+    else:
+        assert total == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Decision edges
+# ---------------------------------------------------------------------------
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_decision_edges_reference_real_tasks(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    ids = {t.task_id for t in report.tasks}
+    for edge in report.decision_edges:
+        assert edge.from_task == "START" or edge.from_task in ids
+        assert edge.to_task in ids
+
+
+# ---------------------------------------------------------------------------
+# Budget cap monotonicity
+# ---------------------------------------------------------------------------
+
+
+@given(plan=_plan_strategy, base=st.floats(min_value=0.0, max_value=100.0))
+@_SETTINGS
+def test_budget_cap_monotonicity(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any], base: float) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    strict = simulate(plan_path, SimulationOptions(budget_cap=base))
+    relaxed = simulate(plan_path, SimulationOptions(budget_cap=base + 1000.0))
+    # A relaxed cap can never be a breach when the strict cap was within
+    # range; and the strict cap can only flag MORE per-task breaches.
+    if not strict.aggregate.budget_breach:
+        assert not relaxed.aggregate.budget_breach
+    strict_violations = sum(1 for t in strict.tasks if t.budget_violation)
+    relaxed_violations = sum(1 for t in relaxed.tasks if t.budget_violation)
+    assert strict_violations >= relaxed_violations
+
+
+# ---------------------------------------------------------------------------
+# History overrides cold prior
+# ---------------------------------------------------------------------------
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_history_samples_is_non_negative(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    assert report.history_samples >= 0
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_task_count_matches_tasks_length(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    assert report.task_count == len(report.tasks)
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_wall_clock_bands_ordered(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    assert report.aggregate.wall_clock_p90 >= report.aggregate.wall_clock_p50
+
+
+@given(plan=_plan_strategy)
+@_SETTINGS
+def test_aggregate_p90_at_least_p50(tmp_path_factory: pytest.TempPathFactory, plan: dict[str, Any]) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan_path = _write_plan(tmp_path, plan)
+    report = simulate(plan_path)
+    assert report.aggregate.total_cost_p90 >= report.aggregate.total_cost_p50
+
+
+@given(observed_rate=st.floats(min_value=0.0, max_value=1.0))
+@_SETTINGS
+def test_traces_drive_abandon_prediction(
+    tmp_path_factory: pytest.TempPathFactory,
+    observed_rate: float,
+) -> None:
+    tmp_path = tmp_path_factory.mktemp("sim")
+    plan = {
+        "name": "Single",
+        "stages": [
+            {
+                "name": "Only",
+                "steps": [{"title": "Task", "role": "backend"}],
+            }
+        ],
+    }
+    plan_path = _write_plan(tmp_path, plan)
+
+    traces_dir = tmp_path / "traces"
+    traces_dir.mkdir()
+    # Build a 100-record trace file with the requested abandon rate.
+    rate_int = round(observed_rate * 100)
+    lines: list[str] = []
+    for i in range(100):
+        status = "abandoned" if i < rate_int else "completed"
+        lines.append('{"role": "backend", "adapter": "mock", "status": "' + status + '", "latency_seconds": 10.0}')
+    (traces_dir / "t.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    report = simulate(plan_path, SimulationOptions(traces_dir=str(traces_dir)))
+    assert report.tasks[0].abandon_probability == pytest.approx(rate_int / 100.0, abs=0.01)

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -204,6 +204,7 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "best-of-n",
         "blast-radius",
         "criterion-profile",
+        "simulate",
     }
 )
 

--- a/tests/unit/test_simulate_cli.py
+++ b/tests/unit/test_simulate_cli.py
@@ -1,0 +1,158 @@
+"""Unit tests for the ``bernstein simulate`` CLI surface (issue #1374).
+
+Covers:
+
+* Happy path: plan file -> markdown summary on stdout.
+* JSON output mode.
+* ``--out`` sidecar (JSON + Markdown).
+* ``--budget-cap`` exit code on breach.
+* Missing plan -> non-zero exit.
+* ``--seed`` propagates into the report.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from bernstein.cli.commands.simulate_cmd import simulate_cmd
+
+_PLAN: dict[str, object] = {
+    "name": "CLI demo plan",
+    "stages": [
+        {
+            "name": "Build",
+            "steps": [
+                {"title": "Add endpoint", "role": "backend"},
+                {"title": "Test endpoint", "role": "qa"},
+            ],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def plan_path(tmp_path: Path) -> Path:
+    target = tmp_path / "plan.yaml"
+    target.write_text(yaml.safe_dump(_PLAN), encoding="utf-8")
+    return target
+
+
+def test_simulate_cli_happy_path_markdown(plan_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path)])
+    assert result.exit_code == 0, result.output
+    assert "# Bernstein simulate" in result.output
+
+
+def test_simulate_cli_json_format(plan_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--format", "json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["plan_name"] == "CLI demo plan"
+
+
+def test_simulate_cli_out_json_sidecar(plan_path: Path, tmp_path: Path) -> None:
+    out_path = tmp_path / "report.json"
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--out", str(out_path)])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(out_path.read_text(encoding="utf-8"))
+    assert parsed["plan_name"] == "CLI demo plan"
+
+
+def test_simulate_cli_out_markdown_sidecar(plan_path: Path, tmp_path: Path) -> None:
+    out_path = tmp_path / "report.md"
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--out", str(out_path)])
+    assert result.exit_code == 0, result.output
+    body = out_path.read_text(encoding="utf-8")
+    assert "# Bernstein simulate" in body
+
+
+def test_simulate_cli_out_unknown_extension_defaults_to_json(plan_path: Path, tmp_path: Path) -> None:
+    out_path = tmp_path / "report.txt"
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--out", str(out_path)])
+    assert result.exit_code == 0, result.output
+    # Unknown extension means JSON sidecar.
+    parsed = json.loads(out_path.read_text(encoding="utf-8"))
+    assert "task_count" in parsed
+
+
+def test_simulate_cli_budget_cap_breach_exits_three(plan_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--budget-cap", "0.0"])
+    assert result.exit_code == 3
+    assert "budget cap" in result.output.lower() or "budget cap" in (result.stderr or "").lower()
+
+
+def test_simulate_cli_budget_cap_high_no_breach(plan_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--budget-cap", "10000"])
+    assert result.exit_code == 0
+
+
+def test_simulate_cli_missing_plan_nonzero(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(tmp_path / "nope.yaml")])
+    # Click rejects nonexistent file in argument parsing.
+    assert result.exit_code != 0
+
+
+def test_simulate_cli_seed_propagates(plan_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, [str(plan_path), "--format", "json", "--seed", "7"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["seed"] == 7
+
+
+def test_simulate_cli_help_lists_options() -> None:
+    runner = CliRunner()
+    result = runner.invoke(simulate_cmd, ["--help"])
+    assert result.exit_code == 0
+    assert "--from-traces" in result.output
+    assert "--seed" in result.output
+    assert "--budget-cap" in result.output
+
+
+def test_simulate_cli_traces_dir_increments_history(plan_path: Path, tmp_path: Path) -> None:
+    traces_dir = tmp_path / "traces"
+    traces_dir.mkdir()
+    (traces_dir / "t.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": 30}\n'
+        '{"role": "qa", "adapter": "mock", "status": "completed", "latency_seconds": 5}\n',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        simulate_cmd,
+        [str(plan_path), "--format", "json", "--traces-dir", str(traces_dir)],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["history_samples"] == 2
+
+
+def test_simulate_cli_metrics_dir_argument(plan_path: Path, tmp_path: Path) -> None:
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir()
+    (metrics_dir / "cost.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "cost_usd": 0.1}\n'
+        '{"role": "backend", "adapter": "mock", "cost_usd": 0.2}\n',
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        simulate_cmd,
+        [str(plan_path), "--format", "json", "--metrics-dir", str(metrics_dir)],
+    )
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["task_count"] == 2

--- a/tests/unit/test_simulate_predictor.py
+++ b/tests/unit/test_simulate_predictor.py
@@ -1,0 +1,437 @@
+"""Unit tests for the simulate predictors (issue #1374).
+
+Each predictor (cost, latency, abandonment, blast-radius) is exercised in
+isolation. Edge cases include: no historical data, single-task plan,
+malformed trace records, defensive clamping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.simulate.predictor import (
+    AbandonmentPredictor,
+    BlastRadiusPredictor,
+    CostPredictor,
+    HistoricalTraces,
+    LatencyPredictor,
+    load_traces,
+    role_criterion,
+)
+from bernstein.core.tasks.models import Complexity, Scope, Task, TaskStatus, TaskType
+
+
+def _make_task(
+    *,
+    task_id: str = "plan-0-0",
+    title: str = "Implement feature",
+    role: str = "backend",
+    description: str = "Add a new endpoint",
+    owned_files: tuple[str, ...] = ("src/api/foo.py",),
+    estimated_minutes: int = 30,
+    cli: str | None = None,
+    model: str | None = None,
+) -> Task:
+    return Task(
+        id=task_id,
+        title=title,
+        description=description,
+        role=role,
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        estimated_minutes=estimated_minutes,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        owned_files=list(owned_files),
+        cli=cli,
+        model=model,
+    )
+
+
+# ---------------------------------------------------------------------------
+# role_criterion
+# ---------------------------------------------------------------------------
+
+
+def test_role_criterion_known_roles() -> None:
+    assert role_criterion("security") == "safety"
+    assert role_criterion("qa") == "quality"
+    assert role_criterion("backend") == "quality"
+    assert role_criterion("frontend") == "speed"
+    assert role_criterion("docs") == "cost"
+
+
+def test_role_criterion_case_insensitive() -> None:
+    assert role_criterion("SECURITY") == "safety"
+    assert role_criterion(" QA ") == "quality"
+
+
+def test_role_criterion_unknown_role_falls_back_quality() -> None:
+    assert role_criterion("rumpelstiltskin") == "quality"
+    assert role_criterion("") == "quality"
+
+
+# ---------------------------------------------------------------------------
+# load_traces
+# ---------------------------------------------------------------------------
+
+
+def test_load_traces_missing_dir_returns_empty() -> None:
+    out = load_traces(None)
+    assert out.is_empty
+    assert out.sample_count == 0
+
+
+def test_load_traces_nonexistent_path_returns_empty(tmp_path: Path) -> None:
+    out = load_traces(tmp_path / "does-not-exist")
+    assert out.is_empty
+
+
+def test_load_traces_empty_dir(tmp_path: Path) -> None:
+    out = load_traces(tmp_path)
+    assert out.is_empty
+
+
+def test_load_traces_skips_invalid_json_lines(tmp_path: Path) -> None:
+    (tmp_path / "trace.jsonl").write_text("not json\n{}\n", encoding="utf-8")
+    out = load_traces(tmp_path)
+    # Records with no role are skipped; we should have zero usable samples.
+    assert out.is_empty
+
+
+def test_load_traces_collects_abandon_rate(tmp_path: Path) -> None:
+    body = (
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": 12.0}\n'
+        '{"role": "backend", "adapter": "mock", "status": "abandoned", "latency_seconds": 8.0}\n'
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": 20.0}\n'
+    )
+    (tmp_path / "trace.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    assert not out.is_empty
+    assert out.sample_count == 3
+    rate = out.abandon_rates[("backend", "mock")]
+    assert rate == pytest.approx(1 / 3)
+    samples = out.latency_samples[("backend", "mock")]
+    assert sorted(samples) == [8.0, 12.0, 20.0]
+
+
+def test_load_traces_handles_abandoned_boolean(tmp_path: Path) -> None:
+    body = '{"role": "qa", "cli": "claude", "abandoned": true}\n{"role": "qa", "cli": "claude", "abandoned": false}\n'
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    rate = out.abandon_rates[("qa", "claude")]
+    assert rate == 0.5
+
+
+def test_load_traces_uses_model_when_adapter_missing(tmp_path: Path) -> None:
+    body = '{"role": "backend", "model": "claude-sonnet-4", "status": "completed"}\n'
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    assert ("backend", "claude-sonnet-4") in out.abandon_rates
+
+
+def test_load_traces_defaults_to_mock_adapter_when_no_id(tmp_path: Path) -> None:
+    body = '{"role": "backend", "status": "completed"}\n'
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    assert ("backend", "mock") in out.abandon_rates
+
+
+def test_load_traces_skips_record_without_role(tmp_path: Path) -> None:
+    body = '{"adapter": "mock", "status": "abandoned"}\n'
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    assert out.is_empty
+
+
+def test_load_traces_skips_record_that_is_a_list(tmp_path: Path) -> None:
+    body = '[1, 2, 3]\n{"role": "backend", "status": "completed"}\n'
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    assert out.sample_count == 1
+
+
+def test_load_traces_skips_negative_latency(tmp_path: Path) -> None:
+    body = (
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": -5.0}\n'
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": 10.0}\n'
+    )
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    samples = out.latency_samples[("backend", "mock")]
+    assert samples == (10.0,)
+
+
+def test_load_traces_skips_nan_latency(tmp_path: Path) -> None:
+    body = (
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": "nan"}\n'
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": 7.0}\n'
+    )
+    (tmp_path / "t.jsonl").write_text(body, encoding="utf-8")
+    out = load_traces(tmp_path)
+    samples = out.latency_samples[("backend", "mock")]
+    assert samples == (7.0,)
+
+
+def test_load_traces_trims_to_limit(tmp_path: Path) -> None:
+    lines = [
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": ' + str(float(i)) + "}\n"
+        for i in range(10)
+    ]
+    (tmp_path / "t.jsonl").write_text("".join(lines), encoding="utf-8")
+    out = load_traces(tmp_path, limit=3)
+    samples = out.latency_samples[("backend", "mock")]
+    assert len(samples) == 3
+    # Newest-last preserved.
+    assert samples[-1] == 9.0
+
+
+def test_load_traces_reads_multiple_files(tmp_path: Path) -> None:
+    (tmp_path / "a.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "status": "completed"}\n', encoding="utf-8"
+    )
+    (tmp_path / "b.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "status": "abandoned"}\n', encoding="utf-8"
+    )
+    out = load_traces(tmp_path)
+    assert out.sample_count == 2
+
+
+# ---------------------------------------------------------------------------
+# CostPredictor
+# ---------------------------------------------------------------------------
+
+
+def test_cost_predictor_cold_start_no_metrics() -> None:
+    pred = CostPredictor(metrics_dir=None)
+    task = _make_task()
+    p50, p90, cold = pred.predict(task)
+    assert p50 >= 0.0
+    assert p90 >= p50
+    assert cold is True
+
+
+def test_cost_predictor_cold_start_missing_metrics_dir(tmp_path: Path) -> None:
+    pred = CostPredictor(metrics_dir=tmp_path / "missing")
+    p50, p90, cold = pred.predict(_make_task())
+    assert cold is True
+    assert p90 >= p50
+
+
+def test_cost_predictor_uses_history_when_available(tmp_path: Path) -> None:
+    (tmp_path / "cost.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "cost_usd": 1.0}\n'
+        '{"role": "backend", "adapter": "mock", "cost_usd": 2.0}\n'
+        '{"role": "backend", "adapter": "mock", "cost_usd": 3.0}\n',
+        encoding="utf-8",
+    )
+    pred = CostPredictor(metrics_dir=tmp_path)
+    task = _make_task(cli="mock")
+    _, _, cold = pred.predict(task)
+    assert cold is False
+
+
+def test_cost_predictor_history_count(tmp_path: Path) -> None:
+    (tmp_path / "cost.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "cost_usd": 0.5}\n' * 3,
+        encoding="utf-8",
+    )
+    pred = CostPredictor(metrics_dir=tmp_path)
+    assert pred.history_count(role="backend", adapter="mock") == 3
+
+
+def test_cost_predictor_history_count_zero_for_no_metrics() -> None:
+    pred = CostPredictor(metrics_dir=None)
+    assert pred.history_count(role="backend", adapter="mock") == 0
+
+
+def test_cost_predictor_returns_non_negative() -> None:
+    pred = CostPredictor(metrics_dir=None)
+    task = _make_task(role="backend", model="claude-sonnet-4")
+    p50, p90, _ = pred.predict(task)
+    assert p50 >= 0.0
+    assert p90 >= 0.0
+
+
+def test_cost_predictor_distinguishes_adapters(tmp_path: Path) -> None:
+    (tmp_path / "cost.jsonl").write_text(
+        '{"role": "backend", "adapter": "claude", "cost_usd": 5.0}\n'
+        '{"role": "backend", "adapter": "claude", "cost_usd": 6.0}\n'
+        '{"role": "backend", "adapter": "mock", "cost_usd": 0.01}\n'
+        '{"role": "backend", "adapter": "mock", "cost_usd": 0.02}\n',
+        encoding="utf-8",
+    )
+    pred = CostPredictor(metrics_dir=tmp_path)
+    claude_p50, _, _ = pred.predict(_make_task(cli="claude"))
+    mock_p50, _, _ = pred.predict(_make_task(cli="mock"))
+    assert claude_p50 > mock_p50
+
+
+# ---------------------------------------------------------------------------
+# LatencyPredictor
+# ---------------------------------------------------------------------------
+
+
+def test_latency_predictor_cold_start_uses_floor() -> None:
+    pred = LatencyPredictor()
+    p50, p90 = pred.predict(_make_task(estimated_minutes=1))
+    assert p50 >= pred.floor_p50
+    assert p90 >= pred.floor_p90
+
+
+def test_latency_predictor_scales_with_estimated_minutes() -> None:
+    pred = LatencyPredictor()
+    p50_short, _ = pred.predict(_make_task(estimated_minutes=10))
+    p50_long, _ = pred.predict(_make_task(estimated_minutes=120))
+    assert p50_long >= p50_short
+
+
+def test_latency_predictor_uses_history_when_available() -> None:
+    traces = HistoricalTraces(
+        latency_samples={("backend", "mock"): (100.0, 200.0, 300.0)},
+        sample_count=3,
+    )
+    pred = LatencyPredictor(traces=traces)
+    p50, p90 = pred.predict(_make_task())
+    # p50 should land somewhere in the middle of the sample set.
+    assert 100.0 <= p50 <= 300.0
+    assert p90 >= p50
+
+
+def test_latency_predictor_p90_never_below_p50() -> None:
+    # Single-sample history shouldn't degenerate to p90<p50.
+    traces = HistoricalTraces(
+        latency_samples={("backend", "mock"): (50.0,)},
+        sample_count=1,
+    )
+    pred = LatencyPredictor(traces=traces)
+    p50, p90 = pred.predict(_make_task())
+    assert p90 >= p50
+
+
+def test_latency_predictor_returns_non_negative() -> None:
+    pred = LatencyPredictor()
+    p50, p90 = pred.predict(_make_task(estimated_minutes=0))
+    assert p50 >= 0.0
+    assert p90 >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# AbandonmentPredictor
+# ---------------------------------------------------------------------------
+
+
+def test_abandonment_predictor_cold_start_uses_prior() -> None:
+    pred = AbandonmentPredictor()
+    prob = pred.predict(_make_task())
+    assert 0.0 < prob < 1.0
+    assert prob == pred.cold_prior
+
+
+def test_abandonment_predictor_history_returns_observed_rate() -> None:
+    traces = HistoricalTraces(
+        abandon_rates={("backend", "mock"): 0.42},
+        sample_count=10,
+    )
+    pred = AbandonmentPredictor(traces=traces)
+    assert pred.predict(_make_task()) == 0.42
+
+
+def test_abandonment_predictor_clamps_above_one() -> None:
+    traces = HistoricalTraces(
+        abandon_rates={("backend", "mock"): 1.5},  # corrupt
+        sample_count=2,
+    )
+    pred = AbandonmentPredictor(traces=traces)
+    assert pred.predict(_make_task()) == 1.0
+
+
+def test_abandonment_predictor_clamps_below_zero() -> None:
+    traces = HistoricalTraces(
+        abandon_rates={("backend", "mock"): -0.5},
+        sample_count=2,
+    )
+    pred = AbandonmentPredictor(traces=traces)
+    assert pred.predict(_make_task()) == 0.0
+
+
+def test_abandonment_predictor_per_role_isolation() -> None:
+    traces = HistoricalTraces(
+        abandon_rates={("backend", "mock"): 0.9, ("qa", "mock"): 0.1},
+        sample_count=4,
+    )
+    pred = AbandonmentPredictor(traces=traces)
+    assert pred.predict(_make_task(role="backend")) == 0.9
+    assert pred.predict(_make_task(role="qa")) == 0.1
+
+
+def test_abandonment_predictor_uses_adapter_default_when_unset() -> None:
+    traces = HistoricalTraces(
+        abandon_rates={("backend", "mock"): 0.3},
+        sample_count=2,
+    )
+    pred = AbandonmentPredictor(traces=traces)
+    assert pred.predict(_make_task(role="backend", cli=None)) == 0.3
+
+
+# ---------------------------------------------------------------------------
+# BlastRadiusPredictor
+# ---------------------------------------------------------------------------
+
+
+def test_blast_radius_predictor_safe_change_low_score() -> None:
+    pred = BlastRadiusPredictor()
+    task = _make_task(
+        description="Add a comment to the README",
+        owned_files=("README.md",),
+    )
+    score = pred.predict(task)
+    assert 0.0 <= score <= 1.0
+    assert score < 0.5
+
+
+def test_blast_radius_predictor_drop_table_scores_one() -> None:
+    pred = BlastRadiusPredictor()
+    task = _make_task(
+        description="DROP TABLE users;\n",
+        owned_files=("db/cleanup.sql",),
+    )
+    score = pred.predict(task)
+    assert score == 1.0
+
+
+def test_blast_radius_predictor_rm_rf_scores_one() -> None:
+    pred = BlastRadiusPredictor()
+    task = _make_task(
+        description="rm -rf $HOME/cache\n",
+        owned_files=("scripts/clean.sh",),
+    )
+    assert pred.predict(task) == 1.0
+
+
+def test_blast_radius_predictor_no_files_returns_zero() -> None:
+    pred = BlastRadiusPredictor()
+    task = _make_task(description="just describe", owned_files=())
+    score = pred.predict(task)
+    assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Edge-case: many tasks vs zero tasks
+# ---------------------------------------------------------------------------
+
+
+def test_cost_predictor_does_not_crash_on_blank_role() -> None:
+    pred = CostPredictor(metrics_dir=None)
+    task = _make_task(role="")
+    p50, p90, _ = pred.predict(task)
+    assert p90 >= p50
+
+
+def test_latency_predictor_does_not_crash_on_blank_role() -> None:
+    pred = LatencyPredictor()
+    p50, p90 = pred.predict(_make_task(role=""))
+    assert p90 >= p50

--- a/tests/unit/test_simulate_report.py
+++ b/tests/unit/test_simulate_report.py
@@ -1,0 +1,270 @@
+"""Unit tests for the simulate report types and renderers (issue #1374).
+
+Covers:
+
+* ``to_dict`` round-trip for every dataclass.
+* JSON render is sorted and stable across runs.
+* Markdown render contains every required section.
+* Mermaid graph compiles to a node-id-safe string.
+* Empty / minimal report still renders.
+"""
+
+from __future__ import annotations
+
+import json
+
+from bernstein.core.simulate.report import (
+    AggregateBands,
+    Bottleneck,
+    CriterionProfileBias,
+    DecisionEdge,
+    SimulationOptions,
+    SimulationReport,
+    TaskPrediction,
+    render_json,
+    render_markdown,
+)
+
+
+def _make_prediction(**overrides: object) -> TaskPrediction:
+    base: dict[str, object] = {
+        "task_id": "plan-0-0",
+        "title": "Sample task",
+        "role": "backend",
+        "adapter": "mock",
+        "cost_p50": 0.10,
+        "cost_p90": 0.30,
+        "latency_p50": 60.0,
+        "latency_p90": 180.0,
+        "abandon_probability": 0.05,
+        "blast_radius_score": 0.10,
+        "depends_on": (),
+        "cold_start": True,
+        "budget_violation": False,
+    }
+    base.update(overrides)
+    return TaskPrediction(**base)  # type: ignore[arg-type]
+
+
+def _make_report(tasks: tuple[TaskPrediction, ...] = ()) -> SimulationReport:
+    aggregate = AggregateBands(
+        total_cost_p50=sum(t.cost_p50 for t in tasks),
+        total_cost_p90=sum(t.cost_p90 for t in tasks),
+        wall_clock_p50=max((t.latency_p50 for t in tasks), default=0.0),
+        wall_clock_p90=max((t.latency_p90 for t in tasks), default=0.0),
+        expected_abandonments=sum(t.abandon_probability for t in tasks),
+        max_blast_radius=max((t.blast_radius_score for t in tasks), default=0.0),
+    )
+    bias = CriterionProfileBias(speed=0.25, cost=0.25, quality=0.25, safety=0.25)
+    return SimulationReport(
+        plan_name="Demo",
+        plan_path="/tmp/demo.yaml",
+        seed=42,
+        task_count=len(tasks),
+        tasks=tasks,
+        aggregate=aggregate,
+        bottlenecks=(),
+        decision_edges=tuple(DecisionEdge(from_task="START", to_task=t.task_id, label=t.role) for t in tasks),
+        criterion_bias=bias,
+        history_samples=0,
+        cold_start=True,
+        notes=("note one", "note two"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# to_dict round-trips
+# ---------------------------------------------------------------------------
+
+
+def test_simulation_options_defaults() -> None:
+    opts = SimulationOptions()
+    assert opts.seed == 42
+    assert opts.from_traces == 50
+    assert opts.budget_cap is None
+
+
+def test_task_prediction_to_dict_roundtrip() -> None:
+    pred = _make_prediction()
+    raw = pred.to_dict()
+    assert raw["task_id"] == "plan-0-0"
+    assert raw["cold_start"] is True
+    assert isinstance(raw["depends_on"], list)
+
+
+def test_task_prediction_to_dict_rounds_floats() -> None:
+    pred = _make_prediction(cost_p50=0.123456789)
+    raw = pred.to_dict()
+    assert raw["cost_p50"] == 0.1235
+
+
+def test_aggregate_bands_to_dict() -> None:
+    agg = AggregateBands(
+        total_cost_p50=1.0,
+        total_cost_p90=2.0,
+        wall_clock_p50=10.0,
+        wall_clock_p90=20.0,
+        expected_abandonments=0.5,
+        max_blast_radius=0.7,
+        budget_cap=5.0,
+        budget_breach=False,
+    )
+    raw = agg.to_dict()
+    assert raw["budget_cap"] == 5.0
+    assert raw["budget_breach"] is False
+
+
+def test_bottleneck_to_dict() -> None:
+    bn = Bottleneck(task_id="plan-0-1", title="x", reason="fan_out", score=2.5)
+    raw = bn.to_dict()
+    assert raw == {"task_id": "plan-0-1", "title": "x", "reason": "fan_out", "score": 2.5}
+
+
+def test_decision_edge_to_dict() -> None:
+    edge = DecisionEdge(from_task="START", to_task="plan-0-0", label="backend")
+    raw = edge.to_dict()
+    assert raw == {"from": "START", "to": "plan-0-0", "label": "backend"}
+
+
+def test_criterion_profile_bias_to_dict() -> None:
+    bias = CriterionProfileBias(speed=0.1, cost=0.2, quality=0.3, safety=0.4)
+    raw = bias.to_dict()
+    assert raw["speed"] == 0.1
+
+
+# ---------------------------------------------------------------------------
+# render_json
+# ---------------------------------------------------------------------------
+
+
+def test_render_json_produces_valid_json() -> None:
+    report = _make_report((_make_prediction(),))
+    out = render_json(report)
+    parsed = json.loads(out)
+    assert parsed["plan_name"] == "Demo"
+    assert isinstance(parsed["tasks"], list)
+
+
+def test_render_json_is_sorted_for_stability() -> None:
+    report = _make_report((_make_prediction(),))
+    out_a = render_json(report)
+    out_b = render_json(report)
+    assert out_a == out_b
+
+
+def test_render_json_includes_notes() -> None:
+    report = _make_report()
+    out = render_json(report)
+    parsed = json.loads(out)
+    assert parsed["notes"] == ["note one", "note two"]
+
+
+def test_render_json_empty_tasks() -> None:
+    report = _make_report()
+    out = render_json(report)
+    parsed = json.loads(out)
+    assert parsed["task_count"] == 0
+    assert parsed["tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# render_markdown
+# ---------------------------------------------------------------------------
+
+
+def test_render_markdown_contains_required_sections() -> None:
+    report = _make_report((_make_prediction(),))
+    md = render_markdown(report)
+    assert "# Bernstein simulate" in md
+    assert "## TL;DR" in md
+    assert "## Per-task predictions" in md
+    assert "## Bottlenecks" in md
+    assert "## Criterion-profile bias" in md
+    assert "## Decision flow" in md
+
+
+def test_render_markdown_includes_mermaid_block() -> None:
+    report = _make_report((_make_prediction(),))
+    md = render_markdown(report)
+    assert "```mermaid" in md
+    assert "graph TD" in md
+
+
+def test_render_markdown_no_bottleneck_says_none() -> None:
+    report = _make_report((_make_prediction(),))
+    md = render_markdown(report)
+    assert "None identified" in md
+
+
+def test_render_markdown_lists_bottlenecks() -> None:
+    pred = _make_prediction()
+    report = _make_report((pred,))
+    report = SimulationReport(
+        plan_name=report.plan_name,
+        plan_path=report.plan_path,
+        seed=report.seed,
+        task_count=report.task_count,
+        tasks=report.tasks,
+        aggregate=report.aggregate,
+        bottlenecks=(Bottleneck(task_id=pred.task_id, title=pred.title, reason="fan_out", score=3.0),),
+        decision_edges=report.decision_edges,
+        criterion_bias=report.criterion_bias,
+        history_samples=report.history_samples,
+        cold_start=report.cold_start,
+        notes=report.notes,
+    )
+    md = render_markdown(report)
+    assert "fan_out" in md
+
+
+def test_render_markdown_shows_budget_cap_when_set() -> None:
+    pred = _make_prediction()
+    base = _make_report((pred,))
+    new_agg = AggregateBands(
+        total_cost_p50=base.aggregate.total_cost_p50,
+        total_cost_p90=base.aggregate.total_cost_p90,
+        wall_clock_p50=base.aggregate.wall_clock_p50,
+        wall_clock_p90=base.aggregate.wall_clock_p90,
+        expected_abandonments=base.aggregate.expected_abandonments,
+        max_blast_radius=base.aggregate.max_blast_radius,
+        budget_cap=1.0,
+        budget_breach=True,
+    )
+    report = SimulationReport(
+        plan_name=base.plan_name,
+        plan_path=base.plan_path,
+        seed=base.seed,
+        task_count=base.task_count,
+        tasks=base.tasks,
+        aggregate=new_agg,
+        bottlenecks=(),
+        decision_edges=base.decision_edges,
+        criterion_bias=base.criterion_bias,
+        history_samples=0,
+        cold_start=False,
+        notes=(),
+    )
+    md = render_markdown(report)
+    assert "Budget cap" in md
+    assert "BREACH" in md
+
+
+def test_render_markdown_cold_start_note_present() -> None:
+    report = _make_report((_make_prediction(),))
+    md = render_markdown(report)
+    assert "cold-start" in md
+
+
+def test_render_markdown_budget_violation_marker_in_table() -> None:
+    pred = _make_prediction(budget_violation=True, title="risky")
+    report = _make_report((pred,))
+    md = render_markdown(report)
+    # Marker is appended after the title in the table cell.
+    assert " !" in md
+
+
+def test_render_markdown_handles_zero_tasks() -> None:
+    report = _make_report()
+    md = render_markdown(report)
+    # Render should not blow up; should still have all section headers.
+    assert "## Per-task predictions" in md

--- a/tests/unit/test_simulate_runner.py
+++ b/tests/unit/test_simulate_runner.py
@@ -1,0 +1,427 @@
+"""Unit tests for the simulate runner (issue #1374).
+
+Covers:
+
+* Deterministic output for a fixed seed.
+* Topological ordering and dependency resolution.
+* Cycle / dangling-dep robustness (still produces a report).
+* Budget cap handling.
+* Single-task / empty-stage / multi-stage plans.
+* Critical-path latency calculation.
+* Decision-edge graph wiring.
+* Cold-start vs history-backed paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bernstein.core.simulate import (
+    SimulationError,
+    SimulationOptions,
+    simulate,
+)
+
+_MINIMAL_PLAN: dict[str, object] = {
+    "name": "Minimal plan",
+    "description": "one task, no deps",
+    "stages": [
+        {
+            "name": "Build",
+            "steps": [
+                {"title": "Implement feature", "role": "backend"},
+            ],
+        }
+    ],
+}
+
+
+_LINEAR_PLAN: dict[str, object] = {
+    "name": "Linear plan",
+    "stages": [
+        {
+            "name": "Stage1",
+            "steps": [{"title": "Task A", "role": "backend"}],
+        },
+        {
+            "name": "Stage2",
+            "depends_on": ["Stage1"],
+            "steps": [{"title": "Task B", "role": "qa"}],
+        },
+    ],
+}
+
+
+_FAN_OUT_PLAN: dict[str, object] = {
+    "name": "Fan-out plan",
+    "stages": [
+        {
+            "name": "Setup",
+            "steps": [{"title": "Bootstrap", "role": "backend"}],
+        },
+        {
+            "name": "Parallel",
+            "depends_on": ["Setup"],
+            "steps": [
+                {"title": "Feature A", "role": "backend"},
+                {"title": "Feature B", "role": "backend"},
+                {"title": "Feature C", "role": "frontend"},
+            ],
+        },
+    ],
+}
+
+
+def _write_plan(tmp_path: Path, plan: dict[str, object]) -> Path:
+    target = tmp_path / "plan.yaml"
+    target.write_text(yaml.safe_dump(plan), encoding="utf-8")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Loading and trivial plans
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_missing_plan_raises(tmp_path: Path) -> None:
+    with pytest.raises(SimulationError):
+        simulate(tmp_path / "does-not-exist.yaml")
+
+
+def test_simulate_invalid_yaml_raises(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("not a mapping", encoding="utf-8")
+    with pytest.raises(SimulationError):
+        simulate(bad)
+
+
+def test_simulate_minimal_plan(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    report = simulate(plan)
+    assert report.task_count == 1
+    assert report.tasks[0].role == "backend"
+    assert report.aggregate.total_cost_p50 >= 0.0
+    assert report.aggregate.total_cost_p90 >= report.aggregate.total_cost_p50
+
+
+def test_simulate_linear_plan(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _LINEAR_PLAN)
+    report = simulate(plan)
+    assert report.task_count == 2
+    # Critical path is sum of latencies for a strict chain.
+    sum_p50 = sum(t.latency_p50 for t in report.tasks)
+    assert report.aggregate.wall_clock_p50 == pytest.approx(sum_p50)
+
+
+def test_simulate_fan_out_plan_wallclock_shorter_than_sum(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    sum_p50 = sum(t.latency_p50 for t in report.tasks)
+    # The three parallel tasks should compress wall-clock below the sum.
+    assert report.aggregate.wall_clock_p50 < sum_p50
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_deterministic_with_fixed_seed(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    a = simulate(plan, SimulationOptions(seed=7))
+    b = simulate(plan, SimulationOptions(seed=7))
+    assert a.to_dict() == b.to_dict()
+
+
+def test_simulate_different_seeds_can_diverge(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    a = simulate(plan, SimulationOptions(seed=1))
+    b = simulate(plan, SimulationOptions(seed=2))
+    # Banding is the same shape but per-task jitter should change at least
+    # one numeric value across the two runs.
+    assert a.to_dict() != b.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Budget cap
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_budget_cap_records_breach(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan, SimulationOptions(budget_cap=0.0))
+    # Any non-trivial plan blows a zero cap.
+    assert report.aggregate.budget_breach is True
+    assert any(t.budget_violation for t in report.tasks)
+
+
+def test_simulate_budget_cap_high_enough_no_breach(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan, SimulationOptions(budget_cap=10_000.0))
+    assert report.aggregate.budget_breach is False
+    assert not any(t.budget_violation for t in report.tasks)
+
+
+def test_simulate_no_budget_cap_does_not_flag(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    assert report.aggregate.budget_breach is False
+
+
+# ---------------------------------------------------------------------------
+# Cycle and dangling dep robustness
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_handles_unknown_stage_dep(tmp_path: Path) -> None:
+    plan_dict: dict[str, object] = {
+        "name": "Dangling",
+        "stages": [
+            {
+                "name": "Only",
+                "depends_on": ["Nope"],
+                "steps": [{"title": "x", "role": "backend"}],
+            }
+        ],
+    }
+    plan = _write_plan(tmp_path, plan_dict)
+    report = simulate(plan)
+    # Still produces one task.
+    assert report.task_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Bottleneck identification
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_bottleneck_fan_out(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    reasons = {b.reason for b in report.bottlenecks}
+    assert "fan_out" in reasons
+
+
+def test_simulate_bottleneck_high_blast_radius(tmp_path: Path) -> None:
+    plan_dict: dict[str, object] = {
+        "name": "Dangerous plan",
+        "stages": [
+            {
+                "name": "Wipe",
+                "steps": [
+                    {
+                        "title": "Clean db",
+                        "role": "backend",
+                        "description": "DROP TABLE accounts; DELETE FROM logs",
+                        "files": ["db/wipe.sql"],
+                    }
+                ],
+            }
+        ],
+    }
+    plan = _write_plan(tmp_path, plan_dict)
+    report = simulate(plan)
+    reasons = {b.reason for b in report.bottlenecks}
+    assert "high_blast_radius" in reasons
+
+
+def test_simulate_bottleneck_high_abandon(tmp_path: Path) -> None:
+    # Seed traces dir with a high abandon rate for the role.
+    pass  # Covered by integration test with real traces dir.
+
+
+# ---------------------------------------------------------------------------
+# Decision flow
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_decision_edges_root_has_start_edge(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    report = simulate(plan)
+    assert any(e.from_task == "START" for e in report.decision_edges)
+
+
+def test_simulate_decision_edges_linear(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _LINEAR_PLAN)
+    report = simulate(plan)
+    # The second task must point at the first.
+    first, second = report.tasks
+    assert any(e.from_task == first.task_id and e.to_task == second.task_id for e in report.decision_edges)
+
+
+# ---------------------------------------------------------------------------
+# Criterion-profile bias
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_criterion_bias_sums_to_one(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    bias = report.criterion_bias
+    total = bias.speed + bias.cost + bias.quality + bias.safety
+    assert total == pytest.approx(1.0)
+
+
+def test_simulate_criterion_bias_security_role(tmp_path: Path) -> None:
+    plan_dict: dict[str, object] = {
+        "name": "Security plan",
+        "stages": [
+            {
+                "name": "Audit",
+                "steps": [{"title": "Pentest", "role": "security"}],
+            }
+        ],
+    }
+    plan = _write_plan(tmp_path, plan_dict)
+    report = simulate(plan)
+    assert report.criterion_bias.safety == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Cold-start handling
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_cold_start_flagged_when_no_history(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    report = simulate(plan)
+    assert report.cold_start is True
+    assert any("cold-start" in note or "heuristic" in note for note in report.notes)
+
+
+def test_simulate_with_metrics_dir_no_data(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    metrics_dir = tmp_path / "metrics"
+    metrics_dir.mkdir()
+    report = simulate(plan, SimulationOptions(metrics_dir=str(metrics_dir)))
+    assert report.cold_start is True
+
+
+def test_simulate_with_traces_dir_no_data(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    traces_dir = tmp_path / "traces"
+    traces_dir.mkdir()
+    report = simulate(plan, SimulationOptions(traces_dir=str(traces_dir)))
+    assert report.history_samples == 0
+
+
+def test_simulate_with_traces_dir_populated(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    traces_dir = tmp_path / "traces"
+    traces_dir.mkdir()
+    (traces_dir / "t.jsonl").write_text(
+        '{"role": "backend", "adapter": "mock", "status": "completed", "latency_seconds": 30.0}\n'
+        '{"role": "backend", "adapter": "mock", "status": "abandoned", "latency_seconds": 10.0}\n',
+        encoding="utf-8",
+    )
+    report = simulate(plan, SimulationOptions(traces_dir=str(traces_dir)))
+    assert report.history_samples == 2
+    # Abandon rate should now reflect the trace data (0.5), not the cold prior.
+    assert report.tasks[0].abandon_probability == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Per-task fields
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_per_task_fields_non_negative(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    for task in report.tasks:
+        assert task.cost_p50 >= 0.0
+        assert task.cost_p90 >= 0.0
+        assert task.latency_p50 >= 0.0
+        assert task.latency_p90 >= 0.0
+        assert 0.0 <= task.abandon_probability <= 1.0
+        assert 0.0 <= task.blast_radius_score <= 1.0
+
+
+def test_simulate_p90_never_below_p50(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    for task in report.tasks:
+        assert task.cost_p90 >= task.cost_p50
+        assert task.latency_p90 >= task.latency_p50
+
+
+def test_simulate_depends_on_resolved_to_ids(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _LINEAR_PLAN)
+    report = simulate(plan)
+    second = report.tasks[1]
+    # depends_on should now reference the first task's id, not its title.
+    first = report.tasks[0]
+    assert first.task_id in second.depends_on
+
+
+def test_simulate_aggregate_max_blast_radius_matches_tasks(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    explicit_max = max(t.blast_radius_score for t in report.tasks)
+    assert report.aggregate.max_blast_radius == pytest.approx(explicit_max)
+
+
+def test_simulate_aggregate_total_cost_matches_tasks(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    sum_p50 = sum(t.cost_p50 for t in report.tasks)
+    assert report.aggregate.total_cost_p50 == pytest.approx(sum_p50)
+
+
+def test_simulate_expected_abandonments_sum_matches(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _FAN_OUT_PLAN)
+    report = simulate(plan)
+    summed = sum(t.abandon_probability for t in report.tasks)
+    assert report.aggregate.expected_abandonments == pytest.approx(summed)
+
+
+# ---------------------------------------------------------------------------
+# Plan path / name
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_uses_plan_name_when_set(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    report = simulate(plan)
+    assert report.plan_name == "Minimal plan"
+
+
+def test_simulate_falls_back_to_stem_when_no_name(tmp_path: Path) -> None:
+    plan_dict: dict[str, object] = {
+        "stages": [{"name": "x", "steps": [{"title": "t", "role": "backend"}]}],
+    }
+    target = tmp_path / "my_plan.yaml"
+    target.write_text(yaml.safe_dump(plan_dict), encoding="utf-8")
+    report = simulate(target)
+    assert report.plan_name == "my_plan"
+
+
+def test_simulate_records_plan_path(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    report = simulate(plan)
+    assert report.plan_path == str(plan)
+
+
+# ---------------------------------------------------------------------------
+# Many-task scaling
+# ---------------------------------------------------------------------------
+
+
+def test_simulate_handles_large_plan(tmp_path: Path) -> None:
+    steps = [{"title": f"Task {i}", "role": "backend"} for i in range(40)]
+    plan_dict: dict[str, object] = {
+        "name": "Big plan",
+        "stages": [{"name": "Big", "steps": steps}],
+    }
+    plan = _write_plan(tmp_path, plan_dict)
+    report = simulate(plan)
+    assert report.task_count == 40
+
+
+def test_simulate_zero_seed_works(tmp_path: Path) -> None:
+    plan = _write_plan(tmp_path, _MINIMAL_PLAN)
+    report = simulate(plan, SimulationOptions(seed=0))
+    assert report.seed == 0


### PR DESCRIPTION
## Summary

- New ``bernstein simulate <plan.yaml>`` command: dry-runs a full multi-agent cycle against historical traces and mock LLMs. Operators see decision flow, cost band (p50/p90), wall-clock, abandonment rate, per-task blast-radius, and bottlenecks BEFORE spending real tokens.
- New subpackage ``src/bernstein/core/simulate/`` (runner + 4 predictors + structured report renderer). Read-only over ``.sdd/traces/`` and ``.sdd/metrics/``; never spawns a real agent or hits the network.
- Reuses ``core/cost/preflight`` and ``core/quality/blast_radius`` so simulated bands match what real runs would surface.

## Closes

Closes #1374.

## What's new

Per-task forecast:
- cost p50/p90 (calibrated against historical ``cost.jsonl`` when available, heuristic fallback otherwise)
- latency p50/p90 (percentile over historical wall-clock samples)
- abandonment probability (per (role, adapter) from trace history)
- blast-radius score (full production scorer)

Aggregate report:
- total cost band
- critical-path wall-clock (p50/p90)
- expected abandonments
- max blast-radius
- bottleneck identification (fan-out, high abandon, high blast-radius, long latency)
- criterion-profile bias chart (speed/cost/quality/safety mix)
- Mermaid decision-flow graph
- optional ``--budget-cap`` with non-zero exit on breach

## Test plan

- [x] 105 unit tests in ``tests/unit/test_simulate_{predictor,runner,report,cli}.py``
- [x] 15 Hypothesis property tests in ``tests/property/test_simulate_properties.py`` (determinism, monotonicity in budget cap, non-negativity, p90>=p50, bias sums to 1, decision edges reference real tasks, trace history overrides cold prior)
- [x] 55 integration tests in ``tests/integration/test_simulate_e2e.py`` (each seed plan in ``examples/plans/*.yaml`` simulates and renders; large-plan stress; CLI end-to-end; trace calibration changes prediction; predicted band envelopes known sample)
- [x] ``uv run pytest tests/unit/test_simulate_* tests/property/test_simulate_* tests/integration/test_simulate_*`` - 175 passed
- [x] ``uv run ruff check`` - clean
- [x] ``uv run pyright src/bernstein/core/simulate/ src/bernstein/cli/commands/simulate_cmd.py`` - 0 errors
- [x] README API coverage test updated (``simulate`` added to documented commands)