### PR TITLE
feat(telemetry): opt-in first-run telemetry with DO_NOT_TRACK precedence (closes spec 2026-05-17)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,196 @@
+# Opt-in operator observability
+
+Bernstein ships with no telemetry enabled.  An operator may opt in to a
+strictly bounded event set so that the project can measure activation
+funnels (install -> first run -> second run within 7 days).  This
+document is the full schema, opt-out matrix, and retention policy.
+
+## TL;DR
+
+- Default is **off**.  Nothing is ever sent unless you run
+  `bernstein telemetry on` (or set `BERNSTEIN_TELEMETRY=1`).
+- `DO_NOT_TRACK=1` always wins.  No event is sent and no install id is
+  generated.
+- The install id is a 128-bit UUID v4 created lazily, **after** opt-in
+  only.  It is the only identifier we send.
+- Every event is mirrored to a local JSONL file so you can audit
+  exactly what was sent.  Rotated weekly, queryable via
+  `bernstein telemetry export`.
+
+## Opt-out matrix
+
+| Signal                                          | Result                |
+|-------------------------------------------------|-----------------------|
+| `DO_NOT_TRACK=1` env var                        | off (universal opt-out) |
+| `BERNSTEIN_TELEMETRY=0` (or `false/no/off/""`)  | off                   |
+| `BERNSTEIN_TELEMETRY=1` (or `true/yes/on`)      | on                    |
+| `~/.bernstein/telemetry.yaml` with `enabled: false` | off               |
+| `~/.bernstein/telemetry.yaml` with `enabled: true`  | on                |
+| None of the above                               | off (default)         |
+
+Precedence: `DO_NOT_TRACK` > `BERNSTEIN_TELEMETRY` > file > default-off.
+
+## Subcommand surface
+
+```
+bernstein telemetry on          # opt in, write config, generate install id
+bernstein telemetry off         # opt out, delete install id, write off-marker
+bernstein telemetry status      # show current state + which signal won
+bernstein telemetry export      # dump the last 30 days of locally queued events
+```
+
+## Closed event set
+
+| Name                  | Fields                                                              |
+|-----------------------|---------------------------------------------------------------------|
+| `install_completed`   | `os`, `py_version`, `install_method`, `bernstein_version`            |
+| `first_run_started`   | `time_since_install_seconds`                                         |
+| `first_run_completed` | `ok`, `duration_ms`, `error_category` (only on failure)              |
+| `command_invoked`     | `name_only`, `bernstein_version`                                     |
+| `daily_active`        | `day_iso`                                                            |
+
+No other event variant is permitted, and the serializer rejects any
+payload whose dataclass does not match the event name.
+
+### Error categories (closed set)
+
+`config_missing | auth_failed | dependency_missing | model_unreachable | timeout | unknown`
+
+## Envelope shape
+
+Every event is wrapped in the same envelope and serialized to a single
+JSON line:
+
+```json
+{
+  "install_id": "<uuid v4 hex>",
+  "name": "<one of the event names above>",
+  "payload": { ... },
+  "schema_version": 1,
+  "timestamp": "<RFC 3339 UTC>"
+}
+```
+
+`install_id` is the only operator-identifying field.  We never send file
+contents, args, prompts, paths, or resource names.
+
+## What we do not collect
+
+- No source code.
+- No command-line arguments.
+- No environment variables.
+- No file paths.
+- No prompts or model outputs.
+- No IP address (the receiver may log one for routing; see Retention).
+- No project, session, or agent names.
+- No timing data finer than `duration_ms` per first-run.
+
+## Network behaviour
+
+- Endpoint: configurable via `BERNSTEIN_TELEMETRY_ENDPOINT`.  Default is
+  a Bernstein-owned receiver.
+- Single HTTP POST per event, 3-second timeout, no retries.
+- All errors are swallowed.  The command always completes normally
+  whether or not the POST succeeded.
+- Shutdown flush is bounded by a 5-second wallclock cap.
+
+## Install id lifecycle
+
+- Generated lazily after `bernstein telemetry on`.
+- Persisted to `~/.bernstein/install-id` with mode `0600` (best effort).
+- Deleted on `bernstein telemetry off`.
+- Never sent before opt-in.  The library raises if any caller asks for
+  the id while telemetry is disabled.
+
+## First-run notice
+
+The first time `bernstein` runs, a one-time notice is printed to stderr:
+
+```
+Bernstein collects no telemetry by default.
+Run `bernstein telemetry on` to opt in and help us prioritize.
+This message will not appear again.
+```
+
+After printing, a marker is persisted to
+`~/.bernstein/first-run-acknowledged` and the notice never appears
+again.
+
+## Local queue
+
+Every event that the client emits is also appended to
+`~/.bernstein/telemetry-queue.jsonl` so an operator can audit exactly
+what was sent.
+
+- One JSON object per line.
+- Rotated weekly: old files become
+  `telemetry-queue.<YYYY-MM-DD>.jsonl`.
+- Queryable via `bernstein telemetry export --days N`.
+
+## Retention policy
+
+| Bucket                 | Server-side retention | Notes                                  |
+|------------------------|-----------------------|----------------------------------------|
+| Event envelopes        | 90 days               | Aggregated daily, then deleted.        |
+| Aggregated counts      | 18 months             | No install id, no per-event detail.    |
+| Access logs (IP, UA)   | 30 days               | Held only for abuse mitigation.        |
+| Local queue            | 7-day rolling window  | Operator-controlled, ships nothing.    |
+
+Deletion request: open an issue or email the maintainers with your
+install id (it is the only thing we can use to find your events) and
+they will be purged.
+
+## Threat model
+
+- The endpoint cannot influence the operator's command outcome.  All
+  network paths are fail-closed and bounded.
+- A compromised endpoint cannot exfiltrate file contents because we
+  never include them in the payload.
+- A malicious operator cannot trick the library into generating an
+  install id before opt-in; `install_id.ensure` raises until
+  `is_enabled` returns True.
+
+## Why this design
+
+- Default-off mirrors rustup, homebrew, and the .NET CLI.  Default-on
+  telemetry is rejected by the Python tooling community (see the
+  GitHub CLI v2.91 controversy).
+- A bounded, closed event set means an external reviewer can audit
+  every payload variant in one short file (`events.py`).
+- Mirroring to a local file means the operator can always verify what
+  was sent.  There is no remote-only source of truth.
+- Lazy install id generation means the on-disk footprint of "default
+  off" is genuinely nothing.
+
+## Configuration files
+
+| Path                                       | Purpose                            |
+|--------------------------------------------|------------------------------------|
+| `~/.bernstein/telemetry.yaml`              | `enabled: <bool>` opt-in state.    |
+| `~/.bernstein/install-id`                  | UUID v4 hex.  Created on opt-in.   |
+| `~/.bernstein/first-run-acknowledged`      | Marker.  Created on first run.     |
+| `~/.bernstein/telemetry-queue.jsonl`       | Locally mirrored events (JSONL).   |
+
+## Implementation map
+
+- `src/bernstein/core/telemetry/config.py` - precedence resolver.
+- `src/bernstein/core/telemetry/install_id.py` - lazy id generation.
+- `src/bernstein/core/telemetry/events.py` - closed event taxonomy.
+- `src/bernstein/core/telemetry/client.py` - bounded HTTP client.
+- `src/bernstein/core/telemetry/wire.py` - integration helpers.
+- `src/bernstein/cli/commands/telemetry_cmd.py` - operator surface.
+
+## Testing
+
+```
+uv run pytest tests/unit/telemetry/ \
+              tests/property/test_telemetry_properties.py \
+              tests/integration/test_telemetry_lifecycle.py
+```
+
+The unit suite covers every precedence layer, every event variant,
+every fail-closed network path, the local queue rotation, and the
+first-run notice idempotence.  Property tests exercise install-id
+uniqueness and payload-schema invariants under random inputs.  The
+integration suite drives a mock receiver through the full first-run
+flow plus opt-in/opt-out flips.

--- a/src/bernstein/cli/commands/telemetry_cmd.py
+++ b/src/bernstein/cli/commands/telemetry_cmd.py
@@ -1,0 +1,142 @@
+"""``bernstein telemetry`` subcommand.
+
+Operator-facing surface:
+
+    bernstein telemetry on        opt in, write config, generate install id
+    bernstein telemetry off       opt out, delete install id
+    bernstein telemetry status    show current state + which signal won
+    bernstein telemetry export    dump last 30 days of locally queued events
+
+The output is deliberately compact and deterministic to enable snapshot
+tests against the ``status`` command.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+from bernstein.core.telemetry import (
+    OptInSource,
+    config_file_path,
+    ensure_install_id,
+    install_id_path,
+    queue_path,
+    read_install_id,
+    read_recent_events,
+    reset_default_client,
+    reset_install_id,
+    resolve,
+    write_enabled,
+)
+
+
+@click.group("telemetry")
+def telemetry_group() -> None:
+    """Manage opt-in operator observability.
+
+    Bernstein collects no telemetry by default.  These commands let an
+    operator opt in to a strictly bounded event set, inspect the local
+    queue, and opt back out at any time.
+    """
+
+
+@telemetry_group.command("on")
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the operator home directory (testing).",
+)
+def telemetry_on(home: Path | None) -> None:
+    """Opt in.  Writes ``enabled: true`` and generates an install id."""
+    write_enabled(True, home=home)
+    reset_default_client()
+    install_id = ensure_install_id(home=home)
+    click.echo(f"telemetry: enabled (install_id={install_id[:8]}...)")
+
+
+@telemetry_group.command("off")
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the operator home directory (testing).",
+)
+def telemetry_off(home: Path | None) -> None:
+    """Opt out.  Writes ``enabled: false`` and deletes the install id."""
+    write_enabled(False, home=home)
+    reset_install_id(home=home)
+    reset_default_client()
+    click.echo("telemetry: disabled")
+
+
+@telemetry_group.command("status")
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the operator home directory (testing).",
+)
+def telemetry_status(home: Path | None) -> None:
+    """Show current state and which precedence layer determined it."""
+    state = resolve(home=home)
+    install_id = read_install_id(home=home)
+    lines: list[str] = []
+    lines.append(f"enabled: {str(state.enabled).lower()}")
+    lines.append(f"source: {state.source.value}")
+    lines.append(f"install_id: {install_id or 'none'}")
+    lines.append(f"config_file: {config_file_path(home)}")
+    lines.append(f"install_id_path: {install_id_path(home)}")
+    lines.append(f"queue: {queue_path(home)}")
+    click.echo("\n".join(lines))
+
+
+@telemetry_group.command("export")
+@click.option(
+    "--days",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Number of days of locally queued events to dump.",
+)
+@click.option(
+    "--home",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Override the operator home directory (testing).",
+)
+def telemetry_export(days: int, home: Path | None) -> None:
+    """Dump locally queued events as JSONL."""
+    for line in read_recent_events(days=days, home=home):
+        click.echo(line)
+
+
+def explain_source(source: OptInSource) -> str:
+    """Return a one-line operator-facing description of ``source``."""
+    if source is OptInSource.DO_NOT_TRACK:
+        return "DO_NOT_TRACK env var (universal opt-out)"
+    if source is OptInSource.ENV:
+        return "BERNSTEIN_TELEMETRY env var"
+    if source is OptInSource.FILE:
+        return "config file (~/.bernstein/telemetry.yaml)"
+    return "default (off)"
+
+
+# Expose the group for registration in main.py.
+def register(parent: Any) -> None:
+    """Register this subgroup on a parent click group."""
+    parent.add_command(telemetry_group)
+
+
+__all__ = [
+    "explain_source",
+    "register",
+    "telemetry_export",
+    "telemetry_group",
+    "telemetry_off",
+    "telemetry_on",
+    "telemetry_status",
+]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -977,3 +977,9 @@ cli.add_command(abandonments_group, "abandonments")
 from bernstein.cli.commands.simulate_cmd import simulate_cmd  # noqa: E402
 
 cli.add_command(simulate_cmd, "simulate")
+
+# Opt-in operator observability (closes spec 2026-05-17).
+# Default off.  Precedence: DO_NOT_TRACK > BERNSTEIN_TELEMETRY > file > off.
+from bernstein.cli.commands.telemetry_cmd import telemetry_group  # noqa: E402
+
+cli.add_command(telemetry_group, "telemetry")

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -1122,6 +1122,25 @@ def run(
       bernstein run plan.yaml --budget 5usd --hard-budget 10usd  # soft + hard caps (#1320)
       bernstein conduct --budget-cap 5.00      # abort spawn if preflight p90 > $5
     """
+    # Opt-in operator observability (spec 2026-05-17).  Defaults to off.
+    # Prints the one-time notice and emits first_run_* events around the
+    # body.  Fail-closed: any internal failure is swallowed.
+    try:
+        from bernstein.core.telemetry.wire import maybe_print_first_run_notice
+
+        maybe_print_first_run_notice()
+    except Exception:
+        pass
+
+    _telemetry_first_run_timer: Any = None
+    try:
+        from bernstein.core.telemetry.wire import FirstRunTimer
+
+        _telemetry_first_run_timer = FirstRunTimer()
+        _telemetry_first_run_timer.__enter__()
+    except Exception:
+        _telemetry_first_run_timer = None
+
     # Issue #1346: validate the run-level criterion profile early so a
     # typo aborts the run before agents spawn.  The resolved name is
     # propagated to spawning code via an env var so child processes
@@ -1420,6 +1439,13 @@ def run(
         raise SystemExit(1) from exc
 
     _finalize_run_output(quiet=quiet)
+
+    # Close the first-run timer (spec 2026-05-17).  Fail-closed.
+    if _telemetry_first_run_timer is not None:
+        import contextlib as _contextlib
+
+        with _contextlib.suppress(Exception):
+            _telemetry_first_run_timer.__exit__(None, None, None)
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -234,6 +234,15 @@ def main() -> None:
     # 1. Set process title
     _set_proctitle(f"bernstein: {args.role} [{args.session}]")
 
+    # Opt-in operator observability (spec 2026-05-17).  Emits only the
+    # bare command name; fail-closed - never raises into the worker.
+    try:
+        from bernstein.core.telemetry.wire import emit_command_invoked
+
+        emit_command_invoked(name_only=cmd[0])
+    except Exception:
+        pass
+
     # 2. Write PID metadata
     pid_file = _write_pid_file(
         Path(args.pid_dir),

--- a/src/bernstein/core/telemetry/__init__.py
+++ b/src/bernstein/core/telemetry/__init__.py
@@ -1,0 +1,127 @@
+"""Opt-in operator observability for Bernstein.
+
+This subpackage implements the activation-funnel measurement defined in
+``.sdd/backlog/open/2026-05-17-feat-opt-in-first-run-telemetry.yaml``.
+
+Top-line invariants (enforced by tests):
+
+* Default state is off.  Nothing is emitted, no install id is generated.
+* Precedence: ``DO_NOT_TRACK=1`` > ``BERNSTEIN_TELEMETRY`` env > config
+  file > default-off.
+* The install id is a UUID v4, persisted only after explicit opt-in.
+* Every network failure is fail-closed; no exception ever bubbles out of
+  the telemetry boundary into the caller.
+* The on-disk queue at ``~/.bernstein/telemetry-queue.jsonl`` is the
+  operator's audit record of every event their install has produced.
+
+The public surface is intentionally small:
+
+>>> from bernstein.core.telemetry import (
+...     Client, TelemetryEvent, ErrorCategory, FirstRunCompletedPayload,
+... )
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Back-compat re-exports.  The legacy ``bernstein.core.telemetry`` symbol
+# space was an alias for ``bernstein.core.observability.telemetry`` served
+# by the meta_path redirect in ``bernstein.core.__init__``.  Now that this
+# directory is a real package the alias is shadowed; re-export the legacy
+# surface here so existing call sites keep working unchanged.
+# ---------------------------------------------------------------------------
+from bernstein.core.observability.telemetry import (  # noqa: F401
+    BUILTIN_PRESETS,
+    ExporterPreset,
+    _init_console_telemetry,  # pyright: ignore[reportPrivateUsage, reportUnusedImport]
+    _init_http_telemetry,  # pyright: ignore[reportPrivateUsage, reportUnusedImport]
+    get_meter,
+    get_preset,
+    get_tracer,
+    init_telemetry,
+    init_telemetry_from_preset,
+    list_presets,
+    start_span,
+)
+from bernstein.core.telemetry.client import (
+    DEFAULT_ENDPOINT,
+    ENDPOINT_ENV,
+    Client,
+    get_client,
+    read_recent_events,
+    reset_default_client,
+)
+from bernstein.core.telemetry.config import (
+    OptInSource,
+    OptInState,
+    config_file_path,
+    first_run_marker_path,
+    install_id_path,
+    is_enabled,
+    is_first_run_acknowledged,
+    mark_first_run_acknowledged,
+    queue_path,
+    resolve,
+    write_enabled,
+)
+from bernstein.core.telemetry.events import (
+    SCHEMA_VERSION,
+    CommandInvokedPayload,
+    DailyActivePayload,
+    ErrorCategory,
+    EventEnvelope,
+    EventPayload,
+    FirstRunCompletedPayload,
+    FirstRunStartedPayload,
+    InstallCompletedPayload,
+    TelemetryEvent,
+    build_envelope,
+    serialize_event,
+)
+from bernstein.core.telemetry.install_id import ensure as ensure_install_id
+from bernstein.core.telemetry.install_id import read as read_install_id
+from bernstein.core.telemetry.install_id import reset as reset_install_id
+
+__all__ = [
+    "BUILTIN_PRESETS",
+    "DEFAULT_ENDPOINT",
+    "ENDPOINT_ENV",
+    "SCHEMA_VERSION",
+    "Client",
+    "CommandInvokedPayload",
+    "DailyActivePayload",
+    "ErrorCategory",
+    "EventEnvelope",
+    "EventPayload",
+    "ExporterPreset",
+    "FirstRunCompletedPayload",
+    "FirstRunStartedPayload",
+    "InstallCompletedPayload",
+    "OptInSource",
+    "OptInState",
+    "TelemetryEvent",
+    "build_envelope",
+    "config_file_path",
+    "ensure_install_id",
+    "first_run_marker_path",
+    "get_client",
+    "get_meter",
+    "get_preset",
+    "get_tracer",
+    "init_telemetry",
+    "init_telemetry_from_preset",
+    "install_id_path",
+    "is_enabled",
+    "is_first_run_acknowledged",
+    "list_presets",
+    "mark_first_run_acknowledged",
+    "queue_path",
+    "read_install_id",
+    "read_recent_events",
+    "reset_default_client",
+    "reset_install_id",
+    "resolve",
+    "serialize_event",
+    "start_span",
+    "write_enabled",
+]

--- a/src/bernstein/core/telemetry/client.py
+++ b/src/bernstein/core/telemetry/client.py
@@ -1,0 +1,275 @@
+"""Bounded, fail-closed HTTP client for opt-in operator telemetry.
+
+Design constraints:
+
+* Default state is off.  ``Client.is_enabled`` resolves the precedence
+  chain on every call; the client never caches the result across emits.
+* No network traffic unless ``is_enabled`` is True.
+* Every send completes in <= 3s.  On any error, the command must still
+  finish normally - exceptions are caught and swallowed at this boundary.
+* Every emitted event is also appended to the local queue file
+  ``~/.bernstein/telemetry-queue.jsonl`` so operators can ``cat`` it.
+* The local queue is rotated weekly.
+
+The client is intentionally synchronous.  ``flush`` is a no-op kept for
+shape parity with future async backends.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import time
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING, Final
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+from bernstein.core.telemetry import config as cfg
+from bernstein.core.telemetry import install_id as install_id_mod
+from bernstein.core.telemetry.events import (
+    EventEnvelope,
+    EventPayload,
+    TelemetryEvent,
+    build_envelope,
+    serialize_event,
+)
+
+_LOG = logging.getLogger(__name__)
+
+DEFAULT_ENDPOINT: Final[str] = "https://telemetry.bernstein.run/v1/events"
+ENDPOINT_ENV: Final[str] = "BERNSTEIN_TELEMETRY_ENDPOINT"
+TIMEOUT_SECONDS: Final[float] = 3.0
+FLUSH_DEADLINE_SECONDS: Final[float] = 5.0
+QUEUE_ROTATION_DAYS: Final[int] = 7
+
+
+def _resolve_endpoint(env: dict[str, str] | None = None) -> str:
+    """Return the receiver URL.  Operators may override via env."""
+    real_env = env if env is not None else dict(os.environ)
+    return real_env.get(ENDPOINT_ENV) or DEFAULT_ENDPOINT
+
+
+def _maybe_rotate_queue(path: Path) -> None:
+    """Rotate the queue file weekly.
+
+    Rotation moves ``telemetry-queue.jsonl`` -> ``telemetry-queue.<iso>.jsonl``
+    when the mtime is older than ``QUEUE_ROTATION_DAYS``.
+    """
+    if not path.exists():
+        return
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+    except OSError:
+        return
+    if datetime.now(tz=UTC) - mtime <= timedelta(days=QUEUE_ROTATION_DAYS):
+        return
+    archive = path.with_name(f"telemetry-queue.{mtime.date().isoformat()}.jsonl")
+    # Best effort.  A failed rotation must not block emission.
+    with contextlib.suppress(OSError):
+        path.rename(archive)
+
+
+def _append_local(line: str, home: Path | None) -> None:
+    """Append a serialized event line to the local queue file."""
+    path = cfg.queue_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _maybe_rotate_queue(path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.write("\n")
+
+
+def read_recent_events(
+    days: int = 30,
+    home: Path | None = None,
+) -> Iterator[str]:
+    """Yield lines from the local queue for the last ``days`` days.
+
+    Used by ``bernstein telemetry export``.  Operators can inspect exactly
+    what was emitted under their install id.  Returns an empty iterator if
+    the queue file does not exist.
+    """
+    path = cfg.queue_path(home)
+    if not path.exists():
+        return iter(())
+    cutoff = date.today() - timedelta(days=days)
+    cutoff_iso = cutoff.isoformat()
+
+    def _gen() -> Iterator[str]:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                stripped = line.rstrip("\n")
+                if not stripped:
+                    continue
+                day_part = _extract_day(stripped)
+                if day_part is None or day_part >= cutoff_iso:
+                    yield stripped
+
+    return _gen()
+
+
+def _extract_day(line: str) -> str | None:
+    """Return the YYYY-MM-DD prefix of the line's timestamp, if any.
+
+    Accepts either compact JSON (``"timestamp":"...``) or pretty-printed
+    JSON (``"timestamp": "...``) so manually-authored queues can be read.
+    """
+    for marker in ('"timestamp":"', '"timestamp": "'):
+        idx = line.find(marker)
+        if idx == -1:
+            continue
+        start = idx + len(marker)
+        return line[start : start + 10]
+    return None
+
+
+class Client:
+    """Opt-in telemetry client.  Default state is off."""
+
+    def __init__(
+        self,
+        *,
+        env: dict[str, str] | None = None,
+        home: Path | None = None,
+        endpoint: str | None = None,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self._env = env
+        self._home = home
+        self._endpoint = endpoint or _resolve_endpoint(env)
+        self._http = http_client
+        self._owns_http = http_client is None
+
+    @property
+    def endpoint(self) -> str:
+        """Return the resolved receiver URL."""
+        return self._endpoint
+
+    def is_enabled(self) -> bool:
+        """Re-resolve precedence; never cached across calls."""
+        return cfg.is_enabled(env=self._env, home=self._home)
+
+    def _get_http(self) -> httpx.Client:
+        if self._http is None:
+            self._http = httpx.Client(timeout=TIMEOUT_SECONDS)
+        return self._http
+
+    def emit(
+        self,
+        name: TelemetryEvent,
+        payload: EventPayload,
+    ) -> bool:
+        """Emit a single event.
+
+        Returns ``True`` if the event was at least appended to the local
+        queue (network may still have failed; that is fine).  Returns
+        ``False`` if telemetry is currently disabled and nothing happened.
+
+        Exceptions are never propagated.  This boundary is explicitly
+        fail-closed: if anything goes wrong, the caller continues.
+        """
+        try:
+            if not self.is_enabled():
+                return False
+            try:
+                install_id = install_id_mod.ensure(home=self._home)
+            except RuntimeError:
+                # Opt-in was flipped off between the is_enabled check and
+                # the id read.  Drop the event silently.
+                return False
+            envelope = build_envelope(name, install_id, payload)
+            line = serialize_event(envelope)
+            try:
+                _append_local(line, self._home)
+            except OSError as exc:
+                _LOG.debug("telemetry: local queue append failed: %s", exc)
+            self._post(line)
+            return True
+        except Exception as exc:
+            _LOG.debug("telemetry: emit failed (suppressed): %s", exc)
+            return False
+
+    def _post(self, body: str) -> None:
+        """POST the serialized event.  Failures are swallowed."""
+        try:
+            http = self._get_http()
+            http.post(
+                self._endpoint,
+                content=body,
+                headers={"content-type": "application/json"},
+                timeout=TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            _LOG.debug("telemetry: POST failed (suppressed): %s", exc)
+
+    def flush(self, deadline_seconds: float = FLUSH_DEADLINE_SECONDS) -> None:
+        """Best-effort shutdown flush.  Bounded by ``deadline_seconds``."""
+        deadline = time.monotonic() + deadline_seconds
+        if time.monotonic() > deadline:
+            return
+        # No background queue today.  Kept for shape parity with future
+        # async implementations.
+
+    def close(self) -> None:
+        """Close any client-owned HTTP resources."""
+        if self._owns_http and self._http is not None:
+            with contextlib.suppress(Exception):
+                self._http.close()
+            self._http = None
+
+    def envelope_preview(
+        self,
+        name: TelemetryEvent,
+        payload: EventPayload,
+    ) -> EventEnvelope | None:
+        """Return the envelope that ``emit`` would produce, or ``None``.
+
+        Available even if telemetry is off and an install id has not been
+        generated; in that case the result is ``None``.  Useful in tests.
+        """
+        if not self.is_enabled():
+            return None
+        existing = install_id_mod.read(self._home)
+        if existing is None:
+            return None
+        return build_envelope(name, existing, payload)
+
+
+# Module-level convenience.  Callers in main.py / worker.py use these.
+
+_default_client: Client | None = None
+
+
+def get_client() -> Client:
+    """Return a process-wide default client."""
+    global _default_client
+    if _default_client is None:
+        _default_client = Client()
+    return _default_client
+
+
+def reset_default_client() -> None:
+    """Drop the cached default client.  Used by tests and ``telemetry off``."""
+    global _default_client
+    if _default_client is not None:
+        _default_client.close()
+    _default_client = None
+
+
+__all__ = [
+    "DEFAULT_ENDPOINT",
+    "ENDPOINT_ENV",
+    "FLUSH_DEADLINE_SECONDS",
+    "QUEUE_ROTATION_DAYS",
+    "TIMEOUT_SECONDS",
+    "Client",
+    "get_client",
+    "read_recent_events",
+    "reset_default_client",
+]

--- a/src/bernstein/core/telemetry/config.py
+++ b/src/bernstein/core/telemetry/config.py
@@ -1,0 +1,173 @@
+"""Opt-in resolution for operator observability.
+
+Precedence (highest first):
+
+1. ``DO_NOT_TRACK=1``                 - universal W3C opt-out signal.
+2. ``BERNSTEIN_TELEMETRY={0|false|no|off|""}``
+                                      - explicit Bernstein opt-out.
+3. ``~/.bernstein/telemetry.yaml`` ``enabled: <bool>``
+                                      - persisted operator choice.
+4. Default                            - off.
+
+The default is and must remain off in every code path.  No event may be
+emitted, and no install id may be generated, until ``is_enabled`` returns
+``True``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Final
+
+import yaml
+
+# Sentinels for env var values that count as "off".  Comparison is done
+# in lowercase, so callers may set BERNSTEIN_TELEMETRY=Off or =FALSE.
+_FALSE_VALUES: Final[frozenset[str]] = frozenset({"0", "false", "no", "off", ""})
+
+_DO_NOT_TRACK: Final[str] = "DO_NOT_TRACK"
+_BERNSTEIN_TELEMETRY: Final[str] = "BERNSTEIN_TELEMETRY"
+
+
+class OptInSource(StrEnum):
+    """Which precedence layer determined the current state."""
+
+    DO_NOT_TRACK = "do_not_track"
+    ENV = "env"
+    FILE = "file"
+    DEFAULT = "default"
+
+
+@dataclass(frozen=True, slots=True)
+class OptInState:
+    """The resolved state plus the signal that determined it."""
+
+    enabled: bool
+    source: OptInSource
+
+
+def _config_dir(home: Path | None = None) -> Path:
+    """Return ``~/.bernstein``.  ``home`` may be injected for tests."""
+    base = home if home is not None else Path.home()
+    return base / ".bernstein"
+
+
+def config_file_path(home: Path | None = None) -> Path:
+    """Return ``~/.bernstein/telemetry.yaml``."""
+    return _config_dir(home) / "telemetry.yaml"
+
+
+def first_run_marker_path(home: Path | None = None) -> Path:
+    """Return ``~/.bernstein/first-run-acknowledged``."""
+    return _config_dir(home) / "first-run-acknowledged"
+
+
+def install_id_path(home: Path | None = None) -> Path:
+    """Return ``~/.bernstein/install-id``."""
+    return _config_dir(home) / "install-id"
+
+
+def queue_path(home: Path | None = None) -> Path:
+    """Return ``~/.bernstein/telemetry-queue.jsonl``."""
+    return _config_dir(home) / "telemetry-queue.jsonl"
+
+
+def _load_yaml_config(path: Path) -> dict[str, object]:
+    """Load the config file or return an empty dict on any error."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data  # pyright: ignore[reportUnknownVariableType]
+
+
+def _file_enabled(home: Path | None) -> bool | None:
+    """Return the file's ``enabled`` field, or ``None`` if it is absent."""
+    path = config_file_path(home)
+    if not path.exists():
+        return None
+    cfg = _load_yaml_config(path)
+    value = cfg.get("enabled")
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def resolve(
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> OptInState:
+    """Resolve the opt-in state.  ``env``/``home`` may be injected for tests."""
+    real_env = env if env is not None else dict(os.environ)
+
+    if real_env.get(_DO_NOT_TRACK) == "1":
+        return OptInState(enabled=False, source=OptInSource.DO_NOT_TRACK)
+
+    raw = real_env.get(_BERNSTEIN_TELEMETRY)
+    if raw is not None:
+        normalized = raw.strip().lower()
+        return OptInState(
+            enabled=normalized not in _FALSE_VALUES,
+            source=OptInSource.ENV,
+        )
+
+    file_choice = _file_enabled(home)
+    if file_choice is not None:
+        return OptInState(enabled=file_choice, source=OptInSource.FILE)
+
+    return OptInState(enabled=False, source=OptInSource.DEFAULT)
+
+
+def is_enabled(
+    env: dict[str, str] | None = None,
+    home: Path | None = None,
+) -> bool:
+    """Shortcut for ``resolve(...).enabled``."""
+    return resolve(env=env, home=home).enabled
+
+
+def write_enabled(
+    enabled: bool,
+    home: Path | None = None,
+) -> Path:
+    """Persist ``enabled`` to the config file.  Creates the dir if needed."""
+    path = config_file_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump({"enabled": enabled}, fh, default_flow_style=False)
+    return path
+
+
+def mark_first_run_acknowledged(home: Path | None = None) -> Path:
+    """Write the first-run-acknowledged marker."""
+    path = first_run_marker_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists():
+        path.write_text("acknowledged\n", encoding="utf-8")
+    return path
+
+
+def is_first_run_acknowledged(home: Path | None = None) -> bool:
+    """Return True if the operator has already seen the first-run notice."""
+    return first_run_marker_path(home).exists()
+
+
+__all__ = [
+    "OptInSource",
+    "OptInState",
+    "config_file_path",
+    "first_run_marker_path",
+    "install_id_path",
+    "is_enabled",
+    "is_first_run_acknowledged",
+    "mark_first_run_acknowledged",
+    "queue_path",
+    "resolve",
+    "write_enabled",
+]

--- a/src/bernstein/core/telemetry/events.py
+++ b/src/bernstein/core/telemetry/events.py
@@ -1,0 +1,221 @@
+"""Event schema and serializer for opt-in operator observability.
+
+This module defines the closed taxonomy of telemetry events emitted by
+Bernstein when an operator has explicitly opted in.  No event variant
+outside the enumerations below is permitted, and every event payload is
+strictly validated before serialization.
+
+The event set is intentionally minimal:
+
+* ``install_completed``    - emitted once after a fresh install
+* ``first_run_started``    - the operator started the first ``bernstein`` run
+* ``first_run_completed``  - the first run finished (ok or with a category)
+* ``command_invoked``      - a worker subprocess was spawned (name only)
+* ``daily_active``         - one heartbeat per UTC day per install id
+
+Error categories are likewise a closed set:
+``config_missing | auth_failed | dependency_missing | model_unreachable |
+timeout | unknown``.
+
+No event payload may contain free-form text, file contents, prompts,
+resource identifiers, args, env vars, or anything resembling secrets.
+The serializer enforces this by accepting only the typed fields below.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Final
+
+
+class TelemetryEvent(StrEnum):
+    """Closed set of event names that may appear in the payload."""
+
+    INSTALL_COMPLETED = "install_completed"
+    FIRST_RUN_STARTED = "first_run_started"
+    FIRST_RUN_COMPLETED = "first_run_completed"
+    COMMAND_INVOKED = "command_invoked"
+    DAILY_ACTIVE = "daily_active"
+
+
+class ErrorCategory(StrEnum):
+    """Closed set of error categories for first_run_completed events."""
+
+    CONFIG_MISSING = "config_missing"
+    AUTH_FAILED = "auth_failed"
+    DEPENDENCY_MISSING = "dependency_missing"
+    MODEL_UNREACHABLE = "model_unreachable"
+    TIMEOUT = "timeout"
+    UNKNOWN = "unknown"
+
+
+SCHEMA_VERSION: Final[int] = 1
+
+
+# ---------------------------------------------------------------------------
+# Event payload dataclasses (strictly typed, closed field sets)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class InstallCompletedPayload:
+    """Fields emitted with install_completed."""
+
+    os: str
+    py_version: str
+    install_method: str
+    bernstein_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class FirstRunStartedPayload:
+    """Fields emitted with first_run_started."""
+
+    time_since_install_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class FirstRunCompletedPayload:
+    """Fields emitted with first_run_completed."""
+
+    ok: bool
+    duration_ms: int
+    error_category: ErrorCategory | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class CommandInvokedPayload:
+    """Fields emitted with command_invoked.  Only the name and version."""
+
+    name_only: str
+    bernstein_version: str
+
+
+@dataclass(frozen=True, slots=True)
+class DailyActivePayload:
+    """Fields emitted with daily_active.  ISO-8601 UTC date only."""
+
+    day_iso: str
+
+
+EventPayload = (
+    InstallCompletedPayload
+    | FirstRunStartedPayload
+    | FirstRunCompletedPayload
+    | CommandInvokedPayload
+    | DailyActivePayload
+)
+
+
+# ---------------------------------------------------------------------------
+# Envelope + serializer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class EventEnvelope:
+    """Wire envelope.  ``install_id`` is required for every emitted event."""
+
+    name: TelemetryEvent
+    install_id: str
+    payload: EventPayload
+    timestamp: str = field(default_factory=lambda: datetime.now(tz=UTC).isoformat())
+    schema_version: int = SCHEMA_VERSION
+
+
+_PAYLOAD_FOR: Final[dict[TelemetryEvent, type[EventPayload]]] = {
+    TelemetryEvent.INSTALL_COMPLETED: InstallCompletedPayload,
+    TelemetryEvent.FIRST_RUN_STARTED: FirstRunStartedPayload,
+    TelemetryEvent.FIRST_RUN_COMPLETED: FirstRunCompletedPayload,
+    TelemetryEvent.COMMAND_INVOKED: CommandInvokedPayload,
+    TelemetryEvent.DAILY_ACTIVE: DailyActivePayload,
+}
+
+
+def expected_payload_type(name: TelemetryEvent) -> type[EventPayload]:
+    """Return the dataclass that ``name`` requires.
+
+    Useful for tests and the consistency check inside ``serialize_event``.
+    """
+    return _PAYLOAD_FOR[name]
+
+
+def _payload_to_dict(payload: EventPayload) -> dict[str, Any]:
+    """Convert a payload dataclass to a JSON-serializable dict.
+
+    Enum values are reduced to their string form.  ``None`` fields are
+    elided so receivers can rely on field presence to detect optionality.
+    """
+    out: dict[str, Any] = {}
+    for slot in payload.__slots__:  # pyright: ignore[reportAny]
+        value = getattr(payload, slot)
+        if value is None:
+            continue
+        if isinstance(value, StrEnum):
+            out[slot] = value.value
+        else:
+            out[slot] = value
+    return out
+
+
+def serialize_event(envelope: EventEnvelope) -> str:
+    """Serialize an envelope to a single JSON line.
+
+    Raises:
+        ValueError: if the envelope's payload type does not match its name,
+            or if the install id is empty.
+    """
+    if not envelope.install_id:
+        raise ValueError("install_id is required for every emitted event")
+    expected = _PAYLOAD_FOR[envelope.name]
+    if not isinstance(envelope.payload, expected):
+        raise ValueError(
+            f"payload type {type(envelope.payload).__name__} does not match "
+            f"event {envelope.name.value} (expected {expected.__name__})"
+        )
+    body: dict[str, Any] = {
+        "schema_version": envelope.schema_version,
+        "name": envelope.name.value,
+        "install_id": envelope.install_id,
+        "timestamp": envelope.timestamp,
+        "payload": _payload_to_dict(envelope.payload),
+    }
+    return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
+def build_envelope(
+    name: TelemetryEvent,
+    install_id: str,
+    payload: EventPayload,
+    *,
+    timestamp: str | None = None,
+) -> EventEnvelope:
+    """Construct an envelope, optionally with a fixed timestamp for tests."""
+    if timestamp is None:
+        return EventEnvelope(name=name, install_id=install_id, payload=payload)
+    return EventEnvelope(
+        name=name,
+        install_id=install_id,
+        payload=payload,
+        timestamp=timestamp,
+    )
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "CommandInvokedPayload",
+    "DailyActivePayload",
+    "ErrorCategory",
+    "EventEnvelope",
+    "EventPayload",
+    "FirstRunCompletedPayload",
+    "FirstRunStartedPayload",
+    "InstallCompletedPayload",
+    "TelemetryEvent",
+    "build_envelope",
+    "expected_payload_type",
+    "serialize_event",
+]

--- a/src/bernstein/core/telemetry/install_id.py
+++ b/src/bernstein/core/telemetry/install_id.py
@@ -1,0 +1,68 @@
+"""Anonymous install identifier with lazy, opt-in-gated generation.
+
+The install id is a 128-bit UUID v4 written once to
+``~/.bernstein/install-id`` and only generated AFTER an explicit opt-in.
+Before opt-in this module's load and read paths must never produce a new
+id.  ``ensure(...)`` is the single mutation entry point; it raises if
+called while telemetry is disabled.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import uuid
+from typing import TYPE_CHECKING
+
+from bernstein.core.telemetry.config import install_id_path, is_enabled
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def read(home: Path | None = None) -> str | None:
+    """Return the persisted id, or ``None`` if the file is missing/empty."""
+    path = install_id_path(home)
+    if not path.exists():
+        return None
+    try:
+        value = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return value or None
+
+
+def ensure(home: Path | None = None) -> str:
+    """Return the install id, generating one if needed.
+
+    Raises:
+        RuntimeError: if telemetry is not currently enabled.  This is the
+            critical invariant: the id must never be created before opt-in.
+    """
+    if not is_enabled(home=home):
+        raise RuntimeError("install id may not be generated before explicit opt-in")
+    existing = read(home)
+    if existing is not None:
+        return existing
+    new_id = uuid.uuid4().hex
+    path = install_id_path(home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Restrict to operator only.  Best-effort on platforms that honour mode.
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(new_id + "\n", encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return new_id
+
+
+def reset(home: Path | None = None) -> None:
+    """Delete the install id.  Called from ``bernstein telemetry off``."""
+    path = install_id_path(home)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+
+
+__all__ = ["ensure", "read", "reset"]

--- a/src/bernstein/core/telemetry/wire.py
+++ b/src/bernstein/core/telemetry/wire.py
@@ -1,0 +1,250 @@
+"""Wire-in helpers for opt-in operator observability.
+
+These helpers are the only place where the rest of the codebase touches
+the telemetry boundary.  All entry points are fail-closed: if anything
+inside the helper raises, the caller never sees it.
+
+Three points integrate with the rest of Bernstein:
+
+* ``emit_first_run_started`` / ``emit_first_run_completed``  - from
+  ``bernstein.cli.run_bootstrap`` around the operator's first command.
+* ``emit_command_invoked``  - from ``bernstein.core.worker`` at spawn
+  time, with the bare command name only.
+* ``maybe_print_first_run_notice``  - from the CLI bootstrap to print
+  the one-time notice and persist the acknowledgement marker.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import sys
+import time
+from typing import TYPE_CHECKING, Any, Final
+
+from bernstein.core.telemetry import config as cfg
+from bernstein.core.telemetry.client import Client, get_client
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from bernstein.core.telemetry.events import (
+    CommandInvokedPayload,
+    DailyActivePayload,
+    ErrorCategory,
+    FirstRunCompletedPayload,
+    FirstRunStartedPayload,
+    InstallCompletedPayload,
+    TelemetryEvent,
+)
+
+_LOG = logging.getLogger(__name__)
+
+
+FIRST_RUN_NOTICE: Final[str] = (
+    "Bernstein collects no telemetry by default.\n"
+    "Run `bernstein telemetry on` to opt in and help us prioritize.\n"
+    "This message will not appear again."
+)
+
+
+def maybe_print_first_run_notice(
+    *,
+    home: Path | None = None,
+    out: Any = None,
+) -> bool:
+    """Print the first-run notice exactly once.
+
+    Returns ``True`` if the notice was printed, ``False`` otherwise.
+    Failures inside the helper never raise.
+    """
+    try:
+        if cfg.is_first_run_acknowledged(home=home):
+            return False
+        message = FIRST_RUN_NOTICE
+        if out is None:
+            print(message, file=sys.stderr)
+        else:
+            try:
+                out.write(message + "\n")
+            except Exception:
+                print(message, file=sys.stderr)
+        cfg.mark_first_run_acknowledged(home=home)
+        return True
+    except Exception as exc:
+        _LOG.debug("telemetry: first-run notice failed (suppressed): %s", exc)
+        return False
+
+
+def _bernstein_version() -> str:
+    """Best-effort version lookup; never raises."""
+    try:
+        from importlib.metadata import version
+
+        return version("bernstein")
+    except Exception:
+        return "unknown"
+
+
+def emit_install_completed(
+    *,
+    install_method: str = "pip",
+    client: Client | None = None,
+) -> None:
+    """Emit a single install_completed event.  No-op when opted out."""
+    _safe_emit(
+        client,
+        TelemetryEvent.INSTALL_COMPLETED,
+        InstallCompletedPayload(
+            os=platform.system().lower(),
+            py_version=platform.python_version(),
+            install_method=install_method,
+            bernstein_version=_bernstein_version(),
+        ),
+    )
+
+
+def emit_first_run_started(
+    *,
+    time_since_install_seconds: int,
+    client: Client | None = None,
+) -> None:
+    """Emit first_run_started.  No-op when opted out."""
+    _safe_emit(
+        client,
+        TelemetryEvent.FIRST_RUN_STARTED,
+        FirstRunStartedPayload(
+            time_since_install_seconds=max(0, int(time_since_install_seconds)),
+        ),
+    )
+
+
+def emit_first_run_completed(
+    *,
+    ok: bool,
+    duration_ms: int,
+    error_category: ErrorCategory | None = None,
+    client: Client | None = None,
+) -> None:
+    """Emit first_run_completed.  No-op when opted out."""
+    if not ok and error_category is None:
+        error_category = ErrorCategory.UNKNOWN
+    if ok:
+        error_category = None
+    _safe_emit(
+        client,
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        FirstRunCompletedPayload(
+            ok=ok,
+            duration_ms=max(0, int(duration_ms)),
+            error_category=error_category,
+        ),
+    )
+
+
+def emit_command_invoked(
+    *,
+    name_only: str,
+    client: Client | None = None,
+) -> None:
+    """Emit command_invoked.  ``name_only`` must be the command name only."""
+    # Defensive: strip anything that looks like an arg or a path separator.
+    clean = (name_only or "").strip().split()[0] if name_only else ""
+    clean = clean.replace("/", "_").replace("\\", "_")
+    if not clean:
+        return
+    _safe_emit(
+        client,
+        TelemetryEvent.COMMAND_INVOKED,
+        CommandInvokedPayload(
+            name_only=clean,
+            bernstein_version=_bernstein_version(),
+        ),
+    )
+
+
+def emit_daily_active(
+    *,
+    day_iso: str,
+    client: Client | None = None,
+) -> None:
+    """Emit daily_active.  Caller deduplicates to at most one per day."""
+    _safe_emit(
+        client,
+        TelemetryEvent.DAILY_ACTIVE,
+        DailyActivePayload(day_iso=day_iso),
+    )
+
+
+class FirstRunTimer:
+    """Context manager that emits start/completed pairs.
+
+    Designed for use at the top of ``bernstein run``::
+
+        with FirstRunTimer() as timer:
+            ...
+            timer.set_error(ErrorCategory.AUTH_FAILED)
+    """
+
+    def __init__(
+        self,
+        *,
+        time_since_install_seconds: int = 0,
+        client: Client | None = None,
+    ) -> None:
+        self._client = client
+        self._time_since_install = time_since_install_seconds
+        self._started_at: float = 0.0
+        self._error: ErrorCategory | None = None
+
+    def __enter__(self) -> FirstRunTimer:
+        self._started_at = time.monotonic()
+        emit_first_run_started(
+            time_since_install_seconds=self._time_since_install,
+            client=self._client,
+        )
+        return self
+
+    def set_error(self, category: ErrorCategory) -> None:
+        """Record an error category to emit on exit."""
+        self._error = category
+
+    def __exit__(
+        self,
+        exc_type: object,
+        exc: object,
+        tb: object,
+    ) -> None:
+        duration_ms = int((time.monotonic() - self._started_at) * 1000)
+        if exc is not None and self._error is None:
+            self._error = ErrorCategory.UNKNOWN
+        emit_first_run_completed(
+            ok=self._error is None,
+            duration_ms=duration_ms,
+            error_category=self._error,
+            client=self._client,
+        )
+
+
+def _safe_emit(
+    client: Client | None,
+    name: TelemetryEvent,
+    payload: object,
+) -> None:
+    """Inner shared boundary used by every emit_* helper."""
+    try:
+        c = client if client is not None else get_client()
+        c.emit(name, payload)  # pyright: ignore[reportArgumentType]
+    except Exception as exc:
+        _LOG.debug("telemetry: wire emit failed (suppressed): %s", exc)
+
+
+__all__ = [
+    "FIRST_RUN_NOTICE",
+    "FirstRunTimer",
+    "emit_command_invoked",
+    "emit_daily_active",
+    "emit_first_run_completed",
+    "emit_first_run_started",
+    "emit_install_completed",
+    "maybe_print_first_run_notice",
+]

--- a/src/bernstein/core/telemetry/wire.py
+++ b/src/bernstein/core/telemetry/wire.py
@@ -210,9 +210,9 @@ class FirstRunTimer:
 
     def __exit__(
         self,
-        exc_type: object,
+        _exc_type: object,
         exc: object,
-        tb: object,
+        _tb: object,
     ) -> None:
         duration_ms = int((time.monotonic() - self._started_at) * 1000)
         if exc is not None and self._error is None:

--- a/tests/integration/test_telemetry_lifecycle.py
+++ b/tests/integration/test_telemetry_lifecycle.py
@@ -1,0 +1,192 @@
+"""Integration tests for the full first-run telemetry lifecycle.
+
+Covers opt-in / opt-out flips, mock receiver, install id lifecycle,
+first-run notice idempotence, and queue persistence.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from bernstein.core.telemetry import (
+    Client,
+    DailyActivePayload,
+    ErrorCategory,
+    TelemetryEvent,
+    install_id_path,
+    queue_path,
+    write_enabled,
+)
+from bernstein.core.telemetry.wire import (
+    FirstRunTimer,
+    emit_command_invoked,
+    emit_first_run_completed,
+    emit_first_run_started,
+    maybe_print_first_run_notice,
+)
+
+
+class _MockReceiver:
+    """Minimal HTTP receiver that captures every event body."""
+
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> _MockReceiver:
+        receiver = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("content-length", "0"))
+                body = self.rfile.read(length).decode("utf-8")
+                try:
+                    receiver.events.append(json.loads(body))
+                except json.JSONDecodeError:
+                    receiver.events.append({"_raw": body})
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *_a: Any, **_kw: Any) -> None:
+                pass
+
+        self._server = HTTPServer(("127.0.0.1", 0), _Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    @property
+    def endpoint(self) -> str:
+        assert self._server is not None
+        host, port = self._server.server_address[:2]
+        return f"http://{host}:{port}/v1/events"
+
+    def __exit__(self, *_a: Any) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+
+@pytest.fixture()
+def home(tmp_path: Path) -> Path:
+    (tmp_path / ".bernstein").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _client_for(home: Path, endpoint: str) -> Client:
+    return Client(env={}, home=home, endpoint=endpoint, http_client=httpx.Client())
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_full_first_run_flow_with_mock_receiver(home: Path) -> None:
+    """First-time operator: notice -> opt-in -> first run -> events delivered."""
+    # 1. Default off.  Notice prints once.
+    buf = io.StringIO()
+    maybe_print_first_run_notice(home=home, out=buf)
+    assert "collects no telemetry" in buf.getvalue()
+
+    # 2. Operator runs `bernstein telemetry on`.
+    write_enabled(True, home=home)
+
+    # 3. First run emits start + complete via FirstRunTimer.
+    with _MockReceiver() as recv:
+        client = _client_for(home, recv.endpoint)
+        try:
+            with FirstRunTimer(time_since_install_seconds=10, client=client) as timer:
+                # simulate the body of the run
+                emit_command_invoked(name_only="run", client=client)
+                timer.set_error(ErrorCategory.AUTH_FAILED)
+        finally:
+            client.close()
+
+    names = [e["name"] for e in recv.events]
+    assert "first_run_started" in names
+    assert "first_run_completed" in names
+    assert "command_invoked" in names
+    completed = next(e for e in recv.events if e["name"] == "first_run_completed")
+    assert completed["payload"]["ok"] is False
+    assert completed["payload"]["error_category"] == "auth_failed"
+
+
+def test_opt_in_then_flip_off(home: Path) -> None:
+    write_enabled(True, home=home)
+    with _MockReceiver() as recv:
+        client = _client_for(home, recv.endpoint)
+        try:
+            emit_first_run_started(time_since_install_seconds=0, client=client)
+        finally:
+            client.close()
+        before = len(recv.events)
+        # Flip off mid-session.
+        write_enabled(False, home=home)
+        client2 = _client_for(home, recv.endpoint)
+        try:
+            emit_first_run_completed(ok=True, duration_ms=1, client=client2)
+        finally:
+            client2.close()
+        after = len(recv.events)
+    assert before == 1
+    assert after == 1  # no new events after opt-out
+
+
+def test_opt_out_then_flip_on(home: Path) -> None:
+    write_enabled(False, home=home)
+    with _MockReceiver() as recv:
+        client = _client_for(home, recv.endpoint)
+        try:
+            emit_first_run_started(time_since_install_seconds=0, client=client)
+        finally:
+            client.close()
+        assert recv.events == []
+        write_enabled(True, home=home)
+        client2 = _client_for(home, recv.endpoint)
+        try:
+            emit_first_run_started(time_since_install_seconds=5, client=client2)
+        finally:
+            client2.close()
+    assert len(recv.events) == 1
+
+
+def test_install_id_is_not_created_until_opt_in(home: Path) -> None:
+    with _MockReceiver() as recv:
+        client = _client_for(home, recv.endpoint)
+        try:
+            emit_first_run_started(time_since_install_seconds=0, client=client)
+        finally:
+            client.close()
+    assert not install_id_path(home=home).exists()
+    assert recv.events == []
+
+
+def test_queue_mirrors_emitted_events(home: Path) -> None:
+    write_enabled(True, home=home)
+    with _MockReceiver() as recv:
+        client = _client_for(home, recv.endpoint)
+        try:
+            for _ in range(3):
+                client.emit(
+                    TelemetryEvent.DAILY_ACTIVE,
+                    DailyActivePayload(day_iso="2026-05-17"),
+                )
+        finally:
+            client.close()
+    lines = queue_path(home=home).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+    for line in lines:
+        assert json.loads(line)["name"] == "daily_active"
+    assert len(recv.events) == 3

--- a/tests/property/test_telemetry_properties.py
+++ b/tests/property/test_telemetry_properties.py
@@ -1,0 +1,180 @@
+"""Property-based tests for the telemetry subsystem (Hypothesis)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.telemetry import (
+    CommandInvokedPayload,
+    DailyActivePayload,
+    ErrorCategory,
+    FirstRunCompletedPayload,
+    FirstRunStartedPayload,
+    InstallCompletedPayload,
+    TelemetryEvent,
+    build_envelope,
+    ensure_install_id,
+    serialize_event,
+    write_enabled,
+)
+
+# ---------------------------------------------------------------------------
+# Install id uniqueness
+# ---------------------------------------------------------------------------
+
+
+@given(st.integers(min_value=2, max_value=20))
+@settings(max_examples=20, deadline=None)
+def test_install_ids_are_unique_across_homes(tmp_path_factory: pytest.TempPathFactory, n: int) -> None:
+    base = tmp_path_factory.mktemp("ids")
+    ids: set[str] = set()
+    for i in range(n):
+        h = base / f"home-{i}"
+        write_enabled(True, home=h)
+        ids.add(ensure_install_id(home=h))
+    assert len(ids) == n
+
+
+@given(st.integers(min_value=1, max_value=5))
+@settings(max_examples=10, deadline=None)
+def test_ensure_install_id_idempotent(tmp_path_factory: pytest.TempPathFactory, calls: int) -> None:
+    h = tmp_path_factory.mktemp("idem")
+    write_enabled(True, home=h)
+    first = ensure_install_id(home=h)
+    for _ in range(calls):
+        assert ensure_install_id(home=h) == first
+
+
+# ---------------------------------------------------------------------------
+# Event serializer invariants
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _install_completed_payloads(draw: st.DrawFn) -> InstallCompletedPayload:
+    return InstallCompletedPayload(
+        os=draw(st.sampled_from(["linux", "darwin", "windows"])),
+        py_version=draw(st.from_regex(r"3\.[0-9]{1,2}\.[0-9]{1,2}", fullmatch=True)),
+        install_method=draw(st.sampled_from(["pip", "uv", "brew", "wheel"])),
+        bernstein_version=draw(st.from_regex(r"[0-9]+\.[0-9]+\.[0-9]+", fullmatch=True)),
+    )
+
+
+@st.composite
+def _first_run_completed_payloads(draw: st.DrawFn) -> FirstRunCompletedPayload:
+    ok = draw(st.booleans())
+    category = None if ok else draw(st.sampled_from(list(ErrorCategory)))
+    return FirstRunCompletedPayload(
+        ok=ok,
+        duration_ms=draw(st.integers(min_value=0, max_value=10**9)),
+        error_category=category,
+    )
+
+
+@given(_install_completed_payloads())
+@settings(max_examples=50)
+def test_install_completed_round_trip(p: InstallCompletedPayload) -> None:
+    env = build_envelope(
+        TelemetryEvent.INSTALL_COMPLETED,
+        install_id="x" * 32,
+        payload=p,
+        timestamp="2026-05-17T00:00:00+00:00",
+    )
+    body = json.loads(serialize_event(env))
+    assert body["payload"]["os"] == p.os
+    assert body["payload"]["py_version"] == p.py_version
+
+
+@given(st.integers(min_value=0, max_value=10**9))
+@settings(max_examples=30)
+def test_first_run_started_serializer(time_since: int) -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_STARTED,
+        install_id="x" * 32,
+        payload=FirstRunStartedPayload(time_since_install_seconds=time_since),
+    )
+    body = json.loads(serialize_event(env))
+    assert body["payload"]["time_since_install_seconds"] == time_since
+
+
+@given(_first_run_completed_payloads())
+@settings(max_examples=50)
+def test_first_run_completed_serializer(p: FirstRunCompletedPayload) -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        install_id="x" * 32,
+        payload=p,
+    )
+    body = json.loads(serialize_event(env))
+    assert body["payload"]["ok"] == p.ok
+    assert body["payload"]["duration_ms"] == p.duration_ms
+    if p.error_category is None:
+        assert "error_category" not in body["payload"]
+    else:
+        assert body["payload"]["error_category"] == p.error_category.value
+
+
+@given(st.text(min_size=1, max_size=64).filter(lambda s: s.strip()))
+@settings(max_examples=30)
+def test_command_invoked_payload_serializes(name: str) -> None:
+    env = build_envelope(
+        TelemetryEvent.COMMAND_INVOKED,
+        install_id="x" * 32,
+        payload=CommandInvokedPayload(name_only=name, bernstein_version="2.0.1"),
+    )
+    body = json.loads(serialize_event(env))
+    assert body["payload"]["name_only"] == name
+
+
+@given(st.dates())
+@settings(max_examples=30)
+def test_daily_active_payload_iso(day: object) -> None:
+    iso = day.isoformat()  # pyright: ignore[reportAttributeAccessIssue]
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="x" * 32,
+        payload=DailyActivePayload(day_iso=iso),
+    )
+    body = json.loads(serialize_event(env))
+    assert body["payload"]["day_iso"] == iso
+
+
+@given(st.text(min_size=1, max_size=32))
+@settings(max_examples=20)
+def test_serializer_output_is_single_json_line(install_id: str) -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id=install_id,
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+    )
+    line = serialize_event(env)
+    assert "\n" not in line
+    json.loads(line)  # must be valid json
+
+
+@given(st.integers(min_value=0, max_value=10**9))
+@settings(max_examples=20)
+def test_duration_ms_never_negative_in_output(duration: int) -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        install_id="x" * 32,
+        payload=FirstRunCompletedPayload(ok=True, duration_ms=duration),
+    )
+    body = json.loads(serialize_event(env))
+    assert body["payload"]["duration_ms"] >= 0
+
+
+@given(st.sampled_from(list(TelemetryEvent)))
+@settings(max_examples=20)
+def test_all_event_names_appear_in_closed_set(name: TelemetryEvent) -> None:
+    assert name.value in {
+        "install_completed",
+        "first_run_started",
+        "first_run_completed",
+        "command_invoked",
+        "daily_active",
+    }

--- a/tests/unit/telemetry/__init__.py
+++ b/tests/unit/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the opt-in operator observability subsystem."""

--- a/tests/unit/telemetry/conftest.py
+++ b/tests/unit/telemetry/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for telemetry unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.telemetry import client as client_mod
+
+
+@pytest.fixture()
+def tmp_home(tmp_path: Path) -> Iterator[Path]:
+    """A temporary operator home directory."""
+    (tmp_path / ".bernstein").mkdir(parents=True, exist_ok=True)
+    yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _reset_default_client() -> Iterator[None]:
+    """Ensure each test starts with a fresh default client."""
+    client_mod.reset_default_client()
+    yield
+    client_mod.reset_default_client()

--- a/tests/unit/telemetry/test_cli_command.py
+++ b/tests/unit/telemetry/test_cli_command.py
@@ -1,0 +1,84 @@
+"""``bernstein telemetry`` subcommand snapshot tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.telemetry_cmd import telemetry_group
+
+
+def _invoke(args: list[str]) -> tuple[int, str]:
+    runner = CliRunner()
+    result = runner.invoke(telemetry_group, args)
+    return result.exit_code, result.output
+
+
+def test_status_default_off(tmp_home: Path) -> None:
+    code, output = _invoke(["status", "--home", str(tmp_home)])
+    assert code == 0
+    assert "enabled: false" in output
+    assert "source: default" in output
+    assert "install_id: none" in output
+
+
+def test_status_after_opt_in(tmp_home: Path) -> None:
+    _invoke(["on", "--home", str(tmp_home)])
+    code, output = _invoke(["status", "--home", str(tmp_home)])
+    assert code == 0
+    assert "enabled: true" in output
+    assert "source: file" in output
+    # install_id should be present (32 hex chars).
+    assert "install_id: none" not in output
+
+
+def test_on_creates_install_id(tmp_home: Path) -> None:
+    code, _ = _invoke(["on", "--home", str(tmp_home)])
+    assert code == 0
+    assert (tmp_home / ".bernstein" / "install-id").exists()
+
+
+def test_off_removes_install_id(tmp_home: Path) -> None:
+    _invoke(["on", "--home", str(tmp_home)])
+    _invoke(["off", "--home", str(tmp_home)])
+    assert not (tmp_home / ".bernstein" / "install-id").exists()
+
+
+def test_off_sets_file_false(tmp_home: Path) -> None:
+    _invoke(["on", "--home", str(tmp_home)])
+    _invoke(["off", "--home", str(tmp_home)])
+    _code, output = _invoke(["status", "--home", str(tmp_home)])
+    assert "enabled: false" in output
+    assert "source: file" in output
+
+
+def test_export_empty_when_no_queue(tmp_home: Path) -> None:
+    code, output = _invoke(["export", "--home", str(tmp_home)])
+    assert code == 0
+    assert output.strip() == ""
+
+
+def test_status_snapshot_default(tmp_home: Path) -> None:
+    _code, output = _invoke(["status", "--home", str(tmp_home)])
+    lines = [line.split(":", 1)[0] for line in output.strip().splitlines()]
+    assert lines == [
+        "enabled",
+        "source",
+        "install_id",
+        "config_file",
+        "install_id_path",
+        "queue",
+    ]
+
+
+def test_status_overridden_by_env_off(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _invoke(["on", "--home", str(tmp_home)])
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    _code, output = _invoke(["status", "--home", str(tmp_home)])
+    assert "source: do_not_track" in output
+    assert "enabled: false" in output

--- a/tests/unit/telemetry/test_event_serializer.py
+++ b/tests/unit/telemetry/test_event_serializer.py
@@ -1,0 +1,261 @@
+"""Event schema and serializer tests for every event variant."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from bernstein.core.telemetry import (
+    SCHEMA_VERSION,
+    CommandInvokedPayload,
+    DailyActivePayload,
+    ErrorCategory,
+    EventEnvelope,
+    FirstRunCompletedPayload,
+    FirstRunStartedPayload,
+    InstallCompletedPayload,
+    TelemetryEvent,
+    build_envelope,
+    serialize_event,
+)
+from bernstein.core.telemetry.events import expected_payload_type
+
+# ---------------------------------------------------------------------------
+# Enum integrity (closed set)
+# ---------------------------------------------------------------------------
+
+
+def test_event_names_are_exhaustive() -> None:
+    expected = {
+        "install_completed",
+        "first_run_started",
+        "first_run_completed",
+        "command_invoked",
+        "daily_active",
+    }
+    assert {e.value for e in TelemetryEvent} == expected
+
+
+def test_error_categories_are_exhaustive() -> None:
+    expected = {
+        "config_missing",
+        "auth_failed",
+        "dependency_missing",
+        "model_unreachable",
+        "timeout",
+        "unknown",
+    }
+    assert {e.value for e in ErrorCategory} == expected
+
+
+# ---------------------------------------------------------------------------
+# Per-variant serializer happy paths
+# ---------------------------------------------------------------------------
+
+
+def _decode(envelope: EventEnvelope) -> dict[str, Any]:
+    return json.loads(serialize_event(envelope))
+
+
+def test_install_completed_round_trip() -> None:
+    env = build_envelope(
+        TelemetryEvent.INSTALL_COMPLETED,
+        install_id="abc",
+        payload=InstallCompletedPayload(
+            os="linux",
+            py_version="3.12.0",
+            install_method="pip",
+            bernstein_version="2.0.1",
+        ),
+    )
+    body = _decode(env)
+    assert body["name"] == "install_completed"
+    assert body["install_id"] == "abc"
+    assert body["schema_version"] == SCHEMA_VERSION
+    assert body["payload"] == {
+        "os": "linux",
+        "py_version": "3.12.0",
+        "install_method": "pip",
+        "bernstein_version": "2.0.1",
+    }
+
+
+def test_first_run_started_round_trip() -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_STARTED,
+        install_id="abc",
+        payload=FirstRunStartedPayload(time_since_install_seconds=42),
+    )
+    body = _decode(env)
+    assert body["payload"] == {"time_since_install_seconds": 42}
+
+
+def test_first_run_completed_ok_round_trip() -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        install_id="abc",
+        payload=FirstRunCompletedPayload(ok=True, duration_ms=123),
+    )
+    body = _decode(env)
+    assert body["payload"] == {"ok": True, "duration_ms": 123}
+
+
+def test_first_run_completed_error_round_trip() -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        install_id="abc",
+        payload=FirstRunCompletedPayload(
+            ok=False,
+            duration_ms=999,
+            error_category=ErrorCategory.AUTH_FAILED,
+        ),
+    )
+    body = _decode(env)
+    assert body["payload"] == {
+        "ok": False,
+        "duration_ms": 999,
+        "error_category": "auth_failed",
+    }
+
+
+def test_command_invoked_round_trip() -> None:
+    env = build_envelope(
+        TelemetryEvent.COMMAND_INVOKED,
+        install_id="abc",
+        payload=CommandInvokedPayload(name_only="claude", bernstein_version="2.0.1"),
+    )
+    body = _decode(env)
+    assert body["payload"] == {"name_only": "claude", "bernstein_version": "2.0.1"}
+
+
+def test_daily_active_round_trip() -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="abc",
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+    )
+    body = _decode(env)
+    assert body["payload"] == {"day_iso": "2026-05-17"}
+
+
+# ---------------------------------------------------------------------------
+# Failure paths
+# ---------------------------------------------------------------------------
+
+
+def test_serializer_rejects_empty_install_id() -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="",
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+    )
+    with pytest.raises(ValueError, match="install_id"):
+        serialize_event(env)
+
+
+def test_serializer_rejects_mismatched_payload() -> None:
+    env = EventEnvelope(
+        name=TelemetryEvent.DAILY_ACTIVE,
+        install_id="abc",
+        payload=CommandInvokedPayload(name_only="x", bernstein_version="2.0.1"),
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        serialize_event(env)
+
+
+def test_expected_payload_type_mapping() -> None:
+    assert expected_payload_type(TelemetryEvent.INSTALL_COMPLETED) is InstallCompletedPayload
+    assert expected_payload_type(TelemetryEvent.FIRST_RUN_STARTED) is FirstRunStartedPayload
+    assert expected_payload_type(TelemetryEvent.FIRST_RUN_COMPLETED) is FirstRunCompletedPayload
+    assert expected_payload_type(TelemetryEvent.COMMAND_INVOKED) is CommandInvokedPayload
+    assert expected_payload_type(TelemetryEvent.DAILY_ACTIVE) is DailyActivePayload
+
+
+# ---------------------------------------------------------------------------
+# JSON shape invariants
+# ---------------------------------------------------------------------------
+
+
+def test_serializer_output_is_one_line() -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="abc",
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+    )
+    line = serialize_event(env)
+    assert "\n" not in line
+
+
+def test_serializer_output_keys_sorted() -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="abc",
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+    )
+    line = serialize_event(env)
+    # Top-level keys are sorted alphabetically.
+    body = json.loads(line)
+    assert list(body.keys()) == sorted(body.keys())
+
+
+def test_serializer_drops_none_optional_fields() -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        install_id="abc",
+        payload=FirstRunCompletedPayload(ok=True, duration_ms=10),
+    )
+    body = _decode(env)
+    assert "error_category" not in body["payload"]
+
+
+def test_serializer_uses_str_enum_values() -> None:
+    env = build_envelope(
+        TelemetryEvent.FIRST_RUN_COMPLETED,
+        install_id="abc",
+        payload=FirstRunCompletedPayload(ok=False, duration_ms=10, error_category=ErrorCategory.TIMEOUT),
+    )
+    body = _decode(env)
+    assert body["payload"]["error_category"] == "timeout"
+    assert isinstance(body["payload"]["error_category"], str)
+
+
+def test_build_envelope_accepts_explicit_timestamp() -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="abc",
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+        timestamp="2026-05-17T00:00:00+00:00",
+    )
+    body = _decode(env)
+    assert body["timestamp"] == "2026-05-17T00:00:00+00:00"
+
+
+def test_build_envelope_default_timestamp_iso() -> None:
+    env = build_envelope(
+        TelemetryEvent.DAILY_ACTIVE,
+        install_id="abc",
+        payload=DailyActivePayload(day_iso="2026-05-17"),
+    )
+    body = _decode(env)
+    # Crude RFC3339 check.
+    assert "T" in body["timestamp"]
+    assert body["timestamp"].endswith("+00:00") or body["timestamp"].endswith("Z")
+
+
+def test_serializer_payload_never_contains_secrets_or_args() -> None:
+    """Closed set check: payloads only contain whitelisted keys."""
+    allowed: set[str] = set()
+    for cls in [
+        InstallCompletedPayload,
+        FirstRunStartedPayload,
+        FirstRunCompletedPayload,
+        CommandInvokedPayload,
+        DailyActivePayload,
+    ]:
+        allowed.update(cls.__slots__)
+    banned_substrings = {"prompt", "args", "secret", "token", "key", "password"}
+    for k in allowed:
+        for b in banned_substrings:
+            assert b not in k.lower(), f"banned substring {b!r} in payload key {k!r}"

--- a/tests/unit/telemetry/test_fail_closed_network.py
+++ b/tests/unit/telemetry/test_fail_closed_network.py
@@ -1,0 +1,241 @@
+"""Fail-closed network tests.
+
+Invariants:
+- Any network/HTTP error is silently swallowed.
+- The local queue is appended even if the network POST fails.
+- emit() never raises into the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from bernstein.core.telemetry import (
+    Client,
+    DailyActivePayload,
+    TelemetryEvent,
+    queue_path,
+    write_enabled,
+)
+
+
+class _FailingTransport(httpx.MockTransport):
+    """Transport that raises on every request."""
+
+    def __init__(self, exc: Exception) -> None:
+        super().__init__(self._handle)
+        self._exc = exc
+        self.calls: int = 0
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        raise self._exc
+
+
+class _StatusTransport(httpx.MockTransport):
+    def __init__(self, status: int) -> None:
+        super().__init__(self._handle)
+        self._status = status
+        self.calls: int = 0
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.calls += 1
+        return httpx.Response(self._status, content=b"")
+
+
+def _make_client(tmp_home: Path, transport: httpx.MockTransport) -> Client:
+    http = httpx.Client(transport=transport)
+    return Client(env={}, home=tmp_home, endpoint="http://test.invalid/v1/events", http_client=http)
+
+
+def _payload() -> DailyActivePayload:
+    return DailyActivePayload(day_iso="2026-05-17")
+
+
+# ---------------------------------------------------------------------------
+# Disabled state: no traffic, no file write, returns False.
+# ---------------------------------------------------------------------------
+
+
+def test_emit_returns_false_when_disabled(tmp_home: Path) -> None:
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+    assert client.emit(TelemetryEvent.DAILY_ACTIVE, _payload()) is False
+    assert transport.calls == 0
+    assert not queue_path(home=tmp_home).exists()
+
+
+def test_emit_does_not_generate_install_id_when_disabled(tmp_home: Path) -> None:
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+    client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    assert not (tmp_home / ".bernstein" / "install-id").exists()
+
+
+# ---------------------------------------------------------------------------
+# Enabled state: every kind of network failure is silently absorbed.
+# ---------------------------------------------------------------------------
+
+
+def _opt_in(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ConnectError("boom"),
+        httpx.ReadTimeout("slow"),
+        httpx.WriteTimeout("slow"),
+        httpx.RemoteProtocolError("garbled"),
+        httpx.PoolTimeout("pool"),
+        ConnectionResetError("rst"),
+    ],
+)
+def test_emit_swallows_network_exceptions(
+    tmp_home: Path,
+    exc: Exception,
+) -> None:
+    _opt_in(tmp_home)
+    transport = _FailingTransport(exc)
+    client = _make_client(tmp_home, transport)
+    # Must not raise.
+    assert client.emit(TelemetryEvent.DAILY_ACTIVE, _payload()) is True
+    # Queue line still appended even though POST failed.
+    contents = queue_path(home=tmp_home).read_text(encoding="utf-8").strip().splitlines()
+    assert len(contents) == 1
+    body: dict[str, Any] = json.loads(contents[0])
+    assert body["name"] == "daily_active"
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 500, 502, 503])
+def test_emit_swallows_http_error_statuses(tmp_home: Path, status: int) -> None:
+    _opt_in(tmp_home)
+    transport = _StatusTransport(status)
+    client = _make_client(tmp_home, transport)
+    assert client.emit(TelemetryEvent.DAILY_ACTIVE, _payload()) is True
+
+
+def test_emit_records_locally_when_network_disabled(tmp_home: Path) -> None:
+    _opt_in(tmp_home)
+    transport = _FailingTransport(httpx.ConnectError("offline"))
+    client = _make_client(tmp_home, transport)
+    client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    assert queue_path(home=tmp_home).exists()
+
+
+def test_emit_appends_one_line_per_event(tmp_home: Path) -> None:
+    _opt_in(tmp_home)
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+    for _ in range(3):
+        client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    lines = queue_path(home=tmp_home).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 3
+
+
+def test_emit_each_queue_line_is_valid_json(tmp_home: Path) -> None:
+    _opt_in(tmp_home)
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+    client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    for line in queue_path(home=tmp_home).read_text(encoding="utf-8").splitlines():
+        json.loads(line)
+
+
+def test_emit_swallows_local_disk_failure(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If even the local queue cannot be written, the network call still happens."""
+    _opt_in(tmp_home)
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+
+    from bernstein.core.telemetry import client as client_mod
+
+    def _raise(*_a: Any, **_kw: Any) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(client_mod, "_append_local", _raise)
+    # Must not raise.
+    client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+
+
+def test_flush_is_bounded(tmp_home: Path) -> None:
+    _opt_in(tmp_home)
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+    import time as _t
+
+    start = _t.monotonic()
+    client.flush(deadline_seconds=0.1)
+    elapsed = _t.monotonic() - start
+    assert elapsed < 0.5
+
+
+def test_close_is_idempotent(tmp_home: Path) -> None:
+    transport = _StatusTransport(200)
+    client = _make_client(tmp_home, transport)
+    client.close()
+    client.close()
+
+
+def test_emit_with_invalid_endpoint_returns_true_but_swallows(tmp_home: Path) -> None:
+    """Even with an unresolvable endpoint, no exception bubbles up."""
+    _opt_in(tmp_home)
+    client = Client(env={}, home=tmp_home, endpoint="http://does-not-resolve.invalid")
+    try:
+        client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    finally:
+        client.close()
+
+
+def test_client_endpoint_from_env(tmp_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_TELEMETRY_ENDPOINT", "https://example.com/x")
+    client = Client(home=tmp_home)
+    assert client.endpoint == "https://example.com/x"
+    client.close()
+
+
+def test_client_default_endpoint(tmp_home: Path) -> None:
+    client = Client(env={}, home=tmp_home)
+    assert client.endpoint.startswith("http")
+    client.close()
+
+
+def test_emit_does_not_log_payload_to_stderr(
+    tmp_home: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    _opt_in(tmp_home)
+    transport = _FailingTransport(httpx.ConnectError("boom"))
+    client = _make_client(tmp_home, transport)
+    client.emit(TelemetryEvent.DAILY_ACTIVE, _payload())
+    captured = capfd.readouterr()
+    # No traceback should appear.
+    assert "Traceback" not in captured.err
+    assert "Traceback" not in captured.out
+
+
+def test_envelope_preview_returns_none_when_disabled(tmp_home: Path) -> None:
+    client = Client(env={}, home=tmp_home)
+    try:
+        assert client.envelope_preview(TelemetryEvent.DAILY_ACTIVE, _payload()) is None
+    finally:
+        client.close()
+
+
+def test_envelope_preview_returns_none_without_install_id(tmp_home: Path) -> None:
+    _opt_in(tmp_home)
+    client = Client(env={}, home=tmp_home)
+    try:
+        # Opt-in is set but the install id has not been ensured yet.
+        assert client.envelope_preview(TelemetryEvent.DAILY_ACTIVE, _payload()) is None
+    finally:
+        client.close()

--- a/tests/unit/telemetry/test_first_run_notice.py
+++ b/tests/unit/telemetry/test_first_run_notice.py
@@ -1,0 +1,51 @@
+"""First-run notice idempotence and persistence tests."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from bernstein.core.telemetry import first_run_marker_path, is_first_run_acknowledged
+from bernstein.core.telemetry.wire import (
+    FIRST_RUN_NOTICE,
+    maybe_print_first_run_notice,
+)
+
+
+def test_notice_prints_once(tmp_home: Path) -> None:
+    buf = io.StringIO()
+    assert maybe_print_first_run_notice(home=tmp_home, out=buf) is True
+    assert FIRST_RUN_NOTICE in buf.getvalue()
+
+
+def test_notice_marker_persists(tmp_home: Path) -> None:
+    buf = io.StringIO()
+    maybe_print_first_run_notice(home=tmp_home, out=buf)
+    assert first_run_marker_path(home=tmp_home).exists()
+    assert is_first_run_acknowledged(home=tmp_home) is True
+
+
+def test_notice_does_not_repeat(tmp_home: Path) -> None:
+    buf = io.StringIO()
+    maybe_print_first_run_notice(home=tmp_home, out=buf)
+    buf2 = io.StringIO()
+    assert maybe_print_first_run_notice(home=tmp_home, out=buf2) is False
+    assert buf2.getvalue() == ""
+
+
+def test_notice_idempotent_across_many_calls(tmp_home: Path) -> None:
+    buf = io.StringIO()
+    for _ in range(10):
+        maybe_print_first_run_notice(home=tmp_home, out=buf)
+    assert buf.getvalue().count("collects no telemetry") == 1
+
+
+def test_notice_handles_broken_writer(tmp_home: Path) -> None:
+    class Broken:
+        def write(self, _s: str) -> None:
+            raise RuntimeError("boom")
+
+    # Must not raise; falls back internally.
+    maybe_print_first_run_notice(home=tmp_home, out=Broken())
+    # Marker still gets persisted.
+    assert is_first_run_acknowledged(home=tmp_home) is True

--- a/tests/unit/telemetry/test_install_id.py
+++ b/tests/unit/telemetry/test_install_id.py
@@ -1,0 +1,115 @@
+"""Install id lifecycle tests.
+
+Invariants:
+- Never generated before opt-in.
+- Generated exactly once after opt-in.
+- Removed on opt-out.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.telemetry import (
+    ensure_install_id,
+    install_id_path,
+    read_install_id,
+    reset_install_id,
+    write_enabled,
+)
+
+_HEX_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+def test_read_returns_none_when_missing(tmp_home: Path) -> None:
+    assert read_install_id(home=tmp_home) is None
+
+
+def test_ensure_raises_when_disabled(tmp_home: Path) -> None:
+    with pytest.raises(RuntimeError):
+        ensure_install_id(home=tmp_home)
+
+
+def test_ensure_succeeds_after_opt_in(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    install_id = ensure_install_id(home=tmp_home)
+    assert _HEX_RE.match(install_id)
+
+
+def test_ensure_is_idempotent(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    a = ensure_install_id(home=tmp_home)
+    b = ensure_install_id(home=tmp_home)
+    assert a == b
+
+
+def test_ensure_persists_to_disk(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    install_id = ensure_install_id(home=tmp_home)
+    on_disk = install_id_path(home=tmp_home).read_text(encoding="utf-8").strip()
+    assert on_disk == install_id
+
+
+def test_ensure_creates_directory(tmp_home: Path) -> None:
+    fresh = tmp_home / "fresh"
+    write_enabled(True, home=fresh)
+    ensure_install_id(home=fresh)
+    assert (fresh / ".bernstein" / "install-id").exists()
+
+
+def test_reset_removes_file(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    ensure_install_id(home=tmp_home)
+    reset_install_id(home=tmp_home)
+    assert read_install_id(home=tmp_home) is None
+
+
+def test_reset_on_missing_is_noop(tmp_home: Path) -> None:
+    # Must not raise.
+    reset_install_id(home=tmp_home)
+
+
+def test_read_returns_none_for_empty_file(tmp_home: Path) -> None:
+    path = install_id_path(home=tmp_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    assert read_install_id(home=tmp_home) is None
+
+
+def test_default_state_no_file(tmp_home: Path) -> None:
+    """The critical invariant: default-off MUST NOT generate an id."""
+    # Trigger nothing.  No write_enabled, no env.
+    assert not install_id_path(home=tmp_home).exists()
+
+
+def test_ensure_blocked_by_explicit_env_opt_out(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with file=true, BERNSTEIN_TELEMETRY=0 blocks generation."""
+    write_enabled(True, home=tmp_home)
+    monkeypatch.setenv("BERNSTEIN_TELEMETRY", "0")
+    with pytest.raises(RuntimeError):
+        ensure_install_id(home=tmp_home)
+
+
+def test_ensure_blocked_by_do_not_track(
+    tmp_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_enabled(True, home=tmp_home)
+    monkeypatch.setenv("DO_NOT_TRACK", "1")
+    with pytest.raises(RuntimeError):
+        ensure_install_id(home=tmp_home)
+
+
+def test_install_id_uniqueness_across_fresh_homes(tmp_path: Path) -> None:
+    ids: set[str] = set()
+    for i in range(8):
+        h = tmp_path / f"h{i}"
+        write_enabled(True, home=h)
+        ids.add(ensure_install_id(home=h))
+    assert len(ids) == 8

--- a/tests/unit/telemetry/test_local_queue.py
+++ b/tests/unit/telemetry/test_local_queue.py
@@ -1,0 +1,107 @@
+"""Local queue rotation tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import httpx
+
+from bernstein.core.telemetry import (
+    Client,
+    DailyActivePayload,
+    TelemetryEvent,
+    queue_path,
+    read_recent_events,
+    write_enabled,
+)
+from bernstein.core.telemetry.client import QUEUE_ROTATION_DAYS
+
+
+def _ok_transport() -> httpx.MockTransport:
+    return httpx.MockTransport(lambda r: httpx.Response(200))
+
+
+def _client(tmp_home: Path) -> Client:
+    return Client(
+        env={},
+        home=tmp_home,
+        endpoint="http://test.invalid/v1/events",
+        http_client=httpx.Client(transport=_ok_transport()),
+    )
+
+
+def test_queue_appends_one_line(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    c = _client(tmp_home)
+    c.emit(TelemetryEvent.DAILY_ACTIVE, DailyActivePayload(day_iso="2026-05-17"))
+    lines = queue_path(home=tmp_home).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["name"] == "daily_active"
+
+
+def test_queue_rotation_after_seven_days(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    c = _client(tmp_home)
+    c.emit(TelemetryEvent.DAILY_ACTIVE, DailyActivePayload(day_iso="2026-05-01"))
+    # Backdate mtime by > 7 days.
+    path = queue_path(home=tmp_home)
+    old_time = time.time() - (QUEUE_ROTATION_DAYS + 1) * 86400
+    import os as _os
+
+    _os.utime(path, (old_time, old_time))
+    # Next emit should rotate.
+    c.emit(TelemetryEvent.DAILY_ACTIVE, DailyActivePayload(day_iso="2026-05-17"))
+    archives = list(tmp_home.glob(".bernstein/telemetry-queue.*.jsonl"))
+    assert len(archives) >= 1
+    # New queue file has one line.
+    fresh = path.read_text(encoding="utf-8").splitlines()
+    assert len(fresh) == 1
+
+
+def test_queue_no_rotation_within_seven_days(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    c = _client(tmp_home)
+    c.emit(TelemetryEvent.DAILY_ACTIVE, DailyActivePayload(day_iso="2026-05-17"))
+    c.emit(TelemetryEvent.DAILY_ACTIVE, DailyActivePayload(day_iso="2026-05-18"))
+    archives = list(tmp_home.glob(".bernstein/telemetry-queue.*.jsonl"))
+    assert archives == []
+    assert len(queue_path(home=tmp_home).read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_read_recent_events_filters_by_date(tmp_home: Path) -> None:
+    """Lines older than the cutoff are excluded."""
+    write_enabled(True, home=tmp_home)
+    qp = queue_path(home=tmp_home)
+    qp.parent.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(tz=UTC).date().isoformat()
+    long_ago = (datetime.now(tz=UTC) - timedelta(days=400)).date().isoformat()
+    qp.write_text(
+        "\n".join(
+            [
+                json.dumps({"name": "a", "timestamp": f"{long_ago}T00:00:00+00:00"}),
+                json.dumps({"name": "b", "timestamp": f"{today}T00:00:00+00:00"}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = list(read_recent_events(days=30, home=tmp_home))
+    parsed = [json.loads(line) for line in out]
+    names = [p.get("name") for p in parsed]
+    assert "b" in names
+    assert "a" not in names
+
+
+def test_read_recent_events_missing_queue(tmp_home: Path) -> None:
+    out = list(read_recent_events(days=30, home=tmp_home))
+    assert out == []
+
+
+def test_read_recent_events_blank_lines_ignored(tmp_home: Path) -> None:
+    qp = queue_path(home=tmp_home)
+    qp.parent.mkdir(parents=True, exist_ok=True)
+    qp.write_text("\n\n\n", encoding="utf-8")
+    assert list(read_recent_events(days=30, home=tmp_home)) == []

--- a/tests/unit/telemetry/test_optin_precedence.py
+++ b/tests/unit/telemetry/test_optin_precedence.py
@@ -1,0 +1,228 @@
+"""Opt-in precedence resolution tests.
+
+Precedence (highest first):
+1. DO_NOT_TRACK=1
+2. BERNSTEIN_TELEMETRY env var
+3. ~/.bernstein/telemetry.yaml enabled: <bool>
+4. Default off
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.telemetry import (
+    OptInSource,
+    is_enabled,
+    resolve,
+    write_enabled,
+)
+
+# ---------------------------------------------------------------------------
+# Default state
+# ---------------------------------------------------------------------------
+
+
+def test_default_off_when_nothing_set(tmp_home: Path) -> None:
+    state = resolve(env={}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.DEFAULT
+
+
+def test_is_enabled_default_off(tmp_home: Path) -> None:
+    assert is_enabled(env={}, home=tmp_home) is False
+
+
+def test_default_off_with_unrelated_env(tmp_home: Path) -> None:
+    state = resolve(env={"PATH": "/usr/bin"}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# DO_NOT_TRACK
+# ---------------------------------------------------------------------------
+
+
+def test_do_not_track_overrides_everything(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(env={"DO_NOT_TRACK": "1", "BERNSTEIN_TELEMETRY": "1"}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.DO_NOT_TRACK
+
+
+def test_do_not_track_zero_is_not_opt_out(tmp_home: Path) -> None:
+    """DO_NOT_TRACK only counts when set to literal '1' (W3C convention)."""
+    state = resolve(env={"DO_NOT_TRACK": "0"}, home=tmp_home)
+    assert state.source is not OptInSource.DO_NOT_TRACK
+
+
+def test_do_not_track_empty_is_not_opt_out(tmp_home: Path) -> None:
+    state = resolve(env={"DO_NOT_TRACK": ""}, home=tmp_home)
+    assert state.source is not OptInSource.DO_NOT_TRACK
+
+
+def test_do_not_track_overrides_bernstein_env(tmp_home: Path) -> None:
+    state = resolve(
+        env={"DO_NOT_TRACK": "1", "BERNSTEIN_TELEMETRY": "1"},
+        home=tmp_home,
+    )
+    assert state.enabled is False
+
+
+def test_do_not_track_overrides_file(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(env={"DO_NOT_TRACK": "1"}, home=tmp_home)
+    assert state.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# BERNSTEIN_TELEMETRY env var
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["0", "false", "FALSE", "False", "no", "No", "off", "OFF", ""],
+)
+def test_bernstein_telemetry_false_values(tmp_home: Path, value: str) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(env={"BERNSTEIN_TELEMETRY": value}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.ENV
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", "True", "ON"])
+def test_bernstein_telemetry_truthy_values(tmp_home: Path, value: str) -> None:
+    state = resolve(env={"BERNSTEIN_TELEMETRY": value}, home=tmp_home)
+    assert state.enabled is True
+    assert state.source is OptInSource.ENV
+
+
+def test_bernstein_telemetry_overrides_file(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(env={"BERNSTEIN_TELEMETRY": "0"}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.ENV
+
+
+def test_bernstein_telemetry_whitespace_stripped(tmp_home: Path) -> None:
+    state = resolve(env={"BERNSTEIN_TELEMETRY": "  off  "}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.ENV
+
+
+# ---------------------------------------------------------------------------
+# File-based opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_file_enabled_true(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(env={}, home=tmp_home)
+    assert state.enabled is True
+    assert state.source is OptInSource.FILE
+
+
+def test_file_enabled_false(tmp_home: Path) -> None:
+    write_enabled(False, home=tmp_home)
+    state = resolve(env={}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.FILE
+
+
+def test_file_missing_falls_to_default(tmp_home: Path) -> None:
+    state = resolve(env={}, home=tmp_home)
+    assert state.source is OptInSource.DEFAULT
+
+
+def test_file_corrupt_falls_to_default(tmp_home: Path) -> None:
+    path = tmp_home / ".bernstein" / "telemetry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(":::: not valid yaml ::::", encoding="utf-8")
+    state = resolve(env={}, home=tmp_home)
+    assert state.source is OptInSource.DEFAULT
+
+
+def test_file_unknown_field_falls_to_default(tmp_home: Path) -> None:
+    path = tmp_home / ".bernstein" / "telemetry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("something_else: true\n", encoding="utf-8")
+    state = resolve(env={}, home=tmp_home)
+    assert state.source is OptInSource.DEFAULT
+
+
+def test_file_non_bool_value_falls_to_default(tmp_home: Path) -> None:
+    path = tmp_home / ".bernstein" / "telemetry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("enabled: maybe\n", encoding="utf-8")
+    state = resolve(env={}, home=tmp_home)
+    assert state.source is OptInSource.DEFAULT
+
+
+def test_file_empty_falls_to_default(tmp_home: Path) -> None:
+    path = tmp_home / ".bernstein" / "telemetry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
+    state = resolve(env={}, home=tmp_home)
+    assert state.source is OptInSource.DEFAULT
+
+
+def test_file_yaml_list_falls_to_default(tmp_home: Path) -> None:
+    path = tmp_home / ".bernstein" / "telemetry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("- enabled\n- true\n", encoding="utf-8")
+    state = resolve(env={}, home=tmp_home)
+    assert state.source is OptInSource.DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Combined precedence
+# ---------------------------------------------------------------------------
+
+
+def test_env_beats_file_off_vs_on(tmp_home: Path) -> None:
+    write_enabled(False, home=tmp_home)
+    state = resolve(env={"BERNSTEIN_TELEMETRY": "1"}, home=tmp_home)
+    assert state.enabled is True
+    assert state.source is OptInSource.ENV
+
+
+def test_env_beats_file_on_vs_off(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(env={"BERNSTEIN_TELEMETRY": "0"}, home=tmp_home)
+    assert state.enabled is False
+    assert state.source is OptInSource.ENV
+
+
+def test_do_not_track_beats_bernstein_truthy(tmp_home: Path) -> None:
+    state = resolve(
+        env={"DO_NOT_TRACK": "1", "BERNSTEIN_TELEMETRY": "1"},
+        home=tmp_home,
+    )
+    assert state.enabled is False
+    assert state.source is OptInSource.DO_NOT_TRACK
+
+
+def test_full_chain_off(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    state = resolve(
+        env={"DO_NOT_TRACK": "1", "BERNSTEIN_TELEMETRY": "1"},
+        home=tmp_home,
+    )
+    assert state.enabled is False
+
+
+def test_write_enabled_creates_dir(tmp_home: Path) -> None:
+    target = tmp_home / "fresh"
+    write_enabled(True, home=target)
+    assert (target / ".bernstein" / "telemetry.yaml").exists()
+
+
+def test_write_enabled_overwrites(tmp_home: Path) -> None:
+    write_enabled(True, home=tmp_home)
+    write_enabled(False, home=tmp_home)
+    state = resolve(env={}, home=tmp_home)
+    assert state.enabled is False

--- a/tests/unit/telemetry/test_wire_helpers.py
+++ b/tests/unit/telemetry/test_wire_helpers.py
@@ -1,0 +1,146 @@
+"""Tests for the wire-in helpers used by main.py / worker.py / run_bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+
+from bernstein.core.telemetry import (
+    Client,
+    ErrorCategory,
+    queue_path,
+    write_enabled,
+)
+from bernstein.core.telemetry.wire import (
+    FirstRunTimer,
+    emit_command_invoked,
+    emit_daily_active,
+    emit_first_run_completed,
+    emit_first_run_started,
+    emit_install_completed,
+)
+
+
+def _ok_transport() -> httpx.MockTransport:
+    return httpx.MockTransport(lambda r: httpx.Response(200))
+
+
+def _enabled_client(tmp_home: Path) -> Client:
+    write_enabled(True, home=tmp_home)
+    return Client(
+        env={},
+        home=tmp_home,
+        endpoint="http://test.invalid/v1/events",
+        http_client=httpx.Client(transport=_ok_transport()),
+    )
+
+
+def test_emit_command_invoked_strips_path(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_command_invoked(name_only="/usr/bin/claude", client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    # Path separators reduced to underscores.
+    assert "_usr_bin_claude" in text
+    assert "/usr/bin" not in text
+
+
+def test_emit_command_invoked_strips_args(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_command_invoked(name_only="claude --apikey SECRET", client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert "SECRET" not in text
+    assert "--apikey" not in text
+    assert "claude" in text
+
+
+def test_emit_command_invoked_drops_empty_name(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_command_invoked(name_only="", client=c)
+    assert not queue_path(home=tmp_home).exists() or queue_path(home=tmp_home).read_text() == ""
+
+
+def test_emit_first_run_started_clamps_negative_time(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_first_run_started(time_since_install_seconds=-50, client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert '"time_since_install_seconds":0' in text
+
+
+def test_emit_first_run_completed_ok_clears_error(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_first_run_completed(ok=True, duration_ms=10, error_category=ErrorCategory.AUTH_FAILED, client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert "error_category" not in text
+
+
+def test_emit_first_run_completed_not_ok_supplies_unknown_default(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_first_run_completed(ok=False, duration_ms=10, client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert '"error_category":"unknown"' in text
+
+
+def test_emit_install_completed_includes_python_and_os(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_install_completed(client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert "install_completed" in text
+    assert "py_version" in text
+    assert "install_method" in text
+
+
+def test_first_run_timer_emits_start_and_complete(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    with FirstRunTimer(time_since_install_seconds=5, client=c):
+        pass
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert "first_run_started" in text
+    assert "first_run_completed" in text
+
+
+def test_first_run_timer_records_set_error(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    with FirstRunTimer(client=c) as t:
+        t.set_error(ErrorCategory.CONFIG_MISSING)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert '"error_category":"config_missing"' in text
+
+
+def test_first_run_timer_records_exception(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    try:
+        with FirstRunTimer(client=c):
+            raise RuntimeError("kaboom")
+    except RuntimeError:
+        pass
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert '"error_category":"unknown"' in text
+
+
+def test_emit_daily_active_writes_day(tmp_home: Path) -> None:
+    c = _enabled_client(tmp_home)
+    emit_daily_active(day_iso="2026-05-17", client=c)
+    text = queue_path(home=tmp_home).read_text(encoding="utf-8")
+    assert '"day_iso":"2026-05-17"' in text
+
+
+def test_emit_command_invoked_is_noop_when_disabled(tmp_home: Path) -> None:
+    c = Client(env={}, home=tmp_home)
+    try:
+        emit_command_invoked(name_only="claude", client=c)
+    finally:
+        c.close()
+    assert not queue_path(home=tmp_home).exists()
+
+
+def test_wire_helpers_never_raise_when_disabled(tmp_home: Path) -> None:
+    c = Client(env={}, home=tmp_home)
+    try:
+        emit_command_invoked(name_only="claude", client=c)
+        emit_first_run_started(time_since_install_seconds=1, client=c)
+        emit_first_run_completed(ok=True, duration_ms=1, client=c)
+        emit_install_completed(client=c)
+        emit_daily_active(day_iso="2026-05-17", client=c)
+    finally:
+        c.close()

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -205,6 +205,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "blast-radius",
         "criterion-profile",
         "simulate",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "telemetry",
     }
 )
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -6,6 +6,7 @@ from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from bernstein.core.telemetry import (
     BUILTIN_PRESETS,
     get_meter,


### PR DESCRIPTION
## Summary

Closes spec `.sdd/backlog/done/2026-05-17-feat-opt-in-first-run-telemetry.yaml`.

Default-off operator-opt-in observability for the activation funnel.

- Precedence: `DO_NOT_TRACK=1` > `BERNSTEIN_TELEMETRY` env > config file > default-off.
- Install id is a UUID v4 generated lazily **after** explicit opt-in only.
- Fail-closed network: 3s timeout, no retries, exceptions swallowed.
- Every event mirrored to `~/.bernstein/telemetry-queue.jsonl` for audit.
- Closed event set (5 variants); closed error taxonomy (6 categories).

## Operator surface

```
bernstein telemetry on        # opt in, write config, generate install id
bernstein telemetry off       # opt out, delete install id
bernstein telemetry status    # show state + which precedence layer won
bernstein telemetry export    # dump last 30 days of locally queued events
```

## Files

- New: `src/bernstein/core/telemetry/{__init__,config,install_id,events,client,wire}.py`
- New: `src/bernstein/cli/commands/telemetry_cmd.py`
- New: `docs/telemetry.md`
- Wire-in: `src/bernstein/cli/main.py`, `src/bernstein/cli/run_bootstrap.py`, `src/bernstein/core/orchestration/worker.py`

## Test plan

- [x] 130 unit tests in `tests/unit/telemetry/` (precedence, install-id, serializer, fail-closed network, first-run notice, local queue, CLI snapshots, wire helpers)
- [x] 10 property-based tests in `tests/property/test_telemetry_properties.py` (install-id uniqueness, payload schema invariants)
- [x] 5 integration tests in `tests/integration/test_telemetry_lifecycle.py` (mock receiver, opt-in/opt-out flips, lifecycle)
- [x] `uv run ruff check src/bernstein/core/telemetry/ src/bernstein/cli/commands/telemetry_cmd.py` clean
- [x] `uv run pyright src/bernstein/core/telemetry/ src/bernstein/cli/commands/telemetry_cmd.py` 0 errors
- [x] Legacy `tests/unit/test_telemetry.py` still passes after package promotion (back-compat re-exports preserved)