### PR TITLE
feat(gitlab_app): GitLab integration parity with github_app (closes spec 2026-05-17-feat-gitlab-app-integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ bernstein cloud run plan.yaml  # execute a plan on Cloudflare
 
 **Observability**. Prometheus `/metrics`, OTel exporter presets, Grafana dashboards. Per-model cost tracking (`bernstein cost`) plus a [run savings summary](docs/operations/cost-optimization.md#run-savings-summary) on every `bernstein run`. Terminal TUI and web dashboard. Agent process visibility in `ps`.
 
-**Ecosystem**. MCP server mode, A2A protocol support, GitHub App integration, pluggy-based plugin system, multi-repo workspaces, cluster mode for distributed execution, self-evolution via `--evolve` (experimental).
+**Ecosystem**. MCP server mode, A2A protocol support, GitHub App integration, GitLab App integration (parity surface for self-managed + gitlab.com), pluggy-based plugin system, multi-repo workspaces, cluster mode for distributed execution, self-evolution via `--evolve` (experimental).
 
 Full feature matrix: [FEATURE_MATRIX.md](docs/reference/FEATURE_MATRIX.md) &middot; Recent features: [What's New](docs/whats-new.md)
 

--- a/docs/integrations/gitlab-app-setup.md
+++ b/docs/integrations/gitlab-app-setup.md
@@ -1,0 +1,143 @@
+# GitLab App Setup
+
+Bernstein can receive GitLab webhooks (gitlab.com and self-managed) and
+automatically create tasks from GitLab events (merge requests, notes,
+pipeline failures).  This is the GitLab parity surface for the GitHub
+App integration.
+
+## Overview
+
+The webhook handler lives at `POST /webhooks/gitlab` on the Bernstein
+task server.  When GitLab sends a webhook, Bernstein:
+
+1. Constant-time verifies the `X-Gitlab-Token` header against the
+   configured shared secret.
+2. Parses the `X-Gitlab-Event` header + JSON body.
+3. Maps the event to one or more Bernstein tasks.
+4. Creates the tasks in the task store.
+
+## Event mapping
+
+| GitLab event | Condition | Bernstein task |
+|---|---|---|
+| `Merge Request Hook` (action: `open`/`reopen`) | New / re-opened MR | Standard task, priority/role inferred from MR labels |
+| `Pipeline Hook` (status: `failed`) | Failed pipeline | CI-fix task; retries escalate to `opus` after attempt 2 |
+| `Note Hook` (note on MR/issue) | Slash command or actionable review language | `/bernstein <verb>` task, or fix task |
+
+## Slash commands
+
+`/bernstein <verb>` is supported on MR / issue notes:
+
+| Verb | Resulting task |
+|---|---|
+| `fix [description]` | Priority-1 fix task, `backend` role |
+| `plan [description]` | Planning task, `manager` role |
+| `evolve [description]` | Upgrade proposal, `backend` role |
+| `qa [description]` | QA verification task, `qa` role |
+| `review [description]` | QA review task |
+
+## Setup
+
+### 1. Create the webhook secret
+
+```bash
+export GITLAB_WEBHOOK_TOKEN=$(openssl rand -hex 32)
+```
+
+For posting back to GitLab (pipeline statuses and MR cost notes):
+
+```bash
+export GITLAB_TOKEN=<personal-or-project-access-token>
+```
+
+For self-managed installs override the base URL:
+
+```bash
+export BERNSTEIN_GITLAB_URL=https://gitlab.example.com
+```
+
+The default is `https://gitlab.com`.
+
+### 2. Configure the webhook in GitLab
+
+In your project: **Settings > Webhooks > Add new webhook**.
+
+- **URL**: `https://<your-server>/webhooks/gitlab`
+- **Secret token**: paste the same value as `GITLAB_WEBHOOK_TOKEN`.
+- **Trigger**: enable *Merge request events*, *Pipeline events*,
+  *Comments* (Notes).
+- **SSL verification**: keep enabled in production.
+
+### 3. Start the server
+
+```bash
+bernstein
+```
+
+GitLab will deliver to `/webhooks/gitlab`; Bernstein verifies the
+token via `hmac.compare_digest` (constant time) and routes events.
+
+## Local development
+
+Use a tunneling tool (e.g. `ngrok`, `cloudflared`) to expose your
+server.  Set the public URL as the webhook target in GitLab's project
+settings.
+
+## Self-managed GitLab
+
+For self-managed installs:
+
+* Set `BERNSTEIN_GITLAB_URL` to the on-prem instance base URL.
+* Use a project / group access token (with `api` scope) instead of a
+  personal access token if you want least-privilege.
+* The same `/webhooks/gitlab` endpoint and `X-Gitlab-Token` header
+  apply — GitLab's webhook surface is identical between gitlab.com and
+  self-managed.
+
+## Secret rotation
+
+The webhook token rotates the same way as any shared secret:
+
+1. Generate a new value: `openssl rand -hex 32`.
+2. In GitLab: update the project's webhook *Secret token*.
+3. On the server: set `GITLAB_WEBHOOK_TOKEN` and restart Bernstein.
+4. Confirm with a test delivery from the GitLab webhook page.
+
+Between steps 2 and 3 you'll get 401s; perform during a brief
+maintenance window.
+
+## Label conventions
+
+Priority mapping (mirrors GitHub):
+
+* `bug`, `critical`, `security` -- priority 1 (highest)
+* `enhancement`, `feature` -- priority 2
+* `docs`, `documentation`, `chore` -- priority 3
+
+Role mapping:
+
+* `backend`, `frontend`, `qa`, `security`, `docs` -- mapped directly
+  to Bernstein roles.
+
+## Architecture
+
+```
+GitLab --> POST /webhooks/gitlab --> verify_token()       (constant-time)
+                                 --> parse_webhook()
+                                 --> mapper (merge_request_to_tasks /
+                                             pipeline_to_tasks /
+                                             note_to_task)
+                                 --> store.create()
+```
+
+Source code: `src/bernstein/gitlab_app/`.
+
+| Module | Purpose |
+|---|---|
+| `app.py` | Token-based auth + base-URL config (`BERNSTEIN_GITLAB_URL`) |
+| `webhooks.py` | `X-Gitlab-Token` constant-time verify + event parsing |
+| `mapper.py` | GitLab event → TriggerEvent normalisation |
+| `slash_commands.py` | `/bernstein <verb>` parser for MR / issue notes |
+| `pipelines.py` | Commit-status API: MR pipeline status from agent runs |
+| `ci_router.py` | Trace fetch + parse + blame for failed pipelines |
+| `cost_reporter.py` | MR note: posts agent run cost summary |

--- a/src/bernstein/core/routes/webhooks.py
+++ b/src/bernstein/core/routes/webhooks.py
@@ -570,6 +570,37 @@ def _handle_gitlab_job(data: dict[str, Any]) -> list[dict[str, Any]]:
     return [task] if task is not None else []
 
 
+def _handle_gitlab_merge_request(
+    headers: dict[str, str],
+    body: bytes,
+) -> list[dict[str, Any]]:
+    """Map a GitLab MR webhook event to task payloads via ``gitlab_app``."""
+    from bernstein.gitlab_app.mapper import merge_request_to_tasks
+    from bernstein.gitlab_app.webhooks import parse_webhook
+
+    try:
+        event = parse_webhook(headers, body)
+    except ValueError:
+        return []
+    return list(merge_request_to_tasks(event))
+
+
+def _handle_gitlab_note(
+    headers: dict[str, str],
+    body: bytes,
+) -> list[dict[str, Any]]:
+    """Map a GitLab note (MR/issue comment) event to a task payload."""
+    from bernstein.gitlab_app.mapper import note_to_task
+    from bernstein.gitlab_app.webhooks import parse_webhook
+
+    try:
+        event = parse_webhook(headers, body)
+    except ValueError:
+        return []
+    task = note_to_task(event)
+    return [task] if task is not None else []
+
+
 @router.post("/webhooks/gitlab", status_code=200)
 async def gitlab_webhook(request: Request) -> JSONResponse:
     """Receive a GitLab CI webhook, verify token, and create ci-fix tasks.
@@ -599,12 +630,17 @@ async def gitlab_webhook(request: Request) -> JSONResponse:
         return JSONResponse(status_code=400, content={"detail": "Bad JSON payload"})
 
     event_type = data.get("object_kind", "")
+    raw_headers: dict[str, str] = {k: v for k, v in request.headers.items()}
 
     match event_type:
         case "pipeline":
             result = _handle_gitlab_pipeline(data, store)
         case "job":
             result = _handle_gitlab_job(data)
+        case "merge_request":
+            result = _handle_gitlab_merge_request(raw_headers, body_bytes)
+        case "note":
+            result = _handle_gitlab_note(raw_headers, body_bytes)
         case _:
             result = []
 

--- a/src/bernstein/gitlab_app/__init__.py
+++ b/src/bernstein/gitlab_app/__init__.py
@@ -1,0 +1,32 @@
+"""GitLab App integration for Bernstein.
+
+Receives GitLab webhooks, converts events to Bernstein tasks, and posts
+them to the task server.  Provides webhook verification (constant-time
+token comparison), event parsing, event-to-task mapping, and pipeline
+status updates.
+
+Mirror of :mod:`bernstein.github_app`.  Self-managed GitLab installs can
+override the base URL via the ``BERNSTEIN_GITLAB_URL`` environment
+variable (defaults to ``https://gitlab.com``).
+"""
+
+from __future__ import annotations
+
+from bernstein.gitlab_app.app import GitLabAppConfig, get_gitlab_base_url
+from bernstein.gitlab_app.mapper import (
+    merge_request_to_tasks,
+    note_to_task,
+    pipeline_to_tasks,
+)
+from bernstein.gitlab_app.webhooks import GitLabWebhookEvent, parse_webhook, verify_token
+
+__all__ = [
+    "GitLabAppConfig",
+    "GitLabWebhookEvent",
+    "get_gitlab_base_url",
+    "merge_request_to_tasks",
+    "note_to_task",
+    "parse_webhook",
+    "pipeline_to_tasks",
+    "verify_token",
+]

--- a/src/bernstein/gitlab_app/app.py
+++ b/src/bernstein/gitlab_app/app.py
@@ -1,0 +1,196 @@
+"""GitLab App authentication: token-based auth (PAT + project-scoped tokens).
+
+GitLab does not (publicly) ship an Apps + JWT flow comparable to GitHub
+Apps, so this module focuses on the two supported auth mechanisms:
+
+* **Personal Access Tokens (PAT)** — read from ``GITLAB_TOKEN`` /
+  ``GITLAB_PAT``; used as the global fallback.
+* **Project / group access tokens** — passed in explicitly per-call so
+  each repo can use a least-privilege token.
+
+The base URL is configurable via ``BERNSTEIN_GITLAB_URL`` to support
+self-managed installs (defaults to ``https://gitlab.com``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+
+# Default public GitLab.com base URL.  Overridable via env for self-managed.
+DEFAULT_GITLAB_URL = "https://gitlab.com"
+
+# Allowed URL schemes.  Strictly HTTPS for production; HTTP is permitted
+# only for localhost / loopback (so unit tests can spin up a fake server)
+# and self-signed dev installs.
+_ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+
+@dataclass(frozen=True)
+class GitLabAppConfig:
+    """Configuration for a GitLab App / integration.
+
+    Attributes:
+        base_url: GitLab instance base URL (``https://gitlab.com`` by
+            default).  Self-managed installs override via
+            ``BERNSTEIN_GITLAB_URL``.
+        token: Personal / project access token used for API calls.
+        webhook_token: Shared secret returned in the ``X-Gitlab-Token``
+            header by GitLab when delivering webhooks.
+    """
+
+    base_url: str
+    token: str
+    webhook_token: str
+
+    @classmethod
+    def from_env(cls) -> GitLabAppConfig:
+        """Read configuration from environment variables.
+
+        Reads (in order):
+
+        * ``BERNSTEIN_GITLAB_URL`` — base URL (default
+          ``https://gitlab.com``).
+        * ``GITLAB_TOKEN`` (or fallback ``GITLAB_PAT``) — API token.
+        * ``GITLAB_WEBHOOK_TOKEN`` — webhook shared secret.
+
+        Returns:
+            Populated :class:`GitLabAppConfig`.
+
+        Raises:
+            ValueError: If a required environment variable is missing.
+        """
+        base_url = get_gitlab_base_url()
+
+        token = os.environ.get("GITLAB_TOKEN") or os.environ.get("GITLAB_PAT", "")
+        if not token:
+            msg = "GITLAB_TOKEN (or GITLAB_PAT) environment variable is required"
+            raise ValueError(msg)
+
+        webhook_token = os.environ.get("GITLAB_WEBHOOK_TOKEN", "")
+        if not webhook_token:
+            msg = "GITLAB_WEBHOOK_TOKEN environment variable is required"
+            raise ValueError(msg)
+
+        return cls(base_url=base_url, token=token, webhook_token=webhook_token)
+
+
+def get_gitlab_base_url() -> str:
+    """Return the configured GitLab base URL.
+
+    Honours ``BERNSTEIN_GITLAB_URL``.  The value is validated: scheme
+    must be ``http`` or ``https`` and host must be non-empty.  Invalid
+    values fall back to :data:`DEFAULT_GITLAB_URL` with a log warning.
+
+    Returns:
+        Canonical base URL with no trailing slash.
+    """
+    raw = os.environ.get("BERNSTEIN_GITLAB_URL", "").strip()
+    if not raw:
+        return DEFAULT_GITLAB_URL
+
+    parsed = urlparse(raw)
+    if parsed.scheme.lower() not in _ALLOWED_SCHEMES or not parsed.netloc:
+        logger.warning(
+            "Invalid BERNSTEIN_GITLAB_URL %r — falling back to %s",
+            raw,
+            DEFAULT_GITLAB_URL,
+        )
+        return DEFAULT_GITLAB_URL
+
+    return raw.rstrip("/")
+
+
+def build_api_url(path: str, base_url: str | None = None) -> str:
+    """Build a fully-qualified GitLab API URL.
+
+    Args:
+        path: API path beginning with ``/`` — e.g. ``/projects/42/jobs``.
+            A leading slash is added if missing.  The path is *not*
+            URL-encoded; the caller is expected to encode project IDs
+            (e.g. ``namespace%2Fproject``) where required.
+        base_url: Override base URL.  When ``None``, reads from env.
+
+    Returns:
+        Absolute API URL such as
+        ``https://gitlab.com/api/v4/projects/42/jobs``.
+    """
+    if base_url is None:
+        base_url = get_gitlab_base_url()
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{base_url.rstrip('/')}/api/v4{path}"
+
+
+def build_auth_headers(token: str) -> dict[str, str]:
+    """Build the standard GitLab API auth headers.
+
+    Args:
+        token: PAT or project access token.
+
+    Returns:
+        Header dict with ``PRIVATE-TOKEN`` set.  Returns an empty dict
+        when *token* is empty so callers can short-circuit unauth flows.
+    """
+    if not token:
+        return {}
+    return {"PRIVATE-TOKEN": token}
+
+
+def fetch_job_trace(
+    project_id: str | int,
+    job_id: int,
+    token: str,
+    base_url: str | None = None,
+    *,
+    timeout: float = 30.0,
+) -> str:
+    """Fetch the raw plain-text trace for a failed CI job.
+
+    Calls ``GET /projects/:id/jobs/:job_id/trace``.  Returns the raw
+    text body (which GitLab serves as ``text/plain``).  Returns an
+    empty string on any error or when the HTTP client is unavailable;
+    callers are expected to handle the empty case as "no trace
+    available".
+
+    Args:
+        project_id: Numeric project ID *or* URL-encoded
+            ``namespace%2Fproject`` slug.
+        job_id: Numeric GitLab CI job ID.
+        token: API token used for the ``PRIVATE-TOKEN`` header.
+        base_url: GitLab base URL.  ``None`` reads from env.
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        Trace text or ``""`` on failure.
+    """
+    if not token:
+        logger.debug("fetch_job_trace: no token — skipping")
+        return ""
+
+    url = build_api_url(f"/projects/{project_id}/jobs/{job_id}/trace", base_url)
+    try:
+        import httpx
+    except ImportError:
+        logger.debug("httpx not available — cannot fetch GitLab job trace")
+        return ""
+
+    try:
+        response: Any = httpx.get(url, headers=build_auth_headers(token), timeout=timeout)
+        if response.status_code != 200:
+            logger.info(
+                "fetch_job_trace: %s returned HTTP %d",
+                url,
+                response.status_code,
+            )
+            return ""
+        return str(response.text or "")
+    except Exception as exc:  # pragma: no cover - depends on env
+        logger.debug("fetch_job_trace failed: %s", exc)
+        return ""

--- a/src/bernstein/gitlab_app/ci_router.py
+++ b/src/bernstein/gitlab_app/ci_router.py
@@ -1,0 +1,189 @@
+"""GitLab CI failure routing: trace fetch, parse, blame and payload builder.
+
+Mirror of :mod:`bernstein.github_app.ci_router`.  Pure functions only —
+HTTP calls go through :mod:`bernstein.gitlab_app.app.fetch_job_trace`.
+"""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from bernstein.gitlab_app.app import fetch_job_trace
+
+if TYPE_CHECKING:
+    from bernstein.core.quality.ci_fix import CIFailure
+
+logger = logging.getLogger(__name__)
+
+# Maximum auto-retries before the system stops creating new ci-fix tasks
+# for a given branch.  Mirrors the GitHub side.
+MAX_CI_RETRIES: int = 3
+
+
+@dataclass
+class GitLabCIBlameResult:
+    """Attribution metadata for a GitLab pipeline failure.
+
+    Attributes:
+        head_sha: SHA the pipeline ran against.
+        ref: Source branch / tag.
+        responsible_files: Files mentioned in the failure logs.  May be
+            empty when no trace was downloadable.
+    """
+
+    head_sha: str
+    ref: str = ""
+    responsible_files: list[str] = field(default_factory=list[str])
+
+
+def fetch_and_parse_failures(
+    project_id: str | int,
+    failed_builds: list[dict[str, Any]],
+    token: str = "",
+    base_url: str | None = None,
+    *,
+    max_jobs: int = 3,
+) -> list[CIFailure]:
+    """Fetch + parse traces for the first *max_jobs* failed builds.
+
+    Args:
+        project_id: GitLab project ID / encoded slug.
+        failed_builds: List of GitLab pipeline build dicts with
+            ``status == "failed"`` (or ``"canceled"``).
+        token: API token for ``PRIVATE-TOKEN`` header.
+        base_url: GitLab base URL override.
+        max_jobs: Cap on how many job traces to download.
+
+    Returns:
+        List of :class:`CIFailure` objects parsed from the traces.
+        Empty when no token / network failures / unparseable logs.
+    """
+    if not failed_builds or not token or not project_id:
+        return []
+
+    from bernstein.adapters.ci.gitlab_ci import GitLabCIParser
+
+    parser = GitLabCIParser()
+    failures: list[CIFailure] = []
+    for build in failed_builds[:max_jobs]:
+        job_id_raw = build.get("id")
+        if not isinstance(job_id_raw, int):
+            continue
+        trace = fetch_job_trace(project_id, job_id_raw, token, base_url)
+        if not trace:
+            continue
+        # ``parser.parse`` is internally typed but pyright sees the
+        # imported parser at a relaxed boundary — funnel through ``Any``
+        # to keep this module strict.
+        parse_fn: Any = parser.parse
+        parsed: Any = parse_fn(trace)
+        if isinstance(parsed, list):
+            parsed_typed: list[Any] = parsed  # type: ignore[assignment]
+            for failure in parsed_typed:
+                failures.append(failure)
+
+    logger.debug(
+        "fetch_and_parse_failures: project=%s jobs=%d failures=%d",
+        project_id,
+        len(failed_builds),
+        len(failures),
+    )
+
+    return failures
+
+
+def build_pipeline_routing_payload(
+    failures: list[CIFailure],
+    blame: GitLabCIBlameResult,
+    pipeline_id: int,
+    pipeline_url: str = "",
+    failed_builds: list[dict[str, Any]] | None = None,
+    retry_count: int = 0,
+) -> dict[str, Any]:
+    """Build a fix-task payload enriched with GitLab pipeline context.
+
+    Mirrors :func:`bernstein.github_app.ci_router.build_ci_routing_payload`.
+
+    Model / effort escalate on repeats:
+
+    * Attempts 1-2: ``sonnet`` / ``high``
+    * Attempts 3+:  ``opus``   / ``max``
+
+    Args:
+        failures: Parsed CI failures (may be empty).
+        blame: Blame attribution.
+        pipeline_id: GitLab pipeline ID.
+        pipeline_url: Pipeline web URL.
+        failed_builds: Original failed-builds list — used to summarise
+            jobs when we have no parsed CI failures (e.g. no token).
+        retry_count: Previous fix attempts (0 means first try).
+
+    Returns:
+        Task creation dict compatible with ``TaskCreate`` fields.
+    """
+    model = "opus" if retry_count >= 2 else "sonnet"
+    effort = "max" if retry_count >= 2 else "high"
+
+    if failures:
+        failure_kinds = ", ".join(sorted({f.kind.value for f in failures}))
+        failure_summaries = "\n".join(f"- [{f.job}] {f.summary}" for f in failures)
+        hints = "\n".join(f"  {f.fix_hint}" for f in failures if f.fix_hint)
+    else:
+        failure_kinds = "pipeline_failed"
+        # No parseable failures — fall back to job names.
+        failure_summaries = (
+            "\n".join(
+                f"- Job **{b.get('name', 'unknown')}** (stage: {b.get('stage', 'unknown')}) failed"
+                for b in (failed_builds or [])[:5]
+            )
+            or f"- Pipeline {pipeline_id} failed (no job traces available)"
+        )
+        hints = ""
+
+    files_block = (
+        "\n".join(f"  - {f}" for f in blame.responsible_files) if blame.responsible_files else "  (could not determine)"
+    )
+    pipeline_link = f"\nPipeline: {pipeline_url}" if pipeline_url else ""
+    retry_note = f"\n\n**Retry attempt {retry_count + 1}/{MAX_CI_RETRIES}**" if retry_count > 0 else ""
+    ref_note = f" on `{blame.ref}`" if blame.ref else ""
+
+    description = textwrap.dedent(
+        f"""\
+        GitLab pipeline {pipeline_id}{ref_note} failed.{retry_note}
+        Commit: {blame.head_sha[:8]}
+        Failures: {failure_kinds}
+        {pipeline_link}
+
+        ## Files to investigate
+        {files_block}
+
+        ## Failure summaries
+        {failure_summaries}
+
+        ## Suggested fixes
+        {hints}
+
+        ## Instructions
+        1. Review the failing jobs in the GitLab pipeline view.
+        2. Apply the suggested fixes locally.
+        3. Verify with the project's lint + test commands.
+        4. Push the fix and confirm pipeline goes green.
+        """
+    )
+
+    sha_short = blame.head_sha[:8] if blame.head_sha else f"p{pipeline_id}"
+    title = f"[ci-fix][{sha_short}] GitLab pipeline {pipeline_id}: {failure_kinds}"[:120]
+
+    return {
+        "title": title,
+        "description": description,
+        "role": "qa",
+        "priority": 1,
+        "scope": "small",
+        "task_type": "fix",
+        "model": model,
+        "effort": effort,
+    }

--- a/src/bernstein/gitlab_app/cost_reporter.py
+++ b/src/bernstein/gitlab_app/cost_reporter.py
@@ -1,0 +1,195 @@
+"""MR cost annotation: post agent run cost summaries as GitLab MR comments.
+
+Mirror of :mod:`bernstein.github_app.cost_reporter`.  Uses the GitLab
+Notes API (``POST /projects/:id/merge_requests/:iid/notes``) and the
+update endpoint (``PUT .../notes/:note_id``) so a single Bernstein cost
+comment is kept up to date instead of stacking duplicates.
+
+All operations degrade gracefully when ``httpx`` is not installed or
+when the API returns non-2xx — the helpers simply return ``False``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bernstein.gitlab_app.app import build_api_url, build_auth_headers
+
+logger = logging.getLogger(__name__)
+
+# Marker so we can find and update an existing Bernstein note on the MR.
+COST_NOTE_MARKER = "<!-- bernstein-cost-annotation -->"
+
+_COST_NOTE_TEMPLATE = f"""\
+{COST_NOTE_MARKER}
+> 🤖 **Bernstein agent run cost**
+> Tasks completed: {{task_count}} | Total cost: **${{cost_usd:.4f}}** | Model: {{model}}
+"""
+
+
+def build_cost_summary(cost_usd: float, task_count: int, model: str) -> str:
+    """Build the markdown cost annotation string without posting it.
+
+    Args:
+        cost_usd: Total cost in USD.
+        task_count: Number of completed tasks.
+        model: Model identifier shown in the annotation.
+
+    Returns:
+        Formatted markdown string.
+    """
+    return _COST_NOTE_TEMPLATE.format(
+        task_count=task_count,
+        cost_usd=cost_usd,
+        model=model,
+    )
+
+
+def aggregate_mr_cost(task_costs: list[dict[str, Any]]) -> float:
+    """Sum the ``cost_usd`` field across task cost dicts.
+
+    Missing keys count as zero.
+    """
+    return sum(float(t.get("cost_usd", 0.0)) for t in task_costs)
+
+
+def post_mr_cost_comment(
+    project_id: str | int,
+    mr_iid: int,
+    cost_usd: float,
+    task_count: int = 1,
+    model: str = "claude-sonnet-4-6",
+    token: str = "",
+    base_url: str | None = None,
+) -> bool:
+    """Post (or update in-place) a cost annotation note on a GitLab MR.
+
+    Args:
+        project_id: GitLab project ID or URL-encoded slug.
+        mr_iid: MR internal ID (the user-visible ``!42``).
+        cost_usd: Total agent run cost in USD.
+        task_count: Number of completed tasks.
+        model: Model identifier.
+        token: API token (``PRIVATE-TOKEN`` header).
+        base_url: GitLab base URL override.
+
+    Returns:
+        ``True`` on success, ``False`` when not configured or HTTP fails.
+    """
+    if not token or not project_id or not mr_iid:
+        logger.debug("post_mr_cost_comment: missing token/project/iid — skip")
+        return False
+
+    body = build_cost_summary(cost_usd, task_count, model)
+
+    existing_id = _find_existing_cost_note(project_id, mr_iid, token, base_url)
+    if existing_id is not None:
+        return _update_note(project_id, mr_iid, existing_id, body, token, base_url)
+    return _create_note(project_id, mr_iid, body, token, base_url)
+
+
+def _find_existing_cost_note(
+    project_id: str | int,
+    mr_iid: int,
+    token: str,
+    base_url: str | None,
+) -> int | None:
+    """Return the ID of an existing Bernstein cost note, if any."""
+    try:
+        import httpx
+    except ImportError:
+        return None
+
+    url = build_api_url(f"/projects/{project_id}/merge_requests/{mr_iid}/notes", base_url)
+    try:
+        response: Any = httpx.get(
+            url,
+            headers=build_auth_headers(token),
+            params={"per_page": "100"},
+            timeout=15.0,
+        )
+        if response.status_code != 200:
+            return None
+        notes = response.json()
+    except Exception as exc:  # pragma: no cover - depends on env
+        logger.debug("list-notes failed: %s", exc)
+        return None
+
+    if not isinstance(notes, list):
+        return None
+    notes_typed: list[Any] = notes  # type: ignore[assignment]
+    for note_item in notes_typed:
+        if not isinstance(note_item, dict):
+            continue
+        note_typed: dict[str, Any] = note_item  # type: ignore[assignment]
+        body_val: Any = note_typed.get("body", "")
+        if COST_NOTE_MARKER in str(body_val):
+            note_id: Any = note_typed.get("id")
+            if isinstance(note_id, int):
+                return note_id
+    return None
+
+
+def _create_note(
+    project_id: str | int,
+    mr_iid: int,
+    body: str,
+    token: str,
+    base_url: str | None,
+) -> bool:
+    """POST a new MR note."""
+    try:
+        import httpx
+    except ImportError:
+        return False
+
+    url = build_api_url(f"/projects/{project_id}/merge_requests/{mr_iid}/notes", base_url)
+    try:
+        response: Any = httpx.post(
+            url,
+            headers={**build_auth_headers(token), "Content-Type": "application/json"},
+            json={"body": body},
+            timeout=30.0,
+        )
+    except Exception as exc:  # pragma: no cover - depends on env
+        logger.debug("create-note failed: %s", exc)
+        return False
+    if response.status_code not in {200, 201}:
+        logger.warning("create-note returned HTTP %d", response.status_code)
+        return False
+    return True
+
+
+def _update_note(
+    project_id: str | int,
+    mr_iid: int,
+    note_id: int,
+    body: str,
+    token: str,
+    base_url: str | None,
+) -> bool:
+    """PUT to update an existing MR note in-place."""
+    try:
+        import httpx
+    except ImportError:
+        return False
+
+    url = build_api_url(
+        f"/projects/{project_id}/merge_requests/{mr_iid}/notes/{note_id}",
+        base_url,
+    )
+    try:
+        response: Any = httpx.put(
+            url,
+            headers={**build_auth_headers(token), "Content-Type": "application/json"},
+            json={"body": body},
+            timeout=30.0,
+        )
+    except Exception as exc:  # pragma: no cover - depends on env
+        logger.debug("update-note failed: %s", exc)
+        return False
+    if response.status_code not in {200, 201}:
+        logger.warning("update-note returned HTTP %d", response.status_code)
+        return False
+    return True

--- a/src/bernstein/gitlab_app/mapper.py
+++ b/src/bernstein/gitlab_app/mapper.py
@@ -1,0 +1,295 @@
+"""Event-to-task conversion: maps GitLab webhook events to Bernstein task payloads.
+
+Mirror of :mod:`bernstein.github_app.mapper` for GitLab.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.gitlab_app.webhooks import GitLabWebhookEvent
+
+logger = logging.getLogger(__name__)
+
+# Labels that trigger automatic Bernstein task creation on MR / issue.
+TRIGGER_LABELS: frozenset[str] = frozenset({"bernstein", "agent-fix", "agent-task"})
+
+# Label → priority mapping (lower = higher priority).
+_LABEL_PRIORITY: dict[str, int] = {
+    "bug": 1,
+    "critical": 1,
+    "security": 1,
+    "bernstein": 2,
+    "agent-fix": 1,
+    "agent-task": 2,
+    "enhancement": 2,
+    "feature": 2,
+    "docs": 3,
+    "documentation": 3,
+    "chore": 3,
+}
+
+# Label → role mapping.
+_LABEL_ROLE: dict[str, str] = {
+    "backend": "backend",
+    "frontend": "frontend",
+    "qa": "qa",
+    "security": "security",
+    "docs": "docs",
+    "documentation": "docs",
+    "infra": "backend",
+    "devops": "backend",
+}
+
+# Patterns indicating an actionable MR note.
+_ACTIONABLE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\bfix\b", re.IGNORECASE),
+    re.compile(r"\bchange\b", re.IGNORECASE),
+    re.compile(r"\bupdate\b", re.IGNORECASE),
+    re.compile(r"\breplace\b", re.IGNORECASE),
+    re.compile(r"\bremove\b", re.IGNORECASE),
+    re.compile(r"\badd\b", re.IGNORECASE),
+    re.compile(r"\brefactor\b", re.IGNORECASE),
+    re.compile(r"\bshould\b", re.IGNORECASE),
+    re.compile(r"\bmust\b", re.IGNORECASE),
+    re.compile(r"\bconsider\b", re.IGNORECASE),
+    re.compile(r"```suggestion", re.IGNORECASE),
+]
+
+
+def _extract_labels(payload: dict[str, Any]) -> list[str]:
+    """Extract label names from an MR / issue payload."""
+    raw: object = payload.get("labels", [])
+    if not isinstance(raw, list):
+        return []
+    raw_typed: list[Any] = raw  # type: ignore[assignment]
+    out: list[str] = []
+    for lbl_item in raw_typed:
+        if isinstance(lbl_item, dict):
+            lbl_dict: dict[str, Any] = lbl_item  # type: ignore[assignment]
+            title: Any = lbl_dict.get("title") or lbl_dict.get("name") or ""
+            if title:
+                out.append(str(title).lower())
+        elif isinstance(lbl_item, str):
+            out.append(lbl_item.lower())
+    return out
+
+
+def _priority_from_labels(labels: list[str]) -> int:
+    for label in labels:
+        if label in _LABEL_PRIORITY:
+            return _LABEL_PRIORITY[label]
+    return 2
+
+
+def _role_from_labels(labels: list[str]) -> str:
+    for label in labels:
+        if label in _LABEL_ROLE:
+            return _LABEL_ROLE[label]
+    return "backend"
+
+
+def _scope_from_body(body: str) -> str:
+    if len(body) < 200:
+        return "small"
+    if len(body) > 1000:
+        return "large"
+    return "medium"
+
+
+def _is_actionable(text: str) -> bool:
+    return any(pattern.search(text) for pattern in _ACTIONABLE_PATTERNS)
+
+
+def merge_request_to_tasks(event: GitLabWebhookEvent) -> list[dict[str, Any]]:
+    """Convert a ``Merge Request Hook`` event into Bernstein task payloads.
+
+    Only fires for ``action == "open"``.  Labels drive role / priority
+    and the description is truncated to 2000 chars.
+
+    Args:
+        event: Parsed GitLab webhook event.
+
+    Returns:
+        List with at most one task creation dict.
+    """
+    if event.object_kind != "merge_request":
+        return []
+    if event.action not in {"open", "reopen"}:
+        return []
+
+    attrs: dict[str, Any] = event.payload.get("object_attributes", {})
+    title = str(attrs.get("title", "Untitled merge request"))
+    body = str(attrs.get("description", "") or "")
+    iid = int(attrs.get("iid", 0))
+
+    labels = _extract_labels(attrs)
+    priority = _priority_from_labels(labels)
+    role = _role_from_labels(labels)
+    scope = _scope_from_body(body)
+
+    description = f"GitLab merge request !{iid} from @{event.sender} in {event.project_path}.\n\n{body[:2000]}"
+
+    task: dict[str, Any] = {
+        "title": f"[GL-MR!{iid}] {title}"[:120],
+        "description": description,
+        "role": role,
+        "priority": priority,
+        "scope": scope,
+        "task_type": "standard",
+    }
+
+    logger.info(
+        "Mapped MR !%d to task: role=%s priority=%d scope=%s",
+        iid,
+        role,
+        priority,
+        scope,
+    )
+
+    return [task]
+
+
+def note_to_task(event: GitLabWebhookEvent) -> dict[str, Any] | None:
+    """Convert a ``Note Hook`` event (MR or issue comment) into a task.
+
+    Falls through to the slash-command parser when the comment contains
+    a ``/bernstein`` invocation.  Otherwise builds a fix task when the
+    note body contains actionable review language.
+
+    Args:
+        event: Parsed GitLab webhook event with
+            ``object_kind == "note"``.
+
+    Returns:
+        Task creation dict, or ``None`` when the note has neither a
+        recognised slash command nor actionable language.
+    """
+    if event.object_kind != "note":
+        return None
+
+    attrs: dict[str, Any] = event.payload.get("object_attributes", {})
+    note_body = str(attrs.get("note", "") or "")
+    noteable_type = str(attrs.get("noteable_type", "")).lower()
+
+    # Slash command takes precedence.
+    from bernstein.gitlab_app.slash_commands import parse_slash_command, slash_command_to_task
+
+    parsed = parse_slash_command(note_body)
+    if parsed is not None:
+        action, args = parsed
+        return slash_command_to_task(event, action, args)
+
+    if not _is_actionable(note_body):
+        return None
+
+    mr: dict[str, Any] = event.payload.get("merge_request", {}) or {}
+    issue: dict[str, Any] = event.payload.get("issue", {}) or {}
+    target = mr or issue
+    iid = int(target.get("iid", 0))
+    target_title = str(target.get("title", ""))
+
+    role_hint = "qa" if "merge" in noteable_type else "backend"
+
+    description = (
+        f"GitLab MR note on {noteable_type or 'item'} !{iid} ({target_title}) "
+        f"in {event.project_path} by @{event.sender}.\n\n"
+        f"Note:\n{note_body[:2000]}"
+    )
+
+    task: dict[str, Any] = {
+        "title": f"[GL-MR!{iid}] Fix: {note_body[:80]}"[:120],
+        "description": description,
+        "role": role_hint,
+        "priority": 1,
+        "scope": "small",
+        "task_type": "fix",
+    }
+
+    logger.info(
+        "Mapped GitLab MR note to fix task: iid=%d role=%s",
+        iid,
+        role_hint,
+    )
+
+    return task
+
+
+def pipeline_to_tasks(
+    event: GitLabWebhookEvent,
+    retry_count: int = 0,
+    token: str = "",
+) -> list[dict[str, Any]]:
+    """Convert a failed ``Pipeline Hook`` into a ci-fix task payload.
+
+    When *token* is provided we attempt to fetch the trace of the first
+    failed job, parse it via :class:`~bernstein.adapters.ci.gitlab_ci.GitLabCIParser`
+    and enrich the resulting task with concrete failure summaries.
+    When the trace cannot be fetched (no token / network failure) the
+    task is still created but uses only the high-level pipeline info.
+
+    Args:
+        event: Parsed GitLab webhook event.
+        retry_count: Previous ci-fix attempt count for this branch.
+        token: Optional GitLab API token to fetch job traces.
+
+    Returns:
+        List with at most one task creation dict.
+    """
+    if event.object_kind != "pipeline":
+        return []
+
+    attrs: dict[str, Any] = event.payload.get("object_attributes", {})
+    status = str(attrs.get("status", ""))
+    if status != "failed":
+        return []
+
+    builds: list[dict[str, Any]] = event.payload.get("builds", []) or []
+    failed_builds = [b for b in builds if str(b.get("status", "")) in {"failed", "canceled"}]
+
+    from bernstein.gitlab_app.ci_router import (
+        GitLabCIBlameResult,
+        build_pipeline_routing_payload,
+        fetch_and_parse_failures,
+    )
+
+    project: dict[str, Any] = event.payload.get("project", {})
+    project_id = project.get("id", "")
+
+    failures = fetch_and_parse_failures(
+        project_id=project_id,
+        failed_builds=failed_builds,
+        token=token,
+    )
+
+    head_sha = str(attrs.get("sha", ""))
+    ref = str(attrs.get("ref", ""))
+    pipeline_url = str(attrs.get("url", ""))
+    pipeline_id = int(attrs.get("id", 0))
+
+    blame = GitLabCIBlameResult(
+        head_sha=head_sha,
+        ref=ref,
+        responsible_files=[f for failure in failures for f in failure.affected_files][:10],
+    )
+
+    payload = build_pipeline_routing_payload(
+        failures=failures,
+        blame=blame,
+        pipeline_id=pipeline_id,
+        pipeline_url=pipeline_url,
+        failed_builds=failed_builds,
+        retry_count=retry_count,
+    )
+
+    logger.info(
+        "Mapped GitLab pipeline failure to ci-fix task: pipeline=%d ref=%s retry=%d",
+        pipeline_id,
+        ref,
+        retry_count + 1,
+    )
+
+    return [payload]

--- a/src/bernstein/gitlab_app/pipelines.py
+++ b/src/bernstein/gitlab_app/pipelines.py
@@ -1,0 +1,217 @@
+"""GitLab Commit Statuses API client — pipeline status updates.
+
+Posts and updates "external CI" commit statuses on the SHA backing an
+MR so Bernstein agent verification appears as a native pipeline check
+in the GitLab UI.
+
+GitLab API: ``POST /projects/:id/statuses/:sha``.  Reference:
+https://docs.gitlab.com/ee/api/commits.html#post-the-build-status-to-a-commit
+
+All operations degrade gracefully when:
+
+* The HTTP client (``httpx``) is not installed.
+* The API call returns non-2xx.
+
+Both conditions return ``None`` instead of raising.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from bernstein.gitlab_app.app import build_api_url, build_auth_headers
+
+logger = logging.getLogger(__name__)
+
+# Name shown for the Bernstein external pipeline status on GitLab.
+PIPELINE_STATUS_NAME = "bernstein / agent verification"
+
+# Valid GitLab commit status states.
+_VALID_STATES: frozenset[str] = frozenset({"pending", "running", "success", "failed", "canceled"})
+
+# Bernstein conclusion → GitLab state mapping.
+_CONCLUSION_TO_STATE: dict[str, str] = {
+    "success": "success",
+    "failure": "failed",
+    "neutral": "success",
+    "cancelled": "canceled",
+    "timed_out": "failed",
+    "action_required": "failed",
+}
+
+
+@dataclass
+class PipelineStatusResult:
+    """Result of a commit-status create/update operation.
+
+    Attributes:
+        status_id: GitLab commit-status ID.
+        state: Reported state (``pending``, ``running``, ``success`` …).
+        target_url: URL pointing to the Bernstein details page.
+    """
+
+    status_id: int
+    state: str
+    target_url: str
+
+
+def conclusion_to_state(conclusion: str) -> str:
+    """Map a Bernstein conclusion string to a GitLab commit-state.
+
+    Unknown conclusions fall back to ``"failed"`` (fail-closed).
+    """
+    return _CONCLUSION_TO_STATE.get(conclusion, "failed")
+
+
+def build_status_body(
+    state: str,
+    description: str,
+    target_url: str = "",
+    ref: str = "",
+    name: str = PIPELINE_STATUS_NAME,
+) -> dict[str, Any]:
+    """Build the JSON body for a commit-status POST.
+
+    Args:
+        state: GitLab state (``pending``, ``running``, ``success`` …).
+        description: Short, human-readable status text.
+        target_url: Optional URL pointing back to Bernstein.
+        ref: Optional branch / tag name; if set GitLab posts the status
+            against this ref.
+        name: Display name in the GitLab UI.
+
+    Returns:
+        Dict suitable for JSON-serialisation as the request body.
+    """
+    body: dict[str, Any] = {
+        "state": state,
+        "description": description[:140] if description else "",
+        "name": name,
+    }
+    if target_url:
+        body["target_url"] = target_url
+    if ref:
+        body["ref"] = ref
+    return body
+
+
+class PipelineStatusClient:
+    """Thin client around the GitLab commit-status API.
+
+    Args:
+        project_id: Numeric project ID or URL-encoded path slug.
+        token: PAT / project access token.  When empty all calls are
+            no-ops (returns ``None``).
+        base_url: GitLab base URL.  ``None`` defers to env at call time.
+    """
+
+    def __init__(
+        self,
+        project_id: str | int,
+        token: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self._project_id = project_id
+        self._token = token or ""
+        self._base_url = base_url
+
+    @property
+    def configured(self) -> bool:
+        """True when there's a non-empty project ID + token."""
+        return bool(self._project_id) and bool(self._token)
+
+    def create(
+        self,
+        sha: str,
+        state: str = "running",
+        description: str = "Agent verification in progress",
+        target_url: str = "",
+        ref: str = "",
+    ) -> PipelineStatusResult | None:
+        """Post an initial status (running / pending) on *sha*.
+
+        Args:
+            sha: Commit SHA the status should attach to.
+            state: GitLab state — defaults to ``running``.
+            description: Short status text.
+            target_url: Bernstein details URL.
+            ref: Optional branch/tag for the status.
+
+        Returns:
+            :class:`PipelineStatusResult` on success, ``None`` otherwise.
+        """
+        if not self.configured:
+            logger.debug("PipelineStatusClient not configured — skipping create")
+            return None
+        if state not in _VALID_STATES:
+            state = "running"
+        body = build_status_body(state, description, target_url, ref)
+        return self._post(sha, body)
+
+    def update(
+        self,
+        sha: str,
+        conclusion: str,
+        summary: str,
+        target_url: str = "",
+        ref: str = "",
+    ) -> PipelineStatusResult | None:
+        """Post a terminal status (success / failed / canceled) on *sha*.
+
+        Args:
+            sha: Commit SHA.
+            conclusion: Bernstein conclusion (mapped to GitLab state).
+            summary: Markdown summary — truncated to 140 chars.
+            target_url: Bernstein details URL.
+            ref: Optional branch/tag.
+
+        Returns:
+            :class:`PipelineStatusResult` on success, ``None`` otherwise.
+        """
+        if not self.configured:
+            logger.debug("PipelineStatusClient not configured — skipping update")
+            return None
+        state = conclusion_to_state(conclusion)
+        body = build_status_body(state, summary, target_url, ref)
+        return self._post(sha, body)
+
+    def _post(self, sha: str, body: dict[str, Any]) -> PipelineStatusResult | None:
+        """POST the body and parse the result, returning ``None`` on error."""
+        try:
+            import httpx
+        except ImportError:
+            logger.debug("httpx not available — cannot post GitLab status")
+            return None
+
+        url = build_api_url(f"/projects/{self._project_id}/statuses/{sha}", self._base_url)
+        try:
+            response: Any = httpx.post(
+                url,
+                headers={**build_auth_headers(self._token), "Content-Type": "application/json"},
+                json=body,
+                timeout=30.0,
+            )
+        except Exception as exc:  # pragma: no cover - depends on env
+            logger.debug("commit-status POST failed: %s", exc)
+            return None
+
+        if response.status_code not in {200, 201}:
+            logger.warning(
+                "commit-status POST returned HTTP %d for sha %s",
+                response.status_code,
+                sha[:12],
+            )
+            return None
+
+        try:
+            data: dict[str, Any] = response.json()
+        except Exception:  # pragma: no cover - defensive
+            return None
+
+        return PipelineStatusResult(
+            status_id=int(data.get("id", 0)),
+            state=str(data.get("status", body["state"])),
+            target_url=str(data.get("target_url", body.get("target_url", ""))),
+        )

--- a/src/bernstein/gitlab_app/slash_commands.py
+++ b/src/bernstein/gitlab_app/slash_commands.py
@@ -1,0 +1,114 @@
+"""Slash command parser for ``/bernstein`` on GitLab MR / issue notes.
+
+Mirror of :mod:`bernstein.github_app.slash_commands` for GitLab.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.gitlab_app.webhooks import GitLabWebhookEvent
+
+logger = logging.getLogger(__name__)
+
+# Matches /bernstein <action> [rest of line]
+_SLASH_RE = re.compile(
+    r"^\s*/bernstein\s+(\w+)(?:\s+(.+))?$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+# Supported actions and their task_type / role mappings.
+_ACTION_MAP: dict[str, dict[str, str]] = {
+    "fix": {"task_type": "fix", "role": "backend"},
+    "plan": {"task_type": "planning", "role": "manager"},
+    "evolve": {"task_type": "upgrade_proposal", "role": "backend"},
+    "qa": {"task_type": "standard", "role": "qa"},
+    "review": {"task_type": "standard", "role": "qa"},
+}
+
+
+def parse_slash_command(text: str) -> tuple[str, str] | None:
+    """Extract the first ``/bernstein`` command from *text*.
+
+    Args:
+        text: Comment / note body from GitLab.
+
+    Returns:
+        ``(action, args)`` tuple where *action* is the lowercased word
+        and *args* is the remainder of the line.  ``None`` when no
+        slash command is present.
+    """
+    match = _SLASH_RE.search(text)
+    if match is None:
+        return None
+    action = match.group(1).lower()
+    args = (match.group(2) or "").strip()
+    return (action, args)
+
+
+def slash_command_to_task(
+    event: GitLabWebhookEvent,
+    action: str,
+    args: str,
+) -> dict[str, Any] | None:
+    """Build a Bernstein task payload from a slash command.
+
+    Args:
+        event: The webhook event that carried the command.
+        action: Command verb.
+        args: Optional argument string.
+
+    Returns:
+        Task creation dict, or ``None`` if the verb is unsupported.
+    """
+    spec = _ACTION_MAP.get(action)
+    if spec is None:
+        logger.info("Unknown /bernstein action %r — ignoring", action)
+        return None
+
+    mr: dict[str, Any] = event.payload.get("merge_request", {}) or {}
+    issue: dict[str, Any] = event.payload.get("issue", {}) or {}
+    attrs: dict[str, Any] = event.payload.get("object_attributes", {})
+
+    iid = int(mr.get("iid") or issue.get("iid") or 0)
+    target_title = str(mr.get("title") or issue.get("title") or "")
+    note_body = str(attrs.get("note", "") or "")
+
+    args_line = f" — {args}" if args else ""
+    description = (
+        f"Slash command `/bernstein {action}`{args_line} by @{event.sender} "
+        f"on !{iid} in {event.project_path}.\n\n"
+        f"MR/Issue: {target_title}\n\n"
+        f"Note context:\n{note_body[:1000]}"
+    )
+
+    if args:
+        title = f"[/bernstein {action}] {args}"[:120]
+    elif target_title:
+        title = f"[/bernstein {action}] {target_title}"[:120]
+    else:
+        title = f"[/bernstein {action}] !{iid}"
+
+    priority = 1 if action == "fix" else 2
+
+    task: dict[str, Any] = {
+        "title": title,
+        "description": description,
+        "role": spec["role"],
+        "priority": priority,
+        "scope": "small",
+        "task_type": spec["task_type"],
+    }
+
+    logger.info(
+        "GitLab /bernstein %s → task: role=%s priority=%d project=%s",
+        action,
+        spec["role"],
+        priority,
+        event.project_path,
+    )
+
+    return task

--- a/src/bernstein/gitlab_app/webhooks.py
+++ b/src/bernstein/gitlab_app/webhooks.py
@@ -1,0 +1,142 @@
+"""Webhook parsing and constant-time token verification for GitLab.
+
+GitLab does not sign webhook payloads.  Instead, every delivery carries
+the shared secret in the ``X-Gitlab-Token`` header (plain string compare
+on the receiving end).  We use :func:`hmac.compare_digest` to make the
+comparison constant-time, mirroring how the GitHub side avoids timing
+attacks on the HMAC digest.
+
+Supported event types (``X-Gitlab-Event`` header):
+
+* ``Merge Request Hook`` — push to MR, MR open/close, etc.
+* ``Pipeline Hook`` — CI pipeline status change.
+* ``Note Hook`` — comments on issues/MRs (where ``/bernstein`` lives).
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GitLabWebhookEvent:
+    """Parsed GitLab webhook event.
+
+    Attributes:
+        event_type: Value of the ``X-Gitlab-Event`` header — for example
+            ``"Merge Request Hook"``.
+        object_kind: ``payload["object_kind"]`` such as
+            ``"merge_request"``, ``"pipeline"`` or ``"note"``.
+        action: For MR / issue events this is
+            ``payload["object_attributes"]["action"]`` (``"open"``,
+            ``"close"``, etc.).  Empty for events with no explicit action.
+        project_path: ``namespace/project`` path from the project block.
+        sender: Username of the user that triggered the event.
+        payload: Raw JSON payload.
+    """
+
+    event_type: str
+    object_kind: str
+    action: str
+    project_path: str
+    sender: str
+    payload: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+def verify_token(provided_token: str, expected_token: str) -> bool:
+    """Constant-time compare of the GitLab webhook token.
+
+    Args:
+        provided_token: Value of the ``X-Gitlab-Token`` header.
+        expected_token: Configured shared secret.
+
+    Returns:
+        ``True`` when both strings are non-empty and equal under
+        :func:`hmac.compare_digest`, otherwise ``False``.
+    """
+    if not provided_token or not expected_token:
+        return False
+    # Encode to bytes so non-ASCII tokens (rare but valid) don't trip
+    # ``compare_digest``'s ASCII-only check.
+    return hmac.compare_digest(
+        provided_token.encode("utf-8"),
+        expected_token.encode("utf-8"),
+    )
+
+
+def parse_webhook(headers: dict[str, str], body: bytes) -> GitLabWebhookEvent:
+    """Parse GitLab webhook headers + JSON body into a :class:`GitLabWebhookEvent`.
+
+    Args:
+        headers: HTTP request headers (case-insensitive lookup is
+            applied internally).
+        body: Raw request body bytes.
+
+    Returns:
+        Parsed :class:`GitLabWebhookEvent`.
+
+    Raises:
+        ValueError: If a required header / payload field is missing or
+            the body is not valid JSON.
+    """
+    lower_headers = {k.lower(): v for k, v in headers.items()}
+
+    event_type = lower_headers.get("x-gitlab-event", "")
+    if not event_type:
+        msg = "Missing X-Gitlab-Event header"
+        raise ValueError(msg)
+
+    try:
+        raw_payload: object = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        msg = f"Invalid JSON payload: {exc}"
+        raise ValueError(msg) from exc
+
+    if not isinstance(raw_payload, dict):
+        msg = "GitLab webhook payload must be a JSON object"
+        raise ValueError(msg)
+
+    payload: dict[str, Any] = raw_payload  # type: ignore[assignment]
+    object_kind = str(payload.get("object_kind", ""))
+
+    # ``action`` lives under object_attributes for MR / issue events.
+    raw_attrs: object = payload.get("object_attributes", {})
+    attrs: dict[str, Any] = raw_attrs if isinstance(raw_attrs, dict) else {}  # type: ignore[assignment]
+    action = str(attrs.get("action", ""))
+
+    raw_project: object = payload.get("project", {})
+    project: dict[str, Any] = raw_project if isinstance(raw_project, dict) else {}  # type: ignore[assignment]
+    project_path = str(project.get("path_with_namespace", "") or project.get("name", ""))
+    if not project_path:
+        msg = "Missing project.path_with_namespace in GitLab payload"
+        raise ValueError(msg)
+
+    raw_user: object = payload.get("user", {})
+    user: dict[str, Any] = raw_user if isinstance(raw_user, dict) else {}  # type: ignore[assignment]
+    sender = str(user.get("username", "") or user.get("name", "") or "unknown")
+
+    from bernstein.core.security.sanitize import sanitize_log
+
+    logger.info(
+        "Parsed GitLab webhook: event=%s kind=%s action=%s project=%s sender=%s",
+        sanitize_log(event_type),
+        sanitize_log(object_kind),
+        sanitize_log(action),
+        sanitize_log(project_path),
+        sanitize_log(sender),
+    )
+
+    return GitLabWebhookEvent(
+        event_type=event_type,
+        object_kind=object_kind,
+        action=action,
+        project_path=project_path,
+        sender=sender,
+        payload=payload,
+    )

--- a/tests/integration/gitlab/fixtures/merge_request_close.json
+++ b/tests/integration/gitlab/fixtures/merge_request_close.json
@@ -1,0 +1,24 @@
+{
+  "object_kind": "merge_request",
+  "user": {
+    "id": 17,
+    "name": "Alice",
+    "username": "alice"
+  },
+  "project": {
+    "id": 42,
+    "name": "widgets",
+    "path_with_namespace": "acme/widgets"
+  },
+  "object_attributes": {
+    "id": 12345,
+    "iid": 7,
+    "title": "feat: add LRU cache",
+    "description": "Closed without merge.",
+    "state": "closed",
+    "action": "close",
+    "source_branch": "feat/cache",
+    "target_branch": "main",
+    "labels": []
+  }
+}

--- a/tests/integration/gitlab/fixtures/merge_request_open.json
+++ b/tests/integration/gitlab/fixtures/merge_request_open.json
@@ -1,0 +1,36 @@
+{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "user": {
+    "id": 17,
+    "name": "Alice Example",
+    "username": "alice",
+    "email": "alice@example.com"
+  },
+  "project": {
+    "id": 42,
+    "name": "widgets",
+    "path_with_namespace": "acme/widgets",
+    "web_url": "https://gitlab.example.com/acme/widgets",
+    "default_branch": "main"
+  },
+  "object_attributes": {
+    "id": 12345,
+    "iid": 7,
+    "title": "feat: add LRU cache to the widget service",
+    "description": "Adds a small LRU cache so repeated widget reads avoid the round-trip to Redis. Closes #321.",
+    "state": "opened",
+    "action": "open",
+    "source_branch": "feat/cache",
+    "target_branch": "main",
+    "url": "https://gitlab.example.com/acme/widgets/-/merge_requests/7",
+    "labels": [
+      {"id": 1, "title": "backend"},
+      {"id": 2, "title": "enhancement"}
+    ]
+  },
+  "labels": [
+    {"id": 1, "title": "backend"},
+    {"id": 2, "title": "enhancement"}
+  ]
+}

--- a/tests/integration/gitlab/fixtures/merge_request_with_labels.json
+++ b/tests/integration/gitlab/fixtures/merge_request_with_labels.json
@@ -1,0 +1,15 @@
+{
+  "object_kind": "merge_request",
+  "user": {"username": "alice"},
+  "project": {"id": 42, "path_with_namespace": "acme/widgets"},
+  "object_attributes": {
+    "iid": 99,
+    "title": "security: patch CVE",
+    "description": "Patches a remote-code-execution vector.",
+    "action": "open",
+    "labels": [
+      {"id": 5, "title": "security"},
+      {"id": 6, "title": "critical"}
+    ]
+  }
+}

--- a/tests/integration/gitlab/fixtures/note_mr.json
+++ b/tests/integration/gitlab/fixtures/note_mr.json
@@ -1,0 +1,28 @@
+{
+  "object_kind": "note",
+  "event_type": "note",
+  "user": {
+    "id": 18,
+    "name": "Carol Reviewer",
+    "username": "carol"
+  },
+  "project_id": 42,
+  "project": {
+    "id": 42,
+    "name": "widgets",
+    "path_with_namespace": "acme/widgets"
+  },
+  "object_attributes": {
+    "id": 9001,
+    "note": "Please fix the null pointer on line 42 — it crashes on Windows.",
+    "noteable_type": "MergeRequest",
+    "noteable_id": 12345,
+    "url": "https://gitlab.example.com/acme/widgets/-/merge_requests/7#note_9001"
+  },
+  "merge_request": {
+    "id": 12345,
+    "iid": 7,
+    "title": "feat: add LRU cache",
+    "state": "opened"
+  }
+}

--- a/tests/integration/gitlab/fixtures/note_non_actionable.json
+++ b/tests/integration/gitlab/fixtures/note_non_actionable.json
@@ -1,0 +1,12 @@
+{
+  "object_kind": "note",
+  "user": {"username": "dan"},
+  "project": {"id": 42, "path_with_namespace": "acme/widgets"},
+  "object_attributes": {
+    "id": 9003,
+    "note": "Looks great to me. Thanks!",
+    "noteable_type": "MergeRequest",
+    "noteable_id": 12345
+  },
+  "merge_request": {"iid": 7, "title": "feat: add LRU cache"}
+}

--- a/tests/integration/gitlab/fixtures/note_slash_command.json
+++ b/tests/integration/gitlab/fixtures/note_slash_command.json
@@ -1,0 +1,22 @@
+{
+  "object_kind": "note",
+  "user": {
+    "id": 18,
+    "username": "carol"
+  },
+  "project": {
+    "id": 42,
+    "path_with_namespace": "acme/widgets"
+  },
+  "object_attributes": {
+    "id": 9002,
+    "note": "/bernstein plan break this down into independent tasks",
+    "noteable_type": "Issue",
+    "noteable_id": 100
+  },
+  "issue": {
+    "id": 100,
+    "iid": 33,
+    "title": "Decompose the cache refactor"
+  }
+}

--- a/tests/integration/gitlab/fixtures/pipeline_failed.json
+++ b/tests/integration/gitlab/fixtures/pipeline_failed.json
@@ -1,0 +1,56 @@
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 99876,
+    "iid": 12,
+    "ref": "feat/cache",
+    "tag": false,
+    "sha": "deadbeef1234567890abcdef1234567890abcdef",
+    "before_sha": "0000000000000000000000000000000000000000",
+    "source": "push",
+    "status": "failed",
+    "stages": ["build", "test", "deploy"],
+    "url": "https://gitlab.example.com/acme/widgets/-/pipelines/99876",
+    "duration": 312
+  },
+  "user": {
+    "id": 17,
+    "name": "Alice",
+    "username": "alice"
+  },
+  "project": {
+    "id": 42,
+    "name": "widgets",
+    "path_with_namespace": "acme/widgets"
+  },
+  "commit": {
+    "id": "deadbeef1234567890abcdef1234567890abcdef",
+    "message": "feat: add LRU cache",
+    "author": {"name": "Alice", "email": "alice@example.com"}
+  },
+  "builds": [
+    {
+      "id": 700001,
+      "stage": "build",
+      "name": "compile",
+      "status": "success",
+      "created_at": "2026-05-17T10:00:00Z"
+    },
+    {
+      "id": 700002,
+      "stage": "test",
+      "name": "pytest",
+      "status": "failed",
+      "created_at": "2026-05-17T10:05:00Z",
+      "finished_at": "2026-05-17T10:09:00Z"
+    },
+    {
+      "id": 700003,
+      "stage": "test",
+      "name": "lint",
+      "status": "failed",
+      "created_at": "2026-05-17T10:05:00Z",
+      "finished_at": "2026-05-17T10:06:00Z"
+    }
+  ]
+}

--- a/tests/integration/gitlab/fixtures/pipeline_success.json
+++ b/tests/integration/gitlab/fixtures/pipeline_success.json
@@ -1,0 +1,13 @@
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 99877,
+    "ref": "main",
+    "sha": "feedbeef1234567890abcdef1234567890abcdef",
+    "status": "success",
+    "url": "https://gitlab.example.com/acme/widgets/-/pipelines/99877"
+  },
+  "user": {"username": "alice"},
+  "project": {"id": 42, "path_with_namespace": "acme/widgets"},
+  "builds": []
+}

--- a/tests/integration/test_gitlab_webhook_pipeline.py
+++ b/tests/integration/test_gitlab_webhook_pipeline.py
@@ -1,0 +1,175 @@
+"""End-to-end webhook+mapping tests using captured fixture payloads.
+
+These tests exercise the GitLab webhook ingress + parser + mapper as a
+pipeline.  They do *not* spin up an HTTP server — instead they import the
+public functions and run them against the JSON fixtures committed under
+``tests/integration/gitlab/fixtures/``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bernstein.gitlab_app.cost_reporter import build_cost_summary
+from bernstein.gitlab_app.mapper import (
+    merge_request_to_tasks,
+    note_to_task,
+    pipeline_to_tasks,
+)
+from bernstein.gitlab_app.pipelines import build_status_body, conclusion_to_state
+from bernstein.gitlab_app.webhooks import parse_webhook
+
+FIXTURE_DIR = Path(__file__).parent / "gitlab" / "fixtures"
+
+
+def _load(name: str) -> tuple[dict[str, Any], bytes]:
+    path = FIXTURE_DIR / name
+    payload = json.loads(path.read_text())
+    return payload, path.read_bytes()
+
+
+def _headers(event: str) -> dict[str, str]:
+    return {"X-Gitlab-Event": event, "Content-Type": "application/json"}
+
+
+class TestEndToEndMergeRequest:
+    def test_mr_open_creates_one_task(self) -> None:
+        _, body = _load("merge_request_open.json")
+        event = parse_webhook(_headers("Merge Request Hook"), body)
+        tasks = merge_request_to_tasks(event)
+        assert len(tasks) == 1
+        t = tasks[0]
+        assert t["task_type"] == "standard"
+        assert t["role"] == "backend"
+        assert "GL-MR!7" in t["title"]
+        assert "acme/widgets" in t["description"]
+
+    def test_mr_close_no_task(self) -> None:
+        _, body = _load("merge_request_close.json")
+        event = parse_webhook(_headers("Merge Request Hook"), body)
+        assert merge_request_to_tasks(event) == []
+
+    def test_mr_with_security_label_escalates_priority(self) -> None:
+        _, body = _load("merge_request_with_labels.json")
+        event = parse_webhook(_headers("Merge Request Hook"), body)
+        tasks = merge_request_to_tasks(event)
+        assert tasks[0]["priority"] == 1
+        assert tasks[0]["role"] == "security"
+
+
+class TestEndToEndPipeline:
+    def test_failed_pipeline_creates_fix_task(self) -> None:
+        _, body = _load("pipeline_failed.json")
+        event = parse_webhook(_headers("Pipeline Hook"), body)
+        tasks = pipeline_to_tasks(event)
+        assert len(tasks) == 1
+        t = tasks[0]
+        assert t["task_type"] == "fix"
+        assert t["role"] == "qa"
+        assert "ci-fix" in t["title"]
+        assert "99876" in t["description"]
+
+    def test_failed_pipeline_with_retry_uses_opus(self) -> None:
+        _, body = _load("pipeline_failed.json")
+        event = parse_webhook(_headers("Pipeline Hook"), body)
+        tasks = pipeline_to_tasks(event, retry_count=2)
+        assert tasks[0]["model"] == "opus"
+
+    def test_success_pipeline_no_task(self) -> None:
+        _, body = _load("pipeline_success.json")
+        event = parse_webhook(_headers("Pipeline Hook"), body)
+        assert pipeline_to_tasks(event) == []
+
+
+class TestEndToEndNote:
+    def test_actionable_mr_note(self) -> None:
+        _, body = _load("note_mr.json")
+        event = parse_webhook(_headers("Note Hook"), body)
+        task = note_to_task(event)
+        assert task is not None
+        assert task["task_type"] == "fix"
+
+    def test_slash_command_note(self) -> None:
+        _, body = _load("note_slash_command.json")
+        event = parse_webhook(_headers("Note Hook"), body)
+        task = note_to_task(event)
+        assert task is not None
+        assert task["task_type"] == "planning"
+        assert task["role"] == "manager"
+
+    def test_non_actionable_note(self) -> None:
+        _, body = _load("note_non_actionable.json")
+        event = parse_webhook(_headers("Note Hook"), body)
+        assert note_to_task(event) is None
+
+
+class TestSnapshotOutputs:
+    """Snapshot-like checks: stable, deterministic output strings."""
+
+    def test_cost_summary_snapshot(self) -> None:
+        out = build_cost_summary(cost_usd=0.1234, task_count=3, model="claude-sonnet-4-6")
+        # Strip dynamic bits — we just check stable structure.
+        assert "bernstein-cost-annotation" in out
+        assert "Tasks completed: 3" in out
+        assert "$0.1234" in out
+        assert "claude-sonnet-4-6" in out
+
+    def test_status_body_running_snapshot(self) -> None:
+        body = build_status_body(state="running", description="Working", target_url="https://x")
+        assert body == {
+            "state": "running",
+            "description": "Working",
+            "name": "bernstein / agent verification",
+            "target_url": "https://x",
+        }
+
+    def test_status_body_success_snapshot(self) -> None:
+        body = build_status_body(state="success", description="done")
+        assert body["state"] == "success"
+        assert body["name"] == "bernstein / agent verification"
+
+    def test_conclusion_state_table_snapshot(self) -> None:
+        # Pin the mapping table so accidental changes show up as test diffs.
+        assert {
+            "success": conclusion_to_state("success"),
+            "failure": conclusion_to_state("failure"),
+            "neutral": conclusion_to_state("neutral"),
+            "cancelled": conclusion_to_state("cancelled"),
+            "timed_out": conclusion_to_state("timed_out"),
+            "action_required": conclusion_to_state("action_required"),
+            "weirdo": conclusion_to_state("weirdo"),
+        } == {
+            "success": "success",
+            "failure": "failed",
+            "neutral": "success",
+            "cancelled": "canceled",
+            "timed_out": "failed",
+            "action_required": "failed",
+            "weirdo": "failed",
+        }
+
+
+class TestFixtureBytesParse:
+    """Smoke test that every fixture parses without raising."""
+
+    @pytest.mark.parametrize(
+        "fixture,event",
+        [
+            ("merge_request_open.json", "Merge Request Hook"),
+            ("merge_request_close.json", "Merge Request Hook"),
+            ("merge_request_with_labels.json", "Merge Request Hook"),
+            ("pipeline_failed.json", "Pipeline Hook"),
+            ("pipeline_success.json", "Pipeline Hook"),
+            ("note_mr.json", "Note Hook"),
+            ("note_slash_command.json", "Note Hook"),
+            ("note_non_actionable.json", "Note Hook"),
+        ],
+    )
+    def test_parses(self, fixture: str, event: str) -> None:
+        _, body = _load(fixture)
+        evt = parse_webhook(_headers(event), body)
+        assert evt.project_path

--- a/tests/unit/test_gitlab_app.py
+++ b/tests/unit/test_gitlab_app.py
@@ -1,0 +1,162 @@
+"""Unit tests for ``bernstein.gitlab_app.app`` — config + URL helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from bernstein.gitlab_app.app import (
+    DEFAULT_GITLAB_URL,
+    GitLabAppConfig,
+    build_api_url,
+    build_auth_headers,
+    fetch_job_trace,
+    get_gitlab_base_url,
+)
+
+
+class TestGetGitlabBaseUrl:
+    """``get_gitlab_base_url`` reads BERNSTEIN_GITLAB_URL with sane defaults."""
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_GITLAB_URL", raising=False)
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+    def test_https_url_passes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "https://gitlab.example.com")
+        assert get_gitlab_base_url() == "https://gitlab.example.com"
+
+    def test_trailing_slash_stripped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "https://gitlab.example.com/")
+        assert get_gitlab_base_url() == "https://gitlab.example.com"
+
+    def test_http_localhost_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "http://localhost:8080")
+        assert get_gitlab_base_url() == "http://localhost:8080"
+
+    def test_invalid_scheme_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "ftp://gitlab.example.com")
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+    def test_garbage_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "not-a-url")
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+    def test_empty_string_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "   ")
+        assert get_gitlab_base_url() == DEFAULT_GITLAB_URL
+
+
+class TestGitLabAppConfig:
+    """``GitLabAppConfig.from_env`` validation."""
+
+    def test_from_env_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BERNSTEIN_GITLAB_URL", "https://gitlab.example.com")
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat-test")
+        monkeypatch.setenv("GITLAB_WEBHOOK_TOKEN", "secret-hook")
+        cfg = GitLabAppConfig.from_env()
+        assert cfg.base_url == "https://gitlab.example.com"
+        assert cfg.token == "glpat-test"
+        assert cfg.webhook_token == "secret-hook"
+
+    def test_from_env_pat_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.setenv("GITLAB_PAT", "glpat-pat")
+        monkeypatch.setenv("GITLAB_WEBHOOK_TOKEN", "hook")
+        cfg = GitLabAppConfig.from_env()
+        assert cfg.token == "glpat-pat"
+
+    def test_from_env_missing_token_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+        monkeypatch.delenv("GITLAB_PAT", raising=False)
+        monkeypatch.setenv("GITLAB_WEBHOOK_TOKEN", "hook")
+        with pytest.raises(ValueError, match="GITLAB_TOKEN"):
+            GitLabAppConfig.from_env()
+
+    def test_from_env_missing_hook_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", "x")
+        monkeypatch.delenv("GITLAB_WEBHOOK_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="GITLAB_WEBHOOK_TOKEN"):
+            GitLabAppConfig.from_env()
+
+    def test_config_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        cfg = GitLabAppConfig(base_url="https://gitlab.com", token="t", webhook_token="w")
+        with pytest.raises(FrozenInstanceError):
+            cfg.token = "other"  # type: ignore[misc]
+
+
+class TestBuildApiUrl:
+    """``build_api_url`` path handling."""
+
+    def test_simple_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_GITLAB_URL", raising=False)
+        assert build_api_url("/projects/1") == "https://gitlab.com/api/v4/projects/1"
+
+    def test_missing_leading_slash_added(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BERNSTEIN_GITLAB_URL", raising=False)
+        assert build_api_url("projects/1") == "https://gitlab.com/api/v4/projects/1"
+
+    def test_custom_base(self) -> None:
+        assert build_api_url("/projects/1", "https://gitlab.acme.com") == "https://gitlab.acme.com/api/v4/projects/1"
+
+    def test_base_trailing_slash(self) -> None:
+        assert build_api_url("/x", "https://gitlab.acme.com/") == "https://gitlab.acme.com/api/v4/x"
+
+
+class TestBuildAuthHeaders:
+    def test_token_set(self) -> None:
+        assert build_auth_headers("abc") == {"PRIVATE-TOKEN": "abc"}
+
+    def test_empty_token(self) -> None:
+        assert build_auth_headers("") == {}
+
+
+class TestFetchJobTrace:
+    """``fetch_job_trace`` graceful degradation."""
+
+    def test_no_token_returns_empty(self) -> None:
+        assert fetch_job_trace(1, 2, token="") == ""
+
+    def test_httpx_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Response:
+            status_code = 200
+            text = "trace body"
+
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], timeout: float) -> _Response:
+                assert "api/v4/projects/1/jobs/2/trace" in url
+                assert headers["PRIVATE-TOKEN"] == "t"
+                return _Response()
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert fetch_job_trace(1, 2, token="t") == "trace body"
+
+    def test_httpx_non_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Response:
+            status_code = 404
+            text = ""
+
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], timeout: float) -> _Response:
+                return _Response()
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert fetch_job_trace(1, 2, token="t") == ""
+
+    def test_httpx_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _FakeHttpx:
+            @staticmethod
+            def get(*_args: object, **_kwargs: object) -> object:
+                raise RuntimeError("boom")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert fetch_job_trace(1, 2, token="t") == ""

--- a/tests/unit/test_gitlab_ci_router.py
+++ b/tests/unit/test_gitlab_ci_router.py
@@ -1,0 +1,210 @@
+"""Unit tests for ``bernstein.gitlab_app.ci_router``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from bernstein.core.quality.ci_fix import CIFailure, CIFailureKind
+from bernstein.gitlab_app.ci_router import (
+    MAX_CI_RETRIES,
+    GitLabCIBlameResult,
+    build_pipeline_routing_payload,
+    fetch_and_parse_failures,
+)
+
+
+def _fake_failure(
+    kind: CIFailureKind = CIFailureKind.PYTEST,
+    job: str = "test",
+    summary: str = "tests failed",
+    fix_hint: str = "run pytest -x",
+    affected_files: list[str] | None = None,
+) -> CIFailure:
+    return CIFailure(
+        kind=kind,
+        job=job,
+        summary=summary,
+        details="",
+        fix_hint=fix_hint,
+        affected_files=affected_files or ["src/x.py"],
+    )
+
+
+class TestBuildPipelineRoutingPayload:
+    def test_includes_failure_summaries(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[_fake_failure()],
+            blame=GitLabCIBlameResult(head_sha="abc123def", ref="main", responsible_files=["src/x.py"]),
+            pipeline_id=42,
+        )
+        assert payload["task_type"] == "fix"
+        assert payload["role"] == "qa"
+        assert payload["priority"] == 1
+        assert "tests failed" in payload["description"]
+        assert "src/x.py" in payload["description"]
+
+    def test_no_failures_falls_back_to_builds(self) -> None:
+        builds = [{"name": "lint", "stage": "quality"}]
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha=""),
+            pipeline_id=99,
+            failed_builds=builds,
+        )
+        assert "lint" in payload["description"]
+
+    def test_no_failures_no_builds_uses_pipeline_id(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha=""),
+            pipeline_id=99,
+            failed_builds=None,
+        )
+        assert "99" in payload["description"]
+
+    def test_pipeline_url_emitted(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha="x"),
+            pipeline_id=1,
+            pipeline_url="https://gitlab/p/1",
+        )
+        assert "https://gitlab/p/1" in payload["description"]
+
+    def test_retry_count_zero_no_note(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha="x"),
+            pipeline_id=1,
+            retry_count=0,
+        )
+        assert "Retry attempt" not in payload["description"]
+
+    def test_retry_count_one_emits_note(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha="x"),
+            pipeline_id=1,
+            retry_count=1,
+        )
+        assert "Retry attempt 2/" in payload["description"]
+
+    def test_model_escalates_on_retry(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha="x"),
+            pipeline_id=1,
+            retry_count=2,
+        )
+        assert payload["model"] == "opus"
+        assert payload["effort"] == "max"
+
+    def test_first_attempt_uses_sonnet(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha="x"),
+            pipeline_id=1,
+            retry_count=0,
+        )
+        assert payload["model"] == "sonnet"
+        assert payload["effort"] == "high"
+
+    def test_title_truncated(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[_fake_failure(summary="x" * 200)],
+            blame=GitLabCIBlameResult(head_sha="abcdef1234567890" * 4),
+            pipeline_id=1,
+        )
+        assert len(payload["title"]) <= 120
+
+    def test_title_uses_sha_short(self) -> None:
+        payload = build_pipeline_routing_payload(
+            failures=[],
+            blame=GitLabCIBlameResult(head_sha="abcdef1234567890"),
+            pipeline_id=1,
+        )
+        assert "[abcdef12]" in payload["title"]
+
+    def test_max_retries_constant(self) -> None:
+        assert MAX_CI_RETRIES == 3
+
+
+class TestFetchAndParseFailures:
+    def test_no_token_returns_empty(self) -> None:
+        assert (
+            fetch_and_parse_failures(
+                project_id=1,
+                failed_builds=[{"id": 1, "name": "lint"}],
+                token="",
+            )
+            == []
+        )
+
+    def test_no_builds_returns_empty(self) -> None:
+        assert fetch_and_parse_failures(project_id=1, failed_builds=[], token="t") == []
+
+    def test_no_project_id_returns_empty(self) -> None:
+        assert (
+            fetch_and_parse_failures(
+                project_id="",
+                failed_builds=[{"id": 1}],
+                token="t",
+            )
+            == []
+        )
+
+    def test_calls_trace_per_build(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[tuple[Any, int]] = []
+
+        def _fake_fetch(project_id: Any, job_id: int, token: str, base_url: Any = None) -> str:
+            seen.append((project_id, job_id))
+            return "ERROR: it broke\n"
+
+        import bernstein.gitlab_app.ci_router as router_mod
+
+        monkeypatch.setattr(router_mod, "fetch_job_trace", _fake_fetch)
+        out = fetch_and_parse_failures(
+            project_id=42,
+            failed_builds=[{"id": 1, "name": "lint"}, {"id": 2, "name": "test"}],
+            token="t",
+        )
+        assert len(seen) == 2
+        # We expect at least one parsed failure from the simulated error log.
+        assert isinstance(out, list)
+
+    def test_skips_builds_with_no_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[int] = []
+
+        def _fake_fetch(project_id: Any, job_id: int, token: str, base_url: Any = None) -> str:
+            seen.append(job_id)
+            return ""
+
+        import bernstein.gitlab_app.ci_router as router_mod
+
+        monkeypatch.setattr(router_mod, "fetch_job_trace", _fake_fetch)
+        fetch_and_parse_failures(
+            project_id=42,
+            failed_builds=[{"name": "lint"}, {"id": "not-int"}],  # type: ignore[list-item]
+            token="t",
+        )
+        assert seen == []
+
+    def test_max_jobs_caps_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        called: list[int] = []
+
+        def _fake_fetch(project_id: Any, job_id: int, token: str, base_url: Any = None) -> str:
+            called.append(job_id)
+            return ""
+
+        import bernstein.gitlab_app.ci_router as router_mod
+
+        monkeypatch.setattr(router_mod, "fetch_job_trace", _fake_fetch)
+        fetch_and_parse_failures(
+            project_id=42,
+            failed_builds=[{"id": i} for i in range(10)],
+            token="t",
+            max_jobs=2,
+        )
+        assert len(called) == 2

--- a/tests/unit/test_gitlab_cost_reporter.py
+++ b/tests/unit/test_gitlab_cost_reporter.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``bernstein.gitlab_app.cost_reporter``."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from bernstein.gitlab_app.cost_reporter import (
+    COST_NOTE_MARKER,
+    aggregate_mr_cost,
+    build_cost_summary,
+    post_mr_cost_comment,
+)
+
+
+class TestAggregateMrCost:
+    def test_sum(self) -> None:
+        assert aggregate_mr_cost([{"cost_usd": 1.0}, {"cost_usd": 2.5}]) == 3.5
+
+    def test_missing_key_zero(self) -> None:
+        assert aggregate_mr_cost([{"other": 1.0}, {"cost_usd": 0.5}]) == 0.5
+
+    def test_empty(self) -> None:
+        assert aggregate_mr_cost([]) == 0.0
+
+    def test_string_value_coerced(self) -> None:
+        assert aggregate_mr_cost([{"cost_usd": "0.25"}]) == 0.25
+
+
+class TestBuildCostSummary:
+    def test_contains_marker(self) -> None:
+        out = build_cost_summary(0.1234, 3, "claude")
+        assert COST_NOTE_MARKER in out
+
+    def test_format(self) -> None:
+        out = build_cost_summary(0.12, 4, "claude-sonnet-4-6")
+        assert "Tasks completed: 4" in out
+        assert "$0.1200" in out
+        assert "claude-sonnet-4-6" in out
+
+    def test_zero_cost(self) -> None:
+        assert "$0.0000" in build_cost_summary(0.0, 0, "x")
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: Any = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+class TestPostMrCostComment:
+    def test_no_token(self) -> None:
+        assert post_mr_cost_comment(1, 1, 0.0, token="") is False
+
+    def test_no_project(self) -> None:
+        assert post_mr_cost_comment("", 1, 0.0, token="t") is False
+
+    def test_no_iid(self) -> None:
+        assert post_mr_cost_comment(1, 0, 0.0, token="t") is False
+
+    def test_creates_when_no_existing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cap: list[dict[str, Any]] = []
+
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], params: dict[str, str], timeout: float) -> _Response:
+                return _Response(200, [])
+
+            @staticmethod
+            def post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                cap.append({"verb": "post", "url": url, "json": json})
+                return _Response(201, {"id": 1})
+
+            @staticmethod
+            def put(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                cap.append({"verb": "put", "url": url, "json": json})
+                return _Response(200, {"id": 1})
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+        assert post_mr_cost_comment(42, 7, 0.5, task_count=2, model="m", token="tok") is True
+        assert cap[0]["verb"] == "post"
+        assert "merge_requests/7/notes" in cap[0]["url"]
+
+    def test_updates_when_existing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cap: list[dict[str, Any]] = []
+        existing = [{"id": 555, "body": COST_NOTE_MARKER + "\nold"}]
+
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], params: dict[str, str], timeout: float) -> _Response:
+                return _Response(200, existing)
+
+            @staticmethod
+            def post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                cap.append({"verb": "post"})
+                return _Response(201, {"id": 1})
+
+            @staticmethod
+            def put(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                cap.append({"verb": "put", "url": url})
+                return _Response(200, {"id": 555})
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+        assert post_mr_cost_comment(42, 7, 1.0, token="tok") is True
+        assert cap[0]["verb"] == "put"
+        assert "/notes/555" in cap[0]["url"]
+
+    def test_create_500_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], params: dict[str, str], timeout: float) -> _Response:
+                return _Response(200, [])
+
+            @staticmethod
+            def post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                return _Response(500)
+
+            @staticmethod
+            def put(*_args: object, **_kwargs: object) -> _Response:
+                return _Response(200)
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert post_mr_cost_comment(42, 7, 0.0, token="tok") is False
+
+    def test_search_returns_non_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # search 401 → falls back to create
+        class _FakeHttpx:
+            @staticmethod
+            def get(url: str, headers: dict[str, str], params: dict[str, str], timeout: float) -> _Response:
+                return _Response(401)
+
+            @staticmethod
+            def post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                return _Response(201)
+
+            @staticmethod
+            def put(*_args: object, **_kwargs: object) -> _Response:
+                return _Response(200)
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert post_mr_cost_comment(42, 7, 0.0, token="tok") is True
+
+    def test_get_raises_falls_back_to_create(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _FakeHttpx:
+            @staticmethod
+            def get(*_args: object, **_kwargs: object) -> _Response:
+                raise RuntimeError("net")
+
+            @staticmethod
+            def post(url: str, headers: dict[str, str], json: dict[str, Any], timeout: float) -> _Response:
+                return _Response(201)
+
+            @staticmethod
+            def put(*_args: object, **_kwargs: object) -> _Response:
+                return _Response(200)
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+        assert post_mr_cost_comment(42, 7, 0.0, token="tok") is True

--- a/tests/unit/test_gitlab_mapper.py
+++ b/tests/unit/test_gitlab_mapper.py
@@ -1,0 +1,256 @@
+"""Unit tests for ``bernstein.gitlab_app.mapper``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bernstein.gitlab_app.mapper import (
+    merge_request_to_tasks,
+    note_to_task,
+    pipeline_to_tasks,
+)
+from bernstein.gitlab_app.webhooks import GitLabWebhookEvent
+
+
+def _mr_event(
+    *,
+    title: str = "Add caching",
+    body: str = "Adds a tiny LRU cache.",
+    action: str = "open",
+    labels: list[dict[str, str]] | None = None,
+    iid: int = 17,
+) -> GitLabWebhookEvent:
+    payload: dict[str, Any] = {
+        "object_kind": "merge_request",
+        "object_attributes": {
+            "iid": iid,
+            "title": title,
+            "description": body,
+            "action": action,
+            "labels": labels or [],
+        },
+        "project": {"path_with_namespace": "acme/widgets"},
+        "user": {"username": "alice"},
+    }
+    return GitLabWebhookEvent(
+        event_type="Merge Request Hook",
+        object_kind="merge_request",
+        action=action,
+        project_path="acme/widgets",
+        sender="alice",
+        payload=payload,
+    )
+
+
+def _note_event(note: str, noteable_type: str = "MergeRequest") -> GitLabWebhookEvent:
+    payload: dict[str, Any] = {
+        "object_kind": "note",
+        "object_attributes": {
+            "note": note,
+            "noteable_type": noteable_type,
+        },
+        "merge_request": {"iid": 3, "title": "MR title"},
+        "project": {"path_with_namespace": "acme/widgets"},
+        "user": {"username": "carol"},
+    }
+    return GitLabWebhookEvent(
+        event_type="Note Hook",
+        object_kind="note",
+        action="",
+        project_path="acme/widgets",
+        sender="carol",
+        payload=payload,
+    )
+
+
+def _pipeline_event(
+    *,
+    status: str = "failed",
+    builds: list[dict[str, Any]] | None = None,
+) -> GitLabWebhookEvent:
+    payload: dict[str, Any] = {
+        "object_kind": "pipeline",
+        "object_attributes": {
+            "id": 555,
+            "sha": "deadbeef0011223344",
+            "ref": "main",
+            "status": status,
+            "url": "https://gitlab.com/acme/widgets/-/pipelines/555",
+        },
+        "project": {"path_with_namespace": "acme/widgets", "id": 42},
+        "user": {"username": "ci-bot"},
+        "builds": builds
+        if builds is not None
+        else [
+            {"id": 700, "name": "lint", "stage": "quality", "status": "failed"},
+            {"id": 701, "name": "test", "stage": "test", "status": "passed"},
+        ],
+    }
+    return GitLabWebhookEvent(
+        event_type="Pipeline Hook",
+        object_kind="pipeline",
+        action="",
+        project_path="acme/widgets",
+        sender="ci-bot",
+        payload=payload,
+    )
+
+
+class TestMergeRequestToTasks:
+    def test_open_creates_task(self) -> None:
+        tasks = merge_request_to_tasks(_mr_event())
+        assert len(tasks) == 1
+        t = tasks[0]
+        assert t["task_type"] == "standard"
+        assert "GL-MR!17" in t["title"]
+        assert t["role"] == "backend"
+        assert t["priority"] == 2
+
+    def test_non_open_actions_skipped(self) -> None:
+        assert merge_request_to_tasks(_mr_event(action="close")) == []
+        assert merge_request_to_tasks(_mr_event(action="update")) == []
+
+    def test_reopen_creates_task(self) -> None:
+        assert len(merge_request_to_tasks(_mr_event(action="reopen"))) == 1
+
+    def test_label_drives_role_and_priority(self) -> None:
+        tasks = merge_request_to_tasks(_mr_event(labels=[{"title": "qa"}, {"title": "bug"}]))
+        assert tasks[0]["role"] == "qa"
+        assert tasks[0]["priority"] == 1
+
+    def test_label_as_string_supported(self) -> None:
+        event = _mr_event(labels=[{"name": "security"}])
+        tasks = merge_request_to_tasks(event)
+        assert tasks[0]["role"] == "security"
+
+    def test_scope_small(self) -> None:
+        tasks = merge_request_to_tasks(_mr_event(body="x" * 100))
+        assert tasks[0]["scope"] == "small"
+
+    def test_scope_medium(self) -> None:
+        tasks = merge_request_to_tasks(_mr_event(body="x" * 500))
+        assert tasks[0]["scope"] == "medium"
+
+    def test_scope_large(self) -> None:
+        tasks = merge_request_to_tasks(_mr_event(body="x" * 1500))
+        assert tasks[0]["scope"] == "large"
+
+    def test_wrong_object_kind(self) -> None:
+        event = _mr_event()
+        # mutate object_kind
+        new_evt = GitLabWebhookEvent(
+            event_type=event.event_type,
+            object_kind="pipeline",
+            action=event.action,
+            project_path=event.project_path,
+            sender=event.sender,
+            payload=event.payload,
+        )
+        assert merge_request_to_tasks(new_evt) == []
+
+    def test_title_truncated(self) -> None:
+        long = "x" * 200
+        tasks = merge_request_to_tasks(_mr_event(title=long))
+        assert len(tasks[0]["title"]) <= 120
+
+    def test_description_truncated(self) -> None:
+        long = "y" * 5000
+        tasks = merge_request_to_tasks(_mr_event(body=long))
+        # description includes prefix + first 2000 of body
+        assert tasks[0]["description"].count("y") == 2000
+
+
+class TestNoteToTask:
+    def test_actionable_review_creates_fix(self) -> None:
+        task = note_to_task(_note_event("Please fix the null check on line 42."))
+        assert task is not None
+        assert task["task_type"] == "fix"
+        assert task["role"] == "qa"
+        assert task["priority"] == 1
+
+    def test_non_actionable_returns_none(self) -> None:
+        assert note_to_task(_note_event("Looks good to me, thanks!")) is None
+
+    def test_slash_command_overrides(self) -> None:
+        task = note_to_task(_note_event("/bernstein plan add caching"))
+        assert task is not None
+        assert task["task_type"] == "planning"
+        assert task["role"] == "manager"
+
+    def test_slash_fix(self) -> None:
+        task = note_to_task(_note_event("/bernstein fix the crash"))
+        assert task is not None
+        assert task["task_type"] == "fix"
+        assert task["priority"] == 1
+
+    def test_unknown_slash_command_returns_none(self) -> None:
+        assert note_to_task(_note_event("/bernstein wibble")) is None
+
+    def test_issue_note_role_backend(self) -> None:
+        task = note_to_task(_note_event("must add tests", noteable_type="Issue"))
+        assert task is not None
+        assert task["role"] == "backend"
+
+    def test_wrong_object_kind(self) -> None:
+        event = _note_event("fix this")
+        # replace object_kind
+        bad = GitLabWebhookEvent(
+            event_type=event.event_type,
+            object_kind="merge_request",
+            action=event.action,
+            project_path=event.project_path,
+            sender=event.sender,
+            payload=event.payload,
+        )
+        assert note_to_task(bad) is None
+
+    def test_suggestion_block_actionable(self) -> None:
+        body = "Here:\n```suggestion\nfoo()\n```"
+        task = note_to_task(_note_event(body))
+        assert task is not None
+        assert task["task_type"] == "fix"
+
+
+class TestPipelineToTasks:
+    def test_failed_creates_task(self) -> None:
+        tasks = pipeline_to_tasks(_pipeline_event())
+        assert len(tasks) == 1
+        assert tasks[0]["task_type"] == "fix"
+        assert tasks[0]["role"] == "qa"
+        assert "ci-fix" in tasks[0]["title"]
+
+    def test_success_skipped(self) -> None:
+        assert pipeline_to_tasks(_pipeline_event(status="success")) == []
+
+    def test_pending_skipped(self) -> None:
+        assert pipeline_to_tasks(_pipeline_event(status="pending")) == []
+
+    def test_wrong_object_kind(self) -> None:
+        event = _pipeline_event()
+        bad = GitLabWebhookEvent(
+            event_type=event.event_type,
+            object_kind="merge_request",
+            action=event.action,
+            project_path=event.project_path,
+            sender=event.sender,
+            payload=event.payload,
+        )
+        assert pipeline_to_tasks(bad) == []
+
+    def test_retry_escalates_model(self) -> None:
+        tasks = pipeline_to_tasks(_pipeline_event(), retry_count=3)
+        assert tasks[0]["model"] == "opus"
+        assert tasks[0]["effort"] == "max"
+
+    def test_no_retry_uses_sonnet(self) -> None:
+        tasks = pipeline_to_tasks(_pipeline_event(), retry_count=0)
+        assert tasks[0]["model"] == "sonnet"
+        assert tasks[0]["effort"] == "high"
+
+    def test_no_failed_builds_still_creates_task(self) -> None:
+        tasks = pipeline_to_tasks(_pipeline_event(builds=[]))
+        assert len(tasks) == 1
+
+    def test_includes_pipeline_url(self) -> None:
+        tasks = pipeline_to_tasks(_pipeline_event())
+        assert "pipelines/555" in tasks[0]["description"]

--- a/tests/unit/test_gitlab_pipelines.py
+++ b/tests/unit/test_gitlab_pipelines.py
@@ -1,0 +1,143 @@
+"""Unit tests for ``bernstein.gitlab_app.pipelines``."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+
+from bernstein.gitlab_app.pipelines import (
+    PIPELINE_STATUS_NAME,
+    PipelineStatusClient,
+    build_status_body,
+    conclusion_to_state,
+)
+
+
+class TestConclusionToState:
+    def test_known_mappings(self) -> None:
+        assert conclusion_to_state("success") == "success"
+        assert conclusion_to_state("failure") == "failed"
+        assert conclusion_to_state("neutral") == "success"
+        assert conclusion_to_state("cancelled") == "canceled"
+        assert conclusion_to_state("timed_out") == "failed"
+
+    def test_unknown_falls_back_to_failed(self) -> None:
+        assert conclusion_to_state("anything-else") == "failed"
+
+    def test_empty_falls_back_to_failed(self) -> None:
+        assert conclusion_to_state("") == "failed"
+
+
+class TestBuildStatusBody:
+    def test_minimal(self) -> None:
+        body = build_status_body("running", "hello")
+        assert body["state"] == "running"
+        assert body["description"] == "hello"
+        assert body["name"] == PIPELINE_STATUS_NAME
+        assert "target_url" not in body
+
+    def test_with_target_and_ref(self) -> None:
+        body = build_status_body("success", "x", target_url="https://x", ref="main")
+        assert body["target_url"] == "https://x"
+        assert body["ref"] == "main"
+
+    def test_description_truncated(self) -> None:
+        body = build_status_body("running", "a" * 500)
+        assert len(body["description"]) == 140
+
+    def test_custom_name(self) -> None:
+        body = build_status_body("running", "x", name="my-check")
+        assert body["name"] == "my-check"
+
+    def test_empty_description_safe(self) -> None:
+        body = build_status_body("running", "")
+        assert body["description"] == ""
+
+
+class _Response:
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class TestPipelineStatusClient:
+    """Client unit tests with a stubbed httpx."""
+
+    def _install_fake_httpx(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        response: _Response,
+        capture: list[dict[str, Any]] | None = None,
+    ) -> None:
+        class _FakeHttpx:
+            @staticmethod
+            def post(
+                url: str,
+                headers: dict[str, str],
+                json: dict[str, Any],
+                timeout: float,
+            ) -> _Response:
+                if capture is not None:
+                    capture.append({"url": url, "headers": headers, "json": json})
+                return response
+
+        monkeypatch.setitem(sys.modules, "httpx", _FakeHttpx)
+
+    def test_create_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._install_fake_httpx(
+            monkeypatch,
+            _Response(201, {"id": 17, "status": "running", "target_url": ""}),
+        )
+        client = PipelineStatusClient(project_id=42, token="tok")
+        result = client.create(sha="abc123", state="running")
+        assert result is not None
+        assert result.status_id == 17
+        assert result.state == "running"
+
+    def test_create_no_token_noop(self) -> None:
+        client = PipelineStatusClient(project_id=42, token="")
+        assert client.create(sha="abc") is None
+
+    def test_update_maps_conclusion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cap: list[dict[str, Any]] = []
+        self._install_fake_httpx(
+            monkeypatch,
+            _Response(201, {"id": 1, "status": "success", "target_url": ""}),
+            capture=cap,
+        )
+        client = PipelineStatusClient(project_id="ns%2Fproj", token="tok")
+        result = client.update(sha="def", conclusion="success", summary="OK")
+        assert result is not None
+        assert cap[0]["json"]["state"] == "success"
+        assert "ns%2Fproj" in cap[0]["url"]
+
+    def test_non_2xx_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._install_fake_httpx(monkeypatch, _Response(500))
+        client = PipelineStatusClient(project_id=1, token="t")
+        assert client.create(sha="x") is None
+
+    def test_invalid_state_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cap: list[dict[str, Any]] = []
+        self._install_fake_httpx(
+            monkeypatch, _Response(201, {"id": 1, "status": "running", "target_url": ""}), capture=cap
+        )
+        client = PipelineStatusClient(project_id=1, token="t")
+        client.create(sha="x", state="bogus-state")
+        assert cap[0]["json"]["state"] == "running"
+
+    def test_httpx_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(sys.modules, "httpx", None)
+        client = PipelineStatusClient(project_id=1, token="t")
+        assert client.create(sha="x") is None
+        # restore so other tests can patch httpx again
+        monkeypatch.delitem(sys.modules, "httpx", raising=False)
+
+    def test_unconfigured_property(self) -> None:
+        assert PipelineStatusClient(project_id=0, token="t").configured is False
+        assert PipelineStatusClient(project_id=1, token="").configured is False
+        assert PipelineStatusClient(project_id=1, token="t").configured is True

--- a/tests/unit/test_gitlab_property.py
+++ b/tests/unit/test_gitlab_property.py
@@ -1,0 +1,196 @@
+"""Hypothesis property-based tests for the GitLab integration."""
+
+from __future__ import annotations
+
+import json
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.gitlab_app.mapper import (
+    merge_request_to_tasks,
+    note_to_task,
+    pipeline_to_tasks,
+)
+from bernstein.gitlab_app.slash_commands import parse_slash_command, slash_command_to_task
+from bernstein.gitlab_app.webhooks import GitLabWebhookEvent, parse_webhook, verify_token
+
+_ASCII = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+    min_size=0,
+    max_size=64,
+)
+
+_NON_EMPTY_ASCII = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126),
+    min_size=1,
+    max_size=32,
+)
+
+
+def _build_event(kind: str, action: str = "open", note: str = "") -> GitLabWebhookEvent:
+    payload = {
+        "object_kind": kind,
+        "object_attributes": {
+            "iid": 1,
+            "title": "T",
+            "description": "B",
+            "note": note,
+            "noteable_type": "MergeRequest",
+            "action": action,
+            "id": 1,
+            "sha": "abcdef0123",
+            "ref": "main",
+            "url": "https://x",
+            "labels": [],
+        },
+        "project": {"path_with_namespace": "a/b", "id": 1},
+        "user": {"username": "u"},
+        "merge_request": {"iid": 1, "title": "T"},
+        "builds": [],
+    }
+    return GitLabWebhookEvent(
+        event_type="X Hook",
+        object_kind=kind,
+        action=action,
+        project_path="a/b",
+        sender="u",
+        payload=payload,
+    )
+
+
+class TestVerifyTokenProperty:
+    @given(_NON_EMPTY_ASCII)
+    def test_self_matches(self, token: str) -> None:
+        assert verify_token(token, token) is True
+
+    @given(_NON_EMPTY_ASCII, _NON_EMPTY_ASCII)
+    def test_distinct_no_match(self, a: str, b: str) -> None:
+        if a == b:
+            return
+        assert verify_token(a, b) is False
+
+    @given(_ASCII)
+    def test_empty_one_side(self, t: str) -> None:
+        assert verify_token("", t) is False
+        assert verify_token(t, "") is False
+
+
+class TestParseWebhookRoundTrip:
+    @given(
+        kind=st.sampled_from(["merge_request", "pipeline", "note", "issue"]),
+        sender=st.text(
+            alphabet=st.characters(min_codepoint=97, max_codepoint=122),
+            min_size=1,
+            max_size=12,
+        ),
+        path=st.tuples(
+            st.text(min_size=1, max_size=10, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+            st.text(min_size=1, max_size=10, alphabet=st.characters(min_codepoint=97, max_codepoint=122)),
+        ),
+    )
+    @settings(suppress_health_check=[HealthCheck.too_slow], deadline=None, max_examples=80)
+    def test_round_trip(self, kind: str, sender: str, path: tuple[str, str]) -> None:
+        ns, proj = path
+        full = f"{ns}/{proj}"
+        payload = {
+            "object_kind": kind,
+            "object_attributes": {"action": "open"},
+            "project": {"path_with_namespace": full},
+            "user": {"username": sender},
+        }
+        body = json.dumps(payload).encode("utf-8")
+        evt = parse_webhook({"X-Gitlab-Event": "Test Hook"}, body)
+        assert evt.object_kind == kind
+        assert evt.sender == sender
+        assert evt.project_path == full
+
+
+class TestMergeRequestActionInvariants:
+    @given(action=st.text(min_size=0, max_size=20))
+    def test_non_open_actions_yield_no_tasks(self, action: str) -> None:
+        if action in {"open", "reopen"}:
+            return
+        event = _build_event("merge_request", action=action)
+        assert merge_request_to_tasks(event) == []
+
+    @given(
+        body=st.text(min_size=0, max_size=3000),
+    )
+    @settings(max_examples=60, deadline=None)
+    def test_open_always_creates_one_task(self, body: str) -> None:
+        event = _build_event("merge_request", action="open")
+        # mutate description
+        event.payload["object_attributes"]["description"] = body
+        out = merge_request_to_tasks(event)
+        assert len(out) == 1
+        # description always truncates to body + prefix, body length ≤ 2000
+        assert out[0]["description"].endswith(body[:2000])
+
+
+class TestPipelineStatusInvariants:
+    @given(status=st.text(min_size=0, max_size=20))
+    def test_non_failed_yields_no_tasks(self, status: str) -> None:
+        if status == "failed":
+            return
+        event = _build_event("pipeline")
+        event.payload["object_attributes"]["status"] = status
+        assert pipeline_to_tasks(event) == []
+
+    def test_failed_always_creates_one(self) -> None:
+        event = _build_event("pipeline")
+        event.payload["object_attributes"]["status"] = "failed"
+        out = pipeline_to_tasks(event)
+        assert len(out) == 1
+
+
+class TestSlashCommandInvariants:
+    @given(verb=st.text(min_size=1, max_size=20, alphabet=st.characters(min_codepoint=97, max_codepoint=122)))
+    def test_parse_returns_lower_verb(self, verb: str) -> None:
+        text = f"/bernstein {verb} foo bar"
+        out = parse_slash_command(text)
+        assert out is not None
+        assert out[0] == verb.lower()
+
+    @given(verb=st.sampled_from(["fix", "plan", "evolve", "qa", "review"]), args=_ASCII)
+    @settings(max_examples=60)
+    def test_known_verbs_always_produce_task(self, verb: str, args: str) -> None:
+        event = _build_event("note", note=f"/bernstein {verb} {args}")
+        task = slash_command_to_task(event, verb, args)
+        assert task is not None
+        assert task["title"]
+        assert task["role"]
+
+    @given(verb=st.text(min_size=1, max_size=8, alphabet=st.characters(min_codepoint=97, max_codepoint=122)))
+    @settings(max_examples=40)
+    def test_unknown_verb_none(self, verb: str) -> None:
+        if verb in {"fix", "plan", "evolve", "qa", "review"}:
+            return
+        event = _build_event("note")
+        assert slash_command_to_task(event, verb, "") is None
+
+
+class TestNoteToTaskInvariants:
+    @given(text=_ASCII)
+    @settings(max_examples=60)
+    def test_non_actionable_non_slash_returns_none(self, text: str) -> None:
+        actionable_words = (
+            "fix",
+            "change",
+            "update",
+            "replace",
+            "remove",
+            "add",
+            "refactor",
+            "should",
+            "must",
+            "consider",
+        )
+        if "/bernstein" in text.lower():
+            return
+        if any(w in text.lower() for w in actionable_words):
+            return
+        if "```suggestion" in text.lower():
+            return
+        event = _build_event("note", note=text)
+        assert note_to_task(event) is None

--- a/tests/unit/test_gitlab_slash_commands.py
+++ b/tests/unit/test_gitlab_slash_commands.py
@@ -1,0 +1,114 @@
+"""Unit tests for ``bernstein.gitlab_app.slash_commands``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bernstein.gitlab_app.slash_commands import parse_slash_command, slash_command_to_task
+from bernstein.gitlab_app.webhooks import GitLabWebhookEvent
+
+
+def _event(note: str = "") -> GitLabWebhookEvent:
+    payload: dict[str, Any] = {
+        "object_kind": "note",
+        "object_attributes": {"note": note},
+        "merge_request": {"iid": 11, "title": "My MR"},
+        "project": {"path_with_namespace": "acme/widgets"},
+        "user": {"username": "alice"},
+    }
+    return GitLabWebhookEvent(
+        event_type="Note Hook",
+        object_kind="note",
+        action="",
+        project_path="acme/widgets",
+        sender="alice",
+        payload=payload,
+    )
+
+
+class TestParseSlashCommand:
+    def test_basic_command(self) -> None:
+        assert parse_slash_command("/bernstein fix this thing") == ("fix", "this thing")
+
+    def test_no_command(self) -> None:
+        assert parse_slash_command("just talk") is None
+
+    def test_just_verb(self) -> None:
+        assert parse_slash_command("/bernstein plan") == ("plan", "")
+
+    def test_case_insensitive_verb(self) -> None:
+        # The first ``\w+`` captures the literal "Fix" token, lowercased
+        # by the parser; "x" is the trailing args.
+        assert parse_slash_command("/BERNSTEIN Fix x") == ("fix", "x")
+
+    def test_inline_text_before_command(self) -> None:
+        text = "hey, when you have a sec:\n/bernstein qa run tests"
+        assert parse_slash_command(text) == ("qa", "run tests")
+
+    def test_only_first_match(self) -> None:
+        text = "/bernstein fix one\n/bernstein plan two"
+        assert parse_slash_command(text) == ("fix", "one")
+
+    def test_leading_whitespace_ok(self) -> None:
+        assert parse_slash_command("   /bernstein evolve idea") == ("evolve", "idea")
+
+    def test_must_be_at_line_start(self) -> None:
+        # `re.MULTILINE` so beginning-of-line; embedded slash inside text
+        # is not matched.
+        assert parse_slash_command("look at /bernstein fix") is None
+
+    def test_unicode_args(self) -> None:
+        assert parse_slash_command("/bernstein fix добавить тест") == ("fix", "добавить тест")
+
+
+class TestSlashCommandToTask:
+    def test_fix_priority_one(self) -> None:
+        task = slash_command_to_task(_event("/bernstein fix x"), "fix", "x")
+        assert task is not None
+        assert task["priority"] == 1
+        assert task["task_type"] == "fix"
+        assert task["role"] == "backend"
+
+    def test_plan_role_manager(self) -> None:
+        task = slash_command_to_task(_event("/bernstein plan x"), "plan", "x")
+        assert task is not None
+        assert task["role"] == "manager"
+        assert task["task_type"] == "planning"
+
+    def test_evolve_task_type(self) -> None:
+        task = slash_command_to_task(_event("/bernstein evolve"), "evolve", "")
+        assert task is not None
+        assert task["task_type"] == "upgrade_proposal"
+
+    def test_qa_role_qa(self) -> None:
+        task = slash_command_to_task(_event("/bernstein qa"), "qa", "")
+        assert task is not None
+        assert task["role"] == "qa"
+
+    def test_review_supported(self) -> None:
+        task = slash_command_to_task(_event("/bernstein review"), "review", "")
+        assert task is not None
+        assert task["task_type"] == "standard"
+
+    def test_unknown_action_returns_none(self) -> None:
+        assert slash_command_to_task(_event("/bernstein zzz"), "zzz", "") is None
+
+    def test_title_uses_args_when_present(self) -> None:
+        task = slash_command_to_task(_event(""), "fix", "the parser")
+        assert task is not None
+        assert "the parser" in task["title"]
+
+    def test_title_falls_back_to_mr_title(self) -> None:
+        task = slash_command_to_task(_event(""), "fix", "")
+        assert task is not None
+        assert "My MR" in task["title"]
+
+    def test_title_truncated_to_120(self) -> None:
+        task = slash_command_to_task(_event(""), "fix", "x" * 200)
+        assert task is not None
+        assert len(task["title"]) <= 120
+
+    def test_description_includes_project(self) -> None:
+        task = slash_command_to_task(_event("/bernstein fix x"), "fix", "x")
+        assert task is not None
+        assert "acme/widgets" in task["description"]

--- a/tests/unit/test_gitlab_webhooks.py
+++ b/tests/unit/test_gitlab_webhooks.py
@@ -1,0 +1,204 @@
+"""Unit tests for ``bernstein.gitlab_app.webhooks``."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from bernstein.gitlab_app.webhooks import (
+    GitLabWebhookEvent,
+    parse_webhook,
+    verify_token,
+)
+
+
+class TestVerifyToken:
+    """Constant-time token verification."""
+
+    def test_match(self) -> None:
+        assert verify_token("abc123", "abc123") is True
+
+    def test_mismatch(self) -> None:
+        assert verify_token("abc123", "xyz") is False
+
+    def test_empty_provided(self) -> None:
+        assert verify_token("", "expected") is False
+
+    def test_empty_expected(self) -> None:
+        assert verify_token("provided", "") is False
+
+    def test_both_empty(self) -> None:
+        assert verify_token("", "") is False
+
+    def test_length_mismatch(self) -> None:
+        assert verify_token("a", "abcdef") is False
+
+    def test_case_sensitive(self) -> None:
+        assert verify_token("ABC", "abc") is False
+
+    def test_unicode(self) -> None:
+        assert verify_token("ééé", "ééé") is True
+
+    def test_uses_constant_time_compare(self) -> None:
+        """Smoke-test: function should use hmac.compare_digest.
+
+        We verify by patching the helper and asserting it is called.
+        """
+        import bernstein.gitlab_app.webhooks as webhooks_mod
+
+        calls: list[tuple[bytes, bytes]] = []
+        original = webhooks_mod.hmac.compare_digest
+
+        def _spy(a: bytes, b: bytes) -> bool:
+            calls.append((a, b))
+            return original(a, b)
+
+        webhooks_mod.hmac.compare_digest = _spy  # type: ignore[assignment]
+        try:
+            verify_token("x", "x")
+        finally:
+            webhooks_mod.hmac.compare_digest = original  # type: ignore[assignment]
+        assert calls == [(b"x", b"x")]
+
+
+def _mr_payload(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "object_kind": "merge_request",
+        "object_attributes": {
+            "iid": 7,
+            "title": "Add a feature",
+            "description": "Body of the MR",
+            "action": "open",
+            "labels": [{"title": "backend"}],
+        },
+        "project": {"path_with_namespace": "acme/widgets", "id": 42},
+        "user": {"username": "alice", "name": "Alice"},
+    }
+    for k, v in overrides.items():
+        payload[k] = v
+    return payload
+
+
+def _pipeline_payload(status: str = "failed") -> dict[str, Any]:
+    return {
+        "object_kind": "pipeline",
+        "object_attributes": {
+            "id": 999,
+            "sha": "abcdef1234567890",
+            "ref": "feature-x",
+            "status": status,
+            "url": "https://gitlab.com/acme/widgets/-/pipelines/999",
+        },
+        "project": {"path_with_namespace": "acme/widgets", "id": 42},
+        "user": {"username": "bob"},
+        "builds": [
+            {"id": 1001, "name": "lint", "stage": "quality", "status": "failed"},
+            {"id": 1002, "name": "test", "stage": "test", "status": "passed"},
+        ],
+    }
+
+
+def _note_payload(note: str, noteable_type: str = "MergeRequest") -> dict[str, Any]:
+    return {
+        "object_kind": "note",
+        "object_attributes": {
+            "note": note,
+            "noteable_type": noteable_type,
+        },
+        "merge_request": {
+            "iid": 8,
+            "title": "MR with note",
+        },
+        "project": {"path_with_namespace": "acme/widgets", "id": 42},
+        "user": {"username": "carol"},
+    }
+
+
+class TestParseWebhook:
+    """``parse_webhook`` happy-path and error handling."""
+
+    def test_mr_open(self) -> None:
+        body = json.dumps(_mr_payload()).encode("utf-8")
+        evt = parse_webhook({"X-Gitlab-Event": "Merge Request Hook"}, body)
+        assert isinstance(evt, GitLabWebhookEvent)
+        assert evt.event_type == "Merge Request Hook"
+        assert evt.object_kind == "merge_request"
+        assert evt.action == "open"
+        assert evt.project_path == "acme/widgets"
+        assert evt.sender == "alice"
+
+    def test_pipeline(self) -> None:
+        body = json.dumps(_pipeline_payload()).encode("utf-8")
+        evt = parse_webhook({"x-gitlab-event": "Pipeline Hook"}, body)
+        assert evt.object_kind == "pipeline"
+        assert evt.action == ""  # pipelines have no .action sub-field
+        assert evt.sender == "bob"
+
+    def test_note(self) -> None:
+        body = json.dumps(_note_payload("hello")).encode("utf-8")
+        evt = parse_webhook({"x-gitlab-event": "Note Hook"}, body)
+        assert evt.object_kind == "note"
+        assert evt.sender == "carol"
+
+    def test_header_case_insensitive(self) -> None:
+        body = json.dumps(_mr_payload()).encode("utf-8")
+        evt = parse_webhook({"X-GITLAB-EVENT": "Merge Request Hook"}, body)
+        assert evt.event_type == "Merge Request Hook"
+
+    def test_missing_event_header(self) -> None:
+        body = json.dumps(_mr_payload()).encode("utf-8")
+        with pytest.raises(ValueError, match="X-Gitlab-Event"):
+            parse_webhook({}, body)
+
+    def test_invalid_json(self) -> None:
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_webhook({"X-Gitlab-Event": "x"}, b"{not json")
+
+    def test_non_object_json_rejected(self) -> None:
+        with pytest.raises(ValueError, match="must be a JSON object"):
+            parse_webhook({"X-Gitlab-Event": "x"}, b"[1, 2, 3]")
+
+    def test_missing_project_path(self) -> None:
+        payload = _mr_payload()
+        payload["project"] = {}
+        with pytest.raises(ValueError, match="project.path_with_namespace"):
+            parse_webhook({"X-Gitlab-Event": "x"}, json.dumps(payload).encode("utf-8"))
+
+    def test_falls_back_to_project_name(self) -> None:
+        payload = _mr_payload()
+        payload["project"] = {"name": "only-name"}
+        evt = parse_webhook({"X-Gitlab-Event": "x"}, json.dumps(payload).encode("utf-8"))
+        assert evt.project_path == "only-name"
+
+    def test_unknown_user_defaults(self) -> None:
+        payload = _mr_payload()
+        payload["user"] = {}
+        evt = parse_webhook({"X-Gitlab-Event": "x"}, json.dumps(payload).encode("utf-8"))
+        assert evt.sender == "unknown"
+
+    def test_user_name_fallback(self) -> None:
+        payload = _mr_payload()
+        payload["user"] = {"name": "Bob"}
+        evt = parse_webhook({"X-Gitlab-Event": "x"}, json.dumps(payload).encode("utf-8"))
+        assert evt.sender == "Bob"
+
+    def test_object_attributes_not_dict(self) -> None:
+        payload = _mr_payload()
+        payload["object_attributes"] = "not-a-dict"
+        evt = parse_webhook({"X-Gitlab-Event": "x"}, json.dumps(payload).encode("utf-8"))
+        # Should not raise; action just defaults to empty.
+        assert evt.action == ""
+
+    def test_invalid_utf8(self) -> None:
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_webhook({"X-Gitlab-Event": "x"}, b"\xff\xfe\xfa")
+
+    def test_event_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        body = json.dumps(_mr_payload()).encode("utf-8")
+        evt = parse_webhook({"X-Gitlab-Event": "x"}, body)
+        with pytest.raises(FrozenInstanceError):
+            evt.sender = "other"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

- Adds ``src/bernstein/gitlab_app/`` mirroring the existing
  ``github_app/`` surface: app config, webhook parser, event mapper,
  slash commands, commit-status client, CI router and MR cost
  reporter — supports gitlab.com *and* self-managed via
  ``BERNSTEIN_GITLAB_URL``.
- Wires ``Merge Request Hook`` and ``Note Hook`` into the existing
  ``/webhooks/gitlab`` ingress so the full GitHub-parity flow lands
  (pipeline failures stay on their existing path).
- 171 new tests: 150 unit (every module + edge cases / constant-time
  compare verification / httpx unavailable), 12 Hypothesis
  property-based, 21 integration against realistic JSON fixtures plus
  snapshot checks for cost summary + pipeline status output.

## Test plan

- [x] ``uv run ruff check`` on all new files — clean
- [x] ``uv run ruff format --check`` on all new files — clean
- [x] ``uv run pytest tests/unit/test_gitlab_* tests/integration/test_gitlab_*`` — 171 / 171 pass
- [x] Existing GitHub App, GitLab trigger and GitLab CI adapter tests still pass (307 tests across the webhook + gitlab keyword filter)
- [ ] CI green