### PR TITLE
feat(eval): ProgramBench harness (closes #1404)

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -321,6 +321,7 @@ alwaysApply: false
 | `comparative.py`  | Comparative Benchmark Suite for Bernstein |
 | `golden.py`       | Golden test suite for the Bernstein orchestrator |
 | `head_to_head.py` | Framework context report: Bernstein vs. CrewAI and LangGraph |
+| `programbench.py` | ProgramBench evaluation harness for Bernstein |
 | `reproducible.py` | Reproducible benchmark suite for Bernstein |
 | `swe_bench.py`    | SWE-Bench evaluation harness for Bernstein |
 

--- a/.goosehints
+++ b/.goosehints
@@ -322,6 +322,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `comparative.py`  | Comparative Benchmark Suite for Bernstein |
 | `golden.py`       | Golden test suite for the Bernstein orchestrator |
 | `head_to_head.py` | Framework context report: Bernstein vs. CrewAI and LangGraph |
+| `programbench.py` | ProgramBench evaluation harness for Bernstein |
 | `reproducible.py` | Reproducible benchmark suite for Bernstein |
 | `swe_bench.py`    | SWE-Bench evaluation harness for Bernstein |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -322,6 +322,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `comparative.py`  | Comparative Benchmark Suite for Bernstein |
 | `golden.py`       | Golden test suite for the Bernstein orchestrator |
 | `head_to_head.py` | Framework context report: Bernstein vs. CrewAI and LangGraph |
+| `programbench.py` | ProgramBench evaluation harness for Bernstein |
 | `reproducible.py` | Reproducible benchmark suite for Bernstein |
 | `swe_bench.py`    | SWE-Bench evaluation harness for Bernstein |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -322,6 +322,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `comparative.py`  | Comparative Benchmark Suite for Bernstein |
 | `golden.py`       | Golden test suite for the Bernstein orchestrator |
 | `head_to_head.py` | Framework context report: Bernstein vs. CrewAI and LangGraph |
+| `programbench.py` | ProgramBench evaluation harness for Bernstein |
 | `reproducible.py` | Reproducible benchmark suite for Bernstein |
 | `swe_bench.py`    | SWE-Bench evaluation harness for Bernstein |
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -322,6 +322,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `comparative.py`  | Comparative Benchmark Suite for Bernstein |
 | `golden.py`       | Golden test suite for the Bernstein orchestrator |
 | `head_to_head.py` | Framework context report: Bernstein vs. CrewAI and LangGraph |
+| `programbench.py` | ProgramBench evaluation harness for Bernstein |
 | `reproducible.py` | Reproducible benchmark suite for Bernstein |
 | `swe_bench.py`    | SWE-Bench evaluation harness for Bernstein |
 

--- a/src/bernstein/benchmark/programbench.py
+++ b/src/bernstein/benchmark/programbench.py
@@ -430,6 +430,116 @@ def save_results(report: ProgramBenchReport, sdd_dir: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Subprocess assert sandbox
+# ---------------------------------------------------------------------------
+
+
+_SANDBOX_DEFAULT_TIMEOUT_SECONDS = 30
+
+
+_SANDBOX_RUNNER = """\
+import json
+import sys
+
+payload = json.loads(sys.stdin.read())
+setup_code = payload.get("setup_code", "")
+candidate_code = payload.get("candidate_code", "")
+assert_exprs = payload.get("asserts", [])
+task_id = payload.get("task_id", "task")
+
+namespace = {}
+error = None
+try:
+    if setup_code.strip():
+        exec(compile(setup_code, "<" + task_id + ":setup>", "exec"), namespace)
+    if candidate_code.strip():
+        exec(compile(candidate_code, "<" + task_id + ":candidate>", "exec"), namespace)
+except BaseException as exc:
+    error = "setup/candidate error: " + repr(exc)
+
+passed = 0
+if error is None:
+    for expr in assert_exprs:
+        try:
+            result = eval(compile(expr, "<" + task_id + ":assert>", "eval"), namespace)
+            if bool(result):
+                passed += 1
+        except BaseException:
+            continue
+
+print(json.dumps({"passed": passed, "total": len(assert_exprs), "error": error}))
+"""
+
+
+def _run_assert_sandbox(
+    *,
+    task_id: str,
+    setup_code: str,
+    candidate_code: str,
+    asserts: list[str],
+    timeout_seconds: int = _SANDBOX_DEFAULT_TIMEOUT_SECONDS,
+) -> tuple[int, int, str | None]:
+    """Evaluate a candidate's asserts in an isolated Python subprocess.
+
+    The runner script reads JSON on stdin, executes the setup and candidate
+    code in a fresh namespace, then evaluates each assert expression. The
+    harness process never executes candidate code; isolation is provided by
+    the subprocess boundary plus the timeout. This mirrors the call shape
+    used by :mod:`bernstein.core.sandbox` for runtime evaluation.
+
+    Args:
+        task_id: Task identifier used for diagnostic filenames.
+        setup_code: Initial setup Python source.
+        candidate_code: Candidate Python source.
+        asserts: List of Python expressions to evaluate.
+        timeout_seconds: Subprocess timeout in seconds.
+
+    Returns:
+        Tuple of ``(asserts_passed, asserts_total, error_or_None)``.
+    """
+    import subprocess
+    import sys
+
+    payload = json.dumps(
+        {
+            "task_id": task_id,
+            "setup_code": setup_code,
+            "candidate_code": candidate_code,
+            "asserts": list(asserts),
+        }
+    )
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _SANDBOX_RUNNER],
+            input=payload,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return 0, len(asserts), "sandbox timeout"
+    except OSError as exc:
+        return 0, len(asserts), f"sandbox spawn error: {exc!r}"
+
+    if proc.returncode != 0:
+        return 0, len(asserts), f"sandbox exit {proc.returncode}: {proc.stderr[:200]}"
+
+    try:
+        result_data = json.loads(proc.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError) as exc:
+        return 0, len(asserts), f"sandbox output parse error: {exc!r}"
+
+    passed = int(result_data.get("passed", 0))
+    total = int(result_data.get("total", len(asserts)))
+    error: str | None = result_data.get("error")
+    return passed, total, error
+
+
+# ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------
 
@@ -573,10 +683,12 @@ class ProgramBenchHarness:
         task: ProgramBenchTask,
         candidate_code: str,
     ) -> tuple[int, int, str | None]:
-        """Run a candidate solution against task asserts.
+        """Run a candidate solution against task asserts in a subprocess sandbox.
 
         Each assert is a Python expression evaluated against a namespace
-        containing the candidate's exec'd globals plus the task's setup.
+        containing the candidate's globals plus the task's setup. Evaluation
+        runs in a fresh Python interpreter subprocess so the harness process
+        is not contaminated by candidate code or imports.
 
         Args:
             task: The task whose asserts to evaluate.
@@ -589,28 +701,12 @@ class ProgramBenchHarness:
         if not all_asserts:
             return 0, 0, "no asserts defined"
 
-        namespace: dict[str, Any] = {}
-        try:
-            if task.setup_code.strip():
-                exec(compile(task.setup_code, f"<{task.task_id}:setup>", "exec"), namespace)
-            if candidate_code.strip():
-                exec(compile(candidate_code, f"<{task.task_id}:candidate>", "exec"), namespace)
-        except Exception as exc:
-            return 0, len(all_asserts), f"setup/candidate error: {exc!r}"
-
-        passed = 0
-        for expr in all_asserts:
-            try:
-                result = eval(
-                    compile(expr, f"<{task.task_id}:assert>", "eval"),
-                    namespace,
-                )
-                if bool(result):
-                    passed += 1
-            except Exception:
-                continue
-
-        return passed, len(all_asserts), None
+        return _run_assert_sandbox(
+            task_id=task.task_id,
+            setup_code=task.setup_code,
+            candidate_code=candidate_code,
+            asserts=all_asserts,
+        )
 
     # ------------------------------------------------------------------
     # Adapter invocation

--- a/src/bernstein/benchmark/programbench.py
+++ b/src/bernstein/benchmark/programbench.py
@@ -1,0 +1,763 @@
+"""ProgramBench evaluation harness for Bernstein.
+
+Runs Bernstein against ProgramBench tasks and reports partial-credit
+scoring metrics alongside the existing SWE-Bench harness. ProgramBench
+tasks include a state setup, a target implementation, and a set of
+runtime asserts; the per-task score is the fraction of asserts that pass.
+
+Usage::
+
+    harness = ProgramBenchHarness(workdir=Path("."), sample=20)
+    tasks = harness.load_dataset()
+    report = harness.run(adapter="claude", tasks=tasks)
+    save_results(report, Path(".sdd"))
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import statistics
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+_CAST_LIST_ANY = "list[Any]"
+_NEAR_SOLVED_THRESHOLD = 0.5
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProgramBenchTask:
+    """A single ProgramBench evaluation task.
+
+    Args:
+        task_id: Unique identifier, e.g. ``programbench-001``.
+        subset: Subset slug the task belongs to (e.g. ``lite``).
+        description: Natural-language description of the feature to build.
+        setup_code: Python code that establishes the initial state.
+        target_signature: Function signature the agent must implement.
+        asserts: Runtime assertion expressions evaluated against the agent's
+            output. Each entry is a Python expression returning a bool.
+        hidden_asserts: Extra asserts not shown to the agent.
+        tags: Free-form classification labels.
+    """
+
+    task_id: str
+    subset: str
+    description: str
+    setup_code: str
+    target_signature: str
+    asserts: list[str]
+    hidden_asserts: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> ProgramBenchTask:
+        """Parse a ProgramBenchTask from the raw dataset format.
+
+        Args:
+            raw: Dict with ProgramBench dataset fields.
+
+        Returns:
+            Parsed ProgramBenchTask.
+
+        Raises:
+            KeyError: If a required field is missing.
+        """
+
+        def _parse_str_list(value: Any) -> list[str]:
+            if isinstance(value, list):
+                lst = cast(_CAST_LIST_ANY, value)
+                return [str(v) for v in lst]
+            if isinstance(value, str):
+                try:
+                    parsed: Any = json.loads(value)
+                    if isinstance(parsed, list):
+                        plst = cast(_CAST_LIST_ANY, parsed)
+                        return [str(v) for v in plst]
+                except json.JSONDecodeError:
+                    pass
+                return [value] if value else []
+            return []
+
+        if "task_id" not in raw and "id" not in raw:
+            raise KeyError("ProgramBench task missing 'task_id'")
+        task_id = str(raw.get("task_id", raw.get("id", "")))
+        if not task_id:
+            raise KeyError("ProgramBench task has empty 'task_id'")
+
+        return cls(
+            task_id=task_id,
+            subset=str(raw.get("subset", "lite")),
+            description=str(raw.get("description", raw.get("problem_statement", ""))),
+            setup_code=str(raw.get("setup_code", raw.get("setup", ""))),
+            target_signature=str(raw.get("target_signature", raw.get("signature", ""))),
+            asserts=_parse_str_list(raw.get("asserts", raw.get("ASSERTS", []))),
+            hidden_asserts=_parse_str_list(raw.get("hidden_asserts", [])),
+            tags=_parse_str_list(raw.get("tags", [])),
+        )
+
+
+@dataclass
+class TaskResult:
+    """Result of running Bernstein on a single ProgramBench task.
+
+    Args:
+        task_id: Matches the ProgramBenchTask this result is for.
+        score: Partial-credit score in ``[0, 1]``: ``asserts_passed / asserts_total``.
+        asserts_passed: Number of asserts that returned True.
+        asserts_total: Total number of asserts evaluated.
+        fully_solved: True iff every assert passed (score == 1.0).
+        cost_usd: Estimated LLM API cost in USD attributable to this task.
+        duration_seconds: Wall-clock time taken.
+        adapter: Adapter that produced the candidate.
+        log_path: Optional path to the per-task log file.
+        error: Error message if the run failed, else None.
+    """
+
+    task_id: str
+    score: float
+    asserts_passed: int
+    asserts_total: int
+    fully_solved: bool
+    cost_usd: float
+    duration_seconds: float
+    adapter: str
+    log_path: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a plain dict for JSON export.
+
+        Returns:
+            Dict with all fields.
+        """
+        return {
+            "task_id": self.task_id,
+            "score": self.score,
+            "asserts_passed": self.asserts_passed,
+            "asserts_total": self.asserts_total,
+            "fully_solved": self.fully_solved,
+            "cost_usd": self.cost_usd,
+            "duration_seconds": self.duration_seconds,
+            "adapter": self.adapter,
+            "log_path": self.log_path,
+            "error": self.error,
+        }
+
+
+@dataclass
+class AdapterBreakdown:
+    """Aggregate ProgramBench metrics for a single adapter.
+
+    Args:
+        adapter: Adapter name.
+        total: Total tasks evaluated with this adapter.
+        fully_solved: Number of tasks with score == 1.0.
+        near_solved: Number of tasks with score >= 0.5 but < 1.0.
+        failed: Number of tasks with score < 0.5.
+        mean_partial_credit: Mean per-task score.
+        cost_per_task: Mean cost per task.
+        time_per_task: Mean duration per task.
+    """
+
+    adapter: str
+    total: int
+    fully_solved: int
+    near_solved: int
+    failed: int
+    mean_partial_credit: float
+    cost_per_task: float
+    time_per_task: float
+
+    def to_dict(self) -> dict[str, float | int | str]:
+        """Serialise the breakdown for JSON output.
+
+        Returns:
+            Plain JSON-compatible mapping.
+        """
+        return {
+            "adapter": self.adapter,
+            "total": self.total,
+            "fully_solved": self.fully_solved,
+            "near_solved": self.near_solved,
+            "failed": self.failed,
+            "mean_partial_credit": self.mean_partial_credit,
+            "cost_per_task": self.cost_per_task,
+            "time_per_task": self.time_per_task,
+        }
+
+
+@dataclass
+class ProgramBenchReport:
+    """Aggregate report for a ProgramBench evaluation run.
+
+    Args:
+        total_tasks: Total number of tasks evaluated.
+        fully_solved: Number of tasks with score == 1.0.
+        near_solved: Number of tasks with 0.5 <= score < 1.0.
+        failed: Number of tasks with score < 0.5.
+        mean_partial_credit: Mean partial-credit score across all tasks.
+        total_cost_usd: Sum of per-task costs.
+        time_per_task: Mean wall-clock time per task.
+        median_cost_usd: Median cost across all tasks.
+        median_duration_seconds: Median duration across all tasks.
+        per_adapter_breakdown: Per-adapter aggregate metrics.
+        per_task: Per-task results.
+        run_at: ISO-8601 timestamp when the report was generated.
+    """
+
+    total_tasks: int
+    fully_solved: int
+    near_solved: int
+    failed: int
+    mean_partial_credit: float
+    total_cost_usd: float
+    time_per_task: float
+    median_cost_usd: float
+    median_duration_seconds: float
+    per_adapter_breakdown: list[AdapterBreakdown]
+    per_task: list[TaskResult]
+    run_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+def compute_score(asserts_passed: int, asserts_total: int) -> float:
+    """Compute partial-credit score clamped to ``[0, 1]``.
+
+    Args:
+        asserts_passed: Number of asserts that passed.
+        asserts_total: Total number of asserts.
+
+    Returns:
+        Fraction in ``[0, 1]``. Returns ``0.0`` if ``asserts_total <= 0``.
+    """
+    if asserts_total <= 0:
+        return 0.0
+    if asserts_passed <= 0:
+        return 0.0
+    raw = asserts_passed / asserts_total
+    if raw > 1.0:
+        return 1.0
+    return raw
+
+
+def classify_score(score: float) -> str:
+    """Classify a score into ``fully_solved`` / ``near_solved`` / ``failed``.
+
+    Args:
+        score: Per-task score in ``[0, 1]``.
+
+    Returns:
+        Bucket name.
+    """
+    if score >= 1.0:
+        return "fully_solved"
+    if score >= _NEAR_SOLVED_THRESHOLD:
+        return "near_solved"
+    return "failed"
+
+
+# ---------------------------------------------------------------------------
+# Metrics helpers
+# ---------------------------------------------------------------------------
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return statistics.median(values)
+
+
+def _mean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    return statistics.fmean(values)
+
+
+def _compute_adapter_breakdown(results: list[TaskResult]) -> list[AdapterBreakdown]:
+    grouped: dict[str, list[TaskResult]] = defaultdict(list)
+    for result in results:
+        grouped[result.adapter or "unknown"].append(result)
+
+    breakdown: list[AdapterBreakdown] = []
+    for adapter_name, adapter_results in sorted(grouped.items()):
+        fully = sum(1 for r in adapter_results if r.score >= 1.0)
+        near = sum(1 for r in adapter_results if _NEAR_SOLVED_THRESHOLD <= r.score < 1.0)
+        failed = sum(1 for r in adapter_results if r.score < _NEAR_SOLVED_THRESHOLD)
+        breakdown.append(
+            AdapterBreakdown(
+                adapter=adapter_name,
+                total=len(adapter_results),
+                fully_solved=fully,
+                near_solved=near,
+                failed=failed,
+                mean_partial_credit=_mean([r.score for r in adapter_results]),
+                cost_per_task=_mean([r.cost_usd for r in adapter_results]),
+                time_per_task=_mean([r.duration_seconds for r in adapter_results]),
+            )
+        )
+    return breakdown
+
+
+def compute_report(results: list[TaskResult]) -> ProgramBenchReport:
+    """Compute aggregate metrics from a list of task results.
+
+    Args:
+        results: Per-task evaluation outcomes.
+
+    Returns:
+        ProgramBenchReport with aggregate statistics.
+    """
+    if not results:
+        return ProgramBenchReport(
+            total_tasks=0,
+            fully_solved=0,
+            near_solved=0,
+            failed=0,
+            mean_partial_credit=0.0,
+            total_cost_usd=0.0,
+            time_per_task=0.0,
+            median_cost_usd=0.0,
+            median_duration_seconds=0.0,
+            per_adapter_breakdown=[],
+            per_task=[],
+        )
+
+    fully = sum(1 for r in results if r.score >= 1.0)
+    near = sum(1 for r in results if _NEAR_SOLVED_THRESHOLD <= r.score < 1.0)
+    failed = sum(1 for r in results if r.score < _NEAR_SOLVED_THRESHOLD)
+    total_cost = sum(r.cost_usd for r in results)
+
+    return ProgramBenchReport(
+        total_tasks=len(results),
+        fully_solved=fully,
+        near_solved=near,
+        failed=failed,
+        mean_partial_credit=_mean([r.score for r in results]),
+        total_cost_usd=total_cost,
+        time_per_task=_mean([r.duration_seconds for r in results]),
+        median_cost_usd=_median([r.cost_usd for r in results]),
+        median_duration_seconds=_median([r.duration_seconds for r in results]),
+        per_adapter_breakdown=_compute_adapter_breakdown(results),
+        per_task=list(results),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _metrics_results_path(sdd_dir: Path) -> Path:
+    """Return the canonical JSONL metrics path for ProgramBench runs.
+
+    Args:
+        sdd_dir: Project ``.sdd/`` directory (or any root directory).
+
+    Returns:
+        Canonical JSONL metrics path.
+    """
+    return sdd_dir / "metrics" / "programbench_results.jsonl"
+
+
+def report_to_dict(report: ProgramBenchReport) -> dict[str, Any]:
+    """Convert a ProgramBenchReport to a JSON-serialisable dict.
+
+    Args:
+        report: The report to serialise.
+
+    Returns:
+        Plain JSON-compatible mapping.
+    """
+    return {
+        "run_at": report.run_at,
+        "total_tasks": report.total_tasks,
+        "fully_solved": report.fully_solved,
+        "near_solved": report.near_solved,
+        "failed": report.failed,
+        "mean_partial_credit": report.mean_partial_credit,
+        "total_cost_usd": report.total_cost_usd,
+        "time_per_task": report.time_per_task,
+        "median_cost_usd": report.median_cost_usd,
+        "median_duration_seconds": report.median_duration_seconds,
+        "per_adapter_breakdown": [b.to_dict() for b in report.per_adapter_breakdown],
+        "per_task": [r.to_dict() for r in report.per_task],
+    }
+
+
+def save_results(report: ProgramBenchReport, sdd_dir: Path) -> Path:
+    """Persist ProgramBench results to metrics JSONL plus a JSON snapshot.
+
+    Args:
+        report: The aggregate report to persist.
+        sdd_dir: Project ``.sdd/`` directory (or any root directory).
+
+    Returns:
+        Path to the JSON snapshot.
+    """
+    data = report_to_dict(report)
+
+    metrics_path = _metrics_results_path(sdd_dir)
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    with metrics_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(data, sort_keys=True))
+        handle.write("\n")
+
+    out_dir = sdd_dir / "benchmark"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_path = out_dir / "programbench_results.json"
+    snapshot_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    return snapshot_path
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class ProgramBenchHarness:
+    """Runs Bernstein against ProgramBench tasks and collects metrics.
+
+    The harness reuses the same shape as :class:`bernstein.benchmark.swe_bench.SWEBenchRunner`:
+    a separate dataset, a per-task ``run_task`` method, and an aggregating
+    ``run`` entry point.
+
+    Args:
+        workdir: Project working directory.
+        sample: If set, evaluate a random sample of this many tasks.
+        task_id: If set, evaluate only this single task.
+        subset: Which ProgramBench subset slug to load when lazily downloading.
+        seed: Random seed for reproducible sampling.
+        dataset_env_var: Optional env var that, when set, points at a local
+            ``.jsonl`` dataset file.
+    """
+
+    DEFAULT_DATASET_ENV = "BERNSTEIN_PROGRAMBENCH_DATASET"
+
+    def __init__(
+        self,
+        workdir: Path,
+        sample: int | None = None,
+        task_id: str | None = None,
+        subset: str = "lite",
+        seed: int = 42,
+        dataset_env_var: str | None = None,
+    ) -> None:
+        self.workdir = workdir
+        self.sample = sample
+        self.task_id = task_id
+        self.subset = subset
+        self._seed = seed
+        self.dataset_env_var = dataset_env_var or self.DEFAULT_DATASET_ENV
+
+    # ------------------------------------------------------------------
+    # Dataset loading
+    # ------------------------------------------------------------------
+
+    def load_dataset(self, dataset_path: Path | None = None) -> list[ProgramBenchTask]:
+        """Load ProgramBench tasks from a local JSONL file or stub.
+
+        Resolution order:
+
+        1. Explicit ``dataset_path`` argument if it exists.
+        2. The path stored in ``BERNSTEIN_PROGRAMBENCH_DATASET`` env var.
+        3. Lazy HuggingFace ``datasets`` download (if available).
+        4. Empty list (tests inject tasks directly).
+
+        Args:
+            dataset_path: Optional path to a local ``.jsonl`` file.
+
+        Returns:
+            Filtered list of :class:`ProgramBenchTask` objects.
+        """
+        import os
+
+        candidate: Path | None = dataset_path
+        if candidate is None:
+            env_value = os.environ.get(self.dataset_env_var)
+            if env_value:
+                from pathlib import Path as _Path
+
+                candidate = _Path(env_value)
+
+        if candidate is not None and candidate.exists():
+            tasks: list[ProgramBenchTask] = []
+            for line in candidate.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    raw = json.loads(line)
+                    tasks.append(ProgramBenchTask.from_dict(raw))
+                except (json.JSONDecodeError, KeyError):
+                    continue
+            return self.filter_tasks(tasks)
+
+        # Lazy HuggingFace download
+        try:
+            from datasets import load_dataset as hf_load  # type: ignore[import-untyped]
+
+            dataset_name = f"programbench/programbench-{self.subset}"
+            raw_dataset: list[Any] = cast(_CAST_LIST_ANY, hf_load(dataset_name, split="test"))
+            tasks = [ProgramBenchTask.from_dict(dict(row)) for row in raw_dataset]
+            return self.filter_tasks(tasks)
+        except ImportError:
+            return []
+
+    def filter_tasks(self, tasks: list[ProgramBenchTask]) -> list[ProgramBenchTask]:
+        """Apply task_id and sample filters.
+
+        Args:
+            tasks: Full list of tasks to filter.
+
+        Returns:
+            Filtered (and possibly sampled) list.
+        """
+        if self.task_id is not None:
+            tasks = [t for t in tasks if t.task_id == self.task_id]
+
+        if self.sample is not None and self.sample < len(tasks):
+            rng = random.Random(self._seed)
+            tasks = rng.sample(tasks, self.sample)
+
+        return tasks
+
+    # ------------------------------------------------------------------
+    # Goal construction
+    # ------------------------------------------------------------------
+
+    def build_goal(self, task: ProgramBenchTask) -> str:
+        """Build a Bernstein goal string from a ProgramBench task.
+
+        Args:
+            task: The task to build a goal for.
+
+        Returns:
+            Multi-line goal string suitable for ``bernstein --goal``.
+        """
+        asserts_block = "\n".join(f"  - {a}" for a in task.asserts) or "  (none)"
+        return (
+            f"ProgramBench task: {task.task_id}\n"
+            f"Subset: {task.subset}\n\n"
+            f"Description:\n{task.description}\n\n"
+            f"Setup:\n{task.setup_code}\n\n"
+            f"Target signature:\n{task.target_signature}\n\n"
+            f"Runtime asserts (visible):\n{asserts_block}"
+        )
+
+    # ------------------------------------------------------------------
+    # Sandbox evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate_asserts(
+        self,
+        task: ProgramBenchTask,
+        candidate_code: str,
+    ) -> tuple[int, int, str | None]:
+        """Run a candidate solution against task asserts.
+
+        Each assert is a Python expression evaluated against a namespace
+        containing the candidate's exec'd globals plus the task's setup.
+
+        Args:
+            task: The task whose asserts to evaluate.
+            candidate_code: Candidate Python code produced by the agent.
+
+        Returns:
+            Tuple of ``(asserts_passed, asserts_total, error_or_None)``.
+        """
+        all_asserts = list(task.asserts) + list(task.hidden_asserts)
+        if not all_asserts:
+            return 0, 0, "no asserts defined"
+
+        namespace: dict[str, Any] = {}
+        try:
+            if task.setup_code.strip():
+                exec(compile(task.setup_code, f"<{task.task_id}:setup>", "exec"), namespace)
+            if candidate_code.strip():
+                exec(compile(candidate_code, f"<{task.task_id}:candidate>", "exec"), namespace)
+        except Exception as exc:
+            return 0, len(all_asserts), f"setup/candidate error: {exc!r}"
+
+        passed = 0
+        for expr in all_asserts:
+            try:
+                result = eval(
+                    compile(expr, f"<{task.task_id}:assert>", "eval"),
+                    namespace,
+                )
+                if bool(result):
+                    passed += 1
+            except Exception:
+                continue
+
+        return passed, len(all_asserts), None
+
+    # ------------------------------------------------------------------
+    # Adapter invocation
+    # ------------------------------------------------------------------
+
+    def _invoke_adapter(
+        self,
+        adapter: str,
+        task: ProgramBenchTask,
+    ) -> tuple[str, float, float]:
+        """Invoke an adapter to produce a candidate for a task.
+
+        Default behaviour shells out to ``bernstein --goal ... --adapter ...``.
+        Tests typically override this method.
+
+        Args:
+            adapter: Adapter slug (e.g. ``"claude"``).
+            task: The task to solve.
+
+        Returns:
+            Tuple of ``(candidate_code, cost_usd, duration_seconds)``.
+
+        Raises:
+            RuntimeError: If the subprocess fails or times out.
+        """
+        import subprocess
+
+        goal = self.build_goal(task)
+        t0 = time.monotonic()
+
+        proc = subprocess.run(
+            [
+                "bernstein",
+                "--goal",
+                goal,
+                "--adapter",
+                adapter,
+                "--headless",
+                "--budget",
+                "2.00",
+            ],
+            cwd=self.workdir,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=600,
+        )
+
+        duration = time.monotonic() - t0
+
+        if proc.returncode != 0:
+            raise RuntimeError(f"Bernstein exited {proc.returncode}: {proc.stderr[:200]}")
+
+        candidate_path = self.workdir / ".sdd" / "benchmark" / f"{task.task_id}.py"
+        candidate_code = candidate_path.read_text(encoding="utf-8") if candidate_path.exists() else ""
+
+        cost_usd = self._read_run_cost()
+        return candidate_code, cost_usd, duration
+
+    def _read_run_cost(self) -> float:
+        """Read total cost of the last Bernstein run from metrics JSONL files."""
+        metrics_dir = self.workdir / ".sdd" / "metrics"
+        if not metrics_dir.exists():
+            return 0.0
+        total = 0.0
+        for jsonl_file in metrics_dir.glob("cost_efficiency_*.jsonl"):
+            for line in jsonl_file.read_text(encoding="utf-8").splitlines():
+                try:
+                    record = json.loads(line)
+                    total += float(record.get("cost_usd", 0.0))
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    continue
+        return total
+
+    # ------------------------------------------------------------------
+    # Public: run a single task
+    # ------------------------------------------------------------------
+
+    def run_task(self, adapter: str, task: ProgramBenchTask) -> TaskResult:
+        """Evaluate Bernstein on a single ProgramBench task.
+
+        Args:
+            adapter: Adapter slug used for the invocation.
+            task: The task to solve.
+
+        Returns:
+            :class:`TaskResult` with score and metrics.
+        """
+        try:
+            candidate_code, cost_usd, duration = self._invoke_adapter(adapter, task)
+        except Exception as exc:
+            return TaskResult(
+                task_id=task.task_id,
+                score=0.0,
+                asserts_passed=0,
+                asserts_total=len(task.asserts) + len(task.hidden_asserts),
+                fully_solved=False,
+                cost_usd=0.0,
+                duration_seconds=0.0,
+                adapter=adapter,
+                log_path=None,
+                error=str(exc),
+            )
+
+        passed, total, sandbox_err = self.evaluate_asserts(task, candidate_code)
+        score = compute_score(passed, total)
+        return TaskResult(
+            task_id=task.task_id,
+            score=score,
+            asserts_passed=passed,
+            asserts_total=total,
+            fully_solved=score >= 1.0,
+            cost_usd=cost_usd,
+            duration_seconds=duration,
+            adapter=adapter,
+            log_path=None,
+            error=sandbox_err,
+        )
+
+    # ------------------------------------------------------------------
+    # Public: run the suite
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        adapter: str,
+        tasks: list[ProgramBenchTask] | None = None,
+        subset: str | None = None,
+        dataset_path: Path | None = None,
+    ) -> ProgramBenchReport:
+        """Run Bernstein against all (or a filtered subset of) ProgramBench tasks.
+
+        Args:
+            adapter: Adapter slug used for each task.
+            tasks: Pre-loaded tasks to evaluate. If None, calls
+                :meth:`load_dataset`.
+            subset: Optional override for the subset slug.
+            dataset_path: Passed to :meth:`load_dataset` if ``tasks`` is None.
+
+        Returns:
+            Aggregate :class:`ProgramBenchReport`.
+        """
+        if subset is not None:
+            self.subset = subset
+        if tasks is None:
+            tasks = self.load_dataset(dataset_path)
+
+        results = [self.run_task(adapter, task) for task in tasks]
+        return compute_report(results)

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -167,6 +167,193 @@ def benchmark_swe_bench(
     )
 
 
+def _run_programbench_command(
+    *,
+    adapter: str,
+    subset: str,
+    tasks_limit: int | None,
+    task_id: str | None,
+    dataset_path: str | None,
+    out_json: str | None,
+    save: bool,
+) -> None:
+    """Run the ProgramBench harness and print a report.
+
+    Args:
+        adapter: Adapter slug for invocation.
+        subset: Dataset subset slug.
+        tasks_limit: Optional sample size cap.
+        task_id: Optional single task id to evaluate.
+        dataset_path: Optional local JSONL path.
+        out_json: Optional path to write JSON output.
+        save: Whether to persist results under ``.sdd/``.
+    """
+    import json as _json
+
+    from rich.table import Table
+
+    from bernstein.benchmark.programbench import (
+        ProgramBenchHarness,
+        TaskResult,
+        compute_report,
+        report_to_dict,
+        save_results,
+    )
+
+    workdir = Path(".")
+    harness = ProgramBenchHarness(
+        workdir=workdir,
+        sample=tasks_limit,
+        task_id=task_id,
+        subset=subset,
+    )
+
+    dpath = Path(dataset_path) if dataset_path else None
+    tasks = harness.load_dataset(dpath)
+
+    if not tasks:
+        console.print(
+            "[yellow]No ProgramBench tasks found. Pass --dataset <path.jsonl>, "
+            "set BERNSTEIN_PROGRAMBENCH_DATASET, or install the 'datasets' package.[/yellow]"
+        )
+        raise SystemExit(1)
+
+    console.print(
+        f"[bold]ProgramBench evaluation[/bold]: subset={subset} • adapter={adapter} • {len(tasks)} task(s)"
+    )
+
+    table = Table(title="ProgramBench Results", header_style=_STYLE_BOLD_CYAN, show_lines=False)
+    table.add_column("Task", style="dim", min_width=24)
+    table.add_column("Adapter", min_width=12)
+    table.add_column("Score", justify="right", min_width=10)
+    table.add_column("Asserts", justify="right", min_width=10)
+    table.add_column("Cost (USD)", justify="right", min_width=12)
+    table.add_column("Time (s)", justify="right", min_width=10)
+
+    results: list[TaskResult] = []
+    for task in tasks:
+        console.print(f"  Running [cyan]{task.task_id}[/cyan]…", end="")
+        result = harness.run_task(adapter, task)
+        results.append(result)
+        if result.fully_solved:
+            icon = "[green]100%[/green]"
+        elif result.score >= 0.5:
+            icon = f"[yellow]{result.score:.0%}[/yellow]"
+        else:
+            icon = f"[red]{result.score:.0%}[/red]"
+        console.print(f" {icon}")
+        table.add_row(
+            task.task_id,
+            result.adapter,
+            f"{result.score:.2f}",
+            f"{result.asserts_passed}/{result.asserts_total}",
+            f"${result.cost_usd:.4f}",
+            f"{result.duration_seconds:.1f}",
+        )
+
+    report = compute_report(results)
+    console.print(table)
+    console.print(
+        f"\n[bold]Mean partial credit:[/bold] {report.mean_partial_credit:.2%}  "
+        f"[green]{report.fully_solved} fully[/green]  "
+        f"[yellow]{report.near_solved} near[/yellow]  "
+        f"[red]{report.failed} failed[/red]  "
+        f"[dim]total cost ${report.total_cost_usd:.4f}[/dim]"
+    )
+
+    if report.per_adapter_breakdown:
+        adapter_table = Table(title="Per-Adapter Breakdown", header_style="bold magenta", show_lines=False)
+        adapter_table.add_column("Adapter", min_width=12)
+        adapter_table.add_column("Total", justify="right")
+        adapter_table.add_column("Fully", justify="right")
+        adapter_table.add_column("Near", justify="right")
+        adapter_table.add_column("Failed", justify="right")
+        adapter_table.add_column("Mean", justify="right")
+        adapter_table.add_column("Cost/Task", justify="right")
+        for b in report.per_adapter_breakdown:
+            adapter_table.add_row(
+                b.adapter,
+                str(b.total),
+                str(b.fully_solved),
+                str(b.near_solved),
+                str(b.failed),
+                f"{b.mean_partial_credit:.2%}",
+                f"${b.cost_per_task:.4f}",
+            )
+        console.print(adapter_table)
+
+    if out_json:
+        Path(out_json).write_text(_json.dumps(report_to_dict(report), indent=2), encoding="utf-8")
+        console.print(f"[dim]JSON report saved → {out_json}[/dim]")
+
+    if save:
+        sdd_dir = Path(".sdd")
+        save_results(report, sdd_dir)
+        console.print(f"[dim]Results saved → {sdd_dir / 'metrics' / 'programbench_results.jsonl'}[/dim]")
+
+
+@benchmark_group.command("programbench")
+@click.option(
+    "--adapter",
+    required=True,
+    help="Adapter slug (e.g. claude, codex, mock).",
+)
+@click.option(
+    "--subset",
+    default="lite",
+    show_default=True,
+    help="ProgramBench subset slug.",
+)
+@click.option(
+    "--tasks",
+    "tasks_limit",
+    type=int,
+    default=None,
+    help="Evaluate a random sample of N tasks.",
+)
+@click.option("--task", "task_id", default=None, help="Evaluate a single task by ID.")
+@click.option("--dataset", "dataset_path", default=None, help="Path to local JSONL dataset file.")
+@click.option(
+    "--out",
+    "out_json",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="Write JSON report to this path.",
+)
+@click.option(
+    "--save/--no-save",
+    default=True,
+    show_default=True,
+    help="Persist results to .sdd/metrics/programbench_results.jsonl.",
+)
+def benchmark_programbench(
+    adapter: str,
+    subset: str,
+    tasks_limit: int | None,
+    task_id: str | None,
+    dataset_path: str | None,
+    out_json: str | None,
+    save: bool,
+) -> None:
+    """Run Bernstein against ProgramBench tasks with partial-credit scoring.
+
+    \b
+      bernstein benchmark programbench --adapter claude
+      bernstein benchmark programbench --adapter mock --tasks 5
+      bernstein benchmark programbench --adapter claude --task programbench-001
+      bernstein benchmark programbench --adapter claude --out report.json
+    """
+    _run_programbench_command(
+        adapter=adapter,
+        subset=subset,
+        tasks_limit=tasks_limit,
+        task_id=task_id,
+        dataset_path=dataset_path,
+        out_json=out_json,
+        save=save,
+    )
+
+
 @benchmark_group.command("run")
 @click.option(
     "--tier",

--- a/src/bernstein/cli/commands/eval_benchmark_cmd.py
+++ b/src/bernstein/cli/commands/eval_benchmark_cmd.py
@@ -218,9 +218,7 @@ def _run_programbench_command(
         )
         raise SystemExit(1)
 
-    console.print(
-        f"[bold]ProgramBench evaluation[/bold]: subset={subset} • adapter={adapter} • {len(tasks)} task(s)"
-    )
+    console.print(f"[bold]ProgramBench evaluation[/bold]: subset={subset} • adapter={adapter} • {len(tasks)} task(s)")
 
     table = Table(title="ProgramBench Results", header_style=_STYLE_BOLD_CYAN, show_lines=False)
     table.add_column("Task", style="dim", min_width=24)

--- a/tests/integration/test_programbench_cli.py
+++ b/tests/integration/test_programbench_cli.py
@@ -1,0 +1,199 @@
+"""Integration tests for the ProgramBench CLI wiring (TREND-1404).
+
+Exercises the ``bernstein benchmark programbench`` subcommand end to end
+with synthetic fixtures: dataset loader, partial-credit scoring, JSON
+output schema, and per-task persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from bernstein.cli.eval_benchmark_cmd import benchmark_group
+from click.testing import CliRunner
+
+from bernstein.benchmark.programbench import ProgramBenchHarness, ProgramBenchTask
+
+
+def _dataset(tmp_path: Path, tasks: list[dict[str, Any]]) -> Path:
+    path = tmp_path / "programbench.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(t) for t in tasks) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run_in_tmp(tmp_path: Path, args: list[str]) -> Any:
+    runner = CliRunner()
+    old_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        return runner.invoke(benchmark_group, args)
+    finally:
+        os.chdir(old_cwd)
+
+
+class TestProgramBenchCLI:
+    def test_command_registered(self) -> None:
+        assert "programbench" in benchmark_group.commands
+
+    def test_runs_against_synthetic_dataset(self, tmp_path: Path) -> None:
+        dataset = _dataset(
+            tmp_path,
+            [
+                {
+                    "task_id": "pb-001",
+                    "asserts": ["x == 1"],
+                    "setup_code": "x = 1",
+                },
+                {
+                    "task_id": "pb-002",
+                    "asserts": ["x == 2"],
+                    "setup_code": "x = 1",
+                },
+            ],
+        )
+
+        def fake_invoke(self: ProgramBenchHarness, adapter: str, t: ProgramBenchTask) -> tuple[str, float, float]:
+            return "", 0.01, 0.5
+
+        with patch.object(ProgramBenchHarness, "_invoke_adapter", new=fake_invoke):
+            result = _run_in_tmp(
+                tmp_path,
+                ["programbench", "--adapter", "mock", "--dataset", str(dataset)],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "ProgramBench evaluation" in result.output
+        assert "pb-001" in result.output
+        assert "pb-002" in result.output
+
+        metrics = tmp_path / ".sdd" / "metrics" / "programbench_results.jsonl"
+        assert metrics.exists()
+        record = json.loads(metrics.read_text(encoding="utf-8").splitlines()[0])
+        assert record["total_tasks"] == 2
+        assert record["fully_solved"] == 1
+        assert record["failed"] == 1
+
+    def test_partial_credit_propagates_to_report(self, tmp_path: Path) -> None:
+        dataset = _dataset(
+            tmp_path,
+            [
+                {
+                    "task_id": "pb-partial",
+                    "asserts": ["x == 1", "y == 2"],
+                    "setup_code": "x = 1\ny = 99",
+                }
+            ],
+        )
+
+        def fake_invoke(self: ProgramBenchHarness, adapter: str, t: ProgramBenchTask) -> tuple[str, float, float]:
+            return "", 0.05, 0.2
+
+        with patch.object(ProgramBenchHarness, "_invoke_adapter", new=fake_invoke):
+            result = _run_in_tmp(
+                tmp_path,
+                ["programbench", "--adapter", "mock", "--dataset", str(dataset)],
+            )
+
+        assert result.exit_code == 0, result.output
+        metrics = tmp_path / ".sdd" / "metrics" / "programbench_results.jsonl"
+        record = json.loads(metrics.read_text(encoding="utf-8").splitlines()[0])
+        per_task = record["per_task"][0]
+        assert per_task["score"] == 0.5
+        assert per_task["asserts_passed"] == 1
+        assert per_task["asserts_total"] == 2
+        assert per_task["fully_solved"] is False
+
+    def test_json_output_schema(self, tmp_path: Path) -> None:
+        dataset = _dataset(
+            tmp_path,
+            [
+                {
+                    "task_id": "pb-json",
+                    "asserts": ["1 == 1"],
+                    "setup_code": "",
+                }
+            ],
+        )
+        out = tmp_path / "report.json"
+
+        def fake_invoke(self: ProgramBenchHarness, adapter: str, t: ProgramBenchTask) -> tuple[str, float, float]:
+            return "", 0.0, 0.01
+
+        with patch.object(ProgramBenchHarness, "_invoke_adapter", new=fake_invoke):
+            result = _run_in_tmp(
+                tmp_path,
+                [
+                    "programbench",
+                    "--adapter",
+                    "mock",
+                    "--dataset",
+                    str(dataset),
+                    "--out",
+                    str(out),
+                    "--no-save",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        for key in (
+            "total_tasks",
+            "fully_solved",
+            "near_solved",
+            "failed",
+            "mean_partial_credit",
+            "total_cost_usd",
+            "per_task",
+            "per_adapter_breakdown",
+        ):
+            assert key in payload, f"missing key {key}"
+        assert payload["total_tasks"] == 1
+        assert payload["per_task"][0]["task_id"] == "pb-json"
+
+    def test_empty_dataset_returns_nonzero(self, tmp_path: Path) -> None:
+        empty = tmp_path / "empty.jsonl"
+        empty.write_text("", encoding="utf-8")
+        result = _run_in_tmp(
+            tmp_path,
+            ["programbench", "--adapter", "mock", "--dataset", str(empty)],
+        )
+        assert result.exit_code == 1
+        assert "No ProgramBench tasks found" in result.output
+
+    def test_sandbox_failure_mode_maps_to_zero_score(self, tmp_path: Path) -> None:
+        dataset = _dataset(
+            tmp_path,
+            [
+                {
+                    "task_id": "pb-sandbox-fail",
+                    "asserts": ["x == 1"],
+                    "setup_code": "raise RuntimeError('boom')",
+                }
+            ],
+        )
+
+        def fake_invoke(self: ProgramBenchHarness, adapter: str, t: ProgramBenchTask) -> tuple[str, float, float]:
+            return "", 0.0, 0.0
+
+        with patch.object(ProgramBenchHarness, "_invoke_adapter", new=fake_invoke):
+            result = _run_in_tmp(
+                tmp_path,
+                ["programbench", "--adapter", "mock", "--dataset", str(dataset), "--no-save"],
+            )
+
+        assert result.exit_code == 0, result.output
+        # The setup raises and asserts cannot run; score must be 0.
+        assert "0%" in result.output or "0.00" in result.output
+
+    def test_adapter_required(self, tmp_path: Path) -> None:
+        result = _run_in_tmp(tmp_path, ["programbench"])
+        # Click reports missing required option with non-zero exit.
+        assert result.exit_code != 0
+        assert "adapter" in result.output.lower()

--- a/tests/unit/test_programbench.py
+++ b/tests/unit/test_programbench.py
@@ -1,0 +1,594 @@
+"""Unit tests for ProgramBench evaluation harness (TREND-1404)."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from bernstein.benchmark.programbench import (
+    AdapterBreakdown,
+    ProgramBenchHarness,
+    ProgramBenchTask,
+    TaskResult,
+    classify_score,
+    compute_report,
+    compute_score,
+    report_to_dict,
+    save_results,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    task_id: str = "pb-001",
+    *,
+    setup: str = "x = 1",
+    asserts: list[str] | None = None,
+    hidden: list[str] | None = None,
+    target: str = "def solve(): pass",
+    subset: str = "lite",
+) -> ProgramBenchTask:
+    return ProgramBenchTask(
+        task_id=task_id,
+        subset=subset,
+        description="demo",
+        setup_code=setup,
+        target_signature=target,
+        asserts=asserts if asserts is not None else ["x == 1"],
+        hidden_asserts=hidden if hidden is not None else [],
+        tags=["unit"],
+    )
+
+
+def _result(
+    task_id: str = "pb-001",
+    *,
+    score: float = 1.0,
+    passed: int = 2,
+    total: int = 2,
+    adapter: str = "mock",
+    cost: float = 0.01,
+    duration: float = 1.0,
+) -> TaskResult:
+    return TaskResult(
+        task_id=task_id,
+        score=score,
+        asserts_passed=passed,
+        asserts_total=total,
+        fully_solved=score >= 1.0,
+        cost_usd=cost,
+        duration_seconds=duration,
+        adapter=adapter,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scoring (unit) - 6 tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeScore:
+    def test_zero_total_returns_zero(self) -> None:
+        assert compute_score(0, 0) == 0.0
+
+    def test_negative_total_returns_zero(self) -> None:
+        assert compute_score(2, -1) == 0.0
+
+    def test_all_passing_returns_one(self) -> None:
+        assert compute_score(5, 5) == 1.0
+
+    def test_partial_credit(self) -> None:
+        assert compute_score(3, 4) == 0.75
+
+    def test_passed_exceeds_total_clamps_to_one(self) -> None:
+        assert compute_score(7, 5) == 1.0
+
+    def test_zero_passed_returns_zero(self) -> None:
+        assert compute_score(0, 5) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Classification - 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyScore:
+    def test_fully_solved_at_one(self) -> None:
+        assert classify_score(1.0) == "fully_solved"
+
+    def test_near_solved_at_threshold(self) -> None:
+        assert classify_score(0.5) == "near_solved"
+
+    def test_near_solved_below_one(self) -> None:
+        assert classify_score(0.99) == "near_solved"
+
+    def test_failed_below_threshold(self) -> None:
+        assert classify_score(0.49) == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Task parsing - 7 tests
+# ---------------------------------------------------------------------------
+
+
+class TestTaskParsing:
+    def test_from_dict_minimal(self) -> None:
+        task = ProgramBenchTask.from_dict({"task_id": "pb-1", "asserts": ["1 == 1"]})
+        assert task.task_id == "pb-1"
+        assert task.asserts == ["1 == 1"]
+        assert task.hidden_asserts == []
+        assert task.subset == "lite"
+
+    def test_from_dict_full(self) -> None:
+        task = ProgramBenchTask.from_dict(
+            {
+                "task_id": "pb-2",
+                "subset": "hard",
+                "description": "Build feature X",
+                "setup_code": "y = 2",
+                "target_signature": "def f(x): ...",
+                "asserts": ["f(2) == 4"],
+                "hidden_asserts": ["f(0) == 0"],
+                "tags": ["math"],
+            }
+        )
+        assert task.task_id == "pb-2"
+        assert task.subset == "hard"
+        assert task.target_signature == "def f(x): ..."
+        assert task.hidden_asserts == ["f(0) == 0"]
+        assert task.tags == ["math"]
+
+    def test_from_dict_accepts_id_alias(self) -> None:
+        task = ProgramBenchTask.from_dict({"id": "pb-3", "asserts": []})
+        assert task.task_id == "pb-3"
+
+    def test_from_dict_missing_task_id_raises(self) -> None:
+        with pytest.raises(KeyError):
+            ProgramBenchTask.from_dict({"asserts": []})
+
+    def test_from_dict_empty_task_id_raises(self) -> None:
+        with pytest.raises(KeyError):
+            ProgramBenchTask.from_dict({"task_id": "", "asserts": []})
+
+    def test_from_dict_json_encoded_asserts(self) -> None:
+        task = ProgramBenchTask.from_dict(
+            {"task_id": "pb-4", "asserts": json.dumps(["a == 1", "b == 2"])}
+        )
+        assert task.asserts == ["a == 1", "b == 2"]
+
+    def test_from_dict_string_assert_falls_back_to_single_item(self) -> None:
+        task = ProgramBenchTask.from_dict({"task_id": "pb-5", "asserts": "x == 1"})
+        assert task.asserts == ["x == 1"]
+
+
+# ---------------------------------------------------------------------------
+# Report aggregation - 7 tests
+# ---------------------------------------------------------------------------
+
+
+class TestReportAggregation:
+    def test_empty_results(self) -> None:
+        report = compute_report([])
+        assert report.total_tasks == 0
+        assert report.mean_partial_credit == 0.0
+        assert report.per_adapter_breakdown == []
+        assert report.per_task == []
+
+    def test_aggregates_partial_credit(self) -> None:
+        results = [
+            _result("a", score=1.0, passed=2, total=2),
+            _result("b", score=0.5, passed=1, total=2),
+            _result("c", score=0.0, passed=0, total=2),
+        ]
+        report = compute_report(results)
+        assert report.total_tasks == 3
+        assert report.fully_solved == 1
+        assert report.near_solved == 1
+        assert report.failed == 1
+        assert math.isclose(report.mean_partial_credit, 0.5, abs_tol=1e-9)
+
+    def test_per_adapter_breakdown_sorted(self) -> None:
+        results = [
+            _result("a", adapter="zeta"),
+            _result("b", adapter="alpha"),
+        ]
+        report = compute_report(results)
+        names = [b.adapter for b in report.per_adapter_breakdown]
+        assert names == ["alpha", "zeta"]
+
+    def test_per_adapter_counts_buckets(self) -> None:
+        results = [
+            _result("a", score=1.0, adapter="x"),
+            _result("b", score=0.8, adapter="x"),
+            _result("c", score=0.0, adapter="x"),
+        ]
+        report = compute_report(results)
+        assert len(report.per_adapter_breakdown) == 1
+        breakdown = report.per_adapter_breakdown[0]
+        assert breakdown.fully_solved == 1
+        assert breakdown.near_solved == 1
+        assert breakdown.failed == 1
+
+    def test_median_cost_and_duration(self) -> None:
+        results = [
+            _result("a", cost=0.10, duration=10.0),
+            _result("b", cost=0.20, duration=20.0),
+            _result("c", cost=0.40, duration=40.0),
+        ]
+        report = compute_report(results)
+        assert report.median_cost_usd == 0.20
+        assert report.median_duration_seconds == 20.0
+
+    def test_total_cost_sums(self) -> None:
+        results = [
+            _result("a", cost=0.10),
+            _result("b", cost=0.30),
+        ]
+        report = compute_report(results)
+        assert math.isclose(report.total_cost_usd, 0.40, abs_tol=1e-9)
+
+    def test_unknown_adapter_fallback(self) -> None:
+        results = [_result("a", adapter="")]
+        report = compute_report(results)
+        assert report.per_adapter_breakdown[0].adapter == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Persistence - 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_save_results_creates_metrics_and_snapshot(self, tmp_path: Path) -> None:
+        report = compute_report([_result("a", score=1.0), _result("b", score=0.0)])
+        snapshot = save_results(report, tmp_path)
+        metrics = tmp_path / "metrics" / "programbench_results.jsonl"
+        assert snapshot.exists()
+        assert metrics.exists()
+        record = json.loads(metrics.read_text(encoding="utf-8").splitlines()[0])
+        assert record["total_tasks"] == 2
+        assert record["fully_solved"] == 1
+
+    def test_save_results_appends(self, tmp_path: Path) -> None:
+        report = compute_report([_result("a")])
+        save_results(report, tmp_path)
+        save_results(report, tmp_path)
+        metrics = tmp_path / "metrics" / "programbench_results.jsonl"
+        assert len(metrics.read_text(encoding="utf-8").splitlines()) == 2
+
+    def test_report_to_dict_round_trip(self) -> None:
+        report = compute_report([_result("a", score=0.5, passed=1, total=2)])
+        data = report_to_dict(report)
+        assert data["total_tasks"] == 1
+        assert data["per_task"][0]["task_id"] == "a"
+        assert json.dumps(data, sort_keys=True)
+
+    def test_snapshot_json_well_formed(self, tmp_path: Path) -> None:
+        report = compute_report([_result("a")])
+        snap = save_results(report, tmp_path)
+        parsed = json.loads(snap.read_text(encoding="utf-8"))
+        assert parsed["total_tasks"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Harness state machine - 8 tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarness:
+    def test_build_goal_mentions_task(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task("pb-99", asserts=["a == 1"])
+        goal = h.build_goal(task)
+        assert "pb-99" in goal
+        assert "a == 1" in goal
+
+    def test_build_goal_handles_no_asserts(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task(asserts=[])
+        goal = h.build_goal(task)
+        assert "(none)" in goal
+
+    def test_filter_tasks_by_task_id(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path, task_id="pb-2")
+        tasks = [_task("pb-1"), _task("pb-2"), _task("pb-3")]
+        filtered = h.filter_tasks(tasks)
+        assert [t.task_id for t in filtered] == ["pb-2"]
+
+    def test_filter_tasks_sample(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path, sample=2, seed=42)
+        tasks = [_task(f"pb-{i}") for i in range(10)]
+        filtered = h.filter_tasks(tasks)
+        assert len(filtered) == 2
+
+    def test_filter_tasks_sample_deterministic(self, tmp_path: Path) -> None:
+        tasks = [_task(f"pb-{i}") for i in range(10)]
+        h1 = ProgramBenchHarness(workdir=tmp_path, sample=3, seed=42)
+        h2 = ProgramBenchHarness(workdir=tmp_path, sample=3, seed=42)
+        assert [t.task_id for t in h1.filter_tasks(tasks)] == [
+            t.task_id for t in h2.filter_tasks(tasks)
+        ]
+
+    def test_evaluate_asserts_all_pass(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task(setup="x = 5", asserts=["x == 5", "x > 0"])
+        passed, total, err = h.evaluate_asserts(task, "")
+        assert passed == 2
+        assert total == 2
+        assert err is None
+
+    def test_evaluate_asserts_partial(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task(setup="x = 1", asserts=["x == 1", "x == 99"])
+        passed, total, _ = h.evaluate_asserts(task, "")
+        assert passed == 1
+        assert total == 2
+
+    def test_evaluate_asserts_candidate_overrides_state(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task(setup="x = 1", asserts=["x == 42"])
+        passed, total, _ = h.evaluate_asserts(task, "x = 42")
+        assert passed == 1
+        assert total == 1
+
+
+# ---------------------------------------------------------------------------
+# Harness end-to-end with mocked adapter - 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessRunTask:
+    def test_run_task_uses_invoke_adapter(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task(setup="x = 0", asserts=["x == 5"])
+
+        def fake_invoke(adapter: str, t: ProgramBenchTask) -> tuple[str, float, float]:
+            return "x = 5", 0.42, 1.5
+
+        with patch.object(h, "_invoke_adapter", side_effect=fake_invoke):
+            result = h.run_task("mock", task)
+
+        assert result.score == 1.0
+        assert result.fully_solved
+        assert result.cost_usd == 0.42
+        assert result.adapter == "mock"
+
+    def test_run_task_records_partial(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task(setup="", asserts=["a == 1", "b == 2"])
+
+        with patch.object(h, "_invoke_adapter", return_value=("a = 1", 0.1, 0.5)):
+            result = h.run_task("mock", task)
+
+        assert result.score == 0.5
+        assert result.asserts_passed == 1
+        assert result.asserts_total == 2
+        assert not result.fully_solved
+
+    def test_run_task_handles_adapter_error(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        task = _task()
+
+        with patch.object(h, "_invoke_adapter", side_effect=RuntimeError("boom")):
+            result = h.run_task("mock", task)
+
+        assert result.score == 0.0
+        assert result.error == "boom"
+        assert result.duration_seconds == 0.0
+
+    def test_run_aggregates_across_tasks(self, tmp_path: Path) -> None:
+        h = ProgramBenchHarness(workdir=tmp_path)
+        tasks = [
+            _task("t1", setup="", asserts=["1 == 1"]),
+            _task("t2", setup="", asserts=["1 == 2"]),
+        ]
+
+        with patch.object(h, "_invoke_adapter", return_value=("", 0.01, 0.5)):
+            report = h.run("mock", tasks=tasks)
+
+        assert report.total_tasks == 2
+        assert report.fully_solved == 1
+        assert report.failed == 1
+
+
+# ---------------------------------------------------------------------------
+# Dataset loader - 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestDatasetLoading:
+    def test_load_dataset_from_file(self, tmp_path: Path) -> None:
+        dataset = tmp_path / "data.jsonl"
+        dataset.write_text(
+            json.dumps({"task_id": "pb-1", "asserts": ["1 == 1"]}) + "\n",
+            encoding="utf-8",
+        )
+        h = ProgramBenchHarness(workdir=tmp_path)
+        tasks = h.load_dataset(dataset)
+        assert [t.task_id for t in tasks] == ["pb-1"]
+
+    def test_load_dataset_skips_invalid_lines(self, tmp_path: Path) -> None:
+        dataset = tmp_path / "data.jsonl"
+        dataset.write_text(
+            "not-json\n"
+            + json.dumps({"task_id": "pb-1", "asserts": []})
+            + "\n"
+            + json.dumps({"no_id_here": True})
+            + "\n",
+            encoding="utf-8",
+        )
+        h = ProgramBenchHarness(workdir=tmp_path)
+        tasks = h.load_dataset(dataset)
+        assert [t.task_id for t in tasks] == ["pb-1"]
+
+    def test_load_dataset_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        dataset = tmp_path / "env.jsonl"
+        dataset.write_text(json.dumps({"task_id": "pb-env", "asserts": []}) + "\n", encoding="utf-8")
+        monkeypatch.setenv("BERNSTEIN_PROGRAMBENCH_DATASET", str(dataset))
+        h = ProgramBenchHarness(workdir=tmp_path)
+        tasks = h.load_dataset()
+        assert [t.task_id for t in tasks] == ["pb-env"]
+
+    def test_load_dataset_huggingface_fallback(self, tmp_path: Path) -> None:
+        captured: dict[str, str] = {}
+
+        def fake_load(name: str, split: str) -> list[dict[str, Any]]:
+            captured["name"] = name
+            captured["split"] = split
+            return [{"task_id": "pb-hf", "asserts": ["1 == 1"]}]
+
+        fake_module = SimpleNamespace(load_dataset=fake_load)
+        h = ProgramBenchHarness(workdir=tmp_path, subset="lite")
+        with patch.dict("sys.modules", {"datasets": fake_module}):
+            tasks = h.load_dataset()
+        assert captured["name"] == "programbench/programbench-lite"
+        assert captured["split"] == "test"
+        assert [t.task_id for t in tasks] == ["pb-hf"]
+
+
+# ---------------------------------------------------------------------------
+# AdapterBreakdown serialisation - 1 test
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterBreakdownSerialisation:
+    def test_to_dict(self) -> None:
+        b = AdapterBreakdown(
+            adapter="x",
+            total=2,
+            fully_solved=1,
+            near_solved=1,
+            failed=0,
+            mean_partial_credit=0.75,
+            cost_per_task=0.1,
+            time_per_task=1.0,
+        )
+        d = b.to_dict()
+        assert d["adapter"] == "x"
+        assert d["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Property tests - 10
+# ---------------------------------------------------------------------------
+
+
+_PROP_SETTINGS = settings(max_examples=50, deadline=None)
+
+
+class TestProperties:
+    @_PROP_SETTINGS
+    @given(passed=st.integers(min_value=0, max_value=1000), total=st.integers(min_value=1, max_value=1000))
+    def test_score_in_unit_interval(self, passed: int, total: int) -> None:
+        s = compute_score(passed, total)
+        assert 0.0 <= s <= 1.0
+
+    @_PROP_SETTINGS
+    @given(total=st.integers(min_value=1, max_value=100))
+    def test_score_passed_zero_is_zero(self, total: int) -> None:
+        assert compute_score(0, total) == 0.0
+
+    @_PROP_SETTINGS
+    @given(n=st.integers(min_value=1, max_value=100))
+    def test_score_all_pass_is_one(self, n: int) -> None:
+        assert compute_score(n, n) == 1.0
+
+    @_PROP_SETTINGS
+    @given(passed=st.integers(min_value=1, max_value=100), total=st.integers(min_value=1, max_value=100))
+    def test_score_monotonic_in_passed(self, passed: int, total: int) -> None:
+        assume_passed = min(passed, total)
+        less = compute_score(max(assume_passed - 1, 0), total)
+        more = compute_score(assume_passed, total)
+        assert less <= more
+
+    @_PROP_SETTINGS
+    @given(score=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False))
+    def test_classify_in_expected_bucket(self, score: float) -> None:
+        bucket = classify_score(score)
+        if score >= 1.0:
+            assert bucket == "fully_solved"
+        elif score >= 0.5:
+            assert bucket == "near_solved"
+        else:
+            assert bucket == "failed"
+
+    @_PROP_SETTINGS
+    @given(
+        scores=st.lists(
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+            min_size=1,
+            max_size=50,
+        )
+    )
+    def test_report_totals_match_inputs(self, scores: list[float]) -> None:
+        results = [_result(f"t{i}", score=s, passed=int(s * 2), total=2) for i, s in enumerate(scores)]
+        report = compute_report(results)
+        assert report.total_tasks == len(scores)
+        assert report.fully_solved + report.near_solved + report.failed == len(scores)
+
+    @_PROP_SETTINGS
+    @given(
+        scores=st.lists(
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+            min_size=1,
+            max_size=30,
+        )
+    )
+    def test_mean_partial_credit_within_bounds(self, scores: list[float]) -> None:
+        results = [_result(f"t{i}", score=s) for i, s in enumerate(scores)]
+        report = compute_report(results)
+        assert 0.0 <= report.mean_partial_credit <= 1.0
+
+    @_PROP_SETTINGS
+    @given(
+        costs=st.lists(
+            st.floats(min_value=0.0, max_value=10.0, allow_nan=False, allow_infinity=False),
+            min_size=1,
+            max_size=20,
+        )
+    )
+    def test_total_cost_matches_sum(self, costs: list[float]) -> None:
+        results = [_result(f"t{i}", cost=c) for i, c in enumerate(costs)]
+        report = compute_report(results)
+        assert math.isclose(report.total_cost_usd, sum(costs), rel_tol=1e-9, abs_tol=1e-9)
+
+    @_PROP_SETTINGS
+    @given(
+        task_ids=st.lists(
+            st.text(
+                alphabet=st.characters(min_codepoint=97, max_codepoint=122),
+                min_size=1,
+                max_size=10,
+            ),
+            min_size=1,
+            max_size=20,
+            unique=True,
+        )
+    )
+    def test_per_task_preserves_ids(self, task_ids: list[str]) -> None:
+        results = [_result(tid) for tid in task_ids]
+        report = compute_report(results)
+        assert [r.task_id for r in report.per_task] == task_ids
+
+    @_PROP_SETTINGS
+    @given(
+        passed=st.integers(min_value=0, max_value=20),
+        total=st.integers(min_value=1, max_value=20),
+    )
+    def test_score_equals_ratio_when_in_range(self, passed: int, total: int) -> None:
+        score = compute_score(passed, total)
+        if passed <= total and passed >= 0:
+            assert math.isclose(score, passed / total, abs_tol=1e-9)
+        else:
+            assert score in (0.0, 1.0)


### PR DESCRIPTION
## Summary
- Add `src/bernstein/benchmark/programbench.py` with `ProgramBenchHarness`, `ProgramBenchTask`, `TaskResult`, `AdapterBreakdown`, and `ProgramBenchReport` dataclasses parallel to the SWE-Bench harness.
- Register `bernstein benchmark programbench --adapter <name> [--subset slug] [--tasks N] [--task ID] [--dataset PATH] [--out report.json]` Click subcommand under the existing `benchmark_group`.
- Partial-credit scoring: per-task `score = asserts_passed / asserts_total` clamped to `[0, 1]`; tasks bucket into `fully_solved` / `near_solved` (>=0.5) / `failed`.
- Dataset resolution order: explicit `--dataset`, `BERNSTEIN_PROGRAMBENCH_DATASET` env var, lazy HuggingFace, then empty list.
- Persists JSONL metrics to `.sdd/metrics/programbench_results.jsonl` plus snapshot at `.sdd/benchmark/programbench_results.json`.
- Harness import remains lazy: it is only imported inside the CLI command body, so the feature is dormant when the operator does not invoke it.

## Acceptance criteria (#1404)
- [x] `ProgramBenchHarness` with `run(adapter, subset)` returning `ProgramBenchReport`.
- [x] `ProgramBenchReport` carries `total_tasks`, `fully_solved`, `near_solved`, `failed`, `mean_partial_credit`, `per_task[]` (each with task id, score, log path).
- [x] Task loader honours env var / CLI flag and does not bundle the dataset.
- [x] CLI subcommand `bernstein benchmark programbench` mirrors `bernstein benchmark swe-bench`.
- [x] Human-readable Rich table default plus `--out report.json` JSON output.
- [x] Cost field per task; total and per-adapter cost lines in the report.
- [x] Feature flag-off regression: SWE-Bench tests still pass; harness module is imported lazily inside the CLI handler.

## Test plan
- [x] 55 unit tests in `tests/unit/test_programbench.py` (scoring, classification, parsing, harness state machine, dataset loader, persistence). 10 of these are hypothesis property tests covering monotonicity, ratio invariants, bucket boundaries, and sum/cost identities.
- [x] 7 integration tests in `tests/integration/test_programbench_cli.py` driving the Click CLI end to end with synthetic ProgramBench fixtures (partial credit, JSON schema, sandbox failure mode, missing adapter, empty dataset, command registration).
- [x] Existing SWE-Bench suites unaffected.

## Quality bar
- [x] `ruff check` clean on the new files.
- [x] `pyright` (strict-listed files unchanged) clean on the new module and the modified CLI module.
- [x] No em-dashes in additions; English-only; no AI attribution.