### PR TITLE
feat(ci): idempotency self-check in regen_contract_drift (META F)

### DIFF
--- a/scripts/regen_contract_drift.py
+++ b/scripts/regen_contract_drift.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import argparse
 import inspect
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -338,6 +339,78 @@ FIXTURES = {
     "cli_run_callback": regen_cli_run_callback,
 }
 
+# Exit code used when the self-check trips. Anything non-{0,1} is fine; we pick
+# 2 to be distinct from "no changes" (1) and "wrote changes" (0).
+SELF_CHECK_FAIL_EXIT_CODE = 2
+
+
+def _run_regen_logic(targets: list[str]) -> bool:
+    """Run the requested fixture regen functions and return True iff any wrote."""
+    any_changed = False
+    for name in targets:
+        print(f"[regen] running {name}")
+        try:
+            changed = FIXTURES[name]()
+        except Exception as exc:
+            print(f"[regen] {name}: FAILED ({exc.__class__.__name__}: {exc})", file=sys.stderr)
+            continue
+        any_changed = any_changed or changed
+    return any_changed
+
+
+def _git_diff_is_clean() -> bool:
+    """Return True iff the working tree has no unstaged changes.
+
+    Used by the idempotency self-check to detect whether a second regen pass
+    introduced new edits on top of an otherwise-clean tree. Falls back to
+    ``True`` (clean) when git is unavailable so the self-check still acts as a
+    fixture-level guard via the returned ``any_changed`` flag.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--quiet"],
+            capture_output=True,
+            cwd=str(REPO_ROOT),
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        # No git binary; can't compare. Treat as clean and rely on the
+        # fixture-level any_changed check below.
+        return True
+    return result.returncode == 0
+
+
+def _self_check_idempotent(targets: list[str], initial_clean: bool) -> bool:
+    """Re-run regen against just-written tree; return False if non-idempotent.
+
+    A regen step is idempotent when running it against its own output produces
+    no further changes. We assert this two ways:
+
+    1. Fixture level: the second pass must report ``any_changed == False``.
+    2. Working-tree level: if the tree was clean before the first pass, it must
+       remain clean (or at least not gain new diff) after the second pass.
+
+    Returns True when both checks pass, False otherwise.
+    """
+    print("[regen] self-check: re-running regen to verify idempotency")
+    second_any_changed = _run_regen_logic(targets)
+    second_clean = _git_diff_is_clean()
+
+    if second_any_changed:
+        print(
+            "ERROR: regen produced new fixture-level changes on second run (non-idempotent). Aborting.",
+            file=sys.stderr,
+        )
+        return False
+    if initial_clean and not second_clean:
+        print(
+            "ERROR: regen produced new diff on second run (non-idempotent). Aborting.",
+            file=sys.stderr,
+        )
+        return False
+    print("[regen] self-check: OK")
+    return True
+
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -346,6 +419,14 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         choices=[*FIXTURES.keys(), "all"],
         help="Which contract fixture to regenerate.",
+    )
+    parser.add_argument(
+        "--skip-self-check",
+        action="store_true",
+        help=(
+            "Skip the idempotency self-check that re-runs regen and verifies "
+            "no further changes are produced. Useful for debugging."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -356,15 +437,18 @@ def main(argv: list[str] | None = None) -> int:
         sys.path.insert(0, str(src_dir))
 
     targets = list(FIXTURES.keys()) if args.fixture == "all" else [args.fixture]
-    any_changed = False
-    for name in targets:
-        print(f"[regen] running {name}")
-        try:
-            changed = FIXTURES[name]()
-        except Exception as exc:
-            print(f"[regen] {name}: FAILED ({exc.__class__.__name__}: {exc})", file=sys.stderr)
-            continue
-        any_changed = any_changed or changed
+
+    # Snapshot working-tree cleanliness before the first pass so the self-check
+    # can distinguish "we wrote our own diff" from "we keep adding diff on
+    # every invocation".
+    initial_clean = _git_diff_is_clean()
+
+    any_changed = _run_regen_logic(targets)
+
+    if not args.skip_self_check:
+        ok = _self_check_idempotent(targets, initial_clean=initial_clean)
+        if not ok:
+            return SELF_CHECK_FAIL_EXIT_CODE
 
     return 0 if any_changed else 1
 

--- a/tests/unit/test_regen_contract_drift.py
+++ b/tests/unit/test_regen_contract_drift.py
@@ -1,0 +1,127 @@
+"""Unit tests for ``scripts/regen_contract_drift.py``.
+
+Focused on the idempotency self-check (feat:META F): a second regen pass
+against the just-written tree must not produce further changes. If it does,
+the script must exit with the dedicated self-check failure code so the bot
+push job aborts rather than landing churn.
+
+The fixture-regen helpers themselves are exercised indirectly via integration
+runs; these tests stub them out so the self-check path can be tested in
+isolation without touching real source files.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "regen_contract_drift.py"
+
+
+@pytest.fixture
+def regen_module():
+    """Load scripts/regen_contract_drift.py as a module without executing main()."""
+    spec = importlib.util.spec_from_file_location("regen_contract_drift_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _make_stub_fixture(sequence: list[bool]) -> Callable[[], bool]:
+    """Build a stub regen function that returns successive items from ``sequence``.
+
+    Each call pops the head; once exhausted, returns ``False`` (idempotent).
+    Mirrors the real fixture contract of ``True == wrote changes``.
+    """
+
+    def _stub() -> bool:
+        return sequence.pop(0) if sequence else False
+
+    return _stub
+
+
+def test_self_check_passes_when_regen_is_idempotent(regen_module, monkeypatch):
+    """Happy path: first call writes, second call is a no-op. Exit code 0."""
+    # First call returns True (wrote changes); subsequent calls return False
+    # (idempotent). This matches how a correct fixture-regen behaves.
+    stub = _make_stub_fixture([True])
+    monkeypatch.setattr(regen_module, "FIXTURES", {"DOCUMENTED_COMMANDS": stub}, raising=True)
+    # Force the working-tree probe to report "clean" both before and after so
+    # the test does not depend on the host repo state. We patch the helper
+    # rather than spawning git.
+    monkeypatch.setattr(regen_module, "_git_diff_is_clean", lambda: True)
+
+    exit_code = regen_module.main(["--fixture", "DOCUMENTED_COMMANDS"])
+
+    assert exit_code == 0, "idempotent regen should exit 0 when first pass wrote"
+
+
+def test_self_check_aborts_when_fixture_keeps_writing(regen_module, monkeypatch, capsys):
+    """Negative: fixture reports True twice in a row -> abort with code 2."""
+    # Stub keeps returning True forever — i.e. the regen is non-idempotent and
+    # would keep editing the file on every pass. The self-check must catch this.
+    stub = _make_stub_fixture([True, True, True])
+    monkeypatch.setattr(regen_module, "FIXTURES", {"DOCUMENTED_COMMANDS": stub}, raising=True)
+    monkeypatch.setattr(regen_module, "_git_diff_is_clean", lambda: True)
+
+    exit_code = regen_module.main(["--fixture", "DOCUMENTED_COMMANDS"])
+
+    assert exit_code == regen_module.SELF_CHECK_FAIL_EXIT_CODE
+    err = capsys.readouterr().err
+    assert "non-idempotent" in err.lower()
+
+
+def test_self_check_aborts_when_git_diff_dirties_on_second_pass(regen_module, monkeypatch, capsys):
+    """Negative: fixture lies about idempotency but git diff catches it.
+
+    Simulates the case where a fixture returns ``False`` on the second pass
+    (claiming nothing to do) yet still mutates files. The git-diff probe
+    detects the resulting dirty tree and trips the self-check.
+    """
+    # Fixture reports True once, then False — but the working-tree check flips
+    # from clean to dirty between the two passes, mimicking a stealth write.
+    stub = _make_stub_fixture([True, False])
+    monkeypatch.setattr(regen_module, "FIXTURES", {"DOCUMENTED_COMMANDS": stub}, raising=True)
+
+    diff_results = iter([True, False])  # initial=clean, post-second-pass=dirty
+
+    def _fake_diff_clean() -> bool:
+        return next(diff_results)
+
+    monkeypatch.setattr(regen_module, "_git_diff_is_clean", _fake_diff_clean)
+
+    exit_code = regen_module.main(["--fixture", "DOCUMENTED_COMMANDS"])
+
+    assert exit_code == regen_module.SELF_CHECK_FAIL_EXIT_CODE
+    err = capsys.readouterr().err
+    assert "non-idempotent" in err.lower()
+
+
+def test_skip_self_check_flag_disables_second_pass(regen_module, monkeypatch):
+    """``--skip-self-check`` must bypass the re-run guard for debugging use."""
+    call_count = {"n": 0}
+
+    def _counting_stub() -> bool:
+        call_count["n"] += 1
+        return True  # would trip the self-check if run
+
+    monkeypatch.setattr(
+        regen_module,
+        "FIXTURES",
+        {"DOCUMENTED_COMMANDS": _counting_stub},
+        raising=True,
+    )
+    monkeypatch.setattr(regen_module, "_git_diff_is_clean", lambda: True)
+
+    exit_code = regen_module.main(["--fixture", "DOCUMENTED_COMMANDS", "--skip-self-check"])
+
+    assert call_count["n"] == 1, "fixture should run exactly once when self-check skipped"
+    assert exit_code == 0


### PR DESCRIPTION
## Summary

Adds an idempotency self-check to `scripts/regen_contract_drift.py`. After the primary regen pass completes, the script re-runs all selected fixtures and asserts:

1. No fixture reports further changes (fixture-level check).
2. The working tree does not gain new diff between the two passes (git-level check).

If either trips, the script exits with code `2` so the autofix workflow surfaces non-idempotent regen logic before it lands and creates churn PRs.

A `--skip-self-check` flag is preserved for local debugging.

Failure-class F from the META analysis; ref #1273.

## Test plan

- [x] New `tests/unit/test_regen_contract_drift.py` covers four cases:
  - Happy path: first call writes, second call is a no-op, exit 0.
  - Fixture-level non-idempotency: fixture keeps returning `True`, exit 2.
  - Git-diff non-idempotency: fixture lies but tree dirties, exit 2.
  - `--skip-self-check` bypasses the second pass.
- [x] End-to-end sanity: `uv run python scripts/regen_contract_drift.py --fixture all` against current main is idempotent.
- [x] `uv run ruff check` / `ruff format` clean.
- [x] `uv run pytest tests/unit/test_regen_contract_drift.py` passes (4/4).