### PR TITLE
feat(ci): GH API rate-limit guard for long-running agent loops (EDGE-7)

### DIFF
--- a/scripts/gh_rate_limit_guard.sh
+++ b/scripts/gh_rate_limit_guard.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# GitHub API rate-limit guard for long-running loops.
+#
+# Refs: edge-hardening EDGE-7 (premortem p=0.15).
+#
+# Wraps `gh api rate_limit` and emits a verdict suitable for use in a
+# loop's per-iteration preflight. The watchdog and other long-running
+# agent scripts source/call this guard to back off when burn rate is
+# unsafe, rather than waiting for a 403 mid-iteration.
+#
+# Usage:
+#   source scripts/gh_rate_limit_guard.sh
+#   if ! gh_rate_limit_ok 500; then
+#     # remaining < 500: back off
+#     sleep 1800
+#     continue
+#   fi
+#
+# Or stand-alone:
+#   scripts/gh_rate_limit_guard.sh check 500
+#     -> exit 0 (remaining >= threshold)
+#     -> exit 1 (remaining < threshold; also prints "remaining=N" to stderr)
+#     -> exit 2 (API call failed or jq missing)
+#
+# Conservative default threshold is 500 / 5000 (10%). At 30-min cadence
+# with a 5-PR wave, watchdog burns ~30 calls per iteration; threshold
+# leaves ~16 iterations of headroom before exhaustion.
+
+set -u
+
+DEFAULT_THRESHOLD=500
+
+# Returns 0 if remaining-core >= threshold, 1 if below, 2 on error.
+# Prints "remaining=<N> threshold=<T>" to stderr on non-OK paths.
+gh_rate_limit_ok() {
+  local threshold="${1:-$DEFAULT_THRESHOLD}"
+  command -v gh >/dev/null 2>&1 || return 2
+  command -v jq >/dev/null 2>&1 || return 2
+  local remaining
+  remaining=$(gh api rate_limit --jq '.resources.core.remaining' 2>/dev/null) || return 2
+  case "$remaining" in
+    ''|*[!0-9]*) return 2 ;;
+  esac
+  if [ "$remaining" -lt "$threshold" ]; then
+    local reset
+    reset=$(gh api rate_limit --jq '.resources.core.reset' 2>/dev/null || echo "?")
+    echo "rate_limit_low remaining=$remaining threshold=$threshold reset_at_epoch=$reset" >&2
+    return 1
+  fi
+  return 0
+}
+
+# CLI mode: same exit codes as the function.
+if [ "${BASH_SOURCE[0]:-}" = "${0}" ] && [ "${1:-}" = "check" ]; then
+  shift
+  gh_rate_limit_ok "${1:-$DEFAULT_THRESHOLD}"
+  exit $?
+fi

--- a/tests/unit/test_gh_rate_limit_guard.py
+++ b/tests/unit/test_gh_rate_limit_guard.py
@@ -1,0 +1,146 @@
+"""Unit tests for scripts/gh_rate_limit_guard.sh.
+
+Refs: edge-hardening EDGE-7 (premortem p=0.15).
+
+Tests use a shim PATH that injects a fake `gh` binary returning known
+JSON. This isolates the test from the real GitHub API and lets us
+exercise both the OK and rate-limit-low branches.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "gh_rate_limit_guard.sh"
+
+
+def _write_fake_gh(tmp_path: Path, remaining: int) -> Path:
+    """Write a fake `gh` shim that returns a fixed remaining count.
+
+    The guard calls `gh api rate_limit --jq '.resources.core.remaining'`.
+    Our shim ignores --jq and just prints the value directly; the guard
+    pipes the JSON through gh's own --jq so we mimic that by just
+    printing the number when --jq is present, or the full JSON otherwise.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake = bin_dir / "gh"
+    fake.write_text(
+        f"""#!/usr/bin/env bash
+# Fake gh for EDGE-7 rate-limit-guard tests.
+# Args observed in the guard:
+#   gh api rate_limit --jq '.resources.core.remaining'
+#   gh api rate_limit --jq '.resources.core.reset'
+case "$*" in
+  *--jq*'.resources.core.remaining'*)
+    echo {remaining}
+    ;;
+  *--jq*'.resources.core.reset'*)
+    echo 1700000000
+    ;;
+  *)
+    cat <<EOF
+{{
+  "resources": {{
+    "core": {{ "remaining": {remaining}, "reset": 1700000000 }}
+  }}
+}}
+EOF
+    ;;
+esac
+exit 0
+"""
+    )
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _run(threshold: int, fake_bin_dir: Path):
+    env = {
+        "PATH": f"{fake_bin_dir}:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), "check", str(threshold)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_guard_passes_when_remaining_above_threshold(tmp_path: Path) -> None:
+    bin_dir = _write_fake_gh(tmp_path, remaining=3000)
+    result = _run(500, bin_dir)
+    assert result.returncode == 0, (
+        f"guard should pass when remaining > threshold. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_guard_fails_when_remaining_below_threshold(tmp_path: Path) -> None:
+    bin_dir = _write_fake_gh(tmp_path, remaining=100)
+    result = _run(500, bin_dir)
+    assert result.returncode == 1, result.stderr
+    assert "rate_limit_low" in result.stderr
+    assert "remaining=100" in result.stderr
+    assert "threshold=500" in result.stderr
+
+
+def test_guard_fails_when_remaining_equals_threshold_minus_one(tmp_path: Path) -> None:
+    """Boundary: threshold of 500 means remaining < 500 fails."""
+    bin_dir = _write_fake_gh(tmp_path, remaining=499)
+    result = _run(500, bin_dir)
+    assert result.returncode == 1
+
+
+def test_guard_passes_when_remaining_equals_threshold(tmp_path: Path) -> None:
+    """Boundary: remaining == threshold is OK (>=)."""
+    bin_dir = _write_fake_gh(tmp_path, remaining=500)
+    result = _run(500, bin_dir)
+    assert result.returncode == 0
+
+
+def test_guard_returns_2_when_gh_missing(tmp_path: Path) -> None:
+    """If gh is not on PATH the guard must NOT silently say OK.
+
+    The fake bin dir contains only `bash` (symlinked to the real one)
+    so the guard's `command -v gh` call returns nothing.
+    """
+    bin_dir = tmp_path / "min_bin"
+    bin_dir.mkdir()
+    bash_path = shutil.which("bash") or "/bin/bash"
+    os.symlink(bash_path, bin_dir / "bash")
+    # No `gh` shim here.
+    env = {"PATH": str(bin_dir)}
+    result = subprocess.run(
+        [str(bin_dir / "bash"), str(SCRIPT), "check", "500"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 2, (
+        f"missing gh must fail-loud with exit 2, not silently pass. stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_script_is_executable() -> None:
+    assert SCRIPT.exists()
+    assert SCRIPT.stat().st_mode & 0o111
+
+
+def test_script_passes_shellcheck() -> None:
+    """If shellcheck is installed, the guard must be lint-clean."""
+    if not shutil.which("shellcheck"):
+        return  # silent skip; CI has shellcheck and will enforce
+    result = subprocess.run(
+        ["shellcheck", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"shellcheck flagged the guard:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Summary
- Adds `scripts/gh_rate_limit_guard.sh` - sourceable/CLI guard wrapping `gh api rate_limit`.
- Default threshold 500/5000 (10%) leaves ~16 iterations of headroom for the watchdog's burn rate.
- 7 unit tests using a fake `gh` shim cover OK / low / boundary / missing-gh / shellcheck.
- Live `.sdd/runtime/pr_watchdog_loop.sh` patched in-place to source the guard (the watchdog file is gitignored so it cannot ship via this PR).

## Why
Watchdog polls `gh pr list` every 30 min. With 5+ active PRs each iteration burns ~30 API calls. Over 10 h that is 600 calls - well under the 5000/h limit, but burst from `gh pr checks --watch` can spike. Without a preflight, a 403 mid-iteration leaves the watchdog in an inconsistent state.

EDGE-7 of the META-engineering edge-hardening wave. Premortem p=0.15.

## Properties
- Reusable: any long-running loop can `source scripts/gh_rate_limit_guard.sh` and call `gh_rate_limit_ok N`.
- Fails-loud: missing `gh` or `jq` returns exit 2, not silent OK.
- No new deps: uses gh + jq already required by the watchdog.
- shellcheck-clean.

## Test plan
- [x] `uv run pytest tests/unit/test_gh_rate_limit_guard.py -v` 7/7 pass
- [x] `shellcheck scripts/gh_rate_limit_guard.sh` clean
- [x] Live watchdog patch verified `bash -n` clean (existing SC2034/SC2155 warnings predate this patch)
- [ ] CI green on this PR