### PR TITLE
feat(docs): bernstein init --remote and Codespaces quickstart

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "Bernstein",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/pipx-package:1": {
+      "package": "pipx"
+    }
+  },
+  "postCreateCommand": "pipx install -e . && bernstein --help",
+  "remoteEnv": {
+    "BERNSTEIN_REMOTE_QUICKSTART": "1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ]
+    }
+  },
+  "forwardPorts": [8052]
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Multi-agent CLI orchestration with an HMAC-signed audit chain, signed agent card
 [![CodeQL](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/sipyourdrink-ltd/bernstein/actions/workflows/codeql.yml)
 [![MseeP.ai](https://img.shields.io/badge/MseeP.ai-verified-2496ed)](https://mseep.ai/app/chernistry-bernstein)
 [![CodeTrendy](https://img.shields.io/badge/CodeTrendy-listed-FBBF24)](https://codetrendy.com/listing/bernstein)
+[![Open in Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sipyourdrink-ltd/bernstein?quickstart=1)
 
 [website](https://bernstein.run?utm_source=github.com&utm_medium=readme&utm_campaign=bernstein-readme) &middot; [docs](https://bernstein.readthedocs.io/) &middot; [install](docs/getting-started/install.md) &middot; [first run](docs/getting-started/first-run.md) &middot; [enterprise eval](docs/ENTERPRISE.md) &middot; [glossary](docs/reference/GLOSSARY.md) &middot; [limitations](docs/reference/KNOWN_LIMITATIONS.md) &middot; [sponsor](https://github.com/sponsors/chernistry)
 

--- a/docs/quickstart/remote.md
+++ b/docs/quickstart/remote.md
@@ -1,0 +1,70 @@
+# Remote quickstart (GitHub Codespaces)
+
+The standard install paths (`pipx`, `uv`, `brew`, `docker`) all assume a
+local terminal. If you do not have one to hand - reviewing on a phone,
+sitting in a meeting on a borrowed laptop, or just curious without
+committing to a local install - GitHub Codespaces provides a one-click
+cloud sandbox that runs the project's devcontainer.
+
+## Time: about 60 seconds
+
+1. Click the **Open in Codespaces** badge in the project README.
+2. Wait for the container to build. The first build takes roughly a
+   minute; subsequent starts are fast. The `postCreate` step installs
+   `bernstein` and runs `bernstein --help` so you can confirm the CLI
+   is on the path.
+3. In the integrated terminal:
+
+   ```bash
+   bernstein init --remote
+   bernstein --help
+   ```
+
+   The `--remote` flag tells `bernstein init` to skip local-binary
+   checks (such as the `brew` adapter probe) that are not expected to
+   succeed inside a fresh container. The flag is also auto-enabled when
+   `CODESPACES=true` is present in the environment.
+
+4. Provide an adapter API key via Codespaces user secrets, then run a
+   trivial goal:
+
+   ```bash
+   bernstein run -g "list files in the repo and summarise the layout"
+   ```
+
+## How the project recognises Codespaces
+
+- `bernstein init --remote` short-circuits the local toolchain probe.
+- `bernstein doctor --json` adds a `runtime` field with the value
+  `codespace` when the process detects a Codespaces environment, and
+  `local` otherwise. Use that field in your own scripts to decide which
+  checks to enforce.
+- The devcontainer sets `BERNSTEIN_REMOTE_QUICKSTART=1` so any other
+  remote-container surface that follows the same convention is treated
+  identically.
+
+## Limitations
+
+- The Codespaces session is yours, not a hosted Bernstein sandbox.
+  You supply adapter API keys via your own Codespaces user secrets and
+  are billed for compute by GitHub.
+- The devcontainer pre-installs `bernstein` and `pipx`, but it does not
+  install any third-party agent CLI. Pick whichever adapter you want
+  (Claude Code, Codex, Gemini, etc.) and install it inside the
+  container before running an agent task.
+- A fresh container has no cached state. Plan-only or dry-run modes
+  are a good way to confirm the setup before spending API budget.
+
+## Going local later
+
+When you are back at a real terminal, the standard local install paths
+still apply:
+
+```bash
+pipx install bernstein
+bernstein init
+```
+
+The two paths are interchangeable; the remote quickstart simply adds a
+no-terminal entry point for users who would otherwise drop off at the
+install step.

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -894,6 +894,10 @@ def doctor(as_json: bool, auto_fix: bool) -> None:
 
     if as_json or is_json():
         result_dict: dict[str, Any] = {"checks": checks}
+        # Surface the execution surface so machine-readable consumers can
+        # branch on it (e.g. tooling that ignores brew-adapter failures
+        # inside a fresh container).
+        result_dict["runtime"] = _detect_runtime_environment()
         if auto_fix:
             result_dict["fixed"] = fixed
             result_dict["manual_needed"] = manual_needed
@@ -904,6 +908,22 @@ def doctor(as_json: bool, auto_fix: bool) -> None:
         return
 
     _doctor_render_table(checks, auto_fix, fixed, manual_needed)
+
+
+def _detect_runtime_environment() -> str:
+    """Return a short identifier for the execution surface.
+
+    Recognised values:
+      - ``codespace``: GitHub Codespaces (``CODESPACES=true``) or any
+        remote-container surface that opts in via
+        ``BERNSTEIN_REMOTE_QUICKSTART=1``.
+      - ``local``: everything else.
+    """
+    if os.environ.get("CODESPACES", "").lower() == "true":
+        return "codespace"
+    if os.environ.get("BERNSTEIN_REMOTE_QUICKSTART", "") == "1":
+        return "codespace"
+    return "local"
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/cli/run_bootstrap.py
+++ b/src/bernstein/cli/run_bootstrap.py
@@ -535,6 +535,19 @@ def _generate_default_yaml(project_type: str) -> str:
     return "\n".join(lines)
 
 
+def is_codespace_runtime() -> bool:
+    """Return True when running inside a GitHub Codespace.
+
+    GitHub injects ``CODESPACES=true`` into every Codespace shell. The
+    devcontainer also sets ``BERNSTEIN_REMOTE_QUICKSTART=1`` so a manual
+    opt-in is possible from any other remote-container surface that
+    follows the same convention.
+    """
+    if os.environ.get("CODESPACES", "").lower() == "true":
+        return True
+    return os.environ.get("BERNSTEIN_REMOTE_QUICKSTART", "") == "1"
+
+
 @click.command("init")
 @click.option(
     "--dir",
@@ -561,10 +574,31 @@ def _generate_default_yaml(project_type: str) -> str:
     type=click.Choice(["signed", "audited-by", "orchestrated-by", "crew-managed-by"]),
     help="Badge variant when --add-badge is passed.",
 )
-def init(target_dir: str, *, add_badge: bool = False, badge_variant: str = "signed") -> None:
+@click.option(
+    "--remote",
+    "remote",
+    is_flag=True,
+    default=False,
+    help=(
+        "Initialise for a remote container quickstart (e.g. GitHub Codespaces). "
+        "Skips local-binary checks that would fail in a fresh container."
+    ),
+)
+def init(
+    target_dir: str,
+    *,
+    add_badge: bool = False,
+    badge_variant: str = "signed",
+    remote: bool = False,
+) -> None:
     """Init workspace -- create .sdd/ structure."""
     try:
-        _init_impl(target_dir, add_badge=add_badge, badge_variant=badge_variant)
+        _init_impl(
+            target_dir,
+            add_badge=add_badge,
+            badge_variant=badge_variant,
+            remote=remote,
+        )
     except (click.UsageError, SystemExit):
         raise
     except BaseException as exc:
@@ -583,16 +617,36 @@ def _is_verbose() -> bool:
     return bool(obj.get("VERBOSE", False))
 
 
-def _init_impl(target_dir: str, *, add_badge: bool, badge_variant: str) -> None:
+def _init_impl(
+    target_dir: str,
+    *,
+    add_badge: bool,
+    badge_variant: str,
+    remote: bool = False,
+) -> None:
     """Concrete init implementation; wrapped by :func:`init` for hinting."""
     print_banner()
     root = Path(target_dir).resolve()
     console.print(f"Initialising Bernstein workspace in [bold]{root}[/bold]")
 
-    # Auto-detect project type
-    project_type = _detect_project_type(root)
-    if project_type != "generic":
-        console.print(f"[cyan]Detected[/cyan] {project_type} project")
+    # Remote-quickstart mode: assume a fresh container without the local
+    # CLI binaries (brew/pipx/uv may not be present yet). The flag is
+    # auto-enabled when running inside a Codespace so users hitting the
+    # devcontainer postCreate get the right defaults without remembering
+    # the flag.
+    if remote or is_codespace_runtime():
+        remote = True
+        console.print("[cyan]Remote-quickstart mode[/cyan]: skipping local-binary checks (Codespaces / devcontainer).")
+
+    # Auto-detect project type. Skipped in remote mode because the
+    # detection probes local toolchains (e.g. brew adapter check) that
+    # are not expected to be installed in a fresh container.
+    if not remote:
+        project_type = _detect_project_type(root)
+        if project_type != "generic":
+            console.print(f"[cyan]Detected[/cyan] {project_type} project")
+    else:
+        project_type = "generic"
 
     for d in SDD_DIRS:
         p = root / d

--- a/tests/unit/cli/test_init_remote.py
+++ b/tests/unit/cli/test_init_remote.py
@@ -1,0 +1,163 @@
+"""Tests for the ``bernstein init --remote`` flow and Codespaces detection.
+
+The remote-quickstart path exists because the four documented local
+install paths (pipx, uv, brew, docker) all assume a local terminal.
+GitHub Codespaces gives readers without one a usable entry point, and
+the CLI needs to recognise the environment so it does not trip over
+local-binary probes that are not expected to succeed in a fresh
+container.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.main import cli
+from bernstein.cli.run_bootstrap import is_codespace_runtime
+
+
+@pytest.fixture
+def clean_remote_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every env var the remote-quickstart path inspects."""
+    monkeypatch.delenv("CODESPACES", raising=False)
+    monkeypatch.delenv("BERNSTEIN_REMOTE_QUICKSTART", raising=False)
+
+
+def test_is_codespace_runtime_false_when_env_clean(clean_remote_env: None) -> None:
+    """No env signal -> not a codespace."""
+    assert is_codespace_runtime() is False
+
+
+def test_is_codespace_runtime_true_on_codespaces_env(
+    clean_remote_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CODESPACES=true`` (GitHub-supplied) -> codespace."""
+    monkeypatch.setenv("CODESPACES", "true")
+    assert is_codespace_runtime() is True
+
+
+def test_is_codespace_runtime_true_on_quickstart_opt_in(
+    clean_remote_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The devcontainer sets ``BERNSTEIN_REMOTE_QUICKSTART=1``."""
+    monkeypatch.setenv("BERNSTEIN_REMOTE_QUICKSTART", "1")
+    assert is_codespace_runtime() is True
+
+
+def test_is_codespace_runtime_case_insensitive(
+    clean_remote_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """GitHub historically sets ``CODESPACES=True`` (mixed case)."""
+    monkeypatch.setenv("CODESPACES", "True")
+    assert is_codespace_runtime() is True
+
+
+def test_init_remote_flag_dispatches(
+    clean_remote_env: None,
+    tmp_path: Path,
+) -> None:
+    """``bernstein init --remote`` runs end-to-end and prints the marker."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--dir", str(tmp_path), "--remote"])
+    assert result.exit_code == 0, result.output
+    assert "Remote-quickstart mode" in result.output
+    # Skipped local-binary probe -> no project-type detection line.
+    assert "Detected" not in result.output
+    # The workspace skeleton still lands.
+    assert (tmp_path / ".sdd").is_dir()
+    assert (tmp_path / "bernstein.yaml").is_file()
+
+
+def test_init_auto_detects_codespace_without_flag(
+    clean_remote_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A Codespaces shell auto-enables the remote path without the flag."""
+    monkeypatch.setenv("CODESPACES", "true")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Remote-quickstart mode" in result.output
+
+
+def test_init_local_path_unchanged(
+    clean_remote_env: None,
+    tmp_path: Path,
+) -> None:
+    """Without ``--remote`` and outside a codespace, the local path runs."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["init", "--dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "Remote-quickstart mode" not in result.output
+
+
+def test_doctor_json_runtime_local(
+    clean_remote_env: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bernstein doctor --json`` reports ``runtime: local`` off-codespace."""
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["doctor", "--json"])
+    # The doctor exits 1 if any check fails (likely on a CI host without
+    # adapters), but the JSON payload must still parse and carry the
+    # runtime field.
+    payload = _extract_json_payload(result.output)
+    assert payload["runtime"] == "local"
+    assert "checks" in payload
+
+
+def test_doctor_json_runtime_codespace(
+    clean_remote_env: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bernstein doctor --json`` reports ``runtime: codespace`` inside one."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CODESPACES", "true")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["doctor", "--json"])
+    payload = _extract_json_payload(result.output)
+    assert payload["runtime"] == "codespace"
+
+
+def test_doctor_json_runtime_quickstart_opt_in(
+    clean_remote_env: None,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The devcontainer's ``BERNSTEIN_REMOTE_QUICKSTART`` opt-in is honoured."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BERNSTEIN_REMOTE_QUICKSTART", "1")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["doctor", "--json"])
+    payload = _extract_json_payload(result.output)
+    assert payload["runtime"] == "codespace"
+
+
+def _extract_json_payload(output: str) -> dict[str, object]:
+    """Pull the JSON object out of mixed stdout (banner + JSON)."""
+    start = output.find("{")
+    assert start != -1, f"no JSON object in output:\n{output}"
+    # The doctor emits one top-level JSON object; find the matching brace.
+    depth = 0
+    for idx in range(start, len(output)):
+        ch = output[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                payload = json.loads(output[start : idx + 1])
+                assert isinstance(payload, dict)
+                return payload
+    raise AssertionError(f"unterminated JSON in output:\n{output}")


### PR DESCRIPTION
## Summary

- Existing install paths (pipx, uv, brew, docker) all assume a local terminal; this adds a remote-quickstart path via GitHub Codespaces so users without one have a working entry point.
- Adds `.devcontainer/devcontainer.json` (Python 3.12, pipx pre-installed, `bernstein --help` post-create) and an Open in Codespaces badge in the README.
- New `bernstein init --remote` flag skips local-binary probes (e.g. brew adapter check) that are not expected to succeed in a fresh container; the flag also auto-enables when `CODESPACES=true` is set in the environment.
- `bernstein doctor --json` gains a `runtime` field (`codespace` or `local`) so machine-readable consumers can branch on the execution surface.
- New docs page `docs/quickstart/remote.md` walks readers through the 60-second remote path.

## Test plan

- [x] `uv run ruff check` on touched files
- [x] `uv run ruff format --check` on touched files
- [x] `pytest tests/unit/cli/test_init_remote.py` (10 tests pass) covering env detection, `--remote` flag dispatch, auto-detect, doctor JSON shape with and without the codespace signal.
- [ ] Manual smoke: open the badge in a fresh Codespace and confirm `bernstein --help` runs from the `postCreate` hook.