### PR TITLE
fix(ci): honour SARIF suppressions before Code Scanning upload

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -61,7 +61,16 @@ jobs:
           path: results.sarif
           retention-days: 5
 
+      - name: Drop suppressed SARIF results
+        # No-op for scorecard output today (the action does not emit
+        # `suppressions`), but kept consistent with the other SARIF
+        # uploads so any future inline-suppression markers are honoured
+        # before reaching the Security tab.
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            results.sarif > results.filtered.sarif
+
       - name: Upload to Code Scanning
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: results.sarif
+          sarif_file: results.filtered.sarif

--- a/.github/workflows/static-analysis-extended.yml
+++ b/.github/workflows/static-analysis-extended.yml
@@ -119,11 +119,20 @@ jobs:
             --sarif-output=semgrep.sarif \
             "${extra_args[@]}" \
             src/
+      - name: Drop suppressed SARIF results
+        # Inline `# nosemgrep: <rule-id>` markers populate the SARIF
+        # `suppressions` array but Code Scanning still ingests the
+        # result. Strip those locally so the Security tab matches local
+        # intent. See scripts/sarif_drop_suppressed.py.
+        if: always()
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            semgrep.sarif > semgrep.filtered.sarif
       - name: Upload SARIF to Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: semgrep.sarif
+          sarif_file: semgrep.filtered.sarif
           category: semgrep-ce
       - name: Upload SARIF as workflow artifact
         if: always()
@@ -163,11 +172,16 @@ jobs:
           severity: HIGH,CRITICAL
           ignore-unfixed: true
           exit-code: "0"
+      - name: Drop suppressed SARIF results
+        if: always()
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            trivy-fs.sarif > trivy-fs.filtered.sarif
       - name: Upload SARIF to Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: trivy-fs.sarif
+          sarif_file: trivy-fs.filtered.sarif
           category: trivy-fs
       - name: Run Trivy filesystem scan (failing gate)
         # Re-run with exit-code=1 to fail the job on any HIGH/CRITICAL
@@ -224,11 +238,16 @@ jobs:
           # from IaC misconfig checks.
           skip-dirs: ".clusterfuzzlite"
           exit-code: "0"
+      - name: Drop suppressed SARIF results
+        if: always()
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            trivy-iac.sarif > trivy-iac.filtered.sarif
       - name: Upload SARIF to Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: trivy-iac.sarif
+          sarif_file: trivy-iac.filtered.sarif
           category: trivy-iac
       - name: Run Trivy IaC scan (failing gate)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
@@ -291,11 +310,16 @@ jobs:
             --tool vulture \
             --input vulture.txt \
             --output vulture.sarif
+      - name: Drop suppressed SARIF results
+        if: always()
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            vulture.sarif > vulture.filtered.sarif
       - name: Upload SARIF to Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: vulture.sarif
+          sarif_file: vulture.filtered.sarif
           category: vulture
       - name: Upload SARIF as workflow artifact
         if: always()
@@ -343,11 +367,16 @@ jobs:
             --tool refurb \
             --input refurb.txt \
             --output refurb.sarif
+      - name: Drop suppressed SARIF results
+        if: always()
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            refurb.sarif > refurb.filtered.sarif
       - name: Upload SARIF to Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: refurb.sarif
+          sarif_file: refurb.filtered.sarif
           category: refurb
       - name: Upload SARIF as workflow artifact
         if: always()
@@ -405,11 +434,16 @@ jobs:
             --tool perflint \
             --input perflint.txt \
             --output perflint.sarif
+      - name: Drop suppressed SARIF results
+        if: always()
+        run: |
+          python3 scripts/sarif_drop_suppressed.py \
+            perflint.sarif > perflint.filtered.sarif
       - name: Upload SARIF to Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4
         with:
-          sarif_file: perflint.sarif
+          sarif_file: perflint.filtered.sarif
           category: perflint
       - name: Upload SARIF as workflow artifact
         if: always()

--- a/scripts/sarif_drop_suppressed.py
+++ b/scripts/sarif_drop_suppressed.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Drop SARIF results that carry a non-empty `suppressions` array.
+
+Semgrep (and other linters) translate inline `# nosemgrep: <rule-id>`
+markers into SARIF results with a populated `suppressions` array. GitHub
+Code Scanning ingests those results regardless, surfacing phantom alerts
+for code we have deliberately marked as not-an-issue. This filter strips
+them out before upload so the Security tab matches local intent.
+
+Usage::
+
+    python3 scripts/sarif_drop_suppressed.py input.sarif > output.sarif
+    python3 scripts/sarif_drop_suppressed.py input.sarif output.sarif
+    cat input.sarif | python3 scripts/sarif_drop_suppressed.py > output.sarif
+
+Behaviour:
+
+- Results whose `suppressions` is a non-empty array are dropped.
+- Results with missing `suppressions`, `null`, or `[]` are kept.
+- Everything else (runs[*].tool, invocations, properties, ...) is
+  preserved verbatim.
+- Multi-run SARIF logs are handled.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _has_active_suppression(result: dict[str, Any]) -> bool:
+    suppressions = result.get("suppressions")
+    return isinstance(suppressions, list) and len(suppressions) > 0
+
+
+def filter_sarif(sarif: dict[str, Any]) -> dict[str, Any]:
+    """Return a new SARIF dict with suppressed results removed."""
+    runs = sarif.get("runs")
+    if not isinstance(runs, list):
+        return sarif
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        results = run.get("results")
+        if not isinstance(results, list):
+            continue
+        run["results"] = [r for r in results if not (isinstance(r, dict) and _has_active_suppression(r))]
+    return sarif
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    if len(args) > 2:
+        sys.stderr.write("usage: sarif_drop_suppressed.py [input.sarif [output.sarif]]\n")
+        return 2
+    in_path = args[0] if len(args) >= 1 else None
+    out_path = args[1] if len(args) == 2 else None
+
+    if in_path is None:
+        raw = sys.stdin.read()
+    else:
+        with open(in_path, encoding="utf-8") as fh:
+            raw = fh.read()
+
+    sarif = json.loads(raw)
+    filtered = filter_sarif(sarif)
+    payload = json.dumps(filtered, indent=2)
+
+    if out_path is None:
+        sys.stdout.write(payload)
+        sys.stdout.write("\n")
+    else:
+        with open(out_path, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/unit/scripts/__init__.py
+++ b/tests/unit/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for repo-level helper scripts under ``scripts/``."""

--- a/tests/unit/scripts/test_sarif_drop_suppressed.py
+++ b/tests/unit/scripts/test_sarif_drop_suppressed.py
@@ -1,0 +1,197 @@
+"""Unit tests for ``scripts/sarif_drop_suppressed.py``.
+
+Covers the four documented cases from the spec:
+
+- empty ``suppressions`` array on a result (keep)
+- missing ``suppressions`` key (keep)
+- non-empty ``suppressions`` array (drop)
+- multi-run SARIF files (filter every run independently)
+
+Also exercises the CLI surface (stdin->stdout, argv path -> stdout,
+argv in + argv out) so the workflow invocations stay covered.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sarif_drop_suppressed.py"
+
+
+@pytest.fixture
+def sarif_module():
+    """Load scripts/sarif_drop_suppressed.py as a module."""
+    spec = importlib.util.spec_from_file_location("sarif_drop_suppressed_under_test", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop(spec.name, None)
+
+
+def _result(rule_id: str, suppressions: Any | None = ...) -> dict[str, Any]:
+    """Build a minimal SARIF result; pass ``suppressions=...`` to omit the key."""
+    out: dict[str, Any] = {
+        "ruleId": rule_id,
+        "level": "warning",
+        "message": {"text": f"finding {rule_id}"},
+    }
+    if suppressions is not ...:
+        out["suppressions"] = suppressions
+    return out
+
+
+def _sarif(*results_per_run: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "version": "2.1.0",
+        "$schema": "https://example.com/sarif-2.1.0.json",
+        "runs": [
+            {
+                "tool": {"driver": {"name": f"tool-{idx}"}},
+                "results": list(results),
+            }
+            for idx, results in enumerate(results_per_run)
+        ],
+    }
+
+
+def _ids(sarif: dict[str, Any], run: int = 0) -> list[str]:
+    return [r["ruleId"] for r in sarif["runs"][run]["results"]]
+
+
+# ---------------------------------------------------------------------------
+# filter_sarif unit cases
+# ---------------------------------------------------------------------------
+
+
+def test_keeps_result_with_empty_suppressions_array(sarif_module) -> None:
+    sarif = _sarif([_result("R1", suppressions=[])])
+    out = sarif_module.filter_sarif(sarif)
+    assert _ids(out) == ["R1"]
+
+
+def test_keeps_result_with_missing_suppressions_key(sarif_module) -> None:
+    sarif = _sarif([_result("R2")])
+    out = sarif_module.filter_sarif(sarif)
+    assert _ids(out) == ["R2"]
+
+
+def test_keeps_result_with_null_suppressions(sarif_module) -> None:
+    sarif = _sarif([_result("R3", suppressions=None)])
+    out = sarif_module.filter_sarif(sarif)
+    assert _ids(out) == ["R3"]
+
+
+def test_drops_result_with_nonempty_suppressions(sarif_module) -> None:
+    suppression = {"kind": "inSource", "justification": "# nosemgrep: R4"}
+    sarif = _sarif(
+        [
+            _result("R4", suppressions=[suppression]),
+            _result("R5"),
+        ]
+    )
+    out = sarif_module.filter_sarif(sarif)
+    assert _ids(out) == ["R5"]
+
+
+def test_multi_run_filters_each_run_independently(sarif_module) -> None:
+    suppression = {"kind": "inSource"}
+    sarif = _sarif(
+        [
+            _result("A1", suppressions=[suppression]),
+            _result("A2"),
+        ],
+        [
+            _result("B1", suppressions=[]),
+            _result("B2", suppressions=[suppression, suppression]),
+        ],
+    )
+    out = sarif_module.filter_sarif(sarif)
+    assert _ids(out, 0) == ["A2"]
+    assert _ids(out, 1) == ["B1"]
+
+
+def test_preserves_tool_and_top_level_fields(sarif_module) -> None:
+    suppression = {"kind": "inSource"}
+    sarif = _sarif([_result("X1", suppressions=[suppression]), _result("X2")])
+    sarif["runs"][0]["invocations"] = [{"executionSuccessful": True}]
+    sarif["runs"][0]["properties"] = {"category": "semgrep-ce"}
+    out = sarif_module.filter_sarif(sarif)
+    assert out["version"] == "2.1.0"
+    assert out["$schema"].endswith("sarif-2.1.0.json")
+    assert out["runs"][0]["tool"] == {"driver": {"name": "tool-0"}}
+    assert out["runs"][0]["invocations"] == [{"executionSuccessful": True}]
+    assert out["runs"][0]["properties"] == {"category": "semgrep-ce"}
+    assert _ids(out) == ["X2"]
+
+
+def test_run_without_results_key_is_left_alone(sarif_module) -> None:
+    sarif = {"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "t"}}}]}
+    out = sarif_module.filter_sarif(sarif)
+    assert out == sarif
+
+
+def test_no_runs_key_passes_through(sarif_module) -> None:
+    sarif = {"version": "2.1.0"}
+    out = sarif_module.filter_sarif(sarif)
+    assert out == sarif
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args: str, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_cli_stdin_to_stdout(tmp_path: Path) -> None:
+    sarif = _sarif([_result("Y1", suppressions=[{"kind": "inSource"}]), _result("Y2")])
+    proc = _run_cli(stdin=json.dumps(sarif))
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert [r["ruleId"] for r in out["runs"][0]["results"]] == ["Y2"]
+
+
+def test_cli_argv_input_to_stdout(tmp_path: Path) -> None:
+    sarif = _sarif([_result("Z1", suppressions=[{"kind": "inSource"}]), _result("Z2")])
+    in_path = tmp_path / "in.sarif"
+    in_path.write_text(json.dumps(sarif), encoding="utf-8")
+    proc = _run_cli(str(in_path))
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert [r["ruleId"] for r in out["runs"][0]["results"]] == ["Z2"]
+
+
+def test_cli_argv_input_and_output(tmp_path: Path) -> None:
+    sarif = _sarif([_result("Q1", suppressions=[{"kind": "inSource"}]), _result("Q2")])
+    in_path = tmp_path / "in.sarif"
+    out_path = tmp_path / "out.sarif"
+    in_path.write_text(json.dumps(sarif), encoding="utf-8")
+    proc = _run_cli(str(in_path), str(out_path))
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == ""
+    out = json.loads(out_path.read_text(encoding="utf-8"))
+    assert [r["ruleId"] for r in out["runs"][0]["results"]] == ["Q2"]
+
+
+def test_cli_rejects_too_many_args(tmp_path: Path) -> None:
+    proc = _run_cli("a", "b", "c")
+    assert proc.returncode == 2
+    assert "usage" in proc.stderr.lower()


### PR DESCRIPTION
## Summary

Inline `# nosemgrep: <rule-id>` markers translate into SARIF results with a populated `suppressions` array, but GitHub Code Scanning ingests them anyway. The result is phantom alerts in the Security tab for code we have deliberately marked as not-an-issue. This change filters those results locally before upload so the Security tab matches local intent.

## What changes

- New `scripts/sarif_drop_suppressed.py` (stdin/argv in, stdout/argv out). Drops every result whose `suppressions` array is non-empty; preserves tool metadata, all runs, and every other top-level field.
- Workflow steps that call `github/codeql-action/upload-sarif` now run the filter on the input SARIF and upload the `.filtered.sarif`:
  - `.github/workflows/static-analysis-extended.yml` -- semgrep, trivy-fs, trivy-iac, vulture, refurb, perflint
  - `.github/workflows/scorecard.yml` -- scorecard (no-op today, kept consistent for forward compatibility)
- `codeql.yml` produces its own SARIF via CodeQL itself and is intentionally left untouched.

## Before / after

```jsonc
// before -- ingested by Code Scanning
{
  "ruleId": "python.lang.security.audit.eval-detected.eval-detected",
  "message": {"text": "Use of eval"},
  "suppressions": [
    {"kind": "inSource", "justification": "# nosemgrep: eval-detected"}
  ]
}
```

```jsonc
// after the filter -- this result is dropped before upload,
// no phantom alert raised in Code Scanning.
```

## Test plan

- [x] `tests/unit/scripts/test_sarif_drop_suppressed.py` -- 12 cases covering empty array, missing key, null, non-empty array, multi-run files, tool/top-level preservation, and the three CLI shapes (stdin->stdout, argv in -> stdout, argv in + argv out).
- [x] `uv run --no-sync pytest tests/unit/scripts/test_sarif_drop_suppressed.py` passes locally.
- [x] `uv run --no-sync ruff check scripts/sarif_drop_suppressed.py tests/unit/scripts/` clean.
- [x] `python3 -c "import yaml; yaml.safe_load(open('...'))"` confirms both touched workflows parse.
- [ ] Next semgrep / trivy run on this PR populates the SARIF artifact alongside a `.filtered.sarif`; phantom alerts for code with `# nosemgrep:` markers stop appearing in Code Scanning.

## Summary by Sourcery

Filter suppressed SARIF results before uploading to GitHub Code Scanning so inline suppressions are respected and phantom alerts are avoided.

New Features:
- Add a reusable scripts/sarif_drop_suppressed.py helper that drops SARIF results with non-empty suppressions arrays while preserving all other SARIF structure.

Enhancements:
- Update static-analysis and scorecard GitHub workflows to run SARIF output through the suppression filter and upload filtered SARIF files instead of raw tool output.

Tests:
- Add unit test suite for the SARIF suppression filter script, covering SARIF structures, edge cases, and CLI invocation modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code Scanning workflows now automatically filter out suppressed findings from security analysis tools before uploading results, reducing noise in scan reports.

* **Tests**
  * Added comprehensive test coverage for suppressed findings filtering across multiple security analysis tools and scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->