### PR TITLE
fix(tests): patch _init_http_telemetry at observability import path

### DIFF
--- a/tests/unit/test_apm_integration.py
+++ b/tests/unit/test_apm_integration.py
@@ -136,7 +136,7 @@ class TestConfigureDatadog:
 
         with (
             patch.dict("sys.modules", {"ddtrace": None}),
-            patch("bernstein.core.telemetry.init_telemetry_from_preset") as mock_preset,
+            patch("bernstein.core.observability.telemetry.init_telemetry_from_preset") as mock_preset,
         ):
             mock_preset.return_value = None
             result = configure_datadog(cfg)
@@ -200,7 +200,7 @@ class TestConfigureNewRelic:
         result = configure_newrelic()
         assert result is False
 
-    @patch("bernstein.core.telemetry._init_http_telemetry")
+    @patch("bernstein.core.observability.telemetry._init_http_telemetry")
     def test_otlp_path_calls_http_telemetry(self, mock_http: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
         """OTLP path calls _init_http_telemetry with api-key header."""
         monkeypatch.setenv("NEW_RELIC_LICENSE_KEY", "nr-test-key")
@@ -221,7 +221,7 @@ class TestConfigureNewRelic:
         service_name = call_kwargs[1].get("service_name") or call_kwargs[0][2]
         assert service_name == "bernstein-test"
 
-    @patch("bernstein.core.telemetry._init_http_telemetry")
+    @patch("bernstein.core.observability.telemetry._init_http_telemetry")
     def test_uses_nr_endpoint(self, mock_http: MagicMock) -> None:
         """OTLP path uses the correct New Relic endpoint."""
         cfg = NewRelicConfig(
@@ -259,7 +259,7 @@ class TestAutoConfigureApm:
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("NEW_RELIC_LICENSE_KEY", "nr-key")
 
-        with patch("bernstein.core.telemetry._init_http_telemetry") as mock_http:
+        with patch("bernstein.core.observability.telemetry._init_http_telemetry") as mock_http:
             mock_http.return_value = None
             result = auto_configure_apm()
 
@@ -272,7 +272,7 @@ class TestAutoConfigureApm:
         monkeypatch.delenv("DATADOG_API_KEY", raising=False)
         monkeypatch.setenv("DD_AGENT_HOST", "dd-agent")
 
-        with patch("bernstein.core.telemetry.init_telemetry_from_preset") as mock_preset:
+        with patch("bernstein.core.observability.telemetry.init_telemetry_from_preset") as mock_preset:
             mock_preset.return_value = None
             result = auto_configure_apm()
 
@@ -285,8 +285,8 @@ class TestAutoConfigureApm:
         monkeypatch.delenv("DATADOG_API_KEY", raising=False)
 
         with (
-            patch("bernstein.core.telemetry.init_telemetry_from_preset") as mock_dd,
-            patch("bernstein.core.telemetry._init_http_telemetry") as mock_nr,
+            patch("bernstein.core.observability.telemetry.init_telemetry_from_preset") as mock_dd,
+            patch("bernstein.core.observability.telemetry._init_http_telemetry") as mock_nr,
         ):
             mock_dd.return_value = None
             mock_nr.return_value = None


### PR DESCRIPTION
Tests in test_apm_integration.py patched the wrong import path. apm_integration.py imports _init_http_telemetry and init_telemetry_from_preset from bernstein.core.observability.telemetry (lazy import inside configure_newrelic / configure_datadog), so patches against bernstein.core.telemetry never reached the call site and the mocks were never invoked.

Failing test repro:
```
pytest tests/unit/test_apm_integration.py::TestConfigureNewRelic::test_otlp_path_calls_http_telemetry
```

After fix: 27 passed in 2.98s.

Release-ensure auto-hotfix for v2.1.0 unblock.