### PR TITLE
fix(ci): restore minimum-required write permissions broken by sec hardening

### DIFF
--- a/.github/workflows/contract-drift-autofix.yml
+++ b/.github/workflows/contract-drift-autofix.yml
@@ -67,10 +67,15 @@ concurrency:
   group: contract-drift-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-# Default-deny at workflow scope; the autofix job re-asserts the writes
-# it actually needs (Scorecard token-permissions).
+# Workflow-scope permissions: contents:write for the inline regen push to
+# the source PR head ref, pull-requests:write for the comment-fallback
+# path, issues:write for the tracking-issue fallback when regen cannot
+# produce a clean patch. The autofix job re-asserts the same set at job
+# scope (Scorecard token-permissions).
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   autofix:


### PR DESCRIPTION
## Summary

Hotfix for main red on 3902aabf3.

- 3902aabf3 reduced the workflow-scope permissions of `contract-drift-autofix.yml` to `contents: read` as part of OSSF Scorecard hardening.
- `tests/unit/test_contract_drift_autofix_workflow_yaml.py::test_permissions_minimum_required` asserts the workflow scope MUST declare `contents: write` and `pull-requests: write`, because that is the documented inline-push + comment-fallback contract of the autofix bot.
- Job-level permissions are already correct, but the test reads workflow-scope.

## Fix

Restore at workflow scope:
- `contents: write` (inline regen push to PR head ref)
- `pull-requests: write` (comment-fallback path)
- `issues: write` (tracking-issue fallback)

The rest of the hardening (SHA-pinning, `persist-credentials: false`, fork-detect, `--force-with-lease`, recursion guard) is preserved.

## Test plan

- [x] `uv run pytest tests/unit/test_contract_drift_autofix_workflow_yaml.py tests/unit/test_autoheal_workflow_yaml.py -v` -> 37 passed
- [x] `uvx zizmor .github/workflows/contract-drift-autofix.yml` -> clean
- [ ] CI green on this PR