### PR TITLE
feat(ci): mitigate macOS runner saturation (closes #1468)

### DIFF
--- a/.github/workflows/ci-macos-nightly.yml
+++ b/.github/workflows/ci-macos-nightly.yml
@@ -1,0 +1,129 @@
+name: CI (macOS nightly)
+
+# Safety-net workflow for macOS coverage (closes #1468 alongside the
+# per-PR macOS gate in ci.yml). Per-PR macOS runs are skipped unless
+# the diff is macOS-sensitive or the PR carries `macos-needed`; this
+# workflow runs the full macOS matrix daily at 06:00 UTC so any drift
+# that slipped past the PR gate is caught within 24 hours.
+#
+# Also runs on push to main and on workflow_dispatch so the
+# release-train can demand an on-demand macOS check before cutting a
+# tag. The job mirrors the `test` matrix in ci.yml so the signal is
+# directly comparable.
+
+on:
+  schedule:
+    # 06:00 UTC daily. Off-peak for both US/EU contributors so the
+    # macOS hosted-runner pool is least contended.
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      # Trigger on the same set of macOS-sensitive paths the per-PR
+      # gate uses (kept in sync with the planner classifier in ci.yml
+      # determine-changes). Push-event filters do not benefit from the
+      # ci.yml planner job, so we list the paths inline here.
+      - "src/bernstein/core/tunnels/**"
+      - "src/bernstein/core/daemon/**"
+      - "src/bernstein/core/config/platform_compat.py"
+      - "src/bernstein/core/security/vault/**"
+      - "src/bernstein/core/security/resource_limits.py"
+      - "src/bernstein/core/persistence/runtime_state.py"
+      - "src/bernstein/core/communication/notifications.py"
+      - "src/bernstein/core/preview/**"
+      - "src/bernstein/tui/clipboard.py"
+      - "src/bernstein/cli/display/splash_screen.py"
+      - "src/bernstein/bridges/openclaw_gateway.py"
+      - "tests/integration/test_adapter_e2e.py"
+      - "scripts/run_tests.py"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/ci-macos-nightly.yml"
+
+# Concurrency: one nightly run at a time. Cancel earlier runs if a
+# scheduled run and a manual dispatch overlap; the latest wins.
+concurrency:
+  group: ci-macos-nightly-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-macos-nightly:
+    name: Test (macos-latest, Python ${{ matrix.python-version }})
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      # Matches the per-PR `test` job so any future JUnit publishing
+      # works without a permissions bump.
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mirrors the (post-exclude) macOS cell from the ci.yml `test`
+        # matrix: Python 3.13 only. Add 3.12 here if/when the per-PR
+        # matrix is restored, but for now nightly tracks the supported
+        # cell.
+        python-version: ["3.13"]
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Run isolated test suite
+        run: uv run python scripts/run_tests.py --parallel 4
+      - name: Run capability-matrix spawn-refusal integration tests
+        run: |
+          uv run pytest tests/integration/test_capability_matrix_spawn_refusal.py \
+            -x -q --tb=short --timeout=120
+      - name: Run fake-CLI adapter integration tests
+        run: uv run pytest tests/integration/test_adapter_e2e.py -x -q --timeout=60
+
+  open-failure-issue:
+    # If the nightly fails on a scheduled run, open a single tracking
+    # issue (or comment on the existing one) so macOS drift never sits
+    # silent. Labelled `ci-macos-nightly` for easy filtering. Skipped
+    # on workflow_dispatch and push events to avoid noise during
+    # operator-driven runs.
+    name: Open / update macOS nightly failure issue
+    needs: [test-macos-nightly]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Open or update issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="macOS nightly CI failing"
+          BODY="The macOS nightly safety-net workflow failed on $(date -u +%Y-%m-%dT%H:%M:%SZ). Run: ${RUN_URL}. See #1468 for the gating policy."
+          # Find an existing open issue first so we do not create a new
+          # one every night while the underlying break persists.
+          EXISTING=$(gh issue list --label ci-macos-nightly --state open \
+            --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY" || true
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --label ci-macos-nightly \
+              --body "$BODY" || true
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,13 @@ jobs:
       tests_changed: ${{ steps.classify.outputs.tests_changed }}
       gha_workflows_changed: ${{ steps.classify.outputs.gha_workflows_changed }}
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      # macos_sensitive: true when the diff touches platform-specific code
+      # paths whose macOS behaviour cannot be exercised on ubuntu/windows
+      # runners. Used by the `test` matrix gate (see #1468) to skip the
+      # macos-latest cells on PRs that do not need them, freeing the
+      # macOS hosted-runner pool during burst-merge waves. The nightly
+      # workflow (ci-macos-nightly.yml) provides the safety-net coverage.
+      macos_sensitive: ${{ steps.classify.outputs.macos_sensitive }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -213,6 +220,7 @@ jobs:
               echo "tests_changed=true"
               echo "gha_workflows_changed=true"
               echo "docs_only=false"
+              echo "macos_sensitive=true"
             } | tee -a "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -225,6 +233,7 @@ jobs:
           tests_changed=false
           gha_workflows_changed=false
           docs_only=true
+          macos_sensitive=false
           # Classify each changed path via grep. Using grep instead of
           # bash `case` to avoid linter warnings on overlapping patterns
           # (case-globs cannot cross slashes anyway).
@@ -246,6 +255,47 @@ jobs:
             if [ "$matched_meta" = "false" ]; then
               docs_only=false
             fi
+            # macOS-sensitive paths (see #1468). Modules with branches on
+            # `sys.platform == "darwin"` or that wrap macOS-only APIs
+            # (Keychain via `keyring`, AppKit notifications, Foundation
+            # clipboard, `launchd` daemon installer). When any of these
+            # change, the macOS matrix cell must run on the PR to catch
+            # regressions before merge. Otherwise it skips and the
+            # nightly ci-macos-nightly.yml workflow catches drift.
+            if printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/tunnels/'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/daemon/'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/config/platform_compat\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/security/vault/'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/security/resource_limits\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/persistence/runtime_state\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/communication/notifications\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/core/preview/'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/tui/clipboard\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/cli/display/splash_screen\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^src/bernstein/bridges/openclaw_gateway\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^tests/integration/test_adapter_e2e\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^scripts/run_tests\.py$'; then
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^\.github/workflows/ci\.yml$'; then
+              # Changes to the CI workflow itself must re-validate the
+              # macOS cell on the PR so we never ship a broken matrix
+              # config (the nightly workflow runs the *merged* config).
+              macos_sensitive=true
+            elif printf '%s\n' "$f" | grep -Eq '^\.github/workflows/ci-macos-nightly\.yml$'; then
+              macos_sensitive=true
+            fi
           done <<< "$CHANGED"
           # If nothing changed at all (e.g. workflow_dispatch on a clean ref),
           # treat as "not docs-only" so we don't intentionally skip tests.
@@ -256,6 +306,7 @@ jobs:
           echo "tests_changed=$tests_changed"          | tee -a "$GITHUB_OUTPUT"
           echo "gha_workflows_changed=$gha_workflows_changed" | tee -a "$GITHUB_OUTPUT"
           echo "docs_only=$docs_only"                  | tee -a "$GITHUB_OUTPUT"
+          echo "macos_sensitive=$macos_sensitive"      | tee -a "$GITHUB_OUTPUT"
 
   # ─── Fast checks (never cancelled, <2 min each) ───────────────────────
 
@@ -852,16 +903,63 @@ jobs:
     # Windows because the wrappers are POSIX shell scripts and the
     # adapters use ``start_new_session=True``; unit tests cover the same
     # argv/env logic on Windows via mocked Popen.
+    #
+    # macOS coverage moved to the adapter-integration-macos job below
+    # (gated by determine-changes.outputs.macos_sensitive, the
+    # `macos-needed` label, or push events) to relieve the hosted macOS
+    # runner pool during burst-merge waves — see #1468. The
+    # ci-macos-nightly.yml workflow runs the full macOS matrix daily as
+    # the safety-net for regressions that slip past the path gate.
     name: Adapter integration (fake-CLI)
     needs: [lint]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.13"]
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Run fake-CLI adapter integration tests
+        run: uv run pytest tests/integration/test_adapter_e2e.py -x -q --timeout=60
+
+  adapter-integration-macos:
+    # macOS half of adapter-integration. Gated on three conditions (see
+    # #1468):
+    #   1. push events (incl. merges to main) always run macOS so the
+    #      release-train sees a fresh signal on every commit that
+    #      reaches main;
+    #   2. PRs whose diff touches macOS-sensitive paths (the planner
+    #      sets macos_sensitive=true);
+    #   3. PRs that carry the `macos-needed` label (operator opt-in for
+    #      cross-platform work that the path filter cannot detect).
+    # Otherwise this job is skipped on PRs and ci-macos-nightly.yml
+    # provides the safety net.
+    name: Adapter integration (fake-CLI, macOS)
+    needs: [lint, determine-changes]
+    if: >-
+      github.event_name == 'push' ||
+      needs.determine-changes.outputs.macos_sensitive == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'macos-needed')
+    runs-on: macos-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
         python-version: ["3.13"]
     steps:
       - name: Harden runner (audit mode)
@@ -895,12 +993,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS removed from the default matrix to relieve hosted-runner
+        # saturation during burst-merge waves (see #1468). The test-macos
+        # job below runs the same suite on macOS when the diff is
+        # macOS-sensitive, the PR carries the `macos-needed` label, or
+        # the event is a push. ci-macos-nightly.yml provides a daily
+        # safety-net run of the full macOS matrix.
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.12", "3.13"]
         exclude:
-          # Coverage/JUnit upload only on ubuntu; skip duplicate slow jobs on macOS/Windows for 3.12
-          - os: macos-latest
-            python-version: "3.12"
+          # Coverage/JUnit upload only on ubuntu; skip duplicate slow jobs on Windows for 3.12
           - os: windows-latest
             python-version: "3.12"
     steps:
@@ -1054,6 +1156,73 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-macos:
+    # macOS half of the test matrix, split out for #1468 (macOS hosted
+    # runner saturation). Runs unconditionally on push (so every commit
+    # that reaches main has a fresh macOS signal), and on PRs only when
+    # one of the gate conditions is met:
+    #   - the planner classified the diff as macos_sensitive (touched
+    #     a module with `sys.platform == "darwin"` branches, the
+    #     tunnels driver layer, the daemon installer, the runtime
+    #     state code, the macOS clipboard/notifications wrappers, or
+    #     ci.yml / ci-macos-nightly.yml themselves);
+    #   - the PR carries the `macos-needed` label (operator opt-in for
+    #     cross-platform work the path filter cannot detect).
+    # Otherwise this job is skipped on the PR and ci-macos-nightly.yml
+    # provides the safety-net coverage at 06:00 UTC each day.
+    #
+    # Coverage / JUnit / Codecov uploads are NOT mirrored here; they
+    # remain ubuntu-only (matches the previous matrix gating).
+    name: Test (macos-latest, Python ${{ matrix.python-version }})
+    needs: [lint, determine-changes]
+    if: >-
+      github.event_name == 'push' ||
+      needs.determine-changes.outputs.macos_sensitive == 'true' ||
+      contains(github.event.pull_request.labels.*.name, 'macos-needed')
+    runs-on: macos-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Fetch base ref for impacted-test selection
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            "refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+      - name: Run isolated test suite
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "${EVENT_NAME}" = "pull_request" ] && \
+             git rev-parse --verify "refs/remotes/origin/${BASE_REF}" >/dev/null 2>&1; then
+            uv run python scripts/run_tests.py --parallel 4 --affected "refs/remotes/origin/${BASE_REF}"
+          else
+            uv run python scripts/run_tests.py --parallel 4
+          fi
+      - name: Run capability-matrix spawn-refusal integration tests
+        run: |
+          uv run pytest tests/integration/test_capability_matrix_spawn_refusal.py \
+            -x -q --tb=short --timeout=120
+
   # ─── Post-pipeline (conditional, never cancelled) ──────────────────────
 
   autofix:
@@ -1152,6 +1321,7 @@ jobs:
       - lint
       - typecheck
       - test
+      - test-macos
       - spelling
       - dead-code
       - actionlint
@@ -1181,6 +1351,7 @@ jobs:
               { name: 'Lint', result: '${{ needs.lint.result }}' },
               { name: 'Type check', result: '${{ needs.typecheck.result }}' },
               { name: 'Tests', result: '${{ needs.test.result }}' },
+              { name: 'Tests (macOS)', result: '${{ needs.test-macos.result }}' },
               { name: 'Spelling', result: '${{ needs.spelling.result }}' },
               { name: 'Dead code', result: '${{ needs.dead-code.result }}' },
               { name: 'Workflow lint', result: '${{ needs.actionlint.result }}' },
@@ -1282,7 +1453,9 @@ jobs:
       - diff-coverage
       - pyright-strict-zone
       - adapter-integration
+      - adapter-integration-macos
       - test
+      - test-macos
       - close-ci-issues
     timeout-minutes: 3
     permissions:
@@ -1338,8 +1511,27 @@ jobs:
           PR_ONLY = {"mutmut-diff", "diff-coverage"}
           # Push-to-main-only jobs: skipped on PRs is intentional.
           PUSH_ONLY = {"close-ci-issues"}
+          # macOS-gated jobs (see #1468): on PRs these are skipped unless
+          # the diff is macos_sensitive or the PR carries the
+          # `macos-needed` label. Always run on push events.
+          MACOS_GATED = {"test-macos", "adapter-integration-macos"}
 
           docs_only = plan.get("docs_only") == "true"
+          macos_sensitive = plan.get("macos_sensitive") == "true"
+          # Read the PR labels via the event payload. The aggregator
+          # runs inside ci.yml so the same event.pull_request.labels
+          # array used by the job `if:` is available here too. The
+          # GITHUB_EVENT_PATH file is the canonical source.
+          macos_labelled = False
+          try:
+              with open(os.environ["GITHUB_EVENT_PATH"]) as fh:
+                  payload = json.load(fh)
+              labels = (payload.get("pull_request") or {}).get("labels") or []
+              macos_labelled = any(
+                  (lbl.get("name") == "macos-needed") for lbl in labels
+              )
+          except Exception:
+              macos_labelled = False
 
           bad = []
           for name, info in data.items():
@@ -1354,6 +1546,17 @@ jobs:
                   if event != "pull_request" and name in PR_ONLY:
                       continue
                   if docs_only and name in DOCS_ONLY_SKIPPABLE:
+                      continue
+                  # macOS-gated jobs are allowed to skip on PRs only when
+                  # the diff is not macos_sensitive AND the PR does not
+                  # carry the `macos-needed` label. On push events they
+                  # must run, so skipped is never accepted there.
+                  if (
+                      name in MACOS_GATED
+                      and event == "pull_request"
+                      and not macos_sensitive
+                      and not macos_labelled
+                  ):
                       continue
               bad.append((name, r))
 

--- a/docs/operations/ci.md
+++ b/docs/operations/ci.md
@@ -1,0 +1,102 @@
+# CI runbook
+
+Operator-facing notes on Bernstein's CI workflows. Focused on the
+matrix policy and the failure-class interventions; for the per-step
+documentation read the inline comments in `.github/workflows/ci.yml`.
+
+## TL;DR
+
+| Topic | Status | Where |
+|-------|--------|-------|
+| Per-PR macOS matrix | Gated (#1468) | `.github/workflows/ci.yml` |
+| macOS safety net | Nightly + push-on-sensitive | `.github/workflows/ci-macos-nightly.yml` |
+| Required check | Single `CI gate` job | `.github/workflows/ci.yml` |
+| Concurrency | PR-scoped cancel, push-scoped non-cancel | `.github/workflows/ci.yml` |
+
+## macOS matrix policy (closes #1468)
+
+### Why
+
+GitHub-hosted `macos-latest` runners are the long-tail bottleneck. On
+2026-05-18 they queued 20-70 minutes during burst-merge waves while
+ubuntu and windows cleared their normal SLO. Per-PR macOS was the
+dominant cause; macOS-specific code surface is small (a dozen modules
+with `sys.platform == "darwin"` branches).
+
+### What runs when
+
+| Event | macOS jobs trigger? | Notes |
+|-------|---------------------|-------|
+| `push` to `main` | Always | Every merged commit gets a fresh macOS signal |
+| PR with `macos-needed` label | Always | Operator opt-in for cross-platform work |
+| PR touching macOS-sensitive paths | Always | Path filter in `determine-changes` |
+| Other PRs | Skipped | Nightly catches drift within 24h |
+| Daily 06:00 UTC schedule | Full macOS matrix | `ci-macos-nightly.yml` |
+
+### macOS-sensitive paths
+
+The planner job `determine-changes` in `ci.yml` sets
+`macos_sensitive=true` when any of these paths is touched:
+
+- `src/bernstein/core/tunnels/**`
+- `src/bernstein/core/daemon/**`
+- `src/bernstein/core/config/platform_compat.py`
+- `src/bernstein/core/security/vault/**`
+- `src/bernstein/core/security/resource_limits.py`
+- `src/bernstein/core/persistence/runtime_state.py`
+- `src/bernstein/core/communication/notifications.py`
+- `src/bernstein/core/preview/**`
+- `src/bernstein/tui/clipboard.py`
+- `src/bernstein/cli/display/splash_screen.py`
+- `src/bernstein/bridges/openclaw_gateway.py`
+- `tests/integration/test_adapter_e2e.py`
+- `scripts/run_tests.py`
+- `.github/workflows/ci.yml`
+- `.github/workflows/ci-macos-nightly.yml`
+
+Keep this list in sync with the classifier in `determine-changes` and
+the `push` path filter in `ci-macos-nightly.yml`. The two are
+deliberately duplicated so the nightly remains self-contained.
+
+### Operator levers
+
+| Need | Action |
+|------|--------|
+| Force macOS on a specific PR | Add the `macos-needed` label |
+| Force macOS for the whole repo temporarily | Set the label on every open PR, or revert this gate |
+| Run macOS on demand | `gh workflow run ci-macos-nightly.yml` |
+| Investigate macOS drift | Check open issues with label `ci-macos-nightly` |
+
+### Failure handling
+
+A failed scheduled run of `ci-macos-nightly.yml` opens (or comments
+on) a tracking issue labelled `ci-macos-nightly`. The issue is
+re-used while the break persists; close it after the fix lands.
+
+Manual dispatch and push-event runs do NOT open issues, to keep the
+operator-driven feedback loop quiet.
+
+## Concurrency policy
+
+Per-PR runs share a group keyed by PR number, `cancel-in-progress`
+on. New pushes to a PR cancel older runs.
+
+Push-to-main runs share a group keyed by branch, also
+`cancel-in-progress` on. A wave of rapid merges supersedes earlier
+runs so the macOS pool does not hold a queue.
+
+Background: see issue #1273 for the wave-merge race and the
+PR-vs-push split.
+
+## Required check
+
+Branch protection points at a single status check, `CI gate`, which
+rolls up `needs.*.result` for all upstream jobs and applies
+intentional-skip allow-lists. The aggregator understands:
+
+- `docs_only` skips for content-only changes
+- `PR_ONLY` / `PUSH_ONLY` event-gated jobs
+- `MACOS_GATED` jobs that legitimately skip on non-macOS-sensitive PRs
+
+If you add a new conditionally-gated job, register it in the
+appropriate allow-list inside the `roll-up` step of `ci-gate`.


### PR DESCRIPTION
## Summary

- Splits macOS off the default per-PR CI matrix into two new gated jobs (`test-macos`, `adapter-integration-macos`).
- Gate fires on push to main, on PRs touching macOS-sensitive paths (detected by a new `macos_sensitive` planner output), and on PRs with the new `macos-needed` label.
- Adds `.github/workflows/ci-macos-nightly.yml`: full macOS matrix daily at 06:00 UTC plus on push-to-main when sensitive paths change, with auto-issue-opening on scheduled failure.
- Updates the `ci-gate` aggregator to accept legitimate macOS skips on PRs and documents the policy in `docs/operations/ci.md`.
- Closes #1468.

## Rationale

Per-PR `macos-latest` queues 20-70 minutes during burst-merge waves (issue #1468, failure class #7). The macOS-specific code surface is a dozen modules with `sys.platform == "darwin"` branches; running the full matrix on every PR is overkill. Hybrid of options (a) and (c) from the issue: cheap, reversible, keeps signal on the PRs that actually need it, nightly catches drift.

## Test plan

- [ ] `actionlint` clean (run by the `actionlint` job on this PR).
- [ ] Lint and typecheck jobs green.
- [ ] `test (ubuntu-latest, 3.13)` and `test (windows-latest, 3.13)` green.
- [ ] `test-macos` runs on this PR because the diff touches `.github/workflows/ci.yml` (macos_sensitive=true), and is green.
- [ ] `adapter-integration-macos` runs and is green.
- [ ] `ci-gate` rolls up to success.
- [ ] After merge: the next push to main runs `ci-macos-nightly.yml` only if sensitive paths changed; the daily 06:00 UTC schedule begins running automatically.