### PR TITLE
fix(ci): repair main 98f531a04 — agents-md drift + vulture false positive

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -309,10 +309,12 @@ alwaysApply: false
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
 | `resources/`          | MCP resource registrars for Bernstein |
+| `tool_schemas/`       | tool_schemas/ sub-package |
 
 ### `src/bernstein/benchmark/` — SWE-bench
 

--- a/.goosehints
+++ b/.goosehints
@@ -310,10 +310,12 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
 | `resources/`          | MCP resource registrars for Bernstein |
+| `tool_schemas/`       | tool_schemas/ sub-package |
 
 ### `src/bernstein/benchmark/` — SWE-bench
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,10 +310,12 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
 | `resources/`          | MCP resource registrars for Bernstein |
+| `tool_schemas/`       | tool_schemas/ sub-package |
 
 ### `src/bernstein/benchmark/` — SWE-bench
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,10 +310,12 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
 | `resources/`          | MCP resource registrars for Bernstein |
+| `tool_schemas/`       | tool_schemas/ sub-package |
 
 ### `src/bernstein/benchmark/` — SWE-bench
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -310,10 +310,12 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 
 | File                  | Purpose |
 |-----------------------|---------|
+| `input_validation.py` | Schema-validated MCP tool-call inputs with deny-by-default |
 | `remote_transport.py` | Streamable HTTP transport for Bernstein MCP server |
 | `routine_tools.py`    | MCP tools for the rt-003 Routine <-> Scenario bridge |
 | `server.py`           | Bernstein MCP server |
 | `resources/`          | MCP resource registrars for Bernstein |
+| `tool_schemas/`       | tool_schemas/ sub-package |
 
 ### `src/bernstein/benchmark/` — SWE-bench
 

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -133,3 +133,7 @@ depends_on  # noqa
 
 # Protocol method parameter — bound by call site, not used in body
 capture_output  # noqa
+
+# TYPE_CHECKING-only import used inside cast("...") string literal,
+# which vulture's AST walker cannot resolve.
+JsonSchemaValidationError  # noqa


### PR DESCRIPTION
## Summary

Main run [26000149843](https://github.com/sipyourdrink-ltd/bernstein/actions/runs/26000149843) on `98f531a04` failed two jobs:

- **Repo hygiene**: 5 file(s) drift after `feat(mcp): schema-validated tool-call inputs` (#1411). `bernstein agents-md sync` was not run.
- **Dead code (Vulture)**: false positive on `src/bernstein/mcp/input_validation.py:38` (`JsonSchemaValidationError`). The import is used inside a `cast("list[JsonSchemaValidationError]", ...)` string literal at line 332, which vulture's AST walker cannot resolve.

## Fix

- Ran `bernstein agents-md sync` -> AGENTS.md, CLAUDE.md, CONVENTIONS.md, .goosehints, .cursor/rules/module-map.mdc updated (added `input_validation.py` row under `src/bernstein/mcp/`).
- Added `JsonSchemaValidationError` entry to `vulture_whitelist.py` with comment explaining the false positive.

## Test plan

- [x] `bernstein agents-md sync` exits clean.
- [x] `vulture src/ vulture_whitelist.py --min-confidence 80 --exclude tests,docs` no longer reports input_validation.py:38.
- [ ] CI green on this PR before merge.