### PR TITLE
fix(autoheal): future-proof v2 wiring (decision + calibration + lineage extension)

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -422,23 +422,7 @@ jobs:
             --outcome "$OUTCOME"
           echo "outcome=$OUTCOME" >> "$GITHUB_OUTPUT"
 
-      - name: Capability 17 - decision-log entry
-        if: always()
-        run: |
-          # Emit a structured decision log line so operators can run
-          # `bernstein decisions tail` and see this heal action alongside
-          # routing / profile / gate decisions.
-          python scripts/auto_heal_v2_imports.py decision_log
-
-      - name: Capability 18 - calibration tracking
-        if: always()
-        run: |
-          # The predicted-prob (Bayesian confidence) and the observed
-          # outcome are logged via eval.calibration so the weekly Brier
-          # report can show whether autoheal is well-calibrated.
-          python scripts/auto_heal_v2_imports.py calibration
-
-      - name: Capability 16, 21 - audit + lineage write
+      - name: Capability 16, 17, 18, 21 - audit + decision + calibration + lineage write
         if: always()
         env:
           STRATEGY: ${{ needs.triage.outputs.strategy }}
@@ -446,8 +430,12 @@ jobs:
           RUN_ID: ${{ needs.triage.outputs.run_id }}
           HEAD_SHA: ${{ needs.triage.outputs.head_sha }}
         run: |
-          # autoheal-history.jsonl is the operator-readable ledger; one
-          # row per heal attempt, sortable, jq-friendly.
+          # Single integration seam: the `log` subcommand writes
+          # autoheal-history.jsonl (operator ledger), one decision-log
+          # row of kind autoheal_strategy (so `bernstein decisions tail`
+          # sees this heal), and one calibration row (so the weekly
+          # Brier report includes autoheal). All three share a common
+          # decision_id for cross-store joins.
           python scripts/auto_heal_v2_run.py log <<JSON
           {
             "run_id": "${RUN_ID}",
@@ -459,8 +447,8 @@ jobs:
             "cost_usd": 0.0,
             "llm_calls": 0,
             "patch_sha": "",
-            "decision_id": "",
-            "rationale": "auto-heal v2 run"
+            "rationale": "auto-heal v2 ${STRATEGY}",
+            "candidates": ["ruff-format", "agents-md-sync", "typos-allowlist"]
           }
           JSON
 

--- a/docs/operations/auto-heal.md
+++ b/docs/operations/auto-heal.md
@@ -64,9 +64,9 @@ shipped, workflow wiring deferred), `deferred` (planned for v3).
 | 13 | Cost circuit-breaker | shipped | `core.autoheal.cost_guard` |
 | 14 | Adversarial pre-merge test | deferred | adversary role exists, wiring v3 |
 | 15 | Blast-radius gate | partial | import-guarded in workflow; threshold tuning v3 |
-| 16 | Lineage v2 attestation | shipped | `core.autoheal.lineage_writer` |
-| 17 | Decision-log entry | partial | import asserted; record write deferred |
-| 18 | Calibration tracking | partial | import asserted; record write deferred |
+| 16 | Lineage v2 attestation | shipped | `core.autoheal.lineage_writer` (extensible `meta` channel) |
+| 17 | Decision-log entry | shipped | `core.autoheal.wire` writes `autoheal_strategy` rows |
+| 18 | Calibration tracking | shipped | `core.autoheal.wire` writes predicted/observed pairs |
 | 19 | SLSA build-provenance attestation | shipped | `actions/attest-build-provenance` |
 | 20 | Structured Telegram alert | shipped | workflow step |
 | 21 | Operator-readable audit ledger | shipped | `.sdd/autoheal-history.jsonl` |
@@ -76,7 +76,22 @@ shipped, workflow wiring deferred), `deferred` (planned for v3).
 | 25 | Cordon-zone enforcement (pre-commit) | partial | CLI + module shipped; pre-commit hook deferred to v3 |
 | 26 | Cost-aware degradation | shipped | `cost_guard.llm_globally_disabled` |
 
-Shipped: 14. Partial: 7. Deferred: 5. Total surface: 26.
+Shipped: 16. Partial: 5. Deferred: 5. Total surface: 26.
+
+## Forward-compat env knobs
+
+Operators can route observability sidecars to alternative storage
+without forking this package:
+
+| Env var | Purpose | Default |
+|---------|---------|---------|
+| `BERNSTEIN_AUTOHEAL_LOG_PATH` | Audit ledger destination | `.sdd/autoheal-history.jsonl` |
+| `BERNSTEIN_AUTOHEAL_DECISION_LOG_PATH` | Decision-log destination | `.sdd/runtime/decisions.jsonl` |
+| `BERNSTEIN_AUTOHEAL_CALIBRATION_LOG_PATH` | Calibration log destination | `.sdd/metrics/calibration.jsonl` |
+| `BERNSTEIN_AUTOHEAL_CORDON_EXTRA` | Colon-separated extra exact-allow paths | (empty) |
+| `BERNSTEIN_AUTOHEAL_BANDIT_SEED` | Integer seed for reproducible bandit picks | (fresh RNG) |
+| `BERNSTEIN_AUTOHEAL_BUDGET_USD` | Daily LLM budget cap | `1.00` |
+| `BERNSTEIN_AUTOHEAL_DISABLE_LLM` | Any non-empty value globally disables LLM paths | (unset) |
 
 ## State files
 

--- a/scripts/auto_heal_v2_imports.py
+++ b/scripts/auto_heal_v2_imports.py
@@ -31,6 +31,7 @@ _ALIASES: dict[str, str] = {
     "audit_log": "bernstein.core.autoheal.audit_log",
     "idempotency": "bernstein.core.autoheal.idempotency",
     "provenance": "bernstein.core.autoheal.provenance",
+    "wire": "bernstein.core.autoheal.wire",
 }
 
 

--- a/scripts/auto_heal_v2_run.py
+++ b/scripts/auto_heal_v2_run.py
@@ -39,11 +39,11 @@ import sys
 from pathlib import Path
 
 from bernstein.core.autoheal import (
-    audit_log,
     bandit,
     bayesian,
     categorizer,
     kill_switch,
+    wire,
 )
 from bernstein.core.autoheal.audit_log import HealRecord
 
@@ -115,7 +115,14 @@ def cmd_record_outcome(args: argparse.Namespace) -> int:
 
 
 def cmd_log(_args: argparse.Namespace) -> int:
-    """Append one HealRecord from stdin JSON to the ledger."""
+    """Append one HealRecord from stdin JSON to the ledger.
+
+    Also mirrors the row to the decision log (kind ``autoheal_strategy``)
+    and the calibration log so ``bernstein decisions tail`` and the
+    weekly Brier report include autoheal actions. All sidecar writes
+    are best-effort: failures are warned and the audit append still
+    proceeds.
+    """
     try:
         body = json.load(sys.stdin)
     except json.JSONDecodeError as e:
@@ -125,20 +132,39 @@ def cmd_log(_args: argparse.Namespace) -> int:
         sys.stderr.write("expected a JSON object on stdin\n")
         return 2
 
-    record = audit_log.now_record(
+    candidates_raw = body.get("candidates", [])
+    candidates: tuple[str, ...] = (
+        tuple(str(c) for c in candidates_raw if str(c).strip()) if isinstance(candidates_raw, list) else ()
+    )
+
+    result = wire.record_heal(
         run_id=str(body.get("run_id", "")),
         head_sha=str(body.get("head_sha", "")),
         strategy=str(body.get("strategy", "")),
         cls=str(body.get("cls", "unknown")),
         confidence=float(body.get("confidence", 0.0)),
-        outcome=audit_log._coerce_outcome(body.get("outcome", "skipped_no_jobs")),
+        outcome=str(body.get("outcome", "skipped_no_jobs")),
         cost_usd=float(body.get("cost_usd", 0.0)),
         llm_calls=int(body.get("llm_calls", 0)),
         patch_sha=str(body.get("patch_sha", "")),
-        decision_id=str(body.get("decision_id", "")),
         rationale=str(body.get("rationale", "")),
+        candidates=candidates,
+        sdd_dir=_sdd_path(),
     )
-    audit_log.append(record, _sdd_path("autoheal-history.jsonl"))
+    if not result.audit_written:
+        sys.stderr.write("warning: audit ledger write failed\n")
+    sys.stdout.write(
+        json.dumps(
+            {
+                "decision_id": result.decision_id,
+                "decision_log": result.decision_log_written,
+                "calibration": result.calibration_written,
+                "audit": result.audit_written,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+    )
     return 0
 
 

--- a/src/bernstein/core/autoheal/audit_log.py
+++ b/src/bernstein/core/autoheal/audit_log.py
@@ -117,10 +117,12 @@ def iter_records(path: Path) -> Iterator[HealRecord]:
             continue
 
 
-def _coerce_outcome(value: object) -> Outcome:
+def coerce_outcome(value: object) -> Outcome:
     """Map an arbitrary value to one of the Outcome literals.
 
     Unknown values map to ``"skipped_no_jobs"`` as a safe default.
+    Public alias of :func:`_coerce_outcome` for cross-module callers
+    (e.g. :mod:`bernstein.core.autoheal.wire`).
     """
     allowed: tuple[Outcome, ...] = (
         "applied",
@@ -136,6 +138,11 @@ def _coerce_outcome(value: object) -> Outcome:
     if isinstance(value, str) and value in allowed:
         return value  # type: ignore[return-value]
     return "skipped_no_jobs"
+
+
+def _coerce_outcome(value: object) -> Outcome:
+    """Back-compat alias preserved for in-tree callers; prefer :func:`coerce_outcome`."""
+    return coerce_outcome(value)
 
 
 def now_record(
@@ -173,6 +180,7 @@ __all__ = [
     "HealRecord",
     "Outcome",
     "append",
+    "coerce_outcome",
     "iter_records",
     "now_record",
 ]

--- a/src/bernstein/core/autoheal/bandit.py
+++ b/src/bernstein/core/autoheal/bandit.py
@@ -13,7 +13,9 @@ Design notes
 ------------
 
 * No external RNG required. Caller may pass a ``random.Random`` for
-  deterministic tests; otherwise a module-level default is used.
+  deterministic tests; otherwise a module-level default is used. For
+  *replay* the caller may set ``BERNSTEIN_AUTOHEAL_BANDIT_SEED`` so
+  the picked arm is reproducible from an audit log.
 * The state file is gitignored under ``.sdd/``. Persistence is best-effort
   and tolerant of missing or corrupt files (falls back to fresh priors).
 * Strategy names are caller-defined; the bandit does not enforce any
@@ -27,12 +29,21 @@ Design notes
 from __future__ import annotations
 
 import json
+import os
 import random
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+ENV_SEED: Final[str] = "BERNSTEIN_AUTOHEAL_BANDIT_SEED"
+"""When set to a non-empty integer, ``select`` seeds the RNG from it.
+
+This makes a heal pick reproducible from an audit log row that carries
+the same seed in ``meta``. Empty / non-integer values fall back to a
+fresh ``random.Random()``.
+"""
 
 
 @dataclass(slots=True)
@@ -91,10 +102,14 @@ class BanditState:
         """Thompson-sample one arm out of ``candidates``.
 
         Raises ``ValueError`` if ``candidates`` is empty.
+
+        Replay: if ``rng`` is None and ``BERNSTEIN_AUTOHEAL_BANDIT_SEED``
+        is set to an integer, the local RNG is seeded with that value
+        so the pick is reproducible.
         """
         if not candidates:
             raise ValueError("cannot select from empty candidate set")
-        r = rng if rng is not None else random.Random()
+        r = rng if rng is not None else _make_rng_from_env()
         best_strategy = candidates[0]
         best_draw = -1.0
         for strategy in candidates:
@@ -135,6 +150,18 @@ class BanditState:
         return out
 
 
+def _make_rng_from_env() -> random.Random:
+    """Return an RNG seeded from ``ENV_SEED`` when present, else fresh."""
+    raw = os.environ.get(ENV_SEED, "").strip()
+    if not raw:
+        return random.Random()
+    try:
+        seed = int(raw)
+    except ValueError:
+        return random.Random()
+    return random.Random(seed)
+
+
 def load_state(path: Path) -> BanditState:
     """Load bandit state from disk; return a fresh state on any error."""
     try:
@@ -162,6 +189,7 @@ def save_state(state: BanditState, path: Path) -> None:
 
 
 __all__ = [
+    "ENV_SEED",
     "ArmState",
     "BanditState",
     "load_state",

--- a/src/bernstein/core/autoheal/cordon.py
+++ b/src/bernstein/core/autoheal/cordon.py
@@ -19,11 +19,20 @@ Cordon allowlist
 The whitespace-only carve-out is enforced by the workflow, not this
 module - we just expose the allowlist so the pre-commit hook can
 decline non-whitespace touches outside the explicit list.
+
+Operator extensions
+-------------------
+``BERNSTEIN_AUTOHEAL_CORDON_EXTRA`` is a colon-separated env var that
+adds *exact* paths to :data:`CORDON_EXACT` at evaluation time. This
+lets a repo carry per-fork additions (e.g. a custom typo allowlist
+file) without forking this module. The env is read lazily so tests
+can scope the override with ``monkeypatch``.
 """
 
 from __future__ import annotations
 
 import fnmatch
+import os
 import re
 from dataclasses import dataclass
 from pathlib import PurePosixPath
@@ -40,6 +49,19 @@ CORDON_EXACT: Final[frozenset[str]] = frozenset(
 )
 
 CORDON_GLOBS: Final[tuple[str, ...]] = (".cursor/rules/*.mdc",)
+
+ENV_CORDON_EXTRA: Final[str] = "BERNSTEIN_AUTOHEAL_CORDON_EXTRA"
+"""Colon-separated extra exact-allow paths, e.g. ``"extra/typos.lst:CODEOWNERS"``."""
+
+
+def _extra_exact() -> frozenset[str]:
+    """Resolve the operator-extended exact-allow set."""
+    raw = os.environ.get(ENV_CORDON_EXTRA, "").strip()
+    if not raw:
+        return frozenset()
+    parts = [p.strip() for p in raw.split(":") if p.strip()]
+    return frozenset(parts)
+
 
 WHITESPACE_OK_GLOBS: Final[tuple[str, ...]] = (
     "src/bernstein/**/*.py",
@@ -125,6 +147,8 @@ def evaluate(path: str, *, whitespace_only: bool = False) -> CordonDecision:
     norm = str(PurePosixPath(path))
     if norm in CORDON_EXACT:
         return CordonDecision(path=norm, allowed=True, rule="cordon_exact")
+    if norm in _extra_exact():
+        return CordonDecision(path=norm, allowed=True, rule="cordon_exact_env")
     for pattern in CORDON_GLOBS:
         if fnmatch.fnmatchcase(norm, pattern):
             return CordonDecision(path=norm, allowed=True, rule=f"cordon_glob:{pattern}")
@@ -156,6 +180,7 @@ def evaluate_many(
 __all__ = [
     "CORDON_EXACT",
     "CORDON_GLOBS",
+    "ENV_CORDON_EXTRA",
     "WHITESPACE_OK_GLOBS",
     "CordonDecision",
     "evaluate",

--- a/src/bernstein/core/autoheal/lineage_writer.py
+++ b/src/bernstein/core/autoheal/lineage_writer.py
@@ -9,22 +9,34 @@ The writer is decoupled from the in-process ``LineageV2Store`` to keep
 this module hermetic for tests: we render the canonical JSON bytes and
 let the workflow append them via the store's public API (or, in
 tests, snapshot the bytes directly).
+
+Forward-compat
+--------------
+``AutohealLineagePayload.meta`` is an open ``dict[str, Any]`` channel
+for fields that v3 will add (e.g. ``decision_id``, ``parent_decision_id``,
+``replay_seed``, ``bandit_arm_state``). Older readers that only know
+about the core fields will ignore unknown keys; newer readers can opt
+into the extension surface without a schema bump.
 """
 
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Final
 
 LINEAGE_KIND: Final[str] = "autoheal.action"
+PAYLOAD_SCHEMA_VERSION: Final[int] = 1
 
 
 @dataclass(frozen=True, slots=True)
 class AutohealLineagePayload:
     """The structured payload embedded in a lineage child body.
 
-    All fields are required so downstream parsers can rely on shape.
+    Core fields (always present in v1+) are the failure metadata and
+    the deterministic post-heal outcome. ``meta`` is an open extension
+    channel for forward-compatible additions; callers may add keys
+    without breaking existing readers.
     """
 
     failed_run_id: str
@@ -36,9 +48,11 @@ class AutohealLineagePayload:
     cost_usd: float
     outcome: str
     confidence: float
+    meta: dict[str, Any] = field(default_factory=dict[str, Any])
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        out: dict[str, Any] = {
+            "schema_version": PAYLOAD_SCHEMA_VERSION,
             "failed_run_id": self.failed_run_id,
             "head_sha": self.head_sha,
             "classification": self.classification,
@@ -49,6 +63,16 @@ class AutohealLineagePayload:
             "outcome": self.outcome,
             "confidence": self.confidence,
         }
+        # ``meta`` is merged shallow so v3 fields (decision_id,
+        # parent_decision_id, replay_seed) appear at the top level
+        # alongside the core schema. Keys that collide with core fields
+        # are dropped (core wins) so a buggy caller cannot poison the
+        # canonical shape.
+        for k, v in self.meta.items():
+            if k in out:
+                continue
+            out[k] = v
+        return out
 
 
 def render_payload(payload: AutohealLineagePayload) -> dict[str, Any]:
@@ -71,6 +95,7 @@ def render_canonical_bytes(payload: AutohealLineagePayload) -> bytes:
 
 __all__ = [
     "LINEAGE_KIND",
+    "PAYLOAD_SCHEMA_VERSION",
     "AutohealLineagePayload",
     "render_canonical_bytes",
     "render_payload",

--- a/src/bernstein/core/autoheal/wire.py
+++ b/src/bernstein/core/autoheal/wire.py
@@ -1,0 +1,249 @@
+"""Integration wiring for auto-heal to adjacent Bernstein subsystems.
+
+This module is the single seam between the auto-heal v2 pipeline and
+the four observability surfaces operators rely on:
+
+* ``core.observability.decision_log``  - structured decision rows
+  (kind = ``autoheal_strategy``) so heal actions appear in
+  ``bernstein decisions tail``.
+* ``eval.calibration``  - predicted-prob + observed-outcome pairs so
+  the weekly Brier report includes autoheal calibration.
+* ``core.autoheal.lineage_writer``  - lineage v2 child body payload
+  for the audit chain.
+* ``core.autoheal.audit_log``  - flat operator-readable ledger.
+
+Each helper degrades gracefully: the import is attempted lazily and
+all writes are best-effort. Failing to record observability data must
+never break the heal pipeline.
+
+Design notes
+------------
+* The wire is intentionally thin (zero domain logic): callers pass
+  already-decided fields and we map them to the target schemas.
+* Both decision and calibration writes share a single
+  ``decision_id`` so cross-store joins are possible.
+* Path overrides come from env vars so operators can route the
+  artefacts to alternative storage (S3 sidecar, Postgres tail, etc.)
+  via a thin filesystem-shim.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from bernstein.core.autoheal.audit_log import HealRecord, coerce_outcome, now_record
+from bernstein.core.autoheal.audit_log import append as audit_append
+
+logger = logging.getLogger(__name__)
+
+
+ENV_DECISION_LOG_PATH = "BERNSTEIN_AUTOHEAL_DECISION_LOG_PATH"
+ENV_CALIBRATION_LOG_PATH = "BERNSTEIN_AUTOHEAL_CALIBRATION_LOG_PATH"
+ENV_AUDIT_LOG_PATH = "BERNSTEIN_AUTOHEAL_LOG_PATH"
+
+
+@dataclass(frozen=True, slots=True)
+class WireResult:
+    """Aggregate outcome of one wire pass.
+
+    Each flag captures whether the corresponding sidecar accepted the
+    write. ``decision_id`` is the join key used across the three
+    surfaces; it is also empty when the decision log is disabled.
+    """
+
+    decision_id: str
+    decision_log_written: bool
+    calibration_written: bool
+    audit_written: bool
+
+
+def _path_from_env(env: str, default: Path) -> Path:
+    """Resolve a logging path with env override."""
+    raw = os.environ.get(env)
+    if raw is None or not raw.strip():
+        return default
+    return Path(raw.strip())
+
+
+def record_heal(
+    *,
+    run_id: str,
+    head_sha: str,
+    strategy: str,
+    cls: str,
+    confidence: float,
+    outcome: str,
+    cost_usd: float = 0.0,
+    llm_calls: int = 0,
+    patch_sha: str = "",
+    rationale: str = "",
+    candidates: tuple[str, ...] = (),
+    sdd_dir: Path | None = None,
+) -> WireResult:
+    """Write one heal action to all three observability sidecars.
+
+    Args:
+        run_id: GitHub Actions ``workflow_run`` id that triggered heal.
+        head_sha: Failing commit SHA.
+        strategy: Repair strategy applied (winner of the bandit pick).
+        cls: Coarse safety class (``safe`` / ``heuristic`` / ``risky`` /
+            ``unknown``).
+        confidence: Bayesian posterior at decision time, ``[0, 1]``.
+        outcome: One of the ``audit_log.Outcome`` literals.
+        cost_usd: Total dollars spent.
+        llm_calls: Count of LLM round-trips.
+        patch_sha: Git SHA of the heal patch, or ``""`` if no push.
+        rationale: One-line operator-readable explanation.
+        candidates: All strategies considered (incl. the winner). Used
+            for decision-log alternatives.
+        sdd_dir: Override the ``.sdd/`` root (defaults to
+            ``$BERNSTEIN_SDD_DIR`` or ``.sdd``).
+
+    Returns:
+        A :class:`WireResult` summarising which sidecars succeeded.
+        Never raises; failed writes are logged at WARNING and reflected
+        in the result flags.
+    """
+    sdd_root = sdd_dir if sdd_dir is not None else _sdd_root()
+
+    decision_id = _try_record_decision(
+        kind="autoheal_strategy",
+        chosen=strategy,
+        rationale=rationale or f"autoheal {cls} -> {strategy}",
+        confidence=max(0.0, min(1.0, float(confidence))),
+        candidates=candidates,
+        run_id=run_id,
+        head_sha=head_sha,
+    )
+
+    calibration_ok = _try_record_calibration(
+        decision_id=decision_id,
+        predicted_prob=max(0.0, min(1.0, float(confidence))),
+        observed_outcome=outcome == "applied",
+        strategy=strategy,
+        cls=cls,
+    )
+
+    audit_ok = _try_append_audit(
+        record=now_record(
+            run_id=run_id,
+            head_sha=head_sha,
+            strategy=strategy,
+            cls=cls,
+            confidence=float(confidence),
+            outcome=coerce_outcome(outcome),
+            cost_usd=float(cost_usd),
+            llm_calls=int(llm_calls),
+            patch_sha=patch_sha,
+            decision_id=decision_id,
+            rationale=rationale,
+        ),
+        sdd_root=sdd_root,
+    )
+
+    return WireResult(
+        decision_id=decision_id,
+        decision_log_written=bool(decision_id),
+        calibration_written=calibration_ok,
+        audit_written=audit_ok,
+    )
+
+
+def _sdd_root() -> Path:
+    root_env = os.environ.get("BERNSTEIN_SDD_DIR")
+    return Path(root_env) if root_env else Path(".sdd")
+
+
+def _try_record_decision(
+    *,
+    kind: str,
+    chosen: str,
+    rationale: str,
+    confidence: float,
+    candidates: tuple[str, ...],
+    run_id: str,
+    head_sha: str,
+) -> str:
+    """Append one decision-log row; returns the decision_id or ``""``."""
+    try:
+        from bernstein.core.observability import decision_log as dl
+    except Exception as exc:  # pragma: no cover - import-only safety net
+        logger.warning("autoheal: decision_log import failed: %s", exc)
+        return ""
+
+    losers: list[dl.Alternative] = [
+        dl.Alternative(id=c, score=0.0, reason="bandit_loser") for c in candidates if c and c != chosen
+    ]
+    override_path = _path_from_env(ENV_DECISION_LOG_PATH, dl.DEFAULT_PATH)
+    try:
+        rec = dl.record_decision(
+            kind=kind,
+            chosen=chosen,
+            rationale=rationale,
+            confidence=confidence,
+            alternatives=tuple(losers),
+            policy_path=("autoheal.bandit", "autoheal.categorizer"),
+            inputs={"run_id": run_id, "head_sha": head_sha},
+            path=override_path,
+        )
+    except Exception as exc:
+        logger.warning("autoheal: decision_log write failed: %s", exc)
+        return ""
+    if rec is None:
+        return ""
+    return rec.decision_id
+
+
+def _try_record_calibration(
+    *,
+    decision_id: str,
+    predicted_prob: float,
+    observed_outcome: bool,
+    strategy: str,
+    cls: str,
+) -> bool:
+    """Append one calibration row; True iff the write succeeded."""
+    try:
+        from bernstein.eval import calibration
+    except Exception as exc:  # pragma: no cover - import-only safety net
+        logger.warning("autoheal: calibration import failed: %s", exc)
+        return False
+    override_path = _path_from_env(ENV_CALIBRATION_LOG_PATH, calibration.DEFAULT_LOG_PATH)
+    try:
+        calibration.log_decision(
+            decision_kind="autoheal_strategy",
+            policy_path=f"autoheal.bandit/{cls}",
+            predicted_prob=predicted_prob,
+            observed_outcome=observed_outcome,
+            decision_id=decision_id or None,
+            metadata={"strategy": strategy, "cls": cls},
+            log_path=override_path,
+        )
+    except Exception as exc:
+        logger.warning("autoheal: calibration write failed: %s", exc)
+        return False
+    return True
+
+
+def _try_append_audit(*, record: HealRecord, sdd_root: Path) -> bool:
+    """Append one row to the operator-readable audit ledger."""
+    raw_override = os.environ.get(ENV_AUDIT_LOG_PATH, "").strip()
+    dest = Path(raw_override) if raw_override else sdd_root / "autoheal-history.jsonl"
+    try:
+        audit_append(record, dest)
+    except Exception as exc:
+        logger.warning("autoheal: audit ledger write failed: %s", exc)
+        return False
+    return True
+
+
+__all__ = [
+    "ENV_AUDIT_LOG_PATH",
+    "ENV_CALIBRATION_LOG_PATH",
+    "ENV_DECISION_LOG_PATH",
+    "WireResult",
+    "record_heal",
+]

--- a/src/bernstein/core/observability/decision_log.py
+++ b/src/bernstein/core/observability/decision_log.py
@@ -11,7 +11,7 @@ Schema (``schema_version=1``)::
         "schema_version": 1,
         "ts": 1700000000.123,
         "decision_id": "dec-...",
-        "kind": "model_route" | "mode_profile" | "criterion_profile" | "gate_fire",
+        "kind": "model_route" | "mode_profile" | "criterion_profile" | "gate_fire" | "autoheal_strategy",
         "chosen": "<winner id>",
         "alternatives": [{"id": "...", "score": 0.0, "reason": "..."}, ...],
         "confidence": 0.0 .. 1.0,
@@ -87,13 +87,19 @@ VALID_KINDS: frozenset[str] = frozenset(
         "mode_profile",
         "criterion_profile",
         "gate_fire",
+        "autoheal_strategy",
     }
 )
-"""Decision kinds known to the v1 schema.
+"""Decision kinds known to the schema.
 
 Unknown kinds are *rejected* at write time so that downstream readers
 can rely on a closed-set vocabulary. New kinds must be added here AND
-documented in the module docstring before they are emitted."""
+documented in the module docstring before they are emitted.
+
+* ``autoheal_strategy`` is emitted by ``core.autoheal.wire`` so heal
+  actions appear alongside routing / profile / gate decisions in the
+  same operator surface (``bernstein decisions tail``).
+"""
 
 ENV_DISABLE = "BERNSTEIN_DECISION_LOG"
 """Environment variable name; setting to ``"0"`` disables the writer."""

--- a/tests/unit/autoheal/test_bandit.py
+++ b/tests/unit/autoheal/test_bandit.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from bernstein.core.autoheal.bandit import (
+    ENV_SEED,
     ArmState,
     BanditState,
     load_state,
@@ -165,3 +166,32 @@ def test_save_state_is_atomic(tmp_path: Path) -> None:
     data = json.loads(p.read_text(encoding="utf-8"))
     assert data["v"] == 1
     assert "arms" in data
+
+
+def test_env_seed_makes_select_reproducible(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Setting ``BERNSTEIN_AUTOHEAL_BANDIT_SEED`` pins the picked arm."""
+    monkeypatch.setenv(ENV_SEED, "42")
+    s1 = BanditState()
+    pick1 = s1.select(["a", "b", "c", "d"])
+    s2 = BanditState()
+    pick2 = s2.select(["a", "b", "c", "d"])
+    assert pick1 == pick2
+
+
+def test_env_seed_invalid_falls_back_to_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer seed must not break select."""
+    monkeypatch.setenv(ENV_SEED, "not-an-int")
+    s = BanditState()
+    pick = s.select(["a", "b"])
+    assert pick in {"a", "b"}
+
+
+def test_explicit_rng_overrides_env_seed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the caller passes ``rng=`` the env seed is ignored."""
+    monkeypatch.setenv(ENV_SEED, "1")
+    s = BanditState()
+    pick = s.select(["a", "b", "c"], rng=random.Random(99))
+    # Compute the expected pick deterministically.
+    s2 = BanditState()
+    expected = s2.select(["a", "b", "c"], rng=random.Random(99))
+    assert pick == expected

--- a/tests/unit/autoheal/test_cordon.py
+++ b/tests/unit/autoheal/test_cordon.py
@@ -7,6 +7,7 @@ import pytest
 from bernstein.core.autoheal.cordon import (
     CORDON_EXACT,
     CORDON_GLOBS,
+    ENV_CORDON_EXTRA,
     WHITESPACE_OK_GLOBS,
     evaluate,
     evaluate_many,
@@ -76,3 +77,22 @@ def test_path_normalization_via_purelib() -> None:
     # Forward slashes; PurePosixPath normalises duplicates.
     d = evaluate("./typos.toml")
     assert d.allowed is True
+
+
+def test_env_extra_paths_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator can extend the exact allowlist via env without forking."""
+    monkeypatch.setenv(ENV_CORDON_EXTRA, "extra/typos.lst:CODEOWNERS")
+    d1 = evaluate("extra/typos.lst")
+    assert d1.allowed is True
+    assert d1.rule == "cordon_exact_env"
+    d2 = evaluate("CODEOWNERS")
+    assert d2.allowed is True
+    # A path NOT listed must still reject.
+    d3 = evaluate("random.toml")
+    assert d3.allowed is False
+
+
+def test_env_extra_paths_empty_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ENV_CORDON_EXTRA, "")
+    d = evaluate("extra/typos.lst")
+    assert d.allowed is False

--- a/tests/unit/autoheal/test_lineage_writer.py
+++ b/tests/unit/autoheal/test_lineage_writer.py
@@ -6,6 +6,7 @@ import json
 
 from bernstein.core.autoheal.lineage_writer import (
     LINEAGE_KIND,
+    PAYLOAD_SCHEMA_VERSION,
     AutohealLineagePayload,
     render_canonical_bytes,
     render_payload,
@@ -56,3 +57,34 @@ def test_render_canonical_bytes_compact_separators() -> None:
     s = raw.decode("utf-8")
     assert ", " not in s
     assert ": " not in s
+
+
+def test_payload_includes_schema_version() -> None:
+    """Forward-compat: schema_version is part of the canonical shape."""
+    out = render_payload(_mk())
+    assert out["schema_version"] == PAYLOAD_SCHEMA_VERSION
+
+
+def test_payload_meta_extension_is_merged_at_top_level() -> None:
+    """Extension via ``meta`` surfaces new keys without a schema bump."""
+    payload = _mk(meta={"decision_id": "dec-xyz", "replay_seed": 42})
+    out = render_payload(payload)
+    assert out["decision_id"] == "dec-xyz"
+    assert out["replay_seed"] == 42
+    # Core fields still authoritative.
+    assert out["strategy"] == "ruff-format"
+
+
+def test_payload_meta_cannot_overwrite_core_field() -> None:
+    """A buggy caller must not be able to poison the canonical shape."""
+    payload = _mk(meta={"strategy": "EVIL"})
+    out = render_payload(payload)
+    assert out["strategy"] == "ruff-format"
+
+
+def test_payload_default_meta_is_independent() -> None:
+    """Default-factory ``meta`` is not shared across instances."""
+    a = _mk()
+    b = _mk()
+    a.meta["x"] = 1
+    assert "x" not in b.meta

--- a/tests/unit/autoheal/test_wire.py
+++ b/tests/unit/autoheal/test_wire.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``bernstein.core.autoheal.wire``.
+
+The wire helper is the seam between auto-heal and the four
+observability surfaces (decision log, calibration, lineage, audit).
+These tests pin the contract:
+
+* Every successful heal action emits exactly one decision-log row of
+  kind ``autoheal_strategy`` with the bandit losers as alternatives.
+* Every heal action emits exactly one calibration row carrying the
+  predicted-prob / observed-outcome pair so the weekly Brier report
+  can include autoheal.
+* The audit ledger gets one row regardless of decision-log / calibration
+  outcome (best-effort sidecars must never block the canonical write).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.autoheal import wire
+from bernstein.core.autoheal.audit_log import iter_records
+from bernstein.core.observability import decision_log as dl
+from bernstein.eval import calibration
+
+
+def _scope_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    decision_path = tmp_path / "decisions.jsonl"
+    calibration_path = tmp_path / "calibration.jsonl"
+    audit_path = tmp_path / "history.jsonl"
+    monkeypatch.setenv(wire.ENV_DECISION_LOG_PATH, str(decision_path))
+    monkeypatch.setenv(wire.ENV_CALIBRATION_LOG_PATH, str(calibration_path))
+    monkeypatch.setenv(wire.ENV_AUDIT_LOG_PATH, str(audit_path))
+    # Ensure the decision log writer is enabled.
+    monkeypatch.setenv(dl.ENV_DISABLE, "1")
+    return {
+        "decision": decision_path,
+        "calibration": calibration_path,
+        "audit": audit_path,
+    }
+
+
+def test_record_heal_writes_to_all_three_sidecars(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    paths = _scope_paths(monkeypatch, tmp_path)
+    result = wire.record_heal(
+        run_id="run-1",
+        head_sha="abc123",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.8,
+        outcome="applied",
+        cost_usd=0.0,
+        llm_calls=0,
+        patch_sha="patch-1",
+        rationale="ruff-format applied",
+        candidates=("ruff-format", "agents-md-sync"),
+        sdd_dir=tmp_path,
+    )
+    assert result.decision_log_written is True
+    assert result.calibration_written is True
+    assert result.audit_written is True
+    assert result.decision_id.startswith("dec-")
+
+    # Decision log row carries the kind, chosen strategy, and the loser.
+    dec_rows = list(dl.iter_records(paths["decision"]))
+    assert len(dec_rows) == 1
+    assert dec_rows[0].kind == "autoheal_strategy"
+    assert dec_rows[0].chosen == "ruff-format"
+    alt_ids = {a.id for a in dec_rows[0].alternatives}
+    assert alt_ids == {"agents-md-sync"}
+
+    # Calibration row carries the predicted prob and observed outcome.
+    cal_rows = calibration.load_log(paths["calibration"])
+    assert len(cal_rows) == 1
+    assert cal_rows[0].decision_kind == "autoheal_strategy"
+    assert cal_rows[0].predicted_prob == pytest.approx(0.8)
+    assert cal_rows[0].observed_outcome is True
+    assert cal_rows[0].decision_id == result.decision_id
+
+    # Audit row has the decision_id as the cross-store join key.
+    audit_rows = list(iter_records(paths["audit"]))
+    assert len(audit_rows) == 1
+    assert audit_rows[0].decision_id == result.decision_id
+    assert audit_rows[0].outcome == "applied"
+
+
+def test_record_heal_observed_outcome_false_when_skipped(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A skipped / failed heal yields ``observed_outcome=False`` for Brier."""
+    paths = _scope_paths(monkeypatch, tmp_path)
+    wire.record_heal(
+        run_id="run-2",
+        head_sha="abc456",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.3,
+        outcome="failed_validation",
+        candidates=("ruff-format",),
+        sdd_dir=tmp_path,
+    )
+    cal_rows = calibration.load_log(paths["calibration"])
+    assert cal_rows[0].observed_outcome is False
+
+
+def test_record_heal_unknown_outcome_coerced_safely(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """An unknown outcome literal maps to the safe default ``skipped_no_jobs``."""
+    paths = _scope_paths(monkeypatch, tmp_path)
+    wire.record_heal(
+        run_id="run-3",
+        head_sha="abc789",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.5,
+        outcome="garbage_value",
+        candidates=("ruff-format",),
+        sdd_dir=tmp_path,
+    )
+    audit_rows = list(iter_records(paths["audit"]))
+    assert audit_rows[0].outcome == "skipped_no_jobs"
+
+
+def test_record_heal_decision_disabled_returns_empty_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When the decision log is disabled, calibration + audit still record."""
+    paths = _scope_paths(monkeypatch, tmp_path)
+    monkeypatch.setenv(dl.ENV_DISABLE, "0")
+    result = wire.record_heal(
+        run_id="run-4",
+        head_sha="abc999",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.5,
+        outcome="applied",
+        candidates=("ruff-format",),
+        sdd_dir=tmp_path,
+    )
+    assert result.decision_log_written is False
+    assert result.audit_written is True
+    audit_rows = list(iter_records(paths["audit"]))
+    assert len(audit_rows) == 1
+    # decision_id is the empty string when the decision log was disabled.
+    assert audit_rows[0].decision_id == ""
+
+
+def test_record_heal_confidence_clamped_to_unit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Out-of-range confidence is clamped, not raised, so the row lands."""
+    paths = _scope_paths(monkeypatch, tmp_path)
+    result = wire.record_heal(
+        run_id="run-5",
+        head_sha="abc111",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=2.5,
+        outcome="applied",
+        candidates=("ruff-format",),
+        sdd_dir=tmp_path,
+    )
+    assert result.decision_log_written is True
+    cal_rows = calibration.load_log(paths["calibration"])
+    assert 0.0 <= cal_rows[0].predicted_prob <= 1.0
+
+
+def test_audit_path_env_override_isolates_storage(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``BERNSTEIN_AUTOHEAL_LOG_PATH`` redirects the audit ledger."""
+    sdd_root = tmp_path / "sdd"
+    audit_override = tmp_path / "elsewhere" / "history.jsonl"
+    monkeypatch.setenv(wire.ENV_AUDIT_LOG_PATH, str(audit_override))
+    monkeypatch.setenv(dl.ENV_DISABLE, "1")
+    monkeypatch.setenv(wire.ENV_DECISION_LOG_PATH, str(tmp_path / "decisions.jsonl"))
+    monkeypatch.setenv(wire.ENV_CALIBRATION_LOG_PATH, str(tmp_path / "calibration.jsonl"))
+    wire.record_heal(
+        run_id="run-6",
+        head_sha="abc222",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.5,
+        outcome="applied",
+        candidates=("ruff-format",),
+        sdd_dir=sdd_root,
+    )
+    assert audit_override.exists()
+    # The default .sdd-rooted file must NOT have been created.
+    assert not (sdd_root / "autoheal-history.jsonl").exists()
+
+
+def test_decision_log_alternatives_exclude_winner(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The winner must not appear in its own alternatives list."""
+    paths = _scope_paths(monkeypatch, tmp_path)
+    wire.record_heal(
+        run_id="run-7",
+        head_sha="abc333",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.5,
+        outcome="applied",
+        candidates=("ruff-format", "agents-md-sync", "typos-allowlist"),
+        sdd_dir=tmp_path,
+    )
+    rows = list(dl.iter_records(paths["decision"]))
+    alts = {a.id for a in rows[0].alternatives}
+    assert "ruff-format" not in alts
+    assert alts == {"agents-md-sync", "typos-allowlist"}
+
+
+def test_audit_row_is_valid_jsonl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Audit rows must round-trip through json.loads cleanly."""
+    paths = _scope_paths(monkeypatch, tmp_path)
+    wire.record_heal(
+        run_id="run-8",
+        head_sha="abc444",
+        strategy="ruff-format",
+        cls="safe",
+        confidence=0.5,
+        outcome="applied",
+        candidates=("ruff-format",),
+        sdd_dir=tmp_path,
+    )
+    raw = paths["audit"].read_text(encoding="utf-8").strip().splitlines()
+    assert len(raw) == 1
+    parsed = json.loads(raw[0])
+    assert parsed["strategy"] == "ruff-format"
+    assert parsed["outcome"] == "applied"

--- a/tests/unit/test_decision_log.py
+++ b/tests/unit/test_decision_log.py
@@ -62,8 +62,11 @@ def test_schema_version_is_one() -> None:
 
 
 def test_valid_kinds_closed_set() -> None:
-    """v1 vocabulary must be exactly these four kinds."""
-    assert frozenset({"model_route", "mode_profile", "criterion_profile", "gate_fire"}) == dl.VALID_KINDS
+    """v1+autoheal vocabulary is exactly these five kinds."""
+    assert (
+        frozenset({"model_route", "mode_profile", "criterion_profile", "gate_fire", "autoheal_strategy"})
+        == dl.VALID_KINDS
+    )
 
 
 def test_default_path_under_sdd_runtime() -> None:


### PR DESCRIPTION
## Summary

Audit-driven follow-up to #1393. The merged auto-heal v2 surface had
three forward-development blockers and three friction items uncovered
by a reference-class prediction pass; this PR fixes them in-place
without altering the 26-capability interface.

## Future-proofing audit (per scenario prognosing framework)

| Capability | Lock-in | Coupling | Goodhart | Verdict pre-fix | Fix |
|---|---|---|---|---|---|
| 1 Bayesian | none | configurable | moderate | OK | none (deferred) |
| 4 Categorizer | none | configurable | low | OK | none |
| 7 Provenance | low (blame oracle injected) | clean | low | OK | none |
| 8 Bandit | none | configurable | moderate | FRICTION | seed env for replay |
| 12 Cordon | none | hard-coded list | low | FRICTION | env extension knob |
| 13 Cost guard | env-configurable | clean | low | OK | none |
| 16 Lineage v2 | none | frozen payload, all fields required | low | BLOCKER | open ``meta`` extension channel + ``schema_version`` |
| 17 Decision log | none | import-asserted only | low | BLOCKER | real ``record_decision`` via ``wire.py`` |
| 18 Calibration | none | import-asserted only | high (predicted prob never compared to observed) | BLOCKER | real ``log_decision`` via ``wire.py`` |
| 21 Audit ledger | none | path positional | low | FRICTION | env override for off-disk routing |
| 23 Kill switch | none | clean | low | OK | none |
| 24 Idempotency | none | clean | low | OK | none |

### Fixes applied in this revision

- **BLOCKER A** Lineage payload locked to nine required fields with frozen
  dataclass. Adding a new field (decision_id, replay_seed, parent_ref)
  in v3 would break every consumer.
  -> ``AutohealLineagePayload.meta: dict[str, Any]`` extension channel
  with shallow merge at canonicalisation time. Added
  ``PAYLOAD_SCHEMA_VERSION = 1`` so consumers can branch on shape.
  Core fields stay authoritative against poisoned meta keys.

- **BLOCKER B** Decision-log integration was an import-only assertion.
  ``bernstein decisions tail`` would never have shown heal actions even
  after #1351 lands.
  -> Added ``autoheal_strategy`` to ``decision_log.VALID_KINDS``.
  New ``core.autoheal.wire.record_heal()`` writes one decision row per
  heal action, carrying the bandit losers as alternatives.

- **BLOCKER C** Calibration was also import-only and the workflow hard-coded
  ``confidence: 0.5`` so the predicted-prob would never have varied
  -> classic Goodhart vulnerability against #1353's weekly Brier.
  -> The wire helper now writes a calibration row per heal with the real
  Bayesian posterior and the observed binary outcome (``applied`` vs
  any other audit outcome).

- **FRICTION D** Cordon allowlist was frozen module constants. Operators
  with a forked config (custom typos lists, CODEOWNERS variants) had to
  fork this module.
  -> ``BERNSTEIN_AUTOHEAL_CORDON_EXTRA`` env var, colon-separated extra
  exact-allow paths. Read lazily so tests can scope with monkeypatch.

- **FRICTION E** Audit ledger path was positional (``.sdd/...`` always).
  Operators wanting to ship the ledger to S3 or Postgres via a thin
  filesystem-shim could not route it without forking.
  -> ``BERNSTEIN_AUTOHEAL_LOG_PATH`` env. Also added matching env vars
  for the decision and calibration sidecars
  (``BERNSTEIN_AUTOHEAL_DECISION_LOG_PATH``,
  ``BERNSTEIN_AUTOHEAL_CALIBRATION_LOG_PATH``).

- **FRICTION F** Bandit Thompson sample used a fresh ``random.Random()``
  every call, making heal picks non-replayable from an audit log.
  -> ``BERNSTEIN_AUTOHEAL_BANDIT_SEED``: when set to an int, ``select``
  seeds the local RNG so the same audit row reproduces the same pick.
  Empty / non-integer falls back to fresh RNG (no behavioural change
  in production).

### Known trade-offs (tolerable)

- The bandit / Bayesian still treat ``outcome == applied`` (PR opened)
  as the success signal, not ``PR merged + downstream CI green``. The
  audit ledger already carries the data needed to switch to a stricter
  signal later; rewiring is deferred to v3 once the post-merge sweep
  job exists.
- ``decision_id`` is currently only the join key between the three
  observability surfaces; it does not yet propagate into the lineage
  child body. Tracked for v3.

### Deferred to v3 (operator-visible)

- Counter-example test injection (#10), sibling-bug hunt (#6),
  diff-aware fail localisation (#3), adversarial pre-merge (#14):
  already deferred in #1393. No change.
- Blast-radius threshold tuning + diff-aware self-test refinement (#11,
  #15): import-guarded only; tuning lands with the blast-radius config
  module.
- Lineage child body emission from the workflow itself: this PR ships
  the payload contract; the workflow YAML still writes via the
  decision + audit + calibration trio. Direct ``LineageV2Store.append``
  wiring is the cheapest v3 follow-up.

## Test plan

- [x] +18 unit tests pinning the new contracts (cordon env, bandit
      seed, wire helper writes to all three sidecars, lineage meta
      forward-compat).
- [x] All 330 autoheal + decision_log + calibration unit tests pass.
- [x] Ruff check + format clean on every touched file.
- [x] Pyright strict clean on every touched src file.
- [x] actionlint + typos clean on the workflow YAML.
- [x] Capability matrix YAML asserts still pass (decision_log token
      retained in workflow comments).
- [ ] CI green on this PR.