### PR TITLE
feat(orchestration): multi-tracker federation layer

### DIFF
--- a/docs/orchestration/federation.md
+++ b/docs/orchestration/federation.md
@@ -57,6 +57,8 @@ Projects issue in its body, which in turn carries an `External-Link`
 custom field pointing at a Notion page.
 
 ```python
+from pathlib import Path
+
 from bernstein.core.orchestration.federation import (
     FederationBuilder,
     FederationConfig,

--- a/docs/orchestration/federation.md
+++ b/docs/orchestration/federation.md
@@ -1,0 +1,157 @@
+# Multi-tracker federation
+
+## TL;DR
+
+| Component | Purpose |
+|-----------|---------|
+| `FederationConfig` | Typed view over `bernstein.yaml: federation`. |
+| `LinkDetector` (+ 3 defaults) | Find cross-tracker refs in ticket bodies, fields, comments. |
+| `FederationBuilder` | Walks every adapter once and builds the per-run graph. |
+| `FederatedTicketGraph` | Small in-memory graph rendered as agent-run context. |
+| `FederationDispatcher` | Reads/comments/transitions with per-role allow-list and audit. |
+| `CrossTrackerAuditRecord` | JSONL row recording every cross-tracker action. |
+
+Vendor tracker AI is tenant-locked. The federation layer lets one
+Bernstein orchestrator instance pull tickets from Linear, GitHub
+Projects, Jira, Notion, etc. in a single run, detect cross-references,
+and dispatch an agent that can act across the joined surface, with
+every cross-tracker action recorded in the audit log.
+
+## Configuration
+
+Add a `federation` block to `bernstein.yaml`:
+
+```yaml
+federation:
+  linked_trackers:
+    - linear
+    - github_projects
+    - notion
+  link_detectors:
+    - url
+    - custom_field
+    - comment_mention
+  cross_tracker_dispatch:
+    allow:
+      backend:
+        - github_projects
+      reviewer: "*"
+```
+
+Field reference:
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `linked_trackers` | list of strings | Adapter names participating in this federation. |
+| `link_detectors` | list of strings | Detector names to enable. Defaults to all three. |
+| `cross_tracker_dispatch.allow` | mapping role -> trackers | Per-role write allow-list. `"*"` grants every tracker. |
+
+A role missing from the allow-list is deny-all for cross-tracker
+writes. Reads are never gated, but they still produce an audit entry
+so cross-tracker information flow remains traceable.
+
+## Worked example: Linear + GitHub Projects + Notion
+
+Three adapters are configured. A Linear ticket links to a GitHub
+Projects issue in its body, which in turn carries an `External-Link`
+custom field pointing at a Notion page.
+
+```python
+from bernstein.core.orchestration.federation import (
+    FederationBuilder,
+    FederationConfig,
+    FederationDispatcher,
+    write_audit_record,
+)
+
+builder = FederationBuilder(adapters=[linear, github_projects, notion])
+graph = builder.build()
+print(graph.render_context())
+```
+
+Rendered output:
+
+```
+federation:
+  - node: github_projects:42
+    -> notion:abc (custom_field: https://notion.so/p/abc)
+  - node: linear:LIN-1
+    -> github_projects:42 (url: https://github.com/acme/repo/issues/42)
+  - node: notion:abc
+```
+
+The agent run consumes the rendered block as a single context message.
+Tool calls into the dispatcher are namespaced by tracker:
+
+```python
+cfg = FederationConfig.from_dict(yaml_block)
+sink = []
+dispatcher = FederationDispatcher(
+    graph=graph,
+    adapters={
+        "linear": linear,
+        "github_projects": github_projects,
+        "notion": notion,
+    },
+    config=cfg,
+    role="backend",
+    audit_sink=lambda record: write_audit_record(record, Path(".sdd")),
+)
+dispatcher.comment(
+    "github_projects", "42", "linked from LIN-1", from_tracker="linear"
+)
+```
+
+The dispatcher routes the comment to the correct adapter, records the
+`link_kind` derived from the graph (here `url`), and appends one
+JSONL row to `.sdd/lineage/cross-tracker-audit.jsonl`.
+
+## Default detectors
+
+| Detector | Triggers on | Notes |
+|----------|-------------|-------|
+| `URLDetector` | `tracker_uri_base` prefix found in body or comments. | Skips URLs that point at the source tracker. |
+| `CustomFieldDetector` | Custom-field keys named like `External-Link`, `links`. | Case-insensitive on field names. |
+| `CommentMentionDetector` | Prefix-style ids (`JIRA-1234`, `LIN-456`) and optionally bare `#1234`. | Bare-hash mode requires `hash_default_tracker`. |
+
+Detectors are side-effect-free, may be enabled or disabled per project,
+and additional detectors can be passed to `FederationBuilder(detectors=...)`
+without touching the core code path.
+
+## Audit record shape
+
+Every cross-tracker action emits one `CrossTrackerAuditRecord`:
+
+| Field | Description |
+|-------|-------------|
+| `event` | One of `cross_tracker_read`, `cross_tracker_read_miss`, `cross_tracker_comment`, `cross_tracker_transition`, `cross_tracker_write_blocked`. |
+| `timestamp` | Wall-clock seconds. |
+| `role` | Agent role driving the dispatcher. |
+| `tracker_name_from` | Tracker context the agent was reasoning from. |
+| `tracker_name_to` | Adapter that received the call. |
+| `ticket_id_from` | Source ticket id, if any. |
+| `ticket_id_to` | Destination ticket id. |
+| `link_kind` | Detector kind that justified the action, joined with `+` if multiple. |
+| `action` | `read`, `comment`, or `transition:<state>`. |
+| `detail` | Free-form note (e.g. `"adapter read-only"`). |
+
+Records land in `.sdd/lineage/cross-tracker-audit.jsonl` by default and
+can be tailed alongside the lineage merge audit, which uses the same
+field naming convention.
+
+## Permission boundary
+
+The dispatcher consults `FederationConfig.is_allowed(role, tracker)`
+before any write. A blocked attempt raises `FederationPermissionError`
+and produces no audit record, since no action took place. A write that
+reaches a read-only adapter raises `TrackerReadOnlyError` and emits a
+`cross_tracker_write_blocked` audit row with `detail="adapter
+read-only"`. The federation test suite exercises both paths and a
+chained three-tracker setup.
+
+## Out of scope (v1)
+
+- Auto-discovery of which trackers a team uses.
+- Cross-tracker ticket creation.
+- Bi-directional link sync.
+- Cross-tenant federation across organisations.

--- a/src/bernstein/core/orchestration/federation.py
+++ b/src/bernstein/core/orchestration/federation.py
@@ -1,0 +1,731 @@
+"""Multi-tracker federation layer.
+
+Vendor tracker AI today is tenant-locked: Linear Agent reads only
+Linear, Jira Rovo reads only Jira, ClickUp Brain reads only ClickUp.
+Real engineering teams typically run two to four trackers concurrently
+(an issue tracker, a PM tool, a knowledge base, a CI/CD board) and the
+useful work increasingly crosses those surfaces. The federation layer
+lets one Bernstein orchestrator instance pull tickets from many
+configured tracker adapters, detect cross-references between them, and
+dispatch a single agent run that can act across the joined surface.
+
+What this module ships
+----------------------
+* :class:`LinkDetector` protocol plus three default implementations:
+  URL-based, custom-field-based, and comment-mention-based.
+* :class:`FederatedTicketGraph` - a small per-run graph of
+  ``(tracker, ticket_id)`` nodes and labelled directed edges.
+* :class:`FederationBuilder` - assembles the graph by running detectors
+  across the union of adapter outputs.
+* :class:`FederationDispatcher` - the read/comment/transition entry
+  point a single agent run uses to act across the linked surface,
+  guarded by a per-role allow-list and emitting an audit record per
+  cross-tracker action.
+* :class:`FederationConfig` - typed view over ``bernstein.yaml``'s
+  ``federation`` block.
+
+What this module deliberately omits
+-----------------------------------
+* Auto-discovery of which trackers a team uses (separate UX ticket).
+* Cross-tracker ticket creation - read/comment/transition only in v1.
+* Bi-directional link sync - one-way detection only.
+* Cross-tenant federation across organisations.
+
+The audit hook
+--------------
+Each cross-tracker write produces a :class:`CrossTrackerAuditRecord`
+containing ``tracker_name_from`` (the originating tracker context the
+agent reasoned from), ``tracker_name_to`` (the target adapter that
+received the write), the ``link_kind`` that justified the edge, and the
+ticket ids on each side. The default sink appends JSONL to
+``.sdd/lineage/cross-tracker-audit.jsonl``; tests inject an in-memory
+sink instead.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final, Protocol, runtime_checkable
+
+from bernstein.core.orchestration.federation_contract import (
+    Ticket,
+    TrackerAdapter,
+    TrackerReadOnlyError,
+    TrackerUnknownError,
+)
+
+__all__ = [
+    "DEFAULT_AUDIT_RELPATH",
+    "CommentMentionDetector",
+    "CrossTrackerAuditRecord",
+    "CustomFieldDetector",
+    "FederatedTicketGraph",
+    "FederationBuilder",
+    "FederationConfig",
+    "FederationDispatcher",
+    "FederationError",
+    "FederationPermissionError",
+    "GraphEdge",
+    "GraphNode",
+    "LinkDetector",
+    "LinkRef",
+    "URLDetector",
+    "write_audit_record",
+]
+
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_AUDIT_RELPATH: Final[Path] = Path("lineage") / "cross-tracker-audit.jsonl"
+"""Path under ``.sdd/`` where cross-tracker audit records land by default."""
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class FederationError(Exception):
+    """Base class for federation-layer errors."""
+
+
+class FederationPermissionError(FederationError):
+    """Raised when ``cross_tracker_dispatch.allow`` denies a write."""
+
+
+# ---------------------------------------------------------------------------
+# Link detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class LinkRef:
+    """A single detected cross-reference.
+
+    Attributes
+    ----------
+    ref_kind:
+        Free-form label identifying which detector produced the ref
+        (e.g. ``"url"``, ``"custom_field"``, ``"comment_mention"``).
+    target_tracker:
+        Name of the adapter the ref points at.
+    target_id:
+        Adapter-local ticket id on the destination side.
+    source_text:
+        Verbatim slice of input text that triggered the match. Used by
+        the audit log and by debug rendering.
+    """
+
+    ref_kind: str
+    target_tracker: str
+    target_id: str
+    source_text: str
+
+
+@runtime_checkable
+class LinkDetector(Protocol):
+    """A pluggable link detector.
+
+    Implementations receive the source ticket plus the iterable of all
+    configured adapters and return zero or more :class:`LinkRef`
+    instances. Detectors MUST be side-effect-free.
+    """
+
+    name: str
+
+    def detect(self, source: Ticket, adapters: Sequence[TrackerAdapter]) -> Iterable[LinkRef]:
+        """Yield detected refs from ``source`` to other tickets."""
+
+
+@dataclass(frozen=True, slots=True)
+class URLDetector:
+    """Detect refs by matching adapter ``tracker_uri_base`` prefixes.
+
+    The detector inspects the ticket body and every comment body for
+    occurrences of each known adapter's ``tracker_uri_base`` and
+    extracts the trailing id segment. URLs hosting the source adapter
+    itself are ignored - they reference the ticket we already have.
+    """
+
+    name: str = "url"
+
+    def detect(self, source: Ticket, adapters: Sequence[TrackerAdapter]) -> Iterable[LinkRef]:
+        haystacks = [source.body, *(c.body for c in source.comments)]
+        for adapter in adapters:
+            base = getattr(adapter, "tracker_uri_base", "")
+            if not base or adapter.name == source.tracker:
+                continue
+            for text in haystacks:
+                for target_id in _extract_id_after_prefix(text, base):
+                    yield LinkRef(
+                        ref_kind="url",
+                        target_tracker=adapter.name,
+                        target_id=target_id,
+                        source_text=f"{base}{target_id}",
+                    )
+
+
+@dataclass(frozen=True, slots=True)
+class CustomFieldDetector:
+    """Detect refs via ``External-Link``-shaped custom fields.
+
+    Many trackers expose a "linked URL" custom field on tickets. The
+    detector walks ``Ticket.custom_fields`` looking for keys that match
+    ``field_names`` (case-insensitive) and parses each value as one or
+    more cross-tracker URLs.
+    """
+
+    field_names: tuple[str, ...] = ("external-link", "external_link", "links")
+    name: str = "custom_field"
+
+    def detect(self, source: Ticket, adapters: Sequence[TrackerAdapter]) -> Iterable[LinkRef]:
+        wanted = {name.lower() for name in self.field_names}
+        candidates: list[str] = []
+        for key, value in source.custom_fields.items():
+            if key.lower() in wanted:
+                candidates.append(value)
+        if not candidates:
+            return
+        for adapter in adapters:
+            base = getattr(adapter, "tracker_uri_base", "")
+            if not base or adapter.name == source.tracker:
+                continue
+            for value in candidates:
+                for target_id in _extract_id_after_prefix(value, base):
+                    yield LinkRef(
+                        ref_kind="custom_field",
+                        target_tracker=adapter.name,
+                        target_id=target_id,
+                        source_text=f"{base}{target_id}",
+                    )
+
+
+@dataclass(frozen=True, slots=True)
+class CommentMentionDetector:
+    """Detect refs via prefix-style comment mentions.
+
+    The detector recognises adapter-prefixed ids such as ``JIRA-1234``
+    or ``LIN-456``. Prefixes are configured per adapter via
+    ``mention_prefixes``; a default map covers the most common cases.
+    Plain ``#1234`` mentions can be opted in by passing
+    ``hash_default_tracker`` so that the detector knows which adapter
+    the bare ``#`` belongs to.
+    """
+
+    mention_prefixes: Mapping[str, str] = field(
+        default_factory=lambda: {
+            "LIN": "linear",
+            "JIRA": "jira",
+            "ENG": "linear",
+            "PROJ": "github_projects",
+        }
+    )
+    hash_default_tracker: str = ""
+    name: str = "comment_mention"
+
+    def detect(self, source: Ticket, adapters: Sequence[TrackerAdapter]) -> Iterable[LinkRef]:
+        adapter_names = {a.name for a in adapters}
+        haystacks = [source.body, *(c.body for c in source.comments)]
+        for text in haystacks:
+            for prefix, tracker_name in self.mention_prefixes.items():
+                if tracker_name == source.tracker:
+                    continue
+                if tracker_name not in adapter_names:
+                    continue
+                pattern = rf"\b{re.escape(prefix)}-(\d+)\b"
+                for match in re.finditer(pattern, text):
+                    target_id = f"{prefix}-{match.group(1)}"
+                    yield LinkRef(
+                        ref_kind="comment_mention",
+                        target_tracker=tracker_name,
+                        target_id=target_id,
+                        source_text=match.group(0),
+                    )
+            if (
+                self.hash_default_tracker
+                and self.hash_default_tracker != source.tracker
+                and self.hash_default_tracker in adapter_names
+            ):
+                for match in re.finditer(r"(?<!\w)#(\d+)\b", text):
+                    yield LinkRef(
+                        ref_kind="comment_mention",
+                        target_tracker=self.hash_default_tracker,
+                        target_id=match.group(1),
+                        source_text=match.group(0),
+                    )
+
+
+def _extract_id_after_prefix(text: str, prefix: str) -> Iterator[str]:
+    """Yield ids that follow ``prefix`` in ``text``.
+
+    The id segment is everything from the character after ``prefix`` up
+    to the next non-id character (whitespace, slash, query separator).
+    """
+
+    if not prefix or not text:
+        return
+    start = 0
+    while True:
+        index = text.find(prefix, start)
+        if index < 0:
+            return
+        tail = text[index + len(prefix) :]
+        cleaned: list[str] = []
+        for char in tail:
+            if char.isalnum() or char in "-_":
+                cleaned.append(char)
+                continue
+            break
+        token = "".join(cleaned).strip("-_")
+        if token:
+            yield token
+        start = index + len(prefix) + max(len(cleaned), 1)
+
+
+DEFAULT_DETECTORS: Final[tuple[LinkDetector, ...]] = (
+    URLDetector(),
+    CustomFieldDetector(),
+    CommentMentionDetector(),
+)
+
+
+# ---------------------------------------------------------------------------
+# Graph
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class GraphNode:
+    """A node in the federated ticket graph."""
+
+    tracker: str
+    ticket_id: str
+
+    def key(self) -> tuple[str, str]:
+        return (self.tracker, self.ticket_id)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphEdge:
+    """A directed labelled edge between two ticket nodes."""
+
+    source: GraphNode
+    target: GraphNode
+    ref_kind: str
+    source_text: str
+
+
+@dataclass
+class FederatedTicketGraph:
+    """A small in-memory graph of nodes and edges for one agent run.
+
+    The graph is intentionally lightweight: federations of more than a
+    few hundred linked tickets per run are unusual, and the agent only
+    needs to render a single block of context from it. The structure is
+    therefore ``dict[node_key, GraphNode]`` plus a list of edges.
+    """
+
+    nodes: dict[tuple[str, str], GraphNode] = field(default_factory=dict)
+    edges: list[GraphEdge] = field(default_factory=list)
+
+    def add_ticket(self, ticket: Ticket) -> GraphNode:
+        """Insert a ticket as a node, returning the canonical instance."""
+
+        node = GraphNode(tracker=ticket.tracker, ticket_id=ticket.ticket_id)
+        self.nodes.setdefault(node.key(), node)
+        return self.nodes[node.key()]
+
+    def add_edge(self, source: GraphNode, target: GraphNode, ref: LinkRef) -> None:
+        self.nodes.setdefault(source.key(), source)
+        self.nodes.setdefault(target.key(), target)
+        self.edges.append(
+            GraphEdge(
+                source=source,
+                target=target,
+                ref_kind=ref.ref_kind,
+                source_text=ref.source_text,
+            )
+        )
+
+    def neighbours(self, node: GraphNode) -> list[GraphNode]:
+        """Return outbound neighbours of ``node`` in deterministic order."""
+
+        seen: dict[tuple[str, str], GraphNode] = {}
+        for edge in self.edges:
+            if edge.source.key() == node.key():
+                seen.setdefault(edge.target.key(), edge.target)
+        return sorted(seen.values(), key=lambda n: n.key())
+
+    def render_context(self) -> str:
+        """Return a stable string the agent run consumes as context.
+
+        The render is deterministic so trace fixtures can pin against
+        it. One line per node with its outbound edges grouped beneath.
+        """
+
+        if not self.nodes:
+            return "federation: empty\n"
+        lines: list[str] = ["federation:"]
+        for key in sorted(self.nodes):
+            node = self.nodes[key]
+            lines.append(f"  - node: {node.tracker}:{node.ticket_id}")
+            outbound = [e for e in self.edges if e.source.key() == key]
+            outbound.sort(key=lambda e: (e.target.tracker, e.target.ticket_id, e.ref_kind))
+            for edge in outbound:
+                lines.append(
+                    f"    -> {edge.target.tracker}:{edge.target.ticket_id} ({edge.ref_kind}: {edge.source_text})"
+                )
+        return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FederationConfig:
+    """Typed view over the ``federation`` block in ``bernstein.yaml``.
+
+    ``cross_tracker_dispatch_allow`` maps an agent role name (e.g.
+    ``"backend"``) to the set of tracker names that role is allowed to
+    write to during a federated run. A missing role means deny-all.
+    Wildcard ``"*"`` may be used to grant any-tracker write.
+    """
+
+    linked_trackers: tuple[str, ...] = ()
+    link_detector_names: tuple[str, ...] = ("url", "custom_field", "comment_mention")
+    cross_tracker_dispatch_allow: Mapping[str, frozenset[str]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object]) -> FederationConfig:
+        """Build from a parsed YAML mapping. Tolerant of missing keys."""
+
+        linked = _to_string_tuple(raw.get("linked_trackers"))
+        detectors_raw = raw.get("link_detectors")
+        detectors: tuple[str, ...]
+        if detectors_raw is None:
+            detectors = ("url", "custom_field", "comment_mention")
+        else:
+            detectors = _to_string_tuple(detectors_raw)
+        allow_raw = raw.get("cross_tracker_dispatch") or {}
+        allow_block = allow_raw.get("allow", {}) if isinstance(allow_raw, Mapping) else {}
+        allow: dict[str, frozenset[str]] = {}
+        if isinstance(allow_block, Mapping):
+            for role, trackers in allow_block.items():
+                if not isinstance(role, str):
+                    continue
+                allow[role] = frozenset(_to_string_tuple(trackers))
+        return cls(
+            linked_trackers=linked,
+            link_detector_names=detectors,
+            cross_tracker_dispatch_allow=allow,
+        )
+
+    def is_allowed(self, role: str, tracker: str) -> bool:
+        """Return True iff ``role`` may write to ``tracker``."""
+
+        scopes = self.cross_tracker_dispatch_allow.get(role)
+        if scopes is None:
+            return False
+        return "*" in scopes or tracker in scopes
+
+
+def _to_string_tuple(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable):
+        out: list[str] = []
+        for item in value:
+            if isinstance(item, str):
+                out.append(item)
+        return tuple(out)
+    return ()
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FederationBuilder:
+    """Build a :class:`FederatedTicketGraph` from a set of adapters.
+
+    The builder iterates each adapter's ticket list once, registers
+    every ticket as a node, then runs every configured detector against
+    every ticket. Detector output is normalised against the known
+    adapter set so refs pointing at unknown trackers are dropped (with
+    a debug log line).
+    """
+
+    adapters: Sequence[TrackerAdapter]
+    detectors: Sequence[LinkDetector] = DEFAULT_DETECTORS
+
+    def build(self) -> FederatedTicketGraph:
+        graph = FederatedTicketGraph()
+        adapter_map = {a.name: a for a in self.adapters}
+        for adapter in self.adapters:
+            for ticket in adapter.list_tickets():
+                source_node = graph.add_ticket(ticket)
+                for detector in self.detectors:
+                    for ref in detector.detect(ticket, self.adapters):
+                        if ref.target_tracker not in adapter_map:
+                            log.debug(
+                                "federation: dropping ref to unknown tracker %s",
+                                ref.target_tracker,
+                            )
+                            continue
+                        target_node = GraphNode(
+                            tracker=ref.target_tracker,
+                            ticket_id=ref.target_id,
+                        )
+                        graph.add_edge(source_node, target_node, ref)
+        return graph
+
+
+# ---------------------------------------------------------------------------
+# Audit
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class CrossTrackerAuditRecord:
+    """One JSONL row describing a cross-tracker action.
+
+    The shape intentionally mirrors the lineage merge audit record so
+    operators can grep both files with the same field names.
+    """
+
+    event: str
+    timestamp: float
+    role: str
+    tracker_name_from: str
+    tracker_name_to: str
+    ticket_id_from: str
+    ticket_id_to: str
+    link_kind: str
+    action: str
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "event": self.event,
+            "timestamp": self.timestamp,
+            "role": self.role,
+            "tracker_name_from": self.tracker_name_from,
+            "tracker_name_to": self.tracker_name_to,
+            "ticket_id_from": self.ticket_id_from,
+            "ticket_id_to": self.ticket_id_to,
+            "link_kind": self.link_kind,
+            "action": self.action,
+            "detail": self.detail,
+        }
+
+
+AuditSink = Callable[[CrossTrackerAuditRecord], None]
+
+
+def write_audit_record(record: CrossTrackerAuditRecord, root: Path) -> Path:
+    """Append ``record`` to the default JSONL sink under ``root``.
+
+    ``root`` is typically ``Path(".sdd")``. The audit file's parent is
+    created if missing. Returns the path written to.
+    """
+
+    path = root / DEFAULT_AUDIT_RELPATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record.to_dict(), sort_keys=True, separators=(",", ":"))
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+        fh.write("\n")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FederationDispatcher:
+    """Read/comment/transition entry point for federated agent runs.
+
+    The dispatcher binds together the per-run :class:`FederatedTicketGraph`,
+    the adapter map, the :class:`FederationConfig` allow-list, and an
+    audit sink. Agents call into the dispatcher rather than into the
+    raw adapters so every cross-tracker action lands in the audit log.
+    """
+
+    graph: FederatedTicketGraph
+    adapters: Mapping[str, TrackerAdapter]
+    config: FederationConfig
+    role: str
+    audit_sink: AuditSink
+    _clock: Callable[[], float] = field(default=time.time, repr=False)
+
+    def context_for_run(self) -> str:
+        """Return the rendered graph view the agent run consumes."""
+
+        return self.graph.render_context()
+
+    def read(self, tracker_name: str, ticket_id: str) -> Ticket:
+        """Read a ticket via the named adapter.
+
+        Reads are never gated by ``cross_tracker_dispatch.allow`` but
+        do produce an audit entry so cross-tracker information flow is
+        traceable in post-hoc review.
+        """
+
+        adapter = self._require_adapter(tracker_name)
+        try:
+            ticket = adapter.fetch_ticket(ticket_id)
+        except TrackerUnknownError:
+            self._emit(
+                "cross_tracker_read_miss",
+                tracker_to=tracker_name,
+                ticket_to=ticket_id,
+                link_kind="",
+                action="read",
+                detail="not found",
+            )
+            raise
+        self._emit(
+            "cross_tracker_read",
+            tracker_to=tracker_name,
+            ticket_to=ticket_id,
+            link_kind=self._infer_link_kind(tracker_name, ticket_id),
+            action="read",
+        )
+        return ticket
+
+    def comment(self, tracker_name: str, ticket_id: str, body: str, *, from_tracker: str = "") -> None:
+        """Post a comment, gated by the per-role allow-list.
+
+        ``from_tracker`` is the name of the tracker the agent is
+        reasoning from at the moment of the action; it lands in the
+        ``tracker_name_from`` audit field. Empty string means
+        "untargeted" and is recorded verbatim.
+        """
+
+        self._require_allowed(tracker_name)
+        adapter = self._require_adapter(tracker_name)
+        try:
+            adapter.add_comment(ticket_id, body)
+        except TrackerReadOnlyError:
+            self._emit(
+                "cross_tracker_write_blocked",
+                tracker_from=from_tracker,
+                tracker_to=tracker_name,
+                ticket_to=ticket_id,
+                link_kind=self._infer_link_kind(tracker_name, ticket_id),
+                action="comment",
+                detail="adapter read-only",
+            )
+            raise
+        self._emit(
+            "cross_tracker_comment",
+            tracker_from=from_tracker,
+            tracker_to=tracker_name,
+            ticket_to=ticket_id,
+            link_kind=self._infer_link_kind(tracker_name, ticket_id),
+            action="comment",
+        )
+
+    def transition(
+        self,
+        tracker_name: str,
+        ticket_id: str,
+        target_state: str,
+        *,
+        from_tracker: str = "",
+    ) -> None:
+        """Transition a ticket, gated by the per-role allow-list."""
+
+        self._require_allowed(tracker_name)
+        adapter = self._require_adapter(tracker_name)
+        try:
+            adapter.transition(ticket_id, target_state)
+        except TrackerReadOnlyError:
+            self._emit(
+                "cross_tracker_write_blocked",
+                tracker_from=from_tracker,
+                tracker_to=tracker_name,
+                ticket_to=ticket_id,
+                link_kind=self._infer_link_kind(tracker_name, ticket_id),
+                action=f"transition:{target_state}",
+                detail="adapter read-only",
+            )
+            raise
+        self._emit(
+            "cross_tracker_transition",
+            tracker_from=from_tracker,
+            tracker_to=tracker_name,
+            ticket_to=ticket_id,
+            link_kind=self._infer_link_kind(tracker_name, ticket_id),
+            action=f"transition:{target_state}",
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _require_allowed(self, tracker_name: str) -> None:
+        if not self.config.is_allowed(self.role, tracker_name):
+            raise FederationPermissionError(f"role {self.role!r} is not allowed to write to {tracker_name!r}")
+
+    def _require_adapter(self, tracker_name: str) -> TrackerAdapter:
+        try:
+            return self.adapters[tracker_name]
+        except KeyError as exc:
+            raise FederationError(f"unknown tracker {tracker_name!r}") from exc
+
+    def _infer_link_kind(self, tracker: str, ticket_id: str) -> str:
+        """Look up the link kind in the graph by destination node.
+
+        When the destination has multiple inbound edges the kinds are
+        joined with ``+`` so the audit log preserves all justifications
+        for the action.
+        """
+
+        target_key = (tracker, ticket_id)
+        kinds: list[str] = []
+        for edge in self.graph.edges:
+            if edge.target.key() == target_key and edge.ref_kind not in kinds:
+                kinds.append(edge.ref_kind)
+        return "+".join(kinds)
+
+    def _emit(
+        self,
+        event: str,
+        *,
+        tracker_from: str = "",
+        tracker_to: str,
+        ticket_from: str = "",
+        ticket_to: str,
+        link_kind: str,
+        action: str,
+        detail: str = "",
+    ) -> None:
+        record = CrossTrackerAuditRecord(
+            event=event,
+            timestamp=self._clock(),
+            role=self.role,
+            tracker_name_from=tracker_from,
+            tracker_name_to=tracker_to,
+            ticket_id_from=ticket_from,
+            ticket_id_to=ticket_to,
+            link_kind=link_kind,
+            action=action,
+            detail=detail,
+        )
+        self.audit_sink(record)

--- a/src/bernstein/core/orchestration/federation.py
+++ b/src/bernstein/core/orchestration/federation.py
@@ -187,10 +187,7 @@ class CustomFieldDetector:
 
     def detect(self, source: Ticket, adapters: Sequence[TrackerAdapter]) -> Iterable[LinkRef]:
         wanted = {name.lower() for name in self.field_names}
-        candidates: list[str] = []
-        for key, value in source.custom_fields.items():
-            if key.lower() in wanted:
-                candidates.append(value)
+        candidates: list[str] = [value for key, value in source.custom_fields.items() if key.lower() in wanted]
         if not candidates:
             return
         for adapter in adapters:
@@ -444,11 +441,7 @@ def _to_string_tuple(value: object) -> tuple[str, ...]:
     if isinstance(value, str):
         return (value,)
     if isinstance(value, Iterable):
-        out: list[str] = []
-        for item in value:
-            if isinstance(item, str):
-                out.append(item)
-        return tuple(out)
+        return tuple(item for item in value if isinstance(item, str))
     return ()
 
 
@@ -545,9 +538,10 @@ def write_audit_record(record: CrossTrackerAuditRecord, root: Path) -> Path:
     path = root / DEFAULT_AUDIT_RELPATH
     path.parent.mkdir(parents=True, exist_ok=True)
     line = json.dumps(record.to_dict(), sort_keys=True, separators=(",", ":"))
+    # Emit the trailing newline in the same write() so concurrent writers
+    # cannot interleave a half-record into the JSONL file.
     with path.open("a", encoding="utf-8") as fh:
-        fh.write(line)
-        fh.write("\n")
+        fh.write(line + "\n")
     return path
 
 
@@ -698,11 +692,9 @@ class FederationDispatcher:
         """
 
         target_key = (tracker, ticket_id)
-        kinds: list[str] = []
-        for edge in self.graph.edges:
-            if edge.target.key() == target_key and edge.ref_kind not in kinds:
-                kinds.append(edge.ref_kind)
-        return "+".join(kinds)
+        matching = [edge.ref_kind for edge in self.graph.edges if edge.target.key() == target_key]
+        # Preserve first-seen order while deduplicating.
+        return "+".join(dict.fromkeys(matching))
 
     def _emit(
         self,

--- a/src/bernstein/core/orchestration/federation_contract.py
+++ b/src/bernstein/core/orchestration/federation_contract.py
@@ -1,0 +1,126 @@
+"""Minimum tracker contract consumed by the federation layer.
+
+This module exposes a narrow, federation-shaped view of a ticket and a
+``TrackerAdapter`` protocol the federation builder and dispatcher are
+written against. It deliberately does NOT replace
+``bernstein.core.trackers.contract``, which is the canonical
+adapter-implementation contract (``AbstractTrackerAdapter``,
+``CommentResult``, idempotency keys, etag preconditions, ...) consumed
+by concrete adapters such as the GitHub Projects v2 adapter.
+
+Why two surfaces side by side
+-----------------------------
+The federation layer reasons about a normalised cross-tracker graph and
+needs fields the canonical contract intentionally omits at the
+adapter-implementation boundary - in particular per-ticket
+``comments`` and free-form ``custom_fields`` that the link detectors
+scan. A concrete adapter that wants to participate in federation builds
+this view on top of its canonical contract; the federation layer never
+imports from ``bernstein.core.trackers`` directly so the two contracts
+can evolve independently.
+
+The dedicated ``feat/tracker-plugin-hookspec`` ticket will reconcile
+these surfaces; until then the federation layer ships against the
+minimum shape below so its tests and audit log can land in parallel
+with concrete adapter work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+__all__ = [
+    "Comment",
+    "Ticket",
+    "TrackerAdapter",
+    "TrackerError",
+    "TrackerReadOnlyError",
+    "TrackerUnknownError",
+]
+
+
+class TrackerError(Exception):
+    """Base class for federation-shaped tracker errors."""
+
+
+class TrackerReadOnlyError(TrackerError):
+    """Raised when a write call hits a read-only adapter or scope."""
+
+
+class TrackerUnknownError(TrackerError):
+    """Raised when an adapter cannot find a referenced ticket."""
+
+
+@dataclass(frozen=True, slots=True)
+class Comment:
+    """A single comment attached to a ticket.
+
+    Attributes
+    ----------
+    author:
+        Stable identifier of the comment author within the source
+        tracker. Format is provider-specific.
+    body:
+        Plain-text or lightly-marked-up comment body. Adapters strip
+        provider-private control characters before returning.
+    custom_fields:
+        Optional bag of provider-specific extras (e.g. Linear reactions,
+        Jira visibility). The federation layer ignores unknown keys.
+    """
+
+    author: str
+    body: str
+    custom_fields: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class Ticket:
+    """A normalised ticket view used by the federation layer.
+
+    The federation layer consumes only the fields below. Adapters may
+    populate ``custom_fields`` with provider-specific data the custom
+    field link detector matches against.
+    """
+
+    tracker: str
+    ticket_id: str
+    title: str
+    body: str
+    comments: tuple[Comment, ...] = ()
+    custom_fields: dict[str, str] = field(default_factory=dict)
+    url: str = ""
+
+
+@runtime_checkable
+class TrackerAdapter(Protocol):
+    """The minimum surface a tracker adapter must expose to federation.
+
+    Concrete adapters (e.g. ``GitHubProjectsV2Adapter``) typically
+    inherit from ``bernstein.core.trackers.contract.AbstractTrackerAdapter``
+    for their HTTP-API-shaped contract and additionally implement the
+    protocol below for federation participation.
+    """
+
+    name: str
+    tracker_uri_base: str
+
+    def list_tickets(self) -> Iterable[Ticket]:  # pragma: no cover - protocol
+        """Return the open tickets visible to the federation builder."""
+
+    def get_ticket(self, ticket_id: str) -> Ticket:  # pragma: no cover - protocol
+        """Fetch a single ticket by id; raise ``TrackerUnknownError`` if missing."""
+
+    def add_comment(self, ticket_id: str, body: str) -> None:  # pragma: no cover - protocol
+        """Post a comment; raise ``TrackerReadOnlyError`` if not writable."""
+
+    def transition(self, ticket_id: str, state: str) -> None:  # pragma: no cover - protocol
+        """Transition the ticket to ``state``; raise ``TrackerReadOnlyError`` if not writable."""
+
+
+def _silence_unused_imports() -> None:
+    """Reference type-checking-only imports so vulture stays happy."""
+    _ = Sequence

--- a/src/bernstein/core/orchestration/federation_contract.py
+++ b/src/bernstein/core/orchestration/federation_contract.py
@@ -31,7 +31,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Sequence
+    from collections.abc import Iterable
 
 __all__ = [
     "Comment",
@@ -119,8 +119,3 @@ class TrackerAdapter(Protocol):
 
     def transition(self, ticket_id: str, state: str) -> None:  # pragma: no cover - protocol
         """Transition the ticket to ``state``; raise ``TrackerReadOnlyError`` if not writable."""
-
-
-def _silence_unused_imports() -> None:
-    """Reference type-checking-only imports so vulture stays happy."""
-    _ = Sequence

--- a/tests/unit/orchestration/test_federation.py
+++ b/tests/unit/orchestration/test_federation.py
@@ -1,0 +1,671 @@
+"""Unit tests for :mod:`bernstein.core.orchestration.federation`.
+
+The suite covers the three default link detectors, the
+two-tracker and three-tracker graph assemblies, the per-role write
+allow-list, the audit-log shape on success and on read-only failure,
+and the YAML config view.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.orchestration.federation import (
+    DEFAULT_AUDIT_RELPATH,
+    CommentMentionDetector,
+    CrossTrackerAuditRecord,
+    CustomFieldDetector,
+    FederatedTicketGraph,
+    FederationBuilder,
+    FederationConfig,
+    FederationDispatcher,
+    FederationError,
+    FederationPermissionError,
+    GraphNode,
+    LinkRef,
+    URLDetector,
+    write_audit_record,
+)
+from bernstein.core.orchestration.federation_contract import (
+    Comment,
+    Ticket,
+    TrackerReadOnlyError,
+    TrackerUnknownError,
+)
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeAdapter:
+    """Minimal in-memory adapter satisfying :class:`TrackerAdapter`."""
+
+    name: str
+    tracker_uri_base: str = ""
+    tickets: dict[str, Ticket] = field(default_factory=dict)
+    read_only: bool = False
+    comments_written: list[tuple[str, str]] = field(default_factory=list)
+    transitions: list[tuple[str, str]] = field(default_factory=list)
+
+    def fetch_ticket(self, ticket_id: str) -> Ticket:
+        try:
+            return self.tickets[ticket_id]
+        except KeyError as exc:
+            raise TrackerUnknownError(ticket_id) from exc
+
+    def list_tickets(self) -> Iterable[Ticket]:
+        return list(self.tickets.values())
+
+    def add_comment(self, ticket_id: str, body: str) -> None:
+        if self.read_only:
+            raise TrackerReadOnlyError(self.name)
+        if ticket_id not in self.tickets:
+            raise TrackerUnknownError(ticket_id)
+        self.comments_written.append((ticket_id, body))
+
+    def transition(self, ticket_id: str, target_state: str) -> None:
+        if self.read_only:
+            raise TrackerReadOnlyError(self.name)
+        if ticket_id not in self.tickets:
+            raise TrackerUnknownError(ticket_id)
+        self.transitions.append((ticket_id, target_state))
+
+
+def _ticket(
+    tracker: str,
+    ticket_id: str,
+    *,
+    body: str = "",
+    comments: tuple[Comment, ...] = (),
+    custom_fields: dict[str, str] | None = None,
+) -> Ticket:
+    return Ticket(
+        tracker=tracker,
+        ticket_id=ticket_id,
+        title=f"{tracker}:{ticket_id}",
+        body=body,
+        comments=comments,
+        custom_fields=custom_fields or {},
+        url=f"https://example.test/{tracker}/{ticket_id}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# URL detector
+# ---------------------------------------------------------------------------
+
+
+def test_url_detector_finds_cross_tracker_link_in_body() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+    )
+    source = _ticket(
+        "linear",
+        "LIN-1",
+        body="ref https://github.com/acme/repo/issues/42 fixes this",
+    )
+    refs = list(URLDetector().detect(source, [linear, github]))
+    assert refs == [
+        LinkRef(
+            ref_kind="url",
+            target_tracker="github_projects",
+            target_id="42",
+            source_text="https://github.com/acme/repo/issues/42",
+        )
+    ]
+
+
+def test_url_detector_ignores_self_tracker_urls() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    source = _ticket("linear", "LIN-1", body="see https://linear.app/acme/issue/LIN-2")
+    assert list(URLDetector().detect(source, [linear])) == []
+
+
+def test_url_detector_scans_comment_bodies() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+    )
+    source = _ticket(
+        "linear",
+        "LIN-1",
+        comments=(Comment(author="op", body="see https://github.com/acme/repo/issues/9"),),
+    )
+    refs = list(URLDetector().detect(source, [linear, github]))
+    assert [r.target_id for r in refs] == ["9"]
+
+
+def test_url_detector_skips_adapter_with_empty_uri_base() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    notion = FakeAdapter(name="notion", tracker_uri_base="")
+    source = _ticket("linear", "LIN-1", body="https://notion.so/p/xyz")
+    assert list(URLDetector().detect(source, [linear, notion])) == []
+
+
+# ---------------------------------------------------------------------------
+# Custom-field detector
+# ---------------------------------------------------------------------------
+
+
+def test_custom_field_detector_picks_up_external_link_field() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+    )
+    source = _ticket(
+        "linear",
+        "LIN-1",
+        custom_fields={"External-Link": "https://github.com/acme/repo/issues/77"},
+    )
+    refs = list(CustomFieldDetector().detect(source, [linear, github]))
+    assert [(r.ref_kind, r.target_tracker, r.target_id) for r in refs] == [("custom_field", "github_projects", "77")]
+
+
+def test_custom_field_detector_is_case_insensitive_on_field_name() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+    )
+    source = _ticket(
+        "linear",
+        "LIN-1",
+        custom_fields={"links": "https://github.com/acme/repo/issues/5"},
+    )
+    refs = list(CustomFieldDetector().detect(source, [linear, github]))
+    assert len(refs) == 1
+
+
+def test_custom_field_detector_yields_nothing_when_unknown_field() -> None:
+    linear = FakeAdapter(name="linear", tracker_uri_base="https://linear.app/acme/issue/")
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+    )
+    source = _ticket(
+        "linear",
+        "LIN-1",
+        custom_fields={"random": "https://github.com/acme/repo/issues/5"},
+    )
+    assert list(CustomFieldDetector().detect(source, [linear, github])) == []
+
+
+# ---------------------------------------------------------------------------
+# Comment-mention detector
+# ---------------------------------------------------------------------------
+
+
+def test_comment_mention_detector_matches_prefixed_ids() -> None:
+    linear = FakeAdapter(name="linear")
+    jira = FakeAdapter(name="jira")
+    source = _ticket(
+        "linear",
+        "LIN-9",
+        body="follows JIRA-1234 and JIRA-2222 changes",
+    )
+    refs = list(CommentMentionDetector().detect(source, [linear, jira]))
+    assert sorted((r.target_tracker, r.target_id) for r in refs) == [
+        ("jira", "JIRA-1234"),
+        ("jira", "JIRA-2222"),
+    ]
+
+
+def test_comment_mention_detector_ignores_self_tracker_prefix() -> None:
+    linear = FakeAdapter(name="linear")
+    jira = FakeAdapter(name="jira")
+    source = _ticket("linear", "LIN-9", body="links to LIN-10 should not fire")
+    detector = CommentMentionDetector(mention_prefixes={"LIN": "linear", "JIRA": "jira"})
+    assert list(detector.detect(source, [linear, jira])) == []
+
+
+def test_comment_mention_detector_hash_default_tracker() -> None:
+    linear = FakeAdapter(name="linear")
+    github = FakeAdapter(name="github_projects")
+    source = _ticket("linear", "LIN-9", body="closes #42")
+    detector = CommentMentionDetector(
+        mention_prefixes={},
+        hash_default_tracker="github_projects",
+    )
+    refs = list(detector.detect(source, [linear, github]))
+    assert [(r.target_tracker, r.target_id) for r in refs] == [("github_projects", "42")]
+
+
+# ---------------------------------------------------------------------------
+# Graph rendering
+# ---------------------------------------------------------------------------
+
+
+def test_graph_render_context_is_deterministic_and_sorted() -> None:
+    graph = FederatedTicketGraph()
+    n_b = graph.add_ticket(_ticket("b", "2"))
+    n_a = graph.add_ticket(_ticket("a", "1"))
+    graph.add_edge(n_a, n_b, LinkRef(ref_kind="url", target_tracker="b", target_id="2", source_text="x"))
+    rendered = graph.render_context()
+    assert "node: a:1" in rendered
+    assert "node: b:2" in rendered
+    assert rendered.index("node: a:1") < rendered.index("node: b:2")
+    assert "-> b:2 (url: x)" in rendered
+
+
+def test_graph_neighbours_deduplicates_and_sorts() -> None:
+    graph = FederatedTicketGraph()
+    src = graph.add_ticket(_ticket("a", "1"))
+    other = graph.add_ticket(_ticket("b", "2"))
+    third = graph.add_ticket(_ticket("c", "3"))
+    graph.add_edge(
+        src,
+        third,
+        LinkRef("url", "c", "3", "x"),
+    )
+    graph.add_edge(
+        src,
+        other,
+        LinkRef("url", "b", "2", "y"),
+    )
+    graph.add_edge(
+        src,
+        other,
+        LinkRef("custom_field", "b", "2", "z"),
+    )
+    keys = [n.key() for n in graph.neighbours(src)]
+    assert keys == [("b", "2"), ("c", "3")]
+
+
+# ---------------------------------------------------------------------------
+# Two-tracker build
+# ---------------------------------------------------------------------------
+
+
+def test_two_tracker_setup_with_one_url_link_builds_one_edge() -> None:
+    linear = FakeAdapter(
+        name="linear",
+        tracker_uri_base="https://linear.app/acme/issue/",
+        tickets={
+            "LIN-1": _ticket(
+                "linear",
+                "LIN-1",
+                body="see https://github.com/acme/repo/issues/42",
+            )
+        },
+    )
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+        tickets={"42": _ticket("github_projects", "42")},
+    )
+    graph = FederationBuilder(adapters=[linear, github]).build()
+    assert sorted(graph.nodes) == [
+        ("github_projects", "42"),
+        ("linear", "LIN-1"),
+    ]
+    assert len(graph.edges) == 1
+    edge = graph.edges[0]
+    assert edge.source.key() == ("linear", "LIN-1")
+    assert edge.target.key() == ("github_projects", "42")
+    assert edge.ref_kind == "url"
+
+
+def test_builder_drops_refs_to_unknown_trackers() -> None:
+    linear = FakeAdapter(
+        name="linear",
+        tracker_uri_base="https://linear.app/acme/issue/",
+        tickets={
+            "LIN-1": _ticket(
+                "linear",
+                "LIN-1",
+                body="https://notion.so/p/abc",
+            )
+        },
+    )
+    graph = FederationBuilder(adapters=[linear]).build()
+    assert graph.edges == []
+
+
+# ---------------------------------------------------------------------------
+# Three-tracker chain
+# ---------------------------------------------------------------------------
+
+
+def test_three_tracker_chain_yields_chained_edges() -> None:
+    linear = FakeAdapter(
+        name="linear",
+        tracker_uri_base="https://linear.app/acme/issue/",
+        tickets={
+            "LIN-1": _ticket(
+                "linear",
+                "LIN-1",
+                body="ref https://github.com/acme/repo/issues/42",
+            ),
+        },
+    )
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+        tickets={
+            "42": _ticket(
+                "github_projects",
+                "42",
+                custom_fields={"External-Link": "https://notion.so/p/abc"},
+            )
+        },
+    )
+    notion = FakeAdapter(
+        name="notion",
+        tracker_uri_base="https://notion.so/p/",
+        tickets={"abc": _ticket("notion", "abc")},
+    )
+    graph = FederationBuilder(adapters=[linear, github, notion]).build()
+    edge_keys = sorted((e.source.key(), e.target.key(), e.ref_kind) for e in graph.edges)
+    assert edge_keys == [
+        (("github_projects", "42"), ("notion", "abc"), "custom_field"),
+        (("linear", "LIN-1"), ("github_projects", "42"), "url"),
+    ]
+    rendered = graph.render_context()
+    assert "github_projects:42" in rendered
+    assert "notion:abc" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_federation_config_from_dict_parses_allow_list() -> None:
+    raw = {
+        "linked_trackers": ["linear", "jira", "github_projects"],
+        "link_detectors": ["url", "comment_mention"],
+        "cross_tracker_dispatch": {
+            "allow": {
+                "backend": ["jira", "github_projects"],
+                "reviewer": "*",
+            }
+        },
+    }
+    cfg = FederationConfig.from_dict(raw)
+    assert cfg.linked_trackers == ("linear", "jira", "github_projects")
+    assert cfg.link_detector_names == ("url", "comment_mention")
+    assert cfg.is_allowed("backend", "jira") is True
+    assert cfg.is_allowed("backend", "linear") is False
+    assert cfg.is_allowed("reviewer", "linear") is True
+    assert cfg.is_allowed("docs", "jira") is False
+
+
+def test_federation_config_defaults_when_block_missing() -> None:
+    cfg = FederationConfig.from_dict({})
+    assert cfg.linked_trackers == ()
+    assert cfg.link_detector_names == ("url", "custom_field", "comment_mention")
+    assert cfg.is_allowed("backend", "anything") is False
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _dispatcher(
+    *,
+    role: str,
+    allow: dict[str, frozenset[str]],
+    adapters: dict[str, FakeAdapter],
+    graph: FederatedTicketGraph | None = None,
+) -> tuple[FederationDispatcher, list[CrossTrackerAuditRecord]]:
+    sink: list[CrossTrackerAuditRecord] = []
+    cfg = FederationConfig(
+        linked_trackers=tuple(adapters),
+        cross_tracker_dispatch_allow=allow,
+    )
+    dispatcher = FederationDispatcher(
+        graph=graph or FederatedTicketGraph(),
+        adapters=adapters,
+        config=cfg,
+        role=role,
+        audit_sink=sink.append,
+        _clock=lambda: 1700000000.0,
+    )
+    return dispatcher, sink
+
+
+def test_dispatcher_read_emits_audit_and_returns_ticket() -> None:
+    linear = FakeAdapter(name="linear", tickets={"LIN-1": _ticket("linear", "LIN-1")})
+    dispatcher, sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"linear"})},
+        adapters={"linear": linear},
+    )
+    ticket = dispatcher.read("linear", "LIN-1")
+    assert ticket.ticket_id == "LIN-1"
+    assert len(sink) == 1
+    record = sink[0]
+    assert record.event == "cross_tracker_read"
+    assert record.role == "backend"
+    assert record.tracker_name_to == "linear"
+    assert record.ticket_id_to == "LIN-1"
+    assert record.action == "read"
+
+
+def test_dispatcher_comment_records_link_kind_from_graph() -> None:
+    linear = FakeAdapter(name="linear", tickets={"LIN-1": _ticket("linear", "LIN-1")})
+    jira = FakeAdapter(name="jira", tickets={"JIRA-9": _ticket("jira", "JIRA-9")})
+    graph = FederatedTicketGraph()
+    src = graph.add_ticket(linear.tickets["LIN-1"])
+    target = graph.add_ticket(jira.tickets["JIRA-9"])
+    graph.add_edge(
+        src,
+        target,
+        LinkRef(ref_kind="comment_mention", target_tracker="jira", target_id="JIRA-9", source_text="JIRA-9"),
+    )
+    dispatcher, sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"jira"})},
+        adapters={"linear": linear, "jira": jira},
+        graph=graph,
+    )
+    dispatcher.comment("jira", "JIRA-9", "ack", from_tracker="linear")
+    assert jira.comments_written == [("JIRA-9", "ack")]
+    record = sink[-1]
+    assert record.event == "cross_tracker_comment"
+    assert record.tracker_name_from == "linear"
+    assert record.tracker_name_to == "jira"
+    assert record.link_kind == "comment_mention"
+    assert record.action == "comment"
+
+
+def test_dispatcher_transition_routed_and_audited() -> None:
+    jira = FakeAdapter(name="jira", tickets={"JIRA-9": _ticket("jira", "JIRA-9")})
+    dispatcher, sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"jira"})},
+        adapters={"jira": jira},
+    )
+    dispatcher.transition("jira", "JIRA-9", "Done", from_tracker="linear")
+    assert jira.transitions == [("JIRA-9", "Done")]
+    assert sink[-1].event == "cross_tracker_transition"
+    assert sink[-1].action == "transition:Done"
+
+
+def test_dispatcher_blocks_write_when_role_not_in_allow() -> None:
+    jira = FakeAdapter(name="jira", tickets={"JIRA-1": _ticket("jira", "JIRA-1")})
+    dispatcher, sink = _dispatcher(
+        role="docs",
+        allow={"backend": frozenset({"jira"})},
+        adapters={"jira": jira},
+    )
+    with pytest.raises(FederationPermissionError):
+        dispatcher.comment("jira", "JIRA-1", "noop")
+    assert jira.comments_written == []
+    assert sink == []
+
+
+def test_dispatcher_blocks_write_when_tracker_not_in_role_scope() -> None:
+    jira = FakeAdapter(name="jira", tickets={"JIRA-1": _ticket("jira", "JIRA-1")})
+    linear = FakeAdapter(name="linear", tickets={"LIN-1": _ticket("linear", "LIN-1")})
+    dispatcher, _sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"linear"})},
+        adapters={"jira": jira, "linear": linear},
+    )
+    with pytest.raises(FederationPermissionError):
+        dispatcher.transition("jira", "JIRA-1", "Done")
+    assert jira.transitions == []
+
+
+def test_dispatcher_read_only_adapter_raises_and_audits_block() -> None:
+    jira = FakeAdapter(
+        name="jira",
+        tickets={"JIRA-1": _ticket("jira", "JIRA-1")},
+        read_only=True,
+    )
+    dispatcher, sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"jira"})},
+        adapters={"jira": jira},
+    )
+    with pytest.raises(TrackerReadOnlyError):
+        dispatcher.comment("jira", "JIRA-1", "ack")
+    assert sink[-1].event == "cross_tracker_write_blocked"
+    assert sink[-1].detail == "adapter read-only"
+
+
+def test_dispatcher_unknown_adapter_raises_federation_error() -> None:
+    dispatcher, _sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"jira"})},
+        adapters={},
+    )
+    with pytest.raises(FederationError):
+        dispatcher.read("jira", "JIRA-1")
+
+
+def test_dispatcher_read_miss_audits_missing_ticket() -> None:
+    jira = FakeAdapter(name="jira")
+    dispatcher, sink = _dispatcher(
+        role="backend",
+        allow={"backend": frozenset({"jira"})},
+        adapters={"jira": jira},
+    )
+    with pytest.raises(TrackerUnknownError):
+        dispatcher.read("jira", "missing")
+    assert sink[-1].event == "cross_tracker_read_miss"
+    assert sink[-1].detail == "not found"
+
+
+# ---------------------------------------------------------------------------
+# Audit sink
+# ---------------------------------------------------------------------------
+
+
+def test_write_audit_record_appends_json_line(tmp_path: Path) -> None:
+    record = CrossTrackerAuditRecord(
+        event="cross_tracker_comment",
+        timestamp=1700000000.0,
+        role="backend",
+        tracker_name_from="linear",
+        tracker_name_to="jira",
+        ticket_id_from="LIN-1",
+        ticket_id_to="JIRA-9",
+        link_kind="url",
+        action="comment",
+        detail="",
+    )
+    path = write_audit_record(record, tmp_path)
+    assert path == tmp_path / DEFAULT_AUDIT_RELPATH
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["event"] == "cross_tracker_comment"
+    assert parsed["tracker_name_from"] == "linear"
+    assert parsed["tracker_name_to"] == "jira"
+    assert parsed["link_kind"] == "url"
+
+
+def test_write_audit_record_appends_multiple_lines(tmp_path: Path) -> None:
+    record = CrossTrackerAuditRecord(
+        event="cross_tracker_read",
+        timestamp=1.0,
+        role="r",
+        tracker_name_from="",
+        tracker_name_to="jira",
+        ticket_id_from="",
+        ticket_id_to="JIRA-1",
+        link_kind="",
+        action="read",
+    )
+    write_audit_record(record, tmp_path)
+    write_audit_record(record, tmp_path)
+    path = tmp_path / DEFAULT_AUDIT_RELPATH
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 2
+
+
+# ---------------------------------------------------------------------------
+# Permission boundary integration
+# ---------------------------------------------------------------------------
+
+
+def test_permission_boundary_role_not_in_allow_list_cannot_write_to_other_tracker() -> None:
+    """End-to-end check that mirrors the acceptance-criteria scenario."""
+
+    linear = FakeAdapter(
+        name="linear",
+        tracker_uri_base="https://linear.app/acme/issue/",
+        tickets={
+            "LIN-1": _ticket(
+                "linear",
+                "LIN-1",
+                body="see https://github.com/acme/repo/issues/42",
+            )
+        },
+    )
+    github = FakeAdapter(
+        name="github_projects",
+        tracker_uri_base="https://github.com/acme/repo/issues/",
+        tickets={"42": _ticket("github_projects", "42")},
+    )
+    graph = FederationBuilder(adapters=[linear, github]).build()
+    cfg = FederationConfig.from_dict(
+        {
+            "linked_trackers": ["linear", "github_projects"],
+            "cross_tracker_dispatch": {
+                "allow": {"backend": ["linear"]},
+            },
+        }
+    )
+    sink: list[CrossTrackerAuditRecord] = []
+    dispatcher = FederationDispatcher(
+        graph=graph,
+        adapters={"linear": linear, "github_projects": github},
+        config=cfg,
+        role="backend",
+        audit_sink=sink.append,
+    )
+    with pytest.raises(FederationPermissionError):
+        dispatcher.comment("github_projects", "42", "blocked")
+    assert github.comments_written == []
+    assert sink == []
+    dispatcher.read("github_projects", "42")
+    assert sink[-1].event == "cross_tracker_read"
+    assert sink[-1].link_kind == "url"
+
+
+# ---------------------------------------------------------------------------
+# GraphNode helpers
+# ---------------------------------------------------------------------------
+
+
+def test_graph_node_key_round_trip() -> None:
+    node = GraphNode(tracker="x", ticket_id="1")
+    assert node.key() == ("x", "1")
+
+
+def test_empty_graph_render() -> None:
+    assert FederatedTicketGraph().render_context() == "federation: empty\n"


### PR DESCRIPTION
## Summary

- New `bernstein.core.orchestration.federation` module: detectors (URL, custom-field, comment-mention), `FederatedTicketGraph`, `FederationBuilder`, `FederationConfig`, `FederationDispatcher`, and a JSONL cross-tracker audit record.
- Minimum tracker-contract stub under `bernstein.core.trackers` so federation can ship in parallel with the dedicated hookspec ticket; that ticket will extend, not replace, the public types here.
- 30 unit tests under `tests/unit/orchestration/test_federation.py` covering each detector, the two-tracker and three-tracker assemblies, audit shape on success and on read-only failure, and the permission boundary.
- Operator docs at `docs/orchestration/federation.md` with a worked Linear + GitHub Projects + Notion example.

## Why

Vendor tracker AI is tenant-locked: Linear Agent reads only Linear, Rovo reads only Jira, ClickUp Brain reads only ClickUp. Engineering teams routinely use two to four trackers concurrently. The federation layer lets one Bernstein orchestrator pull tickets from N trackers, follow cross-references, and dispatch a single agent run that acts across the joined surface, with every cross-tracker move recorded in the audit log.

## Acceptance criteria

- [x] `LinkDetector` protocol plus three default implementations.
- [x] `FederatedTicketGraph` with `(tracker, ticket_id)` nodes and labelled edges.
- [x] Dispatch entry point that hands the graph to a single agent run and routes back to the right adapter for read/comment/transition.
- [x] Audit records carry `tracker_name_from`, `tracker_name_to`, `link_kind`.
- [x] Tests cover two-tracker, three-tracker chain, and the permission boundary.
- [x] Docs page with worked example.

## Test plan

- [x] `pytest tests/unit/orchestration/test_federation.py` (30 passed locally).
- [x] `ruff check` and `ruff format --check` clean on touched files.
- [ ] CI green on the PR branch.

## Summary by Sourcery

Introduce a federation layer to orchestrate multi-tracker ticket operations with link detection, graph assembly, permission-aware dispatch, and structured auditing across tracker adapters.

New Features:
- Add a `bernstein.core.orchestration.federation` module providing link detectors, a federated ticket graph, a federation builder, configuration, and a dispatcher for cross-tracker reads, comments, and transitions.
- Define a minimal tracker adapter contract under `bernstein.core.trackers` to standardize ticket, comment, and adapter interfaces used by the federation layer.
- Add JSONL-based cross-tracker audit records to capture read and write activity between trackers.

Enhancements:
- Render a deterministic textual view of federated ticket graphs for use as agent context and trace fixtures.

Documentation:
- Add operator documentation for multi-tracker federation configuration and usage, including a Linear + GitHub Projects + Notion example.

Tests:
- Add a comprehensive federation test suite covering link detectors, two- and three-tracker graph builds, dispatcher behavior, permission boundaries, and audit log writing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-tracker federation: build linked ticket graphs, perform cross-tracker reads/comments/transitions with role-based write controls and audit emission.
  * Automatic link detection via URLs, custom fields, and mentions; deterministic rendering for agent context.

* **Documentation**
  * Detailed federation guide with end-to-end example and audit schema.

* **Tests**
  * Comprehensive unit tests covering detection, graph building, dispatcher behavior, permission boundaries, and audit writing.

* **Chores**
  * Added tracker integration package and a stable tracker adapter contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->