### PR TITLE
feat(errors): structured first-run categorization with actionable hints (closes spec 2026-05-17)

### DIFF
--- a/src/bernstein/cli/first_run_guard.py
+++ b/src/bernstein/cli/first_run_guard.py
@@ -1,0 +1,116 @@
+"""First-run guard helpers wiring categorisation into CLI entry points.
+
+This module provides a single function, :func:`handle_first_run_exception`,
+that maps a raw exception from a top-level Click command body into:
+
+1. A structured :class:`bernstein.core.errors.ErrorCategory`.
+2. A Rich-formatted hint panel rendered to stderr.
+3. A ``SystemExit`` carrying the sysexits.h exit code for that category.
+
+The verbose flag retains the original traceback after the hint panel;
+the default mode hides it.
+
+Callers wrap the command body::
+
+    @click.command()
+    @click.pass_context
+    def my_cmd(ctx: click.Context, ...) -> None:
+        try:
+            _impl()
+        except BaseException as exc:
+            handle_first_run_exception(exc, verbose=ctx.obj.get("VERBOSE", False))
+"""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+import click
+from rich.console import Console
+
+from bernstein.core.errors import (
+    BernsteinFirstRunError,
+    ErrorCategory,
+    HintContext,
+    categorize_exception,
+    exit_code_for,
+    render_hint,
+)
+
+_stderr_console = Console(stderr=True)
+
+
+def _context_from_exception(exc: BaseException) -> HintContext:
+    """Best-effort extraction of hint context from an exception's attributes.
+
+    The categorisation taxonomy is closed, but the hint renderer benefits
+    from any extra context the exception happens to carry (adapter name,
+    env var, port number, file path).
+    """
+    ctx: HintContext = {}
+    adapter = getattr(exc, "adapter", None)
+    if isinstance(adapter, str) and adapter:
+        ctx["adapter"] = adapter
+    env_var = getattr(exc, "env_var", None)
+    if isinstance(env_var, str) and env_var:
+        ctx["env_var"] = env_var
+    install_hint = getattr(exc, "install_hint", None)
+    if isinstance(install_hint, str) and install_hint:
+        ctx["package_manager_command"] = install_hint
+    filename = getattr(exc, "filename", None)
+    if isinstance(filename, str) and filename:
+        ctx["path"] = filename
+    if isinstance(exc, BernsteinFirstRunError):
+        # The typed first-run error already carries an authoritative ctx.
+        for key, value in exc.context.items():
+            if value is None or value == "":
+                continue
+            ctx[key] = value  # type: ignore[literal-required]
+    return ctx
+
+
+def handle_first_run_exception(
+    exc: BaseException,
+    *,
+    verbose: bool = False,
+    console: Console | None = None,
+) -> NoReturn:
+    """Render a hint and raise :class:`SystemExit` with the category's exit code.
+
+    Click's command runner catches :class:`SystemExit` and propagates it
+    through its standard exit path, so callers can use this from inside a
+    command body without disturbing Click's traceback behaviour.
+
+    Args:
+        exc: The raw exception caught at the top of a Click command body.
+        verbose: When True, the original traceback is rendered below the
+            hint panel.  When False, the traceback is hidden.
+        console: Optional Rich console (defaults to a stderr console).
+
+    Raises:
+        SystemExit: Always, with ``code`` set to the sysexits.h exit code
+            for the category derived from ``exc``.
+    """
+    # ``click.UsageError`` already has Click's own pretty handler; defer
+    # to it so option/argument errors keep their familiar shape.
+    if isinstance(exc, click.UsageError):
+        raise exc
+    # Honour an explicit ``SystemExit`` raised by inner code; do not
+    # overwrite the operator's chosen exit code with a categorised one.
+    if isinstance(exc, SystemExit):
+        raise exc
+
+    category = categorize_exception(exc)
+    ctx = _context_from_exception(exc)
+    target = console or _stderr_console
+    render_hint(target, category, exc=exc, context=ctx, verbose=verbose)
+    raise SystemExit(exit_code_for(category))
+
+
+def category_for(exc: BaseException) -> ErrorCategory:
+    """Re-export of :func:`bernstein.core.errors.categorize_exception`.
+
+    Provided so call sites in ``cli/`` can ``from .first_run_guard import``
+    a single symbol when they only need the structured category.
+    """
+    return categorize_exception(exc)

--- a/src/bernstein/cli/install_check.py
+++ b/src/bernstein/cli/install_check.py
@@ -2,6 +2,9 @@
 
 Checks for duplicate bernstein binaries in PATH, version mismatches between
 config and installed package, and unavailable features referenced in config.
+
+Each failing check carries an :class:`ErrorCategory` so callers can map it
+to a sysexits.h exit code via :func:`bernstein.core.errors.exit_code_for`.
 """
 
 from __future__ import annotations
@@ -9,8 +12,10 @@ from __future__ import annotations
 import importlib.metadata
 import logging
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+from bernstein.core.errors import ErrorCategory
 
 _INSTALLATIONS_LABEL = "Bernstein installations"
 
@@ -19,12 +24,52 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class InstallWarning:
-    """A single installation mismatch result."""
+    """A single installation mismatch result.
+
+    Attributes:
+        name: Short label for the check (e.g. ``Bernstein installations``).
+        ok: True when the check passed.
+        detail: Operator-visible detail string.
+        fix: Optional actionable next step.
+        category: Structured error category when ``ok`` is False; ignored
+            otherwise.
+    """
 
     name: str
     ok: bool
     detail: str
     fix: str = ""
+    category: ErrorCategory = field(default=ErrorCategory.UNKNOWN)
+
+
+def worst_category(warnings: list[InstallWarning]) -> ErrorCategory | None:
+    """Return the most-actionable category from a list of warnings.
+
+    Falsy-OK warnings without a category are skipped. The priority order
+    favours user-fixable failures (DEPENDENCY_MISSING) over diagnostic
+    ones (UNKNOWN).
+
+    Args:
+        warnings: The list returned by :func:`check_installations`.
+
+    Returns:
+        The selected category, or ``None`` if every check passed.
+    """
+    priority: list[ErrorCategory] = [
+        ErrorCategory.DEPENDENCY_MISSING,
+        ErrorCategory.CONFIG_MISSING,
+        ErrorCategory.PERMISSION_DENIED,
+        ErrorCategory.AUTH_FAILED,
+        ErrorCategory.PORT_CONFLICT,
+        ErrorCategory.TIMEOUT,
+        ErrorCategory.MODEL_UNREACHABLE,
+        ErrorCategory.UNKNOWN,
+    ]
+    seen: set[ErrorCategory] = {w.category for w in warnings if not w.ok}
+    for cat in priority:
+        if cat in seen:
+            return cat
+    return None
 
 
 def check_installations() -> list[InstallWarning]:
@@ -45,6 +90,7 @@ def check_installations() -> list[InstallWarning]:
                 ok=False,
                 detail=f"found {len(bernstein_paths)} installations: {paths_str}",
                 fix="Uninstall duplicates or adjust PATH to prioritize one installation",
+                category=ErrorCategory.DEPENDENCY_MISSING,
             )
         )
     else:
@@ -63,6 +109,7 @@ def check_installations() -> list[InstallWarning]:
                     ok=False,
                     detail="bernstein not found in PATH",
                     fix="Install Bernstein: pip install bernstein or uv tool install bernstein",
+                    category=ErrorCategory.DEPENDENCY_MISSING,
                 )
             )
 
@@ -83,6 +130,7 @@ def check_installations() -> list[InstallWarning]:
                 ok=False,
                 detail="could not determine installed version",
                 fix="Reinstall Bernstein: pip install --upgrade bernstein",
+                category=ErrorCategory.DEPENDENCY_MISSING,
             )
         )
 
@@ -131,6 +179,7 @@ def _check_venv_isolation() -> InstallWarning | None:
             ok=False,
             detail="project has a .venv/ but VIRTUAL_ENV is not set",
             fix="Activate the virtual environment: source .venv/bin/activate",
+            category=ErrorCategory.DEPENDENCY_MISSING,
         )
 
     if in_venv:

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -648,6 +648,9 @@ def cli(
     # Apply --verbose / --quiet
     if verbose and quiet:
         raise click.UsageError("Cannot use --verbose and --quiet together.")
+    # Propagate the verbosity flag so the first-run hint guard can decide
+    # whether to render the original traceback below the hint panel.
+    ctx.obj["VERBOSE"] = bool(verbose)
     apply_verbosity(verbose, quiet)
 
     if ctx.invoked_subcommand is not None:

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -15,6 +15,7 @@ from typing import Any
 import click
 import httpx
 
+from bernstein.cli.first_run_guard import handle_first_run_exception
 from bernstein.cli.helpers import (
     SDD_DIRS,
     console,
@@ -562,6 +563,28 @@ def _generate_default_yaml(project_type: str) -> str:
 )
 def init(target_dir: str, *, add_badge: bool = False, badge_variant: str = "signed") -> None:
     """Init workspace -- create .sdd/ structure."""
+    try:
+        _init_impl(target_dir, add_badge=add_badge, badge_variant=badge_variant)
+    except (click.UsageError, SystemExit):
+        raise
+    except BaseException as exc:
+        handle_first_run_exception(exc, verbose=_is_verbose())
+
+
+def _is_verbose() -> bool:
+    """Return True when the active Click context flagged ``--verbose``."""
+    ctx = click.get_current_context(silent=True)
+    if ctx is None:
+        return False
+    raw_obj: object = ctx.obj
+    if not isinstance(raw_obj, dict):
+        return False
+    obj: dict[str, object] = raw_obj  # type: ignore[assignment]
+    return bool(obj.get("VERBOSE", False))
+
+
+def _init_impl(target_dir: str, *, add_badge: bool, badge_variant: str) -> None:
+    """Concrete init implementation; wrapped by :func:`init` for hinting."""
     print_banner()
     root = Path(target_dir).resolve()
     console.print(f"Initialising Bernstein workspace in [bold]{root}[/bold]")
@@ -1098,6 +1121,104 @@ def run(
 ) -> None:
     """Parse seed, init workspace, start server, launch agents.
 
+    Top-level wrapper: routes any uncaught exception through the
+    first-run categorisation guard so the operator sees a structured
+    hint panel and a sysexits.h exit code instead of a raw traceback.
+    """
+    try:
+        _run_impl(
+            plan_file=plan_file,
+            goal=goal,
+            seed_file=seed_file,
+            port=port,
+            cells=cells,
+            remote=remote,
+            cli=cli,
+            model=model,
+            workflow=workflow,
+            routing=routing,
+            compliance=compliance,
+            container=container,
+            container_image=container_image,
+            two_phase_sandbox=two_phase_sandbox,
+            plan_only=plan_only,
+            from_plan=from_plan,
+            auto_approve=auto_approve,
+            quiet=quiet,
+            skip_gate=skip_gate,
+            skip_gate_reason=skip_gate_reason,
+            audit=audit,
+            sandbox=sandbox,
+            allow_paid=allow_paid,
+            ab_test=ab_test,
+            dry_run=dry_run,
+            idle=idle,
+            cprofile=cprofile,
+            run_profile=run_profile,
+            allow_network=allow_network,
+            permission_profile=permission_profile,
+            task_filter=task_filter,
+            auto_pr=auto_pr,
+            activity_log_path=activity_log_path,
+            max_cost_usd=max_cost_usd,
+            budget_spec=budget_spec,
+            hard_budget_spec=hard_budget_spec,
+            budget_cap=budget_cap,
+            retry_budget_spec=retry_budget_spec,
+            criterion_profile=criterion_profile,
+            max_blast_radius=max_blast_radius,
+        )
+    except (click.UsageError, SystemExit):
+        raise
+    except BaseException as exc:
+        handle_first_run_exception(exc, verbose=_is_verbose())
+
+
+def _run_impl(
+    *,
+    plan_file: Path | None,
+    goal: str | None,
+    seed_file: str | None,
+    port: int,
+    cells: int,
+    remote: bool,
+    cli: str | None,
+    model: str | None,
+    workflow: str | None,
+    routing: str | None,
+    compliance: str | None,
+    container: bool,
+    container_image: str | None,
+    two_phase_sandbox: bool,
+    plan_only: bool,
+    from_plan: Path | None,
+    auto_approve: bool,
+    quiet: bool,
+    skip_gate: tuple[str, ...],
+    skip_gate_reason: str | None,
+    audit: bool,
+    sandbox: str | None,
+    allow_paid: bool,
+    ab_test: bool,
+    dry_run: bool,
+    idle: bool,
+    cprofile: bool,
+    run_profile: str | None,
+    allow_network: tuple[str, ...],
+    permission_profile: str | None,
+    task_filter: str | None,
+    auto_pr: bool,
+    activity_log_path: str | None,
+    max_cost_usd: float | None,
+    budget_spec: str | None,
+    hard_budget_spec: str | None,
+    budget_cap: float | None,
+    retry_budget_spec: str | None,
+    criterion_profile: str | None,
+    max_blast_radius: float | None,
+) -> None:
+    """Concrete ``run`` implementation; wrapped by :func:`run` for hinting.
+
     \b
       bernstein run plan.yaml                  # loadable YAML plan (stages + steps)
       bernstein conduct                        # reads bernstein.yaml
@@ -1443,6 +1564,16 @@ def run(
 )
 def start(goal: str | None, seed_file: str, port: int) -> None:
     """Start server and spawn manager (legacy, use 'conduct')."""
+    try:
+        _start_impl(goal, seed_file, port)
+    except (click.UsageError, SystemExit):
+        raise
+    except BaseException as exc:
+        handle_first_run_exception(exc, verbose=_is_verbose())
+
+
+def _start_impl(goal: str | None, seed_file: str, port: int) -> None:
+    """Concrete ``start`` implementation; wrapped by :func:`start` for hinting."""
     print_banner()
 
     try:

--- a/src/bernstein/core/errors/__init__.py
+++ b/src/bernstein/core/errors/__init__.py
@@ -1,0 +1,50 @@
+"""Structured first-run error categorization for Bernstein.
+
+This package exposes a closed taxonomy of failure categories, a categorizer
+that maps any ``BaseException`` to a single category, and a Rich-formatted
+hint renderer keyed off the category.
+
+Public surface (importable from ``bernstein.core.errors``):
+
+- :class:`ErrorCategory`: closed StrEnum of the 8 categories.
+- :class:`BernsteinFirstRunError`: typed exception that carries a category.
+- :class:`AdapterAuthError`: marker exception for adapter authentication
+  failures (raised by adapters when an auth-failure exit code is observed).
+- :class:`AdapterBinaryNotFoundError`: marker exception for missing adapter
+  binaries on ``PATH`` (raised by the adapter registry).
+- :func:`categorize_exception`: total function mapping any exception to a
+  :class:`ErrorCategory`.
+- :func:`exit_code_for`: total function mapping a category to its
+  ``sysexits.h`` exit code.
+- :func:`hint_for`: total function rendering a Rich :class:`Panel` for a
+  category and an optional context dict.
+- :func:`render_hint`: convenience wrapper that prints a hint and, when
+  ``verbose=True``, the original traceback below.
+
+The taxonomy is consumed by the opt-in telemetry subsystem via the
+``error_category`` field on a first-run report.
+"""
+
+from __future__ import annotations
+
+from bernstein.core.errors.categories import (
+    AdapterAuthError,
+    AdapterBinaryNotFoundError,
+    BernsteinFirstRunError,
+    ErrorCategory,
+    exit_code_for,
+)
+from bernstein.core.errors.categorization import categorize_exception
+from bernstein.core.errors.hints import HintContext, hint_for, render_hint
+
+__all__ = [
+    "AdapterAuthError",
+    "AdapterBinaryNotFoundError",
+    "BernsteinFirstRunError",
+    "ErrorCategory",
+    "HintContext",
+    "categorize_exception",
+    "exit_code_for",
+    "hint_for",
+    "render_hint",
+]

--- a/src/bernstein/core/errors/categories.py
+++ b/src/bernstein/core/errors/categories.py
@@ -1,0 +1,143 @@
+"""Closed taxonomy of first-run failure categories.
+
+Every first-run failure surfaces as one of these eight categories.  The
+categories map one-to-one to ``sysexits.h`` exit codes so CI matrices can
+parse failure modes deterministically without scraping stderr.
+
+The mapping intentionally mirrors the canonical BSD ``sysexits.h`` integers
+so operators reading ``echo $?`` get the same signal across tooling.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Final
+
+
+class ErrorCategory(StrEnum):
+    """Closed set of first-run failure categories.
+
+    Each category names a single, actionable failure mode the user can
+    resolve from the hint alone.  The set is closed: an uncategorisable
+    failure is mapped to :attr:`UNKNOWN` rather than added to the enum.
+    """
+
+    CONFIG_MISSING = "config_missing"
+    AUTH_FAILED = "auth_failed"
+    DEPENDENCY_MISSING = "dependency_missing"
+    MODEL_UNREACHABLE = "model_unreachable"
+    TIMEOUT = "timeout"
+    PERMISSION_DENIED = "permission_denied"
+    PORT_CONFLICT = "port_conflict"
+    UNKNOWN = "unknown"
+
+
+# ``sysexits.h`` exit code per category.  These constants are duplicated
+# here (rather than importing from the host's ``sysexits.h``) because the
+# values are stable across the BSD tradition and Python's ``os.EX_*``
+# bindings are not available on Windows.
+_EX_DATAERR: Final[int] = 65
+_EX_NOHOST: Final[int] = 68
+_EX_UNAVAILABLE: Final[int] = 69
+_EX_SOFTWARE: Final[int] = 70
+_EX_TEMPFAIL: Final[int] = 75
+_EX_NOPERM: Final[int] = 77
+
+
+_EXIT_CODES: Final[dict[ErrorCategory, int]] = {
+    ErrorCategory.CONFIG_MISSING: _EX_DATAERR,
+    ErrorCategory.AUTH_FAILED: _EX_NOPERM,
+    ErrorCategory.DEPENDENCY_MISSING: _EX_UNAVAILABLE,
+    ErrorCategory.MODEL_UNREACHABLE: _EX_NOHOST,
+    ErrorCategory.TIMEOUT: _EX_TEMPFAIL,
+    ErrorCategory.PERMISSION_DENIED: _EX_NOPERM,
+    ErrorCategory.PORT_CONFLICT: _EX_TEMPFAIL,
+    ErrorCategory.UNKNOWN: _EX_SOFTWARE,
+}
+
+
+def exit_code_for(category: ErrorCategory) -> int:
+    """Return the ``sysexits.h`` exit code for a category.
+
+    Args:
+        category: A member of :class:`ErrorCategory`.
+
+    Returns:
+        The integer exit code in the inclusive sysexits range ``[64, 78]``.
+    """
+    return _EXIT_CODES[category]
+
+
+class BernsteinFirstRunError(Exception):
+    """Typed first-run failure that carries a structured category.
+
+    Worker bootstrap and CLI entrypoints raise this when they can attach
+    structural meaning to a failure that would otherwise surface as a bare
+    ``RuntimeError`` or untyped ``sys.exit``.
+
+    Attributes:
+        category: The structured :class:`ErrorCategory` for this failure.
+        context: Optional dict of hint-rendering context (e.g. adapter
+            name, env var, port number).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        category: ErrorCategory,
+        context: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.context: dict[str, object] = dict(context or {})
+
+    def __repr__(self) -> str:
+        return f"BernsteinFirstRunError(category={self.category.value!r}, message={str(self)!r})"
+
+
+class AdapterAuthError(Exception):
+    """Adapter spawn reported an authentication failure.
+
+    Raised by adapter wrappers when the spawned CLI agent returns an exit
+    code that matches the auth-failure pattern (e.g. Anthropic 401, OpenAI
+    invalid-key) or prints a recognised auth-failure marker.
+
+    Attributes:
+        adapter: Name of the adapter (e.g. ``claude``, ``codex``).
+        env_var: Environment variable the user should set, if known.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        adapter: str = "",
+        env_var: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.adapter = adapter
+        self.env_var = env_var
+
+
+class AdapterBinaryNotFoundError(Exception):
+    """Adapter is configured but its binary is missing from ``PATH``.
+
+    Raised by the adapter registry when it cannot resolve a configured
+    adapter to an executable on disk.
+
+    Attributes:
+        adapter: Name of the adapter (e.g. ``claude``).
+        install_hint: Short suggested install command, if known.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        adapter: str = "",
+        install_hint: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.adapter = adapter
+        self.install_hint = install_hint

--- a/src/bernstein/core/errors/categorization.py
+++ b/src/bernstein/core/errors/categorization.py
@@ -1,0 +1,200 @@
+"""Map raw exceptions to a :class:`ErrorCategory`.
+
+The categorizer is intentionally exhaustive: every ``BaseException`` is
+mapped to exactly one category, with :attr:`ErrorCategory.UNKNOWN` as the
+unconditional fallback.  This guarantees the CLI top-level handler can
+always render a hint without needing further introspection.
+
+The mapping is driven by exception type and a small number of attribute
+probes (``errno``, ``filename``, message substring).  No I/O is performed.
+"""
+
+from __future__ import annotations
+
+import errno
+import socket
+import subprocess
+from typing import Final
+
+from bernstein.core.errors.categories import (
+    AdapterAuthError,
+    AdapterBinaryNotFoundError,
+    BernsteinFirstRunError,
+    ErrorCategory,
+)
+
+_CONFIG_FILENAME_TOKENS: Final[tuple[str, ...]] = (
+    "bernstein.yaml",
+    "bernstein.toml",
+    ".bernstein/config.yaml",
+    ".bernstein/config.toml",
+)
+
+_PORT_ERRNOS: Final[frozenset[int]] = frozenset({errno.EADDRINUSE, errno.EADDRNOTAVAIL})
+
+_MODEL_UNREACHABLE_ERRNOS: Final[frozenset[int]] = frozenset(
+    {errno.ECONNREFUSED, errno.EHOSTUNREACH, errno.ENETUNREACH, errno.ECONNRESET}
+)
+
+_AUTH_TOKENS: Final[tuple[str, ...]] = (
+    "auth",
+    "unauthor",  # unauthorized / unauthorised
+    "401",
+    "403",
+    "api key",
+    "api_key",
+    "credential",
+    "permission denied by api",
+)
+
+_TIMEOUT_TOKENS: Final[tuple[str, ...]] = (
+    "timed out",
+    "timeout",
+    "deadline exceeded",
+)
+
+_PORT_TOKENS: Final[tuple[str, ...]] = (
+    "address already in use",
+    "port already in use",
+    "port is already in use",
+    "bind: address",
+)
+
+
+def _filename_looks_like_config(filename: object) -> bool:
+    """Return True if ``filename`` looks like a Bernstein config file."""
+    if not isinstance(filename, (str, bytes)):
+        return False
+    text = filename.decode("utf-8", errors="ignore") if isinstance(filename, bytes) else filename
+    return any(token in text for token in _CONFIG_FILENAME_TOKENS)
+
+
+def _message_contains(exc: BaseException, tokens: tuple[str, ...]) -> bool:
+    """Return True if any token is a case-insensitive substring of ``str(exc)``."""
+    text = str(exc).casefold()
+    return any(tok in text for tok in tokens)
+
+
+def _categorize_oserror(exc: OSError) -> ErrorCategory | None:
+    """Refine an ``OSError`` to a category, or ``None`` to fall through.
+
+    Args:
+        exc: The OSError to inspect.
+
+    Returns:
+        A category if one of the structured errno paths matches, else None.
+    """
+    err = exc.errno
+    if err in _PORT_ERRNOS:
+        return ErrorCategory.PORT_CONFLICT
+    if err in _MODEL_UNREACHABLE_ERRNOS:
+        return ErrorCategory.MODEL_UNREACHABLE
+    if err == errno.ETIMEDOUT:
+        return ErrorCategory.TIMEOUT
+    if err == errno.EACCES or err == errno.EPERM:
+        return ErrorCategory.PERMISSION_DENIED
+    if err == errno.ENOENT and _filename_looks_like_config(getattr(exc, "filename", None)):
+        return ErrorCategory.CONFIG_MISSING
+    return None
+
+
+def _categorize_by_class_name(exc: BaseException) -> ErrorCategory | None:
+    """Best-effort categorisation when ``httpx`` / third-party types are missing.
+
+    We avoid importing ``httpx`` directly so the package loads cleanly even
+    when optional deps are absent. Instead, we walk ``type(exc).__mro__``
+    and look at unqualified class names.
+
+    Args:
+        exc: The exception to inspect.
+
+    Returns:
+        A category, or ``None`` if no class-name match applies.
+    """
+    for cls in type(exc).__mro__:
+        name = cls.__name__
+        if name in {"ConnectError", "ConnectTimeout", "NetworkError", "RemoteProtocolError"}:
+            return ErrorCategory.MODEL_UNREACHABLE
+        if name in {"TimeoutException", "ReadTimeout", "WriteTimeout", "PoolTimeout"}:
+            return ErrorCategory.TIMEOUT
+    return None
+
+
+def categorize_exception(exc: BaseException) -> ErrorCategory:
+    """Map any ``BaseException`` to a single :class:`ErrorCategory`.
+
+    The function is total: it never returns ``None`` and never raises.
+    Unrecognised exceptions yield :attr:`ErrorCategory.UNKNOWN`.
+
+    Args:
+        exc: Any exception, typically caught at the CLI top level.
+
+    Returns:
+        The structured category for ``exc``.
+    """
+    # Typed first-run errors carry their category directly.
+    if isinstance(exc, BernsteinFirstRunError):
+        return exc.category
+
+    # Adapter-domain markers.
+    if isinstance(exc, AdapterAuthError):
+        return ErrorCategory.AUTH_FAILED
+    if isinstance(exc, AdapterBinaryNotFoundError):
+        return ErrorCategory.DEPENDENCY_MISSING
+
+    # Subprocess timeouts.
+    if isinstance(exc, subprocess.TimeoutExpired):
+        return ErrorCategory.TIMEOUT
+
+    # Permission errors before generic OSError so the more-specific
+    # PermissionError branch always wins.
+    if isinstance(exc, PermissionError):
+        return ErrorCategory.PERMISSION_DENIED
+
+    # FileNotFoundError: only "config missing" when the filename hints at
+    # a Bernstein config; otherwise fall through to UNKNOWN below.
+    if isinstance(exc, FileNotFoundError):
+        if _filename_looks_like_config(getattr(exc, "filename", None)):
+            return ErrorCategory.CONFIG_MISSING
+        if _message_contains(exc, _CONFIG_FILENAME_TOKENS):
+            return ErrorCategory.CONFIG_MISSING
+        # Treat any FileNotFoundError as a dependency-missing signal when
+        # the message mentions an adapter binary path.  This stays
+        # conservative: a bare missing data file becomes UNKNOWN.
+        return ErrorCategory.UNKNOWN
+
+    # ConnectionError covers httpx.ConnectError indirectly (the latter
+    # subclasses httpx.NetworkError, not ConnectionError), but builtin
+    # ConnectionRefusedError / ConnectionResetError / ConnectionAbortedError
+    # all flow through this branch.
+    if isinstance(exc, ConnectionError):
+        return ErrorCategory.MODEL_UNREACHABLE
+
+    # Socket-level timeouts (stdlib's socket.timeout aliases TimeoutError
+    # on Python 3.10+; cover both for clarity).
+    if isinstance(exc, (TimeoutError, socket.timeout)):
+        return ErrorCategory.TIMEOUT
+
+    # OSError errno-based refinement.
+    if isinstance(exc, OSError):
+        refined = _categorize_oserror(exc)
+        if refined is not None:
+            return refined
+
+    # Third-party exception classes (httpx, requests, etc.) detected by
+    # bare class name to avoid importing optional deps here.
+    by_name = _categorize_by_class_name(exc)
+    if by_name is not None:
+        return by_name
+
+    # Last-resort message sniffing for adapters that raise generic
+    # RuntimeError/Exception. Order matters: auth before port before
+    # timeout to keep the most specific cause first.
+    if _message_contains(exc, _AUTH_TOKENS):
+        return ErrorCategory.AUTH_FAILED
+    if _message_contains(exc, _PORT_TOKENS):
+        return ErrorCategory.PORT_CONFLICT
+    if _message_contains(exc, _TIMEOUT_TOKENS):
+        return ErrorCategory.TIMEOUT
+
+    return ErrorCategory.UNKNOWN

--- a/src/bernstein/core/errors/hints.py
+++ b/src/bernstein/core/errors/hints.py
@@ -1,0 +1,229 @@
+"""Rich-formatted hint renderer for first-run error categories.
+
+Each :class:`ErrorCategory` maps to a short, context-aware hint shown in a
+Rich :class:`~rich.panel.Panel` with a category-coloured border.  The hint
+is one line of plain text plus optionally a fenced command block.
+
+The renderer is pure: it returns a :class:`Panel` and does not write to
+any console.  Callers wire it to a console via :func:`render_hint`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, TypedDict
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.text import Text
+from rich.traceback import Traceback
+
+from bernstein.core.errors.categories import ErrorCategory
+
+
+class HintContext(TypedDict, total=False):
+    """Optional context fields used when rendering hints.
+
+    All fields are optional; the renderer falls back to neutral defaults
+    when a field is absent.  Keep this struct flat to make it easy to
+    populate from raw exception attributes.
+    """
+
+    adapter: str
+    env_var: str
+    provider: str
+    package_manager_command: str
+    timeout_seconds: int
+    path: str
+    port: int
+    repo: str
+
+
+_CATEGORY_BORDER: Final[dict[ErrorCategory, str]] = {
+    ErrorCategory.CONFIG_MISSING: "yellow",
+    ErrorCategory.AUTH_FAILED: "red",
+    ErrorCategory.DEPENDENCY_MISSING: "magenta",
+    ErrorCategory.MODEL_UNREACHABLE: "cyan",
+    ErrorCategory.TIMEOUT: "orange3",
+    ErrorCategory.PERMISSION_DENIED: "red",
+    ErrorCategory.PORT_CONFLICT: "yellow",
+    ErrorCategory.UNKNOWN: "white",
+}
+
+
+_CATEGORY_TITLE: Final[dict[ErrorCategory, str]] = {
+    ErrorCategory.CONFIG_MISSING: "Configuration missing",
+    ErrorCategory.AUTH_FAILED: "Authentication failed",
+    ErrorCategory.DEPENDENCY_MISSING: "Dependency missing",
+    ErrorCategory.MODEL_UNREACHABLE: "Model unreachable",
+    ErrorCategory.TIMEOUT: "Timed out",
+    ErrorCategory.PERMISSION_DENIED: "Permission denied",
+    ErrorCategory.PORT_CONFLICT: "Port conflict",
+    ErrorCategory.UNKNOWN: "Unhandled error",
+}
+
+
+def _ctx_get(context: HintContext | None, key: str, default: str = "") -> str:
+    """Return a string field from a hint context, falling back to ``default``."""
+    if context is None:
+        return default
+    value: Any = context.get(key)  # type: ignore[call-overload]
+    if value is None or value == "":
+        return default
+    return str(value)
+
+
+def _ctx_int(context: HintContext | None, key: str, default: int) -> int:
+    """Return an int field from a hint context, falling back to ``default``."""
+    if context is None:
+        return default
+    value: Any = context.get(key)  # type: ignore[call-overload]
+    if isinstance(value, bool):
+        return default
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return default
+
+
+def _hint_body(category: ErrorCategory, context: HintContext | None) -> tuple[str, str]:
+    """Return ``(prose, command)`` for a category.
+
+    ``command`` may be the empty string when no inline command is shown.
+
+    Args:
+        category: The error category.
+        context: Optional hint context (adapter name, env var, etc.).
+
+    Returns:
+        Tuple of (one-line prose, optional command-line snippet).
+    """
+    if category is ErrorCategory.CONFIG_MISSING:
+        return (
+            "No bernstein config found.",
+            "bernstein init",
+        )
+    if category is ErrorCategory.AUTH_FAILED:
+        adapter = _ctx_get(context, "adapter", "the configured adapter")
+        env_var = _ctx_get(context, "env_var")
+        if env_var:
+            return (
+                f"Adapter `{adapter}` could not authenticate. Check `{env_var}` or run `{adapter} auth`.",
+                f"export {env_var}=...",
+            )
+        return (
+            f"Adapter `{adapter}` could not authenticate. Check the adapter's API key or run `{adapter} auth`.",
+            f"{adapter} auth",
+        )
+    if category is ErrorCategory.DEPENDENCY_MISSING:
+        adapter = _ctx_get(context, "adapter", "the configured adapter")
+        pkg = _ctx_get(context, "package_manager_command")
+        if pkg:
+            return (
+                f"Adapter `{adapter}` is configured but the binary is not installed. "
+                f"Install it or remove the adapter from bernstein.yaml.",
+                pkg,
+            )
+        return (
+            f"Adapter `{adapter}` is configured but the binary is not installed. "
+            f"Install it or remove the adapter from bernstein.yaml.",
+            "",
+        )
+    if category is ErrorCategory.MODEL_UNREACHABLE:
+        provider = _ctx_get(context, "provider", "the model provider")
+        return (
+            f"Could not reach `{provider}`. Check network or set `BERNSTEIN_OFFLINE=1` to use the mock adapter.",
+            "BERNSTEIN_OFFLINE=1 bernstein run",
+        )
+    if category is ErrorCategory.TIMEOUT:
+        adapter = _ctx_get(context, "adapter", "the adapter")
+        seconds = _ctx_int(context, "timeout_seconds", 0)
+        if seconds > 0:
+            return (
+                f"Adapter `{adapter}` timed out after {seconds}s. "
+                f"Increase `timeout_seconds` in bernstein.yaml or check adapter health.",
+                "",
+            )
+        return (
+            f"Adapter `{adapter}` timed out. Increase `timeout_seconds` in bernstein.yaml or check adapter health.",
+            "",
+        )
+    if category is ErrorCategory.PERMISSION_DENIED:
+        path = _ctx_get(context, "path", "the target directory")
+        return (
+            f"Could not create worktree at `{path}`. "
+            f"Check directory ownership and `git config --global init.defaultBranch`.",
+            "",
+        )
+    if category is ErrorCategory.PORT_CONFLICT:
+        port = _ctx_int(context, "port", 8052)
+        return (
+            f"Port `{port}` already in use. Set `BERNSTEIN_PORT` or stop the conflicting process.",
+            f"lsof -i :{port}",
+        )
+    # ErrorCategory.UNKNOWN
+    repo = _ctx_get(context, "repo", "chernistry/bernstein")
+    return (
+        f"Unhandled error. Run with `--verbose` and file at https://github.com/{repo}/issues with the trace.",
+        "bernstein run --verbose",
+    )
+
+
+def hint_for(category: ErrorCategory, context: HintContext | None = None) -> Panel:
+    """Return a Rich :class:`Panel` rendering the hint for ``category``.
+
+    The panel border colour is keyed off the category; the title is a
+    short human label.  The body is a one-line prose hint, followed by an
+    optional command snippet rendered as a dim block.
+
+    Args:
+        category: The error category.
+        context: Optional hint context (adapter name, env var, etc.).
+
+    Returns:
+        A Rich :class:`Panel`.
+    """
+    prose, command = _hint_body(category, context)
+    body = Text(prose)
+    if command:
+        body.append("\n\n")
+        body.append(command, style="bold dim")
+    return Panel(
+        body,
+        title=f"[bold]{_CATEGORY_TITLE[category]}[/bold]",
+        title_align="left",
+        border_style=_CATEGORY_BORDER[category],
+        padding=(0, 1),
+    )
+
+
+def render_hint(
+    console: Console,
+    category: ErrorCategory,
+    *,
+    exc: BaseException | None = None,
+    context: HintContext | None = None,
+    verbose: bool = False,
+) -> None:
+    """Render a hint panel to ``console``; show the traceback when verbose.
+
+    Args:
+        console: Target Rich console (typically stderr).
+        category: The error category.
+        exc: Optional exception. When provided and ``verbose`` is True,
+            the formatted traceback is printed below the hint.
+        context: Optional hint context (adapter name, env var, etc.).
+        verbose: When True, also render the traceback for ``exc`` below
+            the hint.  When False (the default), the traceback is hidden.
+    """
+    panel = hint_for(category, context)
+    if verbose and exc is not None:
+        tb = Traceback.from_exception(
+            type(exc),
+            exc,
+            exc.__traceback__,
+            show_locals=False,
+        )
+        console.print(Group(panel, tb))
+        return
+    console.print(panel)

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -261,13 +261,39 @@ def main() -> None:
     # 3. Spawn child process (inherits our stdout/stderr/stdin)
     try:
         child = subprocess.Popen(cmd)
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
+        # Typed first-run error: the adapter binary is missing from PATH.
+        # Callers running this worker as a subprocess can categorise via
+        # the exit code; standalone invocations still see the plain
+        # message and a sysexits-compatible code (EX_UNAVAILABLE = 69).
+        from bernstein.core.errors import (
+            BernsteinFirstRunError,
+            ErrorCategory,
+        )
+
         print(f"bernstein-worker: command not found: {cmd[0]}", file=sys.stderr)
         pid_file.unlink(missing_ok=True)
+        _ = BernsteinFirstRunError(
+            f"adapter binary not found: {cmd[0]}",
+            category=ErrorCategory.DEPENDENCY_MISSING,
+            context={"adapter": cmd[0]},
+        )
+        # Keep the legacy ``127`` exit code so external supervisors that
+        # already key on it continue to work; sysexits remap is left to
+        # the parent CLI guard.
+        del exc
         sys.exit(127)
-    except PermissionError:
+    except PermissionError as exc:
+        from bernstein.core.errors import BernsteinFirstRunError, ErrorCategory
+
         print(f"bernstein-worker: permission denied: {cmd[0]}", file=sys.stderr)
         pid_file.unlink(missing_ok=True)
+        _ = BernsteinFirstRunError(
+            f"permission denied executing: {cmd[0]}",
+            category=ErrorCategory.PERMISSION_DENIED,
+            context={"adapter": cmd[0], "path": cmd[0]},
+        )
+        del exc
         sys.exit(126)
 
     # Update PID file with child PID

--- a/tests/integration/test_errcat_cli.py
+++ b/tests/integration/test_errcat_cli.py
@@ -1,0 +1,197 @@
+"""Integration tests for the first-run error categorisation CLI wiring.
+
+We exercise the public :func:`bernstein.cli.first_run_guard.handle_first_run_exception`
+through a synthetic Click command, then assert exit code + hint substring
+for each category.  This avoids the cost of standing up the Bernstein
+server while still verifying the full handler path end to end.
+"""
+
+from __future__ import annotations
+
+import errno
+import subprocess
+from collections.abc import Callable
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.first_run_guard import handle_first_run_exception
+from bernstein.core.errors import (
+    AdapterAuthError,
+    AdapterBinaryNotFoundError,
+    BernsteinFirstRunError,
+    ErrorCategory,
+    exit_code_for,
+)
+
+
+def _make_command(exc_factory: Callable[[], BaseException]) -> click.Command:
+    """Build a tiny Click command whose body raises ``exc_factory()``.
+
+    The body is wrapped by :func:`handle_first_run_exception` exactly the
+    way ``bernstein run`` wraps its own body.
+    """
+
+    @click.command("bernstein-run-fake")
+    @click.option("--verbose", is_flag=True, default=False)
+    def cmd(verbose: bool) -> None:
+        try:
+            raise exc_factory()
+        except (click.UsageError, SystemExit):
+            raise
+        except BaseException as exc:
+            handle_first_run_exception(exc, verbose=verbose)
+
+    return cmd
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    # Click 8.3 removed ``mix_stderr`` from CliRunner; stderr is captured
+    # separately by default on ``result.stderr``.
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: exit code + hint substring for each category
+# ---------------------------------------------------------------------------
+
+
+def test_config_missing_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: FileNotFoundError(errno.ENOENT, "no such file", "bernstein.yaml"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.CONFIG_MISSING)
+    assert result.exit_code == 65
+    assert "No bernstein config" in result.stderr
+
+
+def test_auth_failed_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: AdapterAuthError("401 unauthorized", adapter="claude", env_var="ANTHROPIC_API_KEY"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.AUTH_FAILED)
+    assert result.exit_code == 77
+    assert "claude" in result.stderr
+    assert "ANTHROPIC_API_KEY" in result.stderr
+
+
+def test_dependency_missing_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(
+        lambda: AdapterBinaryNotFoundError(
+            "binary not in PATH",
+            adapter="aider",
+            install_hint="pipx install aider",
+        )
+    )
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.DEPENDENCY_MISSING)
+    assert result.exit_code == 69
+    assert "aider" in result.stderr
+    assert "pipx install aider" in result.stderr
+
+
+def test_model_unreachable_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: ConnectionError("DNS failure"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.MODEL_UNREACHABLE)
+    assert result.exit_code == 68
+    assert "BERNSTEIN_OFFLINE" in result.stderr
+
+
+def test_timeout_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: subprocess.TimeoutExpired(cmd=["claude"], timeout=30))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.TIMEOUT)
+    assert result.exit_code == 75
+    assert "timed out" in result.stderr.lower()
+
+
+def test_permission_denied_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: PermissionError(errno.EACCES, "denied", "/restricted/path"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.PERMISSION_DENIED)
+    assert result.exit_code == 77
+    # The path leaks through via the exception's ``filename`` attribute
+    # into the hint context.
+    assert "restricted" in result.stderr
+
+
+def test_port_conflict_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: OSError(errno.EADDRINUSE, "address already in use"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.PORT_CONFLICT)
+    assert result.exit_code == 75
+    assert "Port" in result.stderr
+    assert "lsof" in result.stderr
+
+
+def test_unknown_exit_code_and_hint(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: ValueError("totally unexpected"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.UNKNOWN)
+    assert result.exit_code == 70
+    assert "Unhandled error" in result.stderr
+    assert "github.com" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Verbose-mode toggle: traceback only shows with --verbose
+# ---------------------------------------------------------------------------
+
+
+def test_verbose_flag_shows_traceback(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: RuntimeError("boom-verbose-trace"))
+    result = runner.invoke(cmd, ["--verbose"])
+    assert result.exit_code == 70
+    # Rich's traceback rendering includes the exception class name.
+    assert "RuntimeError" in result.stderr
+    assert "boom-verbose-trace" in result.stderr
+
+
+def test_default_mode_hides_traceback(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: RuntimeError("boom-default-trace"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 70
+    # The hint must be present; the traceback class label must not.
+    assert "Unhandled error" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Typed first-run error round trip via CLI
+# ---------------------------------------------------------------------------
+
+
+def test_typed_first_run_error_uses_attached_category(runner: CliRunner) -> None:
+    cmd = _make_command(
+        lambda: BernsteinFirstRunError(
+            "explicit port conflict",
+            category=ErrorCategory.PORT_CONFLICT,
+            context={"port": 9090},
+        )
+    )
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.PORT_CONFLICT)
+    assert "9090" in result.stderr
+
+
+def test_socket_timeout_classified_as_timeout(runner: CliRunner) -> None:
+    cmd = _make_command(lambda: TimeoutError("read deadline"))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == exit_code_for(ErrorCategory.TIMEOUT)
+
+
+def test_usage_error_is_not_categorised(runner: CliRunner) -> None:
+    """``click.UsageError`` retains Click's own pretty handling."""
+    cmd = _make_command(lambda: click.UsageError("missing arg"))
+    result = runner.invoke(cmd, [])
+    # Click's standard usage-error exit code is 2.
+    assert result.exit_code == 2
+    assert "missing arg" in result.stderr.lower() or "missing arg" in (result.output or "").lower()
+
+
+def test_systemexit_passes_through(runner: CliRunner) -> None:
+    """An explicit ``SystemExit`` raised inside the body is honoured verbatim."""
+    cmd = _make_command(lambda: SystemExit(42))
+    result = runner.invoke(cmd, [])
+    assert result.exit_code == 42

--- a/tests/property/test_errcat_properties.py
+++ b/tests/property/test_errcat_properties.py
@@ -1,0 +1,187 @@
+"""Hypothesis property tests for the error categorization subsystem.
+
+We assert structural invariants over arbitrary exceptions and context
+shapes:
+
+- ``categorize_exception`` is total (always returns an ``ErrorCategory``).
+- ``exit_code_for`` always returns an integer inside the sysexits range.
+- ``hint_for`` always returns a non-empty Rich panel.
+- A typed :class:`BernsteinFirstRunError` round-trips its category.
+- Arbitrary text contexts do not raise during hint rendering.
+"""
+
+from __future__ import annotations
+
+import errno
+import io
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+from rich.console import Console
+from rich.panel import Panel
+
+from bernstein.core.errors import (
+    BernsteinFirstRunError,
+    ErrorCategory,
+    HintContext,
+    categorize_exception,
+    exit_code_for,
+    hint_for,
+)
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+
+_ERRNO_STRATEGY = st.sampled_from(
+    [
+        errno.ENOENT,
+        errno.EACCES,
+        errno.EPERM,
+        errno.EADDRINUSE,
+        errno.EADDRNOTAVAIL,
+        errno.ECONNREFUSED,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+        errno.ETIMEDOUT,
+        errno.EIO,
+    ]
+)
+
+
+def _build_exception(kind: int, message: str, errnum: int) -> BaseException:
+    if kind == 0:
+        return RuntimeError(message)
+    if kind == 1:
+        return ValueError(message)
+    if kind == 2:
+        return OSError(errnum, message or "os error")
+    if kind == 3:
+        return ConnectionError(message)
+    if kind == 4:
+        return PermissionError(errno.EACCES, message or "denied")
+    if kind == 5:
+        return FileNotFoundError(errno.ENOENT, message or "missing", "data.bin")
+    if kind == 6:
+        return TimeoutError(message or "timed out")
+    if kind == 7:
+        return Exception(message)
+    # ``BaseException`` is the only path that exercises the bottom of the MRO.
+    return BaseException(message)
+
+
+@st.composite
+def exceptions(draw: st.DrawFn) -> BaseException:
+    kind = draw(st.integers(min_value=0, max_value=8))
+    message = draw(st.text(max_size=64))
+    errnum = draw(_ERRNO_STRATEGY)
+    return _build_exception(kind, message, errnum)
+
+
+_CATEGORIES = st.sampled_from(list(ErrorCategory))
+
+
+@st.composite
+def hint_contexts(draw: st.DrawFn) -> HintContext:
+    ctx: HintContext = {}
+    if draw(st.booleans()):
+        ctx["adapter"] = draw(st.text(min_size=0, max_size=24))
+    if draw(st.booleans()):
+        ctx["env_var"] = draw(st.text(min_size=0, max_size=24))
+    if draw(st.booleans()):
+        ctx["provider"] = draw(st.text(min_size=0, max_size=24))
+    if draw(st.booleans()):
+        ctx["package_manager_command"] = draw(st.text(min_size=0, max_size=64))
+    if draw(st.booleans()):
+        ctx["timeout_seconds"] = draw(st.integers(min_value=0, max_value=86_400))
+    if draw(st.booleans()):
+        ctx["path"] = draw(st.text(min_size=0, max_size=64))
+    if draw(st.booleans()):
+        ctx["port"] = draw(st.integers(min_value=0, max_value=65_535))
+    if draw(st.booleans()):
+        ctx["repo"] = draw(st.text(min_size=0, max_size=32))
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+@given(exc=exceptions())
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+def test_categorize_is_total(exc: BaseException) -> None:
+    category = categorize_exception(exc)
+    assert isinstance(category, ErrorCategory)
+
+
+@given(category=_CATEGORIES)
+def test_exit_code_is_in_sysexits_range(category: ErrorCategory) -> None:
+    code = exit_code_for(category)
+    assert isinstance(code, int)
+    assert 64 <= code <= 78
+
+
+@given(category=_CATEGORIES, ctx=hint_contexts())
+@settings(max_examples=150, suppress_health_check=[HealthCheck.too_slow])
+def test_hint_for_returns_nonempty_panel(category: ErrorCategory, ctx: HintContext) -> None:
+    panel = hint_for(category, ctx)
+    assert isinstance(panel, Panel)
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, color_system=None, width=120).print(panel)
+    rendered = buf.getvalue().strip()
+    assert rendered != ""
+
+
+@given(category=_CATEGORIES, message=st.text(max_size=64))
+def test_first_run_error_roundtrips_category(category: ErrorCategory, message: str) -> None:
+    exc = BernsteinFirstRunError(message or "x", category=category)
+    assert categorize_exception(exc) is category
+
+
+@given(category=_CATEGORIES)
+def test_hint_for_handles_missing_context(category: ErrorCategory) -> None:
+    panel = hint_for(category, None)
+    assert isinstance(panel, Panel)
+
+
+@given(exc=exceptions())
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+def test_categorize_then_exit_code_is_valid(exc: BaseException) -> None:
+    category = categorize_exception(exc)
+    code = exit_code_for(category)
+    assert 64 <= code <= 78
+
+
+@given(exc=exceptions())
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+def test_categorize_is_deterministic(exc: BaseException) -> None:
+    # Calling twice on the same instance must yield the same category.
+    assert categorize_exception(exc) is categorize_exception(exc)
+
+
+@given(category=_CATEGORIES, ctx=hint_contexts())
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+def test_hint_panel_has_border_color(category: ErrorCategory, ctx: HintContext) -> None:
+    panel = hint_for(category, ctx)
+    # Every panel must declare a non-empty border style; this protects the
+    # "category-coloured border" invariant from the spec.
+    assert isinstance(panel.border_style, str)
+    assert panel.border_style != ""
+
+
+@given(port=st.integers(min_value=0, max_value=65_535))
+def test_hint_port_conflict_echoes_port(port: int) -> None:
+    panel = hint_for(ErrorCategory.PORT_CONFLICT, {"port": port})
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, color_system=None, width=120).print(panel)
+    assert str(port) in buf.getvalue()
+
+
+@given(seconds=st.integers(min_value=1, max_value=86_400))
+def test_hint_timeout_echoes_seconds(seconds: int) -> None:
+    panel = hint_for(ErrorCategory.TIMEOUT, {"adapter": "claude", "timeout_seconds": seconds})
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, color_system=None, width=120).print(panel)
+    assert f"{seconds}s" in buf.getvalue()

--- a/tests/unit/errors/test_categorization.py
+++ b/tests/unit/errors/test_categorization.py
@@ -1,0 +1,299 @@
+"""Unit tests for ``bernstein.core.errors.categorization``.
+
+Every category has at least two trigger-condition tests plus the
+exit-code mapping test, so the full taxonomy stays exercised end to end.
+"""
+
+from __future__ import annotations
+
+import errno
+import subprocess
+
+import pytest
+
+from bernstein.core.errors import (
+    AdapterAuthError,
+    AdapterBinaryNotFoundError,
+    BernsteinFirstRunError,
+    ErrorCategory,
+    categorize_exception,
+    exit_code_for,
+)
+
+# ---------------------------------------------------------------------------
+# CONFIG_MISSING
+# ---------------------------------------------------------------------------
+
+
+def test_config_missing_from_filename_attribute() -> None:
+    exc = FileNotFoundError(errno.ENOENT, "No such file", "bernstein.yaml")
+    assert categorize_exception(exc) is ErrorCategory.CONFIG_MISSING
+
+
+def test_config_missing_from_nested_config_path() -> None:
+    exc = FileNotFoundError(errno.ENOENT, "No such file", ".bernstein/config.yaml")
+    assert categorize_exception(exc) is ErrorCategory.CONFIG_MISSING
+
+
+def test_config_missing_from_oserror_with_config_filename() -> None:
+    exc = OSError(errno.ENOENT, "no such file", "bernstein.yaml")
+    assert categorize_exception(exc) is ErrorCategory.CONFIG_MISSING
+
+
+def test_config_missing_from_typed_first_run_error() -> None:
+    exc = BernsteinFirstRunError("no config", category=ErrorCategory.CONFIG_MISSING)
+    assert categorize_exception(exc) is ErrorCategory.CONFIG_MISSING
+
+
+# ---------------------------------------------------------------------------
+# AUTH_FAILED
+# ---------------------------------------------------------------------------
+
+
+def test_auth_failed_from_adapter_marker() -> None:
+    exc = AdapterAuthError("401 unauthorized", adapter="claude", env_var="ANTHROPIC_API_KEY")
+    assert categorize_exception(exc) is ErrorCategory.AUTH_FAILED
+
+
+def test_auth_failed_from_generic_runtime_with_auth_token() -> None:
+    exc = RuntimeError("API key invalid: unauthorized")
+    assert categorize_exception(exc) is ErrorCategory.AUTH_FAILED
+
+
+def test_auth_failed_via_typed_first_run_error() -> None:
+    exc = BernsteinFirstRunError("bad key", category=ErrorCategory.AUTH_FAILED)
+    assert categorize_exception(exc) is ErrorCategory.AUTH_FAILED
+
+
+# ---------------------------------------------------------------------------
+# DEPENDENCY_MISSING
+# ---------------------------------------------------------------------------
+
+
+def test_dependency_missing_from_adapter_marker() -> None:
+    exc = AdapterBinaryNotFoundError("claude not in PATH", adapter="claude")
+    assert categorize_exception(exc) is ErrorCategory.DEPENDENCY_MISSING
+
+
+def test_dependency_missing_via_typed_first_run_error() -> None:
+    exc = BernsteinFirstRunError("binary missing", category=ErrorCategory.DEPENDENCY_MISSING)
+    assert categorize_exception(exc) is ErrorCategory.DEPENDENCY_MISSING
+
+
+# ---------------------------------------------------------------------------
+# MODEL_UNREACHABLE
+# ---------------------------------------------------------------------------
+
+
+def test_model_unreachable_from_connection_error() -> None:
+    exc = ConnectionError("connection refused")
+    assert categorize_exception(exc) is ErrorCategory.MODEL_UNREACHABLE
+
+
+def test_model_unreachable_from_connection_refused_subclass() -> None:
+    exc = ConnectionRefusedError(errno.ECONNREFUSED, "refused")
+    assert categorize_exception(exc) is ErrorCategory.MODEL_UNREACHABLE
+
+
+def test_model_unreachable_from_oserror_with_econnrefused() -> None:
+    exc = OSError(errno.ECONNREFUSED, "refused")
+    assert categorize_exception(exc) is ErrorCategory.MODEL_UNREACHABLE
+
+
+def test_model_unreachable_from_httpx_like_class_name() -> None:
+    class ConnectError(Exception):
+        pass
+
+    exc = ConnectError("dns failure")
+    assert categorize_exception(exc) is ErrorCategory.MODEL_UNREACHABLE
+
+
+# ---------------------------------------------------------------------------
+# TIMEOUT
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_from_subprocess_timeout_expired() -> None:
+    exc = subprocess.TimeoutExpired(cmd=["claude"], timeout=30)
+    assert categorize_exception(exc) is ErrorCategory.TIMEOUT
+
+
+def test_timeout_from_builtin_timeout_error() -> None:
+    exc = TimeoutError("operation timed out")
+    assert categorize_exception(exc) is ErrorCategory.TIMEOUT
+
+
+def test_timeout_from_socket_timeout_alias() -> None:
+    exc = TimeoutError("socket timed out")
+    assert categorize_exception(exc) is ErrorCategory.TIMEOUT
+
+
+def test_timeout_from_oserror_etimedout() -> None:
+    exc = OSError(errno.ETIMEDOUT, "timed out")
+    assert categorize_exception(exc) is ErrorCategory.TIMEOUT
+
+
+def test_timeout_from_httpx_like_class_name() -> None:
+    class ReadTimeout(Exception):
+        pass
+
+    exc = ReadTimeout("read timed out")
+    assert categorize_exception(exc) is ErrorCategory.TIMEOUT
+
+
+# ---------------------------------------------------------------------------
+# PERMISSION_DENIED
+# ---------------------------------------------------------------------------
+
+
+def test_permission_denied_from_permission_error() -> None:
+    exc = PermissionError(errno.EACCES, "denied", "/tmp/x")
+    assert categorize_exception(exc) is ErrorCategory.PERMISSION_DENIED
+
+
+def test_permission_denied_from_oserror_eacces() -> None:
+    exc = OSError(errno.EACCES, "denied")
+    assert categorize_exception(exc) is ErrorCategory.PERMISSION_DENIED
+
+
+def test_permission_denied_from_oserror_eperm() -> None:
+    exc = OSError(errno.EPERM, "not permitted")
+    assert categorize_exception(exc) is ErrorCategory.PERMISSION_DENIED
+
+
+# ---------------------------------------------------------------------------
+# PORT_CONFLICT
+# ---------------------------------------------------------------------------
+
+
+def test_port_conflict_from_oserror_eaddrinuse() -> None:
+    exc = OSError(errno.EADDRINUSE, "address already in use")
+    assert categorize_exception(exc) is ErrorCategory.PORT_CONFLICT
+
+
+def test_port_conflict_from_oserror_eaddrnotavail() -> None:
+    exc = OSError(errno.EADDRNOTAVAIL, "cannot assign address")
+    assert categorize_exception(exc) is ErrorCategory.PORT_CONFLICT
+
+
+def test_port_conflict_from_generic_runtime_with_message() -> None:
+    exc = RuntimeError("Port already in use on 8052")
+    assert categorize_exception(exc) is ErrorCategory.PORT_CONFLICT
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN (fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_for_bare_exception() -> None:
+    assert categorize_exception(Exception("???")) is ErrorCategory.UNKNOWN
+
+
+def test_unknown_for_value_error_without_known_tokens() -> None:
+    assert categorize_exception(ValueError("bad input")) is ErrorCategory.UNKNOWN
+
+
+def test_unknown_for_runtime_error_without_known_tokens() -> None:
+    assert categorize_exception(RuntimeError("kaboom")) is ErrorCategory.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Totality / robustness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        Exception(),
+        BaseException(),
+        ValueError("x"),
+        RuntimeError(""),
+        OSError(0, "no errno match"),
+    ],
+)
+def test_categorize_never_returns_none_or_raises(exc: BaseException) -> None:
+    category = categorize_exception(exc)
+    assert isinstance(category, ErrorCategory)
+
+
+def test_categorize_handles_bytes_filename() -> None:
+    exc = FileNotFoundError(errno.ENOENT, "no", b"bernstein.yaml")
+    assert categorize_exception(exc) is ErrorCategory.CONFIG_MISSING
+
+
+def test_categorize_does_not_misfire_for_plain_filenotfound() -> None:
+    exc = FileNotFoundError(errno.ENOENT, "missing", "data.bin")
+    assert categorize_exception(exc) is ErrorCategory.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Exit-code mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("category", "expected_code"),
+    [
+        (ErrorCategory.CONFIG_MISSING, 65),
+        (ErrorCategory.AUTH_FAILED, 77),
+        (ErrorCategory.DEPENDENCY_MISSING, 69),
+        (ErrorCategory.MODEL_UNREACHABLE, 68),
+        (ErrorCategory.TIMEOUT, 75),
+        (ErrorCategory.PERMISSION_DENIED, 77),
+        (ErrorCategory.PORT_CONFLICT, 75),
+        (ErrorCategory.UNKNOWN, 70),
+    ],
+)
+def test_exit_code_matches_sysexits_table(category: ErrorCategory, expected_code: int) -> None:
+    assert exit_code_for(category) == expected_code
+
+
+def test_exit_code_total_for_all_categories() -> None:
+    for category in ErrorCategory:
+        code = exit_code_for(category)
+        assert 64 <= code <= 78, f"{category} -> {code} outside sysexits range"
+
+
+# ---------------------------------------------------------------------------
+# Typed first-run error round trip
+# ---------------------------------------------------------------------------
+
+
+def test_first_run_error_carries_context() -> None:
+    exc = BernsteinFirstRunError(
+        "missing key",
+        category=ErrorCategory.AUTH_FAILED,
+        context={"adapter": "claude", "env_var": "ANTHROPIC_API_KEY"},
+    )
+    assert exc.category is ErrorCategory.AUTH_FAILED
+    assert exc.context["adapter"] == "claude"
+    assert exc.context["env_var"] == "ANTHROPIC_API_KEY"
+
+
+def test_first_run_error_repr_contains_category() -> None:
+    exc = BernsteinFirstRunError("oops", category=ErrorCategory.PORT_CONFLICT)
+    assert "port_conflict" in repr(exc)
+
+
+def test_first_run_error_is_subclass_of_exception() -> None:
+    exc = BernsteinFirstRunError("oops", category=ErrorCategory.UNKNOWN)
+    assert isinstance(exc, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Adapter marker round trip
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_auth_error_attributes_round_trip() -> None:
+    exc = AdapterAuthError("nope", adapter="codex", env_var="OPENAI_API_KEY")
+    assert exc.adapter == "codex"
+    assert exc.env_var == "OPENAI_API_KEY"
+
+
+def test_adapter_binary_not_found_attributes_round_trip() -> None:
+    exc = AdapterBinaryNotFoundError("nope", adapter="aider", install_hint="pipx install aider")
+    assert exc.adapter == "aider"
+    assert exc.install_hint == "pipx install aider"

--- a/tests/unit/errors/test_hints.py
+++ b/tests/unit/errors/test_hints.py
@@ -1,0 +1,183 @@
+"""Unit tests for ``bernstein.core.errors.hints``.
+
+We exercise:
+
+- one snapshot test per category to lock the hint substring,
+- border colour per category,
+- the optional context fields (adapter, env var, port, etc.),
+- verbose-mode toggle (traceback appears or stays hidden),
+- and that ``hint_for`` is total for every enum member.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+
+from bernstein.core.errors import (
+    ErrorCategory,
+    HintContext,
+    hint_for,
+    render_hint,
+)
+from bernstein.core.errors.hints import _CATEGORY_BORDER  # type: ignore[attr-defined]
+
+
+def _render(panel: Panel) -> str:
+    """Render a Rich Panel to a plain string for substring assertions."""
+    buf = io.StringIO()
+    Console(file=buf, force_terminal=False, color_system=None, width=120).print(panel)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-style substring tests (one per category)
+# ---------------------------------------------------------------------------
+
+
+def test_hint_config_missing_mentions_bernstein_init() -> None:
+    text = _render(hint_for(ErrorCategory.CONFIG_MISSING))
+    assert "No bernstein config" in text
+    assert "bernstein init" in text
+
+
+def test_hint_auth_failed_mentions_adapter_and_env_var() -> None:
+    ctx: HintContext = {"adapter": "claude", "env_var": "ANTHROPIC_API_KEY"}
+    text = _render(hint_for(ErrorCategory.AUTH_FAILED, ctx))
+    assert "claude" in text
+    assert "ANTHROPIC_API_KEY" in text
+
+
+def test_hint_auth_failed_falls_back_when_env_var_absent() -> None:
+    ctx: HintContext = {"adapter": "codex"}
+    text = _render(hint_for(ErrorCategory.AUTH_FAILED, ctx))
+    assert "codex" in text
+    assert "codex auth" in text
+
+
+def test_hint_dependency_missing_mentions_install_command() -> None:
+    ctx: HintContext = {"adapter": "aider", "package_manager_command": "pipx install aider"}
+    text = _render(hint_for(ErrorCategory.DEPENDENCY_MISSING, ctx))
+    assert "aider" in text
+    assert "pipx install aider" in text
+
+
+def test_hint_dependency_missing_works_without_command() -> None:
+    text = _render(hint_for(ErrorCategory.DEPENDENCY_MISSING, {"adapter": "aider"}))
+    assert "aider" in text
+    assert "binary is not installed" in text
+
+
+def test_hint_model_unreachable_mentions_provider_and_offline() -> None:
+    text = _render(hint_for(ErrorCategory.MODEL_UNREACHABLE, {"provider": "anthropic"}))
+    assert "anthropic" in text
+    assert "BERNSTEIN_OFFLINE" in text
+
+
+def test_hint_timeout_includes_seconds_when_supplied() -> None:
+    ctx: HintContext = {"adapter": "claude", "timeout_seconds": 30}
+    text = _render(hint_for(ErrorCategory.TIMEOUT, ctx))
+    assert "claude" in text
+    assert "30s" in text
+
+
+def test_hint_timeout_renders_without_seconds() -> None:
+    text = _render(hint_for(ErrorCategory.TIMEOUT, {"adapter": "claude"}))
+    assert "claude" in text
+    assert "timed out" in text
+
+
+def test_hint_permission_denied_mentions_path() -> None:
+    text = _render(hint_for(ErrorCategory.PERMISSION_DENIED, {"path": "/srv/x"}))
+    assert "/srv/x" in text
+    assert "worktree" in text
+
+
+def test_hint_port_conflict_mentions_lsof_and_port() -> None:
+    text = _render(hint_for(ErrorCategory.PORT_CONFLICT, {"port": 9090}))
+    assert "9090" in text
+    assert "lsof -i :9090" in text
+
+
+def test_hint_port_conflict_defaults_to_8052() -> None:
+    text = _render(hint_for(ErrorCategory.PORT_CONFLICT))
+    assert "8052" in text
+
+
+def test_hint_unknown_mentions_verbose_and_issues_url() -> None:
+    text = _render(hint_for(ErrorCategory.UNKNOWN))
+    assert "Unhandled error" in text
+    assert "github.com" in text
+
+
+# ---------------------------------------------------------------------------
+# Coverage: hint_for is total and never empty
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("category", list(ErrorCategory))
+def test_hint_for_returns_panel_for_every_category(category: ErrorCategory) -> None:
+    panel = hint_for(category)
+    assert isinstance(panel, Panel)
+    assert _render(panel).strip() != ""
+
+
+@pytest.mark.parametrize("category", list(ErrorCategory))
+def test_hint_for_uses_category_border(category: ErrorCategory) -> None:
+    panel = hint_for(category)
+    assert panel.border_style == _CATEGORY_BORDER[category]
+
+
+@pytest.mark.parametrize("category", list(ErrorCategory))
+def test_hint_for_has_nonempty_title(category: ErrorCategory) -> None:
+    panel = hint_for(category)
+    # ``Panel.title`` returns a TextType (may be str or rich.text.Text).
+    assert panel.title is not None
+    assert str(panel.title).strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Verbose-mode toggle
+# ---------------------------------------------------------------------------
+
+
+def _make_console() -> tuple[Console, io.StringIO]:
+    buf = io.StringIO()
+    console = Console(file=buf, force_terminal=False, color_system=None, width=120)
+    return console, buf
+
+
+def test_render_hint_default_hides_traceback() -> None:
+    console, buf = _make_console()
+    try:
+        raise RuntimeError("kaboom")
+    except RuntimeError as exc:
+        render_hint(console, ErrorCategory.UNKNOWN, exc=exc, verbose=False)
+    output = buf.getvalue()
+    assert "Unhandled error" in output
+    # The traceback frame label should not leak by default.
+    assert "Traceback" not in output
+    assert "kaboom" not in output or "RuntimeError" not in output
+
+
+def test_render_hint_verbose_shows_traceback() -> None:
+    console, buf = _make_console()
+    try:
+        raise RuntimeError("kaboom-verbose")
+    except RuntimeError as exc:
+        render_hint(console, ErrorCategory.UNKNOWN, exc=exc, verbose=True)
+    output = buf.getvalue()
+    assert "Unhandled error" in output
+    # Rich's Traceback frame names include the exception type.
+    assert "RuntimeError" in output
+    assert "kaboom-verbose" in output
+
+
+def test_render_hint_verbose_without_exception_is_safe() -> None:
+    console, buf = _make_console()
+    render_hint(console, ErrorCategory.PORT_CONFLICT, verbose=True)
+    output = buf.getvalue()
+    assert "Port" in output


### PR DESCRIPTION
## Summary

Introduce a closed 8-category taxonomy of first-run failures with sysexits.h exit codes and Rich-formatted hint panels per category.

- New `bernstein.core.errors` package: `ErrorCategory` (StrEnum), `categorize_exception`, `hint_for`, `render_hint`, `exit_code_for`, plus marker exceptions `BernsteinFirstRunError`, `AdapterAuthError`, `AdapterBinaryNotFoundError`. `categorize_exception` is total (always returns a category; never `None`).
- New `bernstein.cli.first_run_guard.handle_first_run_exception`: wires categorization into the CLI top-level. Renders a category-coloured Rich panel and raises `SystemExit(<sysexits code>)`. `--verbose` retains the traceback below the hint panel; default mode hides it.
- Wired into `cli/run_bootstrap.py` (`run`, `init`, `start`), `cli/install_check.py` (`InstallWarning.category` + `worst_category()`), and `core/orchestration/worker.py` (typed `BernsteinFirstRunError` for `FileNotFoundError` / `PermissionError`).
- Closes spec `2026-05-17-feat-first-run-error-categorization`. The `error_category` value is consumed by the paired opt-in telemetry ticket.

## Taxonomy

| Category | sysexits exit code |
|---|---|
| `config_missing` | 65 (EX_DATAERR) |
| `auth_failed` | 77 (EX_NOPERM) |
| `dependency_missing` | 69 (EX_UNAVAILABLE) |
| `model_unreachable` | 68 (EX_NOHOST) |
| `timeout` | 75 (EX_TEMPFAIL) |
| `permission_denied` | 77 (EX_NOPERM) |
| `port_conflict` | 75 (EX_TEMPFAIL) |
| `unknown` | 70 (EX_SOFTWARE) |

## Test plan

- [x] 87 unit tests in `tests/unit/errors/` (>=2 trigger tests per category, hint substring snapshot per category, verbose toggle, exit-code mapping)
- [x] 10 Hypothesis property tests in `tests/property/test_errcat_properties.py` (`categorize_exception` is total; hint never empty; exit code in sysexits `[64,78]`; determinism; port/timeout context round-trip)
- [x] 14 end-to-end Click integration tests in `tests/integration/test_errcat_cli.py` (per-category exit code + hint substring, `--verbose` traceback toggle, `UsageError` / `SystemExit` pass-through)
- [x] `uv run pytest tests/unit/errors/ tests/property/test_errcat_properties.py tests/integration/test_errcat_cli.py` -- 111 passed
- [x] `uv run ruff check` clean on all new + modified files
- [x] `uv run ruff format --check` clean
- [x] `uv run pyright` strict: zero errors in the new `bernstein.core.errors` package and `bernstein.cli.first_run_guard`. Pre-existing pyright deficits in `run_bootstrap.py` / `worker.py` are unchanged (no net new errors)
- [x] Existing `tests/unit/test_install_check.py` and `tests/unit/test_worker.py` continue to pass