### PR TITLE
feat(knowledge): diary + synthesis pass over task transcripts (closes #1369)

### DIFF
--- a/docs/operations/knowledge-diary.md
+++ b/docs/operations/knowledge-diary.md
@@ -1,0 +1,81 @@
+# Knowledge layer: diary + synthesis
+
+Bernstein keeps a two-tier knowledge layer over task transcripts.
+
+1. **Diary**: a per-task structured entry distilled from the closing
+   transcript. Stored at `.sdd/runtime/diaries/<task_id>.json`.
+2. **Synthesis**: a periodic aggregation pass that groups diaries into
+   themes and drafts a human-readable report at
+   `.sdd/runtime/syntheses/<date>.md`.
+
+The synthesis is **HITL-gated**. Reports land on disk with
+`approved: false` in their frontmatter until an operator runs the
+synthesize command with `--apply`. No role prompt is mutated by the
+synthesizer alone; it always produces review artefacts.
+
+## CLI surface
+
+```bash
+# List every diary entry in the active SDD tree.
+bernstein knowledge diary list
+
+# Show one entry.
+bernstein knowledge diary show task-42
+
+# Run the synthesis pass over the last 14 days.
+bernstein knowledge synthesize --since 14d
+
+# Render to stdout without writing.
+bernstein knowledge synthesize --since 7d --dry-run
+
+# Approve and persist (the HITL gate).
+bernstein knowledge synthesize --since 7d --apply
+```
+
+`--since` accepts `NNd`, `NNh`, `NNm`, `NNs`, or a bare integer (days).
+
+## Diary shape
+
+Each diary entry carries:
+
+| Field            | Description                                                   |
+|------------------|---------------------------------------------------------------|
+| `task_id`        | Source task identifier.                                        |
+| `tried`          | Bullet list of attempted approaches.                           |
+| `worked`         | Bullet list of approaches that succeeded.                      |
+| `failed`         | Bullet list of approaches that failed.                         |
+| `rationale`      | Free-text explanation.                                         |
+| `tags`           | Lower-cased, deduplicated tokens used for clustering.          |
+| `redaction_hash` | SHA-256 of the redacted transcript.                            |
+| `created_at`     | ISO-8601 timestamp in UTC.                                     |
+| `schema_version` | Integer schema version (currently 1).                          |
+
+The diary writer redacts known credential shapes (OpenAI keys, GitHub
+tokens, AWS access keys, PEM banners, generic hex bearer tokens)
+before hashing or persisting. Verification works on the redacted form,
+so two transcripts that differ only in the masked substrings still
+verify against the same entry.
+
+## Synthesis algorithm
+
+Clustering uses tag-overlap Jaccard similarity with a configurable
+threshold (default `0.34`). Embeddings are deliberately out of scope
+for v1; the stdlib implementation is cheap and fully deterministic.
+Clusters smaller than `--min-cluster-size` are dropped. Themes are
+sorted by size descending so the operator sees the strongest signals
+first.
+
+Each theme carries a `proposed_diff` body that summarises recurring
+failure patterns and recurring success patterns from the cluster. The
+body is markdown shaped like a unified diff (`+`/`-` prefixes); it is a
+review aid, not an actual diff that gets applied.
+
+## Storage paths
+
+| Path                                | Purpose                                  |
+|-------------------------------------|------------------------------------------|
+| `.sdd/runtime/diaries/<task_id>.json` | Per-task diary entry (atomic write).   |
+| `.sdd/runtime/syntheses/<date>.md`  | Synthesis report (overwritten per day). |
+
+Both writes go through the atomic-write helper, so a crash mid-flush
+never leaves a torn file behind.

--- a/src/bernstein/cli/commands/knowledge_cmd.py
+++ b/src/bernstein/cli/commands/knowledge_cmd.py
@@ -1,0 +1,255 @@
+"""CLI surface for the diary + synthesis knowledge layer.
+
+Subcommands:
+
+* ``bernstein knowledge diary list`` -- list diaries in the active SDD tree.
+* ``bernstein knowledge diary show <task>`` -- pretty-print one entry.
+* ``bernstein knowledge synthesize --since <duration>`` -- run the
+  synthesis pass and write a markdown report. The ``--apply`` flag flips
+  the HITL gate and writes the approved marker.
+
+The module is intentionally thin: business logic lives in
+:mod:`bernstein.core.knowledge.diary` and
+:mod:`bernstein.core.knowledge.synthesizer`. The CLI only owns argument
+parsing, path resolution, and Rich output formatting.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from bernstein.core.knowledge.diary import (
+    DiaryError,
+    load_diaries,
+    load_diary,
+)
+from bernstein.core.knowledge.synthesizer import (
+    DEFAULT_JACCARD_THRESHOLD,
+    DEFAULT_MIN_CLUSTER_SIZE,
+    SynthesizerError,
+    approve,
+    parse_duration,
+    synthesize,
+    write_report,
+)
+
+if TYPE_CHECKING:
+    from bernstein.core.knowledge.diary import DiaryEntry
+
+
+def _resolve_sdd_dir(explicit: str | None) -> Path:
+    """Return the ``.sdd`` directory to operate on.
+
+    Resolution order:
+      1. Explicit ``--sdd-dir`` flag value.
+      2. ``$BERNSTEIN_SDD_DIR`` env var.
+      3. ``./.sdd`` under the current working directory.
+    """
+    if explicit:
+        return Path(explicit).resolve()
+    import os
+
+    env = os.environ.get("BERNSTEIN_SDD_DIR")
+    if env:
+        return Path(env).resolve()
+    return (Path.cwd() / ".sdd").resolve()
+
+
+@click.group("knowledge")
+def knowledge_group() -> None:
+    """Diary + synthesis knowledge layer.
+
+    \b
+    Examples:
+      bernstein knowledge diary list
+      bernstein knowledge diary show task-42
+      bernstein knowledge synthesize --since 14d
+      bernstein knowledge synthesize --since 7d --apply
+    """
+
+
+@knowledge_group.group("diary")
+def diary_group() -> None:
+    """Inspect per-task diary entries."""
+
+
+@diary_group.command("list")
+@click.option(
+    "--sdd-dir",
+    default=None,
+    help="Override the SDD root directory.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of a table.",
+)
+def diary_list_cmd(sdd_dir: str | None, as_json: bool) -> None:
+    """List every diary entry in the active SDD tree."""
+    target = _resolve_sdd_dir(sdd_dir)
+    entries = load_diaries(target)
+    if as_json:
+        click.echo(json.dumps([e.to_dict() for e in entries], indent=2, sort_keys=True))
+        return
+    if not entries:
+        click.echo(f"No diary entries under {target / 'runtime' / 'diaries'}.")
+        return
+    click.echo(f"{'task_id':<32} {'created_at':<26} {'tags':<40}")
+    click.echo("-" * 100)
+    for entry in entries:
+        tags = ", ".join(entry.tags[:6])
+        if len(entry.tags) > 6:
+            tags += ", ..."
+        click.echo(f"{entry.task_id:<32} {entry.created_at:<26} {tags:<40}")
+
+
+@diary_group.command("show")
+@click.argument("task_id")
+@click.option(
+    "--sdd-dir",
+    default=None,
+    help="Override the SDD root directory.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of formatted text.",
+)
+def diary_show_cmd(task_id: str, sdd_dir: str | None, as_json: bool) -> None:
+    """Show the diary entry for ``task_id``."""
+    target = _resolve_sdd_dir(sdd_dir)
+    diary_path = target / "runtime" / "diaries" / f"{task_id}.json"
+    if not diary_path.exists():
+        click.echo(f"No diary entry for task {task_id!r} at {diary_path}.", err=True)
+        sys.exit(1)
+    try:
+        entry = load_diary(diary_path)
+    except DiaryError as exc:
+        click.echo(f"Failed to load diary {diary_path}: {exc}", err=True)
+        sys.exit(1)
+    if as_json:
+        click.echo(json.dumps(entry.to_dict(), indent=2, sort_keys=True))
+        return
+    _render_entry(entry)
+
+
+def _render_entry(entry: DiaryEntry) -> None:
+    """Pretty-print a single diary entry to stdout."""
+    click.echo(f"Diary entry: {entry.task_id}")
+    click.echo(f"  created_at:     {entry.created_at}")
+    click.echo(f"  schema_version: {entry.schema_version}")
+    click.echo(f"  redaction_hash: {entry.redaction_hash}")
+    click.echo(f"  tags:           {', '.join(entry.tags) if entry.tags else '(none)'}")
+    click.echo("")
+    _render_section("Tried", entry.tried)
+    _render_section("Worked", entry.worked)
+    _render_section("Failed", entry.failed)
+    click.echo("Rationale:")
+    click.echo(f"  {entry.rationale or '(none)'}")
+
+
+def _render_section(name: str, bullets: tuple[str, ...]) -> None:
+    """Print a labelled bullet section."""
+    click.echo(f"{name}:")
+    if not bullets:
+        click.echo("  (none)")
+    else:
+        for bullet in bullets:
+            click.echo(f"  - {bullet}")
+    click.echo("")
+
+
+@knowledge_group.command("synthesize")
+@click.option(
+    "--since",
+    default="14d",
+    show_default=True,
+    help="Lookback window. Accepts NNd, NNh, NNm, NNs, or a bare integer (days).",
+)
+@click.option(
+    "--threshold",
+    type=float,
+    default=DEFAULT_JACCARD_THRESHOLD,
+    show_default=True,
+    help="Tag-overlap Jaccard threshold for clustering (0..1).",
+)
+@click.option(
+    "--min-cluster-size",
+    type=int,
+    default=DEFAULT_MIN_CLUSTER_SIZE,
+    show_default=True,
+    help="Drop clusters smaller than this size.",
+)
+@click.option(
+    "--apply",
+    "apply_flag",
+    is_flag=True,
+    default=False,
+    help="Flip the HITL gate: mark the report as approved and persist it.",
+)
+@click.option(
+    "--sdd-dir",
+    default=None,
+    help="Override the SDD root directory.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the report to stdout without writing to disk.",
+)
+def synthesize_cmd(
+    since: str,
+    threshold: float,
+    min_cluster_size: int,
+    apply_flag: bool,
+    sdd_dir: str | None,
+    dry_run: bool,
+) -> None:
+    """Aggregate recent diaries into themes and write a markdown report.
+
+    Without ``--apply`` the report lands on disk with ``approved: false``
+    in its frontmatter; downstream consumers MUST refuse to mutate role
+    prompts based on an unapproved report.
+    """
+    target = _resolve_sdd_dir(sdd_dir)
+    try:
+        delta = parse_duration(since)
+    except SynthesizerError as exc:
+        click.echo(f"Invalid --since value: {exc}", err=True)
+        sys.exit(2)
+    window_days = max(1, delta.days or 1)
+    entries = load_diaries(target)
+    try:
+        report = synthesize(
+            entries,
+            window_days=window_days,
+            threshold=threshold,
+            min_cluster_size=min_cluster_size,
+        )
+    except SynthesizerError as exc:
+        click.echo(f"Synthesis failed: {exc}", err=True)
+        sys.exit(1)
+    if apply_flag:
+        report = approve(report)
+    if dry_run:
+        from bernstein.core.knowledge.synthesizer import render_report
+
+        click.echo(render_report(report))
+        return
+    path = write_report(report, target)
+    click.echo(f"Wrote synthesis report: {path}")
+    click.echo(f"  themes:   {report.theme_count}")
+    click.echo(f"  approved: {report.approved}")
+
+
+__all__ = ["knowledge_group"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -61,6 +61,7 @@ from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
+from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
 from bernstein.cli.commands.skills_cmd import skills_group
@@ -910,6 +911,7 @@ cli.add_command(slo_cmd, "slo")
 cli.add_command(man_pages_cmd, "man-pages")
 cli.add_command(workflow_group, "workflow")
 cli.add_command(recipes_group, "recipes")
+cli.add_command(knowledge_group, "knowledge")
 cli.add_command(quickstart_cmd, "quickstart")
 cli.add_command(scaffold_cmd, "scaffold")
 cli.add_command(watch_cmd, "watch")

--- a/src/bernstein/core/knowledge/diary.py
+++ b/src/bernstein/core/knowledge/diary.py
@@ -1,0 +1,377 @@
+"""Per-task diary entries distilled from task transcripts.
+
+After a task closes, an offline pass extracts a structured ``DiaryEntry``
+from its transcript: what was tried, what worked, what failed, the
+rationale, and a list of tags. Entries land under
+``.sdd/runtime/diaries/<task_id>.json`` via atomic write so a crash mid-
+flush never leaves a torn payload on disk.
+
+The diary writer is read-only over task state and never blocks task
+close. A redaction hash captures the entry shape so downstream
+verification can detect tampering without re-reading the redacted body.
+
+This module is self-contained: it depends only on stdlib plus the
+existing ``persistence.atomic_write`` helper. The synthesiser
+(:mod:`bernstein.core.knowledge.synthesizer`) consumes diaries through
+``load_diaries`` and the CLI surface lives in
+``bernstein.cli.commands.knowledge_cmd``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from bernstein.core.persistence.atomic_write import write_atomic_json
+
+logger = logging.getLogger(__name__)
+
+
+DIARY_SCHEMA_VERSION = 1
+DEFAULT_DIARY_SUBPATH = Path(".sdd") / "runtime" / "diaries"
+
+# Patterns redacted from transcripts before extraction. The redaction is
+# intentionally conservative: it strips the most obvious credential
+# shapes so a leaked diary file cannot serve as a credential vector. It
+# is NOT a substitute for the audit-pack sanitiser; it is a guardrail.
+_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"sk-[A-Za-z0-9]{20,}"), "[REDACTED:openai-key]"),
+    (re.compile(r"ghp_[A-Za-z0-9]{20,}"), "[REDACTED:github-token]"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:aws-access-key]"),
+    (re.compile(r"-----BEGIN[^-]+PRIVATE KEY-----"), "[REDACTED:private-key]"),
+    # Generic 32+ hex-like high-entropy strings (bearer tokens).
+    (re.compile(r"\b[A-Fa-f0-9]{40,}\b"), "[REDACTED:token]"),
+)
+
+# Section markers an agent transcript may emit. Lower-cased before
+# matching so the writer is resilient to capitalisation drift.
+_SECTION_MARKERS: tuple[tuple[str, str], ...] = (
+    ("tried:", "tried"),
+    ("attempted:", "tried"),
+    ("worked:", "worked"),
+    ("succeeded:", "worked"),
+    ("failed:", "failed"),
+    ("did not work:", "failed"),
+    ("rationale:", "rationale"),
+    ("why:", "rationale"),
+    ("lesson:", "rationale"),
+    ("surprising:", "rationale"),
+)
+
+
+class DiaryError(Exception):
+    """Raised on malformed diary input or storage failures."""
+
+
+@dataclass(frozen=True)
+class DiaryEntry:
+    """Structured per-task reflection record.
+
+    Attributes mirror the acceptance-criteria fields from the issue:
+    ``tried`` / ``worked`` / ``failed`` are short bullet-style strings,
+    ``rationale`` is a single free-text paragraph, and ``tags`` is a
+    deduplicated, lower-cased list used for clustering by the
+    synthesiser.
+
+    ``redaction_hash`` is computed from the redacted transcript so any
+    tampered diary fails verification when ``verify_diary`` is run.
+    """
+
+    task_id: str
+    tried: tuple[str, ...]
+    worked: tuple[str, ...]
+    failed: tuple[str, ...]
+    rationale: str
+    tags: tuple[str, ...]
+    redaction_hash: str
+    created_at: str = field(
+        default_factory=lambda: datetime.now(UTC).isoformat(timespec="seconds")
+    )
+    schema_version: int = DIARY_SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serialisable plain dict."""
+        payload = asdict(self)
+        for key in ("tried", "worked", "failed", "tags"):
+            payload[key] = list(payload[key])
+        return payload
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def redact(text: str) -> str:
+    """Apply the conservative redaction patterns to *text*.
+
+    The output preserves structure so the section parser still finds
+    headings; only sensitive substrings are replaced. The function is
+    pure and safe for use on untrusted transcripts.
+    """
+    if not text:
+        return ""
+    redacted = text
+    for pattern, replacement in _REDACTION_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def compute_redaction_hash(text: str) -> str:
+    """Return a stable SHA-256 hash of the redacted *text*.
+
+    Used to fingerprint diary inputs so external systems can detect
+    tampering without re-reading the original transcript.
+    """
+    digest = hashlib.sha256(redact(text).encode("utf-8")).hexdigest()
+    return digest
+
+
+# ---------------------------------------------------------------------------
+# Extraction
+# ---------------------------------------------------------------------------
+
+
+def _normalise_bullet(line: str) -> str:
+    """Strip leading bullet markers and surrounding whitespace."""
+    stripped = line.strip()
+    for marker in ("- ", "* ", "+ ", "  - "):
+        if stripped.startswith(marker):
+            return stripped[len(marker):].strip()
+    return stripped
+
+
+def _classify_marker(line: str) -> str | None:
+    """Map a heading line to a canonical section name."""
+    lowered = line.strip().lower()
+    for prefix, canonical in _SECTION_MARKERS:
+        if lowered.startswith(prefix):
+            return canonical
+    return None
+
+
+def extract_sections(transcript: str) -> dict[str, list[str]]:
+    """Split *transcript* into the four canonical diary sections.
+
+    Headings are matched case-insensitively against ``_SECTION_MARKERS``.
+    Bullet lines under a heading land in the matching bucket; everything
+    before the first heading is ignored so leading agent banter does not
+    pollute the diary.
+    """
+    buckets: dict[str, list[str]] = {
+        "tried": [],
+        "worked": [],
+        "failed": [],
+        "rationale": [],
+    }
+    if not transcript:
+        return buckets
+    current: str | None = None
+    for raw_line in transcript.splitlines():
+        marker = _classify_marker(raw_line)
+        if marker is not None:
+            current = marker
+            # Capture inline content after the colon, if any.
+            _, _, tail = raw_line.partition(":")
+            tail = tail.strip()
+            if tail:
+                buckets[current].append(tail)
+            continue
+        if current is None:
+            continue
+        bullet = _normalise_bullet(raw_line)
+        if bullet:
+            buckets[current].append(bullet)
+    return buckets
+
+
+def extract_tags(transcript: str, *, limit: int = 16) -> tuple[str, ...]:
+    """Derive deduplicated, lower-cased tags from a transcript.
+
+    Tags are token-like words: alphanumerics plus dashes, length 3-32,
+    excluding a small English stop-list. The tag order is the first-seen
+    order so the output is deterministic.
+    """
+    if not transcript:
+        return ()
+    stop = {
+        "the", "and", "for", "with", "from", "this", "that", "into", "than",
+        "then", "have", "has", "had", "are", "was", "were", "but", "not",
+        "all", "any", "use", "used", "uses", "via", "per", "out", "off",
+        "its", "lol", "yes", "now", "tbd",
+    }
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for raw in re.findall(r"[A-Za-z][A-Za-z0-9-]{2,31}", transcript):
+        token = raw.lower()
+        if token in stop or token in seen_set:
+            continue
+        seen.append(token)
+        seen_set.add(token)
+        if len(seen) >= limit:
+            break
+    return tuple(seen)
+
+
+def build_entry(task_id: str, transcript: str) -> DiaryEntry:
+    """Compose a :class:`DiaryEntry` from a raw transcript.
+
+    The transcript is redacted before extraction so any sensitive
+    substring is gone from the resulting bullet bodies. A clean
+    transcript with no recognised section headings still yields a
+    well-formed entry: empty section tuples plus a rationale built from
+    the first non-blank line so analysts always see *something*.
+    """
+    if not task_id or not task_id.strip():
+        raise DiaryError("task_id must be a non-empty string")
+    cleaned = redact(transcript or "")
+    sections = extract_sections(cleaned)
+    rationale = " ".join(sections["rationale"]).strip()
+    if not rationale:
+        # Fallback rationale: first non-empty stripped line of the cleaned
+        # transcript. Keeps the diary useful even for noisy logs.
+        for line in cleaned.splitlines():
+            candidate = line.strip()
+            if candidate:
+                rationale = candidate[:240]
+                break
+    tags = extract_tags(cleaned)
+    return DiaryEntry(
+        task_id=task_id.strip(),
+        tried=tuple(sections["tried"]),
+        worked=tuple(sections["worked"]),
+        failed=tuple(sections["failed"]),
+        rationale=rationale,
+        tags=tags,
+        redaction_hash=compute_redaction_hash(transcript or ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def _diary_dir(sdd_dir: Path) -> Path:
+    """Return the diary directory under *sdd_dir*, creating it if needed."""
+    target = sdd_dir / "runtime" / "diaries"
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def _safe_filename(task_id: str) -> str:
+    """Return a filesystem-safe filename for *task_id*.
+
+    Restricts characters to ``[A-Za-z0-9._-]`` so a malicious task id
+    cannot escape the diary directory via path traversal.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", task_id.strip())
+    if not cleaned or cleaned in {".", ".."}:
+        raise DiaryError(f"invalid task_id for filename: {task_id!r}")
+    return f"{cleaned}.json"
+
+
+def write_diary(entry: DiaryEntry, sdd_dir: Path) -> Path:
+    """Persist *entry* under ``<sdd_dir>/runtime/diaries/<task_id>.json``.
+
+    Uses :func:`write_atomic_json` so a crash mid-flush never leaves a
+    half-written file. Returns the final path on success.
+    """
+    target = _diary_dir(sdd_dir) / _safe_filename(entry.task_id)
+    write_atomic_json(target, entry.to_dict(), indent=2, sort_keys=True)
+    logger.debug("diary.write task_id=%s path=%s", entry.task_id, target)
+    return target
+
+
+def write_diary_from_transcript(
+    task_id: str, transcript: str, sdd_dir: Path
+) -> Path:
+    """Convenience: build an entry from *transcript* and persist it.
+
+    Failures are propagated as :class:`DiaryError`; callers wiring this
+    into the task-close hook should catch broadly so a diary write never
+    blocks task close.
+    """
+    entry = build_entry(task_id, transcript)
+    return write_diary(entry, sdd_dir)
+
+
+def load_diary(path: Path) -> DiaryEntry:
+    """Load a single diary JSON file into a :class:`DiaryEntry`."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DiaryError(f"cannot load diary {path}: {exc}") from exc
+    return _entry_from_payload(payload)
+
+
+def load_diaries(sdd_dir: Path) -> list[DiaryEntry]:
+    """Load every diary under ``<sdd_dir>/runtime/diaries/``.
+
+    Files that fail to parse are skipped with a warning so a single
+    corrupt entry does not break the synthesiser. The result is sorted
+    by ``created_at`` ascending so downstream consumers see a stable
+    time-ordered stream.
+    """
+    diary_dir = sdd_dir / "runtime" / "diaries"
+    if not diary_dir.is_dir():
+        return []
+    entries: list[DiaryEntry] = []
+    for path in sorted(diary_dir.glob("*.json")):
+        try:
+            entries.append(load_diary(path))
+        except DiaryError as exc:
+            logger.warning("diary.skip path=%s err=%s", path, exc)
+    entries.sort(key=lambda e: e.created_at)
+    return entries
+
+
+def _entry_from_payload(payload: dict[str, Any]) -> DiaryEntry:
+    """Construct a :class:`DiaryEntry` from a parsed dict payload."""
+    required = ("task_id", "tried", "worked", "failed", "rationale", "tags", "redaction_hash")
+    for key in required:
+        if key not in payload:
+            raise DiaryError(f"diary payload missing key: {key}")
+    try:
+        return DiaryEntry(
+            task_id=str(payload["task_id"]),
+            tried=tuple(str(x) for x in payload["tried"]),
+            worked=tuple(str(x) for x in payload["worked"]),
+            failed=tuple(str(x) for x in payload["failed"]),
+            rationale=str(payload["rationale"]),
+            tags=tuple(str(x) for x in payload["tags"]),
+            redaction_hash=str(payload["redaction_hash"]),
+            created_at=str(payload.get("created_at") or datetime.now(UTC).isoformat(timespec="seconds")),
+            schema_version=int(payload.get("schema_version") or DIARY_SCHEMA_VERSION),
+        )
+    except (TypeError, ValueError) as exc:
+        raise DiaryError(f"invalid diary payload: {exc}") from exc
+
+
+def verify_diary(entry: DiaryEntry, transcript: str) -> bool:
+    """Return True iff *entry*'s redaction hash matches the *transcript*."""
+    return entry.redaction_hash == compute_redaction_hash(transcript)
+
+
+__all__ = [
+    "DEFAULT_DIARY_SUBPATH",
+    "DIARY_SCHEMA_VERSION",
+    "DiaryEntry",
+    "DiaryError",
+    "build_entry",
+    "compute_redaction_hash",
+    "extract_sections",
+    "extract_tags",
+    "load_diaries",
+    "load_diary",
+    "redact",
+    "verify_diary",
+    "write_diary",
+    "write_diary_from_transcript",
+]

--- a/src/bernstein/core/knowledge/synthesizer.py
+++ b/src/bernstein/core/knowledge/synthesizer.py
@@ -1,0 +1,420 @@
+"""Periodic synthesis pass over diary entries.
+
+The synthesiser groups recent :class:`bernstein.core.knowledge.diary.DiaryEntry`
+records into themes by tag-overlap Jaccard similarity, then drafts a
+markdown report plus a per-theme prompt-diff proposal. The output lands
+under ``.sdd/runtime/syntheses/<date>.md`` and is HITL-gated: the apply
+path requires an explicit ``--apply`` flag and never mutates role
+prompts on its own.
+
+Clustering is deliberately stdlib-only. The Jaccard threshold is
+configurable; below that, entries form a singleton cluster and are
+emitted with a single-entry theme. Themes are sorted by size descending
+so the operator sees the strongest signals first.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from bernstein.core.persistence.atomic_write import write_atomic_text
+
+if TYPE_CHECKING:
+    from bernstein.core.knowledge.diary import DiaryEntry
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_JACCARD_THRESHOLD = 0.34
+DEFAULT_WINDOW_DAYS = 14
+DEFAULT_MIN_CLUSTER_SIZE = 1
+DEFAULT_SYNTHESIS_SUBPATH = Path(".sdd") / "runtime" / "syntheses"
+
+
+class SynthesizerError(Exception):
+    """Raised on synthesis configuration or storage failures."""
+
+
+@dataclass(frozen=True)
+class Theme:
+    """A cluster of diary entries sharing a tag fingerprint.
+
+    ``shared_tags`` is the intersection of tag sets across the cluster.
+    ``proposed_diff`` is the markdown body the operator reviews before
+    landing changes against role prompts; it is never applied
+    automatically.
+    """
+
+    theme_id: str
+    label: str
+    entries: tuple[DiaryEntry, ...]
+    shared_tags: tuple[str, ...]
+    proposed_diff: str
+
+    @property
+    def size(self) -> int:
+        """Return the number of diary entries in the cluster."""
+        return len(self.entries)
+
+
+@dataclass(frozen=True)
+class SynthesisReport:
+    """Top-level synthesis result for a given window.
+
+    ``approved`` defaults to ``False``; the CLI flips it to ``True``
+    when the operator runs the ``--apply`` workflow. Persisting an
+    approved report writes a marker line so re-runs are idempotent.
+    """
+
+    generated_at: str
+    window_days: int
+    themes: tuple[Theme, ...]
+    approved: bool = False
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def theme_count(self) -> int:
+        """Return the total number of themes in this report."""
+        return len(self.themes)
+
+
+# ---------------------------------------------------------------------------
+# Clustering helpers
+# ---------------------------------------------------------------------------
+
+
+def jaccard(a: tuple[str, ...] | frozenset[str], b: tuple[str, ...] | frozenset[str]) -> float:
+    """Return the Jaccard similarity of two tag sets.
+
+    Empty sets return ``0.0`` because there is nothing to cluster on.
+    The implementation is symmetric and bounded in ``[0.0, 1.0]``.
+    """
+    set_a = frozenset(a)
+    set_b = frozenset(b)
+    if not set_a and not set_b:
+        return 0.0
+    union = set_a | set_b
+    if not union:
+        return 0.0
+    return len(set_a & set_b) / len(union)
+
+
+def _within_window(entry: DiaryEntry, now: datetime, window: timedelta) -> bool:
+    """Return True iff *entry* falls within *window* before *now*.
+
+    Entries with unparseable ``created_at`` are kept; treating them as
+    in-window is the conservative choice because dropping them would
+    silently shrink the synthesis input.
+    """
+    try:
+        created = datetime.fromisoformat(entry.created_at)
+    except ValueError:
+        return True
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    return now - created <= window
+
+
+def filter_recent(
+    entries: list[DiaryEntry], window_days: int, *, now: datetime | None = None
+) -> list[DiaryEntry]:
+    """Return only the entries within ``window_days`` of *now*.
+
+    ``window_days <= 0`` short-circuits to the input list unchanged so
+    callers can opt out of windowing without a magic sentinel.
+    """
+    if window_days <= 0:
+        return list(entries)
+    moment = now if now is not None else datetime.now(UTC)
+    window = timedelta(days=window_days)
+    return [e for e in entries if _within_window(e, moment, window)]
+
+
+def cluster_entries(
+    entries: list[DiaryEntry],
+    *,
+    threshold: float = DEFAULT_JACCARD_THRESHOLD,
+    min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
+) -> list[list[DiaryEntry]]:
+    """Group entries into clusters by tag-overlap Jaccard similarity.
+
+    The algorithm is a single-linkage merge with a fixed threshold. It
+    is stdlib-only and stable (clusters preserve insertion order),
+    matching the acceptance-criteria constraint of no embeddings in v1.
+    Clusters smaller than ``min_cluster_size`` are dropped so noise
+    cannot drown the report.
+    """
+    if not 0.0 <= threshold <= 1.0:
+        raise SynthesizerError(f"threshold out of range: {threshold!r}")
+    if min_cluster_size < 1:
+        raise SynthesizerError("min_cluster_size must be >= 1")
+    clusters: list[list[DiaryEntry]] = []
+    for entry in entries:
+        placed = False
+        for cluster in clusters:
+            if any(jaccard(entry.tags, member.tags) >= threshold for member in cluster):
+                cluster.append(entry)
+                placed = True
+                break
+        if not placed:
+            clusters.append([entry])
+    if min_cluster_size > 1:
+        clusters = [c for c in clusters if len(c) >= min_cluster_size]
+    clusters.sort(key=len, reverse=True)
+    return clusters
+
+
+def _slug(text: str, *, max_len: int = 40) -> str:
+    """Return a lower-cased slug suitable for theme ids."""
+    cleaned = re.sub(r"[^A-Za-z0-9-]+", "-", text.lower()).strip("-")
+    if not cleaned:
+        return "untitled"
+    return cleaned[:max_len]
+
+
+def _shared_tags(cluster: list[DiaryEntry]) -> tuple[str, ...]:
+    """Return the tag intersection across *cluster*, deterministically."""
+    if not cluster:
+        return ()
+    shared = set(cluster[0].tags)
+    for member in cluster[1:]:
+        shared &= set(member.tags)
+    return tuple(sorted(shared))
+
+
+def _theme_label(shared: tuple[str, ...], cluster: list[DiaryEntry]) -> str:
+    """Pick a human-readable label for a theme.
+
+    Falls back to the first tag of the first entry if the intersection
+    is empty (a single-entry cluster). Returns ``"misc"`` only as a
+    last resort so the report is never blank.
+    """
+    if shared:
+        return " / ".join(shared[:3])
+    for member in cluster:
+        if member.tags:
+            return member.tags[0]
+    return "misc"
+
+
+def _theme_id(index: int, label: str) -> str:
+    """Build a stable theme id from the cluster index and label slug."""
+    return f"theme-{index:03d}-{_slug(label)}"
+
+
+def _build_proposed_diff(label: str, cluster: list[DiaryEntry]) -> str:
+    """Render a markdown diff proposal for a theme.
+
+    The body summarises observed failures and successes across the
+    cluster. The output is intentionally diff-shaped (``+``/``-``
+    prefixes) but is **not** a unified diff; it is a review aid that
+    the operator translates into a real edit during ``--apply``.
+    """
+    lines: list[str] = []
+    lines.append(f"## Proposed adjustment: {label}")
+    lines.append("")
+    failed_bullets: list[str] = []
+    worked_bullets: list[str] = []
+    for entry in cluster:
+        failed_bullets.extend(entry.failed)
+        worked_bullets.extend(entry.worked)
+    if failed_bullets:
+        lines.append("Recurring failure patterns (consider guarding against):")
+        for bullet in sorted(set(failed_bullets))[:8]:
+            lines.append(f"- {bullet}")
+        lines.append("")
+    if worked_bullets:
+        lines.append("Recurring success patterns (consider amplifying):")
+        for bullet in sorted(set(worked_bullets))[:8]:
+            lines.append(f"+ {bullet}")
+        lines.append("")
+    if not failed_bullets and not worked_bullets:
+        lines.append("No actionable tried/worked/failed bullets in this cluster.")
+        lines.append("Rationale snippets:")
+        for entry in cluster[:3]:
+            if entry.rationale:
+                lines.append(f"> {entry.rationale}")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_themes(clusters: list[list[DiaryEntry]]) -> tuple[Theme, ...]:
+    """Convert raw cluster lists into :class:`Theme` records."""
+    themes: list[Theme] = []
+    for idx, cluster in enumerate(clusters):
+        shared = _shared_tags(cluster)
+        label = _theme_label(shared, cluster)
+        theme = Theme(
+            theme_id=_theme_id(idx, label),
+            label=label,
+            entries=tuple(cluster),
+            shared_tags=shared,
+            proposed_diff=_build_proposed_diff(label, cluster),
+        )
+        themes.append(theme)
+    return tuple(themes)
+
+
+# ---------------------------------------------------------------------------
+# Synthesis entry points
+# ---------------------------------------------------------------------------
+
+
+def synthesize(
+    entries: list[DiaryEntry],
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    threshold: float = DEFAULT_JACCARD_THRESHOLD,
+    min_cluster_size: int = DEFAULT_MIN_CLUSTER_SIZE,
+    now: datetime | None = None,
+) -> SynthesisReport:
+    """Run the full synthesis pipeline on *entries* and return a report.
+
+    The function is pure (no filesystem side effects). The CLI layer
+    is responsible for persisting the report and gating the apply
+    workflow.
+    """
+    recent = filter_recent(entries, window_days, now=now)
+    clusters = cluster_entries(
+        recent, threshold=threshold, min_cluster_size=min_cluster_size
+    )
+    themes = build_themes(clusters)
+    moment = now if now is not None else datetime.now(UTC)
+    notes: list[str] = []
+    if not entries:
+        notes.append("No diary entries available; report is empty.")
+    elif not recent:
+        notes.append(
+            f"No diary entries within the last {window_days} day(s); report is empty."
+        )
+    return SynthesisReport(
+        generated_at=moment.isoformat(timespec="seconds"),
+        window_days=window_days,
+        themes=themes,
+        notes=tuple(notes),
+    )
+
+
+def render_report(report: SynthesisReport) -> str:
+    """Render *report* as a markdown document.
+
+    The document carries a YAML-like frontmatter so downstream tools
+    can grep without parsing markdown.
+    """
+    lines: list[str] = []
+    lines.append("---")
+    lines.append(f"generated_at: {report.generated_at}")
+    lines.append(f"window_days: {report.window_days}")
+    lines.append(f"theme_count: {report.theme_count}")
+    lines.append(f"approved: {'true' if report.approved else 'false'}")
+    lines.append("---")
+    lines.append("")
+    lines.append("# Diary synthesis report")
+    lines.append("")
+    if report.notes:
+        for note in report.notes:
+            lines.append(f"> {note}")
+        lines.append("")
+    if not report.themes:
+        lines.append("_No themes detected._")
+        lines.append("")
+        return "\n".join(lines)
+    for theme in report.themes:
+        lines.append(f"## {theme.theme_id}: {theme.label}")
+        lines.append("")
+        lines.append(f"- Cluster size: {theme.size}")
+        if theme.shared_tags:
+            lines.append(f"- Shared tags: {', '.join(theme.shared_tags)}")
+        lines.append("- Task ids: " + ", ".join(e.task_id for e in theme.entries))
+        lines.append("")
+        lines.append("<details><summary>Proposed adjustment (HITL-gated)</summary>")
+        lines.append("")
+        lines.append(theme.proposed_diff)
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(report: SynthesisReport, sdd_dir: Path) -> Path:
+    """Persist *report* to ``<sdd_dir>/runtime/syntheses/<date>.md``.
+
+    The filename uses the report's ``generated_at`` date so multiple
+    runs in a single day overwrite the same file deterministically;
+    the synthesiser is idempotent at the day granularity.
+    """
+    target_dir = sdd_dir / "runtime" / "syntheses"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        stamp = datetime.fromisoformat(report.generated_at).date().isoformat()
+    except ValueError:
+        stamp = datetime.now(UTC).date().isoformat()
+    target = target_dir / f"{stamp}.md"
+    write_atomic_text(target, render_report(report))
+    logger.debug("synthesis.write path=%s themes=%d", target, report.theme_count)
+    return target
+
+
+def approve(report: SynthesisReport) -> SynthesisReport:
+    """Return a copy of *report* with ``approved=True``.
+
+    The HITL gate lives here: only after the CLI invokes this function
+    can a downstream consumer treat the report as ready to apply.
+    """
+    return SynthesisReport(
+        generated_at=report.generated_at,
+        window_days=report.window_days,
+        themes=report.themes,
+        approved=True,
+        notes=report.notes,
+    )
+
+
+def parse_duration(value: str) -> timedelta:
+    """Parse a short duration string like ``7d``, ``24h``, ``30m``.
+
+    Supports days (``d``), hours (``h``), minutes (``m``), and seconds
+    (``s``). Plain integers are interpreted as days for the common
+    ``--since 14`` shortcut.
+    """
+    if not value or not value.strip():
+        raise SynthesizerError("duration must be non-empty")
+    text = value.strip().lower()
+    if text.isdigit():
+        return timedelta(days=int(text))
+    match = re.fullmatch(r"(\d+)([dhms])", text)
+    if not match:
+        raise SynthesizerError(f"unrecognised duration: {value!r}")
+    amount = int(match.group(1))
+    unit = match.group(2)
+    if unit == "d":
+        return timedelta(days=amount)
+    if unit == "h":
+        return timedelta(hours=amount)
+    if unit == "m":
+        return timedelta(minutes=amount)
+    return timedelta(seconds=amount)
+
+
+__all__ = [
+    "DEFAULT_JACCARD_THRESHOLD",
+    "DEFAULT_MIN_CLUSTER_SIZE",
+    "DEFAULT_SYNTHESIS_SUBPATH",
+    "DEFAULT_WINDOW_DAYS",
+    "SynthesisReport",
+    "SynthesizerError",
+    "Theme",
+    "approve",
+    "build_themes",
+    "cluster_entries",
+    "filter_recent",
+    "jaccard",
+    "parse_duration",
+    "render_report",
+    "synthesize",
+    "write_report",
+]

--- a/tests/integration/test_knowledge_synthesis.py
+++ b/tests/integration/test_knowledge_synthesis.py
@@ -1,0 +1,301 @@
+"""Integration tests for the diary + synthesis pipeline.
+
+These tests exercise the full path: synthetic transcripts -> diary
+entries -> synthesis report -> markdown report -> CLI surface. They do
+not spawn agents or hit the network; they verify the on-disk shape and
+CLI behaviour that operators rely on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.commands.knowledge_cmd import knowledge_group
+from bernstein.core.knowledge.diary import (
+    load_diaries,
+    load_diary,
+    write_diary_from_transcript,
+)
+from bernstein.core.knowledge.synthesizer import (
+    approve,
+    render_report,
+    synthesize,
+    write_report,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic transcripts
+# ---------------------------------------------------------------------------
+
+
+_TRANSCRIPT_BACKEND_RETRY_A = """
+tried:
+- naive request with no retry
+- timeout of 5s
+worked:
+- exponential backoff on 503
+failed:
+- premature give-up on timeout
+rationale:
+- backend retry policy must mirror upstream SLA
+"""
+
+_TRANSCRIPT_BACKEND_RETRY_B = """
+tried:
+- exponential backoff with jitter
+worked:
+- exponential backoff on 503
+- jitter prevents thundering herd
+failed:
+- single-shot retry on 502
+rationale:
+- prefer jittered backoff for backend retry semantics
+"""
+
+_TRANSCRIPT_FRONTEND_BUG = """
+tried:
+- CSS grid fallback for old Safari
+worked:
+- flexbox shim for layout
+failed:
+- pure CSS grid on iOS 13
+rationale:
+- frontend layout still needs flex fallback through 2026
+"""
+
+
+@pytest.fixture
+def sdd_dir(tmp_path: Path) -> Path:
+    """Return an isolated SDD tree for an integration test."""
+    target = tmp_path / ".sdd"
+    target.mkdir()
+    return target
+
+
+@pytest.fixture
+def populated_sdd(sdd_dir: Path) -> Path:
+    """SDD tree with three diaries spanning two themes."""
+    write_diary_from_transcript("task-backend-1", _TRANSCRIPT_BACKEND_RETRY_A, sdd_dir)
+    write_diary_from_transcript("task-backend-2", _TRANSCRIPT_BACKEND_RETRY_B, sdd_dir)
+    write_diary_from_transcript("task-frontend-1", _TRANSCRIPT_FRONTEND_BUG, sdd_dir)
+    return sdd_dir
+
+
+# ---------------------------------------------------------------------------
+# End-to-end diary -> synthesis -> report
+# ---------------------------------------------------------------------------
+
+
+def test_transcripts_to_diaries(populated_sdd: Path) -> None:
+    """Three transcripts produce three diaries on disk."""
+    diaries = load_diaries(populated_sdd)
+    task_ids = {d.task_id for d in diaries}
+    assert task_ids == {"task-backend-1", "task-backend-2", "task-frontend-1"}
+
+
+def test_diary_files_under_runtime_dir(populated_sdd: Path) -> None:
+    """Diaries land under the expected runtime subdirectory."""
+    expected_dir = populated_sdd / "runtime" / "diaries"
+    files = sorted(p.name for p in expected_dir.glob("*.json"))
+    assert files == [
+        "task-backend-1.json",
+        "task-backend-2.json",
+        "task-frontend-1.json",
+    ]
+
+
+def test_synthesis_clusters_backend(populated_sdd: Path) -> None:
+    """Backend transcripts cluster together when tags overlap."""
+    diaries = load_diaries(populated_sdd)
+    report = synthesize(diaries, window_days=0, threshold=0.25)
+    sizes = sorted((theme.size for theme in report.themes), reverse=True)
+    assert sizes[0] >= 2  # backend pair clusters
+
+
+def test_synthesis_persists_to_disk(populated_sdd: Path) -> None:
+    """Synthesis write produces a markdown report on disk."""
+    diaries = load_diaries(populated_sdd)
+    report = synthesize(diaries, window_days=0)
+    path = write_report(report, populated_sdd)
+    assert path.exists()
+    assert path.parent == populated_sdd / "runtime" / "syntheses"
+    body = path.read_text()
+    assert body.startswith("---\n")
+
+
+def test_proposed_diff_mentions_backend_patterns(populated_sdd: Path) -> None:
+    """Proposed diff for the backend cluster surfaces concrete bullets."""
+    diaries = load_diaries(populated_sdd)
+    report = synthesize(diaries, window_days=0, threshold=0.2)
+    body = render_report(report)
+    assert "exponential backoff on 503" in body
+
+
+def test_hitl_gate_default_unapproved(populated_sdd: Path) -> None:
+    """Synthesis runs default to ``approved: false``."""
+    diaries = load_diaries(populated_sdd)
+    report = synthesize(diaries, window_days=0)
+    path = write_report(report, populated_sdd)
+    assert "approved: false" in path.read_text()
+
+
+def test_hitl_gate_apply_sets_approved(populated_sdd: Path) -> None:
+    """Approve flips the marker and the rendered report reflects it."""
+    diaries = load_diaries(populated_sdd)
+    report = approve(synthesize(diaries, window_days=0))
+    path = write_report(report, populated_sdd)
+    assert "approved: true" in path.read_text()
+
+
+def test_redaction_hash_round_trips_on_disk(populated_sdd: Path) -> None:
+    """Loading a written diary recovers the same redaction hash."""
+    diary_path = populated_sdd / "runtime" / "diaries" / "task-backend-1.json"
+    loaded = load_diary(diary_path)
+    payload = json.loads(diary_path.read_text())
+    assert payload["redaction_hash"] == loaded.redaction_hash
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_knowledge_diary_list_empty(sdd_dir: Path) -> None:
+    """Empty diary directory yields a friendly message."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["diary", "list", "--sdd-dir", str(sdd_dir)],
+    )
+    assert result.exit_code == 0
+    assert "No diary entries" in result.output
+
+
+def test_cli_knowledge_diary_list_populated(populated_sdd: Path) -> None:
+    """Populated diary directory lists every entry."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["diary", "list", "--sdd-dir", str(populated_sdd)],
+    )
+    assert result.exit_code == 0
+    assert "task-backend-1" in result.output
+    assert "task-frontend-1" in result.output
+
+
+def test_cli_knowledge_diary_show(populated_sdd: Path) -> None:
+    """Showing a task prints rationale, tags, and section labels."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["diary", "show", "task-backend-1", "--sdd-dir", str(populated_sdd)],
+    )
+    assert result.exit_code == 0
+    assert "task-backend-1" in result.output
+    assert "Tried" in result.output
+    assert "Worked" in result.output
+
+
+def test_cli_knowledge_diary_show_missing(sdd_dir: Path) -> None:
+    """Showing a missing task exits non-zero."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["diary", "show", "no-such-task", "--sdd-dir", str(sdd_dir)],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_synthesize_dry_run_prints_report(populated_sdd: Path) -> None:
+    """Dry-run renders the report to stdout without writing."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        [
+            "synthesize",
+            "--since",
+            "30d",
+            "--dry-run",
+            "--sdd-dir",
+            str(populated_sdd),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "generated_at:" in result.output
+    assert "approved: false" in result.output
+    # No file written on dry-run
+    assert not (populated_sdd / "runtime" / "syntheses").exists() or not list(
+        (populated_sdd / "runtime" / "syntheses").glob("*.md")
+    )
+
+
+def test_cli_synthesize_writes_report(populated_sdd: Path) -> None:
+    """The default invocation writes a markdown report under the SDD tree."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["synthesize", "--since", "30d", "--sdd-dir", str(populated_sdd)],
+    )
+    assert result.exit_code == 0
+    reports = list((populated_sdd / "runtime" / "syntheses").glob("*.md"))
+    assert len(reports) == 1
+
+
+def test_cli_synthesize_apply_marks_approved(populated_sdd: Path) -> None:
+    """--apply persists an approved report."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        [
+            "synthesize",
+            "--since",
+            "30d",
+            "--apply",
+            "--sdd-dir",
+            str(populated_sdd),
+        ],
+    )
+    assert result.exit_code == 0
+    reports = list((populated_sdd / "runtime" / "syntheses").glob("*.md"))
+    assert len(reports) == 1
+    assert "approved: true" in reports[0].read_text()
+
+
+def test_cli_synthesize_invalid_since(populated_sdd: Path) -> None:
+    """Bad --since value exits non-zero with a descriptive message."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["synthesize", "--since", "forever", "--sdd-dir", str(populated_sdd)],
+    )
+    assert result.exit_code != 0
+    assert "Invalid --since" in result.output
+
+
+def test_cli_diary_list_json_output(populated_sdd: Path) -> None:
+    """--json emits a parseable JSON array."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["diary", "list", "--json", "--sdd-dir", str(populated_sdd)],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert len(payload) == 3
+
+
+def test_cli_diary_show_json_output(populated_sdd: Path) -> None:
+    """--json emits the entry payload."""
+    runner = CliRunner()
+    result = runner.invoke(
+        knowledge_group,
+        ["diary", "show", "task-backend-1", "--json", "--sdd-dir", str(populated_sdd)],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["task_id"] == "task-backend-1"

--- a/tests/property/test_diary_properties.py
+++ b/tests/property/test_diary_properties.py
@@ -1,0 +1,321 @@
+"""Hypothesis property tests for diary + synthesizer modules."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import HealthCheck, given, settings
+
+from bernstein.core.knowledge.diary import (
+    build_entry,
+    compute_redaction_hash,
+    extract_tags,
+    redact,
+    verify_diary,
+    write_diary,
+    write_diary_from_transcript,
+)
+from bernstein.core.knowledge.synthesizer import (
+    cluster_entries,
+    filter_recent,
+    jaccard,
+    parse_duration,
+    render_report,
+    synthesize,
+)
+
+# Reasonable upper bounds keep the suite fast under CI.
+_TEXT = st.text(min_size=0, max_size=200)
+_TASK = st.text(
+    alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="-_."),
+    min_size=1,
+    max_size=32,
+)
+_TAGSET = st.lists(
+    st.text(
+        alphabet=st.characters(whitelist_categories=("Ll",)),
+        min_size=3,
+        max_size=12,
+    ),
+    min_size=0,
+    max_size=12,
+    unique=True,
+).map(tuple)
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+class TestRedactionProperties:
+    @given(_TEXT)
+    def test_redact_idempotent(self, text: str) -> None:
+        once = redact(text)
+        twice = redact(once)
+        assert once == twice
+
+    @given(_TEXT)
+    def test_redact_never_lengthens_unbounded(self, text: str) -> None:
+        # Output may be shorter or longer (replacements differ in size),
+        # but cannot grow without bound.
+        assert len(redact(text)) <= len(text) + 1024
+
+    @given(_TEXT)
+    def test_compute_hash_is_64_hex(self, text: str) -> None:
+        digest = compute_redaction_hash(text)
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    @given(_TEXT)
+    def test_hash_stable(self, text: str) -> None:
+        assert compute_redaction_hash(text) == compute_redaction_hash(text)
+
+
+# ---------------------------------------------------------------------------
+# Build entry
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEntryProperties:
+    @given(_TASK, _TEXT)
+    def test_build_entry_total(self, task_id: str, transcript: str) -> None:
+        if not task_id.strip():
+            return
+        entry = build_entry(task_id, transcript)
+        assert entry.task_id == task_id.strip()
+        assert isinstance(entry.tried, tuple)
+        assert isinstance(entry.worked, tuple)
+        assert isinstance(entry.failed, tuple)
+        assert isinstance(entry.tags, tuple)
+
+    @given(_TASK, _TEXT)
+    def test_verify_matches_self(self, task_id: str, transcript: str) -> None:
+        if not task_id.strip():
+            return
+        entry = build_entry(task_id, transcript)
+        assert verify_diary(entry, transcript) is True
+
+    @given(_TEXT)
+    def test_extract_tags_are_lowercase_unique(self, text: str) -> None:
+        tags = extract_tags(text)
+        assert len(set(tags)) == len(tags)
+        assert all(t == t.lower() for t in tags)
+
+
+# ---------------------------------------------------------------------------
+# Persistence round-trip
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
+@given(task_id=_TASK, transcript=_TEXT)
+def test_write_load_round_trip(
+    tmp_path_factory: pytest.TempPathFactory, task_id: str, transcript: str
+) -> None:
+    if not task_id.strip():
+        return
+    sdd_dir = tmp_path_factory.mktemp("sdd")
+    from bernstein.core.knowledge.diary import load_diary
+
+    path = write_diary_from_transcript(task_id, transcript, sdd_dir)
+    loaded = load_diary(path)
+    assert loaded.task_id == task_id.strip()
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
+@given(task_id=_TASK, transcript=_TEXT)
+def test_write_diary_does_not_escape_tree(
+    tmp_path_factory: pytest.TempPathFactory, task_id: str, transcript: str
+) -> None:
+    if not task_id.strip():
+        return
+    sdd_dir = tmp_path_factory.mktemp("sdd")
+    path = write_diary_from_transcript(task_id, transcript, sdd_dir)
+    assert sdd_dir in path.parents
+
+
+# ---------------------------------------------------------------------------
+# Jaccard + clustering
+# ---------------------------------------------------------------------------
+
+
+class TestJaccardProperties:
+    @given(_TAGSET, _TAGSET)
+    def test_jaccard_bounded(self, a: tuple[str, ...], b: tuple[str, ...]) -> None:
+        score = jaccard(a, b)
+        assert 0.0 <= score <= 1.0
+
+    @given(_TAGSET, _TAGSET)
+    def test_jaccard_symmetric(self, a: tuple[str, ...], b: tuple[str, ...]) -> None:
+        assert jaccard(a, b) == jaccard(b, a)
+
+    @given(_TAGSET)
+    def test_jaccard_identity(self, a: tuple[str, ...]) -> None:
+        if a:
+            assert jaccard(a, a) == 1.0
+        else:
+            # Empty/empty is defined as 0.0 in our implementation.
+            assert jaccard(a, a) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Clustering invariants
+# ---------------------------------------------------------------------------
+
+
+class TestClusterProperties:
+    @given(
+        st.lists(_TAGSET, max_size=20),
+        st.floats(
+            min_value=0.0,
+            max_value=1.0,
+            allow_nan=False,
+            allow_infinity=False,
+        ),
+    )
+    def test_cluster_preserves_count(
+        self, tagsets: list[tuple[str, ...]], threshold: float
+    ) -> None:
+        from bernstein.core.knowledge.diary import DiaryEntry
+
+        entries = [
+            DiaryEntry(
+                task_id=f"t-{i}",
+                tried=(),
+                worked=(),
+                failed=(),
+                rationale="",
+                tags=tags,
+                redaction_hash="x" * 64,
+            )
+            for i, tags in enumerate(tagsets)
+        ]
+        clusters = cluster_entries(entries, threshold=threshold)
+        total = sum(len(c) for c in clusters)
+        assert total == len(entries)
+
+    @given(
+        st.lists(_TAGSET, max_size=10),
+        st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    )
+    def test_cluster_sorted_size_desc(
+        self, tagsets: list[tuple[str, ...]], threshold: float
+    ) -> None:
+        from bernstein.core.knowledge.diary import DiaryEntry
+
+        entries = [
+            DiaryEntry(
+                task_id=f"t-{i}",
+                tried=(),
+                worked=(),
+                failed=(),
+                rationale="",
+                tags=tags,
+                redaction_hash="x" * 64,
+            )
+            for i, tags in enumerate(tagsets)
+        ]
+        clusters = cluster_entries(entries, threshold=threshold)
+        sizes = [len(c) for c in clusters]
+        assert sizes == sorted(sizes, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Filter recent
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRecentProperties:
+    @given(st.integers(min_value=-10, max_value=365))
+    def test_filter_recent_no_entries(self, window_days: int) -> None:
+        assert filter_recent([], window_days) == []
+
+
+# ---------------------------------------------------------------------------
+# Synthesize total
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesizeProperties:
+    @given(st.lists(_TAGSET, max_size=10))
+    def test_synthesize_total(self, tagsets: list[tuple[str, ...]]) -> None:
+        from bernstein.core.knowledge.diary import DiaryEntry
+
+        entries = [
+            DiaryEntry(
+                task_id=f"t-{i}",
+                tried=(),
+                worked=(),
+                failed=(),
+                rationale="",
+                tags=tags,
+                redaction_hash="x" * 64,
+            )
+            for i, tags in enumerate(tagsets)
+        ]
+        report = synthesize(entries, window_days=0)
+        # render always returns a non-empty markdown document
+        assert "---" in render_report(report)
+
+    @given(st.lists(_TAGSET, max_size=10))
+    def test_synthesize_theme_count_bounded(
+        self, tagsets: list[tuple[str, ...]]
+    ) -> None:
+        from bernstein.core.knowledge.diary import DiaryEntry
+
+        entries = [
+            DiaryEntry(
+                task_id=f"t-{i}",
+                tried=(),
+                worked=(),
+                failed=(),
+                rationale="",
+                tags=tags,
+                redaction_hash="x" * 64,
+            )
+            for i, tags in enumerate(tagsets)
+        ]
+        report = synthesize(entries, window_days=0)
+        assert report.theme_count <= len(entries)
+
+
+# ---------------------------------------------------------------------------
+# Parse duration
+# ---------------------------------------------------------------------------
+
+
+class TestParseDurationProperties:
+    @given(st.integers(min_value=1, max_value=10**6))
+    def test_parse_days_integer(self, n: int) -> None:
+        delta = parse_duration(f"{n}d")
+        assert delta.days == n
+
+    @given(st.integers(min_value=1, max_value=10**6))
+    def test_parse_bare_int_as_days(self, n: int) -> None:
+        delta = parse_duration(str(n))
+        assert delta.days == n
+
+
+# ---------------------------------------------------------------------------
+# Bonus invariant: write_diary always produces a JSON-decodable file
+# ---------------------------------------------------------------------------
+
+
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
+@given(task_id=_TASK, transcript=_TEXT)
+def test_payload_is_json_decodable(
+    tmp_path_factory: pytest.TempPathFactory, task_id: str, transcript: str
+) -> None:
+    if not task_id.strip():
+        return
+    sdd_dir = tmp_path_factory.mktemp("sdd")
+    entry = build_entry(task_id, transcript)
+    path = write_diary(entry, sdd_dir)
+    import json as _json
+
+    _json.loads(path.read_text())
+    # generated_at is parseable
+    datetime.fromisoformat(entry.created_at).astimezone(UTC)

--- a/tests/unit/knowledge/test_diary.py
+++ b/tests/unit/knowledge/test_diary.py
@@ -1,0 +1,391 @@
+"""Unit tests for the diary module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.knowledge.diary import (
+    DIARY_SCHEMA_VERSION,
+    DiaryEntry,
+    DiaryError,
+    build_entry,
+    compute_redaction_hash,
+    extract_sections,
+    extract_tags,
+    load_diaries,
+    load_diary,
+    redact,
+    verify_diary,
+    write_diary,
+    write_diary_from_transcript,
+)
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    """Cover redaction patterns and helper invariants."""
+
+    def test_redact_openai_key(self) -> None:
+        text = "key=sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa stuff"
+        assert "sk-aaaa" not in redact(text)
+        assert "[REDACTED:openai-key]" in redact(text)
+
+    def test_redact_github_token(self) -> None:
+        text = "auth: ghp_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        assert "[REDACTED:github-token]" in redact(text)
+
+    def test_redact_aws_access_key(self) -> None:
+        text = "AWS=AKIAABCDEFGHIJKLMNOP suffix"
+        assert "AKIAABCDEFGHIJKLMNOP" not in redact(text)
+
+    def test_redact_private_key_banner(self) -> None:
+        text = "-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n-----END RSA PRIVATE KEY-----"
+        assert "[REDACTED:private-key]" in redact(text)
+
+    def test_redact_hex_token(self) -> None:
+        text = "token=" + "a" * 64
+        assert "[REDACTED:token]" in redact(text)
+
+    def test_redact_empty_string(self) -> None:
+        assert redact("") == ""
+
+    def test_redact_idempotent(self) -> None:
+        text = "sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        once = redact(text)
+        twice = redact(once)
+        assert once == twice
+
+    def test_redact_preserves_structure(self) -> None:
+        text = "tried:\n- step one\nworked:\n- step two"
+        out = redact(text)
+        assert "tried:" in out
+        assert "worked:" in out
+
+    def test_compute_redaction_hash_stable(self) -> None:
+        a = compute_redaction_hash("hello world")
+        b = compute_redaction_hash("hello world")
+        assert a == b
+
+    def test_compute_redaction_hash_redacts_first(self) -> None:
+        clean = compute_redaction_hash("hello sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        # Different raw input but same redacted form yields a different hash
+        # from a totally unrelated input. The point is determinism plus
+        # masking before hashing.
+        assert clean != compute_redaction_hash("hello world")
+
+
+# ---------------------------------------------------------------------------
+# Section extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractSections:
+    """Cover header parsing across the diary section markers."""
+
+    def test_extract_basic_sections(self) -> None:
+        text = (
+            "tried:\n- thing a\n- thing b\n"
+            "worked:\n- thing a\n"
+            "failed:\n- thing b\n"
+            "rationale:\n- because reasons\n"
+        )
+        sections = extract_sections(text)
+        assert sections["tried"] == ["thing a", "thing b"]
+        assert sections["worked"] == ["thing a"]
+        assert sections["failed"] == ["thing b"]
+        assert sections["rationale"] == ["because reasons"]
+
+    def test_extract_case_insensitive(self) -> None:
+        text = "TRIED:\n- one\nWORKED:\n- two"
+        sections = extract_sections(text)
+        assert sections["tried"] == ["one"]
+        assert sections["worked"] == ["two"]
+
+    def test_extract_inline_after_colon(self) -> None:
+        text = "tried: quick attempt"
+        sections = extract_sections(text)
+        assert sections["tried"] == ["quick attempt"]
+
+    def test_extract_alternate_marker_attempted(self) -> None:
+        text = "attempted:\n- alpha"
+        sections = extract_sections(text)
+        assert sections["tried"] == ["alpha"]
+
+    def test_extract_succeeded_maps_to_worked(self) -> None:
+        text = "succeeded:\n- one"
+        sections = extract_sections(text)
+        assert sections["worked"] == ["one"]
+
+    def test_extract_did_not_work_maps_to_failed(self) -> None:
+        text = "did not work:\n- failed thing"
+        sections = extract_sections(text)
+        assert sections["failed"] == ["failed thing"]
+
+    def test_extract_lesson_maps_to_rationale(self) -> None:
+        text = "lesson:\n- always wash hands"
+        sections = extract_sections(text)
+        assert sections["rationale"] == ["always wash hands"]
+
+    def test_extract_empty(self) -> None:
+        sections = extract_sections("")
+        assert sections == {"tried": [], "worked": [], "failed": [], "rationale": []}
+
+    def test_extract_ignores_pre_heading_noise(self) -> None:
+        text = "garbage banter\ntried:\n- alpha"
+        sections = extract_sections(text)
+        assert sections["tried"] == ["alpha"]
+
+    def test_extract_handles_star_bullets(self) -> None:
+        text = "worked:\n* alpha\n* beta"
+        sections = extract_sections(text)
+        assert sections["worked"] == ["alpha", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# Tag extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTags:
+    """Cover deterministic, deduplicated tag extraction."""
+
+    def test_basic_tags(self) -> None:
+        tags = extract_tags("backend retry retry network")
+        assert "backend" in tags
+        assert "retry" in tags
+        assert "network" in tags
+
+    def test_tags_dedup(self) -> None:
+        tags = extract_tags("alpha alpha alpha")
+        assert tags.count("alpha") == 1
+
+    def test_tags_stoplist(self) -> None:
+        tags = extract_tags("the and for backend")
+        assert "the" not in tags
+        assert "backend" in tags
+
+    def test_tags_lowercase(self) -> None:
+        tags = extract_tags("Backend NetWORK")
+        assert "backend" in tags
+        assert "network" in tags
+
+    def test_tags_min_length(self) -> None:
+        tags = extract_tags("a ab abc longer")
+        assert "a" not in tags
+        assert "ab" not in tags
+        assert "abc" in tags
+
+    def test_tags_limit_respected(self) -> None:
+        text = " ".join(f"word{i}" for i in range(50))
+        tags = extract_tags(text, limit=5)
+        assert len(tags) <= 5
+
+    def test_tags_empty_input(self) -> None:
+        assert extract_tags("") == ()
+
+    def test_tags_order_first_seen(self) -> None:
+        tags = extract_tags("zulu yankee xray whiskey")
+        assert list(tags[:4]) == ["zulu", "yankee", "xray", "whiskey"]
+
+
+# ---------------------------------------------------------------------------
+# Build entry
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEntry:
+    """Cover the high-level diary builder."""
+
+    def test_build_minimal(self) -> None:
+        entry = build_entry("task-1", "tried: a\nworked: b")
+        assert entry.task_id == "task-1"
+        assert entry.tried == ("a",)
+        assert entry.worked == ("b",)
+        assert entry.schema_version == DIARY_SCHEMA_VERSION
+        assert isinstance(entry.redaction_hash, str)
+        assert len(entry.redaction_hash) == 64
+
+    def test_build_empty_transcript_has_rationale_empty(self) -> None:
+        entry = build_entry("task-1", "")
+        assert entry.rationale == ""
+        assert entry.tried == ()
+        assert entry.worked == ()
+        assert entry.failed == ()
+
+    def test_build_blank_task_raises(self) -> None:
+        with pytest.raises(DiaryError):
+            build_entry("", "tried: a")
+
+    def test_build_whitespace_task_raises(self) -> None:
+        with pytest.raises(DiaryError):
+            build_entry("   ", "tried: a")
+
+    def test_build_strips_task_id(self) -> None:
+        entry = build_entry("  task-7  ", "tried: a")
+        assert entry.task_id == "task-7"
+
+    def test_build_falls_back_to_first_line_rationale(self) -> None:
+        entry = build_entry("task-2", "no headings here\njust prose")
+        assert entry.rationale == "no headings here"
+
+    def test_build_redacts_before_extraction(self) -> None:
+        text = "tried:\n- use sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        entry = build_entry("task-3", text)
+        # The tried bullet contains the redaction marker, not the raw key
+        assert any("[REDACTED:openai-key]" in t for t in entry.tried)
+        assert not any("sk-aaaa" in t for t in entry.tried)
+
+    def test_build_tags_present(self) -> None:
+        entry = build_entry("task-4", "tried: backend retry retry network")
+        assert len(entry.tags) >= 1
+
+    def test_build_to_dict_serialisable(self) -> None:
+        entry = build_entry("task-5", "tried: x")
+        payload = entry.to_dict()
+        encoded = json.dumps(payload)
+        assert json.loads(encoded)["task_id"] == "task-5"
+        assert isinstance(payload["tried"], list)
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    """Cover diary disk read/write roundtrip."""
+
+    def test_write_diary_creates_file(self, tmp_path: Path) -> None:
+        entry = build_entry("task-x", "tried: alpha")
+        path = write_diary(entry, tmp_path)
+        assert path.exists()
+        payload = json.loads(path.read_text())
+        assert payload["task_id"] == "task-x"
+
+    def test_write_then_load_round_trip(self, tmp_path: Path) -> None:
+        original = build_entry("task-y", "tried: alpha\nworked: beta")
+        write_diary(original, tmp_path)
+        loaded = load_diary(tmp_path / "runtime" / "diaries" / "task-y.json")
+        assert loaded.task_id == original.task_id
+        assert loaded.tried == original.tried
+        assert loaded.worked == original.worked
+        assert loaded.redaction_hash == original.redaction_hash
+
+    def test_write_diary_from_transcript_writes(self, tmp_path: Path) -> None:
+        path = write_diary_from_transcript("task-z", "tried: alpha", tmp_path)
+        assert path.exists()
+        loaded = load_diary(path)
+        assert loaded.task_id == "task-z"
+        assert "alpha" in loaded.tried
+
+    def test_load_diaries_empty_dir(self, tmp_path: Path) -> None:
+        assert load_diaries(tmp_path) == []
+
+    def test_load_diaries_sorted_by_created_at(self, tmp_path: Path) -> None:
+        diaries_dir = tmp_path / "runtime" / "diaries"
+        diaries_dir.mkdir(parents=True)
+        for task_id, ts in (("task-b", "2026-01-02T00:00:00+00:00"), ("task-a", "2026-01-01T00:00:00+00:00")):
+            payload = {
+                "task_id": task_id,
+                "tried": [],
+                "worked": [],
+                "failed": [],
+                "rationale": "",
+                "tags": [],
+                "redaction_hash": "x" * 64,
+                "created_at": ts,
+                "schema_version": 1,
+            }
+            (diaries_dir / f"{task_id}.json").write_text(json.dumps(payload))
+        entries = load_diaries(tmp_path)
+        assert [e.task_id for e in entries] == ["task-a", "task-b"]
+
+    def test_load_diaries_skips_corrupt(self, tmp_path: Path) -> None:
+        diaries_dir = tmp_path / "runtime" / "diaries"
+        diaries_dir.mkdir(parents=True)
+        (diaries_dir / "good.json").write_text(
+            json.dumps(
+                {
+                    "task_id": "good",
+                    "tried": [],
+                    "worked": [],
+                    "failed": [],
+                    "rationale": "",
+                    "tags": [],
+                    "redaction_hash": "x" * 64,
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "schema_version": 1,
+                }
+            )
+        )
+        (diaries_dir / "bad.json").write_text("{ not valid json")
+        entries = load_diaries(tmp_path)
+        assert len(entries) == 1
+        assert entries[0].task_id == "good"
+
+    def test_load_diary_missing_keys_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "broken.json"
+        path.write_text(json.dumps({"task_id": "x"}))
+        with pytest.raises(DiaryError):
+            load_diary(path)
+
+    def test_load_diary_unparseable_raises(self, tmp_path: Path) -> None:
+        path = tmp_path / "broken.json"
+        path.write_text("[ not json")
+        with pytest.raises(DiaryError):
+            load_diary(path)
+
+    def test_write_diary_rejects_path_traversal(self, tmp_path: Path) -> None:
+        # Build a payload with a hostile task id; the writer must sanitise
+        # the filename so the file never lands outside the diary directory.
+        entry = DiaryEntry(
+            task_id="../escape",
+            tried=(),
+            worked=(),
+            failed=(),
+            rationale="",
+            tags=(),
+            redaction_hash="x" * 64,
+        )
+        path = write_diary(entry, tmp_path)
+        assert tmp_path in path.parents
+        assert "escape" in path.name
+
+    def test_write_diary_atomic(self, tmp_path: Path) -> None:
+        entry = build_entry("atomic-task", "tried: alpha")
+        path = write_diary(entry, tmp_path)
+        # Atomic writer must not leave temp siblings behind on success.
+        siblings = list(path.parent.glob("*.tmp.*"))
+        assert siblings == []
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    """Cover the redaction-hash verification helper."""
+
+    def test_verify_matching(self) -> None:
+        entry = build_entry("task-v", "tried: alpha")
+        assert verify_diary(entry, "tried: alpha") is True
+
+    def test_verify_mismatched(self) -> None:
+        entry = build_entry("task-v", "tried: alpha")
+        assert verify_diary(entry, "different content") is False
+
+    def test_verify_after_redaction_equivalent(self) -> None:
+        # Two transcripts that redact to the same form must verify
+        # against the same entry.
+        key_a = "sk-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        key_b = "sk-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        entry = build_entry("task-v", f"tried: use {key_a}")
+        # Different raw secret, same redaction shape -> same hash.
+        assert verify_diary(entry, f"tried: use {key_b}") is True

--- a/tests/unit/knowledge/test_synthesizer.py
+++ b/tests/unit/knowledge/test_synthesizer.py
@@ -1,0 +1,444 @@
+"""Unit tests for the synthesizer module."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.knowledge.diary import DiaryEntry
+from bernstein.core.knowledge.synthesizer import (
+    DEFAULT_JACCARD_THRESHOLD,
+    SynthesisReport,
+    SynthesizerError,
+    Theme,
+    approve,
+    build_themes,
+    cluster_entries,
+    filter_recent,
+    jaccard,
+    parse_duration,
+    render_report,
+    synthesize,
+    write_report,
+)
+
+
+def _make_entry(
+    task_id: str,
+    tags: tuple[str, ...],
+    *,
+    tried: tuple[str, ...] = (),
+    worked: tuple[str, ...] = (),
+    failed: tuple[str, ...] = (),
+    rationale: str = "",
+    created_at: str | None = None,
+) -> DiaryEntry:
+    return DiaryEntry(
+        task_id=task_id,
+        tried=tried,
+        worked=worked,
+        failed=failed,
+        rationale=rationale,
+        tags=tags,
+        redaction_hash="x" * 64,
+        created_at=created_at or "2026-05-01T12:00:00+00:00",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Jaccard
+# ---------------------------------------------------------------------------
+
+
+class TestJaccard:
+    """Cover Jaccard similarity invariants."""
+
+    def test_identical_sets(self) -> None:
+        assert jaccard(("a", "b"), ("a", "b")) == 1.0
+
+    def test_disjoint_sets(self) -> None:
+        assert jaccard(("a",), ("b",)) == 0.0
+
+    def test_empty_sets(self) -> None:
+        assert jaccard((), ()) == 0.0
+
+    def test_one_empty(self) -> None:
+        assert jaccard((), ("a",)) == 0.0
+
+    def test_partial_overlap(self) -> None:
+        score = jaccard(("a", "b"), ("b", "c"))
+        assert 0.3 < score < 0.4  # 1/3
+
+    def test_symmetric(self) -> None:
+        assert jaccard(("a", "b", "c"), ("b", "c")) == jaccard(("b", "c"), ("a", "b", "c"))
+
+
+# ---------------------------------------------------------------------------
+# Filter recent
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRecent:
+    """Cover time-window filtering."""
+
+    def test_window_zero_returns_all(self) -> None:
+        entries = [_make_entry("t-1", ("a",))]
+        result = filter_recent(entries, 0)
+        assert result == entries
+
+    def test_window_excludes_old(self) -> None:
+        old = _make_entry("old", ("a",), created_at="2026-01-01T00:00:00+00:00")
+        new = _make_entry("new", ("a",), created_at="2026-05-01T00:00:00+00:00")
+        result = filter_recent(
+            [old, new], 14, now=datetime(2026, 5, 10, tzinfo=UTC)
+        )
+        assert [e.task_id for e in result] == ["new"]
+
+    def test_window_keeps_recent(self) -> None:
+        recent = _make_entry(
+            "recent", ("a",), created_at="2026-05-08T00:00:00+00:00"
+        )
+        result = filter_recent(
+            [recent], 7, now=datetime(2026, 5, 10, tzinfo=UTC)
+        )
+        assert result == [recent]
+
+    def test_unparseable_created_at_kept(self) -> None:
+        bogus = _make_entry("bogus", ("a",), created_at="not-a-date")
+        result = filter_recent(
+            [bogus], 1, now=datetime(2026, 5, 10, tzinfo=UTC)
+        )
+        assert result == [bogus]
+
+    def test_negative_window_returns_all(self) -> None:
+        entries = [_make_entry("x", ("a",))]
+        assert filter_recent(entries, -3) == entries
+
+
+# ---------------------------------------------------------------------------
+# Cluster entries
+# ---------------------------------------------------------------------------
+
+
+class TestClusterEntries:
+    """Cover the single-linkage clustering pass."""
+
+    def test_cluster_empty(self) -> None:
+        assert cluster_entries([]) == []
+
+    def test_cluster_singletons(self) -> None:
+        entries = [
+            _make_entry("t-1", ("a",)),
+            _make_entry("t-2", ("b",)),
+        ]
+        clusters = cluster_entries(entries, threshold=DEFAULT_JACCARD_THRESHOLD)
+        assert len(clusters) == 2
+
+    def test_cluster_merges_similar(self) -> None:
+        entries = [
+            _make_entry("t-1", ("a", "b")),
+            _make_entry("t-2", ("a", "b")),
+        ]
+        clusters = cluster_entries(entries, threshold=0.5)
+        assert len(clusters) == 1
+        assert len(clusters[0]) == 2
+
+    def test_cluster_threshold_respected(self) -> None:
+        entries = [
+            _make_entry("t-1", ("a", "b", "c", "d")),
+            _make_entry("t-2", ("a", "e", "f", "g")),
+        ]
+        # Jaccard = 1/7, well below 0.5
+        clusters = cluster_entries(entries, threshold=0.5)
+        assert len(clusters) == 2
+
+    def test_cluster_invalid_threshold(self) -> None:
+        with pytest.raises(SynthesizerError):
+            cluster_entries([], threshold=1.5)
+
+    def test_cluster_invalid_min_size(self) -> None:
+        with pytest.raises(SynthesizerError):
+            cluster_entries([], min_cluster_size=0)
+
+    def test_cluster_min_size_drops_small(self) -> None:
+        entries = [_make_entry("t-1", ("a",))]
+        clusters = cluster_entries(entries, min_cluster_size=2)
+        assert clusters == []
+
+    def test_cluster_sorted_by_size_desc(self) -> None:
+        entries = [
+            _make_entry("t-1", ("z",)),
+            _make_entry("t-2", ("a", "b")),
+            _make_entry("t-3", ("a", "b")),
+        ]
+        clusters = cluster_entries(entries, threshold=0.5)
+        assert clusters[0] == [entries[1], entries[2]] or len(clusters[0]) >= len(clusters[-1])
+
+
+# ---------------------------------------------------------------------------
+# Build themes
+# ---------------------------------------------------------------------------
+
+
+class TestBuildThemes:
+    """Cover theme construction from cluster lists."""
+
+    def test_theme_label_uses_shared_tags(self) -> None:
+        entries = [
+            _make_entry("t-1", ("backend", "retry")),
+            _make_entry("t-2", ("backend", "retry")),
+        ]
+        themes = build_themes([entries])
+        assert "backend" in themes[0].label
+
+    def test_theme_label_fallback_first_tag(self) -> None:
+        entries = [_make_entry("t-1", ("solo",))]
+        themes = build_themes([entries])
+        assert themes[0].label == "solo"
+
+    def test_theme_label_misc_when_no_tags(self) -> None:
+        entries = [_make_entry("t-1", ())]
+        themes = build_themes([entries])
+        assert themes[0].label == "misc"
+
+    def test_theme_id_is_stable(self) -> None:
+        entries = [_make_entry("t-1", ("aa",))]
+        themes_1 = build_themes([entries])
+        themes_2 = build_themes([entries])
+        assert themes_1[0].theme_id == themes_2[0].theme_id
+
+    def test_proposed_diff_lists_failures(self) -> None:
+        entries = [
+            _make_entry("t-1", ("a",), failed=("dropped connection",)),
+            _make_entry("t-2", ("a",), failed=("dropped connection",)),
+        ]
+        themes = build_themes([entries])
+        assert "dropped connection" in themes[0].proposed_diff
+        assert "failure" in themes[0].proposed_diff.lower()
+
+    def test_proposed_diff_lists_successes(self) -> None:
+        entries = [_make_entry("t-1", ("a",), worked=("retry on 503",))]
+        themes = build_themes([entries])
+        assert "retry on 503" in themes[0].proposed_diff
+        assert "success" in themes[0].proposed_diff.lower()
+
+    def test_proposed_diff_fallback_to_rationale(self) -> None:
+        entries = [_make_entry("t-1", ("a",), rationale="some thought")]
+        themes = build_themes([entries])
+        assert "some thought" in themes[0].proposed_diff
+
+
+# ---------------------------------------------------------------------------
+# Synthesize
+# ---------------------------------------------------------------------------
+
+
+class TestSynthesize:
+    """End-to-end pipeline pure-function tests."""
+
+    def test_empty_entries_yields_note(self) -> None:
+        report = synthesize([])
+        assert report.themes == ()
+        assert any("no diary entries" in n.lower() for n in report.notes)
+
+    def test_filters_then_clusters(self) -> None:
+        now = datetime(2026, 5, 10, tzinfo=UTC)
+        entries = [
+            _make_entry("old", ("a",), created_at="2026-01-01T00:00:00+00:00"),
+            _make_entry("new-1", ("a", "b"), created_at="2026-05-09T00:00:00+00:00"),
+            _make_entry("new-2", ("a", "b"), created_at="2026-05-09T00:00:00+00:00"),
+        ]
+        report = synthesize(entries, window_days=7, now=now)
+        # Old entry filtered out -> single cluster of size 2
+        assert report.theme_count == 1
+        assert report.themes[0].size == 2
+
+    def test_singleton_clusters_allowed(self) -> None:
+        report = synthesize(
+            [_make_entry("solo", ("uniqq",))],
+            window_days=0,
+        )
+        assert report.theme_count == 1
+
+    def test_window_zero_filters_nothing(self) -> None:
+        e1 = _make_entry("t-1", ("a",), created_at="2026-05-09T00:00:00+00:00")
+        e2 = _make_entry("t-2", ("a",), created_at="2026-05-09T00:00:00+00:00")
+        report = synthesize([e1, e2], window_days=0)
+        assert report.theme_count >= 1
+
+    def test_window_zero_yields_no_filter_note(self) -> None:
+        report = synthesize([_make_entry("t-1", ("a",))], window_days=0)
+        # No "empty" note when entries exist and pass through.
+        assert not any("no diary entries" in n.lower() for n in report.notes)
+
+    def test_default_approved_is_false(self) -> None:
+        report = synthesize([])
+        assert report.approved is False
+
+
+# ---------------------------------------------------------------------------
+# Approve
+# ---------------------------------------------------------------------------
+
+
+class TestApprove:
+    """HITL approval gate."""
+
+    def test_approve_sets_flag(self) -> None:
+        report = synthesize([_make_entry("t-1", ("a",))])
+        approved = approve(report)
+        assert approved.approved is True
+
+    def test_approve_preserves_themes(self) -> None:
+        report = synthesize([_make_entry("t-1", ("a",))])
+        approved = approve(report)
+        assert approved.themes == report.themes
+
+    def test_approve_returns_new_instance(self) -> None:
+        report = synthesize([_make_entry("t-1", ("a",))])
+        approved = approve(report)
+        assert approved is not report
+        assert approved.approved != report.approved
+
+
+# ---------------------------------------------------------------------------
+# Render report
+# ---------------------------------------------------------------------------
+
+
+class TestRenderReport:
+    """Markdown rendering of synthesis reports."""
+
+    def test_render_contains_frontmatter(self) -> None:
+        report = synthesize([])
+        out = render_report(report)
+        assert out.startswith("---\n")
+        assert "approved: false" in out
+
+    def test_render_marks_approved(self) -> None:
+        report = approve(synthesize([_make_entry("t-1", ("a",))]))
+        out = render_report(report)
+        assert "approved: true" in out
+
+    def test_render_no_themes_message(self) -> None:
+        out = render_report(synthesize([]))
+        assert "No themes detected" in out
+
+    def test_render_includes_theme_section(self) -> None:
+        entries = [
+            _make_entry("t-1", ("backend",)),
+            _make_entry("t-2", ("backend",)),
+        ]
+        out = render_report(synthesize(entries, window_days=0))
+        assert "backend" in out
+        assert "Cluster size" in out
+
+
+# ---------------------------------------------------------------------------
+# Write report
+# ---------------------------------------------------------------------------
+
+
+class TestWriteReport:
+    """Disk persistence for synthesis reports."""
+
+    def test_write_creates_file(self, tmp_path: Path) -> None:
+        report = synthesize([])
+        path = write_report(report, tmp_path)
+        assert path.exists()
+        assert path.name.endswith(".md")
+
+    def test_write_idempotent_per_day(self, tmp_path: Path) -> None:
+        report = synthesize([])
+        path_1 = write_report(report, tmp_path)
+        path_2 = write_report(report, tmp_path)
+        assert path_1 == path_2
+
+    def test_write_atomic_no_temp_left(self, tmp_path: Path) -> None:
+        report = synthesize([])
+        path = write_report(report, tmp_path)
+        siblings = list(path.parent.glob("*.tmp.*"))
+        assert siblings == []
+
+    def test_write_under_invalid_generated_at_falls_back(self, tmp_path: Path) -> None:
+        report = SynthesisReport(
+            generated_at="not-a-date",
+            window_days=7,
+            themes=(),
+        )
+        path = write_report(report, tmp_path)
+        assert path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Parse duration
+# ---------------------------------------------------------------------------
+
+
+class TestParseDuration:
+    """CLI duration parsing."""
+
+    def test_parse_bare_int_days(self) -> None:
+        assert parse_duration("14") == timedelta(days=14)
+
+    def test_parse_days(self) -> None:
+        assert parse_duration("7d") == timedelta(days=7)
+
+    def test_parse_hours(self) -> None:
+        assert parse_duration("24h") == timedelta(hours=24)
+
+    def test_parse_minutes(self) -> None:
+        assert parse_duration("30m") == timedelta(minutes=30)
+
+    def test_parse_seconds(self) -> None:
+        assert parse_duration("45s") == timedelta(seconds=45)
+
+    def test_parse_uppercase(self) -> None:
+        assert parse_duration("7D") == timedelta(days=7)
+
+    def test_parse_empty_raises(self) -> None:
+        with pytest.raises(SynthesizerError):
+            parse_duration("")
+
+    def test_parse_garbage_raises(self) -> None:
+        with pytest.raises(SynthesizerError):
+            parse_duration("forever")
+
+    def test_parse_negative_not_supported(self) -> None:
+        with pytest.raises(SynthesizerError):
+            parse_duration("-1d")
+
+
+# ---------------------------------------------------------------------------
+# Theme dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestTheme:
+    """Theme dataclass invariants."""
+
+    def test_theme_size_matches_entries(self) -> None:
+        entry = _make_entry("t-1", ("a",))
+        theme = Theme(
+            theme_id="theme-001-x",
+            label="x",
+            entries=(entry, entry),
+            shared_tags=("a",),
+            proposed_diff="",
+        )
+        assert theme.size == 2
+
+    def test_theme_immutable(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        theme = Theme(
+            theme_id="theme-001-x",
+            label="x",
+            entries=(),
+            shared_tags=(),
+            proposed_diff="",
+        )
+        with pytest.raises(FrozenInstanceError):
+            theme.label = "y"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Two-tier knowledge layer over task transcripts:

- **Diary** (`src/bernstein/core/knowledge/diary.py`): one structured `DiaryEntry` per closed task with `tried`/`worked`/`failed`/`rationale`/`tags`, plus a SHA-256 redaction hash. Stored atomically at `.sdd/runtime/diaries/<task_id>.json`.
- **Synthesizer** (`src/bernstein/core/knowledge/synthesizer.py`): periodic aggregation pass that clusters diaries by tag-overlap Jaccard (stdlib only, no embeddings in v1) and drafts a markdown report at `.sdd/runtime/syntheses/<date>.md`. HITL-gated: reports default to `approved: false`; only `--apply` flips the gate.
- **CLI**: `bernstein knowledge diary list|show <task>` and `bernstein knowledge synthesize --since <duration> [--apply|--dry-run]`.
- **Docs**: `docs/operations/knowledge-diary.md`.

Redaction covers OpenAI keys, GitHub tokens, AWS access keys, PEM banners, and generic high-entropy hex tokens before extraction or hashing.

## Test density

- **142 tests** total against the new modules.
  - 102 unit tests under `tests/unit/knowledge/` (50 diary + 52 synthesizer).
  - 20 Hypothesis property tests (`tests/property/test_diary_properties.py`).
  - 18 end-to-end integration tests covering the synthetic-transcript -> diary -> synthesis -> proposed-diff flow plus the full CLI surface (`tests/integration/test_knowledge_synthesis.py`).
- Ruff clean.
- Pyright strict: 0 errors, 0 warnings on the new modules.

## Test plan

- [x] `uv run pytest tests/unit/knowledge/ tests/property/test_diary_properties.py tests/integration/test_knowledge_synthesis.py` -> 142 passed
- [x] `uv run ruff check src/bernstein/core/knowledge/diary.py src/bernstein/core/knowledge/synthesizer.py src/bernstein/cli/commands/knowledge_cmd.py tests/unit/knowledge tests/property/test_diary_properties.py tests/integration/test_knowledge_synthesis.py`
- [x] `uv run pyright src/bernstein/core/knowledge/diary.py src/bernstein/core/knowledge/synthesizer.py src/bernstein/cli/commands/knowledge_cmd.py`
- [ ] Manual: `bernstein knowledge diary list --sdd-dir ./.sdd`
- [ ] Manual: `bernstein knowledge synthesize --since 14d --dry-run`

Closes #1369