### PR TITLE
fix(iac): forward task prompt via env, eliminate shell-injection surface

### DIFF
--- a/src/bernstein/adapters/iac.py
+++ b/src/bernstein/adapters/iac.py
@@ -47,8 +47,17 @@ def _detect_tool() -> str | None:
     return None
 
 
-def _build_iac_script(tool: str, prompt: str) -> str:
-    """Build a shell script that runs plan/preview, then apply only on success."""
+def _build_iac_script(tool: str) -> str:
+    """Build a shell script that runs plan/preview, then apply only on success.
+
+    The task prompt is **not** interpolated into the script body. It is
+    read at run-time from the ``BERNSTEIN_IAC_PROMPT`` env var. Inlining
+    operator/agent-supplied prompts into a bash literal would allow shell
+    metacharacters (``"``, ``$``, backticks, ``$(...)``) to either break
+    ``set -euo pipefail`` parsing or execute arbitrary commands. Reading
+    the value through the environment keeps the script body a fixed
+    constant string regardless of prompt contents.
+    """
     plan_cmd, apply_cmd = _TOOL_DEFS[tool]
     plan_str = " ".join(plan_cmd)
     apply_str = " ".join(apply_cmd)
@@ -72,7 +81,7 @@ def _build_iac_script(tool: str, prompt: str) -> str:
     return (
         "#!/usr/bin/env bash\n"
         "set -euo pipefail\n"
-        f'echo "Task: {prompt}"\n'
+        'echo "Task: ${BERNSTEIN_IAC_PROMPT:-(no prompt)}"\n'
         f'echo "--- Running {tool} plan ---"\n'
         f"{plan_str}\n"
         f"{check_block}"
@@ -124,9 +133,10 @@ class IaCAdapter(CLIAdapter):
         log_path = workdir / ".sdd" / "runtime" / f"{session_id}.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Write the plan-then-apply script
+        # Write the plan-then-apply script. The prompt is forwarded via
+        # env (see below); never interpolated into the script body.
         script_path = workdir / ".sdd" / "runtime" / f"{session_id}-iac.sh"
-        script_content = _build_iac_script(tool, prompt)
+        script_content = _build_iac_script(tool)
         script_path.write_text(script_content, encoding="utf-8")
         script_path.chmod(0o755)
 
@@ -161,6 +171,12 @@ class IaCAdapter(CLIAdapter):
                 "PULUMI_ACCESS_TOKEN",
             ]
         )
+        # Forward the operator prompt to the IaC script via env so the
+        # script body stays a fixed literal (no shell-metachar injection
+        # surface). The script reads ``BERNSTEIN_IAC_PROMPT`` at run-time
+        # for the human-readable banner line only; the IaC plan/apply
+        # commands themselves never consume it.
+        env["BERNSTEIN_IAC_PROMPT"] = prompt
 
         with log_path.open("w") as log_file:
             try:

--- a/tests/unit/test_adapter_iac.py
+++ b/tests/unit/test_adapter_iac.py
@@ -246,33 +246,82 @@ class TestIaCAdapterSpawn:
 
 class TestPlanBeforeApply:
     def test_terraform_script_has_plan_before_apply(self) -> None:
-        script = _build_iac_script("terraform", "deploy vpc")
+        script = _build_iac_script("terraform")
         plan_pos = script.index("terraform plan")
         apply_pos = script.index("terraform apply")
         assert plan_pos < apply_pos
 
     def test_terraform_script_checks_exit_code(self) -> None:
-        script = _build_iac_script("terraform", "deploy")
+        script = _build_iac_script("terraform")
         assert "plan_exit=$?" in script
         assert "exit 1" in script
 
     def test_pulumi_script_has_preview_before_up(self) -> None:
-        script = _build_iac_script("pulumi", "deploy stack")
+        script = _build_iac_script("pulumi")
         preview_pos = script.index("pulumi preview")
         up_pos = script.index("pulumi up")
         assert preview_pos < up_pos
 
     def test_pulumi_script_checks_exit_code(self) -> None:
-        script = _build_iac_script("pulumi", "deploy")
+        script = _build_iac_script("pulumi")
         assert "$? -ne 0" in script
 
     def test_terraform_script_uses_detailed_exitcode(self) -> None:
-        script = _build_iac_script("terraform", "deploy")
+        script = _build_iac_script("terraform")
         assert "-detailed-exitcode" in script
 
     def test_terraform_script_auto_approve(self) -> None:
-        script = _build_iac_script("terraform", "deploy")
+        script = _build_iac_script("terraform")
         assert "-auto-approve" in script
+
+    def test_script_body_is_prompt_independent(self) -> None:
+        # Regression: the script body MUST be a fixed literal — prompts
+        # used to be f-string interpolated, letting shell metachars
+        # (``"``, ``$()``, ``;``, backticks) either break the script or
+        # execute arbitrary commands inside ``bash -euo pipefail``.
+        # Both calls must now return byte-identical scripts.
+        a = _build_iac_script("terraform")
+        b = _build_iac_script("terraform")
+        assert a == b
+        assert "BERNSTEIN_IAC_PROMPT" in a
+
+    def test_script_does_not_interpolate_attack_prompt(self) -> None:
+        # If the implementation ever regresses to f-string interpolation,
+        # this would catch a representative attack payload appearing as
+        # a literal in the script body.
+        script = _build_iac_script("terraform")
+        for token in ('"; rm -rf /', "$(id)", "`whoami`", "&& curl evil"):
+            assert token not in script
+
+
+# ---------------------------------------------------------------------------
+# Spawn forwards prompt via env, not argv/script body
+# ---------------------------------------------------------------------------
+
+
+class TestIaCSpawnPromptEnv:
+    def test_spawn_forwards_prompt_in_env(self, tmp_path: Path) -> None:
+        adapter = IaCAdapter(tool="terraform")
+        proc_mock = _make_popen_mock(pid=4711)
+        attack_prompt = 'foo"; rm -rf / #'
+        with (
+            patch("bernstein.adapters.iac.subprocess.Popen", return_value=proc_mock) as popen,
+            patch("bernstein.adapters.iac.shutil.which", return_value="/usr/bin/terraform"),
+        ):
+            adapter.spawn(
+                prompt=attack_prompt,
+                workdir=tmp_path,
+                model_config=ModelConfig(model="terraform", effort="high"),
+                session_id="iac-s1",
+            )
+        env_arg = popen.call_args.kwargs["env"]
+        assert env_arg["BERNSTEIN_IAC_PROMPT"] == attack_prompt
+        # The script written to disk must contain only the env reference,
+        # never the raw prompt bytes.
+        script_path = tmp_path / ".sdd" / "runtime" / "iac-s1-iac.sh"
+        body = script_path.read_text(encoding="utf-8")
+        assert attack_prompt not in body
+        assert "${BERNSTEIN_IAC_PROMPT" in body
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The IaC adapter's ``_build_iac_script`` previously f-string-interpolated the operator prompt into a bash literal:

    f'echo \"Task: {prompt}\"\n'

A prompt containing \`\"\`, backticks, \`\$()\`, \`;\`, or \`&&\` would either break \`set -euo pipefail\` parsing of the generated script or execute arbitrary commands inside the IaC worker (with cloud credentials in the env) **before** the terraform/pulumi plan ran.

Even if today every caller is the trusted operator, the adapter processes free-form task descriptions that the orchestrator may pull from backlog YAML, chat handoffs, or LLM-authored tickets - none of which are guaranteed to be metachar-clean.

## Fix

Drop the parameter and read the value from \`BERNSTEIN_IAC_PROMPT\` inside the script body. The script becomes a fixed literal regardless of prompt content; the env var carries the raw bytes through Popen, so even a payload like \`\"; rm -rf /\` only appears as the banner-line text.

## Test plan

- [x] \`uv run pytest tests/unit/test_adapter_iac.py -x -q\` (34 passed)
- [x] \`uv run ruff check src/bernstein/adapters/iac.py tests/unit/test_adapter_iac.py\` (clean)
- [x] Regression tests: \`test_script_does_not_interpolate_attack_prompt\` and \`test_spawn_forwards_prompt_in_env\` would fail if the f-string interpolation comes back.