### PR TITLE
feat(cost): per-quota-envelope attribution + budget hooks (closes #1405)

### DIFF
--- a/src/bernstein/cli/commands/cost.py
+++ b/src/bernstein/cli/commands/cost.py
@@ -8,7 +8,7 @@ import re
 import time
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import click
 from rich.console import Console
@@ -262,6 +262,13 @@ def _aggregate_from_ledger_or_tasks(
     for rec in task_records:
         if dimension == "role":
             label = str(rec.get("role", "") or "unknown")
+        elif dimension == "envelope":
+            raw_tags_env: object = rec.get("cost_tags") or {}
+            if isinstance(raw_tags_env, dict):
+                tags_env = cast("dict[str, Any]", raw_tags_env)
+                label = str(tags_env.get("quota_envelope", "") or "subscription")
+            else:
+                label = "subscription"
         else:
             tags = rec.get("cost_tags") or {}
             label = str(tags.get("feature_label", "") or "unknown") if isinstance(tags, dict) else "unknown"
@@ -589,9 +596,9 @@ def _cost_render_grouped(
 @click.option(
     "--by",
     "group_by",
-    type=click.Choice(["agent", "model", "task", "day", "role", "feature_label"]),
+    type=click.Choice(["agent", "model", "task", "day", "role", "feature_label", "envelope"]),
     default=None,
-    help="Group breakdown by agent, model, task, day, role, or feature_label (issue #1320).",
+    help="Group breakdown by agent, model, task, day, role, feature_label, or envelope (issue #1405).",
 )
 @click.option(
     "--ledger",
@@ -709,10 +716,11 @@ def cost_cmd(
         grouped_data = _aggregate_by_task(task_records)
     elif group_by == "day":
         grouped_data = _aggregate_by_day(task_records)
-    elif group_by in ("role", "feature_label"):
-        # Issue #1320: role / feature_label are tagged dimensions that live
-        # in the rolling spend ledger. Fall back to task_records when the
-        # ledger is missing so old runs still show a sensible view.
+    elif group_by in ("role", "feature_label", "envelope"):
+        # Issue #1320 + #1405: role / feature_label / envelope are tagged
+        # dimensions that live in the rolling spend ledger. Fall back to
+        # task_records when the ledger is missing so old runs still show
+        # a sensible view.
         grouped_data = _aggregate_from_ledger_or_tasks(
             Path(ledger_path),
             task_records,
@@ -845,3 +853,174 @@ def cost_cmd(
         tasks_failed=tasks_failed,
         total_duration_s=total_dur,
     )
+
+
+# ---------------------------------------------------------------------------
+# `bernstein cost-envelopes` subcommand group (issue #1405)
+# ---------------------------------------------------------------------------
+
+
+def _load_envelope_rollup_from_ledger(
+    ledger_path: Path,
+    envelopes_cfg: dict[str, dict[str, Any]],
+    cutoff: float,
+) -> dict[str, dict[str, Any]]:
+    """Build a per-envelope rollup from the spend ledger.
+
+    Falls back to an empty mapping when the ledger is missing. The
+    operator-supplied ``envelopes_cfg`` is consulted for caps + model
+    allowlists; envelopes seen in the ledger but absent from config show
+    up as uncapped buckets so dashboards never lose attribution.
+    """
+    from bernstein.core.cost.cost_rollup_by_envelope import rollup
+    from bernstein.core.cost.cost_tracker import EnvelopeConfig, TokenUsage
+    from bernstein.core.cost.spend_ledger import SpendLedger
+
+    if not ledger_path.exists():
+        return {}
+    entries = SpendLedger.load_entries(ledger_path)
+    if cutoff > 0:
+        entries = [e for e in entries if e.ts >= cutoff]
+    records = [
+        TokenUsage(
+            input_tokens=e.input_tokens,
+            output_tokens=e.output_tokens,
+            model=e.model,
+            cost_usd=e.cost_usd,
+            agent_id=e.agent_id or "unknown",
+            task_id=e.task_id or "unknown",
+            timestamp=e.ts,
+            cache_read_tokens=e.cache_read_tokens,
+            cache_write_tokens=e.cache_write_tokens,
+            quota_envelope=e.quota_envelope or "subscription",
+        )
+        for e in entries
+    ]
+    envelope_objs = {name: EnvelopeConfig.from_dict(name, cfg) for name, cfg in envelopes_cfg.items()}
+    rows = rollup(records, envelope_objs)
+    return {name: row.to_dict() for name, row in rows.items()}
+
+
+def _read_envelopes_from_yaml(yaml_path: Path) -> dict[str, dict[str, Any]]:
+    """Parse the ``cost.envelopes`` block from ``bernstein.yaml``.
+
+    Returns an empty mapping when the file is missing, malformed, or
+    lacks the block. PyYAML is imported lazily so the CLI module stays
+    cheap to load.
+    """
+    if not yaml_path.exists():
+        return {}
+    try:
+        import yaml  # local import: optional for non-CLI callers
+
+        data_raw: object = yaml.safe_load(yaml_path.read_text()) or {}
+    except (OSError, ValueError, TypeError):
+        return {}
+    if not isinstance(data_raw, dict):
+        return {}
+    data = cast("dict[str, Any]", data_raw)
+    cost_block_raw: object = data.get("cost") or {}
+    if not isinstance(cost_block_raw, dict):
+        return {}
+    cost_block = cast("dict[str, Any]", cost_block_raw)
+    envelopes_block_raw: object = cost_block.get("envelopes") or {}
+    if not isinstance(envelopes_block_raw, dict):
+        return {}
+    envelopes_block = cast("dict[str, Any]", envelopes_block_raw)
+    out: dict[str, dict[str, Any]] = {}
+    for name, payload in envelopes_block.items():
+        if isinstance(payload, dict):
+            payload_d = cast("dict[str, Any]", payload)
+            out[str(name)] = {str(k): v for k, v in payload_d.items()}
+    return out
+
+
+@click.group("cost-envelopes")
+def cost_envelopes_group() -> None:
+    """Inspect per-quota-envelope cost attribution (issue #1405)."""
+
+
+@cost_envelopes_group.command("show")
+@click.option(
+    "--ledger",
+    "ledger_path",
+    type=str,
+    default=".sdd/cost/ledger.jsonl",
+    show_default=True,
+    help="Path to the rolling spend ledger JSONL.",
+)
+@click.option(
+    "--config",
+    "config_path",
+    type=str,
+    default="bernstein.yaml",
+    show_default=True,
+    help="Path to the bernstein.yaml file holding ``cost.envelopes``.",
+)
+@click.option("--last", "last", type=str, default=None, help="Time range: 1h, 24h, 7d, 30d.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output raw JSON.")
+def cost_envelopes_show_cmd(
+    ledger_path: str,
+    config_path: str,
+    last: str | None,
+    as_json: bool,
+) -> None:
+    """Render the per-envelope rollup table."""
+    cutoff = _parse_time_range(last) if last else 0.0
+    envelopes_cfg = _read_envelopes_from_yaml(Path(config_path))
+    rollup_data = _load_envelope_rollup_from_ledger(Path(ledger_path), envelopes_cfg, cutoff)
+
+    if as_json or is_json():
+        print_json(
+            {
+                "ledger": ledger_path,
+                "config": config_path,
+                "envelopes": rollup_data,
+            }
+        )
+        return
+
+    if not rollup_data:
+        console.print(
+            "[dim]No envelope data found. Configure ``cost.envelopes`` in bernstein.yaml "
+            "and run at least one task to populate the ledger.[/dim]"
+        )
+        return
+
+    from rich.table import Table
+
+    table = Table(title="Bernstein Cost Envelopes", header_style="bold cyan", show_lines=False)
+    table.add_column("Envelope", min_width=18, no_wrap=True)
+    table.add_column("Spent", justify="right", min_width=10)
+    table.add_column("Cap", justify="right", min_width=10)
+    table.add_column("Pct", justify="right", min_width=6)
+    table.add_column("Hard cap", justify="right", min_width=10)
+    table.add_column("Calls", justify="right", min_width=6)
+    table.add_column("Status", min_width=10)
+
+    for name in sorted(rollup_data):
+        row = rollup_data[name]
+        cap = float(row.get("cap", 0.0) or 0.0)
+        hard_cap = float(row.get("hard_cap", 0.0) or 0.0)
+        spent = float(row.get("total_spend", 0.0) or 0.0)
+        pct = float(row.get("pct_used", 0.0) or 0.0)
+        calls = int(row.get("calls", 0) or 0)
+        if row.get("hard_breached"):
+            status = "[red]HARD BREACH[/red]"
+        elif row.get("threshold_reached"):
+            status = "[yellow]threshold[/yellow]"
+        else:
+            status = "[green]ok[/green]"
+        table.add_row(
+            name,
+            f"${spent:.4f}",
+            f"${cap:.4f}" if cap > 0 else "-",
+            f"{pct * 100:.0f}%" if cap > 0 else "-",
+            f"${hard_cap:.4f}" if hard_cap > 0 else "-",
+            str(calls),
+            status,
+        )
+    console.print(table)
+
+
+__all__ = ["cost_cmd", "cost_envelopes_group", "estimate_cmd"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -66,7 +66,7 @@ from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _ro
 from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.compliance_cmd import compliance_group
 from bernstein.cli.config_path_cmd import config_path_cmd
-from bernstein.cli.cost import cost_cmd, estimate_cmd
+from bernstein.cli.cost import cost_cmd, cost_envelopes_group, estimate_cmd
 from bernstein.cli.debug_cmd import debug_cmd
 from bernstein.cli.dep_impact_cmd import dep_impact_cmd
 from bernstein.cli.diff_cmd import diff_cmd
@@ -857,6 +857,7 @@ cli.add_command(auth_group, "auth")
 cli.add_command(auth_login, "login")
 cli.add_command(evolve)
 cli.add_command(cost_cmd, "cost")
+cli.add_command(cost_envelopes_group, "cost-envelopes")
 cli.add_command(estimate_cmd, "estimate")
 cli.add_command(status)
 cli.add_command(ps_cmd, "ps")

--- a/src/bernstein/core/config/seed_config.py
+++ b/src/bernstein/core/config/seed_config.py
@@ -326,6 +326,12 @@ class SeedConfig:
     model_fallback: ModelFallbackSeedConfig | None = None
     cost_tags: dict[str, str] = field(default_factory=dict)
     cost_autopilot: bool = False
+    # Per-quota-envelope budgets (issue #1405). Parsed from the
+    # ``cost.envelopes`` block of ``bernstein.yaml`` into a mapping of
+    # envelope-name -> raw config dict (``budget_usd``, ``hard_budget_usd``,
+    # ``model_allowlist``, ``threshold_pct``). Empty dict preserves
+    # legacy single-envelope behaviour.
+    cost_envelopes: dict[str, dict[str, Any]] = field(default_factory=dict[str, dict[str, Any]])
     deployment_strategy: str = "rolling"
     org_policies: list[str] = field(default_factory=list)
     metrics: dict[str, MetricSchema] = field(default_factory=dict)

--- a/src/bernstein/core/config/seed_parser.py
+++ b/src/bernstein/core/config/seed_parser.py
@@ -1347,6 +1347,64 @@ def _parse_cost_tags(raw: object) -> dict[str, str]:
     return {str(k): str(v) for k, v in raw.items()}
 
 
+def _parse_cost_envelopes(data: dict[str, object]) -> dict[str, dict[str, Any]]:
+    """Parse the optional ``cost.envelopes`` block (issue #1405).
+
+    Accepted shapes::
+
+        cost:
+          envelopes:
+            subscription:
+              budget_usd: 50
+              hard_budget_usd: 60
+              threshold_pct: 0.8
+              model_allowlist: [opus, sonnet]
+            agent-sdk-credits:
+              budget_usd: 20
+
+    Returns an empty mapping when the block is absent so the legacy
+    single-envelope rollup is preserved verbatim.
+    """
+    cost_block_raw: object = data.get("cost")
+    if cost_block_raw is None:
+        return {}
+    if not isinstance(cost_block_raw, dict):
+        raise SeedError(f"cost must be a mapping, got: {type(cost_block_raw).__name__}")
+    cost_block = cast("dict[str, Any]", cost_block_raw)
+    envelopes_raw: object = cost_block.get("envelopes")
+    if envelopes_raw is None:
+        return {}
+    if not isinstance(envelopes_raw, dict):
+        raise SeedError(f"cost.envelopes must be a mapping, got: {type(envelopes_raw).__name__}")
+    envelopes = cast("dict[str, Any]", envelopes_raw)
+    out: dict[str, dict[str, Any]] = {}
+    for name, payload in envelopes.items():
+        if not isinstance(payload, dict):
+            raise SeedError(f"cost.envelopes.{name} must be a mapping, got: {type(payload).__name__}")
+        payload_dict = cast("dict[str, Any]", payload)
+        norm: dict[str, Any] = {}
+        if "budget_usd" in payload_dict:
+            norm["budget_usd"] = _parse_budget(cast("str | int | float | None", payload_dict["budget_usd"])) or 0.0
+        if "hard_budget_usd" in payload_dict:
+            norm["hard_budget_usd"] = (
+                _parse_budget(cast("str | int | float | None", payload_dict["hard_budget_usd"])) or 0.0
+            )
+        if "threshold_pct" in payload_dict:
+            tp_raw = payload_dict["threshold_pct"]
+            if not isinstance(tp_raw, int | float) or not (0.0 < float(tp_raw) <= 1.0):
+                raise SeedError(f"cost.envelopes.{name}.threshold_pct must be a number in (0, 1], got: {tp_raw!r}")
+            norm["threshold_pct"] = float(tp_raw)
+        if "model_allowlist" in payload_dict:
+            allow_raw = payload_dict["model_allowlist"]
+            if not isinstance(allow_raw, list | tuple):
+                raise SeedError(
+                    f"cost.envelopes.{name}.model_allowlist must be a list, got: {type(allow_raw).__name__}"
+                )
+            norm["model_allowlist"] = [str(x) for x in cast("list[Any]", allow_raw) if str(x).strip()]
+        out[str(name)] = norm
+    return out
+
+
 def _parse_cli(data: dict[str, object]) -> Literal["claude", "codex", "gemini", "qwen", "auto"]:
     cli_raw: object = data.get("cli", "auto")
     if cli_raw not in _VALID_CLIS:
@@ -1522,6 +1580,7 @@ def parse_seed(path: Path) -> SeedConfig:
     model_fallback = _parse_model_fallback(data.get("model_fallback"))
     cost_tags = _parse_cost_tags(data.get("cost_tags", {}))
     cost_autopilot_raw = _validate_optional_bool(data, "cost_autopilot", False)
+    cost_envelopes = _parse_cost_envelopes(data)
     deployment_strategy_raw = _validate_optional_str(data, "deployment_strategy", "rolling")
 
     org_policies_raw: object = data.get("org_policies", [])
@@ -1578,6 +1637,7 @@ def parse_seed(path: Path) -> SeedConfig:
         model_fallback=model_fallback,
         cost_tags=cost_tags,
         cost_autopilot=cost_autopilot_raw,
+        cost_envelopes=cost_envelopes,
         deployment_strategy=deployment_strategy_raw,
         org_policies=org_policies,
         metrics=metrics,

--- a/src/bernstein/core/cost/budget_actions.py
+++ b/src/bernstein/core/cost/budget_actions.py
@@ -211,6 +211,96 @@ def suggest_downgrade(current_model: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Envelope threshold hook (issue #1405)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EnvelopeThresholdEvent:
+    """Payload emitted when a quota envelope crosses its threshold.
+
+    Attributes:
+        envelope: Envelope identifier (e.g. ``"subscription"``).
+        spent_usd: Cumulative spend attributed to the envelope.
+        cap_usd: Configured soft cap.
+        pct_used: ``spent_usd / cap_usd``.
+        threshold_pct: Configured threshold-hook fraction.
+        hard_breached: ``True`` when the hard cap was hit on the same
+            record() call (the hook fires for soft *or* hard transitions
+            so downstream handlers can decide whether to halt or warn).
+        timestamp: Unix timestamp of the firing event.
+        message: Human-readable explanation suitable for logs / Slack.
+    """
+
+    envelope: str
+    spent_usd: float
+    cap_usd: float
+    pct_used: float
+    threshold_pct: float
+    hard_breached: bool
+    timestamp: float = field(default_factory=time.time)
+    message: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "envelope": self.envelope,
+            "spent_usd": round(self.spent_usd, 6),
+            "cap_usd": self.cap_usd,
+            "pct_used": round(self.pct_used, 4),
+            "threshold_pct": self.threshold_pct,
+            "hard_breached": self.hard_breached,
+            "timestamp": self.timestamp,
+            "message": self.message,
+        }
+
+
+def envelope_threshold_reached(
+    *,
+    envelope: str,
+    spent_usd: float,
+    cap_usd: float,
+    threshold_pct: float = 0.80,
+    hard_cap_usd: float = 0.0,
+) -> EnvelopeThresholdEvent | None:
+    """Return an :class:`EnvelopeThresholdEvent` when the threshold trips.
+
+    Returns ``None`` when the cap is unset, the threshold has not been
+    crossed, and the hard cap has not been breached. Otherwise builds a
+    structured event suitable for routing through the budget-hook
+    pipeline.
+
+    Args:
+        envelope: Envelope identifier.
+        spent_usd: Cumulative spend so far on the envelope.
+        cap_usd: Configured soft cap (``0`` = unlimited; returns ``None``).
+        threshold_pct: Fraction of ``cap_usd`` that fires the hook.
+        hard_cap_usd: Configured hard cap. When ``spent_usd >= hard_cap``
+            the hook also fires (with ``hard_breached=True``).
+    """
+    hard_breached = hard_cap_usd > 0 and spent_usd >= hard_cap_usd
+    if cap_usd <= 0 and not hard_breached:
+        return None
+    pct = (spent_usd / cap_usd) if cap_usd > 0 else 0.0
+    if not hard_breached and pct < threshold_pct:
+        return None
+    message = (
+        f"envelope {envelope!r} hard cap breached: spent=${spent_usd:.4f} / cap=${hard_cap_usd:.4f}"
+        if hard_breached
+        else f"envelope {envelope!r} at {pct * 100:.0f}% of ${cap_usd:.4f} cap"
+    )
+    return EnvelopeThresholdEvent(
+        envelope=envelope,
+        spent_usd=spent_usd,
+        cap_usd=cap_usd,
+        pct_used=pct,
+        threshold_pct=threshold_pct,
+        hard_breached=hard_breached,
+        message=message,
+    )
+
+
 def apply_policy(
     policy: BudgetPolicy,
     percentage_used: float,

--- a/src/bernstein/core/cost/cost_rollup_by_envelope.py
+++ b/src/bernstein/core/cost/cost_rollup_by_envelope.py
@@ -1,0 +1,250 @@
+"""Per-quota-envelope cost rollup (issue #1405).
+
+Aggregates :class:`bernstein.core.cost.cost_tracker.TokenUsage` records
+into per-envelope spend / cap / burn reports. The rollup is a pure
+function over a list of records so it can be driven from any source
+(in-memory tracker, JSONL ledger, persisted run snapshot).
+
+Caps are read from operator-supplied :class:`EnvelopeConfig` mappings;
+when an envelope is observed without a configured cap the report shows
+``cap_usd = 0.0`` (unlimited) and ``pct_used = 0.0``.
+
+Forecast-to-cap is a linear extrapolation: ``cap_usd / burn_rate``. Burn
+rate is ``spent_usd / window_seconds`` using the first-to-last record
+timestamp window. When fewer than two records exist or the window is
+zero we return ``None`` for the forecast so dashboards can render
+``"--"`` instead of a misleading projection.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from bernstein.core.cost.cost_tracker import (
+    DEFAULT_ENVELOPE_THRESHOLD,
+    DEFAULT_QUOTA_ENVELOPE,
+    EnvelopeConfig,
+    EnvelopeReport,
+    TokenUsage,
+)
+
+
+@dataclass(frozen=True)
+class EnvelopeRollupRow:
+    """One row of the per-envelope rollup.
+
+    Attributes:
+        name: Envelope identifier.
+        total_spend: Cumulative cost attributed to this envelope.
+        cap: Soft cap from :class:`EnvelopeConfig.budget_usd` (``0`` =
+            unlimited).
+        hard_cap: Hard cap; ``0`` = unlimited.
+        pct_used: ``total_spend / cap`` when ``cap > 0`` else ``0.0``.
+        threshold_pct: Configured threshold-hook fraction.
+        threshold_reached: ``True`` when ``pct_used >= threshold_pct``.
+        hard_breached: ``True`` when ``total_spend >= hard_cap`` (and the
+            hard cap is set).
+        forecast_to_cap_seconds: Seconds until the soft cap is exhausted
+            at the current burn rate, or ``None`` when the projection is
+            undefined.
+        calls: Number of LLM calls attributed to this envelope.
+        models: Sorted tuple of distinct model names observed.
+        first_ts: Earliest record timestamp; ``0.0`` when empty.
+        last_ts: Latest record timestamp; ``0.0`` when empty.
+        burn_rate_usd_per_sec: Average spend rate over the observed
+            window (``0.0`` when the window collapses to a point).
+    """
+
+    name: str
+    total_spend: float
+    cap: float
+    hard_cap: float
+    pct_used: float
+    threshold_pct: float
+    threshold_reached: bool
+    hard_breached: bool
+    forecast_to_cap_seconds: float | None
+    calls: int
+    models: tuple[str, ...]
+    first_ts: float
+    last_ts: float
+    burn_rate_usd_per_sec: float
+
+    def to_envelope_report(self) -> EnvelopeReport:
+        """Return the equivalent live :class:`EnvelopeReport`.
+
+        Useful for dashboard tiles that already render
+        :class:`EnvelopeReport` from the live tracker — the rollup row
+        carries the same fields when driven from a historical ledger.
+        """
+        remaining = max(self.cap - self.total_spend, 0.0) if self.cap > 0 else float("inf")
+        hard_remaining = max(self.hard_cap - self.total_spend, 0.0) if self.hard_cap > 0 else float("inf")
+        return EnvelopeReport(
+            name=self.name,
+            spent_usd=self.total_spend,
+            cap_usd=self.cap,
+            hard_cap_usd=self.hard_cap,
+            pct_used=self.pct_used,
+            threshold_pct=self.threshold_pct,
+            calls=self.calls,
+            remaining_usd=remaining,
+            hard_remaining_usd=hard_remaining,
+            threshold_reached=self.threshold_reached,
+            hard_breached=self.hard_breached,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "name": self.name,
+            "total_spend": round(self.total_spend, 6),
+            "cap": self.cap,
+            "hard_cap": self.hard_cap,
+            "pct_used": round(self.pct_used, 4),
+            "threshold_pct": self.threshold_pct,
+            "threshold_reached": self.threshold_reached,
+            "hard_breached": self.hard_breached,
+            "forecast_to_cap_seconds": self.forecast_to_cap_seconds,
+            "calls": self.calls,
+            "models": list(self.models),
+            "first_ts": self.first_ts,
+            "last_ts": self.last_ts,
+            "burn_rate_usd_per_sec": self.burn_rate_usd_per_sec,
+        }
+
+
+@dataclass
+class _EnvelopeAccum:
+    """Running accumulator used during ``rollup()``."""
+
+    spend: float = 0.0
+    calls: int = 0
+    models: set[str] = field(default_factory=set[str])
+    first_ts: float = 0.0
+    last_ts: float = 0.0
+
+
+def rollup(
+    records: list[TokenUsage],
+    envelopes: dict[str, EnvelopeConfig] | None = None,
+    *,
+    now: float | None = None,
+) -> dict[str, EnvelopeRollupRow]:
+    """Roll a list of :class:`TokenUsage` rows up into per-envelope reports.
+
+    Records without an explicit ``quota_envelope`` fall under
+    :data:`DEFAULT_QUOTA_ENVELOPE`. Configured envelopes that received
+    zero spend still appear in the output so dashboards can show "$0 of
+    $X" tiles without merging two sources.
+
+    Args:
+        records: Token-usage rows to aggregate.
+        envelopes: Operator-supplied envelope configuration. ``None`` is
+            equivalent to an empty mapping.
+        now: Wall-clock timestamp used for the burn-rate window. Defaults
+            to :func:`time.time` and is exposed for deterministic tests.
+
+    Returns:
+        Mapping from envelope name to :class:`EnvelopeRollupRow`. Keys
+        are sorted for stable iteration order.
+    """
+    env_cfg = dict(envelopes or {})
+    accum: dict[str, _EnvelopeAccum] = {name: _EnvelopeAccum() for name in env_cfg}
+
+    for rec in records:
+        name = rec.quota_envelope or DEFAULT_QUOTA_ENVELOPE
+        bucket = accum.get(name)
+        if bucket is None:
+            bucket = _EnvelopeAccum()
+            accum[name] = bucket
+        bucket.spend += rec.cost_usd
+        bucket.calls += 1
+        if rec.model:
+            bucket.models.add(rec.model)
+        ts = rec.timestamp
+        if ts > 0:
+            if bucket.first_ts == 0.0 or ts < bucket.first_ts:
+                bucket.first_ts = ts
+            if ts > bucket.last_ts:
+                bucket.last_ts = ts
+
+    snap_now = now if now is not None else time.time()
+
+    out: dict[str, EnvelopeRollupRow] = {}
+    for name in sorted(accum):
+        bucket = accum[name]
+        cfg = env_cfg.get(name)
+        cap = cfg.budget_usd if cfg is not None else 0.0
+        hard_cap = cfg.hard_budget_usd if cfg is not None else 0.0
+        threshold = cfg.threshold_pct if cfg is not None else DEFAULT_ENVELOPE_THRESHOLD
+        pct = (bucket.spend / cap) if cap > 0 else 0.0
+        threshold_reached = cap > 0 and pct >= threshold
+        hard_breached = hard_cap > 0 and bucket.spend >= hard_cap
+
+        # Burn-rate window: prefer first-to-last record span; fall back
+        # to first-to-now when only one record exists so a long-running
+        # idle envelope still produces a finite forecast.
+        if bucket.first_ts > 0 and bucket.last_ts > bucket.first_ts:
+            window_s = bucket.last_ts - bucket.first_ts
+        elif bucket.first_ts > 0 and snap_now > bucket.first_ts:
+            window_s = snap_now - bucket.first_ts
+        else:
+            window_s = 0.0
+
+        burn_rate = (bucket.spend / window_s) if window_s > 0 else 0.0
+        if cap > 0 and burn_rate > 0:
+            remaining = max(cap - bucket.spend, 0.0)
+            forecast: float | None = remaining / burn_rate
+        else:
+            forecast = None
+
+        out[name] = EnvelopeRollupRow(
+            name=name,
+            total_spend=bucket.spend,
+            cap=cap,
+            hard_cap=hard_cap,
+            pct_used=pct,
+            threshold_pct=threshold,
+            threshold_reached=threshold_reached,
+            hard_breached=hard_breached,
+            forecast_to_cap_seconds=forecast,
+            calls=bucket.calls,
+            models=tuple(sorted(bucket.models)),
+            first_ts=bucket.first_ts,
+            last_ts=bucket.last_ts,
+            burn_rate_usd_per_sec=burn_rate,
+        )
+
+    return out
+
+
+def aggregate_totals(rows: dict[str, EnvelopeRollupRow]) -> dict[str, float]:
+    """Sum spend / cap / hard_cap across every envelope.
+
+    Convenience helper for the CLI total row. Returned keys:
+    ``total_spend``, ``total_cap``, ``total_hard_cap``, ``total_calls``.
+    """
+    total_spend = 0.0
+    total_cap = 0.0
+    total_hard = 0.0
+    total_calls = 0
+    for row in rows.values():
+        total_spend += row.total_spend
+        total_cap += row.cap
+        total_hard += row.hard_cap
+        total_calls += row.calls
+    return {
+        "total_spend": total_spend,
+        "total_cap": total_cap,
+        "total_hard_cap": total_hard,
+        "total_calls": float(total_calls),
+    }
+
+
+__all__ = [
+    "EnvelopeRollupRow",
+    "aggregate_totals",
+    "rollup",
+]

--- a/src/bernstein/core/cost/cost_tracker.py
+++ b/src/bernstein/core/cost/cost_tracker.py
@@ -148,6 +148,160 @@ def _resolve_usage_buffer_size() -> int:
 
 
 # ---------------------------------------------------------------------------
+# Quota envelopes (issue #1405)
+# ---------------------------------------------------------------------------
+
+# Default envelope when an adapter does not classify a call. Existing
+# behaviour is preserved: all spend rolls up under a single bucket named
+# ``"subscription"``.
+DEFAULT_QUOTA_ENVELOPE: str = "subscription"
+
+# Threshold (fraction of envelope cap) at which the
+# ``envelope_threshold_reached`` budget hook fires. Operators can override
+# per-envelope via ``EnvelopeConfig.threshold_pct``.
+DEFAULT_ENVELOPE_THRESHOLD: float = 0.80
+
+
+@dataclass(frozen=True)
+class EnvelopeConfig:
+    """Per-envelope budget configuration loaded from ``bernstein.yaml``.
+
+    Attributes:
+        name: Envelope identifier (e.g. ``"subscription"``).
+        budget_usd: Soft cap for this envelope in USD (``0`` = unlimited).
+        hard_budget_usd: Hard cap for this envelope. Reaching this cap
+            refuses further spawns / records for the envelope.
+        model_allowlist: Optional whitelist of model substrings permitted
+            on this envelope. Empty tuple means any model is allowed.
+        threshold_pct: Fraction of ``budget_usd`` at which the
+            ``envelope_threshold_reached`` hook fires.
+    """
+
+    name: str
+    budget_usd: float = 0.0
+    hard_budget_usd: float = 0.0
+    model_allowlist: tuple[str, ...] = ()
+    threshold_pct: float = DEFAULT_ENVELOPE_THRESHOLD
+
+    def __post_init__(self) -> None:
+        # Frozen dataclass with validation. Use object.__setattr__ to
+        # normalise non-positive caps to zero (no cap) so callers can pass
+        # negative defaults without surprises.
+        if self.budget_usd < 0:
+            object.__setattr__(self, "budget_usd", 0.0)
+        if self.hard_budget_usd < 0:
+            object.__setattr__(self, "hard_budget_usd", 0.0)
+        if not (0.0 < self.threshold_pct <= 1.0):
+            object.__setattr__(self, "threshold_pct", DEFAULT_ENVELOPE_THRESHOLD)
+
+    def model_allowed(self, model: str) -> bool:
+        """Return True when ``model`` is permitted on this envelope.
+
+        Empty ``model_allowlist`` means "no restriction". Otherwise the
+        check is substring-based and case-insensitive so concrete model
+        names (``"claude-sonnet-4"``) match the configured family
+        prefixes (``"sonnet"``).
+        """
+        if not self.model_allowlist:
+            return True
+        m = model.lower()
+        return any(allowed.lower() in m for allowed in self.model_allowlist)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict."""
+        return {
+            "name": self.name,
+            "budget_usd": self.budget_usd,
+            "hard_budget_usd": self.hard_budget_usd,
+            "model_allowlist": list(self.model_allowlist),
+            "threshold_pct": self.threshold_pct,
+        }
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict[str, Any]) -> EnvelopeConfig:
+        """Build from a parsed ``bernstein.yaml`` mapping."""
+        raw_allow = d.get("model_allowlist") or ()
+        allow_iter: list[str] = []
+        if isinstance(raw_allow, list | tuple):
+            allow_iter = [str(x) for x in cast("list[Any]", raw_allow) if str(x).strip()]
+        return cls(
+            name=str(name),
+            budget_usd=float(d.get("budget_usd", 0.0) or 0.0),
+            hard_budget_usd=float(d.get("hard_budget_usd", 0.0) or 0.0),
+            model_allowlist=tuple(allow_iter),
+            threshold_pct=float(d.get("threshold_pct", DEFAULT_ENVELOPE_THRESHOLD) or DEFAULT_ENVELOPE_THRESHOLD),
+        )
+
+
+class EnvelopeBudgetError(RuntimeError):
+    """Raised when a record/spawn would breach a per-envelope hard cap.
+
+    The orchestrator catches this and refuses to admit the call without
+    crashing the run. The exception carries the offending envelope name
+    and the policy reason so callers can log a structured event.
+    """
+
+    def __init__(self, envelope: str, reason: str, *, spent_usd: float, cap_usd: float) -> None:
+        super().__init__(f"envelope {envelope!r} refused: {reason} (spent=${spent_usd:.4f} cap=${cap_usd:.4f})")
+        self.envelope = envelope
+        self.reason = reason
+        self.spent_usd = spent_usd
+        self.cap_usd = cap_usd
+
+
+@dataclass(frozen=True)
+class EnvelopeReport:
+    """Snapshot of one envelope's spend, cap, and burn state.
+
+    Attributes:
+        name: Envelope identifier.
+        spent_usd: Cumulative spend attributed to this envelope.
+        cap_usd: Soft cap from :class:`EnvelopeConfig.budget_usd`.
+        hard_cap_usd: Hard cap from :class:`EnvelopeConfig.hard_budget_usd`.
+        pct_used: ``spent_usd / cap_usd`` (``0.0`` when cap is unset).
+        threshold_pct: Configured fire-the-hook fraction.
+        calls: Number of LLM calls recorded against this envelope.
+        remaining_usd: Soft-cap remaining (``inf`` when uncapped).
+        hard_remaining_usd: Hard-cap remaining (``inf`` when uncapped).
+        threshold_reached: ``True`` when ``pct_used >= threshold_pct``.
+        hard_breached: ``True`` when the hard cap has been hit.
+    """
+
+    name: str
+    spent_usd: float
+    cap_usd: float
+    hard_cap_usd: float
+    pct_used: float
+    threshold_pct: float
+    calls: int
+    remaining_usd: float
+    hard_remaining_usd: float
+    threshold_reached: bool
+    hard_breached: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict (``inf`` rendered as ``None``)."""
+        import math
+
+        def _safe(v: float) -> float | None:
+            return v if math.isfinite(v) else None
+
+        return {
+            "name": self.name,
+            "spent_usd": round(self.spent_usd, 6),
+            "cap_usd": self.cap_usd,
+            "hard_cap_usd": self.hard_cap_usd,
+            "pct_used": round(self.pct_used, 4),
+            "threshold_pct": self.threshold_pct,
+            "calls": self.calls,
+            "remaining_usd": _safe(self.remaining_usd),
+            "hard_remaining_usd": _safe(self.hard_remaining_usd),
+            "threshold_reached": self.threshold_reached,
+            "hard_breached": self.hard_breached,
+        }
+
+
+# ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
 
@@ -181,6 +335,10 @@ class TokenUsage:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     cost_tags: dict[str, str] = field(default_factory=dict)
+    # Per-quota-envelope attribution (issue #1405). Defaults to
+    # ``"subscription"`` so existing single-envelope rollups remain
+    # backwards compatible.
+    quota_envelope: str = DEFAULT_QUOTA_ENVELOPE
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-safe dict."""
@@ -198,6 +356,7 @@ class TokenUsage:
             "cache_read_tokens": self.cache_read_tokens,
             "cache_write_tokens": self.cache_write_tokens,
             "cost_tags": self.cost_tags,
+            "quota_envelope": self.quota_envelope,
         }
 
     @classmethod
@@ -209,6 +368,8 @@ class TokenUsage:
             tags = {str(k): str(v) for k, v in cast("dict[str, Any]", raw_tags).items()}
         else:
             tags = {}
+        env_raw: object = d.get("quota_envelope", DEFAULT_QUOTA_ENVELOPE)
+        envelope = str(env_raw) if env_raw else DEFAULT_QUOTA_ENVELOPE
         return cls(
             input_tokens=int(d["input_tokens"]),
             output_tokens=int(d["output_tokens"]),
@@ -223,6 +384,7 @@ class TokenUsage:
             cache_read_tokens=int(d.get("cache_read_tokens", 0)),
             cache_write_tokens=int(d.get("cache_write_tokens", 0)),
             cost_tags=tags,
+            quota_envelope=envelope,
         )
 
 
@@ -371,6 +533,13 @@ class CostTracker:
     # ``bernstein cost --by ...`` can attribute spend post-hoc.
     spend_ledger: Any | None = None  # SpendLedger; typed as Any to avoid import cycle
 
+    # Per-envelope budgets (issue #1405). Maps envelope name to its
+    # :class:`EnvelopeConfig`. When the dict is empty the legacy
+    # single-envelope behaviour is preserved. Hard caps are enforced
+    # inside ``record()``; the budget hook fires when an envelope crosses
+    # its configured threshold.
+    envelopes: dict[str, EnvelopeConfig] = field(default_factory=dict[str, EnvelopeConfig])
+
     # Mutable tracking state (not constructor args)
     _spent_usd: float = field(default=0.0, init=False, repr=False)
     _usages: deque[TokenUsage] = field(
@@ -407,6 +576,17 @@ class CostTracker:
         init=False,
         repr=False,
     )
+    # Per-envelope spend totals + invocation counts (issue #1405). Updated
+    # under ``_lock`` so envelope rollups stay consistent with ``record()``.
+    _spent_by_envelope: dict[str, float] = field(default_factory=dict[str, float], init=False, repr=False)
+    _calls_by_envelope: dict[str, int] = field(default_factory=dict[str, int], init=False, repr=False)
+    # Envelopes that have already fired the threshold hook so we don't
+    # spam observers each call once they're over the watermark.
+    _envelope_warned: set[str] = field(default_factory=set[str], init=False, repr=False)
+    # Optional hook fired when an envelope crosses its threshold. The hook
+    # receives the offending :class:`EnvelopeReport` so observers can route
+    # the event to logs / dashboards / Slack without re-querying state.
+    _envelope_hook: object | None = field(default=None, init=False, repr=False)
     # Thread-safe lock for atomic budget check-and-record (COST-001).
     # Prevents race where two concurrent agents both pass the budget check
     # before either's cost is recorded, causing budget overshoot.
@@ -441,6 +621,7 @@ class CostTracker:
         role: str = "",
         feature_label: str = "",
         cost_tags: dict[str, str] | None = None,
+        quota_envelope: str = DEFAULT_QUOTA_ENVELOPE,
     ) -> BudgetStatus:
         """Record token usage for an agent and return updated budget status.
 
@@ -456,9 +637,17 @@ class CostTracker:
             cost_usd: Explicit cost override; estimated if omitted.
             cache_read_tokens: Tokens read from prompt cache.
             cache_write_tokens: Tokens written to prompt cache.
+            quota_envelope: Quota envelope tag attributed to this call
+                (issue #1405). Defaults to ``"subscription"`` so legacy
+                callers keep working unchanged.
 
         Returns:
             Current ``BudgetStatus`` after recording.
+
+        Raises:
+            EnvelopeBudgetError: When the envelope has a configured
+                ``hard_budget_usd`` and admitting this call would breach
+                it, or when ``model`` is not in the envelope's allowlist.
         """
         normalized_tenant = normalize_tenant_id(tenant_id)
         if cost_usd is None:
@@ -470,11 +659,35 @@ class CostTracker:
                 cache_write_tokens=cache_write_tokens,
             )
 
+        envelope = quota_envelope or DEFAULT_QUOTA_ENVELOPE
+        env_cfg = self.envelopes.get(envelope)
+
+        # Hard-cap + allowlist gates fire before we mutate any state so a
+        # rejected record never partially updates the totals.
+        if env_cfg is not None:
+            if not env_cfg.model_allowed(model):
+                raise EnvelopeBudgetError(
+                    envelope,
+                    f"model {model!r} not in allowlist {list(env_cfg.model_allowlist)!r}",
+                    spent_usd=self._spent_by_envelope.get(envelope, 0.0),
+                    cap_usd=env_cfg.hard_budget_usd,
+                )
+            if env_cfg.hard_budget_usd > 0:
+                projected = self._spent_by_envelope.get(envelope, 0.0) + cost_usd
+                if projected > env_cfg.hard_budget_usd:
+                    raise EnvelopeBudgetError(
+                        envelope,
+                        "hard budget exhausted",
+                        spent_usd=projected,
+                        cap_usd=env_cfg.hard_budget_usd,
+                    )
+
         merged_tags: dict[str, str] = dict(cost_tags or {})
         if role and "role" not in merged_tags:
             merged_tags["role"] = role
         if feature_label and "feature_label" not in merged_tags:
             merged_tags["feature_label"] = feature_label
+        merged_tags.setdefault("quota_envelope", envelope)
 
         usage = TokenUsage(
             input_tokens=input_tokens,
@@ -487,8 +700,10 @@ class CostTracker:
             cache_read_tokens=cache_read_tokens,
             cache_write_tokens=cache_write_tokens,
             cost_tags=merged_tags,
+            quota_envelope=envelope,
         )
         evicted: TokenUsage | None = None
+        envelope_fired: EnvelopeReport | None = None
         with self._lock:
             # Ring-buffer append: capture the row that would be evicted so we
             # can rotate it to JSONL before it falls off the end.
@@ -499,12 +714,17 @@ class CostTracker:
             self._spent_usd += cost_usd
             self._spent_by_agent[agent_id] = self._spent_by_agent.get(agent_id, 0.0) + cost_usd
             self._spent_by_model[model] = self._spent_by_model.get(model, 0.0) + cost_usd
+            self._spent_by_envelope[envelope] = self._spent_by_envelope.get(envelope, 0.0) + cost_usd
+            self._calls_by_envelope[envelope] = self._calls_by_envelope.get(envelope, 0) + 1
             self._update_accumulators(usage)
             status = self.status()
+            envelope_fired = self._maybe_fire_envelope_threshold_locked(envelope)
 
         if evicted is not None:
             self._rotate_evicted(evicted)
         self._emit_threshold_warnings(status)
+        if envelope_fired is not None:
+            self._invoke_envelope_hook(envelope_fired)
 
         # Push to the rolling spend ledger (issue #1320). Best-effort:
         # ledger IO must never block the record() hot path. Import locally
@@ -517,7 +737,8 @@ class CostTracker:
                 agent_id=agent_id,
                 role=str(merged_tags.get("role", "")),
                 feature_label=str(merged_tags.get("feature_label", "")),
-                extra={k: v for k, v in merged_tags.items() if k not in {"role", "feature_label"}},
+                quota_envelope=envelope,
+                extra={k: v for k, v in merged_tags.items() if k not in {"role", "feature_label", "quota_envelope"}},
             )
             try:
                 self.spend_ledger.record(
@@ -549,6 +770,7 @@ class CostTracker:
         role: str = "",
         feature_label: str = "",
         cost_tags: dict[str, str] | None = None,
+        quota_envelope: str = DEFAULT_QUOTA_ENVELOPE,
     ) -> float:
         """Record cumulative token usage for one agent/task pair.
 
@@ -616,16 +838,22 @@ class CostTracker:
             role=role,
             feature_label=feature_label,
             cost_tags=cost_tags,
+            quota_envelope=quota_envelope,
         )
         self._cumulative_tokens[key] = (cur_input, cur_output, cur_cache_read, cur_cache_write)
         return self._spent_usd - before
 
-    def can_spawn(self) -> bool:
+    def can_spawn(self, *, quota_envelope: str | None = None) -> bool:
         """Atomically check whether the budget permits spawning another agent.
 
         This method acquires the internal lock so that no concurrent
         ``record()`` can change the spend between the caller's check and
         their subsequent spawn decision.
+
+        Args:
+            quota_envelope: Optional envelope to check against in addition
+                to the run-wide caps. When set and the envelope has
+                exhausted its per-envelope hard cap, returns ``False``.
 
         Returns:
             ``True`` if budget is unlimited or spend is below the hard-stop
@@ -635,10 +863,133 @@ class CostTracker:
             # Hard cap (issue #1320) trips independently of the soft cap.
             if self.hard_budget_usd > 0 and self._spent_usd >= self.hard_budget_usd:
                 return False
+            if quota_envelope is not None:
+                env_cfg = self.envelopes.get(quota_envelope)
+                if env_cfg is not None and env_cfg.hard_budget_usd > 0:
+                    spent_env = self._spent_by_envelope.get(quota_envelope, 0.0)
+                    if spent_env >= env_cfg.hard_budget_usd:
+                        return False
             if self.budget_usd <= 0:
                 return True
             pct = self._spent_usd / self.budget_usd
             return pct < self.hard_stop_threshold
+
+    # ---- envelopes (issue #1405) ----------------------------------------
+
+    def configure_envelopes(self, envelopes: dict[str, EnvelopeConfig]) -> None:
+        """Replace the envelope configuration map.
+
+        Convenience setter so callers building a tracker from
+        ``bernstein.yaml`` need not assign ``tracker.envelopes`` directly.
+        Existing envelope spend totals are preserved — the new
+        configuration only affects future records.
+        """
+        self.envelopes = dict(envelopes)
+
+    def set_envelope_threshold_hook(self, hook: object) -> None:
+        """Register a callable fired when an envelope crosses its threshold.
+
+        The hook receives the :class:`EnvelopeReport` for the offending
+        envelope. Callers typically wire this into the
+        :mod:`bernstein.core.cost.budget_actions` envelope-threshold hook.
+        Failures inside the hook are logged and swallowed so observers
+        never break the record hot path.
+        """
+        self._envelope_hook = hook
+
+    def spent_by_envelope(self) -> dict[str, float]:
+        """Return a shallow copy of the per-envelope spend map."""
+        with self._lock:
+            return dict(self._spent_by_envelope)
+
+    def calls_by_envelope(self) -> dict[str, int]:
+        """Return a shallow copy of the per-envelope invocation map."""
+        with self._lock:
+            return dict(self._calls_by_envelope)
+
+    def envelope_report(self, name: str) -> EnvelopeReport:
+        """Return the live :class:`EnvelopeReport` for ``name``.
+
+        Reads spend and the configured cap under the tracker lock so the
+        returned report is consistent with a single record() snapshot.
+        """
+        with self._lock:
+            return self._envelope_report_locked(name)
+
+    def envelope_reports(self) -> dict[str, EnvelopeReport]:
+        """Return a per-envelope report for every observed envelope.
+
+        Both spent-only envelopes (no config) and configured-but-unspent
+        envelopes show up in the map so dashboards can render the full
+        picture without merging two sources.
+        """
+        with self._lock:
+            seen = set(self._spent_by_envelope) | set(self.envelopes)
+            return {name: self._envelope_report_locked(name) for name in sorted(seen)}
+
+    def _envelope_report_locked(self, name: str) -> EnvelopeReport:
+        cfg = self.envelopes.get(name)
+        spent = self._spent_by_envelope.get(name, 0.0)
+        calls = self._calls_by_envelope.get(name, 0)
+        cap = cfg.budget_usd if cfg is not None else 0.0
+        hard_cap = cfg.hard_budget_usd if cfg is not None else 0.0
+        pct = (spent / cap) if cap > 0 else 0.0
+        threshold = cfg.threshold_pct if cfg is not None else DEFAULT_ENVELOPE_THRESHOLD
+        remaining = max(cap - spent, 0.0) if cap > 0 else float("inf")
+        hard_remaining = max(hard_cap - spent, 0.0) if hard_cap > 0 else float("inf")
+        return EnvelopeReport(
+            name=name,
+            spent_usd=spent,
+            cap_usd=cap,
+            hard_cap_usd=hard_cap,
+            pct_used=pct,
+            threshold_pct=threshold,
+            calls=calls,
+            remaining_usd=remaining,
+            hard_remaining_usd=hard_remaining,
+            threshold_reached=cap > 0 and pct >= threshold,
+            hard_breached=hard_cap > 0 and spent >= hard_cap,
+        )
+
+    def _maybe_fire_envelope_threshold_locked(self, envelope: str) -> EnvelopeReport | None:
+        """Return the EnvelopeReport when the threshold has just been crossed.
+
+        Called under ``self._lock``. Does not invoke the hook — the
+        caller fires the hook *after* releasing the lock so a slow
+        observer never blocks other writers.
+        """
+        cfg = self.envelopes.get(envelope)
+        if cfg is None or cfg.budget_usd <= 0:
+            return None
+        spent = self._spent_by_envelope.get(envelope, 0.0)
+        pct = spent / cfg.budget_usd
+        if pct < cfg.threshold_pct:
+            return None
+        if envelope in self._envelope_warned:
+            return None
+        self._envelope_warned.add(envelope)
+        return self._envelope_report_locked(envelope)
+
+    def _invoke_envelope_hook(self, report: EnvelopeReport) -> None:
+        """Best-effort fire the registered envelope-threshold hook.
+
+        Default behaviour (no hook attached) logs a structured warning so
+        operators can see threshold crossings without bespoke wiring.
+        """
+        hook = self._envelope_hook
+        if hook is None:
+            logger.warning(
+                "envelope_threshold_reached envelope=%s spent=$%.4f cap=$%.4f pct=%.2f",
+                report.name,
+                report.spent_usd,
+                report.cap_usd,
+                report.pct_used,
+            )
+            return
+        try:
+            cast("Any", hook)(report)
+        except Exception as exc:  # pragma: no cover - best-effort hook
+            logger.debug("envelope threshold hook raised: %s", exc)
 
     # ---- status -----------------------------------------------------------
 
@@ -765,6 +1116,9 @@ class CostTracker:
                 "|".join(k): list(v)
                 for k, v in self._cumulative_tokens.items()
             },
+            "envelopes": {name: cfg.to_dict() for name, cfg in self.envelopes.items()},
+            "spent_by_envelope": dict(self._spent_by_envelope),
+            "calls_by_envelope": dict(self._calls_by_envelope),
         }
         file_path.write_text(json.dumps(data, indent=2))
         return file_path
@@ -812,6 +1166,35 @@ class CostTracker:
                 key = tuple(k_str.split("|"))
                 if len(key) == 3:
                     tracker._cumulative_tokens[key] = tuple(v_list)  # type: ignore[assignment]
+
+            # Restore envelope state (issue #1405). Backwards compatible:
+            # older snapshots without envelope blocks load as zero-state.
+            raw_env_cfg = data.get("envelopes", {})
+            if isinstance(raw_env_cfg, dict):
+                env_map: dict[str, EnvelopeConfig] = {}
+                for name, payload in cast("dict[str, Any]", raw_env_cfg).items():
+                    if isinstance(payload, dict):
+                        env_map[str(name)] = EnvelopeConfig.from_dict(str(name), cast("dict[str, Any]", payload))
+                tracker.envelopes = env_map
+            raw_env_spent = data.get("spent_by_envelope", {})
+            if isinstance(raw_env_spent, dict):
+                tracker._spent_by_envelope = {
+                    str(k): float(v) for k, v in cast("dict[str, Any]", raw_env_spent).items()
+                }
+            raw_env_calls = data.get("calls_by_envelope", {})
+            if isinstance(raw_env_calls, dict):
+                tracker._calls_by_envelope = {str(k): int(v) for k, v in cast("dict[str, Any]", raw_env_calls).items()}
+
+            # If we loaded usages but not envelope spend, derive it from
+            # usage records so old snapshots still aggregate by envelope.
+            if not tracker._spent_by_envelope and tracker._usages:
+                for u in tracker._usages:
+                    tracker._spent_by_envelope[u.quota_envelope] = (
+                        tracker._spent_by_envelope.get(u.quota_envelope, 0.0) + u.cost_usd
+                    )
+                    tracker._calls_by_envelope[u.quota_envelope] = (
+                        tracker._calls_by_envelope.get(u.quota_envelope, 0) + 1
+                    )
 
             return tracker
         except Exception as exc:

--- a/src/bernstein/core/cost/spend_ledger.py
+++ b/src/bernstein/core/cost/spend_ledger.py
@@ -84,6 +84,10 @@ class CallTags:
     agent_id: str = ""
     role: str = ""
     feature_label: str = ""
+    # Per-quota-envelope attribution (issue #1405). Defaults to
+    # ``"subscription"`` so existing callers keep the legacy
+    # single-envelope rollup.
+    quota_envelope: str = "subscription"
     extra: dict[str, str] = field(default_factory=dict)
 
     def merged(self) -> dict[str, str]:
@@ -101,6 +105,13 @@ class CallTags:
             out["role"] = self.role
         if self.feature_label:
             out["feature_label"] = self.feature_label
+        # Only surface ``quota_envelope`` in the merged tag-map when an
+        # operator has set it to something other than the default. The
+        # ledger column itself always carries the value so the rollup is
+        # complete; we just avoid polluting the tag dict for legacy
+        # single-envelope callers.
+        if self.quota_envelope and self.quota_envelope != "subscription":
+            out["quota_envelope"] = self.quota_envelope
         for k, v in self.extra.items():
             if v:
                 out[str(k)] = str(v)
@@ -130,6 +141,10 @@ class LedgerEntry:
     cache_read_tokens: int
     cache_write_tokens: int
     cost_usd: float
+    # issue #1405: per-quota-envelope attribution. Defaults to
+    # ``"subscription"`` so older ledgers that lack the field deserialise
+    # cleanly via :meth:`from_dict`.
+    quota_envelope: str = "subscription"
     tags: dict[str, str] = field(default_factory=dict)
 
     def to_json(self) -> str:
@@ -155,6 +170,7 @@ class LedgerEntry:
             cache_read_tokens=int(d.get("cache_read_tokens", 0) or 0),
             cache_write_tokens=int(d.get("cache_write_tokens", 0) or 0),
             cost_usd=float(d.get("cost_usd", 0.0) or 0.0),
+            quota_envelope=str(d.get("quota_envelope") or tags.get("quota_envelope") or "subscription"),
             tags=tags,
         )
 
@@ -237,6 +253,7 @@ class SpendLedger:
         cost = max(0.0, float(cost_usd))
         now = ts if ts is not None else time.time()
         merged = tags.merged()
+        envelope = tags.quota_envelope or "subscription"
         entry = LedgerEntry(
             ts=now,
             ts_iso=datetime.fromtimestamp(now, tz=UTC).isoformat(timespec="seconds"),
@@ -251,6 +268,7 @@ class SpendLedger:
             cache_read_tokens=int(cache_read_tokens),
             cache_write_tokens=int(cache_write_tokens),
             cost_usd=cost,
+            quota_envelope=envelope,
             tags=merged,
         )
 
@@ -262,6 +280,7 @@ class SpendLedger:
             self._spent_by["agent"][tags.agent_id or "unknown"] += cost
             self._spent_by["role"][tags.role or "unknown"] += cost
             self._spent_by["model"][model or "unknown"] += cost
+            self._spent_by["envelope"][envelope] += cost
             if tags.feature_label:
                 self._spent_by["feature_label"][tags.feature_label] += cost
             status = self._status_locked()
@@ -472,11 +491,13 @@ def aggregate_entries(
             return e.model or "unknown"
         if dimension == "feature_label":
             return e.feature_label or "unknown"
+        if dimension == "envelope":
+            return e.quota_envelope or "subscription"
         if dimension == "day":
             return datetime.fromtimestamp(e.ts, tz=UTC).strftime("%Y-%m-%d") if e.ts > 0 else "unknown"
         return ""
 
-    if dimension not in {"task", "agent", "role", "model", "feature_label", "day"}:
+    if dimension not in {"task", "agent", "role", "model", "feature_label", "envelope", "day"}:
         return {}
 
     out: dict[str, dict[str, Any]] = defaultdict(

--- a/tests/unit/test_cost_envelope.py
+++ b/tests/unit/test_cost_envelope.py
@@ -1,0 +1,885 @@
+"""Tests for per-quota-envelope cost attribution + budget hooks (issue #1405).
+
+Coverage targets:
+* Envelope routing on ``TokenUsage`` / ``CostTracker.record()``
+* Hard-cap rejection raising :class:`EnvelopeBudgetError`
+* Model allowlist enforcement
+* Multi-envelope aggregation via ``cost_rollup_by_envelope.rollup``
+* Threshold-hook firing via :func:`envelope_threshold_reached`
+* :class:`SpendLedger` envelope tagging + aggregation
+* Property-based invariants for rollup math
+* Integration-style flows with a mock adapter recording across envelopes
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.cost.budget_actions import (
+    EnvelopeThresholdEvent,
+    envelope_threshold_reached,
+)
+from bernstein.core.cost.cost_rollup_by_envelope import (
+    aggregate_totals,
+    rollup,
+)
+from bernstein.core.cost.cost_tracker import (
+    DEFAULT_ENVELOPE_THRESHOLD,
+    DEFAULT_QUOTA_ENVELOPE,
+    CostTracker,
+    EnvelopeBudgetError,
+    EnvelopeConfig,
+    EnvelopeReport,
+    TokenUsage,
+)
+from bernstein.core.cost.spend_ledger import (
+    CallTags,
+    LedgerEntry,
+    SpendLedger,
+    aggregate_entries,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_usage(
+    *,
+    cost: float = 0.01,
+    envelope: str = DEFAULT_QUOTA_ENVELOPE,
+    model: str = "sonnet",
+    ts: float = 1000.0,
+) -> TokenUsage:
+    return TokenUsage(
+        input_tokens=10,
+        output_tokens=20,
+        model=model,
+        cost_usd=cost,
+        agent_id="agent-1",
+        task_id="task-1",
+        timestamp=ts,
+        quota_envelope=envelope,
+    )
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage envelope field
+# ---------------------------------------------------------------------------
+
+
+class TestTokenUsageEnvelope:
+    def test_default_envelope_is_subscription(self) -> None:
+        usage = TokenUsage(
+            input_tokens=1,
+            output_tokens=1,
+            model="m",
+            cost_usd=0.0,
+            agent_id="a",
+            task_id="t",
+        )
+        assert usage.quota_envelope == "subscription"
+
+    def test_explicit_envelope_assignment(self) -> None:
+        usage = _make_usage(envelope="agent-sdk-credits")
+        assert usage.quota_envelope == "agent-sdk-credits"
+
+    def test_envelope_roundtrip_serialisation(self) -> None:
+        usage = _make_usage(envelope="on-demand-tokens")
+        restored = TokenUsage.from_dict(usage.to_dict())
+        assert restored.quota_envelope == "on-demand-tokens"
+
+    def test_legacy_dict_without_envelope_defaults(self) -> None:
+        legacy_dict = {
+            "input_tokens": 1,
+            "output_tokens": 2,
+            "model": "sonnet",
+            "cost_usd": 0.01,
+            "agent_id": "a",
+            "task_id": "t",
+        }
+        usage = TokenUsage.from_dict(legacy_dict)
+        assert usage.quota_envelope == "subscription"
+
+    def test_empty_envelope_string_falls_back_to_default(self) -> None:
+        legacy_dict = {
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "model": "m",
+            "cost_usd": 0.0,
+            "agent_id": "a",
+            "task_id": "t",
+            "quota_envelope": "",
+        }
+        usage = TokenUsage.from_dict(legacy_dict)
+        assert usage.quota_envelope == "subscription"
+
+
+# ---------------------------------------------------------------------------
+# EnvelopeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeConfig:
+    def test_defaults(self) -> None:
+        cfg = EnvelopeConfig(name="sub")
+        assert cfg.budget_usd == 0.0
+        assert cfg.hard_budget_usd == 0.0
+        assert cfg.model_allowlist == ()
+        assert cfg.threshold_pct == DEFAULT_ENVELOPE_THRESHOLD
+
+    def test_negative_caps_normalised_to_zero(self) -> None:
+        cfg = EnvelopeConfig(name="sub", budget_usd=-1.0, hard_budget_usd=-5.0)
+        assert cfg.budget_usd == 0.0
+        assert cfg.hard_budget_usd == 0.0
+
+    def test_invalid_threshold_falls_back_to_default(self) -> None:
+        cfg = EnvelopeConfig(name="sub", threshold_pct=0.0)
+        assert cfg.threshold_pct == DEFAULT_ENVELOPE_THRESHOLD
+        cfg2 = EnvelopeConfig(name="sub", threshold_pct=1.5)
+        assert cfg2.threshold_pct == DEFAULT_ENVELOPE_THRESHOLD
+
+    def test_model_allowed_empty_allowlist(self) -> None:
+        cfg = EnvelopeConfig(name="sub")
+        assert cfg.model_allowed("claude-sonnet-4")
+        assert cfg.model_allowed("any-other-model")
+
+    def test_model_allowed_substring_case_insensitive(self) -> None:
+        cfg = EnvelopeConfig(name="sub", model_allowlist=("Sonnet", "Haiku"))
+        assert cfg.model_allowed("claude-SONNET-4")
+        assert cfg.model_allowed("Haiku-3")
+        assert not cfg.model_allowed("opus-4")
+
+    def test_to_dict_roundtrip(self) -> None:
+        cfg = EnvelopeConfig(
+            name="sdk",
+            budget_usd=10.0,
+            hard_budget_usd=15.0,
+            model_allowlist=("sonnet",),
+            threshold_pct=0.75,
+        )
+        d = cfg.to_dict()
+        restored = EnvelopeConfig.from_dict("sdk", d)
+        assert restored == cfg
+
+
+# ---------------------------------------------------------------------------
+# CostTracker envelope routing & enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestCostTrackerEnvelope:
+    def test_default_envelope_routes_to_subscription_bucket(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.record("a", "t", "sonnet", 100, 50, cost_usd=0.10)
+        assert tr.spent_by_envelope() == {"subscription": pytest.approx(0.10)}
+        assert tr.calls_by_envelope() == {"subscription": 1}
+
+    def test_explicit_envelope_routing(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.record("a", "t", "sonnet", 100, 50, cost_usd=0.10, quota_envelope="sdk")
+        tr.record("a", "t", "sonnet", 100, 50, cost_usd=0.05, quota_envelope="on-demand")
+        assert tr.spent_by_envelope()["sdk"] == pytest.approx(0.10)
+        assert tr.spent_by_envelope()["on-demand"] == pytest.approx(0.05)
+
+    def test_multi_envelope_aggregation(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        for envelope, cost in (("sub", 0.10), ("sub", 0.05), ("sdk", 0.20)):
+            tr.record("a", "t", "sonnet", 1, 1, cost_usd=cost, quota_envelope=envelope)
+        spent = tr.spent_by_envelope()
+        assert spent["sub"] == pytest.approx(0.15)
+        assert spent["sdk"] == pytest.approx(0.20)
+        assert tr.calls_by_envelope() == {"sub": 2, "sdk": 1}
+
+    def test_record_cumulative_propagates_envelope(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.record_cumulative(
+            "a",
+            "t",
+            "sonnet",
+            total_input_tokens=100,
+            total_output_tokens=50,
+            total_cost_usd=0.10,
+            quota_envelope="sdk",
+        )
+        assert tr.spent_by_envelope() == {"sdk": pytest.approx(0.10)}
+
+    def test_hard_cap_rejection_raises(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sdk": EnvelopeConfig(name="sdk", hard_budget_usd=0.10)})
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.08, quota_envelope="sdk")
+        with pytest.raises(EnvelopeBudgetError) as excinfo:
+            tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.05, quota_envelope="sdk")
+        assert excinfo.value.envelope == "sdk"
+        # State must NOT advance on rejection.
+        assert tr.spent_by_envelope()["sdk"] == pytest.approx(0.08)
+
+    def test_hard_cap_zero_disables_enforcement(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sdk": EnvelopeConfig(name="sdk", hard_budget_usd=0.0)})
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=1000.0, quota_envelope="sdk")
+        assert tr.spent_by_envelope()["sdk"] == pytest.approx(1000.0)
+
+    def test_model_allowlist_blocks_disallowed_model(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sdk": EnvelopeConfig(name="sdk", model_allowlist=("sonnet",))})
+        with pytest.raises(EnvelopeBudgetError):
+            tr.record("a", "t", "opus", 1, 1, cost_usd=0.05, quota_envelope="sdk")
+
+    def test_model_allowlist_admits_matching_model(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sdk": EnvelopeConfig(name="sdk", model_allowlist=("sonnet",))})
+        tr.record("a", "t", "claude-sonnet-4", 1, 1, cost_usd=0.05, quota_envelope="sdk")
+        assert tr.spent_by_envelope()["sdk"] == pytest.approx(0.05)
+
+    def test_can_spawn_respects_envelope_hard_cap(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sdk": EnvelopeConfig(name="sdk", hard_budget_usd=0.05)})
+        assert tr.can_spawn(quota_envelope="sdk")
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.05, quota_envelope="sdk")
+        assert not tr.can_spawn(quota_envelope="sdk")
+        # Other envelopes remain admissible.
+        assert tr.can_spawn(quota_envelope="other")
+
+    def test_unknown_envelope_still_tracked(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.05, quota_envelope="custom")
+        assert "custom" in tr.spent_by_envelope()
+
+    def test_envelope_threshold_hook_fires_once(self) -> None:
+        events: list[EnvelopeReport] = []
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=1.0, threshold_pct=0.5)})
+        tr.set_envelope_threshold_hook(events.append)
+        # Stay below threshold first.
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.40, quota_envelope="sub")
+        assert events == []
+        # Cross threshold.
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.20, quota_envelope="sub")
+        assert len(events) == 1
+        assert events[0].name == "sub"
+        # Subsequent records do NOT re-fire.
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.10, quota_envelope="sub")
+        assert len(events) == 1
+
+    def test_envelope_threshold_hook_failure_swallowed(self) -> None:
+        def bad_hook(_report: EnvelopeReport) -> None:
+            raise RuntimeError("boom")
+
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=1.0, threshold_pct=0.5)})
+        tr.set_envelope_threshold_hook(bad_hook)
+        # Must not propagate the hook failure to the caller.
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.80, quota_envelope="sub")
+        assert tr.spent_by_envelope()["sub"] == pytest.approx(0.80)
+
+    def test_envelope_threshold_not_fired_without_cap(self) -> None:
+        events: list[EnvelopeReport] = []
+        tr = CostTracker(run_id="r-1")
+        # No cap configured -> hook can't determine threshold and stays silent.
+        tr.set_envelope_threshold_hook(events.append)
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=100.0)
+        assert events == []
+
+    def test_envelope_report_remaining(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=1.0, hard_budget_usd=2.0)})
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.40, quota_envelope="sub")
+        rep = tr.envelope_report("sub")
+        assert rep.spent_usd == pytest.approx(0.40)
+        assert rep.cap_usd == pytest.approx(1.0)
+        assert rep.remaining_usd == pytest.approx(0.60)
+        assert rep.hard_remaining_usd == pytest.approx(1.60)
+        assert rep.pct_used == pytest.approx(0.40)
+
+    def test_envelope_reports_covers_configured_and_seen(self) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes({"sub": EnvelopeConfig(name="sub", budget_usd=1.0)})
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.10, quota_envelope="custom")
+        reports = tr.envelope_reports()
+        # Both configured-without-spend and spent-without-config must appear.
+        assert "sub" in reports
+        assert "custom" in reports
+        assert reports["sub"].spent_usd == pytest.approx(0.0)
+        assert reports["custom"].spent_usd == pytest.approx(0.10)
+
+    def test_save_and_load_preserves_envelopes(self, tmp_path: Path) -> None:
+        tr = CostTracker(run_id="r-1")
+        tr.configure_envelopes(
+            {
+                "sub": EnvelopeConfig(name="sub", budget_usd=1.0),
+                "sdk": EnvelopeConfig(name="sdk", hard_budget_usd=0.50),
+            }
+        )
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.10, quota_envelope="sub")
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.05, quota_envelope="sdk")
+        path = tr.save(tmp_path)
+
+        loaded = CostTracker.load(tmp_path, "r-1")
+        assert loaded is not None
+        assert path.exists()
+        assert loaded.spent_by_envelope() == {
+            "sub": pytest.approx(0.10),
+            "sdk": pytest.approx(0.05),
+        }
+        assert set(loaded.envelopes) == {"sub", "sdk"}
+
+    def test_legacy_snapshot_derives_envelope_totals_from_usages(self, tmp_path: Path) -> None:
+        # Simulate an older snapshot without envelope blocks.
+        costs_dir = tmp_path / "runtime" / "costs"
+        costs_dir.mkdir(parents=True)
+        snapshot = {
+            "run_id": "r-x",
+            "budget_usd": 0.0,
+            "hard_budget_usd": 0.0,
+            "spent_usd": 0.10,
+            "warn_threshold": 0.8,
+            "critical_threshold": 0.95,
+            "hard_stop_threshold": 1.0,
+            "usages": [
+                {
+                    "input_tokens": 1,
+                    "output_tokens": 1,
+                    "model": "sonnet",
+                    "cost_usd": 0.10,
+                    "agent_id": "a",
+                    "task_id": "t",
+                    "tenant_id": "default",
+                    "timestamp": 1000.0,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                    "quota_envelope": "sdk",
+                }
+            ],
+            "cumulative_tokens": {},
+        }
+        (costs_dir / "r-x.json").write_text(json.dumps(snapshot))
+        loaded = CostTracker.load(tmp_path, "r-x")
+        assert loaded is not None
+        assert loaded.spent_by_envelope()["sdk"] == pytest.approx(0.10)
+
+
+# ---------------------------------------------------------------------------
+# envelope_threshold_reached hook
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeThresholdReached:
+    def test_returns_none_when_under_threshold(self) -> None:
+        assert envelope_threshold_reached(envelope="sub", spent_usd=0.30, cap_usd=1.0, threshold_pct=0.80) is None
+
+    def test_returns_event_at_threshold(self) -> None:
+        evt = envelope_threshold_reached(envelope="sub", spent_usd=0.80, cap_usd=1.0, threshold_pct=0.80)
+        assert isinstance(evt, EnvelopeThresholdEvent)
+        assert evt.envelope == "sub"
+        assert evt.pct_used == pytest.approx(0.80)
+        assert evt.hard_breached is False
+
+    def test_hard_breach_fires_with_zero_soft_cap(self) -> None:
+        evt = envelope_threshold_reached(envelope="sub", spent_usd=2.0, cap_usd=0.0, hard_cap_usd=1.0)
+        assert evt is not None
+        assert evt.hard_breached is True
+
+    def test_disabled_when_no_caps(self) -> None:
+        evt = envelope_threshold_reached(envelope="sub", spent_usd=2.0, cap_usd=0.0, hard_cap_usd=0.0)
+        assert evt is None
+
+    def test_event_dict_is_json_safe(self) -> None:
+        evt = envelope_threshold_reached(envelope="sub", spent_usd=0.80, cap_usd=1.0)
+        assert evt is not None
+        # Must round-trip through json without errors.
+        json.dumps(evt.to_dict())
+
+
+# ---------------------------------------------------------------------------
+# Rollup
+# ---------------------------------------------------------------------------
+
+
+class TestRollup:
+    def test_empty_records_returns_empty_when_no_config(self) -> None:
+        out = rollup([])
+        assert out == {}
+
+    def test_configured_envelope_appears_even_with_zero_spend(self) -> None:
+        out = rollup([], {"sub": EnvelopeConfig(name="sub", budget_usd=1.0)})
+        assert "sub" in out
+        assert out["sub"].total_spend == pytest.approx(0.0)
+
+    def test_rollup_sums_spend_per_envelope(self) -> None:
+        records = [
+            _make_usage(cost=0.10, envelope="sub"),
+            _make_usage(cost=0.05, envelope="sub"),
+            _make_usage(cost=0.20, envelope="sdk"),
+        ]
+        out = rollup(records)
+        assert out["sub"].total_spend == pytest.approx(0.15)
+        assert out["sdk"].total_spend == pytest.approx(0.20)
+
+    def test_rollup_pct_used_calculation(self) -> None:
+        records = [_make_usage(cost=0.60, envelope="sub")]
+        out = rollup(records, {"sub": EnvelopeConfig(name="sub", budget_usd=1.0)})
+        assert out["sub"].pct_used == pytest.approx(0.60)
+
+    def test_rollup_threshold_reached_flag(self) -> None:
+        records = [_make_usage(cost=0.85, envelope="sub")]
+        out = rollup(
+            records,
+            {"sub": EnvelopeConfig(name="sub", budget_usd=1.0, threshold_pct=0.8)},
+        )
+        assert out["sub"].threshold_reached is True
+
+    def test_rollup_hard_breached_flag(self) -> None:
+        records = [_make_usage(cost=1.5, envelope="sub")]
+        out = rollup(
+            records,
+            {"sub": EnvelopeConfig(name="sub", hard_budget_usd=1.0)},
+        )
+        assert out["sub"].hard_breached is True
+
+    def test_rollup_forecast_with_burn_rate(self) -> None:
+        # Two records 10 seconds apart spending $0.20 total -> burn=0.02/s.
+        records = [
+            _make_usage(cost=0.10, envelope="sub", ts=1000.0),
+            _make_usage(cost=0.10, envelope="sub", ts=1010.0),
+        ]
+        out = rollup(records, {"sub": EnvelopeConfig(name="sub", budget_usd=1.0)})
+        row = out["sub"]
+        assert row.burn_rate_usd_per_sec == pytest.approx(0.02)
+        # remaining $0.80 / 0.02/s = 40s
+        assert row.forecast_to_cap_seconds == pytest.approx(40.0)
+
+    def test_rollup_forecast_none_when_single_record(self) -> None:
+        records = [_make_usage(cost=0.10, envelope="sub", ts=1000.0)]
+        out = rollup(
+            records,
+            {"sub": EnvelopeConfig(name="sub", budget_usd=1.0)},
+            now=1000.0,
+        )
+        # Window is zero so no forecast is produced.
+        assert out["sub"].forecast_to_cap_seconds is None
+
+    def test_rollup_models_collected(self) -> None:
+        records = [
+            _make_usage(envelope="sub", model="sonnet"),
+            _make_usage(envelope="sub", model="opus"),
+        ]
+        out = rollup(records)
+        assert out["sub"].models == ("opus", "sonnet")
+
+    def test_rollup_to_envelope_report(self) -> None:
+        records = [_make_usage(cost=0.10, envelope="sub")]
+        out = rollup(records, {"sub": EnvelopeConfig(name="sub", budget_usd=1.0)})
+        report = out["sub"].to_envelope_report()
+        assert isinstance(report, EnvelopeReport)
+        assert report.remaining_usd == pytest.approx(0.90)
+
+    def test_rollup_row_to_dict_json_safe(self) -> None:
+        records = [_make_usage(cost=0.10, envelope="sub")]
+        out = rollup(records)
+        json.dumps(out["sub"].to_dict())
+
+    def test_aggregate_totals(self) -> None:
+        records = [
+            _make_usage(cost=0.10, envelope="sub"),
+            _make_usage(cost=0.20, envelope="sdk"),
+        ]
+        out = rollup(
+            records,
+            {
+                "sub": EnvelopeConfig(name="sub", budget_usd=1.0, hard_budget_usd=2.0),
+                "sdk": EnvelopeConfig(name="sdk", budget_usd=0.50),
+            },
+        )
+        totals = aggregate_totals(out)
+        assert totals["total_spend"] == pytest.approx(0.30)
+        assert totals["total_cap"] == pytest.approx(1.50)
+        assert totals["total_hard_cap"] == pytest.approx(2.0)
+        assert totals["total_calls"] == pytest.approx(2.0)
+
+
+# ---------------------------------------------------------------------------
+# SpendLedger envelope tagging
+# ---------------------------------------------------------------------------
+
+
+class TestSpendLedgerEnvelope:
+    def test_ledger_entry_serialises_envelope(self) -> None:
+        entry = LedgerEntry(
+            ts=1000.0,
+            ts_iso="2026-05-17T00:00:00+00:00",
+            run_id="r-1",
+            task_id="t",
+            agent_id="a",
+            role="",
+            feature_label="",
+            model="sonnet",
+            input_tokens=1,
+            output_tokens=1,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            cost_usd=0.10,
+            quota_envelope="sdk",
+        )
+        roundtrip = LedgerEntry.from_dict(json.loads(entry.to_json()))
+        assert roundtrip.quota_envelope == "sdk"
+
+    def test_legacy_ledger_entry_defaults_envelope(self) -> None:
+        entry = LedgerEntry.from_dict(
+            {
+                "ts": 1000.0,
+                "task_id": "t",
+                "model": "sonnet",
+                "cost_usd": 0.10,
+            }
+        )
+        assert entry.quota_envelope == "subscription"
+
+    def test_record_writes_envelope_dimension(self, tmp_path: Path) -> None:
+        path = tmp_path / "ledger.jsonl"
+        led = SpendLedger(path=path, run_id="r-1")
+        led.record(
+            tags=CallTags(task_id="t", agent_id="a", quota_envelope="sdk"),
+            model="sonnet",
+            cost_usd=0.10,
+        )
+        led.record(
+            tags=CallTags(task_id="t", agent_id="a", quota_envelope="subscription"),
+            model="sonnet",
+            cost_usd=0.05,
+        )
+        env_totals = led.totals_by("envelope")
+        assert env_totals == {"sdk": pytest.approx(0.10), "subscription": pytest.approx(0.05)}
+
+    def test_aggregate_entries_envelope_dimension(self) -> None:
+        entries = [
+            LedgerEntry(
+                ts=1000.0,
+                ts_iso="",
+                run_id="r",
+                task_id="t",
+                agent_id="a",
+                role="",
+                feature_label="",
+                model="sonnet",
+                input_tokens=10,
+                output_tokens=5,
+                cache_read_tokens=0,
+                cache_write_tokens=0,
+                cost_usd=0.10,
+                quota_envelope=env,
+            )
+            for env in ("sub", "sub", "sdk")
+        ]
+        out = aggregate_entries(entries, "envelope")
+        assert out["sub"]["cost_usd"] == pytest.approx(0.20)
+        assert out["sub"]["calls"] == 2
+        assert out["sdk"]["cost_usd"] == pytest.approx(0.10)
+
+    def test_merged_tag_dict_hides_default_envelope(self) -> None:
+        tags = CallTags(task_id="t", quota_envelope="subscription")
+        merged = tags.merged()
+        # Backwards-compat: default envelope must NOT pollute the tag map.
+        assert "quota_envelope" not in merged
+
+    def test_merged_tag_dict_includes_explicit_envelope(self) -> None:
+        tags = CallTags(task_id="t", quota_envelope="sdk")
+        merged = tags.merged()
+        assert merged["quota_envelope"] == "sdk"
+
+
+# ---------------------------------------------------------------------------
+# Property-based invariants (>=10 cases)
+# ---------------------------------------------------------------------------
+
+
+cost_strategy = st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False)
+envelope_strategy = st.sampled_from(["subscription", "agent-sdk-credits", "on-demand-tokens", "custom"])
+model_strategy = st.sampled_from(["sonnet", "opus", "haiku", "gpt-5"])
+
+
+@st.composite
+def usage_strategy(draw: st.DrawFn) -> TokenUsage:
+    cost = draw(cost_strategy)
+    env = draw(envelope_strategy)
+    model = draw(model_strategy)
+    ts = draw(st.floats(min_value=1.0, max_value=1e9, allow_nan=False, allow_infinity=False))
+    return TokenUsage(
+        input_tokens=1,
+        output_tokens=1,
+        model=model,
+        cost_usd=cost,
+        agent_id="a",
+        task_id="t",
+        timestamp=ts,
+        quota_envelope=env,
+    )
+
+
+class TestEnvelopeProperties:
+    @settings(max_examples=50, deadline=None)
+    @given(records=st.lists(usage_strategy(), min_size=0, max_size=30))
+    def test_rollup_total_equals_sum_of_costs(self, records: list[TokenUsage]) -> None:
+        out = rollup(records)
+        total = sum(row.total_spend for row in out.values())
+        expected = sum(r.cost_usd for r in records)
+        assert total == pytest.approx(expected, rel=1e-6)
+
+    @settings(max_examples=50, deadline=None)
+    @given(records=st.lists(usage_strategy(), min_size=0, max_size=30))
+    def test_rollup_calls_equals_record_count(self, records: list[TokenUsage]) -> None:
+        out = rollup(records)
+        total_calls = sum(row.calls for row in out.values())
+        assert total_calls == len(records)
+
+    @settings(max_examples=50, deadline=None)
+    @given(records=st.lists(usage_strategy(), min_size=1, max_size=20))
+    def test_envelope_count_bounded_by_distinct_envelopes(self, records: list[TokenUsage]) -> None:
+        distinct = {r.quota_envelope or "subscription" for r in records}
+        out = rollup(records)
+        assert set(out) == distinct
+
+    @settings(max_examples=50, deadline=None)
+    @given(records=st.lists(usage_strategy(), min_size=0, max_size=20))
+    def test_rollup_pct_used_is_nonnegative(self, records: list[TokenUsage]) -> None:
+        out = rollup(
+            records,
+            {"subscription": EnvelopeConfig(name="subscription", budget_usd=100.0)},
+        )
+        for row in out.values():
+            assert row.pct_used >= 0.0
+
+    @settings(max_examples=50, deadline=None)
+    @given(records=st.lists(usage_strategy(), min_size=0, max_size=20))
+    def test_rollup_burn_rate_nonnegative(self, records: list[TokenUsage]) -> None:
+        out = rollup(records)
+        for row in out.values():
+            assert row.burn_rate_usd_per_sec >= 0.0
+
+    @settings(max_examples=50, deadline=None)
+    @given(records=st.lists(usage_strategy(), min_size=0, max_size=20))
+    def test_rollup_remaining_via_report_nonnegative(self, records: list[TokenUsage]) -> None:
+        out = rollup(
+            records,
+            {"subscription": EnvelopeConfig(name="subscription", budget_usd=100.0)},
+        )
+        for row in out.values():
+            rep = row.to_envelope_report()
+            assert rep.remaining_usd >= 0.0
+
+    @settings(max_examples=50, deadline=None)
+    @given(
+        cost=st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False),
+        cap=st.floats(min_value=0.01, max_value=1000.0, allow_nan=False, allow_infinity=False),
+        threshold=st.floats(min_value=0.01, max_value=1.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_threshold_event_consistency(self, cost: float, cap: float, threshold: float) -> None:
+        evt = envelope_threshold_reached(envelope="sub", spent_usd=cost, cap_usd=cap, threshold_pct=threshold)
+        if cost / cap >= threshold:
+            assert evt is not None
+        else:
+            assert evt is None
+
+    @settings(max_examples=40, deadline=None)
+    @given(
+        cost=st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False),
+        hard_cap=st.floats(min_value=0.01, max_value=1000.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_hard_cap_rejects_records_that_breach(self, cost: float, hard_cap: float) -> None:
+        tr = CostTracker(run_id="r-prop")
+        tr.configure_envelopes({"sub": EnvelopeConfig(name="sub", hard_budget_usd=hard_cap)})
+        if cost > hard_cap:
+            with pytest.raises(EnvelopeBudgetError):
+                tr.record(
+                    "a",
+                    "t",
+                    "sonnet",
+                    1,
+                    1,
+                    cost_usd=cost,
+                    quota_envelope="sub",
+                )
+        else:
+            tr.record(
+                "a",
+                "t",
+                "sonnet",
+                1,
+                1,
+                cost_usd=cost,
+                quota_envelope="sub",
+            )
+            assert tr.spent_by_envelope()["sub"] == pytest.approx(cost)
+
+    @settings(max_examples=40, deadline=None)
+    @given(
+        envelopes=st.lists(envelope_strategy, min_size=0, max_size=8),
+    )
+    def test_calls_by_envelope_count_matches_records(self, envelopes: list[str]) -> None:
+        tr = CostTracker(run_id="r-prop")
+        for env in envelopes:
+            tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.01, quota_envelope=env)
+        counts = tr.calls_by_envelope()
+        for env in set(envelopes):
+            assert counts[env] == envelopes.count(env)
+
+    @settings(max_examples=30, deadline=None)
+    @given(allowlist=st.lists(st.sampled_from(["sonnet", "opus", "haiku"]), min_size=1, max_size=3, unique=True))
+    def test_model_allowlist_blocks_outsiders(self, allowlist: list[str]) -> None:
+        tr = CostTracker(run_id="r-prop")
+        tr.configure_envelopes({"sub": EnvelopeConfig(name="sub", model_allowlist=tuple(allowlist))})
+        outsiders = {"sonnet", "opus", "haiku", "gpt-5"} - set(allowlist)
+        if not outsiders:
+            return
+        outside_model = next(iter(outsiders))
+        # gpt-5 contains no substring of sonnet/opus/haiku; sonnet/opus/haiku
+        # would each match themselves so we only test the outsider case
+        # when at least one of {sonnet, opus, haiku} is excluded.
+        if any(name in outside_model for name in allowlist):
+            return
+        with pytest.raises(EnvelopeBudgetError):
+            tr.record(
+                "a",
+                "t",
+                outside_model,
+                1,
+                1,
+                cost_usd=0.01,
+                quota_envelope="sub",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via a mock adapter (>=5 flows)
+# ---------------------------------------------------------------------------
+
+
+class _MockAdapter:
+    """Minimal adapter-like driver that records token usage via the tracker.
+
+    Mirrors the way the real adapters call ``CostTracker.record()`` from
+    a streaming-merge hook: it advances ``ts`` per call so the rollup can
+    compute a meaningful burn rate.
+    """
+
+    def __init__(self, tracker: CostTracker, *, envelope: str) -> None:
+        self.tracker = tracker
+        self.envelope = envelope
+        self._ts = 1000.0
+
+    def send(self, *, cost_usd: float, model: str = "sonnet") -> None:
+        self._ts += 1.0
+        self.tracker.record(
+            agent_id="agent-mock",
+            task_id="task-mock",
+            model=model,
+            input_tokens=10,
+            output_tokens=10,
+            cost_usd=cost_usd,
+            quota_envelope=self.envelope,
+        )
+
+
+class TestIntegration:
+    def test_two_adapters_separate_envelopes(self) -> None:
+        tr = CostTracker(run_id="r-int")
+        a = _MockAdapter(tr, envelope="subscription")
+        b = _MockAdapter(tr, envelope="agent-sdk-credits")
+        for _ in range(3):
+            a.send(cost_usd=0.05)
+        for _ in range(2):
+            b.send(cost_usd=0.10)
+        spent = tr.spent_by_envelope()
+        assert spent["subscription"] == pytest.approx(0.15)
+        assert spent["agent-sdk-credits"] == pytest.approx(0.20)
+
+    def test_hard_cap_blocks_further_adapter_calls(self) -> None:
+        tr = CostTracker(run_id="r-int")
+        tr.configure_envelopes({"agent-sdk-credits": EnvelopeConfig(name="agent-sdk-credits", hard_budget_usd=0.10)})
+        adapter = _MockAdapter(tr, envelope="agent-sdk-credits")
+        adapter.send(cost_usd=0.06)
+        adapter.send(cost_usd=0.03)
+        with pytest.raises(EnvelopeBudgetError):
+            adapter.send(cost_usd=0.05)
+        assert tr.spent_by_envelope()["agent-sdk-credits"] == pytest.approx(0.09)
+
+    def test_threshold_hook_fires_for_adapter_workflow(self) -> None:
+        events: list[EnvelopeReport] = []
+        tr = CostTracker(run_id="r-int")
+        tr.configure_envelopes({"subscription": EnvelopeConfig(name="subscription", budget_usd=1.0, threshold_pct=0.8)})
+        tr.set_envelope_threshold_hook(events.append)
+        adapter = _MockAdapter(tr, envelope="subscription")
+        for _ in range(9):
+            adapter.send(cost_usd=0.10)
+        assert len(events) == 1
+        assert events[0].name == "subscription"
+        assert events[0].pct_used >= 0.80
+
+    def test_ledger_integration_per_envelope_aggregation(self, tmp_path: Path) -> None:
+        path = tmp_path / "ledger.jsonl"
+        ledger = SpendLedger(path=path, run_id="r-int")
+        tr = CostTracker(run_id="r-int", spend_ledger=ledger)
+        a = _MockAdapter(tr, envelope="subscription")
+        b = _MockAdapter(tr, envelope="agent-sdk-credits")
+        for _ in range(2):
+            a.send(cost_usd=0.05)
+        for _ in range(3):
+            b.send(cost_usd=0.10)
+        # SpendLedger should reflect envelope dimension totals.
+        totals = ledger.totals_by("envelope")
+        assert totals["subscription"] == pytest.approx(0.10)
+        assert totals["agent-sdk-credits"] == pytest.approx(0.30)
+        # Reading the ledger back and running rollup must produce the same totals.
+        entries = SpendLedger.load_entries(path)
+        records = [
+            TokenUsage(
+                input_tokens=e.input_tokens,
+                output_tokens=e.output_tokens,
+                model=e.model,
+                cost_usd=e.cost_usd,
+                agent_id=e.agent_id,
+                task_id=e.task_id,
+                timestamp=e.ts,
+                quota_envelope=e.quota_envelope,
+            )
+            for e in entries
+        ]
+        rollup_out = rollup(records)
+        assert rollup_out["subscription"].total_spend == pytest.approx(0.10)
+        assert rollup_out["agent-sdk-credits"].total_spend == pytest.approx(0.30)
+
+    def test_save_load_then_continue_recording(self, tmp_path: Path) -> None:
+        tr = CostTracker(run_id="r-int")
+        tr.configure_envelopes({"subscription": EnvelopeConfig(name="subscription", budget_usd=2.0)})
+        adapter = _MockAdapter(tr, envelope="subscription")
+        adapter.send(cost_usd=0.10)
+        tr.save(tmp_path)
+        loaded = CostTracker.load(tmp_path, "r-int")
+        assert loaded is not None
+        adapter2 = _MockAdapter(loaded, envelope="subscription")
+        adapter2.send(cost_usd=0.05)
+        assert loaded.spent_by_envelope()["subscription"] == pytest.approx(0.15)
+        # Configured envelope mapping survived reload.
+        assert "subscription" in loaded.envelopes
+
+
+# ---------------------------------------------------------------------------
+# EnvelopeReport JSON safety
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeReportSerialisation:
+    def test_to_dict_renders_inf_as_none(self) -> None:
+        tr = CostTracker(run_id="r-int")
+        tr.record("a", "t", "sonnet", 1, 1, cost_usd=0.01)
+        report = tr.envelope_report("subscription")
+        d = report.to_dict()
+        # Unset cap -> remaining is +inf -> serialised as None.
+        assert d["remaining_usd"] is None
+        assert d["hard_remaining_usd"] is None
+        json.dumps(d)


### PR DESCRIPTION
## Summary
- Tag every LLM call with a ``quota_envelope`` on ``TokenUsage`` / ``LedgerEntry`` / ``CallTags``; default ``"subscription"`` preserves all existing rollups
- Per-envelope soft cap, hard cap, model allowlist, and threshold-hook fraction configurable under ``cost.envelopes`` in ``bernstein.yaml``
- Hard-cap breaches raise ``EnvelopeBudgetError`` so the orchestrator can refuse to spawn on the wrong envelope without crashing the run
- New ``bernstein.core.cost.cost_rollup_by_envelope.rollup`` produces ``EnvelopeRollupRow`` with ``total_spend`` / ``cap`` / ``pct_used`` / ``forecast_to_cap`` so dashboards / CLI render the same data
- ``envelope_threshold_reached`` hook in ``budget_actions`` fires an ``EnvelopeThresholdEvent`` when a soft cap crosses its threshold or the hard cap is breached
- CLI: ``bernstein cost --by envelope`` and new ``bernstein cost-envelopes show`` (table + ``--json``)

## Test plan
- [x] 67 tests in ``tests/unit/test_cost_envelope.py``
  - 50 unit (envelope routing, hard-cap rejection, model allowlist, multi-envelope aggregation, threshold hook firing, save/load round-trip)
  - 11 property-based (hypothesis) covering rollup math, hard-cap admission, calls-by-envelope counts, model-allowlist invariants, threshold-event consistency
  - 5 integration flows driven by a mock adapter (separate envelopes, hard-cap halt, threshold firing, ledger -> rollup round-trip, save -> load -> continue)
  - 1 ``EnvelopeReport`` JSON serialisation check (``inf`` -> ``None``)
- [x] All 149 existing cost / budget / spend / seed tests stay green
- [x] ``ruff check`` + ``ruff format --check`` clean on every changed file
- [x] Pyright delta = 0 new errors against ``main`` baseline on every changed file

Closes #1405