### PR TITLE
fix(preflight): pick most-expensive role for cost estimate, not first

### DIFF
--- a/src/bernstein/cli/run_preflight.py
+++ b/src/bernstein/cli/run_preflight.py
@@ -137,20 +137,38 @@ def _resolve_model_and_cli(
         return est_model, est_cli, est_role
 
     try:
+        from bernstein.core.cost.cost import _model_cost
         from bernstein.core.seed import parse_seed
 
         seed = parse_seed(seed_path)
         if seed.model:
             est_model = seed.model
         if seed.role_model_policy:
+            # Pick the role with the most expensive model so the preflight
+            # estimate is an upper bound on actual spend.  Previously the
+            # loop took only the first dict entry and ``break``-ed, which
+            # is non-deterministic when role insertion order varies and,
+            # worse, can under-report cost by orders of magnitude when a
+            # cheap role (e.g. qa on gemini) shadows an expensive role
+            # (e.g. backend on opus) in the same seed.
+            best_role = est_role
+            best_cli = est_cli
+            best_model = est_model
+            best_cost = _model_cost(est_model)
             for _role, _policy in seed.role_model_policy.items():
-                if isinstance(_role, str):
-                    est_role = _role
-                if "cli" in _policy:
-                    est_cli = _policy["cli"]
-                if "model" in _policy:
-                    est_model = _policy["model"]
-                break
+                if not isinstance(_role, str):
+                    continue
+                role_cli = _policy.get("cli", est_cli)
+                role_model = _policy.get("model", est_model)
+                role_cost = _model_cost(role_model)
+                if role_cost > best_cost:
+                    best_role = _role
+                    best_cli = role_cli
+                    best_model = role_model
+                    best_cost = role_cost
+            est_role = best_role
+            est_cli = best_cli
+            est_model = best_model
         if seed.cli and seed.cli != "auto":
             est_cli = seed.cli
     except Exception:

--- a/tests/unit/test_run_preflight_model_resolution.py
+++ b/tests/unit/test_run_preflight_model_resolution.py
@@ -1,0 +1,91 @@
+"""Regression tests for ``run_preflight._resolve_model_and_cli``.
+
+The preflight cost preview reads the seed's ``role_model_policy`` to pick
+which model price the estimate is computed against. Previously the loop
+took the first dict entry and ``break``-ed, which under-reported cost
+when a cheap role (e.g. qa on gemini) shadowed an expensive role (e.g.
+backend on opus) in the same seed.
+
+These tests pin the new behaviour: the most expensive role wins, so the
+preflight estimate is an upper bound on actual spend.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from bernstein.cli.run_preflight import _resolve_model_and_cli
+
+
+def _write_seed(seed_file: Path, body: str) -> Path:
+    seed_file.write_text(body, encoding="utf-8")
+    return seed_file
+
+
+@pytest.fixture
+def seed_file(tmp_path: Path) -> Path:
+    return tmp_path / "bernstein.yaml"
+
+
+def test_picks_most_expensive_role_not_first(seed_file: Path) -> None:
+    """Insertion order must not determine which role's cost is reported."""
+    # ``qa`` is the *first* role (would have won under the old buggy
+    # loop) but uses cheap gemini; ``backend`` uses opus and must win.
+    _write_seed(
+        seed_file,
+        'goal: "ship"\n'
+        "role_model_policy:\n"
+        "  qa:\n"
+        "    cli: gemini\n"
+        "    model: gemini-3-flash\n"
+        "  backend:\n"
+        "    cli: claude\n"
+        "    model: opus\n",
+    )
+    model, cli, role = _resolve_model_and_cli(str(seed_file), None)
+    assert model == "opus"
+    assert cli == "claude"
+    assert role == "backend"
+
+
+def test_first_role_wins_when_it_is_the_most_expensive(seed_file: Path) -> None:
+    """The first role still wins when nothing else is more expensive."""
+    _write_seed(
+        seed_file,
+        'goal: "ship"\n'
+        "role_model_policy:\n"
+        "  backend:\n"
+        "    cli: claude\n"
+        "    model: opus\n"
+        "  qa:\n"
+        "    cli: gemini\n"
+        "    model: gemini-3-flash\n",
+    )
+    model, cli, role = _resolve_model_and_cli(str(seed_file), None)
+    assert model == "opus"
+    assert cli == "claude"
+    assert role == "backend"
+
+
+def test_model_override_short_circuits(seed_file: Path) -> None:
+    """An explicit ``--model`` override bypasses seed inspection entirely."""
+    _write_seed(
+        seed_file,
+        'goal: "ship"\n'
+        "role_model_policy:\n"
+        "  backend: {cli: claude, model: opus}\n",
+    )
+    model, cli, _role = _resolve_model_and_cli(str(seed_file), "haiku")
+    assert model == "haiku"
+    assert cli == "claude"
+
+
+def test_missing_seed_returns_defaults(tmp_path: Path) -> None:
+    model, cli, role = _resolve_model_and_cli(str(tmp_path / "nope.yaml"), None)
+    assert model == "sonnet"
+    assert cli == "claude"
+    assert role == "backend"


### PR DESCRIPTION
## Summary

\`_resolve_model_and_cli\` iterated \`seed.role_model_policy.items()\` and \`break\`-ed on the first entry. With Python dict insertion order this is technically deterministic, but it produced misleading preflight output: a seed with \`qa: {cli: gemini}\` listed before \`backend: {cli: claude, model: opus}\` would tell the operator the run costs \$0 (gemini is in \`_FREE_ADAPTERS\`) when the actual backend role would burn \$50+ on opus tokens.

Preflight is user-trust load-bearing; the estimate must be an upper bound on spend, never an under-report. Walk the full role policy and pick the role with the highest per-1k-token cost via the existing \`_model_cost\` helper. Adapter-CLI selection follows the chosen role, so the cost estimate and the displayed model name stay consistent.

## Changes

- \`src/bernstein/cli/run_preflight.py\`: replace first-wins break with a max-by-cost scan across all role policy entries.
- \`tests/unit/test_run_preflight_model_resolution.py\`: four regression tests covering ordered-cheap-first, ordered-expensive-first, \`--model\` override short-circuit, and missing-seed defaults.

## Test plan

- [x] \`uv run pytest tests/unit/test_run_preflight_model_resolution.py -x -q\` (4 passed)
- [x] \`uv run pytest tests/unit/test_preflight.py tests/unit/test_cost_preflight_v2.py -x -q\` (22 passed, no regressions)
- [x] \`uv run ruff check src/bernstein/cli/run_preflight.py tests/unit/test_run_preflight_model_resolution.py\` (clean)