### PR TITLE
fix(test): macOS-platform timing fix for test_reaps_stale_heartbeat

### DIFF
--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1468,8 +1468,21 @@ class TestSpawnResiliency:
 
 
 class TestReaping:
+    # NB: ``agent_lifecycle._refresh_heartbeat_from_signals`` calls a *local*
+    # ``_is_process_alive`` symbol (not the one in ``agent_recycling``). Without
+    # patching that second binding the real ``os.kill(pid, 0)`` runs against the
+    # synthetic ``pid=999``; on macOS CI runners that PID is often in use by a
+    # system daemon, the heartbeat is refreshed to "now", and the agent is no
+    # longer considered stale (failure mode: ``assert 'backend-stale' in []``).
+    # Patching both bindings keeps the test deterministic on every platform.
+    @patch("bernstein.core.agents.agent_lifecycle._is_process_alive", return_value=False)
     @patch("bernstein.core.agent_recycling._is_process_alive", return_value=False)
-    def test_reaps_stale_heartbeat(self, _mock_alive: MagicMock, tmp_path: Path) -> None:
+    def test_reaps_stale_heartbeat(
+        self,
+        _mock_alive: MagicMock,
+        _mock_alive_lifecycle: MagicMock,
+        tmp_path: Path,
+    ) -> None:
         transport = _mock_transport(
             {
                 "GET /tasks": httpx.Response(200, json=[]),


### PR DESCRIPTION
## Summary

Hotfix for `tests/unit/test_orchestrator.py::TestReaping::test_reaps_stale_heartbeat` which was failing only on macOS CI runners after main HEAD `a60abcbc9`.

## Root cause

The test patches `bernstein.core.agent_recycling._is_process_alive` to return False, but the actual reap path in `reap_dead_agents` calls `_refresh_heartbeat_from_signals`, which uses a separate `_is_process_alive` symbol defined locally in `bernstein.core.agents.agent_lifecycle` (line 1331). That binding was never patched, so the call fell through to a real `os.kill(pid=999, 0)`.

| Platform | `os.kill(999, 0)` | Heartbeat refreshed? | Reaped? |
|----------|-------------------|----------------------|---------|
| Ubuntu CI | raises (no such PID) | no | yes - test passes |
| Windows CI | raises | no | yes - test passes |
| macOS-latest CI | succeeds (system daemon holds 999) | yes, to `now` | no - test fails |

## Fix

Patch the second binding (`agent_lifecycle._is_process_alive`) in addition to the existing one. Test code only; no production change.

## Test plan

- [x] `uv run pytest tests/unit/test_orchestrator.py::TestReaping -v` passes locally on macOS
- [x] `uv run pytest tests/unit/test_orchestrator.py::TestStaleHeartbeatReapingDefault -v` still passes
- [ ] CI green on macos-latest