### PR TITLE
feat(cli): add bernstein debug bundle for redacted support exports

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -155,6 +155,7 @@ alwaysApply: false
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `debug_bundle.py`       | Debug bundle export -- ``bernstein debug bundle`` |
 | `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -46,9 +46,18 @@ body:
     attributes:
       label: Debug bundle
       description: |
-        Run `bernstein debug` and attach the generated zip file. This collects
-        logs, config (secrets redacted), and runtime state in one file.
-        If the command isn't available yet, attach any relevant files from `.sdd/runtime/`.
+        Run `bernstein debug bundle --last` and attach the generated zip
+        file. The bundle contains a redacted `bernstein.yaml`, a
+        `doctor.json` snapshot, recent traces and metrics, and the tail
+        of `.sdd/runtime/*.log`. Secrets (API keys, tokens, passwords,
+        bearer headers, JWTs, SSH keys) are removed and `$HOME` paths
+        are collapsed to `~` before the zip is written.
+
+        Quick check before sharing: `unzip -p bernstein-debug-*.zip manifest.json`
+        prints the manifest with version, OS, and file list.
+
+        If you cannot run the command, attach any relevant files from
+        `.sdd/runtime/`.
       placeholder: "Drag and drop the bernstein-debug-*.zip file here"
     validations:
       required: false

--- a/.goosehints
+++ b/.goosehints
@@ -156,6 +156,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `debug_bundle.py`       | Debug bundle export -- ``bernstein debug bundle`` |
 | `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `debug_bundle.py`       | Debug bundle export -- ``bernstein debug bundle`` |
 | `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `debug_bundle.py`       | Debug bundle export -- ``bernstein debug bundle`` |
 | `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -156,6 +156,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `dashboard_app.py`      | Bernstein TUI application -- main App class and entry point |
 | `dashboard_header.py`   | Dashboard header and agent display widgets |
 | `dashboard_polling.py`  | Dashboard polling helpers, data loaders, formatters, and constants |
+| `debug_bundle.py`       | Debug bundle export -- ``bernstein debug bundle`` |
 | `first_run_guard.py`    | First-run guard helpers wiring categorisation into CLI entry points |
 | `helpers.py`            | Shared constants, helpers, and utilities for Bernstein CLI modules |
 | `install_check.py`      | Installation mismatch detection -- detect multiple Bernstein installs and config conflicts |

--- a/src/bernstein/cli/debug_bundle.py
+++ b/src/bernstein/cli/debug_bundle.py
@@ -1,0 +1,574 @@
+"""Debug bundle export -- ``bernstein debug bundle``.
+
+Collects a self-contained, redacted ZIP that an operator can attach to a
+GitHub issue without manual back-and-forth on logs, configuration, and
+environment data. Reduces support friction for both reporter and
+maintainer and standardises the artefact attached to issues.
+
+Bundle contents (every text artefact is run through
+:mod:`bernstein.core.security.redactor` before being written):
+
+- ``manifest.json``      -- bernstein version, python version, OS,
+                             install method, selection (task/run/last),
+                             file count, redaction count.
+- ``bernstein.yaml``     -- redacted copy of the project config.
+- ``doctor.json``        -- output of ``bernstein doctor --json``.
+- ``traces/``            -- recent ``.sdd/traces/`` for the selected
+                             task/run.
+- ``metrics/``           -- recent ``.sdd/metrics/`` for the same window.
+- ``logs/``              -- last 200 lines of each ``.sdd/runtime/*.log``.
+- ``source/`` (optional) -- the N most-recently-changed git files under
+                             ``src/`` when ``--include-source-snippets``
+                             is set.
+
+The ZIP plumbing reuses :mod:`bernstein.cli.run_archive`; the redaction
+pass reuses :mod:`bernstein.core.security.redactor`. This module owns
+selection logic, the manifest schema, and the CLI entry point.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import platform
+import subprocess
+import sys
+import zipfile
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import click
+
+import bernstein
+from bernstein.cli.helpers import console
+from bernstein.cli.run_archive import ArchiveManifest  # re-used for plumbing parity
+from bernstein.core.security.redactor import redact_file, redact_text
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+_RUNTIME_LOG_TAIL_LINES = 200
+_TRACE_FILE_LIMIT = 50
+_METRIC_FILE_LIMIT = 50
+_SOURCE_SNIPPET_BYTE_BUDGET = 64 * 1024
+
+
+@dataclass(frozen=True)
+class DebugManifest:
+    """Schema for ``manifest.json`` written at the bundle root.
+
+    Attributes:
+        schema_version: Format version of this manifest. Bump on any
+            backwards-incompatible field change.
+        created_at: ISO-8601 UTC timestamp of bundle creation.
+        bernstein_version: ``bernstein.__version__``.
+        python_version: ``platform.python_version()``.
+        os: Short OS descriptor (``platform.platform()``).
+        install_method: Detected install method: ``pip``, ``pipx``,
+            ``uv-tool``, ``editable``, or ``unknown``.
+        selection: Which selection produced the bundle: dict with
+            keys ``mode`` (``task``/``run``/``last``) and ``id``
+            (``str | None``).
+        files: Sorted list of archive-relative file paths included.
+        redactions_applied: Total number of secret patterns substituted
+            during the redaction pass over all text artefacts.
+    """
+
+    schema_version: int
+    created_at: str
+    bernstein_version: str
+    python_version: str
+    os: str
+    install_method: str
+    selection: dict[str, str | None]
+    files: list[str] = field(default_factory=list)
+    redactions_applied: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def _resolve_last_run(workdir: Path) -> str | None:
+    """Return the most recent run id recorded in ``.sdd/runtime/run_id``."""
+    run_id_path = workdir / ".sdd" / "runtime" / "run_id"
+    if not run_id_path.is_file():
+        return None
+    try:
+        text = run_id_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return text or None
+
+
+@dataclass(frozen=True)
+class Selection:
+    """Resolved bundle selection.
+
+    Attributes:
+        mode: Which selector won: ``task``, ``run``, or ``last``.
+        ident: Optional task or run id; ``None`` when no run yet exists.
+    """
+
+    mode: str
+    ident: str | None
+
+
+def resolve_selection(
+    workdir: Path,
+    task: str | None,
+    run: str | None,
+    last: bool,
+) -> Selection:
+    """Resolve the bundle selection flags into a single selection.
+
+    Precedence: explicit ``--task`` beats explicit ``--run`` beats
+    ``--last`` beats the default (``--last``).
+
+    Args:
+        workdir: Project root directory.
+        task: Optional task id from ``--task``.
+        run: Optional run id from ``--run``.
+        last: Truthy when ``--last`` was passed (default behaviour).
+
+    Returns:
+        The selected :class:`Selection`. ``mode == "last"`` may have
+        ``ident is None`` when no run has been recorded yet -- that
+        case is handled at write time, not here.
+    """
+    if task is not None:
+        return Selection(mode="task", ident=task)
+    if run is not None:
+        return Selection(mode="run", ident=run)
+    # Default == --last
+    return Selection(mode="last", ident=_resolve_last_run(workdir))
+
+
+# ---------------------------------------------------------------------------
+# Host introspection
+# ---------------------------------------------------------------------------
+
+
+def detect_install_method() -> str:
+    """Best-effort detection of how Bernstein was installed.
+
+    Uses ``importlib.metadata`` for distribution location and
+    ``sys.executable`` for the launcher path. Returns one of
+    ``editable``, ``pipx``, ``uv-tool``, ``pip``, or ``unknown``.
+    """
+    exe = sys.executable or ""
+    exe_lower = exe.lower()
+
+    # pipx and uv tool place wrappers under a recognisable directory.
+    if "pipx" in exe_lower or "/pipx/" in exe_lower:
+        return "pipx"
+    if "/uv/tools/" in exe_lower or exe_lower.endswith("/uv-tool"):
+        return "uv-tool"
+
+    # Editable installs expose a ``.pth`` or ``__editable__`` marker on
+    # the distribution. importlib.metadata.files() returns None when
+    # the metadata is missing; we treat that defensively.
+    try:
+        dist = importlib.metadata.distribution("bernstein")
+        files = dist.files or []
+        for file in files:
+            name = str(file)
+            if name.endswith(".pth") or "__editable__" in name:
+                return "editable"
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown"
+
+    return "pip"
+
+
+def build_host_fields() -> dict[str, str]:
+    """Return the host-side fields that go into the manifest."""
+    return {
+        "bernstein_version": bernstein.__version__,
+        "python_version": platform.python_version(),
+        "os": platform.platform(),
+        "install_method": detect_install_method(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# File collection
+# ---------------------------------------------------------------------------
+
+
+def _tail_lines(path: Path, max_lines: int) -> str:
+    """Read up to *max_lines* trailing lines from *path*."""
+    try:
+        all_lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return ""
+    if max_lines <= 0 or len(all_lines) <= max_lines:
+        return "\n".join(all_lines)
+    return "\n".join(all_lines[-max_lines:])
+
+
+def collect_traces(workdir: Path, selection: Selection) -> list[Path]:
+    """Return the recent trace files for the selection.
+
+    When ``selection.ident`` is set, filter by filename containing the
+    id. Otherwise return the most-recently-modified traces, capped by
+    ``_TRACE_FILE_LIMIT``.
+    """
+    trace_dir = workdir / ".sdd" / "traces"
+    if not trace_dir.is_dir():
+        return []
+    candidates = [p for p in trace_dir.iterdir() if p.is_file()]
+    if selection.ident:
+        candidates = [p for p in candidates if selection.ident in p.name]
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[:_TRACE_FILE_LIMIT]
+
+
+def collect_metrics(workdir: Path, selection: Selection) -> list[Path]:
+    """Return the recent metric files for the selection window."""
+    metric_dir = workdir / ".sdd" / "metrics"
+    if not metric_dir.is_dir():
+        return []
+    candidates = [p for p in metric_dir.iterdir() if p.is_file()]
+    if selection.ident:
+        candidates = [p for p in candidates if selection.ident in p.name]
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[:_METRIC_FILE_LIMIT]
+
+
+def collect_runtime_logs(workdir: Path) -> list[Path]:
+    """Return the ``.sdd/runtime/*.log`` files in deterministic order."""
+    runtime_dir = workdir / ".sdd" / "runtime"
+    if not runtime_dir.is_dir():
+        return []
+    logs = sorted(p for p in runtime_dir.glob("*.log") if p.is_file())
+    return logs
+
+
+def _git_recent_src_files(workdir: Path, limit: int) -> list[Path]:
+    """Return the *limit* most-recently-changed git-tracked files under ``src/``.
+
+    Falls back to an empty list when ``git`` is unavailable or the
+    repository check fails.
+    """
+    if limit <= 0:
+        return []
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(workdir), "log", "--name-only", "--pretty=", "-n", "200"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    seen: set[str] = set()
+    ordered: list[Path] = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("src/"):
+            continue
+        if line in seen:
+            continue
+        seen.add(line)
+        candidate = workdir / line
+        if candidate.is_file():
+            ordered.append(candidate)
+        if len(ordered) >= limit:
+            break
+    return ordered
+
+
+def collect_source_snippets(workdir: Path, limit: int) -> list[Path]:
+    """Public entry point so tests can stub it for fixtures without git."""
+    return _git_recent_src_files(workdir, limit)
+
+
+# ---------------------------------------------------------------------------
+# Doctor snapshot
+# ---------------------------------------------------------------------------
+
+
+def collect_doctor_snapshot() -> dict[str, Any]:
+    """Run ``bernstein doctor --json`` and return its parsed output.
+
+    Failures are recorded in-band so the bundle is never aborted by a
+    flaky doctor invocation.
+    """
+    try:
+        proc = subprocess.run(
+            ["bernstein", "doctor", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"error": f"doctor invocation failed: {exc.__class__.__name__}"}
+    if proc.returncode != 0:
+        return {
+            "error": "doctor returned non-zero exit code",
+            "returncode": proc.returncode,
+            "stderr_tail": proc.stderr.splitlines()[-20:],
+        }
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {
+            "error": "doctor output was not JSON",
+            "stdout_tail": proc.stdout.splitlines()[-20:],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembly
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BundleResult:
+    """Outcome of :func:`build_debug_bundle`.
+
+    Attributes:
+        output_path: Where the ZIP was written. ``None`` for
+            ``manifest_only`` runs.
+        manifest: The manifest that was written (or would have been).
+    """
+
+    output_path: Path | None
+    manifest: DebugManifest
+
+
+def build_debug_bundle(
+    workdir: Path,
+    *,
+    task: str | None = None,
+    run: str | None = None,
+    last: bool = True,
+    out: Path | None = None,
+    manifest_only: bool = False,
+    include_source_snippets: int = 0,
+) -> BundleResult:
+    """Assemble the debug bundle and write it to *out*.
+
+    Args:
+        workdir: Project root directory.
+        task: Optional task id selector.
+        run: Optional run id selector.
+        last: Truthy when caller wants the default ``--last`` behaviour.
+        out: Output ZIP path. When ``None``, a timestamped path is
+            chosen under the current working directory.
+        manifest_only: When ``True``, skip ZIP creation and return only
+            the in-memory manifest.
+        include_source_snippets: Number of recently-changed source
+            files to include under ``source/``. ``0`` disables.
+
+    Returns:
+        :class:`BundleResult` with manifest and (optionally) the output
+        path of the written ZIP.
+    """
+    selection = resolve_selection(workdir, task=task, run=run, last=last)
+    host = build_host_fields()
+
+    entries: dict[str, str] = {}
+    total_redactions = 0
+
+    # bernstein.yaml -- redacted
+    config_path = workdir / "bernstein.yaml"
+    if config_path.is_file():
+        cleaned, redactions = redact_file(config_path)
+        entries["bernstein.yaml"] = cleaned
+        total_redactions += redactions
+    else:
+        entries["bernstein.yaml"] = "# bernstein.yaml not found\n"
+
+    # doctor.json
+    doctor_payload = collect_doctor_snapshot()
+    doctor_text = json.dumps(doctor_payload, indent=2, sort_keys=True)
+    cleaned_doctor, doctor_redactions = redact_text(doctor_text)
+    entries["doctor.json"] = cleaned_doctor
+    total_redactions += doctor_redactions
+
+    # traces
+    for trace_path in collect_traces(workdir, selection):
+        cleaned, redactions = redact_file(trace_path)
+        entries[f"traces/{trace_path.name}"] = cleaned
+        total_redactions += redactions
+
+    # metrics
+    for metric_path in collect_metrics(workdir, selection):
+        cleaned, redactions = redact_file(metric_path)
+        entries[f"metrics/{metric_path.name}"] = cleaned
+        total_redactions += redactions
+
+    # runtime logs -- last 200 lines per log file
+    for log_path in collect_runtime_logs(workdir):
+        raw = _tail_lines(log_path, _RUNTIME_LOG_TAIL_LINES)
+        cleaned, redactions = redact_text(raw)
+        entries[f"logs/{log_path.name}"] = cleaned
+        total_redactions += redactions
+
+    # Optional source snippets (file-inclusion budget enforced here)
+    if include_source_snippets > 0:
+        used_bytes = 0
+        for src_path in collect_source_snippets(workdir, include_source_snippets):
+            cleaned, redactions = redact_file(src_path)
+            size = len(cleaned.encode("utf-8", errors="replace"))
+            if used_bytes + size > _SOURCE_SNIPPET_BYTE_BUDGET:
+                break
+            used_bytes += size
+            rel = src_path.relative_to(workdir).as_posix()
+            entries[f"source/{rel}"] = cleaned
+            total_redactions += redactions
+
+    # Build manifest. Files list is sorted for determinism, manifest.json
+    # itself is not in the file list (it is the index of the others).
+    files_list = sorted(entries.keys())
+    manifest = DebugManifest(
+        schema_version=1,
+        created_at=datetime.now(tz=UTC).isoformat(),
+        bernstein_version=host["bernstein_version"],
+        python_version=host["python_version"],
+        os=host["os"],
+        install_method=host["install_method"],
+        selection={"mode": selection.mode, "id": selection.ident},
+        files=files_list,
+        redactions_applied=total_redactions,
+    )
+
+    if manifest_only:
+        return BundleResult(output_path=None, manifest=manifest)
+
+    # Resolve output path
+    output_path = _resolve_output_path(workdir, out, selection)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(asdict(manifest), indent=2) + "\n")
+        for arc_name in files_list:
+            zf.writestr(arc_name, entries[arc_name])
+
+    return BundleResult(output_path=output_path, manifest=manifest)
+
+
+def _resolve_output_path(
+    workdir: Path,
+    out: Path | None,
+    selection: Selection,
+) -> Path:
+    """Pick the ZIP destination path, generating a default when needed."""
+    if out is not None:
+        return out.resolve() if out.is_absolute() or out.parent != Path() else out
+    ts = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
+    suffix = f"-{selection.ident}" if selection.ident else ""
+    return workdir / f"bernstein-debug-{ts}{suffix}.zip"
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat alias for ZIP plumbing
+# ---------------------------------------------------------------------------
+
+# Re-exported for callers that want the older ArchiveManifest shape;
+# the new debug bundle uses :class:`DebugManifest` so this avoids
+# duplicating the run-archive type while keeping the import discoverable.
+__all__ = [
+    "ArchiveManifest",
+    "BundleResult",
+    "DebugManifest",
+    "Selection",
+    "build_debug_bundle",
+    "collect_doctor_snapshot",
+    "collect_metrics",
+    "collect_runtime_logs",
+    "collect_source_snippets",
+    "collect_traces",
+    "debug_group",
+    "detect_install_method",
+    "resolve_selection",
+]
+
+
+# ---------------------------------------------------------------------------
+# Click group + bundle subcommand
+# ---------------------------------------------------------------------------
+
+
+@click.group("debug")
+def debug_group() -> None:
+    """Diagnostics utilities: ``bernstein debug bundle`` and friends."""
+
+
+@debug_group.command("bundle")
+@click.option("--task", type=str, default=None, help="Task id to filter traces/metrics by.")
+@click.option("--run", type=str, default=None, help="Run id to filter traces/metrics by.")
+@click.option(
+    "--last/--no-last",
+    "last",
+    default=True,
+    help="Use the most recent run (default).",
+)
+@click.option(
+    "--out",
+    "-o",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Destination ZIP path (default: timestamped file in CWD).",
+)
+@click.option(
+    "--manifest-only",
+    is_flag=True,
+    default=False,
+    help="Print the manifest JSON to stdout instead of writing a ZIP.",
+)
+@click.option(
+    "--include-source-snippets",
+    "include_source_snippets",
+    type=click.IntRange(min=0),
+    default=0,
+    help="Include the N most-recently-changed src/ files (off by default).",
+)
+def bundle_cmd(
+    task: str | None,
+    run: str | None,
+    last: bool,
+    out: Path | None,
+    manifest_only: bool,
+    include_source_snippets: int,
+) -> None:
+    """Export a redacted debug bundle for bug reports.
+
+    Default selection is ``--last``: traces, metrics, logs from the most
+    recent run plus the project's ``bernstein.yaml`` and a
+    ``doctor.json`` snapshot are zipped together. Every text artefact is
+    passed through the secret-redaction pipeline first.
+    """
+    workdir = Path.cwd()
+    result = build_debug_bundle(
+        workdir,
+        task=task,
+        run=run,
+        last=last,
+        out=out,
+        manifest_only=manifest_only,
+        include_source_snippets=include_source_snippets,
+    )
+
+    if manifest_only:
+        click.echo(json.dumps(asdict(result.manifest), indent=2))
+        return
+
+    assert result.output_path is not None  # invariant of non-manifest path
+    size_bytes = result.output_path.stat().st_size
+    size_kib = size_bytes / 1024
+    console.print(
+        f"Debug bundle written to [bold]{result.output_path}[/bold] "
+        f"({size_kib:.1f} KiB, {len(result.manifest.files)} files, "
+        f"{result.manifest.redactions_applied} redactions)."
+    )

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -70,6 +70,7 @@ from bernstein.cli.commands.skills_cmd import skills_group
 from bernstein.cli.compliance_cmd import compliance_group
 from bernstein.cli.config_path_cmd import config_path_cmd
 from bernstein.cli.cost import cost_cmd, cost_envelopes_group, estimate_cmd
+from bernstein.cli.debug_bundle import debug_group
 from bernstein.cli.debug_cmd import debug_cmd
 from bernstein.cli.dep_impact_cmd import dep_impact_cmd
 from bernstein.cli.diff_cmd import diff_cmd
@@ -955,7 +956,10 @@ cli.add_command(debug_cmd, "debug-bundle")
 # These are the tool-call resolvers; task-level ``approve``/``reject`` live in task_cmd.
 cli.add_command(approve_tool_cmd, "approve-tool")
 cli.add_command(reject_tool_cmd, "reject-tool")
-cli.add_command(debug_cmd, "debug")  # backward-compat alias
+# ``bernstein debug`` is the structured diagnostics group; ``debug bundle``
+# exports a redacted ZIP for bug reports. The flat ``debug-bundle`` alias
+# above stays for back-compat with older issue templates.
+cli.add_command(debug_group, "debug")
 
 # Chat-control bridges (op-001)
 from bernstein.cli.commands.chat_cmd import chat_group  # noqa: E402

--- a/src/bernstein/core/security/redactor.py
+++ b/src/bernstein/core/security/redactor.py
@@ -1,0 +1,98 @@
+"""File-level redaction wrapper for debug-bundle text artefacts.
+
+This is a thin orchestration layer over the lower-level pattern set in
+:mod:`bernstein.core.observability.debug_bundle`. It exposes a stable,
+text-only API that:
+
+- Blanks API keys, tokens, secrets, passwords, bearer headers, JWTs, SSH
+  keys, and URL-embedded credentials.
+- Collapses absolute paths under ``$HOME`` to ``~``.
+- Removes values of environment variables whose names contain
+  ``KEY``/``TOKEN``/``SECRET``/``PASSWORD`` from text-style dumps
+  (``NAME=value`` and ``NAME: value``).
+
+The wrapper is intentionally text-only and idempotent so callers can
+feed it any UTF-8 file content without bespoke parsing.
+
+Usage::
+
+    from bernstein.core.security.redactor import redact_text, redact_file
+
+    cleaned = redact_text(raw)
+    cleaned, count = redact_file(Path("bernstein.yaml"))
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import TYPE_CHECKING
+
+from bernstein.core.observability.debug_bundle import redact_secrets
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["collapse_home", "redact_file", "redact_text"]
+
+_HOME_RE: re.Pattern[str] | None = None
+
+
+def _home_pattern() -> re.Pattern[str] | None:
+    """Return a compiled regex matching the current ``$HOME`` prefix.
+
+    Compiled lazily because ``$HOME`` can be unset in CI runners; we
+    return ``None`` in that case and skip the collapse step.
+    """
+    global _HOME_RE
+    if _HOME_RE is not None:
+        return _HOME_RE
+    home = os.environ.get("HOME") or os.path.expanduser("~")
+    if not home or home == "~":
+        return None
+    # Match the literal home path as a path prefix.
+    _HOME_RE = re.compile(re.escape(home.rstrip("/")))
+    return _HOME_RE
+
+
+def collapse_home(text: str) -> str:
+    """Replace occurrences of ``$HOME`` with ``~`` in *text*."""
+    pattern = _home_pattern()
+    if pattern is None:
+        return text
+    return pattern.sub("~", text)
+
+
+def redact_text(text: str) -> tuple[str, int]:
+    """Redact secrets and collapse ``$HOME`` references in *text*.
+
+    Args:
+        text: Arbitrary UTF-8 string that may contain secrets or
+            absolute paths.
+
+    Returns:
+        A 2-tuple of (redacted text, count of secret redactions
+        applied). The home-collapse step is not counted because it is
+        cosmetic, not a security action.
+    """
+    cleaned, count = redact_secrets(text)
+    cleaned = collapse_home(cleaned)
+    return cleaned, count
+
+
+def redact_file(path: Path) -> tuple[str, int]:
+    """Read *path* as UTF-8 and run :func:`redact_text` over its body.
+
+    Args:
+        path: File to read. Missing or unreadable files yield an empty
+            string and zero redactions; callers decide how to surface
+            the absence.
+
+    Returns:
+        A 2-tuple of (redacted text, count of secret redactions).
+    """
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return "", 0
+    return redact_text(raw)

--- a/tests/unit/cli/test_debug_bundle.py
+++ b/tests/unit/cli/test_debug_bundle.py
@@ -1,0 +1,325 @@
+"""Tests for ``bernstein debug bundle`` (cli/debug_bundle.py).
+
+Covers the acceptance criteria of the debug-bundle export ticket:
+
+- Empty project: the command still produces a valid bundle.
+- Missing run id: ``--last`` works even when no ``run_id`` file exists.
+- Redaction roundtrip: secrets in ``bernstein.yaml`` are scrubbed in
+  the archived copy, and the manifest counts the redactions.
+- Manifest schema: every required field is present with the expected
+  types, and ``schema_version`` is set.
+- File-inclusion budget: ``--include-source-snippets`` does not exceed
+  the documented byte budget.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.cli.debug_bundle import (
+    _SOURCE_SNIPPET_BYTE_BUDGET,
+    DebugManifest,
+    Selection,
+    build_debug_bundle,
+    debug_group,
+    detect_install_method,
+    resolve_selection,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _stub_doctor(monkeypatch: pytest.MonkeyPatch, payload: dict[str, Any] | None = None) -> None:
+    """Replace doctor-snapshot collection with a stub so tests do not shell out."""
+    monkeypatch.setattr(
+        "bernstein.cli.debug_bundle.collect_doctor_snapshot",
+        lambda: payload if payload is not None else {"status": "ok"},
+    )
+
+
+def _stub_source_snippets(monkeypatch: pytest.MonkeyPatch, files: list[Path]) -> None:
+    """Replace git-based source collection with a fixed list."""
+    monkeypatch.setattr(
+        "bernstein.cli.debug_bundle.collect_source_snippets",
+        lambda _workdir, _limit: files,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty project
+# ---------------------------------------------------------------------------
+
+
+def test_empty_project_produces_valid_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty project still yields a manifest and a readable ZIP."""
+    _stub_doctor(monkeypatch)
+    result = build_debug_bundle(tmp_path)
+
+    assert result.output_path is not None
+    assert result.output_path.is_file()
+
+    with zipfile.ZipFile(result.output_path) as zf:
+        names = set(zf.namelist())
+        assert "manifest.json" in names
+        # Even an empty project records a (missing-marker) bernstein.yaml
+        # and the doctor snapshot.
+        assert "bernstein.yaml" in names
+        assert "doctor.json" in names
+        manifest_raw = zf.read("manifest.json").decode("utf-8")
+        manifest = json.loads(manifest_raw)
+        assert manifest["schema_version"] == 1
+        assert manifest["selection"]["mode"] == "last"
+        assert manifest["selection"]["id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Selection resolution / missing run id
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_selection_prefers_task_over_run(tmp_path: Path) -> None:
+    """Explicit ``--task`` wins over ``--run`` and ``--last``."""
+    sel = resolve_selection(tmp_path, task="t-1", run="r-1", last=True)
+    assert sel == Selection(mode="task", ident="t-1")
+
+
+def test_resolve_selection_prefers_run_over_last(tmp_path: Path) -> None:
+    """Explicit ``--run`` wins over the default ``--last``."""
+    sel = resolve_selection(tmp_path, task=None, run="r-9", last=True)
+    assert sel == Selection(mode="run", ident="r-9")
+
+
+def test_last_with_missing_run_id_returns_none(tmp_path: Path) -> None:
+    """``--last`` with no recorded run id yields mode=last and ident=None."""
+    sel = resolve_selection(tmp_path, task=None, run=None, last=True)
+    assert sel.mode == "last"
+    assert sel.ident is None
+
+
+def test_last_reads_run_id_from_runtime_file(tmp_path: Path) -> None:
+    """``--last`` picks up ``.sdd/runtime/run_id`` when present."""
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "run_id").write_text("run-abc\n", encoding="utf-8")
+    sel = resolve_selection(tmp_path, task=None, run=None, last=True)
+    assert sel == Selection(mode="last", ident="run-abc")
+
+
+# ---------------------------------------------------------------------------
+# Redaction roundtrip
+# ---------------------------------------------------------------------------
+
+
+def test_bernstein_yaml_secrets_are_redacted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real API key in ``bernstein.yaml`` does not survive into the ZIP."""
+    secret_value = "sk-ant-api03-nopenopelongtokenvalue"
+    (tmp_path / "bernstein.yaml").write_text(
+        f"providers:\n  ANTHROPIC_API_KEY: {secret_value}\n  base_url: https://api.example.com\n",
+        encoding="utf-8",
+    )
+    _stub_doctor(monkeypatch)
+
+    result = build_debug_bundle(tmp_path)
+
+    assert result.output_path is not None
+    with zipfile.ZipFile(result.output_path) as zf:
+        body = zf.read("bernstein.yaml").decode("utf-8")
+        manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+
+    assert secret_value not in body
+    assert "REDACTED" in body
+    assert manifest["redactions_applied"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Manifest schema validation
+# ---------------------------------------------------------------------------
+
+
+_REQUIRED_MANIFEST_FIELDS: dict[str, type] = {
+    "schema_version": int,
+    "created_at": str,
+    "bernstein_version": str,
+    "python_version": str,
+    "os": str,
+    "install_method": str,
+    "selection": dict,
+    "files": list,
+    "redactions_applied": int,
+}
+
+
+def test_manifest_schema_has_all_fields(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``manifest.json`` carries every documented field with the right type."""
+    _stub_doctor(monkeypatch)
+    result = build_debug_bundle(tmp_path, manifest_only=True)
+
+    payload = asdict(result.manifest)
+    for name, expected_type in _REQUIRED_MANIFEST_FIELDS.items():
+        assert name in payload, f"manifest missing field {name!r}"
+        assert isinstance(payload[name], expected_type), (
+            f"manifest field {name!r} has wrong type: {type(payload[name]).__name__} != {expected_type.__name__}"
+        )
+
+    # Selection sub-keys are also part of the schema contract.
+    assert "mode" in payload["selection"]
+    assert "id" in payload["selection"]
+
+    # install_method must be one of the documented enum values.
+    assert payload["install_method"] in {"pip", "pipx", "uv-tool", "editable", "unknown"}
+
+
+def test_manifest_only_skips_zip_creation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--manifest-only`` does not write a ZIP."""
+    _stub_doctor(monkeypatch)
+    result = build_debug_bundle(tmp_path, manifest_only=True)
+    assert result.output_path is None
+    # No zip files in the tmpdir
+    assert not list(tmp_path.glob("*.zip"))
+
+
+def test_manifest_dataclass_round_trip() -> None:
+    """:class:`DebugManifest` round-trips through ``asdict`` cleanly."""
+    m = DebugManifest(
+        schema_version=1,
+        created_at="2026-05-19T00:00:00+00:00",
+        bernstein_version="9.9.9",
+        python_version="3.13.1",
+        os="Darwin-25.0.0",
+        install_method="pip",
+        selection={"mode": "last", "id": None},
+        files=["bernstein.yaml", "doctor.json"],
+        redactions_applied=2,
+    )
+    payload = asdict(m)
+    assert payload["selection"] == {"mode": "last", "id": None}
+    assert payload["files"] == ["bernstein.yaml", "doctor.json"]
+
+
+# ---------------------------------------------------------------------------
+# File-inclusion budget
+# ---------------------------------------------------------------------------
+
+
+def test_source_snippet_budget_is_enforced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--include-source-snippets`` never exceeds the byte budget."""
+    src = tmp_path / "src" / "pkg"
+    src.mkdir(parents=True)
+    # Each file is ~40 KiB; with a 64 KiB budget at most 2 should land.
+    # Use a benign repeating line so the redactor's secret patterns don't
+    # have to backtrack on a 40 KiB run of a single character.
+    big_files: list[Path] = []
+    line = "def some_function_name(arg):\n    return arg + 1\n"
+    payload = line * (40 * 1024 // len(line) + 1)
+    for index in range(5):
+        path = src / f"big_{index}.py"
+        path.write_text(payload, encoding="utf-8")
+        big_files.append(path)
+    _stub_source_snippets(monkeypatch, big_files)
+    _stub_doctor(monkeypatch)
+
+    result = build_debug_bundle(
+        tmp_path,
+        include_source_snippets=5,
+    )
+
+    assert result.output_path is not None
+    with zipfile.ZipFile(result.output_path) as zf:
+        source_entries = [n for n in zf.namelist() if n.startswith("source/")]
+        total_bytes = sum(zf.getinfo(n).file_size for n in source_entries)
+    assert total_bytes <= _SOURCE_SNIPPET_BYTE_BUDGET, (
+        f"source/ entries used {total_bytes} bytes, budget is {_SOURCE_SNIPPET_BYTE_BUDGET}"
+    )
+    # At least one snippet should have been included if the budget allows.
+    assert source_entries, "expected at least one source snippet under the budget"
+
+
+def test_source_snippets_off_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ``source/`` entries when the flag is omitted."""
+    src = tmp_path / "src" / "pkg"
+    src.mkdir(parents=True)
+    (src / "x.py").write_text("print('hi')\n", encoding="utf-8")
+    _stub_doctor(monkeypatch)
+
+    result = build_debug_bundle(tmp_path)
+    assert result.output_path is not None
+    with zipfile.ZipFile(result.output_path) as zf:
+        assert not any(n.startswith("source/") for n in zf.namelist())
+
+
+# ---------------------------------------------------------------------------
+# Logs windowing
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_logs_tail_to_200_lines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each ``.sdd/runtime/*.log`` is truncated to its last 200 lines."""
+    runtime = tmp_path / ".sdd" / "runtime"
+    runtime.mkdir(parents=True)
+    log_lines = [f"line-{n}" for n in range(500)]
+    (runtime / "orchestrator.log").write_text("\n".join(log_lines), encoding="utf-8")
+    _stub_doctor(monkeypatch)
+
+    result = build_debug_bundle(tmp_path)
+
+    assert result.output_path is not None
+    with zipfile.ZipFile(result.output_path) as zf:
+        body = zf.read("logs/orchestrator.log").decode("utf-8").splitlines()
+    assert len(body) == 200
+    assert body[0] == "line-300"
+    assert body[-1] == "line-499"
+
+
+# ---------------------------------------------------------------------------
+# Install-method detection
+# ---------------------------------------------------------------------------
+
+
+def test_install_method_returns_known_value() -> None:
+    """``detect_install_method`` returns one of the documented enum values."""
+    method = detect_install_method()
+    assert method in {"pip", "pipx", "uv-tool", "editable", "unknown"}
+
+
+# ---------------------------------------------------------------------------
+# Click integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_bundle_smoke(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Invoking ``debug bundle`` end-to-end through Click produces a ZIP."""
+    _stub_doctor(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(debug_group, ["bundle", "--last"])
+
+    assert result.exit_code == 0, result.output
+    zips = list(tmp_path.glob("bernstein-debug-*.zip"))
+    assert len(zips) == 1
+    with zipfile.ZipFile(zips[0]) as zf:
+        assert "manifest.json" in zf.namelist()
+
+
+def test_cli_manifest_only_prints_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--manifest-only`` prints valid JSON and does not write a ZIP."""
+    _stub_doctor(monkeypatch)
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(debug_group, ["bundle", "--manifest-only"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema_version"] == 1
+    assert payload["selection"]["mode"] == "last"
+    assert not list(tmp_path.glob("*.zip"))


### PR DESCRIPTION
## Summary

- Adds a new `bernstein debug` Click group with a `bundle` subcommand that produces a self-contained, redacted ZIP suitable for attachment to a bug report. Default selection is `--last`; `--task`, `--run`, `--out`, `--manifest-only`, and `--include-source-snippets N` are supported.
- Bundle contents (every text artefact passes through secret redaction first): `manifest.json` (bernstein version, python version, OS, install method, selection), redacted `bernstein.yaml`, `doctor.json` snapshot, recent `.sdd/traces/` and `.sdd/metrics/` for the selected task/run, last 200 lines of every `.sdd/runtime/*.log`, optional `source/` snippets under a 64 KiB byte budget.
- ZIP plumbing reuses the existing `run_archive` convention; redaction routes through a new `core.security.redactor` wrapper that scrubs API keys, tokens, bearer headers, JWTs, SSH keys, URL-embedded credentials, and collapses `$HOME` paths to `~`.
- Updates `.github/ISSUE_TEMPLATE/bug_report.yml` to instruct reporters to attach the output of `bernstein debug bundle --last`, with a quick `unzip -p ... manifest.json` self-check so they can verify what they are sharing.
- Keeps the flat `bernstein debug-bundle` alias intact for back-compat with older issue templates.

## Test plan

- [x] `pytest tests/unit/cli/test_debug_bundle.py` (15 tests: empty project, missing run id, redaction roundtrip, manifest schema, file-inclusion budget, log tailing, install-method detection, Click integration for ZIP and `--manifest-only`).
- [x] `uv run ruff check` and `uv run ruff format --check` on the new files (clean).
- [x] `uv run mypy --follow-imports=silent` on `src/bernstein/cli/debug_bundle.py` and `src/bernstein/core/security/redactor.py` (no issues).
- [x] Smoke: `bernstein debug --help`, `bernstein debug bundle --help`, `bernstein debug-bundle --help` (back-compat alias) all return exit 0 with the expected usage lines.