### PR TITLE
fix(qwen): forward Tavily API key via env, never argv

### DIFF
--- a/src/bernstein/adapters/qwen.py
+++ b/src/bernstein/adapters/qwen.py
@@ -75,7 +75,14 @@ class QwenAdapter(CLIAdapter):
     }
 
     def _build_command(self, model_name: str, provider: str, settings: LLMSettings) -> list[str]:
-        """Build the qwen CLI command list (without the final prompt argument)."""
+        """Build the qwen CLI command list (without the final prompt argument).
+
+        The Tavily API key is never placed on argv (it would be visible to
+        any user with ``ps`` access on the host). It is forwarded to the
+        spawned process via the ``TAVILY_API_KEY`` environment variable in
+        :meth:`spawn`. Only the non-sensitive ``--web-search-default``
+        selector is added to argv.
+        """
         cmd: list[str] = ["qwen", "-y"]
 
         # Map abstract/alias names to real Qwen API model IDs.
@@ -87,14 +94,7 @@ class QwenAdapter(CLIAdapter):
             cmd.extend(["--auth-type", "openai"])
 
         if settings.tavily_api_key:
-            cmd.extend(
-                [
-                    "--tavily-api-key",
-                    settings.tavily_api_key,
-                    "--web-search-default",
-                    "tavily",
-                ]
-            )
+            cmd.extend(["--web-search-default", "tavily"])
 
         return cmd
 
@@ -119,11 +119,17 @@ class QwenAdapter(CLIAdapter):
         provider = self._detect_provider(settings)
         api_key, base_url = self._resolve_provider_config(provider, settings)
 
-        env = build_filtered_env(["OPENAI_API_KEY", "OPENAI_BASE_URL"])
+        env = build_filtered_env(["OPENAI_API_KEY", "OPENAI_BASE_URL", "TAVILY_API_KEY"])
         if api_key:
             env["OPENAI_API_KEY"] = api_key
         if base_url:
             env["OPENAI_BASE_URL"] = base_url
+        # Forward the Tavily key via env (never argv) so it does not appear
+        # in ``ps``/audit logs on shared hosts. Qwen Code reads
+        # ``TAVILY_API_KEY`` from the environment when the web_search tool
+        # is enabled. See qwen-code docs: web-search/configuration.
+        if settings.tavily_api_key:
+            env["TAVILY_API_KEY"] = settings.tavily_api_key
 
         # Pass the prompt as a positional argument (one-shot mode) instead of deprecated -p
         cmd = self._build_command(model_config.model, provider, settings)

--- a/tests/contract/contracts/qwen.yaml
+++ b/tests/contract/contracts/qwen.yaml
@@ -1,8 +1,10 @@
 # Contract for the Qwen CLI (adapter: qwen).
 #
 # Always-passed surface from src/bernstein/adapters/qwen.py::_build_command:
-# ``qwen -y --model <resolved> [--auth-type openai] [--tavily-api-key ...]``.
-# Only ``-y`` and ``--model`` are unconditional.
+# ``qwen -y --model <resolved> [--auth-type openai] [--web-search-default tavily]``.
+# Only ``-y`` and ``--model`` are unconditional. The Tavily API key is
+# forwarded via the ``TAVILY_API_KEY`` environment variable, never on argv,
+# to keep it out of ``ps`` output.
 adapter: qwen
 binary: qwen
 install:

--- a/tests/unit/test_adapter_qwen.py
+++ b/tests/unit/test_adapter_qwen.py
@@ -213,10 +213,39 @@ class TestQwenAdapterSpawn:
                 session_id="qwen-s9",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--tavily-api-key" in inner
-        assert inner[inner.index("--tavily-api-key") + 1] == "tvly-test"
+        # The non-sensitive selector flag is still on argv.
         assert "--web-search-default" in inner
         assert inner[inner.index("--web-search-default") + 1] == "tavily"
+        # SECURITY: the Tavily key must NEVER reach argv (visible via ps).
+        assert "--tavily-api-key" not in inner
+        assert "tvly-test" not in inner
+        # It is forwarded via the environment instead.
+        env_arg = popen.call_args.kwargs["env"]
+        assert env_arg["TAVILY_API_KEY"] == "tvly-test"
+
+    def test_tavily_argv_omitted_when_key_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Strip any inherited TAVILY_API_KEY from the parent environment so
+        # the test asserts on the adapter's own injection, not host state.
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        adapter = QwenAdapter()
+        proc_mock = _make_popen_mock(pid=118)
+        settings = _default_settings()
+        with (
+            patch("bernstein.adapters.qwen.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.qwen.LLMSettings", return_value=settings),
+        ):
+            adapter.spawn(
+                prompt="hello",
+                workdir=tmp_path,
+                model_config=ModelConfig(model="qwen-max", effort="high"),
+                session_id="qwen-s9b",
+            )
+        inner = _inner_cmd(popen.call_args.args[0])
+        assert "--web-search-default" not in inner
+        env_arg = popen.call_args.kwargs["env"]
+        assert "TAVILY_API_KEY" not in env_arg
 
     def test_creates_log_dir(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()


### PR DESCRIPTION
## Summary

The Qwen adapter was passing `--tavily-api-key <secret>` on the spawned process command line. Any user with `ps` access on the host could read the key out of `/proc/<pid>/cmdline`, and the value would land in shell history, audit logs, and crash dumps. This is the same credential-leak pattern that the project's `build_filtered_env` infrastructure exists to prevent.

The Qwen Code CLI documents `TAVILY_API_KEY` as a first-class source of the Tavily credential (web-search docs), so the behaviour for the spawned CLI is unchanged. The non-sensitive `--web-search-default tavily` selector stays on argv.

## Changes

- `src/bernstein/adapters/qwen.py`: drop `--tavily-api-key` from argv, inject `TAVILY_API_KEY` into the spawn env, allow it through `build_filtered_env`.
- `tests/unit/test_adapter_qwen.py`: regression — assert key is never on argv, env carries it; add a separate test that env stays clean when the key is unset.
- `tests/contract/contracts/qwen.yaml`: doc-comment now reflects the post-fix surface.

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_qwen.py -x -q` (36 passed)
- [x] `uv run ruff check src/bernstein/adapters/qwen.py tests/unit/test_adapter_qwen.py` (clean)
- [x] `uv run pyright src/bernstein/adapters/qwen.py` (no new errors vs baseline)