### PR TITLE
fix(worker): translate signal-killed child to 128+N exit code

### DIFF
--- a/src/bernstein/core/orchestration/worker.py
+++ b/src/bernstein/core/orchestration/worker.py
@@ -349,6 +349,16 @@ def main() -> None:
     finally:
         pid_file.unlink(missing_ok=True)
 
+    # Translate signal-termination into the conventional ``128 + N`` form
+    # so external supervisors that key on standard codes see a stable
+    # value. ``Popen.wait`` returns ``-N`` when the child was killed by
+    # signal N; passing that through ``sys.exit`` clamps it to
+    # ``256 - N`` (e.g. SIGTERM -> 241), which supervisors then misread
+    # as "unknown failure". ``128 + N`` is the de facto convention used
+    # by bash, sh, and every shell-style runner.
+    if exit_code < 0:
+        exit_code = 128 + (-exit_code)
+
     sys.exit(exit_code)
 
 

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -198,3 +198,38 @@ class TestWorkerProcess:
         )
         exit_code = proc.wait(timeout=10)
         assert exit_code == 127
+
+    def test_worker_exits_128_plus_signal_when_child_killed_by_sigterm(self, tmp_path: Path) -> None:
+        """Regression: a signal-killed child must surface as ``128 + N``.
+
+        Popen.wait returns ``-N`` when the child dies on signal N. The
+        old worker passed that through ``sys.exit`` directly, which the
+        runtime clamps to ``256 - N`` (e.g. SIGTERM -> 241). External
+        supervisors that key on standard codes (sysexits, ``bernstein
+        ps``, shell-style runners) then misread the result as an unknown
+        failure rather than "killed by signal".
+
+        We spawn a child that explicitly self-terminates via SIGTERM so
+        the assertion is portable: 128 + SIGTERM (15) == 143 on every
+        POSIX platform.
+        """
+        pid_dir = tmp_path / "pids"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "bernstein.core.orchestration.worker",
+                "--role",
+                "test",
+                "--session",
+                "sig-exit-test",
+                "--pid-dir",
+                str(pid_dir),
+                "--",
+                sys.executable,
+                "-c",
+                "import os, signal; os.kill(os.getpid(), signal.SIGTERM)",
+            ],
+        )
+        exit_code = proc.wait(timeout=10)
+        assert exit_code == 128 + signal.SIGTERM


### PR DESCRIPTION
## Summary

- ``Popen.wait()`` returns ``-N`` when the child is killed by signal N. The bernstein-worker wrapper passed that through ``sys.exit()`` directly, and Python clamps negative inputs to ``256 - N`` -- SIGTERM (15) became 241, SIGINT (2) became 254.
- External supervisors that key on standard exit codes (``bernstein ps`` watchdog, GitHub Actions runners, shell-style parents, sysexits-aware tooling) read the clamped value as ``unknown failure`` rather than ``killed by signal``.
- Map ``-N`` to ``128 + N`` per the bash / shell convention so the worker now exits 143 on SIGTERM, 130 on SIGINT, etc -- the codes every supervisor already recognises.

## Test plan

- [x] New regression spawns a child that self-terminates via SIGTERM and asserts ``128 + signal.SIGTERM == 143``
- [x] ``uv run pytest tests/unit/test_worker.py`` (2 passed, 5 xpassed -- pre-existing xfail marker for the integration block)
- [x] ``uv run ruff check`` / ``uv run ruff format --check`` clean
- [x] ``uv run pyright --project pyrightconfig.strict.json src/bernstein/core/orchestration/worker.py`` -- 13 errors, all pre-existing on main