### PR TITLE
fix(ci): zizmor - add version comments to SHA-pinned actions

### DIFF
--- a/.github/workflows/contract-drift-autofix.yml
+++ b/.github/workflows/contract-drift-autofix.yml
@@ -117,7 +117,7 @@ jobs:
           # source PR. GITHUB_TOKEN-authored pushes are muted by GitHub.
           token: ${{ secrets.BOT_PAT || secrets.GITHUB_TOKEN }}
 
-      - uses: astral-sh/setup-uv@00714ea9dc27830a1586fe47ef7ad28e4fd5db45 # v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Sync project (dev group)
         run: uv sync --group dev


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #237 (`zizmor/ref-version-mismatch`) on `.github/workflows/contract-drift-autofix.yml:120`.

The `astral-sh/setup-uv` step was SHA-pinned at commit `00714ea9` with a `# v7` comment, but `00714ea9` is an internal `chore: update known checksums for 0.11.12` commit, not the head of the `v7` tag. Zizmor reports the mismatch because the comment claims a tag that does not actually point at the pinned SHA.

Repinned to the v7.6.0 release commit (`37802adc94f370d6bfd71619e3f0bf239e1f3b78`, the current head of the `v7` tag) with a precise `# v7.6.0` comment, so the SHA and the comment agree.

Audited the other three SHA pins in the same file - all match their version comments:

| Line | Action | SHA | Comment | Status |
|------|--------|-----|---------|--------|
| 90   | step-security/harden-runner | ab7a9404 | v2.19.3 | OK |
| 112  | actions/checkout | de0fac2e | v6 | OK |
| 120  | astral-sh/setup-uv | 37802adc | v7.6.0 | FIXED |
| 260  | actions/github-script | 3a2844b7 | v9.0.0 | OK |

## Test plan

- [x] `uvx zizmor .github/workflows/contract-drift-autofix.yml` reports no findings
- [ ] CI green
- [ ] CodeQL alert #237 auto-closes (or dismiss manually after merge)