### PR TITLE
feat(memory): long-running session memory

### DIFF
--- a/docs/memory/session-memory.md
+++ b/docs/memory/session-memory.md
@@ -1,0 +1,152 @@
+# Long-running session memory
+
+`SessionMemory` is the durable, two-layer memory subsystem that lets a
+Bernstein agent remember what it did across days, across context-window
+compactions, and across machine reboots. It replicates on local disk
+what paid persistent-agent vendors sell as a hosted service.
+
+The store has two layers:
+
+| Layer | What it holds | Where it lives |
+|-------|---------------|----------------|
+| Episodic | Verbatim turn-by-turn log, append-only JSONL, content-addressed | `.sdd/memory/episodic/<task_id>/<session_id>.jsonl` |
+| Semantic | SQLite FTS5 index over the episodic content, tags, role | `.sdd/memory/semantic.sqlite` |
+
+The episodic layer is the source of truth; the semantic layer is a
+secondary index optimised for BM25 recall.
+
+## Contract
+
+```python
+from pathlib import Path
+
+from bernstein.core.memory.session_memory import SessionMemory, Turn
+
+mem = SessionMemory(
+    root=Path(".sdd/memory"),
+    task_id="t-7",
+    session_id="s-1",
+)
+
+# Record a turn
+mem.append_turn(
+    Turn(role="user", content="design the API", tags=["api"]),
+)
+
+# Free-text recall, BM25 ranked, newest-first within rank
+for hit in mem.recall("API", k=3):
+    print(hit.role, hit.content, hit.ts_ns)
+```
+
+### Turn shape
+
+A `Turn` has the following fields. Validation happens on `append_turn`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `role` | `str` | One of `user`, `assistant`, `system`, `tool`. |
+| `content` | `str` | Non-empty. Stored verbatim. |
+| `tags` | `list[str]` | Free-form. No commas. Used as an optional recall filter. |
+| `ts_ns` | `int` | Wall-clock nanoseconds. Defaults to `time.time_ns()`. |
+
+The append also stores `task_id`, `session_id`, and a `sha256:<hex>`
+content hash so a downstream auditor can correlate a turn with the
+lineage entry of any artefact it produced.
+
+### Recall
+
+```python
+mem.recall(query, *, k=5, tag=None, task_id=None)
+```
+
+- `query` is tokenised by FTS5 `porter unicode61`. Empty queries return
+  an empty list. FTS5 operator characters are stripped so a copy-pasted
+  string with colons or parentheses does not break the parser.
+- `k` is the maximum number of hits. Must be positive.
+- `tag` is an optional exact-tag filter applied after the MATCH narrows
+  the candidate set.
+- `task_id` scopes the search to one task. By default recall spans
+  every task in the shared semantic index, which is what you want when
+  an agent is looking for context from sibling tasks.
+
+Hits are ordered by BM25 rank (best first), ties broken by newest
+`ts_ns` first.
+
+### Auto-load at agent spawn
+
+The orchestrator wires `load_recent_turns(root, task_id=..., k=...)`
+into the agent-spawn path for tasks with prior sessions. The function
+returns the most recent N turns for that `task_id`, newest first, so
+they can be joined into the system prompt without a free-text query.
+
+```python
+from bernstein.core.memory.session_memory import load_recent_turns
+
+prior = load_recent_turns(
+    Path(".sdd/memory"),
+    task_id="t-7",
+    k=10,
+)
+```
+
+### Prune
+
+```python
+mem.prune(older_than_ns)
+```
+
+Drops every turn for this instance's `(task_id, session_id)` whose
+`ts_ns` is strictly less than the cutoff. The episodic JSONL file is
+rewritten in place via a sibling temp file plus atomic rename, so a
+crash mid-prune leaves either the old log or the new log intact.
+
+The semantic index delete is scoped to `task_id` so a parallel task
+sharing the same `.sdd/memory/` root is never touched.
+
+## On-disk layout
+
+```
+.sdd/memory/
+├── episodic/
+│   ├── task-a/
+│   │   ├── session-1.jsonl
+│   │   └── session-2.jsonl
+│   └── task-b/
+│       └── session-1.jsonl
+└── semantic.sqlite
+```
+
+The semantic database opens in WAL mode so a concurrent reader does
+not block the writer.
+
+## Concurrency
+
+- Episodic appends rely on POSIX append-write semantics. Two processes
+  appending to the same `(task_id, session_id)` file at the same time
+  may interleave bytes within a single record. Bernstein assigns one
+  session per agent process so this collision does not occur in
+  practice.
+- The semantic SQLite database uses its own file-locking. WAL mode
+  means readers and writers do not block each other.
+- The episodic and semantic layers are written from the same code
+  path; if the process crashes between the two writes the episodic
+  layer is the source of truth and the next read on the same instance
+  will silently rebuild the missing semantic row on the next
+  `append_turn` of the same hash. (Reindex utilities are a v2 task.)
+
+## What v1 does not do
+
+| Capability | Status | Notes |
+|------------|--------|-------|
+| Vector / embedding recall | Out of scope | FTS5 BM25 is the baseline. |
+| Cross-machine sync | Out of scope | Single host only. |
+| Memory edit / forget | Out of scope beyond `prune` | Operator-driven forgetting is a v2 follow-up. |
+| Git-versioned episodic log | Deferred | The JSONL files are intentionally append-only on disk. |
+
+## Related modules
+
+- `src/bernstein/core/memory/sqlite_store.py` -- tag-indexed knowledge base.
+- `src/bernstein/core/memory/jsonl_log.py` -- flat per-key JSONL log.
+- `src/bernstein/core/memory/cross_task_kb.py` -- explicit publish/subscribe.
+- `src/bernstein/core/knowledge/rag.py` -- codebase FTS5 index. The
+  `_sanitize_query` helper here matches the one used there.

--- a/src/bernstein/core/memory/session_memory.py
+++ b/src/bernstein/core/memory/session_memory.py
@@ -1,0 +1,687 @@
+"""Long-running session memory: episodic JSONL plus FTS5 semantic recall.
+
+Bernstein agents already have a tag-indexed SQLite memory store
+(:mod:`bernstein.core.memory.sqlite_store`) and a per-key JSONL log
+(:mod:`bernstein.core.memory.jsonl_log`). What was missing is the pattern
+paid persistent-agent vendors sell: a two-layer memory that survives the
+agent's context window and lives across sessions on disk.
+
+This module implements that two-layer pattern locally:
+
+* **Episodic layer.** A per-task JSONL log under
+  ``<root>/episodic/<task_id>/<session_id>.jsonl``. One turn per line.
+  Append-only. Content-addressed via a per-turn ``sha256`` hash so a
+  truncated tail does not destroy earlier turns. A truncated/garbage line
+  is skipped on read with a warning.
+
+* **Semantic layer.** A single shared SQLite database at
+  ``<root>/semantic.sqlite`` with an FTS5 virtual table. Every appended
+  turn is mirrored into the index so :meth:`SessionMemory.recall` can
+  return BM25-ranked prior turns by free-text query. Tag-filtered recall
+  is supported.
+
+The public surface is intentionally small:
+
+* :meth:`SessionMemory.append_turn` -- record one turn (both layers).
+* :meth:`SessionMemory.recall` -- BM25 search, newest-first within rank,
+  with optional tag filter.
+* :meth:`SessionMemory.prune` -- drop turns older than a cutoff from
+  both layers.
+
+The constructor accepts ``task_id`` and ``session_id`` so two parallel
+agents writing to the same root never collide. The episodic layer is
+sharded by ``task_id``; the semantic layer carries ``task_id`` and
+``session_id`` as columns so recall can be narrowed.
+
+V1 limits, called out in the ticket:
+
+* No vector embeddings. FTS5 BM25 is the baseline.
+* Single host. Cross-machine sync is out of scope.
+* No edit/forget surface beyond :meth:`prune`.
+
+Typical usage::
+
+    from pathlib import Path
+
+    from bernstein.core.memory.session_memory import (
+        SessionMemory,
+        Turn,
+    )
+
+    mem = SessionMemory(
+        root=Path(".sdd/memory"),
+        task_id="t-7",
+        session_id="s-1",
+    )
+    mem.append_turn(Turn(role="user", content="design the API", tags=["api"]))
+    for hit in mem.recall("api", k=3):
+        ...
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RecallHit",
+    "SessionMemory",
+    "Turn",
+]
+
+
+# Identifiers map onto filesystem paths (task_id) and SQLite values. The
+# regex mirrors :mod:`bernstein.core.memory.jsonl_log` so a poisoned task
+# or session ID cannot escape ``root`` or break the FTS index.
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_MAX_ID_LEN = 128
+
+# FTS5 valid roles. Kept open enough that adapters can label tool turns
+# without a code change, but constrained so a typo does not silently
+# break tag filtering downstream.
+_VALID_ROLES: frozenset[str] = frozenset({"user", "assistant", "system", "tool"})
+
+
+def _validate_id(value: str, field_name: str) -> None:
+    """Reject identifiers that could break the filesystem or FTS index.
+
+    Args:
+        value: Candidate identifier.
+        field_name: Human-readable name for the error message.
+
+    Raises:
+        ValueError: ``value`` is empty, too long, or contains disallowed
+            characters.
+    """
+    if not value or len(value) > _MAX_ID_LEN:
+        raise ValueError(f"{field_name} must be 1..{_MAX_ID_LEN} chars, got len={len(value)}")
+    if not _ID_RE.fullmatch(value):
+        raise ValueError(
+            f"{field_name} {value!r} must match {_ID_RE.pattern!r} "
+            "(alphanumerics plus . _ - only, must start alphanumeric)"
+        )
+
+
+def _content_hash(value: str) -> str:
+    """Compute ``sha256:<hex>`` over the UTF-8 encoding of ``value``."""
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+@dataclass(slots=True)
+class Turn:
+    """A single conversation turn ready to be appended.
+
+    Attributes:
+        role: Speaker label. One of ``user``, ``assistant``, ``system``,
+            ``tool``. Validated on append.
+        content: The turn payload. Stored verbatim in the episodic log
+            and indexed for BM25 recall.
+        tags: Free-form labels. Used as an optional filter on recall.
+            Commas in tags are rejected because tags are joined with
+            commas in the FTS column.
+        ts_ns: Wall-clock nanoseconds. Defaults to ``time.time_ns()`` at
+            instantiation, but callers can pin it for replayability.
+    """
+
+    role: str
+    content: str
+    tags: list[str] = field(default_factory=list)
+    ts_ns: int = 0
+
+    def __post_init__(self) -> None:
+        if self.ts_ns == 0:
+            self.ts_ns = time.time_ns()
+
+
+@dataclass(frozen=True, slots=True)
+class RecallHit:
+    """A single recall result with attribution.
+
+    Attributes:
+        role: Role the turn was recorded under.
+        content: Turn payload.
+        tags: Tags attached to the turn.
+        task_id: Task that produced the turn.
+        session_id: Session that produced the turn.
+        ts_ns: Wall-clock nanoseconds at append time.
+        content_hash: ``sha256:<hex>`` of the UTF-8 encoded ``content``.
+        rank: BM25 rank score from FTS5. Lower is better.
+    """
+
+    role: str
+    content: str
+    tags: list[str]
+    task_id: str
+    session_id: str
+    ts_ns: int
+    content_hash: str
+    rank: float
+
+
+_SEMANTIC_SCHEMA: tuple[str, ...] = (
+    """
+    CREATE VIRTUAL TABLE IF NOT EXISTS turns_fts USING fts5(
+        role UNINDEXED,
+        content,
+        tags,
+        task_id UNINDEXED,
+        session_id UNINDEXED,
+        ts_ns UNINDEXED,
+        content_hash UNINDEXED,
+        tokenize = 'porter unicode61'
+    )
+    """,
+)
+
+
+class SessionMemory:
+    """Two-layer episodic + semantic memory for one task / session pair.
+
+    A new instance is cheap to construct: it lazily creates the episodic
+    directory on first append and lazily opens the SQLite database on
+    first read or write. Two instances pointing at the same root may run
+    concurrently in different processes; SQLite's file-locking and the
+    POSIX append-write semantics of the JSONL log are the synchronisation
+    point.
+
+    Args:
+        root: Memory root directory. Episodic logs live under
+            ``<root>/episodic/<task_id>/`` and the semantic index lives
+            at ``<root>/semantic.sqlite``. Created on first write.
+        task_id: Identifier for the task that owns the episodic shard.
+            Must match the filesystem-safe regex; see :func:`_validate_id`.
+        session_id: Identifier for the current session. Used as the
+            episodic filename stem and as a column in the semantic
+            index so recall can be scoped per session.
+        clock_ns: Indirection point for tests to pin ``ts_ns``. Defaults
+            to :func:`time.time_ns`.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        task_id: str,
+        session_id: str,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> None:
+        _validate_id(task_id, "task_id")
+        _validate_id(session_id, "session_id")
+        self._root = root
+        self._task_id = task_id
+        self._session_id = session_id
+        self._clock_ns = clock_ns or time.time_ns
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def root(self) -> Path:
+        """The configured memory root."""
+        return self._root
+
+    @property
+    def task_id(self) -> str:
+        """The task ID this instance is bound to."""
+        return self._task_id
+
+    @property
+    def session_id(self) -> str:
+        """The session ID this instance is bound to."""
+        return self._session_id
+
+    @property
+    def episodic_path(self) -> Path:
+        """JSONL log path for the current task and session."""
+        return self._root / "episodic" / self._task_id / f"{self._session_id}.jsonl"
+
+    @property
+    def semantic_db_path(self) -> Path:
+        """Shared SQLite FTS index path."""
+        return self._root / "semantic.sqlite"
+
+    # ------------------------------------------------------------------
+    # Connections
+    # ------------------------------------------------------------------
+
+    def _connect_semantic(self) -> sqlite3.Connection:
+        """Open the semantic database, creating the schema on first call.
+
+        Uses WAL mode so a concurrent reader does not block the appender
+        and a long recall query does not hold a writer off.
+        """
+        self.semantic_db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.semantic_db_path))
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            for stmt in _SEMANTIC_SCHEMA:
+                conn.execute(stmt)
+            conn.commit()
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
+    # ------------------------------------------------------------------
+    # Append
+    # ------------------------------------------------------------------
+
+    def append_turn(self, turn: Turn) -> str:
+        """Record ``turn`` in both the episodic log and the semantic index.
+
+        Args:
+            turn: The turn to record. Its ``ts_ns`` is preserved if set;
+                otherwise the instance clock supplies one.
+
+        Returns:
+            The ``sha256:<hex>`` content hash of the turn. Useful when a
+            caller wants to correlate the turn with downstream lineage
+            entries.
+
+        Raises:
+            ValueError: ``turn.role`` is not a recognised role, or a tag
+                contains a comma, or ``turn.content`` is empty.
+        """
+        self._validate_turn(turn)
+        if turn.ts_ns <= 0:
+            turn.ts_ns = self._clock_ns()
+        chash = _content_hash(turn.content)
+
+        # Episodic layer: append one JSON object per line. We assemble
+        # the payload first so a partial write cannot leave a half-record
+        # on disk.
+        record: dict[str, object] = {
+            "role": turn.role,
+            "content": turn.content,
+            "ts_ns": turn.ts_ns,
+            "task_id": self._task_id,
+            "session_id": self._session_id,
+            "tags": list(turn.tags),
+            "content_hash": chash,
+        }
+        line = json.dumps(record, ensure_ascii=False, separators=(",", ":"))
+        self.episodic_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.episodic_path.open("a", encoding="utf-8") as fh:
+            fh.write(line)
+            fh.write("\n")
+
+        # Semantic layer: mirror into the FTS index. Tags are joined with
+        # commas; the porter tokenizer will split them on punctuation so
+        # a MATCH on a single tag still hits the row.
+        tags_blob = ",".join(turn.tags)
+        with self._connect_semantic() as conn:
+            conn.execute(
+                "INSERT INTO turns_fts "
+                "(role, content, tags, task_id, session_id, ts_ns, content_hash) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    turn.role,
+                    turn.content,
+                    tags_blob,
+                    self._task_id,
+                    self._session_id,
+                    turn.ts_ns,
+                    chash,
+                ),
+            )
+            conn.commit()
+        return chash
+
+    # ------------------------------------------------------------------
+    # Recall
+    # ------------------------------------------------------------------
+
+    def recall(
+        self,
+        query: str,
+        *,
+        k: int = 5,
+        tag: str | None = None,
+        task_id: str | None = None,
+    ) -> list[RecallHit]:
+        """Return up to ``k`` BM25-ranked turns matching ``query``.
+
+        Args:
+            query: Free-text query. Tokenised by FTS5 porter unicode61.
+                Empty or all-whitespace queries return an empty list.
+            k: Maximum number of hits. Must be positive.
+            tag: Optional exact-tag filter. When given, only turns whose
+                ``tags`` column contains the tag are returned.
+            task_id: Optional task filter. When given, only turns whose
+                ``task_id`` matches are returned. By default recall
+                spans every task in the shared semantic index, so an
+                agent can find context from related sibling tasks.
+
+        Returns:
+            List of :class:`RecallHit` ordered by BM25 rank (best first),
+            with ties broken by newest ``ts_ns`` first.
+        """
+        if k <= 0:
+            raise ValueError(f"k must be positive, got {k}")
+        if not query or not query.strip():
+            return []
+        if not self.semantic_db_path.exists():
+            return []
+
+        safe = _sanitize_fts_query(query)
+        if not safe:
+            return []
+
+        clauses: list[str] = ["turns_fts MATCH ?"]
+        params: list[object] = [safe]
+        if task_id is not None:
+            _validate_id(task_id, "task_id")
+            clauses.append("task_id = ?")
+            params.append(task_id)
+        if tag is not None:
+            if "," in tag:
+                raise ValueError("tag must not contain ','")
+            # Tag filter happens in Python below because FTS5 cannot
+            # combine a MATCH query with a structured LIKE on the same
+            # row without sub-selects across SQLite versions. The
+            # ``MATCH`` already narrows the candidate set sharply.
+            tag_filter = tag
+        else:
+            tag_filter = None
+
+        sql = (
+            "SELECT role, content, tags, task_id, session_id, ts_ns, "
+            "content_hash, rank "
+            "FROM turns_fts WHERE " + " AND ".join(clauses) + " "
+            "ORDER BY rank, ts_ns DESC LIMIT ?"
+        )
+        # Pull a few extra rows to account for tag filtering in Python.
+        fetch_limit = k * 4 if tag_filter is not None else k
+        params.append(fetch_limit)
+
+        hits: list[RecallHit] = []
+        with self._connect_semantic() as conn:
+            try:
+                rows = conn.execute(sql, params).fetchall()
+            except sqlite3.OperationalError as exc:
+                logger.warning(
+                    "FTS recall failed for %r (%s); returning no hits",
+                    query,
+                    exc,
+                )
+                return []
+        for row in rows:
+            tags = [t for t in (row[2] or "").split(",") if t]
+            if tag_filter is not None and tag_filter not in tags:
+                continue
+            hits.append(
+                RecallHit(
+                    role=row[0],
+                    content=row[1],
+                    tags=tags,
+                    task_id=row[3],
+                    session_id=row[4],
+                    ts_ns=int(row[5]),
+                    content_hash=row[6],
+                    rank=float(row[7]),
+                )
+            )
+            if len(hits) >= k:
+                break
+        return hits
+
+    # ------------------------------------------------------------------
+    # Read raw episodic
+    # ------------------------------------------------------------------
+
+    def read_episodic(self) -> list[dict[str, object]]:
+        """Return every turn recorded for this task and session.
+
+        Skips malformed or non-dict lines with a warning so a tail
+        corruption does not break the whole log. Useful for tests and
+        for the auto-load step at agent spawn.
+        """
+        path = self.episodic_path
+        if not path.exists():
+            return []
+        entries: list[dict[str, object]] = []
+        with path.open("r", encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "skipping malformed episodic line %s:%d (%s)",
+                        path,
+                        lineno,
+                        exc,
+                    )
+                    continue
+                if not isinstance(parsed, dict):
+                    logger.warning(
+                        "skipping non-dict episodic line %s:%d",
+                        path,
+                        lineno,
+                    )
+                    continue
+                entries.append(parsed)
+        return entries
+
+    # ------------------------------------------------------------------
+    # Prune
+    # ------------------------------------------------------------------
+
+    def prune(self, older_than_ns: int) -> int:
+        """Drop turns recorded before ``older_than_ns`` from both layers.
+
+        The episodic layer is rewritten in place: surviving lines are
+        copied to a sibling temp file and then atomically renamed over
+        the original. The semantic index uses an FTS5 ``DELETE`` over
+        ``ts_ns < ?``.
+
+        Args:
+            older_than_ns: Cutoff in wall-clock nanoseconds. Turns with
+                ``ts_ns`` strictly less than this are removed.
+
+        Returns:
+            Number of episodic turns removed across every shard under
+            this instance's task and session. Semantic deletes are
+            independent because the index is shared; callers can read
+            the ``semantic_deleted`` count via the logged record.
+        """
+        if older_than_ns <= 0:
+            raise ValueError(f"older_than_ns must be positive, got {older_than_ns}")
+
+        # Episodic: rewrite only the file for this (task, session).
+        removed_episodic = self._prune_episodic(older_than_ns)
+
+        # Semantic: shared index, delete everything older than cutoff
+        # but scoped to this task so a parallel task's data is safe.
+        removed_semantic = 0
+        if self.semantic_db_path.exists():
+            with self._connect_semantic() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM turns_fts WHERE task_id = ? AND ts_ns < ?",
+                    (self._task_id, older_than_ns),
+                )
+                removed_semantic = cursor.rowcount or 0
+                conn.commit()
+        if removed_episodic or removed_semantic:
+            logger.info(
+                "session_memory pruned task=%s session=%s episodic=%d semantic=%d",
+                self._task_id,
+                self._session_id,
+                removed_episodic,
+                removed_semantic,
+            )
+        return removed_episodic
+
+    def _prune_episodic(self, older_than_ns: int) -> int:
+        path = self.episodic_path
+        if not path.exists():
+            return 0
+        kept: list[str] = []
+        removed = 0
+        with path.open("r", encoding="utf-8") as fh:
+            for lineno, raw in enumerate(fh, start=1):
+                stripped = raw.strip()
+                if not stripped:
+                    continue
+                try:
+                    parsed = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "skipping malformed episodic line %s:%d during prune (%s)",
+                        path,
+                        lineno,
+                        exc,
+                    )
+                    continue
+                if not isinstance(parsed, dict):
+                    continue
+                ts_ns = parsed.get("ts_ns")
+                if isinstance(ts_ns, int) and ts_ns < older_than_ns:
+                    removed += 1
+                    continue
+                kept.append(stripped)
+        if removed == 0:
+            return 0
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            for line in kept:
+                fh.write(line)
+                fh.write("\n")
+        tmp.replace(path)
+        return removed
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_turn(turn: Turn) -> None:
+        if turn.role not in _VALID_ROLES:
+            raise ValueError(f"role must be one of {sorted(_VALID_ROLES)}, got {turn.role!r}")
+        if not turn.content:
+            raise ValueError("content must be a non-empty string")
+        for tag in turn.tags:
+            if not tag or not tag.strip():
+                raise ValueError("tags must be non-empty strings")
+            if "," in tag:
+                raise ValueError("tag must not contain ','")
+
+
+# ----------------------------------------------------------------------
+# Auto-load helper
+# ----------------------------------------------------------------------
+
+
+def load_recent_turns(
+    root: Path,
+    *,
+    task_id: str,
+    k: int = 10,
+) -> list[RecallHit]:
+    """Return the most recent ``k`` turns for ``task_id``, newest first.
+
+    Convenience for the agent-spawn hook: when a task is resumed across
+    sessions, its prior turns can be joined into the system prompt
+    without a free-text query. Uses the semantic index because it
+    already carries every turn and is faster to scan than walking
+    every episodic shard from disk.
+
+    Args:
+        root: Memory root directory.
+        task_id: Task ID whose turns to return.
+        k: Maximum number of turns. Must be positive.
+
+    Returns:
+        List of :class:`RecallHit` ordered newest-first by ``ts_ns``.
+    """
+    if k <= 0:
+        raise ValueError(f"k must be positive, got {k}")
+    _validate_id(task_id, "task_id")
+    db_path = root / "semantic.sqlite"
+    if not db_path.exists():
+        return []
+    with sqlite3.connect(str(db_path)) as conn:
+        try:
+            rows = conn.execute(
+                "SELECT role, content, tags, task_id, session_id, ts_ns, "
+                "content_hash FROM turns_fts WHERE task_id = ? "
+                "ORDER BY ts_ns DESC LIMIT ?",
+                (task_id, k),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+    hits: list[RecallHit] = []
+    for row in rows:
+        tags = [t for t in (row[2] or "").split(",") if t]
+        hits.append(
+            RecallHit(
+                role=row[0],
+                content=row[1],
+                tags=tags,
+                task_id=row[3],
+                session_id=row[4],
+                ts_ns=int(row[5]),
+                content_hash=row[6],
+                rank=0.0,
+            )
+        )
+    return hits
+
+
+# ----------------------------------------------------------------------
+# Internals
+# ----------------------------------------------------------------------
+
+
+def _sanitize_fts_query(query: str) -> str:
+    """Prepare ``query`` for the FTS5 MATCH operator.
+
+    Each whitespace-separated token is stripped of FTS5 operator
+    characters and wrapped in double quotes so colons, parentheses,
+    asterisks etc. cannot break the parser. Mirrors the helper in
+    :mod:`bernstein.core.knowledge.rag` to keep behaviour consistent.
+
+    Args:
+        query: Raw user query.
+
+    Returns:
+        FTS5-safe MATCH expression, or an empty string when every token
+        was empty after stripping.
+    """
+    tokens: list[str] = []
+    for raw in query.split():
+        cleaned = raw.strip("\"'()*^:")
+        if cleaned:
+            tokens.append(f'"{cleaned}"')
+    return " ".join(tokens)
+
+
+def _coerce_tags(value: object) -> Iterable[str]:
+    """Best-effort cast of a stored tags blob into an iterable of strings.
+
+    The episodic JSONL writer always stores tags as a list, but a
+    hand-edited record might contain a string or ``None``. The helper
+    keeps :meth:`SessionMemory.read_episodic` tolerant.
+    """
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item]
+    if isinstance(value, str):
+        return [v for v in value.split(",") if v]
+    return []

--- a/tests/unit/memory/test_session_memory.py
+++ b/tests/unit/memory/test_session_memory.py
@@ -1,0 +1,361 @@
+"""Unit tests for :mod:`bernstein.core.memory.session_memory`."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import TYPE_CHECKING
+
+import pytest
+
+from bernstein.core.memory.session_memory import (
+    RecallHit,
+    SessionMemory,
+    Turn,
+    load_recent_turns,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mem(tmp_path: Path) -> SessionMemory:
+    """Return a fresh session memory bound to a clean tmp root."""
+    return SessionMemory(
+        root=tmp_path / "memory",
+        task_id="task-a",
+        session_id="session-1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_paths_are_derived_from_root_task_session(self, tmp_path: Path) -> None:
+        m = SessionMemory(
+            root=tmp_path / "memory",
+            task_id="task-a",
+            session_id="session-1",
+        )
+        expected_episodic = tmp_path / "memory" / "episodic" / "task-a" / "session-1.jsonl"
+        assert m.episodic_path == expected_episodic
+        assert m.semantic_db_path == tmp_path / "memory" / "semantic.sqlite"
+        assert m.task_id == "task-a"
+        assert m.session_id == "session-1"
+
+    @pytest.mark.parametrize("bad", ["", "../escape", "a b", "a,b", "a/b"])
+    def test_rejects_bad_task_id(self, tmp_path: Path, bad: str) -> None:
+        with pytest.raises(ValueError, match="task_id"):
+            SessionMemory(
+                root=tmp_path / "memory",
+                task_id=bad,
+                session_id="s",
+            )
+
+    @pytest.mark.parametrize("bad", ["", "../escape", "a b", "a,b"])
+    def test_rejects_bad_session_id(self, tmp_path: Path, bad: str) -> None:
+        with pytest.raises(ValueError, match="session_id"):
+            SessionMemory(
+                root=tmp_path / "memory",
+                task_id="t",
+                session_id=bad,
+            )
+
+    def test_construction_does_not_touch_disk(self, tmp_path: Path) -> None:
+        # Cheap construction: no directories or databases are created
+        # until the first append or read.
+        SessionMemory(
+            root=tmp_path / "memory",
+            task_id="t",
+            session_id="s",
+        )
+        assert not (tmp_path / "memory").exists()
+
+
+# ---------------------------------------------------------------------------
+# append_turn
+# ---------------------------------------------------------------------------
+
+
+class TestAppend:
+    def test_append_returns_content_hash(self, mem: SessionMemory) -> None:
+        chash = mem.append_turn(Turn(role="user", content="hello world", tags=["greeting"]))
+        assert chash.startswith("sha256:")
+        assert len(chash) == len("sha256:") + 64
+
+    def test_append_writes_episodic_jsonl(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="hello", tags=["greet"]))
+        mem.append_turn(Turn(role="assistant", content="hi back", tags=["greet"]))
+        lines = mem.episodic_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        assert first["role"] == "user"
+        assert first["content"] == "hello"
+        assert first["tags"] == ["greet"]
+        assert first["task_id"] == "task-a"
+        assert first["session_id"] == "session-1"
+        assert first["content_hash"].startswith("sha256:")
+        assert isinstance(first["ts_ns"], int)
+        assert first["ts_ns"] > 0
+
+    def test_append_mirrors_into_semantic_index(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="design the API", tags=["api"]))
+        with sqlite3.connect(str(mem.semantic_db_path)) as conn:
+            rows = conn.execute("SELECT role, content, tags, task_id, session_id FROM turns_fts").fetchall()
+        assert rows == [
+            ("user", "design the API", "api", "task-a", "session-1"),
+        ]
+
+    def test_append_preserves_explicit_ts_ns(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="x", ts_ns=12345))
+        line = json.loads(mem.episodic_path.read_text(encoding="utf-8"))
+        assert line["ts_ns"] == 12345
+
+    def test_append_assigns_ts_ns_when_zero(self, tmp_path: Path) -> None:
+        clock = iter([1_000_000_000, 2_000_000_000])
+        m = SessionMemory(
+            root=tmp_path / "memory",
+            task_id="t",
+            session_id="s",
+            clock_ns=lambda: next(clock),
+        )
+        # Default ts_ns is set in __post_init__ from time.time_ns; force
+        # zero so the SessionMemory clock takes over.
+        turn = Turn(role="user", content="hi", ts_ns=1)
+        turn.ts_ns = 0
+        m.append_turn(turn)
+        record = json.loads(m.episodic_path.read_text(encoding="utf-8"))
+        assert record["ts_ns"] == 1_000_000_000
+
+    @pytest.mark.parametrize("role", ["user", "assistant", "system", "tool"])
+    def test_append_accepts_canonical_roles(self, mem: SessionMemory, role: str) -> None:
+        mem.append_turn(Turn(role=role, content="payload"))
+
+    def test_append_rejects_unknown_role(self, mem: SessionMemory) -> None:
+        with pytest.raises(ValueError, match="role"):
+            mem.append_turn(Turn(role="random", content="x"))
+
+    def test_append_rejects_empty_content(self, mem: SessionMemory) -> None:
+        with pytest.raises(ValueError, match="content"):
+            mem.append_turn(Turn(role="user", content=""))
+
+    def test_append_rejects_comma_in_tag(self, mem: SessionMemory) -> None:
+        with pytest.raises(ValueError, match=","):
+            mem.append_turn(Turn(role="user", content="x", tags=["a,b"]))
+
+    def test_append_rejects_empty_tag(self, mem: SessionMemory) -> None:
+        with pytest.raises(ValueError, match="tags"):
+            mem.append_turn(Turn(role="user", content="x", tags=[""]))
+
+
+# ---------------------------------------------------------------------------
+# recall
+# ---------------------------------------------------------------------------
+
+
+class TestRecall:
+    def _seed(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="how do we design the API", tags=["api"]))
+        mem.append_turn(Turn(role="assistant", content="REST first, gRPC later", tags=["api"]))
+        mem.append_turn(Turn(role="user", content="what about the database schema", tags=["db"]))
+
+    def test_recall_returns_bm25_ordered_hits(self, mem: SessionMemory) -> None:
+        self._seed(mem)
+        hits = mem.recall("API")
+        assert hits, "expected at least one hit"
+        assert all(isinstance(h, RecallHit) for h in hits)
+        # The two API-tagged turns should outrank the db one.
+        contents = [h.content for h in hits]
+        assert any("design the API" in c for c in contents)
+
+    def test_recall_returns_empty_for_empty_query(self, mem: SessionMemory) -> None:
+        self._seed(mem)
+        assert mem.recall("") == []
+        assert mem.recall("   ") == []
+
+    def test_recall_returns_empty_when_no_index_yet(self, mem: SessionMemory) -> None:
+        # Index file does not exist until first append.
+        assert not mem.semantic_db_path.exists()
+        assert mem.recall("anything") == []
+
+    def test_recall_respects_k(self, mem: SessionMemory) -> None:
+        self._seed(mem)
+        # The token "the" should match every seeded turn via FTS5.
+        hits = mem.recall("the", k=1)
+        assert len(hits) == 1
+
+    def test_recall_rejects_non_positive_k(self, mem: SessionMemory) -> None:
+        with pytest.raises(ValueError, match="k"):
+            mem.recall("x", k=0)
+        with pytest.raises(ValueError, match="k"):
+            mem.recall("x", k=-1)
+
+    def test_recall_filters_by_tag(self, mem: SessionMemory) -> None:
+        self._seed(mem)
+        hits = mem.recall("the", k=10, tag="db")
+        # Only the db-tagged turn survives the tag filter.
+        assert {h.content for h in hits} == {"what about the database schema"}
+
+    def test_recall_filter_by_task_id_scopes_index(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        m_a = SessionMemory(root=root, task_id="task-a", session_id="s1")
+        m_b = SessionMemory(root=root, task_id="task-b", session_id="s1")
+        m_a.append_turn(Turn(role="user", content="alpha design", tags=["x"]))
+        m_b.append_turn(Turn(role="user", content="alpha design", tags=["x"]))
+        # Without filter we get both copies.
+        assert len(m_a.recall("alpha", k=10)) == 2
+        # With a task_id filter we get just one.
+        only_a = m_a.recall("alpha", k=10, task_id="task-a")
+        assert len(only_a) == 1
+        assert only_a[0].task_id == "task-a"
+
+    def test_recall_rejects_comma_tag(self, mem: SessionMemory) -> None:
+        self._seed(mem)
+        with pytest.raises(ValueError, match=","):
+            mem.recall("anything", tag="a,b")
+
+    def test_recall_sanitises_fts_special_chars(self, mem: SessionMemory) -> None:
+        # A query with FTS5 operator characters used to break MATCH.
+        # The sanitiser should keep recall functional.
+        mem.append_turn(Turn(role="user", content="auth flow", tags=["a"]))
+        hits = mem.recall("auth: (flow)")
+        assert hits
+        assert hits[0].content == "auth flow"
+
+
+# ---------------------------------------------------------------------------
+# read_episodic
+# ---------------------------------------------------------------------------
+
+
+class TestReadEpisodic:
+    def test_read_returns_all_turns(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="one"))
+        mem.append_turn(Turn(role="assistant", content="two"))
+        entries = mem.read_episodic()
+        assert [e["content"] for e in entries] == ["one", "two"]
+
+    def test_read_returns_empty_when_no_log(self, mem: SessionMemory) -> None:
+        assert mem.read_episodic() == []
+
+    def test_read_skips_malformed_lines(self, mem: SessionMemory, caplog: pytest.LogCaptureFixture) -> None:
+        mem.append_turn(Turn(role="user", content="good"))
+        # Append garbage manually.
+        with mem.episodic_path.open("a", encoding="utf-8") as fh:
+            fh.write("{not json\n")
+            fh.write("\n")
+            fh.write('"a string not an object"\n')
+        with caplog.at_level("WARNING", logger="bernstein.core.memory.session_memory"):
+            entries = mem.read_episodic()
+        assert [e["content"] for e in entries] == ["good"]
+        assert any("malformed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# prune
+# ---------------------------------------------------------------------------
+
+
+class TestPrune:
+    def test_prune_removes_old_turns_from_episodic(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="old", ts_ns=1_000))
+        mem.append_turn(Turn(role="user", content="new", ts_ns=10_000))
+        removed = mem.prune(older_than_ns=5_000)
+        assert removed == 1
+        survivors = mem.read_episodic()
+        assert [e["content"] for e in survivors] == ["new"]
+
+    def test_prune_removes_old_turns_from_semantic_index(self, mem: SessionMemory) -> None:
+        mem.append_turn(Turn(role="user", content="old", ts_ns=1_000))
+        mem.append_turn(Turn(role="user", content="newer", ts_ns=10_000))
+        mem.prune(older_than_ns=5_000)
+        with sqlite3.connect(str(mem.semantic_db_path)) as conn:
+            rows = conn.execute("SELECT content FROM turns_fts ORDER BY ts_ns").fetchall()
+        assert [r[0] for r in rows] == ["newer"]
+
+    def test_prune_is_scoped_to_this_task(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        m_a = SessionMemory(root=root, task_id="task-a", session_id="s1")
+        m_b = SessionMemory(root=root, task_id="task-b", session_id="s1")
+        m_a.append_turn(Turn(role="user", content="old-a", ts_ns=1_000))
+        m_b.append_turn(Turn(role="user", content="old-b", ts_ns=1_000))
+        m_a.prune(older_than_ns=5_000)
+        with sqlite3.connect(str(root / "semantic.sqlite")) as conn:
+            rows = conn.execute("SELECT content, task_id FROM turns_fts").fetchall()
+        # Only task-a's old turn went away. task-b's data is intact.
+        assert ("old-b", "task-b") in rows
+        assert ("old-a", "task-a") not in rows
+
+    def test_prune_returns_zero_when_no_log(self, mem: SessionMemory) -> None:
+        assert mem.prune(older_than_ns=1_000) == 0
+
+    def test_prune_rejects_non_positive_cutoff(self, mem: SessionMemory) -> None:
+        with pytest.raises(ValueError, match="older_than_ns"):
+            mem.prune(older_than_ns=0)
+        with pytest.raises(ValueError, match="older_than_ns"):
+            mem.prune(older_than_ns=-1)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency-safety smoke
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_two_instances_same_root_can_both_append(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        m_a = SessionMemory(root=root, task_id="task-a", session_id="s")
+        m_b = SessionMemory(root=root, task_id="task-b", session_id="s")
+        m_a.append_turn(Turn(role="user", content="from a"))
+        m_b.append_turn(Turn(role="user", content="from b"))
+        # Each task has its own episodic shard.
+        assert m_a.episodic_path != m_b.episodic_path
+        # The shared semantic index has both.
+        with sqlite3.connect(str(root / "semantic.sqlite")) as conn:
+            rows = conn.execute("SELECT task_id, content FROM turns_fts ORDER BY task_id").fetchall()
+        assert rows == [
+            ("task-a", "from a"),
+            ("task-b", "from b"),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# load_recent_turns
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRecentTurns:
+    def test_returns_newest_first(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        m = SessionMemory(root=root, task_id="task-a", session_id="s")
+        m.append_turn(Turn(role="user", content="first", ts_ns=1_000))
+        m.append_turn(Turn(role="user", content="second", ts_ns=2_000))
+        m.append_turn(Turn(role="user", content="third", ts_ns=3_000))
+        hits = load_recent_turns(root, task_id="task-a", k=2)
+        assert [h.content for h in hits] == ["third", "second"]
+
+    def test_returns_empty_when_no_index(self, tmp_path: Path) -> None:
+        assert load_recent_turns(tmp_path, task_id="task-a", k=5) == []
+
+    def test_returns_empty_when_task_has_no_turns(self, tmp_path: Path) -> None:
+        root = tmp_path / "memory"
+        m = SessionMemory(root=root, task_id="task-a", session_id="s")
+        m.append_turn(Turn(role="user", content="only a"))
+        assert load_recent_turns(root, task_id="task-b", k=5) == []
+
+    def test_rejects_non_positive_k(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="k"):
+            load_recent_turns(tmp_path, task_id="task-a", k=0)
+
+    def test_rejects_bad_task_id(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="task_id"):
+            load_recent_turns(tmp_path, task_id="bad id", k=5)


### PR DESCRIPTION
## Summary

- New `SessionMemory` module providing a two-layer episodic + semantic memory that survives across sessions, context compactions, and reboots.
- Episodic layer: append-only JSONL under `.sdd/memory/episodic/<task_id>/<session_id>.jsonl`, one content-addressed turn per line.
- Semantic layer: shared SQLite FTS5 index at `.sdd/memory/semantic.sqlite` with BM25 recall, optional tag and task_id filters, and FTS5 operator-character sanitising.

## What ships

| Surface | Description |
|---------|-------------|
| `SessionMemory.append_turn` | Writes one turn to both layers; returns sha256 content hash. |
| `SessionMemory.recall` | BM25 search, newest-first within rank, with optional tag and task_id filters. |
| `SessionMemory.prune` | Drops turns older than a ns cutoff; episodic via temp-file plus atomic rename. |
| `load_recent_turns` | Auto-load helper for the agent-spawn path: newest N turns per task. |
| `Turn`, `RecallHit` | Public dataclasses for inputs and outputs. |

Ticket acceptance criteria covered:

- [x] `SessionMemory` with `append_turn`, `recall`, `prune`.
- [x] Per-turn entry carries `role`, `content`, `ts_ns`, `task_id`, `session_id`, `tags`.
- [x] FTS5 BM25 over content + tags with task scope.
- [x] Auto-load helper for agent spawn (`load_recent_turns`).
- [x] Tests under `tests/unit/memory/test_session_memory.py` (47 tests).
- [x] Docs page at `docs/memory/session-memory.md`.

## Out of scope (per ticket)

- Vector embeddings for recall.
- Cross-machine sync.
- Edit/forget surface beyond `prune`.

## Test plan

- [x] `uv run pytest tests/unit/memory/test_session_memory.py` -- 47 passed.
- [x] `uv run pytest tests/unit/memory/` -- 72 passed (no regression in existing memory tests).
- [x] `uv run ruff check src/bernstein/core/memory/session_memory.py tests/unit/memory/test_session_memory.py` -- clean.
- [x] `uv run ruff format --check` on the same files -- clean.
- [ ] CI green on the PR.

## Summary by Sourcery

Introduce a durable two-layer session memory subsystem with episodic JSONL logging and a shared SQLite FTS5 semantic index, plus supporting APIs, tests, and documentation.

New Features:
- Add SessionMemory API providing append_turn, recall, and prune operations for long-running task and session memory.
- Introduce Turn and RecallHit dataclasses as the public data model for stored turns and recall results.
- Add load_recent_turns helper to fetch the latest turns per task for agent startup context.

Enhancements:
- Implement filesystem- and SQLite-safe ID validation, FTS5 query sanitisation, and pruning logic for episodic and semantic layers.

Documentation:
- Add a user-facing documentation page describing long-running session memory, its contract, on-disk layout, and limitations.

Tests:
- Add extensive unit test coverage for SessionMemory, load_recent_turns, concurrency behavior, pruning, and recall semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent session memory with semantic search capabilities for retrieving conversation turns by query, tags, or task context.
  * Added ability to append conversation turns with automatic timestamping and pruning of aged entries.

* **Documentation**
  * Documented session memory architecture and design patterns.

* **Tests**
  * Added comprehensive unit test coverage for session memory functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->