### PR TITLE
feat(memory): cross-task knowledge share via publish/subscribe

### DIFF
--- a/docs/memory/cross-task-share.md
+++ b/docs/memory/cross-task-share.md
@@ -1,0 +1,119 @@
+# Cross-task knowledge share
+
+`CrossTaskKB` is the public surface on top of the existing tag-indexed SQLite
+memory store. It lets one task **publish** a fact under a tag and another task
+**subscribe** on that tag, without writing files into a shared worktree path
+and hoping the next agent reads them.
+
+The facade is a thin wrapper. It does not introduce new storage. Every fact
+is persisted as a row in the existing `memory` table (with `type='cross_task'`)
+plus an attribution sidecar row that carries the lineage-style triple
+`(producer_task_id, ts_ns, content_hash)`.
+
+## Contract
+
+```python
+from bernstein.core.memory.cross_task_kb import CrossTaskKB
+from bernstein.core.memory.sqlite_store import SQLiteMemoryStore
+
+store = SQLiteMemoryStore(Path(".sdd/memory/memory.db"))
+facade = CrossTaskKB(store, run_id="r-1", producer_task_id="t-7")
+
+# Publish
+facade.publish(tag="api-schema", key="users", value="...", scope="run")
+
+# Subscribe (yields newest-first, one fact per key)
+for fact in facade.subscribe(tag="api-schema", scope="run"):
+    use(fact.value)
+```
+
+### Fact attribution
+
+Every fact carries the same triple a lineage entry would:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `producer_task_id` | `str` | Task ID of the publisher. |
+| `ts_ns` | `int` | Wall-clock nanoseconds at publish time. |
+| `content_hash` | `str` | `sha256:<hex>` over the UTF-8 value bytes. |
+
+This mirrors `bernstein.core.lineage.recorder.LineageRecorder.record_write`, so
+an auditor can correlate a fact with the lineage entry of the artefact that
+produced it.
+
+## Scope rules
+
+| Scope | Visibility | Use when |
+|-------|------------|----------|
+| `run` | Same `run_id` only. | Short-lived hand-offs between agents in the same orchestration run. |
+| `project` | Any task in the same `.sdd/` root. | Conventions, decisions, schemas the whole project should see across runs. |
+
+Both scopes are single-host. Cross-machine replication is out of scope; the
+ticket calls it out explicitly as v2.
+
+## Conflict resolution
+
+Two tasks publishing under the same `(scope, tag, key)`: **last-write-wins**.
+The earlier rows are not deleted, so the audit log retains every version, but
+`subscribe()` only returns the newest one per key. A warning is logged into
+the trace when a prior fact under the same identity is overwritten.
+
+Operator-policy resolution (allow/deny/prompt) is a v2 follow-up.
+
+## Lifecycle hook
+
+Each publish fires the `kb.fact_published` lifecycle event. Hook plugins
+receive the attribution payload plus `tag`, `key`, `scope`. The hook is
+best-effort: a misbehaving plugin cannot block the publish path.
+
+## CLI
+
+```
+bernstein memory share <key> <value> --tag <tag> --scope run|project
+bernstein memory query --tag <tag> --scope run|project [--raw]
+```
+
+`query` redacts emails, phone numbers, SSNs, and credit card numbers in the
+output by default. Pass `--raw` to print stored values verbatim - useful for
+operator debugging when the redaction is itself the issue.
+
+The CLI reads `BERNSTEIN_RUN_ID` and `BERNSTEIN_TASK_ID` from the environment
+for attribution. Outside an orchestrator-spawned session the producer task ID
+defaults to `manual-cli`.
+
+## Telemetry
+
+`CrossTaskKB.counter.snapshot()` returns `(publish, subscribe)` counts for the
+current process. The orchestrator reads these into the run summary.
+
+## Worked example
+
+A researcher publishes the discovered API schema:
+
+```python
+researcher = CrossTaskKB(store, run_id="r-1", producer_task_id="researcher-1")
+researcher.publish(
+    tag="api-schema",
+    key="users",
+    value="{name: str, email: str}",
+    scope="project",
+)
+```
+
+A backend agent in a later task subscribes on the same tag:
+
+```python
+backend = CrossTaskKB(store, run_id="r-1", producer_task_id="backend-1")
+for fact in backend.subscribe(tag="api-schema", scope="project"):
+    print(fact.key, fact.value, "from", fact.producer_task_id)
+```
+
+The backend agent sees `users / {name: str, email: str} / from researcher-1`.
+
+## Out of scope (v1)
+
+- Vector or embedding similarity for tag matching. v1 = exact tag string only.
+- Cross-machine replication.
+- Conflict resolution beyond last-write-wins.
+- Auto-injection into role prompts. Agents have to opt in by calling the
+  facade or the CLI.

--- a/src/bernstein/cli/commands/memory_cmd.py
+++ b/src/bernstein/cli/commands/memory_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import cast
 
@@ -9,11 +10,27 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from bernstein.core.memory.cross_task_kb import CrossTaskKB, Scope, redact_value
 from bernstein.core.memory.sqlite_store import MemoryType, SQLiteMemoryStore
 
 _MEMORY_DB_PATH = ".sdd/memory/memory.db"
 
 console = Console()
+
+
+def _resolve_db_path() -> Path:
+    """Return the SQLite path the CLI should operate on."""
+    return Path(_MEMORY_DB_PATH)
+
+
+def _resolve_run_id() -> str:
+    """Return the active run id; falls back to ``BERNSTEIN_RUN_ID`` env var."""
+    return os.environ.get("BERNSTEIN_RUN_ID", "")
+
+
+def _resolve_task_id() -> str:
+    """Return the active task id; falls back to ``BERNSTEIN_TASK_ID`` env var."""
+    return os.environ.get("BERNSTEIN_TASK_ID", "manual-cli")
 
 
 @click.group("memory")
@@ -103,3 +120,95 @@ def remove_memory(entry_id: int) -> None:
         console.print(f"[green]✓[/green] Removed memory entry [bold]#{entry_id}[/bold]")
     else:
         console.print(f"[red]✗[/red] Entry [bold]#{entry_id}[/bold] not found")
+
+
+# ---------------------------------------------------------------------------
+# Cross-task knowledge share: publish/subscribe on tag-indexed memory.
+# ---------------------------------------------------------------------------
+
+
+@memory_group.command("share")
+@click.argument("key")
+@click.argument("value")
+@click.option("--tag", required=True, help="Subscription tag for this fact.")
+@click.option(
+    "--scope",
+    type=click.Choice(["run", "project"]),
+    default="project",
+    help="run = current orchestration run only; project = whole .sdd/ root.",
+)
+def share_fact(key: str, value: str, tag: str, scope: str) -> None:
+    """Publish a fact under ``tag``/``key`` for other tasks to subscribe to.
+
+    Manual operator escape hatch over the cross-task knowledge-base facade.
+    """
+    db_path = _resolve_db_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    store = SQLiteMemoryStore(db_path)
+    facade = CrossTaskKB(
+        store,
+        run_id=_resolve_run_id(),
+        producer_task_id=_resolve_task_id(),
+    )
+    fact = facade.publish(
+        tag=tag,
+        key=key,
+        value=value,
+        scope=cast("Scope", scope),
+    )
+    console.print(
+        f"[green]✓[/green] Published [bold]{fact.tag}/{fact.key}[/bold] "
+        f"(scope={fact.scope}, hash={fact.content_hash[:19]}...)"
+    )
+
+
+@memory_group.command("query")
+@click.option("--tag", required=True, help="Subscription tag to query.")
+@click.option(
+    "--scope",
+    type=click.Choice(["run", "project"]),
+    default="project",
+    help="run = current orchestration run only; project = whole .sdd/ root.",
+)
+@click.option(
+    "--raw",
+    is_flag=True,
+    default=False,
+    help="Print raw values without PII redaction. Off by default.",
+)
+def query_facts(tag: str, scope: str, raw: bool) -> None:
+    """List facts published under ``tag`` with values redacted by default."""
+    db_path = _resolve_db_path()
+    if not db_path.exists():
+        console.print("[dim]No memory database found.[/dim]")
+        return
+
+    store = SQLiteMemoryStore(db_path)
+    facade = CrossTaskKB(
+        store,
+        run_id=_resolve_run_id(),
+        producer_task_id=_resolve_task_id(),
+    )
+    facts = list(facade.subscribe(tag=tag, scope=cast("Scope", scope)))
+    if not facts:
+        console.print(f"[dim]No facts published under tag={tag!r} scope={scope!r}.[/dim]")
+        return
+
+    table = Table(title=f"Cross-task facts (tag={tag}, scope={scope})")
+    table.add_column("Key", style="cyan")
+    table.add_column("Producer", style="green")
+    table.add_column("Value")
+    table.add_column("Hash", style="dim")
+
+    for fact in facts:
+        display = fact.value if raw else redact_value(fact.value)
+        if len(display) > 200:
+            display = display[:200] + "..."
+        table.add_row(
+            fact.key,
+            fact.producer_task_id or "(unknown)",
+            display,
+            fact.content_hash[:19] + "...",
+        )
+
+    console.print(table)

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -85,6 +85,11 @@ class LifecycleEvent(StrEnum):
     # successfully loads a checkpoint and is about to re-spawn the task.
     # Plugins can react to track resume metrics, gate flaky tasks, etc.
     TASK_RESUME = "task.resume"
+    # feat-cross-task-kb: fires when a task publishes a fact through the
+    # cross-task knowledge-base facade. Payload carries the attribution
+    # triple ``(producer_task_id, ts_ns, content_hash)`` plus ``tag``,
+    # ``key``, and ``scope``.
+    KB_FACT_PUBLISHED = "kb.fact_published"
 
     # ------------------------------------------------------------------
     # Cross-CLI lifecycle events (camelCase, T1323).

--- a/src/bernstein/core/memory/cross_task_kb.py
+++ b/src/bernstein/core/memory/cross_task_kb.py
@@ -1,0 +1,490 @@
+"""Cross-task knowledge base: explicit publish/subscribe over tag-indexed memory.
+
+The orchestrator already ships a tag-indexed SQLite store and a JSONL log under
+``bernstein.core.memory``. What was missing is a small, explicit public surface
+for one task to *publish* a fact under a tag and another task to *subscribe* on
+that tag - without writing files to a shared worktree path and hoping the next
+agent reads them.
+
+This module is a thin facade. It does not introduce new storage. Every fact is
+persisted as a row in the existing ``memory`` table with ``type='cross_task'``
+and an extra ``cross_task_meta`` row carrying the lineage-style attribution
+triple ``(producer_task_id, ts_ns, content_hash)``. That mirrors the pattern
+used by :mod:`bernstein.core.lineage.recorder` for artefact writes.
+
+Two scopes are supported, both single-host:
+
+* ``run`` - facts visible only within the current orchestration run. The
+  ``run_id`` is supplied at facade-construction time.
+* ``project`` - facts visible to every task in the same ``.sdd/`` project root.
+
+Conflict resolution for two tasks publishing the same ``(scope, tag, key)`` is
+last-write-wins, with a warning emitted into the trace log. Operator-policy
+resolution is out of scope for this iteration; see the ticket for v2 plans.
+
+Public surface::
+
+    facade = CrossTaskKB(store, run_id="r-1", producer_task_id="t-7")
+    facade.publish(tag="api-schema", key="users", value="...", scope="run")
+    for fact in facade.subscribe(tag="api-schema", scope="run"):
+        ...
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from bernstein.core.memory.sqlite_store import SQLiteMemoryStore
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "CrossTaskKB",
+    "Fact",
+    "PublishCounter",
+    "Scope",
+    "redact_value",
+]
+
+Scope = Literal["run", "project"]
+"""Visibility scope for a published fact.
+
+``run``     - same orchestration run only (single ``run_id``).
+``project`` - any task in the same ``.sdd/`` project root.
+"""
+
+_VALID_SCOPES: frozenset[str] = frozenset({"run", "project"})
+
+
+@dataclass(frozen=True, slots=True)
+class Fact:
+    """A single published fact with attribution.
+
+    The triple ``(producer_task_id, ts_ns, content_hash)`` mirrors the
+    attribution shape used by :class:`bernstein.core.lineage.entry.LineageEntry`
+    so a downstream auditor can correlate a fact with the lineage entry of the
+    artefact that produced it.
+
+    Attributes:
+        tag: The subscription tag the value was published under.
+        key: A short stable identifier scoped under ``tag``.
+        value: The published payload. Returned as stored; subscribers that
+            need redaction should call :func:`redact_value` themselves.
+        scope: ``"run"`` or ``"project"``.
+        producer_task_id: Task ID of the agent that published the fact.
+        ts_ns: Wall-clock nanoseconds at publish time.
+        content_hash: ``sha256:<hex>`` of the UTF-8 encoded ``value`` bytes.
+    """
+
+    tag: str
+    key: str
+    value: str
+    scope: Scope
+    producer_task_id: str
+    ts_ns: int
+    content_hash: str
+
+
+class PublishCounter:
+    """Thread-safe in-process counters for publish/subscribe operations.
+
+    Exposed so the orchestrator's run summary can read totals without taking
+    a dependency on the SQLite schema. Counters reset per process.
+    """
+
+    __slots__ = ("_lock", "publish", "subscribe")
+
+    def __init__(self) -> None:
+        self.publish: int = 0
+        self.subscribe: int = 0
+        self._lock = threading.Lock()
+
+    def incr_publish(self) -> None:
+        with self._lock:
+            self.publish += 1
+
+    def incr_subscribe(self, count: int = 1) -> None:
+        with self._lock:
+            self.subscribe += count
+
+    def snapshot(self) -> tuple[int, int]:
+        """Return ``(publish, subscribe)`` counts atomically."""
+        with self._lock:
+            return self.publish, self.subscribe
+
+
+_GLOBAL_COUNTER = PublishCounter()
+
+
+def get_global_counter() -> PublishCounter:
+    """Return the process-global counter consumed by the run summary."""
+    return _GLOBAL_COUNTER
+
+
+def _content_hash(value: str) -> str:
+    """Compute ``sha256:<hex>`` over the UTF-8 encoding of ``value``."""
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _validate_tag(tag: str) -> None:
+    if not tag or not tag.strip():
+        raise ValueError("tag must be a non-empty string")
+    if "," in tag:
+        # The underlying ``memory.tags`` column is comma-joined; a comma in
+        # the tag itself would break the tag-LIKE filter used by ``list()``.
+        raise ValueError("tag must not contain ','")
+
+
+def _validate_key(key: str) -> None:
+    if not key or not key.strip():
+        raise ValueError("key must be a non-empty string")
+
+
+def _validate_scope(scope: str) -> None:
+    if scope not in _VALID_SCOPES:
+        raise ValueError(f"scope must be one of {sorted(_VALID_SCOPES)}, got {scope!r}")
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+# The patterns mirror :mod:`bernstein.core.observability.log_redact`. We
+# duplicate a minimal subset here so this module does not depend on the
+# observability stack. Keep the regex list in sync if the canonical patterns
+# evolve.
+_REDACT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}\b"),
+    re.compile(r"(?:\+\d{1,3}[\s\-])?\(?\d{3}\)?[\s.\-]\d{3}[\s.\-]\d{4}\b"),
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    re.compile(r"\b(?:\d{4}[\s\-]?){3}\d{4}\b"),
+)
+
+
+def redact_value(value: str) -> str:
+    """Return ``value`` with email/phone/SSN/credit-card matches masked.
+
+    Used by the CLI ``query`` subcommand. Storage is never mutated; redaction
+    happens on read so an operator can still audit raw values out of band.
+    """
+    out = value
+    for pattern in _REDACT_PATTERNS:
+        out = pattern.sub("[REDACTED]", out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Facade
+# ---------------------------------------------------------------------------
+
+
+_META_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cross_task_meta (
+    memory_id INTEGER PRIMARY KEY,
+    scope TEXT NOT NULL,
+    tag TEXT NOT NULL,
+    key TEXT NOT NULL,
+    producer_task_id TEXT NOT NULL,
+    ts_ns INTEGER NOT NULL,
+    content_hash TEXT NOT NULL,
+    run_id TEXT,
+    FOREIGN KEY(memory_id) REFERENCES memory(id) ON DELETE CASCADE
+)
+"""
+
+_META_INDEXES_SQL: tuple[str, ...] = (
+    "CREATE INDEX IF NOT EXISTS idx_cross_task_scope_tag ON cross_task_meta(scope, tag)",
+    "CREATE INDEX IF NOT EXISTS idx_cross_task_run ON cross_task_meta(scope, run_id, tag)",
+    "CREATE INDEX IF NOT EXISTS idx_cross_task_key ON cross_task_meta(scope, tag, key)",
+)
+
+
+class CrossTaskKB:
+    """Publish/subscribe facade over the existing SQLite memory store.
+
+    A facade instance is bound to a single producing task and a single run.
+    Subscribers are free to read facts from any producer; the binding only
+    affects what ``publish`` will write into the attribution fields.
+
+    Args:
+        store: The shared :class:`SQLiteMemoryStore`. The facade reuses the
+            underlying database file - it does not open a parallel store.
+        run_id: Identifier for the current orchestration run; required for
+            ``scope='run'`` publish and subscribe.
+        producer_task_id: Task ID of the publishing agent. Used as the
+            ``producer_task_id`` attribution field on facts this facade
+            writes. Subscribers that only read may pass an empty string.
+        hook_dispatch: Optional callable invoked once per publish with
+            ``(event_name, payload)``. Wired by the orchestrator to fan a
+            ``kb.fact_published`` lifecycle event out to plugins. The
+            facade fires this best-effort; failures are swallowed so a
+            misbehaving hook cannot break the publish path.
+        counter: Counter for run-summary aggregation. Defaults to the
+            process-global instance.
+        clock_ns: Indirection point for tests to pin ``ts_ns``.
+    """
+
+    def __init__(
+        self,
+        store: SQLiteMemoryStore,
+        *,
+        run_id: str = "",
+        producer_task_id: str = "",
+        hook_dispatch: Callable[[str, dict[str, object]], None] | None = None,
+        counter: PublishCounter | None = None,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> None:
+        self._store = store
+        self._run_id = run_id
+        self._producer_task_id = producer_task_id
+        self._hook_dispatch = hook_dispatch
+        self._counter = counter if counter is not None else _GLOBAL_COUNTER
+        self._clock_ns = clock_ns or time.time_ns
+        self._init_meta_table()
+
+    @property
+    def store(self) -> SQLiteMemoryStore:
+        """The underlying SQLite store. Exposed for tests and inspection."""
+        return self._store
+
+    @property
+    def counter(self) -> PublishCounter:
+        """The publish/subscribe counter consumed by the run summary."""
+        return self._counter
+
+    def _init_meta_table(self) -> None:
+        """Create the attribution sidecar table on first use."""
+        with sqlite3.connect(self._store.db_path) as conn:
+            conn.execute(_META_TABLE_SQL)
+            for stmt in _META_INDEXES_SQL:
+                conn.execute(stmt)
+
+    # ------------------------------------------------------------------
+    # Publish
+    # ------------------------------------------------------------------
+
+    def publish(
+        self,
+        tag: str,
+        key: str,
+        value: str,
+        *,
+        scope: Scope,
+    ) -> Fact:
+        """Publish a fact under ``tag``/``key`` with the given ``scope``.
+
+        Last-write-wins on ``(scope, tag, key)``. The previous fact is left
+        in storage so the audit log retains every version; only the latest
+        is returned by :meth:`subscribe`. A trace warning is logged when a
+        prior fact under the same identity already exists.
+
+        Args:
+            tag: Subscription tag. Non-empty, no commas.
+            key: Stable identifier within the tag. Non-empty.
+            value: The payload. Stored verbatim.
+            scope: ``"run"`` or ``"project"``.
+
+        Returns:
+            The :class:`Fact` that was persisted, including its attribution
+            triple.
+
+        Raises:
+            ValueError: ``tag``, ``key``, or ``scope`` failed validation.
+        """
+        _validate_tag(tag)
+        _validate_key(key)
+        _validate_scope(scope)
+
+        ts_ns = self._clock_ns()
+        chash = _content_hash(value)
+
+        # The free-text content lives in ``memory.content`` so the existing
+        # tag-LIKE search keeps working for operators who already query the
+        # store directly. The structured metadata sits in the sidecar table.
+        # We embed ``scope`` and ``key`` into the memory tags so a CLI
+        # ``memory list --tag <tag>`` surface still works without joining.
+        memory_tags = [tag, f"cross_task:{scope}", f"key:{key}"]
+        memory_id = self._store.add(
+            type="cross_task",
+            content=value,
+            tags=memory_tags,
+            importance=1.0,
+            task_id=self._producer_task_id or None,
+        )
+
+        existing_warning = ""
+        with sqlite3.connect(self._store.db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT memory_id FROM cross_task_meta
+                WHERE scope = ? AND tag = ? AND key = ?
+                  AND (? = '' OR run_id IS NULL OR run_id = ?)
+                ORDER BY ts_ns DESC LIMIT 1
+                """,
+                (scope, tag, key, self._run_id, self._run_id),
+            ).fetchone()
+            if row is not None:
+                existing_warning = (
+                    f"cross-task fact ({scope}, {tag}, {key}) overwritten; "
+                    f"previous memory_id={row[0]} - last-write-wins"
+                )
+            conn.execute(
+                """
+                INSERT INTO cross_task_meta
+                    (memory_id, scope, tag, key, producer_task_id, ts_ns, content_hash, run_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    memory_id,
+                    scope,
+                    tag,
+                    key,
+                    self._producer_task_id,
+                    ts_ns,
+                    chash,
+                    self._run_id if scope == "run" else None,
+                ),
+            )
+
+        if existing_warning:
+            logger.warning(existing_warning)
+
+        fact = Fact(
+            tag=tag,
+            key=key,
+            value=value,
+            scope=scope,
+            producer_task_id=self._producer_task_id,
+            ts_ns=ts_ns,
+            content_hash=chash,
+        )
+
+        self._counter.incr_publish()
+        self._emit_trace("kb.publish", fact)
+        self._fire_hook("kb.fact_published", fact)
+        return fact
+
+    # ------------------------------------------------------------------
+    # Subscribe
+    # ------------------------------------------------------------------
+
+    def subscribe(
+        self,
+        tag: str,
+        *,
+        scope: Scope,
+    ) -> Iterator[Fact]:
+        """Yield the most recent fact per ``key`` published under ``tag``.
+
+        Args:
+            tag: Subscription tag. Non-empty, no commas.
+            scope: ``"run"`` or ``"project"``. ``run`` returns only facts
+                published with the same ``run_id`` as this facade.
+
+        Yields:
+            One :class:`Fact` per ``key``, newest first by ``ts_ns``.
+
+        Raises:
+            ValueError: ``tag`` or ``scope`` failed validation.
+        """
+        _validate_tag(tag)
+        _validate_scope(scope)
+
+        # Pick the latest row per key for the requested (scope, tag),
+        # filtered by run_id when scope='run'. Done in two steps to keep
+        # the SQL portable across SQLite versions: collect the matching
+        # meta rows, then keep the newest per key in Python.
+        if scope == "run":
+            where_run = "AND meta.run_id = ?"
+            params: tuple[object, ...] = (scope, tag, self._run_id)
+        else:
+            where_run = ""
+            params = (scope, tag)
+
+        query = f"""
+            SELECT meta.tag, meta.key, mem.content, meta.scope,
+                   meta.producer_task_id, meta.ts_ns, meta.content_hash
+            FROM cross_task_meta meta
+            JOIN memory mem ON mem.id = meta.memory_id
+            WHERE meta.scope = ? AND meta.tag = ? {where_run}
+            ORDER BY meta.ts_ns DESC
+        """
+
+        latest_by_key: dict[str, Fact] = {}
+        with sqlite3.connect(self._store.db_path) as conn:
+            for row in conn.execute(query, params):
+                key = row[1]
+                if key in latest_by_key:
+                    continue
+                latest_by_key[key] = Fact(
+                    tag=row[0],
+                    key=row[1],
+                    value=row[2],
+                    scope=row[3],
+                    producer_task_id=row[4] or "",
+                    ts_ns=int(row[5]),
+                    content_hash=row[6],
+                )
+        results: list[Fact] = sorted(latest_by_key.values(), key=lambda f: f.ts_ns, reverse=True)
+
+        self._counter.incr_subscribe(len(results))
+        for fact in results:
+            self._emit_trace("kb.subscribe", fact)
+            yield fact
+
+    # ------------------------------------------------------------------
+    # Trace + hook emission
+    # ------------------------------------------------------------------
+
+    def _emit_trace(self, event: str, fact: Fact) -> None:
+        """Emit a structured trace line for ``event``.
+
+        We use the standard :mod:`logging` channel so existing trace
+        collectors (JSONL trace writers configured at the logging layer)
+        pick it up. Best-effort; failures must never break the caller.
+        """
+        try:
+            logger.info(
+                "%s tag=%s key=%s scope=%s producer=%s ts_ns=%d hash=%s",
+                event,
+                fact.tag,
+                fact.key,
+                fact.scope,
+                fact.producer_task_id,
+                fact.ts_ns,
+                fact.content_hash,
+            )
+        except Exception as exc:  # pragma: no cover - logging must never break flow
+            logger.debug("cross_task_kb trace emit failed: %s", exc)
+
+    def _fire_hook(self, event: str, fact: Fact) -> None:
+        """Dispatch ``event`` through the optional hook callback.
+
+        The orchestrator wires this to fire a ``kb.fact_published``
+        lifecycle event. Hook failures are logged at debug level and
+        swallowed: a misbehaving plugin must not break the publish path.
+        """
+        if self._hook_dispatch is None:
+            return
+        payload: dict[str, object] = {
+            "tag": fact.tag,
+            "key": fact.key,
+            "scope": fact.scope,
+            "producer_task_id": fact.producer_task_id,
+            "ts_ns": fact.ts_ns,
+            "content_hash": fact.content_hash,
+        }
+        try:
+            self._hook_dispatch(event, payload)
+        except Exception as exc:  # pragma: no cover - hook must not break flow
+            logger.debug("cross_task_kb hook dispatch failed: %s", exc)

--- a/src/bernstein/core/memory/sqlite_store.py
+++ b/src/bernstein/core/memory/sqlite_store.py
@@ -17,7 +17,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MemoryType = Literal["convention", "decision", "learning", "episodic", "semantic", "procedural"]
+MemoryType = Literal[
+    "convention",
+    "decision",
+    "learning",
+    "episodic",
+    "semantic",
+    "procedural",
+    "cross_task",
+]
 
 
 @dataclass(frozen=True)

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -3735,6 +3735,17 @@ class Orchestrator:
         else:
             duration_str = f"{seconds}s"
 
+        # Cross-task KB counters are best-effort: the import is lazy so a
+        # broken module never blocks summary generation.
+        kb_publish = 0
+        kb_subscribe = 0
+        try:
+            from bernstein.core.memory.cross_task_kb import get_global_counter
+
+            kb_publish, kb_subscribe = get_global_counter().snapshot()
+        except Exception as exc:  # pragma: no cover - summary must never break
+            logger.debug("cross_task_kb counter snapshot failed: %s", exc)
+
         lines = [
             "# Run Summary",
             "",
@@ -3743,6 +3754,8 @@ class Orchestrator:
             f"**Files modified:** {files_modified}",
             f"**Estimated cost:** ${total_cost:.4f}",
             f"**Wall-clock duration:** {duration_str}",
+            f"**kb.publish:** {kb_publish}",
+            f"**kb.subscribe:** {kb_subscribe}",
             "",
             "## Tasks",
             "",

--- a/templates/roles/manager/system_prompt.md
+++ b/templates/roles/manager/system_prompt.md
@@ -64,6 +64,17 @@ curl -s -X POST http://127.0.0.1:8052/tasks \
 6. If a task depends on another, note it in the description (the system handles ordering)
 7. **Include context hints**. For each task, list the specific files, functions, and architectural decisions the assigned agent needs to know in the description. This eliminates agent orientation time. Example: "You'll modify `TaskContextBuilder.build_context()` in `src/bernstein/core/context.py`. It uses AST parsing via `_parse_python_file()`. Related: `spawner.py` calls it during prompt rendering."
 
+## Cross-task knowledge share
+
+When two tasks need to share a fact (e.g. an API schema discovered by one task and consumed by another), point the producing agent at the cross-task knowledge base instead of writing files into shared worktree paths. CLI surface:
+
+```bash
+bernstein memory share <key> <value> --tag <tag> --scope run|project
+bernstein memory query --tag <tag>
+```
+
+Programmatic surface lives at `bernstein.core.memory.cross_task_kb.CrossTaskKB`. Use `scope=run` for facts that only matter within the current orchestration run, `scope=project` for facts the whole project should see across runs. See `docs/memory/cross-task-share.md` for the full contract.
+
 ## When done planning
 
 Mark your own task as complete (remember the `Authorization` header):

--- a/templates/roles/retrieval/system_prompt.md
+++ b/templates/roles/retrieval/system_prompt.md
@@ -34,5 +34,16 @@ You build and optimize search, indexing, and retrieval systems.
 - Document any new index schemas or collection changes
 - If blocked, post to BULLETIN and move to next task
 
+## Cross-task knowledge share
+
+If you discover something downstream tasks need (a schema, a corpus location, a tuned parameter set), publish it through the cross-task knowledge base instead of dropping a markdown file in the worktree. CLI surface:
+
+```bash
+bernstein memory share <key> <value> --tag <tag> --scope run|project
+bernstein memory query --tag <tag>
+```
+
+Programmatic surface: `bernstein.core.memory.cross_task_kb.CrossTaskKB`. Use `scope=run` for facts that only matter within this orchestration run, `scope=project` for facts the whole project should see across runs. See `docs/memory/cross-task-share.md` for the full contract.
+
 ## Current task
 {{TASK_DESCRIPTION}}

--- a/tests/unit/memory/test_cross_task_kb.py
+++ b/tests/unit/memory/test_cross_task_kb.py
@@ -1,0 +1,346 @@
+"""Unit tests for :mod:`bernstein.core.memory.cross_task_kb`."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.memory.cross_task_kb import (
+    CrossTaskKB,
+    Fact,
+    PublishCounter,
+    redact_value,
+)
+from bernstein.core.memory.sqlite_store import SQLiteMemoryStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> SQLiteMemoryStore:
+    """Return a fresh SQLite store backed by ``tmp_path/memory.db``."""
+    return SQLiteMemoryStore(tmp_path / "memory.db")
+
+
+@pytest.fixture
+def kb(store: SQLiteMemoryStore) -> CrossTaskKB:
+    """Return a facade for the canonical (run, producer) pair."""
+    return CrossTaskKB(store, run_id="run-1", producer_task_id="task-a")
+
+
+# ---------------------------------------------------------------------------
+# Publish
+# ---------------------------------------------------------------------------
+
+
+class TestPublish:
+    def test_publish_returns_fact_with_attribution(self, kb: CrossTaskKB) -> None:
+        fact = kb.publish(tag="api-schema", key="users", value="payload", scope="run")
+        assert isinstance(fact, Fact)
+        assert fact.tag == "api-schema"
+        assert fact.key == "users"
+        assert fact.value == "payload"
+        assert fact.scope == "run"
+        assert fact.producer_task_id == "task-a"
+        assert fact.ts_ns > 0
+        assert fact.content_hash.startswith("sha256:")
+
+    def test_publish_writes_into_existing_memory_table(
+        self,
+        kb: CrossTaskKB,
+        store: SQLiteMemoryStore,
+    ) -> None:
+        kb.publish(tag="api-schema", key="users", value="payload", scope="run")
+        entries = store.list(limit=10)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.type == "cross_task"
+        assert entry.content == "payload"
+        # Tag-LIKE filter keeps working for operators querying the store directly.
+        assert "api-schema" in entry.tags
+        assert "cross_task:run" in entry.tags
+        assert "key:users" in entry.tags
+
+    def test_publish_validates_tag(self, kb: CrossTaskKB) -> None:
+        with pytest.raises(ValueError, match="tag"):
+            kb.publish(tag="", key="users", value="x", scope="run")
+        with pytest.raises(ValueError, match=","):
+            kb.publish(tag="a,b", key="users", value="x", scope="run")
+
+    def test_publish_validates_key(self, kb: CrossTaskKB) -> None:
+        with pytest.raises(ValueError, match="key"):
+            kb.publish(tag="t", key="", value="x", scope="run")
+
+    def test_publish_validates_scope(self, kb: CrossTaskKB) -> None:
+        with pytest.raises(ValueError, match="scope"):
+            kb.publish(tag="t", key="k", value="x", scope="global")  # type: ignore[arg-type]
+
+    def test_publish_last_write_wins_with_warning(
+        self,
+        kb: CrossTaskKB,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        kb.publish(tag="t", key="k", value="v1", scope="run")
+        with caplog.at_level("WARNING", logger="bernstein.core.memory.cross_task_kb"):
+            kb.publish(tag="t", key="k", value="v2", scope="run")
+        assert any("last-write-wins" in r.message for r in caplog.records)
+
+    def test_publish_fires_hook_callback(self, store: SQLiteMemoryStore) -> None:
+        events: list[tuple[str, dict[str, object]]] = []
+
+        def dispatch(event: str, payload: dict[str, object]) -> None:
+            events.append((event, payload))
+
+        kb = CrossTaskKB(
+            store,
+            run_id="run-1",
+            producer_task_id="task-a",
+            hook_dispatch=dispatch,
+        )
+        kb.publish(tag="t", key="k", value="v", scope="run")
+        assert len(events) == 1
+        name, payload = events[0]
+        assert name == "kb.fact_published"
+        assert payload["tag"] == "t"
+        assert payload["key"] == "k"
+        assert payload["scope"] == "run"
+        assert payload["producer_task_id"] == "task-a"
+        assert isinstance(payload["ts_ns"], int)
+        assert isinstance(payload["content_hash"], str)
+
+    def test_publish_increments_counter(self, kb: CrossTaskKB) -> None:
+        before_pub, _ = kb.counter.snapshot()
+        kb.publish(tag="t", key="k", value="v", scope="run")
+        kb.publish(tag="t", key="k2", value="v", scope="run")
+        after_pub, _ = kb.counter.snapshot()
+        assert after_pub - before_pub == 2
+
+    def test_publish_hook_failure_is_swallowed(self, store: SQLiteMemoryStore) -> None:
+        def boom(_event: str, _payload: dict[str, object]) -> None:
+            raise RuntimeError("plugin exploded")
+
+        kb = CrossTaskKB(
+            store,
+            run_id="run-1",
+            producer_task_id="task-a",
+            hook_dispatch=boom,
+        )
+        # Must not raise: a misbehaving plugin cannot break the publish path.
+        fact = kb.publish(tag="t", key="k", value="v", scope="run")
+        assert fact.tag == "t"
+
+
+# ---------------------------------------------------------------------------
+# Subscribe
+# ---------------------------------------------------------------------------
+
+
+class TestSubscribe:
+    def test_subscribe_returns_published_fact(self, kb: CrossTaskKB) -> None:
+        kb.publish(tag="api-schema", key="users", value="payload", scope="run")
+        facts = list(kb.subscribe(tag="api-schema", scope="run"))
+        assert len(facts) == 1
+        assert facts[0].key == "users"
+        assert facts[0].value == "payload"
+        assert facts[0].producer_task_id == "task-a"
+
+    def test_subscribe_returns_one_per_key_latest_wins(self, kb: CrossTaskKB) -> None:
+        kb.publish(tag="t", key="k", value="v1", scope="run")
+        kb.publish(tag="t", key="k", value="v2", scope="run")
+        facts = list(kb.subscribe(tag="t", scope="run"))
+        assert len(facts) == 1
+        assert facts[0].value == "v2"
+
+    def test_subscribe_returns_facts_from_multiple_keys(self, kb: CrossTaskKB) -> None:
+        kb.publish(tag="t", key="a", value="va", scope="run")
+        kb.publish(tag="t", key="b", value="vb", scope="run")
+        kb.publish(tag="t", key="c", value="vc", scope="run")
+        facts = sorted(kb.subscribe(tag="t", scope="run"), key=lambda f: f.key)
+        assert [f.key for f in facts] == ["a", "b", "c"]
+        assert [f.value for f in facts] == ["va", "vb", "vc"]
+
+    def test_subscribe_unknown_tag_empty(self, kb: CrossTaskKB) -> None:
+        kb.publish(tag="t1", key="k", value="v", scope="run")
+        assert list(kb.subscribe(tag="t2", scope="run")) == []
+
+    def test_subscribe_validates_inputs(self, kb: CrossTaskKB) -> None:
+        with pytest.raises(ValueError):
+            list(kb.subscribe(tag="", scope="run"))
+        with pytest.raises(ValueError):
+            list(kb.subscribe(tag="t", scope="bad"))  # type: ignore[arg-type]
+
+    def test_subscribe_increments_counter_by_result_count(
+        self,
+        kb: CrossTaskKB,
+    ) -> None:
+        kb.publish(tag="t", key="a", value="va", scope="run")
+        kb.publish(tag="t", key="b", value="vb", scope="run")
+        _, sub_before = kb.counter.snapshot()
+        list(kb.subscribe(tag="t", scope="run"))
+        _, sub_after = kb.counter.snapshot()
+        assert sub_after - sub_before == 2
+
+
+# ---------------------------------------------------------------------------
+# Scope isolation
+# ---------------------------------------------------------------------------
+
+
+class TestScopeIsolation:
+    def test_run_scope_isolates_across_runs(self, store: SQLiteMemoryStore) -> None:
+        kb_run_1 = CrossTaskKB(store, run_id="run-1", producer_task_id="t1")
+        kb_run_2 = CrossTaskKB(store, run_id="run-2", producer_task_id="t2")
+        kb_run_1.publish(tag="t", key="k", value="v1", scope="run")
+        kb_run_2.publish(tag="t", key="k", value="v2", scope="run")
+
+        run_1_facts = list(kb_run_1.subscribe(tag="t", scope="run"))
+        run_2_facts = list(kb_run_2.subscribe(tag="t", scope="run"))
+
+        assert len(run_1_facts) == 1
+        assert run_1_facts[0].value == "v1"
+        assert len(run_2_facts) == 1
+        assert run_2_facts[0].value == "v2"
+
+    def test_project_scope_visible_across_runs(self, store: SQLiteMemoryStore) -> None:
+        kb_a = CrossTaskKB(store, run_id="run-1", producer_task_id="t1")
+        kb_b = CrossTaskKB(store, run_id="run-2", producer_task_id="t2")
+        kb_a.publish(tag="t", key="k", value="vp", scope="project")
+
+        facts = list(kb_b.subscribe(tag="t", scope="project"))
+        assert len(facts) == 1
+        assert facts[0].value == "vp"
+
+    def test_run_scope_does_not_leak_into_project(self, store: SQLiteMemoryStore) -> None:
+        kb_a = CrossTaskKB(store, run_id="run-1", producer_task_id="t1")
+        kb_a.publish(tag="t", key="k", value="v-run", scope="run")
+        # A consumer reading project scope must not see run-only facts.
+        kb_b = CrossTaskKB(store, run_id="run-2", producer_task_id="t2")
+        assert list(kb_b.subscribe(tag="t", scope="project")) == []
+
+    def test_project_scope_does_not_leak_into_run(self, store: SQLiteMemoryStore) -> None:
+        kb_a = CrossTaskKB(store, run_id="run-1", producer_task_id="t1")
+        kb_a.publish(tag="t", key="k", value="v-proj", scope="project")
+        kb_b = CrossTaskKB(store, run_id="run-2", producer_task_id="t2")
+        assert list(kb_b.subscribe(tag="t", scope="run")) == []
+
+
+# ---------------------------------------------------------------------------
+# Concurrent writes
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentWrites:
+    def test_concurrent_publish_persists_all_writes(self, store: SQLiteMemoryStore) -> None:
+        """Many threads publish in parallel; the store keeps every write.
+
+        SQLite serialises writes at the file level; we assert no writes are
+        lost. Each thread publishes under a distinct (tag, key) so the
+        subscribe path can recover the full set without last-write-wins
+        collapsing rows.
+        """
+        n_threads = 16
+        errors: list[BaseException] = []
+
+        def publish(idx: int) -> None:
+            try:
+                kb = CrossTaskKB(
+                    store,
+                    run_id="run-1",
+                    producer_task_id=f"task-{idx}",
+                )
+                kb.publish(tag="t", key=f"k{idx}", value=f"v{idx}", scope="run")
+            except BaseException as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=publish, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"concurrent publish raised: {errors!r}"
+        reader = CrossTaskKB(store, run_id="run-1", producer_task_id="reader")
+        facts = list(reader.subscribe(tag="t", scope="run"))
+        assert len(facts) == n_threads
+        assert {f.key for f in facts} == {f"k{i}" for i in range(n_threads)}
+
+    def test_concurrent_publish_same_key_yields_one_latest(
+        self,
+        store: SQLiteMemoryStore,
+    ) -> None:
+        """N threads publish to the same (tag, key); subscribe collapses to one fact."""
+        n_threads = 16
+        errors: list[BaseException] = []
+
+        def publish(idx: int) -> None:
+            try:
+                kb = CrossTaskKB(
+                    store,
+                    run_id="run-1",
+                    producer_task_id=f"task-{idx}",
+                )
+                kb.publish(tag="t", key="shared", value=f"v{idx}", scope="run")
+            except BaseException as exc:  # pragma: no cover - asserted below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=publish, args=(i,)) for i in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"concurrent publish raised: {errors!r}"
+        reader = CrossTaskKB(store, run_id="run-1", producer_task_id="reader")
+        facts = list(reader.subscribe(tag="t", scope="run"))
+        assert len(facts) == 1
+        assert facts[0].key == "shared"
+
+
+# ---------------------------------------------------------------------------
+# Redaction helper
+# ---------------------------------------------------------------------------
+
+
+class TestRedaction:
+    def test_redact_value_masks_email(self) -> None:
+        assert redact_value("ping ada@example.org now") == "ping [REDACTED] now"
+
+    def test_redact_value_passes_through_clean_text(self) -> None:
+        assert redact_value("no pii here") == "no pii here"
+
+    def test_redact_value_masks_credit_card(self) -> None:
+        assert "[REDACTED]" in redact_value("card 4242 4242 4242 4242 ok")
+
+
+# ---------------------------------------------------------------------------
+# Counter sanity
+# ---------------------------------------------------------------------------
+
+
+class TestPublishCounter:
+    def test_counter_is_thread_safe(self) -> None:
+        counter = PublishCounter()
+        n = 200
+
+        def bump() -> None:
+            for _ in range(n):
+                counter.incr_publish()
+                counter.incr_subscribe()
+
+        threads = [threading.Thread(target=bump) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        pub, sub = counter.snapshot()
+        assert pub == 8 * n
+        assert sub == 8 * n


### PR DESCRIPTION
## Summary

- Add `CrossTaskKB` facade on top of the existing tag-indexed SQLite memory store. Tasks publish facts under a tag/key and other tasks subscribe on the tag; the facade does not introduce new storage.
- Persist the lineage-style attribution triple `(producer_task_id, ts_ns, content_hash)` per fact, mirroring `bernstein.core.lineage.recorder.LineageRecorder.record_write`.
- Two scopes, both single-host: `run` (current orchestration run only) and `project` (whole `.sdd/` root). Last-write-wins on `(scope, tag, key)` with a trace warning on overwrite.
- Fire the new `kb.fact_published` lifecycle event so plugins can react. Hook failures are swallowed so a misbehaving plugin cannot break the publish path.
- Add `bernstein memory share` and `bernstein memory query` CLI subcommands. `query` redacts emails, phones, SSNs, and credit-card numbers by default.

## Test plan

- [x] `uv run ruff check` on all touched files
- [x] `uv run ruff format --check` on all touched files
- [x] `uv run mypy src/bernstein/core/memory` (only pre-existing errors remain in `sqlite_store.py`)
- [x] `uv run pytest tests/unit/memory/` - 25 tests pass
- [ ] Smoke test: `bernstein memory share users '{name: str}' --tag api-schema --scope project`
- [ ] Smoke test: `bernstein memory query --tag api-schema --scope project`
- [ ] Manual run summary check: verify `kb.publish` and `kb.subscribe` counters appear in `.sdd/runtime/summary.md`