### PR TITLE
feat(adapters): per-adapter rate-limit meter visible in bernstein status

### DIFF
--- a/docs/observability/rate-limits.md
+++ b/docs/observability/rate-limits.md
@@ -1,0 +1,93 @@
+# Adapter rate-limit meter
+
+The orchestrator wires a per-adapter `RateLimitMeter` into every CLI
+adapter that extends `bernstein.adapters.base.CLIAdapter`. The meter
+records rolling counters for upstream 429-class signals so
+`bernstein status` and trace consumers have a single place to look
+when a wave of agents starts saturating an upstream provider.
+
+The meter only reports. It does not enforce request limits and it
+does not auto-pause work. Operator decisions stay with the operator.
+
+## What the meter tracks
+
+| Field | Meaning |
+|-------|---------|
+| `requests_per_minute_target` | Operator-declared RPM target. `0` keeps the column unset. |
+| `last_429_ts` | Unix timestamp of the most recent 429-class event. |
+| `consecutive_429_count` | 429-class events since the last clean request. |
+| `backoff_seconds_current` | Advisory exponential backoff value. |
+| `hits_in_window` | 429-class events within the rolling window (default 5 minutes). |
+| `last_error_code` | Provider-specific error label, when the adapter supplies one. |
+
+## Surfaces
+
+The meter is visible in three places:
+
+1. `bernstein status` Rich panel - only renders when at least one
+   meter has fired inside the rolling window.
+2. `bernstein status --json` - emits a `rate_limit_meters` array with
+   one snapshot per active adapter.
+3. Trace consumers - `rate_limit.hit` events fold to one line per
+   adapter via `bernstein.adapters.base.fold_rate_limit_events`:
+   `"<adapter> hit 429 x<n> in last <window>"`.
+
+## Lifecycle event
+
+Every meter update calls `bernstein.adapters.base.record_rate_limit_hit`,
+which fires a `rate_limit.hit` lifecycle event when an emit callback
+is bound. Bind the callback to the orchestrator's `HookRegistry`
+with `bernstein.core.lifecycle.hooks.bind_rate_limit_emit(registry)`.
+
+The event payload carries:
+
+```json
+{
+  "adapter": "claude",
+  "provider": "anthropic",
+  "error_code": "anthropic_429",
+  "meter": { "...": "snapshot returned by RateLimitMeter.to_snapshot()" }
+}
+```
+
+## Provider-specific 429 codes
+
+The 4-6 most-used adapters are wired explicitly. Other adapters
+inherit the default meter through the base class and update it via
+`_probe_fast_exit` whenever an early non-zero exit looks like a
+rate-limit signal.
+
+| Adapter | Provider label | Wire-level signal |
+|---------|----------------|-------------------|
+| `claude` | `anthropic` | HTTP 429 with `error.type=rate_limit_error`; the CLI also surfaces "you've hit your limit" plus a "resets ..." banner. |
+| `codex` | `openai` | HTTP 429 with `error.code` in `rate_limit_exceeded`, `insufficient_quota`. |
+| `openai_agents` | `openai` | Same as Codex; the SDK forwards the upstream 429 verbatim. |
+| `gemini` | `google_generative_language` | HTTP 429 with status `RESOURCE_EXHAUSTED`. |
+| `cursor` | `cursor` | Cursor proxy returns HTTP 429 when its account-tier window is exhausted. |
+| `copilot` | `github_copilot` | GitHub Copilot returns HTTP 429 once the account quota for chat completions is exhausted. |
+
+The fast-exit probe in `CLIAdapter._probe_fast_exit` also matches a
+broader set of textual cues that providers ship inside the CLI's
+stdout or stderr: `rate limit`, `usage limit`, `quota exceeded`,
+`too many requests`, `overloaded`, `hit your limit`, `limit exceeded`.
+The probe records on the meter and re-raises a `RateLimitError` so
+the spawn loop falls back through the existing rate-limit cooldown
+path.
+
+## Tuning
+
+The rolling window defaults to 5 minutes
+(`RATE_LIMIT_WINDOW_SECONDS = 300`). The exponential backoff curve
+starts at 1 second and doubles per consecutive hit up to a 60-second
+cap. Both values live in `bernstein.adapters.base` and are pure
+data, so a downstream consumer can override them by re-importing the
+constants.
+
+## Out of scope
+
+- Token-bucket scheduling. The meter records and reports; v2 may
+  layer a scheduler.
+- Cross-machine aggregation. Single-host view first.
+- Auto-pause-and-resume. Operator decision.
+- A new CLI subcommand. The status panel plus JSON output are the
+  only surfaces.

--- a/src/bernstein/adapters/base.py
+++ b/src/bernstein/adapters/base.py
@@ -46,6 +46,260 @@ class RateLimitError(SpawnError):
     """Raised when an adapter detects provider-side rate limiting on startup."""
 
 
+# ---------------------------------------------------------------------------
+# Rate-limit meter (per-adapter observability surface)
+# ---------------------------------------------------------------------------
+
+#: Default panel/window for rolling 429 counts, in seconds.
+RATE_LIMIT_WINDOW_SECONDS: int = 300
+
+#: Initial backoff after the first 429, in seconds.
+_DEFAULT_INITIAL_BACKOFF_SECONDS: float = 1.0
+
+#: Hard cap on exponential backoff growth, in seconds.
+_DEFAULT_MAX_BACKOFF_SECONDS: float = 60.0
+
+
+@dataclass
+class RateLimitMeter:
+    """Per-adapter rolling counters for upstream rate-limit pressure.
+
+    The meter records, reports, and decays. It does not enforce: there
+    is no token-bucket scheduler here. The intent is to give
+    ``bernstein status`` and trace consumers a single place to read
+    "how often is this adapter hitting 429 right now and how long is it
+    waiting between retries".
+
+    Attributes:
+        adapter_name: Short adapter identifier (e.g. ``"claude"``).
+        provider: Human-readable upstream provider label.
+        requests_per_minute_target: Operator-declared RPM target, when
+            known. ``0`` means "unset", and the meter just records
+            429-related stats without an RPM denominator.
+        last_429_ts: Unix timestamp of the most recent 429-class event,
+            or ``0.0`` if none observed.
+        consecutive_429_count: 429-class events observed since the last
+            successful request. Reset by :meth:`record_success`.
+        backoff_seconds_current: Current advisory backoff. Grows
+            exponentially per consecutive 429, capped at
+            ``_DEFAULT_MAX_BACKOFF_SECONDS``.
+        window_hits: Timestamps of 429-class events within the active
+            rolling window, used for the "x<n> in last <window>"
+            summary line.
+        last_error_code: Last observed provider-side error label, when
+            the adapter could supply one (e.g. ``"anthropic_429"``).
+    """
+
+    adapter_name: str
+    provider: str = ""
+    requests_per_minute_target: int = 0
+    last_429_ts: float = 0.0
+    consecutive_429_count: int = 0
+    backoff_seconds_current: float = 0.0
+    window_hits: list[float] = field(default_factory=list[float])
+    last_error_code: str = ""
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
+
+    def record_hit(
+        self,
+        *,
+        error_code: str = "",
+        now: float | None = None,
+        window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+    ) -> None:
+        """Register one 429-class event on this meter.
+
+        Args:
+            error_code: Provider-specific error label (optional).
+            now: Override clock for tests; defaults to ``time.time()``.
+            window_seconds: Rolling window for ``window_hits`` retention.
+        """
+        ts = time.time() if now is None else now
+        with self._lock:
+            self.last_429_ts = ts
+            self.consecutive_429_count += 1
+            self.last_error_code = error_code
+            self.window_hits.append(ts)
+            self._prune_locked(ts, window_seconds)
+            # Exponential backoff: 1s, 2s, 4s, ... capped.
+            prev = self.backoff_seconds_current
+            if prev <= 0:
+                self.backoff_seconds_current = _DEFAULT_INITIAL_BACKOFF_SECONDS
+            else:
+                self.backoff_seconds_current = min(prev * 2.0, _DEFAULT_MAX_BACKOFF_SECONDS)
+
+    def record_success(self) -> None:
+        """Reset the consecutive-failure counter after a clean request."""
+        with self._lock:
+            self.consecutive_429_count = 0
+            self.backoff_seconds_current = 0.0
+
+    def hits_in_window(
+        self,
+        *,
+        now: float | None = None,
+        window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+    ) -> int:
+        """Return the number of 429-class events within the rolling window."""
+        ts = time.time() if now is None else now
+        with self._lock:
+            self._prune_locked(ts, window_seconds)
+            return len(self.window_hits)
+
+    def is_active(
+        self,
+        *,
+        now: float | None = None,
+        window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+    ) -> bool:
+        """Return True when at least one 429 fired inside the window."""
+        return self.hits_in_window(now=now, window_seconds=window_seconds) > 0
+
+    def to_snapshot(
+        self,
+        *,
+        now: float | None = None,
+        window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+    ) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot for status surfaces."""
+        ts = time.time() if now is None else now
+        with self._lock:
+            self._prune_locked(ts, window_seconds)
+            last_ago = (ts - self.last_429_ts) if self.last_429_ts > 0 else None
+            return {
+                "adapter": self.adapter_name,
+                "provider": self.provider,
+                "requests_per_minute_target": self.requests_per_minute_target,
+                "last_429_ts": self.last_429_ts,
+                "last_429_ago_seconds": last_ago,
+                "consecutive_429_count": self.consecutive_429_count,
+                "backoff_seconds_current": self.backoff_seconds_current,
+                "window_seconds": window_seconds,
+                "hits_in_window": len(self.window_hits),
+                "last_error_code": self.last_error_code,
+            }
+
+    def _prune_locked(self, now: float, window_seconds: int) -> None:
+        """Drop hits older than ``window_seconds``. Caller holds ``_lock``."""
+        cutoff = now - window_seconds
+        self.window_hits = [t for t in self.window_hits if t >= cutoff]
+
+
+# ---------------------------------------------------------------------------
+# Process-local meter registry
+# ---------------------------------------------------------------------------
+
+_METERS_LOCK: threading.Lock = threading.Lock()
+_METERS: dict[str, RateLimitMeter] = {}
+
+#: Optional emit callback. Bound by the orchestrator to a HookRegistry so
+#: meter updates can fire ``rate_limit.hit`` lifecycle events without the
+#: adapters taking a hard dependency on the lifecycle package.
+_RATE_LIMIT_EMIT: Callable[[RateLimitMeter, str], None] | None = None
+
+
+def register_rate_limit_meter(meter: RateLimitMeter) -> None:
+    """Make ``meter`` visible to ``bernstein status`` and trace consumers.
+
+    Safe to call repeatedly with the same meter: the registry keys on
+    ``adapter_name`` so re-registration just refreshes the entry.
+    """
+    with _METERS_LOCK:
+        _METERS[meter.adapter_name] = meter
+
+
+def get_rate_limit_meters() -> dict[str, RateLimitMeter]:
+    """Return a shallow copy of the currently-registered meter set."""
+    with _METERS_LOCK:
+        return dict(_METERS)
+
+
+def reset_rate_limit_meters() -> None:
+    """Drop every registered meter. For tests only."""
+    with _METERS_LOCK:
+        _METERS.clear()
+
+
+def set_rate_limit_emit_callback(
+    callback: Callable[[RateLimitMeter, str], None] | None,
+) -> None:
+    """Bind (or clear) the optional ``rate_limit.hit`` emit callback.
+
+    The orchestrator owns its :class:`HookRegistry`; calling this with a
+    bound emit lets adapters surface the event without importing the
+    lifecycle subsystem directly. Passing ``None`` clears the binding —
+    used by tests that want to assert no event was emitted.
+    """
+    global _RATE_LIMIT_EMIT
+    _RATE_LIMIT_EMIT = callback
+
+
+def fold_rate_limit_events(
+    events: list[dict[str, Any]],
+    *,
+    window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+) -> list[str]:
+    """Collapse a sequence of ``rate_limit.hit`` events into one line per adapter.
+
+    Each input dict is expected to carry at least an ``adapter`` key — the
+    standard payload emitted by :func:`record_rate_limit_hit`. Events
+    missing an adapter label are grouped under ``"unknown"`` so they
+    remain visible to operators rather than being silently dropped.
+
+    Args:
+        events: Ordered list of ``rate_limit.hit`` event payload dicts.
+        window_seconds: Window length to mention in the folded summary.
+
+    Returns:
+        One human-readable line per adapter, sorted alphabetically:
+        ``"<adapter> hit 429 x<n> in last <window>"``.
+    """
+    counts: dict[str, int] = {}
+    for event in events:
+        adapter_raw = event.get("adapter") if isinstance(event, dict) else None
+        adapter = str(adapter_raw) if adapter_raw else "unknown"
+        counts[adapter] = counts.get(adapter, 0) + 1
+    window_label = _format_window_label(window_seconds)
+    return [f"{adapter} hit 429 x{count} in last {window_label}" for adapter, count in sorted(counts.items())]
+
+
+def _format_window_label(window_seconds: int) -> str:
+    """Render a window length as the shortest natural-language label."""
+    if window_seconds <= 0:
+        return "0s"
+    if window_seconds % 3600 == 0:
+        hours = window_seconds // 3600
+        return f"{hours}h"
+    if window_seconds % 60 == 0:
+        minutes = window_seconds // 60
+        return f"{minutes}min"
+    return f"{window_seconds}s"
+
+
+def record_rate_limit_hit(
+    meter: RateLimitMeter,
+    *,
+    error_code: str = "",
+    now: float | None = None,
+    window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+) -> None:
+    """Update ``meter`` and fire ``rate_limit.hit`` if a callback is bound.
+
+    Centralised so every touchpoint emits the same payload and so the
+    meter registration stays in lockstep with the emit.
+    """
+    meter.record_hit(error_code=error_code, now=now, window_seconds=window_seconds)
+    register_rate_limit_meter(meter)
+    callback = _RATE_LIMIT_EMIT
+    if callback is None:
+        return
+    try:
+        callback(meter, error_code)
+    except Exception as exc:
+        # Observability must never break the spawn/spawn-probe path.
+        logger.warning("rate_limit.hit emit failed for %s: %s", meter.adapter_name, exc)
+
+
 @dataclass
 class SpawnResult:
     """Result of spawning an agent process."""
@@ -127,8 +381,50 @@ class CLIAdapter(ABC):
 
     external_endpoints: tuple[tuple[str, int], ...] = ()
 
+    #: Subclasses may override to declare the upstream provider label that
+    #: shows up in the ``bernstein status`` rate-limit panel. Defaults to
+    #: the adapter name when left blank.
+    rate_limit_provider: str = ""
+
+    #: Subclasses may override to declare an operator-visible RPM target.
+    #: ``0`` keeps the column unset.
+    rate_limit_target_rpm: int = 0
+
     def __init__(self) -> None:
         self._resource_limits: ResourceLimits | None = None
+        self._rate_limit_meter: RateLimitMeter | None = None
+
+    @property
+    def rate_limit_meter(self) -> RateLimitMeter:
+        """Return the per-adapter meter, instantiating it on first read.
+
+        The meter is created lazily so adapters that never see a 429 do
+        not pay for an unused dataclass instance. The first access also
+        registers the meter so ``bernstein status`` can find it even if
+        no hit has yet been recorded.
+        """
+        if self._rate_limit_meter is None:
+            try:
+                adapter_name = self.name()
+            except Exception:
+                adapter_name = type(self).__name__.lower()
+            provider = self.rate_limit_provider or adapter_name
+            self._rate_limit_meter = RateLimitMeter(
+                adapter_name=adapter_name,
+                provider=provider,
+                requests_per_minute_target=self.rate_limit_target_rpm,
+            )
+            register_rate_limit_meter(self._rate_limit_meter)
+        return self._rate_limit_meter
+
+    def record_rate_limit_hit(self, *, error_code: str = "") -> None:
+        """Convenience hook for adapter HTTP error handlers.
+
+        Concrete adapters call this from their 429 detection paths so
+        the meter is updated and the lifecycle event fires through one
+        well-known funnel.
+        """
+        record_rate_limit_hit(self.rate_limit_meter, error_code=error_code)
 
     def enforce_network_policy(self) -> None:
         """Refuse to spawn when the adapter's known endpoints are denied.
@@ -335,6 +631,12 @@ class CLIAdapter(ABC):
         tail_lines = self._read_last_lines(log_path, n=10)
         tail_text = tail_lines[-1] if tail_lines else "(no log output)"
         if self._is_rate_limit_error(tail_lines):
+            # Tap the meter once before raising so the panel and the
+            # ``rate_limit.hit`` event both see the spawn-time 429.
+            try:
+                self.record_rate_limit_hit(error_code=f"{provider_name}_fast_exit_429")
+            except Exception as exc:
+                logger.debug("rate-limit meter update failed for %s: %s", provider_name, exc)
             raise RateLimitError(f"{provider_name} rate-limited during startup: {tail_text}")
         raise SpawnError(f"{provider_name} exited early with code {exit_code}: {tail_text}")
 

--- a/src/bernstein/adapters/claude.py
+++ b/src/bernstein/adapters/claude.py
@@ -111,6 +111,10 @@ class ClaudeCodeAdapter(CLIAdapter):
     """Spawn and monitor Claude Code CLI sessions."""
 
     external_endpoints = (("api.anthropic.com", 443),)
+    # Surface the upstream provider on the ``bernstein status``
+    # rate-limit panel. Anthropic uses HTTP 429 plus structured
+    # ``rate_limit_error`` types on the messages API.
+    rate_limit_provider = "anthropic"
 
     # Track Popen objects for reliable is_alive() via poll()
     _procs: ClassVar[dict[int, subprocess.Popen[bytes]]] = {}
@@ -173,6 +177,10 @@ class ClaudeCodeAdapter(CLIAdapter):
                 "Claude Code rate-limited; blocking spawns for %.0fs",
                 _RATE_LIMIT_COOLDOWN,
             )
+            # Record on the per-adapter meter so ``bernstein status`` can
+            # surface the hit before the spawn loop reaches ``_probe_fast_exit``.
+            with contextlib.suppress(Exception):
+                self.record_rate_limit_hit(error_code="anthropic_rate_limit_probe")
             return True
 
         self._rate_limit_checked_at = now

--- a/src/bernstein/adapters/codex.py
+++ b/src/bernstein/adapters/codex.py
@@ -28,6 +28,10 @@ class CodexAdapter(CLIAdapter):
     """Spawn and monitor OpenAI Codex CLI sessions."""
 
     external_endpoints = (("api.openai.com", 443),)
+    # OpenAI returns HTTP 429 with ``rate_limit_exceeded`` /
+    # ``insufficient_quota`` error codes; the meter records both under
+    # the same provider label.
+    rate_limit_provider = "openai"
 
     def spawn(
         self,

--- a/src/bernstein/adapters/copilot.py
+++ b/src/bernstein/adapters/copilot.py
@@ -22,6 +22,11 @@ class CopilotAdapter(CLIAdapter):
     initial prompt.
     """
 
+    # GitHub Copilot surfaces 429s when the underlying account hits the
+    # Copilot quota; we record under the Copilot label so the panel
+    # attributes pressure to the right surface.
+    rate_limit_provider = "github_copilot"
+
     def spawn(
         self,
         *,
@@ -89,6 +94,9 @@ class CopilotAdapter(CLIAdapter):
                 raise RuntimeError(msg) from exc
             except PermissionError as exc:
                 raise RuntimeError(f"Permission denied executing copilot: {exc}") from exc
+
+        # Detect spawn-time 429s; updates the meter through the base hook.
+        self._probe_fast_exit(proc, log_path, provider_name="copilot")
 
         result = SpawnResult(pid=proc.pid, log_path=log_path, proc=proc)
         if timeout_seconds > 0:

--- a/src/bernstein/adapters/cursor.py
+++ b/src/bernstein/adapters/cursor.py
@@ -59,6 +59,11 @@ from bernstein.core.models import ApiTier, ApiTierInfo, ModelConfig, ProviderTyp
 class CursorAdapter(CLIAdapter):
     """Spawn and monitor Cursor Agent CLI sessions."""
 
+    # Cursor surfaces 429s when its proxy back-pressures the upstream
+    # model account; we record under the proxy label so the panel does
+    # not falsely attribute the hit to the underlying model vendor.
+    rate_limit_provider = "cursor"
+
     def spawn(
         self,
         *,
@@ -154,6 +159,11 @@ class CursorAdapter(CLIAdapter):
                 ) from exc
             except PermissionError as exc:
                 raise RuntimeError(f"Permission denied executing cursor-agent: {exc}") from exc
+
+        # Detect fast-exit rate-limit signals before declaring the spawn
+        # successful; this also records on the per-adapter meter via the
+        # base-class hook.
+        self._probe_fast_exit(proc, log_path, provider_name="cursor")
 
         # ``proc`` MUST be threaded into ``SpawnResult``; downstream
         # spawner_core uses it for stdin-IPC registration and ``bernstein

--- a/src/bernstein/adapters/gemini.py
+++ b/src/bernstein/adapters/gemini.py
@@ -28,6 +28,9 @@ class GeminiAdapter(CLIAdapter):
     """Spawn and monitor Google Gemini CLI sessions."""
 
     external_endpoints = (("generativelanguage.googleapis.com", 443),)
+    # Google Generative Language returns HTTP 429 with status
+    # ``RESOURCE_EXHAUSTED`` once per-minute quotas are tripped.
+    rate_limit_provider = "google_generative_language"
 
     def spawn(
         self,

--- a/src/bernstein/adapters/openai_agents.py
+++ b/src/bernstein/adapters/openai_agents.py
@@ -91,6 +91,10 @@ class OpenAIAgentsAdapter(PluginAdapter):
     still import the module for discovery/testing.
     """
 
+    # The SDK forwards 429s from api.openai.com with the standard
+    # ``rate_limit_exceeded`` / ``insufficient_quota`` error codes.
+    rate_limit_provider = "openai"
+
     def plugin_info(self) -> AdapterPluginInfo:
         """Return metadata for the ``bernstein agents`` listing."""
         return AdapterPluginInfo(

--- a/src/bernstein/cli/commands/status_cmd.py
+++ b/src/bernstein/cli/commands/status_cmd.py
@@ -19,7 +19,7 @@ from bernstein.cli.helpers import (
     print_json,
     server_get,
 )
-from bernstein.cli.status import render_status
+from bernstein.cli.status import collect_rate_limit_snapshots, render_status
 from bernstein.cli.ui import make_console
 from bernstein.core.agent_discovery import AgentCapabilities, DiscoveryResult, discover_agents_cached
 from bernstein.tui.worker_badges import format_worker_badge, get_badge_for_worker
@@ -174,6 +174,15 @@ def status(as_json: bool, no_color: bool, view_mode: str | None) -> None:
                 "[red]Cannot reach task server.[/red] Is Bernstein running? Run [bold]bernstein[/bold] to start."
             )
         raise SystemExit(1)
+
+    # Attach the local rate-limit meter snapshots so JSON consumers see
+    # the same surface the rendered panel uses. The server payload may
+    # also carry an entry under ``rate_limit_meters``; we let local data
+    # win when present because the orchestrator process owns the meter
+    # state. The key is namespaced so legacy schema readers ignore it.
+    snapshots = collect_rate_limit_snapshots()
+    if snapshots:
+        data["rate_limit_meters"] = snapshots
 
     if as_json or is_json():
         print_json(data)

--- a/src/bernstein/cli/status.py
+++ b/src/bernstein/cli/status.py
@@ -15,6 +15,7 @@ from rich.text import Text
 if TYPE_CHECKING:
     from rich.console import Console
 
+from bernstein.adapters.base import RATE_LIMIT_WINDOW_SECONDS, get_rate_limit_meters
 from bernstein.cli.ui import (
     STATUS_COLORS,
     AgentInfo,
@@ -197,6 +198,80 @@ def _build_provider_table(provider_status: dict[str, Any]) -> Table | None:
             str(payload.get("tier", "unknown")),
             str(payload.get("model", "\u2014")),
             _format_quota(snapshot),
+        )
+    return table
+
+
+def _format_last_429_cell(snapshot: dict[str, Any]) -> str:
+    """Render the "last 429" cell as a short human duration."""
+    ago_obj = snapshot.get("last_429_ago_seconds")
+    if not isinstance(ago_obj, (int, float)):
+        return "-"
+    return f"{format_duration(float(ago_obj))} ago"
+
+
+def _format_backoff_cell(snapshot: dict[str, Any]) -> str:
+    """Render the "current backoff" cell, hiding zero values."""
+    backoff = float(snapshot.get("backoff_seconds_current", 0.0) or 0.0)
+    if backoff <= 0:
+        return "-"
+    return f"{backoff:.0f}s"
+
+
+def _format_rpm_cell(snapshot: dict[str, Any]) -> str:
+    """Render the "requests-in-window" cell with the operator's RPM target."""
+    hits = int(snapshot.get("hits_in_window", 0) or 0)
+    window_seconds = int(snapshot.get("window_seconds", RATE_LIMIT_WINDOW_SECONDS) or RATE_LIMIT_WINDOW_SECONDS)
+    target = int(snapshot.get("requests_per_minute_target", 0) or 0)
+    base = f"{hits}/{window_seconds // 60}m"
+    if target > 0:
+        return f"{base} (target {target}/m)"
+    return base
+
+
+def collect_rate_limit_snapshots(
+    *,
+    window_seconds: int = RATE_LIMIT_WINDOW_SECONDS,
+    now: float | None = None,
+) -> list[dict[str, Any]]:
+    """Return the meter snapshots that have fired inside ``window_seconds``.
+
+    Each snapshot already carries the adapter name, provider, hit count,
+    and current advisory backoff. Sorted by ``last_429_ts`` descending so
+    the freshest pressure shows up first.
+    """
+    snapshots: list[dict[str, Any]] = []
+    for meter in get_rate_limit_meters().values():
+        if not meter.is_active(now=now, window_seconds=window_seconds):
+            continue
+        snapshots.append(meter.to_snapshot(now=now, window_seconds=window_seconds))
+    snapshots.sort(key=lambda snap: float(snap.get("last_429_ts", 0.0) or 0.0), reverse=True)
+    return snapshots
+
+
+def _build_rate_limit_table(snapshots: list[dict[str, Any]]) -> Table | None:
+    """Build the ``Rate limits`` panel; returns ``None`` when nothing active."""
+    if not snapshots:
+        return None
+
+    table = Table(
+        title="Rate limits",
+        show_lines=False,
+        header_style=_STYLE_BOLD_CYAN,
+    )
+    table.add_column("Adapter", min_width=10)
+    table.add_column("Provider", min_width=14)
+    table.add_column("Requests-in-window", min_width=18)
+    table.add_column("Last 429", min_width=12)
+    table.add_column("Backoff", min_width=10)
+
+    for snapshot in snapshots:
+        table.add_row(
+            str(snapshot.get("adapter", "-")),
+            str(snapshot.get("provider", "-")),
+            _format_rpm_cell(snapshot),
+            _format_last_429_cell(snapshot),
+            _format_backoff_cell(snapshot),
         )
     return table
 
@@ -430,6 +505,18 @@ def render_status(
         if provider_table is not None:
             con.print()
             con.print(provider_table)
+
+    # Rate-limit panel renders only when at least one adapter meter has
+    # fired inside the rolling window; the panel stays dark on idle runs
+    # so it does not add noise to the default status view.
+    rate_limit_snapshots = data.get("rate_limit_meters")
+    if not isinstance(rate_limit_snapshots, list) or not rate_limit_snapshots:
+        rate_limit_snapshots = collect_rate_limit_snapshots()
+    typed_snapshots = [snap for snap in rate_limit_snapshots if isinstance(snap, dict)]
+    rate_limit_table = _build_rate_limit_table(typed_snapshots)
+    if rate_limit_table is not None:
+        con.print()
+        con.print(rate_limit_table)
 
     dependency_scan_line = _format_dependency_scan_line(dependency_scan)
     if dependency_scan_line is not None:

--- a/src/bernstein/core/lifecycle/hooks.py
+++ b/src/bernstein/core/lifecycle/hooks.py
@@ -38,6 +38,7 @@ __all__ = [
     "HookRegistry",
     "LifecycleContext",
     "LifecycleEvent",
+    "bind_rate_limit_emit",
     "discover_default_hook_scripts",
     "parse_hook_decision",
 ]
@@ -96,6 +97,13 @@ class LifecycleEvent(StrEnum):
     ERROR_OCCURRED = "errorOccurred"
     IDLE = "idle"
     SESSION_END = "sessionEnd"
+
+    # ------------------------------------------------------------------
+    # Adapter rate-limit observability (feat/adapter-rate-limit-meter).
+    # Emitted once per 429-class upstream signal, with the adapter name
+    # and provider error code on ``context.data``.
+    # ------------------------------------------------------------------
+    RATE_LIMIT_HIT = "rate_limit.hit"
 
 
 #: The cross-CLI standardised event vocabulary introduced by issue #1323.
@@ -561,6 +569,36 @@ def _apply_decision(
 DEFAULT_HOOK_DIR_NAME: str = ".bernstein/hooks"
 
 _DEFAULT_HOOK_SUFFIXES: tuple[str, ...] = (".sh", ".py")
+
+
+def bind_rate_limit_emit(registry: HookRegistry) -> None:
+    """Wire the adapter rate-limit meter into ``registry``.
+
+    After this call, every ``record_rate_limit_hit(...)`` from
+    :mod:`bernstein.adapters.base` synchronously runs the registry for
+    :attr:`LifecycleEvent.RATE_LIMIT_HIT` with a context whose ``data``
+    field carries ``adapter``, ``provider``, ``error_code`` and the
+    meter snapshot.
+
+    The orchestrator typically calls this once at startup.
+    """
+    # Import lazily so importing this module does not pull in the
+    # adapters package eagerly (and so the test surface can replace the
+    # callback without touching the import order).
+    from bernstein.adapters import base as _adapters_base
+
+    def _emit(meter: _adapters_base.RateLimitMeter, error_code: str) -> None:
+        snapshot = meter.to_snapshot()
+        payload: dict[str, Any] = {
+            "adapter": meter.adapter_name,
+            "provider": meter.provider,
+            "error_code": error_code,
+            "meter": snapshot,
+        }
+        ctx = LifecycleContext(event=LifecycleEvent.RATE_LIMIT_HIT, data=payload)
+        registry.run(LifecycleEvent.RATE_LIMIT_HIT, ctx)
+
+    _adapters_base.set_rate_limit_emit_callback(_emit)
 
 
 def discover_default_hook_scripts(

--- a/tests/unit/adapters/test_rate_limit_meter.py
+++ b/tests/unit/adapters/test_rate_limit_meter.py
@@ -1,0 +1,247 @@
+"""Tests for the per-adapter rate-limit meter on ``CLIAdapter``.
+
+The meter exposed by :mod:`bernstein.adapters.base` is the
+observability surface for upstream 429-class signals. These tests
+cover three guarantees:
+
+* ``record_hit`` mutates the rolling counters and the consecutive
+  failure count in the expected way.
+* ``fold_rate_limit_events`` collapses a series of ``rate_limit.hit``
+  payloads into one line per adapter for trace consumers.
+* The ``bernstein status`` rate-limit panel renders only when at
+  least one meter has fired inside the rolling window.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from bernstein.adapters.base import (
+    RATE_LIMIT_WINDOW_SECONDS,
+    RateLimitMeter,
+    fold_rate_limit_events,
+    get_rate_limit_meters,
+    record_rate_limit_hit,
+    register_rate_limit_meter,
+    reset_rate_limit_meters,
+    set_rate_limit_emit_callback,
+)
+from bernstein.cli.status import (
+    _build_rate_limit_table,
+    collect_rate_limit_snapshots,
+    render_status,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_meters() -> Any:
+    """Reset the process-local meter registry around every test."""
+    reset_rate_limit_meters()
+    set_rate_limit_emit_callback(None)
+    yield
+    reset_rate_limit_meters()
+    set_rate_limit_emit_callback(None)
+
+
+# ---------------------------------------------------------------------------
+# Meter state transitions
+# ---------------------------------------------------------------------------
+
+
+def test_record_hit_updates_counters_and_backoff() -> None:
+    meter = RateLimitMeter(adapter_name="claude", provider="anthropic")
+
+    meter.record_hit(error_code="anthropic_429", now=1000.0)
+    meter.record_hit(error_code="anthropic_429", now=1001.0)
+    meter.record_hit(error_code="anthropic_429", now=1002.0)
+
+    assert meter.consecutive_429_count == 3
+    assert meter.last_429_ts == pytest.approx(1002.0)
+    assert meter.last_error_code == "anthropic_429"
+    # Exponential backoff: 1s, 2s, 4s.
+    assert meter.backoff_seconds_current == pytest.approx(4.0)
+    assert meter.hits_in_window(now=1002.0) == 3
+
+
+def test_record_success_resets_streak_but_not_window() -> None:
+    meter = RateLimitMeter(adapter_name="codex")
+    meter.record_hit(now=500.0)
+    meter.record_hit(now=510.0)
+    meter.record_success()
+
+    assert meter.consecutive_429_count == 0
+    assert meter.backoff_seconds_current == 0.0
+    # The window keeps the historical hits — success only clears the streak.
+    assert meter.hits_in_window(now=515.0) == 2
+
+
+def test_hits_outside_window_are_pruned() -> None:
+    meter = RateLimitMeter(adapter_name="copilot")
+    meter.record_hit(now=0.0)
+    meter.record_hit(now=100.0)
+    meter.record_hit(now=200.0)
+
+    # Window cutoff is now-window. Anything older than 150s is dropped.
+    assert meter.hits_in_window(now=350.0, window_seconds=150) == 1
+    assert meter.is_active(now=350.0, window_seconds=150) is True
+    assert meter.is_active(now=400.0, window_seconds=100) is False
+
+
+def test_to_snapshot_carries_expected_fields() -> None:
+    meter = RateLimitMeter(
+        adapter_name="gemini",
+        provider="google_generative_language",
+        requests_per_minute_target=60,
+    )
+    meter.record_hit(error_code="RESOURCE_EXHAUSTED", now=2000.0)
+
+    snapshot = meter.to_snapshot(now=2005.0)
+
+    assert snapshot["adapter"] == "gemini"
+    assert snapshot["provider"] == "google_generative_language"
+    assert snapshot["consecutive_429_count"] == 1
+    assert snapshot["hits_in_window"] == 1
+    assert snapshot["last_error_code"] == "RESOURCE_EXHAUSTED"
+    assert snapshot["requests_per_minute_target"] == 60
+    assert snapshot["last_429_ago_seconds"] == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle emit and module-level registry
+# ---------------------------------------------------------------------------
+
+
+def test_record_rate_limit_hit_fires_emit_callback() -> None:
+    fired: list[tuple[str, str]] = []
+
+    def _capture(meter: RateLimitMeter, error_code: str) -> None:
+        fired.append((meter.adapter_name, error_code))
+
+    set_rate_limit_emit_callback(_capture)
+    meter = RateLimitMeter(adapter_name="claude")
+    record_rate_limit_hit(meter, error_code="anthropic_overloaded")
+
+    assert fired == [("claude", "anthropic_overloaded")]
+    assert "claude" in get_rate_limit_meters()
+
+
+def test_emit_callback_failure_is_swallowed() -> None:
+    def _boom(_meter: RateLimitMeter, _code: str) -> None:
+        raise RuntimeError("hook server is down")
+
+    set_rate_limit_emit_callback(_boom)
+    meter = RateLimitMeter(adapter_name="codex")
+    # Must not raise: observability is best-effort.
+    record_rate_limit_hit(meter, error_code="openai_429")
+    assert meter.consecutive_429_count == 1
+
+
+def test_register_keeps_one_entry_per_adapter() -> None:
+    meter_a = RateLimitMeter(adapter_name="cursor")
+    meter_b = RateLimitMeter(adapter_name="cursor")
+    register_rate_limit_meter(meter_a)
+    register_rate_limit_meter(meter_b)
+
+    registered = get_rate_limit_meters()
+    assert list(registered.keys()) == ["cursor"]
+    # Last registration wins.
+    assert registered["cursor"] is meter_b
+
+
+# ---------------------------------------------------------------------------
+# Trace fold
+# ---------------------------------------------------------------------------
+
+
+def test_fold_rate_limit_events_collapses_per_adapter() -> None:
+    events = [
+        {"adapter": "claude", "error_code": "anthropic_429"},
+        {"adapter": "claude", "error_code": "anthropic_429"},
+        {"adapter": "codex", "error_code": "openai_429"},
+    ]
+    lines = fold_rate_limit_events(events, window_seconds=RATE_LIMIT_WINDOW_SECONDS)
+    assert lines == [
+        "claude hit 429 x2 in last 5min",
+        "codex hit 429 x1 in last 5min",
+    ]
+
+
+def test_fold_rate_limit_events_handles_missing_adapter_label() -> None:
+    events = [
+        {"adapter": "gemini"},
+        {"error_code": "no_adapter"},
+    ]
+    lines = fold_rate_limit_events(events, window_seconds=60)
+    assert lines == [
+        "gemini hit 429 x1 in last 1min",
+        "unknown hit 429 x1 in last 1min",
+    ]
+
+
+def test_fold_rate_limit_events_empty_returns_empty() -> None:
+    assert fold_rate_limit_events([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Status panel
+# ---------------------------------------------------------------------------
+
+
+def test_collect_rate_limit_snapshots_returns_only_active() -> None:
+    active = RateLimitMeter(adapter_name="claude", provider="anthropic")
+    active.record_hit(now=1000.0)
+    register_rate_limit_meter(active)
+
+    idle = RateLimitMeter(adapter_name="codex", provider="openai")
+    register_rate_limit_meter(idle)
+
+    snapshots = collect_rate_limit_snapshots(window_seconds=60, now=1010.0)
+    assert [s["adapter"] for s in snapshots] == ["claude"]
+
+
+def test_rate_limit_table_returns_none_when_idle() -> None:
+    assert _build_rate_limit_table([]) is None
+
+
+def test_rate_limit_table_renders_when_active() -> None:
+    snapshots = [
+        {
+            "adapter": "claude",
+            "provider": "anthropic",
+            "requests_per_minute_target": 60,
+            "hits_in_window": 3,
+            "window_seconds": 300,
+            "last_429_ago_seconds": 12.0,
+            "backoff_seconds_current": 4.0,
+        }
+    ]
+    table = _build_rate_limit_table(snapshots)
+    assert table is not None
+    assert table.row_count == 1
+
+
+def test_render_status_omits_panel_when_no_meters_fired() -> None:
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120, color_system=None)
+    payload: dict[str, Any] = {"tasks": [], "agents": [], "summary": {"total": 0}, "elapsed_seconds": 0}
+    render_status(payload, console=console)
+    assert "Rate limits" not in buf.getvalue()
+
+
+def test_render_status_shows_panel_when_meter_active() -> None:
+    meter = RateLimitMeter(adapter_name="claude", provider="anthropic")
+    meter.record_hit(error_code="anthropic_429")
+    register_rate_limit_meter(meter)
+
+    buf = StringIO()
+    console = Console(file=buf, force_terminal=True, width=120, color_system=None)
+    payload: dict[str, Any] = {"tasks": [], "agents": [], "summary": {"total": 0}, "elapsed_seconds": 0}
+    render_status(payload, console=console)
+    output = buf.getvalue()
+    assert "Rate limits" in output
+    assert "claude" in output
+    assert "anthropic" in output


### PR DESCRIPTION
## Summary

- Adds a `RateLimitMeter` to `bernstein.adapters.base` with rolling counters (`requests_per_minute_target`, `last_429_ts`, `consecutive_429_count`, `backoff_seconds_current`) and a process-local registry so every adapter exposes the same observability surface.
- Centralises 429 reporting through `record_rate_limit_hit`, which updates the meter and fires a new `LifecycleEvent.RATE_LIMIT_HIT` event when an emit callback is bound via `bind_rate_limit_emit`.
- Wires the six most-used adapters (claude, codex, cursor, copilot, gemini, openai_agents) so the panel shows the upstream provider label (anthropic / openai / google_generative_language / cursor / github_copilot); other adapters inherit the default behaviour from `_probe_fast_exit`.
- Adds a `Rate limits` panel under `bernstein status` that only renders when at least one meter has fired in the last 5 minutes; `bernstein status --json` gains a `rate_limit_meters` array carrying the same snapshot.
- Provides `fold_rate_limit_events` so trace consumers collapse `rate_limit.hit` events to one line per adapter: `"<adapter> hit 429 x<n> in last <window>"`.

## Test plan

- [x] `uv run pytest tests/unit/adapters/test_rate_limit_meter.py` (15 passed)
- [x] `uv run pytest tests/unit/adapters/` (131 passed)
- [x] `uv run pytest tests/unit/test_cli_status.py tests/unit/test_lifecycle.py tests/unit/test_hook_lifecycle_events.py` (passed)
- [x] `uv run ruff check src/bernstein/adapters/ src/bernstein/cli/ src/bernstein/core/lifecycle/ tests/unit/adapters/`
- [x] `uv run ruff format --check` for touched files
- [ ] Manual: run `bernstein status` after a synthetic 429 to confirm the panel renders
- [ ] Manual: run `bernstein status --json | jq .rate_limit_meters` to confirm machine-readable output

## Notes

- `uv run mypy src/bernstein/adapters` returns the same 90 errors as `main`; no new ones introduced.
- Out of scope, per ticket: token-bucket scheduling, cross-machine aggregation, auto-pause-and-resume, new CLI subcommand.