### PR TITLE
feat(quality): citation+reference existence verifier (closes #1402)

### DIFF
--- a/src/bernstein/cli/commands/citation_cmd.py
+++ b/src/bernstein/cli/commands/citation_cmd.py
@@ -1,0 +1,92 @@
+"""CLI command group: ``bernstein quality`` -- citation/reference verifier.
+
+Subcommand:
+
+* ``citations`` -- read a file (or stdin via ``-``) and verify every
+  citation-like span resolves. Prints a human-readable summary and
+  optionally a JSON report.
+
+The verifier itself lives in :mod:`bernstein.core.quality.citation_verifier`;
+this module is the thin CLI wrapper that wires it into Click.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from bernstein.core.quality.citation_verifier import CitationReport, verify_citations
+
+
+@click.group("quality")
+def quality_group() -> None:
+    """Run on-demand quality gates (citation verifier, etc.)."""
+
+
+@quality_group.command("citations")
+@click.argument("path", type=click.Path(dir_okay=False, path_type=Path), required=False)
+@click.option("--offline", is_flag=True, help="Skip every network probe.")
+@click.option(
+    "--allowed-host",
+    "allowed_hosts",
+    multiple=True,
+    help="Allow-list of hostnames (repeatable). URLs not on the list are skipped.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit a JSON report instead of a human-readable summary.",
+)
+@click.option(
+    "--repo-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=None,
+    help="Repository root for filesystem path citations.",
+)
+def citations_cmd(
+    path: Path | None,
+    offline: bool,
+    allowed_hosts: tuple[str, ...],
+    as_json: bool,
+    repo_root: Path | None,
+) -> None:
+    """Verify citations inside PATH (or read from stdin when PATH is omitted)."""
+    text = sys.stdin.read() if path is None else path.read_text(encoding="utf-8", errors="replace")
+
+    report = verify_citations(
+        text,
+        offline=offline,
+        allowed_hosts=list(allowed_hosts) if allowed_hosts else None,
+        repo_root=repo_root,
+    )
+
+    if as_json:
+        click.echo(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    else:
+        _print_human(report)
+
+    if not report.ok:
+        sys.exit(1)
+
+
+def _print_human(report: CitationReport) -> None:
+    """Render *report* as a compact human-readable summary."""
+    click.echo(
+        f"total={report.total}"
+        f" resolved={len(report.resolved)}"
+        f" unresolved={len(report.unresolved)}"
+        f" skipped={len(report.skipped)}"
+        f" suspicious={len(report.suspicious)}",
+    )
+    if report.unresolved:
+        click.echo("unresolved:")
+        for c in report.unresolved:
+            click.echo(f"  - {c.kind}: {c.value} (offset {c.offset})")
+    if report.suspicious:
+        click.echo("suspicious:")
+        for c in report.suspicious:
+            click.echo(f"  - {c.kind}: {c.value} (offset {c.offset})")

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -56,6 +56,7 @@ from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
 from bernstein.cli.commands.best_of_n_rank_cmd import best_of_n_group
+from bernstein.cli.commands.citation_cmd import quality_group as citation_quality_group
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
 from bernstein.cli.commands.export_cmd import export_cmd
@@ -889,6 +890,9 @@ cli.add_command(dep_impact_cmd, "dep-impact")
 cli.add_command(fingerprint_group, "fingerprint")
 cli.add_command(fleet_group, "fleet")
 cli.add_command(triggers_group, "triggers")
+
+# Citation/reference existence verifier (closes #1402)
+cli.add_command(citation_quality_group, "quality")
 
 # New CLI commands
 cli.add_command(dry_run_cmd, "dry-run")

--- a/src/bernstein/core/config/config_schema.py
+++ b/src/bernstein/core/config/config_schema.py
@@ -132,6 +132,11 @@ class QualityGatesSchema(BaseModel):
     type_check_command: str = "pyright ."
     tests: bool = False
     test_command: str = "pytest tests/ -x -q"
+    # Citation/reference existence verifier (issue #1402). Off by default to
+    # keep the hot path zero-cost; opt in per project by setting to true.
+    verify_citations: bool = False
+    verify_citations_offline: bool = False
+    verify_citations_allowed_hosts: list[str] | None = None
 
 
 class RoleModelPolicyEntry(BaseModel):

--- a/src/bernstein/core/quality/citation_verifier.py
+++ b/src/bernstein/core/quality/citation_verifier.py
@@ -1,0 +1,515 @@
+"""Citation and reference existence verifier (quality gate).
+
+Closes #1402.
+
+This module extracts citation-like spans from agent-produced artefacts
+(URLs, DOIs, arXiv IDs, GitHub issue/PR refs, repo-local file paths) and
+verifies that every span resolves to a real target. Hallucinated citations
+are returned as ``unresolved`` so the gate can block the merge.
+
+Design notes
+------------
+
+* Public surface: :func:`verify_citations` plus the :class:`CitationReport`
+  dataclass. Both are import-stable.
+* Offline mode skips every network call -- only filesystem checks run and
+  hosts listed in ``allowed_hosts`` (or the IETF reserved test-hosts) are
+  treated as resolvable. This keeps the gate usable in air-gapped CI.
+* Hot-path: when the gate is not opted into via
+  ``bernstein.yaml :: quality.verify_citations: true`` the module is not
+  imported by :mod:`bernstein.core.quality.gate_pipeline` and costs zero.
+* No third-party HTTP libraries. The verifier uses :mod:`urllib.request`
+  with a 3 second timeout and HEAD probes (falling back to GET on 405).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Span extraction regexes
+# ---------------------------------------------------------------------------
+
+# arXiv IDs use either the legacy "category/YYMMNNN" or the modern
+# "YYMM.NNNNN" form. We accept both. The optional "v<digit>" suffix is the
+# version pin.
+_ARXIV_RE: Final[re.Pattern[str]] = re.compile(
+    r"""(?ix)
+    arxiv:\s*
+    (
+        \d{4}\.\d{4,5}(?:v\d+)?           # modern
+        |
+        [a-z\-]+(?:\.[a-z]{2})?/\d{7}     # legacy
+    )
+    """,
+)
+
+# DOI grammar per Crossref: "10." + registrant + "/" + suffix. We restrict
+# the suffix to printable characters that are not whitespace so we do not
+# swallow surrounding punctuation, then we trim trailing punctuation that
+# routinely follows DOIs in prose.
+_DOI_RE: Final[re.Pattern[str]] = re.compile(
+    r"""(?ix)
+    \b
+    (
+        10\.\d{4,9}                       # registrant
+        /
+        [^\s\"'<>]+                      # suffix
+    )
+    """,
+)
+
+# GitHub "org/repo#N" pattern. The slug parts use GitHub's actual rules:
+# alphanumerics plus "-", "_", ".".
+_GH_REF_RE: Final[re.Pattern[str]] = re.compile(
+    r"""(?x)
+    (?<![\w/])
+    ([A-Za-z0-9][A-Za-z0-9\-_.]*)
+    /
+    ([A-Za-z0-9][A-Za-z0-9\-_.]*)
+    \#
+    (\d+)
+    \b
+    """,
+)
+
+# URL pattern matches both http and https schemes. We deliberately keep the
+# match greedy enough to capture query strings and fragments but trim a
+# trailing set of punctuation characters at the end so URLs embedded in
+# prose ("see https://foo.com.") do not absorb the surrounding period.
+_URL_RE: Final[re.Pattern[str]] = re.compile(
+    r"""(?ix)
+    \b(https?://[^\s\"'<>\)]+)
+    """,
+)
+
+# Repo-local file paths look like "src/.../foo.py" or "tests/.../bar.py".
+# We restrict to "<word>/.../*.<ext>" with a known extension to keep the
+# false-positive rate low.
+_FILE_PATH_RE: Final[re.Pattern[str]] = re.compile(
+    r"""(?x)
+    (?<![\w/])
+    (
+        (?:src|tests|docs|scripts|benchmarks|examples)
+        /
+        [A-Za-z0-9_./-]+
+        \.
+        (?:py|md|yaml|yml|toml|json|rst|txt|sh)
+    )
+    \b
+    """,
+)
+
+_DOI_TRAILING_PUNCT: Final[str] = ".,;:)]}\"'>"
+
+# Hosts that are always considered resolvable in offline mode. RFC 2606
+# reserves example.com / example.org / example.net for documentation use,
+# and the verifier treats them as fixtures that should never fail offline.
+_OFFLINE_ALLOWED_HOSTS: Final[frozenset[str]] = frozenset(
+    {
+        "example.com",
+        "example.org",
+        "example.net",
+        "www.example.com",
+        "www.example.org",
+        "www.example.net",
+        "localhost",
+        "127.0.0.1",
+    },
+)
+
+# Network timeout for HEAD/GET probes.
+_HTTP_TIMEOUT_S: Final[float] = 3.0
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Citation:
+    """A single citation-like span extracted from an artefact.
+
+    Attributes:
+        kind: Citation kind: ``"url"``, ``"doi"``, ``"arxiv"``, ``"github"``,
+            or ``"path"``.
+        value: The verbatim span text (post-normalization).
+        offset: Byte offset of the span in the original artefact text. Used
+            for human-readable error reporting.
+    """
+
+    kind: str
+    value: str
+    offset: int
+
+
+@dataclass(frozen=True)
+class CitationReport:
+    """Result of running the verifier against a single artefact.
+
+    Attributes:
+        total: Total number of citation spans extracted.
+        resolved: Spans that resolved to a real target.
+        unresolved: Spans that did not resolve (hallucinated, dead-link, or
+            malformed). The gate fails when this list is non-empty.
+        suspicious: Spans that resolved but looked off (IDN homoglyphs,
+            self-signed redirects, etc.). The gate warns but does not fail.
+        skipped: Spans that were skipped because they were unreachable in
+            offline mode or did not pass an allow-host filter. These are
+            never counted as failures.
+    """
+
+    total: int
+    resolved: tuple[Citation, ...] = field(default_factory=tuple)
+    unresolved: tuple[Citation, ...] = field(default_factory=tuple)
+    suspicious: tuple[Citation, ...] = field(default_factory=tuple)
+    skipped: tuple[Citation, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        """Return True when no citation is unresolved."""
+        return not self.unresolved
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable rendering of the report."""
+        return {
+            "total": self.total,
+            "ok": self.ok,
+            "resolved": [_citation_to_dict(c) for c in self.resolved],
+            "unresolved": [_citation_to_dict(c) for c in self.unresolved],
+            "suspicious": [_citation_to_dict(c) for c in self.suspicious],
+            "skipped": [_citation_to_dict(c) for c in self.skipped],
+        }
+
+
+def _citation_to_dict(c: Citation) -> dict[str, object]:
+    return {"kind": c.kind, "value": c.value, "offset": c.offset}
+
+
+# ---------------------------------------------------------------------------
+# Span extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_citations(text: str) -> list[Citation]:
+    """Extract every citation-like span from *text*.
+
+    The order of citations in the returned list matches their order of
+    appearance in *text*. Overlapping matches (for example a DOI that
+    appears inside a URL) are deduplicated: URL matches always win over
+    DOI matches because the URL form is unambiguous.
+
+    Args:
+        text: Free-form artefact text.
+
+    Returns:
+        List of :class:`Citation` records.
+    """
+    citations: list[Citation] = []
+    occupied: list[tuple[int, int]] = []
+
+    def _claim(start: int, end: int) -> bool:
+        for o_start, o_end in occupied:
+            if start < o_end and end > o_start:
+                return False
+        occupied.append((start, end))
+        return True
+
+    # URLs first so they win over DOI / path matches embedded inside them.
+    for match in _URL_RE.finditer(text):
+        raw = match.group(1)
+        normalized = _strip_trailing_punct(raw)
+        end = match.start(1) + len(normalized)
+        if _claim(match.start(1), end):
+            citations.append(Citation(kind="url", value=normalized, offset=match.start(1)))
+
+    for match in _ARXIV_RE.finditer(text):
+        if _claim(match.start(), match.end()):
+            citations.append(Citation(kind="arxiv", value=match.group(1), offset=match.start(1)))
+
+    for match in _DOI_RE.finditer(text):
+        raw = match.group(1)
+        normalized = _strip_trailing_punct(raw)
+        end = match.start(1) + len(normalized)
+        if _claim(match.start(1), end):
+            citations.append(Citation(kind="doi", value=normalized, offset=match.start(1)))
+
+    for match in _GH_REF_RE.finditer(text):
+        if _claim(match.start(), match.end()):
+            citations.append(Citation(kind="github", value=match.group(0), offset=match.start()))
+
+    for match in _FILE_PATH_RE.finditer(text):
+        if _claim(match.start(1), match.end(1)):
+            citations.append(Citation(kind="path", value=match.group(1), offset=match.start(1)))
+
+    citations.sort(key=lambda c: c.offset)
+    return citations
+
+
+def _strip_trailing_punct(value: str) -> str:
+    """Trim trailing punctuation that prose routinely appends to citations."""
+    return value.rstrip(_DOI_TRAILING_PUNCT)
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def _normalize_host(value: str) -> str:
+    """Return the lower-cased host from a URL, or empty string on failure."""
+    try:
+        parsed = urllib.parse.urlsplit(value)
+    except ValueError:
+        return ""
+    host = parsed.hostname or ""
+    return host.lower()
+
+
+def _is_idn_suspicious(host: str) -> bool:
+    """Flag hostnames that mix scripts (a classic homoglyph trick)."""
+    if not host:
+        return False
+    # Pure ASCII is always safe.
+    if host.isascii():
+        return False
+    # Mixed ASCII + non-ASCII in the same label is the canonical homoglyph
+    # red flag (e.g. "g00gle" with a Cyrillic "o" interleaved).
+    for label in host.split("."):
+        has_ascii_letter = any(ch.isascii() and ch.isalpha() for ch in label)
+        has_non_ascii = any(not ch.isascii() for ch in label)
+        if has_ascii_letter and has_non_ascii:
+            return True
+    return False
+
+
+def _check_url(
+    citation: Citation,
+    *,
+    offline: bool,
+    allowed_hosts: frozenset[str] | None,
+) -> tuple[str, bool]:
+    """Resolve a URL citation.
+
+    Returns:
+        Tuple ``(bucket, suspicious)`` where bucket is one of
+        ``"resolved"``, ``"unresolved"``, or ``"skipped"``.
+    """
+    host = _normalize_host(citation.value)
+    if not host:
+        return "unresolved", False
+
+    suspicious = _is_idn_suspicious(host)
+
+    if allowed_hosts is not None and host not in allowed_hosts:
+        return "skipped", suspicious
+
+    if offline:
+        if host in _OFFLINE_ALLOWED_HOSTS or (allowed_hosts is not None and host in allowed_hosts):
+            return "resolved", suspicious
+        return "skipped", suspicious
+
+    try:
+        request = urllib.request.Request(citation.value, method="HEAD")
+        with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_S) as resp:
+            status = int(resp.status)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 405:
+            return _check_url_fallback_get(citation), suspicious
+        if 200 <= exc.code < 400:
+            return "resolved", suspicious
+        return "unresolved", suspicious
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return "unresolved", suspicious
+
+    if 200 <= status < 400:
+        return "resolved", suspicious
+    return "unresolved", suspicious
+
+
+def _check_url_fallback_get(citation: Citation) -> str:
+    """Fallback for servers that reject HEAD with 405."""
+    try:
+        request = urllib.request.Request(citation.value, method="GET")
+        with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_S) as resp:
+            return "resolved" if 200 <= int(resp.status) < 400 else "unresolved"
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError):
+        return "unresolved"
+
+
+def _check_arxiv(citation: Citation, *, offline: bool) -> str:
+    """Resolve an arXiv ID via the public abstract URL."""
+    if offline:
+        # Validate shape only: arXiv IDs are deterministic enough that a
+        # shape check is meaningful even offline.
+        return "resolved" if _ARXIV_RE.fullmatch(f"arXiv:{citation.value}") else "unresolved"
+    url = f"https://arxiv.org/abs/{citation.value}"
+    probe = Citation(kind="url", value=url, offset=citation.offset)
+    bucket, _ = _check_url(probe, offline=False, allowed_hosts=None)
+    return bucket
+
+
+def _check_doi(citation: Citation, *, offline: bool) -> str:
+    """Resolve a DOI via dx.doi.org."""
+    if offline:
+        return "resolved" if _DOI_RE.fullmatch(citation.value) else "unresolved"
+    url = f"https://doi.org/{citation.value}"
+    probe = Citation(kind="url", value=url, offset=citation.offset)
+    bucket, _ = _check_url(probe, offline=False, allowed_hosts=None)
+    return bucket
+
+
+def _check_github(citation: Citation, *, offline: bool) -> str:
+    """Resolve a "org/repo#N" GitHub reference."""
+    match = _GH_REF_RE.fullmatch(citation.value)
+    if match is None:
+        return "unresolved"
+    if offline:
+        return "resolved"
+    org, repo, num = match.group(1), match.group(2), match.group(3)
+    url = f"https://github.com/{org}/{repo}/issues/{num}"
+    probe = Citation(kind="url", value=url, offset=citation.offset)
+    bucket, _ = _check_url(probe, offline=False, allowed_hosts=None)
+    return bucket
+
+
+def _check_path(citation: Citation, *, repo_root: Path | None) -> str:
+    """Resolve a repo-local file path against *repo_root*."""
+    root = repo_root or Path.cwd()
+    candidate = (root / citation.value).resolve()
+    # Containment check: refuse to confirm paths that escape the repo
+    # root, otherwise an artefact could "cite" /etc/passwd.
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError:
+        return "unresolved"
+    return "resolved" if candidate.exists() else "unresolved"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def verify_citations(
+    text: str,
+    *,
+    offline: bool = False,
+    allowed_hosts: list[str] | None = None,
+    repo_root: Path | None = None,
+) -> CitationReport:
+    """Verify every citation in *text* against an authoritative source.
+
+    Args:
+        text: Free-form artefact text. Pass the raw markdown / plaintext
+            body; the verifier handles its own extraction.
+        offline: When True, network probes are skipped. URLs whose host
+            sits in :data:`_OFFLINE_ALLOWED_HOSTS` (RFC 2606 reserved
+            test hosts) or in ``allowed_hosts`` resolve as a fixture.
+        allowed_hosts: Optional allow-list of hostnames. When set, every
+            URL whose host is not in the list is skipped (never failed).
+            Useful for whitelisting canonical sources in a slow CI env.
+        repo_root: Filesystem root for ``path`` citations. Defaults to
+            the current working directory.
+
+    Returns:
+        :class:`CitationReport`.
+    """
+    citations = extract_citations(text)
+    allow_set = frozenset(h.lower() for h in allowed_hosts) if allowed_hosts is not None else None
+
+    resolved: list[Citation] = []
+    unresolved: list[Citation] = []
+    suspicious: list[Citation] = []
+    skipped: list[Citation] = []
+
+    for citation in citations:
+        bucket, is_suspicious = _dispatch(
+            citation,
+            offline=offline,
+            allowed_hosts=allow_set,
+            repo_root=repo_root,
+        )
+        if bucket == "resolved":
+            resolved.append(citation)
+        elif bucket == "unresolved":
+            unresolved.append(citation)
+        elif bucket == "skipped":
+            skipped.append(citation)
+        if is_suspicious:
+            suspicious.append(citation)
+
+    return CitationReport(
+        total=len(citations),
+        resolved=tuple(resolved),
+        unresolved=tuple(unresolved),
+        suspicious=tuple(suspicious),
+        skipped=tuple(skipped),
+    )
+
+
+def _dispatch(
+    citation: Citation,
+    *,
+    offline: bool,
+    allowed_hosts: frozenset[str] | None,
+    repo_root: Path | None,
+) -> tuple[str, bool]:
+    """Route *citation* to the right resolver, return (bucket, suspicious)."""
+    if citation.kind == "url":
+        return _check_url(citation, offline=offline, allowed_hosts=allowed_hosts)
+    if citation.kind == "arxiv":
+        return _check_arxiv(citation, offline=offline), False
+    if citation.kind == "doi":
+        return _check_doi(citation, offline=offline), False
+    if citation.kind == "github":
+        return _check_github(citation, offline=offline), False
+    if citation.kind == "path":
+        return _check_path(citation, repo_root=repo_root), False
+    return "unresolved", False
+
+
+# ---------------------------------------------------------------------------
+# Gate-pipeline adapter
+# ---------------------------------------------------------------------------
+
+
+def gate_verify_citations(
+    artefact_text: str,
+    *,
+    offline: bool = False,
+    allowed_hosts: list[str] | None = None,
+    repo_root: Path | None = None,
+) -> tuple[bool, str]:
+    """Adapter used by the quality gate pipeline.
+
+    Returns:
+        Tuple ``(passed, details)`` where ``passed`` is True iff no
+        citation went unresolved, and ``details`` is a one-line summary
+        suitable for inclusion in a :class:`GateResult`.
+    """
+    report = verify_citations(
+        artefact_text,
+        offline=offline,
+        allowed_hosts=allowed_hosts,
+        repo_root=repo_root,
+    )
+    if report.ok:
+        return True, (
+            f"citation_verifier: {len(report.resolved)}/{report.total} resolved"
+            f" ({len(report.skipped)} skipped, {len(report.suspicious)} suspicious)"
+        )
+    unresolved_summary = ", ".join(f"{c.kind}:{c.value}" for c in report.unresolved[:5])
+    if len(report.unresolved) > 5:
+        unresolved_summary += f" (+{len(report.unresolved) - 5} more)"
+    return False, f"citation_verifier: {len(report.unresolved)} unresolved -- {unresolved_summary}"

--- a/tests/integration/quality/test_citation_verifier_http.py
+++ b/tests/integration/quality/test_citation_verifier_http.py
@@ -1,0 +1,126 @@
+"""Integration tests for the citation verifier against a fixture HTTP server.
+
+A small in-process ``http.server.HTTPServer`` impersonates the public
+endpoints (arXiv abstract, doi.org redirector, github issue page, plus
+a couple of synthetic 200/404/405 routes) so the verifier's online code
+paths can be exercised without touching the real internet.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from contextlib import closing
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import ClassVar
+
+import pytest
+
+from bernstein.core.quality import citation_verifier as cv
+from bernstein.core.quality.citation_verifier import verify_citations
+
+
+class _FixtureHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP handler with a routing table the verifier can exercise."""
+
+    # Map of "<method> <path>" -> (status, body).
+    routes: ClassVar[dict[str, tuple[int, bytes]]] = {
+        "HEAD /ok": (200, b""),
+        "GET /ok": (200, b"ok"),
+        "HEAD /redirect": (301, b""),
+        "GET /redirect": (301, b""),
+        "HEAD /missing": (404, b""),
+        "GET /missing": (404, b"missing"),
+        "HEAD /head-not-allowed": (405, b""),
+        "GET /head-not-allowed": (200, b"ok"),
+        "HEAD /server-error": (500, b""),
+        "GET /server-error": (500, b"oops"),
+    }
+
+    def do_HEAD(self) -> None:
+        self._dispatch("HEAD")
+
+    def do_GET(self) -> None:
+        self._dispatch("GET")
+
+    def _dispatch(self, method: str) -> None:
+        key = f"{method} {self.path}"
+        status, body = self.routes.get(key, (404, b"missing"))
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        if method != "HEAD":
+            self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return  # silence stderr noise during tests
+
+
+@pytest.fixture
+def http_server() -> Iterator[str]:
+    """Spin up the fixture HTTP server on an ephemeral port.
+
+    Yields the base URL (e.g. ``http://127.0.0.1:54321``).
+    """
+    server = HTTPServer(("127.0.0.1", 0), _FixtureHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address[0], server.server_address[1]
+        yield f"http://{host}:{port}"
+    finally:
+        server.shutdown()
+        with closing(server.socket):
+            pass
+        thread.join(timeout=2)
+
+
+def test_integration_200_resolves(http_server: str) -> None:
+    report = verify_citations(f"see {http_server}/ok here")
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_integration_404_unresolved(http_server: str) -> None:
+    report = verify_citations(f"see {http_server}/missing here")
+    assert not report.ok
+    assert len(report.unresolved) == 1
+
+
+def test_integration_405_falls_back_to_get_resolves(http_server: str) -> None:
+    report = verify_citations(f"see {http_server}/head-not-allowed here")
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_integration_3xx_redirect_resolves(http_server: str) -> None:
+    report = verify_citations(f"see {http_server}/redirect here")
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_integration_5xx_unresolved(http_server: str) -> None:
+    report = verify_citations(f"see {http_server}/server-error here")
+    assert not report.ok
+    assert len(report.unresolved) == 1
+
+
+def test_integration_mixed_artefact(http_server: str) -> None:
+    text = (
+        f"resolved at {http_server}/ok"
+        f" but {http_server}/missing failed"
+        f" and {http_server}/head-not-allowed worked after fallback"
+    )
+    report = verify_citations(text)
+    assert report.total == 3
+    assert len(report.resolved) == 2
+    assert len(report.unresolved) == 1
+
+
+def test_integration_short_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Wire a deliberately tiny timeout and an unreachable server.
+    monkeypatch.setattr(cv, "_HTTP_TIMEOUT_S", 0.001)
+    # 198.51.100.1 is from TEST-NET-2 (RFC 5737) -- guaranteed
+    # non-routable.
+    report = verify_citations("see https://198.51.100.1/x")
+    assert not report.ok

--- a/tests/property/test_citation_verifier_properties.py
+++ b/tests/property/test_citation_verifier_properties.py
@@ -1,0 +1,234 @@
+"""Property-based tests for the citation verifier (issue #1402).
+
+Hypothesis hammers the verifier with structured-random inputs to make
+sure invariants hold across edge cases that hand-written tests miss.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.quality.citation_verifier import (
+    Citation,
+    extract_citations,
+    verify_citations,
+)
+
+_SUPPRESS = (HealthCheck.too_slow, HealthCheck.filter_too_much)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_clean_text(s: str) -> bool:
+    # Avoid control characters that confuse regex anchoring.
+    return all(c.isprintable() or c == " " for c in s)
+
+
+_simple_text = st.text(
+    alphabet=st.characters(blacklist_categories=("Cc", "Cs")),
+    min_size=0,
+    max_size=200,
+).filter(_is_clean_text)
+
+
+# ---------------------------------------------------------------------------
+# Property 1: extract_citations is total and never raises.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=200)
+@given(text=_simple_text)
+def test_extract_is_total(text: str) -> None:
+    # Property: extract_citations must accept any text input and return a
+    # list of Citation records. Critical for use as a quality gate that
+    # consumes arbitrary agent-produced output.
+    result = extract_citations(text)
+    assert isinstance(result, list)
+    for c in result:
+        assert isinstance(c, Citation)
+        assert c.kind in {"url", "doi", "arxiv", "github", "path"}
+
+
+# ---------------------------------------------------------------------------
+# Property 2: verify_citations is total in offline mode.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=200)
+@given(text=_simple_text)
+def test_verify_total_offline(text: str) -> None:
+    report = verify_citations(text, offline=True)
+    assert (
+        report.total
+        == len(report.resolved) + len(report.unresolved) + len(report.skipped)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 3: offsets always non-negative and within text bounds.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=200)
+@given(text=_simple_text)
+def test_offsets_within_text(text: str) -> None:
+    for c in extract_citations(text):
+        assert 0 <= c.offset <= len(text)
+
+
+# ---------------------------------------------------------------------------
+# Property 4: every extracted citation occurs in the source text.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=200)
+@given(text=_simple_text)
+def test_extracted_values_substring(text: str) -> None:
+    for c in extract_citations(text):
+        # URLs and DOIs may have trailing punctuation stripped; the
+        # remaining prefix must still appear verbatim.
+        assert c.value in text
+
+
+# ---------------------------------------------------------------------------
+# Property 5: ordering invariant (offsets non-decreasing).
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=200)
+@given(text=_simple_text)
+def test_citations_sorted_by_offset(text: str) -> None:
+    cs = extract_citations(text)
+    offsets = [c.offset for c in cs]
+    assert offsets == sorted(offsets)
+
+
+# ---------------------------------------------------------------------------
+# Property 6: synthetic arXiv IDs always extract.
+# ---------------------------------------------------------------------------
+
+
+_year_month = st.integers(min_value=1, max_value=99).map(lambda y: f"{y:02d}")
+_month = st.integers(min_value=1, max_value=12).map(lambda m: f"{m:02d}")
+_seq = st.integers(min_value=0, max_value=99_999).map(lambda n: f"{n:05d}")
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=100)
+@given(yy=_year_month, mm=_month, seq=_seq)
+def test_synthetic_arxiv_extracts(yy: str, mm: str, seq: str) -> None:
+    aid = f"{yy}{mm}.{seq}"
+    text = f"see arXiv:{aid} for details"
+    found = [c.value for c in extract_citations(text) if c.kind == "arxiv"]
+    assert aid in found
+
+
+# ---------------------------------------------------------------------------
+# Property 7: synthetic DOI strings always extract.
+# ---------------------------------------------------------------------------
+
+
+_doi_suffix = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz0123456789._-",
+    min_size=1,
+    max_size=20,
+)
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=100)
+@given(registrant=st.integers(min_value=1000, max_value=999_999_999), suffix=_doi_suffix)
+def test_synthetic_doi_extracts(registrant: int, suffix: str) -> None:
+    assume(not suffix.endswith(("." , "-", "_")))
+    doi = f"10.{registrant}/{suffix}"
+    text = f"see {doi} for details"
+    found = [c.value for c in extract_citations(text) if c.kind == "doi"]
+    assert doi in found
+
+
+# ---------------------------------------------------------------------------
+# Property 8: GitHub ref pattern is robust.
+# ---------------------------------------------------------------------------
+
+
+_slug_alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=100)
+@given(
+    org=st.text(alphabet=_slug_alphabet, min_size=1, max_size=20),
+    repo=st.text(alphabet=_slug_alphabet, min_size=1, max_size=20),
+    num=st.integers(min_value=1, max_value=999_999),
+)
+def test_synthetic_github_ref_extracts(org: str, repo: str, num: int) -> None:
+    ref = f"{org}/{repo}#{num}"
+    text = f"see {ref} here"
+    found = [c.value for c in extract_citations(text) if c.kind == "github"]
+    assert ref in found
+
+
+# ---------------------------------------------------------------------------
+# Property 9: offline+empty allow-list never resolves arbitrary hosts.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=100)
+@given(host=st.from_regex(r"[a-z]{3,10}\.invalidtld", fullmatch=True))
+def test_offline_unknown_host_skipped(host: str) -> None:
+    text = f"see https://{host}/path here"
+    report = verify_citations(text, offline=True, allowed_hosts=[])
+    # Unknown host with empty allow-list: skipped, never failed.
+    assert len(report.skipped) == 1
+    assert not report.unresolved
+
+
+# ---------------------------------------------------------------------------
+# Property 10: allow-host filter strictly partitions URLs.
+# ---------------------------------------------------------------------------
+
+
+_hostname = st.from_regex(r"[a-z]{3,15}\.example", fullmatch=True)
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=100)
+@given(host=_hostname)
+def test_listed_host_resolves_offline(host: str) -> None:
+    text = f"see https://{host}/x here"
+    report = verify_citations(text, offline=True, allowed_hosts=[host])
+    assert len(report.resolved) == 1
+    assert not report.unresolved
+
+
+# ---------------------------------------------------------------------------
+# Property 11: report.ok matches unresolved emptiness.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=200)
+@given(text=_simple_text)
+def test_report_ok_iff_no_unresolved(text: str) -> None:
+    report = verify_citations(text, offline=True)
+    assert report.ok == (len(report.unresolved) == 0)
+
+
+# ---------------------------------------------------------------------------
+# Property 12: path resolver never escapes the repo root.
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=_SUPPRESS, max_examples=50)
+@given(suffix=st.from_regex(r"src/[a-z]{1,10}/[a-z]{1,10}\.py", fullmatch=True))
+def test_path_outside_repo_unresolved(suffix: str, tmp_path_factory: object) -> None:
+    # Generate a fresh tmp_path on each call.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        text = f"changed {suffix}"
+        report = verify_citations(text, offline=True, repo_root=root)
+        # No such file exists in the empty tmp dir -> must be unresolved.
+        assert any(c.value == suffix for c in report.unresolved)

--- a/tests/unit/quality/test_citation_verifier.py
+++ b/tests/unit/quality/test_citation_verifier.py
@@ -1,0 +1,586 @@
+"""Unit tests for :mod:`bernstein.core.quality.citation_verifier` (issue #1402).
+
+These tests run entirely offline. Network-bound resolution paths are tested
+in ``tests/integration/quality/test_citation_verifier_http.py`` against a
+fixture HTTP server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from bernstein.core.quality.citation_verifier import (
+    Citation,
+    CitationReport,
+    _is_idn_suspicious,
+    _normalize_host,
+    _strip_trailing_punct,
+    extract_citations,
+    gate_verify_citations,
+    verify_citations,
+)
+
+# ---------------------------------------------------------------------------
+# extract_citations -- URL extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_simple_http_url() -> None:
+    cs = extract_citations("see http://example.com for details")
+    assert any(c.kind == "url" and c.value == "http://example.com" for c in cs)
+
+
+def test_extract_simple_https_url() -> None:
+    cs = extract_citations("see https://example.com for details")
+    assert any(c.kind == "url" and c.value == "https://example.com" for c in cs)
+
+
+def test_extract_url_strips_trailing_period() -> None:
+    cs = extract_citations("Visit https://example.com.")
+    urls = [c for c in cs if c.kind == "url"]
+    assert urls == [Citation(kind="url", value="https://example.com", offset=urls[0].offset)]
+
+
+def test_extract_url_strips_trailing_comma() -> None:
+    cs = extract_citations("Visit https://example.com, then continue")
+    urls = [c for c in cs if c.kind == "url"]
+    assert urls[0].value == "https://example.com"
+
+
+def test_extract_url_preserves_path_query_fragment() -> None:
+    cs = extract_citations("see https://example.com/path?x=1#frag end")
+    urls = [c for c in cs if c.kind == "url"]
+    assert urls[0].value == "https://example.com/path?x=1#frag"
+
+
+def test_extract_multiple_urls() -> None:
+    cs = extract_citations("a https://example.com b https://example.org c")
+    urls = [c.value for c in cs if c.kind == "url"]
+    assert "https://example.com" in urls
+    assert "https://example.org" in urls
+
+
+def test_extract_no_url_for_bare_text() -> None:
+    cs = extract_citations("plain text without any references")
+    assert cs == []
+
+
+# ---------------------------------------------------------------------------
+# extract_citations -- arXiv
+# ---------------------------------------------------------------------------
+
+
+def test_extract_modern_arxiv() -> None:
+    cs = extract_citations("see arXiv:2401.12345 for details")
+    assert any(c.kind == "arxiv" and c.value == "2401.12345" for c in cs)
+
+
+def test_extract_modern_arxiv_with_version() -> None:
+    cs = extract_citations("arXiv:2401.12345v2")
+    arx = [c for c in cs if c.kind == "arxiv"]
+    assert arx and arx[0].value == "2401.12345v2"
+
+
+def test_extract_legacy_arxiv() -> None:
+    cs = extract_citations("see arXiv:cs.LG/0701001 for details")
+    arx = [c for c in cs if c.kind == "arxiv"]
+    assert arx and arx[0].value == "cs.LG/0701001"
+
+
+def test_extract_arxiv_case_insensitive() -> None:
+    cs = extract_citations("ARXIV:2401.12345")
+    assert any(c.kind == "arxiv" for c in cs)
+
+
+def test_extract_arxiv_missing_id_not_matched() -> None:
+    cs = extract_citations("arXiv: not an id")
+    assert not any(c.kind == "arxiv" for c in cs)
+
+
+# ---------------------------------------------------------------------------
+# extract_citations -- DOI
+# ---------------------------------------------------------------------------
+
+
+def test_extract_doi() -> None:
+    cs = extract_citations("see 10.1038/nature12373 for details")
+    assert any(c.kind == "doi" and c.value == "10.1038/nature12373" for c in cs)
+
+
+def test_extract_doi_strips_trailing_period() -> None:
+    cs = extract_citations("see 10.1038/nature12373.")
+    dois = [c for c in cs if c.kind == "doi"]
+    assert dois and dois[0].value == "10.1038/nature12373"
+
+
+def test_extract_doi_complex_suffix() -> None:
+    cs = extract_citations("doi 10.1234/abc.def-ghi_jkl(2023)")
+    dois = [c for c in cs if c.kind == "doi"]
+    assert dois and dois[0].value.startswith("10.1234/abc.def-ghi_jkl")
+
+
+def test_extract_no_doi_for_short_registrant() -> None:
+    cs = extract_citations("number 10.1/x is too short")
+    assert not any(c.kind == "doi" for c in cs)
+
+
+# ---------------------------------------------------------------------------
+# extract_citations -- GitHub refs
+# ---------------------------------------------------------------------------
+
+
+def test_extract_github_issue_ref() -> None:
+    cs = extract_citations("see chernistry/bernstein#1402 for context")
+    gh = [c for c in cs if c.kind == "github"]
+    assert gh and gh[0].value == "chernistry/bernstein#1402"
+
+
+def test_extract_github_repo_with_dot() -> None:
+    cs = extract_citations("see foo/bar.baz#42")
+    gh = [c for c in cs if c.kind == "github"]
+    assert gh and gh[0].value == "foo/bar.baz#42"
+
+
+def test_extract_no_github_without_hash() -> None:
+    cs = extract_citations("just org/repo here")
+    assert not any(c.kind == "github" for c in cs)
+
+
+# ---------------------------------------------------------------------------
+# extract_citations -- file paths
+# ---------------------------------------------------------------------------
+
+
+def test_extract_repo_file_path_py() -> None:
+    cs = extract_citations("changed src/bernstein/core/quality/citation_verifier.py here")
+    paths = [c for c in cs if c.kind == "path"]
+    assert paths and paths[0].value == "src/bernstein/core/quality/citation_verifier.py"
+
+
+def test_extract_repo_file_path_md() -> None:
+    cs = extract_citations("see docs/architecture/DESIGN.md")
+    paths = [c for c in cs if c.kind == "path"]
+    assert paths and paths[0].value == "docs/architecture/DESIGN.md"
+
+
+def test_extract_no_path_for_unknown_root() -> None:
+    cs = extract_citations("/etc/passwd is bad")
+    assert not any(c.kind == "path" for c in cs)
+
+
+def test_extract_no_path_for_unknown_extension() -> None:
+    cs = extract_citations("src/foo/bar.xyz unknown ext")
+    assert not any(c.kind == "path" for c in cs)
+
+
+# ---------------------------------------------------------------------------
+# extract_citations -- ordering and de-dup
+# ---------------------------------------------------------------------------
+
+
+def test_extract_returns_in_document_order() -> None:
+    text = "first arXiv:2401.12345 then https://example.com then 10.1234/foo.bar"
+    cs = extract_citations(text)
+    offsets = [c.offset for c in cs]
+    assert offsets == sorted(offsets)
+
+
+def test_extract_does_not_double_match_url_and_doi() -> None:
+    # A DOI embedded inside a URL must not also be reported as a DOI.
+    cs = extract_citations("see https://doi.org/10.1038/nature12373 for refs")
+    kinds = [c.kind for c in cs]
+    assert kinds.count("doi") == 0
+    assert kinds.count("url") == 1
+
+
+# ---------------------------------------------------------------------------
+# verify_citations -- offline mode
+# ---------------------------------------------------------------------------
+
+
+def test_offline_example_com_resolves() -> None:
+    report = verify_citations("see https://example.com here", offline=True)
+    assert report.ok
+    assert report.total == 1
+    assert len(report.resolved) == 1
+
+
+def test_offline_unknown_host_is_skipped_not_failed() -> None:
+    report = verify_citations("see https://unknown-host-xyz.invalid here", offline=True)
+    assert report.ok  # not failed
+    assert len(report.skipped) == 1
+    assert len(report.unresolved) == 0
+
+
+def test_offline_allowed_hosts_resolves() -> None:
+    report = verify_citations(
+        "see https://mycorp.example here",
+        offline=True,
+        allowed_hosts=["mycorp.example"],
+    )
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_offline_doi_shape_check_resolves() -> None:
+    report = verify_citations("doi 10.1038/nature12373", offline=True)
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_offline_arxiv_shape_check_resolves() -> None:
+    report = verify_citations("arXiv:2401.12345", offline=True)
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_offline_github_ref_resolves() -> None:
+    report = verify_citations("see foo/bar#123", offline=True)
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+# ---------------------------------------------------------------------------
+# verify_citations -- allow-host filter
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_hosts_filter_skips_non_listed(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When allowed_hosts is set, a non-listed URL must be skipped (not
+    # failed) even when offline mode is off.
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("network must not be called when filtered")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    report = verify_citations(
+        "see https://blocked.example",
+        allowed_hosts=["allowed.example"],
+    )
+    assert report.ok
+    assert len(report.skipped) == 1
+
+
+def test_allowed_hosts_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise AssertionError("network must not be called when offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    report = verify_citations(
+        "see https://MyCorp.Example",
+        offline=True,
+        allowed_hosts=["mycorp.example"],
+    )
+    assert len(report.resolved) == 1
+
+
+# ---------------------------------------------------------------------------
+# verify_citations -- malformed URLs
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_url_no_host_is_unresolved() -> None:
+    # urlsplit gives an empty hostname here -> unresolved.
+    cs = [Citation(kind="url", value="http://", offset=0)]
+    with patch("bernstein.core.quality.citation_verifier.extract_citations", return_value=cs):
+        report = verify_citations("dummy")
+    assert not report.ok
+    assert len(report.unresolved) == 1
+
+
+def test_truncated_url_is_unresolved() -> None:
+    cs = [Citation(kind="url", value="ht!tp://broken", offset=0)]
+    with patch("bernstein.core.quality.citation_verifier.extract_citations", return_value=cs):
+        report = verify_citations("dummy")
+    assert not report.ok
+
+
+# ---------------------------------------------------------------------------
+# verify_citations -- repo-local paths
+# ---------------------------------------------------------------------------
+
+
+def test_path_resolves_when_file_exists(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").write_text("# stub")
+    report = verify_citations("changed src/foo.py", repo_root=tmp_path)
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_path_unresolved_when_file_missing(tmp_path: Path) -> None:
+    report = verify_citations("changed src/missing.py", repo_root=tmp_path)
+    assert not report.ok
+    assert len(report.unresolved) == 1
+
+
+def test_path_escape_attempt_is_unresolved(tmp_path: Path) -> None:
+    # A traversal that escapes the repo root must not be reported as
+    # resolved even if the absolute target exists.
+    report = verify_citations("see src/../../etc/passwd-no", repo_root=tmp_path)
+    # Either unresolved or not extracted; either way the gate must not
+    # call it resolved.
+    assert all(c.kind != "path" or c not in report.resolved for c in report.resolved)
+
+
+# ---------------------------------------------------------------------------
+# Dead link detection (offline allow-host whitelist disabled)
+# ---------------------------------------------------------------------------
+
+
+def test_dead_url_unresolved_via_urlerror(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error as _urlerr
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise _urlerr.URLError("no route")
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise)
+    report = verify_citations("see https://dead.example.test")
+    assert not report.ok
+    assert len(report.unresolved) == 1
+
+
+def test_dead_url_unresolved_via_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise TimeoutError("timeout")
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise)
+    report = verify_citations("see https://slow.example.test")
+    assert not report.ok
+
+
+def test_404_returns_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error as _urlerr
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise _urlerr.HTTPError("https://x", 404, "not found", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("urllib.request.urlopen", _raise)
+    report = verify_citations("see https://gone.example.test")
+    assert not report.ok
+
+
+def test_405_falls_back_to_get(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error as _urlerr
+
+    calls: list[str] = []
+
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self) -> _FakeResp:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    def _maybe_raise(req: object, *args: object, **kwargs: object) -> _FakeResp:
+        method = getattr(req, "get_method", lambda: "")()
+        calls.append(method)
+        if method == "HEAD":
+            raise _urlerr.HTTPError("https://x", 405, "method not allowed", {}, None)  # type: ignore[arg-type]
+        return _FakeResp()
+
+    monkeypatch.setattr("urllib.request.urlopen", _maybe_raise)
+    report = verify_citations("see https://no-head.example.test")
+    assert report.ok
+    assert "HEAD" in calls
+    assert "GET" in calls
+
+
+def test_redirect_3xx_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeResp:
+        status = 301
+
+        def __enter__(self) -> _FakeResp:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+    report = verify_citations("see https://redirect.example.test")
+    assert report.ok
+
+
+# ---------------------------------------------------------------------------
+# IDN handling
+# ---------------------------------------------------------------------------
+
+
+def test_pure_ascii_host_not_suspicious() -> None:
+    assert not _is_idn_suspicious("example.com")
+
+
+def test_pure_unicode_host_not_suspicious() -> None:
+    # Pure-script labels are common (intl TLDs) and must not be flagged.
+    assert not _is_idn_suspicious("пример.рф")
+
+
+def test_mixed_script_label_flagged() -> None:
+    # "exаmple.com" -- the "а" is Cyrillic. Pyright/Ruff allow unicode in
+    # source strings; the verifier must flag this label.
+    assert _is_idn_suspicious("exаmple.com")  # noqa: RUF001 - intentional homoglyph
+
+
+def test_idn_suspicious_url_appears_in_report(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeResp:
+        status = 200
+
+        def __enter__(self) -> _FakeResp:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+    report = verify_citations("see https://exаmple.com")  # noqa: RUF001 - intentional homoglyph
+    assert any(_is_idn_suspicious(_normalize_host(c.value)) for c in report.suspicious)
+
+
+def test_empty_host_returns_empty_string() -> None:
+    assert _normalize_host("not a url at all") == ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_strip_trailing_punct_handles_multiple() -> None:
+    assert _strip_trailing_punct("https://x.com).") == "https://x.com"
+
+
+def test_strip_trailing_punct_keeps_significant_chars() -> None:
+    assert _strip_trailing_punct("https://x.com/path?a=b") == "https://x.com/path?a=b"
+
+
+# ---------------------------------------------------------------------------
+# CitationReport
+# ---------------------------------------------------------------------------
+
+
+def test_citation_report_ok_true_when_no_unresolved() -> None:
+    report = CitationReport(total=0)
+    assert report.ok
+
+
+def test_citation_report_ok_false_when_unresolved() -> None:
+    bad = Citation(kind="url", value="http://x", offset=0)
+    report = CitationReport(total=1, unresolved=(bad,))
+    assert not report.ok
+
+
+def test_citation_report_to_dict_is_serialisable() -> None:
+    import json as _json
+
+    good = Citation(kind="url", value="https://example.com", offset=4)
+    report = CitationReport(total=1, resolved=(good,))
+    payload = report.to_dict()
+    assert _json.dumps(payload, sort_keys=True)  # must not raise
+
+
+def test_citation_report_to_dict_includes_all_buckets() -> None:
+    citation = Citation(kind="url", value="https://x.com", offset=0)
+    report = CitationReport(
+        total=4,
+        resolved=(citation,),
+        unresolved=(citation,),
+        suspicious=(citation,),
+        skipped=(citation,),
+    )
+    payload = report.to_dict()
+    assert {"total", "ok", "resolved", "unresolved", "suspicious", "skipped"} <= set(payload)
+
+
+# ---------------------------------------------------------------------------
+# Gate adapter
+# ---------------------------------------------------------------------------
+
+
+def test_gate_passes_when_all_resolve() -> None:
+    passed, details = gate_verify_citations("see https://example.com", offline=True)
+    assert passed
+    assert "1/1 resolved" in details
+
+
+def test_gate_fails_when_unresolved(tmp_path: Path) -> None:
+    passed, details = gate_verify_citations(
+        "changed src/missing.py", offline=True, repo_root=tmp_path,
+    )
+    assert not passed
+    assert "unresolved" in details
+    assert "src/missing.py" in details
+
+
+def test_gate_summary_truncates_long_unresolved_list(tmp_path: Path) -> None:
+    text = " ".join(f"src/missing_{i}.py" for i in range(10))
+    passed, details = gate_verify_citations(text, offline=True, repo_root=tmp_path)
+    assert not passed
+    assert "more" in details
+
+
+def test_gate_includes_skipped_in_summary() -> None:
+    passed, details = gate_verify_citations(
+        "see https://not-allowlisted.invalid",
+        offline=True,
+    )
+    assert passed
+    assert "skipped" in details
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_text_returns_empty_report() -> None:
+    report = verify_citations("", offline=True)
+    assert report.total == 0
+    assert report.ok
+
+
+def test_only_whitespace_returns_empty_report() -> None:
+    report = verify_citations("   \n\t\n   ", offline=True)
+    assert report.total == 0
+
+
+def test_unicode_text_does_not_crash() -> None:
+    report = verify_citations("ссылка на https://example.com тут", offline=True)
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_localhost_resolved_offline() -> None:
+    report = verify_citations("see http://localhost:8080", offline=True)
+    assert report.ok
+    assert len(report.resolved) == 1
+
+
+def test_very_long_text_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The verifier must handle large artefacts without quadratic blowup.
+    text = ("filler " * 10_000) + "see https://example.com end"
+    report = verify_citations(text, offline=True)
+    assert report.ok
+
+
+def test_multiple_kinds_in_same_text(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "foo.py").touch()
+    text = (
+        "fix in src/foo.py per arXiv:2401.12345 (10.1038/nature12373) "
+        "see https://example.com chernistry/bernstein#1402"
+    )
+    report = verify_citations(text, offline=True, repo_root=tmp_path)
+    assert report.ok
+    assert report.total == 5
+    kinds = {c.kind for c in report.resolved}
+    assert kinds == {"url", "doi", "arxiv", "github", "path"}
+
+
+def test_repeat_url_extracted_each_time() -> None:
+    cs = extract_citations("a https://example.com b https://example.com c")
+    urls = [c for c in cs if c.kind == "url"]
+    assert len(urls) == 2

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -207,6 +207,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "simulate",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "telemetry",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "quality",
     }
 )
 


### PR DESCRIPTION
## Summary

Adds a quality gate that verifies every citation in agent-produced output actually resolves. Closes #1402.

* **Extractors**: URLs (HTTP/HTTPS), DOIs, arXiv IDs (legacy + modern, optional version pin), GitHub `org/repo#N` refs, repo-local file paths
* **Resolvers**: HEAD probe with 3 s timeout and GET fallback on 405; filesystem check (with traversal containment) for paths; shape check for DOIs/arXiv when offline
* **Public surface**: `verify_citations(text, *, offline, allowed_hosts, repo_root) -> CitationReport` plus `CitationReport.to_dict()`
* **Opt-in**: `bernstein.yaml :: quality.verify_citations: true` (default false -- zero overhead when not enabled)
* **CLI**: `bernstein quality citations <file-or-stdin>` with `--offline`, `--allowed-host`, `--json`, `--repo-root`
* **IDN homoglyph detection**: mixed ASCII/non-ASCII labels surface in `report.suspicious`

## Test plan

- [x] 65 unit tests (`tests/unit/quality/test_citation_verifier.py`) -- offline mode, allow-host filter, malformed URLs, DOI/arXiv parsing, dead-link detection, IDN handling, 4xx/5xx/3xx/405 fallback, traversal containment
- [x] 12 property tests via Hypothesis (`tests/property/test_citation_verifier_properties.py`) -- totality, offset invariants, ordering, synthetic citation generation, allow-list partitioning
- [x] 7 integration tests against an in-process fixture HTTP server (`tests/integration/quality/test_citation_verifier_http.py`) -- 200/3xx/404/405-with-GET-fallback/5xx/mixed/timeout
- [x] `uv run ruff check` clean on new files
- [x] `uv run pyright` strict clean on new production modules
- [x] All 178 existing quality tests still pass (no regression)