### PR TITLE
sec(demo): bump flask + pytest in demo template to close OSSF VulnerabilitiesID

### DIFF
--- a/templates/demo/requirements.txt
+++ b/templates/demo/requirements.txt
@@ -1,2 +1,2 @@
-flask>=3.0.0
-pytest>=8.0.0
+flask>=3.1.3
+pytest>=9.0.3


### PR DESCRIPTION
## Summary

Bumps the lower-bound constraints for `flask` and `pytest` in
`templates/demo/requirements.txt` so OSSF Scorecard's
VulnerabilitiesID check stops flagging the demo template:

- `flask >= 3.0.0` -> `flask >= 3.1.3` (closes GHSA-68rp-wp8r-4726 / CVE-2026-27205)
- `pytest >= 8.0.0` -> `pytest >= 9.0.3` (closes GHSA-6w46-j5rx-g56g / CVE-2025-71176)

This template seeds bernstein init demos only; the orchestrator
itself does not depend on flask, and pytest is already at 9.0.3 via
`uv.lock`. The bump is a documentation-grade hygiene fix.

## Context

Companion to issue #1482 (OSSF Scorecard signals - triage decisions).

The DangerousWorkflowID alert that triggered this triage sweep was
already remediated in PR #1481 / commit `3902aabf3` (split checkout
into trusted `main` ref + verify-via-`git merge-base --is-ancestor`
guard). This PR closes the only remaining cheap-fix OSSF signal.

The other 6 OSSF signals (CodeReview / Maintained / CIIBestPractices /
SAST / Fuzzing / CITests) were dismissed with rationale in code-scanning;
see #1482 for the triage table and the operator-pickup checklist (CII
badge registration, OSSF-recognised fuzzing harness).

## Test plan

- [ ] CI green (lint/test affect only `templates/demo/`, no runtime code).
- [ ] After merge, next OSSF Scorecard scheduled run drops the
      VulnerabilitiesID alert (will be visible in the security tab on
      the next scorecard cron tick or the next workflow_dispatch).