### PR TITLE
fix(security): constant-time HMAC compare in audit chain verifiers

### DIFF
--- a/src/bernstein/core/security/audit.py
+++ b/src/bernstein/core/security/audit.py
@@ -270,14 +270,18 @@ def _verify_log_file(log_path: Path, prev_hmac: str, key: bytes, errors: list[st
             continue
 
         stored_hmac = entry.pop("hmac", "")
-        if entry.get("prev_hmac") != prev_hmac:
+        entry_prev = str(entry.get("prev_hmac", ""))
+        # Constant-time compare on the chain link — verification is offline
+        # but a leaky compare in audit code is a CodeQL/Bandit smell and
+        # masks regressions when the same helper is later reused on a
+        # network surface.
+        if not _hmac.compare_digest(entry_prev, prev_hmac):
             errors.append(
-                f"{log_path.name}:{line_no}: prev_hmac mismatch "
-                f"(expected {prev_hmac[:16]}…, got {str(entry.get('prev_hmac', ''))[:16]}…)"
+                f"{log_path.name}:{line_no}: prev_hmac mismatch (expected {prev_hmac[:16]}…, got {entry_prev[:16]}…)"
             )
 
         expected_hmac = _compute_hmac(key, prev_hmac, entry)
-        if stored_hmac != expected_hmac:
+        if not _hmac.compare_digest(stored_hmac, expected_hmac):
             errors.append(
                 f"{log_path.name}:{line_no}: HMAC mismatch (expected {expected_hmac[:16]}…, got {stored_hmac[:16]}…)"
             )

--- a/src/bernstein/core/security/audit_integrity.py
+++ b/src/bernstein/core/security/audit_integrity.py
@@ -7,6 +7,7 @@ with or if the chain is broken.
 
 from __future__ import annotations
 
+import hmac as _hmac
 import json
 import logging
 import time
@@ -182,7 +183,12 @@ def _verify_entry_chain(
         stored_hmac = entry.get("hmac", "")
         entry_prev_hmac = entry.get("prev_hmac", "")
 
-        if prev_hmac is not None and entry_prev_hmac != prev_hmac:
+        # Constant-time compare on the chain link and entry HMAC. Audit
+        # verification runs offline today but the same code path is reused
+        # by the runtime tamper-evidence guard; keeping the compares
+        # timing-safe avoids regressing the contract when verification
+        # moves onto a network surface.
+        if prev_hmac is not None and not _hmac.compare_digest(entry_prev_hmac, prev_hmac):
             errors.append(
                 f"{filename}:{line_no}: chain broken — "
                 f"prev_hmac {entry_prev_hmac[:16]}... != expected {prev_hmac[:16]}..."
@@ -191,7 +197,7 @@ def _verify_entry_chain(
         payload = {k: v for k, v in entry.items() if k != "hmac"}
         expected_hmac = _compute_hmac(key, entry_prev_hmac, payload)
 
-        if stored_hmac != expected_hmac:
+        if not _hmac.compare_digest(stored_hmac, expected_hmac):
             errors.append(
                 f"{filename}:{line_no}: HMAC mismatch — "
                 f"stored {stored_hmac[:16]}... != computed {expected_hmac[:16]}..."


### PR DESCRIPTION
## Summary

`AuditLog._verify_log_file` (and the runtime-startup `audit_integrity.verify_chain` it shares behaviour with) compared on-disk HMAC and prev_hmac via plain ``!=``. This is the textbook non-constant-time secret-comparison pattern Bandit/CodeQL flag.

While audit verification runs offline today, the same helper is reused by the runtime tamper-evidence guard surfaced over IPC. Replacing both compares with ``hmac.compare_digest`` keeps the verifier timing-safe if the verification path is later reused on a network surface (and removes a Bandit alert anyone running the security review will see).

## Test plan

- [x] `uv run pytest tests/unit/test_audit_integrity.py tests/unit/test_audit_chain_byteflip_regression.py tests/unit/test_audit_key.py tests/unit/test_audit_multitenant.py tests/unit/test_audit_adversarial.py` - 71 pass.
- [x] Full audit test sweep `uv run pytest tests/unit/ -k audit` - 392 pass, 1 skipped.
- [x] `uv run ruff check` and `uv run ruff format` clean.

## Notes

Behaviour preserved: every existing tamper-detection test (byteflip regression, HMAC mismatch coverage, forged-record adversarial cases) still flags every previously-flagged tampering. No new test added because function-level behaviour is unchanged - only the comparison primitive swapped.