### PR TITLE
fix(replay): hold lock across seq + file write in ReplayGateway

### DIFF
--- a/src/bernstein/core/replay/gateway.py
+++ b/src/bernstein/core/replay/gateway.py
@@ -216,13 +216,18 @@ class ReplayGateway:
         response: Any,
         metadata: dict[str, Any] | None,
     ) -> None:
-        """Append one event to ``events.jsonl``."""
-        with self._lock:
-            self._seq += 1
-            seq = self._seq
+        """Append one event to ``events.jsonl``.
 
+        Sequence assignment AND the file write happen under ``self._lock``.
+        Splitting these two steps (lock-then-release before opening the
+        file) let two concurrent record calls swap their ``seq`` order in
+        the file, and worse — concurrent file writes past PIPE_BUF can
+        interleave bytes, producing malformed JSONL the replay loader
+        then silently skips. The lock is local to the gateway, so the
+        critical section is short and uncontended for typical adapter
+        traffic.
+        """
         entry: dict[str, Any] = {
-            "seq": seq,
             "ts": time.time(),
             "kind": kind,
             "key": key,
@@ -231,12 +236,20 @@ class ReplayGateway:
         if metadata:
             entry["metadata"] = _make_jsonable(metadata)
 
-        try:
-            with self._path.open("a") as f:
-                f.write(json.dumps(entry, default=str) + "\n")
-        except OSError as exc:
-            # Recording is a debug aid; failures must not break the run.
-            logger.warning("ReplayGateway: failed to record %r: %s", kind, exc)
+        with self._lock:
+            self._seq += 1
+            entry["seq"] = self._seq
+            # ``json.dumps`` runs inside the lock so the ``seq`` field is
+            # consistent with the file order; the lock also serialises the
+            # subsequent file.write so two concurrent records can never
+            # interleave bytes past PIPE_BUF.
+            line = json.dumps(entry, default=str)
+            try:
+                with self._path.open("a", encoding="utf-8") as f:
+                    f.write(line + "\n")
+            except OSError as exc:
+                # Recording is a debug aid; failures must not break the run.
+                logger.warning("ReplayGateway: failed to record %r: %s", kind, exc)
 
     # ------------------------------------------------------------------
     # Replay
@@ -249,13 +262,15 @@ class ReplayGateway:
                 f"No events log at {self._path}; nothing to replay. "
                 "Was BERNSTEIN_RECORD=1 set during the original run?",
             )
-        with self._path.open() as f:
+        # encoding="utf-8" mirrors the record path; relying on the platform
+        # default broke replay on Windows runners where cp1252 was active.
+        with self._path.open(encoding="utf-8") as f:
             for raw in f:
-                raw = raw.strip()
-                if not raw:
+                row_str = raw.strip()
+                if not row_str:
                     continue
                 try:
-                    row = json.loads(raw)
+                    row = json.loads(row_str)
                 except json.JSONDecodeError:
                     logger.warning("ReplayGateway: skipping malformed line in %s", self._path)
                     continue
@@ -266,22 +281,28 @@ class ReplayGateway:
                 self._fixtures_by_kind.setdefault(kind, []).append(response)
 
     def _replay_lookup(self, *, kind: str, key: str) -> Any:
-        """Pop the next fixture for ``(kind, key)`` (or FIFO by ``kind``)."""
-        bucket = self._fixtures_by_key.get((kind, key))
-        if bucket:
-            response = bucket.pop(0)
-            # Also remove the matching entry from the by-kind queue
-            # (FIFO match — first identical response).
-            kind_bucket = self._fixtures_by_kind.get(kind, [])
-            for i, item in enumerate(kind_bucket):
-                if item == response:
-                    kind_bucket.pop(i)
-                    break
-            return response
+        """Pop the next fixture for ``(kind, key)`` (or FIFO by ``kind``).
 
-        kind_bucket = self._fixtures_by_kind.get(kind)
-        if kind_bucket:
-            return kind_bucket.pop(0)
+        Holds ``self._lock`` for the entire pop so concurrent dispatches
+        cannot drain the same bucket twice or skip rows that another
+        thread has already popped under the by-kind fallback.
+        """
+        with self._lock:
+            bucket = self._fixtures_by_key.get((kind, key))
+            if bucket:
+                response = bucket.pop(0)
+                # Also remove the matching entry from the by-kind queue
+                # (FIFO match — first identical response).
+                kind_bucket = self._fixtures_by_kind.get(kind, [])
+                for i, item in enumerate(kind_bucket):
+                    if item == response:
+                        kind_bucket.pop(i)
+                        break
+                return response
+
+            kind_bucket = self._fixtures_by_kind.get(kind)
+            if kind_bucket:
+                return kind_bucket.pop(0)
 
         raise ReplayMissError(
             f"No fixture for kind={kind!r} key={key!r} in {self._path}. "

--- a/tests/unit/test_replay_gateway.py
+++ b/tests/unit/test_replay_gateway.py
@@ -11,6 +11,7 @@ Covers the MVP slice of issue #1319:
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 
 import pytest
@@ -274,3 +275,63 @@ def test_diff_both_empty(tmp_path: Path) -> None:
     result = diff_event_logs(a, b)
     assert result.diverged is False
     assert "empty" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Regression: concurrent record/replay must produce well-formed JSONL
+# ---------------------------------------------------------------------------
+
+
+def test_record_is_thread_safe_under_concurrent_dispatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent ``dispatch`` calls must produce well-formed JSONL with
+    unique ``seq`` values, and replay must be able to drain every event.
+
+    Regression guard for the gateway recording race: ``seq`` assignment
+    used to happen under the lock but the JSON encode and file open/write
+    were outside it. POSIX ``O_APPEND`` masks the race for short writes
+    today, but a future writer (or a switch to buffered I/O) would let
+    bytes interleave past one ``write()`` syscall. Keeping seq + write
+    inside the same lock pins the invariant the replay loader depends on.
+    """
+    monkeypatch.setenv(RECORD_ENV_VAR, "1")
+    gw = ReplayGateway("run-race", tmp_path)
+
+    # A response just over typical PIPE_BUF (4 KiB on Linux/macOS) so an
+    # unlocked write path would expose interleaving more reliably. The
+    # body is reproducible per thread index for later assertions.
+    big = "X" * 6000
+
+    def _worker(i: int) -> None:
+        gw.dispatch(
+            kind="llm",
+            key=f"k-{i}",
+            invoke=lambda i=i: {"i": i, "body": big},
+        )
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(40)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Every line must parse and every seq must be unique + monotonic.
+    raw_lines = gw.path.read_text(encoding="utf-8").splitlines()
+    assert len(raw_lines) == 40
+    rows = [json.loads(line) for line in raw_lines]
+    seqs = [int(r["seq"]) for r in rows]
+    assert sorted(seqs) == list(range(1, 41)), "seq numbers must be unique 1..N"
+
+    # Replay must drain all 40 fixtures by FIFO without raising.
+    replay = ReplayGateway("run-race", tmp_path, mode=GatewayMode.REPLAY)
+    seen: set[int] = set()
+    for _ in range(40):
+        out = replay.dispatch(
+            kind="llm",
+            key="any",  # force the FIFO fallback
+            invoke=lambda: (_ for _ in ()).throw(AssertionError("invoke must not run")),
+        )
+        seen.add(int(out["i"]))
+    assert seen == set(range(40))


### PR DESCRIPTION
## Summary

- ``ReplayGateway._record`` released the lock before JSON encode and file open/write, so two concurrent record calls could race the write path. POSIX O_APPEND masks this today for short lines, but any future buffered writer or a write past one ``write()`` syscall lets bytes interleave -- and the replay loader silently drops malformed JSONL.
- ``_replay_lookup`` mutated the per-kind/per-key fixture queues with no lock, so two threads could pop the same bucket twice or skip the FIFO fallback bucket.
- ``_load_fixtures`` opened the events log with the platform default encoding while the record path always wrote UTF-8 -- a Windows run with cp1252 active read back a different byte string from what was written.

All three paths now share ``self._lock`` and pin UTF-8.

## Test plan

- [x] ``uv run pytest tests/unit/test_replay_gateway.py`` (24 tests, all pass; new regression test covers 40-thread concurrent dispatch with responses past PIPE_BUF)
- [x] ``uv run ruff check src/bernstein/core/replay/gateway.py tests/unit/test_replay_gateway.py``
- [x] ``uv run ruff format --check`` (clean)
- [x] ``uv run pyright --project pyrightconfig.strict.json src/bernstein/core/replay/gateway.py`` (5 pre-existing errors, none introduced by this PR)