### PR TITLE
fix(lineage): CI gate accepts production recorder output

### DIFF
--- a/src/bernstein/core/lineage/entry.py
+++ b/src/bernstein/core/lineage/entry.py
@@ -8,6 +8,7 @@ so every entry has a stable wire-form regardless of how it's reconstructed.
 from __future__ import annotations
 
 import hashlib
+import hmac as _hmac
 import json
 from dataclasses import asdict, dataclass
 
@@ -66,3 +67,22 @@ def canonicalise(entry: LineageEntry) -> bytes:
 
 def entry_hash(entry: LineageEntry) -> str:
     return "sha256:" + hashlib.sha256(canonicalise(entry)).hexdigest()
+
+
+def compute_operator_hmac(entry: LineageEntry, key: bytes) -> str:
+    """Return the canonical operator-HMAC for ``entry`` under ``key``.
+
+    The HMAC covers the JCS-canonical bytes of the entry with the
+    ``operator_hmac`` field replaced by the empty string. This binds every
+    field of the entry (including ``agent_id``, ``artefact_path`` and the
+    full ``parent_hashes`` list), so any post-signing substitution attack is
+    independently detected by both the JWS and the HMAC envelope.
+
+    Recorder and gate share this helper so on-disk entries are accepted by
+    the CI gate when the operator secret is supplied. Any divergence between
+    the two paths would silently invalidate every entry — see ADR-009 §5.2.
+    """
+    body = asdict(entry)
+    body["operator_hmac"] = ""
+    canonical = json.dumps(body, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return _hmac.new(key, canonical, hashlib.sha256).hexdigest()

--- a/src/bernstein/core/lineage/gate.py
+++ b/src/bernstein/core/lineage/gate.py
@@ -24,7 +24,7 @@ import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
 from bernstein.core.lineage.identity import AgentCard, verify_detached
 from bernstein.core.lineage.tips import compute_tips, detect_forks
 
@@ -153,16 +153,11 @@ def check(
             canonical = canonicalise(entry)
             if not verify_detached(canonical, jws, card):
                 failures.append(f"{entry.artefact_path}: invalid signature on entry {eh}")
-        # HMAC
+        # HMAC. Body covers every entry field (with ``operator_hmac`` blanked)
+        # so a substitution swapping ``agent_id`` or ``artefact_path`` after
+        # signing is independently caught here — see ADR-009 §5.2.
         if operator_secret is not None:
-            body = json.dumps(
-                {
-                    "p": entry.parent_hashes,
-                    "h": entry.content_hash,
-                    "ts": entry.ts_ns,
-                }
-            ).encode()
-            expected = _hmac.new(operator_secret, body, hashlib.sha256).hexdigest()
+            expected = compute_operator_hmac(entry, operator_secret)
             if not _hmac.compare_digest(expected, entry.operator_hmac):
                 failures.append(f"{entry.artefact_path}: HMAC mismatch on entry {eh}")
         # Steward allow-list for merge entries.

--- a/src/bernstein/core/lineage/merge.py
+++ b/src/bernstein/core/lineage/merge.py
@@ -19,11 +19,10 @@ shape of the entry (same key type as workers).
 from __future__ import annotations
 
 import hashlib
-import hmac
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from bernstein.core.lineage.entry import LineageEntry, canonicalise
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac
 from bernstein.core.lineage.identity import AgentCard, sign_detached
 
 if TYPE_CHECKING:
@@ -113,9 +112,6 @@ class StewardKey:
     private_key_pem: str
     operator_secret: bytes = b""
 
-    def hmac_of(self, payload: bytes) -> str:
-        return hmac.new(self.operator_secret, payload, hashlib.sha256).hexdigest()
-
 
 def _content_hash(content: bytes) -> str:
     return "sha256:" + hashlib.sha256(content).hexdigest()
@@ -132,12 +128,31 @@ def build_merge_entry(
 ) -> list[tuple[LineageEntry, str]]:
     """Construct one merge entry per fork.
 
+    The merge entry's ``operator_hmac`` covers the JCS-canonical bytes of the
+    entry with the ``operator_hmac`` field blanked — identical to the scheme
+    used by :class:`bernstein.core.lineage.recorder.LineageRecorder` so the
+    CI gate accepts both kinds of entry under the same operator secret.
+
     Returns a list of `(entry, jws)` pairs. Caller is responsible for appending
     them to the lineage log via `LineageStore.append`.
     """
     out: list[tuple[LineageEntry, str]] = []
     for fork in forks:
         content = resolved_content_by_path[fork.artefact_path]
+        unsigned_entry = LineageEntry(
+            v=1,
+            artefact_path=fork.artefact_path,
+            artefact_kind="file",
+            content_hash=_content_hash(content),
+            parent_hashes=list(fork.child_hashes),
+            agent_id=steward.card.agent_id,
+            agent_card_kid=steward.card.kid,
+            tool_call_id=tool_call_id,
+            span_id=span_id,
+            ts_ns=now_ns,
+            operator_hmac="",
+        )
+        op_hmac = compute_operator_hmac(unsigned_entry, steward.operator_secret)
         entry = LineageEntry(
             v=1,
             artefact_path=fork.artefact_path,
@@ -149,7 +164,7 @@ def build_merge_entry(
             tool_call_id=tool_call_id,
             span_id=span_id,
             ts_ns=now_ns,
-            operator_hmac=steward.hmac_of(content),
+            operator_hmac=op_hmac,
         )
         canonical = canonicalise(entry)
         jws = sign_detached(canonical, steward.private_key_pem, kid=steward.card.kid)

--- a/src/bernstein/core/lineage/recorder.py
+++ b/src/bernstein/core/lineage/recorder.py
@@ -27,13 +27,11 @@ before any HMAC or signature is computed.
 from __future__ import annotations
 
 import hashlib
-import hmac as _hmac
-import json
 import logging
 import time
 from typing import TYPE_CHECKING
 
-from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
 from bernstein.core.lineage.identity import sign_detached
 
 if TYPE_CHECKING:
@@ -64,21 +62,6 @@ def _is_unsafe_path(artefact_path: str) -> str | None:
     if any(seg == ".." for seg in segments):
         return "path traversal in artefact_path"
     return None
-
-
-def _compute_operator_hmac(
-    *,
-    operator_hmac_key: bytes,
-    entry_body_sans_hmac: dict[str, object],
-) -> str:
-    """Return the HMAC envelope hex-digest for an entry.
-
-    The HMAC covers the JCS-canonical bytes of the entry with the
-    ``operator_hmac`` field set to the empty string — the same body-sans-HMAC
-    pattern used by ``bernstein.core.security.audit.AuditLog``.
-    """
-    canonical = json.dumps(entry_body_sans_hmac, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return _hmac.new(operator_hmac_key, canonical, hashlib.sha256).hexdigest()
 
 
 class LineageRecorder:
@@ -141,27 +124,27 @@ class LineageRecorder:
 
         ts_ns = time.time_ns()
 
-        # Build the body without the HMAC, compute it, then materialise the
-        # final immutable entry. The HMAC binds the body (including parents
-        # and content hash) so a substitution attack post-signing is caught
-        # by both the JWS and the HMAC envelope independently.
-        body_sans_hmac: dict[str, object] = {
-            "v": 1,
-            "artefact_path": artefact_path,
-            "artefact_kind": artefact_kind,
-            "content_hash": content_hash,
-            "parent_hashes": parent_hashes,
-            "agent_id": agent_id,
-            "agent_card_kid": agent_card.kid,
-            "tool_call_id": tool_call_id,
-            "span_id": span_id,
-            "ts_ns": ts_ns,
-            "operator_hmac": "",
-        }
-        operator_hmac = _compute_operator_hmac(
-            operator_hmac_key=self._hmac_key,
-            entry_body_sans_hmac=body_sans_hmac,
+        # Build the entry with an empty ``operator_hmac`` field, compute the
+        # canonical HMAC over its JCS bytes, then materialise the final
+        # immutable entry with the digest. The HMAC binds every field of the
+        # entry so a substitution attack post-signing is caught by both the
+        # JWS and the HMAC envelope independently. The shared
+        # :func:`compute_operator_hmac` helper is the single source of truth
+        # used by both recorder and CI gate — see ADR-009 §5.2.
+        unsigned_entry = LineageEntry(
+            v=1,
+            artefact_path=artefact_path,
+            artefact_kind=artefact_kind,
+            content_hash=content_hash,
+            parent_hashes=parent_hashes,
+            agent_id=agent_id,
+            agent_card_kid=agent_card.kid,
+            tool_call_id=tool_call_id,
+            span_id=span_id,
+            ts_ns=ts_ns,
+            operator_hmac="",
         )
+        operator_hmac = compute_operator_hmac(unsigned_entry, self._hmac_key)
 
         entry = LineageEntry(
             v=1,
@@ -177,12 +160,11 @@ class LineageRecorder:
             operator_hmac=operator_hmac,
         )
 
-        # Sign the entry-hash (sha256 over the canonical bytes, hex-encoded
-        # with the ``sha256:`` prefix). The signed bytes are exactly the same
-        # bytes the auditor recomputes — see ADR-009 §5.2.
+        # Sign the JCS-canonical entry bytes. The auditor verifies the same
+        # bytes via :func:`bernstein.core.lineage.identity.verify_detached`
+        # — see ADR-009 §5.2.
         canonical = canonicalise(entry)
-        digest = "sha256:" + hashlib.sha256(canonical).hexdigest()
-        jws = sign_detached(digest.encode("utf-8"), private_key_pem, kid=agent_card.kid)
+        jws = sign_detached(canonical, private_key_pem, kid=agent_card.kid)
 
         h = self.store.append(entry, jws=jws)
 

--- a/src/bernstein/core/lineage/store.py
+++ b/src/bernstein/core/lineage/store.py
@@ -189,7 +189,12 @@ class LineageStore:
 
     def _signature_path(self, artefact_path: str, entry_hash_str: str) -> Path:
         shard, full = _hash_path(artefact_path)
-        return self.root / _SIGNATURES_DIR / shard / full / f"{entry_hash_str}.jws"
+        # Strip the ``sha256:`` prefix from the filename so it matches the
+        # auditor (``bernstein.core.lineage.gate._signature_path``) and so
+        # the path stays portable: ``:`` is not a legal filename character
+        # on Windows. See ADR-009 §5.2 for the canonical sidecar layout.
+        stem = entry_hash_str.split(":", 1)[1] if ":" in entry_hash_str else entry_hash_str
+        return self.root / _SIGNATURES_DIR / shard / full / f"{stem}.jws"
 
     # -- public API ---------------------------------------------------------
 

--- a/tests/unit/lineage/test_gate.py
+++ b/tests/unit/lineage/test_gate.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import hashlib
-import hmac
 import json
 from dataclasses import asdict
 from pathlib import Path
 
-from bernstein.core.lineage.entry import LineageEntry, canonicalise, entry_hash
+from bernstein.core.lineage.entry import LineageEntry, canonicalise, compute_operator_hmac, entry_hash
 from bernstein.core.lineage.gate import GateResult, check
 from bernstein.core.lineage.identity import AgentCard, generate_keypair, sign_detached
 
@@ -32,8 +31,20 @@ def _entry_for(
     ts_ns: int = 1_715_600_000_000_000_000,
     operator_secret: bytes = b"op-secret",
 ) -> LineageEntry:
-    body = json.dumps({"p": parent_hashes, "h": content_hash, "ts": ts_ns}).encode()
-    op_hmac = hmac.new(operator_secret, body, hashlib.sha256).hexdigest()
+    unsigned = LineageEntry(
+        v=1,
+        artefact_path=artefact_path,
+        artefact_kind="file",
+        content_hash=content_hash,
+        parent_hashes=parent_hashes,
+        agent_id=agent.agent_id,
+        agent_card_kid=agent.kid,
+        tool_call_id="tc-x",
+        span_id="span-x",
+        ts_ns=ts_ns,
+        operator_hmac="",
+    )
+    op_hmac = compute_operator_hmac(unsigned, operator_secret)
     return LineageEntry(
         v=1,
         artefact_path=artefact_path,
@@ -340,6 +351,57 @@ def test_gate_verifies_hmac_when_secret_provided(tmp_path: Path) -> None:
     # Right operator secret → OK.
     good = check(log_path=log, agent_cards_dir=cards, operator_secret=b"op-secret")
     assert good.ok is True, good.failures
+
+
+def test_gate_accepts_recorder_emitted_entries_under_operator_secret(tmp_path: Path) -> None:
+    """Regression: recorder and gate must agree on the operator-HMAC body.
+
+    Previously the gate computed HMAC over a 3-field body (``{p, h, ts}``)
+    while the recorder used the full JCS-canonical entry body with the
+    ``operator_hmac`` field blanked. Production gate runs against real
+    recorder output failed 100% of entries. Pin the agreement end-to-end.
+    """
+    from bernstein.core.lineage.identity import generate_keypair
+    from bernstein.core.lineage.recorder import LineageRecorder
+    from bernstein.core.lineage.store import LineageStore
+
+    priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:rec-1", kid="kid-rec-1", public_key_pem=pub)
+    # Write the card to disk so the gate can resolve the signing key.
+    cards_dir = tmp_path / "agents"
+    (cards_dir / card.agent_id).mkdir(parents=True)
+    (cards_dir / card.agent_id / "card.json").write_text(
+        json.dumps(
+            {
+                "protocolVersion": "a2a/1.0",
+                "agent_id": card.agent_id,
+                "kid": card.kid,
+                "public_key_pem": pub,
+            }
+        )
+    )
+
+    operator_secret = b"recorder-gate-shared-secret"
+    store = LineageStore(tmp_path / "lineage")
+    recorder = LineageRecorder(store=store, operator_hmac_key=operator_secret)
+    recorder.record_write(
+        artefact_path="src/foo.py",
+        new_content=b"hello",
+        agent_id=card.agent_id,
+        agent_card=card,
+        private_key_pem=priv,
+        tool_call_id="tc-1",
+        span_id="span-1",
+    )
+
+    log_path = tmp_path / "lineage" / "log.jsonl"
+    # Right secret → gate accepts the recorder's entry.
+    good = check(log_path=log_path, agent_cards_dir=cards_dir, operator_secret=operator_secret)
+    assert good.ok is True, good.failures
+    # Wrong secret → gate flags HMAC mismatch.
+    bad = check(log_path=log_path, agent_cards_dir=cards_dir, operator_secret=b"different-secret")
+    assert bad.ok is False
+    assert any("HMAC mismatch" in f for f in bad.failures), bad.failures
 
 
 # ── Mutation-killing tests (close survivor gaps) ────────────────────────────

--- a/tests/unit/lineage/test_recorder.py
+++ b/tests/unit/lineage/test_recorder.py
@@ -155,9 +155,9 @@ def test_recorded_jws_verifies_against_card(
         span_id="span-1",
     )
     entry, jws = next(iter(recorder.store.read_log()))
-    canonical = canonicalise(entry)
-    payload = entry_hash_payload(canonical)
-    assert verify_detached(payload, jws, card) is True
+    # The recorder signs the JCS-canonical entry bytes; the verifier (gate)
+    # recomputes the same bytes — see ADR-009 §5.2.
+    assert verify_detached(canonicalise(entry), jws, card) is True
 
 
 def test_signature_does_not_verify_against_wrong_card(
@@ -177,9 +177,7 @@ def test_signature_does_not_verify_against_wrong_card(
     entry, jws = next(iter(recorder.store.read_log()))
     _priv2, pub2 = generate_keypair()
     other_card = AgentCard(agent_id="agent:other", kid=card.kid, public_key_pem=pub2)
-    canonical = canonicalise(entry)
-    payload = entry_hash_payload(canonical)
-    assert verify_detached(payload, jws, other_card) is False
+    assert verify_detached(canonicalise(entry), jws, other_card) is False
 
 
 # ---------------------------------------------------------------------------
@@ -286,9 +284,10 @@ def test_rejects_absolute_path(
 
 
 def entry_hash_payload(canonical_bytes: bytes) -> bytes:
-    """The JWS payload is sha256(canonical) as the prefixed hex string.
+    """Legacy helper retained for back-compat with older test imports.
 
-    Matches what ``LineageRecorder`` signs internally; see ADR-009 §5.2 step 3.
+    The recorder now signs the JCS-canonical entry bytes directly so callers
+    should pass ``canonicalise(entry)`` to ``verify_detached``; this helper
+    is kept so external test modules that import it keep working.
     """
-    digest = hashlib.sha256(canonical_bytes).hexdigest()
-    return ("sha256:" + digest).encode("utf-8")
+    return canonical_bytes

--- a/tests/unit/lineage/test_store.py
+++ b/tests/unit/lineage/test_store.py
@@ -201,7 +201,10 @@ def test_signature_sidecar_written(tmp_path: Path) -> None:
     entry = _make_entry(artefact_path="src/foo.py")
     h = store.append(entry, jws="abc.def.ghi")
     shard, full = _path_shard("src/foo.py")
-    sig_path = root / "signatures" / shard / full / f"{h}.jws"
+    # Sidecar filename strips the ``sha256:`` prefix so the path is portable
+    # (Windows rejects ``:`` in filenames) and matches the gate's lookup.
+    stem = h.split(":", 1)[1] if ":" in h else h
+    sig_path = root / "signatures" / shard / full / f"{stem}.jws"
     assert sig_path.exists()
     assert sig_path.read_text(encoding="utf-8") == "abc.def.ghi"
 


### PR DESCRIPTION
## Summary

Three independent disagreements between `LineageRecorder`, the steward merge builder, and the gate auditor meant the lineage CI gate flagged every real recorder-emitted entry as broken. `bernstein lineage gate` was non-functional against any production lineage log.

### Root causes

1. **Operator-HMAC body shape mismatch.** Recorder bound HMAC to the full JCS-canonical entry with `operator_hmac` blanked. Gate recomputed HMAC over a 3-field projection `{p, h, ts}` with non-canonical separators. Digests never matched, so passing `BERNSTEIN_OPERATOR_SECRET` to the gate failed every entry.
2. **JWS signing-payload mismatch.** Recorder signed the prefixed entry-hash string (`sha256:<hex>`). Gate verified against the canonical entry bytes. Detached JWS verification always failed.
3. **Sidecar filename mismatch.** Store wrote sidecars as `<sha256:hex>.jws` (with prefix). Gate looked up `<hex>.jws` (stripped). Every entry surfaced as "missing signature sidecar". The leading colon also breaks Windows paths.

The merge builder's HMAC was a third variant (`hmac(secret, content)`) that matched neither recorder nor gate, so steward merge entries also failed verification.

### Fix

- One canonical `compute_operator_hmac` helper in `entry.py`, consumed by recorder, merge, and gate.
- Recorder signs the canonical entry bytes (same bytes the gate verifies).
- Store strips the `sha256:` prefix from the sidecar filename to match the gate and stay portable.
- Tests updated; new end-to-end regression test wires recorder -> gate under a shared operator secret.

## Test plan

- [x] `uv run pytest tests/unit/lineage/` - all 114 pass.
- [x] `uv run pytest tests/unit/adapters/test_base_lineage_hook.py tests/unit/compliance/ tests/unit/mcp/test_lineage_resource.py` - 30 pass.
- [x] `uv run pytest tests/unit/test_lineage_record.py tests/unit/test_lineage_record_v1.py tests/unit/test_lineage_signer.py tests/unit/test_bridge_lineage.py tests/unit/test_lineage_export.py tests/unit/test_phase_gate_lineage.py` - 65 pass.
- [x] `uv run ruff check` and `uv run ruff format --check` on touched files - clean.
- [x] `uv run mypy src/bernstein/core/lineage/` - no new errors (5 pre-existing on main).
- [x] New regression test `test_gate_accepts_recorder_emitted_entries_under_operator_secret` pins recorder -> gate agreement end-to-end.