### PR TITLE
sec(ci): drop cancelled from auto-release alert triggers

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,8 +31,10 @@ jobs:
     name: Alert on stale release trigger
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # `cancelled` excluded: usually means superseded by concurrency
+    # or operator-cancelled, not a real failure worth alerting.
     if: >-
-      contains(fromJSON('["failure","cancelled","timed_out","action_required"]'),
+      contains(fromJSON('["failure","timed_out","action_required"]'),
         github.event.workflow_run.conclusion)
     permissions:
       contents: read


### PR DESCRIPTION
Closes #1488. Run #26062190970 on b107f38cc was cancelled by branch-scoped concurrency, not a real failure. `cancelled` conclusions on workflow_run are almost always superseded-by-newer-push or operator-stopped. Stopping the noise at source.