### PR TITLE
fix(tests): repair 4 post-merge regressions on main (#1390/#1387/#1344/#1350 fallouts)

### DIFF
--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -1209,6 +1209,8 @@ def task_counts(
         pending_approval=counts.get("pending_approval", 0),
         waiting_for_subtasks=counts.get("waiting_for_subtasks", 0),
         orphaned=counts.get("orphaned", 0),
+        abandoned=counts.get("abandoned", 0),
+        blocked_by_abandon=counts.get("blocked_by_abandon", 0),
         total=counts.get("total", 0),
     )
 

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -479,6 +479,8 @@ class TaskCountsResponse(BaseModel):
     pending_approval: int = 0
     waiting_for_subtasks: int = 0
     orphaned: int = 0
+    abandoned: int = 0
+    blocked_by_abandon: int = 0
     total: int = 0
 
 

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -461,9 +461,15 @@ class TestQwenAdapterSpawn:
                 session_id="q7",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--tavily-api-key" in inner
-        assert inner[inner.index("--tavily-api-key") + 1] == "tv-key-xyz"
+        # Security: Tavily key is forwarded via env (not argv) so it never
+        # appears in ``ps``/audit logs on shared hosts. Qwen Code reads
+        # ``TAVILY_API_KEY`` from the environment when the web_search tool
+        # is enabled.
+        assert "--tavily-api-key" not in inner
+        assert "tv-key-xyz" not in inner
         assert "--web-search-default" in inner
+        env = popen.call_args.kwargs.get("env", {})
+        assert env.get("TAVILY_API_KEY") == "tv-key-xyz"
 
     def test_spawn_result_pid(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()

--- a/tests/unit/test_apm_integration.py
+++ b/tests/unit/test_apm_integration.py
@@ -158,9 +158,13 @@ class TestConfigureDatadog:
         assert cfg.env == "test"
         assert cfg.agent_host == "custom-host"
 
-    @patch("bernstein.core.telemetry.init_telemetry_from_preset")
+    @patch("bernstein.core.observability.telemetry.init_telemetry_from_preset")
     def test_otlp_fallback_calls_preset(self, mock_preset: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When ddtrace is missing, falls back to OTLP preset."""
+        """When ddtrace is missing, falls back to OTLP preset.
+
+        ``configure_datadog`` does a local import of ``init_telemetry_from_preset``
+        from ``bernstein.core.observability.telemetry``, so we patch that path.
+        """
         monkeypatch.delenv("DD_API_KEY", raising=False)
         monkeypatch.delenv("DATADOG_API_KEY", raising=False)
         cfg = DatadogConfig(use_otlp=False, agent_host="dd-host")
@@ -170,11 +174,11 @@ class TestConfigureDatadog:
             result = configure_datadog(cfg)
 
         # Should have attempted the OTLP fallback
-        if result:
-            mock_preset.assert_called_once()
-            call_args = mock_preset.call_args
-            assert call_args[0][0] == "datadog"
-            assert "dd-host" in call_args[1].get("endpoint_override", "")
+        assert result is True
+        mock_preset.assert_called_once()
+        call_args = mock_preset.call_args
+        assert call_args[0][0] == "datadog"
+        assert "dd-host" in call_args[1].get("endpoint_override", "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_stop.py
+++ b/tests/unit/test_cli_stop.py
@@ -318,11 +318,22 @@ class TestHardStopFallbacks:
         killed: set[int] = set()
 
         def _record_agent(pid: int, label: str, seen: set[int]) -> None:
-            del label, seen
+            del label
+            # Mirror real ``_kill_agent_pid`` semantics: the function is
+            # idempotent because it tracks killed pids in ``seen`` and bails
+            # out on a second call.  Without this update the two-pass scan in
+            # ``_collect_repo_processes`` looks like it kills the same pid
+            # twice when in fact the second call short-circuits in
+            # production.
+            if pid in seen:
+                return
+            seen.add(pid)
             agent_calls.append(pid)
 
         def _record_infra(pid: int, label: str, seen: set[int]) -> None:
-            del seen
+            if pid in seen:
+                return
+            seen.add(pid)
             infra_calls.append((pid, label))
 
         with (


### PR DESCRIPTION
## TL;DR

Four test failures on `main` after recent feature merges. Each is a real post-merge regression where the test was not updated alongside the feature PR (or the schema field was missed).

| # | Test | Root cause | Followup to |
|---|---|---|---|
| 1 | `test_adapter_non_claude::TestQwenAdapterSpawn::test_tavily_flags_when_key_present` | qwen adapter moved the Tavily API key from argv to env (security fix) so it does not leak into `ps`/audit logs; test still asserted argv presence | #1390 (qwen security fix) |
| 2 | `test_apm_integration::TestConfigureDatadog::test_otlp_fallback_calls_preset` | telemetry was refactored and the symbol lives at `bernstein.core.observability.telemetry`; the test patched the back-compat re-export path which `configure_datadog`'s local import does not bind to | #1387 (opt-in telemetry refactor) |
| 3 | `test_cli_stop::TestHardStopFallbacks::test_collect_repo_processes_targets_repo_owned_runtime_processes` | second-pass orphan-shell cleanup re-fires `_kill_agent_pid` for the same pid; production code is idempotent via the shared `killed` set but the test mock dropped the `seen` argument so dedup never happened in test | #1344 (fe-smoke bug sweep, two-pass scan) |
| 4 | `test_frontend_smoke_bug_sweep::TestBug4TaskCountsAllStatuses::test_schema_fields_cover_every_enum_value` | `TaskStatus.ABANDONED` (and `BLOCKED_BY_ABANDON`) added by the abandon primitive but `TaskCountsResponse` schema was not extended, so the GUI badge can never render a real count | #1350 / #1358 (abandon primitive) |

## What changed

- **#1 (test only)**: assert `TAVILY_API_KEY` env var is set on the spawned process and `--tavily-api-key` is NOT in argv. Do not revert the security fix.
- **#2 (test only)**: patch `bernstein.core.observability.telemetry.init_telemetry_from_preset` (where the local import resolves), tighten the assertion to `result is True` so the mock is required to be called.
- **#3 (test only)**: `_record_agent`/`_record_infra` now mirror the real `_kill_agent_pid`/`_kill_named_pid` semantics by mutating the `seen` set so the second-pass re-fire is correctly de-duplicated (matching production behaviour).
- **#4 (code)**: add `abandoned: int = 0` and `blocked_by_abandon: int = 0` to `TaskCountsResponse` in `server_models.py`, plumb both counts through the `/tasks/counts` route in `routes/task_crud.py`. Non-breaking (default 0).

Net diff: 5 files, +36 / -11 lines.

## Test plan

- [x] `uv run pytest tests/unit/test_adapter_non_claude.py::TestQwenAdapterSpawn::test_tavily_flags_when_key_present` green
- [x] `uv run pytest tests/unit/test_apm_integration.py::TestConfigureDatadog::test_otlp_fallback_calls_preset` green
- [x] `uv run pytest tests/unit/test_cli_stop.py::TestHardStopFallbacks::test_collect_repo_processes_targets_repo_owned_runtime_processes` green
- [x] `uv run pytest tests/unit/test_frontend_smoke_bug_sweep.py::TestBug4TaskCountsAllStatuses` (all 3 tests) green
- [x] Full files `tests/unit/test_adapter_non_claude.py`, `tests/unit/test_cli_stop.py`, `tests/unit/test_frontend_smoke_bug_sweep.py` green (97 passing)
- [x] `TestConfigureDatadog` subset (4/4) green
- [x] `uv run ruff check` clean on touched files
- [x] `uv run ruff format --check` clean on touched files
- [x] `pyright` baseline preserved (471 errors with and without changes, none introduced)

## Out of scope

`tests/unit/test_apm_integration.py::TestConfigureNewRelic::{test_otlp_path_calls_http_telemetry,test_uses_nr_endpoint}` also fail on `main` but they are pre-existing failures unrelated to the four regressions in this fix.