### PR TITLE
fix(agent_ipc): serialise concurrent stdin writes per session

### DIFF
--- a/src/bernstein/core/agents/agent_ipc.py
+++ b/src/bernstein/core/agents/agent_ipc.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from typing import IO, Any
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,14 @@ logger = logging.getLogger(__name__)
 # Registry of stdin pipes keyed by session_id.
 # Populated by adapters that keep the pipe open after spawn.
 _stdin_pipes: dict[str, IO[bytes]] = {}
+
+# Per-session write lock so two threads sending to the same agent cannot
+# interleave bytes on the stdin pipe. Pipe writes past PIPE_BUF (4 KiB on
+# Linux, 512 B on macOS pre-Sequoia) are not atomic, and user-supplied
+# instructions routinely cross that boundary. Without the lock, the
+# downstream JSON parser sees garbled lines and disconnects the agent.
+_pipe_write_locks: dict[str, threading.Lock] = {}
+_pipe_registry_lock = threading.Lock()
 
 # Maximum length of a sanitised session_id rendered into a log record.
 # session_id is normally a UUID-ish slug well under this bound; the cap
@@ -33,18 +42,37 @@ def _safe_id(session_id: str) -> str:
     return (session_id.replace("\n", "_").replace("\r", "_").replace("\t", "_").replace("\x1b", "_"))[:_SAFE_ID_MAX_LEN]
 
 
+def _get_write_lock(session_id: str) -> threading.Lock:
+    """Return the per-session write lock, creating it on first use."""
+    with _pipe_registry_lock:
+        lock = _pipe_write_locks.get(session_id)
+        if lock is None:
+            lock = threading.Lock()
+            _pipe_write_locks[session_id] = lock
+        return lock
+
+
 def register_stdin_pipe(session_id: str, pipe: IO[bytes]) -> None:
     """Register a stdin pipe for an agent session.
 
     Called by adapters after spawning an agent that supports stdin IPC.
     """
-    _stdin_pipes[session_id] = pipe
+    with _pipe_registry_lock:
+        _stdin_pipes[session_id] = pipe
+        _pipe_write_locks.setdefault(session_id, threading.Lock())
     logger.debug("Registered stdin pipe for session %s", _safe_id(session_id))
 
 
 def unregister_stdin_pipe(session_id: str) -> None:
     """Remove a stdin pipe when an agent exits."""
-    removed = _stdin_pipes.pop(session_id, None)
+    with _pipe_registry_lock:
+        removed = _stdin_pipes.pop(session_id, None)
+        # Keep the lock object alive: another thread may already be
+        # inside ``send_message`` past the lookup; dropping the lock now
+        # would let a later registration return a fresh lock that does
+        # not serialise against the in-flight write. The lock is cheap
+        # (one ``threading.Lock``) and the registry grows linearly with
+        # session count, which is bounded by adapter cap.
     if removed:
         logger.debug("Unregistered stdin pipe for session %s", _safe_id(session_id))
 
@@ -59,26 +87,38 @@ def send_message(session_id: str, message: str) -> bool:
 
     Returns True if delivered via pipe, False if pipe unavailable or broken.
     Caller should fall back to file-based signals on False.
+
+    Thread-safe: holds a per-session lock for the write+flush so two
+    concurrent senders to the same agent cannot interleave bytes past
+    PIPE_BUF.
     """
     pipe = _stdin_pipes.get(session_id)
     if pipe is None:
         return False
 
-    try:
-        payload = json.dumps(
-            {
-                "type": "user_message",
-                "content": message,
-            }
-        )
-        pipe.write(payload.encode("utf-8") + b"\n")
-        pipe.flush()
-        logger.debug("Sent message via stdin pipe to session %s", _safe_id(session_id))
-        return True
-    except (OSError, ValueError) as exc:
-        logger.warning("Stdin pipe broken for session %s: %s", _safe_id(session_id), exc)
-        unregister_stdin_pipe(session_id)
-        return False
+    lock = _get_write_lock(session_id)
+    with lock:
+        # Re-check the pipe under the lock: another thread may have
+        # unregistered it after a broken-pipe error since we sampled
+        # the registry above.
+        pipe = _stdin_pipes.get(session_id)
+        if pipe is None:
+            return False
+        try:
+            payload = json.dumps(
+                {
+                    "type": "user_message",
+                    "content": message,
+                }
+            )
+            pipe.write(payload.encode("utf-8") + b"\n")
+            pipe.flush()
+            logger.debug("Sent message via stdin pipe to session %s", _safe_id(session_id))
+            return True
+        except (OSError, ValueError) as exc:
+            logger.warning("Stdin pipe broken for session %s: %s", _safe_id(session_id), exc)
+            unregister_stdin_pipe(session_id)
+            return False
 
 
 def broadcast_message(message: str, workdir: Any = None) -> dict[str, str]:

--- a/tests/unit/test_agent_ipc.py
+++ b/tests/unit/test_agent_ipc.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import io
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -103,3 +105,78 @@ def test_logging_path_uses_sanitized_session_id(caplog) -> None:  # type: ignore
     assert "INJECTED" in joined  # content kept (sanitized but visible)
     # No record contains a raw newline — every one is single-line.
     assert all("\n" not in rec.getMessage() for rec in caplog.records)
+
+
+class _SerialisingPipe:
+    """BytesIO-backed pipe that simulates non-atomic large writes.
+
+    Splits each write into 256-byte chunks and yields the GIL between
+    them so concurrent send_message calls without a lock can interleave.
+    Models pipe behaviour past PIPE_BUF without requiring an actual OS
+    pipe in the test process.
+    """
+
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
+        self._inner_lock = threading.Lock()
+
+    def write(self, data: bytes) -> int:
+        # Deliberately NOT holding self._inner_lock around the chunked
+        # write: that would mask the very race the test is built to
+        # expose if the caller forgets to serialise. The buffer-level
+        # write is protected only enough to keep BytesIO consistent.
+        total = 0
+        for i in range(0, len(data), 256):
+            chunk = data[i : i + 256]
+            with self._inner_lock:
+                self.buffer.write(chunk)
+            total += len(chunk)
+            # Yield so the scheduler can pick another worker.
+            threading.Event().wait(0.0001)
+        return total
+
+    def flush(self) -> None:  # pragma: no cover - matches IO API
+        return None
+
+
+def test_send_message_serialises_concurrent_writes_to_same_session() -> None:
+    """Concurrent send_message calls to one session must not interleave bytes.
+
+    Regression for the agent_ipc pipe race: writes past PIPE_BUF are not
+    atomic, and the previous send_message wrote to the pipe without a
+    lock. Two managers nudging the same agent simultaneously could
+    splice their JSON payloads, which the adapter's stream-json parser
+    rejected, kicking the agent off the wire.
+    """
+    _stdin_pipes.clear()
+    pipe = _SerialisingPipe()
+    register_stdin_pipe("A-race", pipe)  # type: ignore[arg-type]
+
+    big = "X" * 8192  # well past macOS PIPE_BUF (512 B) and Linux (4 KiB)
+    payload_count = 20
+    start = threading.Event()
+
+    def _worker(i: int) -> None:
+        start.wait()
+        send_message("A-race", f"{i}:{big}")
+
+    workers = [threading.Thread(target=_worker, args=(i,)) for i in range(payload_count)]
+    for t in workers:
+        t.start()
+    start.set()
+    for t in workers:
+        t.join()
+
+    # Every line on the wire must be one complete JSON record.
+    written = pipe.buffer.getvalue().decode("utf-8")
+    lines = [line for line in written.splitlines() if line]
+    assert len(lines) == payload_count
+    import json as _json
+
+    seen: set[str] = set()
+    for line in lines:
+        row = _json.loads(line)
+        assert row["type"] == "user_message"
+        # Each content must be one of the expected payloads.
+        seen.add(row["content"].split(":", 1)[0])
+    assert seen == {str(i) for i in range(payload_count)}


### PR DESCRIPTION
## Summary

- ``send_message`` wrote to the agent stdin pipe without holding any lock; two senders to the same agent (dashboard send-bar + an ``@``-mention wake, for example) could interleave their JSON payloads past PIPE_BUF (4 KiB on Linux, 512 B on older macOS), and the adapter's stream-json parser then rejected the spliced line and disconnected the agent.
- Per-session ``threading.Lock`` now guards the encode + write + flush trio in ``send_message``. ``register_stdin_pipe`` / ``unregister_stdin_pipe`` use a shared registry lock, and the per-session locks are deliberately kept alive after unregister so an in-flight writer cannot race past the lookup against a fresh lock issued to a later registration.

## Test plan

- [x] ``uv run pytest tests/unit/test_agent_ipc.py`` (9 tests, all pass; new regression test asserts well-formed JSONL across 20 concurrent senders with 8 KiB payloads)
- [x] Verified the new regression test fails on unpatched code with ``json.decoder.JSONDecodeError``
- [x] ``uv run ruff check`` / ``uv run ruff format --check`` clean
- [x] ``uv run pyright --project pyrightconfig.strict.json src/bernstein/core/agents/agent_ipc.py`` -- 0 errors