### PR TITLE
feat(adapters): bernstein adapters check - conformance + capability report (closes spec 2026-05-17)

### DIFF
--- a/docs/operations/adapters.md
+++ b/docs/operations/adapters.md
@@ -1,0 +1,148 @@
+# Adapter conformance + capability report
+
+`bernstein adapters check` answers one question:
+
+> Of the 44 adapters this install declares, which ones are reachable on
+> this machine, which ones conform to the contract, and which ones are
+> missing binaries or have drifted?
+
+The command is a one-shot inventory. Re-running it is cheap (no
+network, no agent spawn) and the output is consumable both by humans
+(Rich table) and by CI dashboards (`--format json`).
+
+## TL;DR
+
+| Command                                         | When to use it |
+|-------------------------------------------------|----------------|
+| `bernstein adapters list`                       | Quick "what ships?" listing - one line per adapter, no contract probing |
+| `bernstein adapters list-status`                | Compact conformance status per adapter (Rich table) |
+| `bernstein adapters check`                      | Full table - binary path, version, capabilities, conformance, notes |
+| `bernstein adapters check <name>`               | Drill down to one adapter |
+| `bernstein adapters check --format json`        | CI-consumable payload keyed on `adapters` and `summary` |
+| `bernstein adapters check --strict`             | Exit non-zero on any `conformance == "fail"` row |
+
+## What every row contains
+
+```
+AdapterStatus(
+    name="claude",
+    module_path="bernstein/adapters/claude.py",
+    binary_resolved="/usr/local/bin/claude",
+    version_string="1.0.42",
+    capabilities=frozenset({"--model", "--effort", "--permission-mode", ...}),
+    conformance="ok",
+    conformance_detail="",
+    last_modified_utc="2026-05-17T16:15:21.849480+00:00",
+    contract_hash="8a3f42703dc55c2442ca8c0620bd25fd1823748e970d03519434ac885439dbc5",
+)
+```
+
+Field-by-field:
+
+* **name** - registry key.
+* **module_path** - repo-relative source path of the adapter module.
+* **binary_resolved** - `shutil.which(binary)` output, or `None` when
+  the binary is not on `PATH` (or the adapter is a no-binary wrapper
+  such as `mock`, `generic`, or `openai_agents`).
+* **version_string** - first non-empty trimmed line of
+  `<binary> --version`, captured with a 5-second timeout. `None` when
+  the call fails, times out, or the binary is missing.
+* **capabilities** - flags + subcommands the contract YAML declares
+  as the required surface. Empty when no contract exists.
+* **conformance** - one of `ok` / `fail` / `skip`. See verdict table
+  below.
+* **conformance_detail** - human-readable reason. Empty on `ok`.
+* **last_modified_utc** - ISO-8601 UTC mtime of the adapter module
+  file. Useful as a cache key in dashboards.
+* **contract_hash** - SHA-256 of the loaded contract bytes. Empty
+  when the adapter has no contract on disk.
+
+## Verdict table
+
+| Verdict | When? |
+|---------|-------|
+| `ok`    | Binary present, `<binary> --help` advertises every required flag and subcommand |
+| `fail`  | Binary present but help text is missing at least one required token (contract drift) |
+| `skip`  | No contract on disk, or binary missing, or `--help` failed / timed out |
+
+`skip` is the default state for adapters that simply have no contract
+yet - operators see "we know about it, but we haven't promised what
+it does". `fail` is the only verdict that should ever turn red on a
+healthy install.
+
+## JSON contract
+
+```json
+{
+  "adapters": [
+    {
+      "name": "claude",
+      "module_path": "bernstein/adapters/claude.py",
+      "binary_resolved": "/usr/local/bin/claude",
+      "version_string": "1.0.42",
+      "capabilities": ["--effort", "--include-hook-events", "--model"],
+      "conformance": "ok",
+      "conformance_detail": "",
+      "last_modified_utc": "2026-05-17T16:15:21.849480+00:00",
+      "contract_hash": "8a3f4270..."
+    }
+  ],
+  "summary": {
+    "total": 44,
+    "reachable": 10,
+    "conform": 6,
+    "fail": 0,
+    "skip": 38
+  }
+}
+```
+
+Capabilities are emitted as a sorted list so downstream diffs are
+stable.
+
+## Strict mode
+
+`--strict` flips the process exit code:
+
+* No `fail` rows -> exit `0`.
+* Any `fail` row -> exit `1`.
+
+`skip` rows are tolerated - they typically reflect "operator has not
+installed this CLI yet", which is informational not actionable.
+
+## Conformance check details
+
+The check is in-process and never spawns pytest:
+
+1. `shutil.which(binary)` resolves the upstream CLI.
+2. If reachable, `<binary> --version` is captured with a 5s timeout.
+3. The contract YAML (when present) is loaded and hashed.
+4. The contract's required flags + subcommands are matched against
+   `<binary> --help` output (token-boundary regex; ANSI escapes are
+   stripped).
+
+Adapters that lack a contract YAML fall through with `conformance ==
+"skip"` and an empty capability set. This is intentional - the
+contract suite ships with curated coverage of the load-bearing CLIs.
+
+## CI integration
+
+```yaml
+# .github/workflows/adapters-check.yml
+- name: Adapter conformance gate
+  run: bernstein adapters check --strict --format json | tee adapters.json
+```
+
+Dashboards parse `adapters.json` and surface per-adapter trend lines.
+The `contract_hash` field is the recommended cache key when stitching
+historical reports.
+
+## Related commands
+
+* `bernstein adapters list` - quick "what ships?" enumeration; no
+  contract probing.
+* `bernstein adapters contract-check <name>` - deeper contract check
+  for a single adapter (includes model-list assertions when an auth
+  secret is set).
+* `bernstein doctor` - host-readiness checks; surfaces a subset of the
+  adapter status alongside other environment signals.

--- a/src/bernstein/adapters/conformance.py
+++ b/src/bernstein/adapters/conformance.py
@@ -514,6 +514,36 @@ class {class_name}(CLIAdapter):
 '''
 
 
+# ---------------------------------------------------------------------------
+# In-process conformance check re-export
+# ---------------------------------------------------------------------------
+#
+# The Click surface ``bernstein adapters check`` (see
+# :mod:`bernstein.cli.commands.adapters_cmd`) exposes per-adapter
+# conformance verdicts without spawning pytest. The check itself lives
+# in :mod:`bernstein.adapters.report` so it can share the contract
+# loader with the human-facing report. We re-export the entry point
+# here so callers that grep for ``conformance.check_adapter_in_process``
+# land at the right symbol.
+
+
+def check_adapter_in_process(
+    name: str,
+    *,
+    binary_resolved: str | None,
+    contracts_dir: Path | None = None,
+) -> object:
+    """In-process conformance verdict for one adapter.
+
+    See :func:`bernstein.adapters.report.check_adapter_in_process` for
+    the full docstring and verdict semantics. This shim keeps the
+    public re-export at the module operators historically grep for.
+    """
+    from bernstein.adapters.report import check_adapter_in_process as _impl
+
+    return _impl(name, binary_resolved=binary_resolved, contracts_dir=contracts_dir)
+
+
 def generate_adapter_scaffold(
     cli_name: str,
     class_name: str,

--- a/src/bernstein/adapters/registry.py
+++ b/src/bernstein/adapters/registry.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import inspect
 import logging
 from importlib.metadata import entry_points
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 from bernstein.adapters.aichat import AIChatAdapter
 from bernstein.adapters.aider import AiderAdapter
@@ -168,3 +172,20 @@ def register_adapter(name: str, adapter: type[CLIAdapter] | CLIAdapter) -> None:
         adapter: Adapter class or instance.
     """
     _ADAPTERS[name] = adapter
+
+
+def iter_adapter_specs() -> Iterator[tuple[str, type[CLIAdapter] | CLIAdapter]]:
+    """Yield every registered adapter as ``(name, class-or-instance)`` pairs.
+
+    The iterator triggers entry-point discovery on first use so third-
+    party adapters are surfaced alongside the built-ins. Pairs are
+    emitted in alphabetic order by name so downstream consumers can
+    rely on a deterministic enumeration.
+
+    The values are the raw registry entries (either a class or a
+    pre-built instance). Callers that need a live adapter should pass
+    each one through :func:`get_adapter` or instantiate themselves.
+    """
+    _load_entrypoint_adapters()
+    for name in sorted(_ADAPTERS.keys()):
+        yield name, _ADAPTERS[name]

--- a/src/bernstein/adapters/report.py
+++ b/src/bernstein/adapters/report.py
@@ -1,0 +1,463 @@
+"""Adapter conformance + capability report.
+
+Produces a snapshot of every CLI adapter Bernstein knows about:
+
+* whether the upstream binary resolves on ``PATH``
+* a captured ``<binary> --version`` string (best-effort, 5s timeout)
+* the contract's declared capability surface (flags + subcommands)
+* an in-process conformance verdict: ``ok`` / ``fail`` / ``skip``
+* module mtime + contract sha256 for cache-busting in dashboards
+
+The module is consumed by ``bernstein adapters check`` (Rich + JSON
+surfaces) and is intentionally side-effect free apart from running
+``shutil.which`` and a single ``<binary> --version`` subprocess per
+adapter. No pytest subprocess is spawned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein.adapters._contract import (
+    CONTRACTS_DIR,
+    ContractSpec,
+    _capability_failures,  # pyright: ignore[reportPrivateUsage]
+    _strip_ansi,  # pyright: ignore[reportPrivateUsage]
+)
+
+if TYPE_CHECKING:
+    from bernstein.adapters.base import CLIAdapter
+
+# Per-adapter binary overrides where the registry key differs from the
+# CLI binary on PATH. Mirrors the table in
+# ``bernstein.cli.commands.adapter_cmd._BINARY_OVERRIDES`` so the report
+# stays consistent with ``bernstein adapters list``.
+_BINARY_OVERRIDES: dict[str, str] = {
+    "claude": "claude",
+    "codex": "codex",
+    "devin_terminal": "devin",
+    "q_dev": "q",
+    "open_interpreter": "interpreter",
+    "openai_agents": "python",
+    "cloudflare": "wrangler",
+    "letta_code": "letta",
+    "continue": "continue",
+    "openhands": "openhands",
+    "mock": "",
+    "generic": "",
+    "composio": "ao",
+    "devin": "devin",
+}
+
+# Conformance verdict values.
+CONFORMANCE_OK: Literal["ok"] = "ok"
+CONFORMANCE_FAIL: Literal["fail"] = "fail"
+CONFORMANCE_SKIP: Literal["skip"] = "skip"
+
+ConformanceVerdict = Literal["ok", "fail", "skip"]
+
+# Hard ceiling for ``<binary> --version`` capture.
+_VERSION_TIMEOUT_SECONDS = 5
+
+
+@dataclass(frozen=True)
+class AdapterStatus:
+    """One row in the adapter conformance + capability report.
+
+    Args:
+        name: Registry key (e.g. ``claude``, ``codex``).
+        module_path: Repo-relative source path of the adapter module.
+        binary_resolved: Absolute path on ``PATH``, or ``None`` if missing
+            or the adapter has no binary (mock, generic, openai_agents).
+        version_string: Trimmed first line of ``<binary> --version``, or
+            ``None`` when the call failed / timed out / binary is missing.
+        capabilities: Frozenset of flags + subcommands the contract
+            advertises as the required surface. Empty when no contract.
+        conformance: Verdict - ``ok`` / ``fail`` / ``skip``.
+        conformance_detail: Human-readable reason. Empty on ``ok``.
+        last_modified_utc: ISO-8601 UTC timestamp of the adapter module
+            file's mtime. Empty when the module path cannot be resolved.
+        contract_hash: SHA-256 of the loaded contract bytes, or empty
+            string when the adapter has no contract on disk.
+    """
+
+    name: str
+    module_path: str
+    binary_resolved: str | None
+    version_string: str | None
+    capabilities: frozenset[str]
+    conformance: ConformanceVerdict
+    conformance_detail: str
+    last_modified_utc: str
+    contract_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict.
+
+        ``capabilities`` is emitted as a sorted list so the JSON output is
+        deterministic across runs.
+        """
+        data = asdict(self)
+        data["capabilities"] = sorted(self.capabilities)
+        return data
+
+
+@dataclass(frozen=True)
+class ReportSummary:
+    """Aggregate counts for the adapter report footer.
+
+    Args:
+        total: Number of adapters in the report.
+        reachable: How many adapters had a resolvable binary on ``PATH``.
+        conform: How many adapters earned a ``conformance == "ok"`` row.
+        fail: How many adapters earned a ``conformance == "fail"`` row.
+        skip: How many adapters earned a ``conformance == "skip"`` row.
+    """
+
+    total: int
+    reachable: int
+    conform: int
+    fail: int
+    skip: int
+
+    def to_dict(self) -> dict[str, int]:
+        """Serialize to a JSON-friendly dict."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AdapterReport:
+    """Full report payload returned by :func:`build_report`.
+
+    Args:
+        adapters: One :class:`AdapterStatus` per adapter, sorted by name.
+        summary: Aggregate counts.
+    """
+
+    adapters: tuple[AdapterStatus, ...] = field(default_factory=tuple)
+    summary: ReportSummary = field(default_factory=lambda: ReportSummary(0, 0, 0, 0, 0))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a JSON-friendly dict."""
+        return {
+            "adapters": [s.to_dict() for s in self.adapters],
+            "summary": self.summary.to_dict(),
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize to a JSON string (sorted, deterministic)."""
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _binary_for_adapter(name: str) -> str:
+    """Map a registry key to its expected CLI binary name."""
+    return _BINARY_OVERRIDES.get(name, name)
+
+
+def _resolve_module_path(adapter: type[CLIAdapter] | CLIAdapter) -> str:
+    """Repo-relative module path for an adapter (best-effort)."""
+    try:
+        target = adapter if inspect.isclass(adapter) else type(adapter)
+        src = inspect.getsourcefile(target) or inspect.getfile(target)
+    except (TypeError, OSError):
+        return "<unknown>"
+    if not src:
+        return "<unknown>"
+    path = Path(src).resolve()
+    parts = path.parts
+    if "bernstein" in parts:
+        idx = parts.index("bernstein")
+        return str(Path(*parts[idx:]))
+    return path.name
+
+
+def _module_mtime_utc(adapter: type[CLIAdapter] | CLIAdapter) -> str:
+    """ISO-8601 UTC mtime of the adapter module, or ``""`` on error."""
+    try:
+        target = adapter if inspect.isclass(adapter) else type(adapter)
+        src = inspect.getsourcefile(target) or inspect.getfile(target)
+        if not src:
+            return ""
+        from datetime import UTC, datetime
+
+        ts = Path(src).stat().st_mtime
+        return datetime.fromtimestamp(ts, tz=UTC).isoformat()
+    except (TypeError, OSError):
+        return ""
+
+
+def _contract_hash(name: str, contracts_dir: Path | None = None) -> str:
+    """Return ``sha256`` of the contract YAML, or ``""`` when absent."""
+    base = contracts_dir if contracts_dir is not None else CONTRACTS_DIR
+    path = base / f"{name}.yaml"
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return ""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _contract_capabilities(spec: ContractSpec) -> frozenset[str]:
+    """All flags + subcommands a contract declares as required."""
+    return frozenset(tuple(spec.required_flags) + tuple(spec.required_subcommands))
+
+
+def _capture_version(binary: str, *, timeout: int = _VERSION_TIMEOUT_SECONDS) -> str | None:
+    """Run ``<binary> --version`` with a hard timeout. Never raises.
+
+    Returns the first non-empty trimmed line of stdout+stderr, or
+    ``None`` when the call fails for any reason. ``--version`` is the
+    universally supported flag; the few CLIs that prefer ``version``
+    (no dashes) still respond to ``--version`` with the usage banner,
+    which is good enough to populate a "saw something" column.
+    """
+    if not binary:
+        return None
+    try:
+        proc = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    combined = ((proc.stdout or "") + (proc.stderr or "")).strip()
+    if not combined:
+        return None
+    first_line = _strip_ansi(combined).splitlines()[0].strip()
+    return first_line or None
+
+
+# ---------------------------------------------------------------------------
+# In-process conformance check
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConformanceVerdictPayload:
+    """In-process conformance verdict for one adapter.
+
+    Args:
+        verdict: ``ok`` / ``fail`` / ``skip``.
+        detail: Human-readable reason; empty on ``ok``.
+        capabilities: Capability set the verdict was computed against.
+    """
+
+    verdict: ConformanceVerdict
+    detail: str
+    capabilities: frozenset[str]
+
+
+def check_adapter_in_process(
+    name: str,
+    *,
+    binary_resolved: str | None,
+    contracts_dir: Path | None = None,
+) -> ConformanceVerdictPayload:
+    """Run a lightweight, in-process conformance check for one adapter.
+
+    The check is deliberately simple and never spawns pytest:
+
+    * If no contract YAML exists, the verdict is ``skip`` with detail
+      ``"no contract"``. The adapter is not declared as conformance-
+      tracked and gets a benign pass-through.
+    * If a contract exists but the binary did not resolve, the verdict
+      is ``skip`` with detail ``"binary missing"``. Capabilities are
+      still surfaced for the operator.
+    * If the binary resolved, ``<binary> --help`` is invoked with a 5s
+      timeout and the captured text is matched against the contract's
+      required flags + subcommands. Any miss is a ``fail``; an all-pass
+      is ``ok``. ``--help`` failing to launch is a ``skip``.
+
+    Args:
+        name: Adapter registry key.
+        binary_resolved: Absolute path returned by ``shutil.which`` for
+            the adapter's binary, or ``None`` when missing.
+        contracts_dir: Override for the contracts directory (used by
+            unit tests). Defaults to the packaged contracts dir.
+
+    Returns:
+        A populated :class:`ConformanceVerdictPayload`.
+    """
+    base = contracts_dir if contracts_dir is not None else CONTRACTS_DIR
+    contract_path = base / f"{name}.yaml"
+    if not contract_path.exists():
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_SKIP,
+            detail="no contract",
+            capabilities=frozenset(),
+        )
+
+    try:
+        spec = ContractSpec.load(name, contracts_dir=base)
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_SKIP,
+            detail=f"contract load failed: {exc}",
+            capabilities=frozenset(),
+        )
+
+    capabilities = _contract_capabilities(spec)
+
+    if not binary_resolved:
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_SKIP,
+            detail="binary missing",
+            capabilities=capabilities,
+        )
+
+    # Adapter declared a contract but the binary is on disk - assert
+    # the help text still advertises every required token.
+    help_cmd = spec.resolved_help_command()
+    try:
+        proc = subprocess.run(
+            help_cmd,
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_SKIP,
+            detail=f"--help failed: {exc}",
+            capabilities=capabilities,
+        )
+    except subprocess.TimeoutExpired:
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_SKIP,
+            detail="--help timed out",
+            capabilities=capabilities,
+        )
+
+    help_text = (proc.stdout or "") + (proc.stderr or "")
+    failures = _capability_failures(spec, help_text)
+    if failures:
+        return ConformanceVerdictPayload(
+            verdict=CONFORMANCE_FAIL,
+            detail="; ".join(failures),
+            capabilities=capabilities,
+        )
+
+    return ConformanceVerdictPayload(
+        verdict=CONFORMANCE_OK,
+        detail="",
+        capabilities=capabilities,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Report builder
+# ---------------------------------------------------------------------------
+
+
+def _summarize(rows: tuple[AdapterStatus, ...]) -> ReportSummary:
+    reachable = sum(1 for r in rows if r.binary_resolved)
+    conform = sum(1 for r in rows if r.conformance == CONFORMANCE_OK)
+    fail = sum(1 for r in rows if r.conformance == CONFORMANCE_FAIL)
+    skip = sum(1 for r in rows if r.conformance == CONFORMANCE_SKIP)
+    return ReportSummary(
+        total=len(rows),
+        reachable=reachable,
+        conform=conform,
+        fail=fail,
+        skip=skip,
+    )
+
+
+def _status_for_one(
+    name: str,
+    adapter: type[CLIAdapter] | CLIAdapter,
+    *,
+    contracts_dir: Path | None = None,
+    capture_version: bool = True,
+) -> AdapterStatus:
+    """Compute :class:`AdapterStatus` for a single registry entry."""
+    binary_name = _binary_for_adapter(name)
+    binary_resolved = shutil.which(binary_name) if binary_name else None
+    version = _capture_version(binary_name) if capture_version and binary_resolved else None
+    verdict = check_adapter_in_process(name, binary_resolved=binary_resolved, contracts_dir=contracts_dir)
+    return AdapterStatus(
+        name=name,
+        module_path=_resolve_module_path(adapter),
+        binary_resolved=binary_resolved,
+        version_string=version,
+        capabilities=verdict.capabilities,
+        conformance=verdict.verdict,
+        conformance_detail=verdict.detail,
+        last_modified_utc=_module_mtime_utc(adapter),
+        contract_hash=_contract_hash(name, contracts_dir=contracts_dir),
+    )
+
+
+def build_report(
+    *,
+    contracts_dir: Path | None = None,
+    capture_version: bool = True,
+    only: str | None = None,
+) -> AdapterReport:
+    """Snapshot every registered adapter into an :class:`AdapterReport`.
+
+    Args:
+        contracts_dir: Override the contract directory (tests use this).
+        capture_version: Set to ``False`` in tests to bypass real
+            ``<binary> --version`` subprocesses.
+        only: When set, restrict the report to a single adapter name
+            (raises :class:`KeyError` if absent from the registry).
+
+    Returns:
+        Fully populated :class:`AdapterReport` sorted by adapter name.
+    """
+    # Lazy import so tests can patch ``bernstein.adapters.registry``.
+    from bernstein.adapters.registry import iter_adapter_specs
+
+    rows_list: list[AdapterStatus] = []
+    found_only = False
+    for name, adapter in iter_adapter_specs():
+        if only is not None and name != only:
+            continue
+        if only is not None:
+            found_only = True
+        rows_list.append(
+            _status_for_one(
+                name,
+                adapter,
+                contracts_dir=contracts_dir,
+                capture_version=capture_version,
+            )
+        )
+
+    if only is not None and not found_only:
+        raise KeyError(only)
+
+    rows_list.sort(key=lambda r: r.name)
+    rows = tuple(rows_list)
+    return AdapterReport(adapters=rows, summary=_summarize(rows))
+
+
+__all__ = [
+    "CONFORMANCE_FAIL",
+    "CONFORMANCE_OK",
+    "CONFORMANCE_SKIP",
+    "AdapterReport",
+    "AdapterStatus",
+    "ConformanceVerdict",
+    "ConformanceVerdictPayload",
+    "ReportSummary",
+    "build_report",
+    "check_adapter_in_process",
+]

--- a/src/bernstein/cli/commands/__init__.py
+++ b/src/bernstein/cli/commands/__init__.py
@@ -1,1 +1,22 @@
-"""commands sub-package."""
+"""commands sub-package.
+
+Re-exports the ``adapters`` Click group so callers can do::
+
+    from bernstein.cli.commands import adapters_group
+
+without depending on the historical layout under ``adapter_cmd``.
+"""
+
+from __future__ import annotations
+
+from bernstein.cli.commands.adapter_cmd import adapters_group
+from bernstein.cli.commands.adapters_cmd import (
+    adapters_check_cmd,
+    adapters_list_status_cmd,
+)
+
+__all__ = [
+    "adapters_check_cmd",
+    "adapters_group",
+    "adapters_list_status_cmd",
+]

--- a/src/bernstein/cli/commands/adapter_cmd.py
+++ b/src/bernstein/cli/commands/adapter_cmd.py
@@ -236,6 +236,18 @@ def _register_contract_subcommand() -> None:
 _register_contract_subcommand()
 
 
+def _register_check_subcommand() -> None:
+    """Attach the conformance + capability report subcommands."""
+    try:
+        from bernstein.cli.commands.adapters_cmd import register_adapters_check
+    except Exception:  # pragma: no cover -- defensive
+        return
+    register_adapters_check(adapters_group)
+
+
+_register_check_subcommand()
+
+
 @adapters_group.command("list")
 @click.option(
     "--json",

--- a/src/bernstein/cli/commands/adapters_cmd.py
+++ b/src/bernstein/cli/commands/adapters_cmd.py
@@ -1,0 +1,245 @@
+"""``bernstein adapters check`` - conformance + capability report.
+
+Surfaces the same data the conformance pytest suite covers, but with no
+pytest subprocess and an operator-friendly Rich table on stdout. JSON
+output is wired through ``--format json`` and consumed by CI dashboards.
+
+The command attaches to the pre-existing ``adapters`` group declared in
+:mod:`bernstein.cli.commands.adapter_cmd`. The wiring lives in
+:func:`register_adapters_check` so the main CLI module can call it
+once without exposing import-order quirks.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import click
+
+from bernstein.adapters.report import (
+    CONFORMANCE_FAIL,
+    CONFORMANCE_OK,
+    AdapterStatus,
+    build_report,
+)
+from bernstein.cli.helpers import console
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from bernstein.adapters.report import AdapterReport
+
+# ``check`` output formats. Public so tests can reference the choices.
+FORMAT_TABLE = "table"
+FORMAT_JSON = "json"
+FORMAT_CHOICES = (FORMAT_TABLE, FORMAT_JSON)
+
+
+def _format_capabilities(caps: frozenset[str]) -> str:
+    """Compact, deterministic capability list for the table column."""
+    if not caps:
+        return "-"
+    return ",".join(sorted(caps))
+
+
+def _format_conformance(verdict: str) -> str:
+    """Colourize a verdict for the Rich table."""
+    if verdict == CONFORMANCE_OK:
+        return f"[green]{verdict}[/green]"
+    if verdict == CONFORMANCE_FAIL:
+        return f"[red]{verdict}[/red]"
+    return f"[yellow]{verdict}[/yellow]"
+
+
+def _render_table_rows(report: AdapterReport) -> str:
+    """Render the Rich-coloured table to a deterministic string.
+
+    Splits the heavy lifting out of the Click command so unit tests can
+    snapshot the output without spinning up a TTY.
+    """
+    from io import StringIO
+
+    from rich.console import Console
+    from rich.table import Table
+
+    table = Table(title=f"Bernstein adapter report ({report.summary.total})", show_lines=False)
+    table.add_column("adapter", style="cyan", no_wrap=True)
+    table.add_column("binary", style="white")
+    table.add_column("version", style="dim")
+    table.add_column("caps", style="white")
+    table.add_column("conformance", style="bold")
+    table.add_column("notes", style="dim")
+
+    for row in report.adapters:
+        binary = row.binary_resolved or "[yellow](not in PATH)[/yellow]"
+        version = row.version_string or "[dim](n/a)[/dim]"
+        caps = _format_capabilities(row.capabilities)
+        verdict = _format_conformance(row.conformance)
+        notes = row.conformance_detail or ""
+        table.add_row(row.name, binary, version, caps, verdict, notes)
+
+    buf = StringIO()
+    sub_console = Console(file=buf, force_terminal=False, color_system=None, width=200)
+    sub_console.print(table)
+    footer = (
+        f"\n{report.summary.total} adapters total"
+        f" - {report.summary.reachable} reachable"
+        f" - {report.summary.conform} conform"
+        f" - {report.summary.fail} fail"
+        f" - {report.summary.skip} skip"
+    )
+    sub_console.print(footer)
+    return buf.getvalue()
+
+
+def _render_list_rows(report: AdapterReport) -> str:
+    """One-line status per adapter for ``bernstein adapters check --list``."""
+    from io import StringIO
+
+    from rich.console import Console
+    from rich.table import Table
+
+    table = Table(title=f"Bernstein adapters ({report.summary.total})", show_lines=False)
+    table.add_column("adapter", style="cyan", no_wrap=True)
+    table.add_column("module", style="dim")
+    table.add_column("binary", style="white")
+    table.add_column("conformance", style="bold")
+
+    for row in report.adapters:
+        binary = row.binary_resolved or "[yellow]missing[/yellow]"
+        table.add_row(row.name, row.module_path, binary, _format_conformance(row.conformance))
+
+    buf = StringIO()
+    sub_console = Console(file=buf, force_terminal=False, color_system=None, width=200)
+    sub_console.print(table)
+    return buf.getvalue()
+
+
+def _emit_report(
+    report: AdapterReport,
+    *,
+    output_format: str,
+    list_mode: bool,
+) -> None:
+    """Push the report to the console in the requested format."""
+    if output_format == FORMAT_JSON:
+        click.echo(report.to_json())
+        return
+    if list_mode:
+        console.print(_render_list_rows(report), end="")
+    else:
+        console.print(_render_table_rows(report), end="")
+
+
+def _exit_code(report: AdapterReport, *, strict: bool) -> int:
+    """Decide the process exit code for ``bernstein adapters check``."""
+    if strict and report.summary.fail > 0:
+        return 1
+    return 0
+
+
+def _execute_check(
+    name: str | None,
+    *,
+    output_format: str,
+    strict: bool,
+    list_mode: bool,
+    contracts_dir: Path | None,
+    capture_version: bool,
+) -> int:
+    """Build the report and emit it; return the process exit code.
+
+    Split out from the Click command so unit + integration tests can
+    exercise the full pipeline without invoking ``click.testing``.
+    """
+    try:
+        report = build_report(
+            contracts_dir=contracts_dir,
+            capture_version=capture_version,
+            only=name,
+        )
+    except KeyError:
+        click.echo(f"Unknown adapter: {name!r}", err=True)
+        return 2
+
+    _emit_report(report, output_format=output_format, list_mode=list_mode)
+    return _exit_code(report, strict=strict)
+
+
+@click.command("check")
+@click.argument("name", required=False)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(list(FORMAT_CHOICES)),
+    default=FORMAT_TABLE,
+    show_default=True,
+    help="Output format - rich table for humans, json for CI dashboards.",
+)
+@click.option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Exit non-zero when any adapter has conformance==fail.",
+)
+def adapters_check_cmd(name: str | None, output_format: str, strict: bool) -> None:
+    """Run the adapter conformance + capability report.
+
+    With no NAME, reports on every registered adapter. With NAME, only
+    that adapter is reported on. ``--format json`` emits a stable JSON
+    document keyed on ``adapters`` and ``summary``.
+    """
+    rc = _execute_check(
+        name,
+        output_format=output_format,
+        strict=strict,
+        list_mode=False,
+        contracts_dir=None,
+        capture_version=True,
+    )
+    sys.exit(rc)
+
+
+@click.command("list-status")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(list(FORMAT_CHOICES)),
+    default=FORMAT_TABLE,
+    show_default=True,
+    help="Output format - rich table for humans, json for CI dashboards.",
+)
+def adapters_list_status_cmd(output_format: str) -> None:
+    """One-line conformance status per adapter (compact view of ``check``)."""
+    rc = _execute_check(
+        None,
+        output_format=output_format,
+        strict=False,
+        list_mode=True,
+        contracts_dir=None,
+        capture_version=False,
+    )
+    sys.exit(rc)
+
+
+def register_adapters_check(group: click.Group) -> None:
+    """Attach the conformance subcommands to an existing ``adapters`` group.
+
+    Called from :mod:`bernstein.cli.commands.adapter_cmd` so the new
+    surface lands at ``bernstein adapters check`` without duplicating
+    the group definition.
+    """
+    group.add_command(adapters_check_cmd, "check")
+    group.add_command(adapters_list_status_cmd, "list-status")
+
+
+__all__ = [
+    "FORMAT_CHOICES",
+    "FORMAT_JSON",
+    "FORMAT_TABLE",
+    "AdapterStatus",
+    "adapters_check_cmd",
+    "adapters_list_status_cmd",
+    "register_adapters_check",
+]

--- a/tests/integration/adapters/test_adapters_check_cli.py
+++ b/tests/integration/adapters/test_adapters_check_cli.py
@@ -1,0 +1,173 @@
+"""Integration tests for ``bernstein adapters check``.
+
+These tests exercise the full Click command surface end-to-end -
+from ``CliRunner.invoke`` through the real adapter registry to the
+final stdout payload. They don't shell out to a real binary; the
+``--help`` capture is mocked at the report module level so the
+suite runs offline.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.adapters import report as report_mod
+from bernstein.adapters.base import CLIAdapter
+from bernstein.cli.commands.adapter_cmd import adapters_group
+from bernstein.cli.commands.adapters_cmd import (
+    adapters_check_cmd,
+    adapters_list_status_cmd,
+)
+
+
+class _Stub(CLIAdapter):
+    """Bare adapter stub for integration tests."""
+
+    def name(self) -> str:
+        return "stub"
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: Any,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def empty_contracts(tmp_path: Path) -> Path:
+    """Empty contracts directory so all adapters fall into ``skip``."""
+    d = tmp_path / "contracts"
+    d.mkdir()
+    return d
+
+
+def test_adapters_check_against_real_registry_emits_json() -> None:
+    """``bernstein adapters check --format json`` runs end-to-end and parses."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_check_cmd, ["--format", "json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["total"] >= 44
+    # Every row has the contract surface from the dataclass.
+    for row in parsed["adapters"]:
+        assert "conformance" in row
+        assert row["conformance"] in {"ok", "fail", "skip"}
+
+
+def test_adapters_check_against_real_registry_table_renders() -> None:
+    """Default Rich table prints adapter names and the footer."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_check_cmd, [])
+    assert result.exit_code == 0, result.output
+    assert "claude" in result.output
+    assert "adapters total" in result.output
+
+
+def test_adapters_check_single_adapter_form_works() -> None:
+    """``bernstein adapters check claude`` filters to a single row."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_check_cmd, ["claude", "--format", "json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["total"] == 1
+    assert parsed["adapters"][0]["name"] == "claude"
+
+
+def test_adapters_check_unknown_adapter_returns_exit_two() -> None:
+    """An unknown adapter NAME exits with code 2 (Click convention)."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_check_cmd, ["never-heard-of-it"])
+    assert result.exit_code == 2
+
+
+def test_adapters_check_strict_with_failure_returns_one(empty_contracts: Path, tmp_path: Path) -> None:
+    """``--strict`` exits 1 when at least one row is ``fail``."""
+
+    def _iter() -> Any:
+        yield "alpha", _Stub
+
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="usage: alpha\n", stderr="")
+    (empty_contracts / "alpha.yaml").write_text(
+        "adapter: alpha\nbinary: alpha\ninstall:\n  method: ''\n  spec: ''\n"
+        "auth:\n  required_for_help: false\n  required_for_models: false\n  secret_env: ''\n"
+        "required_flags:\n  - '--required'\nrequired_subcommands: []\n"
+        "expected_models:\n  command: []\n  required_present: []\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _iter):
+        with patch.object(report_mod, "CONTRACTS_DIR", empty_contracts):
+            with patch.object(report_mod, "_binary_for_adapter", return_value="alpha"):
+                with patch.object(report_mod.shutil, "which", return_value="/usr/bin/alpha"):
+                    with patch.object(report_mod.subprocess, "run", return_value=completed):
+                        result = runner.invoke(adapters_check_cmd, ["--strict", "--format", "json"])
+    assert result.exit_code == 1, result.output
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["fail"] >= 1
+
+
+def test_adapters_check_strict_zero_when_only_skip(empty_contracts: Path) -> None:
+    """Strict mode tolerates ``skip`` (binary missing is expected)."""
+
+    def _iter() -> Any:
+        yield "alpha", _Stub
+
+    runner = CliRunner()
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _iter):
+        with patch.object(report_mod, "CONTRACTS_DIR", empty_contracts):
+            result = runner.invoke(adapters_check_cmd, ["--strict", "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+
+def test_adapters_group_lists_check_subcommand() -> None:
+    """``bernstein adapters --help`` advertises the ``check`` subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_group, ["--help"])
+    assert result.exit_code == 0
+    assert "check" in result.output
+    assert "list-status" in result.output
+
+
+def test_adapters_list_status_cli_runs_against_real_registry() -> None:
+    """``list-status`` exits 0 and lists every adapter in JSON mode."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_list_status_cmd, ["--format", "json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["total"] >= 44
+    # No row carries a captured version (list-status skips capture).
+    for row in parsed["adapters"]:
+        assert row["version_string"] is None
+
+
+def test_adapters_check_invalid_format_rejected() -> None:
+    """Click rejects unknown ``--format`` values."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_check_cmd, ["--format", "yaml"])
+    assert result.exit_code != 0
+    assert "invalid" in result.output.lower() or "choose from" in result.output.lower()
+
+
+def test_adapters_check_table_output_has_consistent_columns() -> None:
+    """The Rich table always carries adapter / binary / version / caps columns."""
+    runner = CliRunner()
+    result = runner.invoke(adapters_check_cmd, [])
+    assert result.exit_code == 0
+    for column in ("adapter", "binary", "version", "caps", "conformance"):
+        assert column in result.output, f"missing column header: {column}"

--- a/tests/property/test_adapter_report_properties.py
+++ b/tests/property/test_adapter_report_properties.py
@@ -1,0 +1,250 @@
+"""Property-based tests for ``bernstein.adapters.report``.
+
+Pins invariants that should hold for any plausible adapter registry
+and any plausible mix of conformance verdicts:
+
+* The summary counters cover every row exactly once.
+* JSON serialisation round-trips for any populated report.
+* The ``conformance`` field always lands in the closed verdict set.
+* Capability sets emit sorted lists in JSON regardless of insertion
+  order.
+* ``build_report(only=name)`` filters to exactly one row when the name
+  is in the registry.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.report import (
+    CONFORMANCE_FAIL,
+    CONFORMANCE_OK,
+    CONFORMANCE_SKIP,
+    AdapterReport,
+    AdapterStatus,
+    ReportSummary,
+    _summarize,
+    build_report,
+)
+
+_VERDICTS = (CONFORMANCE_OK, CONFORMANCE_FAIL, CONFORMANCE_SKIP)
+
+
+class _Stub(CLIAdapter):
+    """Bare CLIAdapter stub for property tests."""
+
+    def name(self) -> str:
+        return "stub"
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Any,
+        model_config: Any,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> Any:
+        raise NotImplementedError
+
+
+def _status(name: str, verdict: str, *, binary: str | None) -> AdapterStatus:
+    """Compact factory for AdapterStatus rows in property tests."""
+    return AdapterStatus(
+        name=name,
+        module_path=f"{name}.py",
+        binary_resolved=binary,
+        version_string=None,
+        capabilities=frozenset(),
+        conformance=verdict,  # type: ignore[arg-type]
+        conformance_detail="",
+        last_modified_utc="",
+        contract_hash="",
+    )
+
+
+@st.composite
+def _adapter_status(draw: st.DrawFn) -> AdapterStatus:
+    name = draw(st.text(alphabet=st.characters(whitelist_categories=("Lu", "Ll")), min_size=1, max_size=12))
+    verdict = draw(st.sampled_from(_VERDICTS))
+    binary = draw(st.one_of(st.none(), st.just("/usr/bin/" + name)))
+    caps = draw(st.sets(st.text(min_size=1, max_size=6), max_size=5))
+    return AdapterStatus(
+        name=name,
+        module_path=f"{name}.py",
+        binary_resolved=binary,
+        version_string=None,
+        capabilities=frozenset(caps),
+        conformance=verdict,  # type: ignore[arg-type]
+        conformance_detail="",
+        last_modified_utc="",
+        contract_hash="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Summary invariants
+# ---------------------------------------------------------------------------
+
+
+@given(rows=st.lists(_adapter_status(), max_size=20))
+def test_summary_total_matches_row_count(rows: list[AdapterStatus]) -> None:
+    """``summary.total`` equals the number of rows for any registry shape."""
+    s = _summarize(tuple(rows))
+    assert s.total == len(rows)
+
+
+@given(rows=st.lists(_adapter_status(), max_size=20))
+def test_summary_verdict_counters_cover_every_row(rows: list[AdapterStatus]) -> None:
+    """conform + fail + skip == total for any row distribution."""
+    s = _summarize(tuple(rows))
+    assert s.conform + s.fail + s.skip == s.total
+
+
+@given(rows=st.lists(_adapter_status(), max_size=20))
+def test_summary_reachable_le_total(rows: list[AdapterStatus]) -> None:
+    """``reachable`` is bounded by ``total``."""
+    s = _summarize(tuple(rows))
+    assert 0 <= s.reachable <= s.total
+
+
+@given(rows=st.lists(_adapter_status(), max_size=20))
+def test_summary_no_negative_counters(rows: list[AdapterStatus]) -> None:
+    """Every counter is non-negative for any input."""
+    s = _summarize(tuple(rows))
+    assert all(v >= 0 for v in (s.total, s.reachable, s.conform, s.fail, s.skip))
+
+
+# ---------------------------------------------------------------------------
+# JSON round-trip
+# ---------------------------------------------------------------------------
+
+
+@given(rows=st.lists(_adapter_status(), max_size=12))
+def test_report_json_round_trip(rows: list[AdapterStatus]) -> None:
+    """Any report serialises to JSON and parses back to an equivalent dict."""
+    report = AdapterReport(adapters=tuple(rows), summary=_summarize(tuple(rows)))
+    payload = report.to_json()
+    parsed = json.loads(payload)
+    assert parsed["summary"]["total"] == len(rows)
+
+
+@given(rows=st.lists(_adapter_status(), min_size=1, max_size=8))
+def test_report_json_capabilities_always_sorted(rows: list[AdapterStatus]) -> None:
+    """JSON ``capabilities`` is always a sorted list."""
+    report = AdapterReport(adapters=tuple(rows), summary=_summarize(tuple(rows)))
+    parsed = json.loads(report.to_json())
+    for row in parsed["adapters"]:
+        assert row["capabilities"] == sorted(row["capabilities"])
+
+
+@given(rows=st.lists(_adapter_status(), max_size=10))
+def test_report_summary_is_int_only(rows: list[AdapterStatus]) -> None:
+    """JSON-serialised summary contains ints (no leaked sets)."""
+    report = AdapterReport(adapters=tuple(rows), summary=_summarize(tuple(rows)))
+    parsed = json.loads(report.to_json())
+    for v in parsed["summary"].values():
+        assert isinstance(v, int)
+
+
+# ---------------------------------------------------------------------------
+# Verdict membership
+# ---------------------------------------------------------------------------
+
+
+@given(rows=st.lists(_adapter_status(), max_size=10))
+def test_every_verdict_is_in_closed_set(rows: list[AdapterStatus]) -> None:
+    """Every row's conformance lives in the closed verdict set."""
+    assert all(r.conformance in _VERDICTS for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# build_report filter
+# ---------------------------------------------------------------------------
+
+
+@given(names=st.lists(st.sampled_from(["aichat", "claude", "codex", "gemini"]), min_size=1, max_size=4, unique=True))
+def test_build_report_only_filters_to_single_row(names: list[str]) -> None:
+    """``only=name`` against a stub registry produces exactly one row."""
+
+    def _iter() -> Any:
+        for n in names:
+            yield n, _Stub
+
+    chosen = names[0]
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _iter):
+        report = build_report(capture_version=False, only=chosen)
+    assert len(report.adapters) == 1
+    assert report.adapters[0].name == chosen
+
+
+@given(names=st.lists(st.text(min_size=1, max_size=10, alphabet="abcdef"), min_size=1, max_size=6, unique=True))
+def test_build_report_sorts_by_name(names: list[str]) -> None:
+    """``build_report`` always returns rows in alphabetic order."""
+
+    def _iter() -> Any:
+        for n in names:
+            yield n, _Stub
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _iter):
+        report = build_report(capture_version=False)
+    emitted = [a.name for a in report.adapters]
+    assert emitted == sorted(emitted)
+
+
+# ---------------------------------------------------------------------------
+# Report summary helpers - extra coverage
+# ---------------------------------------------------------------------------
+
+
+@given(
+    ok=st.integers(min_value=0, max_value=10),
+    fail=st.integers(min_value=0, max_value=10),
+    skip=st.integers(min_value=0, max_value=10),
+)
+def test_summary_handles_uniform_verdict_distributions(ok: int, fail: int, skip: int) -> None:
+    """Summary counts match the input verdict distribution."""
+    rows: list[AdapterStatus] = []
+    rows.extend(_status(f"o{i}", CONFORMANCE_OK, binary=f"/usr/bin/o{i}") for i in range(ok))
+    rows.extend(_status(f"f{i}", CONFORMANCE_FAIL, binary=f"/usr/bin/f{i}") for i in range(fail))
+    rows.extend(_status(f"s{i}", CONFORMANCE_SKIP, binary=None) for i in range(skip))
+    s = _summarize(tuple(rows))
+    assert s.conform == ok
+    assert s.fail == fail
+    assert s.skip == skip
+
+
+@given(
+    n_with_binary=st.integers(min_value=0, max_value=10),
+    n_without=st.integers(min_value=0, max_value=10),
+)
+def test_summary_reachable_counts_binary_resolved(n_with_binary: int, n_without: int) -> None:
+    """``reachable`` counts only rows whose ``binary_resolved`` is set."""
+    rows: list[AdapterStatus] = []
+    rows.extend(_status(f"w{i}", CONFORMANCE_OK, binary=f"/usr/bin/w{i}") for i in range(n_with_binary))
+    rows.extend(_status(f"x{i}", CONFORMANCE_SKIP, binary=None) for i in range(n_without))
+    s = _summarize(tuple(rows))
+    assert s.reachable == n_with_binary
+
+
+@given(rows=st.lists(_adapter_status(), max_size=15))
+def test_summary_is_reconstructible_from_rows(rows: list[AdapterStatus]) -> None:
+    """The summary depends only on the rows, not the report container."""
+    s1 = _summarize(tuple(rows))
+    s2 = _summarize(tuple(rows))
+    assert s1 == s2
+
+
+def test_report_summary_with_zero_rows_is_zero_summary() -> None:
+    """Empty report has an all-zero summary (sanity for boundary)."""
+    assert _summarize(()) == ReportSummary(0, 0, 0, 0, 0)

--- a/tests/unit/adapters/test_report.py
+++ b/tests/unit/adapters/test_report.py
@@ -1,0 +1,800 @@
+"""Unit tests for ``bernstein.adapters.report``.
+
+The conformance + capability report is the data spine for
+``bernstein adapters check``. These tests pin every branch:
+
+* Binary present and version captured.
+* Binary missing -> ``skip`` with ``binary missing``.
+* Binary present but ``--help`` lacks a required flag -> ``fail``.
+* JSON output round-trips through ``json.loads``.
+* ``build_report(only=...)`` filters and raises on miss.
+* The Click command's exit code obeys ``--strict``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.adapters import report as report_mod
+from bernstein.adapters.base import CLIAdapter
+from bernstein.adapters.report import (
+    CONFORMANCE_FAIL,
+    CONFORMANCE_OK,
+    CONFORMANCE_SKIP,
+    AdapterReport,
+    AdapterStatus,
+    ConformanceVerdictPayload,
+    ReportSummary,
+    _binary_for_adapter,
+    _capture_version,
+    _contract_capabilities,
+    _contract_hash,
+    _module_mtime_utc,
+    _resolve_module_path,
+    _status_for_one,
+    _summarize,
+    build_report,
+    check_adapter_in_process,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class _Stub(CLIAdapter):
+    """Bare minimum CLIAdapter for tests; never spawns."""
+
+    def name(self) -> str:
+        return "stub"
+
+    def spawn(
+        self,
+        *,
+        prompt: str,
+        workdir: Path,
+        model_config: Any,
+        session_id: str,
+        mcp_config: dict[str, Any] | None = None,
+        timeout_seconds: int = 1800,
+        task_scope: str = "medium",
+        budget_multiplier: float = 1.0,
+        system_addendum: str = "",
+    ) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def contracts_tmp(tmp_path: Path) -> Path:
+    """Empty contracts directory test fixture."""
+    d = tmp_path / "contracts"
+    d.mkdir()
+    return d
+
+
+def _write_contract(
+    directory: Path,
+    name: str,
+    *,
+    binary: str = "stub",
+    flags: tuple[str, ...] = ("--model",),
+    subcommands: tuple[str, ...] = (),
+) -> Path:
+    """Write a minimal contract YAML for tests."""
+    flags_yaml = ("\n" + "\n".join(f"  - {f!r}" for f in flags)) if flags else " []"
+    sub_yaml = ("\n" + "\n".join(f"  - {s!r}" for s in subcommands)) if subcommands else " []"
+    body = (
+        f"adapter: {name}\n"
+        f"binary: {binary}\n"
+        "install:\n  method: npm\n  spec: ''\n"
+        "auth:\n  required_for_help: false\n  required_for_models: false\n  secret_env: ''\n"
+        f"required_flags:{flags_yaml}\n"
+        f"required_subcommands:{sub_yaml}\n"
+        "expected_models:\n  command: []\n  required_present: []\n"
+    )
+    path = directory / f"{name}.yaml"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Dataclass + helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_status_to_dict_emits_sorted_capabilities() -> None:
+    """``capabilities`` round-trips as a sorted list."""
+    s = AdapterStatus(
+        name="x",
+        module_path="x.py",
+        binary_resolved=None,
+        version_string=None,
+        capabilities=frozenset({"z", "a", "m"}),
+        conformance=CONFORMANCE_SKIP,
+        conformance_detail="",
+        last_modified_utc="",
+        contract_hash="",
+    )
+    payload = s.to_dict()
+    assert payload["capabilities"] == ["a", "m", "z"]
+
+
+def test_adapter_status_to_dict_round_trips_through_json() -> None:
+    """A status dict serialises to JSON and back without loss."""
+    s = AdapterStatus(
+        name="x",
+        module_path="x.py",
+        binary_resolved="/usr/local/bin/x",
+        version_string="1.0",
+        capabilities=frozenset({"--model"}),
+        conformance=CONFORMANCE_OK,
+        conformance_detail="",
+        last_modified_utc="2026-05-17T00:00:00+00:00",
+        contract_hash="deadbeef",
+    )
+    text = json.dumps(s.to_dict())
+    loaded = json.loads(text)
+    assert loaded["name"] == "x"
+    assert loaded["capabilities"] == ["--model"]
+    assert loaded["conformance"] == "ok"
+
+
+def test_report_summary_to_dict_returns_int_counts() -> None:
+    """Summary counts serialise as ints (no leaked sets)."""
+    s = ReportSummary(total=3, reachable=2, conform=1, fail=1, skip=1)
+    assert s.to_dict() == {"total": 3, "reachable": 2, "conform": 1, "fail": 1, "skip": 1}
+
+
+def test_adapter_report_to_dict_keys() -> None:
+    """The top-level payload always has ``adapters`` and ``summary`` keys."""
+    r = AdapterReport()
+    payload = r.to_dict()
+    assert set(payload.keys()) == {"adapters", "summary"}
+
+
+def test_adapter_report_to_json_is_parseable() -> None:
+    """``to_json`` emits valid JSON that round-trips through ``json.loads``."""
+    s = AdapterStatus(
+        name="x",
+        module_path="x.py",
+        binary_resolved="/usr/bin/x",
+        version_string="1.0",
+        capabilities=frozenset({"--model"}),
+        conformance=CONFORMANCE_OK,
+        conformance_detail="",
+        last_modified_utc="",
+        contract_hash="",
+    )
+    r = AdapterReport(adapters=(s,), summary=ReportSummary(1, 1, 1, 0, 0))
+    parsed = json.loads(r.to_json())
+    assert parsed["summary"]["conform"] == 1
+    assert parsed["adapters"][0]["name"] == "x"
+
+
+def test_summarize_counts_each_verdict_class() -> None:
+    """Aggregator splits rows into reachable/conform/fail/skip buckets."""
+    rows: tuple[AdapterStatus, ...] = (
+        AdapterStatus("a", "a.py", "/usr/bin/a", "1", frozenset(), CONFORMANCE_OK, "", "", ""),
+        AdapterStatus("b", "b.py", None, None, frozenset(), CONFORMANCE_SKIP, "binary missing", "", ""),
+        AdapterStatus("c", "c.py", "/usr/bin/c", "1", frozenset(), CONFORMANCE_FAIL, "missing flag", "", ""),
+    )
+    s = _summarize(rows)
+    assert s.total == 3
+    assert s.reachable == 2
+    assert s.conform == 1
+    assert s.fail == 1
+    assert s.skip == 1
+
+
+def test_summarize_empty_input_returns_zero_summary() -> None:
+    """No rows -> all counters zero."""
+    s = _summarize(())
+    assert s == ReportSummary(0, 0, 0, 0, 0)
+
+
+def test_binary_for_adapter_uses_override_table() -> None:
+    """Adapter names with binary overrides take the override."""
+    assert _binary_for_adapter("q_dev") == "q"
+    assert _binary_for_adapter("devin_terminal") == "devin"
+    assert _binary_for_adapter("composio") == "ao"
+
+
+def test_binary_for_adapter_falls_back_to_name() -> None:
+    """Unknown registry keys default to their own name as the binary."""
+    assert _binary_for_adapter("custom-third-party") == "custom-third-party"
+
+
+def test_binary_for_adapter_empty_string_for_no_binary_adapters() -> None:
+    """Adapters with no upstream binary surface as empty string."""
+    assert _binary_for_adapter("mock") == ""
+    assert _binary_for_adapter("generic") == ""
+
+
+def test_contract_hash_returns_empty_when_contract_missing(contracts_tmp: Path) -> None:
+    """Missing contract files surface as an empty hash, not a crash."""
+    assert _contract_hash("nonexistent", contracts_dir=contracts_tmp) == ""
+
+
+def test_contract_hash_is_stable_for_same_bytes(contracts_tmp: Path) -> None:
+    """Two reads of the same contract produce the same digest."""
+    _write_contract(contracts_tmp, "stub", flags=("--model",))
+    assert _contract_hash("stub", contracts_dir=contracts_tmp) == _contract_hash("stub", contracts_dir=contracts_tmp)
+
+
+def test_contract_hash_changes_when_bytes_change(contracts_tmp: Path) -> None:
+    """Editing the contract YAML invalidates the digest."""
+    _write_contract(contracts_tmp, "stub", flags=("--model",))
+    first = _contract_hash("stub", contracts_dir=contracts_tmp)
+    _write_contract(contracts_tmp, "stub", flags=("--model", "--effort"))
+    second = _contract_hash("stub", contracts_dir=contracts_tmp)
+    assert first != second
+
+
+def test_contract_capabilities_collects_flags_and_subs() -> None:
+    """Both required flags and subcommands feed the capability set."""
+    from bernstein.adapters._contract import ContractSpec
+
+    spec = ContractSpec(
+        adapter="x",
+        binary="x",
+        install_method="",
+        install_spec="",
+        auth_required_for_help=False,
+        auth_required_for_models=False,
+        auth_secret_env="",
+        required_flags=("--a", "--b"),
+        required_subcommands=("run",),
+        help_command=(),
+        models_command=(),
+        models_required_present=(),
+    )
+    assert _contract_capabilities(spec) == frozenset({"--a", "--b", "run"})
+
+
+def test_resolve_module_path_for_unknown_returns_marker() -> None:
+    """An object inspect can't reach surfaces the fallback marker."""
+
+    class Inline:
+        pass
+
+    # Inline classes living in a test module typically resolve to the
+    # test file itself - either way the helper must produce a string.
+    result = _resolve_module_path(Inline)
+    assert isinstance(result, str)
+    assert result  # non-empty
+
+
+def test_module_mtime_utc_returns_iso_or_empty() -> None:
+    """mtime helper returns an ISO timestamp for inspectable adapters."""
+    ts = _module_mtime_utc(_Stub)
+    assert ts == "" or ("T" in ts and (ts.endswith("+00:00") or ts.endswith("UTC")))
+
+
+# ---------------------------------------------------------------------------
+# capture_version
+# ---------------------------------------------------------------------------
+
+
+def test_capture_version_returns_first_line_of_output() -> None:
+    """The captured version is the first stripped output line."""
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="1.0.42\nmore\n", stderr="")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        assert _capture_version("anything") == "1.0.42"
+
+
+def test_capture_version_falls_back_to_stderr_when_stdout_empty() -> None:
+    """Some CLIs emit ``--version`` on stderr; we still capture it."""
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="banner 2.1\n")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        assert _capture_version("x") == "banner 2.1"
+
+
+def test_capture_version_returns_none_on_filenotfound() -> None:
+    """A missing binary never raises - we just return ``None``."""
+    with patch.object(report_mod.subprocess, "run", side_effect=FileNotFoundError()):
+        assert _capture_version("missing") is None
+
+
+def test_capture_version_returns_none_on_timeout() -> None:
+    """A timeout swallows cleanly without bubbling up."""
+    with patch.object(
+        report_mod.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd="x", timeout=5),
+    ):
+        assert _capture_version("x") is None
+
+
+def test_capture_version_returns_none_on_empty_output() -> None:
+    """Empty stdout+stderr never produces a fake version string."""
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        assert _capture_version("x") is None
+
+
+def test_capture_version_empty_binary_returns_none() -> None:
+    """No binary name means no subprocess - return ``None`` immediately."""
+    assert _capture_version("") is None
+
+
+def test_capture_version_strips_ansi_escapes() -> None:
+    """ANSI escape sequences in version output do not leak."""
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="\x1b[1mclaude-code\x1b[0m 1.0.42\n",
+        stderr="",
+    )
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        out = _capture_version("claude")
+        assert out == "claude-code 1.0.42"
+
+
+# ---------------------------------------------------------------------------
+# check_adapter_in_process
+# ---------------------------------------------------------------------------
+
+
+def test_check_adapter_no_contract_yields_skip(contracts_tmp: Path) -> None:
+    """No contract -> ``skip`` with the ``no contract`` reason."""
+    v = check_adapter_in_process("ghost", binary_resolved=None, contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_SKIP
+    assert v.detail == "no contract"
+    assert v.capabilities == frozenset()
+
+
+def test_check_adapter_binary_missing_yields_skip(contracts_tmp: Path) -> None:
+    """Contract on disk but no binary -> ``skip``/``binary missing``."""
+    _write_contract(contracts_tmp, "stub", flags=("--model",))
+    v = check_adapter_in_process("stub", binary_resolved=None, contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_SKIP
+    assert v.detail == "binary missing"
+    assert v.capabilities == frozenset({"--model"})
+
+
+def test_check_adapter_help_failure_yields_skip(contracts_tmp: Path) -> None:
+    """``--help`` blowing up surfaces as ``skip`` not ``fail``."""
+    _write_contract(contracts_tmp, "stub", flags=("--model",))
+    with patch.object(report_mod.subprocess, "run", side_effect=FileNotFoundError()):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_SKIP
+    assert "--help failed" in v.detail
+
+
+def test_check_adapter_help_timeout_yields_skip(contracts_tmp: Path) -> None:
+    """A slow CLI is recorded as ``skip``/``--help timed out``."""
+    _write_contract(contracts_tmp, "stub", flags=("--model",))
+    with patch.object(
+        report_mod.subprocess,
+        "run",
+        side_effect=subprocess.TimeoutExpired(cmd="stub", timeout=5),
+    ):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_SKIP
+    assert "timed out" in v.detail
+
+
+def test_check_adapter_help_passing_yields_ok(contracts_tmp: Path) -> None:
+    """Help text containing every required flag earns the ``ok`` verdict."""
+    _write_contract(contracts_tmp, "stub", flags=("--model", "--effort"))
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="usage: stub [--model M] [--effort E]\n", stderr=""
+    )
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_OK
+    assert v.detail == ""
+    assert v.capabilities == frozenset({"--model", "--effort"})
+
+
+def test_check_adapter_help_missing_flag_yields_fail(contracts_tmp: Path) -> None:
+    """Help text missing a required flag -> ``fail`` with a useful note."""
+    _write_contract(contracts_tmp, "stub", flags=("--model", "--effort"))
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="usage: stub [--model M]\n", stderr="")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_FAIL
+    assert "--effort" in v.detail
+
+
+def test_check_adapter_missing_subcommand_yields_fail(contracts_tmp: Path) -> None:
+    """A missing required subcommand also produces ``fail``."""
+    _write_contract(
+        contracts_tmp,
+        "stub",
+        flags=(),
+        subcommands=("plan",),
+    )
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="usage: stub --help\n", stderr="")
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_FAIL
+    assert "plan" in v.detail
+
+
+def test_check_adapter_subcommand_present_yields_ok(contracts_tmp: Path) -> None:
+    """Subcommand present at a token boundary passes."""
+    _write_contract(contracts_tmp, "stub", flags=(), subcommands=("run",))
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="Commands:\n  run    Run the agent\n  list   ...\n", stderr=""
+    )
+    with patch.object(report_mod.subprocess, "run", return_value=completed):
+        v = check_adapter_in_process("stub", binary_resolved="/usr/bin/stub", contracts_dir=contracts_tmp)
+    assert v.verdict == CONFORMANCE_OK
+
+
+# ---------------------------------------------------------------------------
+# build_report
+# ---------------------------------------------------------------------------
+
+
+def _stub_iter() -> Any:
+    """Return a one-off two-adapter registry iterator for build_report tests."""
+
+    def _gen() -> Any:
+        yield "alpha", _Stub
+        yield "beta", _Stub
+
+    return _gen
+
+
+def test_build_report_sorts_by_adapter_name(contracts_tmp: Path) -> None:
+    """The report is always sorted alphabetically by adapter name."""
+
+    def _reversed() -> Any:
+        yield "zzz", _Stub
+        yield "aaa", _Stub
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _reversed):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    assert [a.name for a in report.adapters] == ["aaa", "zzz"]
+
+
+def test_build_report_summary_matches_rows(contracts_tmp: Path) -> None:
+    """``summary.total`` always equals ``len(adapters)``."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    assert report.summary.total == len(report.adapters)
+
+
+def test_build_report_only_filters_to_single_adapter(contracts_tmp: Path) -> None:
+    """``only="alpha"`` yields exactly one row."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False, only="alpha")
+    assert len(report.adapters) == 1
+    assert report.adapters[0].name == "alpha"
+
+
+def test_build_report_only_unknown_raises_keyerror(contracts_tmp: Path) -> None:
+    """An unknown ``only`` raises ``KeyError`` for the CLI to translate."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with pytest.raises(KeyError):
+            build_report(contracts_dir=contracts_tmp, capture_version=False, only="missing")
+
+
+def test_build_report_skips_capture_version_when_disabled(contracts_tmp: Path) -> None:
+    """Test mode never invokes a real subprocess."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with patch.object(report_mod, "_capture_version") as cap:
+            build_report(contracts_dir=contracts_tmp, capture_version=False)
+        cap.assert_not_called()
+
+
+def test_build_report_returns_immutable_adapters_tuple(contracts_tmp: Path) -> None:
+    """``adapters`` is a tuple so callers cannot mutate the snapshot."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    assert isinstance(report.adapters, tuple)
+
+
+def test_build_report_uses_iter_adapter_specs_only_once(contracts_tmp: Path) -> None:
+    """Each call materialises exactly one registry pass."""
+    calls = {"n": 0}
+
+    def _spy() -> Any:
+        calls["n"] += 1
+        yield "alpha", _Stub
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _spy):
+        build_report(contracts_dir=contracts_tmp, capture_version=False)
+    assert calls["n"] == 1
+
+
+def test_build_report_captures_status_module_path(contracts_tmp: Path) -> None:
+    """Row's ``module_path`` is populated even with the stub adapter."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    assert all(isinstance(a.module_path, str) and a.module_path for a in report.adapters)
+
+
+def test_build_report_real_registry_total_is_at_least_44() -> None:
+    """The real registry has 44+ adapters."""
+    report = build_report(capture_version=False)
+    assert report.summary.total >= 44
+
+
+def test_build_report_only_real_adapter_returns_one_row() -> None:
+    """``only="claude"`` against the real registry yields a single row."""
+    report = build_report(capture_version=False, only="claude")
+    assert len(report.adapters) == 1
+    assert report.adapters[0].name == "claude"
+
+
+def test_status_for_one_returns_skip_when_no_binary(contracts_tmp: Path) -> None:
+    """Mock adapter has no binary -> skip without capturing version."""
+    s = _status_for_one("mock", _Stub, contracts_dir=contracts_tmp, capture_version=True)
+    assert s.binary_resolved is None
+    assert s.version_string is None
+    assert s.conformance == CONFORMANCE_SKIP
+
+
+def test_status_for_one_handles_unknown_adapter(contracts_tmp: Path) -> None:
+    """Unknown adapter without a contract is a clean ``skip``."""
+    s = _status_for_one("never-heard-of-it", _Stub, contracts_dir=contracts_tmp, capture_version=False)
+    assert s.conformance == CONFORMANCE_SKIP
+
+
+# ---------------------------------------------------------------------------
+# JSON contract
+# ---------------------------------------------------------------------------
+
+
+def test_full_report_to_json_round_trips(contracts_tmp: Path) -> None:
+    """Full report JSON is parseable and keys are stable."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    parsed = json.loads(report.to_json())
+    assert "adapters" in parsed and "summary" in parsed
+    for row in parsed["adapters"]:
+        assert {
+            "name",
+            "module_path",
+            "binary_resolved",
+            "version_string",
+            "capabilities",
+            "conformance",
+            "conformance_detail",
+            "last_modified_utc",
+            "contract_hash",
+        } <= set(row.keys())
+
+
+def test_json_capabilities_are_sorted_list(contracts_tmp: Path) -> None:
+    """JSON ``capabilities`` is a sorted list (deterministic for diffs)."""
+    _write_contract(contracts_tmp, "alpha", flags=("--zeta", "--alpha"))
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    payload = json.loads(report.to_json())
+    for row in payload["adapters"]:
+        assert row["capabilities"] == sorted(row["capabilities"])
+
+
+def test_json_summary_total_matches_adapters_length(contracts_tmp: Path) -> None:
+    """``summary.total`` always matches ``len(adapters)`` in JSON."""
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    parsed = json.loads(report.to_json())
+    assert parsed["summary"]["total"] == len(parsed["adapters"])
+
+
+# ---------------------------------------------------------------------------
+# Click command exit code semantics
+# ---------------------------------------------------------------------------
+
+
+def test_cli_check_strict_zero_when_no_failures(contracts_tmp: Path) -> None:
+    """``--strict`` returns 0 when no row is ``fail``."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+            result = CliRunner().invoke(adapters_check_cmd, ["--strict", "--format", "json"])
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_check_strict_nonzero_when_failure_present(contracts_tmp: Path) -> None:
+    """``--strict`` returns 1 when at least one row is ``fail``."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    _write_contract(contracts_tmp, "alpha", flags=("--needed",))
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="usage: alpha\n", stderr="")
+
+    def _iter() -> Any:
+        yield "alpha", _Stub
+
+    with patch.object(report_mod, "_binary_for_adapter", return_value="alpha"):
+        with patch.object(report_mod.shutil, "which", return_value="/usr/bin/alpha"):
+            with patch.object(report_mod.subprocess, "run", return_value=completed):
+                with patch("bernstein.adapters.registry.iter_adapter_specs", _iter):
+                    with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+                        result = CliRunner().invoke(adapters_check_cmd, ["--strict", "--format", "json"])
+    assert result.exit_code == 1, result.output
+
+
+def test_cli_check_unknown_adapter_emits_error_and_exits_two(contracts_tmp: Path) -> None:
+    """Unknown adapter NAME produces a useful stderr line and exit 2."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        result = CliRunner().invoke(adapters_check_cmd, ["never-heard-of-it", "--format", "json"])
+    assert result.exit_code == 2
+
+
+def test_cli_check_default_format_is_table(contracts_tmp: Path) -> None:
+    """Default ``--format`` is ``table`` and produces non-JSON output."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+            result = CliRunner().invoke(adapters_check_cmd, [])
+    assert result.exit_code == 0
+    assert "alpha" in result.output
+    # Must not start with "{" (would indicate JSON crept into the default).
+    assert not result.output.lstrip().startswith("{")
+
+
+def test_cli_check_json_format_is_parseable(contracts_tmp: Path) -> None:
+    """``--format json`` emits a parseable document."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+            result = CliRunner().invoke(adapters_check_cmd, ["--format", "json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["total"] == 2
+
+
+def test_cli_check_single_adapter_yields_one_row(contracts_tmp: Path) -> None:
+    """``check <name>`` filters the report to a single adapter."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+            result = CliRunner().invoke(adapters_check_cmd, ["alpha", "--format", "json"])
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["total"] == 1
+    assert parsed["adapters"][0]["name"] == "alpha"
+
+
+def test_cli_check_table_includes_summary_footer(contracts_tmp: Path) -> None:
+    """The Rich table renders a single-line footer summary."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+            result = CliRunner().invoke(adapters_check_cmd, [])
+    assert "adapters total" in result.output
+
+
+def test_cli_check_strict_only_triggers_on_fail_not_skip(contracts_tmp: Path) -> None:
+    """``--strict`` ignores ``skip`` rows (binary missing is expected)."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_check_cmd
+
+    _write_contract(contracts_tmp, "alpha", flags=("--model",))
+
+    def _iter() -> Any:
+        yield "alpha", _Stub
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _iter):
+        with patch("bernstein.adapters.report.CONTRACTS_DIR", contracts_tmp):
+            with patch.object(report_mod.shutil, "which", return_value=None):
+                result = CliRunner().invoke(adapters_check_cmd, ["--strict", "--format", "json"])
+    assert result.exit_code == 0
+
+
+def test_cli_list_status_runs_against_real_registry() -> None:
+    """``list-status`` exits 0 against the real registry."""
+    from click.testing import CliRunner
+
+    from bernstein.cli.commands.adapters_cmd import adapters_list_status_cmd
+
+    result = CliRunner().invoke(adapters_list_status_cmd, ["--format", "json"])
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed["summary"]["total"] >= 44
+
+
+# ---------------------------------------------------------------------------
+# Snapshot-style structural test for the table renderer
+# ---------------------------------------------------------------------------
+
+
+def test_render_table_rows_contains_every_adapter_name(contracts_tmp: Path) -> None:
+    """The rendered Rich table mentions every adapter name in the report."""
+    from bernstein.cli.commands.adapters_cmd import _render_table_rows
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    rendered = _render_table_rows(report)
+    for status in report.adapters:
+        assert status.name in rendered
+
+
+def test_render_table_rows_has_summary_footer(contracts_tmp: Path) -> None:
+    """The renderer always appends the summary footer line."""
+    from bernstein.cli.commands.adapters_cmd import _render_table_rows
+
+    with patch("bernstein.adapters.registry.iter_adapter_specs", _stub_iter()):
+        report = build_report(contracts_dir=contracts_tmp, capture_version=False)
+    rendered = _render_table_rows(report)
+    assert "adapters total" in rendered
+    assert "reachable" in rendered
+    assert "conform" in rendered
+
+
+def test_render_list_rows_is_compact() -> None:
+    """``list-status`` table omits version/notes columns."""
+    from bernstein.cli.commands.adapters_cmd import _render_list_rows
+
+    report = AdapterReport(
+        adapters=(
+            AdapterStatus("alpha", "alpha.py", None, None, frozenset(), CONFORMANCE_SKIP, "binary missing", "", ""),
+        ),
+        summary=ReportSummary(1, 0, 0, 0, 1),
+    )
+    rendered = _render_list_rows(report)
+    assert "alpha" in rendered
+
+
+def test_payload_is_dataclass_frozen() -> None:
+    """``AdapterStatus`` is frozen so consumers can't mutate it in place."""
+    s = AdapterStatus(
+        name="x",
+        module_path="x.py",
+        binary_resolved=None,
+        version_string=None,
+        capabilities=frozenset(),
+        conformance=CONFORMANCE_SKIP,
+        conformance_detail="",
+        last_modified_utc="",
+        contract_hash="",
+    )
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        s.name = "y"  # type: ignore[misc]
+
+
+def test_conformance_verdict_payload_is_frozen() -> None:
+    """``ConformanceVerdictPayload`` is frozen for safety in caching layers."""
+    v = ConformanceVerdictPayload(verdict=CONFORMANCE_OK, detail="", capabilities=frozenset())
+    with pytest.raises((AttributeError, dataclasses.FrozenInstanceError)):
+        v.detail = "mutated"  # type: ignore[misc]
+
+
+def test_capabilities_field_is_frozenset() -> None:
+    """The capability set is a frozenset to prevent in-place mutation."""
+    s = AdapterStatus(
+        name="x",
+        module_path="x.py",
+        binary_resolved=None,
+        version_string=None,
+        capabilities=frozenset({"a"}),
+        conformance=CONFORMANCE_SKIP,
+        conformance_detail="",
+        last_modified_utc="",
+        contract_hash="",
+    )
+    assert isinstance(s.capabilities, frozenset)


### PR DESCRIPTION
## Summary

- Adds ``bernstein adapters check`` - one-shot conformance + capability report (Rich table + JSON) running fully in-process (no pytest subprocess)
- Adds ``bernstein adapters list-status`` - compact one-line status per adapter
- Surfaces binary resolution, ``<binary> --version`` capture (5s timeout), contract-driven capability matrix, ok/fail/skip verdict, mtime, contract hash

## Implementation

- ``src/bernstein/adapters/report.py`` - ``AdapterStatus`` frozen dataclass + ``build_report()`` + in-process conformance check
- ``src/bernstein/adapters/registry.py`` - new ``iter_adapter_specs()`` enumerator
- ``src/bernstein/adapters/conformance.py`` - thin re-export shim for ``check_adapter_in_process``
- ``src/bernstein/cli/commands/adapters_cmd.py`` - Click subcommands attached to the existing ``adapters`` group
- ``docs/operations/adapters.md`` - operator docs (verdict table + JSON contract)

## Test plan

- [x] 61 unit tests in ``tests/unit/adapters/test_report.py`` (binary present + version captured, binary missing -> skip, contract mismatch -> fail, JSON round-trip, strict mode exit codes, frozen dataclass guarantees)
- [x] 14 property tests in ``tests/property/test_adapter_report_properties.py`` (summary invariants, JSON sorted capabilities, verdict membership, build_report filter)
- [x] 10 integration tests in ``tests/integration/adapters/test_adapters_check_cli.py`` (real registry, group wiring, strict modes, format validation)
- [x] Pyright strict clean for all new modules
- [x] Ruff lint + format clean
- [x] Existing ``tests/unit/adapters/`` 116 tests still pass

Closes spec ``.sdd/backlog/open/2026-05-17-feat-cli-adapter-conformance-report-subcommand.yaml``.