### PR TITLE
sec(ci): pin codecov-action to v6.0.1 immutable SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,7 +1148,7 @@ jobs:
           retention-days: 1
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
         with:
           files: coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
Closes zizmor ref-version-mismatch alert #411. ci.yml line 1151 had codecov-action pinned to an older floating-v6 SHA that no longer matches the v6 tag's current commit, so the `# v6` comment was wrong. Pinned to immutable v6.0.1 release SHA.