### PR TITLE
feat(ci): trunk health SLO + Andon gate - hold merges on red trunk

### DIFF
--- a/.github/workflows/trunk-andon-gate.yml
+++ b/.github/workflows/trunk-andon-gate.yml
@@ -1,0 +1,66 @@
+name: Trunk Andon Gate
+
+# Companion to `trunk-health-slo.yml`. Fails on every PR while
+# TRUNK_UNSTABLE == 'true' unless the PR carries `hotfix-cleared`.
+# Lives in its own workflow file (not inside ci.yml) so it can be
+# enabled, disabled, or required-as-a-check independently of the main
+# CI pipeline and so flipping the toggle does not invalidate cached
+# ci.yml jobs across in-flight PRs.
+#
+# Borrowed-from: Toyota Andon cord. The trunk pulls the cord; new work
+# pauses until cleared. The `hotfix-cleared` label is the explicit
+# "this is the cord-clearing fix, let it through" override.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_dispatch:
+
+concurrency:
+  group: trunk-andon-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  gate:
+    name: Andon gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Check TRUNK_UNSTABLE
+        env:
+          # Read-only access to repo variables suffices.
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+
+          UNSTABLE=$(gh api "repos/${REPO}/actions/variables/TRUNK_UNSTABLE" \
+            --jq '.value' 2>/dev/null || echo "false")
+
+          echo "TRUNK_UNSTABLE=${UNSTABLE}"
+
+          if [ "${UNSTABLE}" != "true" ]; then
+            echo "Trunk healthy. Gate passes."
+            exit 0
+          fi
+
+          # Trunk red: only `hotfix-cleared`-labeled PRs may merge.
+          if echo "${PR_LABELS}" | jq -e 'index("hotfix-cleared")' >/dev/null 2>&1; then
+            echo "::notice::Trunk unstable, but PR is labeled hotfix-cleared. Gate passes."
+            exit 0
+          fi
+
+          echo "::error::Trunk is in an unstable state (TRUNK_UNSTABLE=true)."
+          echo "Merge held by Andon gate. Land the hotfix first (or apply the 'hotfix-cleared' label if this PR IS the hotfix)."
+          exit 1

--- a/.github/workflows/trunk-health-slo.yml
+++ b/.github/workflows/trunk-health-slo.yml
@@ -95,10 +95,12 @@ jobs:
           fi
 
           echo "TOTAL=${TOTAL} RED=${RED} RED_PCT=${RED_PCT}% THRESHOLD=${THRESHOLD_PCT}% UNSTABLE=${UNSTABLE}"
-          echo "unstable=${UNSTABLE}" >> "${GITHUB_OUTPUT}"
-          echo "red_pct=${RED_PCT}" >> "${GITHUB_OUTPUT}"
-          echo "red=${RED}" >> "${GITHUB_OUTPUT}"
-          echo "total=${TOTAL}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "unstable=${UNSTABLE}"
+            echo "red_pct=${RED_PCT}"
+            echo "red=${RED}"
+            echo "total=${TOTAL}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Toggle TRUNK_UNSTABLE repo variable
         env:

--- a/.github/workflows/trunk-health-slo.yml
+++ b/.github/workflows/trunk-health-slo.yml
@@ -1,0 +1,148 @@
+name: Trunk Health SLO
+
+# Compute the last-24h main-red rate (failed CI runs / total CI runs on
+# main) and toggle the repo variable TRUNK_UNSTABLE accordingly. A
+# companion gate workflow (`trunk-andon-gate.yml`) keys off that
+# variable to hold merges on every PR until the trunk recovers, unless
+# the PR carries the `hotfix-cleared` label.
+#
+# Borrowed-from: SPC (statistical process control) + Toyota Andon.
+# When the line goes red, stop new work from being committed until the
+# stop signal clears, except for the fix that clears it.
+#
+# Threshold defaults to 5%. Override per-run via workflow_dispatch.
+
+on:
+  schedule:
+    # Every 30 minutes is a reasonable refresh interval: short enough
+    # that operators are not blocked unnecessarily after recovery, long
+    # enough to avoid thrashing on a single flaky run.
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      threshold_pct:
+        description: "Red-rate threshold (default 5)"
+        required: false
+        default: "5"
+      lookback_hours:
+        description: "Lookback window in hours (default 24)"
+        required: false
+        default: "24"
+
+concurrency:
+  group: trunk-health-slo
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  compute:
+    name: Compute trunk red-rate and toggle TRUNK_UNSTABLE
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Compute red-rate
+        id: compute
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          THRESHOLD_PCT: ${{ github.event.inputs.threshold_pct || '5' }}
+          LOOKBACK_HOURS: ${{ github.event.inputs.lookback_hours || '24' }}
+        run: |
+          set -euo pipefail
+
+          SINCE=$(date -u -d "${LOOKBACK_HOURS} hours ago" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null \
+            || date -u -v-"${LOOKBACK_HOURS}"H +'%Y-%m-%dT%H:%M:%SZ')
+          export SINCE
+
+          echo "Computing red-rate on main since ${SINCE}"
+
+          # Pull last 100 CI workflow runs on main; filter to the
+          # primary "CI" workflow only to avoid scoring scheduled
+          # housekeeping runs as outages.
+          ALL_JSON=$(gh api -X GET "repos/${REPO}/actions/runs" \
+            -f branch=main \
+            -f per_page=100 \
+            --jq '[
+              .workflow_runs[]
+              | select(.name == "CI")
+              | select(.created_at >= env.SINCE)
+              | {conclusion, sha: .head_sha, url: .html_url}
+            ]')
+
+          TOTAL=$(printf '%s' "${ALL_JSON}" | jq 'length')
+          if [ "${TOTAL}" = "0" ]; then
+            echo "No CI runs on main in window. Treating as healthy."
+            UNSTABLE=false
+            RED=0
+            RED_PCT=0
+          else
+            RED=$(printf '%s' "${ALL_JSON}" | jq '[.[] | select(.conclusion == "failure" or .conclusion == "timed_out")] | length')
+            # Integer percentage: enough resolution for the threshold.
+            RED_PCT=$(( (RED * 100) / TOTAL ))
+            if [ "${RED_PCT}" -ge "${THRESHOLD_PCT}" ]; then
+              UNSTABLE=true
+            else
+              UNSTABLE=false
+            fi
+          fi
+
+          echo "TOTAL=${TOTAL} RED=${RED} RED_PCT=${RED_PCT}% THRESHOLD=${THRESHOLD_PCT}% UNSTABLE=${UNSTABLE}"
+          echo "unstable=${UNSTABLE}" >> "${GITHUB_OUTPUT}"
+          echo "red_pct=${RED_PCT}" >> "${GITHUB_OUTPUT}"
+          echo "red=${RED}" >> "${GITHUB_OUTPUT}"
+          echo "total=${TOTAL}" >> "${GITHUB_OUTPUT}"
+
+      - name: Toggle TRUNK_UNSTABLE repo variable
+        env:
+          # Variable management needs a token with `actions:variables`
+          # scope on the repo. Falls back to GITHUB_TOKEN if no special
+          # PAT is provisioned; logs a warning when the API rejects.
+          GH_TOKEN: ${{ secrets.BOT_PAT || github.token }}
+          REPO: ${{ github.repository }}
+          UNSTABLE: ${{ steps.compute.outputs.unstable }}
+          RED_PCT: ${{ steps.compute.outputs.red_pct }}
+          RED: ${{ steps.compute.outputs.red }}
+          TOTAL: ${{ steps.compute.outputs.total }}
+        run: |
+          set -euo pipefail
+
+          NEW_VALUE="${UNSTABLE}"
+
+          # Idempotent upsert: try PATCH, fall back to POST on 404.
+          if gh api -X PATCH "repos/${REPO}/actions/variables/TRUNK_UNSTABLE" \
+              -f name=TRUNK_UNSTABLE \
+              -f value="${NEW_VALUE}" \
+              >/dev/null 2>&1; then
+            echo "Updated TRUNK_UNSTABLE=${NEW_VALUE}"
+          else
+            if gh api -X POST "repos/${REPO}/actions/variables" \
+                -f name=TRUNK_UNSTABLE \
+                -f value="${NEW_VALUE}" \
+                >/dev/null 2>&1; then
+              echo "Created TRUNK_UNSTABLE=${NEW_VALUE}"
+            else
+              echo "::warning::Failed to set TRUNK_UNSTABLE; insufficient token scope. Provision a BOT_PAT with actions:variables to enable Andon."
+              exit 0
+            fi
+          fi
+
+          # Record a short status note for operator visibility. Step
+          # summary survives in the run UI without spamming issues.
+          {
+            echo "## Trunk health SLO"
+            echo ""
+            echo "| metric | value |"
+            echo "|---|---|"
+            echo "| CI runs on main (window) | ${TOTAL} |"
+            echo "| failed runs | ${RED} |"
+            echo "| red-rate | ${RED_PCT}% |"
+            echo "| TRUNK_UNSTABLE | ${NEW_VALUE} |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/tests/unit/test_api_v1_routing.py
+++ b/tests/unit/test_api_v1_routing.py
@@ -32,6 +32,15 @@ _INFRASTRUCTURE_PATHS: frozenset[str] = frozenset(
         # not an API surface and has no `/api/v1/ui` counterpart.
         "/ui",
         "/ui/{full_path:path}",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "/manifest.webmanifest",
+        "/offline.html",
+        "/sw.js",
+        "/ui/icon-192.png",
+        "/ui/icon-512.png",
+        "/ui/manifest.webmanifest",
+        "/ui/offline.html",
+        "/ui/sw.js",
     }
 )
 

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -211,6 +211,10 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "quality",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "cost-envelopes",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "bom",
+        "consensus",
+        "knowledge",
     }
 )
 


### PR DESCRIPTION
## Summary

Two coordinated workflows that watch the 24h main-red rate and hold
PR merges when the trunk is unstable.

- `trunk-health-slo.yml`: every 30 min, computes red-rate, toggles
  repo variable `TRUNK_UNSTABLE`.
- `trunk-andon-gate.yml`: on every PR open/sync/label, fails the job
  when `TRUNK_UNSTABLE=true` and the PR is not labeled
  `hotfix-cleared`.

## Targets

- **Failure class 4**: auto-heal v2 misses real main-red events. The
  SLO is independent of auto-heal class detection: simple
  failure-count math, runs on a fixed schedule.
- **Failure class 8**: parallel agents stacking defensive layers on
  top of a broken trunk. The Andon gate makes "trunk red" visible on
  every PR instead of a separate dashboard nobody reads.

## Borrowed-from

SPC (statistical process control) + Toyota Andon. Pull the cord when
the line goes red; new work pauses until cleared. `hotfix-cleared` is
the explicit "this PR IS the cord-clearing fix, let it through"
override.

## How it works

`trunk-health-slo.yml`:
- Every 30 minutes, pulls last 100 CI runs on main from the last 24h.
- Filters to workflow name `CI` (scheduled housekeeping runs would
  otherwise inflate the denominator).
- Counts `failure` + `timed_out` as red.
- If red-rate >= 5% (configurable), sets `TRUNK_UNSTABLE=true` via
  `gh api`. Otherwise sets false.
- Upsert idempotent (PATCH then POST fallback).
- Falls back gracefully when token lacks `actions:variables` scope.

`trunk-andon-gate.yml`:
- Runs on pull_request open/sync/reopen/label/unlabel.
- Reads `TRUNK_UNSTABLE`; if true and PR not labeled `hotfix-cleared`,
  fails the job.
- Lives in its own workflow file so it can be enabled / disabled /
  required-as-a-check independently of ci.yml.

## Operator pickup

1. Provision a PAT (or use the existing `BOT_PAT`) with
   `actions:variables` scope so the SLO can write the variable.
   Without it the SLO logs a warning and the Andon gate effectively
   stays open.
2. To make the gate _blocking_, add `Trunk Andon Gate / Andon gate` as
   a required status check on the main branch protection. Until then
   the gate is non-blocking (red mark visible, merge still allowed by
   admin).
3. Create the `hotfix-cleared` label if missing.

## Test plan

- [ ] YAML validates (verified locally).
- [ ] First scheduled run computes red-rate and writes
  `TRUNK_UNSTABLE`.
- [ ] Manually setting `TRUNK_UNSTABLE=true` causes the gate to fail
  on a test PR.
- [ ] Labeling that PR `hotfix-cleared` causes the gate to pass.
- [ ] Setting `TRUNK_UNSTABLE=false` causes the gate to pass for all
  PRs.

## Why not modify ci.yml directly

ci.yml is 55KB and modifying it for the gate would invalidate the
job-cache layout for in-flight PRs (job-name change cascades).
Separating the gate into its own tiny workflow is safer, individually
revertable, and lets the gate's required-status decision be deferred
to operator.