### PR TITLE
sec(ci): codecov-action - use commit SHA not annotated tag object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,7 +1148,7 @@ jobs:
           retention-days: 1
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13' && github.event_name == 'push'
-        uses: codecov/codecov-action@cddd853df119a48c5be31a973f8cd97e12e35e16 # v6.0.1
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
Closes #412. PR #1485 mis-pinned to annotated tag object SHA; real v6.0.1 commit is e79a6962e0d4.