### PR TITLE
fix: repair main test regressions ahead of v2.1.0

### DIFF
--- a/src/bernstein/core/routes/task_crud.py
+++ b/src/bernstein/core/routes/task_crud.py
@@ -1209,6 +1209,8 @@ def task_counts(
         pending_approval=counts.get("pending_approval", 0),
         waiting_for_subtasks=counts.get("waiting_for_subtasks", 0),
         orphaned=counts.get("orphaned", 0),
+        abandoned=counts.get("abandoned", 0),
+        blocked_by_abandon=counts.get("blocked_by_abandon", 0),
         total=counts.get("total", 0),
     )
 

--- a/src/bernstein/core/server/server_models.py
+++ b/src/bernstein/core/server/server_models.py
@@ -479,6 +479,8 @@ class TaskCountsResponse(BaseModel):
     pending_approval: int = 0
     waiting_for_subtasks: int = 0
     orphaned: int = 0
+    abandoned: int = 0
+    blocked_by_abandon: int = 0
     total: int = 0
 
 

--- a/tests/unit/test_adapter_non_claude.py
+++ b/tests/unit/test_adapter_non_claude.py
@@ -461,9 +461,13 @@ class TestQwenAdapterSpawn:
                 session_id="q7",
             )
         inner = _inner_cmd(popen.call_args.args[0])
-        assert "--tavily-api-key" in inner
-        assert inner[inner.index("--tavily-api-key") + 1] == "tv-key-xyz"
+        # PR #1390 moved the Tavily key out of argv into env so it never
+        # shows up in process listings. Keep the --web-search-default
+        # check, and assert the key is forwarded via TAVILY_API_KEY env.
         assert "--web-search-default" in inner
+        assert "--tavily-api-key" not in inner
+        env = popen.call_args.kwargs.get("env", {})
+        assert env.get("TAVILY_API_KEY") == "tv-key-xyz"
 
     def test_spawn_result_pid(self, tmp_path: Path) -> None:
         adapter = QwenAdapter()

--- a/tests/unit/test_apm_integration.py
+++ b/tests/unit/test_apm_integration.py
@@ -131,12 +131,12 @@ class TestConfigureDatadog:
         assert result is False
 
     def test_falls_back_to_otlp_preset_when_ddtrace_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Without ddtrace, falls back to OTLP preset using bernstein.core.telemetry."""
+        """Without ddtrace, falls back to OTLP preset using bernstein.core.observability.telemetry."""
         cfg = DatadogConfig(use_otlp=False, agent_host="dd-agent", agent_port=8126)
 
         with (
             patch.dict("sys.modules", {"ddtrace": None}),
-            patch("bernstein.core.telemetry.init_telemetry_from_preset") as mock_preset,
+            patch("bernstein.core.observability.telemetry.init_telemetry_from_preset") as mock_preset,
         ):
             mock_preset.return_value = None
             result = configure_datadog(cfg)
@@ -158,9 +158,14 @@ class TestConfigureDatadog:
         assert cfg.env == "test"
         assert cfg.agent_host == "custom-host"
 
-    @patch("bernstein.core.telemetry.init_telemetry_from_preset")
+    @patch("bernstein.core.observability.telemetry.init_telemetry_from_preset")
     def test_otlp_fallback_calls_preset(self, mock_preset: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When ddtrace is missing, falls back to OTLP preset."""
+        """When ddtrace is missing, falls back to OTLP preset.
+
+        The apm module imports init_telemetry_from_preset lazily from
+        bernstein.core.observability.telemetry inside the fallback branch,
+        so the patch target has to match that source module.
+        """
         monkeypatch.delenv("DD_API_KEY", raising=False)
         monkeypatch.delenv("DATADOG_API_KEY", raising=False)
         cfg = DatadogConfig(use_otlp=False, agent_host="dd-host")

--- a/tests/unit/test_cli_stop.py
+++ b/tests/unit/test_cli_stop.py
@@ -318,11 +318,15 @@ class TestHardStopFallbacks:
         killed: set[int] = set()
 
         def _record_agent(pid: int, label: str, seen: set[int]) -> None:
-            del label, seen
+            del label
+            # Mirror the real helper: add the PID to ``killed`` so the
+            # second-pass orphan-shell sweep skips it instead of double-
+            # counting (#1397 introduced the second pass).
+            seen.add(pid)
             agent_calls.append(pid)
 
         def _record_infra(pid: int, label: str, seen: set[int]) -> None:
-            del seen
+            seen.add(pid)
             infra_calls.append((pid, label))
 
         with (

--- a/tests/unit/test_gui_smoke_findings.py
+++ b/tests/unit/test_gui_smoke_findings.py
@@ -96,8 +96,16 @@ class TestMockIdleEnvValidation:
             "BERNSTEIN_MOCK_FAIL_RATE": "nan-please",  # not a float
         }
         rc, log = _run_idle_mock_script(env, tmp_path=tmp_path)
-        assert rc == 0, f"crash on malformed FAIL_RATE; log:\n{log}"
-        assert "WARN bad BERNSTEIN_MOCK_FAIL_RATE" in log
+        # The script must tolerate the malformed FAIL_RATE — log a warning and
+        # fall back to the default. After that the simulated-failure dice
+        # roll (default 5%) may legitimately exit non-zero; that is a
+        # separate concern from "did the parse error crash us?", so we only
+        # assert the parse warning was emitted, not the exit code.
+        assert "WARN bad BERNSTEIN_MOCK_FAIL_RATE" in log, f"missing warn; log:\n{log}"
+        # Cap-stone: rc must be a clean 0 (no failure dice) or 1 (the
+        # default fail_rate hit). A traceback would surface as a non-{0,1}
+        # exit or an empty log.
+        assert rc in (0, 1), f"unexpected crash rc={rc}; log:\n{log}"
 
     def test_idle_clamps_inverted_range(self, tmp_path: Path) -> None:
         # Original code used random.randint(min(lo,hi), max(lo,hi)) which works


### PR DESCRIPTION
Four test classes were red on main after today's feature push. All four were stale fixtures, not implementation bugs. Plus one missing schema field.

## What this fixes

- tests/unit/test_adapter_non_claude.py - tavily test asserted --tavily-api-key in argv. PR #1390 moved that key into env. Updated to assert TAVILY_API_KEY env forwarding.
- tests/unit/test_apm_integration.py - patched the wrong module path. apm_integration.py imports init_telemetry_from_preset lazily from bernstein.core.observability.telemetry. Updated patch targets.
- tests/unit/test_cli_stop.py - the _record_agent mock did not add PIDs to the killed set, so the second-pass orphan-shell sweep added in #1397 double-counted PID 10. Mock now mirrors the real helper.
- tests/unit/test_gui_smoke_findings.py - FAIL_RATE test asserted rc == 0, which races against the default 0.05 simulated-failure dice. Test now asserts the parse warning was emitted and rc is in (0, 1), separating parse-tolerance from the dice roll.
- src/bernstein/core/server/server_models.py + src/bernstein/core/routes/task_crud.py - TaskCountsResponse missing abandoned + blocked_by_abandon fields after #1358 added two new TaskStatus values. Schema-fields-cover-every-enum-value regression guard now passes.

Zero behaviour change.