### PR TITLE
feat(compliance): AI-BOM export with cross-walk to CycloneDX-AI (closes #1371)

### DIFF
--- a/src/bernstein/cli/commands/bom_cmd.py
+++ b/src/bernstein/cli/commands/bom_cmd.py
@@ -1,0 +1,174 @@
+"""``bernstein bom`` -- emit and verify AI-BOM exports.
+
+The AI Bill of Materials is a deterministic projection over the lineage
+v2 chain, the cost ledger, the decision log and the adapter contract
+YAMLs (see ``bernstein.core.compliance.ai_bom`` for the data model).
+
+Commands:
+
+* ``bernstein bom emit --run <id> [--format <fmt>] [--out <path>]``
+  Read the run snapshot (or load a custom snapshot JSON via
+  ``--snapshot``) and emit the encoded BOM. ``--format`` defaults to
+  ``json`` and accepts ``json``, ``cyclonedx`` and ``spdx``.
+* ``bernstein bom verify <path>`` -- structural verification report.
+
+Both subcommands are pure projections / pure verifications: no network
+calls, no writes outside the resolved output path. This matches the
+"BOM is not a source of truth" invariant in issue #1371.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import click
+
+
+@click.group("bom")
+def bom_group() -> None:
+    """AI Bill of Materials -- model/prompt/tool provenance.
+
+    \b
+    Examples:
+      bernstein bom emit --run 20260518-101010 --format cyclonedx
+      bernstein bom emit --snapshot /tmp/run.json --format json --out bom.json
+      bernstein bom verify ./bernstein-2.1.0.bom.json
+    """
+
+
+@bom_group.command("emit")
+@click.option(
+    "--run",
+    "run_id",
+    default=None,
+    help="Bernstein run identifier. Reads .sdd/runs/<run>/bom_snapshot.json.",
+)
+@click.option(
+    "--snapshot",
+    "snapshot_path",
+    default=None,
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+    help="Explicit snapshot JSON path. Mutually exclusive with --run.",
+)
+@click.option(
+    "--format",
+    "fmt",
+    default="json",
+    type=click.Choice(["json", "cyclonedx", "spdx"]),
+    show_default=True,
+    help="Output encoding. Defaults to Bernstein-native JSON.",
+)
+@click.option(
+    "--out",
+    "out_path",
+    default=None,
+    type=click.Path(dir_okay=False, resolve_path=True),
+    help="Write encoded BOM to this path (default: stdout).",
+)
+@click.option(
+    "--workdir",
+    default=".",
+    show_default=True,
+    help="Project root (used to resolve .sdd/runs when --run is given).",
+)
+def emit_cmd(
+    run_id: str | None,
+    snapshot_path: str | None,
+    fmt: str,
+    out_path: str | None,
+    workdir: str,
+) -> None:
+    """Emit an AI-BOM derived from an existing run snapshot."""
+    from bernstein.core.compliance.ai_bom import (
+        BOMError,
+        encode_bom,
+        generate_bom,
+    )
+
+    if run_id and snapshot_path:
+        click.echo("error: --run and --snapshot are mutually exclusive", err=True)
+        raise SystemExit(2)
+    if not run_id and not snapshot_path:
+        click.echo("error: one of --run or --snapshot is required", err=True)
+        raise SystemExit(2)
+
+    if run_id:
+        snap_path = Path(workdir).resolve() / ".sdd" / "runs" / run_id / "bom_snapshot.json"
+        if not snap_path.exists():
+            click.echo(f"error: snapshot not found at {snap_path}", err=True)
+            raise SystemExit(1)
+    else:
+        assert snapshot_path is not None
+        snap_path = Path(snapshot_path)
+
+    try:
+        snapshot_raw: Any = json.loads(snap_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        click.echo(f"error: failed to load snapshot: {exc}", err=True)
+        raise SystemExit(1) from None
+
+    if not isinstance(snapshot_raw, dict):
+        click.echo("error: snapshot must decode to a JSON object", err=True)
+        raise SystemExit(1)
+
+    snapshot: dict[str, Any] = cast("dict[str, Any]", snapshot_raw)
+
+    try:
+        bom = generate_bom(snapshot)
+        payload = encode_bom(bom, fmt=fmt)
+    except BOMError as exc:
+        click.echo(f"error: {exc}", err=True)
+        raise SystemExit(1) from None
+
+    if out_path:
+        Path(out_path).write_bytes(payload)
+        click.echo(f"wrote {len(payload)} bytes to {out_path}")
+        return
+
+    sys.stdout.buffer.write(payload)
+    sys.stdout.buffer.write(b"\n")
+
+
+@bom_group.command("verify")
+@click.argument(
+    "bom_path",
+    type=click.Path(dir_okay=False, exists=True, resolve_path=True),
+)
+@click.option(
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Only emit exit code; suppress the verification report.",
+)
+def verify_cmd(bom_path: str, quiet: bool) -> None:
+    """Verify a previously emitted AI-BOM."""
+    from bernstein.core.compliance.ai_bom import verify_bom
+
+    raw = Path(bom_path).read_bytes()
+    report = verify_bom(raw)
+
+    if quiet:
+        raise SystemExit(0 if report.ok else 1)
+
+    if report.ok:
+        click.echo(f"PASS: checked {report.checked_count} element(s)")
+    else:
+        click.echo(f"FAIL: {len(report.errors)} error(s); checked {report.checked_count} element(s)")
+        for err in report.errors:
+            click.echo(f"  - {err}")
+    raise SystemExit(0 if report.ok else 1)
+
+
+# Optional helper for tests / other callers: serialise a snapshot dict into
+# the BOM emit pipeline without going through Click's invocation machinery.
+def emit_bom_from_snapshot(snapshot: dict[str, Any], fmt: str = "json") -> bytes:
+    """Encode ``snapshot`` directly. Thin wrapper for non-CLI callers."""
+    from bernstein.core.compliance.ai_bom import encode_bom, generate_bom
+
+    return encode_bom(generate_bom(snapshot), fmt=fmt)
+
+
+__all__ = ["bom_group", "emit_bom_from_snapshot"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -56,6 +56,7 @@ from bernstein.cli.checkpoint_cmd import checkpoint_cmd
 from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
 from bernstein.cli.commands.best_of_n_rank_cmd import best_of_n_group
+from bernstein.cli.commands.bom_cmd import bom_group
 from bernstein.cli.commands.citation_cmd import quality_group as citation_quality_group
 from bernstein.cli.commands.consensus_cmd import consensus_group
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
@@ -897,6 +898,7 @@ cli.add_command(checkpoint_cmd, "checkpoint")
 cli.add_command(resume_cmd, "resume")
 cli.add_command(wrap_up, "wrap-up")
 cli.add_command(audit_group, "audit")
+cli.add_command(bom_group, "bom")
 cli.add_command(compliance_group, "compliance")
 cli.add_command(verify_cmd, "verify")
 cli.add_command(chaos_group, "chaos")

--- a/src/bernstein/core/compliance/__init__.py
+++ b/src/bernstein/core/compliance/__init__.py
@@ -13,6 +13,23 @@ the dotted import path keeps working even though
 
 from __future__ import annotations
 
+from bernstein.core.compliance.ai_bom import (
+    AIBOM,
+    BOM_SCHEMA_URL,
+    BOM_SCHEMA_VERSION,
+    SUPPORTED_FORMATS,
+    AdapterEntry,
+    BOMError,
+    BOMVerificationReport,
+    DataSourceEntry,
+    ModelEntry,
+    PromptEntry,
+    ToolEntry,
+    bom_content_hash,
+    encode_bom,
+    generate_bom,
+    verify_bom,
+)
 from bernstein.core.compliance.article12 import (
     ARTICLE12_PARAGRAPH_MAP,
     CSV_FIELDS,
@@ -39,20 +56,35 @@ from bernstein.core.security.compliance import (
 )
 
 __all__ = [
+    "AIBOM",
     "ARTICLE12_PARAGRAPH_MAP",
+    "BOM_SCHEMA_URL",
+    "BOM_SCHEMA_VERSION",
     "CSV_FIELDS",
+    "SUPPORTED_FORMATS",
+    "AdapterEntry",
+    "BOMError",
+    "BOMVerificationReport",
     "ComplianceConfig",
     "CompliancePreset",
+    "DataSourceEntry",
+    "ModelEntry",
     "ParagraphFn",
+    "PromptEntry",
     "SBOMEntry",
+    "ToolEntry",
     "ai_label_for_file",
+    "bom_content_hash",
     "build_pack",
+    "encode_bom",
     "export_evidence_bundle",
     "export_soc2_package",
+    "generate_bom",
     "generate_sbom",
     "load_compliance_config",
     "parse_period",
     "persist_compliance_config",
     "render_csv",
     "render_pdf",
+    "verify_bom",
 ]

--- a/src/bernstein/core/compliance/ai_bom.py
+++ b/src/bernstein/core/compliance/ai_bom.py
@@ -1,0 +1,608 @@
+"""AI Bill of Materials (AI-BOM) export.
+
+A Bernstein run touches many artefacts: model invocations, prompt
+templates, adapter binaries, MCP tools and data sources. Operators and
+auditors need a machine-readable manifest enumerating *which* exact
+(model, prompt_sha, adapter, version, data_source) tuples shaped a given
+run so that a downstream incident can be attributed to a specific tuple
+and a release can be reproduced byte-for-byte.
+
+This module is the projection over existing state described by issue
+#1371. It cannot record new facts: every list element sources its hash
+from the lineage v2 chain, the cost ledger, or the adapter contract
+YAMLs. Re-running ``generate_bom(run_id)`` against the same inputs is
+expected to yield the same bytes (deterministic encoding).
+
+Public surface (mirrors ``article12.py``):
+
+* :class:`AIBOM` -- the frozen dataclass shape.
+* :class:`ModelEntry`, :class:`PromptEntry`, :class:`AdapterEntry`,
+  :class:`ToolEntry`, :class:`DataSourceEntry` -- list element shapes.
+* :func:`generate_bom` -- pure projection over a snapshot dict.
+* :func:`encode_bom` -- format dispatcher (json | cyclonedx | spdx).
+* :func:`verify_bom` -- structural + hash verifier.
+
+The CycloneDX 1.5 encoder follows the AI/ML extension recommendations
+documented at https://cyclonedx.org/capabilities/aibom/. The SPDX 2.3
+encoder emits the SBOM subset relevant to model+package listing; AI-
+specific fields cross-walk to ``annotations`` so a vanilla SPDX
+validator accepts the document.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from typing import Any, cast
+
+__all__ = [
+    "AIBOM",
+    "BOM_SCHEMA_URL",
+    "BOM_SCHEMA_VERSION",
+    "SUPPORTED_FORMATS",
+    "AdapterEntry",
+    "BOMError",
+    "BOMVerificationReport",
+    "DataSourceEntry",
+    "ModelEntry",
+    "PromptEntry",
+    "ToolEntry",
+    "encode_bom",
+    "generate_bom",
+    "verify_bom",
+]
+
+
+BOM_SCHEMA_VERSION = "1.0"
+BOM_SCHEMA_URL = "https://bernstein.run/compliance/ai-bom/v1"
+
+SUPPORTED_FORMATS: frozenset[str] = frozenset({"json", "cyclonedx", "spdx"})
+
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class BOMError(ValueError):
+    """Raised when BOM generation or verification fails."""
+
+
+# ---------------------------------------------------------------------------
+# Element shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ModelEntry:
+    """Single model invocation tuple.
+
+    Hash is sourced from the lineage chain entry that recorded the model
+    call (typically the adapter's tool-call artefact). It is never
+    recomputed here.
+    """
+
+    name: str
+    provider: str
+    version: str
+    sha256: str
+    invocation_count: int
+
+    def __post_init__(self) -> None:
+        _require_sha(self.sha256, "ModelEntry.sha256")
+        if self.invocation_count < 0:
+            raise BOMError(f"ModelEntry.invocation_count must be >= 0, got {self.invocation_count}")
+
+
+@dataclass(frozen=True, slots=True)
+class PromptEntry:
+    """Prompt template used during the run.
+
+    ``sha256`` is the lineage-chain hash of the canonical template
+    bytes; it doubles as the deduplication key.
+    """
+
+    name: str
+    role: str
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _require_sha(self.sha256, "PromptEntry.sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class AdapterEntry:
+    """CLI adapter / agent binary."""
+
+    name: str
+    version: str
+    sha256: str
+    binary: str
+
+    def __post_init__(self) -> None:
+        _require_sha(self.sha256, "AdapterEntry.sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolEntry:
+    """MCP tool or other tool surface used by an agent."""
+
+    name: str
+    kind: str
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _require_sha(self.sha256, "ToolEntry.sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class DataSourceEntry:
+    """External data source referenced during the run."""
+
+    uri: str
+    kind: str
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _require_sha(self.sha256, "DataSourceEntry.sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class AIBOM:
+    """AI Bill of Materials root.
+
+    Frozen + slots: the dataclass shape itself is canonical, so any
+    surprise attribute would alter the deterministic JSON shape.
+
+    Attributes:
+        schema: schema URL constant used by external tooling.
+        schema_version: integer-tagged schema version.
+        run_id: opaque Bernstein run identifier.
+        started_at: ISO-8601 UTC start timestamp.
+        finished_at: ISO-8601 UTC finish timestamp.
+        lineage_root_hash: ``sha256:...`` over the lineage v2 root.
+        bernstein_version: package version recorded in the snapshot.
+        models: deduped sorted list of model invocation entries.
+        prompts: deduped sorted list of prompt entries.
+        adapters: deduped sorted list of adapter entries.
+        tools: deduped sorted list of tool entries.
+        data_sources: deduped sorted list of data source entries.
+    """
+
+    schema: str
+    schema_version: str
+    run_id: str
+    started_at: str
+    finished_at: str
+    lineage_root_hash: str
+    bernstein_version: str
+    models: tuple[ModelEntry, ...]
+    prompts: tuple[PromptEntry, ...]
+    adapters: tuple[AdapterEntry, ...]
+    tools: tuple[ToolEntry, ...]
+    data_sources: tuple[DataSourceEntry, ...]
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            raise BOMError("AIBOM.run_id must be non-empty")
+        if self.schema_version != BOM_SCHEMA_VERSION:
+            raise BOMError(
+                f"AIBOM.schema_version must be {BOM_SCHEMA_VERSION!r}, got {self.schema_version!r}",
+            )
+        _require_sha(self.lineage_root_hash, "AIBOM.lineage_root_hash")
+
+
+@dataclass(frozen=True, slots=True)
+class BOMVerificationReport:
+    """Result of :func:`verify_bom`.
+
+    ``ok`` is true only when every check passes. ``errors`` enumerates
+    each independent failure so an operator sees the full picture rather
+    than the first error.
+    """
+
+    ok: bool
+    errors: tuple[str, ...] = field(default_factory=tuple)
+    checked_count: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Generation
+# ---------------------------------------------------------------------------
+
+
+def generate_bom(snapshot: Mapping[str, Any]) -> AIBOM:
+    """Project ``snapshot`` into an :class:`AIBOM`.
+
+    The function is pure: it performs no I/O and does not recompute any
+    hash. All hash fields are sourced from the caller-provided snapshot
+    dict, which is the join between lineage v2 (#1377), the cost ledger
+    (#1330), the decision log (#1351) and the adapter contract YAMLs.
+
+    Args:
+        snapshot: dict with the keys described in
+            :class:`BOMSnapshotProtocol` (see module docs). Missing keys
+            raise :class:`BOMError`.
+
+    Returns:
+        A deterministic :class:`AIBOM` whose element lists are sorted
+        and deduplicated.
+    """
+    for required in (
+        "run_id",
+        "started_at",
+        "finished_at",
+        "lineage_root_hash",
+    ):
+        if required not in snapshot:
+            raise BOMError(f"snapshot missing required key: {required!r}")
+
+    models = tuple(sorted(_dedupe_models(snapshot.get("models", [])), key=_model_sort_key))
+    prompts = tuple(sorted(_dedupe_prompts(snapshot.get("prompts", [])), key=_prompt_sort_key))
+    adapters = tuple(sorted(_dedupe_adapters(snapshot.get("adapters", [])), key=_adapter_sort_key))
+    tools = tuple(sorted(_dedupe_tools(snapshot.get("tools", [])), key=_tool_sort_key))
+    data_sources = tuple(
+        sorted(_dedupe_data_sources(snapshot.get("data_sources", [])), key=_data_source_sort_key),
+    )
+
+    return AIBOM(
+        schema=BOM_SCHEMA_URL,
+        schema_version=BOM_SCHEMA_VERSION,
+        run_id=str(snapshot["run_id"]),
+        started_at=str(snapshot["started_at"]),
+        finished_at=str(snapshot["finished_at"]),
+        lineage_root_hash=str(snapshot["lineage_root_hash"]),
+        bernstein_version=str(snapshot.get("bernstein_version", "0+unknown")),
+        models=models,
+        prompts=prompts,
+        adapters=adapters,
+        tools=tools,
+        data_sources=data_sources,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Encoding dispatch
+# ---------------------------------------------------------------------------
+
+
+def encode_bom(bom: AIBOM, fmt: str = "json") -> bytes:
+    """Encode ``bom`` in ``fmt``.
+
+    The dispatcher mirrors the encoder-registry pattern used by
+    ``article12.py``: each encoder is its own module under
+    ``ai_bom_encoders/`` so adding a new format is one file plus one
+    registry entry. The output is deterministic: encoding the same
+    :class:`AIBOM` twice yields byte-identical results.
+    """
+    if fmt not in SUPPORTED_FORMATS:
+        raise BOMError(
+            f"unsupported BOM format {fmt!r}; expected one of {sorted(SUPPORTED_FORMATS)}",
+        )
+    encoder = _ENCODERS[fmt]
+    return encoder(bom)
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+
+def verify_bom(payload: object) -> BOMVerificationReport:
+    """Verify a serialised BOM document.
+
+    Checks performed:
+
+    1. Parse the JSON envelope and assert top-level keys + types.
+    2. Every list element exposes a well-formed ``sha256:...`` string.
+    3. The ``lineage_root_hash`` is well-formed.
+    4. ``schema_version`` matches the implementation.
+    5. Sort order is preserved (catches manual reordering attacks).
+
+    The check is structural; cryptographic verification of the lineage
+    root itself is delegated to ``lineage.verify(root_hash)`` which has
+    its own keying and is intentionally out of scope here.
+    """
+    errors: list[str] = []
+    checked = 0
+    try:
+        doc = _coerce_payload(payload)
+    except BOMError as exc:
+        return BOMVerificationReport(ok=False, errors=(str(exc),), checked_count=0)
+
+    schema_version = doc.get("schema_version")
+    if schema_version != BOM_SCHEMA_VERSION:
+        errors.append(
+            f"schema_version mismatch: got {schema_version!r}, expected {BOM_SCHEMA_VERSION!r}",
+        )
+
+    if not isinstance(doc.get("run_id"), str) or not doc["run_id"]:
+        errors.append("run_id must be a non-empty string")
+
+    root_hash = doc.get("lineage_root_hash")
+    if not isinstance(root_hash, str) or not _SHA256_RE.match(root_hash):
+        errors.append(f"lineage_root_hash is not a well-formed sha256: {root_hash!r}")
+
+    list_keys: tuple[tuple[str, Callable[[dict[str, Any]], tuple[str, ...]]], ...] = (
+        ("models", _model_dict_sort_key),
+        ("prompts", _prompt_dict_sort_key),
+        ("adapters", _adapter_dict_sort_key),
+        ("tools", _tool_dict_sort_key),
+        ("data_sources", _data_source_dict_sort_key),
+    )
+    for key, sort_key in list_keys:
+        items_raw = doc.get(key, [])
+        if not isinstance(items_raw, list):
+            errors.append(f"{key} must be a list, got {type(items_raw).__name__}")
+            continue
+        items_list: list[Any] = cast("list[Any]", items_raw)
+        last_key: tuple[str, ...] | None = None
+        for index, item in enumerate(items_list):
+            checked += 1
+            if not isinstance(item, dict):
+                errors.append(f"{key}[{index}] is not an object")
+                continue
+            item_d: dict[str, Any] = cast("dict[str, Any]", item)
+            sha = item_d.get("sha256")
+            if not isinstance(sha, str) or not _SHA256_RE.match(sha):
+                errors.append(f"{key}[{index}].sha256 is not a well-formed sha256: {sha!r}")
+                continue
+            cur_key = sort_key(item_d)
+            if last_key is not None and cur_key < last_key:
+                errors.append(f"{key}[{index}] breaks deterministic ordering")
+            last_key = cur_key
+
+    ok = not errors
+    return BOMVerificationReport(ok=ok, errors=tuple(errors), checked_count=checked)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers - dedupe + sort
+# ---------------------------------------------------------------------------
+
+
+def _coerce_payload(payload: object) -> dict[str, Any]:
+    """Normalise BOM input to a dict.
+
+    Accepts ``Mapping``, bytes, or str. Anything else raises a
+    :class:`BOMError`. Typed as ``object`` so the verifier surface
+    handles operator mistakes without TypeErrors leaking through.
+    """
+    if isinstance(payload, Mapping):
+        return dict(cast("Mapping[str, Any]", payload))
+    data: Any
+    if isinstance(payload, (bytes, bytearray)):
+        try:
+            data = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise BOMError(f"payload is not valid UTF-8 JSON: {exc}") from None
+    elif isinstance(payload, str):
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise BOMError(f"payload is not valid JSON: {exc}") from None
+    else:
+        raise BOMError(f"unsupported payload type: {type(payload).__name__}")
+    if not isinstance(data, dict):
+        raise BOMError("BOM payload must decode to a JSON object")
+    return cast("dict[str, Any]", data)
+
+
+def _require_sha(value: str, label: str) -> None:
+    if not _SHA256_RE.match(value):
+        raise BOMError(f"{label} must be a well-formed sha256:<hex>, got {value!r}")
+
+
+def _model_sort_key(entry: ModelEntry) -> tuple[str, str, str, str]:
+    return (entry.provider, entry.name, entry.version, entry.sha256)
+
+
+def _prompt_sort_key(entry: PromptEntry) -> tuple[str, str, str]:
+    return (entry.role, entry.name, entry.sha256)
+
+
+def _adapter_sort_key(entry: AdapterEntry) -> tuple[str, str, str]:
+    return (entry.name, entry.version, entry.sha256)
+
+
+def _tool_sort_key(entry: ToolEntry) -> tuple[str, str, str]:
+    return (entry.kind, entry.name, entry.sha256)
+
+
+def _data_source_sort_key(entry: DataSourceEntry) -> tuple[str, str, str]:
+    return (entry.kind, entry.uri, entry.sha256)
+
+
+def _model_dict_sort_key(item: dict[str, Any]) -> tuple[str, ...]:
+    return (
+        str(item.get("provider", "")),
+        str(item.get("name", "")),
+        str(item.get("version", "")),
+        str(item.get("sha256", "")),
+    )
+
+
+def _prompt_dict_sort_key(item: dict[str, Any]) -> tuple[str, ...]:
+    return (str(item.get("role", "")), str(item.get("name", "")), str(item.get("sha256", "")))
+
+
+def _adapter_dict_sort_key(item: dict[str, Any]) -> tuple[str, ...]:
+    return (
+        str(item.get("name", "")),
+        str(item.get("version", "")),
+        str(item.get("sha256", "")),
+    )
+
+
+def _tool_dict_sort_key(item: dict[str, Any]) -> tuple[str, ...]:
+    return (str(item.get("kind", "")), str(item.get("name", "")), str(item.get("sha256", "")))
+
+
+def _data_source_dict_sort_key(item: dict[str, Any]) -> tuple[str, ...]:
+    return (str(item.get("kind", "")), str(item.get("uri", "")), str(item.get("sha256", "")))
+
+
+def _dedupe_models(items: Iterable[Any]) -> list[ModelEntry]:
+    seen: dict[tuple[str, ...], ModelEntry] = {}
+    for raw in items:
+        entry = _coerce_model(raw)
+        key = (entry.provider, entry.name, entry.version, entry.sha256)
+        if key in seen:
+            # Sum invocations across duplicates so multiple lineage
+            # entries for the same model collapse without losing count.
+            prior = seen[key]
+            seen[key] = ModelEntry(
+                name=prior.name,
+                provider=prior.provider,
+                version=prior.version,
+                sha256=prior.sha256,
+                invocation_count=prior.invocation_count + entry.invocation_count,
+            )
+        else:
+            seen[key] = entry
+    return list(seen.values())
+
+
+def _dedupe_prompts(items: Iterable[Any]) -> list[PromptEntry]:
+    return list({_prompt_sort_key(_coerce_prompt(r)): _coerce_prompt(r) for r in items}.values())
+
+
+def _dedupe_adapters(items: Iterable[Any]) -> list[AdapterEntry]:
+    return list({_adapter_sort_key(_coerce_adapter(r)): _coerce_adapter(r) for r in items}.values())
+
+
+def _dedupe_tools(items: Iterable[Any]) -> list[ToolEntry]:
+    return list({_tool_sort_key(_coerce_tool(r)): _coerce_tool(r) for r in items}.values())
+
+
+def _dedupe_data_sources(items: Iterable[Any]) -> list[DataSourceEntry]:
+    return list(
+        {_data_source_sort_key(_coerce_data_source(r)): _coerce_data_source(r) for r in items}.values(),
+    )
+
+
+def _coerce_model(raw: Any) -> ModelEntry:
+    if isinstance(raw, ModelEntry):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise BOMError(f"model entry must be a mapping or ModelEntry, got {type(raw).__name__}")
+    raw_m = cast("Mapping[str, Any]", raw)
+    return ModelEntry(
+        name=str(raw_m["name"]),
+        provider=str(raw_m["provider"]),
+        version=str(raw_m["version"]),
+        sha256=str(raw_m["sha256"]),
+        invocation_count=int(raw_m.get("invocation_count", 1)),
+    )
+
+
+def _coerce_prompt(raw: Any) -> PromptEntry:
+    if isinstance(raw, PromptEntry):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise BOMError(f"prompt entry must be a mapping or PromptEntry, got {type(raw).__name__}")
+    raw_m = cast("Mapping[str, Any]", raw)
+    return PromptEntry(
+        name=str(raw_m["name"]),
+        role=str(raw_m["role"]),
+        sha256=str(raw_m["sha256"]),
+    )
+
+
+def _coerce_adapter(raw: Any) -> AdapterEntry:
+    if isinstance(raw, AdapterEntry):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise BOMError(f"adapter entry must be a mapping or AdapterEntry, got {type(raw).__name__}")
+    raw_m = cast("Mapping[str, Any]", raw)
+    return AdapterEntry(
+        name=str(raw_m["name"]),
+        version=str(raw_m["version"]),
+        sha256=str(raw_m["sha256"]),
+        binary=str(raw_m.get("binary", raw_m["name"])),
+    )
+
+
+def _coerce_tool(raw: Any) -> ToolEntry:
+    if isinstance(raw, ToolEntry):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise BOMError(f"tool entry must be a mapping or ToolEntry, got {type(raw).__name__}")
+    raw_m = cast("Mapping[str, Any]", raw)
+    return ToolEntry(
+        name=str(raw_m["name"]),
+        kind=str(raw_m["kind"]),
+        sha256=str(raw_m["sha256"]),
+    )
+
+
+def _coerce_data_source(raw: Any) -> DataSourceEntry:
+    if isinstance(raw, DataSourceEntry):
+        return raw
+    if not isinstance(raw, Mapping):
+        raise BOMError(f"data source entry must be a mapping, got {type(raw).__name__}")
+    raw_m = cast("Mapping[str, Any]", raw)
+    return DataSourceEntry(
+        uri=str(raw_m["uri"]),
+        kind=str(raw_m["kind"]),
+        sha256=str(raw_m["sha256"]),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical native encoder
+# ---------------------------------------------------------------------------
+
+
+def _encode_native_json(bom: AIBOM) -> bytes:
+    """RFC 8785-ish canonical JSON.
+
+    ``sort_keys=True`` + minimal separators + UTF-8 covers the subset
+    relevant to flat objects of strings / ints / lists. We never put
+    floats or None into a BOM, so the corner cases of the spec around
+    ES6 number formatting and recursive ordering do not apply.
+    """
+    doc = asdict(bom)
+    # asdict() turns tuples into lists, which is what JSON wants.
+    return json.dumps(
+        doc,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _encode_cyclonedx(bom: AIBOM) -> bytes:
+    from bernstein.core.compliance.ai_bom_encoders.cyclonedx import encode_cyclonedx
+
+    return encode_cyclonedx(bom)
+
+
+def _encode_spdx(bom: AIBOM) -> bytes:
+    from bernstein.core.compliance.ai_bom_encoders.spdx import encode_spdx
+
+    return encode_spdx(bom)
+
+
+_ENCODERS: dict[str, Callable[[AIBOM], bytes]] = {
+    "json": _encode_native_json,
+    "cyclonedx": _encode_cyclonedx,
+    "spdx": _encode_spdx,
+}
+
+
+# ---------------------------------------------------------------------------
+# Convenience constructors
+# ---------------------------------------------------------------------------
+
+
+def bom_content_hash(bom: AIBOM) -> str:
+    """Return ``sha256:<hex>`` over the canonical JSON form of ``bom``.
+
+    Operators use this to anchor the BOM in the decision log: the hash
+    is stable across encoder format (since we always hash the native
+    JSON), so a re-emit under a different ``--format`` flag still
+    points at the same logical record.
+    """
+    canonical = _encode_native_json(bom)
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()

--- a/src/bernstein/core/compliance/ai_bom_encoders/__init__.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/__init__.py
@@ -1,0 +1,11 @@
+"""AI-BOM encoders registered via :mod:`bernstein.core.compliance.ai_bom`.
+
+Each encoder module exposes a single ``encode_<fmt>`` function that
+accepts an :class:`bernstein.core.compliance.ai_bom.AIBOM` and returns
+deterministic UTF-8 bytes. The dispatcher in ``ai_bom.py`` owns the
+format-name registry; encoders themselves are stateless.
+"""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/cyclonedx.py
@@ -1,0 +1,165 @@
+"""CycloneDX 1.5 + AI/ML extension encoder.
+
+The output shape follows the public CycloneDX AI-BOM capability
+overview: https://cyclonedx.org/capabilities/aibom/.
+
+Notes on cross-walk:
+
+* ``components`` carries one entry per model, prompt, adapter, tool and
+  data source. Models use ``type=machine-learning-model`` (an AI/ML
+  extension type registered in CycloneDX 1.5). Prompts and tools use
+  ``type=data`` with a ``properties`` block tagging the role; this is
+  the recommended idiom in the AI-BOM whitepaper for assets that do not
+  have a first-class CycloneDX type yet.
+* The Bernstein run-id is embedded under ``metadata.properties`` so an
+  external tool can correlate the BOM with the recorder log without
+  parsing free text.
+* Lineage root hash is embedded as ``metadata.properties[bernstein:lineage_root_hash]``
+  for the same reason.
+
+The encoder is deterministic: identical :class:`AIBOM` -> identical bytes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.compliance.ai_bom import (
+        AIBOM,
+        AdapterEntry,
+        DataSourceEntry,
+        ModelEntry,
+        PromptEntry,
+        ToolEntry,
+    )
+
+__all__ = ["encode_cyclonedx"]
+
+
+CYCLONEDX_SPEC_VERSION = "1.5"
+CYCLONEDX_BOM_FORMAT = "CycloneDX"
+CYCLONEDX_SERIAL_NS = "urn:uuid:bernstein-ai-bom"
+
+
+def encode_cyclonedx(bom: AIBOM) -> bytes:
+    """Return CycloneDX 1.5 (AI/ML extension) JSON bytes."""
+    components: list[dict[str, Any]] = []
+    for model in bom.models:
+        components.append(_model_component(model))
+    for prompt in bom.prompts:
+        components.append(_prompt_component(prompt))
+    for adapter in bom.adapters:
+        components.append(_adapter_component(adapter))
+    for tool in bom.tools:
+        components.append(_tool_component(tool))
+    for source in bom.data_sources:
+        components.append(_data_source_component(source))
+
+    doc: dict[str, Any] = {
+        "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+        "bomFormat": CYCLONEDX_BOM_FORMAT,
+        "specVersion": CYCLONEDX_SPEC_VERSION,
+        "version": 1,
+        "serialNumber": f"{CYCLONEDX_SERIAL_NS}:{bom.run_id}",
+        "metadata": {
+            "timestamp": bom.finished_at,
+            "tools": [
+                {
+                    "vendor": "bernstein",
+                    "name": "bernstein",
+                    "version": bom.bernstein_version,
+                },
+            ],
+            "properties": [
+                {"name": "bernstein:run_id", "value": bom.run_id},
+                {"name": "bernstein:started_at", "value": bom.started_at},
+                {"name": "bernstein:finished_at", "value": bom.finished_at},
+                {"name": "bernstein:lineage_root_hash", "value": bom.lineage_root_hash},
+                {"name": "bernstein:schema", "value": bom.schema},
+                {"name": "bernstein:schema_version", "value": bom.schema_version},
+            ],
+        },
+        "components": components,
+    }
+    return json.dumps(doc, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _hash_block(sha256: str) -> list[dict[str, str]]:
+    """Convert ``sha256:<hex>`` to the CycloneDX ``hashes`` shape."""
+    _, _, digest = sha256.partition(":")
+    return [{"alg": "SHA-256", "content": digest}]
+
+
+def _bom_ref(prefix: str, sha256: str) -> str:
+    digest = sha256.split(":", 1)[1]
+    return f"bernstein:{prefix}:{digest[:16]}"
+
+
+def _model_component(model: ModelEntry) -> dict[str, Any]:
+    return {
+        "bom-ref": _bom_ref("model", model.sha256),
+        "type": "machine-learning-model",
+        "name": model.name,
+        "version": model.version,
+        "publisher": model.provider,
+        "hashes": _hash_block(model.sha256),
+        "properties": [
+            {"name": "bernstein:invocation_count", "value": str(model.invocation_count)},
+            {"name": "bernstein:role", "value": "model"},
+        ],
+    }
+
+
+def _prompt_component(prompt: PromptEntry) -> dict[str, Any]:
+    return {
+        "bom-ref": _bom_ref("prompt", prompt.sha256),
+        "type": "data",
+        "name": prompt.name,
+        "hashes": _hash_block(prompt.sha256),
+        "properties": [
+            {"name": "bernstein:role", "value": prompt.role},
+            {"name": "bernstein:asset_kind", "value": "prompt-template"},
+        ],
+    }
+
+
+def _adapter_component(adapter: AdapterEntry) -> dict[str, Any]:
+    return {
+        "bom-ref": _bom_ref("adapter", adapter.sha256),
+        "type": "application",
+        "name": adapter.name,
+        "version": adapter.version,
+        "hashes": _hash_block(adapter.sha256),
+        "properties": [
+            {"name": "bernstein:binary", "value": adapter.binary},
+            {"name": "bernstein:role", "value": "adapter"},
+        ],
+    }
+
+
+def _tool_component(tool: ToolEntry) -> dict[str, Any]:
+    return {
+        "bom-ref": _bom_ref("tool", tool.sha256),
+        "type": "application",
+        "name": tool.name,
+        "hashes": _hash_block(tool.sha256),
+        "properties": [
+            {"name": "bernstein:tool_kind", "value": tool.kind},
+            {"name": "bernstein:role", "value": "tool"},
+        ],
+    }
+
+
+def _data_source_component(source: DataSourceEntry) -> dict[str, Any]:
+    return {
+        "bom-ref": _bom_ref("source", source.sha256),
+        "type": "data",
+        "name": source.uri,
+        "hashes": _hash_block(source.sha256),
+        "properties": [
+            {"name": "bernstein:source_kind", "value": source.kind},
+            {"name": "bernstein:role", "value": "data-source"},
+        ],
+    }

--- a/src/bernstein/core/compliance/ai_bom_encoders/spdx.py
+++ b/src/bernstein/core/compliance/ai_bom_encoders/spdx.py
@@ -1,0 +1,159 @@
+"""SPDX 2.3 encoder for the AI-BOM.
+
+SPDX 2.3 has no first-class AI/ML asset type. The cross-walk:
+
+* Every model / prompt / adapter / tool / data source becomes an SPDX
+  ``Package`` with a ``SHA256`` checksum sourced from the lineage chain.
+* Bernstein-specific attributes (provider, role, invocation count) land
+  in the package ``annotations`` list with ``annotationType=OTHER``.
+* The document ``creationInfo`` records the Bernstein run-id under
+  ``comment`` so external SPDX tooling sees it without crashing on an
+  unknown field.
+
+The encoder is deterministic.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from bernstein.core.compliance.ai_bom import (
+        AIBOM,
+        AdapterEntry,
+        DataSourceEntry,
+        ModelEntry,
+        PromptEntry,
+        ToolEntry,
+    )
+
+__all__ = ["encode_spdx"]
+
+
+SPDX_VERSION = "SPDX-2.3"
+DATA_LICENSE = "CC0-1.0"
+
+
+def encode_spdx(bom: AIBOM) -> bytes:
+    """Return SPDX 2.3 JSON bytes."""
+    packages: list[dict[str, Any]] = []
+    for model in bom.models:
+        packages.append(_model_package(model))
+    for prompt in bom.prompts:
+        packages.append(_prompt_package(prompt))
+    for adapter in bom.adapters:
+        packages.append(_adapter_package(adapter))
+    for tool in bom.tools:
+        packages.append(_tool_package(tool))
+    for source in bom.data_sources:
+        packages.append(_data_source_package(source))
+
+    doc: dict[str, Any] = {
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "spdxVersion": SPDX_VERSION,
+        "dataLicense": DATA_LICENSE,
+        "name": f"bernstein-ai-bom-{bom.run_id}",
+        "documentNamespace": f"https://bernstein.run/spdx/{bom.run_id}",
+        "creationInfo": {
+            "created": bom.finished_at,
+            "creators": [f"Tool: bernstein-{bom.bernstein_version}"],
+            "comment": f"bernstein run_id={bom.run_id} lineage_root={bom.lineage_root_hash}",
+        },
+        "packages": packages,
+    }
+    return json.dumps(doc, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _checksum(sha256: str) -> dict[str, str]:
+    return {"algorithm": "SHA256", "checksumValue": sha256.split(":", 1)[1]}
+
+
+def _annotation(comment: str) -> dict[str, str]:
+    return {
+        "annotationType": "OTHER",
+        "annotator": "Tool: bernstein",
+        "comment": comment,
+        "annotationDate": "1970-01-01T00:00:00Z",
+    }
+
+
+def _spdx_id(prefix: str, sha256: str) -> str:
+    digest = sha256.split(":", 1)[1]
+    return f"SPDXRef-{prefix}-{digest[:16]}"
+
+
+def _model_package(model: ModelEntry) -> dict[str, Any]:
+    return {
+        "SPDXID": _spdx_id("model", model.sha256),
+        "name": model.name,
+        "versionInfo": model.version,
+        "supplier": f"Organization: {model.provider}",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "checksums": [_checksum(model.sha256)],
+        "annotations": [
+            _annotation("bernstein:role=model"),
+            _annotation(f"bernstein:invocation_count={model.invocation_count}"),
+        ],
+    }
+
+
+def _prompt_package(prompt: PromptEntry) -> dict[str, Any]:
+    return {
+        "SPDXID": _spdx_id("prompt", prompt.sha256),
+        "name": prompt.name,
+        "versionInfo": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "checksums": [_checksum(prompt.sha256)],
+        "annotations": [
+            _annotation("bernstein:asset_kind=prompt-template"),
+            _annotation(f"bernstein:role={prompt.role}"),
+        ],
+    }
+
+
+def _adapter_package(adapter: AdapterEntry) -> dict[str, Any]:
+    return {
+        "SPDXID": _spdx_id("adapter", adapter.sha256),
+        "name": adapter.name,
+        "versionInfo": adapter.version,
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "checksums": [_checksum(adapter.sha256)],
+        "annotations": [
+            _annotation("bernstein:role=adapter"),
+            _annotation(f"bernstein:binary={adapter.binary}"),
+        ],
+    }
+
+
+def _tool_package(tool: ToolEntry) -> dict[str, Any]:
+    return {
+        "SPDXID": _spdx_id("tool", tool.sha256),
+        "name": tool.name,
+        "versionInfo": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "checksums": [_checksum(tool.sha256)],
+        "annotations": [
+            _annotation("bernstein:role=tool"),
+            _annotation(f"bernstein:tool_kind={tool.kind}"),
+        ],
+    }
+
+
+def _data_source_package(source: DataSourceEntry) -> dict[str, Any]:
+    return {
+        "SPDXID": _spdx_id("source", source.sha256),
+        "name": source.uri,
+        "versionInfo": "NOASSERTION",
+        "downloadLocation": "NOASSERTION",
+        "filesAnalyzed": False,
+        "checksums": [_checksum(source.sha256)],
+        "annotations": [
+            _annotation("bernstein:role=data-source"),
+            _annotation(f"bernstein:source_kind={source.kind}"),
+        ],
+    }

--- a/src/bernstein/core/knowledge/diary.py
+++ b/src/bernstein/core/knowledge/diary.py
@@ -90,9 +90,7 @@ class DiaryEntry:
     rationale: str
     tags: tuple[str, ...]
     redaction_hash: str
-    created_at: str = field(
-        default_factory=lambda: datetime.now(UTC).isoformat(timespec="seconds")
-    )
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat(timespec="seconds"))
     schema_version: int = DIARY_SCHEMA_VERSION
 
     def to_dict(self) -> dict[str, Any]:
@@ -143,7 +141,7 @@ def _normalise_bullet(line: str) -> str:
     stripped = line.strip()
     for marker in ("- ", "* ", "+ ", "  - "):
         if stripped.startswith(marker):
-            return stripped[len(marker):].strip()
+            return stripped[len(marker) :].strip()
     return stripped
 
 
@@ -201,10 +199,38 @@ def extract_tags(transcript: str, *, limit: int = 16) -> tuple[str, ...]:
     if not transcript:
         return ()
     stop = {
-        "the", "and", "for", "with", "from", "this", "that", "into", "than",
-        "then", "have", "has", "had", "are", "was", "were", "but", "not",
-        "all", "any", "use", "used", "uses", "via", "per", "out", "off",
-        "its", "lol", "yes", "now", "tbd",
+        "the",
+        "and",
+        "for",
+        "with",
+        "from",
+        "this",
+        "that",
+        "into",
+        "than",
+        "then",
+        "have",
+        "has",
+        "had",
+        "are",
+        "was",
+        "were",
+        "but",
+        "not",
+        "all",
+        "any",
+        "use",
+        "used",
+        "uses",
+        "via",
+        "per",
+        "out",
+        "off",
+        "its",
+        "lol",
+        "yes",
+        "now",
+        "tbd",
     }
     seen: list[str] = []
     seen_set: set[str] = set()
@@ -289,9 +315,7 @@ def write_diary(entry: DiaryEntry, sdd_dir: Path) -> Path:
     return target
 
 
-def write_diary_from_transcript(
-    task_id: str, transcript: str, sdd_dir: Path
-) -> Path:
+def write_diary_from_transcript(task_id: str, transcript: str, sdd_dir: Path) -> Path:
     """Convenience: build an entry from *transcript* and persist it.
 
     Failures are propagated as :class:`DiaryError`; callers wiring this

--- a/src/bernstein/core/knowledge/synthesizer.py
+++ b/src/bernstein/core/knowledge/synthesizer.py
@@ -120,9 +120,7 @@ def _within_window(entry: DiaryEntry, now: datetime, window: timedelta) -> bool:
     return now - created <= window
 
 
-def filter_recent(
-    entries: list[DiaryEntry], window_days: int, *, now: datetime | None = None
-) -> list[DiaryEntry]:
+def filter_recent(entries: list[DiaryEntry], window_days: int, *, now: datetime | None = None) -> list[DiaryEntry]:
     """Return only the entries within ``window_days`` of *now*.
 
     ``window_days <= 0`` short-circuits to the input list unchanged so
@@ -279,18 +277,14 @@ def synthesize(
     workflow.
     """
     recent = filter_recent(entries, window_days, now=now)
-    clusters = cluster_entries(
-        recent, threshold=threshold, min_cluster_size=min_cluster_size
-    )
+    clusters = cluster_entries(recent, threshold=threshold, min_cluster_size=min_cluster_size)
     themes = build_themes(clusters)
     moment = now if now is not None else datetime.now(UTC)
     notes: list[str] = []
     if not entries:
         notes.append("No diary entries available; report is empty.")
     elif not recent:
-        notes.append(
-            f"No diary entries within the last {window_days} day(s); report is empty."
-        )
+        notes.append(f"No diary entries within the last {window_days} day(s); report is empty.")
     return SynthesisReport(
         generated_at=moment.isoformat(timespec="seconds"),
         window_days=window_days,

--- a/tests/integration/test_bom_cli.py
+++ b/tests/integration/test_bom_cli.py
@@ -1,0 +1,350 @@
+"""Integration tests for ``bernstein bom`` -- end-to-end CLI flow.
+
+≥10 round-trip tests on synthetic run -> BOM -> verify. The shape we
+test mirrors the production integration: a JSON snapshot drops into
+``.sdd/runs/<run_id>/bom_snapshot.json`` and the CLI projects it into
+an encoded BOM (json/cyclonedx/spdx). Verify then re-reads the BOM.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from click.testing import CliRunner
+
+from bernstein.cli.commands.bom_cmd import bom_group
+
+
+def _sha(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode()).hexdigest()
+
+
+def _snapshot() -> dict[str, Any]:
+    return {
+        "run_id": "20260518-test-001",
+        "started_at": "2026-05-18T10:10:10Z",
+        "finished_at": "2026-05-18T10:11:00Z",
+        "lineage_root_hash": _sha("lineage-root"),
+        "bernstein_version": "2.1.0",
+        "models": [
+            {
+                "name": "claude-3-7-sonnet",
+                "provider": "anthropic",
+                "version": "2026-02-15",
+                "sha256": _sha("model-sonnet"),
+                "invocation_count": 4,
+            },
+        ],
+        "prompts": [
+            {"name": "manager-system", "role": "manager", "sha256": _sha("prompt-manager")},
+        ],
+        "adapters": [
+            {
+                "name": "claude",
+                "version": "1.4.0",
+                "sha256": _sha("adapter-claude"),
+                "binary": "claude",
+            },
+        ],
+        "tools": [
+            {"name": "git", "kind": "shell", "sha256": _sha("tool-git")},
+        ],
+        "data_sources": [
+            {"uri": "git+https://github.com/x/y@deadbeef", "kind": "repo", "sha256": _sha("source-x")},
+        ],
+    }
+
+
+def _write_snapshot(workdir: Path, run_id: str, snap: dict[str, Any]) -> Path:
+    run_dir = workdir / ".sdd" / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    snap_path = run_dir / "bom_snapshot.json"
+    snap_path.write_text(json.dumps(snap), encoding="utf-8")
+    return snap_path
+
+
+# ---------------------------------------------------------------------------
+# 1. ``bom emit`` happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestBOMEmit:
+    def test_emit_json_to_stdout(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(bom_group, ["emit", "--snapshot", str(snap_path)])
+        assert result.exit_code == 0, result.output
+        decoded = json.loads(result.output.strip())
+        assert decoded["run_id"] == "20260518-test-001"
+        assert decoded["schema_version"] == "1.0"
+
+    def test_emit_cyclonedx_to_stdout(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            ["emit", "--snapshot", str(snap_path), "--format", "cyclonedx"],
+        )
+        assert result.exit_code == 0, result.output
+        decoded = json.loads(result.output.strip())
+        assert decoded["bomFormat"] == "CycloneDX"
+        assert decoded["specVersion"] == "1.5"
+
+    def test_emit_spdx_to_stdout(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            ["emit", "--snapshot", str(snap_path), "--format", "spdx"],
+        )
+        assert result.exit_code == 0, result.output
+        decoded = json.loads(result.output.strip())
+        assert decoded["spdxVersion"] == "SPDX-2.3"
+
+    def test_emit_with_run_id_reads_runs_dir(self, tmp_path: Path) -> None:
+        run_id = "20260518-from-runs"
+        _write_snapshot(tmp_path, run_id, _snapshot())
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            ["emit", "--run", run_id, "--workdir", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        decoded = json.loads(result.output.strip())
+        assert decoded["run_id"] == "20260518-test-001"
+
+    def test_emit_writes_to_out_path(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        out_path = tmp_path / "bom.json"
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            [
+                "emit",
+                "--snapshot",
+                str(snap_path),
+                "--out",
+                str(out_path),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert out_path.exists()
+        decoded = json.loads(out_path.read_text(encoding="utf-8"))
+        assert decoded["run_id"] == "20260518-test-001"
+
+
+# ---------------------------------------------------------------------------
+# 2. ``bom emit`` validation
+# ---------------------------------------------------------------------------
+
+
+class TestBOMEmitValidation:
+    def test_mutually_exclusive_run_and_snapshot(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            ["emit", "--run", "x", "--snapshot", str(tmp_path / "missing.json")],
+        )
+        assert result.exit_code != 0
+
+    def test_neither_run_nor_snapshot(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(bom_group, ["emit"])
+        assert result.exit_code != 0
+        assert "required" in result.output
+
+    def test_missing_run_snapshot_errors(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            ["emit", "--run", "does-not-exist", "--workdir", str(tmp_path)],
+        )
+        assert result.exit_code != 0
+        assert "not found" in result.output
+
+    def test_corrupt_snapshot_errors(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text("not valid json", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(
+            bom_group,
+            ["emit", "--snapshot", str(snap_path)],
+        )
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Round-trip emit -> verify
+# ---------------------------------------------------------------------------
+
+
+class TestRoundTrip:
+    def test_json_roundtrip(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        bom_path = tmp_path / "bom.json"
+        runner = CliRunner()
+
+        emit = runner.invoke(
+            bom_group,
+            ["emit", "--snapshot", str(snap_path), "--out", str(bom_path)],
+        )
+        assert emit.exit_code == 0, emit.output
+
+        verify = runner.invoke(bom_group, ["verify", str(bom_path)])
+        assert verify.exit_code == 0, verify.output
+        assert "PASS" in verify.output
+
+    def test_verify_tamper_detection(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        bom_path = tmp_path / "bom.json"
+        runner = CliRunner()
+
+        runner.invoke(
+            bom_group,
+            ["emit", "--snapshot", str(snap_path), "--out", str(bom_path)],
+        )
+        # Tamper with one sha
+        doc = json.loads(bom_path.read_text(encoding="utf-8"))
+        doc["models"][0]["sha256"] = "not-a-sha"
+        bom_path.write_text(json.dumps(doc), encoding="utf-8")
+
+        verify = runner.invoke(bom_group, ["verify", str(bom_path)])
+        assert verify.exit_code != 0
+        assert "FAIL" in verify.output
+
+    def test_verify_quiet_mode(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        bom_path = tmp_path / "bom.json"
+        runner = CliRunner()
+        runner.invoke(
+            bom_group,
+            ["emit", "--snapshot", str(snap_path), "--out", str(bom_path)],
+        )
+        verify = runner.invoke(bom_group, ["verify", "--quiet", str(bom_path)])
+        assert verify.exit_code == 0
+        assert verify.output.strip() == ""
+
+    def test_emit_twice_byte_identical(self, tmp_path: Path) -> None:
+        """Pure projection: re-emitting the same snapshot gives identical bytes."""
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        runner = CliRunner()
+
+        r1 = runner.invoke(bom_group, ["emit", "--snapshot", str(snap_path)])
+        r2 = runner.invoke(bom_group, ["emit", "--snapshot", str(snap_path)])
+        assert r1.exit_code == 0 and r2.exit_code == 0
+        assert r1.output == r2.output
+
+    def test_cyclonedx_roundtrip_carries_run_id(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        bom_path = tmp_path / "bom.cdx.json"
+        runner = CliRunner()
+        runner.invoke(
+            bom_group,
+            [
+                "emit",
+                "--snapshot",
+                str(snap_path),
+                "--format",
+                "cyclonedx",
+                "--out",
+                str(bom_path),
+            ],
+        )
+        decoded = json.loads(bom_path.read_text(encoding="utf-8"))
+        props = {p["name"]: p["value"] for p in decoded["metadata"]["properties"]}
+        assert props["bernstein:run_id"] == "20260518-test-001"
+
+    def test_spdx_roundtrip_packages_count(self, tmp_path: Path) -> None:
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        bom_path = tmp_path / "bom.spdx.json"
+        runner = CliRunner()
+        runner.invoke(
+            bom_group,
+            [
+                "emit",
+                "--snapshot",
+                str(snap_path),
+                "--format",
+                "spdx",
+                "--out",
+                str(bom_path),
+            ],
+        )
+        decoded = json.loads(bom_path.read_text(encoding="utf-8"))
+        # 1 model + 1 prompt + 1 adapter + 1 tool + 1 source = 5 packages
+        assert len(decoded["packages"]) == 5
+
+    def test_multi_run_emits_are_independent(self, tmp_path: Path) -> None:
+        snap_a = _snapshot()
+        snap_b = dict(snap_a)
+        snap_b["run_id"] = "20260518-test-002"
+        a_path = tmp_path / "a.json"
+        b_path = tmp_path / "b.json"
+        a_path.write_text(json.dumps(snap_a), encoding="utf-8")
+        b_path.write_text(json.dumps(snap_b), encoding="utf-8")
+        runner = CliRunner()
+        r_a = runner.invoke(bom_group, ["emit", "--snapshot", str(a_path)])
+        r_b = runner.invoke(bom_group, ["emit", "--snapshot", str(b_path)])
+        assert r_a.output != r_b.output
+
+    def test_emit_then_verify_with_run_id(self, tmp_path: Path) -> None:
+        run_id = "20260518-from-runs-2"
+        _write_snapshot(tmp_path, run_id, _snapshot())
+        bom_path = tmp_path / "bom.json"
+        runner = CliRunner()
+        emit = runner.invoke(
+            bom_group,
+            [
+                "emit",
+                "--run",
+                run_id,
+                "--workdir",
+                str(tmp_path),
+                "--out",
+                str(bom_path),
+            ],
+        )
+        assert emit.exit_code == 0, emit.output
+        verify = runner.invoke(bom_group, ["verify", str(bom_path)])
+        assert verify.exit_code == 0, verify.output
+
+    def test_verify_garbage_file_fails(self, tmp_path: Path) -> None:
+        bad = tmp_path / "bad.json"
+        bad.write_text("just text", encoding="utf-8")
+        runner = CliRunner()
+        verify = runner.invoke(bom_group, ["verify", str(bad)])
+        assert verify.exit_code != 0
+
+    def test_three_format_roundtrip_same_run(self, tmp_path: Path) -> None:
+        """Emitting the same snapshot in all three formats produces the
+        expected per-format payload while preserving the run identity."""
+        snap_path = tmp_path / "snap.json"
+        snap_path.write_text(json.dumps(_snapshot()), encoding="utf-8")
+        runner = CliRunner()
+
+        for fmt, key in (
+            ("json", "schema_version"),
+            ("cyclonedx", "bomFormat"),
+            ("spdx", "spdxVersion"),
+        ):
+            out = tmp_path / f"bom.{fmt}.json"
+            result = runner.invoke(
+                bom_group,
+                ["emit", "--snapshot", str(snap_path), "--format", fmt, "--out", str(out)],
+            )
+            assert result.exit_code == 0, result.output
+            decoded = json.loads(out.read_text(encoding="utf-8"))
+            assert key in decoded

--- a/tests/unit/compliance/test_ai_bom.py
+++ b/tests/unit/compliance/test_ai_bom.py
@@ -1,0 +1,912 @@
+"""Unit tests for the AI Bill of Materials module.
+
+Covers ≥45 unit tests, ≥15 Hypothesis property tests, and a snapshot
+test for the CycloneDX-AI JSON shape. The bar is "MAXIMUM density" per
+issue #1371.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import strategies as st
+
+from bernstein.core.compliance.ai_bom import (
+    AIBOM,
+    BOM_SCHEMA_URL,
+    BOM_SCHEMA_VERSION,
+    SUPPORTED_FORMATS,
+    AdapterEntry,
+    BOMError,
+    DataSourceEntry,
+    ModelEntry,
+    PromptEntry,
+    ToolEntry,
+    bom_content_hash,
+    encode_bom,
+    generate_bom,
+    verify_bom,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha(label: str) -> str:
+    return "sha256:" + hashlib.sha256(label.encode()).hexdigest()
+
+
+def _root_hash() -> str:
+    return _sha("lineage-root")
+
+
+def _minimal_snapshot(**overrides: Any) -> dict[str, Any]:
+    snap: dict[str, Any] = {
+        "run_id": "20260518-101010",
+        "started_at": "2026-05-18T10:10:10Z",
+        "finished_at": "2026-05-18T10:11:00Z",
+        "lineage_root_hash": _root_hash(),
+        "bernstein_version": "2.1.0",
+        "models": [],
+        "prompts": [],
+        "adapters": [],
+        "tools": [],
+        "data_sources": [],
+    }
+    snap.update(overrides)
+    return snap
+
+
+def _full_snapshot() -> dict[str, Any]:
+    return _minimal_snapshot(
+        models=[
+            {
+                "name": "claude-3-7-sonnet",
+                "provider": "anthropic",
+                "version": "2026-02-15",
+                "sha256": _sha("model-sonnet"),
+                "invocation_count": 3,
+            },
+            {
+                "name": "gpt-4o",
+                "provider": "openai",
+                "version": "2026-04-09",
+                "sha256": _sha("model-gpt-4o"),
+                "invocation_count": 1,
+            },
+        ],
+        prompts=[
+            {"name": "manager-system", "role": "manager", "sha256": _sha("prompt-manager")},
+            {"name": "qa-system", "role": "qa", "sha256": _sha("prompt-qa")},
+        ],
+        adapters=[
+            {
+                "name": "claude",
+                "version": "1.4.0",
+                "sha256": _sha("adapter-claude"),
+                "binary": "claude",
+            },
+        ],
+        tools=[
+            {"name": "git", "kind": "shell", "sha256": _sha("tool-git")},
+        ],
+        data_sources=[
+            {"uri": "git+https://github.com/x/y@deadbeef", "kind": "repo", "sha256": _sha("source-x")},
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Dataclass invariants
+# ---------------------------------------------------------------------------
+
+
+class TestDataclassInvariants:
+    def test_model_entry_rejects_bad_sha(self) -> None:
+        with pytest.raises(BOMError):
+            ModelEntry(name="m", provider="p", version="v", sha256="abc", invocation_count=1)
+
+    def test_prompt_entry_rejects_bad_sha(self) -> None:
+        with pytest.raises(BOMError):
+            PromptEntry(name="n", role="r", sha256="not-a-sha")
+
+    def test_adapter_entry_rejects_bad_sha(self) -> None:
+        with pytest.raises(BOMError):
+            AdapterEntry(name="n", version="v", sha256="x", binary="x")
+
+    def test_tool_entry_rejects_bad_sha(self) -> None:
+        with pytest.raises(BOMError):
+            ToolEntry(name="n", kind="k", sha256="x")
+
+    def test_data_source_entry_rejects_bad_sha(self) -> None:
+        with pytest.raises(BOMError):
+            DataSourceEntry(uri="u", kind="k", sha256="x")
+
+    def test_model_entry_rejects_negative_invocations(self) -> None:
+        with pytest.raises(BOMError):
+            ModelEntry(
+                name="m",
+                provider="p",
+                version="v",
+                sha256=_sha("x"),
+                invocation_count=-1,
+            )
+
+    def test_aibom_rejects_empty_run_id(self) -> None:
+        with pytest.raises(BOMError):
+            AIBOM(
+                schema=BOM_SCHEMA_URL,
+                schema_version=BOM_SCHEMA_VERSION,
+                run_id="",
+                started_at="x",
+                finished_at="x",
+                lineage_root_hash=_root_hash(),
+                bernstein_version="0+u",
+                models=(),
+                prompts=(),
+                adapters=(),
+                tools=(),
+                data_sources=(),
+            )
+
+    def test_aibom_rejects_bad_schema_version(self) -> None:
+        with pytest.raises(BOMError):
+            AIBOM(
+                schema=BOM_SCHEMA_URL,
+                schema_version="9.9",
+                run_id="r1",
+                started_at="x",
+                finished_at="x",
+                lineage_root_hash=_root_hash(),
+                bernstein_version="0+u",
+                models=(),
+                prompts=(),
+                adapters=(),
+                tools=(),
+                data_sources=(),
+            )
+
+    def test_aibom_rejects_bad_root_hash(self) -> None:
+        with pytest.raises(BOMError):
+            AIBOM(
+                schema=BOM_SCHEMA_URL,
+                schema_version=BOM_SCHEMA_VERSION,
+                run_id="r1",
+                started_at="x",
+                finished_at="x",
+                lineage_root_hash="abc",
+                bernstein_version="0+u",
+                models=(),
+                prompts=(),
+                adapters=(),
+                tools=(),
+                data_sources=(),
+            )
+
+    def test_model_entry_is_frozen(self) -> None:
+        entry = ModelEntry(
+            name="m",
+            provider="p",
+            version="v",
+            sha256=_sha("m"),
+            invocation_count=1,
+        )
+        # Frozen dataclass with slots raises FrozenInstanceError / AttributeError
+        # depending on Python version; covering the union catches both.
+        with pytest.raises((AttributeError, TypeError)):
+            entry.name = "other"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# 2. generate_bom: snapshot validation
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBOMValidation:
+    def test_missing_run_id_raises(self) -> None:
+        snap = _minimal_snapshot()
+        del snap["run_id"]
+        with pytest.raises(BOMError, match="run_id"):
+            generate_bom(snap)
+
+    def test_missing_started_at_raises(self) -> None:
+        snap = _minimal_snapshot()
+        del snap["started_at"]
+        with pytest.raises(BOMError, match="started_at"):
+            generate_bom(snap)
+
+    def test_missing_finished_at_raises(self) -> None:
+        snap = _minimal_snapshot()
+        del snap["finished_at"]
+        with pytest.raises(BOMError, match="finished_at"):
+            generate_bom(snap)
+
+    def test_missing_lineage_root_hash_raises(self) -> None:
+        snap = _minimal_snapshot()
+        del snap["lineage_root_hash"]
+        with pytest.raises(BOMError, match="lineage_root_hash"):
+            generate_bom(snap)
+
+    def test_empty_lists_produce_empty_tuples(self) -> None:
+        bom = generate_bom(_minimal_snapshot())
+        assert bom.models == ()
+        assert bom.prompts == ()
+        assert bom.adapters == ()
+        assert bom.tools == ()
+        assert bom.data_sources == ()
+
+    def test_default_bernstein_version_when_absent(self) -> None:
+        snap = _minimal_snapshot()
+        snap.pop("bernstein_version")
+        bom = generate_bom(snap)
+        assert bom.bernstein_version == "0+unknown"
+
+    def test_bad_sha_in_model_propagates(self) -> None:
+        snap = _minimal_snapshot(
+            models=[{"name": "n", "provider": "p", "version": "v", "sha256": "x"}],
+        )
+        with pytest.raises(BOMError):
+            generate_bom(snap)
+
+
+# ---------------------------------------------------------------------------
+# 3. generate_bom: determinism, dedupe, sort
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBOMDeterminism:
+    def test_full_snapshot_produces_expected_counts(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        assert len(bom.models) == 2
+        assert len(bom.prompts) == 2
+        assert len(bom.adapters) == 1
+        assert len(bom.tools) == 1
+        assert len(bom.data_sources) == 1
+
+    def test_duplicate_models_collapse_to_summed_invocations(self) -> None:
+        sha = _sha("m1")
+        snap = _minimal_snapshot(
+            models=[
+                {"name": "m", "provider": "p", "version": "v", "sha256": sha, "invocation_count": 2},
+                {"name": "m", "provider": "p", "version": "v", "sha256": sha, "invocation_count": 5},
+            ],
+        )
+        bom = generate_bom(snap)
+        assert len(bom.models) == 1
+        assert bom.models[0].invocation_count == 7
+
+    def test_duplicate_prompts_collapse(self) -> None:
+        sha = _sha("prompt-x")
+        snap = _minimal_snapshot(
+            prompts=[
+                {"name": "x", "role": "r", "sha256": sha},
+                {"name": "x", "role": "r", "sha256": sha},
+            ],
+        )
+        bom = generate_bom(snap)
+        assert len(bom.prompts) == 1
+
+    def test_duplicate_adapters_collapse(self) -> None:
+        sha = _sha("adapter-x")
+        snap = _minimal_snapshot(
+            adapters=[
+                {"name": "x", "version": "1", "sha256": sha, "binary": "x"},
+                {"name": "x", "version": "1", "sha256": sha, "binary": "x"},
+            ],
+        )
+        bom = generate_bom(snap)
+        assert len(bom.adapters) == 1
+
+    def test_duplicate_tools_collapse(self) -> None:
+        sha = _sha("tool-x")
+        snap = _minimal_snapshot(
+            tools=[
+                {"name": "x", "kind": "k", "sha256": sha},
+                {"name": "x", "kind": "k", "sha256": sha},
+            ],
+        )
+        bom = generate_bom(snap)
+        assert len(bom.tools) == 1
+
+    def test_duplicate_data_sources_collapse(self) -> None:
+        sha = _sha("source-x")
+        snap = _minimal_snapshot(
+            data_sources=[
+                {"uri": "u", "kind": "k", "sha256": sha},
+                {"uri": "u", "kind": "k", "sha256": sha},
+            ],
+        )
+        bom = generate_bom(snap)
+        assert len(bom.data_sources) == 1
+
+    def test_models_sorted_by_provider_name_version(self) -> None:
+        snap = _minimal_snapshot(
+            models=[
+                {"name": "z", "provider": "b", "version": "1", "sha256": _sha("z")},
+                {"name": "a", "provider": "a", "version": "1", "sha256": _sha("a")},
+            ],
+        )
+        bom = generate_bom(snap)
+        assert bom.models[0].provider == "a"
+        assert bom.models[1].provider == "b"
+
+    def test_same_snapshot_yields_same_bom(self) -> None:
+        bom1 = generate_bom(_full_snapshot())
+        bom2 = generate_bom(_full_snapshot())
+        assert bom1 == bom2
+
+    def test_input_list_order_does_not_affect_output(self) -> None:
+        snap_a = _full_snapshot()
+        snap_b = _full_snapshot()
+        snap_b["models"] = list(reversed(snap_b["models"]))
+        snap_b["prompts"] = list(reversed(snap_b["prompts"]))
+        assert generate_bom(snap_a) == generate_bom(snap_b)
+
+
+# ---------------------------------------------------------------------------
+# 4. Pure projection: no I/O during generate
+# ---------------------------------------------------------------------------
+
+
+class TestPureProjection:
+    def test_no_writes_during_generate(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+        """generate_bom must not write any files. Critical invariant.
+
+        Issue #1371 mandates that the BOM module is a pure projection
+        over existing state. Re-recording its own facts would create a
+        new source of truth.
+        """
+        original_open = open
+        write_calls: list[str] = []
+
+        def _spy_open(*args: Any, **kwargs: Any) -> Any:
+            mode = kwargs.get("mode") if "mode" in kwargs else (args[1] if len(args) > 1 else "r")
+            if "w" in mode or "a" in mode or "x" in mode:
+                write_calls.append(str(args[0]))
+            return original_open(*args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", _spy_open)
+        generate_bom(_full_snapshot())
+        assert write_calls == []
+
+    def test_generate_does_not_mutate_snapshot(self) -> None:
+        snap = _full_snapshot()
+        before = json.dumps(snap, sort_keys=True)
+        generate_bom(snap)
+        after = json.dumps(snap, sort_keys=True)
+        assert before == after
+
+
+# ---------------------------------------------------------------------------
+# 5. Encoders
+# ---------------------------------------------------------------------------
+
+
+class TestEncoders:
+    def test_supported_formats_constant(self) -> None:
+        assert {"json", "cyclonedx", "spdx"} == SUPPORTED_FORMATS
+
+    def test_native_json_roundtrip_keys(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        encoded = encode_bom(bom, fmt="json")
+        decoded = json.loads(encoded)
+        assert decoded["run_id"] == bom.run_id
+        assert decoded["lineage_root_hash"] == bom.lineage_root_hash
+        assert decoded["schema_version"] == BOM_SCHEMA_VERSION
+        assert len(decoded["models"]) == 2
+
+    def test_native_json_is_deterministic(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        assert encode_bom(bom, fmt="json") == encode_bom(bom, fmt="json")
+
+    def test_cyclonedx_keys_present(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        decoded = json.loads(encode_bom(bom, fmt="cyclonedx"))
+        assert decoded["bomFormat"] == "CycloneDX"
+        assert decoded["specVersion"] == "1.5"
+        assert "components" in decoded
+        assert any(c["type"] == "machine-learning-model" for c in decoded["components"])
+
+    def test_cyclonedx_carries_run_id_property(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        decoded = json.loads(encode_bom(bom, fmt="cyclonedx"))
+        props = {p["name"]: p["value"] for p in decoded["metadata"]["properties"]}
+        assert props["bernstein:run_id"] == bom.run_id
+        assert props["bernstein:lineage_root_hash"] == bom.lineage_root_hash
+
+    def test_cyclonedx_hashes_are_sha256_blocks(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        decoded = json.loads(encode_bom(bom, fmt="cyclonedx"))
+        for component in decoded["components"]:
+            for h in component["hashes"]:
+                assert h["alg"] == "SHA-256"
+                assert len(h["content"]) == 64
+
+    def test_cyclonedx_serial_number_per_run(self) -> None:
+        bom_a = generate_bom(_full_snapshot())
+        snap_b = _full_snapshot()
+        snap_b["run_id"] = "different"
+        bom_b = generate_bom(snap_b)
+        a = json.loads(encode_bom(bom_a, fmt="cyclonedx"))
+        b = json.loads(encode_bom(bom_b, fmt="cyclonedx"))
+        assert a["serialNumber"] != b["serialNumber"]
+
+    def test_spdx_keys_present(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        decoded = json.loads(encode_bom(bom, fmt="spdx"))
+        assert decoded["spdxVersion"] == "SPDX-2.3"
+        assert decoded["dataLicense"] == "CC0-1.0"
+        assert decoded["SPDXID"] == "SPDXRef-DOCUMENT"
+        assert decoded["name"].startswith("bernstein-ai-bom-")
+
+    def test_spdx_packages_carry_sha256_checksums(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        decoded = json.loads(encode_bom(bom, fmt="spdx"))
+        for pkg in decoded["packages"]:
+            assert pkg["checksums"][0]["algorithm"] == "SHA256"
+            assert len(pkg["checksums"][0]["checksumValue"]) == 64
+
+    def test_spdx_comment_carries_run_id_and_root(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        decoded = json.loads(encode_bom(bom, fmt="spdx"))
+        comment = decoded["creationInfo"]["comment"]
+        assert bom.run_id in comment
+        assert bom.lineage_root_hash in comment
+
+    def test_encode_bom_unknown_format(self) -> None:
+        bom = generate_bom(_minimal_snapshot())
+        with pytest.raises(BOMError, match="unsupported"):
+            encode_bom(bom, fmt="xml")
+
+
+# ---------------------------------------------------------------------------
+# 6. Snapshot test for CycloneDX-AI JSON shape
+# ---------------------------------------------------------------------------
+
+
+class TestCycloneDXSnapshot:
+    """Pin the exact CycloneDX-AI shape for one canonical fixture.
+
+    A change here forces the reviewer to consciously update the wire
+    contract -- which is exactly what we want for a compliance surface.
+    """
+
+    def test_canonical_cyclonedx_shape(self) -> None:
+        snap = {
+            "run_id": "fixture-run-001",
+            "started_at": "2026-01-01T00:00:00Z",
+            "finished_at": "2026-01-01T00:01:00Z",
+            "lineage_root_hash": "sha256:" + "a" * 64,
+            "bernstein_version": "9.9.9",
+            "models": [
+                {
+                    "name": "model-x",
+                    "provider": "acme",
+                    "version": "v1",
+                    "sha256": "sha256:" + "b" * 64,
+                    "invocation_count": 1,
+                },
+            ],
+            "prompts": [
+                {"name": "p1", "role": "manager", "sha256": "sha256:" + "c" * 64},
+            ],
+            "adapters": [
+                {
+                    "name": "a1",
+                    "version": "1.0",
+                    "sha256": "sha256:" + "d" * 64,
+                    "binary": "a1",
+                },
+            ],
+            "tools": [{"name": "t1", "kind": "shell", "sha256": "sha256:" + "e" * 64}],
+            "data_sources": [{"uri": "u1", "kind": "repo", "sha256": "sha256:" + "f" * 64}],
+        }
+        bom = generate_bom(snap)
+        decoded = json.loads(encode_bom(bom, fmt="cyclonedx"))
+
+        # Top-level frame
+        assert decoded["bomFormat"] == "CycloneDX"
+        assert decoded["specVersion"] == "1.5"
+        assert decoded["version"] == 1
+        assert decoded["serialNumber"] == "urn:uuid:bernstein-ai-bom:fixture-run-001"
+
+        # metadata.tools points at bernstein
+        assert decoded["metadata"]["tools"][0]["name"] == "bernstein"
+        assert decoded["metadata"]["tools"][0]["version"] == "9.9.9"
+
+        # Components: 1 model + 1 prompt + 1 adapter + 1 tool + 1 source = 5
+        assert len(decoded["components"]) == 5
+        kinds = [c["type"] for c in decoded["components"]]
+        assert "machine-learning-model" in kinds
+        # The model carries provider as `publisher`
+        model_comp = next(c for c in decoded["components"] if c["type"] == "machine-learning-model")
+        assert model_comp["publisher"] == "acme"
+        assert model_comp["version"] == "v1"
+
+
+# ---------------------------------------------------------------------------
+# 7. verify_bom
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyBOM:
+    def test_passes_for_freshly_encoded_bom(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        report = verify_bom(encode_bom(bom, fmt="json"))
+        assert report.ok is True
+        assert report.errors == ()
+        assert report.checked_count >= 5
+
+    def test_rejects_garbage_payload(self) -> None:
+        report = verify_bom(b"\xff\xfe not json")
+        assert report.ok is False
+        assert any("JSON" in e or "UTF-8" in e for e in report.errors)
+
+    def test_rejects_non_object_payload(self) -> None:
+        report = verify_bom(b"[1,2,3]")
+        assert report.ok is False
+
+    def test_rejects_wrong_schema_version(self) -> None:
+        doc = json.loads(encode_bom(generate_bom(_full_snapshot()), fmt="json"))
+        doc["schema_version"] = "0.1"
+        report = verify_bom(json.dumps(doc).encode("utf-8"))
+        assert report.ok is False
+        assert any("schema_version" in e for e in report.errors)
+
+    def test_rejects_missing_run_id(self) -> None:
+        doc = json.loads(encode_bom(generate_bom(_full_snapshot()), fmt="json"))
+        doc["run_id"] = ""
+        report = verify_bom(json.dumps(doc).encode("utf-8"))
+        assert report.ok is False
+
+    def test_rejects_bad_root_hash(self) -> None:
+        doc = json.loads(encode_bom(generate_bom(_full_snapshot()), fmt="json"))
+        doc["lineage_root_hash"] = "not-a-sha"
+        report = verify_bom(json.dumps(doc).encode("utf-8"))
+        assert report.ok is False
+
+    def test_detects_bad_element_sha(self) -> None:
+        doc = json.loads(encode_bom(generate_bom(_full_snapshot()), fmt="json"))
+        doc["models"][0]["sha256"] = "garbage"
+        report = verify_bom(json.dumps(doc).encode("utf-8"))
+        assert report.ok is False
+        assert any("sha256" in e for e in report.errors)
+
+    def test_detects_reordering_attack(self) -> None:
+        snap = _full_snapshot()
+        snap["models"] = [
+            {
+                "name": "a",
+                "provider": "a",
+                "version": "1",
+                "sha256": _sha("a"),
+                "invocation_count": 1,
+            },
+            {
+                "name": "b",
+                "provider": "b",
+                "version": "1",
+                "sha256": _sha("b"),
+                "invocation_count": 1,
+            },
+        ]
+        doc = json.loads(encode_bom(generate_bom(snap), fmt="json"))
+        doc["models"].reverse()  # Break sort order
+        report = verify_bom(json.dumps(doc).encode("utf-8"))
+        assert report.ok is False
+        assert any("ordering" in e for e in report.errors)
+
+    def test_accepts_mapping_payload(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        doc = json.loads(encode_bom(bom, fmt="json"))
+        report = verify_bom(doc)
+        assert report.ok is True
+
+    def test_accepts_str_payload(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        report = verify_bom(encode_bom(bom, fmt="json").decode("utf-8"))
+        assert report.ok is True
+
+    def test_rejects_unsupported_payload_type(self) -> None:
+        report = verify_bom(12345)  # type: ignore[arg-type]
+        assert report.ok is False
+
+    def test_reports_multiple_errors(self) -> None:
+        bad: dict[str, Any] = {
+            "schema_version": "0.1",
+            "run_id": "",
+            "lineage_root_hash": "nope",
+            "models": [{"name": "x", "provider": "p", "version": "v", "sha256": "bad"}],
+            "prompts": [],
+            "adapters": [],
+            "tools": [],
+            "data_sources": [],
+        }
+        report = verify_bom(json.dumps(bad).encode("utf-8"))
+        assert report.ok is False
+        assert len(report.errors) >= 3
+
+
+# ---------------------------------------------------------------------------
+# 8. bom_content_hash
+# ---------------------------------------------------------------------------
+
+
+class TestBOMContentHash:
+    def test_returns_sha256_prefix(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        h = bom_content_hash(bom)
+        assert h.startswith("sha256:")
+        assert len(h) == len("sha256:") + 64
+
+    def test_stable_across_calls(self) -> None:
+        bom = generate_bom(_full_snapshot())
+        assert bom_content_hash(bom) == bom_content_hash(bom)
+
+    def test_changes_when_data_changes(self) -> None:
+        bom_a = generate_bom(_full_snapshot())
+        snap_b = _full_snapshot()
+        snap_b["run_id"] = "different"
+        bom_b = generate_bom(snap_b)
+        assert bom_content_hash(bom_a) != bom_content_hash(bom_b)
+
+    def test_independent_of_encoder(self) -> None:
+        """Hash is over native JSON; format choice is irrelevant.
+
+        This pins the "stable record id" property: a release tagged
+        ``2.1.0`` whose BOM was emitted as CycloneDX and re-emitted as
+        SPDX still surfaces the same logical record in the decision log.
+        """
+        bom = generate_bom(_full_snapshot())
+        h1 = bom_content_hash(bom)
+        # Encode in another format -- hash unchanged because we hash the
+        # canonical native JSON, not the encoded bytes.
+        encode_bom(bom, fmt="cyclonedx")
+        encode_bom(bom, fmt="spdx")
+        assert bom_content_hash(bom) == h1
+
+
+# ---------------------------------------------------------------------------
+# 9. Property-based tests with Hypothesis (≥15)
+# ---------------------------------------------------------------------------
+
+
+_hex_64 = st.text(alphabet="0123456789abcdef", min_size=64, max_size=64)
+
+
+@st.composite
+def _sha_strategy(draw: st.DrawFn) -> str:
+    return "sha256:" + draw(_hex_64)
+
+
+_safe_text = st.text(
+    alphabet=st.characters(blacklist_categories=("Cc", "Cs"), max_codepoint=0x7F),
+    min_size=1,
+    max_size=12,
+)
+
+
+@st.composite
+def _model_dict(draw: st.DrawFn) -> dict[str, Any]:
+    return {
+        "name": draw(_safe_text),
+        "provider": draw(_safe_text),
+        "version": draw(_safe_text),
+        "sha256": draw(_sha_strategy()),
+        "invocation_count": draw(st.integers(min_value=0, max_value=10_000)),
+    }
+
+
+@st.composite
+def _prompt_dict(draw: st.DrawFn) -> dict[str, Any]:
+    return {
+        "name": draw(_safe_text),
+        "role": draw(_safe_text),
+        "sha256": draw(_sha_strategy()),
+    }
+
+
+@st.composite
+def _adapter_dict(draw: st.DrawFn) -> dict[str, Any]:
+    return {
+        "name": draw(_safe_text),
+        "version": draw(_safe_text),
+        "sha256": draw(_sha_strategy()),
+        "binary": draw(_safe_text),
+    }
+
+
+@st.composite
+def _tool_dict(draw: st.DrawFn) -> dict[str, Any]:
+    return {
+        "name": draw(_safe_text),
+        "kind": draw(_safe_text),
+        "sha256": draw(_sha_strategy()),
+    }
+
+
+@st.composite
+def _source_dict(draw: st.DrawFn) -> dict[str, Any]:
+    return {
+        "uri": draw(_safe_text),
+        "kind": draw(_safe_text),
+        "sha256": draw(_sha_strategy()),
+    }
+
+
+@st.composite
+def _snapshot(draw: st.DrawFn) -> dict[str, Any]:
+    return {
+        "run_id": draw(_safe_text),
+        "started_at": "2026-01-01T00:00:00Z",
+        "finished_at": "2026-01-01T01:00:00Z",
+        "lineage_root_hash": draw(_sha_strategy()),
+        "bernstein_version": draw(_safe_text),
+        "models": draw(st.lists(_model_dict(), max_size=5)),
+        "prompts": draw(st.lists(_prompt_dict(), max_size=5)),
+        "adapters": draw(st.lists(_adapter_dict(), max_size=5)),
+        "tools": draw(st.lists(_tool_dict(), max_size=5)),
+        "data_sources": draw(st.lists(_source_dict(), max_size=5)),
+    }
+
+
+_HYPOTHESIS_SETTINGS = settings(
+    max_examples=40,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+
+class TestProperties:
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_generate_is_idempotent(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom1 = generate_bom(snap)
+        bom2 = generate_bom(snap)
+        assert bom1 == bom2
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_native_json_is_deterministic(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        assert encode_bom(bom, fmt="json") == encode_bom(bom, fmt="json")
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_cyclonedx_is_deterministic(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        assert encode_bom(bom, fmt="cyclonedx") == encode_bom(bom, fmt="cyclonedx")
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_spdx_is_deterministic(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        assert encode_bom(bom, fmt="spdx") == encode_bom(bom, fmt="spdx")
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_input_permutation_invariant(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        rev = dict(snap)
+        rev["models"] = list(reversed(snap["models"]))
+        rev["prompts"] = list(reversed(snap["prompts"]))
+        rev["adapters"] = list(reversed(snap["adapters"]))
+        rev["tools"] = list(reversed(snap["tools"]))
+        rev["data_sources"] = list(reversed(snap["data_sources"]))
+        assert generate_bom(snap) == generate_bom(rev)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_freshly_emitted_bom_verifies(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        report = verify_bom(encode_bom(bom, fmt="json"))
+        assert report.ok is True, report.errors
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_content_hash_changes_with_run_id(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom_a = generate_bom(snap)
+        snap_b = dict(snap)
+        snap_b["run_id"] = snap["run_id"] + "x"
+        bom_b = generate_bom(snap_b)
+        assert bom_content_hash(bom_a) != bom_content_hash(bom_b)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_content_hash_stable_across_format(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        h_before = bom_content_hash(bom)
+        encode_bom(bom, fmt="cyclonedx")
+        encode_bom(bom, fmt="spdx")
+        h_after = bom_content_hash(bom)
+        assert h_before == h_after
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_models_dedup_invariant_on_doubling(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        doubled = dict(snap)
+        doubled["models"] = snap["models"] + snap["models"]
+        bom_single = generate_bom(snap)
+        bom_doubled = generate_bom(doubled)
+        # Count of unique models is unchanged; invocation counts double.
+        assert len(bom_doubled.models) == len(bom_single.models)
+        for original, dbl in zip(
+            sorted(bom_single.models, key=lambda m: m.sha256),
+            sorted(bom_doubled.models, key=lambda m: m.sha256),
+            strict=False,
+        ):
+            assert dbl.invocation_count == 2 * original.invocation_count
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_models_sorted_after_dedup(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        keys = [(m.provider, m.name, m.version, m.sha256) for m in bom.models]
+        assert keys == sorted(keys)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_prompts_sorted_after_dedup(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        keys = [(p.role, p.name, p.sha256) for p in bom.prompts]
+        assert keys == sorted(keys)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_adapters_sorted_after_dedup(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        keys = [(a.name, a.version, a.sha256) for a in bom.adapters]
+        assert keys == sorted(keys)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_tools_sorted_after_dedup(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        keys = [(t.kind, t.name, t.sha256) for t in bom.tools]
+        assert keys == sorted(keys)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_data_sources_sorted_after_dedup(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        keys = [(d.kind, d.uri, d.sha256) for d in bom.data_sources]
+        assert keys == sorted(keys)
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_cyclonedx_components_sha256_well_formed(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        decoded = json.loads(encode_bom(bom, fmt="cyclonedx"))
+        for comp in decoded["components"]:
+            for h in comp["hashes"]:
+                assert h["alg"] == "SHA-256"
+                assert len(h["content"]) == 64
+
+    @_HYPOTHESIS_SETTINGS
+    @given(snap=_snapshot())
+    def test_spdx_packages_sha256_well_formed(self, snap: dict[str, Any]) -> None:
+        assume(snap["run_id"])
+        bom = generate_bom(snap)
+        decoded = json.loads(encode_bom(bom, fmt="spdx"))
+        for pkg in decoded["packages"]:
+            assert pkg["checksums"][0]["algorithm"] == "SHA256"
+            assert len(pkg["checksums"][0]["checksumValue"]) == 64


### PR DESCRIPTION
## Summary

- Add a deterministic AI Bill of Materials surface that projects an
  existing run's lineage / cost / adapter state into a machine-readable
  manifest of (model, prompt_sha, adapter, version, data_source) tuples.
- Three encoders behind a single dispatcher (mirrors `article12.py`):
  Bernstein-native JSON, CycloneDX 1.5 with the AI/ML extension shape,
  and SPDX 2.3 with annotations cross-walking AI-specific fields.
- `bernstein bom emit` and `bernstein bom verify` CLI surface.

## Design

- `generate_bom` is a pure projection: no I/O, no recomputed hashes.
  Every list element sources its sha256 from the lineage chain. The
  test `TestPureProjection::test_no_writes_during_generate` enforces
  this by hooking `builtins.open`.
- Encoder dispatcher follows the article12 policy-encoder registry
  pattern. Adding a new format is one module under
  `ai_bom_encoders/` plus one dict entry.
- CycloneDX output emits `type=machine-learning-model` components
  per the AI/ML extension shape documented at
  https://cyclonedx.org/capabilities/aibom/. Run id and lineage root
  land in `metadata.properties` so external tooling can correlate.
- Determinism: `encode_bom(bom, fmt=X) == encode_bom(bom, fmt=X)` for
  every fmt. Hypothesis verifies this across all three formats.

## Test density (per #1371)

- 72 unit tests in `tests/unit/compliance/test_ai_bom.py`
  - 16 Hypothesis property tests (determinism, idempotence,
    permutation invariance, sorted invariants, well-formed checksums)
  - 1 CycloneDX-AI JSON shape snapshot test
- 19 integration tests in `tests/integration/test_bom_cli.py`
  covering emit/verify round-trips for all three formats and
  tamper detection

## Test plan

- [x] `uv run pytest tests/unit/compliance/test_ai_bom.py tests/integration/test_bom_cli.py` (91 passed)
- [x] `uv run ruff check` clean on the new modules
- [x] `uv run pyright` strict-clean on the new modules
- [x] `bernstein bom --help` exposes the new group