### PR TITLE
feat(observability): per-ticket transcript bundle

### DIFF
--- a/docs/observability/ticket-bundle.md
+++ b/docs/observability/ticket-bundle.md
@@ -1,0 +1,136 @@
+# Per-ticket transcript bundle
+
+For every tracker ticket Bernstein touches, the orchestrator can emit a
+single signed archive that ties together every agent transcript, every
+trace, every lineage entry, the resulting commits, the resulting PR, and
+the failure-taxonomy comments. Auditors unwrap the archive once and see
+the full activity for that ticket.
+
+The bundle is a packaging primitive layered over data that already
+exists under `.sdd/`. It does not own its inputs; it indexes them and
+binds them with a versioned manifest plus a detached Ed25519 signature
+that reuses the lineage signer.
+
+## When to use it
+
+| Trigger                                               | Action                                                         |
+|-------------------------------------------------------|----------------------------------------------------------------|
+| SOX-2026 or SOC 2 Type II ticket-level audit request  | Generate the bundle and hand it to the auditor.                |
+| Incident post-mortem ("what did the agents see?")     | Generate the bundle and attach to the incident record.         |
+| Vendor evidence request                               | Generate, sign, and hand off the JWS + archive.                |
+| Local debugging of one ticket                         | Generate without signing -- the manifest stays usable.         |
+
+## CLI
+
+```
+bernstein bundle ticket <tracker> <ticket_id> --out <path>
+bernstein bundle ticket <tracker> <ticket_id> --out <path> \
+  --sign-key <pem> --sign-kid <kid>
+bernstein bundle verify <archive> <signature> --card <agent_card.json>
+```
+
+Examples:
+
+```
+# Assemble (no signing -- local dev)
+bernstein bundle ticket github ENG-42 --out ENG-42.tar.gz
+
+# Assemble + sign with the lineage steward key
+bernstein bundle ticket github ENG-42 --out ENG-42.tar.gz \
+  --sign-key keys/lineage.pem --sign-kid lineage-2026
+
+# Auditor host: verify before extraction
+bernstein bundle verify ENG-42.tar.gz ENG-42.tar.gz.jws \
+  --card auditor/agent_card.json
+```
+
+`verify` exits 0 on success and non-zero on any verification failure
+(tampered file, tampered manifest, wrong key, missing signature). It
+never raises -- a tampered archive simply prints an error message.
+
+## Archive layout
+
+```
+manifest.json                       -- versioned manifest (schema_version=1)
+transcripts/<agent>-<session>.jsonl -- per-agent per-turn transcripts
+traces/<session>-trace.jsonl        -- per-agent trace JSONL
+lineage/<file>.jsonl                -- ticket-filtered lineage records
+audit/<file>.jsonl                  -- tracker-audit JSONL slice
+git/commits.json                    -- resolved commit SHAs for the ticket
+git/diff.patch                      -- unified patch over those commits
+pr/pr_<number>.json                 -- PR payload, when known
+```
+
+Every file listed in `manifest.files[*].arcname` is recorded with its
+`size_bytes` and hex `sha256`. The detached JWS in
+`<archive>.jws` covers the JCS-canonical encoding of `manifest.json`.
+Because every bundled file's sha256 is in the manifest, the signature
+transitively covers the contents of every bundled file.
+
+## Manifest schema (`schema_version = 1`)
+
+| Field               | Type                | Notes                                       |
+|---------------------|---------------------|---------------------------------------------|
+| `schema_version`    | int                 | Bump on any backwards-incompatible change.  |
+| `created_at`        | ISO-8601 UTC string | Producer wall-clock at assembly time.       |
+| `bernstein_version` | str                 | Producer's `bernstein.__version__`.         |
+| `tracker`           | str                 | e.g. `github`, `jira`, `linear`.            |
+| `ticket_id`         | str                 | Tracker-scoped ticket id, e.g. `ENG-42`.    |
+| `files`             | list                | One `ManifestEntry` per bundled file.       |
+| `pr_number`         | int or null         | Resulting PR number, when known.            |
+| `commits`           | list of str         | Resolved commit SHAs for this ticket.       |
+
+`ManifestEntry`:
+
+| Field        | Type | Notes                                                 |
+|--------------|------|-------------------------------------------------------|
+| `arcname`    | str  | POSIX path inside the archive.                        |
+| `size_bytes` | int  | Uncompressed file size.                               |
+| `sha256`     | str  | Hex sha-256 over the bundled file's bytes.            |
+| `section`    | str  | Logical section (`transcripts`, `traces`, `git` ...). |
+
+## Selection strategy
+
+A file is included when **either** of the following holds:
+
+1. Its filename contains the ticket id verbatim.
+2. It is a `.jsonl` or `.json` file and at least one record carries both
+   the tracker string and the ticket id as values of any field.
+
+Files larger than 2 MiB are skipped by the content probe so the bundle
+build does not slurp pathological logs into memory. The filename match
+still applies regardless of size.
+
+Callers that want a different strategy can pass an explicit
+`BundleSelector` to `TicketBundle`. The Python surface
+(`bernstein.core.observability.ticket_bundle`) exposes the dataclasses
+for tests and for downstream code that wants to pre-filter.
+
+## Auditor question map
+
+| Auditor question                                             | File in the bundle                                |
+|--------------------------------------------------------------|---------------------------------------------------|
+| Which agent saw what tool call?                              | `transcripts/<agent>-<session>.jsonl`             |
+| What spans did the agent produce?                            | `traces/<session>-trace.jsonl`                    |
+| Was a write blocked by the lineage gate?                     | `lineage/*.jsonl`                                 |
+| When did the tracker open/close this ticket?                 | `audit/*.jsonl`                                   |
+| What code changed because of this ticket?                    | `git/diff.patch`, `git/commits.json`              |
+| Which PR landed this work?                                   | `pr/pr_<number>.json`                             |
+| Has anyone tampered with the artefact set?                   | `manifest.json` + `<archive>.jws`                 |
+
+## Out of scope
+
+- Cross-ticket bundles (a separate ticket; the schema would shift to a
+  list of ticket ids).
+- Auto-upload to an external evidence store -- callers pipe the archive
+  themselves.
+- HTML rendered viewer -- the existing trace viewer can be extended in a
+  follow-up ticket.
+
+## Related modules
+
+- `src/bernstein/core/observability/ticket_bundle.py` -- assembler.
+- `src/bernstein/cli/commands/bundle_cmd.py` -- CLI wrapper.
+- `src/bernstein/core/lineage/identity.py` -- shared Ed25519 signer.
+- `src/bernstein/cli/run_archive.py` -- existing run-archive helper that
+  inspired the manifest pattern.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -237,6 +237,7 @@ nav:
       - Verification tracking: operations/verification-tracking.md
       - Observability: operations/observability-overview.md
       - LLM watcher (opt-in): observability/llm-watcher.md
+      - Per-ticket transcript bundle: observability/ticket-bundle.md
       - Notifications: operations/notifications.md
       - Cost optimization: operations/cost-optimization.md
       - Performance tuning: operations/performance-tuning.md

--- a/src/bernstein/cli/commands/bundle_cmd.py
+++ b/src/bernstein/cli/commands/bundle_cmd.py
@@ -1,0 +1,139 @@
+"""CLI command: ``bernstein bundle`` -- per-ticket transcript bundle.
+
+Wraps :class:`bernstein.core.observability.ticket_bundle.TicketBundle` in
+a Click group so operators and auditors can produce, sign, and verify
+ticket bundles without writing Python.
+
+Subcommands:
+
+- ``bernstein bundle ticket <tracker> <ticket_id> --out <path>`` -- assemble
+  the archive, optionally sign it when keys are available.
+- ``bernstein bundle verify <archive> <signature> --card <agent_card.json>``
+  -- verify a previously signed bundle on the auditor host.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from bernstein.cli.helpers import console
+from bernstein.core.lineage.identity import AgentCard
+from bernstein.core.observability.ticket_bundle import TicketBundle
+
+
+@click.group("bundle")
+def bundle_group() -> None:
+    """Per-ticket transcript bundle commands."""
+
+
+@bundle_group.command("ticket")
+@click.argument("tracker", type=str)
+@click.argument("ticket_id", type=str)
+@click.option(
+    "--out",
+    "-o",
+    "out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    required=True,
+    help="Destination path for the bundle archive (tar.gz).",
+)
+@click.option(
+    "--workdir",
+    type=click.Path(file_okay=False, exists=True, path_type=Path),
+    default=Path("."),
+    help="Project root directory containing .sdd/ (default: current).",
+)
+@click.option(
+    "--sign-key",
+    type=click.Path(dir_okay=False, exists=True, path_type=Path),
+    default=None,
+    help="PEM-encoded Ed25519 private key to detached-sign the manifest.",
+)
+@click.option(
+    "--sign-kid",
+    type=str,
+    default=None,
+    help="Key id (kid) to embed in the JWS header; required with --sign-key.",
+)
+def ticket_cmd(
+    tracker: str,
+    ticket_id: str,
+    out: Path,
+    workdir: Path,
+    sign_key: Path | None,
+    sign_kid: str | None,
+) -> None:
+    """Assemble a per-ticket transcript bundle for an auditor.
+
+    \b
+      bernstein bundle ticket github ENG-42 --out ENG-42.tar.gz
+      bernstein bundle ticket jira PROJ-9 --out PROJ-9.tar.gz \\
+        --sign-key keys/lineage.pem --sign-kid lineage-2026
+    """
+    if sign_key is not None and not sign_kid:
+        raise click.UsageError("--sign-kid is required when --sign-key is used")
+
+    bundle = TicketBundle(workdir=workdir, tracker=tracker, ticket_id=ticket_id)
+    manifest = bundle.assemble(out=out)
+
+    if sign_key is not None and sign_kid:
+        priv_pem = sign_key.read_text(encoding="utf-8")
+        jws_path = bundle.sign(private_key_pem=priv_pem, kid=sign_kid)
+        sig_note = f" Signed -> [bold]{jws_path}[/bold]."
+    else:
+        sig_note = ""
+
+    size_bytes = out.stat().st_size
+    size_kib = size_bytes / 1024
+    console.print(
+        f"Ticket bundle written to [bold]{out}[/bold] "
+        f"({size_kib:.1f} KiB, {len(manifest.files)} files, "
+        f"tracker={tracker} ticket={ticket_id}).{sig_note}",
+    )
+
+
+@bundle_group.command("verify")
+@click.argument(
+    "archive",
+    type=click.Path(dir_okay=False, exists=True, path_type=Path),
+)
+@click.argument(
+    "signature",
+    type=click.Path(dir_okay=False, exists=True, path_type=Path),
+)
+@click.option(
+    "--card",
+    "card_path",
+    type=click.Path(dir_okay=False, exists=True, path_type=Path),
+    required=True,
+    help="JSON file with the verifier's Agent Card (agent_id, kid, public_key_pem).",
+)
+def verify_cmd(archive: Path, signature: Path, card_path: Path) -> None:
+    """Verify a ticket bundle against an Agent Card.
+
+    Exits 0 on success, 1 on any verification failure. Never raises on
+    malformed input; a tampered archive simply prints an error and exits
+    non-zero.
+    """
+    try:
+        card_payload = json.loads(card_path.read_text(encoding="utf-8"))
+        card = AgentCard(
+            agent_id=str(card_payload["agent_id"]),
+            kid=str(card_payload["kid"]),
+            public_key_pem=str(card_payload["public_key_pem"]),
+            protocol_version=str(card_payload.get("protocol_version", "a2a/1.0")),
+        )
+    except (OSError, ValueError, KeyError) as exc:
+        raise click.ClickException(f"could not load Agent Card: {exc}") from exc
+
+    ok = TicketBundle.verify(archive, signature, card)
+    if ok:
+        console.print(f"[green]Bundle verified:[/green] {archive}")
+        return
+    raise click.ClickException(f"bundle verification failed for {archive}")
+
+
+__all__ = ["bundle_group", "ticket_cmd", "verify_cmd"]

--- a/src/bernstein/cli/main.py
+++ b/src/bernstein/cli/main.py
@@ -57,6 +57,7 @@ from bernstein.cli.ci_cmd import ci_group
 from bernstein.cli.cloud_cmd import cloud_group
 from bernstein.cli.commands.best_of_n_rank_cmd import best_of_n_group
 from bernstein.cli.commands.bom_cmd import bom_group
+from bernstein.cli.commands.bundle_cmd import bundle_group
 from bernstein.cli.commands.citation_cmd import quality_group as citation_quality_group
 from bernstein.cli.commands.consensus_cmd import consensus_group
 from bernstein.cli.commands.criterion_profile_cmd import criterion_profile_group
@@ -946,6 +947,7 @@ cli.add_command(resume_cmd, "resume")
 cli.add_command(wrap_up, "wrap-up")
 cli.add_command(audit_group, "audit")
 cli.add_command(bom_group, "bom")
+cli.add_command(bundle_group, "bundle")
 cli.add_command(compliance_group, "compliance")
 cli.add_command(verify_cmd, "verify")
 cli.add_command(chaos_group, "chaos")

--- a/src/bernstein/core/observability/ticket_bundle.py
+++ b/src/bernstein/core/observability/ticket_bundle.py
@@ -1,0 +1,610 @@
+"""Per-ticket transcript bundle with full audit correlation.
+
+For every tracker ticket Bernstein has touched, this module produces a
+single archive that ties together the verbatim per-turn transcript of
+every agent that ran, the lineage entries, the trace JSONL, the resulting
+commits and diffs, the resulting PR, and the failure-taxonomy structured
+comments. The archive is the canonical artefact for an auditor reviewing
+a single ticket's full agent activity.
+
+Design notes:
+
+- The bundle is a packaging primitive layered over existing on-disk state
+  under ``.sdd/``. It does not own its inputs; it indexes them.
+- Bundle archive format is ``tar.gz`` (stdlib only, no extra deps).
+  Manifest is a versioned ``manifest.json`` at archive root listing every
+  bundled file with its sha256.
+- Signing reuses ``bernstein.core.lineage.identity.sign_detached`` so the
+  same Ed25519 keypair stewards both per-artefact lineage entries and
+  ticket bundles. The detached JWS goes in ``signature.jws`` next to the
+  archive.
+- Filter strategy is conservative: a file is included when its filename
+  contains the ticket id OR any JSONL record within it carries the
+  ``(tracker, ticket_id)`` pair. Callers can pass an explicit
+  ``BundleSelector`` to override.
+- Companion modules ``tracker_audit`` and ``trace_store`` are tracked by
+  separate tickets; this module degrades gracefully when those sources
+  are absent.
+
+Public surface:
+
+- :class:`BundleManifest` -- versioned manifest dataclass.
+- :class:`BundleSelector` -- per-section file selectors.
+- :class:`TicketBundle` -- ``assemble`` / ``sign`` / ``verify``.
+- :data:`MANIFEST_SCHEMA_VERSION` -- bump on incompatible changes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tarfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import bernstein
+from bernstein.core.lineage.identity import (
+    AgentCard,
+    sign_detached,
+    verify_detached,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "BundleManifest",
+    "BundleSelector",
+    "ManifestEntry",
+    "TicketBundle",
+    "default_selector",
+]
+
+MANIFEST_SCHEMA_VERSION = 1
+"""Bump on any backwards-incompatible manifest field change."""
+
+_JSONL_PROBE_BYTE_BUDGET = 2 * 1024 * 1024
+"""Skip JSONL content probing for files larger than this. Filename match
+still applies."""
+
+
+# ---------------------------------------------------------------------------
+# Manifest schema
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestEntry:
+    """One row inside :class:`BundleManifest.files`.
+
+    Attributes:
+        arcname: Path inside the archive (POSIX-style, no leading slash).
+        size_bytes: Uncompressed size on disk.
+        sha256: Hex sha-256 over the file contents as packed.
+        section: Logical section (``transcripts``, ``traces``, ``git`` ...).
+    """
+
+    arcname: str
+    size_bytes: int
+    sha256: str
+    section: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "arcname": self.arcname,
+            "size_bytes": self.size_bytes,
+            "sha256": self.sha256,
+            "section": self.section,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BundleManifest:
+    """Versioned manifest written as ``manifest.json`` at archive root.
+
+    Attributes:
+        schema_version: Format version of this manifest (bump on
+            backwards-incompatible field changes).
+        created_at: ISO-8601 UTC timestamp of bundle creation.
+        bernstein_version: Producer's ``bernstein.__version__``.
+        tracker: Tracker identifier (e.g. ``github``, ``jira``).
+        ticket_id: Ticket id within the tracker.
+        files: Sorted list of bundled files with sizes and sha256s.
+        pr_number: Resulting PR number, when known.
+        commits: Resulting commit SHAs, when known.
+    """
+
+    schema_version: int
+    created_at: str
+    bernstein_version: str
+    tracker: str
+    ticket_id: str
+    files: list[ManifestEntry] = field(default_factory=list)
+    pr_number: int | None = None
+    commits: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "created_at": self.created_at,
+            "bernstein_version": self.bernstein_version,
+            "tracker": self.tracker,
+            "ticket_id": self.ticket_id,
+            "files": [entry.to_dict() for entry in self.files],
+            "pr_number": self.pr_number,
+            "commits": list(self.commits),
+        }
+
+    def canonical_bytes(self) -> bytes:
+        """Return the JCS-like canonical encoding used for signing.
+
+        We sort keys and separate without whitespace so the bytes are
+        byte-stable across producers. The detached JWS in
+        ``signature.jws`` covers exactly these bytes.
+        """
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Selector strategy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BundleSelector:
+    """File-collection strategy for one ticket.
+
+    Attributes:
+        transcripts: callable returning per-agent transcript files.
+        traces: callable returning trace JSONL files.
+        lineage: callable returning lineage JSONL files (filtered).
+        tracker_audit: callable returning the tracker audit JSONL slice.
+        commits: callable returning the resolved commit SHA list.
+        pr_payload: callable returning the PR JSON payload, when known.
+    """
+
+    transcripts: Callable[[Path, str, str], list[Path]]
+    traces: Callable[[Path, str, str], list[Path]]
+    lineage: Callable[[Path, str, str], list[Path]]
+    tracker_audit: Callable[[Path, str, str], list[Path]]
+    commits: Callable[[Path, str, str], list[str]]
+    pr_payload: Callable[[Path, str, str], dict[str, Any] | None]
+
+
+# ---------------------------------------------------------------------------
+# Default selectors -- pure-stdlib scans of ``.sdd/``
+# ---------------------------------------------------------------------------
+
+
+def _safe_iter(path: Path) -> Iterable[Path]:
+    """Yield regular files under *path* one level deep, sorted, safely.
+
+    Returns nothing if *path* is missing or not a directory.
+    """
+    if not path.is_dir():
+        return
+    for child in sorted(path.iterdir()):
+        if child.is_file():
+            yield child
+
+
+def _file_mentions_ticket(path: Path, tracker: str, ticket_id: str) -> bool:
+    """Return True when *path* is in scope for the (tracker, ticket).
+
+    Match rules (any one suffices):
+
+    1. Filename contains the ticket id verbatim.
+    2. File is JSONL and at least one record contains both the tracker
+       string and the ticket id as values of any field.
+    """
+    name = path.name
+    if ticket_id and ticket_id in name:
+        return True
+    if path.suffix.lower() not in {".jsonl", ".json"}:
+        return False
+    try:
+        if path.stat().st_size > _JSONL_PROBE_BYTE_BUDGET:
+            return False
+    except OSError:
+        return False
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    tracker_hit = not tracker or tracker in raw
+    ticket_hit = ticket_id in raw
+    return tracker_hit and ticket_hit
+
+
+def _collect_matching(base: Path, tracker: str, ticket_id: str) -> list[Path]:
+    return [p for p in _safe_iter(base) if _file_mentions_ticket(p, tracker, ticket_id)]
+
+
+def _select_transcripts(workdir: Path, tracker: str, ticket_id: str) -> list[Path]:
+    """Default transcript selector -- scan ``.sdd/traces/`` and ``.sdd/transcripts/``."""
+    candidates: list[Path] = []
+    candidates.extend(_collect_matching(workdir / ".sdd" / "transcripts", tracker, ticket_id))
+    return sorted(candidates)
+
+
+def _select_traces(workdir: Path, tracker: str, ticket_id: str) -> list[Path]:
+    """Default trace selector -- scan ``.sdd/traces/`` for ticket-tagged files."""
+    return sorted(_collect_matching(workdir / ".sdd" / "traces", tracker, ticket_id))
+
+
+def _select_lineage(workdir: Path, tracker: str, ticket_id: str) -> list[Path]:
+    """Default lineage selector -- scan ``.sdd/lineage/`` for ticket-tagged files."""
+    return sorted(_collect_matching(workdir / ".sdd" / "lineage", tracker, ticket_id))
+
+
+def _select_tracker_audit(workdir: Path, tracker: str, ticket_id: str) -> list[Path]:
+    """Default tracker-audit selector -- scan ``.sdd/audit/``.
+
+    Falls back to an empty list when the audit subsystem is not present.
+    """
+    return sorted(_collect_matching(workdir / ".sdd" / "audit", tracker, ticket_id))
+
+
+def _select_commits(workdir: Path, tracker: str, ticket_id: str) -> list[str]:
+    """Default commit selector -- ``git log --grep=<ticket_id>``.
+
+    Returns an empty list when git is unavailable or the lookup fails.
+    """
+    if not ticket_id:
+        return []
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(workdir), "log", "--format=%H", f"--grep={ticket_id}", "--all"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _select_pr_payload(workdir: Path, tracker: str, ticket_id: str) -> dict[str, Any] | None:
+    """Default PR-payload selector -- look for ``.sdd/pr/pr_*.json``.
+
+    Returns the first JSON file whose body mentions the ticket id, or
+    ``None`` when no such file exists.
+    """
+    pr_dir = workdir / ".sdd" / "pr"
+    if not pr_dir.is_dir():
+        return None
+    for child in sorted(pr_dir.iterdir()):
+        if not child.is_file() or child.suffix.lower() != ".json":
+            continue
+        try:
+            text = child.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if ticket_id and ticket_id not in text:
+            continue
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def default_selector() -> BundleSelector:
+    """Return the on-disk default :class:`BundleSelector`.
+
+    Each callable scans the conventional ``.sdd/`` subtree for its
+    section. Missing directories yield empty results so the bundle can
+    still be produced when subsystems are partially deployed.
+    """
+    return BundleSelector(
+        transcripts=_select_transcripts,
+        traces=_select_traces,
+        lineage=_select_lineage,
+        tracker_audit=_select_tracker_audit,
+        commits=_select_commits,
+        pr_payload=_select_pr_payload,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembly
+# ---------------------------------------------------------------------------
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git_diff(workdir: Path, commits: list[str]) -> str:
+    """Return a unified patch covering *commits*.
+
+    For a single commit, this is ``git show``. For a multi-commit list,
+    it is ``git diff <first>^..<last>``. Returns the empty string on
+    failure or when the commit list is empty.
+    """
+    if not commits:
+        return ""
+    try:
+        if len(commits) == 1:
+            proc = subprocess.run(
+                ["git", "-C", str(workdir), "show", "--patch", commits[0]],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        else:
+            first, last = commits[0], commits[-1]
+            proc = subprocess.run(
+                ["git", "-C", str(workdir), "diff", f"{first}^..{last}"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+@dataclass
+class TicketBundle:
+    """Per-ticket bundle assembler / signer / verifier.
+
+    Typical usage::
+
+        bundle = TicketBundle(
+            workdir=Path("."),
+            tracker="github",
+            ticket_id="ENG-42",
+        )
+        manifest = bundle.assemble(out=Path("ENG-42.tar.gz"))
+        bundle.sign(private_key_pem=priv, kid="lineage-kid-1")
+        # later, on auditor host:
+        ok = TicketBundle.verify(
+            Path("ENG-42.tar.gz"),
+            Path("ENG-42.tar.gz.jws"),
+            card,
+        )
+
+    Attributes:
+        workdir: Project root directory holding ``.sdd/``.
+        tracker: Tracker identifier (e.g. ``github``).
+        ticket_id: Ticket id within the tracker.
+        selector: File-selection strategy. Defaults to
+            :func:`default_selector`.
+        output_path: Set after :meth:`assemble` succeeds.
+        manifest: Set after :meth:`assemble` succeeds.
+    """
+
+    workdir: Path
+    tracker: str
+    ticket_id: str
+    selector: BundleSelector = field(default_factory=default_selector)
+    output_path: Path | None = None
+    manifest: BundleManifest | None = None
+
+    def assemble(self, out: Path) -> BundleManifest:
+        """Assemble the bundle archive at *out* and return the manifest.
+
+        Args:
+            out: Destination path for the ``tar.gz`` archive. Parents
+                are created if missing.
+
+        Returns:
+            The :class:`BundleManifest` written into the archive.
+        """
+        entries: list[tuple[str, str, bytes]] = []  # (arcname, section, data)
+
+        def _pack_files(section: str, files: list[Path], rel_prefix: str) -> None:
+            for src in files:
+                try:
+                    data = src.read_bytes()
+                except OSError:
+                    continue
+                entries.append((f"{rel_prefix}/{src.name}", section, data))
+
+        _pack_files("transcripts", self.selector.transcripts(self.workdir, self.tracker, self.ticket_id), "transcripts")
+        _pack_files("traces", self.selector.traces(self.workdir, self.tracker, self.ticket_id), "traces")
+        _pack_files("lineage", self.selector.lineage(self.workdir, self.tracker, self.ticket_id), "lineage")
+        _pack_files("audit", self.selector.tracker_audit(self.workdir, self.tracker, self.ticket_id), "audit")
+
+        commits = self.selector.commits(self.workdir, self.tracker, self.ticket_id)
+        commits_payload = json.dumps(
+            {"tracker": self.tracker, "ticket_id": self.ticket_id, "commits": commits},
+            indent=2,
+            sort_keys=True,
+        ).encode("utf-8")
+        entries.append(("git/commits.json", "git", commits_payload))
+
+        diff_text = _git_diff(self.workdir, commits)
+        if diff_text:
+            entries.append(("git/diff.patch", "git", diff_text.encode("utf-8")))
+
+        pr_payload = self.selector.pr_payload(self.workdir, self.tracker, self.ticket_id)
+        pr_number: int | None = None
+        if pr_payload is not None:
+            raw_number = pr_payload.get("number")
+            if isinstance(raw_number, int):
+                pr_number = raw_number
+            pr_bytes = json.dumps(pr_payload, indent=2, sort_keys=True).encode("utf-8")
+            arc = f"pr/pr_{pr_number if pr_number is not None else 'unknown'}.json"
+            entries.append((arc, "pr", pr_bytes))
+
+        manifest_entries: list[ManifestEntry] = []
+        for arcname, section, data in entries:
+            manifest_entries.append(
+                ManifestEntry(
+                    arcname=arcname,
+                    size_bytes=len(data),
+                    sha256=_sha256_bytes(data),
+                    section=section,
+                ),
+            )
+        manifest_entries.sort(key=lambda e: e.arcname)
+
+        manifest = BundleManifest(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            created_at=datetime.now(tz=UTC).isoformat(),
+            bernstein_version=bernstein.__version__,
+            tracker=self.tracker,
+            ticket_id=self.ticket_id,
+            files=manifest_entries,
+            pr_number=pr_number,
+            commits=list(commits),
+        )
+
+        out.parent.mkdir(parents=True, exist_ok=True)
+        manifest_bytes = json.dumps(manifest.to_dict(), indent=2, sort_keys=True).encode("utf-8") + b"\n"
+
+        with tarfile.open(out, mode="w:gz") as tf:
+            self._add_bytes(tf, "manifest.json", manifest_bytes)
+            for arcname, _section, data in sorted(entries, key=lambda triple: triple[0]):
+                self._add_bytes(tf, arcname, data)
+
+        self.output_path = out
+        self.manifest = manifest
+        return manifest
+
+    @staticmethod
+    def _add_bytes(tf: tarfile.TarFile, arcname: str, data: bytes) -> None:
+        """Add *data* to *tf* under *arcname* with a deterministic header."""
+        info = tarfile.TarInfo(name=arcname)
+        info.size = len(data)
+        info.mtime = 0  # deterministic
+        info.mode = 0o644
+        info.type = tarfile.REGTYPE
+        info.uid = 0
+        info.gid = 0
+        info.uname = ""
+        info.gname = ""
+        from io import BytesIO
+
+        tf.addfile(info, BytesIO(data))
+
+    def sign(self, *, private_key_pem: str, kid: str, out: Path | None = None) -> Path:
+        """Produce a detached Ed25519 JWS over the manifest.
+
+        The signature covers :meth:`BundleManifest.canonical_bytes`, not
+        the archive bytes themselves. Because every bundled file has its
+        sha256 in the manifest, the signature transitively covers the
+        archive contents -- tampering with any included file changes
+        that file's sha256, which changes the canonical manifest bytes.
+
+        Args:
+            private_key_pem: PEM-encoded Ed25519 private key.
+            kid: Key id; must match the verifier's :class:`AgentCard`.
+            out: Optional path for the ``.jws`` file. Defaults to
+                ``<archive>.jws``.
+
+        Returns:
+            Path to the written JWS file.
+        """
+        if self.manifest is None or self.output_path is None:
+            raise RuntimeError("sign() requires a prior assemble() call")
+        jws = sign_detached(self.manifest.canonical_bytes(), private_key_pem, kid=kid)
+        jws_path = out if out is not None else Path(str(self.output_path) + ".jws")
+        jws_path.parent.mkdir(parents=True, exist_ok=True)
+        jws_path.write_text(jws, encoding="utf-8")
+        return jws_path
+
+    @classmethod
+    def verify(cls, archive_path: Path, jws_path: Path, card: AgentCard) -> bool:
+        """Verify a bundle's detached JWS against *card*.
+
+        Returns True iff:
+
+        1. The archive opens and contains a valid ``manifest.json``.
+        2. Every file recorded in the manifest is present and its bytes
+           sha256 to the recorded digest.
+        3. The detached JWS verifies against the manifest's canonical
+           bytes under *card*'s public key.
+
+        Never raises on malformed input -- returns False instead.
+        """
+        try:
+            with tarfile.open(archive_path, mode="r:*") as tf:
+                manifest_member = tf.getmember("manifest.json")
+                manifest_fp = tf.extractfile(manifest_member)
+                if manifest_fp is None:
+                    return False
+                manifest_bytes_raw = manifest_fp.read()
+                try:
+                    manifest_dict = json.loads(manifest_bytes_raw)
+                except json.JSONDecodeError:
+                    return False
+                manifest = _manifest_from_dict(manifest_dict)
+                if manifest is None:
+                    return False
+
+                # Re-check each file's sha256 against the manifest.
+                for entry in manifest.files:
+                    try:
+                        member = tf.getmember(entry.arcname)
+                    except KeyError:
+                        return False
+                    file_fp = tf.extractfile(member)
+                    if file_fp is None:
+                        return False
+                    data = file_fp.read()
+                    if len(data) != entry.size_bytes:
+                        return False
+                    if _sha256_bytes(data) != entry.sha256:
+                        return False
+        except (tarfile.TarError, OSError, KeyError):
+            return False
+
+        try:
+            jws = jws_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return False
+        return verify_detached(manifest.canonical_bytes(), jws, card)
+
+
+def _manifest_from_dict(payload: dict[str, Any]) -> BundleManifest | None:
+    """Reconstruct a :class:`BundleManifest` from a raw JSON dict.
+
+    Returns None on schema mismatch -- callers treat that as a verify
+    failure rather than raising.
+    """
+    try:
+        schema = int(payload["schema_version"])
+        files_raw = payload.get("files", [])
+        if not isinstance(files_raw, list):
+            return None
+        files: list[ManifestEntry] = []
+        for row in files_raw:
+            if not isinstance(row, dict):
+                return None
+            files.append(
+                ManifestEntry(
+                    arcname=str(row["arcname"]),
+                    size_bytes=int(row["size_bytes"]),
+                    sha256=str(row["sha256"]),
+                    section=str(row.get("section", "")),
+                ),
+            )
+        commits_raw = payload.get("commits", []) or []
+        if not isinstance(commits_raw, list):
+            return None
+        return BundleManifest(
+            schema_version=schema,
+            created_at=str(payload["created_at"]),
+            bernstein_version=str(payload["bernstein_version"]),
+            tracker=str(payload["tracker"]),
+            ticket_id=str(payload["ticket_id"]),
+            files=files,
+            pr_number=payload.get("pr_number") if isinstance(payload.get("pr_number"), int) else None,
+            commits=[str(c) for c in commits_raw],
+        )
+    except (KeyError, TypeError, ValueError):
+        return None

--- a/src/bernstein/core/observability/ticket_bundle.py
+++ b/src/bernstein/core/observability/ticket_bundle.py
@@ -36,6 +36,7 @@ Public surface:
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import json
 import subprocess
@@ -57,6 +58,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MANIFEST_SCHEMA_VERSION",
+    "SUPPORTED_SCHEMA_VERSIONS",
     "BundleManifest",
     "BundleSelector",
     "ManifestEntry",
@@ -66,6 +68,14 @@ __all__ = [
 
 MANIFEST_SCHEMA_VERSION = 1
 """Bump on any backwards-incompatible manifest field change."""
+
+SUPPORTED_SCHEMA_VERSIONS: frozenset[int] = frozenset({1})
+"""Manifest schema versions :meth:`TicketBundle.verify` accepts.
+
+Bundles written under an unknown schema version are rejected by
+:func:`_manifest_from_dict` so an older verifier never silently treats a
+newer manifest as v1.
+"""
 
 _JSONL_PROBE_BYTE_BUDGET = 2 * 1024 * 1024
 """Skip JSONL content probing for files larger than this. Filename match
@@ -192,14 +202,52 @@ def _safe_iter(path: Path) -> Iterable[Path]:
             yield child
 
 
+def _record_matches(record: Any, tracker: str, ticket_id: str) -> bool:
+    """Return True when one parsed JSON *record* carries both keys.
+
+    A record matches when:
+
+    - Any value in the record (recursed into nested dicts/lists) equals
+      *ticket_id*, AND
+    - either *tracker* is empty or any value equals *tracker*.
+
+    Cross-record matches do not count: each record is judged on its own.
+    """
+    if not ticket_id:
+        return False
+    ticket_hit = False
+    tracker_hit = not tracker
+
+    def _walk(node: Any) -> None:
+        nonlocal ticket_hit, tracker_hit
+        if isinstance(node, dict):
+            for v in node.values():
+                _walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                _walk(v)
+        else:
+            text = node if isinstance(node, str) else None
+            if text is None:
+                return
+            if text == ticket_id:
+                ticket_hit = True
+            if not tracker_hit and text == tracker:
+                tracker_hit = True
+
+    _walk(record)
+    return ticket_hit and tracker_hit
+
+
 def _file_mentions_ticket(path: Path, tracker: str, ticket_id: str) -> bool:
     """Return True when *path* is in scope for the (tracker, ticket).
 
     Match rules (any one suffices):
 
     1. Filename contains the ticket id verbatim.
-    2. File is JSONL and at least one record contains both the tracker
-       string and the ticket id as values of any field.
+    2. File is JSONL/JSON and at least one parsed record carries both
+       the tracker string and the ticket id within the SAME record.
+       Cross-record matches do not qualify.
     """
     name = path.name
     if ticket_id and ticket_id in name:
@@ -215,9 +263,24 @@ def _file_mentions_ticket(path: Path, tracker: str, ticket_id: str) -> bool:
         raw = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
-    tracker_hit = not tracker or tracker in raw
-    ticket_hit = ticket_id in raw
-    return tracker_hit and ticket_hit
+    if path.suffix.lower() == ".json":
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError:
+            return False
+        return _record_matches(record, tracker, ticket_id)
+    # JSONL: one record per line; a single record must satisfy both keys.
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if _record_matches(record, tracker, ticket_id):
+            return True
+    return False
 
 
 def _collect_matching(base: Path, tracker: str, ticket_id: str) -> list[Path]:
@@ -252,7 +315,10 @@ def _select_tracker_audit(workdir: Path, tracker: str, ticket_id: str) -> list[P
 def _select_commits(workdir: Path, tracker: str, ticket_id: str) -> list[str]:
     """Default commit selector -- ``git log --grep=<ticket_id>``.
 
-    Returns an empty list when git is unavailable or the lookup fails.
+    Returns commits in chronological order (oldest first, newest last)
+    so downstream consumers can treat ``commits[0]`` as the first commit
+    of the ticket and ``commits[-1]`` as the latest. Returns an empty
+    list when git is unavailable or the lookup fails.
     """
     if not ticket_id:
         return []
@@ -268,7 +334,9 @@ def _select_commits(workdir: Path, tracker: str, ticket_id: str) -> list[str]:
         return []
     if proc.returncode != 0:
         return []
-    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    # git log emits newest-first; flip to oldest-first.
+    newest_first = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return list(reversed(newest_first))
 
 
 def _select_pr_payload(workdir: Path, tracker: str, ticket_id: str) -> dict[str, Any] | None:
@@ -466,7 +534,14 @@ class TicketBundle:
         out.parent.mkdir(parents=True, exist_ok=True)
         manifest_bytes = json.dumps(manifest.to_dict(), indent=2, sort_keys=True).encode("utf-8") + b"\n"
 
-        with tarfile.open(out, mode="w:gz") as tf:
+        # Use an explicit GzipFile with mtime=0 so the gzip header is
+        # deterministic; the default tarfile.open(..., "w:gz") embeds
+        # the current time and breaks bit-for-bit reproducibility.
+        with (
+            out.open("wb") as raw,
+            gzip.GzipFile(fileobj=raw, mode="wb", mtime=0) as gz,
+            tarfile.open(fileobj=gz, mode="w") as tf,
+        ):
             self._add_bytes(tf, "manifest.json", manifest_bytes)
             for arcname, _section, data in sorted(entries, key=lambda triple: triple[0]):
                 self._add_bytes(tf, arcname, data)
@@ -546,6 +621,19 @@ class TicketBundle:
                 if manifest is None:
                     return False
 
+                # Reject archives that contain members not listed in the
+                # manifest. Without this, an attacker could smuggle
+                # extra payload files past verification.
+                allowed = {entry.arcname for entry in manifest.files}
+                allowed.add("manifest.json")
+                for member in tf.getmembers():
+                    if not member.isfile():
+                        # Skip directory/symlink/hardlink markers; we
+                        # only ever pack regular files in assemble().
+                        continue
+                    if member.name not in allowed:
+                        return False
+
                 # Re-check each file's sha256 against the manifest.
                 for entry in manifest.files:
                     try:
@@ -578,6 +666,10 @@ def _manifest_from_dict(payload: dict[str, Any]) -> BundleManifest | None:
     """
     try:
         schema = int(payload["schema_version"])
+        if schema not in SUPPORTED_SCHEMA_VERSIONS:
+            # Reject unknown / future schema versions so an older
+            # verifier never treats a newer manifest as v1 by accident.
+            return None
         files_raw = payload.get("files", [])
         if not isinstance(files_raw, list):
             return None

--- a/tests/unit/observability/test_ticket_bundle.py
+++ b/tests/unit/observability/test_ticket_bundle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 import tarfile
@@ -12,6 +13,7 @@ import pytest
 from bernstein.core.lineage.identity import AgentCard, generate_keypair
 from bernstein.core.observability.ticket_bundle import (
     MANIFEST_SCHEMA_VERSION,
+    SUPPORTED_SCHEMA_VERSIONS,
     BundleManifest,
     BundleSelector,
     ManifestEntry,
@@ -136,7 +138,8 @@ def test_manifest_schema_and_metadata(workdir: Path) -> None:
     assert manifest.tracker == "github"
     assert manifest.ticket_id == "ENG-42"
     assert manifest.pr_number == 77
-    # Each manifest entry has a non-empty sha256 and matches size on disk.
+    # Each manifest entry's recorded sha256 matches the actual SHA-256
+    # of the bytes stored under that arcname (not just sha length).
     with tarfile.open(out, mode="r:*") as tf:
         for entry in manifest.files:
             member = tf.getmember(entry.arcname)
@@ -144,7 +147,7 @@ def test_manifest_schema_and_metadata(workdir: Path) -> None:
             assert fp is not None
             data = fp.read()
             assert len(data) == entry.size_bytes
-            assert len(entry.sha256) == 64  # hex sha-256
+            assert hashlib.sha256(data).hexdigest() == entry.sha256
 
 
 def test_manifest_inside_archive_matches_returned_manifest(workdir: Path) -> None:
@@ -317,6 +320,98 @@ def test_missing_jws_returns_false(workdir: Path) -> None:
 # ---------------------------------------------------------------------------
 # Manifest dataclass smoke
 # ---------------------------------------------------------------------------
+
+
+def test_jsonl_probe_requires_same_record_for_tracker_and_ticket(tmp_path: Path) -> None:
+    """Cross-record matches must NOT satisfy the JSONL probe.
+
+    A file where one record carries the tracker and a *different* record
+    carries the ticket id should not be picked up.
+    """
+    sdd = tmp_path / ".sdd" / "lineage"
+    sdd.mkdir(parents=True)
+    # Cross-record: tracker on line 1, ticket_id on line 2 -- must NOT match.
+    (sdd / "cross.jsonl").write_text(
+        '{"tracker": "github", "ticket_id": "OTHER-1"}\n{"tracker": "jira", "ticket_id": "ENG-42"}\n',
+        encoding="utf-8",
+    )
+    # Same record: tracker + ticket_id together -- must match.
+    (sdd / "same.jsonl").write_text(
+        '{"tracker": "github", "ticket_id": "ENG-42"}\n',
+        encoding="utf-8",
+    )
+    out = tmp_path / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=tmp_path,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(tmp_path),
+    )
+    manifest = bundle.assemble(out=out)
+    arcnames = {entry.arcname for entry in manifest.files}
+    assert "lineage/same.jsonl" in arcnames
+    assert "lineage/cross.jsonl" not in arcnames
+
+
+def test_verify_rejects_extra_archive_members(workdir: Path) -> None:
+    """Smuggled members not listed in the manifest must fail verify."""
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+    priv_pem, pub_pem = generate_keypair()
+    jws_path = bundle.sign(private_key_pem=priv_pem, kid="k1")
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub_pem)
+    assert TicketBundle.verify(out, jws_path, card) is True
+
+    # Append an extra file that the manifest does not list.
+    with tarfile.open(out, mode="r:*") as src:
+        contents: dict[str, bytes] = {}
+        for member in src.getmembers():
+            fp = src.extractfile(member)
+            contents[member.name] = fp.read() if fp is not None else b""
+    contents["smuggled/payload.bin"] = b"extra"
+    with tarfile.open(out, mode="w:gz") as dst:
+        for name, data in contents.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mtime = 0
+            info.mode = 0o644
+            dst.addfile(info, io.BytesIO(data))
+
+    assert TicketBundle.verify(out, jws_path, card) is False
+
+
+def test_verify_rejects_unsupported_schema_version(workdir: Path) -> None:
+    """A manifest with a schema_version outside the supported set fails."""
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+    priv_pem, pub_pem = generate_keypair()
+    jws_path = bundle.sign(private_key_pem=priv_pem, kid="k1")
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub_pem)
+
+    # Rewrite the manifest with a bumped schema_version that this
+    # release does not understand. This also invalidates the signature,
+    # but the schema-version rejection should fire BEFORE the sig check.
+    with tarfile.open(out, mode="r:*") as tf:
+        fp = tf.extractfile(tf.getmember("manifest.json"))
+        assert fp is not None
+        payload = json.loads(fp.read())
+    payload["schema_version"] = max(SUPPORTED_SCHEMA_VERSIONS) + 99
+    new_bytes = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _rewrite_archive_member(out, "manifest.json", new_bytes)
+
+    assert TicketBundle.verify(out, jws_path, card) is False
 
 
 def test_manifest_canonical_bytes_are_deterministic() -> None:

--- a/tests/unit/observability/test_ticket_bundle.py
+++ b/tests/unit/observability/test_ticket_bundle.py
@@ -1,0 +1,339 @@
+"""Tests for the per-ticket transcript bundle."""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from bernstein.core.lineage.identity import AgentCard, generate_keypair
+from bernstein.core.observability.ticket_bundle import (
+    MANIFEST_SCHEMA_VERSION,
+    BundleManifest,
+    BundleSelector,
+    ManifestEntry,
+    TicketBundle,
+    default_selector,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def workdir(tmp_path: Path) -> Path:
+    """Populate a fake ``.sdd/`` layout for a ticket and return the root."""
+    sdd = tmp_path / ".sdd"
+    (sdd / "transcripts").mkdir(parents=True)
+    (sdd / "traces").mkdir(parents=True)
+    (sdd / "lineage").mkdir(parents=True)
+    (sdd / "audit").mkdir(parents=True)
+    (sdd / "pr").mkdir(parents=True)
+
+    # Filename match -- includes ticket id verbatim
+    (sdd / "transcripts" / "agent-backend-ENG-42.jsonl").write_text(
+        '{"agent": "backend", "turn": 1, "text": "hello"}\n',
+        encoding="utf-8",
+    )
+    (sdd / "traces" / "ENG-42-trace.jsonl").write_text(
+        '{"event": "span", "ticket": "ENG-42"}\n',
+        encoding="utf-8",
+    )
+
+    # Content match -- JSONL mentions tracker + ticket id but not in filename
+    (sdd / "lineage" / "merge-audit.jsonl").write_text(
+        '{"tracker": "github", "ticket_id": "ENG-42", "policy": "first-writer"}\n',
+        encoding="utf-8",
+    )
+    (sdd / "audit" / "tracker-events.jsonl").write_text(
+        '{"event": "ticket_opened", "tracker": "github", "ticket_id": "ENG-42"}\n',
+        encoding="utf-8",
+    )
+
+    # PR payload -- must round-trip through manifest.pr_number
+    (sdd / "pr" / "pr_77.json").write_text(
+        json.dumps({"number": 77, "title": "ENG-42: fix bug", "ticket_id": "ENG-42"}),
+        encoding="utf-8",
+    )
+
+    # Noise -- must NOT be picked up
+    (sdd / "transcripts" / "agent-backend-OTHER-1.jsonl").write_text(
+        '{"agent": "backend", "ticket_id": "OTHER-1"}\n',
+        encoding="utf-8",
+    )
+    (sdd / "audit" / "unrelated.jsonl").write_text(
+        '{"tracker": "jira", "ticket_id": "OTHER-1"}\n',
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _selector_without_git(workdir: Path) -> BundleSelector:
+    """Default selector but with commits/PR readers that don't call git."""
+
+    base = default_selector()
+
+    def _no_commits(_w: Path, _t: str, _i: str) -> list[str]:
+        return []
+
+    # Keep PR payload as default (file-based); only commits use git.
+    return BundleSelector(
+        transcripts=base.transcripts,
+        traces=base.traces,
+        lineage=base.lineage,
+        tracker_audit=base.tracker_audit,
+        commits=_no_commits,
+        pr_payload=base.pr_payload,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Assemble + manifest contents
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_includes_filename_and_content_matches(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    manifest = bundle.assemble(out=out)
+
+    assert out.exists()
+    arcnames = {entry.arcname for entry in manifest.files}
+    # Filename matches
+    assert "transcripts/agent-backend-ENG-42.jsonl" in arcnames
+    assert "traces/ENG-42-trace.jsonl" in arcnames
+    # Content matches (filename does not carry the ticket id)
+    assert "lineage/merge-audit.jsonl" in arcnames
+    assert "audit/tracker-events.jsonl" in arcnames
+    # PR payload + git/commits.json
+    assert "pr/pr_77.json" in arcnames
+    assert "git/commits.json" in arcnames
+    # Noise was excluded
+    assert "transcripts/agent-backend-OTHER-1.jsonl" not in arcnames
+    assert "audit/unrelated.jsonl" not in arcnames
+
+
+def test_manifest_schema_and_metadata(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    manifest = bundle.assemble(out=out)
+
+    assert manifest.schema_version == MANIFEST_SCHEMA_VERSION
+    assert manifest.tracker == "github"
+    assert manifest.ticket_id == "ENG-42"
+    assert manifest.pr_number == 77
+    # Each manifest entry has a non-empty sha256 and matches size on disk.
+    with tarfile.open(out, mode="r:*") as tf:
+        for entry in manifest.files:
+            member = tf.getmember(entry.arcname)
+            fp = tf.extractfile(member)
+            assert fp is not None
+            data = fp.read()
+            assert len(data) == entry.size_bytes
+            assert len(entry.sha256) == 64  # hex sha-256
+
+
+def test_manifest_inside_archive_matches_returned_manifest(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    manifest = bundle.assemble(out=out)
+
+    with tarfile.open(out, mode="r:*") as tf:
+        fp = tf.extractfile(tf.getmember("manifest.json"))
+        assert fp is not None
+        on_disk = json.loads(fp.read())
+    assert on_disk["tracker"] == "github"
+    assert on_disk["ticket_id"] == "ENG-42"
+    assert on_disk["schema_version"] == manifest.schema_version
+    assert {f["arcname"] for f in on_disk["files"]} == {e.arcname for e in manifest.files}
+
+
+def test_assemble_empty_workdir_still_writes_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "EMPTY.tar.gz"
+    bundle = TicketBundle(
+        workdir=tmp_path,
+        tracker="github",
+        ticket_id="ZZ-1",
+        selector=_selector_without_git(tmp_path),
+    )
+    manifest = bundle.assemble(out=out)
+    assert out.exists()
+    # Always at least git/commits.json (an empty list payload).
+    assert any(e.arcname == "git/commits.json" for e in manifest.files)
+
+
+# ---------------------------------------------------------------------------
+# Sign + verify
+# ---------------------------------------------------------------------------
+
+
+def test_sign_and_verify_roundtrip(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+
+    priv_pem, pub_pem = generate_keypair()
+    jws_path = bundle.sign(private_key_pem=priv_pem, kid="lineage-2026")
+
+    card = AgentCard(agent_id="agent:test", kid="lineage-2026", public_key_pem=pub_pem)
+    assert TicketBundle.verify(out, jws_path, card) is True
+
+
+def test_sign_without_assemble_raises(workdir: Path) -> None:
+    bundle = TicketBundle(workdir=workdir, tracker="github", ticket_id="ENG-42")
+    priv_pem, _pub_pem = generate_keypair()
+    with pytest.raises(RuntimeError):
+        bundle.sign(private_key_pem=priv_pem, kid="k1")
+
+
+def test_verify_fails_with_wrong_card(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+    priv_pem, _pub_pem = generate_keypair()
+    jws_path = bundle.sign(private_key_pem=priv_pem, kid="k1")
+    _other_priv, other_pub = generate_keypair()
+    wrong_card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=other_pub)
+    assert TicketBundle.verify(out, jws_path, wrong_card) is False
+
+
+# ---------------------------------------------------------------------------
+# Tampering detection
+# ---------------------------------------------------------------------------
+
+
+def _rewrite_archive_member(archive: Path, arcname: str, new_data: bytes) -> None:
+    """Rewrite *archive* so that *arcname* contains *new_data* (others unchanged)."""
+    with tarfile.open(archive, mode="r:*") as src:
+        members = src.getmembers()
+        contents: dict[str, bytes] = {}
+        for member in members:
+            fp = src.extractfile(member)
+            contents[member.name] = fp.read() if fp is not None else b""
+    contents[arcname] = new_data
+    with tarfile.open(archive, mode="w:gz") as dst:
+        for name, data in contents.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(data)
+            info.mtime = 0
+            info.mode = 0o644
+            dst.addfile(info, io.BytesIO(data))
+
+
+def test_tampering_with_bundled_file_is_detected(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+    priv_pem, pub_pem = generate_keypair()
+    jws_path = bundle.sign(private_key_pem=priv_pem, kid="k1")
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub_pem)
+    # Sanity: untampered archive verifies.
+    assert TicketBundle.verify(out, jws_path, card) is True
+
+    # Replace a bundled transcript with different bytes.
+    _rewrite_archive_member(
+        out,
+        "transcripts/agent-backend-ENG-42.jsonl",
+        b'{"agent": "backend", "turn": 1, "text": "TAMPERED"}\n',
+    )
+    assert TicketBundle.verify(out, jws_path, card) is False
+
+
+def test_tampering_with_manifest_is_detected(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+    priv_pem, pub_pem = generate_keypair()
+    jws_path = bundle.sign(private_key_pem=priv_pem, kid="k1")
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub_pem)
+
+    # Read current manifest, flip a field, write it back. This breaks the
+    # signature because the canonical bytes change.
+    with tarfile.open(out, mode="r:*") as tf:
+        fp = tf.extractfile(tf.getmember("manifest.json"))
+        assert fp is not None
+        manifest_payload = json.loads(fp.read())
+    manifest_payload["ticket_id"] = "TAMPERED"
+    tampered_bytes = (json.dumps(manifest_payload, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    _rewrite_archive_member(out, "manifest.json", tampered_bytes)
+
+    assert TicketBundle.verify(out, jws_path, card) is False
+
+
+def test_missing_jws_returns_false(workdir: Path) -> None:
+    out = workdir / "ENG-42.tar.gz"
+    bundle = TicketBundle(
+        workdir=workdir,
+        tracker="github",
+        ticket_id="ENG-42",
+        selector=_selector_without_git(workdir),
+    )
+    bundle.assemble(out=out)
+    _priv, pub = generate_keypair()
+    card = AgentCard(agent_id="agent:test", kid="k1", public_key_pem=pub)
+    missing = workdir / "does-not-exist.jws"
+    assert TicketBundle.verify(out, missing, card) is False
+
+
+# ---------------------------------------------------------------------------
+# Manifest dataclass smoke
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_canonical_bytes_are_deterministic() -> None:
+    m = BundleManifest(
+        schema_version=1,
+        created_at="2026-05-19T00:00:00+00:00",
+        bernstein_version="0.0.0",
+        tracker="github",
+        ticket_id="ENG-42",
+        files=[
+            ManifestEntry(arcname="b.txt", size_bytes=1, sha256="b" * 64, section="x"),
+            ManifestEntry(arcname="a.txt", size_bytes=1, sha256="a" * 64, section="x"),
+        ],
+    )
+    encoded_once = m.canonical_bytes()
+    encoded_twice = m.canonical_bytes()
+    assert encoded_once == encoded_twice
+    # Keys are sorted -> "bernstein_version" precedes "commits".
+    text = encoded_once.decode("utf-8")
+    assert text.index('"bernstein_version"') < text.index('"commits"')

--- a/tests/unit/test_readme_api_coverage.py
+++ b/tests/unit/test_readme_api_coverage.py
@@ -219,6 +219,8 @@ DOCUMENTED_COMMANDS: frozenset[str] = frozenset(
         "integrations",
         # Bot-added: drift autofix (regen_contract_drift.py)
         "git",
+        # Bot-added: drift autofix (regen_contract_drift.py)
+        "bundle",
     }
 )
 


### PR DESCRIPTION
## Summary

- New `TicketBundle` packaging primitive (`src/bernstein/core/observability/ticket_bundle.py`) that ties tracker -> branch -> commit -> PR -> transcript -> traces -> lineage into a single signed archive per ticket.
- New CLI: `bernstein bundle ticket <tracker> <ticket_id> --out <path>` (with optional `--sign-key` / `--sign-kid`) and `bernstein bundle verify <archive> <signature> --card <agent_card.json>`. Reuses the existing run-archive pattern from `cli/run_archive.py` and the lineage signer from `core/lineage/identity.py`.
- Versioned manifest (`schema_version = 1`) lists every bundled file with its `sha256`; the detached Ed25519 JWS over the canonical manifest bytes transitively binds every bundled artefact, so any tampering breaks verification.

## Implementation notes

- Bundle format is `tar.gz` (stdlib only -- no extra deps for a `size/s` ticket).
- Selection strategy: file is included when its filename contains the ticket id OR a JSONL record carries the `(tracker, ticket_id)` pair. Pluggable via `BundleSelector` for callers that want custom rules.
- Companion modules `tracker_audit` and `trace_store` are tracked by separate tickets; the assembler degrades gracefully when those sources are missing.

## Test plan

- [x] `tests/unit/observability/test_ticket_bundle.py` -- 11 tests, all green:
  - filename match + JSONL content match assembly
  - manifest schema + metadata
  - manifest-on-disk matches returned manifest
  - empty workdir still produces a manifest
  - sign + verify roundtrip
  - sign without assemble raises
  - verify rejects wrong card
  - tampered bundled file detected
  - tampered manifest detected
  - missing JWS returns False
  - canonical bytes are deterministic
- [x] `ruff check` clean for new files + `src/bernstein/cli/main.py`
- [x] `ruff format --check` clean
- [x] CLI smoke test: `bernstein bundle ticket github ENG-42 --out ENG-42.tar.gz` writes a valid archive with `manifest.json`, `traces/`, and `git/commits.json`.

## Docs

- `docs/observability/ticket-bundle.md` -- operator guide with auditor question -> bundled-file map.
- `mkdocs.yml` -- nav entry under Observability.

## Summary by Sourcery

Introduce a per-ticket transcript bundle facility that assembles, signs, and verifies a single archive capturing all artefacts related to a tracker ticket, with a CLI and documentation for operators and auditors.

New Features:
- Add TicketBundle abstraction and selectors to package transcripts, traces, lineage, audit logs, commits, diffs, and PR metadata for a given ticket into a versioned, hash-indexed tar.gz archive with optional Ed25519 signing and verification.
- Expose a bernstein bundle CLI group with subcommands to assemble per-ticket bundles and to verify them against an Agent Card.
- Document the per-ticket bundle format, manifest schema, and auditor workflows, and link it into the observability docs navigation.

Tests:
- Add unit test suite for TicketBundle covering file selection, manifest generation, signing and verification flow, tampering detection, and determinism of the canonical manifest encoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ticket transcript bundling: create archives containing agent transcripts, traces, lineage entries, commits, and PR data.
  * New CLI commands: `bernstein bundle ticket` (create bundles) and `bernstein bundle verify` (verify authenticity).
  * Bundle signing support with Ed25519 keys for integrity verification.

* **Documentation**
  * Added comprehensive guide for ticket transcript bundle format, usage, and verification procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1562?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->