### PR TITLE
feat(ci): consolidate workflow_run fanout via reusable workflows

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -26,19 +26,35 @@ name: Auto-heal v2
 # All Python state lives under .sdd/ which is gitignored. The workflow
 # never commits state - only patches that pass the cordon and self-test.
 #
-# Safety note (zizmor dangerous-triggers): workflow_run is intentional
-# so we can react to CI failures landed on main. The canonical-repo
-# gate, the branches: [main] filter, the bot-author filter, and the
-# fix(ci-heal-v2): commit-prefix recursion guard prevent self-triggers.
-on:  # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-
-concurrency:
-  group: ci-heal-v2-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+# Invocation: this workflow is now invoked by `post-ci-dispatcher.yml`
+# via workflow_call. The dispatcher reads the upstream CI run metadata
+# once and routes here together with the other post-CI children, so we
+# no longer pay an independent workflow_run cold start per fanout child.
+# The dispatcher also serialises auto-heal with bernstein-ci-fix via
+# the `heal_outcome` workflow output below: bernstein-ci-fix runs only
+# when this heal did not open a PR.
+on:
+  workflow_call:
+    inputs:
+      head_sha:
+        description: Full 40-char SHA the upstream CI run executed on.
+        required: true
+        type: string
+      run_id:
+        description: GitHub Actions run id of the upstream CI run.
+        required: true
+        type: string
+      display_title:
+        description: Display title of the upstream CI run (commit subject).
+        required: true
+        type: string
+    outputs:
+      heal_outcome:
+        description: >-
+          Outcome label of the heal attempt: applied, skipped_no_jobs, or
+          failed_validation. Consumed by post-ci-dispatcher to decide
+          whether bernstein-ci-fix should run as a fallback fixer.
+        value: ${{ jobs.heal.outputs.outcome }}
 
 permissions: {}
 
@@ -56,13 +72,12 @@ jobs:
       actions: read
       pull-requests: read
       contents: read
+    # Recursion guard: skip when the failing run was itself a heal commit.
+    # Conclusion / branch / canonical-repo gating already happened in the
+    # dispatcher.
     if: >
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.head_branch == 'main' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      !startsWith(github.event.workflow_run.display_title, 'fix(ci-heal-v2):') &&
-      !startsWith(github.event.workflow_run.display_title, 'fix(ci-heal):') &&
-      github.event.workflow_run.actor.login != 'github-actions[bot]'
+      !startsWith(inputs.display_title, 'fix(ci-heal-v2):') &&
+      !startsWith(inputs.display_title, 'fix(ci-heal):')
     outputs:
       head_sha: ${{ steps.meta.outputs.head_sha }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
@@ -80,11 +95,11 @@ jobs:
           egress-policy: audit
 
       # Scorecard dangerous-workflow note: this checkout uses the trusted
-      # `main` branch ref, NOT the event-supplied head_sha. The filters at
-      # the top of the workflow already guarantee `head_branch == 'main'`
-      # and `head_repository.full_name == github.repository`, so the
-      # failing-commit SHA is always reachable from origin/main at runtime.
-      # We then `git checkout` that SHA after explicitly verifying it is
+      # `main` branch ref, NOT the event-supplied head_sha. The dispatcher
+      # has already gated on `head_branch == 'main'` and
+      # `head_repository.full_name == github.repository`, so the failing-
+      # commit SHA is always reachable from origin/main at runtime. We
+      # then `git checkout` that SHA after explicitly verifying it is
       # reachable from the freshly-fetched main ref, which gives Scorecard
       # an attacker-controlled-input-free entrypoint while preserving the
       # "operate on the failing SHA" semantic.
@@ -97,7 +112,7 @@ jobs:
 
       - name: Verify and pin to failing commit
         env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
         run: |
           set -euo pipefail
           # Guard rails: refuse anything that doesn't look like a full SHA
@@ -129,8 +144,8 @@ jobs:
       - name: Extract failure metadata
         id: meta
         env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          RUN_ID: ${{ inputs.run_id }}
         run: |
           {
             echo "head_sha=${HEAD_SHA}"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,21 +3,35 @@ name: Auto-release
 # Triggers after CI passes on main — bumps patch version and publishes
 # Only releases when meaningful source/test/template files changed.
 #
-# Safety note (zizmor dangerous-triggers): this workflow is intentionally
-# `workflow_run`-driven. It runs in the context of the canonical repo, only
-# fires on the `main` branch (fork PRs are filtered out by the
-# `branches: [main]` selector), and never checks out untrusted PR head code
-# — it only reads commit metadata via `gh api` and tags releases from main.
-# No fork-controlled inputs reach a `run:` script.
-on:  # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-
-concurrency:
-  group: auto-release-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+# This workflow is invoked by `post-ci-dispatcher.yml` via workflow_call.
+# The dispatcher pays the workflow_run cold start once and routes here
+# along with the other post-CI children. The file path stays at
+# .github/workflows/auto-release.yml so external tooling
+# (scripts/safe-push-main.sh, operator runbooks) keeps resolving runs by
+# name.
+on:
+  workflow_call:
+    inputs:
+      conclusion:
+        description: CI run conclusion forwarded from the dispatcher.
+        required: true
+        type: string
+      head_branch:
+        description: Branch the upstream CI run executed on.
+        required: true
+        type: string
+      head_sha:
+        description: Full 40-char SHA the upstream CI run executed on.
+        required: true
+        type: string
+      run_id:
+        description: GitHub Actions run id of the upstream CI run.
+        required: true
+        type: string
+      html_url:
+        description: HTML URL of the upstream CI run.
+        required: true
+        type: string
 
 permissions: {}
 
@@ -35,7 +49,7 @@ jobs:
     # or operator-cancelled, not a real failure worth alerting.
     if: >-
       contains(fromJSON('["failure","timed_out","action_required"]'),
-        github.event.workflow_run.conclusion)
+        inputs.conclusion)
     permissions:
       contents: read
       issues: write
@@ -46,8 +60,8 @@ jobs:
           egress-policy: audit
       - name: Log the skipped trigger
         env:
-          STATUS: ${{ github.event.workflow_run.conclusion }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
+          STATUS: ${{ inputs.conclusion }}
+          SHA: ${{ inputs.head_sha }}
         run: |
           echo "::error::release skipped — CI conclusion was ${STATUS} on ${SHA}"
 
@@ -55,10 +69,10 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          STATUS: ${{ github.event.workflow_run.conclusion }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
-          HTML_URL: ${{ github.event.workflow_run.html_url }}
+          STATUS: ${{ inputs.conclusion }}
+          BRANCH: ${{ inputs.head_branch }}
+          SHA: ${{ inputs.head_sha }}
+          HTML_URL: ${{ inputs.html_url }}
           REPO: ${{ github.repository }}
         run: |
           if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
@@ -79,9 +93,9 @@ jobs:
       - name: Open or update tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
-          STATUS: ${{ github.event.workflow_run.conclusion }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
-          HTML_URL: ${{ github.event.workflow_run.html_url }}
+          STATUS: ${{ inputs.conclusion }}
+          SHA: ${{ inputs.head_sha }}
+          HTML_URL: ${{ inputs.html_url }}
           REPO: ${{ github.repository }}
         run: |
           SHORT_SHA="${SHA:0:7}"
@@ -161,7 +175,7 @@ jobs:
     name: Detect open auto-release-skipped issues
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.event.workflow_run.conclusion == 'success'
+    if: inputs.conclusion == 'success'
     permissions:
       contents: read
       issues: read
@@ -199,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: detect-stale-alerts
-    if: github.event.workflow_run.conclusion == 'success' && needs.detect-stale-alerts.outputs.has_stale == 'true'
+    if: inputs.conclusion == 'success' && needs.detect-stale-alerts.outputs.has_stale == 'true'
     permissions:
       contents: read
       issues: write
@@ -212,8 +226,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          NEW_SHA: ${{ github.event.workflow_run.head_sha }}
-          HTML_URL: ${{ github.event.workflow_run.html_url }}
+          NEW_SHA: ${{ inputs.head_sha }}
+          HTML_URL: ${{ inputs.html_url }}
         run: |
           SHORT_NEW="${NEW_SHA:0:7}"
           # Match issues opened by the alert job above. Author scope is
@@ -242,7 +256,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 5
-    if: github.event.workflow_run.conclusion == 'success'
+    if: inputs.conclusion == 'success'
     outputs:
       should_release: ${{ steps.decide.outputs.should_release }}
     steps:
@@ -255,7 +269,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
         run: |
           # Skip bot commits (prevents release loop)
           AUTHOR=$(gh api "repos/${REPO}/commits/${HEAD_SHA}" \

--- a/.github/workflows/bernstein-ci-fix.yml
+++ b/.github/workflows/bernstein-ci-fix.yml
@@ -1,38 +1,46 @@
 name: "Bernstein CI Fix"
 
-# Trigger when CI completes with a failure on main. Bernstein then runs
-# in headless mode against the failing commit, attempts a fix, and either:
+# When CI fails on main, Bernstein runs in headless mode against the failing
+# commit, attempts a fix, and either:
 #   - opens an `auto-heal/<sha>` PR with the proposed diff, or
 #   - falls back to creating a `ci-fix` issue documenting what was tried.
 #
-# Guards:
-#   - Only fires on the canonical repo (head_repository.full_name == github.repository)
-#     so fork-PR pushes can't burn the LLM budget.
+# Invocation: this workflow is now invoked by `post-ci-dispatcher.yml`
+# via workflow_call. The dispatcher reserves bernstein-ci-fix as the
+# fallback fixer: it only runs when auto-heal v2 did not open a heal PR.
+# That ordering removes the parallel race the two heals previously ran
+# into on the same failing SHA.
+#
+# Guards (re-enforced locally for defence in depth):
+#   - Only fires on the canonical repo (head_repository.full_name == github.repository).
 #   - Recursion guard: skips when the failing run was itself an `auto-heal:` PR.
-#   - Concurrency: one attempt per failing SHA (idempotent — a re-run on the
-#     same SHA cancels the older attempt).
 #   - Feature flag `BERNSTEIN_CI_FIX_ENABLED` (repo variable) gates the whole
 #     workflow so it stays off until explicitly enabled per environment.
 #   - No `actions: write` permission — auto-heal cannot trigger more
 #     workflows recursively.
-#
-# Safety note (zizmor dangerous-triggers): this workflow uses `workflow_run`
-# intentionally so it can fix CI failures landed on main. The canonical-repo
-# gate (head_repository.full_name == github.repository), the `branches: [main]`
-# selector, and the recursion guard above ensure fork PRs and auto-heal
-# commits never reach the LLM. The auto-heal job operates on a fresh branch
-# from the trusted main HEAD, not on attacker-supplied PR head code.
-on:  # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-
-# One attempt per SHA; cancels older attempts on the same SHA so a re-run is
-# idempotent.
-concurrency:
-  group: auto-heal-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+on:
+  workflow_call:
+    inputs:
+      head_sha:
+        description: Full 40-char SHA the upstream CI run executed on.
+        required: true
+        type: string
+      head_branch:
+        description: Branch the upstream CI run executed on.
+        required: true
+        type: string
+      run_id:
+        description: GitHub Actions run id of the upstream CI run.
+        required: true
+        type: string
+      display_title:
+        description: Display title of the upstream CI run (commit subject).
+        required: true
+        type: string
+      actor_login:
+        description: Login of the actor that triggered the upstream CI run.
+        required: true
+        type: string
 
 # Workflow-level permissions are minimal; each job below declares
 # the narrower scopes it actually needs (zizmor excessive-permissions).
@@ -48,30 +56,15 @@ jobs:
       actions: read
       pull-requests: read
       contents: read
-    # Gate: only run on a real CI failure on the canonical repo, with the
-    # autofix variable enabled, and not on auto-heal commits (recursion guard).
-    #
-    # Recursion guard rationale:
-    #   The triggering workflow_run carries the head commit's message via
-    #   `display_title`. Auto-heal commits are formatted as
-    #   `auto-heal: fix CI on <sha>`; if such a commit fails CI, we must
-    #   NOT spin up another auto-heal attempt — that would loop. Also skip
-    #   bot-authored commits in general (bernstein[bot], dependabot, etc.)
-    #   to avoid burning budget on automated traffic.
-    #
-    # Cost guard rationale:
-    #   `head_repository.full_name == github.repository` is the only
-    #   non-forgeable check on a workflow_run event payload (Sonar S8232).
-    #   Forks have a different head_repository, so this implicitly limits
-    #   auto-heal to org commits.
-    if: >
-      github.event.workflow_run.conclusion == 'failure' &&
+    # Gate: only run when the autofix variable is enabled and the upstream
+    # run was not an auto-heal commit (recursion guard). Conclusion / branch
+    # / canonical-repo gating already happened in the dispatcher.
+    if: >-
       vars.BERNSTEIN_CI_FIX_ENABLED == 'true' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      !startsWith(github.event.workflow_run.display_title, 'auto-heal:') &&
-      github.event.workflow_run.actor.login != 'bernstein[bot]' &&
-      github.event.workflow_run.actor.login != 'bernstein-orchestrator[bot]' &&
-      github.event.workflow_run.actor.login != 'github-actions[bot]'
+      !startsWith(inputs.display_title, 'auto-heal:') &&
+      inputs.actor_login != 'bernstein[bot]' &&
+      inputs.actor_login != 'bernstein-orchestrator[bot]' &&
+      inputs.actor_login != 'github-actions[bot]'
     outputs:
       head_sha: ${{ steps.meta.outputs.head_sha }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
@@ -89,9 +82,9 @@ jobs:
       - name: Extract failure metadata
         id: meta
         env:
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          BRANCH: ${{ inputs.head_branch }}
+          RUN_ID: ${{ inputs.run_id }}
         run: |
           SHORT_SHA="${HEAD_SHA:0:12}"
           {

--- a/.github/workflows/bisect-on-red.yml
+++ b/.github/workflows/bisect-on-red.yml
@@ -15,16 +15,25 @@ name: Bisect on Red
 # red event). Instead we report the most-likely culprit based on file
 # overlap between the failing workflow's scope and each candidate
 # merge's diff. Operators can escalate to manual bisect from there.
+#
+# Trigger: invoked by `post-ci-dispatcher.yml` via workflow_call so the
+# fanout shares a single dispatcher boot with the other post-CI children.
 
 on:
-  workflow_run: # zizmor: ignore[dangerous-triggers]
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-
-concurrency:
-  group: bisect-on-red-${{ github.event.workflow_run.head_sha }}
-  cancel-in-progress: false
+  workflow_call:
+    inputs:
+      head_sha:
+        description: Full 40-char SHA the upstream CI run executed on.
+        required: true
+        type: string
+      run_id:
+        description: GitHub Actions run id of the upstream CI run.
+        required: true
+        type: string
+      html_url:
+        description: HTML URL of the upstream CI run.
+        required: true
+        type: string
 
 permissions: {}
 
@@ -33,7 +42,6 @@ jobs:
     name: Identify culprit PR
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event.workflow_run.conclusion == 'failure'
     permissions:
       contents: read
       pull-requests: write
@@ -56,7 +64,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ inputs.run_id }}
         run: |
           set -euo pipefail
 
@@ -77,9 +85,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_SHA: ${{ inputs.head_sha }}
           FAILED_JOBS: ${{ steps.failing.outputs.jobs }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_URL: ${{ inputs.html_url }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/post-ci-dispatcher.yml
+++ b/.github/workflows/post-ci-dispatcher.yml
@@ -1,0 +1,183 @@
+name: Post-CI dispatcher
+
+# Single workflow_run: CI completed listener that consolidates the fanout
+# previously paid out across five sibling workflows (auto-release, auto-heal,
+# bernstein-ci-fix, bisect-on-red, telegram-notify). Each child is now a
+# reusable workflow (on: workflow_call:) and runs only when the dispatcher's
+# routing logic selects it.
+#
+# Routing summary:
+#   - telegram-notify    -> fires on any non-success, non-skipped conclusion.
+#   - auto-release       -> fires on the main branch only.
+#   - auto-heal          -> fires on failure on main, gated on canonical repo
+#                            and recursion guards.
+#   - bernstein-ci-fix   -> fires on failure on main only when auto-heal did
+#                            NOT open a heal PR. Prevents the parallel race
+#                            that previously caused both heals to fight over
+#                            the same SHA.
+#   - bisect-on-red      -> fires on failure on main.
+#
+# Each child reusable workflow re-checks its own preconditions, so the
+# dispatcher gates are best-effort routing rather than security boundaries.
+#
+# Safety note (zizmor dangerous-triggers): the workflow_run trigger is
+# intentional and only reads metadata fields (conclusion, sha, branch,
+# repository) into the dispatcher's job-level if: conditions. No
+# attacker-controlled value reaches a run: script in this file. The child
+# reusable workflows enforce their own canonical-repo and recursion guards.
+on:  # zizmor: ignore[dangerous-triggers]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+concurrency:
+  group: post-ci-dispatcher-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  # Surface the upstream CI run metadata once so each child reusable
+  # workflow can receive it via workflow_call inputs. Computing this in
+  # a single boot is the entire reason this dispatcher exists.
+  meta:
+    name: Resolve upstream metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      head_sha: ${{ steps.out.outputs.head_sha }}
+      short_sha: ${{ steps.out.outputs.short_sha }}
+      head_branch: ${{ steps.out.outputs.head_branch }}
+      head_repo: ${{ steps.out.outputs.head_repo }}
+      conclusion: ${{ steps.out.outputs.conclusion }}
+      run_id: ${{ steps.out.outputs.run_id }}
+      run_name: ${{ steps.out.outputs.run_name }}
+      html_url: ${{ steps.out.outputs.html_url }}
+      display_title: ${{ steps.out.outputs.display_title }}
+      actor_login: ${{ steps.out.outputs.actor_login }}
+      event: ${{ steps.out.outputs.event }}
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Capture event metadata
+        id: out
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          HTML_URL: ${{ github.event.workflow_run.html_url }}
+          DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+          ACTOR_LOGIN: ${{ github.event.workflow_run.actor.login }}
+          EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          set -euo pipefail
+          {
+            echo "head_sha=${HEAD_SHA}"
+            echo "short_sha=${HEAD_SHA:0:12}"
+            echo "head_branch=${HEAD_BRANCH}"
+            echo "head_repo=${HEAD_REPO}"
+            echo "conclusion=${CONCLUSION}"
+            echo "run_id=${RUN_ID}"
+            echo "run_name=${RUN_NAME}"
+            echo "html_url=${HTML_URL}"
+            echo "display_title=${DISPLAY_TITLE}"
+            echo "actor_login=${ACTOR_LOGIN}"
+            echo "event=${EVENT}"
+          } >> "$GITHUB_OUTPUT"
+
+  telegram-notify:
+    name: Telegram notify
+    needs: meta
+    if: >-
+      needs.meta.outputs.conclusion != 'success' &&
+      needs.meta.outputs.conclusion != 'skipped' &&
+      needs.meta.outputs.conclusion != 'neutral'
+    uses: ./.github/workflows/telegram-notify.yml
+    secrets: inherit
+    with:
+      conclusion: ${{ needs.meta.outputs.conclusion }}
+      head_branch: ${{ needs.meta.outputs.head_branch }}
+      head_sha: ${{ needs.meta.outputs.head_sha }}
+      run_id: ${{ needs.meta.outputs.run_id }}
+      html_url: ${{ needs.meta.outputs.html_url }}
+
+  auto-release:
+    name: Auto-release
+    needs: meta
+    if: needs.meta.outputs.head_branch == 'main'
+    uses: ./.github/workflows/auto-release.yml
+    secrets: inherit
+    with:
+      conclusion: ${{ needs.meta.outputs.conclusion }}
+      head_branch: ${{ needs.meta.outputs.head_branch }}
+      head_sha: ${{ needs.meta.outputs.head_sha }}
+      run_id: ${{ needs.meta.outputs.run_id }}
+      html_url: ${{ needs.meta.outputs.html_url }}
+
+  auto-heal:
+    name: Auto-heal v2
+    needs: meta
+    if: >-
+      needs.meta.outputs.conclusion == 'failure' &&
+      needs.meta.outputs.head_branch == 'main' &&
+      needs.meta.outputs.head_repo == github.repository &&
+      !startsWith(needs.meta.outputs.display_title, 'fix(ci-heal-v2):') &&
+      !startsWith(needs.meta.outputs.display_title, 'fix(ci-heal):') &&
+      needs.meta.outputs.actor_login != 'github-actions[bot]'
+    uses: ./.github/workflows/auto-heal.yml
+    secrets: inherit
+    with:
+      head_sha: ${{ needs.meta.outputs.head_sha }}
+      run_id: ${{ needs.meta.outputs.run_id }}
+      display_title: ${{ needs.meta.outputs.display_title }}
+
+  bernstein-ci-fix:
+    name: Bernstein CI fix
+    needs: [meta, auto-heal]
+    # Run only on real CI failures on main from the canonical repo, and only
+    # when auto-heal did NOT open a heal PR. This serialises the two fixers
+    # so they no longer race on the same failing SHA (ticket acceptance:
+    # auto-heal and bernstein-ci-fix call each other via dispatcher when
+    # one fails instead of both firing in parallel).
+    if: >-
+      always() &&
+      needs.meta.outputs.conclusion == 'failure' &&
+      needs.meta.outputs.head_branch == 'main' &&
+      needs.meta.outputs.head_repo == github.repository &&
+      !startsWith(needs.meta.outputs.display_title, 'auto-heal:') &&
+      needs.meta.outputs.actor_login != 'bernstein[bot]' &&
+      needs.meta.outputs.actor_login != 'bernstein-orchestrator[bot]' &&
+      needs.meta.outputs.actor_login != 'github-actions[bot]' &&
+      (needs.auto-heal.result == 'skipped' ||
+        needs.auto-heal.outputs.heal_outcome == '' ||
+        needs.auto-heal.outputs.heal_outcome == 'skipped_no_jobs' ||
+        needs.auto-heal.outputs.heal_outcome == 'failed_validation')
+    uses: ./.github/workflows/bernstein-ci-fix.yml
+    secrets: inherit
+    with:
+      head_sha: ${{ needs.meta.outputs.head_sha }}
+      head_branch: ${{ needs.meta.outputs.head_branch }}
+      run_id: ${{ needs.meta.outputs.run_id }}
+      display_title: ${{ needs.meta.outputs.display_title }}
+      actor_login: ${{ needs.meta.outputs.actor_login }}
+
+  bisect-on-red:
+    name: Bisect on red
+    needs: meta
+    if: >-
+      needs.meta.outputs.conclusion == 'failure' &&
+      needs.meta.outputs.head_branch == 'main'
+    uses: ./.github/workflows/bisect-on-red.yml
+    secrets: inherit
+    with:
+      head_sha: ${{ needs.meta.outputs.head_sha }}
+      run_id: ${{ needs.meta.outputs.run_id }}
+      html_url: ${{ needs.meta.outputs.html_url }}

--- a/.github/workflows/telegram-notify.yml
+++ b/.github/workflows/telegram-notify.yml
@@ -1,20 +1,36 @@
 name: Telegram CI Notifications
 
-# Safety note (zizmor dangerous-triggers): this workflow uses `workflow_run`
-# so it can notify on completion of the upstream CI run. It runs only on the
-# `main` branch of the canonical repo (fork PRs are excluded by the
-# `branches: [main]` selector), never checks out any code, and only forwards
-# a fixed metadata set (conclusion, branch, sha, run id) to Telegram. No
-# attacker-controlled value reaches a `run:` block.
-on:  # zizmor: ignore[dangerous-triggers]
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
-
-concurrency:
-  group: telegram-${{ github.event.workflow_run.head_branch }}
-  cancel-in-progress: true
+# Telegram fan-out for CI completion events. Originally listened to
+# `workflow_run: CI completed` directly; now invoked by
+# `post-ci-dispatcher.yml` via workflow_call so the dispatcher pays the
+# cold start once and routes to every child reusable in a single boot.
+#
+# The file path stays at .github/workflows/telegram-notify.yml so existing
+# branch protection rules, runtime tooling, and operator runbooks keep
+# resolving the workflow by name. Only the trigger surface changed.
+on:
+  workflow_call:
+    inputs:
+      conclusion:
+        description: CI run conclusion (success/failure/cancelled/timed_out/...).
+        required: true
+        type: string
+      head_branch:
+        description: Branch the upstream CI run executed on.
+        required: true
+        type: string
+      head_sha:
+        description: Full 40-char SHA the upstream CI run executed on.
+        required: true
+        type: string
+      run_id:
+        description: GitHub Actions run id of the upstream CI run.
+        required: true
+        type: string
+      html_url:
+        description: HTML URL of the upstream CI run.
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -22,14 +38,14 @@ permissions:
 
 jobs:
   notify:
-    # Notify on anything that isn't 'success' (so cancelled/timed_out/
-    # action_required runs no longer disappear silently — see #1273).
-    # 'skipped' is intentional and stays quiet.
-    if: >-
-      github.event.workflow_run.conclusion != 'success'
-      && github.event.workflow_run.conclusion != 'skipped'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Defence-in-depth: the dispatcher already gates this child, but keep
+    # the local guard so an ad-hoc workflow_call invocation can't fire a
+    # success-state Telegram message.
+    if: >-
+      inputs.conclusion != 'success' &&
+      inputs.conclusion != 'skipped'
     steps:
       - name: Harden runner (audit mode)
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -39,11 +55,11 @@ jobs:
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
-          STATUS: ${{ github.event.workflow_run.conclusion }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
-          HTML_URL: ${{ github.event.workflow_run.html_url }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          STATUS: ${{ inputs.conclusion }}
+          BRANCH: ${{ inputs.head_branch }}
+          SHA: ${{ inputs.head_sha }}
+          HTML_URL: ${{ inputs.html_url }}
+          RUN_ID: ${{ inputs.run_id }}
           REPO: ${{ github.repository }}
         run: |
           if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then

--- a/docs/operations/post-ci-dispatcher.md
+++ b/docs/operations/post-ci-dispatcher.md
@@ -1,0 +1,115 @@
+# Post-CI dispatcher
+
+## TL;DR
+
+| Item | Value |
+|------|-------|
+| File | `.github/workflows/post-ci-dispatcher.yml` |
+| Trigger | `workflow_run: CI completed` on `main` |
+| Children | `auto-release`, `auto-heal`, `bernstein-ci-fix`, `bisect-on-red`, `telegram-notify` |
+| Boots paid | 1 per CI completion (was 5) |
+
+Single `workflow_run: CI completed` listener that resolves the upstream
+metadata once and routes to five reusable workflows via `workflow_call`.
+Replaces five sibling listeners that each paid an independent runner
+cold start plus a GHA token mint per CI completion.
+
+## What changed
+
+The five post-CI workflows kept their file paths so existing branch
+protection rules, runtime tooling, and operator runbooks continue to
+resolve them by name. Their internals now declare `on: workflow_call:`
+instead of `on: workflow_run:`; the dispatcher owns the upstream event.
+
+| Workflow file | Trigger before | Trigger now |
+|---|---|---|
+| `auto-release.yml` | `workflow_run: CI completed` | `workflow_call` |
+| `auto-heal.yml` | `workflow_run: CI completed` | `workflow_call` |
+| `bernstein-ci-fix.yml` | `workflow_run: CI completed` | `workflow_call` |
+| `bisect-on-red.yml` | `workflow_run: CI completed` | `workflow_call` |
+| `telegram-notify.yml` | `workflow_run: CI completed` | `workflow_call` |
+| `post-ci-dispatcher.yml` | n/a (new) | `workflow_run: CI completed` |
+
+## Sequence
+
+```
+CI run completes on main
+        |
+        v
++---------------------------+
+| post-ci-dispatcher.yml    |  (1 boot, reads workflow_run metadata)
+|   meta:                   |
+|     head_sha, conclusion, |
+|     head_branch, run_id,  |
+|     display_title, ...    |
++-------------+-------------+
+              |
+   +----------+----------+----------+----------+-----------+
+   |          |          |          |          |           |
+   v          v          v          v          v           v
+telegram-  auto-      auto-heal  bernstein-  bisect-     (dispatcher
+notify     release               ci-fix     on-red       outputs)
+(non-      (main      (failure,  (failure,  (failure,
+ success)   branch)    canonical  canonical  main)
+                       repo)      repo,
+                                  and auto-heal
+                                  did NOT open
+                                  a PR)
+```
+
+## Race resolution
+
+Before: `auto-heal` and `bernstein-ci-fix` both listened to
+`workflow_run: CI completed` and ran in parallel. On a real failure both
+tried to open a heal PR on the same SHA, occasionally producing competing
+patches.
+
+After: the dispatcher serialises them via `needs:`. `bernstein-ci-fix`
+runs only when `auto-heal` either skipped or did not open a PR. The
+serialisation point is the reusable workflow output
+`auto-heal.heal_outcome` (one of `applied`, `skipped_no_jobs`,
+`failed_validation`).
+
+## Inputs forwarded by the dispatcher
+
+The dispatcher resolves the upstream `workflow_run` event into typed
+inputs once and passes them to each child:
+
+| Input | Used by |
+|---|---|
+| `conclusion` | telegram-notify, auto-release |
+| `head_branch` | telegram-notify, auto-release, bernstein-ci-fix |
+| `head_sha` | every child |
+| `run_id` | every child |
+| `html_url` | telegram-notify, auto-release, bisect-on-red |
+| `display_title` | auto-heal, bernstein-ci-fix (recursion guards) |
+| `actor_login` | bernstein-ci-fix (bot filtering) |
+
+## Security model
+
+The `workflow_run` trigger is intentional and zizmor-annotated. The
+dispatcher only reads metadata fields into `if:` conditions and forwards
+them as typed inputs. It never executes attacker-controlled values in a
+`run:` script.
+
+Each child reusable workflow re-checks its own preconditions
+(canonical-repo gate, recursion guards, bot allowlist) for
+defence-in-depth. The dispatcher gates are routing decisions, not
+security boundaries.
+
+## Operator runbook
+
+| Question | Answer |
+|---|---|
+| Which workflow do I look at for a failed heal on a given SHA? | The dispatcher run lists each reusable child as a sub-run. Open `post-ci-dispatcher.yml` for the SHA, drill into the failing child. |
+| Where does `gh run list --workflow "auto-release.yml"` go? | Still works: reusable workflow runs are listed under their workflow file even when triggered via `workflow_call`. |
+| How do I disable a single child? | Set its `if:` guard to `false` in the dispatcher (preferred), or open the reusable workflow and gate its first job. |
+| How do I rerun only the post-CI fanout after CI succeeded? | Rerun the dispatcher workflow; CI itself is unaffected. |
+
+## Testing the dispatcher
+
+A real `workflow_run` event can be observed by pushing a commit to main
+and watching the dispatcher boot, or simulated locally by invoking each
+reusable workflow with `gh workflow run` and synthetic inputs. The unit
+test `tests/unit/test_post_ci_dispatcher_yaml.py` asserts the
+dispatcher's structural invariants (trigger, children, race serialisation).

--- a/tests/unit/test_autoheal_workflow_yaml.py
+++ b/tests/unit/test_autoheal_workflow_yaml.py
@@ -47,15 +47,43 @@ def test_workflow_name_is_v2(workflow: dict[str, object]) -> None:
     assert "Auto-heal" in name or "auto-heal" in name
 
 
-def test_workflow_run_trigger_pinned_to_ci(workflow: dict[str, object]) -> None:
+def test_workflow_call_trigger_with_inputs(workflow: dict[str, object]) -> None:
+    """v2 is now invoked by post-ci-dispatcher.yml via workflow_call.
+
+    The workflow_run fanout was consolidated into a single dispatcher so
+    we no longer pay a per-child cold start. The dispatcher reads the
+    upstream CI run metadata once and forwards it via workflow_call inputs.
+    """
     # PyYAML parses ``on:`` as boolean True under YAML 1.1 -- so the key
     # arrives as ``True``. Tolerate both forms.
     on = workflow.get(True, workflow.get("on"))
     assert isinstance(on, dict)
-    wfr = on.get("workflow_run")
-    assert isinstance(wfr, dict)
-    assert wfr.get("workflows") == ["CI"]
-    assert wfr.get("branches") == ["main"]
+    wfc = on.get("workflow_call")
+    assert isinstance(wfc, dict), "auto-heal must declare workflow_call"
+    assert "workflow_run" not in on, (
+        "auto-heal must not listen to workflow_run directly; "
+        "post-ci-dispatcher.yml owns that surface now"
+    )
+    inputs = wfc.get("inputs", {})
+    assert isinstance(inputs, dict)
+    for key in ("head_sha", "run_id", "display_title"):
+        assert key in inputs, f"workflow_call input {key} missing"
+
+
+def test_workflow_call_exposes_heal_outcome(workflow: dict[str, object]) -> None:
+    """Dispatcher gates bernstein-ci-fix on this output.
+
+    Acceptance criterion: auto-heal and bernstein-ci-fix call each other
+    via dispatcher (instead of both firing in parallel). The serialisation
+    relies on the dispatcher reading the heal outcome via this output.
+    """
+    on = workflow.get(True, workflow.get("on"))
+    assert isinstance(on, dict)
+    wfc = on.get("workflow_call")
+    assert isinstance(wfc, dict)
+    outputs = wfc.get("outputs", {})
+    assert isinstance(outputs, dict)
+    assert "heal_outcome" in outputs, "heal_outcome workflow_call output missing"
 
 
 def test_workflow_level_permissions_are_empty(workflow: dict[str, object]) -> None:
@@ -63,12 +91,17 @@ def test_workflow_level_permissions_are_empty(workflow: dict[str, object]) -> No
     assert perms == {} or perms == "{}"
 
 
-def test_concurrency_group_is_v2_namespaced(workflow: dict[str, object]) -> None:
-    conc = workflow.get("concurrency")
-    assert isinstance(conc, dict)
-    group = conc.get("group", "")
-    assert isinstance(group, str)
-    assert "ci-heal-v2-" in group
+def test_no_top_level_concurrency_under_workflow_call(workflow: dict[str, object]) -> None:
+    """Top-level concurrency is owned by the dispatcher now.
+
+    The dispatcher applies a per-SHA concurrency group covering all
+    fanout children; per-child concurrency would cancel cousin runs and
+    is left out so the dispatcher stays the single arbitrator.
+    """
+    assert "concurrency" not in workflow, (
+        "auto-heal must not set its own concurrency; "
+        "post-ci-dispatcher.yml owns the per-SHA concurrency group"
+    )
 
 
 def test_all_action_uses_pinned_to_sha(workflow_text: str) -> None:

--- a/tests/unit/test_post_ci_dispatcher_yaml.py
+++ b/tests/unit/test_post_ci_dispatcher_yaml.py
@@ -1,0 +1,151 @@
+"""Structural assertions on ``.github/workflows/post-ci-dispatcher.yml``.
+
+The dispatcher consolidates five sibling ``workflow_run: CI completed``
+listeners (auto-release, auto-heal, bernstein-ci-fix, bisect-on-red,
+telegram-notify) into a single boot that calls each child via
+``workflow_call``. The acceptance criteria are encoded as tests here so
+the consolidation cannot silently regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+try:
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
+    pytest.skip("pyyaml not installed", allow_module_level=True)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DISPATCHER = REPO_ROOT / ".github" / "workflows" / "post-ci-dispatcher.yml"
+
+CHILDREN = (
+    "auto-release",
+    "auto-heal",
+    "bernstein-ci-fix",
+    "bisect-on-red",
+    "telegram-notify",
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    return cast("dict[str, Any]", yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
+def _on(workflow: dict[str, Any]) -> dict[str, Any]:
+    # PyYAML maps unquoted ``on:`` to True under YAML 1.1; tolerate both.
+    on = workflow.get(True, workflow.get("on"))
+    assert isinstance(on, dict), "workflow must have an `on:` block"
+    return on
+
+
+@pytest.fixture(scope="module")
+def dispatcher() -> dict[str, Any]:
+    return _load(DISPATCHER)
+
+
+def test_dispatcher_file_exists() -> None:
+    assert DISPATCHER.exists(), "post-ci-dispatcher.yml must exist at the documented path"
+
+
+def test_dispatcher_listens_to_workflow_run_ci_main(dispatcher: dict[str, Any]) -> None:
+    """Single workflow_run: CI completed listener on main."""
+    on = _on(dispatcher)
+    wfr = on.get("workflow_run")
+    assert isinstance(wfr, dict)
+    assert wfr.get("workflows") == ["CI"]
+    assert wfr.get("types") == ["completed"]
+    assert wfr.get("branches") == ["main"]
+
+
+def test_dispatcher_has_meta_job(dispatcher: dict[str, Any]) -> None:
+    """Meta job resolves the upstream event once and exposes named outputs."""
+    jobs = dispatcher["jobs"]
+    assert "meta" in jobs, "meta job must exist to surface upstream metadata"
+    meta = jobs["meta"]
+    outputs = meta.get("outputs") or {}
+    for key in ("head_sha", "head_branch", "conclusion", "run_id", "display_title", "actor_login"):
+        assert key in outputs, f"meta job must expose `{key}` as an output"
+
+
+@pytest.mark.parametrize("child", CHILDREN)
+def test_dispatcher_calls_each_child(dispatcher: dict[str, Any], child: str) -> None:
+    """Each former workflow_run listener must be invoked via workflow_call."""
+    jobs = dispatcher["jobs"]
+    assert child in jobs, f"dispatcher missing job for `{child}`"
+    job = jobs[child]
+    uses = job.get("uses", "")
+    assert isinstance(uses, str)
+    assert uses.endswith(f"{child}.yml"), f"job `{child}` must reuse `{child}.yml`"
+    assert job.get("secrets") == "inherit", (
+        f"job `{child}` must inherit secrets so reusables can reach TG/PyPI/etc."
+    )
+
+
+def test_bernstein_ci_fix_serialised_after_auto_heal(dispatcher: dict[str, Any]) -> None:
+    """bernstein-ci-fix runs only when auto-heal did NOT open a heal PR.
+
+    Acceptance criterion: auto-heal and bernstein-ci-fix call each other
+    via dispatcher (instead of both firing in parallel on the same
+    failing SHA). The serialisation is implemented as needs: auto-heal
+    plus a gate on auto-heal's heal_outcome output.
+    """
+    jobs = dispatcher["jobs"]
+    ci_fix = jobs["bernstein-ci-fix"]
+    needs = ci_fix.get("needs")
+    if isinstance(needs, str):
+        needs = [needs]
+    assert isinstance(needs, list)
+    assert "auto-heal" in needs, "bernstein-ci-fix must declare needs: auto-heal"
+    if_cond = ci_fix.get("if", "")
+    assert isinstance(if_cond, str)
+    assert "needs.auto-heal" in if_cond, (
+        "bernstein-ci-fix.if must inspect needs.auto-heal to serialise the heals"
+    )
+
+
+def test_dispatcher_concurrency_per_sha(dispatcher: dict[str, Any]) -> None:
+    """Dispatcher owns the per-SHA concurrency group covering the fanout."""
+    conc = dispatcher.get("concurrency")
+    assert isinstance(conc, dict)
+    group = conc.get("group", "")
+    assert isinstance(group, str)
+    assert "head_sha" in group, "concurrency group must key on head_sha so reruns idempotently supersede"
+
+
+def test_dispatcher_workflow_permissions_minimal(dispatcher: dict[str, Any]) -> None:
+    """Workflow-level permissions are empty; child jobs declare their own."""
+    perms = dispatcher.get("permissions")
+    assert perms == {} or perms == "{}"
+
+
+@pytest.mark.parametrize(
+    "child_yaml",
+    [
+        ".github/workflows/auto-release.yml",
+        ".github/workflows/auto-heal.yml",
+        ".github/workflows/bernstein-ci-fix.yml",
+        ".github/workflows/bisect-on-red.yml",
+        ".github/workflows/telegram-notify.yml",
+    ],
+)
+def test_children_expose_workflow_call(child_yaml: str) -> None:
+    """Each former workflow_run listener must be a workflow_call reusable.
+
+    The file path must stay the same (so branch protection and external
+    tooling that resolve workflows by file name keep working), but the
+    trigger surface must move to workflow_call so the dispatcher owns
+    the single workflow_run boot.
+    """
+    path = REPO_ROOT / child_yaml
+    assert path.exists(), f"child workflow `{child_yaml}` must exist at the original path"
+    data = _load(path)
+    on = _on(data)
+    assert "workflow_call" in on, f"`{child_yaml}` must declare on: workflow_call:"
+    assert "workflow_run" not in on, (
+        f"`{child_yaml}` must NOT keep workflow_run; the dispatcher owns that trigger now"
+    )


### PR DESCRIPTION
## Summary

- Five sibling workflows (`auto-release`, `auto-heal`, `bernstein-ci-fix`, `bisect-on-red`, `telegram-notify`) previously each paid a runner cold start + GHA token mint per CI completion. Consolidate them under a single dispatcher (`post-ci-dispatcher.yml`) that listens to `workflow_run: CI completed` once and routes via `workflow_call` to each child.
- Each child reusable keeps its original file path so branch protection rules, `gh run list --workflow "<file>.yml"`, and operator runbooks keep resolving by name. Only the trigger surface moved.
- Serialise the previously-racing fixers: `bernstein-ci-fix` runs only when `auto-heal` did NOT open a heal PR. The handshake is the new `heal_outcome` reusable-workflow output on `auto-heal.yml`.
- Out of scope (per ticket): `notify-other-failures.yml` listens to nightly workflows, not CI, so it is untouched.

## Files

| File | Change |
|---|---|
| `.github/workflows/post-ci-dispatcher.yml` | New dispatcher (the single `workflow_run` listener) |
| `.github/workflows/auto-release.yml` | `workflow_run` -> `workflow_call`, inputs added |
| `.github/workflows/auto-heal.yml` | `workflow_run` -> `workflow_call`, new `heal_outcome` output |
| `.github/workflows/bernstein-ci-fix.yml` | `workflow_run` -> `workflow_call`, dispatcher gates serialise vs auto-heal |
| `.github/workflows/bisect-on-red.yml` | `workflow_run` -> `workflow_call` |
| `.github/workflows/telegram-notify.yml` | `workflow_run` -> `workflow_call` |
| `tests/unit/test_post_ci_dispatcher_yaml.py` | New structural tests for the dispatcher acceptance criteria |
| `tests/unit/test_autoheal_workflow_yaml.py` | Updated trigger assertions, new `heal_outcome` assertion |
| `docs/operations/post-ci-dispatcher.md` | Operator runbook (sequence diagram, race resolution, runbook) |

## Test plan

- [x] `actionlint -shellcheck= .github/workflows/*.yml` -> clean
- [x] `uv run pytest tests/unit/test_post_ci_dispatcher_yaml.py tests/unit/test_autoheal_workflow_yaml.py tests/unit/test_release_attestation_workflow.py` -> 50 passed
- [ ] Push a no-op commit to main and confirm a single `post-ci-dispatcher` run appears with the five child jobs (`auto-release`, `auto-heal`, `bernstein-ci-fix`, `bisect-on-red`, `telegram-notify`) skipped or running per their dispatcher gates, instead of five independent workflow_run boots.
- [ ] Induce a CI failure on main and confirm `bernstein-ci-fix` only runs when `auto-heal` did NOT open a PR (race resolution).
- [ ] Verify `gh run list --workflow "auto-release.yml" --branch main` continues to surface runs (reusable workflow runs are listed under their file even when called via workflow_call).

## Summary by Sourcery

Consolidate post-CI GitHub Actions fanout behind a single workflow_run dispatcher and convert the existing post-CI workflows into reusable workflow_call children, while serialising auto-heal and bernstein-ci-fix to avoid races.

New Features:
- Introduce a post-CI dispatcher workflow that listens to CI workflow_run completions and routes events to reusable child workflows.
- Expose a heal_outcome output from the auto-heal workflow so downstream fixers can react to the heal result.

Enhancements:
- Convert auto-release, auto-heal, bernstein-ci-fix, bisect-on-red, and telegram-notify workflows from direct workflow_run listeners to reusable workflow_call workflows invoked by the dispatcher.
- Unify post-CI concurrency by moving per-SHA concurrency control to the dispatcher and removing per-child concurrency groups.
- Refine routing and guard conditions across post-CI workflows so they consume dispatcher-supplied metadata instead of raw workflow_run events.

Documentation:
- Add an operator runbook documenting the post-CI dispatcher, its routing behaviour, race resolution, and operational guidance.

Tests:
- Add structural tests for the post-CI dispatcher workflow to lock in trigger configuration, child wiring, and heal serialisation semantics.
- Update auto-heal workflow tests to assert workflow_call usage, heal_outcome output, and dispatcher-owned concurrency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the post-CI dispatcher workflow architecture and its execution model.

* **Tests**
  * Added unit tests validating dispatcher workflow structure and child workflow integration.
  * Updated auto-heal workflow tests to reflect new trigger mechanism.

* **Chores**
  * Refactored post-CI workflows to use a centralized dispatcher pattern for improved coordination and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->