### PR TITLE
fix(ci): auto-heal - explicitly trigger CI on heal PR branch

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -451,6 +451,20 @@ jobs:
           echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
+      - name: Trigger CI on heal PR branch
+        # PRs opened via secrets.GITHUB_TOKEN do not emit `pull_request`
+        # events for downstream workflows, so CI never auto-starts on the
+        # newly pushed heal branch. Dispatch ci.yml explicitly so a heal
+        # PR has green/red signal without requiring a human re-trigger.
+        # Best-effort: a dispatch failure must not block the heal PR.
+        if: steps.cordon.outputs.noop != 'true' && steps.open_pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAL_BRANCH: ci-heal/${{ needs.triage.outputs.short_sha }}
+        run: |
+          gh workflow run ci.yml --ref "${HEAL_BRANCH}" \
+            || echo "::warning::ci.yml dispatch failed for ${HEAL_BRANCH} -- PR review will trigger"
+
       - name: Capability 19 - SLSA build provenance attestation
         if: steps.cordon.outputs.noop != 'true'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
## Summary

PRs created via `secrets.GITHUB_TOKEN` do NOT emit `pull_request` events for downstream workflows, so a freshly opened auto-heal PR sits without any CI signal until a human re-triggers. This wires an explicit `gh workflow run ci.yml --ref ci-heal/<short_sha>` step right after the heal PR opens, so the v2 pipeline produces actionable green/red signal end to end.

The dispatch is best-effort: a permissions or transient API hiccup must not block the heal PR itself.

Operator pickup item 1 from the v2 audit `a3c4b51caf65f89f5`.

## Test plan

- [x] Workflow YAML still parses (yaml.safe_load OK; jobs unchanged)
- [x] `tests/unit/test_autoheal_workflow_yaml.py` + `tests/integration/test_autoheal_workflow.py` all pass against modified file (43/43)
- [ ] CI green
- [ ] Next real heal event end-to-end produces a heal PR with CI fired automatically (operator-observed)