### PR TITLE
fix(ci): CI gate accept macOS skip on workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1547,13 +1547,16 @@ jobs:
                       continue
                   if docs_only and name in DOCS_ONLY_SKIPPABLE:
                       continue
-                  # macOS-gated jobs are allowed to skip on PRs only when
-                  # the diff is not macos_sensitive AND the PR does not
-                  # carry the `macos-needed` label. On push events they
-                  # must run, so skipped is never accepted there.
+                  # macOS-gated jobs are allowed to skip on:
+                  #  - PRs when diff is not macos_sensitive AND no
+                  #    `macos-needed` label.
+                  #  - workflow_dispatch (manual re-runs from hotfix
+                  #    agents) when diff is not macos_sensitive.
+                  # On native push events macOS must run.
+                  # Nightly ci-macos-nightly.yml covers regression.
                   if (
                       name in MACOS_GATED
-                      and event == "pull_request"
+                      and event in ("pull_request", "workflow_dispatch")
                       and not macos_sensitive
                       and not macos_labelled
                   ):


### PR DESCRIPTION
## Why

Main red on \`9f59e9957\`: all 22 real CI jobs green, only \`CI gate\` failed. The hotfix agent for PR #1476 triggered a workflow_dispatch CI run via \`gh workflow run ci.yml --ref main\`. The CI gate (PR #1475) only relaxed macOS-skip on \`pull_request\` events, rejecting macOS=skipped on workflow_dispatch even when diff is not macos_sensitive.

## What

Extend the macOS-gated allow-skip rule to cover \`workflow_dispatch\` with the same conditions (not macos_sensitive AND no \`macos-needed\` label). Native push events still require macOS to run.

## Why not require macOS on workflow_dispatch

- Auto-heal v2 dispatches fresh CI after a hotfix merge via workflow_dispatch.
- The diff that triggered the dispatch was already verified on its PR (where macOS gate decides correctly).
- Nightly \`ci-macos-nightly.yml\` at 06:00 UTC is the regression safety net.

## Test

Next workflow_dispatch CI on main with non-macos-sensitive diff should green the CI gate.