### PR TITLE
feat(docs): surface per-step cli and model routing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ Hand-curated release notes: [`docs/release-notes/v2.0.0.md`](docs/release-notes/
 
 - **Worktree-debris cleanup (2026-05-17).** Reaped 50 stale parent-level `bernstein-wt-*` worktrees plus `bernstein-audit-6e` (hireex/rebirth worktree on a bernstein-named path). Every branch tip was tag-rescued under `rescue/<branch>-20260517T152307Z` and pushed to origin before the worktree was force-removed and the local branch deleted. Three active-agent worktrees were preserved (`bernstein-wt-fix-determine-changes`, `bernstein-wt-fix-reviewer-prompts`, `bernstein-wt-syn-gitlab`). `git worktree list` is back to canonical: the main checkout plus the in-repo `.claude/worktrees/` registry.
 
+### Documentation
+
+- **Per-step CLI and model routing surfaced.** Added [`docs/workflows/per-step-routing.md`](docs/workflows/per-step-routing.md) documenting the existing per-step `cli:` / `model:` / `effort:` plan fields, the surfaces that honour them, the surfaces that drop them, and a trace-based verification recipe. `templates/bernstein.yaml` now ships a commented-out per-stage override example that points at the new page. `templates/workflows/idea-to-pr.yaml` and `templates/workflows/refactor-with-tests.yaml` carry inline comments showing where operators most often want to pin different adapters or models and the plan-YAML lift to do it. The runtime support already existed (`plan_loader._parse_step` at `plan_loader.py:255-294`, `planner.py:86-96`); this PR closes the discoverability gap raised in discussion #962.
+
 ## [1.10.1] — 2026-05-07
 
 ### Added — adapters

--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ one). `fresh_context: true` mints a new agent session per iteration. The
 `interactive: true` flag is reserved for the approval-gate work tracked in
 ticket #1110 and currently raises a clear `NotImplementedError`.
 
+Need one step to run on a different CLI adapter or model than the rest of
+the run (e.g. opencode for red/green/refactor, claude for the review)? See
+[Per-step CLI and model routing](docs/workflows/per-step-routing.md) for the
+worked plan-YAML example and the trace-verification recipe.
+
 
 ## use cases
 

--- a/docs/workflows/per-step-routing.md
+++ b/docs/workflows/per-step-routing.md
@@ -1,0 +1,202 @@
+# Per-step CLI and model routing
+
+**How do I run one step with one CLI agent and the next step with a different one?**
+
+Bernstein supports per-step routing on plan YAML files and on tasks
+posted directly to the task server. A step can pin its own adapter
+(`cli:`) and its own model (`model:` / `effort:`), and those hints win
+over the top-level plan-wide defaults. Use this when one stage of the
+work needs a different runtime than the rest of the plan, for example
+running red/green/refactor on one adapter and the review pass on
+another.
+
+This page covers what the per-step fields do, where they are honoured,
+where they are silently dropped, and how to verify the route the
+orchestrator actually took.
+
+---
+
+## TL;DR
+
+| Field | Type | Scope | Wins over |
+|-------|------|-------|-----------|
+| `cli` | string | One step | Top-level plan `cli:` and role policy. |
+| `model` | enum | One step | Cascade router initial pick. |
+| `effort` | enum | One step | Cascade router effort default. |
+
+- Set them inside `steps:` in a plan YAML.
+- Leave them off when the step should follow the plan-wide default.
+- `bernstein.yaml` itself takes a top-level `cli:` only; the per-step
+  override lives on each plan step.
+- Workflow manifests under `templates/workflows/*.yaml` do **not**
+  carry these fields today; see [Where it works](#where-it-works) below.
+
+---
+
+## What the fields mean
+
+### `cli`
+
+Pins the adapter for one step. Accepts any name the adapter registry
+knows: `claude`, `codex`, `gemini`, `qwen`, `opencode`, `cursor`,
+`copilot`, and so on (see the full list with `bernstein adapters list`).
+A per-step `cli:` overrides:
+
+1. The top-level `cli:` in the plan or in `bernstein.yaml`.
+2. The role default supplied by the model-routing policy.
+3. The `auto`-detection result.
+
+If the named adapter is not installed, the run fails fast with a clear
+error rather than silently substituting a different one.
+
+### `model`
+
+Pins the model variant for one step: `auto`, `opus`, `sonnet`,
+`haiku`. Only meaningful when the resolved adapter is Claude-compatible
+(other adapters bind their own models and ignore this hint). When set,
+the cascade router skips its initial selection logic and uses the
+pinned model as attempt 0.
+
+### `effort`
+
+Pins the effort tier for one step: `low`, `normal`, `high`, `max`.
+This is a Claude-adapter knob that maps onto the inline reasoning
+budget. Like `model:`, it is honoured when the adapter is
+Claude-compatible.
+
+---
+
+## Worked example
+
+Discussion #962 asks the canonical question: red/green/refactor on one
+adapter, review on another. Express that in a plan:
+
+```yaml
+name: rgr-with-review
+description: >
+  Red/green/refactor on opencode; bring claude in for the review pass.
+
+cli: opencode   # plan-wide default
+
+stages:
+  - name: rgr
+    steps:
+      - title: "Red: write the failing test"
+        role: qa
+        # cli omitted on purpose: this step inherits the plan-wide
+        # opencode adapter so the test is authored by the same runtime
+        # that will implement the fix below.
+
+      - title: "Green: make it pass"
+        role: backend
+        # cli also inherited from the plan-wide default.
+
+      - title: "Refactor: tighten the implementation"
+        role: backend
+        # still on opencode.
+
+  - name: review
+    depends_on: [rgr]
+    steps:
+      - title: "Independent review pass"
+        role: reviewer
+        cli: claude          # override: review uses a different runtime
+        model: opus          # high-stakes review pinned to opus
+        effort: high
+```
+
+Three steps inherit `cli: opencode`. The fourth pins `cli: claude`
+plus `model: opus` and `effort: high` so the review pass runs on a
+different adapter and a heavier model than the rest of the plan. No
+manager agent needed; the plan is the decomposition.
+
+---
+
+## Where it works
+
+| Surface | Per-step `cli:` / `model:` / `effort:` | Notes |
+|---------|----------------------------------------|-------|
+| Plan YAML (`bernstein run --from-plan`) | Yes | Read in `plan_loader._parse_step`. Stored on the resulting `Task` row. |
+| `POST /tasks` on the task server | Yes | The HTTP payload accepts the same keys; the planner forwards them when it creates child tasks (`planner.py:86`). |
+| Manager-emitted plans | Yes | When the manager agent decomposes a goal it can stamp `cli` and `model` on individual steps. |
+| Workflow manifests (`templates/workflows/*.yaml`) | No | The Archon-style manifest schema validates with `extra="forbid"` (`workflow_spec.py`). Per-node routing is tracked separately; use a plan YAML when you need it today. |
+| `bernstein.yaml` | Top-level only | The seed file has one global `cli:`. Per-step routing belongs on the plan or task. |
+
+If you write a workflow manifest and need per-step routing, the
+recommended path is to author it as a plan YAML instead. Plans and
+workflows are sibling primitives that target different shapes; the
+plan loader is the one with full routing-hint support today.
+
+---
+
+## When the hint is forwarded vs. dropped
+
+The orchestrator forwards `cli` / `model` / `effort` in these
+places:
+
+1. **Plan ingest.** `plan_loader._parse_step` reads them off each step
+   dict and writes them onto the `Task` (`plan_loader.py:255-294`).
+2. **Planner-emitted child tasks.** When the planner posts derived
+   tasks to the task server, it includes `cli`, `model`, and `effort`
+   in the JSON body (`planner.py:91-96`). A regression in this exact
+   path was fixed in PR #1259 and pinned by
+   `tests/unit/test_per_step_routing.py`.
+3. **Spawner dispatch.** The agent spawner reads `task.cli` and
+   resolves the adapter from the registry before launching the
+   process; if `task.cli` is unset it falls back to the role policy
+   plus the orchestrator-wide default.
+
+The hint is dropped (silently or with a warning) in these cases:
+
+- The adapter named in `cli:` is not installed. The run aborts with a
+  registry-miss error; it does **not** substitute `auto`.
+- `model:` / `effort:` are set on a step whose resolved adapter is not
+  Claude-compatible. The fields are accepted by the schema but the
+  non-Claude adapter ignores them. No warning today; track the actual
+  pick in the trace (next section).
+- Workflow manifest nodes carry `cli:` or `model:`. The manifest
+  loader rejects the file at validation time (`workflow_spec.py`
+  enforces `extra="forbid"`).
+
+---
+
+## How to verify the route in the trace
+
+Every task spawn writes one JSONL event per attempt under
+`.sdd/traces/<task_id>.jsonl`. The relevant fields:
+
+| Field | Meaning |
+|-------|---------|
+| `task.cli` | The adapter override on the task row. Empty when unset. |
+| `task.model` | The model override on the task row. Empty when unset. |
+| `task.effort` | The effort override on the task row. Empty when unset. |
+| `spawn.adapter` | The adapter actually launched. Compare to `task.cli`. |
+| `spawn.model` | The model the adapter reported it loaded. |
+
+Two quick checks:
+
+```bash
+# Show the override on every task in the run.
+jq -r '[.task_id, .task.cli, .task.model, .task.effort] | @tsv' \
+  .sdd/traces/*.jsonl | sort -u
+
+# Confirm each spawn used the requested adapter.
+jq -r 'select(.event=="spawn") | [.task_id, .task.cli, .spawn.adapter] | @tsv' \
+  .sdd/traces/*.jsonl
+```
+
+If `task.cli` is `claude` but `spawn.adapter` is `codex`, the run hit
+an adapter-resolution fallback (almost always: `claude` is not
+installed or not on `PATH`). The `bernstein doctor` output names the
+exact registry miss.
+
+---
+
+## See also
+
+- [Plans (YAML schema)](../architecture/plans.md) - full schema for
+  the plan file, including the rest of the step fields.
+- [Model routing and escalation](../architecture/model-routing.md) -
+  what the cascade router does when `model:` is not pinned.
+- `templates/plan.yaml` - the in-repo seed file with the commented
+  `cli:` override example.

--- a/templates/bernstein.yaml
+++ b/templates/bernstein.yaml
@@ -1,5 +1,13 @@
 ## bernstein.yaml — project seed file
 ## Copy to your project root and edit before running `bernstein run`.
+##
+## The top-level `cli:` and `model:` keys below apply to every step
+## the orchestrator schedules. When one stage of a run needs a
+## different adapter or model than the rest (e.g. opencode for the
+## red/green/refactor loop, claude for the review pass), declare the
+## override on the matching step in a plan YAML. See
+## `docs/workflows/per-step-routing.md` for the full pattern and
+## `templates/plan.yaml` for the in-repo example.
 
 # Required: high-level objective for this run.
 goal: >
@@ -7,13 +15,37 @@ goal: >
 
 # CLI agent backend.  One of: auto, claude, codex, gemini, qwen.
 # "auto" detects installed agents and picks the best available.
+# Per-step overrides live on plan steps (see docs/workflows/per-step-routing.md).
 cli: auto
 
 # Maximum number of agents running concurrently.
 max_agents: 4
 
 # Optional model override (e.g. opus, sonnet, gpt-5.4).
+# Per-step `model:` on a plan step wins over this default.
 # model: opus
+
+# ---------------------------------------------------------------------------
+# Per-step routing (commented example)
+# ---------------------------------------------------------------------------
+# `bernstein.yaml` only takes plan-wide adapter and model defaults. To pin a
+# different adapter or model on one step of a run, lift the work into a plan
+# YAML (`bernstein run --from-plan path/to/plan.yaml`) and declare the
+# override on the matching step:
+#
+#   stages:
+#     - name: refactor
+#       steps:
+#         - title: "Refactor the auth module"
+#           role: backend
+#           cli: opencode           # adapter override for this step only
+#           model: sonnet           # model override for this step only
+#           effort: high            # effort tier override (Claude-compatible)
+#
+# When the step has no `cli:` / `model:` it inherits the values above.
+# See docs/workflows/per-step-routing.md for the worked red/green/refactor
+# example, the verification recipe, and the full list of where the hint is
+# forwarded vs. dropped.
 
 # Role team.  "auto" lets the manager choose; or list explicit roles.
 # team: auto

--- a/templates/workflows/idea-to-pr.yaml
+++ b/templates/workflows/idea-to-pr.yaml
@@ -1,9 +1,19 @@
 name: idea-to-pr
 description: "Take a goal from idea to merged PR: research, plan, implement, test, ship."
 version: "1.0.0"
+# Per-step CLI / model routing.
+#
+# Workflow manifest nodes inherit the orchestrator's adapter and model
+# defaults (the top-level `cli:` in bernstein.yaml and the role policy).
+# When one node needs a different runtime, lift the manifest into a
+# plan YAML and pin `cli:` / `model:` / `effort:` per step there.
+# See docs/workflows/per-step-routing.md for the discoverability gap
+# this comment addresses (discussion #962) and the worked example.
 nodes:
   - id: research
     agent: manager
+    # No per-node override: research runs on the orchestrator-wide
+    # default adapter and model from bernstein.yaml + role policy.
     prompt: |
       Research the goal: {goal}
 
@@ -14,6 +24,9 @@ nodes:
   - id: plan
     depends_on: [research]
     agent: architect
+    # Architects benefit from a heavier model; express that by lifting
+    # this step into a plan YAML and pinning `model: opus` /
+    # `effort: high`. See docs/workflows/per-step-routing.md.
     prompt: |
       Turn the research brief into a concrete plan for: {goal}
 
@@ -24,6 +37,15 @@ nodes:
   - id: implement
     depends_on: [plan]
     agent: backend
+    # The backend implement step is the canonical place to pin a
+    # different adapter when the team has a cheaper / faster runtime
+    # for code edits than for review. In a plan YAML this looks like:
+    #
+    #   - title: "Carry out the plan"
+    #     role: backend
+    #     cli: opencode      # cheaper runtime for the bulk of edits
+    #
+    # See docs/workflows/per-step-routing.md for the full pattern.
     prompt: |
       Carry out the plan for: {goal}
 

--- a/templates/workflows/refactor-with-tests.yaml
+++ b/templates/workflows/refactor-with-tests.yaml
@@ -1,9 +1,18 @@
 name: refactor-with-tests
 description: "Find a target, propose a refactor, implement it, and loop on tests until green."
 version: "1.0.0"
+# Per-step CLI / model routing.
+#
+# This is the canonical red/green/refactor shape from discussion #962.
+# The propose / implement / verify nodes below are the three places
+# operators most often want to pin different adapters or models.
+# Workflow manifest nodes inherit the orchestrator defaults; lift this
+# manifest into a plan YAML when you want to pin one CLI per stage.
+# See docs/workflows/per-step-routing.md for the worked example.
 nodes:
   - id: find-target
     agent: architect
+    # Inherits the orchestrator default adapter and model.
     prompt: |
       Identify the highest-value refactor target inside: {goal}
 
@@ -13,6 +22,14 @@ nodes:
   - id: propose
     depends_on: [find-target]
     agent: architect
+    # The "red" step: author the failing tests / design proposal.
+    # In a plan YAML, pin a cheap adapter here:
+    #
+    #   - title: "Propose the refactor"
+    #     role: architect
+    #     cli: opencode     # cheap runtime for the write-up
+    #
+    # See docs/workflows/per-step-routing.md.
     prompt: |
       Propose a refactor for the target identified above.
 
@@ -22,6 +39,14 @@ nodes:
   - id: implement
     depends_on: [propose]
     agent: backend
+    # The "green" step: apply the refactor and write tests.
+    # Pin a different adapter when implementation cost is the bottleneck:
+    #
+    #   - title: "Apply the refactor"
+    #     role: backend
+    #     cli: codex        # alternate runtime for the bulk edits
+    #
+    # See docs/workflows/per-step-routing.md.
     prompt: |
       Apply the proposed refactor. Keep behavioural diffs zero;
       everything else (renames, splits, parameterisations) is fair
@@ -30,6 +55,18 @@ nodes:
 
   - id: tests-green
     depends_on: [implement]
+    # The "refactor" / verify step: loops until pytest exits 0.
+    # When you lift this into a plan YAML and add a separate review
+    # step after `tests-green`, pin the review pass to a heavier
+    # adapter and model:
+    #
+    #   - title: "Independent review of the refactor"
+    #     role: reviewer
+    #     cli: claude       # different runtime for the review
+    #     model: opus       # heavier model for the review pass
+    #     effort: high
+    #
+    # See docs/workflows/per-step-routing.md.
     command: "pytest -x -q"
     loop:
       until: "pytest -x -q"


### PR DESCRIPTION
## Summary

- Adds `docs/workflows/per-step-routing.md` documenting the existing per-step `cli:` / `model:` / `effort:` fields on plan-YAML steps: what each one does, where the hint is forwarded, where it is dropped, and a `.sdd/traces/` based verification recipe.
- Updates `templates/bernstein.yaml` with a commented-out per-stage override example plus a header pointer to the new docs page; the seed file itself only accepts plan-wide defaults today, so the example shows the plan-YAML lift.
- Annotates `templates/workflows/idea-to-pr.yaml` and `templates/workflows/refactor-with-tests.yaml` with inline comments on the nodes where operators most often want to pin a different adapter or model (the discussion #962 red/green/refactor + review shape). Workflow manifest schema is `extra="forbid"` so the comments point at the plan-YAML lift rather than introducing a live field.
- Links the new page from the README "YAML workflow manifests" section and adds a CHANGELOG Unreleased > Documentation entry with the source-of-truth code pointers (`plan_loader._parse_step`, `planner.py`).
- No runtime change. The planner and plan loader already honour per-step routing hints; this PR closes the documentation discoverability gap.

## Test plan

- [x] `uv run python -c "from bernstein.core.workflows.workflow_spec import load_workflow_spec_from_text; ..."` parses every workflow YAML under `templates/workflows/` cleanly after the comment additions.
- [x] Pre-push hooks (lint, architecture contracts, typecheck) pass.
- [ ] mkdocs build picks up the new page once added to the nav (out of scope for this PR; the page is reachable via the README and the seed-file pointer).
- [ ] Manual: read `docs/workflows/per-step-routing.md` end to end and confirm the trace-verification jq snippets match the actual `.sdd/traces/*.jsonl` field names on a recent run.