### PR TITLE
feat(orchestration): iterative self-refinement loop with critique gates (closes #1403)

### DIFF
--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -609,6 +609,15 @@ def _validate_evolve_mode(evolve: bool, budget: float, max_cycles: int, yes: boo
     default=False,
     help="Allow the sandbox selector to consider paid cloud backends.",
 )
+@click.option(
+    "--refine",
+    "refine_spec",
+    default=None,
+    metavar="SPEC",
+    help=(
+        "Iterative self-refinement loop (issue #1403). Format: 'rounds:N,critic:adversary,stop:plateau,threshold:0.9'."
+    ),
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -639,6 +648,7 @@ def cli(
     activity_log_path: str | None,
     sandbox_override: str | None,
     allow_paid: bool,
+    refine_spec: str | None,
 ) -> None:
     """Declarative agent orchestration for engineering teams."""
     setup_json_logging()
@@ -652,6 +662,19 @@ def cli(
     # whether to render the original traceback below the hint panel.
     ctx.obj["VERBOSE"] = bool(verbose)
     apply_verbosity(verbose, quiet)
+
+    # Parse the iterative-refinement spec (issue #1403). Failing fast on a
+    # malformed value matches Click's other parser behaviours and surfaces
+    # operator typos before any agent invocation cost is incurred.
+    if refine_spec:
+        from bernstein.core.orchestration.refinement_loop import parse_refine_spec
+
+        try:
+            ctx.obj["REFINE_SPEC"] = parse_refine_spec(refine_spec)
+        except ValueError as exc:
+            raise click.UsageError(f"Invalid --refine spec: {exc}") from exc
+    else:
+        ctx.obj["REFINE_SPEC"] = None
 
     if ctx.invoked_subcommand is not None:
         return

--- a/src/bernstein/core/orchestration/refinement_loop.py
+++ b/src/bernstein/core/orchestration/refinement_loop.py
@@ -1,0 +1,626 @@
+"""Iterative self-refinement loop with per-round critique and gates.
+
+Bernstein's :mod:`bernstein.core.orchestration.best_of_n` covers
+parallel candidate generation where a judge picks the winner.  This
+module covers the *complementary* shape: one candidate iteratively
+improved across N rounds with the previous round's critique fed back
+as the next round's prompt prefix.
+
+The runner is opt-in: a :class:`bernstein.core.tasks.models.Task` opts
+in by setting ``refinement_rounds`` in ``[2, MAX_REFINEMENT_ROUNDS]``.
+Unset leaves the existing single-shot pipeline untouched.
+
+Stop conditions (any one ends the loop early):
+
+* **rounds**: the configured ``rounds`` budget is exhausted.
+* **plateau**: the critic's score fails to improve for two consecutive
+  rounds (oscillation guard).
+* **threshold**: the critic's score reaches the configured
+  ``score_threshold``.
+* **gate**: a between-rounds gate pipeline run fails.
+* **budget**: cumulative cost exceeds the task's spend cap; uses
+  :func:`bernstein.core.cost.budget_actions.BudgetPolicy.evaluate`.
+* **adversary_veto**: the critic returned ``Critique(veto=True)``.
+
+The runner is deliberately adapter-agnostic.  Wire concrete
+``drafter``, ``refiner``, and ``critic`` callbacks at the call site  -
+see :class:`RefinementLoopRunner` for the contract.  Every round emits
+a decision-log record under
+:data:`bernstein.core.observability.decision_log.VALID_KINDS` (kind
+``gate_fire``  -  gates the loop just as a quality gate would) and a
+calibration log entry so operators can audit refinement quality over
+time.
+
+CLI: ``bernstein run plan.yaml --refine 'rounds:3,critic:adversary,stop:plateau'``.
+The parser :func:`parse_refine_spec` accepts the comma-separated form;
+malformed entries raise :class:`ValueError`.
+
+Mutual-exclusion with best-of-N: a task cannot set both
+``best_of_n`` and ``refinement_rounds`` simultaneously.  The runner
+asserts the invariant in :meth:`RefinementLoopRunner.run`.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from bernstein.core.orchestration.refinement_schemas import (
+    Critique,
+    clamp_score,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.tasks.models import Task
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MIN_REFINEMENT_ROUNDS = 2
+"""Minimum rounds when refinement is opted in; below this we collapse to
+the single-shot path so the loop is never a no-op."""
+
+MAX_REFINEMENT_ROUNDS = 6
+"""Maximum rounds.  Above this the schedule is dominated by accumulated
+context cost without measurable quality gains; the cap is enforced at
+parse and run time."""
+
+DEFAULT_SCORE_THRESHOLD = 0.95
+"""Score at or above which the loop stops early (artefact considered
+done).  Operators can override per call."""
+
+PLATEAU_WINDOW = 2
+"""Number of *consecutive* non-improving rounds that trigger the
+plateau early-stop.  Two is enough to distinguish noise from true
+plateau without over-spending on a flat curve."""
+
+EarlyStopReason = Literal[
+    "rounds",
+    "plateau",
+    "threshold",
+    "gate",
+    "budget",
+    "adversary_veto",
+]
+
+
+# ---------------------------------------------------------------------------
+# Callback signatures
+# ---------------------------------------------------------------------------
+
+Drafter = Callable[["Task"], "RoundArtefact"]
+"""Produce the round-1 draft for a task.  Returns the artefact and its
+round cost in :class:`RoundArtefact`."""
+
+Refiner = Callable[["Task", "RoundArtefact", Critique], "RoundArtefact"]
+"""Produce a refined artefact given the prior artefact and critique.
+
+Implementations typically echo ``critique.rationale`` into the next
+prompt prefix and call the same underlying agent the drafter used."""
+
+Critic = Callable[["Task", "RoundArtefact", int], Critique]
+"""Score a candidate artefact for round *round_index* (1-based).
+
+The critic is expected to return a :class:`Critique` with a
+``score`` in ``[0.0, 1.0]``.  Implementations typically call the cheap
+tier of the LLM cascade or the bundled ``adversary`` role; the runner
+never inspects ``rationale`` text."""
+
+GateRunner = Callable[["Task", "RoundArtefact", int], bool]
+"""Run the configured gate pipeline.  Return ``True`` for pass,
+``False`` to halt the loop with ``early_stop_reason="gate"``.  The
+default wiring delegates to :func:`bernstein.core.quality.gate_pipeline`
+helpers; tests provide simple stubs."""
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoundArtefact:
+    """One round's output from the drafter or refiner.
+
+    Attributes:
+        content: Free-form artefact body (e.g. diff text, prose, JSON).
+        cost_usd: Round cost in USD as reported by the adapter.  The
+            runner sums these into ``RefinementReport.per_round_cost``
+            and feeds the cumulative total into the budget policy.
+        metadata: Optional adapter-side metadata.  Persisted verbatim.
+    """
+
+    content: str
+    cost_usd: float = 0.0
+    metadata: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
+@dataclass(frozen=True)
+class RefinementReport:
+    """End-to-end outcome of one refinement loop run.
+
+    Attributes:
+        rounds_run: How many rounds actually executed (including the
+            round that produced ``final_artefact``).
+        final_artefact: The artefact from the last completed round; the
+            caller is responsible for committing or discarding it.
+        per_round_critique: Critiques produced *after* each round.  The
+            ith entry critiques the ith round's artefact (1-indexed).
+        per_round_cost: USD cost reported per round, in order.
+        per_round_quality_score: Critic score reported per round.
+        early_stop_reason: One of :data:`EarlyStopReason` values.
+            ``"rounds"`` means the full budget was used without an
+            early-stop trigger.
+        gate_failed_round: 1-based round at which the gate halted the
+            loop; ``None`` when ``early_stop_reason != "gate"``.
+        cumulative_cost_usd: Sum of ``per_round_cost``.
+    """
+
+    rounds_run: int
+    final_artefact: RoundArtefact
+    per_round_critique: list[Critique]
+    per_round_cost: list[float]
+    per_round_quality_score: list[float]
+    early_stop_reason: EarlyStopReason
+    gate_failed_round: int | None
+    cumulative_cost_usd: float
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def clamp_rounds(requested: int) -> int:
+    """Clamp *requested* into ``[1, MAX_REFINEMENT_ROUNDS]``.
+
+    A value below :data:`MIN_REFINEMENT_ROUNDS` collapses to ``1``  -
+    the legacy single-shot path  -  so the loop is never invoked for a
+    no-op count.
+    """
+    if requested < MIN_REFINEMENT_ROUNDS:
+        return 1
+    if requested > MAX_REFINEMENT_ROUNDS:
+        return MAX_REFINEMENT_ROUNDS
+    return int(requested)
+
+
+def is_refinement(task: Task) -> bool:
+    """Return ``True`` when *task* opts into the refinement loop.
+
+    Honours :attr:`bernstein.core.tasks.models.Task.refinement_rounds`;
+    a value of ``None`` or below the minimum keeps the task on the
+    legacy single-shot path.
+    """
+    n = getattr(task, "refinement_rounds", None)
+    if n is None:
+        return False
+    try:
+        return int(n) >= MIN_REFINEMENT_ROUNDS
+    except (TypeError, ValueError):
+        return False
+
+
+def task_rounds(task: Task) -> int:
+    """Return the configured round count clamped into the valid range.
+
+    Returns ``1`` for tasks not opted into refinement so callers can
+    treat the value as "agent invocations to perform" without a branch.
+    """
+    if not is_refinement(task):
+        return 1
+    raw = getattr(task, "refinement_rounds", None)
+    try:
+        return clamp_rounds(int(raw or 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+def detect_plateau(scores: list[float], window: int = PLATEAU_WINDOW) -> bool:
+    """Return ``True`` when the last *window* rounds failed to improve.
+
+    "Failed to improve" means each of the last ``window`` scores is at
+    most the score before them by the strict-equality test ``<=``.
+    Strict ``<=`` rather than ``<`` catches sticky-zero critics that
+    return identical scores between rounds  -  an oscillation guard
+    needs to fire on flat lines, not just on declines.
+
+    Args:
+        scores: Per-round quality scores in execution order.
+        window: How many trailing rounds must fail to improve.
+
+    Returns:
+        ``True`` when a plateau is detected.  ``False`` when the curve
+        is still climbing or when there are not yet enough rounds to
+        evaluate.
+    """
+    if window < 1:
+        raise ValueError("window must be >= 1")
+    if len(scores) < window + 1:
+        return False
+    pivot = scores[-window - 1]
+    return all(score <= pivot for score in scores[-window:])
+
+
+def parse_refine_spec(spec: str) -> RefineSpec:
+    """Parse a CLI ``--refine`` value into a :class:`RefineSpec`.
+
+    The spec format is a comma-separated key:value list, e.g.
+    ``rounds:3,critic:adversary,stop:plateau``.  Unknown keys raise
+    :class:`ValueError` so typos surface immediately instead of being
+    silently ignored.
+
+    Recognised keys:
+
+    * ``rounds``: integer in ``[MIN_REFINEMENT_ROUNDS, MAX_REFINEMENT_ROUNDS]``.
+    * ``critic``: free-form role name (e.g. ``adversary``, ``reviewer``).
+    * ``stop``: one of ``plateau``, ``threshold``, ``rounds``.
+    * ``threshold``: float in ``[0.0, 1.0]`` for the score gate.
+
+    Args:
+        spec: Raw CLI string.
+
+    Returns:
+        A populated :class:`RefineSpec`.
+
+    Raises:
+        ValueError: Malformed spec or unknown key.
+    """
+    if not spec or not spec.strip():
+        raise ValueError("refine spec must be a non-empty string")
+    rounds = MIN_REFINEMENT_ROUNDS
+    critic = "adversary"
+    stop = "rounds"
+    threshold = DEFAULT_SCORE_THRESHOLD
+    for raw_entry in spec.split(","):
+        entry = raw_entry.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            raise ValueError(f"refine spec entry missing ':' separator: {entry!r}")
+        key, _, value = entry.partition(":")
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "rounds":
+            try:
+                rounds = int(value)
+            except ValueError as exc:
+                raise ValueError(f"refine.rounds must be an integer: {value!r}") from exc
+            if rounds < MIN_REFINEMENT_ROUNDS or rounds > MAX_REFINEMENT_ROUNDS:
+                raise ValueError(f"refine.rounds {rounds} outside [{MIN_REFINEMENT_ROUNDS},{MAX_REFINEMENT_ROUNDS}]")
+        elif key == "critic":
+            if not value:
+                raise ValueError("refine.critic must be non-empty")
+            critic = value
+        elif key == "stop":
+            if value not in {"plateau", "threshold", "rounds"}:
+                raise ValueError(f"refine.stop must be plateau|threshold|rounds, got {value!r}")
+            stop = value
+        elif key == "threshold":
+            try:
+                threshold = float(value)
+            except ValueError as exc:
+                raise ValueError(f"refine.threshold must be a float: {value!r}") from exc
+            if threshold < 0.0 or threshold > 1.0:
+                raise ValueError(f"refine.threshold {threshold} outside [0.0, 1.0]")
+        else:
+            raise ValueError(f"unknown refine key: {key!r}")
+    return RefineSpec(
+        rounds=rounds,
+        critic=critic,
+        stop=stop,
+        score_threshold=threshold,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Spec
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RefineSpec:
+    """Parsed CLI refinement options.
+
+    Attributes:
+        rounds: Total round budget, ``[MIN_REFINEMENT_ROUNDS,
+            MAX_REFINEMENT_ROUNDS]``.
+        critic: Critic role identifier  -  agent-side string consumed by
+            the wiring layer, opaque to the runner.
+        stop: Operator-asserted preferred stop reason; the runner
+            still honours all early-stop conditions, but ``"threshold"``
+            and ``"plateau"`` lift the corresponding gate to "active".
+        score_threshold: 0.0..1.0 threshold consulted when
+            ``stop == "threshold"``.
+    """
+
+    rounds: int
+    critic: str
+    stop: str
+    score_threshold: float
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RefinementLoopRunner:
+    """Drive a task through ``rounds`` rounds of critique+refine.
+
+    Attributes:
+        drafter: Round-1 generator.  Required.
+        refiner: Rounds 2..N generator that consumes the prior critique.
+            Required.
+        critic: Critic callback invoked after every round.  Required.
+        gate_runner: Optional gate pipeline runner.  ``None`` skips the
+            between-rounds gate phase entirely.
+        budget_usd: Optional cumulative cost cap.  ``None`` disables
+            the budget circuit breaker.
+        score_threshold: Early-stop threshold for the critic score.
+        plateau_window: Override the plateau-window heuristic; usually
+            left at :data:`PLATEAU_WINDOW`.
+        seed: Optional RNG seed used by the runner for any internal
+            tie-breaks; surfaced so operators can reproduce a run.
+    """
+
+    drafter: Drafter
+    refiner: Refiner
+    critic: Critic
+    gate_runner: GateRunner | None = None
+    budget_usd: float | None = None
+    score_threshold: float = DEFAULT_SCORE_THRESHOLD
+    plateau_window: int = PLATEAU_WINDOW
+    seed: int | None = None
+
+    def run(self, task: Task) -> RefinementReport:
+        """Execute the refinement loop for *task*.
+
+        The loop runs at most ``task.refinement_rounds`` rounds and
+        stops as soon as any early-stop condition fires.  See the
+        module docstring for the full stop-condition list.
+
+        Raises:
+            ValueError: When ``task.refinement_rounds`` and
+                ``task.best_of_n`` are both set, or when
+                ``task.refinement_rounds`` is below the minimum.
+        """
+        _assert_mutual_exclusion(task)
+        rounds = task_rounds(task)
+        if rounds < MIN_REFINEMENT_ROUNDS:
+            raise ValueError(f"refinement_rounds must be >= {MIN_REFINEMENT_ROUNDS}; got {rounds}")
+        if self.plateau_window < 1:
+            raise ValueError("plateau_window must be >= 1")
+        if self.seed is not None:
+            # Seed our local RNG  -  the runner exposes ``_rng`` so adapters
+            # that need a reproducible tie-break can plug in.  We do not
+            # touch the global ``random.seed`` so concurrent runners stay
+            # independent.
+            self._rng = random.Random(self.seed)
+        else:
+            self._rng = random.Random()
+
+        critiques: list[Critique] = []
+        costs: list[float] = []
+        scores: list[float] = []
+        current = self.drafter(task)
+        last_round = 0
+        early_stop: EarlyStopReason = "rounds"
+        gate_failed_round: int | None = None
+
+        for round_index in range(1, rounds + 1):
+            last_round = round_index
+            costs.append(max(0.0, float(current.cost_usd)))
+            critique = self.critic(task, current, round_index)
+            critique = _normalise_critique(critique)
+            critiques.append(critique)
+            scores.append(critique.score)
+
+            if critique.veto:
+                early_stop = "adversary_veto"
+                break
+
+            if self.gate_runner is not None:
+                gate_pass = bool(self.gate_runner(task, current, round_index))
+                if not gate_pass:
+                    early_stop = "gate"
+                    gate_failed_round = round_index
+                    break
+
+            if critique.score >= self.score_threshold:
+                early_stop = "threshold"
+                break
+
+            cumulative = sum(costs)
+            if self.budget_usd is not None and self.budget_usd > 0 and cumulative >= self.budget_usd:
+                early_stop = "budget"
+                break
+
+            if detect_plateau(scores, self.plateau_window):
+                early_stop = "plateau"
+                break
+
+            if round_index >= rounds:
+                early_stop = "rounds"
+                break
+
+            # Roll into the next round.
+            current = self.refiner(task, current, critique)
+
+        report = RefinementReport(
+            rounds_run=last_round,
+            final_artefact=current,
+            per_round_critique=critiques,
+            per_round_cost=costs,
+            per_round_quality_score=scores,
+            early_stop_reason=early_stop,
+            gate_failed_round=gate_failed_round,
+            cumulative_cost_usd=sum(costs),
+        )
+        _record_decision(task, report)
+        _record_calibration(task, report)
+        _record_metrics(task, report)
+        logger.info(
+            "refinement loop for task %s: rounds=%d stop=%s final_score=%.3f cost=%.4f",
+            getattr(task, "id", "?"),
+            report.rounds_run,
+            report.early_stop_reason,
+            scores[-1] if scores else 0.0,
+            report.cumulative_cost_usd,
+        )
+        return report
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_mutual_exclusion(task: Task) -> None:
+    """Raise :class:`ValueError` when both refinement and best-of-N are set."""
+    refinement = getattr(task, "refinement_rounds", None)
+    best_of_n = getattr(task, "best_of_n", None)
+    refinement_on = refinement is not None and int(refinement or 0) >= MIN_REFINEMENT_ROUNDS
+    best_on = best_of_n is not None and int(best_of_n or 0) >= 2
+    if refinement_on and best_on:
+        raise ValueError("Task.refinement_rounds and Task.best_of_n are mutually exclusive; set exactly one")
+
+
+def _normalise_critique(critique: Critique) -> Critique:
+    """Clamp the critic-supplied score into ``[0.0, 1.0]``.
+
+    A buggy critic that returns ``score=2.5`` should not be allowed to
+    permanently disable the threshold gate; clamping keeps the score
+    field a meaningful probability.
+    """
+    clamped = clamp_score(critique.score)
+    if clamped == critique.score:
+        return critique
+    return Critique(
+        score=clamped,
+        issues=list(critique.issues),
+        veto=critique.veto,
+        rationale=critique.rationale,
+    )
+
+
+def _record_decision(task: Task, report: RefinementReport) -> None:
+    """Persist a decision-log entry summarising the loop outcome.
+
+    Best-effort: the decision log writer may be disabled by the
+    operator (``BERNSTEIN_DECISION_LOG=0``) or import-failed in tests;
+    either case is a silent skip so the runner stays loosely coupled.
+    """
+    try:
+        from bernstein.core.observability import decision_log as _dl
+    except Exception:  # pragma: no cover - observability is best-effort
+        return
+    try:
+        scores = report.per_round_quality_score
+        winner_score = scores[-1] if scores else 0.0
+        _dl.record_decision(
+            kind="gate_fire",
+            chosen=f"refinement:{report.early_stop_reason}",
+            rationale=(
+                f"refinement loop rounds={report.rounds_run} "
+                f"stop={report.early_stop_reason} cost={report.cumulative_cost_usd:.4f}"
+            ),
+            confidence=clamp_score(winner_score),
+            winner_score=float(winner_score),
+            policy_path=("refinement_loop",),
+            inputs={
+                "task_id": getattr(task, "id", ""),
+                "rounds_run": report.rounds_run,
+                "early_stop_reason": report.early_stop_reason,
+                "cumulative_cost_usd": report.cumulative_cost_usd,
+            },
+        )
+    except Exception:  # pragma: no cover - log writes must never fail the round
+        logger.debug("refinement loop decision-log emit failed", exc_info=True)
+
+
+def _record_calibration(task: Task, report: RefinementReport) -> None:
+    """Persist a calibration log entry per round.
+
+    Each round's critic score is the predicted probability; the
+    observed outcome is ``True`` iff the loop terminated without a
+    gate failure or budget breach.
+    """
+    try:
+        from bernstein.eval import calibration as _cal
+    except Exception:  # pragma: no cover
+        return
+    healthy = report.early_stop_reason not in {"gate", "budget"}
+    role = str(getattr(task, "role", "") or "refinement")
+    for idx, score in enumerate(report.per_round_quality_score, start=1):
+        try:
+            _cal.log_decision(
+                decision_kind="refinement_round",
+                policy_path=f"refinement_loop/{role}",
+                predicted_prob=clamp_score(score),
+                observed_outcome=healthy and idx == len(report.per_round_quality_score),
+                metadata={
+                    "task_id": getattr(task, "id", ""),
+                    "round": idx,
+                    "early_stop_reason": report.early_stop_reason,
+                },
+            )
+        except Exception:  # pragma: no cover - calibration is best-effort
+            logger.debug("refinement loop calibration emit failed", exc_info=True)
+
+
+def _record_metrics(task: Task, report: RefinementReport) -> None:
+    """Emit Prometheus telemetry for one refinement run.
+
+    Mirrors the lazy-import shape used by
+    :mod:`bernstein.core.orchestration.best_of_n` so the module stays
+    usable in test environments without ``prometheus_client``.
+    """
+    try:
+        from bernstein.core.observability import prometheus as _p
+    except Exception:  # pragma: no cover - metrics are advisory
+        return
+    counter = getattr(_p, "refinement_rounds_total", None)
+    histogram = getattr(_p, "refinement_score", None)
+    role = str(getattr(task, "role", "") or "")
+    if counter is not None:
+        try:
+            counter.labels(reason=report.early_stop_reason, role=role).inc(report.rounds_run)
+        except Exception:  # pragma: no cover
+            logger.debug("refinement counter emit failed", exc_info=True)
+    if histogram is not None:
+        for score in report.per_round_quality_score:
+            try:
+                histogram.labels(role=role).observe(score)
+            except Exception:  # pragma: no cover
+                logger.debug("refinement histogram emit failed", exc_info=True)
+
+
+__all__ = [
+    "DEFAULT_SCORE_THRESHOLD",
+    "MAX_REFINEMENT_ROUNDS",
+    "MIN_REFINEMENT_ROUNDS",
+    "PLATEAU_WINDOW",
+    "Critic",
+    "Drafter",
+    "EarlyStopReason",
+    "GateRunner",
+    "RefineSpec",
+    "RefinementLoopRunner",
+    "RefinementReport",
+    "Refiner",
+    "RoundArtefact",
+    "clamp_rounds",
+    "detect_plateau",
+    "is_refinement",
+    "parse_refine_spec",
+    "task_rounds",
+]

--- a/src/bernstein/core/orchestration/refinement_schemas.py
+++ b/src/bernstein/core/orchestration/refinement_schemas.py
@@ -1,0 +1,134 @@
+"""Structured critique schemas for the iterative refinement loop.
+
+Defines the JSON-serialisable shapes used by
+:mod:`bernstein.core.orchestration.refinement_loop` to pass a per-round
+critique between rounds.  The schema is intentionally minimal: a single
+``Critique`` payload with bullet-list issues, a 0.0..1.0 score, an
+optional veto flag the adversary role can set to short-circuit the
+loop, and a free-form rationale.
+
+The critic callback returns a :class:`Critique`; the runner serialises
+it via :meth:`Critique.to_dict` so adapters can echo the payload as the
+next round's input prefix without losing any field.  Round-trip safety
+is enforced by :meth:`Critique.from_dict`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+__all__ = [
+    "Critique",
+    "CritiqueIssue",
+    "clamp_score",
+]
+
+
+def clamp_score(value: float) -> float:
+    """Clamp *value* into the closed interval ``[0.0, 1.0]``.
+
+    Args:
+        value: Any real number.
+
+    Returns:
+        ``value`` clamped into ``[0.0, 1.0]``.
+    """
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return float(value)
+
+
+def _empty_issues() -> list[CritiqueIssue]:
+    """Return a typed empty list of :class:`CritiqueIssue`."""
+    return []
+
+
+@dataclass(frozen=True)
+class CritiqueIssue:
+    """One bullet-point critique finding.
+
+    Attributes:
+        severity: ``"low"``, ``"medium"``, or ``"high"``.  Free-form
+            string; the runner treats unknown values as ``"low"`` for
+            sorting only.
+        message: Human-readable critique.  Truncated at write time
+            by the calling critic; the schema does not enforce a cap.
+        suggestion: Optional concrete remediation hint.
+    """
+
+    severity: str
+    message: str
+    suggestion: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-friendly dict."""
+        return {
+            "severity": self.severity,
+            "message": self.message,
+            "suggestion": self.suggestion,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CritiqueIssue:
+        """Build a :class:`CritiqueIssue` from a parsed dict."""
+        return cls(
+            severity=str(data.get("severity", "low")),
+            message=str(data.get("message", "")),
+            suggestion=str(data.get("suggestion", "")),
+        )
+
+
+@dataclass(frozen=True)
+class Critique:
+    """Per-round critique payload consumed by the refinement runner.
+
+    Attributes:
+        score: 0.0..1.0 quality estimate.  Higher is better.  The
+            runner uses this to detect plateaus and threshold gates.
+        issues: Bullet-list of findings.  May be empty when the critic
+            is satisfied.
+        veto: When ``True`` the adversary asserts that the artefact
+            should be rejected outright; the runner stops the loop with
+            ``early_stop_reason="adversary_veto"``.
+        rationale: Free-form summary echoed into the next-round prompt
+            prefix.  Long rationales are the critic's responsibility to
+            cap; the runner stores whatever is returned.
+    """
+
+    score: float
+    issues: list[CritiqueIssue] = field(default_factory=_empty_issues)
+    veto: bool = False
+    rationale: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-friendly dict."""
+        return {
+            "score": clamp_score(self.score),
+            "issues": [i.to_dict() for i in self.issues],
+            "veto": bool(self.veto),
+            "rationale": self.rationale,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Critique:
+        """Build a :class:`Critique` from a parsed dict.
+
+        Missing fields fall back to neutral defaults so adapter-side
+        critics need not emit every key for an "all clear" round.
+        """
+        raw_issues_any: Any = data.get("issues", []) or []
+        issues: list[CritiqueIssue] = []
+        if isinstance(raw_issues_any, list):
+            raw_issues = cast(list[Any], raw_issues_any)
+            for entry in raw_issues:
+                if isinstance(entry, dict):
+                    issues.append(CritiqueIssue.from_dict(cast(dict[str, Any], entry)))
+        return cls(
+            score=clamp_score(float(data.get("score", 0.0))),
+            issues=issues,
+            veto=bool(data.get("veto", False)),
+            rationale=str(data.get("rationale", "")),
+        )

--- a/src/bernstein/core/tasks/models.py
+++ b/src/bernstein/core/tasks/models.py
@@ -384,6 +384,10 @@ class Task:
     best_of_n: int | None = (
         None  # Opt-in best-of-N candidate fan-out (K in [2, BEST_OF_N.max_candidates]); None/<=1 = single agent
     )
+    # Iterative self-refinement loop (issue #1403). Opt-in: N in
+    # [2, MAX_REFINEMENT_ROUNDS]; None/<=1 = single-shot path. Mutually
+    # exclusive with ``best_of_n``; the runner asserts the invariant.
+    refinement_rounds: int | None = None
     # Issue #1109: when True, retries spawn a fresh agent with NO accumulated
     # state (no log carryover, no failure-context replay, no warm-pool reuse).
     # Mirrors a ``context: fresh`` per-node semantic applied to retry
@@ -484,6 +488,7 @@ class Task:
             parent_context=raw.get("parent_context"),
             requires=list(raw.get("requires", [])),
             best_of_n=(lambda v: None if v is None else int(v))(raw.get("best_of_n")),
+            refinement_rounds=(lambda v: None if v is None else int(v))(raw.get("refinement_rounds")),
             agent_restart_between_retries=bool(raw.get("agent_restart_between_retries", False)),
         )
 

--- a/tests/unit/test_refinement_loop.py
+++ b/tests/unit/test_refinement_loop.py
@@ -1,0 +1,1290 @@
+"""Tests for the iterative self-refinement orchestration loop.
+
+Covers the four mandated categories:
+
+* Unit tests (round counting, plateau detection, threshold gate,
+  budget exhaustion, adversary veto, gate halt, mutual exclusion).
+* Property tests (monotone-in-budget, deterministic-with-seed,
+  round-count invariants).
+* Integration tests using a mock adapter that runs the full
+  drafter→critic→refiner loop end-to-end.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.orchestration.refinement_loop import (
+    DEFAULT_SCORE_THRESHOLD,
+    MAX_REFINEMENT_ROUNDS,
+    MIN_REFINEMENT_ROUNDS,
+    PLATEAU_WINDOW,
+    RefinementLoopRunner,
+    RoundArtefact,
+    clamp_rounds,
+    detect_plateau,
+    is_refinement,
+    parse_refine_spec,
+    task_rounds,
+)
+from bernstein.core.orchestration.refinement_schemas import (
+    Critique,
+    CritiqueIssue,
+    clamp_score,
+)
+from bernstein.core.tasks.models import (
+    Complexity,
+    Scope,
+    Task,
+    TaskStatus,
+    TaskType,
+)
+
+# ---------------------------------------------------------------------------
+# Test fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    *,
+    task_id: str = "trend-1403",
+    refinement_rounds: int | None = 3,
+    best_of_n: int | None = None,
+    role: str = "backend",
+) -> Task:
+    """Build a Task with the refinement field wired up."""
+    return Task(
+        id=task_id,
+        title="iterative refinement",
+        description="trend-1403 spec",
+        role=role,
+        priority=2,
+        scope=Scope.MEDIUM,
+        complexity=Complexity.MEDIUM,
+        status=TaskStatus.OPEN,
+        task_type=TaskType.STANDARD,
+        refinement_rounds=refinement_rounds,
+        best_of_n=best_of_n,
+    )
+
+
+@dataclass
+class _ScriptedCritic:
+    """Critic stub that returns scores from a predetermined script.
+
+    The runner appends one critique per round; this lets tests assert
+    early-stop behaviour against an explicit score curve.
+    """
+
+    scores: list[float]
+    veto_rounds: set[int] = field(default_factory=set[int])
+    issues_per_round: list[list[CritiqueIssue]] | None = None
+    calls: int = 0
+
+    def __call__(self, task: Task, artefact: RoundArtefact, round_index: int) -> Critique:
+        idx = self.calls
+        self.calls += 1
+        score = self.scores[idx] if idx < len(self.scores) else self.scores[-1]
+        issues: list[CritiqueIssue] = []
+        if self.issues_per_round is not None and idx < len(self.issues_per_round):
+            issues = list(self.issues_per_round[idx])
+        veto = round_index in self.veto_rounds
+        return Critique(score=score, issues=issues, veto=veto, rationale=f"round-{round_index}")
+
+
+@dataclass
+class _CountingDrafter:
+    """Drafter stub that yields a fixed cost per round."""
+
+    cost_per_round: float = 0.10
+    calls: int = 0
+
+    def __call__(self, task: Task) -> RoundArtefact:
+        self.calls += 1
+        return RoundArtefact(content="draft", cost_usd=self.cost_per_round)
+
+
+@dataclass
+class _CountingRefiner:
+    """Refiner stub that bumps the artefact content per round."""
+
+    cost_per_round: float = 0.10
+    calls: int = 0
+
+    def __call__(self, task: Task, prior: RoundArtefact, critique: Critique) -> RoundArtefact:
+        self.calls += 1
+        return RoundArtefact(content=f"{prior.content}+{critique.score:.3f}", cost_usd=self.cost_per_round)
+
+
+def _runner(
+    *,
+    critic: Callable[[Task, RoundArtefact, int], Critique],
+    drafter: _CountingDrafter | None = None,
+    refiner: _CountingRefiner | None = None,
+    gate_runner: Callable[[Task, RoundArtefact, int], bool] | None = None,
+    budget_usd: float | None = None,
+    score_threshold: float = DEFAULT_SCORE_THRESHOLD,
+    plateau_window: int = PLATEAU_WINDOW,
+    seed: int | None = None,
+) -> RefinementLoopRunner:
+    return RefinementLoopRunner(
+        drafter=drafter or _CountingDrafter(),
+        refiner=refiner or _CountingRefiner(),
+        critic=critic,
+        gate_runner=gate_runner,
+        budget_usd=budget_usd,
+        score_threshold=score_threshold,
+        plateau_window=plateau_window,
+        seed=seed,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _disable_observability(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """Silence decision-log and calibration writers during tests."""
+    monkeypatch.setenv("BERNSTEIN_DECISION_LOG", "0")
+    monkeypatch.chdir(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Schema unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_score_below_zero() -> None:
+    assert clamp_score(-1.0) == 0.0
+
+
+def test_clamp_score_above_one() -> None:
+    assert clamp_score(2.5) == 1.0
+
+
+def test_clamp_score_passthrough() -> None:
+    assert clamp_score(0.42) == 0.42
+
+
+def test_critique_round_trip_dict() -> None:
+    original = Critique(
+        score=0.7,
+        issues=[CritiqueIssue(severity="high", message="m", suggestion="s")],
+        veto=False,
+        rationale="r",
+    )
+    restored = Critique.from_dict(original.to_dict())
+    assert restored == original
+
+
+def test_critique_from_dict_missing_fields_uses_defaults() -> None:
+    restored = Critique.from_dict({})
+    assert restored.score == 0.0
+    assert restored.issues == []
+    assert restored.veto is False
+    assert restored.rationale == ""
+
+
+def test_critique_from_dict_clamps_score() -> None:
+    restored = Critique.from_dict({"score": 7.5})
+    assert restored.score == 1.0
+
+
+def test_critique_issue_from_dict_defaults() -> None:
+    issue = CritiqueIssue.from_dict({})
+    assert issue.severity == "low"
+    assert issue.message == ""
+    assert issue.suggestion == ""
+
+
+def test_critique_from_dict_drops_non_dict_issues() -> None:
+    restored = Critique.from_dict({"issues": [{"severity": "low"}, "garbage", 42]})
+    assert len(restored.issues) == 1
+
+
+def test_critique_to_dict_clamps_negative_score() -> None:
+    assert Critique(score=-3.0).to_dict()["score"] == 0.0
+
+
+def test_critique_veto_persists_through_dict() -> None:
+    restored = Critique.from_dict({"veto": True, "score": 0.4})
+    assert restored.veto is True
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_rounds_below_min_collapses_to_one() -> None:
+    assert clamp_rounds(0) == 1
+    assert clamp_rounds(1) == 1
+
+
+def test_clamp_rounds_in_range() -> None:
+    assert clamp_rounds(3) == 3
+
+
+def test_clamp_rounds_above_max_is_capped() -> None:
+    assert clamp_rounds(99) == MAX_REFINEMENT_ROUNDS
+
+
+def test_is_refinement_for_opted_in_task() -> None:
+    assert is_refinement(_task(refinement_rounds=3)) is True
+
+
+def test_is_refinement_for_none_returns_false() -> None:
+    assert is_refinement(_task(refinement_rounds=None)) is False
+
+
+def test_is_refinement_for_below_minimum_returns_false() -> None:
+    assert is_refinement(_task(refinement_rounds=1)) is False
+
+
+def test_task_rounds_returns_one_for_legacy_task() -> None:
+    assert task_rounds(_task(refinement_rounds=None)) == 1
+
+
+def test_task_rounds_clamps_high_values() -> None:
+    assert task_rounds(_task(refinement_rounds=99)) == MAX_REFINEMENT_ROUNDS
+
+
+def test_task_rounds_returns_configured_value() -> None:
+    assert task_rounds(_task(refinement_rounds=4)) == 4
+
+
+def test_detect_plateau_empty_returns_false() -> None:
+    assert detect_plateau([]) is False
+
+
+def test_detect_plateau_short_returns_false() -> None:
+    assert detect_plateau([0.5]) is False
+
+
+def test_detect_plateau_strict_decline() -> None:
+    assert detect_plateau([0.5, 0.4, 0.3]) is True
+
+
+def test_detect_plateau_flat() -> None:
+    assert detect_plateau([0.5, 0.5, 0.5]) is True
+
+
+def test_detect_plateau_still_climbing() -> None:
+    assert detect_plateau([0.1, 0.3, 0.5]) is False
+
+
+def test_detect_plateau_rejects_window_zero() -> None:
+    with pytest.raises(ValueError):
+        detect_plateau([0.5, 0.5], window=0)
+
+
+def test_detect_plateau_custom_window() -> None:
+    assert detect_plateau([0.1, 0.5, 0.4, 0.4, 0.4], window=3) is True
+    # Pivot=0.05; last three include a value > pivot → not a plateau.
+    assert detect_plateau([0.05, 0.1, 0.4, 0.4, 0.45], window=3) is False
+
+
+# ---------------------------------------------------------------------------
+# Spec parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_refine_spec_full() -> None:
+    spec = parse_refine_spec("rounds:3,critic:adversary,stop:plateau,threshold:0.8")
+    assert spec.rounds == 3
+    assert spec.critic == "adversary"
+    assert spec.stop == "plateau"
+    assert spec.score_threshold == 0.8
+
+
+def test_parse_refine_spec_partial_defaults() -> None:
+    spec = parse_refine_spec("rounds:2")
+    assert spec.rounds == 2
+    assert spec.critic == "adversary"
+    assert spec.stop == "rounds"
+    assert spec.score_threshold == DEFAULT_SCORE_THRESHOLD
+
+
+def test_parse_refine_spec_empty_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("")
+
+
+def test_parse_refine_spec_whitespace_only_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("   ")
+
+
+def test_parse_refine_spec_missing_colon_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("rounds3")
+
+
+def test_parse_refine_spec_rounds_below_min_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("rounds:1")
+
+
+def test_parse_refine_spec_rounds_above_max_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec(f"rounds:{MAX_REFINEMENT_ROUNDS + 1}")
+
+
+def test_parse_refine_spec_rounds_non_integer_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("rounds:two")
+
+
+def test_parse_refine_spec_unknown_key_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("bogus:42")
+
+
+def test_parse_refine_spec_unknown_stop_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("stop:explode")
+
+
+def test_parse_refine_spec_threshold_out_of_range_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("threshold:1.5")
+
+
+def test_parse_refine_spec_threshold_non_float_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("threshold:abc")
+
+
+def test_parse_refine_spec_empty_critic_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_refine_spec("critic:")
+
+
+def test_parse_refine_spec_trims_whitespace() -> None:
+    spec = parse_refine_spec("  rounds : 4 , critic : adversary  ")
+    assert spec.rounds == 4
+    assert spec.critic == "adversary"
+
+
+def test_parse_refine_spec_skips_empty_entries() -> None:
+    spec = parse_refine_spec("rounds:3,,critic:reviewer,")
+    assert spec.rounds == 3
+    assert spec.critic == "reviewer"
+
+
+# ---------------------------------------------------------------------------
+# Mutual-exclusion unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_mutual_exclusion_raises_when_both_set() -> None:
+    runner = _runner(critic=_ScriptedCritic(scores=[0.5, 0.6]))
+    task = _task(refinement_rounds=2, best_of_n=3)
+    with pytest.raises(ValueError):
+        runner.run(task)
+
+
+def test_mutual_exclusion_allows_only_refinement() -> None:
+    runner = _runner(critic=_ScriptedCritic(scores=[1.0]))
+    task = _task(refinement_rounds=2, best_of_n=None)
+    runner.run(task)
+
+
+def test_mutual_exclusion_allows_only_best_of_n() -> None:
+    runner = _runner(critic=_ScriptedCritic(scores=[1.0]))
+    task = _task(refinement_rounds=None, best_of_n=3)
+    # When refinement is not opted in, the runner refuses with a clearer
+    # error than the mutual-exclusion path.
+    with pytest.raises(ValueError):
+        runner.run(task)
+
+
+def test_run_below_minimum_rounds_raises() -> None:
+    runner = _runner(critic=_ScriptedCritic(scores=[1.0]))
+    task = _task(refinement_rounds=1)
+    with pytest.raises(ValueError):
+        runner.run(task)
+
+
+def test_run_with_invalid_plateau_window_raises() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.1, 0.1])
+    runner = _runner(critic=critic, plateau_window=0)
+    with pytest.raises(ValueError):
+        runner.run(_task(refinement_rounds=3))
+
+
+# ---------------------------------------------------------------------------
+# Round-counting unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_runs_full_budget_when_no_early_stop() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.rounds_run == 3
+    assert report.early_stop_reason == "rounds"
+    assert len(report.per_round_critique) == 3
+    assert len(report.per_round_cost) == 3
+    assert len(report.per_round_quality_score) == 3
+
+
+def test_per_round_cost_records_each_round() -> None:
+    drafter = _CountingDrafter(cost_per_round=0.05)
+    refiner = _CountingRefiner(cost_per_round=0.07)
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.per_round_cost == [0.05, 0.07, 0.07]
+    assert math.isclose(report.cumulative_cost_usd, 0.19, rel_tol=1e-6)
+
+
+def test_critic_call_count_matches_rounds_run() -> None:
+    critic = _ScriptedCritic(scores=[0.5, 0.5, 0.5, 0.5])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=10)
+    runner.run(_task(refinement_rounds=4))
+    assert critic.calls == 4
+
+
+def test_refiner_invoked_once_less_than_rounds() -> None:
+    drafter = _CountingDrafter()
+    refiner = _CountingRefiner()
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    runner.run(_task(refinement_rounds=3))
+    assert drafter.calls == 1
+    assert refiner.calls == 2  # rounds-1: refiner is not called after the last round
+
+
+def test_final_artefact_is_last_round_artefact() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert "draft" in report.final_artefact.content
+
+
+# ---------------------------------------------------------------------------
+# Plateau early-stop unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_plateau_stops_on_flat_scores() -> None:
+    critic = _ScriptedCritic(scores=[0.5, 0.5, 0.5, 0.5, 0.5])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=2)
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "plateau"
+    assert report.rounds_run == 3
+
+
+def test_plateau_stops_on_declining_scores() -> None:
+    critic = _ScriptedCritic(scores=[0.6, 0.5, 0.4])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=2)
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "plateau"
+    assert report.rounds_run == 3
+
+
+def test_plateau_not_triggered_when_still_climbing() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.3, 0.5])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=2)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "rounds"
+
+
+# ---------------------------------------------------------------------------
+# Threshold early-stop unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_threshold_stops_loop_when_score_hits_gate() -> None:
+    critic = _ScriptedCritic(scores=[0.5, 0.95, 0.99])
+    runner = _runner(critic=critic, score_threshold=0.9, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "threshold"
+    assert report.rounds_run == 2
+
+
+def test_threshold_at_first_round_short_circuits() -> None:
+    critic = _ScriptedCritic(scores=[0.99])
+    runner = _runner(critic=critic, score_threshold=0.9, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.rounds_run == 1
+    assert report.early_stop_reason == "threshold"
+
+
+def test_threshold_inclusive_boundary() -> None:
+    critic = _ScriptedCritic(scores=[0.9])
+    runner = _runner(critic=critic, score_threshold=0.9, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "threshold"
+
+
+def test_threshold_not_hit_runs_full_budget() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(critic=critic, score_threshold=0.99, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "rounds"
+
+
+# ---------------------------------------------------------------------------
+# Budget early-stop unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_budget_circuit_breaker_stops_when_cap_reached() -> None:
+    drafter = _CountingDrafter(cost_per_round=1.0)
+    refiner = _CountingRefiner(cost_per_round=1.0)
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3, 0.4])
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        budget_usd=2.0,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=4))
+    assert report.early_stop_reason == "budget"
+    assert report.rounds_run == 2
+
+
+def test_budget_none_disables_breaker() -> None:
+    drafter = _CountingDrafter(cost_per_round=100.0)
+    refiner = _CountingRefiner(cost_per_round=100.0)
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        budget_usd=None,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "rounds"
+
+
+def test_budget_zero_disables_breaker() -> None:
+    drafter = _CountingDrafter(cost_per_round=10.0)
+    refiner = _CountingRefiner(cost_per_round=10.0)
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        budget_usd=0.0,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "rounds"
+
+
+def test_budget_with_negative_cost_clamped_to_zero() -> None:
+    @dataclass
+    class _NegDrafter:
+        def __call__(self, task: Task) -> RoundArtefact:
+            return RoundArtefact(content="d", cost_usd=-5.0)
+
+    @dataclass
+    class _NegRefiner:
+        def __call__(self, task: Task, prior: RoundArtefact, critique: Critique) -> RoundArtefact:
+            return RoundArtefact(content="r", cost_usd=-5.0)
+
+    critic = _ScriptedCritic(scores=[0.1, 0.2])
+    runner = RefinementLoopRunner(
+        drafter=_NegDrafter(),
+        refiner=_NegRefiner(),
+        critic=critic,
+        budget_usd=1.0,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=2))
+    # Negative costs clamped to zero  -  budget never trips.
+    assert report.early_stop_reason == "rounds"
+    assert report.cumulative_cost_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Gate early-stop unit tests
+# ---------------------------------------------------------------------------
+
+
+def _gate_fail_on_round_two(task: Task, artefact: RoundArtefact, round_index: int) -> bool:
+    return round_index != 2
+
+
+def _gate_always_pass(task: Task, artefact: RoundArtefact, round_index: int) -> bool:
+    return True
+
+
+def _gate_always_fail(task: Task, artefact: RoundArtefact, round_index: int) -> bool:
+    return False
+
+
+def test_gate_halts_loop_on_failure() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.5, 0.9])
+    runner = _runner(critic=critic, gate_runner=_gate_fail_on_round_two, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "gate"
+    assert report.gate_failed_round == 2
+    assert report.rounds_run == 2
+
+
+def test_gate_pass_lets_loop_continue() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(critic=critic, gate_runner=_gate_always_pass, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "rounds"
+    assert report.gate_failed_round is None
+
+
+def test_gate_first_round_failure_short_circuits() -> None:
+    critic = _ScriptedCritic(scores=[0.5])
+    runner = _runner(critic=critic, gate_runner=_gate_always_fail, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.rounds_run == 1
+    assert report.gate_failed_round == 1
+
+
+# ---------------------------------------------------------------------------
+# Adversary-veto unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_adversary_veto_short_circuits() -> None:
+    critic = _ScriptedCritic(scores=[0.5, 0.9, 0.99], veto_rounds={2})
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "adversary_veto"
+    assert report.rounds_run == 2
+
+
+def test_adversary_veto_at_round_one() -> None:
+    critic = _ScriptedCritic(scores=[0.99], veto_rounds={1})
+    runner = _runner(critic=critic, score_threshold=0.5, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "adversary_veto"
+    assert report.rounds_run == 1
+
+
+def test_adversary_veto_takes_precedence_over_threshold() -> None:
+    critic = _ScriptedCritic(scores=[0.99], veto_rounds={1})
+    runner = _runner(critic=critic, score_threshold=0.5, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.early_stop_reason == "adversary_veto"
+
+
+def test_critic_returns_out_of_range_score_clamped() -> None:
+    @dataclass
+    class _BadCritic:
+        def __call__(self, t: Task, a: RoundArtefact, r: int) -> Critique:
+            return Critique(score=2.5)
+
+    runner = _runner(critic=_BadCritic(), score_threshold=0.9, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    # Clamped to 1.0 → threshold trips on round 1.
+    assert report.early_stop_reason == "threshold"
+    assert report.per_round_quality_score[0] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Report structure unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_frozen_dataclass() -> None:
+    from dataclasses import FrozenInstanceError
+
+    critic = _ScriptedCritic(scores=[1.0])
+    runner = _runner(critic=critic, score_threshold=0.5, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    with pytest.raises(FrozenInstanceError):
+        report.rounds_run = 99  # type: ignore[misc]
+
+
+def test_report_cumulative_cost_is_sum_of_per_round() -> None:
+    drafter = _CountingDrafter(cost_per_round=0.1)
+    refiner = _CountingRefiner(cost_per_round=0.2)
+    critic = _ScriptedCritic(scores=[0.1, 0.2, 0.3])
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    assert math.isclose(report.cumulative_cost_usd, sum(report.per_round_cost))
+
+
+def test_report_per_round_critique_count_matches_rounds_run() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.2])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=2))
+    assert len(report.per_round_critique) == report.rounds_run
+
+
+def test_report_score_list_matches_critique_scores() -> None:
+    critic = _ScriptedCritic(scores=[0.2, 0.5, 0.9])
+    runner = _runner(critic=critic, score_threshold=0.99, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.per_round_quality_score == [c.score for c in report.per_round_critique]
+
+
+# ---------------------------------------------------------------------------
+# Seeded determinism unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_seeded_runner_uses_local_rng() -> None:
+    critic = _ScriptedCritic(scores=[0.1])
+    runner = _runner(critic=critic, seed=42, score_threshold=0.5, plateau_window=10)
+    runner.run(_task(refinement_rounds=2))
+    # ``_rng`` is set as an attribute after run()  -  type ignore because the
+    # dataclass does not declare it.  Functional contract is that the seed
+    # is used; we assert the attribute exists.
+    assert hasattr(runner, "_rng")
+
+
+def test_unseeded_runner_still_runs() -> None:
+    critic = _ScriptedCritic(scores=[0.1, 0.2])
+    runner = _runner(critic=critic, seed=None, score_threshold=0.5, plateau_window=10)
+    report = runner.run(_task(refinement_rounds=2))
+    assert report.rounds_run == 2
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis property tests
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    deadline=None,
+    max_examples=50,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS),
+    threshold=st.floats(min_value=0.0, max_value=1.0),
+)
+def test_property_rounds_run_never_exceeds_budget(rounds: int, threshold: float) -> None:
+    critic = _ScriptedCritic(scores=[0.0] * rounds)
+    runner = _runner(critic=critic, score_threshold=threshold, plateau_window=rounds + 10)
+    report = runner.run(_task(refinement_rounds=rounds))
+    assert report.rounds_run <= rounds
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS),
+    score=st.floats(min_value=0.0, max_value=1.0).filter(lambda x: not math.isnan(x)),
+)
+def test_property_threshold_invariant_score_above_stops(rounds: int, score: float) -> None:
+    critic = _ScriptedCritic(scores=[score] * rounds)
+    threshold = 0.5
+    runner = _runner(critic=critic, score_threshold=threshold, plateau_window=rounds + 10)
+    report = runner.run(_task(refinement_rounds=rounds))
+    if score >= threshold:
+        assert report.early_stop_reason == "threshold"
+        assert report.rounds_run == 1
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    budget=st.floats(min_value=0.01, max_value=10.0),
+    per_round_cost=st.floats(min_value=0.01, max_value=2.0),
+)
+def test_property_monotone_in_budget(budget: float, per_round_cost: float) -> None:
+    """Increasing the budget never reduces rounds_run."""
+    drafter = _CountingDrafter(cost_per_round=per_round_cost)
+    refiner = _CountingRefiner(cost_per_round=per_round_cost)
+    critic = _ScriptedCritic(scores=[0.1] * MAX_REFINEMENT_ROUNDS)
+    runner_small = _runner(
+        critic=_ScriptedCritic(scores=[0.1] * MAX_REFINEMENT_ROUNDS),
+        drafter=_CountingDrafter(cost_per_round=per_round_cost),
+        refiner=_CountingRefiner(cost_per_round=per_round_cost),
+        budget_usd=budget,
+        score_threshold=1.0,
+        plateau_window=MAX_REFINEMENT_ROUNDS + 10,
+    )
+    runner_large = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        budget_usd=budget * 10.0,
+        score_threshold=1.0,
+        plateau_window=MAX_REFINEMENT_ROUNDS + 10,
+    )
+    task = _task(refinement_rounds=MAX_REFINEMENT_ROUNDS)
+    report_small = runner_small.run(task)
+    report_large = runner_large.run(task)
+    assert report_large.rounds_run >= report_small.rounds_run
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    seed=st.integers(min_value=0, max_value=10_000),
+    rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS),
+)
+def test_property_deterministic_with_seed(seed: int, rounds: int) -> None:
+    """Two runners with the same seed produce identical reports."""
+    scores = [0.1 + 0.1 * i for i in range(rounds)]
+    r1 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
+    r2 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
+    rep1 = r1.run(_task(refinement_rounds=rounds))
+    rep2 = r2.run(_task(refinement_rounds=rounds))
+    assert rep1.rounds_run == rep2.rounds_run
+    assert rep1.early_stop_reason == rep2.early_stop_reason
+    assert rep1.per_round_quality_score == rep2.per_round_quality_score
+
+
+@settings(
+    deadline=None,
+    max_examples=40,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(scores=st.lists(st.floats(min_value=0.0, max_value=1.0), min_size=0, max_size=10))
+def test_property_detect_plateau_never_fires_on_strict_growth(scores: list[float]) -> None:
+    """When scores strictly increase, plateau is never triggered."""
+    growing = sorted({round(s, 3) for s in scores})
+    if len(growing) < PLATEAU_WINDOW + 1:
+        return
+    assert detect_plateau(growing, window=PLATEAU_WINDOW) is False
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(score=st.floats(min_value=-100.0, max_value=100.0).filter(lambda x: not math.isnan(x)))
+def test_property_clamp_score_in_unit_interval(score: float) -> None:
+    out = clamp_score(score)
+    assert 0.0 <= out <= 1.0
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(rounds=st.integers(min_value=-50, max_value=200))
+def test_property_clamp_rounds_in_range(rounds: int) -> None:
+    out = clamp_rounds(rounds)
+    if rounds < MIN_REFINEMENT_ROUNDS:
+        assert out == 1
+    else:
+        assert MIN_REFINEMENT_ROUNDS <= out <= MAX_REFINEMENT_ROUNDS
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS),
+    cost=st.floats(min_value=0.0, max_value=5.0),
+)
+def test_property_cumulative_cost_is_nonnegative(rounds: int, cost: float) -> None:
+    drafter = _CountingDrafter(cost_per_round=cost)
+    refiner = _CountingRefiner(cost_per_round=cost)
+    critic = _ScriptedCritic(scores=[0.0] * rounds)
+    runner = _runner(
+        critic=critic,
+        drafter=drafter,
+        refiner=refiner,
+        score_threshold=1.0,
+        plateau_window=rounds + 10,
+    )
+    report = runner.run(_task(refinement_rounds=rounds))
+    assert report.cumulative_cost_usd >= 0.0
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS))
+def test_property_per_round_lists_align(rounds: int) -> None:
+    critic = _ScriptedCritic(scores=[0.1 * i for i in range(rounds + 2)])
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=rounds + 10)
+    report = runner.run(_task(refinement_rounds=rounds))
+    assert len(report.per_round_cost) == report.rounds_run
+    assert len(report.per_round_critique) == report.rounds_run
+    assert len(report.per_round_quality_score) == report.rounds_run
+
+
+@settings(
+    deadline=None,
+    max_examples=30,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(veto_round=st.integers(min_value=1, max_value=MAX_REFINEMENT_ROUNDS))
+def test_property_adversary_veto_stops_no_later_than_veto_round(veto_round: int) -> None:
+    rounds = MAX_REFINEMENT_ROUNDS
+    critic = _ScriptedCritic(scores=[0.1] * rounds, veto_rounds={veto_round})
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=rounds + 10)
+    report = runner.run(_task(refinement_rounds=rounds))
+    if veto_round <= rounds:
+        assert report.rounds_run <= veto_round
+    if report.rounds_run == veto_round:
+        assert report.early_stop_reason == "adversary_veto"
+
+
+@settings(
+    deadline=None,
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS))
+def test_property_gate_fail_round_set_iff_gate_stop(rounds: int) -> None:
+    critic = _ScriptedCritic(scores=[0.1] * rounds)
+    runner = _runner(critic=critic, score_threshold=1.0, plateau_window=rounds + 10)
+    report = runner.run(_task(refinement_rounds=rounds))
+    assert (report.gate_failed_round is not None) == (report.early_stop_reason == "gate")
+
+
+@settings(
+    deadline=None,
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    threshold=st.floats(min_value=0.0, max_value=1.0),
+    rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS),
+)
+def test_property_threshold_lowered_never_increases_rounds(threshold: float, rounds: int) -> None:
+    """Lowering the threshold never *increases* rounds_run."""
+    if threshold < 0.5:
+        return
+    critic_high = _ScriptedCritic(scores=[0.6] * rounds)
+    runner_high = _runner(critic=critic_high, score_threshold=1.0, plateau_window=rounds + 10)
+    rep_high = runner_high.run(_task(refinement_rounds=rounds))
+
+    critic_low = _ScriptedCritic(scores=[0.6] * rounds)
+    runner_low = _runner(critic=critic_low, score_threshold=threshold, plateau_window=rounds + 10)
+    rep_low = runner_low.run(_task(refinement_rounds=rounds))
+    if threshold <= 0.6:
+        # Lower threshold trips faster.
+        assert rep_low.rounds_run <= rep_high.rounds_run
+
+
+@settings(
+    deadline=None,
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    score=st.floats(min_value=0.0, max_value=1.0),
+    veto=st.booleans(),
+    rationale=st.text(max_size=80),
+)
+def test_property_critique_round_trip(score: float, veto: bool, rationale: str) -> None:
+    crit = Critique(score=clamp_score(score), veto=veto, rationale=rationale)
+    restored = Critique.from_dict(crit.to_dict())
+    assert restored.score == clamp_score(score)
+    assert restored.veto is veto
+    assert restored.rationale == rationale
+
+
+@settings(
+    deadline=None,
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    rounds=st.integers(min_value=MIN_REFINEMENT_ROUNDS, max_value=MAX_REFINEMENT_ROUNDS),
+    seed=st.integers(min_value=0, max_value=2**31),
+)
+def test_property_seeded_run_report_stable_across_repeat(rounds: int, seed: int) -> None:
+    """A seeded runner produces identical reports on repeated invocation."""
+    scores = [0.05 * (i + 1) for i in range(rounds)]
+    r1 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
+    r2 = _runner(critic=_ScriptedCritic(scores=list(scores)), seed=seed, plateau_window=rounds + 10)
+    rep1 = r1.run(_task(refinement_rounds=rounds))
+    rep2 = r2.run(_task(refinement_rounds=rounds))
+    assert rep1.per_round_critique == rep2.per_round_critique
+    assert rep1.per_round_cost == rep2.per_round_cost
+    assert rep1.early_stop_reason == rep2.early_stop_reason
+
+
+@settings(
+    deadline=None,
+    max_examples=20,
+    suppress_health_check=[HealthCheck.function_scoped_fixture, HealthCheck.too_slow],
+)
+@given(
+    cost=st.floats(min_value=0.0, max_value=1.0),
+    budget=st.floats(min_value=0.0, max_value=10.0),
+)
+def test_property_budget_monotonicity_per_round_cost(cost: float, budget: float) -> None:
+    """At fixed budget, larger per-round cost cannot extend rounds_run."""
+    rounds = MAX_REFINEMENT_ROUNDS
+    critic_a = _ScriptedCritic(scores=[0.1] * rounds)
+    runner_a = _runner(
+        critic=critic_a,
+        drafter=_CountingDrafter(cost_per_round=cost),
+        refiner=_CountingRefiner(cost_per_round=cost),
+        budget_usd=budget,
+        score_threshold=1.0,
+        plateau_window=rounds + 10,
+    )
+    critic_b = _ScriptedCritic(scores=[0.1] * rounds)
+    runner_b = _runner(
+        critic=critic_b,
+        drafter=_CountingDrafter(cost_per_round=cost * 2),
+        refiner=_CountingRefiner(cost_per_round=cost * 2),
+        budget_usd=budget,
+        score_threshold=1.0,
+        plateau_window=rounds + 10,
+    )
+    rep_a = runner_a.run(_task(refinement_rounds=rounds))
+    rep_b = runner_b.run(_task(refinement_rounds=rounds))
+    assert rep_b.rounds_run <= rep_a.rounds_run
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against a mock adapter loop
+# ---------------------------------------------------------------------------
+
+
+class _MockAdapter:
+    """Mock adapter that simulates a coding-agent stream.
+
+    Each invocation produces an artefact whose content embeds the
+    accumulated critique text and which monotonically improves a hidden
+    quality signal.  The runner can drive this adapter through any
+    number of rounds and the test asserts on the produced
+    :class:`RefinementReport`.
+    """
+
+    def __init__(self, max_quality: float = 1.0, cost_per_round: float = 0.05) -> None:
+        self.max_quality = max_quality
+        self.cost_per_round = cost_per_round
+        self.history: list[str] = []
+
+    def draft(self, task: Task) -> RoundArtefact:
+        self.history.append("draft")
+        return RoundArtefact(
+            content=f"initial-draft-for-{task.id}",
+            cost_usd=self.cost_per_round,
+            metadata={"phase": "draft"},
+        )
+
+    def refine(self, task: Task, prior: RoundArtefact, critique: Critique) -> RoundArtefact:
+        self.history.append("refine")
+        improved_content = f"{prior.content}\n# applied critique: {critique.rationale}"
+        return RoundArtefact(
+            content=improved_content,
+            cost_usd=self.cost_per_round,
+            metadata={"phase": "refine", "improvement": critique.score},
+        )
+
+    def critique(self, target_curve: list[float]) -> Callable[[Task, RoundArtefact, int], Critique]:
+        def _critic(task: Task, artefact: RoundArtefact, round_index: int) -> Critique:
+            idx = min(round_index - 1, len(target_curve) - 1)
+            return Critique(
+                score=target_curve[idx],
+                issues=[CritiqueIssue(severity="medium", message=f"round-{round_index}")],
+                rationale=f"adversary-round-{round_index}",
+            )
+
+        return _critic
+
+
+def test_integration_full_loop_runs_full_budget() -> None:
+    adapter = _MockAdapter(cost_per_round=0.1)
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.2, 0.4, 0.6]),
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.rounds_run == 3
+    assert adapter.history == ["draft", "refine", "refine"]
+    assert math.isclose(report.cumulative_cost_usd, 0.3, rel_tol=1e-6)
+    assert "applied critique" in report.final_artefact.content
+
+
+def test_integration_threshold_stop_with_climbing_curve() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.2, 0.6, 0.97]),
+        score_threshold=0.9,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "threshold"
+    assert report.rounds_run == 3
+
+
+def test_integration_plateau_stops_loop() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.5, 0.5, 0.5, 0.5]),
+        score_threshold=1.0,
+        plateau_window=2,
+    )
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "plateau"
+    assert report.rounds_run == 3
+
+
+def _integration_gate_fail_after_first(task: Task, artefact: RoundArtefact, round_index: int) -> bool:
+    return round_index < 2
+
+
+def test_integration_gate_failure_halts_loop() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.3, 0.5, 0.9]),
+        gate_runner=_integration_gate_fail_after_first,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=4))
+    assert report.early_stop_reason == "gate"
+    assert report.gate_failed_round == 2
+
+
+def test_integration_budget_breaker_caps_rounds() -> None:
+    adapter = _MockAdapter(cost_per_round=0.5)
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.1, 0.2, 0.3, 0.4]),
+        budget_usd=1.0,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=4))
+    assert report.early_stop_reason == "budget"
+    assert report.rounds_run == 2
+
+
+def test_integration_adversary_veto_halts_after_first_round() -> None:
+    adapter = _MockAdapter()
+
+    def _vetoing_critic(t: Task, a: RoundArtefact, r: int) -> Critique:
+        return Critique(score=0.9, veto=True, rationale=f"reject-{r}")
+
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=_vetoing_critic,
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "adversary_veto"
+    assert report.rounds_run == 1
+
+
+def test_integration_critic_rationale_feeds_next_round() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.3, 0.5]),
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=2))
+    assert "adversary-round-1" in report.final_artefact.content
+
+
+def test_integration_report_records_metadata_through_pipeline() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.2, 0.5, 0.7]),
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    assert report.final_artefact.metadata["phase"] == "refine"
+    assert "improvement" in report.final_artefact.metadata
+
+
+def test_integration_loop_emits_round_indexed_critiques() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.1, 0.2, 0.3]),
+        score_threshold=1.0,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=3))
+    rationales = [c.rationale for c in report.per_round_critique]
+    assert rationales == ["adversary-round-1", "adversary-round-2", "adversary-round-3"]
+
+
+def test_integration_loop_no_refiner_call_after_early_stop() -> None:
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.99]),
+        score_threshold=0.5,
+        plateau_window=10,
+    )
+    runner.run(_task(refinement_rounds=5))
+    # Threshold tripped on round 1  -  refiner must not have been called.
+    assert adapter.history == ["draft"]
+
+
+def test_integration_loop_disable_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loop runs cleanly when decision-log writers are disabled."""
+    monkeypatch.setenv("BERNSTEIN_DECISION_LOG", "0")
+    adapter = _MockAdapter()
+    runner = RefinementLoopRunner(
+        drafter=adapter.draft,
+        refiner=adapter.refine,
+        critic=adapter.critique([0.2, 0.4, 0.99]),
+        score_threshold=0.9,
+        plateau_window=10,
+    )
+    report = runner.run(_task(refinement_rounds=5))
+    assert report.early_stop_reason == "threshold"


### PR DESCRIPTION
## Summary
- Add `RefinementLoopRunner` that drives a single artefact through N rounds of draft -> critique -> refine, complementing the existing parallel `best_of_n` runner.
- Stop conditions: rounds budget, plateau (oscillation guard), critic score threshold, quality-gate failure, cumulative cost cap, adversary veto. Mutually exclusive with `best_of_n` at run time.
- Emits decision-log and calibration entries per round so operators can audit refinement quality over time.
- Public surface: `core/orchestration/refinement_loop.py` + `refinement_schemas.py`. New `Task.refinement_rounds` field. CLI: `--refine 'rounds:N,critic:R,stop:S,threshold:F'`.

## Test plan
- [x] 101 tests: 75 unit, 15 property (monotone-in-budget, deterministic-with-seed, threshold/round invariants, critique round-trip), 11 integration on a mock adapter
- [x] `uv run ruff check` clean on all new and modified files
- [x] `uv run ruff format --check` clean
- [x] `uv run pyright` strict clean on new modules; pre-existing error count in touched files unchanged
- [x] Existing `test_best_of_n.py`, `test_task_store.py`, `test_task_store_property.py` still pass