### PR TITLE
feat(ci): add CodeRabbit and Sourcery configs at repo root

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,63 @@
+# CodeRabbit AI code review config
+# Repo: sipyourdrink-ltd/bernstein
+# Public OSS repo — CodeRabbit Pro features apply at no cost.
+# Docs: https://docs.coderabbit.ai/getting-started/configure-coderabbit
+
+language: en
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+
+  tools:
+    # Lean on existing CI for these; skip duplicate noise
+    ruff:
+      enabled: false
+    markdownlint:
+      enabled: false
+    shellcheck:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: false   # already covered by trufflehog.yml workflow
+    languagetool:
+      enabled: false   # noise on technical writing
+    # Keep AI-grounded ones on
+    ast-grep:
+      enabled: true
+
+  path_filters:
+    - "!.sdd/**"
+    - "!.worktrees/**"
+    - "!**/_default_templates/**"
+    - "!docs/api/**"
+    - "!**/*.lock"
+    - "!**/*.snap"
+
+  path_instructions:
+    - path: "src/bernstein/adapters/**"
+      instructions: |
+        Adapter conformance is enforced by tests/unit/adapters/conformance.py.
+        Comment only on logic / safety, not on adapter stub coverage.
+    - path: ".github/workflows/**"
+      instructions: |
+        SHA-pin all third-party actions. Add `permissions:` and `concurrency:`
+        blocks if missing. Flag any `--no-verify`, force-push, or `-i` flag.
+    - path: "src/bernstein/core/lineage/**"
+      instructions: |
+        Lineage records must be append-only and signed. Flag any code that
+        mutates an existing entry or skips the HMAC step.
+
+chat:
+  auto_reply: true

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,46 @@
+# Sourcery config — Python refactor suggestions
+# Repo: sipyourdrink-ltd/bernstein
+# Docs: https://docs.sourcery.ai/Configuration/Project-Settings/
+
+version: '1'
+
+ignore:
+  - .sdd/
+  - .worktrees/
+  - src/bernstein/_default_templates/
+  - tests/fixtures/
+  - "**/*.snap"
+  - docs/api/
+
+rule_settings:
+  enable:
+    - default
+    - sourcery
+  disable:
+    # These collide with the project's idiomatic patterns
+    - inline-immediately-returned-variable
+    - hoist-similar-statement-from-if
+  rule_types:
+    - refactoring
+    - suggestion
+    - comment
+
+metrics:
+  quality_threshold: 25.0
+  enable:
+    - method_length
+    - method_lines
+    - method_cyclomatic_complexity
+    - method_cognitive_complexity
+    - method_working_memory
+
+github:
+  review: true
+  sourcery_branch: sourcery/{base_branch}
+
+clone_detection:
+  min_lines: 6
+  min_duplicates: 2
+
+proxy:
+  no_ssl_verify: false


### PR DESCRIPTION
## Summary

- Pre-commit code-review-app configs so they activate on the first PR after the operator installs the Marketplace apps.
- `.coderabbit.yaml`: chill profile, auto-review on main, lean tool selection (shellcheck/yamllint/ast-grep on; ruff/markdownlint off since they are already covered by CI), path filters to skip `.sdd/`, `.worktrees/`, snapshots, and lockfiles, plus per-path instructions for adapters, workflows, and lineage.
- `.sourcery.yaml`: default plus sourcery rules with two project-specific disables, quality threshold 25, clone detection min_lines 6, GitHub review enabled.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.coderabbit.yaml'))\"` parses without error.
- [x] `python3 -c \"import yaml; yaml.safe_load(open('.sourcery.yaml'))\"` parses without error.
- [x] `pre-commit run check-yaml --files .coderabbit.yaml .sourcery.yaml` passes.
- [x] `pre-commit run trailing-whitespace end-of-file-fixer mixed-line-ending --files .coderabbit.yaml .sourcery.yaml` all pass.
- [ ] After merge plus Marketplace install, confirm CodeRabbit posts a review on the next PR.
- [ ] After merge plus Marketplace install, confirm Sourcery posts refactor suggestions on the next PR.