### PR TITLE
feat(cli): bernstein integrations list - enumerate wired-in adapters

### DIFF
--- a/.cursor/rules/module-map.mdc
+++ b/.cursor/rules/module-map.mdc
@@ -132,6 +132,7 @@ alwaysApply: false
 | `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
+| `use_cases.py`             | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
 
 ### `src/bernstein/agents/` — agent catalog & discovery

--- a/.goosehints
+++ b/.goosehints
@@ -133,6 +133,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
+| `use_cases.py`             | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
 
 ### `src/bernstein/agents/` — agent catalog & discovery

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
+| `use_cases.py`             | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
 
 ### `src/bernstein/agents/` — agent catalog & discovery

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
+| `use_cases.py`             | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
 
 ### `src/bernstein/agents/` — agent catalog & discovery

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -133,6 +133,7 @@ Bernstein is named after Leonard Bernstein, the American conductor and composer.
 | `report.py`                | Adapter conformance + capability report |
 | `rovo.py`                  | Atlassian Rovo Dev CLI adapter |
 | `skills_injector.py`       | Inject per-task Claude Code skills into the worktree before spawn |
+| `use_cases.py`             | Per-adapter metadata for the ``bernstein integrations list`` command |
 | `ci/`                      | CI system adapters for log parsing and failure extraction |
 
 ### `src/bernstein/agents/` — agent catalog & discovery

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ bernstein init
 bernstein run -g "fix the failing test in tests/test_foo.py"
 ```
 
+See installed integrations: `bernstein integrations list --installed`.
+
 ## sponsor
 
 if bernstein routed a model that saved you a claude bill, $25 covers a month of my coffee.

--- a/docs/adapters/index.md
+++ b/docs/adapters/index.md
@@ -1,0 +1,84 @@
+# Integrations index
+
+Bernstein ships ready-made adapters for the CLI coding agents under
+`src/bernstein/adapters/`. This page lists every wired-in integration
+with a one-line use case so you do not have to grep the source tree.
+
+The same data is available from the CLI:
+
+```bash
+bernstein integrations list                # one line per adapter
+bernstein integrations list --details      # per-adapter block with config knob
+bernstein integrations list --installed    # only adapters whose binary is on $PATH
+bernstein integrations list --json         # stable JSON for CI dashboards
+```
+
+Per-adapter copy lives in
+[`src/bernstein/adapters/use_cases.py`](../../src/bernstein/adapters/use_cases.py).
+That module is the single source of truth - this page links to it so we
+do not maintain two copies of the same list.
+
+## Selecting an adapter
+
+Set the active adapter through the `cli:` knob in `bernstein.yaml`:
+
+```yaml
+cli: claude            # or any other registry key listed below
+```
+
+Use `bernstein adapters check <name>` to verify conformance for a
+single adapter, and `bernstein adapters list` for a richer view that
+includes source paths and conformance verdicts.
+
+## Categories
+
+The current registry covers four broad categories. Names below match
+the registry keys you pass via `cli:`.
+
+### Mainstream coding agents
+
+These are the most exercised adapters in the test matrix.
+
+- `claude` - Anthropic Claude Code CLI.
+- `codex` - OpenAI Codex CLI.
+- `cursor` - Cursor Agent CLI.
+- `aider` - Aider pair-programming CLI.
+- `gemini` - Google Gemini CLI.
+- `copilot` - GitHub Copilot CLI.
+- `goose` - Block Goose.
+
+### Local and offline
+
+For air-gap or BYO-model scenarios.
+
+- `ollama` - drives Aider against an Ollama or OpenAI-compatible server.
+- `gptme` - local-first coding agent with shell tools.
+- `mock` - test stub, no API keys or network.
+- `generic` - wrap any coding agent CLI by command string.
+
+### Specialised adapters
+
+- `iac` - infrastructure-as-code (Terraform / Pulumi) with plan-before-apply.
+- `clm` - sovereign LLM gateway over mTLS for regulated deployments.
+- `cloudflare` - Cloudflare Agents SDK via wrangler.
+- `openai_agents` - in-process OpenAI Agents SDK v2 (requires the
+  `[openai]` extra).
+
+### Other supported CLIs
+
+See `bernstein integrations list` for the full enumerated set. The
+registry currently surfaces ~40 adapters; this page lists categories
+rather than re-listing each entry so the index does not drift.
+
+## Adding a new adapter
+
+1. Add a `<name>.py` module under `src/bernstein/adapters/` implementing
+   `CLIAdapter`.
+2. Register the class in `src/bernstein/adapters/registry.py`.
+3. Add an entry to `src/bernstein/adapters/use_cases.py` so the new
+   adapter shows up in `bernstein integrations list` with a meaningful
+   headline.
+4. Cover the adapter with a conformance test under `tests/contract/`.
+
+The contract for new adapters lives in
+[ADAPTER_GUIDE.md](./ADAPTER_GUIDE.md).

--- a/src/bernstein/adapters/use_cases.py
+++ b/src/bernstein/adapters/use_cases.py
@@ -1,0 +1,292 @@
+"""Per-adapter metadata for the ``bernstein integrations list`` command.
+
+Bernstein ships many CLI adapters under :mod:`bernstein.adapters`. Each
+adapter file already carries a module docstring with implementation
+notes, but the docstrings are written for contributors patching the
+adapter and not for end users picking which CLI to wire up.
+
+This module is the single source of truth for end-user copy:
+
+* ``headline`` - one-line use case suitable for a CLI table row.
+* ``binary`` - the executable name probed via ``shutil.which`` to
+  determine the ``--installed`` flag (overrides the registry key).
+* ``details`` - optional multi-line description used by
+  ``bernstein integrations list --details``.
+* ``docs_path`` - optional repo-relative path to the per-adapter doc
+  page.  When absent the index page is linked instead.
+
+Adapters whose copy is missing fall back to the first line of the
+module docstring (see ``integrations_cmd._fallback_headline``). New
+adapters can either register an entry here or rely on a clean module
+docstring; both paths keep the data in the package tree, not in a
+separate markdown file that would drift.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AdapterUseCase:
+    """End-user copy describing what an adapter is for.
+
+    Attributes:
+        headline: Single-line summary, no trailing punctuation. Shown in
+            the default table view.
+        binary: Name of the CLI binary on ``$PATH`` that the adapter
+            shells out to. Empty when the adapter is in-process (e.g.
+            ``mock``, ``generic``, SDK-only adapters).
+        details: Optional longer-form description shown by
+            ``--details``. Use plain hyphens, no em-dashes.
+        docs_path: Optional repo-relative path to per-adapter docs
+            (e.g. ``docs/adapters/claude.md``).
+    """
+
+    headline: str
+    binary: str = ""
+    details: str = ""
+    docs_path: str = ""
+
+
+# Adapter name -> use case copy. Keys must match the registry keys in
+# ``bernstein.adapters.registry``. When in doubt about a binary name,
+# cross-reference ``adapter_cmd._BINARY_OVERRIDES``.
+USE_CASES: dict[str, AdapterUseCase] = {
+    "aichat": AdapterUseCase(
+        headline="Multi-provider chat CLI with shell command and file context",
+        binary="aichat",
+        details=(
+            "Wraps the aichat binary so Bernstein can route prompts to any "
+            "OpenAI, Anthropic, or local provider it supports without "
+            "swapping adapters."
+        ),
+    ),
+    "aider": AdapterUseCase(
+        headline="Pair-programming CLI with automatic commits in the worktree",
+        binary="aider",
+        details=(
+            "Non-interactive aider run via --message --yes. Aider commits "
+            "directly, which is fine inside an isolated Bernstein worktree "
+            "and gets merged when the branch lands."
+        ),
+    ),
+    "amp": AdapterUseCase(
+        headline="Sourcegraph Amp CLI for repository-wide refactors",
+        binary="amp",
+    ),
+    "auggie": AdapterUseCase(
+        headline="Augment Code Auggie CLI driven from Bernstein",
+        binary="auggie",
+    ),
+    "autohand": AdapterUseCase(
+        headline="Autohand Code CLI for autonomous task execution",
+        binary="autohand",
+    ),
+    "charm": AdapterUseCase(
+        headline="Charm Crush CLI - terminal coding agent with TUI affordances",
+        binary="crush",
+    ),
+    "claude": AdapterUseCase(
+        headline="Anthropic Claude Code CLI - default headless coding agent",
+        binary="claude",
+        details=(
+            "Spawns ``claude --print`` with MCP config merging, "
+            "cache-control blocks, and per-role tool allowlists. The most "
+            "broadly exercised adapter in the test matrix."
+        ),
+        docs_path="docs/adapters/ADAPTER_GUIDE.md",
+    ),
+    "cline": AdapterUseCase(
+        headline="Cline (formerly Claude Dev) CLI for autonomous tasks",
+        binary="cline",
+    ),
+    "clm": AdapterUseCase(
+        headline="Sovereign LLM gateway adapter with mTLS launcher",
+        binary="clm",
+        details=(
+            "For customer-side CLM gateways behind an mTLS boundary. "
+            "Useful for air-gap and regulated deployments where requests "
+            "never leave the customer network."
+        ),
+        docs_path="docs/adapters/clm.md",
+    ),
+    "cloudflare": AdapterUseCase(
+        headline="Cloudflare Agents SDK driver via wrangler dev or worker trigger",
+        binary="wrangler",
+    ),
+    "codebuff": AdapterUseCase(
+        headline="Codebuff CLI integration",
+        binary="codebuff",
+    ),
+    "codex": AdapterUseCase(
+        headline="OpenAI Codex CLI - GPT-family coding agent",
+        binary="codex",
+        details=(
+            "Non-interactive Codex run with structured output. Pairs well "
+            "with Claude in the same Bernstein plan when you want a "
+            "cross-model review pass."
+        ),
+    ),
+    "cody": AdapterUseCase(
+        headline="Sourcegraph Cody CLI with code graph context",
+        binary="cody",
+    ),
+    "composio": AdapterUseCase(
+        headline="Composio Agent Orchestrator (ao) CLI",
+        binary="ao",
+    ),
+    "continue": AdapterUseCase(
+        headline="Continue.dev CLI for IDE-style coding agents in the terminal",
+        binary="continue",
+    ),
+    "copilot": AdapterUseCase(
+        headline="GitHub Copilot CLI driven headlessly from Bernstein",
+        binary="copilot",
+    ),
+    "cursor": AdapterUseCase(
+        headline="Cursor Agent CLI - print mode with workspace trust",
+        binary="cursor-agent",
+        details=(
+            "Headless cursor-agent runs with --print, --force for actual "
+            "edits, and --trust to skip the workspace prompt. Shares the "
+            "editor's .cursor/mcp.json by default."
+        ),
+    ),
+    "devin_terminal": AdapterUseCase(
+        headline="Devin for Terminal (Cognition) CLI",
+        binary="devin",
+    ),
+    "droid": AdapterUseCase(
+        headline="Droid CLI by Factory AI",
+        binary="droid",
+    ),
+    "forge": AdapterUseCase(
+        headline="Forge CLI integration",
+        binary="forge",
+    ),
+    "gemini": AdapterUseCase(
+        headline="Google Gemini CLI for Gemini 2.5 Pro and Flash",
+        binary="gemini",
+    ),
+    "generic": AdapterUseCase(
+        headline="Wrap an arbitrary coding agent CLI by command string",
+        binary="",
+        details=(
+            "Use this when your tool of choice has no first-class adapter "
+            "yet. Configure ``cli_command`` and ``display_name`` and "
+            "Bernstein will spawn it with the orchestration contract."
+        ),
+    ),
+    "goose": AdapterUseCase(
+        headline="Block Goose - extensible coding agent with provider switch",
+        binary="goose",
+    ),
+    "gptme": AdapterUseCase(
+        headline="gptme - local-first coding agent with shell and Python tools",
+        binary="gptme",
+    ),
+    "hermes": AdapterUseCase(
+        headline="Hermes Agent by Nous Research",
+        binary="hermes",
+    ),
+    "iac": AdapterUseCase(
+        headline="Infrastructure-as-Code agent (Terraform/Pulumi) with plan-before-apply",
+        binary="",
+        details=(
+            "Orchestrates IaC agents that always run plan/preview before "
+            "apply. Enforces operator approval on destructive changes."
+        ),
+    ),
+    "junie": AdapterUseCase(
+        headline="JetBrains Junie CLI for IDE-aligned coding tasks",
+        binary="junie",
+    ),
+    "kilo": AdapterUseCase(
+        headline="Kilo CLI by Stackblitz",
+        binary="kilo",
+    ),
+    "kimi": AdapterUseCase(
+        headline="Kimi CLI for Moonshot models",
+        binary="kimi",
+    ),
+    "kiro": AdapterUseCase(
+        headline="Kiro CLI integration",
+        binary="kiro",
+    ),
+    "letta_code": AdapterUseCase(
+        headline="Letta Code CLI - stateful coding agent",
+        binary="letta",
+    ),
+    "mistral": AdapterUseCase(
+        headline="Mistral Vibe CLI",
+        binary="mistral",
+    ),
+    "mock": AdapterUseCase(
+        headline="Test-only stub adapter - no API keys, no network",
+        binary="",
+        details=(
+            "Used for zero-API-key demos, CI smoke tests, and the "
+            "conformance harness. Selecting ``mock`` skips real LLM "
+            "calls entirely."
+        ),
+    ),
+    "ollama": AdapterUseCase(
+        headline="Local Ollama / OpenAI-compatible models without cloud keys",
+        binary="ollama",
+        details=(
+            "Drives Aider as the coding frontend with Ollama (or any "
+            "OpenAI-compatible) server. Useful for offline development "
+            "and benchmark runs that must stay on-prem."
+        ),
+    ),
+    "open_interpreter": AdapterUseCase(
+        headline="Open Interpreter CLI - natural language to shell and code",
+        binary="interpreter",
+    ),
+    "openai_agents": AdapterUseCase(
+        headline="OpenAI Agents SDK v2 (in-process Python adapter)",
+        binary="",
+        details=(
+            "Imports the OpenAI Agents SDK and runs the session via a "
+            "Python entrypoint instead of a subprocess. Install with "
+            "``pip install 'bernstein[openai]'``."
+        ),
+        docs_path="docs/adapters/openai-agents.md",
+    ),
+    "opencode": AdapterUseCase(
+        headline="OpenCode (sst/opencode) terminal coding agent",
+        binary="opencode",
+    ),
+    "openhands": AdapterUseCase(
+        headline="OpenHands (formerly OpenDevin) headless run",
+        binary="openhands",
+    ),
+    "pi": AdapterUseCase(
+        headline="pi-coding-agent CLI",
+        binary="pi",
+    ),
+    "plandex": AdapterUseCase(
+        headline="Plandex CLI - context-aware planning agent",
+        binary="plandex",
+    ),
+    "q_dev": AdapterUseCase(
+        headline="AWS Q Developer CLI (binary: q)",
+        binary="q",
+    ),
+    "qwen": AdapterUseCase(
+        headline="Qwen CLI for OpenAI-compatible Qwen models",
+        binary="qwen",
+    ),
+    "ralphex": AdapterUseCase(
+        headline="Ralphex (umputun/ralphex) coding agent",
+        binary="ralphex",
+    ),
+    "rovo": AdapterUseCase(
+        headline="Atlassian Rovo Dev CLI",
+        binary="rovo",
+    ),
+}
+
+
+__all__ = ["USE_CASES", "AdapterUseCase"]

--- a/src/bernstein/cli/commands/integrations_cmd.py
+++ b/src/bernstein/cli/commands/integrations_cmd.py
@@ -1,0 +1,237 @@
+"""``bernstein integrations list`` - enumerate wired-in CLI adapters.
+
+Users currently have to read ``src/bernstein/adapters/`` to discover
+which CLI tools Bernstein can drive. This command surfaces the same
+information directly from the registry:
+
+* ``bernstein integrations list`` - one line per adapter (name + headline).
+* ``--details`` - per-adapter block with binary, config knob, docs link.
+* ``--json`` - stable machine-readable payload for CI dashboards.
+* ``--installed`` - filter to adapters whose binary is on ``$PATH``.
+
+Per-adapter copy is sourced from :mod:`bernstein.adapters.use_cases`
+which sits alongside the adapter implementations. When an entry is
+absent we fall back to the first line of the adapter module docstring
+so newly-added adapters still appear with a sensible summary.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import shutil
+import sys
+
+import click
+
+from bernstein.adapters.use_cases import USE_CASES, AdapterUseCase
+from bernstein.cli.helpers import console
+
+FORMAT_TABLE = "table"
+FORMAT_JSON = "json"
+DOCS_INDEX = "docs/adapters/index.md"
+CONFIG_KNOB = "cli"
+
+
+def _fallback_headline(adapter_obj: object) -> str:
+    """Use the first line of the module docstring when no curated copy exists.
+
+    Strips the trailing "CLI adapter" boilerplate so the line reads as a
+    use case rather than a tautology.
+    """
+    target = adapter_obj if inspect.isclass(adapter_obj) else type(adapter_obj)
+    try:
+        module = inspect.getmodule(target)
+    except Exception:  # pragma: no cover - defensive
+        module = None
+    raw = (getattr(module, "__doc__", None) or "").strip()
+    if not raw:
+        return ""
+    first_line = raw.splitlines()[0].strip().rstrip(".")
+    # Strip the common "X CLI adapter" / "X adapter" suffix.
+    for suffix in (" CLI adapter", " adapter for Bernstein", " adapter"):
+        if first_line.lower().endswith(suffix.lower()):
+            first_line = first_line[: -len(suffix)].rstrip(" -")
+            break
+    return first_line
+
+
+def _docs_link(name: str, use_case: AdapterUseCase | None) -> str:
+    """Resolve the per-adapter doc link, falling back to the index page."""
+    if use_case and use_case.docs_path:
+        return use_case.docs_path
+    return DOCS_INDEX
+
+
+def _binary_for(name: str, use_case: AdapterUseCase | None) -> str:
+    """Pick the binary name to probe via ``shutil.which``.
+
+    Priority: explicit use-case entry, then the override table in
+    :mod:`bernstein.cli.commands.adapter_cmd`, then the registry key
+    itself. Empty string means "no external binary" (in-process or
+    SDK-only adapters).
+    """
+    if use_case is not None:
+        return use_case.binary
+    # Lazy import keeps the dependency graph one-way: integrations_cmd
+    # depends on adapter_cmd, never the reverse.
+    overrides = importlib.import_module("bernstein.cli.commands.adapter_cmd")._BINARY_OVERRIDES
+    if name in overrides:
+        return overrides[name]
+    return name
+
+
+def _enumerate_rows() -> list[dict[str, object]]:
+    """Snapshot the live registry plus the synthetic ``generic`` adapter."""
+    registry = importlib.import_module("bernstein.adapters.registry")
+    registry._load_entrypoint_adapters()
+
+    rows: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for name, adapter in sorted(registry._ADAPTERS.items()):
+        rows.append(_row_for(name, adapter))
+        seen.add(name)
+
+    # ``generic`` is constructed lazily inside ``get_adapter`` and not
+    # registered in ``_ADAPTERS`` on import. Surface it so the listing
+    # matches what ``--help`` would suggest.
+    if "generic" not in seen:
+        generic_mod = importlib.import_module("bernstein.adapters.generic")
+        rows.append(_row_for("generic", generic_mod.GenericAdapter))
+
+    rows.sort(key=lambda r: str(r["name"]))
+    return rows
+
+
+def _row_for(name: str, adapter_obj: object) -> dict[str, object]:
+    """Build the JSON-shaped row for a single adapter."""
+    use_case = USE_CASES.get(name)
+    headline = (use_case.headline if use_case else "") or _fallback_headline(adapter_obj)
+    binary = _binary_for(name, use_case)
+    installed = bool(binary) and shutil.which(binary) is not None
+    return {
+        "name": name,
+        "headline": headline,
+        "binary": binary,
+        "installed": installed,
+        "config_knob": CONFIG_KNOB,
+        "docs": _docs_link(name, use_case),
+        "details": use_case.details if use_case else "",
+    }
+
+
+def _filter_installed(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Drop rows whose binary is not currently on ``$PATH``."""
+    return [row for row in rows if row["installed"]]
+
+
+def _render_summary_table(rows: list[dict[str, object]]) -> None:
+    """Default ``integrations list`` view: name + headline."""
+    from rich.table import Table
+
+    table = Table(title=f"Bernstein integrations ({len(rows)})", show_lines=False)
+    table.add_column("name", style="cyan", no_wrap=True)
+    table.add_column("installed", style="green", no_wrap=True)
+    table.add_column("headline", style="white")
+    for row in rows:
+        installed_marker = "[green]yes[/green]" if row["installed"] else "[dim]no[/dim]"
+        if not row["binary"]:
+            installed_marker = "[dim]n/a[/dim]"
+        table.add_row(str(row["name"]), installed_marker, str(row["headline"] or "-"))
+    console.print(table)
+
+
+def _render_details(rows: list[dict[str, object]]) -> None:
+    """``--details`` view: per-adapter block with binary, config, docs."""
+    for row in rows:
+        console.print(f"[cyan bold]{row['name']}[/cyan bold]")
+        console.print(f"  headline   : {row['headline'] or '-'}")
+        binary = str(row["binary"]) or "-"
+        installed = "installed" if row["installed"] else "missing"
+        if not row["binary"]:
+            installed = "n/a"
+        console.print(f"  binary     : {binary}  ({installed})")
+        console.print(f"  config knob: {row['config_knob']}: {row['name']}")
+        console.print(f"  docs       : {row['docs']}")
+        if row["details"]:
+            console.print(f"  notes      : {row['details']}")
+        console.print()
+
+
+@click.group("integrations")
+def integrations_group() -> None:
+    """List and inspect the CLI agents Bernstein knows how to drive."""
+
+
+@integrations_group.command("list")
+@click.option(
+    "--details",
+    is_flag=True,
+    default=False,
+    help="Show a fuller per-adapter block instead of one line per adapter.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit a stable JSON document for programmatic consumption.",
+)
+@click.option(
+    "--installed",
+    "installed_only",
+    is_flag=True,
+    default=False,
+    help="Filter to adapters whose binary is currently on $PATH.",
+)
+def integrations_list_cmd(details: bool, as_json: bool, installed_only: bool) -> None:
+    """Enumerate every CLI adapter Bernstein knows about.
+
+    With no flags, prints a one-line summary per adapter. Use ``--details``
+    for per-adapter blocks, ``--json`` for CI dashboards, and
+    ``--installed`` to filter to adapters that are usable right now.
+    """
+    rows = _enumerate_rows()
+    if installed_only:
+        rows = _filter_installed(rows)
+
+    if as_json:
+        payload = {"count": len(rows), "adapters": rows}
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if details:
+        _render_details(rows)
+        return
+
+    _render_summary_table(rows)
+
+
+def register(group: click.Group) -> None:
+    """Attach the integrations group to the top-level CLI."""
+    group.add_command(integrations_group, "integrations")
+
+
+__all__ = [
+    "CONFIG_KNOB",
+    "DOCS_INDEX",
+    "FORMAT_JSON",
+    "FORMAT_TABLE",
+    "_enumerate_rows",
+    "_filter_installed",
+    "_row_for",
+    "integrations_group",
+    "integrations_list_cmd",
+    "register",
+]
+
+
+def main(argv: list[str] | None = None) -> int:  # pragma: no cover
+    """Standalone entry point - used by direct ``python -m`` invocation."""
+    integrations_list_cmd.main(args=argv, standalone_mode=False)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -63,6 +63,7 @@ from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
 from bernstein.cli.commands.decisions_cmd import decisions_group
 from bernstein.cli.commands.export_cmd import export_cmd
 from bernstein.cli.commands.fleet_cmd import fleet_group
+from bernstein.cli.commands.integrations_cmd import integrations_group
 from bernstein.cli.commands.knowledge_cmd import knowledge_group
 from bernstein.cli.commands.resume_cmd import resume_cmd
 from bernstein.cli.commands.role_adapter_policy_cmd import security_group as _role_adapter_security_group
@@ -888,6 +889,7 @@ cli.add_command(commit_stats_cmd, "commit-stats")
 cli.add_command(stop)
 cli.add_command(test_adapter, "test-adapter")
 cli.add_command(adapters_group, "adapters")
+cli.add_command(integrations_group, "integrations")
 cli.add_command(run, "run")  # visible: `bernstein run [plan.yaml]`
 cli.add_command(cook, "cook")
 cli.add_command(init)

--- a/tests/unit/cli/test_integrations_list.py
+++ b/tests/unit/cli/test_integrations_list.py
@@ -1,0 +1,169 @@
+"""Tests for ``bernstein integrations list``.
+
+The command surfaces the adapter registry to end users so they do not
+need to grep ``src/bernstein/adapters/`` to find out which CLI tools
+are wired in. These tests cover the default summary view, ``--details``,
+``--json``, and ``--installed`` filtering.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from bernstein.adapters.use_cases import USE_CASES, AdapterUseCase
+from bernstein.cli.commands.integrations_cmd import (
+    CONFIG_KNOB,
+    DOCS_INDEX,
+    _enumerate_rows,
+    _fallback_headline,
+    _filter_installed,
+)
+from bernstein.cli.main import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_integrations_group_registered_on_main_cli(runner: CliRunner) -> None:
+    """The ``integrations`` group is reachable from the top-level CLI."""
+    result = runner.invoke(cli, ["integrations", "--help"])
+    assert result.exit_code == 0, result.output
+    assert "list" in result.output
+
+
+def test_integrations_list_outputs_summary_table(runner: CliRunner) -> None:
+    """Default view prints a table with the registry adapters."""
+    result = runner.invoke(cli, ["integrations", "list"])
+    assert result.exit_code == 0, result.output
+    assert "Bernstein integrations" in result.output
+    # Spot-check a handful of well-known adapter names.
+    for expected in ("claude", "codex", "gemini", "aider", "cursor", "generic"):
+        assert expected in result.output, f"adapter {expected!r} missing from output\n{result.output}"
+
+
+def test_integrations_list_details_shows_metadata_blocks(runner: CliRunner) -> None:
+    """``--details`` prints the per-adapter block with config knob + docs."""
+    result = runner.invoke(cli, ["integrations", "list", "--details"])
+    assert result.exit_code == 0, result.output
+    assert "headline" in result.output
+    assert "config knob" in result.output
+    assert f"{CONFIG_KNOB}: claude" in result.output
+    assert DOCS_INDEX in result.output
+
+
+def test_integrations_list_json_is_valid_and_has_min_40_entries(runner: CliRunner) -> None:
+    """``--json`` emits a parseable object with >=40 adapters."""
+    result = runner.invoke(cli, ["integrations", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, dict)
+    assert payload["count"] == len(payload["adapters"])
+    assert payload["count"] >= 40, f"expected >=40 adapters, got {payload['count']}"
+    expected_keys = {
+        "name",
+        "headline",
+        "binary",
+        "installed",
+        "config_knob",
+        "docs",
+        "details",
+    }
+    for row in payload["adapters"]:
+        assert expected_keys.issubset(row.keys()), row
+        assert isinstance(row["installed"], bool)
+
+    names = {row["name"] for row in payload["adapters"]}
+    assert {"claude", "codex", "gemini", "aider", "generic"}.issubset(names)
+
+
+def test_integrations_list_installed_filter_drops_missing(
+    runner: CliRunner,
+) -> None:
+    """``--installed`` filters to adapters whose binary is on $PATH.
+
+    We stub ``shutil.which`` so the test is deterministic across hosts.
+    """
+
+    def _fake_which(binary: str) -> str | None:
+        return "/usr/local/bin/claude" if binary == "claude" else None
+
+    with patch(
+        "bernstein.cli.commands.integrations_cmd.shutil.which",
+        side_effect=_fake_which,
+    ):
+        result = runner.invoke(cli, ["integrations", "list", "--installed", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    names = {row["name"] for row in payload["adapters"]}
+    assert names == {"claude"}, names
+    assert payload["count"] == 1
+
+
+def test_integrations_list_unknown_subcommand_returns_nonzero(
+    runner: CliRunner,
+) -> None:
+    """Click rejects unknown subcommands under the ``integrations`` group."""
+    result = runner.invoke(cli, ["integrations", "definitely-not-a-cmd"])
+    assert result.exit_code != 0
+    assert "No such command" in result.output or "Error" in result.output
+
+
+def test_enumerate_rows_includes_generic_adapter() -> None:
+    """The synthetic ``generic`` adapter must appear in the listing."""
+    rows = _enumerate_rows()
+    names = {row["name"] for row in rows}
+    assert "generic" in names
+
+
+def test_filter_installed_predicate() -> None:
+    """``_filter_installed`` keeps only rows with ``installed=True``."""
+    rows: list[dict[str, Any]] = [
+        {"name": "a", "installed": True, "binary": "a"},
+        {"name": "b", "installed": False, "binary": "b"},
+        {"name": "c", "installed": True, "binary": "c"},
+    ]
+    kept = {row["name"] for row in _filter_installed(rows)}
+    assert kept == {"a", "c"}
+
+
+def test_use_case_entries_have_clean_text() -> None:
+    """Curated copy must not contain em-dashes (style rule)."""
+    for name, entry in USE_CASES.items():
+        assert isinstance(entry, AdapterUseCase), name
+        assert "—" not in entry.headline, (name, entry.headline)
+        assert "—" not in entry.details, (name, entry.details)
+        # Headlines stay compact so they fit a terminal column.
+        assert len(entry.headline) <= 120, (name, entry.headline)
+
+
+def test_fallback_headline_strips_adapter_suffix() -> None:
+    """The docstring fallback removes ``CLI adapter`` boilerplate.
+
+    The fallback reads the *module* docstring of the adapter's defining
+    module. We synthesise a stub module with a known docstring and feed
+    a class declared inside it.
+    """
+    import types
+
+    fake_mod = types.ModuleType("fake_adapter_module")
+    fake_mod.__doc__ = "Sample CLI adapter."
+
+    class _Stub: ...
+
+    _Stub.__module__ = fake_mod.__name__
+    import sys as _sys
+
+    _sys.modules[fake_mod.__name__] = fake_mod
+    try:
+        headline = _fallback_headline(_Stub)
+    finally:
+        _sys.modules.pop(fake_mod.__name__, None)
+    assert headline == "Sample"

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -215,6 +215,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "bom",
         "consensus",
         "knowledge",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "integrations",
     }
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -223,7 +223,7 @@ wheels = [
 
 [[package]]
 name = "bernstein"
-version = "2.1.0"
+version = "2.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "asn1crypto" },


### PR DESCRIPTION
## Summary

- Adds a top-level `bernstein integrations` Click group with a `list` subcommand that prints every CLI adapter registered under `src/bernstein/adapters/`, sourced from the live registry rather than a parallel doc.
- New `src/bernstein/adapters/use_cases.py` holds per-adapter end-user copy (headline, binary, optional details, optional docs path) so the description sits next to adapter code. Adapters without an entry fall back to the first line of their module docstring.
- Flags: default one-line summary, `--details` per-adapter block (binary, config knob, docs link), `--json` for stable machine output, `--installed` to filter to adapters whose binary is on `$PATH` (probed via `shutil.which`).
- README install section gains a one-liner pointer, and `docs/adapters/index.md` links category examples to the metadata module so the docs cannot silently drift.

Users currently grep the source tree to discover which CLI tools are wired in; this gives them an enumerable surface that always matches the registry.

## Test plan

- [x] `uv run ruff check` on changed files: clean
- [x] `uv run ruff format --check` on changed files: clean
- [x] `uv run pytest tests/unit/cli/test_integrations_list.py`: 10 passed
- [x] Manual smoke: `bernstein integrations list`, `--details`, `--json`, `--installed`
- [x] Manual smoke: `bernstein integrations --help` discoverable from top-level CLI