### PR TITLE
feat(ci): required-check name canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1409,7 +1409,13 @@ jobs:
     #
     # Coverage / JUnit / Codecov uploads are NOT mirrored here; they
     # remain ubuntu-only (matches the previous matrix gating).
-    name: Test (macos-latest, Python ${{ matrix.python-version }})
+    # Literal job name -- NOT templated. The branch-protection required
+    # context for macOS test runs depends on this exact string; when the
+    # job is skipped via the `if:` gate, GitHub posts the templated form
+    # verbatim, which never matches a required-context rule. The literal
+    # form keeps the name resolvable in every state (success, fail, skip).
+    # required-check-canary.yml asserts this remains literal.
+    name: Test (macos-latest, Python 3.13)
     needs: [lint, determine-changes]
     if: >-
       github.event_name == 'push' ||

--- a/.github/workflows/required-check-canary.yml
+++ b/.github/workflows/required-check-canary.yml
@@ -1,0 +1,199 @@
+name: Required-check name canary
+
+# Branch protection on `main` requires a single context named `CI gate`,
+# emitted by the `ci-gate` job in `.github/workflows/ci.yml`. If a future
+# refactor renames the job key, edits its `name:`, or adds a second job
+# that also produces a `CI gate` check, the required-context rule
+# silently weakens -- GitHub treats an unknown required-context name as
+# pass-through, so PRs would merge without the rolled-up gate signal.
+#
+# This canary fails the PR (and the weekly scheduled run) if any of the
+# locked invariants drifts. It is intentionally narrow: it does not try
+# to read live branch-protection state, only the in-tree workflow files
+# the operator has aligned protection against.
+#
+# Invariants asserted:
+#   1. `.github/workflows/ci.yml` has a job whose key is `ci-gate`.
+#   2. That job's `name:` is exactly `CI gate`.
+#   3. The `test-macos` job's `name:` is a literal string (no `${{ ... }}`
+#      template) and equals `Test (macos-latest, Python 3.13)`. Required
+#      context names must resolve in every job state including `skipped`.
+#   4. No other job in any `.github/workflows/*.yml` file emits a
+#      check-run named `CI gate`. The required context must be unique.
+#
+# Run modes:
+#   * pull_request -- only when a workflow file under `.github/workflows/`
+#     changes. Catches the regression at PR-review time.
+#   * schedule -- weekly safety net for indirect drift.
+#   * workflow_dispatch -- manual operator verification.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  schedule:
+    - cron: "23 7 * * 1"  # Weekly, Monday 07:23 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: required-check-canary-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  verify:
+    name: Required-check name canary
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Verify required-check invariants
+        env:
+          REQUIRED_CONTEXT: "CI gate"
+          REQUIRED_JOB_KEY: "ci-gate"
+          MACOS_JOB_KEY: "test-macos"
+          MACOS_JOB_NAME: "Test (macos-latest, Python 3.13)"
+        run: |
+          python3 - <<'PY'
+          """Assert that the in-tree workflow files still match the single
+          required context the operator has pinned in branch protection.
+
+          Prints a structured report; exits non-zero on any invariant break.
+          """
+          from __future__ import annotations
+
+          import os
+          import sys
+          from pathlib import Path
+
+          try:
+              import yaml
+          except ModuleNotFoundError:
+              print("::error::pyyaml is not available on this runner")
+              sys.exit(2)
+
+          REQUIRED_CONTEXT = os.environ["REQUIRED_CONTEXT"]
+          REQUIRED_JOB_KEY = os.environ["REQUIRED_JOB_KEY"]
+          MACOS_JOB_KEY = os.environ["MACOS_JOB_KEY"]
+          MACOS_JOB_NAME = os.environ["MACOS_JOB_NAME"]
+
+          CI = Path(".github/workflows/ci.yml")
+          WORKFLOWS_DIR = Path(".github/workflows")
+
+          failures: list[str] = []
+
+          if not CI.exists():
+              print(f"::error file={CI}::ci.yml not found")
+              sys.exit(2)
+
+          ci_doc = yaml.safe_load(CI.read_text(encoding="utf-8"))
+          jobs = ci_doc.get("jobs") if isinstance(ci_doc, dict) else None
+          if not isinstance(jobs, dict):
+              failures.append("ci.yml has no `jobs:` mapping")
+              jobs = {}
+
+          # Invariant 1: ci-gate job exists.
+          ci_gate = jobs.get(REQUIRED_JOB_KEY)
+          if not isinstance(ci_gate, dict):
+              failures.append(
+                  f"ci.yml: job key `{REQUIRED_JOB_KEY}` missing. "
+                  "Branch protection requires this job to emit the "
+                  f"`{REQUIRED_CONTEXT}` check."
+              )
+              ci_gate = {}
+
+          # Invariant 2: ci-gate.name == "CI gate".
+          ci_gate_name = ci_gate.get("name")
+          if ci_gate_name != REQUIRED_CONTEXT:
+              failures.append(
+                  f"ci.yml: job `{REQUIRED_JOB_KEY}` has name={ci_gate_name!r}; "
+                  f"required-context drift if not {REQUIRED_CONTEXT!r}."
+              )
+
+          # Invariant 3: test-macos job has a literal name.
+          # NOTE: the GitHub Actions expression markers are reconstructed
+          # via string concatenation so the YAML parser does not try to
+          # interpret the Python literals as workflow expressions.
+          TEMPLATE_OPEN = "$" "{{"
+          TEMPLATE_CLOSE = "}" "}"
+          macos_job = jobs.get(MACOS_JOB_KEY)
+          macos_name_seen = None
+          if not isinstance(macos_job, dict):
+              failures.append(
+                  f"ci.yml: job key `{MACOS_JOB_KEY}` missing."
+              )
+          else:
+              macos_name = macos_job.get("name", "")
+              macos_name_seen = macos_name
+              if not isinstance(macos_name, str):
+                  failures.append(
+                      f"ci.yml: `{MACOS_JOB_KEY}.name` is not a string"
+                  )
+              elif TEMPLATE_OPEN in macos_name or TEMPLATE_CLOSE in macos_name:
+                  failures.append(
+                      f"ci.yml: `{MACOS_JOB_KEY}.name` is templated "
+                      f"({macos_name!r}). Skip-state check runs would post "
+                      "the unresolved template, breaking any required-context "
+                      "rule keyed on the literal form."
+                  )
+              elif macos_name != MACOS_JOB_NAME:
+                  failures.append(
+                      f"ci.yml: `{MACOS_JOB_KEY}.name` is {macos_name!r}; "
+                      f"canary expects {MACOS_JOB_NAME!r}. If the rename is "
+                      "intentional, update both this canary and the operator "
+                      "runbook."
+                  )
+
+          # Invariant 4: no other workflow emits a job named "CI gate".
+          collisions: list[str] = []
+          for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+              try:
+                  wf = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+              except yaml.YAMLError:
+                  continue
+              wf_jobs = wf.get("jobs") if isinstance(wf, dict) else None
+              if not isinstance(wf_jobs, dict):
+                  continue
+              for key, body in wf_jobs.items():
+                  if not isinstance(body, dict):
+                      continue
+                  if body.get("name") != REQUIRED_CONTEXT:
+                      continue
+                  if wf_path == CI and key == REQUIRED_JOB_KEY:
+                      continue
+                  collisions.append(f"{wf_path}:{key}")
+
+          if collisions:
+              failures.append(
+                  f"Found extra jobs emitting `{REQUIRED_CONTEXT}` check: "
+                  + ", ".join(collisions)
+                  + ". Branch protection's single required context must be "
+                  "uniquely produced."
+              )
+
+          # Report.
+          print("Required-check name canary")
+          print(f"  required context : {REQUIRED_CONTEXT!r}")
+          print(f"  ci-gate job key  : {REQUIRED_JOB_KEY!r}")
+          print(f"  ci-gate.name     : {ci_gate_name!r}")
+          print(f"  test-macos.name  : {macos_name_seen!r}")
+
+          if failures:
+              print("::error::Required-check name canary FAILED")
+              for line in failures:
+                  print(f"::error::{line}")
+              sys.exit(1)
+
+          print("All invariants hold. Branch protection alignment intact.")
+          PY

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -1,0 +1,187 @@
+"""Structural assertions on the required-check name canary.
+
+The canary in ``.github/workflows/required-check-canary.yml`` defends the
+single `CI gate` required context configured in branch protection on
+`main`. These tests guard the canary itself plus the in-tree invariants
+the canary asserts at workflow-run time, so that a refactor cannot
+weaken the canary AND drift the required context in the same PR.
+
+Invariants exercised here:
+
+1. ``ci.yml`` exposes a ``ci-gate`` job whose ``name:`` is exactly
+   ``CI gate``.
+2. ``ci.yml`` exposes a ``test-macos`` job whose ``name:`` is the
+   literal string ``Test (macos-latest, Python 3.13)`` (no ``${{ ... }}``
+   template, which would resolve to a different string when the job is
+   skipped via the gate condition).
+3. No other job across ``.github/workflows/*.yml`` emits a check-run
+   named ``CI gate``. The required context must be uniquely produced.
+4. The canary workflow file itself exists and is wired to the
+   ``pull_request``/``schedule``/``workflow_dispatch`` triggers, with
+   every action SHA-pinned and the verify step asserting the same set
+   of invariants.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+CI = Path(".github/workflows/ci.yml")
+CANARY = Path(".github/workflows/required-check-canary.yml")
+WORKFLOWS_DIR = Path(".github/workflows")
+
+REQUIRED_CONTEXT = "CI gate"
+REQUIRED_JOB_KEY = "ci-gate"
+MACOS_JOB_KEY = "test-macos"
+MACOS_JOB_NAME = "Test (macos-latest, Python 3.13)"
+
+
+@pytest.fixture(scope="module")
+def ci_doc() -> dict[str, object]:
+    return yaml.safe_load(CI.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def canary_text() -> str:
+    return CANARY.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def canary_doc(canary_text: str) -> dict[str, object]:
+    return yaml.safe_load(canary_text)
+
+
+# ---------------------------------------------------------------------------
+# Invariants on ci.yml that branch protection depends on
+# ---------------------------------------------------------------------------
+
+
+def test_ci_gate_job_exists(ci_doc: dict[str, object]) -> None:
+    jobs = ci_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get(REQUIRED_JOB_KEY)
+    assert isinstance(job, dict), (
+        f"ci.yml must keep a `{REQUIRED_JOB_KEY}` job -- it produces the `{REQUIRED_CONTEXT}` required check on `main`."
+    )
+
+
+def test_ci_gate_name_is_literal_required_context(ci_doc: dict[str, object]) -> None:
+    jobs = ci_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs[REQUIRED_JOB_KEY]
+    assert isinstance(job, dict)
+    assert job.get("name") == REQUIRED_CONTEXT, (
+        f"ci-gate.name must equal {REQUIRED_CONTEXT!r}. "
+        "Branch protection's required context is keyed on this exact string."
+    )
+
+
+def test_test_macos_name_is_literal(ci_doc: dict[str, object]) -> None:
+    jobs = ci_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get(MACOS_JOB_KEY)
+    assert isinstance(job, dict)
+    name = job.get("name")
+    assert isinstance(name, str)
+    assert "${{" not in name and "}}" not in name, (
+        f"`{MACOS_JOB_KEY}.name` must NOT be templated. "
+        "Skip-state check runs post the unresolved template, breaking any "
+        "downstream required-context rule keyed on the literal form."
+    )
+    assert name == MACOS_JOB_NAME, (
+        f"`{MACOS_JOB_KEY}.name` is {name!r}; expected {MACOS_JOB_NAME!r}. "
+        "If the rename is intentional, update the canary expectation in the "
+        "same PR."
+    )
+
+
+def test_ci_gate_check_run_name_is_unique_across_workflows() -> None:
+    collisions: list[str] = []
+    for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        wf = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
+        if not isinstance(wf, dict):
+            continue
+        jobs = wf.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+        for key, body in jobs.items():
+            if not isinstance(body, dict):
+                continue
+            if body.get("name") != REQUIRED_CONTEXT:
+                continue
+            if wf_path == CI and key == REQUIRED_JOB_KEY:
+                continue
+            collisions.append(f"{wf_path}:{key}")
+    assert not collisions, (
+        f"Multiple jobs emit a check named {REQUIRED_CONTEXT!r}: {collisions}. "
+        "Branch protection's single required context must be uniquely produced."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariants on the canary workflow itself
+# ---------------------------------------------------------------------------
+
+
+def test_canary_workflow_exists() -> None:
+    assert CANARY.exists(), "required-check name canary workflow is missing"
+
+
+def test_canary_has_pull_request_schedule_and_dispatch_triggers(
+    canary_doc: dict[str, object],
+) -> None:
+    # PyYAML 1.1 parses bare ``on:`` as the boolean True; tolerate both.
+    on = canary_doc.get(True, canary_doc.get("on"))
+    assert isinstance(on, dict)
+    assert "pull_request" in on, "canary must run on PRs that touch workflow files"
+    assert "schedule" in on, "canary must run on a weekly cron"
+    assert "workflow_dispatch" in on, "canary must be manually runnable"
+
+
+def test_canary_pull_request_paths_filtered_to_workflows(
+    canary_doc: dict[str, object],
+) -> None:
+    on = canary_doc.get(True, canary_doc.get("on"))
+    assert isinstance(on, dict)
+    pr = on.get("pull_request")
+    assert isinstance(pr, dict)
+    paths = pr.get("paths") or []
+    assert any(".github/workflows/" in p for p in paths), "canary should only fire on PRs that modify workflow files"
+
+
+def test_canary_actions_pinned_to_sha(canary_text: str) -> None:
+    """Every ``uses:`` must reference a 40-char SHA, not a tag."""
+    uses_lines = [m.group(0) for m in re.finditer(r"uses:\s*[^\s#]+", canary_text)]
+    pattern = re.compile(r"uses:\s*[\w./-]+@[0-9a-f]{40}\b")
+    for line in uses_lines:
+        assert pattern.match(line), f"action not pinned to 40-char SHA: {line}"
+
+
+def test_canary_permissions_locked_down(canary_doc: dict[str, object]) -> None:
+    # Workflow-level permissions are empty; job-level grants only `contents: read`.
+    perms = canary_doc.get("permissions")
+    assert perms == {} or perms == "{}"
+    jobs = canary_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    verify = jobs.get("verify")
+    assert isinstance(verify, dict)
+    job_perms = verify.get("permissions")
+    assert isinstance(job_perms, dict)
+    assert job_perms == {"contents": "read"}
+
+
+def test_canary_asserts_required_context_name(canary_text: str) -> None:
+    """The literal expected context names must appear in the canary env block."""
+    assert f'REQUIRED_CONTEXT: "{REQUIRED_CONTEXT}"' in canary_text
+    assert f'REQUIRED_JOB_KEY: "{REQUIRED_JOB_KEY}"' in canary_text
+    assert f'MACOS_JOB_KEY: "{MACOS_JOB_KEY}"' in canary_text
+    assert f'MACOS_JOB_NAME: "{MACOS_JOB_NAME}"' in canary_text


### PR DESCRIPTION
## Summary

- Prevent required-context drift: canary fails if a workflow rename silently weakens branch protection on `main`.
- Branch protection is pinned to a single `CI gate` context (operator-side migration already done). The new canary in `.github/workflows/required-check-canary.yml` locks the in-tree shape behind it.
- Belt-and-braces: rename `test-macos` job's `name:` from the `${{ matrix.python-version }}` template to the literal `Test (macos-latest, Python 3.13)`. Skipped check runs post the unresolved template verbatim; the literal form keeps the context name resolvable in every job state (success, fail, skip).

## What the canary enforces

1. `ci.yml` has a `ci-gate` job whose `name:` is exactly `CI gate`.
2. `ci.yml` has a `test-macos` job whose `name:` is a literal string (no `${{ ... }}`) and equals `Test (macos-latest, Python 3.13)`.
3. No other workflow emits a job named `CI gate`. The required context must be uniquely produced.

Triggers:
- `pull_request` paths-filtered to `.github/workflows/**` (catches regression at PR-review time).
- weekly cron (safety net).
- `workflow_dispatch` (manual verification).

## Test plan

- [x] `uv run pytest tests/unit/test_required_check_canary_workflow_yaml.py` -- 10 passed
- [x] `actionlint .github/workflows/required-check-canary.yml` -- clean
- [x] Local dry-run of the embedded Python against the in-tree workflows -- all invariants hold
- [x] Negative-path dry-run: temporarily broke `ci-gate.name` to `CI gate OOPS` and confirmed the canary exits non-zero with a clear error
- [ ] First green run of `Required-check name canary` on this PR
- [ ] Weekly scheduled run lands on the upcoming Monday 07:23 UTC slot

## Scope notes

This PR is the regression-prevention half of `.sdd/backlog/open/2026-05-19-feat-ci-required-check-canary.md`. Branch protection has already been migrated to the single `CI gate` context, so the live-API verification path and operator runbook in the original ticket are no longer needed in-tree. The structural canary plus the literal `test-macos` rename close the failure mode the ticket flagged.