### PR TITLE
fix(tests): NewRelic OTLP patch path

### DIFF
--- a/tests/unit/test_apm_integration.py
+++ b/tests/unit/test_apm_integration.py
@@ -200,7 +200,7 @@ class TestConfigureNewRelic:
         result = configure_newrelic()
         assert result is False
 
-    @patch("bernstein.core.telemetry._init_http_telemetry")
+    @patch("bernstein.core.observability.telemetry._init_http_telemetry")
     def test_otlp_path_calls_http_telemetry(self, mock_http: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
         """OTLP path calls _init_http_telemetry with api-key header."""
         monkeypatch.setenv("NEW_RELIC_LICENSE_KEY", "nr-test-key")
@@ -221,7 +221,7 @@ class TestConfigureNewRelic:
         service_name = call_kwargs[1].get("service_name") or call_kwargs[0][2]
         assert service_name == "bernstein-test"
 
-    @patch("bernstein.core.telemetry._init_http_telemetry")
+    @patch("bernstein.core.observability.telemetry._init_http_telemetry")
     def test_uses_nr_endpoint(self, mock_http: MagicMock) -> None:
         """OTLP path uses the correct New Relic endpoint."""
         cfg = NewRelicConfig(
@@ -259,7 +259,7 @@ class TestAutoConfigureApm:
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("NEW_RELIC_LICENSE_KEY", "nr-key")
 
-        with patch("bernstein.core.telemetry._init_http_telemetry") as mock_http:
+        with patch("bernstein.core.observability.telemetry._init_http_telemetry") as mock_http:
             mock_http.return_value = None
             result = auto_configure_apm()
 


### PR DESCRIPTION
PR #1423 fixed the Datadog OTLP fallback test but missed the matching NewRelic case. The test patches `bernstein.core.telemetry._init_http_telemetry`, but apm_integration.py imports the symbol lazily from `bernstein.core.observability.telemetry` inside the OTLP branch. Test patches the wrong module, mock never registers the call.

Updates the three NewRelic OTLP tests to patch the source module. Datadog-style fix; zero behaviour change.

Local run: 27 / 27 pass.

This is the last red on main blocking v2.1.0 release.