### PR TITLE
fix(security): mask credentials in logger calls

### DIFF
--- a/src/bernstein/adapters/caching_adapter.py
+++ b/src/bernstein/adapters/caching_adapter.py
@@ -76,6 +76,9 @@ class CachingAdapter(CLIAdapter):
             f.write(event.to_json_line() + "\n")
 
         correlation = self._correlator.add_event(event)
+        # ``new_cache_key`` is a hash of prompt prefix bytes (not a
+        # credential); ``delta_tokens`` is an LLM-token count.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "Cache break: reason=%s, key=%s, delta_tokens=%s, break_label=%s",
             event.reason.value,

--- a/src/bernstein/adapters/env_isolation.py
+++ b/src/bernstein/adapters/env_isolation.py
@@ -228,6 +228,8 @@ def build_filtered_env(
 
         provider_secrets = load_secrets(secrets_config)
         if provider_secrets:
+            # Only the count and provider name are logged, not secret values.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.debug(
                 "Injecting %d secret(s) from %s into agent env",
                 len(provider_secrets),

--- a/src/bernstein/core/agents/agent_lifecycle.py
+++ b/src/bernstein/core/agents/agent_lifecycle.py
@@ -482,6 +482,8 @@ def _try_compact_and_retry(
         except Exception as _be:
             logger.debug("Budget post-compaction reconcile failed for %s: %s", task_id, _be)
 
+    # "token" here counts LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.info(
         "Compacted task %s description: %d → %d tokens (saved %d, correlation=%s)",
         task_id,

--- a/src/bernstein/core/agents/agent_session_token_breakdown.py
+++ b/src/bernstein/core/agents/agent_session_token_breakdown.py
@@ -182,6 +182,8 @@ def _load_prompt_token_report(sdd_dir: Path, session_id: str) -> dict[str, Any] 
         # so an attacker cannot inject fake log lines (CodeQL
         # py/log-injection #98).
         safe_sid = session_id.replace("\r", "").replace("\n", "")
+        # "token" here is an LLM context-token usage report, not a credential.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.debug("Cannot load prompt token report for %s: %s", safe_sid, exc)
         return None
 

--- a/src/bernstein/core/agents/spawn_prompt.py
+++ b/src/bernstein/core/agents/spawn_prompt.py
@@ -1021,6 +1021,8 @@ def _render_prompt(
             )
 
             _pt_report = analyse_prompt_sections(named_sections, session_id=session_id)
+            # "token" here counts LLM context tokens, not credentials.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.debug(
                 "Prompt token breakdown for %s: sys=%d%% ctx=%d%% user=%d%% total=%d",
                 session_id,
@@ -1032,8 +1034,12 @@ def _render_prompt(
             save_prompt_token_report(_pt_report, workdir)
             if _pt_report.suggestions:
                 for _sug in _pt_report.suggestions:
+                    # "token" here is an LLM context-token suggestion, not a credential.
+                    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
                     logger.info("Prompt token suggestion [%s]: %s", session_id, _sug)
         except Exception as _pt_exc:
+            # "token" here is LLM context tokens, not credentials.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.debug("Prompt token analysis failed: %s", _pt_exc)
 
     # Apply staged context collapse (T418): truncate → drop sections → strip metadata
@@ -1044,6 +1050,8 @@ def _render_prompt(
         compressed = "".join(content for _, content in collapse_result.sections)
         if collapse_result.steps:
             total_freed = sum(s.tokens_freed for s in collapse_result.steps)
+            # "token" here counts LLM context tokens, not credentials.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info(
                 "Context collapsed: %d → %d tokens (%d freed, %d steps, %s)",
                 collapse_result.original_tokens,
@@ -1081,6 +1089,8 @@ def _render_prompt(
         compressed, original_tokens, compressed_tokens, dropped = compressor.compress_sections(named_sections)
         if dropped:
             reduction_pct = (1.0 - compressed_tokens / max(1, original_tokens)) * 100
+            # "token" here counts LLM context tokens, not credentials.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info(
                 "Prompt compressed: %d → %d tokens (%.0f%% reduction), dropped: %s",
                 original_tokens,

--- a/src/bernstein/core/agents/spawner_core.py
+++ b/src/bernstein/core/agents/spawner_core.py
@@ -1014,6 +1014,9 @@ class AgentSpawner:
             os.close(fd)
 
         self._agent_token_files[session_id] = token_path
+        # Only the session_id and task list (non-secret) are logged; the
+        # token itself stays in the on-disk file referenced by token_path.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info("Issued zero-trust token for session %s (tasks=%s)", session_id, task_ids or "unrestricted")
         return token_path
 
@@ -1033,6 +1036,8 @@ class AgentSpawner:
             try:
                 token_path.unlink()
             except OSError as exc:
+                # Only the file path (not its contents) is logged.
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
                 logger.debug("Could not delete token file %s: %s", token_path, exc)
 
     def set_shutdown_event(self, shutdown_event: threading.Event | None) -> None:
@@ -1910,6 +1915,8 @@ class AgentSpawner:
             _token_path = self._issue_agent_token(session_id, role, task_ids_for_scope)
             prompt = prompt + _render_auth_section(_token_path)
         except Exception as _token_exc:
+            # Only the session_id and exception are logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning("Zero-trust token issuance failed for %s: %s", session_id, _token_exc)
 
         # Prompt size pre-check: estimate token count and reject or

--- a/src/bernstein/core/credential_scoping.py
+++ b/src/bernstein/core/credential_scoping.py
@@ -766,6 +766,8 @@ def resolve_default_policy(
         import logging
 
         logger = logging.getLogger(__name__)
+        # Only the env-var *name* (not its value) is logged.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "credential scoping disabled via %s=1; spawned agents will inherit the orchestrator's full credential set",
             ENV_DISABLE_CREDENTIAL_SCOPING,
@@ -795,6 +797,8 @@ def resolve_default_policy(
     import logging
 
     logger = logging.getLogger(__name__)
+    # Only candidate file paths and the env-var *name* are logged.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.warning(
         "no credential policy file found (looked in: %s); spawned agents will "
         "inherit the orchestrator's full credential set. Ship one at "

--- a/src/bernstein/core/git/jira_sync.py
+++ b/src/bernstein/core/git/jira_sync.py
@@ -50,6 +50,8 @@ def fetch_jira_issues(config: JiraSyncConfig) -> list[dict[str, Any]]:
     """
     token = os.environ.get(config.auth_token_env, "")
     if not token:
+        # Only the env-var *name* (not its value) is logged.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning("Jira auth token env var %s is not set", config.auth_token_env)
         return []
 

--- a/src/bernstein/core/orchestration/orchestrator.py
+++ b/src/bernstein/core/orchestration/orchestrator.py
@@ -4566,7 +4566,9 @@ if __name__ == "__main__":
             resolve_default_policy(workdir=workdir)
         except Exception as exc:
             # Never let policy load kill the orchestrator — log and fall
-            # through to the legacy unscoped path.
+            # through to the legacy unscoped path. Only the exception
+            # message is logged here, not credential values.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning("Credential policy resolution failed: %s", exc)
 
         # Load MCP config from user global + project seed

--- a/src/bernstein/core/orchestration/tick_pipeline.py
+++ b/src/bernstein/core/orchestration/tick_pipeline.py
@@ -806,6 +806,8 @@ def collapse_prompt_sections(
         )
         return sections, result
 
+    # "token" here counts LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.info(
         "Prompt sections exceed token budget%s: %d > %d tokens — applying staged collapse",
         task_ctx,
@@ -824,6 +826,8 @@ def collapse_prompt_sections(
         )
     else:
         freed = result.original_tokens - result.compressed_tokens
+        # "token" here counts LLM context tokens, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "Context collapse freed %d tokens%s (%d → %d, %.0f%% reduction)",
             freed,

--- a/src/bernstein/core/protocols/cluster/cluster_auth.py
+++ b/src/bernstein/core/protocols/cluster/cluster_auth.py
@@ -103,6 +103,9 @@ class ClusterAuthenticator:
             scopes=scopes,
         )
         self._node_tokens[node_id] = f"node-{node_id}"
+        # Only the node_id and scope list are logged; the JWT itself stays in
+        # the return value.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
         logger.info("Issued cluster token for node %s with scopes %s", node_id, scopes)
         return token
 
@@ -197,7 +200,12 @@ class ClusterAuthenticator:
             token: The JWT token string to revoke.
         """
         self._revoked_tokens.add(token)
-        logger.info("Revoked cluster token (hash: %s...)", token[:16])
+        # JWT prefix would be the public header (alg/typ) only, but we
+        # mask anyway so the log line is unambiguous in audit review.
+        from bernstein.core.security.redactor import mask
+
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
+        logger.info("Revoked cluster token: %s", mask(token, keep=4))
 
     def revoke_node(self, node_id: str) -> None:
         """Revoke all tokens associated with a node.
@@ -207,6 +215,8 @@ class ClusterAuthenticator:
         """
         session_id = self._node_tokens.pop(node_id, None)
         if session_id:
+            # Only the node_id (public identifier) is logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info("Revoked tokens for node %s", node_id)
 
     def is_node_authenticated(self, node_id: str) -> bool:

--- a/src/bernstein/core/protocols/mcp/mcp_auth_lifecycle.py
+++ b/src/bernstein/core/protocols/mcp/mcp_auth_lifecycle.py
@@ -244,6 +244,8 @@ class AuthLifecycleManager:
             session.expires_at = new_expiry
             session.state = AuthState.ACTIVE
             session.refresh_count = 0  # reset on success
+            # Only the MCP server name (a public identifier) is logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info("Token refreshed for MCP server '%s'", name)
             return RefreshOutcome(
                 server_name=name,
@@ -252,6 +254,8 @@ class AuthLifecycleManager:
             )
         except Exception as exc:
             session.state = AuthState.EXPIRED
+            # Only the MCP server name and exception message are logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning("Token refresh failed for '%s': %s", name, exc)
             return RefreshOutcome(
                 server_name=name,

--- a/src/bernstein/core/protocols/mcp/mcp_manager.py
+++ b/src/bernstein/core/protocols/mcp/mcp_manager.py
@@ -990,6 +990,8 @@ def refresh_oauth_token(
             access_token = data.get("access_token")
             if not access_token:
                 raise OAuthRefreshError(f"No access_token in refresh response for '{server_name}'")
+            # Only the MCP server name (a public identifier) is logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info("OAuth token refreshed for MCP server '%s'", server_name)
             return str(access_token)
     except urllib.error.HTTPError as exc:

--- a/src/bernstein/core/security/auth.py
+++ b/src/bernstein/core/security/auth.py
@@ -1015,7 +1015,18 @@ class AuthService:
                 timeout=10.0,
             )
             if resp.status_code != 200:
-                logger.error("OIDC token exchange failed: %s %s", resp.status_code, resp.text)
+                # ``resp.text`` from an IdP token endpoint can echo back the
+                # client_secret or contain an ``access_token`` even on
+                # non-200 paths (some IdPs return tokens with HTTP 4xx); mask
+                # the body before it reaches stdout/log files.
+                from bernstein.core.security.redactor import mask
+
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
+                logger.error(
+                    "OIDC token exchange failed: %s %s",
+                    resp.status_code,
+                    mask(resp.text),
+                )
                 return None
             return resp.json()  # type: ignore[no-any-return]
 

--- a/src/bernstein/core/security/auth_middleware.py
+++ b/src/bernstein/core/security/auth_middleware.py
@@ -494,6 +494,8 @@ class SSOAuthMiddleware(BaseHTTPMiddleware):
         # is unconfigured, or when the token omits the claim entirely.
         resource_error = _resource_indicator_check(claims, self._expected_resource)
         if resource_error is not None:
+            # Only the request path and configured expected_resource are logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning(
                 "SSO token rejected: resource indicator mismatch (path=%s, expected=%s)",
                 path,

--- a/src/bernstein/core/security/oauth_pkce.py
+++ b/src/bernstein/core/security/oauth_pkce.py
@@ -366,7 +366,19 @@ class PKCEFlow:
             )
 
         if resp.status_code != 200:
-            logger.error("PKCE token exchange failed: %s %s", resp.status_code, resp.text)
+            # ``resp.text`` from a token endpoint can echo the
+            # client_secret or contain a partial access_token even on
+            # error paths; mask before logging. The exception body
+            # still propagates the raw text to the caller so callers
+            # that need it for debugging can opt in there.
+            from bernstein.core.security.redactor import mask
+
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
+            logger.error(
+                "PKCE token exchange failed: %s %s",
+                resp.status_code,
+                mask(resp.text),
+            )
             raise OAuthError(f"Token exchange failed (HTTP {resp.status_code}): {resp.text[:200]}")
 
         data: dict[str, Any] = resp.json()

--- a/src/bernstein/core/security/permission_delegation.py
+++ b/src/bernstein/core/security/permission_delegation.py
@@ -175,6 +175,8 @@ class PermissionDelegator:
 
         self._tokens[token.token_id] = token
 
+        # ``token_id`` is an opaque internal handle (not the JWT itself).
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "Created delegation token %s for worker %s (scope: %s)",
             token.token_id,
@@ -233,6 +235,8 @@ class PermissionDelegator:
 
         # Check permission
         if required_permission not in token.permissions:
+            # ``token_id`` is an opaque internal handle (not the JWT itself).
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning(
                 "Token %s lacks permission %s",
                 token_id,
@@ -279,6 +283,8 @@ class PermissionDelegator:
         """
         if token_id in self._tokens:
             del self._tokens[token_id]
+            # ``token_id`` is an opaque internal handle (not the JWT itself).
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info("Revoked delegation token %s", token_id)
             return True
         return False
@@ -297,6 +303,8 @@ class PermissionDelegator:
         for token_id in to_revoke:
             del self._tokens[token_id]
 
+        # Counts and worker_id only — not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "Revoked %d tokens for worker %s",
             len(to_revoke),

--- a/src/bernstein/core/security/post_tool_enforcement.py
+++ b/src/bernstein/core/security/post_tool_enforcement.py
@@ -159,6 +159,9 @@ def run_post_tool_enforcement(
     )
 
     if secrets_found:
+        # Only the count of detected secrets and tool metadata are logged; the
+        # actual secret values stay in the redacted-output buffer.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.debug(
             "Post-tool redaction: %d secret(s) found in tool output — session=%s, tool=%s",
             len(secrets_found),

--- a/src/bernstein/core/security/redactor.py
+++ b/src/bernstein/core/security/redactor.py
@@ -16,24 +16,25 @@ feed it any UTF-8 file content without bespoke parsing.
 
 Usage::
 
-    from bernstein.core.security.redactor import redact_text, redact_file
+    from bernstein.core.security.redactor import redact_text, redact_file, mask
 
     cleaned = redact_text(raw)
     cleaned, count = redact_file(Path("bernstein.yaml"))
+    safe = mask(api_key)  # short-value helper for logger.info("got %s", mask(token))
 """
 
 from __future__ import annotations
 
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from bernstein.core.observability.debug_bundle import redact_secrets
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-__all__ = ["collapse_home", "redact_file", "redact_text"]
+__all__ = ["collapse_home", "mask", "redact_file", "redact_text"]
 
 _HOME_RE: re.Pattern[str] | None = None
 
@@ -78,6 +79,41 @@ def redact_text(text: str) -> tuple[str, int]:
     cleaned, count = redact_secrets(text)
     cleaned = collapse_home(cleaned)
     return cleaned, count
+
+
+def mask(value: Any, *, keep: int = 0) -> str:
+    """Mask an individual short value for safe inclusion in a log line.
+
+    Use this for credential-shaped scalars (API keys, bearer tokens, OAuth
+    response bodies, JWT signatures) where the file-level
+    :func:`redact_text` pipeline is overkill but you still want a
+    one-shot, hard-to-misuse helper at the call site::
+
+        logger.info("token issued: %s", mask(token))
+        logger.error("OAuth failed: %s %s", status, mask(resp.text))
+
+    Args:
+        value: Anything stringifiable. ``None`` becomes ``"<none>"`` so
+            log lines stay scannable without leaking type info.
+        keep: Number of trailing characters to keep visible (default
+            ``0``). Use sparingly for correlation; values above ``4``
+            risk re-exposing short secrets and are clamped.
+
+    Returns:
+        A redacted string of the form ``"***"`` (default) or
+        ``"***abcd"`` when ``keep > 0``. Empty strings render as
+        ``"<empty>"`` so a missing secret is visually distinct from a
+        masked one.
+    """
+    if value is None:
+        return "<none>"
+    text = str(value)
+    if not text:
+        return "<empty>"
+    keep = max(0, min(keep, 4))
+    if keep == 0 or len(text) <= keep:
+        return "***"
+    return f"***{text[-keep:]}"
 
 
 def redact_file(path: Path) -> tuple[str, int]:

--- a/src/bernstein/core/security/secrets.py
+++ b/src/bernstein/core/security/secrets.py
@@ -84,8 +84,12 @@ class SecretsRefresher:
                     fetched_at=time.monotonic(),
                     ttl=self.config.ttl,
                 )
+                # ``key`` is ``provider:path`` (cache key, not a secret value).
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
                 logger.debug("Background secrets refresh successful for %s", key)
             except Exception as exc:
+                # ``config.path`` is the vault/secrets-manager path (non-secret).
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
                 logger.warning("Background secrets refresh failed for %s: %s", self.config.path, exc)
 
             # Wait for next interval or stop signal
@@ -403,6 +407,8 @@ def load_secrets(config: SecretsConfig) -> dict[str, str]:
     if cached is not None and config.ttl > 0:
         age = now - cached.fetched_at
         if age < cached.ttl:
+            # ``key`` is ``provider:path`` (cache key, not a secret value).
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.debug("Using cached secrets for %s (age=%.0fs, ttl=%ds)", key, age, config.ttl)
             return cached.values
 
@@ -411,6 +417,8 @@ def load_secrets(config: SecretsConfig) -> dict[str, str]:
     try:
         raw_secrets = provider.fetch(config.path)
     except SecretsError as exc:
+        # Only the provider name and exception message are logged, not values.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning("Secrets manager unavailable (%s), falling back to env vars: %s", config.provider, exc)
         return _fallback_from_env(config)
 
@@ -419,6 +427,8 @@ def load_secrets(config: SecretsConfig) -> dict[str, str]:
 
     # Cache result
     _cache[key] = _CachedSecrets(values=mapped, fetched_at=now, ttl=config.ttl)
+    # Only the count, provider, and path are logged, not secret values.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.info("Loaded %d secret(s) from %s:%s", len(mapped), config.provider, config.path)
     return mapped
 

--- a/src/bernstein/core/security/sigstore_attestation.py
+++ b/src/bernstein/core/security/sigstore_attestation.py
@@ -203,6 +203,8 @@ def _get_identity_token() -> str | None:
                 data = json.loads(resp.read())
                 return str(data.get("value", ""))
         except Exception as exc:
+            # Only the exception (no token value) is logged here.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.debug("Failed to fetch GitHub OIDC token: %s", exc)
 
     return None  # sigstore will trigger interactive flow

--- a/src/bernstein/core/security/vault_injector.py
+++ b/src/bernstein/core/security/vault_injector.py
@@ -177,6 +177,8 @@ class _VaultInjector:
             expires_at=expires_at,
             revocable=bool(lease_id),
         )
+        # Vault path and lease_id are non-secret metadata, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info(
             "Vault credential issued: path=%s lease=%s ttl=%ds",
             config.path,
@@ -266,11 +268,19 @@ class _AwsInjector:
             expires_at=expires_at,
             revocable=False,  # STS credentials expire automatically
         )
-        logger.info("AWS STS credential issued: key=%s ttl=%ds", access_key[:8] + "****", ttl)
+        # AWS access-key ids are themselves credential material (paired
+        # with the secret key they grant API access); mask before
+        # logging rather than expose any prefix.
+        from bernstein.core.security.redactor import mask
+
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
+        logger.info("AWS STS credential issued: key=%s ttl=%ds", mask(access_key, keep=4), ttl)
         return env_vars, lease
 
     def revoke(self, lease: CredentialLease) -> None:
         """AWS STS credentials expire automatically; active revocation is not supported."""
+        # Only the lease expiry timestamp is logged, not credential material.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.debug(
             "AWS STS credentials expire automatically at %s; no active revocation needed",
             lease.expires_at.isoformat(),
@@ -321,6 +331,8 @@ class _OnePasswordInjector:
             expires_at=expires_at,
             revocable=False,
         )
+        # Only the 1Password item path and field count are logged, not values.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.info("1Password credential fetched: item=%s fields=%d", config.path, len(env_vars))
         return env_vars, lease
 

--- a/src/bernstein/core/server/webhook_verify.py
+++ b/src/bernstein/core/server/webhook_verify.py
@@ -70,6 +70,8 @@ class WebhookSignatureVerifier:
         """
         secret = self._resolve_secret(request)
         if not secret:
+            # Only the env-var *name* (not the secret value) is logged.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.error(
                 "Rejecting webhook request: no secret configured (checked app state and %s). Endpoint is disabled.",
                 self._secret_env_var,

--- a/src/bernstein/core/tasks/task_lifecycle.py
+++ b/src/bernstein/core/tasks/task_lifecycle.py
@@ -707,6 +707,8 @@ def retry_or_fail_task(
             # Canonical escalation: double the previous limit (default 4k -> 8k -> 16k...)
             current_limit = task.max_output_tokens or 4096
             new_max_output_tokens = min(current_limit * 2, 1_000_000)
+            # "token" here is the LLM output budget, not a credential.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.info(
                 "Escalating max_output_tokens for task %s: %d -> %d",
                 task_id,

--- a/src/bernstein/core/tokens/cascading_token_counter.py
+++ b/src/bernstein/core/tokens/cascading_token_counter.py
@@ -94,6 +94,8 @@ def _count_tokens_via_api(text: str, model: str) -> int | None:
             logger.debug("cascading_token_counter: API tier returned %d tokens", count)
             return count
     except (urllib.error.URLError, KeyError, ValueError, OSError) as exc:
+        # "token" here counts LLM tokens, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.debug("cascading_token_counter: API tier failed: %s", exc)
         return None
 
@@ -159,6 +161,8 @@ async def _count_tokens_via_cheap_model(text: str) -> int | None:
         return None
 
     except Exception as exc:
+        # "token" here counts LLM tokens, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.debug("cascading_token_counter: cheap-model tier failed: %s", exc)
         return None
 

--- a/src/bernstein/core/tokens/context_collapse.py
+++ b/src/bernstein/core/tokens/context_collapse.py
@@ -467,6 +467,8 @@ def _log_steps(steps: list[CollapseStep], stage_name: str) -> None:
         return
     freed = sum(s.tokens_freed for s in steps)
     section_names = ", ".join(s.section_name for s in steps)
+    # "token" here counts LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.info(
         "Collapse stage %s: freed %d tokens from [%s]",
         stage_name,

--- a/src/bernstein/core/tokens/prompt_token_analysis.py
+++ b/src/bernstein/core/tokens/prompt_token_analysis.py
@@ -278,7 +278,11 @@ def save_prompt_token_report(
     out_path = metrics_dir / name
     try:
         out_path.write_text(json.dumps(report.to_dict(), indent=2), encoding="utf-8")
+        # "token" here is an LLM context-token usage report, not a credential.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.debug("Prompt token report written: %s", out_path)
     except OSError as exc:
+        # "token" here is an LLM context-token usage report, not a credential.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning("Failed to write prompt token report: %s", exc)
     return out_path

--- a/src/bernstein/core/tokens/token_binding.py
+++ b/src/bernstein/core/tokens/token_binding.py
@@ -138,6 +138,8 @@ class TokenBindingValidator:
         if self._enforce_run_binding and self._run_id:
             token_run_id = claims.get("run_id", "")
             if token_run_id != self._run_id:
+                # ``run_id`` is a non-secret run identifier (not a credential).
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
                 logger.warning(
                     "Token run_id mismatch: expected %r, got %r (client=%s)",
                     self._run_id,
@@ -154,6 +156,8 @@ class TokenBindingValidator:
         if jti:
             rate_result = self._check_rate_limit(jti)
             if not rate_result.valid:
+                # ``jti`` is the JWT identifier claim (a non-secret correlation id).
+                # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure  # noqa: E501
                 logger.warning(
                     "Rate limit exceeded for token jti=%s (client=%s)",
                     jti,

--- a/src/bernstein/core/tokens/token_counter.py
+++ b/src/bernstein/core/tokens/token_counter.py
@@ -168,6 +168,8 @@ async def count_tokens(
         log.debug("Token count via API: %d", tokens)
         return tokens
     except Exception as exc:
+        # "token" here counts LLM context tokens, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         log.debug("API token count failed (%s); trying cheap model", exc)
 
     # Level 2 — Cheap LLM
@@ -176,6 +178,8 @@ async def count_tokens(
         log.debug("Token count via cheap model: %d", tokens)
         return tokens
     except Exception as exc:
+        # "token" here counts LLM context tokens, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         log.debug("Cheap-model token count failed (%s); falling back to estimation", exc)
 
     # Level 3 — Bytes estimation (never fails)

--- a/src/bernstein/core/tokens/token_monitor.py
+++ b/src/bernstein/core/tokens/token_monitor.py
@@ -808,6 +808,8 @@ def _handle_auto_kill(orch: Any, session: Any, monitor: Any, total: int) -> bool
     if not monitor.should_kill(session.id, files_changed, tenant_id=tenant_id):
         return False
 
+    # "token" here counts LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.warning(
         "Token runaway: agent %s consumed %d tokens with 0 file changes (tenant=%s threshold=%d) — killing",
         session.id,
@@ -837,6 +839,8 @@ def _handle_quadratic_warning(orch: Any, session: Any, monitor: Any, total: int)
         return
     if monitor.was_warned(session.id):
         return
+    # "token" here counts LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.warning(
         "Quadratic token growth detected for agent %s: %d tokens and rising super-linearly",
         session.id,
@@ -880,6 +884,8 @@ def _handle_budget_nudge(orch: Any, session: Any, monitor: Any) -> None:
         return
     if not monitor.should_nudge_budget(session.id, session.tokens_used, session.token_budget):
         return
+    # "token" here counts LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.info(
         "Token budget nudge fired for agent %s (%d/%d tokens, %.0f%%)",
         session.id,

--- a/src/bernstein/core/tokens/token_waste_report.py
+++ b/src/bernstein/core/tokens/token_waste_report.py
@@ -345,6 +345,8 @@ def generate_session_waste_report(
             raw = tokens_file.read_text(encoding="utf-8", errors="ignore")
             records = _parse_token_records(raw)
         except OSError as exc:
+            # "token" here refers to LLM context tokens (integers), not credentials.
+            # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
             logger.warning("token_waste_report: could not read %s: %s", tokens_file, exc)
 
     report = analyze_token_waste(
@@ -355,6 +357,8 @@ def generate_session_waste_report(
         oversized_threshold=oversized_threshold,
     )
 
+    # "token" here refers to LLM context tokens, not credentials.
+    # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
     logger.info("token_waste_report: %s", report.summary())
 
     if save:
@@ -394,4 +398,6 @@ def _save_report(report: TokenWasteReport, workdir: Path) -> None:
     try:
         out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     except OSError as exc:
+        # "token" here refers to LLM context tokens, not credentials.
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning("token_waste_report: could not save report: %s", exc)

--- a/src/bernstein/github_app/app.py
+++ b/src/bernstein/github_app/app.py
@@ -240,6 +240,8 @@ def create_installation_token(config: GitHubAppConfig, installation_id: int) -> 
             logger.info("Created installation token via JWT + httpx")
             return token
     except Exception as exc:
+        # Only the exception message is logged here (no token value).
+        # nosemgrep: python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure
         logger.warning("JWT-based token creation failed: %s", exc)
 
     msg = f"Failed to create installation token for installation {installation_id}"

--- a/tests/unit/security/test_redactor_mask.py
+++ b/tests/unit/security/test_redactor_mask.py
@@ -1,0 +1,110 @@
+"""Tests for the :func:`bernstein.core.security.redactor.mask` helper.
+
+These are the regression tests for the credential-leak fixes introduced
+to address Semgrep
+``python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure``
+alerts: every changed call site relies on ``mask`` returning ``"***"``
+(or ``"***xxxx"`` with a short suffix) so the secret value never
+reaches the log output.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from bernstein.core.security.redactor import mask
+
+
+class TestMaskBasics:
+    def test_none_renders_as_placeholder(self) -> None:
+        assert mask(None) == "<none>"
+
+    def test_empty_string_renders_as_placeholder(self) -> None:
+        assert mask("") == "<empty>"
+
+    def test_non_empty_string_collapses_to_stars(self) -> None:
+        assert mask("super-secret-token") == "***"
+
+    def test_secret_value_does_not_appear_in_result(self) -> None:
+        secret = "ghp_1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        out = mask(secret)
+        assert secret not in out
+        assert out == "***"
+
+    def test_int_and_other_scalars_are_stringified(self) -> None:
+        # Defensive: callers sometimes pass non-string values; the
+        # helper must still hide them rather than crashing.
+        assert mask(12345) == "***"
+
+
+class TestMaskKeepSuffix:
+    def test_keep_zero_is_default(self) -> None:
+        assert mask("abcdef") == "***"
+
+    def test_keep_reveals_only_trailing_chars(self) -> None:
+        assert mask("abcdef", keep=2) == "***ef"
+
+    def test_keep_is_clamped_to_four(self) -> None:
+        # Anything above 4 risks leaking short secrets; the helper
+        # silently clamps so callers can't misconfigure.
+        out = mask("abcdefgh", keep=99)
+        assert out == "***efgh"
+
+    def test_keep_larger_than_input_collapses_to_stars(self) -> None:
+        # If the visible suffix would be the whole string, we degrade
+        # to the safe default rather than emit the full value.
+        assert mask("ab", keep=4) == "***"
+
+    def test_negative_keep_is_treated_as_zero(self) -> None:
+        assert mask("abcdef", keep=-3) == "***"
+
+
+class TestMaskIntegratesWithLogging:
+    """End-to-end: a real :mod:`logging` handler must never see the
+    secret payload when ``mask`` is used at the call site.
+    """
+
+    @pytest.fixture
+    def caplog_at_debug(self, caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+        caplog.set_level(logging.DEBUG)
+        return caplog
+
+    def test_mask_keeps_secret_out_of_log_record(
+        self,
+        caplog_at_debug: pytest.LogCaptureFixture,
+    ) -> None:
+        log = logging.getLogger("test_mask_keeps_secret_out_of_log_record")
+        secret = "sk-live-9f3a2b1c4d5e6f7a8b9c0d1e2f3a4b5c"
+
+        log.info("token issued: %s", mask(secret))
+
+        records = [r for r in caplog_at_debug.records if r.name == log.name]
+        assert records, "expected the test logger to capture at least one record"
+        rendered = records[-1].getMessage()
+        assert "***" in rendered
+        assert secret not in rendered
+
+    def test_mask_with_keep_suffix_does_not_leak_full_secret(
+        self,
+        caplog_at_debug: pytest.LogCaptureFixture,
+    ) -> None:
+        log = logging.getLogger("test_mask_with_keep_suffix_does_not_leak_full_secret")
+        secret = "AKIAEXAMPLE1234567890QWERTYUIOPASDF"
+
+        log.info("api key issued: %s", mask(secret, keep=4))
+
+        records = [r for r in caplog_at_debug.records if r.name == log.name]
+        rendered = records[-1].getMessage()
+        # Only the last 4 chars may surface; everything else is hidden.
+        assert rendered.endswith(secret[-4:])
+        assert secret not in rendered
+
+
+class TestMaskIdempotent:
+    def test_mask_is_idempotent_on_its_own_output(self) -> None:
+        # Defensive: re-masking an already-masked value must be a no-op
+        # so accidental double-wrapping does not corrupt audit trails.
+        assert mask(mask("secret")) == "***"
+        assert mask(mask("secret", keep=2)) == "***"


### PR DESCRIPTION
## Summary

Audit of all 60 open Semgrep alerts for the rule
`python.lang.security.audit.logging.logger-credential-leak.python-logger-credential-disclosure`.

Each callsite is classified as a real leak, a false positive, or a clean
redesign. Real fixes route the value through a new
`bernstein.core.security.redactor.mask` helper. False positives get
per-line `# nosemgrep:` suppression with a one-line rationale.

## Per-category counts

| Category | Count |
|---|---|
| Real fix (mask the value) | 4 |
| False positive (suppress + comment) | 56 |
| Drop the interpolation | 0 |
| **Total alerts addressed** | **60** |

## Real fixes (mask the value)

1. `src/bernstein/core/security/auth.py:1018` -- OIDC token exchange logs
   `resp.text` from the IdP on non-200 paths. IdPs can echo the
   `client_secret` back in error bodies, or include a partial
   `access_token` even with HTTP 4xx. Mask before logging.
2. `src/bernstein/core/security/oauth_pkce.py:369` -- same shape, PKCE
   token endpoint.
3. `src/bernstein/core/security/vault_injector.py:269` -- AWS STS issued
   credential. Previously logged `access_key[:8] + "****"` which exposes
   the deterministic `AKIA` prefix plus four account-distinguishing
   characters. Replaced with `mask(access_key, keep=4)` so only the last
   four chars surface.
4. `src/bernstein/core/protocols/cluster/cluster_auth.py:200` -- cluster
   token revoke. The old `token[:16]` slice is non-secret JWT header
   material in practice, but the call now goes through
   `mask(token, keep=4)` for defense in depth and audit clarity.

## False positives (suppress with rationale)

The Semgrep rule fires on the substrings `token`/`secret` in log
messages, regardless of what the logged argument actually is. The 56
remaining alerts fall into five families:

| Pattern | Sites | Example |
|---|---|---|
| LLM context-token counts (integers) | 25 | `core/tokens/*`, `core/agents/spawn_prompt.py`, `core/orchestration/tick_pipeline.py` |
| Opaque internal handles (jti, token_id, lease_id, session_id) | 12 | `core/security/permission_delegation.py`, `core/tokens/token_binding.py`, `core/protocols/cluster/cluster_auth.py` |
| Env-var *names* / config paths | 7 | `core/git/jira_sync.py`, `core/credential_scoping.py`, `core/security/vault_injector.py` |
| Provider/server identifiers + counts | 8 | `core/security/secrets.py`, `adapters/env_isolation.py`, `core/protocols/mcp/*` |
| Exception-only logs (no token value) | 4 | `github_app/app.py`, `core/security/sigstore_attestation.py`, `core/orchestration/orchestrator.py` |

Each suppression is on the line above the log call, with a short
comment explaining what the value actually is (so future reviewers do
not have to repeat the audit).

## New redactor helper

The existing `bernstein.core.security.redactor` module only had
file-level (`redact_text`, `redact_file`) APIs aimed at debug bundles.
Added a scalar helper for log-call sites:

```python
mask(value, *, keep=0) -> str
# mask("ghp_abc...") -> "***"
# mask("AKIA1234EXAMPLE", keep=4) -> "***MPLE"
# mask(None) -> "<none>";  mask("") -> "<empty>"
# ``keep`` is clamped to 4 to keep short secrets unrecoverable
```

13 unit tests live in `tests/unit/security/test_redactor_mask.py`,
including a `caplog`-based end-to-end check that the original secret
payload never reaches the captured `logging.LogRecord` output.

## Verification

- `uv run ruff check src/bernstein` -> clean
- `semgrep --config=p/python src/bernstein` for the credential-leak
  rule -> **0 hits**
- Tests for changed files all pass:
  `tests/unit/security/test_redactor_mask.py`,
  `tests/unit/test_oauth_pkce.py`, `tests/unit/test_vault_injector.py`,
  `tests/unit/test_cluster_auth.py`,
  `tests/unit/test_permission_delegation_and_matrix.py`,
  `tests/unit/test_secrets.py`, `tests/unit/test_auth.py`,
  `tests/unit/test_auth_middleware.py`,
  `tests/unit/test_credential_scoping.py`,
  `tests/unit/test_token_*.py`, `tests/unit/test_spawner_agent_token.py`,
  `tests/unit/test_cache_break_correlator.py`,
  `tests/unit/test_mcp_config.py` -> 250+ tests green

## Test plan

- [ ] CI Semgrep scan reports 0 remaining alerts for
  `python-logger-credential-disclosure`
- [ ] `uv run ruff check src/bernstein` is green
- [ ] `uv run pytest tests/unit/security/test_redactor_mask.py` -> 13 pass
- [ ] No regression on `tests/unit/test_oauth_pkce.py`,
  `tests/unit/test_vault_injector.py`, `tests/unit/test_cluster_auth.py`

## Summary by Sourcery

Audit and remediate logger call sites flagged for potential credential leaks, introducing a reusable masking helper and annotating remaining safe logs for future security review.

New Features:
- Add a mask helper in the redactor module for safely logging credential-shaped values with optional short suffix exposure.

Bug Fixes:
- Mask sensitive OAuth/OIDC response bodies, AWS access key identifiers, and cluster JWTs before logging to prevent credential leakage in logs.

Enhancements:
- Document and suppress Semgrep false positives at numerous logging sites with rationale comments clarifying that only non-secret metadata or token counts are logged.

Tests:
- Add unit tests for the new redactor.mask helper, including end-to-end logging checks to ensure secrets never appear in log records.