### PR TITLE
feat(ci): advisory PR push-lock for parallel-agent waves (EDGE-6)

### DIFF
--- a/scripts/pr_push_lock.sh
+++ b/scripts/pr_push_lock.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# Advisory PR push-lock for parallel-agent waves.
+#
+# Refs: edge-hardening EDGE-6 (premortem p=0.30). See
+# personal_core_services/.sdd/docs/playbooks/multi_pr_landing_wave.md
+# (section "Advisory push-lock for parallel agents") for the full
+# convention.
+#
+# Usage:
+#   pr_push_lock.sh acquire <pr-number> <agent-id> [ttl-seconds]
+#   pr_push_lock.sh release <pr-number> <agent-id>
+#   pr_push_lock.sh status  <pr-number>
+#
+# Exit codes:
+#   0 - lock acquired (acquire), released (release), or free (status)
+#   1 - lock held by another agent (acquire failed after retries)
+#   2 - usage error
+#
+# Advisory only: no filesystem locks, no kernel arbitration. Each
+# cooperating agent must consult this script before pushing to a PR
+# head ref. Non-cooperating tools (git itself, gh CLI direct invocation)
+# are not bound and rely on --force-with-lease for data safety.
+
+set -u
+set -o pipefail
+
+LOCK_FILE="${PR_PUSH_LOCK_FILE:-.sdd/runtime/pr_push_lock.jsonl}"
+DEFAULT_TTL_SEC="${PR_PUSH_LOCK_DEFAULT_TTL_SEC:-600}"
+RETRY_COUNT="${PR_PUSH_LOCK_RETRY_COUNT:-5}"
+RETRY_SLEEP_SEC="${PR_PUSH_LOCK_RETRY_SLEEP_SEC:-30}"
+
+now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+now_epoch() {
+  date -u +%s
+}
+
+iso_to_epoch() {
+  local v="$1"
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$v" +%s 2>/dev/null \
+    || date -u -d "$v" +%s 2>/dev/null \
+    || echo 0
+}
+
+usage() {
+  cat <<'EOF' >&2
+Usage:
+  pr_push_lock.sh acquire <pr-number> <agent-id> [ttl-seconds]
+  pr_push_lock.sh release <pr-number> <agent-id>
+  pr_push_lock.sh status  <pr-number>
+EOF
+  exit 2
+}
+
+ensure_lock_dir() {
+  local dir
+  dir=$(dirname "$LOCK_FILE")
+  [ -d "$dir" ] || mkdir -p "$dir"
+  [ -f "$LOCK_FILE" ] || : > "$LOCK_FILE"
+}
+
+# Print the most recent unreleased, unexpired record for a PR, or empty.
+# Output: "<agent>\t<expires_iso>" or empty if no holder.
+#
+# Implementation: portable bash/grep/sed (no gawk extensions). Reads the
+# lock file in reverse, tracks released agents, returns the first active
+# acquire record that is not subsequently released.
+current_holder() {
+  local pr="$1"
+  [ -f "$LOCK_FILE" ] || return 0
+  local pr_pattern="\"pr\"[[:space:]]*:[[:space:]]*${pr}([^0-9]|$)"
+  local -a released_agents=()
+
+  # Read newest first via tac fallback (BSD has no tac).
+  local lines
+  if command -v tac >/dev/null 2>&1; then
+    lines=$(tac "$LOCK_FILE")
+  else
+    lines=$(tail -r "$LOCK_FILE" 2>/dev/null || awk '{a[NR]=$0} END{for(i=NR;i>=1;i--) print a[i]}' "$LOCK_FILE")
+  fi
+
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Match this PR only.
+    if ! echo "$line" | grep -qE "$pr_pattern"; then
+      continue
+    fi
+    local agent
+    agent=$(echo "$line" | sed -n 's/.*"agent"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    [ -z "$agent" ] && continue
+    # If this is a release record, remember the agent and skip.
+    if echo "$line" | grep -q '"released_at"'; then
+      released_agents+=("$agent")
+      continue
+    fi
+    # Active acquire record. Check if a later release matches this agent.
+    local already_released=0
+    local r
+    for r in "${released_agents[@]+"${released_agents[@]}"}"; do
+      if [ "$r" = "$agent" ]; then
+        already_released=1
+        break
+      fi
+    done
+    [ "$already_released" = "1" ] && continue
+    local expires_iso
+    expires_iso=$(echo "$line" | sed -n 's/.*"expires_at"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    printf '%s\t%s\n' "$agent" "$expires_iso"
+    return 0
+  done <<< "$lines"
+}
+
+is_expired() {
+  local expires_iso="$1"
+  [ -z "$expires_iso" ] && return 0
+  local exp_e
+  exp_e=$(iso_to_epoch "$expires_iso")
+  [ "$exp_e" -eq 0 ] && return 0
+  local now_e
+  now_e=$(now_epoch)
+  [ "$now_e" -ge "$exp_e" ]
+}
+
+acquire() {
+  local pr="$1"
+  local agent="$2"
+  local ttl="${3:-$DEFAULT_TTL_SEC}"
+  ensure_lock_dir
+  local attempt
+  for ((attempt=1; attempt<=RETRY_COUNT; attempt++)); do
+    local holder
+    holder=$(current_holder "$pr")
+    if [ -z "$holder" ]; then
+      break
+    fi
+    local cur_agent cur_exp
+    cur_agent=$(echo "$holder" | cut -f1)
+    cur_exp=$(echo "$holder" | cut -f2)
+    if [ "$cur_agent" = "$agent" ]; then
+      # We already hold it; refresh.
+      break
+    fi
+    if is_expired "$cur_exp"; then
+      break
+    fi
+    echo "pr=$pr held by $cur_agent until $cur_exp (attempt $attempt/$RETRY_COUNT)" >&2
+    if [ "$attempt" -lt "$RETRY_COUNT" ]; then
+      sleep "$RETRY_SLEEP_SEC"
+    fi
+  done
+  # Re-check after retries. Only block if the lock is held by a
+  # DIFFERENT agent AND has not yet expired. Expired locks are treated
+  # as free here (the natural expiry path).
+  local final_holder
+  final_holder=$(current_holder "$pr")
+  if [ -n "$final_holder" ]; then
+    local final_agent final_exp
+    final_agent=$(echo "$final_holder" | cut -f1)
+    final_exp=$(echo "$final_holder" | cut -f2)
+    if [ "$final_agent" != "$agent" ] && ! is_expired "$final_exp"; then
+      echo "skipping pr=$pr reason=lock-held-by=$final_agent" >&2
+      return 1
+    fi
+  fi
+  local started expires
+  started=$(now_iso)
+  local started_e
+  started_e=$(now_epoch)
+  local expires_e=$((started_e + ttl))
+  expires=$(date -u -r "$expires_e" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || date -u -d "@$expires_e" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+    || echo "")
+  printf '{"pr":%s,"agent":"%s","started_at":"%s","expires_at":"%s"}\n' \
+    "$pr" "$agent" "$started" "$expires" >> "$LOCK_FILE"
+  echo "acquired pr=$pr agent=$agent expires=$expires"
+  return 0
+}
+
+release() {
+  local pr="$1"
+  local agent="$2"
+  ensure_lock_dir
+  local released
+  released=$(now_iso)
+  printf '{"pr":%s,"agent":"%s","released_at":"%s"}\n' \
+    "$pr" "$agent" "$released" >> "$LOCK_FILE"
+  echo "released pr=$pr agent=$agent at=$released"
+  return 0
+}
+
+status() {
+  local pr="$1"
+  local holder
+  holder=$(current_holder "$pr")
+  if [ -z "$holder" ]; then
+    echo "pr=$pr lock=free"
+    return 0
+  fi
+  local cur_agent cur_exp
+  cur_agent=$(echo "$holder" | cut -f1)
+  cur_exp=$(echo "$holder" | cut -f2)
+  if is_expired "$cur_exp"; then
+    echo "pr=$pr lock=expired prev_agent=$cur_agent prev_expires=$cur_exp"
+  else
+    echo "pr=$pr lock=held agent=$cur_agent expires=$cur_exp"
+  fi
+  return 0
+}
+
+[ "$#" -ge 1 ] || usage
+op="$1"
+shift
+case "$op" in
+  acquire)
+    [ "$#" -ge 2 ] || usage
+    acquire "$@"
+    ;;
+  release)
+    [ "$#" -ge 2 ] || usage
+    release "$@"
+    ;;
+  status)
+    [ "$#" -ge 1 ] || usage
+    status "$@"
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/tests/unit/test_pr_push_lock.py
+++ b/tests/unit/test_pr_push_lock.py
@@ -1,0 +1,117 @@
+"""Unit tests for scripts/pr_push_lock.sh - advisory parallel-agent PR lock.
+
+Refs: edge-hardening EDGE-6 (premortem p=0.30).
+
+Tests cover the cooperative contract documented in
+personal_core_services/.sdd/docs/playbooks/multi_pr_landing_wave.md
+under "Advisory push-lock for parallel agents":
+  * free file -> status 'free'
+  * acquire creates an active record; status -> 'held'
+  * release appends a release record; status -> 'free'
+  * second agent on held lock -> exit 1 with 'skipping' message
+  * expired lock is reclaimable
+  * different PRs are independent
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "pr_push_lock.sh"
+
+
+def _run(args: list[str], lock_file: Path, **env_extra: str):
+    """Run pr_push_lock.sh with isolated lock file + fast retry params."""
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+        "PR_PUSH_LOCK_FILE": str(lock_file),
+        "PR_PUSH_LOCK_RETRY_COUNT": "2",
+        "PR_PUSH_LOCK_RETRY_SLEEP_SEC": "0",
+        **env_extra,
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_script_exists_and_is_executable() -> None:
+    assert SCRIPT.exists(), "scripts/pr_push_lock.sh must exist"
+    assert SCRIPT.stat().st_mode & 0o111, "scripts/pr_push_lock.sh must be executable"
+
+
+def test_status_on_missing_lock_file_reports_free(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.jsonl"
+    result = _run(["status", "1452"], lock)
+    assert result.returncode == 0, result.stderr
+    assert "lock=free" in result.stdout
+
+
+def test_acquire_then_status_held(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.jsonl"
+    acq = _run(["acquire", "1452", "agent-a", "600"], lock)
+    assert acq.returncode == 0, acq.stderr
+    assert "acquired" in acq.stdout
+
+    status = _run(["status", "1452"], lock)
+    assert status.returncode == 0, status.stderr
+    assert "lock=held" in status.stdout
+    assert "agent=agent-a" in status.stdout
+
+
+def test_release_makes_lock_free(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.jsonl"
+    _run(["acquire", "1452", "agent-a", "600"], lock)
+    rel = _run(["release", "1452", "agent-a"], lock)
+    assert rel.returncode == 0, rel.stderr
+    assert "released" in rel.stdout
+
+    status = _run(["status", "1452"], lock)
+    assert "lock=free" in status.stdout
+
+
+def test_second_agent_blocked_on_held_lock(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.jsonl"
+    _run(["acquire", "1452", "agent-a", "600"], lock)
+    result = _run(["acquire", "1452", "agent-b", "600"], lock)
+    assert result.returncode == 1, (
+        f"second agent must exit 1 when lock is held. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "lock-held-by=agent-a" in result.stderr
+
+
+def test_different_prs_independent(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.jsonl"
+    a = _run(["acquire", "1452", "agent-a", "600"], lock)
+    b = _run(["acquire", "1453", "agent-b", "600"], lock)
+    assert a.returncode == 0 and b.returncode == 0, (a.stderr, b.stderr)
+    assert "lock=held" in _run(["status", "1452"], lock).stdout
+    assert "lock=held" in _run(["status", "1453"], lock).stdout
+
+
+def test_expired_lock_can_be_reclaimed(tmp_path: Path) -> None:
+    lock = tmp_path / "lock.jsonl"
+    # Acquire with 1-second TTL, sleep past expiry, then re-acquire as
+    # a different agent. The expired record must NOT block the new one.
+    a = _run(["acquire", "1452", "agent-a", "1"], lock)
+    assert a.returncode == 0, a.stderr
+    time.sleep(2)
+    b = _run(["acquire", "1452", "agent-b", "600"], lock)
+    assert b.returncode == 0, f"expired lock should be reclaimable. stdout={b.stdout!r} stderr={b.stderr!r}"
+    assert "acquired" in b.stdout
+    status = _run(["status", "1452"], lock)
+    assert "agent=agent-b" in status.stdout
+
+
+def test_same_agent_reacquire_succeeds(tmp_path: Path) -> None:
+    """An agent that already holds the lock can re-acquire (refresh)."""
+    lock = tmp_path / "lock.jsonl"
+    a1 = _run(["acquire", "1452", "agent-a", "600"], lock)
+    a2 = _run(["acquire", "1452", "agent-a", "600"], lock)
+    assert a1.returncode == 0 and a2.returncode == 0


### PR DESCRIPTION
## Summary
- Adds `scripts/pr_push_lock.sh` (acquire/release/status verbs) and 8 unit tests for cooperative agent push coordination.
- JSONL-append lock file lives at `.sdd/runtime/pr_push_lock.jsonl` (already gitignored per repo convention).
- Companion playbook section in `personal_core_services/.sdd/docs/playbooks/multi_pr_landing_wave.md` under 'Advisory push-lock for parallel agents'.

## Why
Watchdog + polish-verify + META hardening + hand-dispatched shepherds may all touch the same PR head ref. git's native `--force-with-lease` is correct for data safety but produces failed pushes that need retry logic. Advisory lock lets cooperating agents back off voluntarily and save compute on lease-rejected re-pushes.

EDGE-6 of the META-engineering edge-hardening wave. Premortem p=0.30.

## Properties
- Advisory only - no kernel locks, no fsync, no fcntl. Non-cooperating tools (raw git, gh CLI) are not bound; `--force-with-lease` remains the actual data-safety rail.
- 10-minute default TTL with graceful expiry (crashed agents do not leave permanent locks).
- Same agent can re-acquire (refresh).
- Different PRs are fully independent.
- shellcheck-clean.

## Test plan
- [x] `uv run pytest tests/unit/test_pr_push_lock.py -v` 8/8 pass
- [x] `shellcheck scripts/pr_push_lock.sh` clean
- [x] Manual smoke: acquire, contend, release, expire/reclaim, cross-PR independence
- [ ] CI green on this PR