### PR TITLE
feat(observability): content-addressed trace store + viewer

### DIFF
--- a/docs/observability/trace-store.md
+++ b/docs/observability/trace-store.md
@@ -1,0 +1,98 @@
+# Content-addressed local trace store + viewer
+
+Bernstein writes agent traces to `.sdd/traces/` as the orchestrator runs.
+The **content-addressed trace store** layers a sha256-keyed archive plus a
+small read-only FastAPI viewer on top of those traces, so operators get
+the experience of a paid trace platform (search, timeline, replayable
+JSON) without paying for one.
+
+## Why
+
+- Paid trace platforms charge per trace count, every month, forever.
+- Local disk is free, never expires, and stays inside the operator's
+  trust boundary.
+- The same store doubles as the input to Bernstein's replay primitive.
+
+## On-disk layout
+
+```
+.sdd/traces/
+  blobs/
+    <sha256[:2]>/
+      <sha256>.jsonl.zst    # if zstandard is installed
+      <sha256>.jsonl.gz     # otherwise (stdlib gzip)
+  index.jsonl               # one TraceIndexEntry per line
+```
+
+- Each blob is the uncompressed trace bytes, compressed with whichever
+  codec the writer had available. The filename always carries the codec
+  via its extension, so readers can pick the right decoder regardless of
+  which codec wrote it.
+- `index.jsonl` carries the searchable metadata: `trace_id`, `task_id`,
+  `sha256`, `byte_size`, `started_at`, `ended_at`, `model`, `cost_usd`,
+  `codec`. The viewer reads this file; nothing else.
+- The sha256 is the source of truth. `bernstein trace verify <id>`
+  rereads the blob bytes and rehashes them.
+
+## CLI
+
+| Command                                | What it does                                      |
+| -------------------------------------- | ------------------------------------------------- |
+| `bernstein trace show <task-id>`       | Pretty-print the live JSONL trace for a task.     |
+| `bernstein trace <task-id>`            | Back-compat alias of `show`.                      |
+| `bernstein trace serve --port 8765`    | Run the read-only viewer on `127.0.0.1`.          |
+| `bernstein trace verify <trace-id>`    | Confirm the on-disk bytes match the indexed hash. |
+| `bernstein trace reindex`              | Rebuild `index.jsonl` from the blob tree.         |
+
+`trace serve` binds to loopback by default. To expose the viewer on a
+specific interface (e.g. when running inside a sandbox), pass
+`--bind 0.0.0.0` explicitly. Bernstein never opens it on a public
+interface for you.
+
+## Viewer endpoints
+
+The FastAPI app served by `bernstein trace serve` exposes:
+
+- `GET /` - HTML index with `task`, `model`, free-text filters.
+- `GET /traces/<trace-id>` - pretty-printed JSON body.
+- `GET /traces/<trace-id>/timeline` - HTML timeline of steps.
+- `GET /api/traces` - JSON mirror of the filtered index.
+- `GET /api/traces/<trace-id>` - JSON body of a single trace.
+
+The HTML is intentionally minimal: HTML + inline CSS, no JS framework,
+so screenshots are stable and the viewer survives in environments
+without a bundler.
+
+## Python API
+
+The `ContentAddressedTraceStore` class is the public Python surface.
+
+```python
+from pathlib import Path
+from bernstein.core.observability.trace_store import (
+    ContentAddressedTraceStore,
+    TraceMetadataHints,
+)
+
+store = ContentAddressedTraceStore(Path(".sdd/traces"))
+
+# Store finalised trace bytes (idempotent).
+entry = store.put(trace_bytes, hints=TraceMetadataHints(task_id="T-12"))
+
+# Read back, verify, search.
+raw = store.get(entry.trace_id)
+assert store.verify(entry.trace_id)
+results = store.search(task_id="T-12", model="sonnet")
+
+# Rebuild the index after a crash or manual blob copy.
+store.reindex()
+```
+
+## Out of scope (v1)
+
+- Shipping traces to an external store. A separate ticket covers
+  S3/GCS sinks via the existing `bernstein.core.storage` registry.
+- Sharing traces across machines. The viewer is local-only.
+- Full-text search inside trace bodies. `task_id` / `model` / free-text
+  substring is enough in v1; we can plug in SQLite FTS5 later without
+  changing the on-disk layout.

--- a/src/bernstein/cli/commands/advanced_cmd.py
+++ b/src/bernstein/cli/commands/advanced_cmd.py
@@ -937,32 +937,55 @@ def recap(archive: str, as_json: bool) -> None:
 # ---------------------------------------------------------------------------
 
 
-@click.command("trace")
-@click.argument("task_id")
-@click.option(
-    "--as-json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Output raw JSON.",
-)
+class _TraceGroup(click.Group):
+    """Click group that falls back to ``show`` when the first positional
+    arg is not a registered subcommand.
+
+    This preserves the legacy ``bernstein trace <task-id>`` invocation
+    after the command was promoted to a group with ``serve``, ``verify``,
+    and ``reindex`` subcommands.
+    """
+
+    def resolve_command(
+        self,
+        ctx: click.Context,
+        args: list[str],
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        if args and not args[0].startswith("-") and args[0] not in self.commands:
+            args = ["show", *args]
+        return super().resolve_command(ctx, args)
+
+
+@click.group("trace", cls=_TraceGroup, invoke_without_command=True)
 @click.option(
     "--traces-dir",
     default=".sdd/traces",
     show_default=True,
     help="Directory containing trace files.",
 )
-def trace_cmd(task_id: str, as_json: bool, traces_dir: str) -> None:
-    """Show execution trace for a task.
+@click.pass_context
+def trace_cmd(ctx: click.Context, traces_dir: str) -> None:
+    """Inspect, serve, and verify local agent traces.
 
-    Displays the step-by-step trace of what a task's agent did.
+    \b
+      bernstein trace <task-id>           Pretty-print a task trace (alias of show)
+      bernstein trace show <task-id>      Pretty-print a task trace
+      bernstein trace serve --port 8765   Run the local read-only viewer
+      bernstein trace verify <trace-id>   Confirm on-disk bytes match sha256
+      bernstein trace reindex             Rebuild .sdd/traces/index.jsonl
     """
+    ctx.obj = {"traces_dir": traces_dir}
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+def _trace_show_task(task_id: str, *, traces_dir: str, as_json: bool) -> None:
+    """Pretty-print a single trace file for ``task_id``."""
     traces_path = Path(traces_dir)
     if not traces_path.exists():
         console.print(f"[red]Traces directory not found:[/red] {traces_path}")
         raise SystemExit(1)
 
-    # Find trace file for this task
     trace_files = list(traces_path.glob(f"*{task_id}*.json")) + list(traces_path.glob(f"*{task_id}*.jsonl"))
 
     if not trace_files:
@@ -981,7 +1004,6 @@ def trace_cmd(task_id: str, as_json: bool, traces_dir: str) -> None:
             console.print_json(json.dumps(data))
             return
 
-        # Pretty print trace
         from rich.syntax import Syntax
 
         syntax = Syntax(content, "json", theme="monokai", line_numbers=True)
@@ -989,6 +1011,78 @@ def trace_cmd(task_id: str, as_json: bool, traces_dir: str) -> None:
     except Exception as e:
         console.print(f"[red]Error reading trace:[/red] {e}")
         raise SystemExit(1) from e
+
+
+@trace_cmd.command("show")
+@click.argument("task_id")
+@click.option(
+    "--as-json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Output raw JSON.",
+)
+@click.pass_context
+def trace_show_cmd(ctx: click.Context, task_id: str, as_json: bool) -> None:
+    """Show execution trace for a task."""
+    traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
+    _trace_show_task(task_id, traces_dir=traces_dir, as_json=as_json)
+
+
+@trace_cmd.command("serve")
+@click.option("--port", default=8765, show_default=True, type=int, help="TCP port to bind.")
+@click.option(
+    "--bind",
+    default="127.0.0.1",
+    show_default=True,
+    help="Interface to bind. Defaults to loopback to keep traces local.",
+)
+@click.pass_context
+def trace_serve_cmd(ctx: click.Context, port: int, bind: str) -> None:
+    """Run a read-only FastAPI viewer over the local content-addressed store."""
+    import uvicorn
+
+    from bernstein.core.observability.trace_store import (
+        ContentAddressedTraceStore,
+        build_viewer_app,
+    )
+
+    traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
+    store = ContentAddressedTraceStore(Path(traces_dir))
+    app = build_viewer_app(store)
+    console.print(
+        f"[green]Trace viewer:[/green] http://{bind}:{port}/  "
+        f"(root: {store.root}, traces indexed: {len(store.index())})"
+    )
+    uvicorn.run(app, host=bind, port=port, log_level="warning")
+
+
+@trace_cmd.command("verify")
+@click.argument("trace_id")
+@click.pass_context
+def trace_verify_cmd(ctx: click.Context, trace_id: str) -> None:
+    """Confirm the on-disk bytes for ``trace_id`` match the indexed sha256."""
+    from bernstein.core.observability.trace_store import ContentAddressedTraceStore
+
+    traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
+    store = ContentAddressedTraceStore(Path(traces_dir))
+    if store.verify(trace_id):
+        console.print(f"[green]OK[/green] {trace_id}")
+        return
+    console.print(f"[red]FAIL[/red] {trace_id}")
+    raise SystemExit(1)
+
+
+@trace_cmd.command("reindex")
+@click.pass_context
+def trace_reindex_cmd(ctx: click.Context) -> None:
+    """Rebuild ``.sdd/traces/index.jsonl`` from the on-disk blob tree."""
+    from bernstein.core.observability.trace_store import ContentAddressedTraceStore
+
+    traces_dir = (ctx.obj or {}).get("traces_dir", ".sdd/traces")
+    store = ContentAddressedTraceStore(Path(traces_dir))
+    count = store.reindex()
+    console.print(f"[green]Reindex complete:[/green] {count} entries")
 
 
 # ---------------------------------------------------------------------------

--- a/src/bernstein/core/observability/trace_store.py
+++ b/src/bernstein/core/observability/trace_store.py
@@ -1,0 +1,793 @@
+"""Content-addressed local trace store + read-only viewer support.
+
+This module sits next to the existing ``traces.py`` emitter and indexer.
+Where ``traces.py`` writes per-task JSONL files for the live orchestrator,
+``trace_store.py`` archives finalised traces as content-addressed blobs so
+that operators can run a local read-only viewer over them without paying
+for a hosted trace platform.
+
+The layout under the configured traces directory (default ``.sdd/traces/``)
+is::
+
+    blobs/<sha256[:2]>/<sha256>.jsonl.<ext>   # immutable trace blobs
+    index.jsonl                                # one TraceIndexEntry per line
+
+``<ext>`` is ``zst`` when the optional ``zstandard`` package is importable;
+otherwise we fall back to ``gz`` (stdlib ``gzip``). The codec used for a
+given blob is recorded in its index entry, so the store can read either
+format regardless of which codec wrote it.
+
+Design notes
+------------
+
+* **Append-only.** ``put`` is idempotent: writing the same bytes a second
+  time is a no-op and returns the existing sha256.
+* **Cheap to verify.** ``verify`` rereads the blob, decompresses it, and
+  rehashes; the index does not have to be trusted.
+* **Cheap to rebuild.** ``reindex`` discards ``index.jsonl`` and walks the
+  ``blobs/`` tree, regenerating the index from the on-disk bytes.
+* **No new heavy deps.** FastAPI + uvicorn are already in ``pyproject.toml``;
+  zstandard is optional; the HTML viewer is a single inline template with
+  HTMX-friendly endpoints.
+
+The public surface is intentionally small:
+
+* :class:`ContentAddressedTraceStore` - ``put``, ``get``, ``verify``,
+  ``reindex``, ``index``.
+* :class:`TraceIndexEntry` - one row in ``index.jsonl``.
+* :func:`build_viewer_app` - FastAPI factory used by ``bernstein trace serve``.
+
+See ``docs/observability/trace-store.md`` for the operator-facing guide.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+import logging
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BLOBS_DIRNAME: Final = "blobs"
+_INDEX_FILENAME: Final = "index.jsonl"
+_GZIP_EXT: Final = "gz"
+_ZSTD_EXT: Final = "zst"
+_CODEC_GZIP: Final = "gzip"
+_CODEC_ZSTD: Final = "zstd"
+
+
+def _zstd_available() -> bool:
+    """Return True if the optional ``zstandard`` codec can be imported."""
+    try:  # pragma: no cover - import shape check
+        import zstandard  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TraceIndexEntry:
+    """One row in ``index.jsonl``.
+
+    The index is intentionally narrow: it carries just enough metadata to
+    list, search, and de-duplicate traces in the viewer. Detailed trace
+    bodies are read on-demand from the content-addressed blob.
+
+    Attributes:
+        trace_id: Logical trace identifier (matches ``AgentTrace.trace_id``
+            when the source is the live emitter; otherwise any unique
+            string the caller chose).
+        task_id: Task identifier the trace belongs to. Empty string if the
+            trace is not attached to a task.
+        sha256: Hex digest of the uncompressed trace bytes. Doubles as the
+            blob lookup key.
+        byte_size: Size of the uncompressed trace bytes.
+        started_at: Unix timestamp of the first event in the trace.
+        ended_at: Unix timestamp of the last event in the trace; ``None``
+            if the trace is still open.
+        model: Optional model short name (e.g. ``"sonnet"``).
+        cost_usd: Optional total USD cost recorded with the trace.
+        codec: Compression codec used for the on-disk blob (``"zstd"`` or
+            ``"gzip"``).
+    """
+
+    trace_id: str
+    task_id: str
+    sha256: str
+    byte_size: int
+    started_at: float
+    ended_at: float | None = None
+    model: str = ""
+    cost_usd: float = 0.0
+    codec: str = _CODEC_GZIP
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> TraceIndexEntry:
+        return cls(
+            trace_id=str(d.get("trace_id", "")),
+            task_id=str(d.get("task_id", "")),
+            sha256=str(d.get("sha256", "")),
+            byte_size=int(d.get("byte_size", 0)),
+            started_at=float(d.get("started_at", 0.0)),
+            ended_at=None if d.get("ended_at") is None else float(d["ended_at"]),
+            model=str(d.get("model", "")),
+            cost_usd=float(d.get("cost_usd", 0.0)),
+            codec=str(d.get("codec", _CODEC_GZIP)),
+        )
+
+
+@dataclass
+class TraceMetadataHints:
+    """Optional metadata a caller can attach when storing a trace.
+
+    The hints are not required for correctness: ``put`` will derive what it
+    can from the trace bytes when a hint is missing. The hint takes
+    precedence when supplied.
+    """
+
+    trace_id: str = ""
+    task_id: str = ""
+    started_at: float = 0.0
+    ended_at: float | None = None
+    model: str = ""
+    cost_usd: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Codec helpers
+# ---------------------------------------------------------------------------
+
+
+def _compress(data: bytes, codec: str) -> bytes:
+    if codec == _CODEC_ZSTD:
+        import zstandard  # local import; only reached when available
+
+        return zstandard.ZstdCompressor().compress(data)
+    return gzip.compress(data)
+
+
+def _decompress(data: bytes, codec: str) -> bytes:
+    if codec == _CODEC_ZSTD:
+        import zstandard
+
+        return zstandard.ZstdDecompressor().decompress(data)
+    return gzip.decompress(data)
+
+
+def _ext_for_codec(codec: str) -> str:
+    return _ZSTD_EXT if codec == _CODEC_ZSTD else _GZIP_EXT
+
+
+def _codec_for_ext(ext: str) -> str:
+    return _CODEC_ZSTD if ext == _ZSTD_EXT else _CODEC_GZIP
+
+
+# ---------------------------------------------------------------------------
+# Metadata extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_hints_from_bytes(raw: bytes) -> TraceMetadataHints:
+    """Best-effort metadata extraction from JSON or JSONL trace bytes.
+
+    The function is lossy on purpose: when fields are missing we leave the
+    defaults in place. Callers that need exact metadata should pass an
+    explicit :class:`TraceMetadataHints`.
+    """
+    text = raw.decode("utf-8", errors="replace").strip()
+    if not text:
+        return TraceMetadataHints()
+
+    # Try a single JSON object first (matches AgentTrace.write payload).
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        obj = None
+    if isinstance(obj, dict):
+        return _hints_from_obj(obj)
+
+    # Fall back to JSONL: scan first/last non-empty lines.
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return TraceMetadataHints()
+
+    first: dict[str, Any] = {}
+    last: dict[str, Any] = {}
+    try:
+        first = json.loads(lines[0])
+        if not isinstance(first, dict):
+            first = {}
+    except json.JSONDecodeError:
+        first = {}
+    try:
+        last = json.loads(lines[-1])
+        if not isinstance(last, dict):
+            last = {}
+    except json.JSONDecodeError:
+        last = {}
+
+    hints = _hints_from_obj(first)
+    if last:
+        end_ts = _coerce_float(last.get("end_ts") or last.get("timestamp") or last.get("ts"))
+        if end_ts is not None:
+            hints.ended_at = end_ts
+        if not hints.model:
+            hints.model = str(last.get("model", "") or "")
+        if not hints.cost_usd:
+            hints.cost_usd = float(last.get("cost_usd", 0.0) or 0.0)
+    return hints
+
+
+def _hints_from_obj(obj: dict[str, Any]) -> TraceMetadataHints:
+    """Build hints from a single trace JSON object."""
+    task_ids = obj.get("task_ids")
+    task_id = ""
+    if isinstance(task_ids, list) and task_ids:
+        task_id = str(task_ids[0])
+    elif isinstance(obj.get("task_id"), str):
+        task_id = str(obj["task_id"])
+
+    started = _coerce_float(obj.get("spawn_ts") or obj.get("started_at") or obj.get("ts") or obj.get("timestamp"))
+    ended = _coerce_float(obj.get("end_ts") or obj.get("ended_at"))
+    return TraceMetadataHints(
+        trace_id=str(obj.get("trace_id", "") or ""),
+        task_id=task_id,
+        started_at=started if started is not None else 0.0,
+        ended_at=ended,
+        model=str(obj.get("model", "") or ""),
+        cost_usd=float(obj.get("cost_usd", 0.0) or 0.0),
+    )
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class ContentAddressedTraceStore:
+    """Content-addressed archive of agent trace bodies.
+
+    The store is rooted at a directory (typically ``.sdd/traces/``) and
+    keeps the on-disk layout described in the module docstring. It is
+    safe to construct in a process that has no traces yet - directories
+    are created lazily on first ``put`` / ``reindex`` call.
+
+    Args:
+        traces_dir: Path to the traces directory.
+        prefer_zstd: If True and ``zstandard`` is importable, new blobs
+            are written with zstd compression; otherwise gzip is used.
+            Existing blobs are read with whatever codec their filename
+            declares, regardless of this flag.
+    """
+
+    def __init__(self, traces_dir: Path, *, prefer_zstd: bool = True) -> None:
+        self._dir = traces_dir
+        self._prefer_zstd = prefer_zstd and _zstd_available()
+
+    # -- Paths --------------------------------------------------------------
+
+    @property
+    def root(self) -> Path:
+        """Filesystem root of the store."""
+        return self._dir
+
+    @property
+    def blobs_dir(self) -> Path:
+        return self._dir / _BLOBS_DIRNAME
+
+    @property
+    def index_path(self) -> Path:
+        return self._dir / _INDEX_FILENAME
+
+    @property
+    def codec(self) -> str:
+        """Codec used for newly written blobs."""
+        return _CODEC_ZSTD if self._prefer_zstd else _CODEC_GZIP
+
+    def _blob_path(self, sha256: str, codec: str) -> Path:
+        if len(sha256) < 2:
+            msg = "sha256 too short for content-addressed layout"
+            raise ValueError(msg)
+        return self.blobs_dir / sha256[:2] / f"{sha256}.jsonl.{_ext_for_codec(codec)}"
+
+    def _existing_blob_path(self, sha256: str) -> Path | None:
+        """Return the on-disk path of the blob with this digest, if any."""
+        if len(sha256) < 2:
+            return None
+        bucket = self.blobs_dir / sha256[:2]
+        if not bucket.exists():
+            return None
+        for ext in (_ZSTD_EXT, _GZIP_EXT):
+            candidate = bucket / f"{sha256}.jsonl.{ext}"
+            if candidate.exists():
+                return candidate
+        return None
+
+    # -- Writes -------------------------------------------------------------
+
+    def put(
+        self,
+        trace_bytes: bytes,
+        *,
+        hints: TraceMetadataHints | None = None,
+    ) -> TraceIndexEntry:
+        """Store ``trace_bytes`` and append/refresh its index entry.
+
+        The operation is idempotent: writing the same bytes twice produces
+        the same sha256, leaves the blob on disk unchanged, and refreshes
+        the index entry in place (latest metadata wins).
+        """
+        if not isinstance(trace_bytes, (bytes, bytearray)):
+            msg = "trace_bytes must be bytes"
+            raise TypeError(msg)
+        raw = bytes(trace_bytes)
+        sha256 = hashlib.sha256(raw).hexdigest()
+
+        existing = self._existing_blob_path(sha256)
+        if existing is not None:
+            codec = _codec_for_ext(existing.suffix.lstrip("."))
+        else:
+            codec = self.codec
+            target = self._blob_path(sha256, codec)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(_compress(raw, codec))
+
+        entry = self._build_entry(raw, sha256, codec, hints)
+        self._upsert_index(entry)
+        return entry
+
+    def _build_entry(
+        self,
+        raw: bytes,
+        sha256: str,
+        codec: str,
+        hints: TraceMetadataHints | None,
+    ) -> TraceIndexEntry:
+        derived = _extract_hints_from_bytes(raw)
+        if hints is None:
+            hints = TraceMetadataHints()
+
+        trace_id = hints.trace_id or derived.trace_id or sha256[:16]
+        task_id = hints.task_id or derived.task_id
+        started_at = hints.started_at or derived.started_at
+        ended_at = hints.ended_at if hints.ended_at is not None else derived.ended_at
+        model = hints.model or derived.model
+        cost_usd = hints.cost_usd or derived.cost_usd
+
+        return TraceIndexEntry(
+            trace_id=trace_id,
+            task_id=task_id,
+            sha256=sha256,
+            byte_size=len(raw),
+            started_at=started_at,
+            ended_at=ended_at,
+            model=model,
+            cost_usd=cost_usd,
+            codec=codec,
+        )
+
+    # -- Reads --------------------------------------------------------------
+
+    def get(self, trace_id: str) -> bytes | None:
+        """Return uncompressed trace bytes for ``trace_id``.
+
+        ``trace_id`` can be either the logical trace identifier or the
+        sha256 digest of the blob. Returns ``None`` if no matching entry
+        exists in the index or the blob is missing on disk.
+        """
+        entry = self._lookup_entry(trace_id)
+        if entry is None:
+            return None
+        path = self._existing_blob_path(entry.sha256)
+        if path is None:
+            return None
+        codec = _codec_for_ext(path.suffix.lstrip("."))
+        return _decompress(path.read_bytes(), codec)
+
+    def index(self) -> list[TraceIndexEntry]:
+        """Return all index entries, most recent ``started_at`` first."""
+        entries = list(self._read_index())
+        entries.sort(key=lambda e: e.started_at, reverse=True)
+        return entries
+
+    def verify(self, trace_id: str) -> bool:
+        """Confirm the on-disk bytes match the indexed sha256.
+
+        Returns ``False`` if the trace is unknown, the blob is missing,
+        or the recomputed digest disagrees with the index entry.
+        """
+        entry = self._lookup_entry(trace_id)
+        if entry is None:
+            return False
+        path = self._existing_blob_path(entry.sha256)
+        if path is None:
+            return False
+        codec = _codec_for_ext(path.suffix.lstrip("."))
+        try:
+            raw = _decompress(path.read_bytes(), codec)
+        except Exception:
+            return False
+        return hashlib.sha256(raw).hexdigest() == entry.sha256
+
+    # -- Index maintenance --------------------------------------------------
+
+    def reindex(self) -> int:
+        """Rebuild ``index.jsonl`` by walking the blobs tree.
+
+        Returns the number of entries written.
+        """
+        entries: list[TraceIndexEntry] = []
+        if self.blobs_dir.exists():
+            for blob_path in sorted(self.blobs_dir.rglob("*.jsonl.*")):
+                if not blob_path.is_file():
+                    continue
+                sha256 = blob_path.name.split(".", 1)[0]
+                codec = _codec_for_ext(blob_path.suffix.lstrip("."))
+                try:
+                    raw = _decompress(blob_path.read_bytes(), codec)
+                except Exception:
+                    logger.warning("trace_store: skipping unreadable blob %s", blob_path)
+                    continue
+                if hashlib.sha256(raw).hexdigest() != sha256:
+                    logger.warning("trace_store: digest mismatch for %s", blob_path)
+                    continue
+                entries.append(self._build_entry(raw, sha256, codec, hints=None))
+
+        entries.sort(key=lambda e: e.started_at, reverse=True)
+        self._write_index(entries)
+        return len(entries)
+
+    # -- Search helpers (used by the viewer) -------------------------------
+
+    def search(
+        self,
+        *,
+        task_id: str = "",
+        model: str = "",
+        text: str = "",
+    ) -> list[TraceIndexEntry]:
+        """Return index entries matching the given filters.
+
+        All filters are applied with case-insensitive substring matching.
+        Empty filters match everything; ``text`` matches against
+        ``trace_id``, ``task_id``, or ``sha256``.
+        """
+        task_needle = task_id.lower()
+        model_needle = model.lower()
+        text_needle = text.lower()
+
+        results: list[TraceIndexEntry] = []
+        for entry in self.index():
+            if task_needle and task_needle not in entry.task_id.lower():
+                continue
+            if model_needle and model_needle not in entry.model.lower():
+                continue
+            if text_needle and not (
+                text_needle in entry.trace_id.lower()
+                or text_needle in entry.task_id.lower()
+                or text_needle in entry.sha256.lower()
+            ):
+                continue
+            results.append(entry)
+        return results
+
+    # -- Internals ----------------------------------------------------------
+
+    def _lookup_entry(self, trace_id: str) -> TraceIndexEntry | None:
+        if not trace_id:
+            return None
+        for entry in self._read_index():
+            if entry.trace_id == trace_id or entry.sha256 == trace_id:
+                return entry
+        return None
+
+    def _read_index(self) -> Iterator[TraceIndexEntry]:
+        if not self.index_path.exists():
+            return iter(())
+        return self._iter_index_file()
+
+    def _iter_index_file(self) -> Iterator[TraceIndexEntry]:
+        with self.index_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    yield TraceIndexEntry.from_dict(obj)
+
+    def _upsert_index(self, entry: TraceIndexEntry) -> None:
+        existing = [e for e in self._read_index() if e.sha256 != entry.sha256]
+        existing.append(entry)
+        existing.sort(key=lambda e: e.started_at, reverse=True)
+        self._write_index(existing)
+
+    def _write_index(self, entries: list[TraceIndexEntry]) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        tmp = self.index_path.with_suffix(self.index_path.suffix + ".tmp")
+        with tmp.open("w", encoding="utf-8") as fh:
+            for entry in entries:
+                fh.write(json.dumps(entry.to_dict(), sort_keys=True))
+                fh.write("\n")
+        tmp.replace(self.index_path)
+
+
+# ---------------------------------------------------------------------------
+# Viewer (FastAPI factory)
+# ---------------------------------------------------------------------------
+
+_VIEWER_INDEX_HTML: Final = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Bernstein local trace viewer</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 0; padding: 1.5rem; color: #1f2328; }
+  h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+  form { margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap; }
+  input[type=text] { padding: 0.35rem 0.5rem; border: 1px solid #d0d7de; border-radius: 4px; }
+  button { padding: 0.35rem 0.75rem; border: 1px solid #d0d7de;
+           background: #f6f8fa; border-radius: 4px; cursor: pointer; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  th, td { text-align: left; padding: 0.35rem 0.5rem; border-bottom: 1px solid #eaeef2; vertical-align: top; }
+  th { background: #f6f8fa; }
+  td.sha { font-family: ui-monospace, SFMono-Regular, monospace; color: #57606a; }
+  td.id { font-family: ui-monospace, SFMono-Regular, monospace; }
+  a { color: #0969da; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .meta { color: #57606a; font-size: 0.85rem; margin-bottom: 0.5rem; }
+</style>
+</head>
+<body>
+<h1>Bernstein local trace viewer</h1>
+<p class="meta">Root: <code>__ROOT__</code> &middot; __COUNT__ traces indexed</p>
+<form method="get" action="/">
+  <input type="text" name="task" placeholder="task id" value="__TASK__" />
+  <input type="text" name="model" placeholder="model" value="__MODEL__" />
+  <input type="text" name="q" placeholder="search" value="__Q__" />
+  <button type="submit">Filter</button>
+  <a href="/">Reset</a>
+</form>
+<table>
+  <thead>
+    <tr>
+      <th>started</th><th>task</th><th>trace</th><th>model</th>
+      <th>cost</th><th>bytes</th><th>sha256</th><th>actions</th>
+    </tr>
+  </thead>
+  <tbody>
+__ROWS__
+  </tbody>
+</table>
+</body>
+</html>
+"""
+
+
+def _render_index_html(
+    store: ContentAddressedTraceStore,
+    entries: list[TraceIndexEntry],
+    *,
+    task: str,
+    model: str,
+    q: str,
+) -> str:
+    import html as _html
+
+    rows: list[str] = []
+    for entry in entries:
+        rows.append(
+            "<tr>"
+            f"<td>{_html.escape(_fmt_ts(entry.started_at))}</td>"
+            f'<td class="id">{_html.escape(entry.task_id) or "-"}</td>'
+            f'<td class="id">{_html.escape(entry.trace_id)}</td>'
+            f"<td>{_html.escape(entry.model) or '-'}</td>"
+            f"<td>{entry.cost_usd:.4f}</td>"
+            f"<td>{entry.byte_size}</td>"
+            f'<td class="sha">{_html.escape(entry.sha256[:12])}</td>'
+            "<td>"
+            f'<a href="/traces/{_html.escape(entry.trace_id)}">json</a> '
+            f'<a href="/traces/{_html.escape(entry.trace_id)}/timeline">timeline</a>'
+            "</td>"
+            "</tr>"
+        )
+    if not rows:
+        rows.append(
+            '<tr><td colspan="8" style="text-align:center; color:#57606a; padding:1rem;">'
+            "No traces match the current filter.</td></tr>"
+        )
+    return (
+        _VIEWER_INDEX_HTML.replace("__ROOT__", _html.escape(str(store.root)))
+        .replace("__COUNT__", str(len(entries)))
+        .replace("__TASK__", _html.escape(task))
+        .replace("__MODEL__", _html.escape(model))
+        .replace("__Q__", _html.escape(q))
+        .replace("__ROWS__", "\n".join(rows))
+    )
+
+
+def _fmt_ts(ts: float) -> str:
+    import datetime as _dt
+
+    if not ts:
+        return "-"
+    try:
+        return _dt.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+    except (ValueError, OSError, OverflowError):
+        return "-"
+
+
+def build_viewer_app(store: ContentAddressedTraceStore) -> Any:
+    """Return a FastAPI application that serves the local viewer.
+
+    The app exposes:
+
+    * ``GET /`` - HTML index with task / model / free-text filters.
+    * ``GET /traces/{trace_id}`` - pretty-printed JSON or JSONL body.
+    * ``GET /traces/{trace_id}/timeline`` - timeline of trace steps.
+    * ``GET /api/traces`` - JSON list mirror of the index (HTMX-friendly).
+    * ``GET /api/traces/{trace_id}`` - JSON body of a single trace.
+
+    Importing ``fastapi`` lazily keeps the rest of the module importable
+    in environments where the optional viewer extra is not installed.
+    """
+    from fastapi import FastAPI, HTTPException, Query
+    from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse
+
+    app = FastAPI(title="Bernstein trace viewer", docs_url=None, redoc_url=None)
+
+    @app.get("/", response_class=HTMLResponse)
+    def _index(
+        task: str = Query(default=""),
+        model: str = Query(default=""),
+        q: str = Query(default=""),
+    ) -> HTMLResponse:
+        entries = store.search(task_id=task, model=model, text=q)
+        return HTMLResponse(_render_index_html(store, entries, task=task, model=model, q=q))
+
+    @app.get("/api/traces")
+    def _api_index(
+        task: str = Query(default=""),
+        model: str = Query(default=""),
+        q: str = Query(default=""),
+    ) -> JSONResponse:
+        entries = store.search(task_id=task, model=model, text=q)
+        return JSONResponse({"traces": [e.to_dict() for e in entries]})
+
+    @app.get("/api/traces/{trace_id}")
+    def _api_trace(trace_id: str) -> JSONResponse:
+        raw = store.get(trace_id)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="trace not found")
+        try:
+            body = json.loads(raw)
+        except json.JSONDecodeError:
+            body = {"raw": raw.decode("utf-8", errors="replace")}
+        return JSONResponse({"trace_id": trace_id, "body": body})
+
+    @app.get("/traces/{trace_id}", response_class=PlainTextResponse)
+    def _show_trace(trace_id: str) -> PlainTextResponse:
+        raw = store.get(trace_id)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="trace not found")
+        try:
+            pretty = json.dumps(json.loads(raw), indent=2, sort_keys=True)
+        except json.JSONDecodeError:
+            pretty = raw.decode("utf-8", errors="replace")
+        return PlainTextResponse(pretty, media_type="application/json")
+
+    @app.get("/traces/{trace_id}/timeline", response_class=HTMLResponse)
+    def _timeline(trace_id: str) -> HTMLResponse:
+        raw = store.get(trace_id)
+        if raw is None:
+            raise HTTPException(status_code=404, detail="trace not found")
+        return HTMLResponse(_render_timeline_html(trace_id, raw))
+
+    return app
+
+
+_TIMELINE_HTML: Final = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Trace __TRACE__</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; margin: 0; padding: 1.5rem; color: #1f2328; }
+  h1 { font-size: 1.1rem; margin: 0 0 1rem; }
+  ol { padding-left: 1.5rem; }
+  li { margin-bottom: 0.4rem; font-size: 0.9rem; }
+  .type { display: inline-block; padding: 0 0.4rem; border-radius: 3px;
+          background: #ddf4ff; color: #0969da; margin-right: 0.4rem;
+          font-family: ui-monospace, monospace; font-size: 0.8rem; }
+  .ts { color: #57606a; font-size: 0.8rem; margin-left: 0.4rem; }
+  .detail { color: #1f2328; }
+  a { color: #0969da; }
+</style>
+</head>
+<body>
+<h1>Trace timeline: <code>__TRACE__</code> &middot;
+    <a href="/">back</a> &middot;
+    <a href="/traces/__TRACE__">json</a></h1>
+__BODY__
+</body>
+</html>
+"""
+
+
+def _render_timeline_html(trace_id: str, raw: bytes) -> str:
+    import html as _html
+
+    steps: list[dict[str, Any]] = []
+    try:
+        obj = json.loads(raw)
+        if isinstance(obj, dict):
+            steps_field = obj.get("steps")
+            if isinstance(steps_field, list):
+                steps = [s for s in steps_field if isinstance(s, dict)]
+    except json.JSONDecodeError:
+        for line in raw.decode("utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                steps.append(obj)
+
+    if not steps:
+        body = "<p>No timeline steps recorded.</p>"
+    else:
+        items: list[str] = []
+        for step in steps:
+            step_type = _html.escape(str(step.get("type", "step")))
+            detail = _html.escape(str(step.get("detail", "")))
+            ts = _fmt_ts(float(step.get("timestamp", 0.0) or 0.0))
+            items.append(
+                f'<li><span class="type">{step_type}</span>'
+                f'<span class="detail">{detail}</span>'
+                f'<span class="ts">{_html.escape(ts)}</span></li>'
+            )
+        body = "<ol>" + "\n".join(items) + "</ol>"
+
+    return _TIMELINE_HTML.replace("__TRACE__", _html.escape(trace_id)).replace("__BODY__", body)
+
+
+__all__ = [
+    "ContentAddressedTraceStore",
+    "TraceIndexEntry",
+    "TraceMetadataHints",
+    "build_viewer_app",
+]

--- a/src/bernstein/core/observability/trace_store.py
+++ b/src/bernstein/core/observability/trace_store.py
@@ -233,7 +233,7 @@ def _extract_hints_from_bytes(raw: bytes) -> TraceMetadataHints:
         if not hints.model:
             hints.model = str(last.get("model", "") or "")
         if not hints.cost_usd:
-            hints.cost_usd = float(last.get("cost_usd", 0.0) or 0.0)
+            hints.cost_usd = _coerce_float(last.get("cost_usd")) or 0.0
     return hints
 
 
@@ -254,7 +254,7 @@ def _hints_from_obj(obj: dict[str, Any]) -> TraceMetadataHints:
         started_at=started if started is not None else 0.0,
         ended_at=ended,
         model=str(obj.get("model", "") or ""),
-        cost_usd=float(obj.get("cost_usd", 0.0) or 0.0),
+        cost_usd=_coerce_float(obj.get("cost_usd")) or 0.0,
     )
 
 
@@ -348,7 +348,8 @@ class ContentAddressedTraceStore:
         if not isinstance(trace_bytes, (bytes, bytearray)):
             msg = "trace_bytes must be bytes"
             raise TypeError(msg)
-        raw = bytes(trace_bytes)
+        # Normalise bytearray to bytes; passthrough for bytes is a no-op.
+        raw = bytes(trace_bytes) if isinstance(trace_bytes, bytearray) else trace_bytes
         sha256 = hashlib.sha256(raw).hexdigest()
 
         existing = self._existing_blob_path(sha256)
@@ -505,7 +506,7 @@ class ContentAddressedTraceStore:
         if not trace_id:
             return None
         for entry in self._read_index():
-            if entry.trace_id == trace_id or entry.sha256 == trace_id:
+            if trace_id in (entry.trace_id, entry.sha256):
                 return entry
         return None
 
@@ -605,9 +606,8 @@ def _render_index_html(
 ) -> str:
     import html as _html
 
-    rows: list[str] = []
-    for entry in entries:
-        rows.append(
+    rows: list[str] = [
+        (
             "<tr>"
             f"<td>{_html.escape(_fmt_ts(entry.started_at))}</td>"
             f'<td class="id">{_html.escape(entry.task_id) or "-"}</td>'
@@ -622,14 +622,17 @@ def _render_index_html(
             "</td>"
             "</tr>"
         )
+        for entry in entries
+    ]
     if not rows:
         rows.append(
             '<tr><td colspan="8" style="text-align:center; color:#57606a; padding:1rem;">'
             "No traces match the current filter.</td></tr>"
         )
+    total_indexed = len(store.index())
     return (
         _VIEWER_INDEX_HTML.replace("__ROOT__", _html.escape(str(store.root)))
-        .replace("__COUNT__", str(len(entries)))
+        .replace("__COUNT__", str(total_indexed))
         .replace("__TASK__", _html.escape(task))
         .replace("__MODEL__", _html.escape(model))
         .replace("__Q__", _html.escape(q))
@@ -774,7 +777,7 @@ def _render_timeline_html(trace_id: str, raw: bytes) -> str:
         for step in steps:
             step_type = _html.escape(str(step.get("type", "step")))
             detail = _html.escape(str(step.get("detail", "")))
-            ts = _fmt_ts(float(step.get("timestamp", 0.0) or 0.0))
+            ts = _fmt_ts(_coerce_float(step.get("timestamp")) or 0.0)
             items.append(
                 f'<li><span class="type">{step_type}</span>'
                 f'<span class="detail">{detail}</span>'

--- a/tests/unit/observability/__init__.py
+++ b/tests/unit/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for :mod:`bernstein.core.observability` add-ons."""

--- a/tests/unit/observability/test_trace_store.py
+++ b/tests/unit/observability/test_trace_store.py
@@ -1,0 +1,384 @@
+"""Unit tests for the content-addressed local trace store.
+
+The tests cover:
+
+* sha256-keyed blob layout, gzip fallback when zstd is absent.
+* idempotent ``put`` (writing the same bytes twice does not duplicate).
+* metadata extraction from both single-JSON and JSONL trace formats.
+* ``get``, ``verify``, ``reindex``, ``search`` correctness.
+* viewer endpoints (FastAPI TestClient) render index, json, timeline.
+* CLI surface registers ``trace serve``, ``trace verify``, ``trace reindex``.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from bernstein.cli.commands.advanced_cmd import trace_cmd
+from bernstein.core.observability.trace_store import (
+    ContentAddressedTraceStore,
+    TraceIndexEntry,
+    TraceMetadataHints,
+    build_viewer_app,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _agent_trace_json(
+    *,
+    trace_id: str = "trace-001",
+    task_id: str = "T-1",
+    model: str = "sonnet",
+    spawn_ts: float = 100.0,
+    end_ts: float = 200.0,
+    cost_usd: float = 0.0042,
+) -> bytes:
+    """Build a single-object trace payload that mirrors ``AgentTrace.write``."""
+    return json.dumps(
+        {
+            "trace_id": trace_id,
+            "session_id": "sess-1",
+            "task_ids": [task_id],
+            "agent_role": "backend",
+            "model": model,
+            "effort": "high",
+            "spawn_ts": spawn_ts,
+            "end_ts": end_ts,
+            "outcome": "success",
+            "cost_usd": cost_usd,
+            "steps": [
+                {"type": "orient", "timestamp": spawn_ts + 1, "detail": "read file"},
+                {"type": "edit", "timestamp": spawn_ts + 2, "detail": "write file"},
+                {"type": "verify", "timestamp": spawn_ts + 3, "detail": "ran tests"},
+            ],
+        }
+    ).encode("utf-8")
+
+
+def _jsonl_trace_bytes() -> bytes:
+    """Build a JSONL trace (one event per line)."""
+    lines = [
+        {"type": "spawn", "trace_id": "tr-jsonl", "task_id": "T-9", "timestamp": 10.0, "model": "haiku"},
+        {"type": "orient", "timestamp": 11.0},
+        {"type": "complete", "timestamp": 12.0, "model": "haiku", "cost_usd": 0.01},
+    ]
+    return "\n".join(json.dumps(o) for o in lines).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Core store behavior
+# ---------------------------------------------------------------------------
+
+
+def test_put_returns_sha256_indexed_entry(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path)
+    raw = _agent_trace_json()
+    expected = hashlib.sha256(raw).hexdigest()
+
+    entry = store.put(raw)
+
+    assert entry.sha256 == expected
+    assert entry.byte_size == len(raw)
+    assert entry.trace_id == "trace-001"
+    assert entry.task_id == "T-1"
+    assert entry.model == "sonnet"
+    assert entry.started_at == 100.0
+    assert entry.ended_at == 200.0
+    assert entry.codec in {"gzip", "zstd"}
+
+
+def test_blob_uses_content_addressed_layout(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+
+    blob_dir = tmp_path / "blobs" / entry.sha256[:2]
+    blob_file = blob_dir / f"{entry.sha256}.jsonl.gz"
+    assert blob_file.exists(), f"expected blob at {blob_file}"
+    # And it is a valid gzip stream that round-trips back to ``raw``.
+    assert gzip.decompress(blob_file.read_bytes()) == raw
+
+
+def test_put_is_idempotent(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+
+    first = store.put(raw)
+    second = store.put(raw)
+
+    # Same digest, single index entry, single blob on disk.
+    assert first.sha256 == second.sha256
+    assert len(store.index()) == 1
+    blob_files = list((tmp_path / "blobs").rglob("*.jsonl.gz"))
+    assert len(blob_files) == 1
+
+
+def test_get_returns_decompressed_bytes(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    store.put(raw)
+
+    assert store.get("trace-001") == raw
+    # Look-up by sha256 also resolves.
+    assert store.get(hashlib.sha256(raw).hexdigest()) == raw
+    assert store.get("does-not-exist") is None
+
+
+def test_verify_detects_digest_mismatch(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+
+    assert store.verify("trace-001") is True
+
+    # Corrupt the blob: replace the gzipped bytes with a different gzipped payload.
+    blob = tmp_path / "blobs" / entry.sha256[:2] / f"{entry.sha256}.jsonl.gz"
+    blob.write_bytes(gzip.compress(b"tampered"))
+    assert store.verify("trace-001") is False
+
+
+def test_verify_handles_missing_blob(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+
+    # Delete the blob; the index still references it.
+    (tmp_path / "blobs" / entry.sha256[:2] / f"{entry.sha256}.jsonl.gz").unlink()
+    assert store.verify("trace-001") is False
+    assert store.get("trace-001") is None
+
+
+def test_reindex_rebuilds_index_from_blobs(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw_a = _agent_trace_json(trace_id="a", task_id="T-A", spawn_ts=100.0)
+    raw_b = _agent_trace_json(trace_id="b", task_id="T-B", spawn_ts=200.0)
+    store.put(raw_a)
+    store.put(raw_b)
+
+    # Destroy the index and rebuild from disk.
+    store.index_path.unlink()
+    count = store.reindex()
+    assert count == 2
+    ids = sorted(e.trace_id for e in store.index())
+    assert ids == ["a", "b"]
+    # And the most recent ``started_at`` is first in the listing.
+    assert store.index()[0].trace_id == "b"
+
+
+def test_reindex_skips_corrupt_blob(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _agent_trace_json()
+    entry = store.put(raw)
+    # Drop a bogus blob into the same bucket.
+    bucket = tmp_path / "blobs" / entry.sha256[:2]
+    (bucket / "deadbeef.jsonl.gz").write_bytes(b"not gzip")
+    store.index_path.unlink()
+    assert store.reindex() == 1
+
+
+def test_search_filters_by_task_model_and_text(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json(trace_id="a", task_id="T-1", model="sonnet"))
+    store.put(_agent_trace_json(trace_id="b", task_id="T-2", model="haiku"))
+
+    assert {e.trace_id for e in store.search(task_id="T-1")} == {"a"}
+    assert {e.trace_id for e in store.search(model="haiku")} == {"b"}
+    assert {e.trace_id for e in store.search(text="t-2")} == {"b"}
+    # Empty filter returns everything.
+    assert {e.trace_id for e in store.search()} == {"a", "b"}
+
+
+def test_jsonl_payload_metadata_extraction(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = _jsonl_trace_bytes()
+    entry = store.put(raw)
+
+    assert entry.trace_id == "tr-jsonl"
+    assert entry.task_id == "T-9"
+    assert entry.started_at == 10.0
+    assert entry.ended_at == 12.0
+    assert entry.model == "haiku"
+    assert entry.cost_usd == pytest.approx(0.01)
+
+
+def test_explicit_hints_override_derived_metadata(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    raw = b"{}"  # empty trace
+    entry = store.put(
+        raw,
+        hints=TraceMetadataHints(
+            trace_id="override-id",
+            task_id="T-X",
+            started_at=42.0,
+            ended_at=43.0,
+            model="opus",
+            cost_usd=0.99,
+        ),
+    )
+    assert entry.trace_id == "override-id"
+    assert entry.task_id == "T-X"
+    assert entry.started_at == 42.0
+    assert entry.ended_at == 43.0
+    assert entry.model == "opus"
+    assert entry.cost_usd == 0.99
+
+
+def test_index_round_trip_via_dataclass(tmp_path: Path) -> None:
+    entry = TraceIndexEntry(
+        trace_id="t",
+        task_id="T",
+        sha256="0" * 64,
+        byte_size=1,
+        started_at=1.0,
+    )
+    assert TraceIndexEntry.from_dict(entry.to_dict()) == entry
+
+
+def test_put_rejects_non_bytes(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path)
+    with pytest.raises(TypeError):
+        store.put("not bytes")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Viewer
+# ---------------------------------------------------------------------------
+
+
+def test_viewer_index_lists_entries(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json())
+    client = TestClient(build_viewer_app(store))
+
+    resp = client.get("/")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Bernstein local trace viewer" in body
+    assert "trace-001" in body
+    assert "T-1" in body
+
+
+def test_viewer_filters_by_task(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json(trace_id="a", task_id="T-1"))
+    store.put(_agent_trace_json(trace_id="b", task_id="T-2"))
+    client = TestClient(build_viewer_app(store))
+
+    resp = client.get("/", params={"task": "T-1"})
+    assert resp.status_code == 200
+    # The filtered view should not list trace b.
+    assert ">b<" not in resp.text
+
+
+def test_viewer_api_returns_index(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json())
+    client = TestClient(build_viewer_app(store))
+
+    resp = client.get("/api/traces")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["traces"]) == 1
+    assert data["traces"][0]["trace_id"] == "trace-001"
+
+
+def test_viewer_returns_pretty_json_body(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json())
+    client = TestClient(build_viewer_app(store))
+
+    resp = client.get("/traces/trace-001")
+    assert resp.status_code == 200
+    parsed = json.loads(resp.text)
+    assert parsed["trace_id"] == "trace-001"
+
+
+def test_viewer_timeline_renders_steps(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json())
+    client = TestClient(build_viewer_app(store))
+
+    resp = client.get("/traces/trace-001/timeline")
+    assert resp.status_code == 200
+    assert "orient" in resp.text
+    assert "edit" in resp.text
+    assert "verify" in resp.text
+
+
+def test_viewer_404_for_unknown_trace(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    client = TestClient(build_viewer_app(store))
+    assert client.get("/traces/missing").status_code == 404
+    assert client.get("/traces/missing/timeline").status_code == 404
+    assert client.get("/api/traces/missing").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def test_cli_registers_subcommands() -> None:
+    """The ``trace`` Click group exposes verify, reindex, serve, show."""
+    sub = {name: cmd for name, cmd in trace_cmd.commands.items()}
+    for required in ("verify", "reindex", "serve", "show"):
+        assert required in sub, f"missing trace subcommand: {required}"
+
+
+def test_cli_verify_passes_and_fails(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json())
+
+    runner = CliRunner()
+    ok = runner.invoke(trace_cmd, ["--traces-dir", str(tmp_path), "verify", "trace-001"])
+    assert ok.exit_code == 0, ok.output
+
+    bad = runner.invoke(trace_cmd, ["--traces-dir", str(tmp_path), "verify", "no-such"])
+    assert bad.exit_code == 1
+
+
+def test_cli_reindex_walks_blobs(tmp_path: Path) -> None:
+    store = ContentAddressedTraceStore(tmp_path, prefer_zstd=False)
+    store.put(_agent_trace_json(trace_id="a"))
+    store.put(_agent_trace_json(trace_id="b", spawn_ts=200.0))
+    store.index_path.unlink()
+
+    runner = CliRunner()
+    result = runner.invoke(trace_cmd, ["--traces-dir", str(tmp_path), "reindex"])
+    assert result.exit_code == 0, result.output
+    assert "2 entries" in result.output
+
+
+def test_cli_legacy_task_id_routes_to_show(tmp_path: Path) -> None:
+    """``bernstein trace <task-id>`` still pretty-prints the task trace."""
+    traces_dir = tmp_path
+    payload = _agent_trace_json()
+    # Write a per-trace JSON file matching the legacy ``trace-<id>.json`` layout
+    # so the show subcommand finds it via its existing glob.
+    (traces_dir / "trace-T-1.json").write_bytes(payload)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        trace_cmd,
+        ["--traces-dir", str(traces_dir), "T-1", "--as-json"],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_serve_defaults_to_loopback() -> None:
+    """``trace serve`` must default to ``127.0.0.1`` (no remote bind)."""
+    serve_cmd = trace_cmd.commands["serve"]
+    bind_param = next(p for p in serve_cmd.params if getattr(p, "name", "") == "bind")
+    assert bind_param.default == "127.0.0.1"
+    port_param = next(p for p in serve_cmd.params if getattr(p, "name", "") == "port")
+    assert port_param.default == 8765

--- a/uv.lock
+++ b/uv.lock
@@ -1693,11 +1693,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add a sha256-keyed local trace archive plus a read-only FastAPI viewer over `.sdd/traces/`. Operators get the paid-trace-platform UI (search, timeline, JSON view) at zero marginal cost.

- New `ContentAddressedTraceStore` (`src/bernstein/core/observability/trace_store.py`) with `put` / `get` / `verify` / `reindex` / `search`.
- On-disk layout `.sdd/traces/blobs/<sha256[:2]>/<sha256>.jsonl.{zst,gz}` plus `index.jsonl`. zstd is used when `zstandard` is importable; stdlib gzip otherwise. The codec is recorded in the filename and the index entry so reads work regardless of which codec wrote.
- `put` is idempotent: same bytes -> same sha -> single blob -> one index entry.
- `verify` reads the blob and rehashes; the index is not trusted.
- `reindex` rebuilds `index.jsonl` from the blob tree (skips corrupt or digest-mismatched blobs).
- `bernstein trace` is promoted from a single command to a Click group with `show`, `serve`, `verify`, `reindex` subcommands. The legacy `bernstein trace <task-id>` shape still works via a `resolve_command` fallback that routes to `show`.
- `bernstein trace serve` binds to `127.0.0.1` by default (`--bind` to override). Viewer is HTML + inline CSS, no JS framework: `GET /`, `GET /traces/<id>`, `GET /traces/<id>/timeline`, `GET /api/traces`, `GET /api/traces/<id>`.
- Docs in `docs/observability/trace-store.md` cover layout, CLI, endpoints, Python API.

Closes the `feat-2026-05-19-local-trace-store-viewer` backlog ticket (moved to `claimed/` locally).

## Test plan

- [x] `uv run pytest tests/unit/observability/test_trace_store.py` - 24 tests pass (store, viewer, CLI).
- [x] `uv run pytest tests/unit/test_cli_decomposition.py tests/unit/test_traces.py tests/unit/test_trace_tools.py tests/unit/observability/` - 83 tests pass.
- [x] `uv run ruff check` clean on touched files; `uv run ruff format --check` clean.
- [x] Pre-push hooks (lint + import-linter) green.
- [ ] Manual smoke: `bernstein trace serve --port 8765` and open `http://127.0.0.1:8765/` after a run.

## Summary by Sourcery

Introduce a content-addressed local trace store with a FastAPI-based viewer and extend the `bernstein trace` CLI to manage and inspect local traces.

New Features:
- Add a sha256-keyed content-addressed trace store with indexing, verification, reindexing, and search capabilities.
- Provide a read-only FastAPI viewer for local traces with HTML and JSON endpoints for listing, viewing, and timeline inspection.
- Extend the `bernstein trace` CLI into a group with `show`, `serve`, `verify`, and `reindex` subcommands while preserving the legacy invocation shape.

Enhancements:
- Document the trace store layout, CLI usage, viewer endpoints, and Python API in a new observability guide.
- Add unit test coverage for the trace store, viewer endpoints, and new CLI subcommands under the observability test suite.