### PR TITLE
fix(ci): branch-scoped concurrency to drain runner queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,14 @@ on:
 #     when two merges landed in quick succession.
 #
 # The conditional in `group:` selects the right key per event type, and
-# `cancel-in-progress` only fires for pull_request events.
+# `cancel-in-progress` fires for both pull_request and push: a rapid
+# wave of merges on `main` (13 commits in 90 min during the May 2026
+# META wave) used to saturate the runner queue because each sha-unique
+# group kept its own full-matrix run alive. Branch-scoped grouping +
+# always-cancel-in-progress lets the latest push supersede stale ones.
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('sha-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('branch-{0}', github.ref) }}
+  cancel-in-progress: true
 
 jobs:
   # ─── Planner (determines which downstream jobs may legitimately skip) ──


### PR DESCRIPTION
## Why

CI runner queue saturated during the May 2026 META wave - 13 commits landed on \`main\` in 90 min and **no CI run completed for the entire 90-min window**. Root cause: concurrency group was sha-unique on push events with \`cancel-in-progress\` only firing for pull_request. Each merge spawned its own full-matrix run that never superseded the previous queued one.

## What

- Group push events by branch ref (\`branch-{github.ref}\`) instead of sha.
- Set \`cancel-in-progress: true\` unconditionally so the newest push to main cancels older queued matrices on the same branch.
- Pull-request behavior unchanged (already correctly grouped by PR number and cancelling).

## Test

After this PR merges, the next rapid wave of pushes to main should leave only the newest sha's run queued; older ones will auto-cancel via concurrency rather than sit blocking runners.

Manual cleanup already done: 5 stale queued runs cancelled to clear the immediate backlog.

## Related

- Partially mitigates issue #1468 (macOS runner saturation).
- Trunk Andon gate (#1456) and bisect-on-red (#1457) both rely on CI runs actually completing to function; this fix unblocks them.