### PR TITLE
fix(ci): actionlint level=error to clear annotation cap noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,12 @@ jobs:
       - uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
           reporter: github-check
+          level: error
+          fail_on_error: true
+          # `level: error` filters reviewdog output to error-only findings.
+          # Without it, shellcheck warnings (SC2016/2221/2222/2034) flood
+          # GH check annotations and hit the 22-result cap, which itself
+          # fails reviewdog. Errors stay loud, noise stays quiet.
 
   lineage-gate:
     # ADR-009 Lineage Gate — required check. Verifies the on-disk lineage


### PR DESCRIPTION
## Why

Workflow lint job has been failing because reviewdog's github-check reporter caps at 22 annotations per check_run. Our 7 self-hosted workflows emit shellcheck warnings (SC2016 / SC2221 / SC2222 / SC2034) that flood the annotation slots. After PR #1472 cleared the lone real error in release-please.yml, the job STILL fails with \`Too many results (annotations) in diff\`.

## What

Add explicit \`level: error\` + \`fail_on_error: true\` to the reviewdog/action-actionlint step in \`.github/workflows/ci.yml\`. With \`level: error\`, reviewdog only annotates error-level findings; warnings/info land in the step summary instead of annotations. With zero current errors → zero annotations → green check.

## Test

Next push to main should produce a green Workflow lint job. Existing shellcheck warnings stay visible in step summary for follow-up cleanup (separate ticket).