### PR TITLE
fix(ci): emit CI gate for paths-ignored-only PRs

### DIFF
--- a/.github/workflows/ci-gate-stub.yml
+++ b/.github/workflows/ci-gate-stub.yml
@@ -1,0 +1,121 @@
+name: CI gate stub
+
+# Synthetic emitter for the `CI gate` required check on PRs whose diff
+# is entirely paths-ignored by `.github/workflows/ci.yml`.
+#
+# Problem
+# -------
+# Branch protection on `main` requires a single context named `CI gate`,
+# emitted by the `ci-gate` job in `ci.yml`. `ci.yml` is configured with
+# a `paths-ignore:` list (SDKs, packaging, docs, infra configs, etc.)
+# so PRs whose diff is fully contained in those paths never trigger
+# `ci.yml` at all — and therefore never publish a `CI gate` check.
+# Such PRs sit `BLOCKED` indefinitely (e.g. Renovate lockfile bumps
+# under `sdk/typescript/**` or `packages/vscode/**`).
+#
+# Fix
+# ---
+# This workflow's `paths:` filter MIRRORS `ci.yml`'s `paths-ignore:`
+# list. When a PR touches any of these files, this workflow fires and
+# emits a job named exactly `CI gate` that immediately succeeds. For
+# PRs whose diff is *fully* paths-ignored by ci.yml, this is the only
+# emitter and unblocks the merge. For PRs with a mixed diff (some
+# ignored, some not), both this stub AND the real `ci-gate` job in
+# ci.yml fire; branch protection treats two passing checks with the
+# same name as passing.
+#
+# IMPORTANT — keep in sync
+# ------------------------
+# The `paths:` list below MUST stay aligned with the `paths-ignore:`
+# list in `.github/workflows/ci.yml`. The canary
+# `tests/unit/test_required_check_canary_workflow_yaml.py` asserts
+# that exactly two files emit a `CI gate` check
+# (ci.yml + ci-gate-stub.yml) and no others. If you add or remove an
+# entry from `ci.yml`'s `paths-ignore:`, update the matching entry
+# here.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      # Documentation & prose
+      - "docs/**"
+      - "*.md"
+      - "!README.md"
+      - "LICENSE"
+      - "CONTRIBUTORS.md"
+      # Runtime state (never committed)
+      - ".sdd/**"
+      # Non-Python packages & SDKs
+      - "sdk/typescript/**"
+      - "packages/vscode/**"
+      - "packages/cursor-plugin/**"
+      - "packaging/**"
+      - "Formula/**"
+      # Deployment & infra configs
+      - "deploy/**"
+      - "docker/**"
+      - "docker-compose.yaml"
+      - "Dockerfile"
+      - "action.yml"
+      - "action/**"
+      # CI tool configs
+      - "codecov.yml"
+      - "sonar-project.properties"
+      # GitHub meta
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/FUNDING.yml"
+      - ".github/CODEOWNERS"
+      - ".github/pull_request_template.md"
+      - ".github/dependabot.yml"
+      - ".github/labeler.yml"
+      - ".github/release-drafter.yml"
+      - ".github/copilot-instructions.md"
+      - ".github/codeql/**"
+      # Non-code project files
+      - "marketing/**"
+      - "benchmarks/**"
+      - "examples/**"
+      - "plans/**"
+      - "agents/**"
+      - "commands/**"
+      - "rules/**"
+      - ".bernstein/**"
+      - ".plugin/**"
+      - "scripts/gen_tickets_*.py"
+      - "scripts/gen_roadmap_*.py"
+      - "scripts/generate_benchmark_docs.py"
+
+concurrency:
+  group: ci-gate-stub-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci-gate:
+    # The check-run name posted to the PR is taken from this `name:`.
+    # It MUST equal the required-context string `CI gate` so branch
+    # protection's single required check is satisfied. The canary
+    # (required-check-canary.yml + tests/unit/test_required_check_canary_workflow_yaml.py)
+    # asserts this exact string and allow-lists this file alongside
+    # ci.yml as the only two emitters.
+    name: CI gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner (audit mode)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+      - name: Emit synthetic CI gate success
+        run: |
+          echo "Diff is fully (or partially) contained in ci.yml's paths-ignore list."
+          echo "Emitting synthetic 'CI gate' success so branch protection on main"
+          echo "does not block PRs whose only changes are in SDK/packaging/docs/infra paths."
+          echo ""
+          echo "If you expected the real CI to run for this PR, verify that at least"
+          echo "one changed path is NOT covered by ci.yml's paths-ignore list."

--- a/.github/workflows/required-check-canary.yml
+++ b/.github/workflows/required-check-canary.yml
@@ -18,8 +18,10 @@ name: Required-check name canary
 #   3. The `test-macos` job's `name:` is a literal string (no `${{ ... }}`
 #      template) and equals `Test (macos-latest, Python 3.13)`. Required
 #      context names must resolve in every job state including `skipped`.
-#   4. No other job in any `.github/workflows/*.yml` file emits a
-#      check-run named `CI gate`. The required context must be unique.
+#   4. Exactly two workflow files emit a check-run named `CI gate`:
+#      `ci.yml::ci-gate` (real aggregator) and
+#      `ci-gate-stub.yml::ci-gate` (synthetic emitter for PRs whose diff
+#      is entirely paths-ignored by ci.yml). No other emitter allowed.
 #
 # Run modes:
 #   * pull_request -- only when a workflow file under `.github/workflows/`
@@ -64,6 +66,7 @@ jobs:
           REQUIRED_JOB_KEY: "ci-gate"
           MACOS_JOB_KEY: "test-macos"
           MACOS_JOB_NAME: "Test (macos-latest, Python 3.13)"
+          STUB_WORKFLOW: ".github/workflows/ci-gate-stub.yml"
         run: |
           python3 - <<'PY'
           """Assert that the in-tree workflow files still match the single
@@ -87,9 +90,18 @@ jobs:
           REQUIRED_JOB_KEY = os.environ["REQUIRED_JOB_KEY"]
           MACOS_JOB_KEY = os.environ["MACOS_JOB_KEY"]
           MACOS_JOB_NAME = os.environ["MACOS_JOB_NAME"]
+          STUB_WORKFLOW = os.environ["STUB_WORKFLOW"]
 
           CI = Path(".github/workflows/ci.yml")
+          STUB = Path(STUB_WORKFLOW)
           WORKFLOWS_DIR = Path(".github/workflows")
+
+          # Allow-listed (file, job-key) pairs that may emit the
+          # `CI gate` check. See workflow header for rationale.
+          ALLOWED_EMITTERS = {
+              (CI, REQUIRED_JOB_KEY),
+              (STUB, REQUIRED_JOB_KEY),
+          }
 
           failures: list[str] = []
 
@@ -155,8 +167,11 @@ jobs:
                       "runbook."
                   )
 
-          # Invariant 4: no other workflow emits a job named "CI gate".
-          collisions: list[str] = []
+          # Invariant 4: only allow-listed workflow files emit a job
+          # named "CI gate". Two emitters are intentional: ci.yml (real
+          # aggregator) and ci-gate-stub.yml (synthetic success for
+          # paths-ignored-only PRs).
+          seen_emitters: set[tuple[Path, str]] = set()
           for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
               try:
                   wf = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
@@ -170,16 +185,23 @@ jobs:
                       continue
                   if body.get("name") != REQUIRED_CONTEXT:
                       continue
-                  if wf_path == CI and key == REQUIRED_JOB_KEY:
-                      continue
-                  collisions.append(f"{wf_path}:{key}")
+                  seen_emitters.add((wf_path, key))
 
-          if collisions:
+          unexpected = seen_emitters - ALLOWED_EMITTERS
+          missing = ALLOWED_EMITTERS - seen_emitters
+          if unexpected:
               failures.append(
-                  f"Found extra jobs emitting `{REQUIRED_CONTEXT}` check: "
-                  + ", ".join(collisions)
-                  + ". Branch protection's single required context must be "
-                  "uniquely produced."
+                  f"Unexpected emitters of `{REQUIRED_CONTEXT}` check: "
+                  + ", ".join(f"{p}:{k}" for p, k in sorted(unexpected))
+                  + ". Allow-list is "
+                  + ", ".join(f"{p}:{k}" for p, k in sorted(ALLOWED_EMITTERS))
+                  + "."
+              )
+          if missing:
+              failures.append(
+                  f"Missing required emitters of `{REQUIRED_CONTEXT}` check: "
+                  + ", ".join(f"{p}:{k}" for p, k in sorted(missing))
+                  + ". Both ci.yml and ci-gate-stub.yml must keep their `ci-gate` job."
               )
 
           # Report.

--- a/tests/unit/test_required_check_canary_workflow_yaml.py
+++ b/tests/unit/test_required_check_canary_workflow_yaml.py
@@ -14,8 +14,11 @@ Invariants exercised here:
    literal string ``Test (macos-latest, Python 3.13)`` (no ``${{ ... }}``
    template, which would resolve to a different string when the job is
    skipped via the gate condition).
-3. No other job across ``.github/workflows/*.yml`` emits a check-run
-   named ``CI gate``. The required context must be uniquely produced.
+3. Exactly two files under ``.github/workflows/*.yml`` emit a check-run
+   named ``CI gate``: ``ci.yml`` (real aggregator) and
+   ``ci-gate-stub.yml`` (synthetic emitter for PRs whose diff is fully
+   paths-ignored by ci.yml — see PR opening this allow-list). No other
+   workflow may emit this check name.
 4. The canary workflow file itself exists and is wired to the
    ``pull_request``/``schedule``/``workflow_dispatch`` triggers, with
    every action SHA-pinned and the verify step asserting the same set
@@ -37,12 +40,26 @@ except ModuleNotFoundError:  # pragma: no cover - dev env should have pyyaml
 
 CI = Path(".github/workflows/ci.yml")
 CANARY = Path(".github/workflows/required-check-canary.yml")
+STUB = Path(".github/workflows/ci-gate-stub.yml")
 WORKFLOWS_DIR = Path(".github/workflows")
 
 REQUIRED_CONTEXT = "CI gate"
 REQUIRED_JOB_KEY = "ci-gate"
 MACOS_JOB_KEY = "test-macos"
 MACOS_JOB_NAME = "Test (macos-latest, Python 3.13)"
+
+# Allow-listed `CI gate` emitters. Branch protection still depends on
+# a single required-context *name*, but two workflow files now legitimately
+# produce it:
+#   - ci.yml::ci-gate       — real rolled-up aggregator
+#   - ci-gate-stub.yml::ci-gate — synthetic success for PRs whose diff is
+#     entirely contained in ci.yml's paths-ignore list, otherwise such PRs
+#     are permanently BLOCKED (e.g. Renovate lockfile bumps under
+#     sdk/typescript/** or packages/vscode/**).
+ALLOWED_CI_GATE_EMITTERS = {
+    (CI, REQUIRED_JOB_KEY),
+    (STUB, REQUIRED_JOB_KEY),
+}
 
 
 @pytest.fixture(scope="module")
@@ -104,8 +121,23 @@ def test_test_macos_name_is_literal(ci_doc: dict[str, object]) -> None:
     )
 
 
-def test_ci_gate_check_run_name_is_unique_across_workflows() -> None:
-    collisions: list[str] = []
+def test_ci_gate_check_run_name_emitters_are_allow_listed() -> None:
+    """Only the allow-listed workflow files may emit a `CI gate` check.
+
+    Two emitters are intentional:
+      * ``ci.yml::ci-gate`` -- the real aggregator that rolls up every
+        required upstream job.
+      * ``ci-gate-stub.yml::ci-gate`` -- a synthetic success for PRs whose
+        diff is entirely contained in ci.yml's ``paths-ignore`` list (so
+        ci.yml never fires). Without this stub such PRs sit ``BLOCKED``
+        on ``main`` indefinitely (Renovate lockfile bumps for
+        ``sdk/typescript/**`` were the originally reported regression).
+
+    Any additional emitter is rejected so a future refactor cannot
+    weaken branch protection by silently introducing a third source
+    of the required context.
+    """
+    seen: list[str] = []
     for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
         wf = yaml.safe_load(wf_path.read_text(encoding="utf-8"))
         if not isinstance(wf, dict):
@@ -118,12 +150,23 @@ def test_ci_gate_check_run_name_is_unique_across_workflows() -> None:
                 continue
             if body.get("name") != REQUIRED_CONTEXT:
                 continue
-            if wf_path == CI and key == REQUIRED_JOB_KEY:
-                continue
-            collisions.append(f"{wf_path}:{key}")
-    assert not collisions, (
-        f"Multiple jobs emit a check named {REQUIRED_CONTEXT!r}: {collisions}. "
-        "Branch protection's single required context must be uniquely produced."
+            seen.append(f"{wf_path}:{key}")
+
+    seen_pairs = set()
+    for entry in seen:
+        wf_str, key = entry.rsplit(":", 1)
+        seen_pairs.add((Path(wf_str), key))
+
+    unexpected = seen_pairs - ALLOWED_CI_GATE_EMITTERS
+    missing = ALLOWED_CI_GATE_EMITTERS - seen_pairs
+    assert not unexpected, (
+        f"Unexpected emitters of {REQUIRED_CONTEXT!r}: {sorted(unexpected)}. "
+        "Branch protection's required context is allow-listed to "
+        f"{sorted(ALLOWED_CI_GATE_EMITTERS)} only."
+    )
+    assert not missing, (
+        f"Missing expected emitters of {REQUIRED_CONTEXT!r}: {sorted(missing)}. "
+        "Both ci.yml::ci-gate and ci-gate-stub.yml::ci-gate must remain."
     )
 
 
@@ -185,3 +228,65 @@ def test_canary_asserts_required_context_name(canary_text: str) -> None:
     assert f'REQUIRED_JOB_KEY: "{REQUIRED_JOB_KEY}"' in canary_text
     assert f'MACOS_JOB_KEY: "{MACOS_JOB_KEY}"' in canary_text
     assert f'MACOS_JOB_NAME: "{MACOS_JOB_NAME}"' in canary_text
+
+
+# ---------------------------------------------------------------------------
+# Invariants on the synthetic CI gate stub
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def stub_doc() -> dict[str, object]:
+    return yaml.safe_load(STUB.read_text(encoding="utf-8"))
+
+
+def test_stub_workflow_exists() -> None:
+    assert STUB.exists(), (
+        "ci-gate-stub.yml is missing. Without it, PRs whose diff is entirely "
+        "paths-ignored by ci.yml sit BLOCKED on `main` because the required "
+        "`CI gate` context is never published."
+    )
+
+
+def test_stub_emits_ci_gate_check(stub_doc: dict[str, object]) -> None:
+    jobs = stub_doc.get("jobs")
+    assert isinstance(jobs, dict)
+    job = jobs.get(REQUIRED_JOB_KEY)
+    assert isinstance(job, dict), (
+        f"ci-gate-stub.yml must define a `{REQUIRED_JOB_KEY}` job."
+    )
+    assert job.get("name") == REQUIRED_CONTEXT, (
+        f"ci-gate-stub.yml::{REQUIRED_JOB_KEY}.name must equal "
+        f"{REQUIRED_CONTEXT!r} so branch protection's required context "
+        "is satisfied on paths-ignored-only PRs."
+    )
+
+
+def test_stub_paths_mirror_ci_paths_ignore(
+    ci_doc: dict[str, object], stub_doc: dict[str, object]
+) -> None:
+    """The stub's ``paths:`` list MUST be identical to ci.yml's
+    ``pull_request.paths-ignore:`` list. Otherwise a PR could fail both
+    filters and emit no `CI gate` check at all (BLOCKED forever), or
+    succeed both and waste a runner.
+    """
+    ci_on = ci_doc.get(True, ci_doc.get("on"))
+    assert isinstance(ci_on, dict)
+    pr = ci_on.get("pull_request")
+    assert isinstance(pr, dict)
+    ci_paths_ignore = pr.get("paths-ignore")
+    assert isinstance(ci_paths_ignore, list)
+
+    stub_on = stub_doc.get(True, stub_doc.get("on"))
+    assert isinstance(stub_on, dict)
+    stub_pr = stub_on.get("pull_request")
+    assert isinstance(stub_pr, dict)
+    stub_paths = stub_pr.get("paths")
+    assert isinstance(stub_paths, list)
+
+    assert stub_paths == ci_paths_ignore, (
+        "ci-gate-stub.yml `paths:` must mirror ci.yml `pull_request.paths-ignore:` exactly.\n"
+        f"  ci.yml paths-ignore : {ci_paths_ignore}\n"
+        f"  stub paths          : {stub_paths}\n"
+        "When you add or remove an entry in one file, update the other in the same PR."
+    )


### PR DESCRIPTION
## Summary

Branch protection on `main` requires a single context `CI gate` emitted only by the `ci-gate` job in `ci.yml`. `ci.yml` is wired with a long `paths-ignore:` list (SDKs, packaging, docs, infra configs, etc.), so PRs whose diff is **entirely** contained in those paths never trigger `ci.yml` at all -- which means they never publish a `CI gate` check and sit BLOCKED forever.

### Symptom

PR #1516 (Renovate lockfile bump touching only `sdk/typescript/package-lock.json` + `packages/vscode/package-lock.json`) is BLOCKED. Same fate would hit every Renovate / Dependabot lockfile PR for those SDKs, packaging-only PRs, docs-only PRs, infra-config-only PRs, etc.

### Fix

New workflow `.github/workflows/ci-gate-stub.yml` is a synthetic emitter:

- `on.pull_request.paths:` mirrors `ci.yml`'s `pull_request.paths-ignore:` 1:1.
- Single job `ci-gate` whose `name:` is exactly `CI gate` (the required-context string).
- One step that prints a summary and exits 0. No build, no dependencies, ~30s of runner time.

When a PR touches any of the paths-ignored paths the stub fires and emits a passing `CI gate` check. For PRs whose diff is fully paths-ignored, the stub is the only emitter and unblocks the merge. For PRs with mixed diffs (some ignored, some not), both ci.yml and the stub fire -- branch protection treats two passing checks with the same name as passing.

### Canary alignment

The canary (`required-check-canary.yml`) and its structural pytest (`tests/unit/test_required_check_canary_workflow_yaml.py`) both used to assert the `CI gate` check-run name is **unique** across the workflow tree. Both have been updated to allow-list **exactly two** emitters:

- `ci.yml::ci-gate` -- real aggregator
- `ci-gate-stub.yml::ci-gate` -- synthetic stub

A new test asserts the stub's `paths:` list is identical to `ci.yml`'s `paths-ignore:` so the two files stay in lockstep -- if a path is added to one, the canary fails until it is added to the other.

## Test plan

- [x] `actionlint .github/workflows/ci-gate-stub.yml .github/workflows/required-check-canary.yml .github/workflows/ci.yml` clean
- [x] `pytest tests/unit/test_required_check_canary_workflow_yaml.py` -- 13/13 pass (3 new tests for the stub)
- [x] Smoke-tested the inline canary's allow-list logic locally
- [ ] After merge: PR #1516 re-trigger via touch -- expect synthetic `CI gate` check to land and PR to flip to MERGEABLE

## Summary by Sourcery

Add a synthetic CI gate workflow for paths-ignored-only pull requests and update the CI canary and tests to allow exactly two CI gate emitters and keep their path filters in sync.

CI:
- Introduce a ci-gate-stub workflow that emits the required CI gate check for pull requests whose changes fall entirely under ci.yml’s paths-ignore list.
- Update the required-check canary workflow to allow exactly ci.yml and ci-gate-stub.yml to emit the CI gate check and to validate their emitters accordingly.

Tests:
- Extend the required-check canary tests to allow-list the two CI gate emitters and add invariants ensuring the stub workflow exists, emits the CI gate job, and mirrors ci.yml’s paths-ignore list in its paths filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD infrastructure with enhanced build validation checks to ensure consistent code quality across pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->