### PR TITLE
feat(sdd): bernstein ticket validate - JSON Schema validator (closes spec 2026-05-17)

### DIFF
--- a/docs/sdd/ticket_schema.md
+++ b/docs/sdd/ticket_schema.md
@@ -1,0 +1,103 @@
+# SDD ticket schema (v1)
+
+Bernstein ships a portable JSON Schema for the YAML frontmatter on every
+`.sdd/backlog/*.md` (or `.yaml`) ticket. The same schema is reachable from
+any project that depends on Bernstein, via `importlib.resources` or via the
+`bernstein ticket validate` CLI.
+
+## TL;DR
+
+| What | Where |
+|------|-------|
+| Schema file | `bernstein/sdd/schema/ticket.v1.json` (Draft-07) |
+| Loader API | `bernstein.sdd.validator.load_schema("v1")` |
+| Validator API | `bernstein.sdd.validator.validate_ticket(path)` |
+| CLI | `bernstein ticket validate <path-or-glob>` |
+| Exit codes | `0` pass / `1` fail / `2` schema not found |
+
+## Required keys
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `id` | string | Slug, `^[a-z0-9][a-z0-9-]{2,80}$` |
+| `created` | string | ISO 8601 date, `YYYY-MM-DD` |
+| `status` | enum | `open`, `claimed`, `in_progress`, `blocked`, `closed`, `closed_hit`, `closed_miss`, `closed_partial`, `deduped`, `superseded` |
+| `priority` | enum | `P0`, `P1`, `P2` |
+| `effort` | enum | `S`, `M`, `L` |
+
+A ticket missing any of these fields is a hard failure.
+
+## Recommended keys
+
+Missing keys produce **warnings** (or **errors** under `--strict`).
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `owner` | string \| null | Single assignee or `null` |
+| `success_metric` | object | `name`, `current`, `target`, `window_days >= 1` |
+| `acceptance_criteria` | array of strings | At least one item |
+| `evidence` | array of objects | Each item needs `source` |
+| `risk` | string | Free text |
+| `rice` | object | `reach`, `impact`, `confidence (0..1)`, `effort_days (>= 0.25)`, `score` |
+| `ladder_to` | string | Strategic anchor |
+
+Extra unknown keys are allowed and ignored.
+
+## CLI usage
+
+```
+bernstein ticket validate .sdd/backlog/open/feat-x.md
+bernstein ticket validate '.sdd/backlog/open/*.md' '.sdd/backlog/closed/*.yaml'
+bernstein ticket validate --strict '.sdd/backlog/open/*.md'
+bernstein ticket validate --schema v1 --format json '.sdd/backlog/open/*.md'
+```
+
+Default output (human):
+
+```
+[OK]   .sdd/backlog/open/feat-foo.md
+[FAIL] .sdd/backlog/open/bug-bar.md
+        - priority: 'wip' is not one of ['P0', 'P1', 'P2']
+[WARN] .sdd/backlog/open/chore-baz.md
+        - warning: recommended key missing: success_metric
+```
+
+`--format json` emits a single JSON object with `schema`, `strict`,
+`reports[]`, and a `summary` block - safe to feed to downstream linters.
+
+## Programmatic usage
+
+```python
+from pathlib import Path
+from bernstein.sdd import validate_ticket
+
+report = validate_ticket(Path(".sdd/backlog/open/feat-x.md"), strict=False)
+if not report.ok:
+    for issue in report.errors:
+        print(issue.render())
+```
+
+## Adoption (downstream project)
+
+1. Add `bernstein` to your dependencies.
+2. Run `bernstein ticket validate '.sdd/backlog/open/*.md'` in CI.
+3. Optionally wire the schema directly into editor tooling - the file lives
+   inside the installed package, reachable via
+   `importlib.resources.files("bernstein.sdd.schema").joinpath("ticket.v1.json")`.
+
+## Extending the schema
+
+- New keys: add them as `additionalProperties: true`-compatible entries -
+  they ship as recommended unless explicitly required.
+- New status values: extend the `status` enum in a v2 schema; never widen v1.
+- Promote a warning to a hard requirement: add it to `required` in v2 and
+  ship the new file as `ticket.v2.json`. Old tickets keep validating against
+  v1 by passing `--schema v1`.
+
+## Testing
+
+```
+uv run pytest tests/unit/sdd/ -x -q
+uv run pytest tests/property/test_ticket_validator_properties.py -x -q
+uv run pytest tests/integration/test_ticket_validate_cli.py -x -q
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dependencies = [
     # ``src/bernstein/core/orchestration/phase_schemas.py``.  Already pulled in
     # transitively by several deps; promoted to a direct dep so the phase
     # pipeline does not silently degrade if a transitive owner drops it.
-    "jsonschema>=4.17",
+    "jsonschema>=4.20",
     # RFC 3161 TimeStampToken ASN.1 parsing for the multi-tenant audit
     # export verifier. Pure-Python, MIT-licensed, ~250KB wheel; ships the
     # ``tsp.TSTInfo`` / ``cms.ContentInfo`` types we need without us
@@ -94,6 +94,12 @@ dependencies = [
     # rendered by `bernstein compliance pack`. MIT-licensed, no native deps.
     # Used exclusively by ``bernstein.core.compliance.article12``.
     "reportlab>=4.0,<5",
+    # YAML frontmatter parsing for `bernstein ticket validate` (SDD ticket
+    # schema). Lightweight, MIT-licensed; piggybacks on the already-pinned
+    # PyYAML for the YAML body. The validator gracefully falls back to a
+    # PyYAML-only parser so the dep is not strictly required at runtime,
+    # but pinning it here keeps downstream behaviour consistent.
+    "python-frontmatter>=1.1",
 ]
 
 [project.urls]
@@ -282,6 +288,10 @@ artifacts = [
     # Web GUI built assets — Vite output committed to the package tree so
     # the wheel ships pre-built. Rebuild with: cd web && npm run build.
     "src/bernstein/gui/static/**/*",
+    # SDD ticket schemas. Shipped alongside the validator so downstream
+    # projects can lint their .sdd/backlog tickets via importlib.resources
+    # without a source checkout. Loader: bernstein.sdd.validator.load_schema.
+    "src/bernstein/sdd/schema/*.json",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/src/bernstein/cli/commands/ticket_cmd.py
+++ b/src/bernstein/cli/commands/ticket_cmd.py
@@ -1,18 +1,20 @@
-"""`bernstein from-ticket <url>` CLI command.
+"""`bernstein from-ticket <url>` and `bernstein ticket ...` CLI commands.
 
 Imports a task into Bernstein from a supported ticket URL (Linear web URL or
 ``linear://`` shortcut, GitHub issue URL, or Jira Cloud ``/browse/KEY-N`` URL).
 
-The heavy lifting lives in :mod:`bernstein.core.integrations.tickets`; this
-module only handles CLI plumbing, role/scope inference, and POSTing to the
-task server.
+The heavy lifting for the importer lives in
+:mod:`bernstein.core.integrations.tickets`; the ``bernstein ticket validate``
+sub-command delegates to :mod:`bernstein.sdd.validator`.
 """
 
 from __future__ import annotations
 
+import glob as _glob
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 import click
@@ -24,8 +26,13 @@ from bernstein.core.integrations.tickets import (
     TicketPayload,
     fetch_ticket,
 )
+from bernstein.sdd.validator import (
+    SchemaNotFoundError,
+    ValidationReport,
+    validate_ticket,
+)
 
-__all__ = ["from_ticket", "ticket_group"]
+__all__ = ["from_ticket", "ticket_group", "ticket_validate"]
 
 
 # ---------------------------------------------------------------------------
@@ -253,3 +260,121 @@ def ticket_group() -> None:
 def ticket_import(url: str, role: str | None, priority: str | None, dry_run: bool, run: bool) -> None:
     """Alias for `bernstein from-ticket`. Imports a task from a ticket URL."""
     _do_import(url, role=role, priority=priority, dry_run=dry_run, run=run)
+
+
+# ---------------------------------------------------------------------------
+# bernstein ticket validate
+# ---------------------------------------------------------------------------
+
+
+def _expand_targets(patterns: tuple[str, ...]) -> list[Path]:
+    """Expand a sequence of file paths / globs into a deterministic list."""
+    seen: dict[Path, None] = {}
+    for pat in patterns:
+        if not pat:
+            continue
+        candidate = Path(pat)
+        if candidate.exists():
+            seen.setdefault(candidate.resolve(), None)
+            continue
+        matches = sorted(_glob.glob(pat, recursive=True))
+        if not matches:
+            # Still record the literal path so the report shows a missing-file
+            # error instead of silently swallowing the input.
+            seen.setdefault(candidate.resolve(), None)
+            continue
+        for m in matches:
+            seen.setdefault(Path(m).resolve(), None)
+    return list(seen.keys())
+
+
+def _render_human(report: ValidationReport) -> str:
+    if report.errors:
+        tag = "[red][FAIL][/red]"
+    elif report.warnings:
+        tag = "[yellow][WARN][/yellow]"
+    else:
+        tag = "[green][OK]  [/green]"
+    lines = [f"{tag} {report.path}"]
+    for err in report.errors:
+        lines.append(f"        - {err.render()}")
+    for warn in report.warnings:
+        lines.append(f"        - warning: {warn.render()}")
+    return "\n".join(lines)
+
+
+@ticket_group.command("validate")
+@click.argument("paths", nargs=-1, required=True)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Promote recommended-key warnings to errors.",
+)
+@click.option(
+    "--schema",
+    "schema_version",
+    default="v1",
+    show_default=True,
+    help="Schema version label (e.g. v1).",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["human", "json"]),
+    default="human",
+    show_default=True,
+    help="Output format.",
+)
+def ticket_validate(
+    paths: tuple[str, ...],
+    strict: bool,
+    schema_version: str,
+    output_format: str,
+) -> None:
+    """Validate one or more SDD ticket files against the packaged JSON schema.
+
+    PATHS may be one or more file paths or glob patterns. Exit codes:
+
+    \b
+      0  all files pass
+      1  at least one file failed
+      2  schema version not found
+    """
+    targets = _expand_targets(paths)
+    if not targets:
+        if output_format == "json":
+            print_json({"status": "fail", "error": "no input paths"})
+        else:
+            console.print("[red]No input paths.[/red]")
+        raise SystemExit(1)
+
+    try:
+        reports = [validate_ticket(p, schema_version=schema_version, strict=strict) for p in targets]
+    except SchemaNotFoundError as exc:
+        if output_format == "json":
+            print_json({"status": "schema_not_found", "error": str(exc)})
+        else:
+            console.print(f"[red]Schema not found:[/red] {exc}")
+        raise SystemExit(2) from exc
+
+    any_failed = any(not r.ok for r in reports)
+
+    if output_format == "json":
+        payload = {
+            "schema": schema_version,
+            "strict": strict,
+            "reports": [r.to_dict() for r in reports],
+            "summary": {
+                "total": len(reports),
+                "ok": sum(1 for r in reports if r.status == "ok"),
+                "warn": sum(1 for r in reports if r.status == "warn"),
+                "fail": sum(1 for r in reports if r.status == "fail"),
+            },
+        }
+        print_json(payload)
+    else:
+        for rep in reports:
+            console.print(_render_human(rep))
+
+    raise SystemExit(1 if any_failed else 0)

--- a/src/bernstein/sdd/__init__.py
+++ b/src/bernstein/sdd/__init__.py
@@ -1,0 +1,30 @@
+"""SDD (Spec-Driven Development) tooling.
+
+Public surface:
+
+- :class:`bernstein.sdd.validator.ValidationReport`
+- :func:`bernstein.sdd.validator.validate_ticket`
+- :func:`bernstein.sdd.validator.load_schema`
+"""
+
+from __future__ import annotations
+
+from bernstein.sdd.validator import (
+    SchemaNotFoundError,
+    ValidationIssue,
+    ValidationReport,
+    list_recommended_keys,
+    load_schema,
+    validate_ticket,
+    validate_ticket_metadata,
+)
+
+__all__ = [
+    "SchemaNotFoundError",
+    "ValidationIssue",
+    "ValidationReport",
+    "list_recommended_keys",
+    "load_schema",
+    "validate_ticket",
+    "validate_ticket_metadata",
+]

--- a/src/bernstein/sdd/schema/__init__.py
+++ b/src/bernstein/sdd/schema/__init__.py
@@ -1,0 +1,8 @@
+"""Packaged SDD schemas (JSON Schema Draft-07).
+
+Files in this directory ship in the wheel and are loaded via
+``importlib.resources``. Do not move them - downstream tools rely on
+the import path ``bernstein.sdd.schema``.
+"""
+
+from __future__ import annotations

--- a/src/bernstein/sdd/schema/ticket.v1.json
+++ b/src/bernstein/sdd/schema/ticket.v1.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://bernstein.run/schema/sdd/ticket.v1.json",
+  "title": "Bernstein SDD Ticket v1",
+  "description": "Frontmatter schema for .sdd/backlog tickets used by Bernstein and downstream projects.",
+  "type": "object",
+  "required": ["id", "created", "status", "priority", "effort"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{2,80}$",
+      "description": "Lowercase slug. 3-81 chars, must start with [a-z0-9]."
+    },
+    "created": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO-8601 calendar date (YYYY-MM-DD)."
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "open",
+        "claimed",
+        "in_progress",
+        "blocked",
+        "closed",
+        "closed_hit",
+        "closed_miss",
+        "closed_partial",
+        "deduped",
+        "superseded"
+      ]
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["P0", "P1", "P2"]
+    },
+    "effort": {
+      "type": "string",
+      "enum": ["S", "M", "L"]
+    },
+    "owner": {
+      "type": ["string", "null"]
+    },
+    "success_metric": {
+      "type": "object",
+      "required": ["name", "current", "target", "window_days"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "current": {},
+        "target": {},
+        "window_days": {"type": "integer", "minimum": 1}
+      },
+      "additionalProperties": true
+    },
+    "acceptance_criteria": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1},
+      "minItems": 1
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["source"],
+        "properties": {
+          "source": {"type": "string", "minLength": 1},
+          "rows_cited": {"type": ["integer", "string"]},
+          "value": {}
+        },
+        "additionalProperties": true
+      }
+    },
+    "risk": {"type": "string"},
+    "rice": {
+      "type": "object",
+      "properties": {
+        "reach": {"type": "number", "minimum": 0},
+        "impact": {"type": "number", "minimum": 0},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "effort_days": {"type": "number", "minimum": 0.25},
+        "score": {"type": "number"}
+      },
+      "additionalProperties": true
+    },
+    "ladder_to": {"type": "string"},
+    "tags": {
+      "type": "array",
+      "items": {"type": "string", "minLength": 1}
+    },
+    "title": {"type": "string"},
+    "role": {"type": "string"},
+    "scope": {"type": "string"},
+    "complexity": {"type": "string"},
+    "type": {"type": "string"}
+  },
+  "additionalProperties": true
+}

--- a/src/bernstein/sdd/validator.py
+++ b/src/bernstein/sdd/validator.py
@@ -1,0 +1,385 @@
+"""JSON-Schema validator for SDD ticket frontmatter.
+
+The schema lives next to this module under ``bernstein.sdd.schema`` and ships
+in the wheel. It is loaded via :mod:`importlib.resources` so installed packages
+work without a source checkout.
+
+Public surface:
+
+- :class:`ValidationReport`  - per-file result.
+- :class:`ValidationIssue`   - single error / warning entry.
+- :func:`validate_ticket`    - validate one file on disk.
+- :func:`validate_ticket_metadata`  - validate an already-parsed mapping.
+- :func:`load_schema`        - load a packaged schema by version label.
+- :class:`SchemaNotFoundError`  - raised when an unknown version is requested.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from typing import Any, cast
+
+import jsonschema
+import yaml
+from jsonschema import FormatChecker
+
+__all__ = [
+    "RECOMMENDED_KEYS",
+    "SchemaNotFoundError",
+    "ValidationIssue",
+    "ValidationReport",
+    "list_recommended_keys",
+    "load_schema",
+    "parse_frontmatter",
+    "validate_ticket",
+    "validate_ticket_metadata",
+]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Recommended (non-required) keys. Missing keys produce warnings, not errors.
+RECOMMENDED_KEYS: tuple[str, ...] = (
+    "owner",
+    "success_metric",
+    "acceptance_criteria",
+    "evidence",
+    "risk",
+    "rice",
+    "ladder_to",
+)
+
+_SCHEMA_PACKAGE = "bernstein.sdd.schema"
+_SCHEMA_FILENAME_TEMPLATE = "ticket.{version}.json"
+_FRONTMATTER_DELIM = "---"
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class SchemaNotFoundError(LookupError):
+    """Raised when the requested schema version is not packaged."""
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A single validation issue (error or warning)."""
+
+    message: str
+    path: tuple[str | int, ...] = ()
+    code: str = ""
+
+    def render(self) -> str:
+        """Return a human-readable single line."""
+        prefix = ""
+        if self.path:
+            prefix = ".".join(str(p) for p in self.path) + ": "
+        return f"{prefix}{self.message}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "message": self.message,
+            "path": list(self.path),
+            "code": self.code,
+        }
+
+
+@dataclass
+class ValidationReport:
+    """Per-file validation report."""
+
+    path: Path
+    errors: list[ValidationIssue] = field(default_factory=list[ValidationIssue])
+    warnings: list[ValidationIssue] = field(default_factory=list[ValidationIssue])
+
+    @property
+    def ok(self) -> bool:
+        """True iff there are no errors."""
+        return not self.errors
+
+    @property
+    def status(self) -> str:
+        if self.errors:
+            return "fail"
+        if self.warnings:
+            return "warn"
+        return "ok"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "status": self.status,
+            "errors": [e.to_dict() for e in self.errors],
+            "warnings": [w.to_dict() for w in self.warnings],
+        }
+
+    @classmethod
+    def error(cls, path: Path, message: str, code: str = "") -> ValidationReport:
+        """Build a report containing a single top-level error."""
+        return cls(path=path, errors=[ValidationIssue(message=message, code=code or "parse_error")])
+
+
+# ---------------------------------------------------------------------------
+# Schema loading
+# ---------------------------------------------------------------------------
+
+_SCHEMA_CACHE: dict[str, dict[str, Any]] = {}
+_VERSION_RE = re.compile(r"^v[0-9]+(?:\.[0-9]+)?$")
+
+
+def _coerce_version(version: str) -> str:
+    """Normalize a version label. Strict: must look like ``v1`` or ``v1.2``."""
+    if not version:
+        raise SchemaNotFoundError(f"invalid schema version: {version!r}")
+    if not _VERSION_RE.match(version):
+        raise SchemaNotFoundError(f"invalid schema version: {version!r}")
+    return version
+
+
+def load_schema(version: str = "v1") -> dict[str, Any]:
+    """Load the packaged JSON schema for *version* (e.g. ``"v1"``).
+
+    Raises :class:`SchemaNotFoundError` if the file is not packaged.
+    """
+    canonical = _coerce_version(version)
+    cached = _SCHEMA_CACHE.get(canonical)
+    if cached is not None:
+        return cached
+    filename = _SCHEMA_FILENAME_TEMPLATE.format(version=canonical)
+    try:
+        resource = resources.files(_SCHEMA_PACKAGE).joinpath(filename)
+        if not resource.is_file():
+            raise SchemaNotFoundError(f"schema not found: {filename}")
+        raw = resource.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError) as exc:
+        raise SchemaNotFoundError(f"schema not found: {filename}") from exc
+    try:
+        loaded_raw: Any = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SchemaNotFoundError(f"schema {filename} is not valid JSON: {exc}") from exc
+    if not isinstance(loaded_raw, dict):
+        raise SchemaNotFoundError(f"schema {filename} is not a JSON object")
+    loaded_dict = cast("dict[str, Any]", loaded_raw)
+    loaded: dict[str, Any] = {str(k): v for k, v in loaded_dict.items()}
+    # Sanity-check it really is Draft-07 compatible.
+    jsonschema.Draft7Validator.check_schema(loaded)
+    _SCHEMA_CACHE[canonical] = loaded
+    return loaded
+
+
+def list_recommended_keys(version: str = "v1") -> tuple[str, ...]:
+    """Return the recommended-key list for *version*. Currently version-agnostic."""
+    _coerce_version(version)
+    return RECOMMENDED_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_frontmatter(text: str) -> dict[str, Any] | None:
+    """Extract a YAML frontmatter mapping from *text*.
+
+    Supports three shapes:
+
+    1. Markdown with leading ``---`` fenced frontmatter.
+    2. A ``.yaml`` file whose body is a single mapping (no fences).
+    3. A ``.yaml`` file that opens with ``---`` then a mapping.
+
+    Returns ``None`` if no mapping could be extracted.
+    """
+    if not text:
+        return None
+    stripped = text.lstrip("﻿")  # drop BOM if any
+    # Case 1 / 3: fenced frontmatter at top of file.
+    if stripped.startswith(_FRONTMATTER_DELIM):
+        # Use splitlines to find the closing fence.
+        lines = stripped.splitlines()
+        # Strip the opening fence line (it may contain trailing chars).
+        if lines and lines[0].strip() == _FRONTMATTER_DELIM:
+            body_lines: list[str] = []
+            closed = False
+            for line in lines[1:]:
+                if line.strip() == _FRONTMATTER_DELIM:
+                    closed = True
+                    break
+                body_lines.append(line)
+            # When the closing fence is missing, fall back to the whole tail.
+            fence_body = "\n".join(body_lines) if closed else "\n".join(lines[1:])
+            return _safe_yaml_mapping(fence_body)
+    # Case 2: raw YAML mapping (no fences).
+    return _safe_yaml_mapping(stripped)
+
+
+def _safe_yaml_mapping(text: str) -> dict[str, Any] | None:
+    if not text.strip():
+        return None
+    try:
+        loaded: Any = yaml.safe_load(text)
+    except yaml.YAMLError:
+        return None
+    if isinstance(loaded, dict):
+        # YAML loads keys as Any; coerce to str-keyed for jsonschema.
+        loaded_dict = cast("dict[Any, Any]", loaded)
+        return {str(k): _normalize_yaml_value(v) for k, v in loaded_dict.items()}
+    return None
+
+
+def _normalize_yaml_value(value: Any) -> Any:
+    """Coerce non-JSON YAML scalars into JSON-friendly equivalents.
+
+    PyYAML returns ``datetime.date`` / ``datetime.datetime`` for ISO scalars,
+    which ``jsonschema`` then rejects with ``"is not of type string"``. We
+    normalise those to ISO 8601 strings so ``format: date`` / ``date-time``
+    checks see what the author wrote on disk.
+    """
+    if isinstance(value, _dt.datetime):
+        return value.isoformat()
+    if isinstance(value, _dt.date):
+        return value.isoformat()
+    if isinstance(value, list):
+        items = cast("list[Any]", value)
+        return [_normalize_yaml_value(item) for item in items]
+    if isinstance(value, dict):
+        nested = cast("dict[Any, Any]", value)
+        return {str(k): _normalize_yaml_value(v) for k, v in nested.items()}
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+_format_checker_singleton: FormatChecker | None = None
+
+
+def _format_checker() -> FormatChecker:
+    """Return a shared FormatChecker that validates the ``date`` format strictly.
+
+    The vanilla Draft-07 ``date`` check in ``jsonschema`` only fires when the
+    optional ``strict-rfc3339`` / ``rfc3339-validator`` dependency is installed.
+    To keep behaviour deterministic across environments we register our own
+    ISO-8601 date predicate.
+    """
+    global _format_checker_singleton
+    if _format_checker_singleton is None:
+        fc = FormatChecker()
+
+        @fc.checks("date", ValueError)
+        def _check_date(value: Any) -> bool:
+            if not isinstance(value, str):
+                return False
+            _dt.date.fromisoformat(value)
+            return True
+
+        # Reference the registered checker so static analysers do not flag it.
+        assert _check_date is not None
+        _format_checker_singleton = fc
+    return _format_checker_singleton
+
+
+def _issue_from_error(err: jsonschema.ValidationError) -> ValidationIssue:
+    path_parts: tuple[str | int, ...] = tuple(err.absolute_path)
+    code = err.validator if isinstance(err.validator, str) else ""
+    return ValidationIssue(message=err.message, path=path_parts, code=code)
+
+
+def _missing_recommended(metadata: Mapping[str, Any], keys: tuple[str, ...]) -> list[ValidationIssue]:
+    out: list[ValidationIssue] = []
+    for key in keys:
+        if key not in metadata:
+            out.append(
+                ValidationIssue(
+                    message=f"recommended key missing: {key}",
+                    path=(key,),
+                    code="recommended_missing",
+                )
+            )
+    return out
+
+
+def validate_ticket_metadata(
+    metadata: Mapping[str, Any] | None,
+    *,
+    schema_version: str = "v1",
+    strict: bool = False,
+    path: Path | None = None,
+) -> ValidationReport:
+    """Validate a parsed frontmatter mapping. Mainly for in-memory callers.
+
+    With ``strict=True`` recommended-key warnings are promoted to errors.
+    """
+    target = path if path is not None else Path("<memory>")
+    if metadata is None:
+        return ValidationReport.error(target, "no frontmatter", code="no_frontmatter")
+    # The runtime check is load-bearing: callers reach this branch from
+    # JSON / YAML deserialisation paths that may yield a list or scalar.
+    if not isinstance(metadata, Mapping):  # type: ignore[unreachable]
+        return ValidationReport.error(target, "frontmatter is not a mapping", code="not_mapping")
+
+    schema = load_schema(schema_version)
+    validator: Any = jsonschema.Draft7Validator(schema, format_checker=_format_checker())
+    instance: dict[str, Any] = dict(metadata)
+    raw_errors = cast("list[jsonschema.ValidationError]", list(validator.iter_errors(instance)))
+    errors = [_issue_from_error(e) for e in raw_errors]
+    recommended = _missing_recommended(metadata, RECOMMENDED_KEYS)
+
+    if strict:
+        errors.extend(recommended)
+        return ValidationReport(path=target, errors=errors, warnings=[])
+    return ValidationReport(path=target, errors=errors, warnings=recommended)
+
+
+def validate_ticket(
+    path: Path | str,
+    *,
+    schema_version: str = "v1",
+    strict: bool = False,
+) -> ValidationReport:
+    """Validate a single ticket file on disk.
+
+    The file may be:
+
+    - a markdown file with leading ``---`` fenced frontmatter;
+    - a YAML file with the same ``---`` fences;
+    - a YAML file containing a single mapping (no fences).
+
+    On a parse error or a missing/empty file the returned report has
+    ``ok=False`` and a single error.
+    """
+    target = Path(path)
+    if not target.exists():
+        return ValidationReport.error(target, "file does not exist", code="missing_file")
+    if not target.is_file():
+        return ValidationReport.error(target, "path is not a file", code="not_a_file")
+    try:
+        text = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        return ValidationReport.error(target, f"could not read file: {exc}", code="read_error")
+    metadata = parse_frontmatter(text)
+    if metadata is None:
+        return ValidationReport.error(target, "no frontmatter", code="no_frontmatter")
+    report = validate_ticket_metadata(
+        metadata,
+        schema_version=schema_version,
+        strict=strict,
+        path=target,
+    )
+    return report

--- a/tests/fixtures/sdd_tickets/invalid/bad_date.md
+++ b/tests/fixtures/sdd_tickets/invalid/bad_date.md
@@ -1,0 +1,9 @@
+---
+id: bug-bad-date
+created: "not-a-date"
+status: open
+priority: P1
+effort: M
+---
+
+Created is not an ISO date.

--- a/tests/fixtures/sdd_tickets/invalid/bad_id.md
+++ b/tests/fixtures/sdd_tickets/invalid/bad_id.md
@@ -1,0 +1,9 @@
+---
+id: "BAD ID with spaces"
+created: 2026-05-17
+status: open
+priority: P1
+effort: M
+---
+
+Id violates slug pattern.

--- a/tests/fixtures/sdd_tickets/invalid/bad_status.md
+++ b/tests/fixtures/sdd_tickets/invalid/bad_status.md
@@ -1,0 +1,9 @@
+---
+id: bug-bad-status
+created: 2026-05-17
+status: wip
+priority: P1
+effort: M
+---
+
+Status not in enum.

--- a/tests/fixtures/sdd_tickets/invalid/missing_priority.md
+++ b/tests/fixtures/sdd_tickets/invalid/missing_priority.md
@@ -1,0 +1,8 @@
+---
+id: bug-missing-priority
+created: 2026-05-17
+status: open
+effort: S
+---
+
+Missing required 'priority' key.

--- a/tests/fixtures/sdd_tickets/invalid/no_frontmatter.md
+++ b/tests/fixtures/sdd_tickets/invalid/no_frontmatter.md
@@ -1,0 +1,3 @@
+# no frontmatter at all
+
+Just markdown body without leading fenced YAML.

--- a/tests/fixtures/sdd_tickets/valid/minimal.md
+++ b/tests/fixtures/sdd_tickets/valid/minimal.md
@@ -1,0 +1,11 @@
+---
+id: feat-2026-05-17-minimal
+created: 2026-05-17
+status: open
+priority: P1
+effort: M
+---
+
+# minimal valid ticket
+
+Body content here. This file is used by the SDD ticket validator test suite.

--- a/tests/fixtures/sdd_tickets/valid/rich.md
+++ b/tests/fixtures/sdd_tickets/valid/rich.md
@@ -1,0 +1,33 @@
+---
+id: feat-rich-example
+created: 2026-04-01
+status: in_progress
+priority: P0
+effort: L
+owner: alice
+tags: ["cli", "sdd"]
+acceptance_criteria:
+  - "Schema is loadable"
+  - "Validator exits 1 on failure"
+success_metric:
+  name: "ticket_lint_pass_rate"
+  current: 0.6
+  target: 0.95
+  window_days: 14
+evidence:
+  - source: ".sdd/audit/2026-05-17.md"
+    rows_cited: 12
+    value: "p95 < 0.05"
+risk: "low - schema is additive"
+rice:
+  reach: 100
+  impact: 2.0
+  confidence: 0.8
+  effort_days: 1.5
+  score: 106.7
+ladder_to: "operator-trust"
+---
+
+# rich valid ticket
+
+Used to exercise the recommended-key warning suppression path.

--- a/tests/fixtures/sdd_tickets/valid/yaml_only.yaml
+++ b/tests/fixtures/sdd_tickets/valid/yaml_only.yaml
@@ -1,0 +1,8 @@
+---
+id: feat-yaml-only
+created: 2026-05-01
+status: claimed
+priority: P2
+effort: S
+owner: null
+---

--- a/tests/integration/test_ticket_validate_cli.py
+++ b/tests/integration/test_ticket_validate_cli.py
@@ -1,0 +1,146 @@
+"""Integration tests for the ``bernstein ticket validate`` Click command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.ticket_cmd import ticket_group
+
+FIXTURES = Path(__file__).resolve().parents[1] / "fixtures" / "sdd_tickets"
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_cli_exits_zero_for_valid_minimal_fixture(runner: CliRunner) -> None:
+    result = runner.invoke(
+        ticket_group,
+        ["validate", str(FIXTURES / "valid" / "minimal.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "[OK]" in result.output or "minimal.md" in result.output
+
+
+def test_cli_exits_one_for_invalid_fixture(runner: CliRunner) -> None:
+    result = runner.invoke(
+        ticket_group,
+        ["validate", str(FIXTURES / "invalid" / "bad_status.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "bad_status.md" in result.output
+
+
+def test_cli_glob_expands_multiple_files(runner: CliRunner, tmp_path: Path) -> None:
+    # Compose a small mixed directory and pass a glob.
+    for name in ("minimal.md", "rich.md"):
+        (tmp_path / name).write_text((FIXTURES / "valid" / name).read_text())
+    result = runner.invoke(
+        ticket_group,
+        ["validate", str(tmp_path / "*.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "minimal.md" in result.output
+    assert "rich.md" in result.output
+
+
+def test_cli_glob_mixed_pass_fail_exits_one(runner: CliRunner, tmp_path: Path) -> None:
+    (tmp_path / "ok.md").write_text((FIXTURES / "valid" / "minimal.md").read_text())
+    (tmp_path / "fail.md").write_text((FIXTURES / "invalid" / "bad_status.md").read_text())
+    result = runner.invoke(
+        ticket_group,
+        ["validate", str(tmp_path / "*.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "ok.md" in result.output
+    assert "fail.md" in result.output
+
+
+def test_cli_strict_promotes_warnings_to_errors(runner: CliRunner) -> None:
+    # Minimal fixture passes by default but fails under --strict because
+    # recommended keys are missing.
+    result = runner.invoke(
+        ticket_group,
+        ["validate", "--strict", str(FIXTURES / "valid" / "minimal.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+
+
+def test_cli_strict_on_rich_fixture_still_passes(runner: CliRunner) -> None:
+    result = runner.invoke(
+        ticket_group,
+        ["validate", "--strict", str(FIXTURES / "valid" / "rich.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+
+def test_cli_format_json_emits_machine_readable_payload(runner: CliRunner) -> None:
+    result = runner.invoke(
+        ticket_group,
+        [
+            "validate",
+            "--format",
+            "json",
+            str(FIXTURES / "valid" / "minimal.md"),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["schema"] == "v1"
+    assert payload["summary"]["total"] == 1
+    assert payload["reports"][0]["status"] in {"ok", "warn"}
+
+
+def test_cli_format_json_for_failing_file_exits_one(runner: CliRunner) -> None:
+    result = runner.invoke(
+        ticket_group,
+        [
+            "validate",
+            "--format",
+            "json",
+            str(FIXTURES / "invalid" / "bad_status.md"),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["reports"][0]["status"] == "fail"
+    assert payload["summary"]["fail"] == 1
+
+
+def test_cli_schema_not_found_exits_two(runner: CliRunner) -> None:
+    result = runner.invoke(
+        ticket_group,
+        ["validate", "--schema", "v777", str(FIXTURES / "valid" / "minimal.md")],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 2
+
+
+def test_cli_no_args_errors_out(runner: CliRunner) -> None:
+    result = runner.invoke(ticket_group, ["validate"], catch_exceptions=False)
+    # Click reports missing argument with exit code 2.
+    assert result.exit_code != 0
+
+
+def test_cli_missing_path_reports_as_failure(runner: CliRunner, tmp_path: Path) -> None:
+    nope = tmp_path / "does-not-exist.md"
+    result = runner.invoke(
+        ticket_group,
+        ["validate", str(nope)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "does-not-exist" in result.output

--- a/tests/property/test_ticket_validator_properties.py
+++ b/tests/property/test_ticket_validator_properties.py
@@ -1,0 +1,201 @@
+"""Property-based tests for ``bernstein.sdd.validator``.
+
+We use Hypothesis to bash the schema with a wide range of inputs:
+
+- Slug-pattern boundaries (length, charset).
+- ISO date round-trip vs malformed dates.
+- Enum exhaustiveness (any non-enum string is rejected; every enum value
+  is accepted).
+- Strict mode invariants: report contains no warnings when strict=True.
+- Determinism: validating the same payload twice yields the same outcome.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+import string
+from typing import Any
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.sdd.validator import (
+    RECOMMENDED_KEYS,
+    validate_ticket_metadata,
+)
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,80}$")
+_STATUSES = (
+    "open",
+    "claimed",
+    "in_progress",
+    "blocked",
+    "closed",
+    "closed_hit",
+    "closed_miss",
+    "closed_partial",
+    "deduped",
+    "superseded",
+)
+_PRIORITIES = ("P0", "P1", "P2")
+_EFFORTS = ("S", "M", "L")
+
+
+def _base() -> dict[str, Any]:
+    return {
+        "id": "feat-baseline-id",
+        "created": "2026-05-17",
+        "status": "open",
+        "priority": "P1",
+        "effort": "M",
+    }
+
+
+@st.composite
+def _valid_id(draw: Any) -> str:
+    head = draw(st.sampled_from(list(string.ascii_lowercase + string.digits)))
+    body_len = draw(st.integers(min_value=2, max_value=20))
+    body = draw(
+        st.text(
+            alphabet=st.sampled_from(list(string.ascii_lowercase + string.digits + "-")),
+            min_size=body_len,
+            max_size=body_len,
+        )
+    )
+    return head + body
+
+
+@given(slug=_valid_id())
+def test_property_valid_slug_pattern_accepted(slug: str) -> None:
+    if not _SLUG_RE.match(slug):
+        # Filter out anything that drifted out of pattern by chance.
+        return
+    meta = _base()
+    meta["id"] = slug
+    rep = validate_ticket_metadata(meta)
+    assert rep.ok, [e.render() for e in rep.errors]
+
+
+@given(slug=st.text(min_size=0, max_size=4))
+def test_property_short_slugs_rejected(slug: str) -> None:
+    if _SLUG_RE.match(slug):
+        return
+    meta = _base()
+    meta["id"] = slug
+    rep = validate_ticket_metadata(meta)
+    assert not rep.ok
+
+
+@given(status=st.sampled_from(_STATUSES))
+def test_property_all_enum_statuses_accepted(status: str) -> None:
+    meta = _base()
+    meta["status"] = status
+    rep = validate_ticket_metadata(meta)
+    assert rep.ok
+
+
+@given(status=st.text(min_size=1, max_size=30))
+def test_property_arbitrary_status_strings_rejected_when_not_in_enum(status: str) -> None:
+    if status in _STATUSES:
+        return
+    meta = _base()
+    meta["status"] = status
+    rep = validate_ticket_metadata(meta)
+    assert not rep.ok
+
+
+@given(priority=st.sampled_from(_PRIORITIES), effort=st.sampled_from(_EFFORTS))
+def test_property_priority_effort_combinations(priority: str, effort: str) -> None:
+    meta = _base()
+    meta["priority"] = priority
+    meta["effort"] = effort
+    rep = validate_ticket_metadata(meta)
+    assert rep.ok
+
+
+@given(date_obj=st.dates(min_value=_dt.date(1970, 1, 1), max_value=_dt.date(2099, 12, 31)))
+def test_property_iso_dates_accepted(date_obj: _dt.date) -> None:
+    meta = _base()
+    meta["created"] = date_obj.isoformat()
+    rep = validate_ticket_metadata(meta)
+    assert rep.ok
+
+
+@given(bad=st.text(min_size=1, max_size=15))
+def test_property_non_iso_dates_rejected(bad: str) -> None:
+    try:
+        _dt.date.fromisoformat(bad)
+    except ValueError:
+        meta = _base()
+        meta["created"] = bad
+        rep = validate_ticket_metadata(meta)
+        assert not rep.ok
+
+
+@given(
+    extra=st.dictionaries(
+        keys=st.text(
+            alphabet=st.sampled_from(list(string.ascii_lowercase + "_")),
+            min_size=1,
+            max_size=10,
+        ).filter(lambda k: k not in RECOMMENDED_KEYS and k not in _base()),
+        values=st.one_of(st.text(max_size=10), st.integers(), st.booleans(), st.none()),
+        max_size=5,
+    )
+)
+def test_property_extra_keys_do_not_break_validation(extra: dict[str, Any]) -> None:
+    meta = {**_base(), **extra}
+    rep = validate_ticket_metadata(meta)
+    assert rep.ok
+
+
+@given(missing=st.sampled_from(["id", "created", "status", "priority", "effort"]))
+def test_property_each_required_key_removed_causes_failure(missing: str) -> None:
+    meta = _base()
+    del meta[missing]
+    rep = validate_ticket_metadata(meta)
+    assert not rep.ok
+    assert any(missing in e.message for e in rep.errors)
+
+
+@given(window_days=st.integers(min_value=-10, max_value=0))
+def test_property_success_metric_nonpositive_window_rejected(window_days: int) -> None:
+    meta = _base()
+    meta["success_metric"] = {
+        "name": "x",
+        "current": 1,
+        "target": 2,
+        "window_days": window_days,
+    }
+    rep = validate_ticket_metadata(meta)
+    assert not rep.ok
+
+
+@given(confidence=st.floats(min_value=1.0001, max_value=10.0, allow_nan=False, allow_infinity=False))
+def test_property_rice_confidence_above_one_rejected(confidence: float) -> None:
+    meta = _base()
+    meta["rice"] = {"confidence": confidence}
+    rep = validate_ticket_metadata(meta)
+    assert not rep.ok
+
+
+@given(
+    strict=st.booleans(),
+)
+def test_property_strict_invariant_no_warnings(strict: bool) -> None:
+    rep = validate_ticket_metadata(_base(), strict=strict)
+    if strict:
+        # Strict mode never emits warnings - everything is an error or nothing.
+        assert rep.warnings == []
+    else:
+        # Default mode emits a warning for every missing recommended key.
+        assert len(rep.warnings) == len(RECOMMENDED_KEYS)
+
+
+@given(payload=st.dictionaries(st.text(max_size=10), st.text(max_size=10), max_size=10))
+def test_property_validate_metadata_is_deterministic(payload: dict[str, str]) -> None:
+    rep_a = validate_ticket_metadata(payload)
+    rep_b = validate_ticket_metadata(payload)
+    assert rep_a.ok == rep_b.ok
+    assert len(rep_a.errors) == len(rep_b.errors)

--- a/tests/unit/sdd/test_validator.py
+++ b/tests/unit/sdd/test_validator.py
@@ -1,0 +1,581 @@
+"""Unit tests for ``bernstein.sdd.validator``.
+
+Coverage:
+
+- Schema load: cache, version normalisation, error paths.
+- Frontmatter parser: fenced markdown, raw YAML, BOM, empty body, malformed YAML.
+- Validation: each required-key omission, enum violations, format checks,
+  recommended-key warnings, strict mode promotion, nested mappings.
+- File-on-disk paths: missing file, directory, unreadable, .yaml extension.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import pytest
+
+from bernstein.sdd import (
+    SchemaNotFoundError,
+    ValidationIssue,
+    ValidationReport,
+    list_recommended_keys,
+    load_schema,
+    validate_ticket,
+    validate_ticket_metadata,
+)
+from bernstein.sdd.validator import (
+    RECOMMENDED_KEYS,
+    parse_frontmatter,
+)
+
+FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "sdd_tickets"
+
+
+def _minimal_meta() -> dict[str, Any]:
+    return {
+        "id": "feat-2026-05-17-min",
+        "created": "2026-05-17",
+        "status": "open",
+        "priority": "P1",
+        "effort": "M",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema loading (5 tests)
+# ---------------------------------------------------------------------------
+
+
+def test_load_schema_v1_returns_object() -> None:
+    schema = load_schema("v1")
+    assert isinstance(schema, dict)
+    assert schema["$schema"].startswith("http://json-schema.org/draft-07")
+    assert "id" in schema["required"]
+
+
+def test_load_schema_caches_result() -> None:
+    a = load_schema("v1")
+    b = load_schema("v1")
+    assert a is b
+
+
+def test_load_schema_unknown_version_raises() -> None:
+    with pytest.raises(SchemaNotFoundError):
+        load_schema("v999")
+
+
+def test_load_schema_invalid_version_label_raises() -> None:
+    with pytest.raises(SchemaNotFoundError):
+        load_schema("not-a-version")
+
+
+def test_load_schema_resource_importable_from_installed_package() -> None:
+    # Equivalent to how a downstream wheel-installed consumer would load it.
+    pkg = resources.files("bernstein.sdd.schema")
+    found = pkg.joinpath("ticket.v1.json")
+    assert found.is_file()
+    payload = json.loads(found.read_text(encoding="utf-8"))
+    jsonschema.Draft7Validator.check_schema(payload)
+
+
+# ---------------------------------------------------------------------------
+# Recommended keys helper
+# ---------------------------------------------------------------------------
+
+
+def test_recommended_keys_list_is_stable() -> None:
+    assert list_recommended_keys("v1") == RECOMMENDED_KEYS
+    assert "owner" in RECOMMENDED_KEYS
+    assert "rice" in RECOMMENDED_KEYS
+
+
+def test_recommended_keys_invalid_label_raises() -> None:
+    with pytest.raises(SchemaNotFoundError):
+        list_recommended_keys("not-a-version")
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_frontmatter_returns_none_for_empty() -> None:
+    assert parse_frontmatter("") is None
+
+
+def test_parse_frontmatter_returns_none_for_whitespace() -> None:
+    assert parse_frontmatter("   \n  \n") is None
+
+
+def test_parse_frontmatter_fenced_md() -> None:
+    text = "---\nid: foo\ncreated: 2026-05-17\n---\nbody\n"
+    out = parse_frontmatter(text)
+    assert out is not None
+    assert out["id"] == "foo"
+    assert out["created"] == "2026-05-17"
+
+
+def test_parse_frontmatter_unclosed_fence_consumes_tail() -> None:
+    text = "---\nid: foo\ncreated: 2026-05-17\nstatus: open\n"
+    out = parse_frontmatter(text)
+    assert out is not None
+    assert out["id"] == "foo"
+    assert out["status"] == "open"
+
+
+def test_parse_frontmatter_yaml_only_with_fence() -> None:
+    text = "---\nid: foo\nstatus: open\n---\n"
+    out = parse_frontmatter(text)
+    assert out is not None
+    assert out["status"] == "open"
+
+
+def test_parse_frontmatter_raw_yaml_mapping() -> None:
+    out = parse_frontmatter("id: bar\nstatus: open\n")
+    assert out is not None
+    assert out["id"] == "bar"
+
+
+def test_parse_frontmatter_returns_none_for_scalar() -> None:
+    assert parse_frontmatter("just a string\n") is None
+
+
+def test_parse_frontmatter_returns_none_for_list() -> None:
+    assert parse_frontmatter("- one\n- two\n") is None
+
+
+def test_parse_frontmatter_handles_bom() -> None:
+    text = "﻿---\nid: bom\nstatus: open\n---\n"
+    out = parse_frontmatter(text)
+    assert out is not None
+    assert out["id"] == "bom"
+
+
+def test_parse_frontmatter_invalid_yaml_returns_none() -> None:
+    out = parse_frontmatter("---\nid: : :\n bad: [unterminated\n---\n")
+    assert out is None
+
+
+def test_parse_frontmatter_coerces_date_scalar_to_iso_string() -> None:
+    out = parse_frontmatter("---\nid: x\ncreated: 2026-05-17\n---\n")
+    assert out is not None
+    assert isinstance(out["created"], str)
+    assert out["created"] == "2026-05-17"
+
+
+# ---------------------------------------------------------------------------
+# Required keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("missing_key", ["id", "created", "status", "priority", "effort"])
+def test_required_key_missing_yields_error(missing_key: str) -> None:
+    meta = _minimal_meta()
+    del meta[missing_key]
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+    assert any(missing_key in e.message for e in report.errors)
+
+
+# ---------------------------------------------------------------------------
+# Enum and pattern violations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_status", ["wip", "WIP", "done", "", "OPEN"])
+def test_invalid_status_rejected(bad_status: str) -> None:
+    meta = _minimal_meta()
+    meta["status"] = bad_status
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+@pytest.mark.parametrize("bad_priority", ["P3", "p1", "high", "1"])
+def test_invalid_priority_rejected(bad_priority: str) -> None:
+    meta = _minimal_meta()
+    meta["priority"] = bad_priority
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+@pytest.mark.parametrize("bad_effort", ["XL", "xl", "small", "1", ""])
+def test_invalid_effort_rejected(bad_effort: str) -> None:
+    meta = _minimal_meta()
+    meta["effort"] = bad_effort
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    ["AB", "x", "BAD", "has space", "has_underscore", "-starts-with-dash", "UPPER-CASE"],
+)
+def test_invalid_id_pattern_rejected(bad_id: str) -> None:
+    meta = _minimal_meta()
+    meta["id"] = bad_id
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+@pytest.mark.parametrize(
+    "ok_id",
+    ["abc", "feat-x", "2026-05-17-foo", "feat-2026-05-17-bernstein-ticket-validate-cmd"],
+)
+def test_valid_id_pattern_accepted(ok_id: str) -> None:
+    meta = _minimal_meta()
+    meta["id"] = ok_id
+    report = validate_ticket_metadata(meta, strict=False)
+    assert report.ok
+
+
+def test_invalid_date_rejected() -> None:
+    meta = _minimal_meta()
+    meta["created"] = "not-a-date"
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_invalid_date_shape_rejected() -> None:
+    meta = _minimal_meta()
+    meta["created"] = "2026-13-40"
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_date_must_be_string_not_int() -> None:
+    meta = _minimal_meta()
+    meta["created"] = 2026
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+# ---------------------------------------------------------------------------
+# Nested objects (rice / success_metric)
+# ---------------------------------------------------------------------------
+
+
+def test_rice_confidence_out_of_range_rejected() -> None:
+    meta = _minimal_meta()
+    meta["rice"] = {"reach": 10, "impact": 1, "confidence": 1.5, "effort_days": 1}
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_rice_effort_days_below_minimum_rejected() -> None:
+    meta = _minimal_meta()
+    meta["rice"] = {"effort_days": 0.1}
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_rice_accepted_when_all_in_range() -> None:
+    meta = _minimal_meta()
+    meta["rice"] = {"reach": 10, "impact": 1.5, "confidence": 0.8, "effort_days": 1, "score": 12}
+    report = validate_ticket_metadata(meta)
+    assert report.ok
+
+
+def test_success_metric_missing_required_subkey_rejected() -> None:
+    meta = _minimal_meta()
+    meta["success_metric"] = {"name": "x", "current": 1, "target": 2}  # window_days missing
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_success_metric_window_days_zero_rejected() -> None:
+    meta = _minimal_meta()
+    meta["success_metric"] = {"name": "x", "current": 1, "target": 2, "window_days": 0}
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_success_metric_accepts_well_formed_object() -> None:
+    meta = _minimal_meta()
+    meta["success_metric"] = {"name": "x", "current": 1, "target": 2, "window_days": 7}
+    report = validate_ticket_metadata(meta)
+    assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# Owner / acceptance_criteria / evidence
+# ---------------------------------------------------------------------------
+
+
+def test_owner_accepts_string() -> None:
+    meta = _minimal_meta()
+    meta["owner"] = "alice"
+    report = validate_ticket_metadata(meta)
+    assert report.ok
+
+
+def test_owner_accepts_null() -> None:
+    meta = _minimal_meta()
+    meta["owner"] = None
+    report = validate_ticket_metadata(meta)
+    assert report.ok
+
+
+def test_owner_rejects_integer() -> None:
+    meta = _minimal_meta()
+    meta["owner"] = 7
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_acceptance_criteria_empty_array_rejected() -> None:
+    meta = _minimal_meta()
+    meta["acceptance_criteria"] = []
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_acceptance_criteria_with_blank_item_rejected() -> None:
+    meta = _minimal_meta()
+    meta["acceptance_criteria"] = [""]
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+def test_evidence_item_requires_source() -> None:
+    meta = _minimal_meta()
+    meta["evidence"] = [{"rows_cited": 5}]
+    report = validate_ticket_metadata(meta)
+    assert not report.ok
+
+
+# ---------------------------------------------------------------------------
+# Recommended-key warnings + strict mode promotion
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_ticket_emits_recommended_warnings() -> None:
+    report = validate_ticket_metadata(_minimal_meta(), strict=False)
+    assert report.ok
+    warning_paths = {tuple(w.path) for w in report.warnings}
+    for key in RECOMMENDED_KEYS:
+        assert (key,) in warning_paths
+
+
+def test_strict_mode_promotes_warnings_to_errors() -> None:
+    report = validate_ticket_metadata(_minimal_meta(), strict=True)
+    assert not report.ok
+    assert not report.warnings
+    err_paths = {tuple(e.path) for e in report.errors}
+    for key in RECOMMENDED_KEYS:
+        assert (key,) in err_paths
+
+
+def test_full_ticket_no_warnings_no_errors() -> None:
+    meta = _minimal_meta()
+    meta["owner"] = "alice"
+    meta["success_metric"] = {
+        "name": "lint_pass",
+        "current": 0.5,
+        "target": 0.9,
+        "window_days": 7,
+    }
+    meta["acceptance_criteria"] = ["c1", "c2"]
+    meta["evidence"] = [{"source": "audit.md", "rows_cited": 1, "value": "ok"}]
+    meta["risk"] = "low"
+    meta["rice"] = {"reach": 1, "impact": 1, "confidence": 0.7, "effort_days": 1, "score": 1}
+    meta["ladder_to"] = "trust"
+    report = validate_ticket_metadata(meta, strict=False)
+    assert report.ok
+    assert not report.warnings
+
+
+# ---------------------------------------------------------------------------
+# Report dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_validation_report_to_dict_round_trip() -> None:
+    report = validate_ticket_metadata({"id": "x"}, strict=False, path=Path("foo.md"))
+    payload = report.to_dict()
+    assert payload["path"] == "foo.md"
+    assert payload["status"] in {"fail", "warn", "ok"}
+    assert isinstance(payload["errors"], list)
+    assert isinstance(payload["warnings"], list)
+
+
+def test_validation_issue_render_path_present() -> None:
+    issue = ValidationIssue(message="must be string", path=("rice", "score"), code="type")
+    assert issue.render().startswith("rice.score:")
+
+
+def test_validation_issue_render_path_empty() -> None:
+    issue = ValidationIssue(message="top-level fail")
+    assert issue.render() == "top-level fail"
+
+
+def test_validation_report_error_factory() -> None:
+    r = ValidationReport.error(Path("x.md"), "no frontmatter")
+    assert r.status == "fail"
+    assert r.errors[0].code == "parse_error"
+
+
+def test_metadata_none_returns_error_report() -> None:
+    r = validate_ticket_metadata(None)
+    assert not r.ok
+    assert "frontmatter" in r.errors[0].message
+
+
+def test_metadata_non_mapping_returns_error_report() -> None:
+    r = validate_ticket_metadata([1, 2, 3])  # type: ignore[arg-type]
+    assert not r.ok
+
+
+# ---------------------------------------------------------------------------
+# File-on-disk paths
+# ---------------------------------------------------------------------------
+
+
+def test_validate_ticket_missing_file(tmp_path: Path) -> None:
+    r = validate_ticket(tmp_path / "nope.md")
+    assert not r.ok
+    assert r.errors[0].code == "missing_file"
+
+
+def test_validate_ticket_directory(tmp_path: Path) -> None:
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    r = validate_ticket(sub)
+    assert not r.ok
+    assert r.errors[0].code == "not_a_file"
+
+
+def test_validate_ticket_empty_file_reports_no_frontmatter(tmp_path: Path) -> None:
+    p = tmp_path / "empty.md"
+    p.write_text("")
+    r = validate_ticket(p)
+    assert not r.ok
+    assert r.errors[0].code == "no_frontmatter"
+
+
+def test_validate_ticket_no_frontmatter_reports_error() -> None:
+    r = validate_ticket(FIXTURES / "invalid" / "no_frontmatter.md")
+    assert not r.ok
+    assert r.errors[0].code == "no_frontmatter"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["minimal.md", "rich.md", "yaml_only.yaml"],
+)
+def test_valid_fixtures_pass(filename: str) -> None:
+    r = validate_ticket(FIXTURES / "valid" / filename)
+    assert r.ok, f"{filename} should be valid, got errors: {[e.render() for e in r.errors]}"
+
+
+def test_rich_fixture_has_no_warnings() -> None:
+    r = validate_ticket(FIXTURES / "valid" / "rich.md")
+    assert r.ok
+    assert not r.warnings
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "missing_priority.md",
+        "bad_status.md",
+        "bad_id.md",
+        "bad_date.md",
+        "no_frontmatter.md",
+        "empty.md",
+    ],
+)
+def test_invalid_fixtures_fail(filename: str) -> None:
+    r = validate_ticket(FIXTURES / "invalid" / filename)
+    assert not r.ok
+
+
+def test_validate_ticket_strict_mode_on_minimal_fixture() -> None:
+    r = validate_ticket(FIXTURES / "valid" / "minimal.md", strict=True)
+    assert not r.ok  # minimal lacks recommended keys
+
+
+def test_validate_ticket_strict_mode_on_rich_fixture_passes() -> None:
+    r = validate_ticket(FIXTURES / "valid" / "rich.md", strict=True)
+    assert r.ok
+
+
+def test_validate_ticket_unknown_schema_raises_lookup() -> None:
+    with pytest.raises(SchemaNotFoundError):
+        validate_ticket(FIXTURES / "valid" / "minimal.md", schema_version="v123")
+
+
+def test_validate_ticket_metadata_preserves_path_field() -> None:
+    p = Path("/tmp/x.md")
+    r = validate_ticket_metadata(_minimal_meta(), path=p)
+    assert r.path == p
+
+
+def test_validate_ticket_metadata_string_path_coerced() -> None:
+    r = validate_ticket(str(FIXTURES / "valid" / "minimal.md"))
+    assert r.ok
+
+
+def test_deep_copy_of_metadata_is_not_mutated() -> None:
+    meta = _minimal_meta()
+    original = deepcopy(meta)
+    validate_ticket_metadata(meta)
+    assert meta == original
+
+
+# ---------------------------------------------------------------------------
+# Smoke / regression
+# ---------------------------------------------------------------------------
+
+
+def test_status_enum_includes_closed_hit() -> None:
+    meta = _minimal_meta()
+    meta["status"] = "closed_hit"
+    r = validate_ticket_metadata(meta)
+    assert r.ok
+
+
+def test_status_enum_includes_superseded() -> None:
+    meta = _minimal_meta()
+    meta["status"] = "superseded"
+    r = validate_ticket_metadata(meta)
+    assert r.ok
+
+
+def test_extra_unknown_keys_allowed() -> None:
+    meta = _minimal_meta()
+    meta["some_future_key"] = "anything"
+    meta["another"] = {"nested": True}
+    r = validate_ticket_metadata(meta)
+    assert r.ok
+
+
+def test_report_status_label_ordering() -> None:
+    r_ok = validate_ticket_metadata(
+        {
+            **_minimal_meta(),
+            **{
+                "owner": "x",
+                "success_metric": {"name": "x", "current": 1, "target": 2, "window_days": 1},
+                "acceptance_criteria": ["a"],
+                "evidence": [{"source": "s"}],
+                "risk": "low",
+                "rice": {},
+                "ladder_to": "x",
+            },
+        }
+    )
+    assert r_ok.status == "ok"
+
+    r_warn = validate_ticket_metadata(_minimal_meta())
+    assert r_warn.status == "warn"
+
+    bad = _minimal_meta()
+    bad["status"] = "wip"
+    r_fail = validate_ticket_metadata(bad)
+    assert r_fail.status == "fail"

--- a/uv.lock
+++ b/uv.lock
@@ -245,6 +245,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyfiglet" },
     { name = "python-dotenv" },
+    { name = "python-frontmatter" },
     { name = "pyyaml" },
     { name = "reportlab" },
     { name = "rich" },
@@ -379,7 +380,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'eval'", specifier = ">=0.24" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },
-    { name = "jsonschema", specifier = ">=4.17" },
+    { name = "jsonschema", specifier = ">=4.20" },
     { name = "keyring", specifier = ">=25.0" },
     { name = "kubernetes", marker = "extra == 'k8s'", specifier = ">=35.0.0" },
     { name = "mcp", specifier = ">=1.0" },
@@ -406,6 +407,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.4.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-frontmatter", specifier = ">=1.1" },
     { name = "python-telegram-bot", marker = "extra == 'telegram'", specifier = ">=22.7" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "reportlab", specifier = ">=4.0,<5" },
@@ -3452,6 +3454,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/de/910fa208120314a12f9a88ea63e03707261692af782c99283f1a2c8a5e6f/python-frontmatter-1.1.0.tar.gz", hash = "sha256:7118d2bd56af9149625745c58c9b51fb67e8d1294a0c76796dafdc72c36e5f6d", size = 16256, upload-time = "2024-01-16T18:50:04.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/87/3c8da047b3ec5f99511d1b4d7a5bc72d4b98751c7e78492d14dc736319c5/python_frontmatter-1.1.0-py3-none-any.whl", hash = "sha256:335465556358d9d0e6c98bbeb69b1c969f2a4a21360587b9873bfc3b213407c1", size = 9834, upload-time = "2024-01-16T18:50:00.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Ships a portable Draft-07 JSON Schema for `.sdd/backlog` ticket frontmatter inside the wheel at `bernstein/sdd/schema/ticket.v1.json`, loadable from any installed package via `importlib.resources`.
- Adds `bernstein ticket validate <path|glob>` Click command with `--strict`, `--schema v1`, `--format json`. Exit codes: `0` pass, `1` fail, `2` schema not found.
- Includes recommended-key warnings (`owner`, `success_metric`, `acceptance_criteria`, `evidence`, `risk`, `rice`, `ladder_to`) that `--strict` promotes to errors. Custom `FormatChecker` enforces the `date` format without needing `rfc3339-validator`.

Closes spec `.sdd/backlog/open/2026-05-17-feat-bernstein-ticket-validate-command.yaml`.

## Acceptance criteria coverage

- [x] `bernstein ticket validate` registered + reachable from CLI (via existing `ticket_group` in `ticket_cmd.py`)
- [x] `ticket.v1.json` schema present + valid Draft-07
- [x] Glob input works; per-file report rendered
- [x] Exit code `1` on any failure, `0` otherwise, `2` on schema-not-found
- [x] `--strict` promotes warnings to errors
- [x] `--format json` outputs machine-readable per-file results plus a summary
- [x] Schema is packaged in the wheel (`src/bernstein/sdd/schema/*.json` pinned in `tool.hatch.build.targets.wheel` artifacts) and loadable from an installed package
- [x] Documentation at `docs/sdd/ticket_schema.md`
- [x] Tests cover valid + invalid + strict + glob + schema-not-found

## Test plan

- [x] `uv run pytest tests/unit/sdd/ -x -q` -> 96 passed
- [x] `uv run pytest tests/property/test_ticket_validator_properties.py -x -q` -> 13 passed
- [x] `uv run pytest tests/integration/test_ticket_validate_cli.py -x -q` -> 11 passed
- [x] `uv run ruff check` on touched files -> clean
- [x] `uv run pyright` on `src/bernstein/sdd/` -> no new errors (pre-existing errors in unchanged `_do_import` path)
- [x] `uv run bernstein ticket validate <fixture>` smoke-tested end-to-end