### PR TITLE
feat(doctor): adapter-binary + network-reachability + CI-context checks (closes spec 2026-05-17)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -23,6 +23,7 @@ alwaysApply: false
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
+| `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |
 | `git/`                  | git sub-package |
 | `grpc_gen/`             | Generated gRPC stubs — run ``scripts/generate_proto.sh`` to populate |
@@ -126,6 +127,7 @@ alwaysApply: false
 | `qwen.py`                  | Qwen CLI adapter for OpenAI compatible models |
 | `ralphex.py`               | Ralphex (umputun/ralphex) CLI adapter |
 | `registry.py`              | Adapter registry — look up CLI adapters by name |
+| `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
@@ -151,6 +153,7 @@ alwaysApply: false
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |
 | `keybindings.py`        | Keybinding system for the Bernstein TUI |
@@ -172,6 +175,7 @@ alwaysApply: false
 | `usage_provisioning.py` | Usage budget tracking and overage detection for Bernstein |
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
+| `doctor/`               | Bernstein doctor sub-package - extended diagnostic checks |
 | `plan/`                 | plan sub-package |
 | `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |

--- a/.goosehints
+++ b/.goosehints
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
+| `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |
 | `git/`                  | git sub-package |
 | `grpc_gen/`             | Generated gRPC stubs — run ``scripts/generate_proto.sh`` to populate |
@@ -127,6 +128,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `qwen.py`                  | Qwen CLI adapter for OpenAI compatible models |
 | `ralphex.py`               | Ralphex (umputun/ralphex) CLI adapter |
 | `registry.py`              | Adapter registry — look up CLI adapters by name |
+| `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
@@ -152,6 +154,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |
 | `keybindings.py`        | Keybinding system for the Bernstein TUI |
@@ -173,6 +176,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `usage_provisioning.py` | Usage budget tracking and overage detection for Bernstein |
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
+| `doctor/`               | Bernstein doctor sub-package - extended diagnostic checks |
 | `plan/`                 | plan sub-package |
 | `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
+| `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |
 | `git/`                  | git sub-package |
 | `grpc_gen/`             | Generated gRPC stubs — run ``scripts/generate_proto.sh`` to populate |
@@ -127,6 +128,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `qwen.py`                  | Qwen CLI adapter for OpenAI compatible models |
 | `ralphex.py`               | Ralphex (umputun/ralphex) CLI adapter |
 | `registry.py`              | Adapter registry — look up CLI adapters by name |
+| `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
@@ -152,6 +154,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |
 | `keybindings.py`        | Keybinding system for the Bernstein TUI |
@@ -173,6 +176,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `usage_provisioning.py` | Usage budget tracking and overage detection for Bernstein |
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
+| `doctor/`               | Bernstein doctor sub-package - extended diagnostic checks |
 | `plan/`                 | plan sub-package |
 | `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
+| `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |
 | `git/`                  | git sub-package |
 | `grpc_gen/`             | Generated gRPC stubs — run ``scripts/generate_proto.sh`` to populate |
@@ -127,6 +128,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `qwen.py`                  | Qwen CLI adapter for OpenAI compatible models |
 | `ralphex.py`               | Ralphex (umputun/ralphex) CLI adapter |
 | `registry.py`              | Adapter registry — look up CLI adapters by name |
+| `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
@@ -152,6 +154,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |
 | `keybindings.py`        | Keybinding system for the Bernstein TUI |
@@ -173,6 +176,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `usage_provisioning.py` | Usage budget tracking and overage detection for Bernstein |
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
+| `doctor/`               | Bernstein doctor sub-package - extended diagnostic checks |
 | `plan/`                 | plan sub-package |
 | `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -24,6 +24,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `cost/`                 | cost sub-package |
 | `daemon/`               | Daemon installation helpers for Bernstein |
 | `distribution/`         | Distribution utilities — air-gap wheelhouse build, verify, signing |
+| `errors/`               | Structured first-run error categorization for Bernstein |
 | `fleet/`                | Fleet dashboard — supervise multiple Bernstein projects in one view |
 | `git/`                  | git sub-package |
 | `grpc_gen/`             | Generated gRPC stubs — run ``scripts/generate_proto.sh`` to populate |
@@ -127,6 +128,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `qwen.py`                  | Qwen CLI adapter for OpenAI compatible models |
 | `ralphex.py`               | Ralphex (umputun/ralphex) CLI adapter |
 | `registry.py`              | Adapter registry — look up CLI adapters by name |
+| `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
@@ -152,6 +154,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |
 | `keybindings.py`        | Keybinding system for the Bernstein TUI |
@@ -173,6 +176,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `usage_provisioning.py` | Usage budget tracking and overage detection for Bernstein |
 | `commands/`             | commands sub-package |
 | `display/`              | ui sub-package |
+| `doctor/`               | Bernstein doctor sub-package - extended diagnostic checks |
 | `plan/`                 | plan sub-package |
 | `scaffold/`             | Bernstein scaffold subsystem |
 | `utils/`                | utils sub-package |

--- a/docs/operations/doctor.md
+++ b/docs/operations/doctor.md
@@ -1,0 +1,144 @@
+# bernstein doctor
+
+`bernstein doctor` is the single-command checklist for diagnosing a
+broken Bernstein installation before opening an issue. The legacy
+`bernstein doctor` runs the same checks it always did; the new
+`bernstein doctor extended` subcommand layers on three additional
+categories: adapter binaries, network reachability, and CI/sandbox
+context.
+
+## Quick start
+
+```bash
+bernstein doctor                                      # legacy report
+bernstein doctor extended                             # full extended report
+bernstein doctor extended --json                      # machine-readable output
+bernstein doctor extended --adapter claude --provider anthropic
+BERNSTEIN_OFFLINE=1 bernstein doctor extended         # skip every network probe
+```
+
+Exit code: `1` if any check fails, `0` otherwise. Warnings do not
+trigger a non-zero exit but are echoed to stderr.
+
+## Check categories
+
+| Category        | Source module                                         | Honors                |
+|-----------------|-------------------------------------------------------|-----------------------|
+| `installation`  | `bernstein.cli.install_check` (preserved unchanged)   | n/a                   |
+| `adapter`       | `bernstein.cli.doctor.adapter_checks`                 | `bernstein.yaml`      |
+| `network`       | `bernstein.cli.doctor.network_checks`                 | `BERNSTEIN_OFFLINE=1` |
+| `environment`   | `bernstein.cli.doctor.environment_checks`             | env vars + file probes|
+
+### Installation checks
+
+Unchanged from before:
+
+- duplicate `bernstein` binaries on `PATH`
+- installed package version
+- virtual-environment isolation
+
+### Adapter binary checks
+
+For each adapter declared in `bernstein.yaml`:
+
+1. resolve the binary via `shutil.which`
+2. spawn `<binary> --version` with a 5-second timeout
+3. report PATH presence, version string, exit code, or hang
+
+Status mapping:
+
+| Outcome                        | Status |
+|--------------------------------|--------|
+| binary present, version capture| `ok`   |
+| `--version` hangs              | `warn` |
+| `--version` exits non-zero     | `warn` |
+| binary not on `PATH`           | `fail` |
+
+### Network reachability
+
+Each provider maps to a single hostname. The check opens a TCP
+connection to port 443 with a 2-second timeout.
+
+| Provider     | Host                                       |
+|--------------|--------------------------------------------|
+| anthropic    | `api.anthropic.com`                        |
+| openai       | `api.openai.com`                           |
+| google       | `generativelanguage.googleapis.com`        |
+| openrouter   | `openrouter.ai`                            |
+| groq         | `api.groq.com`                             |
+| mistral      | `api.mistral.ai`                           |
+| deepseek     | `api.deepseek.com`                         |
+
+Set `BERNSTEIN_OFFLINE=1` to skip every network probe. The doctor
+report shows a single compact `network:*` skip row in that case.
+
+DNS-resolution failures, refused connections, and timeouts are reported
+distinctly so the operator can tell a broken resolver from blocked
+egress.
+
+### Environment / sandbox detection
+
+Detection combines environment variables with light-weight file
+probes. Detected environments are surfaced in the report so issue
+reporters can include the context automatically.
+
+| Marker                        | Source                              |
+|-------------------------------|-------------------------------------|
+| `GITHUB_ACTIONS=true`         | GitHub Actions                      |
+| `GITLAB_CI=true`              | GitLab CI                           |
+| `BUILDKITE=true`              | Buildkite                           |
+| `CIRCLECI=true`               | CircleCI                            |
+| `JENKINS_URL`                 | Jenkins                             |
+| `DEVCONTAINER=true`           | VS Code devcontainer                |
+| `REMOTE_CONTAINERS=true`      | VS Code devcontainer (remote)       |
+| `INVOCATION_ID`               | systemd-run                         |
+| `/.dockerenv` exists          | Docker                              |
+| `CI=true` (no specific match) | Generic CI                          |
+
+Multiple markers can match simultaneously (for example, Docker inside
+GitHub Actions). The renderer suppresses the generic `CI` row when a
+more specific environment matched.
+
+## Example output
+
+```
+                    Bernstein Doctor
+─────────────────────────────────────────────────────────────────
+ Check               Category      Status   Detail                Remediation
+ install:bernstein   installation  ✓ OK     v2.0.1
+ adapter:claude      adapter       ✓ OK     /usr/local/bin/claude -> claude-code 2.1.5
+ adapter:codex       adapter       ✗ FAIL   Binary `codex` not in PATH   Install via vendor instructions
+ network:anthropic   network       ✓ OK     reachable: api.anthropic.com:443
+ network:openai      network       ✓ OK     reachable: api.openai.com:443
+ env:github-actions  environment   ✓ OK     GitHub Actions detected
+─────────────────────────────────────────────────────────────────
+ 4 OK   0 WARN   1 FAIL   0 SKIP
+```
+
+## Programmatic API
+
+```python
+import asyncio
+from bernstein.cli.doctor import run_all, render_report, exit_code_for
+
+results = asyncio.run(run_all())
+render_report(results)
+raise SystemExit(exit_code_for(results))
+```
+
+Every result is a frozen `DoctorResult(name, category, status, detail,
+remediation)` dataclass. `category` is one of `installation`,
+`adapter`, `network`, `environment`. `status` is one of `ok`, `warn`,
+`fail`, `skip`.
+
+## Troubleshooting matrix
+
+| Symptom                                         | Likely fix                                                   |
+|-------------------------------------------------|--------------------------------------------------------------|
+| `adapter:* fail - Binary not in PATH`           | install the vendor CLI or remove the adapter from config     |
+| `adapter:* warn - exited 2`                     | upgrade the binary; check `<bin> --version` manually         |
+| `adapter:* warn - timed out after 5s`           | the binary is wedged; kill stale processes                   |
+| `network:* fail - DNS lookup failed`            | fix `/etc/resolv.conf` or your DNS resolver                  |
+| `network:* fail - connection refused`           | check proxy or firewall egress rules                         |
+| `network:* skip - BERNSTEIN_OFFLINE=1`          | expected when air-gapped; clear the env var to re-enable     |
+| `env:docker` with no other CI markers           | host is a vanilla Docker container; include in bug reports   |

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -653,6 +653,88 @@ def doctor_scoping_cmd(ctx: click.Context, agent_id: str, role: str) -> None:
     raise SystemExit(0)
 
 
+@doctor.command("extended")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit JSON instead of the Rich table.",
+)
+@click.option(
+    "--adapter",
+    "adapter_filter",
+    multiple=True,
+    help="Restrict adapter checks to this name (repeatable).",
+)
+@click.option(
+    "--provider",
+    "provider_filter",
+    multiple=True,
+    help="Restrict network checks to this provider (repeatable).",
+)
+def doctor_extended_cmd(
+    as_json: bool,
+    adapter_filter: tuple[str, ...],
+    provider_filter: tuple[str, ...],
+) -> None:
+    """Run the extended doctor: adapter binaries, network, environment.
+
+    \b
+    Categories:
+      - installation: legacy install_check (preserved behavior)
+      - adapter:     `which <bin>` + `<bin> --version` per adapter
+      - network:     TCP/443 reachability per provider (honors BERNSTEIN_OFFLINE)
+      - environment: GitHub Actions / GitLab CI / Buildkite / Docker / devcontainer / systemd-run
+
+    \b
+    Examples:
+      bernstein doctor extended
+      bernstein doctor extended --json
+      bernstein doctor extended --adapter claude --provider anthropic
+    """
+    import asyncio
+    import json as _json
+    import sys
+
+    from bernstein.cli.doctor import exit_code_for, render_report, run_all, summarize
+
+    results = asyncio.run(
+        run_all(
+            adapter_names=list(adapter_filter) or None,
+            provider_names=list(provider_filter) or None,
+        )
+    )
+
+    if as_json:
+        payload = {
+            "results": [
+                {
+                    "name": r.name,
+                    "category": r.category,
+                    "status": r.status,
+                    "detail": r.detail,
+                    "remediation": r.remediation,
+                }
+                for r in results
+            ],
+            "summary": summarize(results),
+        }
+        console.print_json(_json.dumps(payload))
+    else:
+        rendered = render_report(results, console=console)
+        if rendered:  # captured text - only set when console was None
+            pass
+
+    counts = summarize(results)
+    if counts["fail"] == 0 and counts["warn"] > 0:
+        sys.stderr.write(
+            f"doctor: {counts['warn']} warning(s); see report above.\n",
+        )
+
+    raise SystemExit(exit_code_for(results))
+
+
 # ---------------------------------------------------------------------------
 # recap
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/doctor/__init__.py
+++ b/src/bernstein/cli/doctor/__init__.py
@@ -1,0 +1,64 @@
+"""Bernstein doctor sub-package - extended diagnostic checks.
+
+Splits the doctor into four categories so failures are easy to locate:
+
+- ``installation_checks`` re-exports :mod:`bernstein.cli.install_check` so
+  the legacy install-mismatch detection runs unchanged.
+- ``adapter_checks`` probes every CLI adapter binary referenced in
+  ``bernstein.yaml`` for PATH presence and ``--version`` output.
+- ``network_checks`` opens TCP/443 connections to provider endpoints with
+  a short timeout. Honors ``BERNSTEIN_OFFLINE=1``.
+- ``environment_checks`` detects GitHub Actions, GitLab CI, Buildkite,
+  Docker, devcontainers and systemd-run sandboxes.
+
+Every check returns a :class:`DoctorResult` so the report renderer can
+display them in a single Rich table.
+"""
+
+from __future__ import annotations
+
+from bernstein.cli import install_check as installation_checks
+from bernstein.cli.doctor.adapter_checks import (
+    ADAPTER_BINARIES,
+    check_adapter_binary,
+    run_adapter_checks,
+)
+from bernstein.cli.doctor.environment_checks import (
+    ENVIRONMENT_PROBES,
+    detect_environments,
+    run_environment_checks,
+)
+from bernstein.cli.doctor.network_checks import (
+    PROVIDER_HOSTS,
+    check_provider_reachability,
+    run_network_checks,
+)
+from bernstein.cli.doctor.report import (
+    STATUS_GLYPHS,
+    DoctorResult,
+    DoctorStatus,
+    exit_code_for,
+    render_report,
+    run_all,
+    summarize,
+)
+
+__all__ = [
+    "ADAPTER_BINARIES",
+    "ENVIRONMENT_PROBES",
+    "PROVIDER_HOSTS",
+    "STATUS_GLYPHS",
+    "DoctorResult",
+    "DoctorStatus",
+    "check_adapter_binary",
+    "check_provider_reachability",
+    "detect_environments",
+    "exit_code_for",
+    "installation_checks",
+    "render_report",
+    "run_adapter_checks",
+    "run_all",
+    "run_environment_checks",
+    "run_network_checks",
+    "summarize",
+]

--- a/src/bernstein/cli/doctor/adapter_checks.py
+++ b/src/bernstein/cli/doctor/adapter_checks.py
@@ -1,0 +1,293 @@
+"""Adapter binary reachability checks.
+
+For every adapter referenced in ``bernstein.yaml`` (or, when no config is
+available, the default short-list), ``check_adapter_binary`` resolves the
+binary on PATH with :func:`shutil.which` and shells out
+``<binary> --version`` with a short timeout. The result is reported as a
+:class:`DoctorResult` so the renderer can show version, missing-binary
+and hung-binary cases side by side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from bernstein.cli.doctor.report import DoctorResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+
+# Default mapping from adapter name to the binary the adapter spawns.
+# Kept in sync with src/bernstein/adapters/*.py. The mapping is exposed
+# publicly so callers can override or extend it.
+ADAPTER_BINARIES: dict[str, str] = {
+    "aichat": "aichat",
+    "aider": "aider",
+    "amp": "amp",
+    "auggie": "auggie",
+    "autohand": "autohand",
+    "charm": "crush",
+    "claude": "claude",
+    "cline": "cline",
+    "codebuff": "codebuff",
+    "codex": "codex",
+    "cody": "cody",
+    "composio": "ao",
+    "continue": "continue",
+    "copilot": "gh",
+    "cursor": "cursor-agent",
+    "devin_terminal": "devin",
+    "droid": "droid",
+    "forge": "forge",
+    "gemini": "gemini",
+    "goose": "goose",
+    "gptme": "gptme",
+    "hermes": "hermes",
+    "iac": "terraform",
+    "junie": "junie",
+    "kilo": "kilo",
+    "kimi": "kimi",
+    "kiro": "kiro",
+    "letta_code": "letta",
+    "mistral": "mistral",
+    "ollama": "ollama",
+    "open_interpreter": "interpreter",
+    "opencode": "opencode",
+    "openhands": "openhands",
+    "pi": "pi",
+    "plandex": "plandex",
+    "q_dev": "q",
+    "qwen": "qwen",
+    "ralphex": "ralphex",
+    "rovo": "rovo",
+}
+
+
+_VERSION_TIMEOUT_SECONDS = 5.0
+
+
+async def check_adapter_binary(
+    adapter_name: str,
+    declared_binary: str,
+    *,
+    timeout: float = _VERSION_TIMEOUT_SECONDS,
+) -> DoctorResult:
+    """Check that the declared binary is on PATH and responds to ``--version``.
+
+    Args:
+        adapter_name: Adapter identifier as used in ``bernstein.yaml``.
+        declared_binary: Executable to look up via :func:`shutil.which`.
+        timeout: How long to wait for ``--version`` before warning.
+
+    Returns:
+        DoctorResult with status ``ok`` (version captured), ``warn``
+        (binary present but hung or exited non-zero), or ``fail``
+        (binary missing).
+    """
+    name = f"adapter:{adapter_name}"
+    if not declared_binary:
+        return DoctorResult(
+            name=name,
+            category="adapter",
+            status="fail",
+            detail="no binary declared for adapter",
+            remediation=f"Add a binary mapping for `{adapter_name}` or remove it from bernstein.yaml",
+        )
+
+    path = shutil.which(declared_binary)
+    if path is None:
+        return DoctorResult(
+            name=name,
+            category="adapter",
+            status="fail",
+            detail=f"Binary `{declared_binary}` not in PATH",
+            remediation=(
+                f"Install via the adapter's vendor instructions or remove `{adapter_name}` from bernstein.yaml"
+            ),
+        )
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            declared_binary,
+            "--version",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (OSError, asyncio.CancelledError) as exc:  # pragma: no cover - rare
+        return DoctorResult(
+            name=name,
+            category="adapter",
+            status="warn",
+            detail=f"failed to spawn `{declared_binary} --version`: {exc}",
+            remediation="Verify the binary is executable",
+        )
+
+    try:
+        out_bytes, err_bytes = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except TimeoutError:
+        await _terminate_and_wait(proc)
+        return DoctorResult(
+            name=name,
+            category="adapter",
+            status="warn",
+            detail=f"`{declared_binary} --version` timed out after {timeout:g}s",
+            remediation="Adapter binary may be wedged; try running it directly",
+        )
+
+    out = out_bytes.decode("utf-8", errors="replace").strip()
+    err = err_bytes.decode("utf-8", errors="replace").strip()
+    version = _first_nonempty_line(out) or _first_nonempty_line(err) or "version output empty"
+
+    if proc.returncode and proc.returncode != 0:
+        return DoctorResult(
+            name=name,
+            category="adapter",
+            status="warn",
+            detail=f"`{declared_binary} --version` exited {proc.returncode}: {version}",
+            remediation="Reinstall or upgrade the adapter binary",
+        )
+
+    return DoctorResult(
+        name=name,
+        category="adapter",
+        status="ok",
+        detail=f"{path} -> {version}",
+    )
+
+
+async def run_adapter_checks(
+    adapter_names: Iterable[str] | None = None,
+    *,
+    binaries: Mapping[str, str] | None = None,
+    config_path: Path | None = None,
+) -> list[DoctorResult]:
+    """Run binary checks for the requested adapters in parallel.
+
+    When ``adapter_names`` is ``None``, the list is loaded from
+    ``bernstein.yaml`` (or falls back to the curated default of common
+    adapters). Unknown adapters are still checked - the report will mark
+    them missing rather than silently skipping.
+    """
+    table = dict(binaries) if binaries is not None else dict(ADAPTER_BINARIES)
+    names = (
+        list(adapter_names)
+        if adapter_names is not None
+        else _load_adapters_from_yaml(config_path) or _default_adapter_list()
+    )
+    if not names:
+        return [
+            DoctorResult(
+                name="adapter:none",
+                category="adapter",
+                status="skip",
+                detail="no adapters configured",
+                remediation="Add an `agents:` section to bernstein.yaml",
+            )
+        ]
+
+    coros = [check_adapter_binary(n, table.get(n, n)) for n in names]
+    return list(await asyncio.gather(*coros))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _terminate_and_wait(proc: asyncio.subprocess.Process) -> None:
+    """Best-effort terminate plus wait so transports close cleanly.
+
+    Without the explicit wait, asyncio occasionally emits a stray
+    "Event loop is closed" warning when the subprocess transport is
+    finalised after pytest has already torn the loop down.
+    """
+    try:
+        proc.kill()
+    except ProcessLookupError:  # pragma: no cover - race
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=1.0)
+    except (TimeoutError, ProcessLookupError):  # pragma: no cover - defensive
+        return
+
+
+def _first_nonempty_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _default_adapter_list() -> list[str]:
+    """Fallback adapter list when no project config is available."""
+    return ["claude", "codex", "gemini", "qwen", "aider"]
+
+
+def _load_adapters_from_yaml(config_path: Path | None) -> list[str]:
+    """Best-effort scrape of adapter names from bernstein.yaml.
+
+    The function is intentionally tolerant of missing config or malformed
+    YAML - the doctor must never crash because the user's config is
+    broken. Returns an empty list when nothing can be parsed.
+    """
+    path = config_path or (Path.cwd() / "bernstein.yaml")
+    if not path.is_file():
+        return []
+
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover - PyYAML always present in prod
+        return []
+
+    try:
+        with path.open(encoding="utf-8") as fh:
+            raw: object = yaml.safe_load(fh)
+    except Exception:
+        return []
+
+    if not isinstance(raw, dict):
+        return []
+
+    return _extract_adapter_names(cast("dict[str, object]", raw))
+
+
+def _extract_adapter_names(raw: dict[str, object]) -> list[str]:
+    """Pure extractor for adapter names from a parsed YAML mapping."""
+    seen: list[str] = []
+    seen_set: set[str] = set()
+
+    def _add(candidate: object) -> None:
+        if isinstance(candidate, str) and candidate and candidate not in seen_set:
+            seen.append(candidate)
+            seen_set.add(candidate)
+
+    _add(raw.get("cli"))
+
+    adapters_raw = raw.get("adapters")
+    if isinstance(adapters_raw, list):
+        items_list = cast("list[object]", adapters_raw)
+        for item in items_list:
+            if isinstance(item, str):
+                _add(item)
+            elif isinstance(item, dict):
+                item_dict = cast("dict[str, object]", item)
+                _add(item_dict.get("name") or item_dict.get("cli"))
+    elif isinstance(adapters_raw, dict):
+        adapters_map = cast("dict[str, object]", adapters_raw)
+        for key in adapters_map:
+            _add(key)
+
+    role_policy = raw.get("role_model_policy")
+    if isinstance(role_policy, dict):
+        policy_map = cast("dict[str, object]", role_policy)
+        for entry in policy_map.values():
+            if isinstance(entry, dict):
+                entry_map = cast("dict[str, object]", entry)
+                _add(entry_map.get("cli"))
+
+    return seen

--- a/src/bernstein/cli/doctor/environment_checks.py
+++ b/src/bernstein/cli/doctor/environment_checks.py
@@ -1,0 +1,186 @@
+"""CI / sandbox environment detection.
+
+Detects whether bernstein is running inside a common build environment
+so users opening issues can include the context automatically. The
+detection logic combines environment variables with light-weight file
+probes (for example ``/.dockerenv``).
+
+Detection order is significant: more specific environments are reported
+first so a Docker-in-GitHub-Actions run is labelled "GitHub Actions"
+rather than "Docker".
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bernstein.cli.doctor.report import DoctorResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class EnvironmentProbe:
+    """A single environment-detection probe."""
+
+    label: str
+    detail_hint: str
+    env_var: str | None = None
+    env_value: str | None = None  # If set, env_var must equal this string.
+    file_path: str | None = None  # If set, file_path must exist.
+
+    def matches(self, env: Mapping[str, str], file_exists: Callable[[str], bool]) -> bool:
+        if self.env_var is not None:
+            value = env.get(self.env_var, "")
+            if self.env_value is None:
+                if not value:
+                    return False
+            elif value != self.env_value:
+                return False
+        return not (self.file_path is not None and not file_exists(self.file_path))
+
+
+# Ordered list of probes. The first match wins, but every match is
+# reported so the operator can see "GitHub Actions inside Docker" if
+# both signals are present.
+ENVIRONMENT_PROBES: list[EnvironmentProbe] = [
+    EnvironmentProbe(
+        label="GitHub Actions",
+        detail_hint="GITHUB_ACTIONS=true",
+        env_var="GITHUB_ACTIONS",
+        env_value="true",
+    ),
+    EnvironmentProbe(
+        label="GitLab CI",
+        detail_hint="GITLAB_CI=true",
+        env_var="GITLAB_CI",
+        env_value="true",
+    ),
+    EnvironmentProbe(
+        label="Buildkite",
+        detail_hint="BUILDKITE=true",
+        env_var="BUILDKITE",
+        env_value="true",
+    ),
+    EnvironmentProbe(
+        label="CircleCI",
+        detail_hint="CIRCLECI=true",
+        env_var="CIRCLECI",
+        env_value="true",
+    ),
+    EnvironmentProbe(
+        label="Jenkins",
+        detail_hint="JENKINS_URL set",
+        env_var="JENKINS_URL",
+    ),
+    EnvironmentProbe(
+        label="Docker",
+        detail_hint="/.dockerenv present",
+        file_path="/.dockerenv",
+    ),
+    EnvironmentProbe(
+        label="VS Code devcontainer",
+        detail_hint="DEVCONTAINER=true",
+        env_var="DEVCONTAINER",
+        env_value="true",
+    ),
+    EnvironmentProbe(
+        label="VS Code devcontainer (remote)",
+        detail_hint="REMOTE_CONTAINERS=true",
+        env_var="REMOTE_CONTAINERS",
+        env_value="true",
+    ),
+    EnvironmentProbe(
+        label="systemd-run",
+        detail_hint="INVOCATION_ID set",
+        env_var="INVOCATION_ID",
+    ),
+    EnvironmentProbe(
+        label="Generic CI",
+        detail_hint="CI=true",
+        env_var="CI",
+        env_value="true",
+    ),
+]
+
+
+def detect_environments(
+    env: Mapping[str, str] | None = None,
+    *,
+    file_exists: Callable[[str], bool] | None = None,
+    probes: Sequence[EnvironmentProbe] | None = None,
+) -> list[EnvironmentProbe]:
+    """Return every probe that currently matches.
+
+    The ``Generic CI`` probe is suppressed when a more specific CI
+    environment has already matched (it exists as a fallback signal).
+    """
+    env_map = env if env is not None else dict(os.environ)
+    exists = file_exists if file_exists is not None else _default_file_exists
+    probe_list = list(probes) if probes is not None else ENVIRONMENT_PROBES
+
+    matches: list[EnvironmentProbe] = []
+    for probe in probe_list:
+        if probe.matches(env_map, exists):
+            matches.append(probe)
+
+    if len(matches) > 1:
+        specific = [p for p in matches if p.label != "Generic CI"]
+        if specific:
+            return specific
+    return matches
+
+
+def run_environment_checks(
+    env: Mapping[str, str] | None = None,
+    *,
+    file_exists: Callable[[str], bool] | None = None,
+) -> list[DoctorResult]:
+    """Return DoctorResult rows describing the detected environment.
+
+    Always returns at least one row. When no probe matches the row reads
+    ``status="ok"`` so the absence of any CI/sandbox marker is itself
+    visible in the table.
+    """
+    matches = detect_environments(env=env, file_exists=file_exists)
+    if not matches:
+        return [
+            DoctorResult(
+                name="env:host",
+                category="environment",
+                status="ok",
+                detail="local workstation (no CI/sandbox markers detected)",
+            )
+        ]
+
+    return [
+        DoctorResult(
+            name=f"env:{_slug(probe.label)}",
+            category="environment",
+            status="ok",
+            detail=f"{probe.label} detected ({probe.detail_hint})",
+            remediation="Include this in any bug report",
+        )
+        for probe in matches
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_file_exists(p: str) -> bool:
+    """Wrap :func:`Path.is_file` and swallow OS errors quietly."""
+    try:
+        return Path(p).exists()
+    except OSError:  # pragma: no cover - hardly reachable
+        return False
+
+
+def _slug(label: str) -> str:
+    return "".join(c.lower() if c.isalnum() else "-" for c in label).strip("-").replace("--", "-")

--- a/src/bernstein/cli/doctor/network_checks.py
+++ b/src/bernstein/cli/doctor/network_checks.py
@@ -1,0 +1,164 @@
+"""Network reachability checks for provider endpoints.
+
+Each known provider maps to a single hostname. The check opens a TCP
+connection to port 443 with a 2-second timeout. DNS-resolution failures
+are reported distinctly from connection failures so the operator can
+tell a misconfigured resolver from a blocked egress.
+
+When ``BERNSTEIN_OFFLINE=1`` is set every check returns ``status="skip"``
+immediately - no DNS lookup, no socket, no telemetry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import socket
+from typing import TYPE_CHECKING
+
+from bernstein.cli.doctor.report import DoctorResult
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+
+# Provider -> host. Keep ASCII-only; some operators feed these into other
+# tooling that does not handle Unicode hostnames.
+PROVIDER_HOSTS: dict[str, str] = {
+    "anthropic": "api.anthropic.com",
+    "openai": "api.openai.com",
+    "google": "generativelanguage.googleapis.com",
+    "openrouter": "openrouter.ai",
+    "groq": "api.groq.com",
+    "mistral": "api.mistral.ai",
+    "deepseek": "api.deepseek.com",
+}
+
+
+OFFLINE_ENV_VAR = "BERNSTEIN_OFFLINE"
+
+_DEFAULT_TIMEOUT_SECONDS = 2.0
+
+
+def _is_offline() -> bool:
+    return os.environ.get(OFFLINE_ENV_VAR, "").strip() == "1"
+
+
+async def check_provider_reachability(
+    provider: str,
+    *,
+    host: str | None = None,
+    port: int = 443,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> DoctorResult:
+    """Probe a provider's API hostname.
+
+    Returns:
+        DoctorResult with status:
+          - ``skip`` if ``BERNSTEIN_OFFLINE=1`` or the provider is unknown,
+          - ``ok`` if the TCP connection completed inside ``timeout``,
+          - ``fail`` for DNS, connection-refused, blocked, or timed-out.
+    """
+    name = f"network:{provider}"
+    if _is_offline():
+        return DoctorResult(
+            name=name,
+            category="network",
+            status="skip",
+            detail=f"{OFFLINE_ENV_VAR}=1",
+        )
+
+    target_host = host or PROVIDER_HOSTS.get(provider)
+    if target_host is None:
+        return DoctorResult(
+            name=name,
+            category="network",
+            status="skip",
+            detail=f"unknown provider `{provider}`",
+            remediation="Pass an explicit host or register the provider in PROVIDER_HOSTS",
+        )
+
+    try:
+        reader_writer = await asyncio.wait_for(
+            asyncio.open_connection(target_host, port),
+            timeout=timeout,
+        )
+    except TimeoutError:
+        return DoctorResult(
+            name=name,
+            category="network",
+            status="fail",
+            detail=f"connection to {target_host}:{port} timed out after {timeout:g}s",
+            remediation="check network egress, proxy config, or set BERNSTEIN_OFFLINE=1",
+        )
+    except socket.gaierror as exc:
+        return DoctorResult(
+            name=name,
+            category="network",
+            status="fail",
+            detail=f"DNS lookup failed for {target_host}: {exc}",
+            remediation="check /etc/resolv.conf or your DNS resolver",
+        )
+    except OSError as exc:
+        return DoctorResult(
+            name=name,
+            category="network",
+            status="fail",
+            detail=f"connection to {target_host}:{port} refused: {exc}",
+            remediation="check network egress or proxy config",
+        )
+
+    _close(reader_writer)
+    return DoctorResult(
+        name=name,
+        category="network",
+        status="ok",
+        detail=f"reachable: {target_host}:{port}",
+    )
+
+
+async def run_network_checks(
+    provider_names: Iterable[str] | None = None,
+    *,
+    hosts: Mapping[str, str] | None = None,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> list[DoctorResult]:
+    """Run reachability checks for every requested provider in parallel.
+
+    When ``provider_names`` is ``None``, every entry of ``PROVIDER_HOSTS``
+    is probed. When offline mode is active a single skip-row is emitted
+    instead of one per provider to keep the report compact.
+    """
+    if _is_offline():
+        return [
+            DoctorResult(
+                name="network:*",
+                category="network",
+                status="skip",
+                detail=f"{OFFLINE_ENV_VAR}=1 - all network checks skipped",
+            )
+        ]
+
+    table = dict(hosts) if hosts is not None else dict(PROVIDER_HOSTS)
+    names = list(provider_names) if provider_names is not None else list(table.keys())
+    if not names:
+        return [
+            DoctorResult(
+                name="network:none",
+                category="network",
+                status="skip",
+                detail="no providers configured",
+            )
+        ]
+
+    coros = [check_provider_reachability(name, host=table.get(name), timeout=timeout) for name in names]
+    return list(await asyncio.gather(*coros))
+
+
+def _close(reader_writer: tuple[asyncio.StreamReader, asyncio.StreamWriter]) -> None:
+    """Best-effort close of an open connection; never raise."""
+    _, writer = reader_writer
+    try:
+        writer.close()
+    except Exception:  # pragma: no cover - defensive
+        return

--- a/src/bernstein/cli/doctor/report.py
+++ b/src/bernstein/cli/doctor/report.py
@@ -1,0 +1,184 @@
+"""DoctorResult dataclass and Rich-based report renderer.
+
+Every doctor check returns a :class:`DoctorResult`. The renderer collects
+results into one Rich table with status glyphs, then prints a one-line
+summary footer and computes the exit code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from rich.console import Console
+
+
+DoctorStatus = Literal["ok", "warn", "fail", "skip"]
+DoctorCategory = Literal["installation", "adapter", "network", "environment"]
+
+
+# Public mapping from status to a (glyph, color) tuple. Used by the renderer
+# and also by tests that need the exact display string.
+STATUS_GLYPHS: dict[str, tuple[str, str]] = {
+    "ok": ("✓", "green"),
+    "warn": ("⚠", "yellow"),
+    "fail": ("✗", "red"),
+    "skip": ("○", "dim"),
+}
+
+
+@dataclass(frozen=True)
+class DoctorResult:
+    """A single doctor check result.
+
+    Attributes:
+        name: Stable identifier for the check (for example ``adapter:claude``).
+        category: One of ``installation``, ``adapter``, ``network``,
+            ``environment``.
+        status: One of ``ok``, ``warn``, ``fail``, ``skip``.
+        detail: Short human-readable detail line.
+        remediation: Optional remediation hint. Empty for passing checks.
+    """
+
+    name: str
+    category: DoctorCategory
+    status: DoctorStatus
+    detail: str
+    remediation: str = ""
+    extra: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+
+def summarize(results: Sequence[DoctorResult]) -> dict[str, int]:
+    """Count results by status. Always returns all four keys."""
+    counts: dict[str, int] = {"ok": 0, "warn": 0, "fail": 0, "skip": 0}
+    for r in results:
+        counts[r.status] = counts.get(r.status, 0) + 1
+    return counts
+
+
+def exit_code_for(results: Sequence[DoctorResult]) -> int:
+    """Return the process exit code for a result set.
+
+    ``1`` if any FAIL is present, ``0`` otherwise. WARN does not change the
+    exit code (the renderer surfaces it via stderr instead).
+    """
+    return 1 if any(r.status == "fail" for r in results) else 0
+
+
+def render_report(
+    results: Sequence[DoctorResult],
+    console: Console | None = None,
+    *,
+    show_skip: bool = True,
+) -> str:
+    """Render results to a Rich table and return the captured plain text.
+
+    A console is created on-demand when one is not supplied. The captured
+    string lets tests assert on the rendered output without relying on
+    terminal width quirks.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+    from rich.table import Table
+
+    buf = StringIO()
+    target = console or Console(file=buf, width=120, record=True, color_system=None)
+    table = Table(
+        title="Bernstein Doctor",
+        header_style="bold cyan",
+        show_lines=False,
+    )
+    table.add_column("Check", min_width=18, overflow="fold")
+    table.add_column("Category", min_width=10)
+    table.add_column("Status", min_width=6)
+    table.add_column("Detail", min_width=24, overflow="fold")
+    table.add_column("Remediation", overflow="fold")
+
+    for r in results:
+        if not show_skip and r.status == "skip":
+            continue
+        glyph, color = STATUS_GLYPHS.get(r.status, ("?", "white"))
+        table.add_row(
+            r.name,
+            r.category,
+            f"[{color}]{glyph} {r.status.upper()}[/{color}]",
+            r.detail,
+            r.remediation,
+        )
+
+    target.print(table)
+    counts = summarize(results)
+    footer = (
+        f"[green]{counts['ok']} OK[/green]  "
+        f"[yellow]{counts['warn']} WARN[/yellow]  "
+        f"[red]{counts['fail']} FAIL[/red]  "
+        f"[dim]{counts['skip']} SKIP[/dim]"
+    )
+    target.print(footer)
+    return target.export_text() if console is None else buf.getvalue()
+
+
+async def run_all(
+    *,
+    adapter_names: Iterable[str] | None = None,
+    provider_names: Iterable[str] | None = None,
+) -> list[DoctorResult]:
+    """Run every doctor category and return the merged result list.
+
+    The four categories run in parallel where safe. Installation checks
+    remain synchronous because they shell out trivially and complete
+    instantly.
+    """
+    from bernstein.cli.doctor.adapter_checks import run_adapter_checks
+    from bernstein.cli.doctor.environment_checks import run_environment_checks
+    from bernstein.cli.doctor.network_checks import run_network_checks
+    from bernstein.cli.install_check import check_installations
+
+    install_results = _installation_to_doctor(check_installations())
+    env_results = run_environment_checks()
+
+    adapter_task = asyncio.create_task(run_adapter_checks(adapter_names))
+    network_task = asyncio.create_task(run_network_checks(provider_names))
+
+    adapter_results, network_results = await asyncio.gather(
+        adapter_task,
+        network_task,
+        return_exceptions=False,
+    )
+
+    return [
+        *install_results,
+        *adapter_results,
+        *network_results,
+        *env_results,
+    ]
+
+
+def _installation_to_doctor(install_results: object) -> list[DoctorResult]:
+    """Adapt legacy InstallWarning objects to DoctorResult."""
+    from typing import cast
+
+    results: list[DoctorResult] = []
+    if not isinstance(install_results, list):  # pragma: no cover - defensive
+        return results
+    items = cast("list[object]", install_results)
+    for warning in items:
+        ok = bool(getattr(warning, "ok", False))
+        name = str(getattr(warning, "name", "unknown"))
+        detail = str(getattr(warning, "detail", ""))
+        fix = str(getattr(warning, "fix", ""))
+        results.append(
+            DoctorResult(
+                name=name,
+                category="installation",
+                status="ok" if ok else "fail",
+                detail=detail,
+                remediation=fix,
+            )
+        )
+    return results

--- a/tests/integration/test_doctor_lifecycle.py
+++ b/tests/integration/test_doctor_lifecycle.py
@@ -1,0 +1,133 @@
+"""End-to-end lifecycle tests for ``bernstein doctor extended``.
+
+These exercise the full check pipeline (installation -> adapter ->
+network -> environment) via :func:`bernstein.cli.doctor.run_all`, with
+network and adapter side-effects stubbed so the tests run anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands import advanced_cmd
+from bernstein.cli.doctor import DoctorResult, run_all
+from bernstein.cli.doctor import adapter_checks as adapter_mod
+from bernstein.cli.doctor import network_checks as network_mod
+
+
+def _ok_writer() -> tuple[Any, Any]:
+    class _W:
+        def close(self) -> None: ...
+
+    return (object(), _W())
+
+
+def _patch_network_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_OFFLINE", raising=False)
+
+    async def fake_open(host: str, port: int) -> Any:
+        return _ok_writer()
+
+    monkeypatch.setattr(network_mod.asyncio, "open_connection", fake_open)
+
+
+def _patch_adapter_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_mod.shutil, "which", lambda _name: None)
+
+
+def test_run_all_offline_only_skip_for_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_OFFLINE", "1")
+    _patch_adapter_missing(monkeypatch)
+
+    results = asyncio.run(run_all(adapter_names=["claude"], provider_names=["anthropic"]))
+    network_rows = [r for r in results if r.category == "network"]
+    assert all(r.status == "skip" for r in network_rows)
+
+
+def test_run_all_categories_all_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_OFFLINE", "1")  # keep tests offline
+    _patch_adapter_missing(monkeypatch)
+
+    results = asyncio.run(run_all(adapter_names=["claude", "codex"]))
+    categories = {r.category for r in results}
+    assert "adapter" in categories
+    assert "network" in categories
+    assert "environment" in categories
+
+
+def test_run_all_adapter_failures_propagate(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_OFFLINE", "1")
+    _patch_adapter_missing(monkeypatch)
+
+    results = asyncio.run(run_all(adapter_names=["claude"]))
+    adapter_rows = [r for r in results if r.category == "adapter"]
+    assert any(r.status == "fail" for r in adapter_rows)
+
+
+def test_doctor_extended_cli_exit_code_zero_when_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No real network. Offline mode forces network checks to skip, and
+    # adapter binaries probably exist for at least one entry.
+    monkeypatch.setenv("BERNSTEIN_OFFLINE", "1")
+
+    runner = CliRunner()
+
+    # Force adapter checks to return only ok statuses so the exit code is 0.
+    async def fake_adapter_check(*_args: Any, **_kwargs: Any) -> DoctorResult:
+        return DoctorResult(name="adapter:claude", category="adapter", status="ok", detail="fake")
+
+    monkeypatch.setattr(adapter_mod, "check_adapter_binary", fake_adapter_check)
+
+    # Patch the legacy installation check to always pass to keep the test deterministic.
+    from bernstein.cli import install_check
+
+    monkeypatch.setattr(install_check, "check_installations", lambda: [])
+
+    result = runner.invoke(advanced_cmd.doctor, ["extended", "--adapter", "claude"])
+    assert result.exit_code == 0, result.output
+
+
+def test_doctor_extended_cli_failure_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_OFFLINE", "1")
+    monkeypatch.setattr(adapter_mod.shutil, "which", lambda _name: None)
+
+    # Force an installation failure so the overall exit code is 1.
+    from bernstein.cli import install_check
+
+    class _Fake:
+        def __init__(self) -> None:
+            self.name = "Bernstein installations"
+            self.ok = False
+            self.detail = "synthetic failure"
+            self.fix = "do nothing"
+
+    monkeypatch.setattr(install_check, "check_installations", lambda: [_Fake()])
+
+    runner = CliRunner()
+    result = runner.invoke(advanced_cmd.doctor, ["extended", "--adapter", "claude", "--provider", "anthropic"])
+    assert result.exit_code == 1, result.output
+
+
+def test_doctor_extended_cli_json_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    import json
+
+    monkeypatch.setenv("BERNSTEIN_OFFLINE", "1")
+    monkeypatch.setattr(adapter_mod.shutil, "which", lambda _name: None)
+
+    from bernstein.cli import install_check
+
+    monkeypatch.setattr(install_check, "check_installations", lambda: [])
+
+    runner = CliRunner()
+    result = runner.invoke(
+        advanced_cmd.doctor,
+        ["extended", "--json", "--adapter", "claude", "--provider", "anthropic"],
+    )
+    # Exit code is 1 (adapter:claude is fail), but JSON must still parse.
+    payload = json.loads(result.output)
+    assert "results" in payload
+    assert "summary" in payload
+    assert payload["summary"]["fail"] >= 1

--- a/tests/property/test_doctor_properties.py
+++ b/tests/property/test_doctor_properties.py
@@ -1,0 +1,204 @@
+"""Property-based tests for the doctor subsystem.
+
+These tests do not exercise network or subprocess paths. They drive the
+pure helpers (summarize, exit_code_for, environment detection, etc.) with
+random valid input to surface invariants that case-based tests can miss.
+"""
+
+from __future__ import annotations
+
+import string
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from bernstein.cli.doctor.adapter_checks import _first_nonempty_line, _load_adapters_from_yaml
+from bernstein.cli.doctor.environment_checks import detect_environments
+from bernstein.cli.doctor.report import (
+    DoctorResult,
+    exit_code_for,
+    render_report,
+    summarize,
+)
+
+STATUSES = ("ok", "warn", "fail", "skip")
+CATEGORIES = ("installation", "adapter", "network", "environment")
+
+
+def _result_strategy() -> st.SearchStrategy[DoctorResult]:
+    safe_text = st.text(alphabet=string.printable, min_size=0, max_size=40).filter(
+        lambda s: "[" not in s and "]" not in s
+    )
+    return st.builds(
+        DoctorResult,
+        name=safe_text.filter(lambda s: bool(s.strip())),
+        category=st.sampled_from(CATEGORIES),
+        status=st.sampled_from(STATUSES),
+        detail=safe_text,
+        remediation=safe_text,
+    )
+
+
+@settings(deadline=None, max_examples=80)
+@given(results=st.lists(_result_strategy(), max_size=40))
+def test_summarize_counts_sum_equals_input_length(results: list[DoctorResult]) -> None:
+    counts = summarize(results)
+    assert sum(counts.values()) == len(results)
+    assert set(counts.keys()) == {"ok", "warn", "fail", "skip"}
+
+
+@settings(deadline=None, max_examples=80)
+@given(results=st.lists(_result_strategy(), max_size=40))
+def test_exit_code_iff_any_fail(results: list[DoctorResult]) -> None:
+    has_fail = any(r.status == "fail" for r in results)
+    assert (exit_code_for(results) == 1) == has_fail
+
+
+@settings(deadline=None, max_examples=40)
+@given(results=st.lists(_result_strategy(), max_size=20))
+def test_render_report_never_raises(results: list[DoctorResult]) -> None:
+    # Smoke test that the renderer copes with arbitrary detail strings.
+    text = render_report(results)
+    assert isinstance(text, str)
+
+
+_LINE_ALPHABET = string.ascii_letters + string.digits + " \t.-_"
+
+
+@settings(deadline=None, max_examples=80)
+@given(
+    text=st.lists(
+        st.text(alphabet=_LINE_ALPHABET, min_size=0, max_size=20),
+        min_size=0,
+        max_size=10,
+    )
+)
+def test_first_nonempty_line_returns_first_stripped_or_empty(text: list[str]) -> None:
+    joined = "\n".join(text)
+    expected = ""
+    for line in text:
+        if line.strip():
+            expected = line.strip()
+            break
+    assert _first_nonempty_line(joined) == expected
+
+
+@settings(deadline=None, max_examples=60)
+@given(
+    keys=st.lists(
+        st.sampled_from(
+            [
+                "GITHUB_ACTIONS",
+                "GITLAB_CI",
+                "BUILDKITE",
+                "CIRCLECI",
+                "JENKINS_URL",
+                "DEVCONTAINER",
+                "REMOTE_CONTAINERS",
+                "INVOCATION_ID",
+                "CI",
+            ]
+        ),
+        unique=True,
+        max_size=5,
+    )
+)
+def test_environment_detection_is_subset_of_known_labels(keys: list[str]) -> None:
+    env: dict[str, str] = {}
+    for k in keys:
+        env[k] = (
+            "true"
+            if k in ("GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "CIRCLECI", "DEVCONTAINER", "REMOTE_CONTAINERS", "CI")
+            else "value"
+        )
+    matches = detect_environments(env=env, file_exists=lambda _p: False)
+    labels = {m.label for m in matches}
+    # No invented labels.
+    expected_universe = {
+        "GitHub Actions",
+        "GitLab CI",
+        "Buildkite",
+        "CircleCI",
+        "Jenkins",
+        "VS Code devcontainer",
+        "VS Code devcontainer (remote)",
+        "systemd-run",
+        "Generic CI",
+    }
+    assert labels.issubset(expected_universe)
+
+
+@settings(deadline=None, max_examples=40)
+@given(
+    extras=st.dictionaries(
+        st.text(alphabet=string.ascii_uppercase, min_size=1, max_size=5),
+        st.text(alphabet=string.printable, min_size=0, max_size=10),
+        max_size=5,
+    )
+)
+def test_environment_detection_ignores_unknown_vars(extras: dict[str, str]) -> None:
+    # Junk env vars must not cause spurious detections.
+    safe_env = {
+        k: v
+        for k, v in extras.items()
+        if k
+        not in {
+            "GITHUB_ACTIONS",
+            "GITLAB_CI",
+            "BUILDKITE",
+            "CIRCLECI",
+            "JENKINS_URL",
+            "DEVCONTAINER",
+            "REMOTE_CONTAINERS",
+            "INVOCATION_ID",
+            "CI",
+        }
+    }
+    matches = detect_environments(env=safe_env, file_exists=lambda _p: False)
+    assert matches == []
+
+
+@settings(deadline=None, max_examples=40)
+@given(label=st.text(alphabet=string.ascii_letters + string.digits + "_-", min_size=1, max_size=20))
+def test_render_report_handles_arbitrary_labels(label: str) -> None:
+    result = DoctorResult(
+        name=label,
+        category="installation",
+        status="ok",
+        detail="",
+    )
+    text = render_report([result])
+    assert "Bernstein Doctor" in text
+
+
+@settings(deadline=None, max_examples=40)
+@given(content=st.text(alphabet=string.printable, max_size=200))
+def test_load_adapters_from_yaml_never_raises(tmp_path_factory, content: str) -> None:  # type: ignore[no-untyped-def]
+    # Even for completely junk content, the YAML loader must return a list.
+    p = tmp_path_factory.mktemp("yaml") / "bernstein.yaml"
+    try:
+        p.write_text(content, encoding="utf-8")
+    except UnicodeEncodeError:
+        return  # Hypothesis fed us bytes Python cannot write; skip.
+    result = _load_adapters_from_yaml(p)
+    assert isinstance(result, list)
+    assert all(isinstance(x, str) for x in result)
+
+
+@settings(deadline=None, max_examples=40)
+@given(
+    statuses=st.lists(st.sampled_from(STATUSES), max_size=20),
+)
+def test_summarize_is_order_independent(statuses: list[str]) -> None:
+    forward = [
+        DoctorResult(name=f"x{i}", category="installation", status=s, detail="")  # type: ignore[arg-type]
+        for i, s in enumerate(statuses)
+    ]
+    reverse = list(reversed(forward))
+    assert summarize(forward) == summarize(reverse)
+
+
+@settings(deadline=None, max_examples=40)
+@given(results=st.lists(_result_strategy(), max_size=20))
+def test_exit_code_only_zero_or_one(results: list[DoctorResult]) -> None:
+    assert exit_code_for(results) in (0, 1)

--- a/tests/unit/doctor/__init__.py
+++ b/tests/unit/doctor/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the bernstein.cli.doctor sub-package."""

--- a/tests/unit/doctor/test_adapter_checks.py
+++ b/tests/unit/doctor/test_adapter_checks.py
@@ -1,0 +1,215 @@
+"""Unit tests for adapter binary doctor checks."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.doctor import adapter_checks
+from bernstein.cli.doctor.adapter_checks import (
+    ADAPTER_BINARIES,
+    check_adapter_binary,
+    run_adapter_checks,
+)
+
+
+def _run(coro: object) -> object:
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# check_adapter_binary
+# ---------------------------------------------------------------------------
+
+
+def test_missing_binary_returns_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+
+    result = _run(check_adapter_binary("claude", "claude"))
+
+    assert result.status == "fail"  # type: ignore[union-attr]
+    assert "not in PATH" in result.detail  # type: ignore[union-attr]
+    assert "Install via the adapter" in result.remediation  # type: ignore[union-attr]
+    assert result.category == "adapter"  # type: ignore[union-attr]
+    assert result.name == "adapter:claude"  # type: ignore[union-attr]
+
+
+def test_blank_declared_binary_returns_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _run(check_adapter_binary("ghost", ""))
+
+    assert result.status == "fail"  # type: ignore[union-attr]
+    assert "no binary declared" in result.detail  # type: ignore[union-attr]
+
+
+def test_version_ok_uses_first_nonempty_stdout_line(tmp_path: Path) -> None:
+    bin_path = _write_script(tmp_path, "echo 'fakeprog 1.2.3'\nexit 0\n")
+
+    result = _run(check_adapter_binary("fakeprog", str(bin_path)))
+
+    assert result.status == "ok"  # type: ignore[union-attr]
+    assert "fakeprog 1.2.3" in result.detail  # type: ignore[union-attr]
+    assert result.remediation == ""  # type: ignore[union-attr]
+
+
+def test_version_nonzero_exit_returns_warn(tmp_path: Path) -> None:
+    bin_path = _write_script(tmp_path, "echo 'broken' 1>&2\nexit 2\n")
+
+    result = _run(check_adapter_binary("brokenbin", str(bin_path)))
+
+    assert result.status == "warn"  # type: ignore[union-attr]
+    assert "exited 2" in result.detail  # type: ignore[union-attr]
+    assert "broken" in result.detail  # type: ignore[union-attr]
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_version_timeout_returns_warn(tmp_path: Path) -> None:
+    bin_path = _write_script(tmp_path, "sleep 3\n")
+
+    result = _run(check_adapter_binary("slowbin", str(bin_path), timeout=0.2))
+
+    assert result.status == "warn"  # type: ignore[union-attr]
+    assert "timed out" in result.detail  # type: ignore[union-attr]
+
+
+def test_empty_version_output_still_ok(tmp_path: Path) -> None:
+    bin_path = _write_script(tmp_path, "exit 0\n")
+
+    result = _run(check_adapter_binary("silent", str(bin_path)))
+
+    assert result.status == "ok"  # type: ignore[union-attr]
+    assert "version output empty" in result.detail  # type: ignore[union-attr]
+
+
+def test_version_falls_back_to_stderr(tmp_path: Path) -> None:
+    # Some CLIs write --version to stderr (notably `claude --version` in
+    # some prerelease builds). The adapter check must handle that.
+    bin_path = _write_script(tmp_path, "echo 'stderrver 9.9' 1>&2\nexit 0\n")
+
+    result = _run(check_adapter_binary("stderrver", str(bin_path)))
+
+    assert result.status == "ok"  # type: ignore[union-attr]
+    assert "stderrver 9.9" in result.detail  # type: ignore[union-attr]
+
+
+def test_name_uses_adapter_namespace() -> None:
+    result = _run(check_adapter_binary("aider", "definitely-missing-bin-xyz-doctor"))
+    assert result.name == "adapter:aider"  # type: ignore[union-attr]
+
+
+def test_returns_frozen_dataclass() -> None:
+    from dataclasses import FrozenInstanceError
+
+    result = _run(check_adapter_binary("anything", "this-bin-does-not-exist-ever"))
+    with pytest.raises(FrozenInstanceError):
+        result.status = "ok"  # type: ignore[misc,union-attr]
+
+
+# ---------------------------------------------------------------------------
+# run_adapter_checks
+# ---------------------------------------------------------------------------
+
+
+def test_run_adapter_checks_uses_explicit_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+    results = _run(run_adapter_checks(["claude", "aider"]))
+
+    assert len(results) == 2  # type: ignore[arg-type]
+    names = sorted(r.name for r in results)  # type: ignore[union-attr]
+    assert names == ["adapter:aider", "adapter:claude"]
+
+
+def test_run_adapter_checks_empty_emits_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_checks, "_load_adapters_from_yaml", lambda _p: [])
+    monkeypatch.setattr(adapter_checks, "_default_adapter_list", lambda: [])
+
+    results = _run(run_adapter_checks(None))
+
+    assert len(results) == 1  # type: ignore[arg-type]
+    assert results[0].status == "skip"  # type: ignore[index,union-attr]
+    assert results[0].name == "adapter:none"  # type: ignore[index,union-attr]
+
+
+def test_run_adapter_checks_uses_default_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(adapter_checks, "_load_adapters_from_yaml", lambda _p: [])
+
+    results = _run(run_adapter_checks(None))
+
+    # Default fallback list has 5 entries.
+    assert len(results) == 5  # type: ignore[arg-type]
+
+
+def test_run_adapter_checks_uses_yaml_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    yaml_text = "cli: claude\nadapters:\n  - aider\n  - codex\n"
+    (tmp_path / "bernstein.yaml").write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+
+    results = _run(run_adapter_checks(None, config_path=tmp_path / "bernstein.yaml"))
+    names = sorted(r.name for r in results)  # type: ignore[union-attr]
+    assert "adapter:claude" in names
+    assert "adapter:aider" in names
+    assert "adapter:codex" in names
+
+
+def test_run_adapter_checks_tolerates_broken_yaml(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    (tmp_path / "bernstein.yaml").write_text(":::not-yaml:::", encoding="utf-8")
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+
+    # Must not raise; falls back to default list.
+    results = _run(run_adapter_checks(None, config_path=tmp_path / "bernstein.yaml"))
+    assert len(results) >= 1  # type: ignore[arg-type]
+
+
+def test_run_adapter_checks_with_custom_binary_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+    results = _run(run_adapter_checks(["x"], binaries={"x": "my-bin"}))
+    assert results[0].detail.startswith("Binary `my-bin` not in PATH")  # type: ignore[index,union-attr]
+
+
+def test_run_adapter_checks_runs_in_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force each check to "sleep" via subprocess so parallelism matters.
+    # Using a missing-binary path keeps the test fast and deterministic.
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+    results = _run(run_adapter_checks(["a", "b", "c", "d"]))
+    assert len(results) == 4  # type: ignore[arg-type]
+
+
+def test_run_adapter_checks_role_model_policy_picks_up_cli(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    yaml_text = "role_model_policy:\n  manager: {cli: claude}\n  qa: {cli: codex}\n"
+    (tmp_path / "bernstein.yaml").write_text(yaml_text, encoding="utf-8")
+    monkeypatch.setattr(adapter_checks.shutil, "which", lambda _name: None)
+
+    results = _run(run_adapter_checks(None, config_path=tmp_path / "bernstein.yaml"))
+    names = sorted(r.name for r in results)  # type: ignore[union-attr]
+    assert "adapter:claude" in names
+    assert "adapter:codex" in names
+
+
+def test_adapter_binaries_has_core_entries() -> None:
+    for adapter in ("claude", "codex", "gemini", "aider"):
+        assert adapter in ADAPTER_BINARIES
+
+
+def test_adapter_binaries_are_strings() -> None:
+    for name, binary in ADAPTER_BINARIES.items():
+        assert isinstance(name, str)
+        assert isinstance(binary, str)
+        assert binary, f"empty binary for adapter {name}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_script(tmp_path: Path, body: str) -> Path:
+    """Write a temporary shell script and return its absolute path."""
+    if sys.platform.startswith("win"):  # pragma: no cover
+        pytest.skip("POSIX shell scripts required for adapter version probe tests.")
+    path = tmp_path / "fakebin"
+    path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+    path.chmod(0o755)
+    return path

--- a/tests/unit/doctor/test_environment_checks.py
+++ b/tests/unit/doctor/test_environment_checks.py
@@ -1,0 +1,134 @@
+"""Unit tests for CI / sandbox environment detection."""
+
+from __future__ import annotations
+
+from bernstein.cli.doctor.environment_checks import (
+    ENVIRONMENT_PROBES,
+    EnvironmentProbe,
+    detect_environments,
+    run_environment_checks,
+)
+
+
+def _no_files(_: str) -> bool:
+    return False
+
+
+def test_no_env_returns_local() -> None:
+    results = run_environment_checks(env={}, file_exists=_no_files)
+    assert len(results) == 1
+    assert results[0].name == "env:host"
+    assert "local workstation" in results[0].detail
+
+
+def test_detects_github_actions() -> None:
+    matches = detect_environments(env={"GITHUB_ACTIONS": "true"}, file_exists=_no_files)
+    labels = [m.label for m in matches]
+    assert "GitHub Actions" in labels
+
+
+def test_detects_gitlab_ci() -> None:
+    results = run_environment_checks(env={"GITLAB_CI": "true"}, file_exists=_no_files)
+    assert any("GitLab CI" in r.detail for r in results)
+
+
+def test_detects_buildkite() -> None:
+    results = run_environment_checks(env={"BUILDKITE": "true"}, file_exists=_no_files)
+    assert any("Buildkite" in r.detail for r in results)
+
+
+def test_detects_circleci() -> None:
+    matches = detect_environments(env={"CIRCLECI": "true"}, file_exists=_no_files)
+    assert any(m.label == "CircleCI" for m in matches)
+
+
+def test_detects_jenkins_via_jenkins_url() -> None:
+    matches = detect_environments(env={"JENKINS_URL": "http://jenkins/"}, file_exists=_no_files)
+    assert any(m.label == "Jenkins" for m in matches)
+
+
+def test_detects_docker_via_dockerenv_file() -> None:
+    matches = detect_environments(env={}, file_exists=lambda p: p == "/.dockerenv")
+    assert any(m.label == "Docker" for m in matches)
+
+
+def test_detects_devcontainer_env() -> None:
+    matches = detect_environments(env={"DEVCONTAINER": "true"}, file_exists=_no_files)
+    assert any(m.label.startswith("VS Code devcontainer") for m in matches)
+
+
+def test_detects_remote_containers_env() -> None:
+    matches = detect_environments(env={"REMOTE_CONTAINERS": "true"}, file_exists=_no_files)
+    assert any(m.label.startswith("VS Code devcontainer") for m in matches)
+
+
+def test_detects_systemd_run() -> None:
+    matches = detect_environments(env={"INVOCATION_ID": "abc"}, file_exists=_no_files)
+    assert any(m.label == "systemd-run" for m in matches)
+
+
+def test_specific_environment_hides_generic_ci() -> None:
+    # GitHub Actions sets both GITHUB_ACTIONS=true and CI=true. We must
+    # collapse the generic CI row when something more specific matched.
+    matches = detect_environments(
+        env={"GITHUB_ACTIONS": "true", "CI": "true"},
+        file_exists=_no_files,
+    )
+    labels = [m.label for m in matches]
+    assert "GitHub Actions" in labels
+    assert "Generic CI" not in labels
+
+
+def test_only_generic_ci_when_no_specific_match() -> None:
+    matches = detect_environments(env={"CI": "true"}, file_exists=_no_files)
+    labels = [m.label for m in matches]
+    assert labels == ["Generic CI"]
+
+
+def test_env_value_mismatch_skipped() -> None:
+    # GITHUB_ACTIONS must equal literal "true"; "1" should not match.
+    matches = detect_environments(env={"GITHUB_ACTIONS": "1"}, file_exists=_no_files)
+    assert not any(m.label == "GitHub Actions" for m in matches)
+
+
+def test_probe_dataclass_is_frozen() -> None:
+    from dataclasses import FrozenInstanceError
+
+    import pytest
+
+    probe = EnvironmentProbe(label="x", detail_hint="x", env_var="X")
+    with pytest.raises(FrozenInstanceError):
+        probe.label = "y"  # type: ignore[misc]
+
+
+def test_environment_probes_have_unique_labels() -> None:
+    labels = [p.label for p in ENVIRONMENT_PROBES]
+    assert len(labels) == len(set(labels))
+
+
+def test_run_environment_checks_marks_remediation_when_in_ci() -> None:
+    results = run_environment_checks(env={"GITHUB_ACTIONS": "true"}, file_exists=_no_files)
+    assert all(r.category == "environment" for r in results)
+    assert any("bug report" in r.remediation for r in results)
+
+
+def test_docker_inside_github_actions_reports_both() -> None:
+    matches = detect_environments(
+        env={"GITHUB_ACTIONS": "true"},
+        file_exists=lambda p: p == "/.dockerenv",
+    )
+    labels = [m.label for m in matches]
+    assert "GitHub Actions" in labels
+    assert "Docker" in labels
+
+
+def test_unicode_env_value_does_not_crash() -> None:
+    # Pathological input must not raise.
+    matches = detect_environments(env={"GITHUB_ACTIONS": "é"}, file_exists=_no_files)
+    assert all(isinstance(m, EnvironmentProbe) for m in matches)
+
+
+def test_run_uses_real_os_environ_when_not_provided() -> None:
+    # Smoke test: must not raise even if os.environ has unrelated values.
+    results = run_environment_checks()
+    assert results, "run_environment_checks must always return at least one row"

--- a/tests/unit/doctor/test_network_checks.py
+++ b/tests/unit/doctor/test_network_checks.py
@@ -1,0 +1,188 @@
+"""Unit tests for network reachability doctor checks."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any
+
+import pytest
+
+from bernstein.cli.doctor import network_checks
+from bernstein.cli.doctor.network_checks import (
+    OFFLINE_ENV_VAR,
+    PROVIDER_HOSTS,
+    check_provider_reachability,
+    run_network_checks,
+)
+
+
+def _run(coro: object) -> Any:
+    return asyncio.run(coro)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Offline switch
+# ---------------------------------------------------------------------------
+
+
+def test_check_skips_when_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(OFFLINE_ENV_VAR, "1")
+    result = _run(check_provider_reachability("anthropic"))
+    assert result.status == "skip"
+    assert result.detail == f"{OFFLINE_ENV_VAR}=1"
+
+
+def test_run_network_checks_compact_skip_when_offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(OFFLINE_ENV_VAR, "1")
+    results = _run(run_network_checks())
+    assert len(results) == 1
+    assert results[0].status == "skip"
+    assert results[0].name == "network:*"
+
+
+def test_offline_only_when_value_is_literal_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(OFFLINE_ENV_VAR, "true")
+    # Should not be treated as offline; provider lookup proceeds even for unknown providers.
+    result = _run(check_provider_reachability("unknown-provider"))
+    assert result.status == "skip"
+    assert "unknown provider" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Unknown provider
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_provider_returns_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+    result = _run(check_provider_reachability("does-not-exist"))
+    assert result.status == "skip"
+    assert "unknown provider" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# Reachability success / failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_ok_path_uses_fake_open_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    async def fake_open(host: str, port: int) -> tuple[Any, Any]:
+        class _W:
+            def close(self) -> None: ...
+
+        return (object(), _W())
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    result = _run(check_provider_reachability("anthropic"))
+    assert result.status == "ok"
+    assert "api.anthropic.com" in result.detail
+
+
+def test_dns_failure_returns_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    async def fake_open(host: str, port: int) -> Any:
+        raise socket.gaierror(-2, "Name or service not known")
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    result = _run(check_provider_reachability("anthropic"))
+    assert result.status == "fail"
+    assert "DNS lookup failed" in result.detail
+    assert "/etc/resolv.conf" in result.remediation
+
+
+def test_connection_refused_returns_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    async def fake_open(host: str, port: int) -> Any:
+        raise OSError(111, "Connection refused")
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    result = _run(check_provider_reachability("openai"))
+    assert result.status == "fail"
+    assert "refused" in result.detail
+
+
+def test_timeout_returns_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    async def fake_open(host: str, port: int) -> Any:
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    result = _run(check_provider_reachability("openai", timeout=0.05))
+    assert result.status == "fail"
+    assert "timed out" in result.detail
+
+
+# ---------------------------------------------------------------------------
+# run_network_checks orchestration
+# ---------------------------------------------------------------------------
+
+
+def test_run_network_checks_uses_explicit_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    async def fake_open(host: str, port: int) -> tuple[Any, Any]:
+        class _W:
+            def close(self) -> None: ...
+
+        return (object(), _W())
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    results = _run(run_network_checks(["anthropic", "openai"]))
+    assert {r.name for r in results} == {"network:anthropic", "network:openai"}
+
+
+def test_run_network_checks_default_covers_all_providers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    async def fake_open(host: str, port: int) -> Any:
+        raise OSError(111, "refused")
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    results = _run(run_network_checks())
+    assert {r.name for r in results} == {f"network:{p}" for p in PROVIDER_HOSTS}
+
+
+def test_run_network_checks_empty_providers_returns_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+    results = _run(run_network_checks([], hosts={}))
+    assert len(results) == 1
+    assert results[0].name == "network:none"
+
+
+def test_provider_hosts_table_is_complete() -> None:
+    for required in ("anthropic", "openai", "google", "openrouter"):
+        assert required in PROVIDER_HOSTS, f"missing provider {required}"
+        assert PROVIDER_HOSTS[required], f"empty host for {required}"
+
+
+def test_custom_host_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(OFFLINE_ENV_VAR, raising=False)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_open(host: str, port: int) -> tuple[Any, Any]:
+        captured["host"] = host
+        captured["port"] = port
+
+        class _W:
+            def close(self) -> None: ...
+
+        return (object(), _W())
+
+    monkeypatch.setattr(network_checks.asyncio, "open_connection", fake_open)
+
+    result = _run(check_provider_reachability("anthropic", host="proxy.example.test", port=8443))
+    assert result.status == "ok"
+    assert captured == {"host": "proxy.example.test", "port": 8443}

--- a/tests/unit/doctor/test_report.py
+++ b/tests/unit/doctor/test_report.py
@@ -1,0 +1,163 @@
+"""Unit tests for the doctor report renderer and aggregator."""
+
+from __future__ import annotations
+
+import asyncio
+from io import StringIO
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from bernstein.cli.doctor import report as report_mod
+from bernstein.cli.doctor.report import (
+    STATUS_GLYPHS,
+    DoctorResult,
+    exit_code_for,
+    render_report,
+    run_all,
+    summarize,
+)
+
+
+def _make(status: str = "ok", category: str = "installation") -> DoctorResult:
+    return DoctorResult(
+        name=f"sample:{status}",
+        category=category,  # type: ignore[arg-type]
+        status=status,  # type: ignore[arg-type]
+        detail=f"detail-{status}",
+    )
+
+
+def test_summarize_zero_when_no_results() -> None:
+    assert summarize([]) == {"ok": 0, "warn": 0, "fail": 0, "skip": 0}
+
+
+def test_summarize_counts_each_status() -> None:
+    results = [_make("ok"), _make("ok"), _make("fail"), _make("warn"), _make("skip")]
+    assert summarize(results) == {"ok": 2, "warn": 1, "fail": 1, "skip": 1}
+
+
+def test_exit_code_zero_when_no_fail() -> None:
+    assert exit_code_for([_make("ok"), _make("warn"), _make("skip")]) == 0
+
+
+def test_exit_code_one_when_any_fail() -> None:
+    assert exit_code_for([_make("ok"), _make("fail")]) == 1
+
+
+def test_render_report_includes_all_status_glyphs() -> None:
+    results = [_make("ok"), _make("warn"), _make("fail"), _make("skip")]
+    text = render_report(results)
+    for status in ("OK", "WARN", "FAIL", "SKIP"):
+        assert status in text
+
+
+def test_render_report_footer_has_counts() -> None:
+    results = [_make("ok"), _make("ok"), _make("warn")]
+    text = render_report(results)
+    assert "2 OK" in text
+    assert "1 WARN" in text
+
+
+def test_render_report_show_skip_false_hides_skip_rows() -> None:
+    buf = StringIO()
+    console = Console(file=buf, width=120, color_system=None, record=True)
+    render_report([_make("skip"), _make("ok")], console=console, show_skip=False)
+    rendered = console.export_text()
+    assert "sample:skip" not in rendered
+    assert "sample:ok" in rendered
+
+
+def test_status_glyphs_cover_every_status() -> None:
+    for status in ("ok", "warn", "fail", "skip"):
+        assert status in STATUS_GLYPHS
+
+
+def test_run_all_merges_categories(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_adapter(_: object = None) -> list[DoctorResult]:
+        return [_make("ok", category="adapter")]
+
+    async def fake_network(_: object = None) -> list[DoctorResult]:
+        return [_make("skip", category="network")]
+
+    monkeypatch.setattr(report_mod, "run_adapter_checks", fake_adapter, raising=False)
+    monkeypatch.setattr(report_mod, "run_network_checks", fake_network, raising=False)
+
+    # Patch lazy imports inside run_all.
+    import bernstein.cli.doctor.adapter_checks as adapter_mod
+    import bernstein.cli.doctor.network_checks as network_mod
+
+    monkeypatch.setattr(adapter_mod, "run_adapter_checks", fake_adapter)
+    monkeypatch.setattr(network_mod, "run_network_checks", fake_network)
+
+    # Avoid actually probing installation checks; replace check_installations.
+    from bernstein.cli import install_check
+
+    monkeypatch.setattr(install_check, "check_installations", lambda: [])
+
+    # Force environment probe to produce a known marker.
+    import bernstein.cli.doctor.environment_checks as env_mod
+
+    monkeypatch.setattr(env_mod, "run_environment_checks", lambda: [_make("ok", category="environment")])
+
+    results = asyncio.run(run_all())
+    categories = {r.category for r in results}
+    assert categories == {"adapter", "network", "environment"}
+
+
+def test_run_all_handles_empty_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    import bernstein.cli.doctor.adapter_checks as adapter_mod
+    import bernstein.cli.doctor.environment_checks as env_mod
+    import bernstein.cli.doctor.network_checks as network_mod
+
+    async def empty(_: Any = None, **__: Any) -> list[DoctorResult]:
+        return []
+
+    monkeypatch.setattr(adapter_mod, "run_adapter_checks", empty)
+    monkeypatch.setattr(network_mod, "run_network_checks", empty)
+    monkeypatch.setattr(env_mod, "run_environment_checks", lambda: [])
+
+    from bernstein.cli import install_check
+
+    monkeypatch.setattr(install_check, "check_installations", lambda: [])
+
+    results = asyncio.run(run_all())
+    assert results == []
+
+
+def test_render_report_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Snapshot test for the Rich report (stable layout, no terminal width drift).
+    results = [
+        DoctorResult(name="install:bernstein", category="installation", status="ok", detail="v1.0"),
+        DoctorResult(
+            name="adapter:claude",
+            category="adapter",
+            status="fail",
+            detail="Binary `claude` not in PATH",
+            remediation="install claude",
+        ),
+        DoctorResult(name="network:anthropic", category="network", status="skip", detail="BERNSTEIN_OFFLINE=1"),
+        DoctorResult(
+            name="env:github-actions",
+            category="environment",
+            status="ok",
+            detail="GitHub Actions detected",
+        ),
+    ]
+    text = render_report(results)
+    # Key tokens that must appear in the rendered table:
+    for token in (
+        "Bernstein Doctor",
+        "install:bernstein",
+        "adapter:claude",
+        "FAIL",
+        "BERNSTEIN_OFFLINE=1",
+        "GitHub Actions detected",
+    ):
+        assert token in text, f"missing token: {token}"
+
+
+def test_doctor_result_extra_default_empty_tuple() -> None:
+    result = DoctorResult(name="x", category="installation", status="ok", detail="")
+    assert result.extra == ()


### PR DESCRIPTION
## Summary

Extends \`bernstein doctor\` with three additional check categories so a
user can diagnose a broken setup before opening an issue:

- **adapter**: \`which <bin>\` + \`<bin> --version\` per declared adapter
- **network**: TCP/443 reachability per provider (honors \`BERNSTEIN_OFFLINE=1\`)
- **environment**: GitHub Actions / GitLab CI / Buildkite / Docker / devcontainer / systemd-run / generic CI

New \`bernstein doctor extended\` subcommand renders results into a single
Rich table with a summary footer (\`N OK, N WARN, N FAIL, N SKIP\`).
Existing \`check_installations\` behaviour is preserved and re-exported
through \`bernstein.cli.doctor.installation_checks\`.

## Exit codes

- Any \`FAIL\` -> exit 1
- WARN-only -> exit 0 + stderr summary
- All OK -> exit 0

## Test plan

- [x] \`uv run pytest tests/unit/doctor/ -x -q\` (66 unit tests)
- [x] \`uv run pytest tests/property/test_doctor_properties.py -x -q\` (10 hypothesis tests)
- [x] \`uv run pytest tests/integration/test_doctor_lifecycle.py -x -q\` (6 integration tests)
- [x] \`uv run ruff check src/bernstein/cli/doctor/ tests/unit/doctor/\` clean
- [x] \`uv run pyright src/bernstein/cli/doctor/\` clean
- [x] \`bernstein doctor extended --help\` renders the new subcommand
- [x] \`BERNSTEIN_OFFLINE=1 bernstein doctor extended\` skips network probes