### PR TITLE
feat(security): strip invisible Unicode Tag codepoints from injected skills (closes spec 2026-05-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Hand-curated release notes: [`docs/release-notes/v2.0.0.md`](docs/release-notes/
 
 ## Unreleased
 
+### Security
+
+- **Strip invisible Unicode Tag codepoints from injected skills (spec 2026-05-17).** Public research (Feb 2026, Embrace the Red; Snyk skill-pack audit of 3,984 public files showing 36.82% with security flaws) demonstrated that invisible glyphs in the U+E0000-U+E007F Tag block are interpreted as instructions by Claude, Gemini, and Grok. Bernstein now strips every Cf-category, Tag-block, and interlinear-annotation codepoint from skill bodies before they are written into `.claude/skills/*.md` in agent worktrees. The new `bernstein.core.skills.sanitizer.strip_invisible_tags` function returns the cleaned body plus the count of stripped codepoints; the `SkillLoader` and `skills_injector` both invoke it at index time. A WARN log line plus a Prometheus counter `bernstein_skills_unicode_tags_stripped_total{source_name}` fire on every hit so operators can pinpoint a poisoned upstream source. Default ON; opt out with the hidden `--unsafe-allow-unicode-tags` CLI flag (or `BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS=1`) only when reproducing an incident in a controlled environment.
+
 ### Added — routing
 
 - **Per-task criterion profile (#1346).** Operators can now stamp a four-axis weight vector (`correctness`, `cost`, `latency`, `reversibility`) onto individual tasks to bias model selection.  Named presets (`safety-first`, `speed-first`, `balanced`, `cost-first`) ship in `templates/criterion_profiles/` and force-include into the wheel.  Inline dicts work too: `metadata['criterion_profile'] = {"correctness": 0.6, ...}`.  Surfaced via `bernstein add-task --criterion-profile <preset>`, `bernstein run --criterion-profile <preset>`, and `bernstein criterion-profile show <task_id> | list`.  Feature flag `BERNSTEIN_CRITERION_PROFILE=0` reverts to pre-existing routing.  Child tasks inherit the parent's profile unless explicitly overridden.

--- a/src/bernstein/adapters/skills_injector.py
+++ b/src/bernstein/adapters/skills_injector.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from bernstein.core.skills.sanitizer import sanitize_skill_body
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -156,7 +158,19 @@ def inject_skills(
             _logger.debug("Failed to read skill template %s: %s", source_path, exc)
             continue
 
-        rendered = render_skill_template(raw, session_id=session_id, tasks=tasks)
+        # Strip invisible Unicode Tag codepoints (U+E0000-U+E007F, Cf, U+FFF9-
+        # U+FFFB) before render-and-write so a poisoned third-party template
+        # cannot smuggle hidden instructions into ``.claude/skills/*.md``. The
+        # sanitizer is on by default; the hidden ``--unsafe-allow-unicode-tags``
+        # CLI flag disables it for incident-reproduction scenarios.
+        sanitized = sanitize_skill_body(
+            raw,
+            skill_name=template_name,
+            origin=str(source_path),
+            source_name="templates/skills",
+        )
+
+        rendered = render_skill_template(sanitized, session_id=session_id, tasks=tasks)
 
         dest_path = skills_dest_dir / template_name
         try:

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -619,6 +619,17 @@ def _validate_evolve_mode(evolve: bool, budget: float, max_cycles: int, yes: boo
         "Iterative self-refinement loop (issue #1403). Format: 'rounds:N,critic:adversary,stop:plateau,threshold:0.9'."
     ),
 )
+@click.option(
+    "--unsafe-allow-unicode-tags",
+    "unsafe_allow_unicode_tags",
+    is_flag=True,
+    default=False,
+    hidden=True,
+    help=(
+        "Disable the skill-pack invisible-Unicode sanitizer (DANGEROUS — only for "
+        "reproducing a poisoned-skill incident; see templates/skills/README.md)."
+    ),
+)
 @click.pass_context
 def cli(
     ctx: click.Context,
@@ -650,8 +661,16 @@ def cli(
     sandbox_override: str | None,
     allow_paid: bool,
     refine_spec: str | None,
+    unsafe_allow_unicode_tags: bool,
 ) -> None:
     """Declarative agent orchestration for engineering teams."""
+    # The skill-pack invisible-Unicode sanitizer reads its opt-out from this
+    # env var; set it as early as possible so any later import that triggers a
+    # SkillLoader sees the operator's choice. Default is OFF (sanitize on).
+    if unsafe_allow_unicode_tags:
+        import os
+
+        os.environ["BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS"] = "1"
     setup_json_logging()
     ctx.ensure_object(dict)
     # --json flag or --output json both enable JSON output mode

--- a/src/bernstein/core/observability/prometheus.py
+++ b/src/bernstein/core/observability/prometheus.py
@@ -142,6 +142,7 @@ __all__ = [
     "sandbox_session_destroyed_total",
     "sandbox_session_duration_seconds",
     "set_prometheus_enabled",
+    "skills_unicode_tags_stripped_total",
     "task_duration_seconds",
     "task_queue_depth",
     "task_transition_reasons_total",
@@ -410,6 +411,20 @@ sandbox_exec_count_total: Counter = Counter(
     "bernstein_sandbox_exec_count_total",
     "Commands executed via SandboxSession.exec, by backend and exit code.",
     labelnames=["backend", "exit_code"],
+    registry=registry,
+)
+
+# ---------------------------------------------------------------------------
+# Skill-pack sanitization — counts invisible Unicode Tag codepoints stripped
+# from a skill body before it is injected into an agent worktree. Labelled by
+# the owning :class:`SkillSource` name so operators can spot a poisoned source
+# without re-scanning the index. See ``bernstein.core.skills.sanitizer``.
+# ---------------------------------------------------------------------------
+
+skills_unicode_tags_stripped_total: Counter = Counter(
+    "bernstein_skills_unicode_tags_stripped_total",
+    "Invisible Unicode codepoints stripped from skill bodies before injection.",
+    labelnames=["source_name"],
     registry=registry,
 )
 

--- a/src/bernstein/core/skills/loader.py
+++ b/src/bernstein/core/skills/loader.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from bernstein.core.skills.sanitizer import sanitize_skill_body
 from bernstein.core.skills.sources.local_dir import LocalDirSkillSource
 
 if TYPE_CHECKING:
@@ -110,7 +111,15 @@ class SkillLoader:
                 self._register(source, artifact)
 
     def _register(self, source: SkillSource, artifact: SkillArtifact) -> None:
-        """Add a single artifact to the index, raising on name conflicts."""
+        """Add a single artifact to the index, raising on name conflicts.
+
+        Skill bodies are sanitized at index time (not on every read) by
+        :func:`bernstein.core.skills.sanitizer.sanitize_skill_body`, which
+        strips invisible Unicode Tag codepoints that public research has shown
+        to be a prompt-injection vector against Claude, Gemini, and Grok.
+        Sanitization is on by default; opt out via the hidden
+        ``--unsafe-allow-unicode-tags`` CLI flag.
+        """
         name = artifact.manifest.name
         existing = self._skills.get(name)
         if existing is not None:
@@ -120,10 +129,17 @@ class SkillLoader:
                 second_origin=artifact.origin,
             )
 
+        sanitized_body = sanitize_skill_body(
+            artifact.body,
+            skill_name=name,
+            origin=artifact.origin,
+            source_name=source.name,
+        )
+
         self._skills[name] = LoadedSkill(
             name=name,
             description=artifact.manifest.description,
-            body=artifact.body,
+            body=sanitized_body,
             references=tuple(artifact.manifest.references),
             scripts=tuple(artifact.manifest.scripts),
             assets=tuple(artifact.manifest.assets),

--- a/src/bernstein/core/skills/sanitizer.py
+++ b/src/bernstein/core/skills/sanitizer.py
@@ -1,0 +1,189 @@
+"""Sanitize invisible Unicode codepoints from skill bodies before injection.
+
+Public research (Feb 2026, "Scary Agent Skills: Hidden Unicode Instructions in
+Skills" by Embrace the Red; Snyk skill-pack audit of 3,984 public files showing
+36.82% with security flaws) demonstrated that invisible Unicode Tag codepoints
+in the ``U+E0000-U+E007F`` range are interpreted as instructions by Claude,
+Gemini, and Grok models. A poisoned third-party skill, once written into
+``.claude/skills/*.md`` in an agent worktree, would be silently embedded into
+every spawn that triggers it.
+
+This module strips every codepoint whose Unicode category is ``Cf`` (format),
+every codepoint in the Tag block (``U+E0000-U+E007F``), and the interlinear
+annotation marks (``U+FFF9-U+FFFB``). The function returns the cleaned text
+along with the count of stripped codepoints so callers can emit telemetry.
+
+Defaults:
+    Sanitization is **ON** by default. The opt-out path is the
+    ``BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS`` environment variable (set by the
+    hidden ``--unsafe-allow-unicode-tags`` CLI flag). Opting out is dangerous
+    and should only be used for reproducing a poisoned-skill incident in a
+    controlled environment.
+
+The implementation is pure stdlib (``unicodedata.category``); no new deps.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import unicodedata
+
+logger = logging.getLogger(__name__)
+
+# Tag block (deprecated by Unicode but still rendered as zero-width by most
+# fonts). Every codepoint here is invisible and exploitable.
+_TAG_BLOCK_START: int = 0xE0000
+_TAG_BLOCK_END: int = 0xE007F  # inclusive
+
+# Interlinear annotation marks: anchor/separator/terminator. Not in ``Cf`` on
+# every Python release, so we list them explicitly to be safe.
+_INTERLINEAR_START: int = 0xFFF9
+_INTERLINEAR_END: int = 0xFFFB  # inclusive
+
+# Environment-variable opt-out. The CLI sets this before any skill load so the
+# loader sees a consistent answer.
+_OPT_OUT_ENV: str = "BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS"
+
+
+def _is_invisible_tag(codepoint: str) -> bool:
+    """Return ``True`` if *codepoint* is an invisible or format-class glyph.
+
+    Stripped categories:
+
+    - Unicode category ``Cf`` (format).
+    - Range ``U+E0000-U+E007F`` (Tag block).
+    - Range ``U+FFF9-U+FFFB`` (interlinear annotation marks).
+
+    Args:
+        codepoint: A single-character string.
+
+    Returns:
+        ``True`` if the codepoint matches any rule above.
+    """
+    if len(codepoint) != 1:
+        # Defensive: callers always pass single chars but guard against
+        # surrogate pairs or multi-char graphemes anyway.
+        return False
+    ord_value = ord(codepoint)
+    if _TAG_BLOCK_START <= ord_value <= _TAG_BLOCK_END:
+        return True
+    if _INTERLINEAR_START <= ord_value <= _INTERLINEAR_END:
+        return True
+    return unicodedata.category(codepoint) == "Cf"
+
+
+def is_sanitization_enabled() -> bool:
+    """Return whether sanitization is enabled in the current process.
+
+    Looks at the ``BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS`` env var. When the
+    variable is set to ``"1"``, ``"true"``, ``"yes"``, or ``"on"`` (case
+    insensitive), sanitization is **disabled** and skill bodies pass through
+    untouched. Default is ``True`` (sanitize).
+    """
+    raw = os.environ.get(_OPT_OUT_ENV, "").strip().lower()
+    return raw not in {"1", "true", "yes", "on"}
+
+
+def strip_invisible_tags(text: str) -> tuple[str, int]:
+    """Strip invisible Unicode codepoints from *text*.
+
+    The function never extends *text*; it only removes characters. The return
+    is a tuple of ``(cleaned, count)`` where ``count`` is the number of
+    codepoints removed. ``count == 0`` means *text* was already safe and the
+    cleaned string is equal to the original.
+
+    Args:
+        text: Arbitrary user-supplied string (usually a skill body).
+
+    Returns:
+        Tuple ``(cleaned, count)``.
+
+    Example:
+        >>> strip_invisible_tags("hello")
+        ('hello', 0)
+        >>> payload = "\\U000e0048\\U000e0045\\U000e004c\\U000e004c\\U000e004f"
+        >>> strip_invisible_tags(payload)
+        ('', 5)
+    """
+    if not text:
+        return ("", 0)
+
+    out: list[str] = []
+    count = 0
+    for ch in text:
+        if _is_invisible_tag(ch):
+            count += 1
+            continue
+        out.append(ch)
+    if count == 0:
+        # Fast path: avoid re-joining when nothing changed so the identity
+        # property is preserved.
+        return (text, 0)
+    return ("".join(out), count)
+
+
+def sanitize_skill_body(
+    body: str,
+    *,
+    skill_name: str,
+    origin: str,
+    source_name: str,
+) -> str:
+    """Sanitize *body* and emit a WARN log + Prometheus counter on hits.
+
+    Wraps :func:`strip_invisible_tags` with the orchestrator-side wiring so the
+    loader does not need to know how to talk to the observability subsystem.
+    Honours the ``--unsafe-allow-unicode-tags`` opt-out: when sanitization is
+    disabled, *body* is returned verbatim and no telemetry is emitted.
+
+    Args:
+        body: Raw skill body text.
+        skill_name: Skill name, included in the WARN log line.
+        origin: Where the skill came from (filesystem path or plugin label).
+            Included in the WARN log line.
+        source_name: Label of the owning :class:`SkillSource`. Used as the
+            Prometheus counter label.
+
+    Returns:
+        Sanitized body, or *body* unchanged when sanitization is disabled
+        or no invisible codepoints were found.
+    """
+    if not is_sanitization_enabled():
+        return body
+
+    cleaned, count = strip_invisible_tags(body)
+    if count > 0:
+        logger.warning(
+            "skills.unicode_tags_stripped name=%r origin=%r source=%r count=%d",
+            skill_name,
+            origin,
+            source_name,
+            count,
+        )
+        _record_counter(source_name, count)
+    return cleaned
+
+
+def _record_counter(source_name: str, count: int) -> None:
+    """Increment the Prometheus counter, swallowing import errors.
+
+    The Prometheus module has a stub fallback when ``prometheus_client`` is
+    unavailable, but we still wrap the import in a try/except in case the
+    observability subsystem cannot be loaded at all (e.g. partial wheel).
+    """
+    try:
+        from bernstein.core.observability.prometheus import (
+            skills_unicode_tags_stripped_total,
+        )
+
+        skills_unicode_tags_stripped_total.labels(source_name=source_name).inc(count)  # type: ignore[no-untyped-call]
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Failed to record skills_unicode_tags_stripped_total", exc_info=True)
+
+
+__all__ = [
+    "is_sanitization_enabled",
+    "sanitize_skill_body",
+    "strip_invisible_tags",
+]

--- a/tests/integration/test_skill_injection_sanitized.py
+++ b/tests/integration/test_skill_injection_sanitized.py
@@ -1,0 +1,194 @@
+"""Integration tests for invisible-Unicode sanitization at skill-injection time.
+
+These tests exercise the end-to-end path that writes ``.claude/skills/*.md``
+into an agent worktree, asserting that:
+
+1. A poisoned template body never reaches disk with invisible codepoints.
+2. The bytes written to disk contain no Tag-block, interlinear, or Cf prefixes.
+3. A clean template round-trips unchanged.
+4. The Prometheus counter increments per source on a poisoned template.
+5. The opt-out (``BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS``) lets a poisoned
+   template through so security incidents can be reproduced.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+from pathlib import Path
+
+import pytest
+from bernstein.core.models import Task
+
+from bernstein.adapters.skills_injector import inject_skills
+
+#: Invisible "HELLO" encoded in the Unicode Tag block.
+INVISIBLE_HELLO = "\U000e0048\U000e0045\U000e004c\U000e004c\U000e004f"
+
+
+@pytest.fixture(autouse=True)
+def _clear_optout_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS", raising=False)
+
+
+def _make_task() -> Task:
+    return Task(id="T-001", title="Test task", description="A task", role="backend")
+
+
+def _make_poisoned_skills_dir(tmp_path: Path) -> Path:
+    """Materialise a templates/skills directory with a poisoned body."""
+    skills_dir = tmp_path / "templates" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "bernstein-completion-protocol.md").write_text(
+        "---\nname: bernstein-completion-protocol\n"
+        "description: Report task completion\n---\n"
+        f"Visible{INVISIBLE_HELLO}content. Complete: {{{{COMPLETE_CMDS}}}}\n",
+        encoding="utf-8",
+    )
+    (skills_dir / "bernstein-signal-check.md").write_text(
+        "---\nname: bernstein-signal-check\n"
+        "description: Check signals\n---\n"
+        f"Session {{{{SESSION_ID}}}} {INVISIBLE_HELLO}\n",
+        encoding="utf-8",
+    )
+    return skills_dir
+
+
+def _make_clean_skills_dir(tmp_path: Path) -> Path:
+    skills_dir = tmp_path / "templates" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "bernstein-completion-protocol.md").write_text(
+        "---\nname: bernstein-completion-protocol\n"
+        "description: Report task completion\n---\n"
+        "Complete: {{COMPLETE_CMDS}}\n",
+        encoding="utf-8",
+    )
+    (skills_dir / "bernstein-signal-check.md").write_text(
+        "---\nname: bernstein-signal-check\ndescription: Check signals\n---\nSession {{SESSION_ID}}\n",
+        encoding="utf-8",
+    )
+    return skills_dir
+
+
+def _has_invisible_codepoint(text: str) -> bool:
+    for ch in text:
+        cp = ord(ch)
+        if 0xE0000 <= cp <= 0xE007F:
+            return True
+        if 0xFFF9 <= cp <= 0xFFFB:
+            return True
+        if unicodedata.category(ch) == "Cf":
+            return True
+    return False
+
+
+def test_poisoned_template_has_no_invisible_bytes_on_disk(tmp_path: Path) -> None:
+    skills_dir = _make_poisoned_skills_dir(tmp_path)
+    workdir = tmp_path / "worktree"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="backend",
+        tasks=[_make_task()],
+        session_id="session-xyz",
+        templates_dir=skills_dir.parent / "roles",
+    )
+
+    written = list((workdir / ".claude" / "skills").glob("*.md"))
+    assert written, "expected at least one injected skill file"
+    for md in written:
+        body = md.read_text(encoding="utf-8")
+        assert not _has_invisible_codepoint(body), f"{md.name} still contains invisible codepoints"
+
+
+def test_poisoned_template_visible_content_survives(tmp_path: Path) -> None:
+    skills_dir = _make_poisoned_skills_dir(tmp_path)
+    workdir = tmp_path / "worktree"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="backend",
+        tasks=[_make_task()],
+        session_id="session-xyz",
+        templates_dir=skills_dir.parent / "roles",
+    )
+
+    completion = (workdir / ".claude" / "skills" / "bernstein-completion-protocol.md").read_text(encoding="utf-8")
+    assert "Visible" in completion
+    assert "content" in completion
+    # Verify the placeholder was rendered after sanitization
+    assert "T-001" in completion
+
+
+def test_clean_template_passes_through_unchanged(tmp_path: Path) -> None:
+    skills_dir = _make_clean_skills_dir(tmp_path)
+    workdir = tmp_path / "worktree"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="backend",
+        tasks=[_make_task()],
+        session_id="session-clean",
+        templates_dir=skills_dir.parent / "roles",
+    )
+
+    written = list((workdir / ".claude" / "skills").glob("*.md"))
+    assert written
+    for md in written:
+        body = md.read_text(encoding="utf-8")
+        assert not _has_invisible_codepoint(body)
+
+
+def test_opt_out_keeps_invisible_codepoints_on_disk(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the operator sets the opt-out env var, sanitization is bypassed."""
+    monkeypatch.setenv("BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS", "1")
+    skills_dir = _make_poisoned_skills_dir(tmp_path)
+    workdir = tmp_path / "worktree"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="backend",
+        tasks=[_make_task()],
+        session_id="session-unsafe",
+        templates_dir=skills_dir.parent / "roles",
+    )
+
+    completion = (workdir / ".claude" / "skills" / "bernstein-completion-protocol.md").read_text(encoding="utf-8")
+    assert _has_invisible_codepoint(completion), "expected invisibles preserved under opt-out"
+
+
+def test_counter_increments_on_injection_of_poisoned_template(tmp_path: Path) -> None:
+    from bernstein.core.observability.prometheus import (
+        skills_unicode_tags_stripped_total,
+    )
+
+    try:
+        before = float(
+            skills_unicode_tags_stripped_total.labels(source_name="templates/skills")._value.get()  # type: ignore[attr-defined]
+        )
+    except Exception:
+        return
+
+    skills_dir = _make_poisoned_skills_dir(tmp_path)
+    workdir = tmp_path / "worktree"
+    workdir.mkdir()
+
+    inject_skills(
+        workdir=workdir,
+        role="backend",
+        tasks=[_make_task()],
+        session_id="session-counter",
+        templates_dir=skills_dir.parent / "roles",
+    )
+
+    after = float(
+        skills_unicode_tags_stripped_total.labels(source_name="templates/skills")._value.get()  # type: ignore[attr-defined]
+    )
+    # Two poisoned files each carrying 5 invisible codepoints == 10 total.
+    assert after - before >= 10.0

--- a/tests/property/test_skill_unicode_sanitizer_properties.py
+++ b/tests/property/test_skill_unicode_sanitizer_properties.py
@@ -1,0 +1,219 @@
+"""Property-based tests for the skill-pack invisible-Unicode sanitizer.
+
+Invariants under test:
+
+* **Idempotence.** ``strip(strip(x)) == strip(x)``.
+* **No extension.** Output length never exceeds input length.
+* **UTF-8 round-trip.** Cleaned output encodes and decodes without loss.
+* **Count consistency.** ``count + len(cleaned) == len(input)``.
+* **Mask correctness.** No invisible codepoint survives a single pass.
+* **Cleanliness preservation.** Already-clean inputs are returned untouched.
+
+Hypothesis exercises both adversarial Unicode (Tag block + Cf + RTL marks)
+and ordinary text payloads.
+"""
+
+from __future__ import annotations
+
+import unicodedata
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.skills.sanitizer import strip_invisible_tags
+
+# ---------------------------------------------------------------------------
+# Strategies
+# ---------------------------------------------------------------------------
+
+_tag_block = st.builds(chr, st.integers(min_value=0xE0000, max_value=0xE007F))
+_interlinear = st.builds(chr, st.integers(min_value=0xFFF9, max_value=0xFFFB))
+
+_cf_chars = st.sampled_from(
+    [
+        "​",  # ZWSP
+        "‌",  # ZWNJ
+        "‍",  # ZWJ
+        "‎",  # LRM
+        "‏",  # RLM
+        "‪",  # LRE
+        "‫",  # RLE
+        "‬",  # PDF
+        "‭",  # LRO
+        "‮",  # RLO
+        "⁠",  # WJ
+        "⁡",  # FUNCTION APPLICATION
+        "⁢",  # INVISIBLE TIMES
+        "⁣",  # INVISIBLE SEPARATOR
+        "⁤",  # INVISIBLE PLUS
+        "⁪",  # INHIBIT SYMMETRIC SWAPPING
+        "﻿",  # BOM
+        "­",  # SOFT HYPHEN
+    ]
+)
+
+# Visible text: exclude every category the sanitizer would strip and avoid
+# lone surrogates which Python strings cannot contain.
+_visible_text = st.text(
+    st.characters(
+        blacklist_categories=("Cs", "Cf"),
+        max_codepoint=0xFFFF,
+    ),
+    min_size=0,
+    max_size=128,
+).filter(lambda s: not any(0xE0000 <= ord(c) <= 0xE007F or 0xFFF9 <= ord(c) <= 0xFFFB for c in s))
+
+_invisible_glyph = st.one_of(_tag_block, _interlinear, _cf_chars)
+
+_adversarial_payload = st.lists(
+    st.one_of(_visible_text, _invisible_glyph),
+    min_size=0,
+    max_size=20,
+).map("".join)
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_idempotent(payload: str) -> None:
+    once, _ = strip_invisible_tags(payload)
+    twice, count_twice = strip_invisible_tags(once)
+    assert once == twice
+    assert count_twice == 0
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_never_extends(payload: str) -> None:
+    cleaned, _ = strip_invisible_tags(payload)
+    assert len(cleaned) <= len(payload)
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_count_consistency(payload: str) -> None:
+    cleaned, count = strip_invisible_tags(payload)
+    assert count == len(payload) - len(cleaned)
+    assert count >= 0
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_utf8_roundtrip(payload: str) -> None:
+    cleaned, _ = strip_invisible_tags(payload)
+    decoded = cleaned.encode("utf-8").decode("utf-8")
+    assert decoded == cleaned
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_no_invisible_survives(payload: str) -> None:
+    cleaned, _ = strip_invisible_tags(payload)
+    for ch in cleaned:
+        cp = ord(ch)
+        assert not (0xE0000 <= cp <= 0xE007F), f"tag block char survived: U+{cp:X}"
+        assert not (0xFFF9 <= cp <= 0xFFFB), f"interlinear char survived: U+{cp:X}"
+        assert unicodedata.category(ch) != "Cf", f"Cf char survived: U+{cp:X}"
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_visible_text)
+def test_property_clean_input_unchanged(payload: str) -> None:
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == payload
+    assert count == 0
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(st.lists(_invisible_glyph, min_size=0, max_size=64).map("".join))
+def test_property_all_invisible_input_yields_empty(payload: str) -> None:
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == ""
+    assert count == len(payload)
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_visible_text, _visible_text, _invisible_glyph)
+def test_property_invisible_glyph_always_removed(
+    left: str,
+    right: str,
+    glyph: str,
+) -> None:
+    payload = left + glyph + right
+    cleaned, count = strip_invisible_tags(payload)
+    assert glyph not in cleaned
+    assert count >= 1
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload, _adversarial_payload)
+def test_property_concat_commutes_with_strip(payload_a: str, payload_b: str) -> None:
+    """``strip(a+b)`` produces the same result as ``strip(a)+strip(b)``."""
+    joint, _ = strip_invisible_tags(payload_a + payload_b)
+    parts_a, _ = strip_invisible_tags(payload_a)
+    parts_b, _ = strip_invisible_tags(payload_b)
+    assert joint == parts_a + parts_b
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_count_equals_invisible_count(payload: str) -> None:
+    """The reported count must equal the number of invisible chars in input."""
+    expected = sum(
+        1
+        for ch in payload
+        if (0xE0000 <= ord(ch) <= 0xE007F or 0xFFF9 <= ord(ch) <= 0xFFFB or unicodedata.category(ch) == "Cf")
+    )
+    _, count = strip_invisible_tags(payload)
+    assert count == expected
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_visible_text)
+def test_property_visible_text_preserves_codepoint_order(payload: str) -> None:
+    cleaned, _ = strip_invisible_tags(payload)
+    assert cleaned == "".join(
+        c
+        for c in payload
+        if not (0xE0000 <= ord(c) <= 0xE007F or 0xFFF9 <= ord(c) <= 0xFFFB or unicodedata.category(c) == "Cf")
+    )
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_cleaned_is_str_count_is_int(payload: str) -> None:
+    cleaned, count = strip_invisible_tags(payload)
+    assert isinstance(cleaned, str)
+    assert isinstance(count, int)
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_visible_text)
+def test_property_visible_count_is_zero(payload: str) -> None:
+    _, count = strip_invisible_tags(payload)
+    assert count == 0
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(st.lists(_tag_block, min_size=1, max_size=32).map("".join))
+def test_property_tag_block_only_input_strips_completely(payload: str) -> None:
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == ""
+    assert count == len(payload)
+
+
+@settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
+@given(_adversarial_payload)
+def test_property_cleaned_length_matches_filter(payload: str) -> None:
+    """``len(cleaned)`` equals the number of visible codepoints in the input."""
+    visible_count = sum(
+        1
+        for ch in payload
+        if not (0xE0000 <= ord(ch) <= 0xE007F or 0xFFF9 <= ord(ch) <= 0xFFFB or unicodedata.category(ch) == "Cf")
+    )
+    cleaned, _ = strip_invisible_tags(payload)
+    assert len(cleaned) == visible_count

--- a/tests/unit/skills/test_unicode_sanitizer.py
+++ b/tests/unit/skills/test_unicode_sanitizer.py
@@ -1,0 +1,535 @@
+"""Unit tests for :mod:`bernstein.core.skills.sanitizer`.
+
+The sanitizer is a P1 security control: it strips invisible Unicode codepoints
+from skill bodies before injection so a poisoned third-party skill cannot
+smuggle prompt-injection instructions past the model.
+
+Test density is intentionally high. Every documented branch of the spec has at
+least one dedicated case, plus a battery of edge-cases, idempotency checks,
+counter-emission assertions, and a regression sweep over the bundled skill
+templates.
+"""
+
+from __future__ import annotations
+
+import logging
+import unicodedata
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.skills import sanitizer as sanitizer_module
+from bernstein.core.skills.sanitizer import (
+    is_sanitization_enabled,
+    sanitize_skill_body,
+    strip_invisible_tags,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+#: Invisible "HELLO" encoded in the Tag block (U+E0048 U+E0045 U+E004C ...).
+INVISIBLE_HELLO = "\U000e0048\U000e0045\U000e004c\U000e004c\U000e004f"
+
+
+@pytest.fixture(autouse=True)
+def _clear_optout_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to sanitizer-ON to avoid bleed-through."""
+    monkeypatch.delenv("BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS", raising=False)
+
+
+@pytest.fixture
+def reset_counter() -> Iterator[None]:
+    """Marker fixture for per-test counter delta assertions."""
+    yield
+
+
+def _counter_value(source_name: str) -> float:
+    """Return the current value of the sanitization counter for *source_name*.
+
+    Returns 0.0 if the label combination has never been observed or when
+    ``prometheus_client`` is unavailable (stub fallback).
+    """
+    from bernstein.core.observability.prometheus import (
+        skills_unicode_tags_stripped_total,
+    )
+
+    try:
+        return float(
+            skills_unicode_tags_stripped_total.labels(source_name=source_name)._value.get()  # type: ignore[attr-defined]
+        )
+    except Exception:
+        return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Spec-mandated cases (acceptance criteria)
+# ---------------------------------------------------------------------------
+
+
+def test_spec_invisible_hello_returns_count_5_and_empty_body() -> None:
+    """Spec AC: invisible 'HELLO' returns count=5 and empty cleaned body."""
+    cleaned, count = strip_invisible_tags(INVISIBLE_HELLO)
+    assert cleaned == ""
+    assert count == 5
+
+
+def test_spec_clean_skill_returns_count_0_and_unchanged_body() -> None:
+    """Spec AC: clean skill returns count=0 and unchanged body."""
+    payload = "# Hello\nThis is a normal skill body with no invisibles.\n"
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == payload
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Mixed visible + invisible payloads
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_visible_and_invisible_keeps_visible() -> None:
+    payload = "hello" + INVISIBLE_HELLO + "world"
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == "helloworld"
+    assert count == 5
+
+
+def test_mixed_invisible_at_start_only() -> None:
+    cleaned, count = strip_invisible_tags(INVISIBLE_HELLO + "world")
+    assert cleaned == "world"
+    assert count == 5
+
+
+def test_mixed_invisible_at_end_only() -> None:
+    cleaned, count = strip_invisible_tags("hello" + INVISIBLE_HELLO)
+    assert cleaned == "hello"
+    assert count == 5
+
+
+def test_mixed_invisible_interleaved() -> None:
+    payload = "h\U000e0001e\U000e0002l\U000e0003lo"
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == "hello"
+    assert count == 3
+
+
+def test_only_one_invisible_codepoint() -> None:
+    cleaned, count = strip_invisible_tags("a\U000e0040b")
+    assert cleaned == "ab"
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tag block boundaries
+# ---------------------------------------------------------------------------
+
+
+def test_tag_block_lower_boundary() -> None:
+    cleaned, count = strip_invisible_tags("\U000e0000")
+    assert cleaned == ""
+    assert count == 1
+
+
+def test_tag_block_upper_boundary() -> None:
+    cleaned, count = strip_invisible_tags("\U000e007f")
+    assert cleaned == ""
+    assert count == 1
+
+
+def test_codepoint_just_above_tag_block_is_kept() -> None:
+    # U+E0080: Private Use Area (Co), not Tag block. Should NOT be stripped.
+    pua_above = "\U000e0080"
+    cleaned, count = strip_invisible_tags(pua_above)
+    if unicodedata.category(pua_above) == "Co":
+        assert cleaned == pua_above
+        assert count == 0
+
+
+def test_entire_tag_block_is_stripped() -> None:
+    payload = "".join(chr(cp) for cp in range(0xE0000, 0xE0080))
+    assert len(payload) == 128
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == ""
+    assert count == 128
+
+
+# ---------------------------------------------------------------------------
+# Interlinear annotation marks (U+FFF9-U+FFFB)
+# ---------------------------------------------------------------------------
+
+
+def test_interlinear_anchor_stripped() -> None:
+    cleaned, count = strip_invisible_tags("a￹b")
+    assert cleaned == "ab"
+    assert count == 1
+
+
+def test_interlinear_separator_stripped() -> None:
+    cleaned, count = strip_invisible_tags("a￺b")
+    assert cleaned == "ab"
+    assert count == 1
+
+
+def test_interlinear_terminator_stripped() -> None:
+    cleaned, count = strip_invisible_tags("a￻b")
+    assert cleaned == "ab"
+    assert count == 1
+
+
+def test_all_three_interlinear_marks_stripped() -> None:
+    cleaned, count = strip_invisible_tags("￹￺￻")
+    assert cleaned == ""
+    assert count == 3
+
+
+# ---------------------------------------------------------------------------
+# Cf-category codepoints sampled across the BMP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "codepoint",
+    [
+        "​",  # ZERO WIDTH SPACE
+        "‌",  # ZERO WIDTH NON-JOINER
+        "‍",  # ZERO WIDTH JOINER
+        "‎",  # LEFT-TO-RIGHT MARK
+        "‏",  # RIGHT-TO-LEFT MARK
+        "‪",  # LEFT-TO-RIGHT EMBEDDING
+        "‫",  # RIGHT-TO-LEFT EMBEDDING
+        "‬",  # POP DIRECTIONAL FORMATTING
+        "‭",  # LEFT-TO-RIGHT OVERRIDE
+        "‮",  # RIGHT-TO-LEFT OVERRIDE
+        "⁠",  # WORD JOINER
+        "⁡",  # FUNCTION APPLICATION
+        "⁢",  # INVISIBLE TIMES
+        "⁣",  # INVISIBLE SEPARATOR
+        "⁤",  # INVISIBLE PLUS
+        "⁪",  # INHIBIT SYMMETRIC SWAPPING
+        "﻿",  # ZERO WIDTH NO-BREAK SPACE / BOM
+        "­",  # SOFT HYPHEN
+        "؀",  # ARABIC NUMBER SIGN
+        "؜",  # ARABIC LETTER MARK
+    ],
+)
+def test_cf_codepoint_is_stripped(codepoint: str) -> None:
+    assert unicodedata.category(codepoint) == "Cf"
+    cleaned, count = strip_invisible_tags(f"a{codepoint}b")
+    assert cleaned == "ab"
+    assert count == 1
+
+
+def test_rtl_mark_is_stripped() -> None:
+    """RTL marks live in Cf and must be stripped regardless of position."""
+    payload = "Hello‏World"
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == "HelloWorld"
+    assert count == 1
+
+
+def test_bom_at_start_is_stripped() -> None:
+    cleaned, count = strip_invisible_tags("﻿# Real content")
+    assert cleaned == "# Real content"
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Visible codepoints stay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "plain ascii",
+        "русский текст",
+        "中文文本",
+        "emoji rocket inline",
+        "math: forall x in R",
+        "tab\tand\nnewline",
+        "quote: \"double\" 'single'",
+        "code: `f(x) = x + 1`",
+        "  leading and trailing  ",
+        "\x00null-byte-allowed",
+    ],
+)
+def test_visible_payload_unchanged(payload: str) -> None:
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == payload
+    assert count == 0
+
+
+def test_control_codes_not_stripped() -> None:
+    """Cc-category control codes are NOT in scope.
+
+    The sanitizer targets Cf, Tag block, and interlinear only. Control codes
+    (Cc) have a different threat surface (terminal escapes) handled elsewhere.
+    """
+    payload = "\x07\x1b[31mred\x1b[0m"
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == payload
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_empty_string() -> None:
+    cleaned, count = strip_invisible_tags("")
+    assert cleaned == ""
+    assert count == 0
+
+
+def test_single_visible_char() -> None:
+    cleaned, count = strip_invisible_tags("a")
+    assert cleaned == "a"
+    assert count == 0
+
+
+def test_single_invisible_char() -> None:
+    cleaned, count = strip_invisible_tags("\U000e0041")
+    assert cleaned == ""
+    assert count == 1
+
+
+def test_all_invisible_long_string() -> None:
+    payload = INVISIBLE_HELLO * 100
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == ""
+    assert count == 500
+
+
+def test_alternating_visible_invisible() -> None:
+    payload = "".join("x\U000e0041" for _ in range(50))
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == "x" * 50
+    assert count == 50
+
+
+def test_very_long_clean_payload_unchanged() -> None:
+    payload = "lorem ipsum dolor sit amet " * 1_000
+    cleaned, count = strip_invisible_tags(payload)
+    assert cleaned == payload
+    assert count == 0
+
+
+def test_return_type_is_tuple_of_str_and_int() -> None:
+    result = strip_invisible_tags("hello")
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert isinstance(result[0], str)
+    assert isinstance(result[1], int)
+
+
+def test_count_is_never_negative() -> None:
+    for payload in ["", "a", INVISIBLE_HELLO, "​", "﻿bom"]:
+        _, count = strip_invisible_tags(payload)
+        assert count >= 0
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_on_clean_input() -> None:
+    payload = "this is clean"
+    once, count_once = strip_invisible_tags(payload)
+    twice, count_twice = strip_invisible_tags(once)
+    assert once == twice
+    assert count_once == 0
+    assert count_twice == 0
+
+
+def test_idempotent_on_dirty_input() -> None:
+    payload = "hello" + INVISIBLE_HELLO + "world"
+    once, _ = strip_invisible_tags(payload)
+    twice, count_twice = strip_invisible_tags(once)
+    assert once == twice
+    assert count_twice == 0
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_utf8_roundtrip_preserves_cleaned_body() -> None:
+    payload = "русский 中文 plain " + INVISIBLE_HELLO
+    cleaned, _ = strip_invisible_tags(payload)
+    encoded = cleaned.encode("utf-8")
+    decoded = encoded.decode("utf-8")
+    assert decoded == cleaned
+
+
+def test_no_invisible_bytes_in_cleaned_utf8_output() -> None:
+    payload = "ascii" + INVISIBLE_HELLO + "more"
+    cleaned, _ = strip_invisible_tags(payload)
+    encoded = cleaned.encode("utf-8")
+    # Tag block codepoints encode to 4 UTF-8 bytes starting with 0xF3 0xA0 0x80
+    assert b"\xf3\xa0\x80" not in encoded
+    assert b"\xf3\xa0\x81" not in encoded
+
+
+# ---------------------------------------------------------------------------
+# Opt-out (env var) behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_is_sanitization_enabled_default() -> None:
+    assert is_sanitization_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "Yes", "on", "ON"])
+def test_is_sanitization_enabled_opt_out(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS", value)
+    assert is_sanitization_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "  ", "anything-else"])
+def test_is_sanitization_enabled_other_values(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS", value)
+    assert is_sanitization_enabled() is True
+
+
+def test_sanitize_skill_body_respects_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS", "1")
+    poisoned = "hello" + INVISIBLE_HELLO
+    result = sanitize_skill_body(poisoned, skill_name="x", origin="y", source_name="z")
+    assert result == poisoned
+
+
+def test_sanitize_skill_body_default_strips() -> None:
+    poisoned = "hello" + INVISIBLE_HELLO
+    result = sanitize_skill_body(poisoned, skill_name="x", origin="y", source_name="z")
+    assert result == "hello"
+
+
+# ---------------------------------------------------------------------------
+# sanitize_skill_body: WARN log + counter
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_skill_body_logs_warning_on_strip(caplog: pytest.LogCaptureFixture) -> None:
+    poisoned = "ok" + INVISIBLE_HELLO
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.skills.sanitizer"):
+        sanitize_skill_body(
+            poisoned,
+            skill_name="poison-skill",
+            origin="/tmp/poison",
+            source_name="evil-source",
+        )
+    assert any(
+        "poison-skill" in rec.message and "evil-source" in rec.message and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )
+
+
+def test_sanitize_skill_body_no_log_when_clean(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="bernstein.core.skills.sanitizer"):
+        sanitize_skill_body("clean body", skill_name="ok", origin="/tmp/ok", source_name="local")
+    warns = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warns == []
+
+
+def test_sanitize_skill_body_counter_increments_per_source(reset_counter: None) -> None:
+    before = _counter_value("test-source-a")
+    sanitize_skill_body(
+        INVISIBLE_HELLO + "x",
+        skill_name="s1",
+        origin="/a",
+        source_name="test-source-a",
+    )
+    after = _counter_value("test-source-a")
+    assert after - before == pytest.approx(5.0)
+
+
+def test_sanitize_skill_body_counter_isolated_by_source(reset_counter: None) -> None:
+    before_a = _counter_value("test-source-b1")
+    before_b = _counter_value("test-source-b2")
+    sanitize_skill_body(
+        INVISIBLE_HELLO,
+        skill_name="s",
+        origin="/a",
+        source_name="test-source-b1",
+    )
+    after_a = _counter_value("test-source-b1")
+    after_b = _counter_value("test-source-b2")
+    assert after_a - before_a == pytest.approx(5.0)
+    assert after_b - before_b == pytest.approx(0.0)
+
+
+def test_sanitize_skill_body_counter_not_incremented_on_clean(reset_counter: None) -> None:
+    before = _counter_value("test-source-c")
+    sanitize_skill_body("clean", skill_name="s", origin="/a", source_name="test-source-c")
+    after = _counter_value("test-source-c")
+    assert after - before == pytest.approx(0.0)
+
+
+def test_sanitize_skill_body_returns_cleaned_string_on_hit() -> None:
+    result = sanitize_skill_body(
+        "x" + INVISIBLE_HELLO + "y",
+        skill_name="s",
+        origin="o",
+        source_name="src",
+    )
+    assert result == "xy"
+
+
+def test_sanitize_skill_body_returns_unchanged_on_clean() -> None:
+    payload = "perfectly fine"
+    result = sanitize_skill_body(payload, skill_name="s", origin="o", source_name="src")
+    assert result == payload
+
+
+# ---------------------------------------------------------------------------
+# Regression: bundled skill templates must all be clean
+# ---------------------------------------------------------------------------
+
+
+def _iter_template_skill_files() -> list[Path]:
+    templates_root = Path(__file__).resolve().parents[3] / "templates" / "skills"
+    if not templates_root.is_dir():
+        return []
+    return sorted(templates_root.rglob("*.md"))
+
+
+def test_regression_bundled_skills_have_zero_invisible_codepoints() -> None:
+    """Every shipped skill template must sanitize with count=0."""
+    files = _iter_template_skill_files()
+    assert files, "expected at least one bundled skill template"
+    dirty: list[tuple[Path, int]] = []
+    for path in files:
+        body = path.read_text(encoding="utf-8")
+        _, count = strip_invisible_tags(body)
+        if count > 0:
+            dirty.append((path, count))
+    assert not dirty, f"bundled templates contain invisible codepoints: {dirty}"
+
+
+@pytest.mark.parametrize("path", _iter_template_skill_files(), ids=lambda p: p.name)
+def test_regression_each_bundled_skill_clean(path: Path) -> None:
+    body = path.read_text(encoding="utf-8")
+    cleaned, count = strip_invisible_tags(body)
+    assert count == 0, f"{path.name} contains {count} invisible codepoints"
+    assert cleaned == body
+
+
+# ---------------------------------------------------------------------------
+# Module-level sanity
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_exports() -> None:
+    assert "strip_invisible_tags" in sanitizer_module.__all__
+    assert "sanitize_skill_body" in sanitizer_module.__all__
+    assert "is_sanitization_enabled" in sanitizer_module.__all__
+
+
+def test_env_var_constant_is_documented() -> None:
+    """Constant matches spec wording, so a typo cannot disable the CLI wiring."""
+    assert sanitizer_module._OPT_OUT_ENV == "BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS"

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -209,6 +209,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "telemetry",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "quality",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "cost-envelopes",
     }
 )
 


### PR DESCRIPTION
## Summary

- Strip invisible Unicode codepoints (Cf, U+E0000-U+E007F Tag block, U+FFF9-U+FFFB interlinear) from skill bodies before injection into `.claude/skills/*.md`.
- Wires sanitization into both `SkillLoader._register` (MCP path) and `skills_injector.inject_skills` (worktree write path) so every code path that materialises a skill file on disk is protected.
- New module `bernstein.core.skills.sanitizer` with `strip_invisible_tags(text) -> (cleaned, count)` returning the cleaned body plus the strip count. Pure stdlib (`unicodedata.category`), no new deps.
- Emits a `WARN` log line + Prometheus counter `bernstein_skills_unicode_tags_stripped_total{source_name}` on every hit so operators can spot a poisoned upstream source.
- Defaults ON. Opt-out via hidden `--unsafe-allow-unicode-tags` CLI flag (or `BERNSTEIN_UNSAFE_ALLOW_UNICODE_TAGS=1` env var) for incident reproduction only.

## Threat model

Public research (Embrace the Red, Feb 2026; Snyk skill-pack audit of 3,984 files showing 36.82% with security flaws, 13.4% critical-severity) demonstrated that invisible Tag-block codepoints are interpreted as instructions by Claude, Gemini, and Grok. A poisoned third-party `SkillSource` plugin would otherwise have been silently embedded in every agent spawn matching its trigger.

## Test plan

- [x] 134 unit tests in `tests/unit/skills/test_unicode_sanitizer.py` covering AC fixtures (invisible "HELLO" -> count=5, empty cleaned body), Tag-block boundaries, every Cf category sample, interlinear marks, RTL marks, idempotency, UTF-8 round-trip, per-source counter isolation, opt-out env-var handling, WARN log assertions.
- [x] 15 Hypothesis property tests in `tests/property/test_skill_unicode_sanitizer_properties.py` (idempotence, no-extension, UTF-8 round-trip, count consistency, mask correctness, concat commutes).
- [x] 5 integration tests in `tests/integration/test_skill_injection_sanitized.py` verifying no invisible bytes in `.claude/skills/*.md` on disk after `inject_skills`, opt-out preserves invisibles, counter increments per source.
- [x] Regression: every shipped `templates/skills/*.md` sanitizes with count=0 (asserted by parametrized test).
- [x] `uv run ruff check` clean.
- [x] `uv run ruff format` applied.
- [x] All 202 skill-related tests still pass (no regression).