### PR TITLE
sec: close 16 PinnedDependenciesID CodeQL alerts

### DIFF
--- a/examples/cluster/cloudflared/Dockerfile
+++ b/examples/cluster/cloudflared/Dockerfile
@@ -1,9 +1,12 @@
 # cloudflared sidecar for the Bernstein central server.
 #
-# Pinned to a specific tag rather than `latest` so reproducing a
-# deployment doesn't depend on whatever Cloudflare promoted last.
-# Bump the tag deliberately when you want a newer version.
-FROM cloudflare/cloudflared:2025.1.0
+# Pinned by both tag AND manifest digest so deployments are reproducible
+# and Scorecard pinned-dependencies passes. Bump the tag + digest pair
+# deliberately when you want a newer version (look up via
+# `regctl image digest cloudflare/cloudflared:<tag>` or the Docker Hub
+# tag detail page).
+# cloudflare/cloudflared:2025.1.0
+FROM cloudflare/cloudflared:2025.1.0@sha256:3247f3ef49eda23244b8aa5583f82b7c3880b0d057e1172d0e818f5e678d9f27
 
 # The image's default entrypoint is cloudflared itself, so we only need
 # to provide arguments. We support two run modes:


### PR DESCRIPTION
## Summary

OSSF Scorecard flagged 16 ``PinnedDependenciesID`` alerts in a scan
against commit ``4f1f456`` (before the Docker/action hardening
commits landed). Most are already fixed on main, but the Scorecard
report had not been re-run yet.

## What this PR does

1. Pins ``examples/cluster/cloudflared/Dockerfile`` ``FROM`` directive
   to the manifest list digest (``sha256:3247f3ef...``), matching
   Scorecard's exact remediation tip. This was the one remaining
   unpinned container image on main.

2. (Out of band, before this commit landed) A ``workflow_dispatch``
   run of ``scorecard.yml`` against main reconciled 10 stale alerts
   (Dockerfile + docker/demo/Dockerfile FROM digests, the agents.sh
   and demo-cycle.sh ``curl | python3 -c`` API calls, action SHA pins).
   Those alerts auto-closed.

## Remaining 6 alerts (to dismiss as won't fix)

These are install steps Scorecard requires to be hash-pinned via
``--require-hashes`` requirements files or npm integrity manifests.
Each is one transitive build-time install of a single named version,
and adding a separate hashed-requirements file per Dockerfile is
high-maintenance for very low risk:

| Alert | File:line                                           | What            | Reason "won't fix"                                                                                  |
|-------|-----------------------------------------------------|-----------------|------------------------------------------------------------------------------------------------------|
| #409  | Dockerfile:8                                        | hatchling==1.29.0 pip install | Version-pinned; --require-hashes file for the build-only wheel is brittle and adds maintenance churn |
| #410  | docker/demo/Dockerfile:13                           | hatchling==1.29.0 pip install | Same as #409                                                                                         |
| #384  | docker/demo/Dockerfile:21                           | @anthropic-ai/claude-code@2.1.143 npm install -g | Version-pinned; npm integrity for one global install in demo image is overkill                       |
| #387  | .github/workflows/adapter-contract-drift.yml:129    | ``npm install -g "$SPEC"`` | $SPEC is dynamic per-contract -- cannot hash-pin                                                     |
| #388  | .github/workflows/adapter-contract-drift.yml:132    | ``python -m pip install --user pipx`` | Same dynamic install method dispatcher; this is the workflow's entire purpose                        |
| #381  | examples/cluster/cloudflared/Dockerfile:6           | cloudflared FROM | **FIXED in this PR**                                                                                |

All five "won't fix" entries are dismissed via the API after this PR
merges, with the rationale captured on the alert.

## Test plan

- [x] ``uvx zizmor .github/workflows/`` clean (1 informational
      ``use-trusted-publishing`` finding pre-existing, unrelated).
- [ ] CI green on the PR.
- [ ] After merge, re-trigger ``scorecard.yml`` so #381 closes
      automatically.
- [ ] Verify ``gh api .../code-scanning/alerts ... | length`` returns
      0 open PinnedDependenciesID alerts.

Closes Scorecard PinnedDependenciesID alerts #377, #378, #379, #380,
#381, #382, #383, #385, #386, #389, #390, #391, #392 (already-fixed,
auto-closed by rescan + this PR's digest pin) and dismisses
#384, #387, #388, #409, #410 as won't-fix with justification above.