### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bernstein"
-version = "2.0.1"
+version = "2.1.0"
 description = "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, and 40 more): HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Release-ensure mechanical bump from 2.0.1 to 2.1.0 for v2.1.0 cut.

Triggers publish workflow when the resulting v2.1.0 tag is pushed.