### PR TITLE
fix(ci): repair main ccd26da16 - 3 root causes

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,8 +1,16 @@
 name: Release Please
 
 on:
-  push:
-    branches: [main]
+  # Disabled-by-default: only fires when an operator runs the workflow
+  # manually from the Actions UI. Re-enable automatic main-branch runs by
+  # uncommenting the ``push`` trigger below once the operator has enabled
+  # "Allow GitHub Actions to create and approve pull requests" under Repo
+  # Settings -> Actions, OR has provided a fine-grained PAT via
+  # ``secrets.RELEASE_PLEASE_PAT`` and swapped the token below.
+  # See docs/maintainers/ci-apps.md.
+  workflow_dispatch:
+  # push:
+  #   branches: [main]
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -17,11 +25,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Disabled until the operator enables "Allow GitHub Actions to create
-    # and approve pull requests" under Repo Settings → Actions, OR provides
-    # a fine-grained PAT via ``secrets.RELEASE_PLEASE_PAT`` and swaps the
-    # token below. See docs/maintainers/ci-apps.md.
-    if: false
     steps:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:

--- a/tests/unit/test_gui_cli.py
+++ b/tests/unit/test_gui_cli.py
@@ -313,7 +313,12 @@ def test_cli_serve_with_tunnel_prints_onboarding(
 ) -> None:
     _patch_uvicorn_noop(monkeypatch)
     runner = CliRunner()
-    result = runner.invoke(gui_cli.gui_group, ["serve", "--minimal", "--no-open", "--tunnel"])
+    # Pass an explicit provider so the registry does not have to discover
+    # a real ``cloudflared`` binary on PATH (CI runners do not ship one).
+    result = runner.invoke(
+        gui_cli.gui_group,
+        ["serve", "--minimal", "--no-open", "--tunnel", "--tunnel-provider", "cloudflared"],
+    )
     assert result.exit_code == 0, result.output
     assert "Tunnel (cloudflared) up" in result.output
     assert "Bernstein PWA onboarding" in result.output

--- a/tests/unit/test_gui_qr.py
+++ b/tests/unit/test_gui_qr.py
@@ -35,6 +35,10 @@ def test_render_returns_str() -> None:
     assert isinstance(out, str)
 
 
+@pytest.mark.skipif(
+    not qr_module._qrcode_available(),
+    reason="qrcode extra not installed; render_ascii_qr emits fallback diagnostic",
+)
 def test_render_contains_dark_modules() -> None:
     out = qr_module.render_ascii_qr("https://example.com")
     assert qr_module.QR_DARK in out
@@ -47,6 +51,10 @@ def test_render_is_rectangular() -> None:
     assert len({len(r) for r in rows}) == 1
 
 
+@pytest.mark.skipif(
+    not qr_module._qrcode_available(),
+    reason="qrcode extra not installed; fallback diagnostic is not square",
+)
 def test_render_is_square() -> None:
     out = qr_module.render_ascii_qr("https://example.com/abcd")
     rows = out.splitlines()


### PR DESCRIPTION
## Summary

Hotfix the three CI failures introduced by ccd26da16 (PR #1442 PWA + tunnel + QR onboarding follow-up):

| # | Job | Symptom | Fix |
|---|-----|---------|-----|
| 1 | Workflow lint | `release-please.yml:24:9: constant expression "false" in condition [if-cond]` | Replace `if: false` job gate with a `workflow_dispatch`-only trigger. Comment retains the operator re-enable note. |
| 2 | Test isolated runner | `test_render_contains_dark_modules` asserts `██ in <fallback diagnostic>` when `qrcode` extra is absent | `@pytest.mark.skipif(not _qrcode_available())` on the dark-module + square shape tests. Fallback path already covered by `test_render_fallback_when_qrcode_missing`. |
| 3 | Test isolated runner | `test_cli_serve_with_tunnel_prints_onboarding` exits 1 with `Tunnel start failed: No tunnel binary found on PATH (tried: cloudflared)` because default `--tunnel-provider auto` walks `shutil.which()` | Pass explicit `--tunnel-provider cloudflared` so the fake driver is used without binary discovery. |

Local verification:

```
$ uv run pytest tests/unit/test_gui_qr.py tests/unit/test_gui_cli.py
45 passed, 4 skipped
$ actionlint -ignore shellcheck .github/workflows/release-please.yml
(no output)
```

## Test plan
- [x] `uv run pytest tests/unit/test_gui_qr.py tests/unit/test_gui_cli.py` green locally
- [x] `actionlint -ignore shellcheck .github/workflows/release-please.yml` clean
- [ ] CI green on this PR