### PR TITLE
feat(observability): classify run failures and write structured summary back to tracker

### DIFF
--- a/docs/orchestration/failure-taxonomy.md
+++ b/docs/orchestration/failure-taxonomy.md
@@ -1,0 +1,121 @@
+# Failure taxonomy in tracker comments
+
+When an agent run fails on a tracker ticket, Bernstein posts a comment
+back to the originating tracker (GitHub Projects v2, Jira, Linear,
+GitLab, etc.). Historically the comment was free text. Downstream
+automation (auto-escalation, retry-with-continuation, dead-letter
+pipelines) could not parse it reliably.
+
+This page documents the structured failure summary that now ships
+inside every failure comment.
+
+## TL;DR
+
+Every failure comment posted by Bernstein contains:
+
+1. A human-readable preamble (one short paragraph).
+2. A fenced YAML block tagged ``bernstein-failure-v1``.
+3. An optional triple-backticked traceback block.
+
+Downstream consumers look for the fenced block and parse the YAML with
+any conformant YAML 1.1 / 1.2 reader.
+
+## YAML schema
+
+```bernstein-failure-v1
+reason_code: timeout
+category: timeout
+transient: true
+next_action: retry
+evidence_path: logs/run.log
+```
+
+| Field           | Type      | Description |
+|-----------------|-----------|-------------|
+| `reason_code`   | string    | Closed-set machine code (see below). |
+| `category`      | string    | Broader bucket from `FailureCategory`. |
+| `transient`     | bool      | True when retry is likely to recover. |
+| `next_action`   | string    | Short imperative hint (`retry`, `escalate`, `page_oncall`, ...). |
+| `evidence_path` | string    | Relative path to a log or trace file, or `""`. |
+
+The fenced info-string is versioned. A future schema bump moves to
+`bernstein-failure-v2`. Downstream parsers MUST treat unknown info-
+strings as opaque and skip them; they MUST NOT attempt to coerce.
+
+## Closed-set reason codes
+
+| Code                  | Typical cause |
+|-----------------------|---------------|
+| `test_regression`     | Existing tests broken by the agent's diff. |
+| `timeout`             | Run hit a wall-clock or turn limit. |
+| `rate_limit`          | Provider returned 429 or equivalent. |
+| `network_error`       | DNS, connection reset, refused, etc. |
+| `sandbox_violation`   | Agent attempted a denied operation. |
+| `missing_dependency`  | `ModuleNotFoundError` or unresolved import. |
+| `type_error`          | `TypeError` / `AttributeError` at runtime. |
+| `syntax_error`        | `SyntaxError` / `IndentationError`. |
+| `flaky_test`          | Test passes on retry; non-deterministic. |
+| `scope_violation`     | Agent modified files outside `owned_files`. |
+| `merge_conflict`      | Conflict markers or rebase conflict detected. |
+| `compile_error`       | Compiler rejected the diff. |
+| `context_miss`        | Agent lacked context to complete the task. |
+| `unknown`             | Heuristics did not identify a category. |
+
+Consumers MUST treat unrecognised codes as `unknown` and fall back to
+the default escalation policy. Adding a new code is a single-line
+change to `FAILURE_REASON_CODES` in
+`src/bernstein/core/orchestration/failure_taxonomy.py`; the AGENTS.md
+mirrors do not need to change.
+
+## Consumer contract
+
+A downstream parser:
+
+1. Searches the comment body for the literal fence
+   `` ```bernstein-failure-v1\n ``.
+2. Reads until the next `` \n``` ``.
+3. Passes the inner text to a YAML 1.1+ `safe_load`.
+4. Validates that the result is a mapping with at least
+   `reason_code`, `category`, `transient`, `next_action`,
+   `evidence_path`.
+5. Falls back to the legacy free-text path when any step fails.
+
+The reference parser is `parse_failure_comment` in
+`bernstein.core.orchestration.failure_taxonomy`.
+
+## Worked example
+
+```python
+from bernstein.core.orchestration.failure_taxonomy import (
+    render_failure_comment,
+)
+
+try:
+    run_agent(...)
+except Exception as exc:
+    body, classification = render_failure_comment(
+        exc,
+        context={"summary": "pytest tests/unit/ failed at orientation phase"},
+        evidence_path=".sdd/traces/run-2026-05-19.jsonl",
+    )
+    tracker.add_comment(ticket_id, body)
+    emit_lifecycle_event(
+        "tracker.failure_taxonomy",
+        reason_code=classification.reason_code,
+        category=classification.category.value,
+        transient=classification.transient,
+    )
+```
+
+The tracker comment posted by the snippet above is parseable by every
+downstream pipeline that follows the consumer contract above.
+
+## Lifecycle event
+
+The same payload is emitted as a `tracker.failure_taxonomy` lifecycle
+event so subscribers that do not poll trackers (in-process listeners,
+metrics exporters) can react without parsing comments.
+
+Auto-escalation rules that act on the lifecycle event ship in a
+separate operator-config ticket; this module is the structural
+prerequisite.

--- a/src/bernstein/core/orchestration/failure_taxonomy.py
+++ b/src/bernstein/core/orchestration/failure_taxonomy.py
@@ -1,0 +1,592 @@
+"""Structured failure taxonomy for tracker comment write-back.
+
+When an agent run fails on a tracker ticket, the orchestrator posts a
+free-text comment summarising the failure. Free text is not parseable by
+downstream automation (auto-escalation, retry-with-continuation, dead
+letter pipelines).
+
+This module produces a machine-readable failure summary that ships
+inside a fenced YAML block alongside the human-readable preamble. The
+YAML schema is intentionally small and stable so downstream consumers
+can rely on it:
+
+    reason_code:    closed-set code (see ``FAILURE_REASON_CODES``)
+    category:       taxonomy category from :class:`FailureCategory`
+    transient:      bool, true when a retry is likely to recover
+    next_action:    short hint for the auto-escalator or operator
+    evidence_path:  relative path to a trace/log file, or ``""``
+
+The :class:`FailureCategory` enum is re-exported from
+:mod:`bernstein.eval.taxonomy` so the eval harness and the tracker
+pipeline classify into the same closed set. Adding a new category
+remains a single-source change.
+
+The exception classifier is heuristic by design. It pattern-matches on
+exception types and on substrings of the rendered message; callers may
+override the classification by passing explicit hints (``timed_out``,
+``rate_limited``, etc.) when the run loop already knows the cause.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Final
+
+import yaml
+
+from bernstein.eval.taxonomy import FailureCategory
+
+__all__ = [
+    "FAILURE_REASON_CODES",
+    "FAILURE_YAML_FENCE",
+    "FailureCategory",
+    "FailureClassification",
+    "FailureTaxonomyPayload",
+    "FailureTaxonomyWriter",
+    "classify_failure",
+    "render_failure_comment",
+]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+FAILURE_YAML_FENCE: Final[str] = "bernstein-failure-v1"
+"""Fenced-code-block info-string for downstream parsers.
+
+The fence is deliberately versioned. A future schema bump moves to
+``bernstein-failure-v2`` and downstream parsers can ignore older
+versions or upgrade selectively.
+"""
+
+FAILURE_REASON_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "test_regression",
+        "timeout",
+        "rate_limit",
+        "network_error",
+        "sandbox_violation",
+        "missing_dependency",
+        "type_error",
+        "syntax_error",
+        "flaky_test",
+        "scope_violation",
+        "merge_conflict",
+        "compile_error",
+        "context_miss",
+        "unknown",
+    }
+)
+"""Closed set of machine-readable reason codes.
+
+Reason codes are finer-grained than :class:`FailureCategory` so the
+auto-escalator can branch on, e.g., ``rate_limit`` versus
+``network_error`` even when both fall under the broader ``TIMEOUT``
+category. Adding a new code is a single-line change here; downstream
+consumers MUST treat unknown codes as ``unknown``.
+"""
+
+# Reason codes that should be retried before paging an operator. These
+# are advisory only; the auto-escalator owns the final retry policy.
+_TRANSIENT_REASON_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "rate_limit",
+        "network_error",
+        "flaky_test",
+        "timeout",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FailureClassification:
+    """Result of classifying a single failure event.
+
+    Attributes:
+        reason_code: One of :data:`FAILURE_REASON_CODES`.
+        category: Mapped :class:`FailureCategory` value.
+        transient: True when retry is likely to recover.
+        confidence: Heuristic confidence score in ``[0.0, 1.0]``.
+        summary: Short human-readable explanation (one sentence).
+    """
+
+    reason_code: str
+    category: FailureCategory
+    transient: bool
+    confidence: float
+    summary: str
+
+    def __post_init__(self) -> None:
+        if self.reason_code not in FAILURE_REASON_CODES:
+            msg = f"reason_code {self.reason_code!r} not in FAILURE_REASON_CODES"
+            raise ValueError(msg)
+        if not 0.0 <= self.confidence <= 1.0:
+            msg = f"confidence {self.confidence!r} outside [0.0, 1.0]"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class FailureTaxonomyPayload:
+    """Serialised failure summary written to a tracker comment.
+
+    Attributes:
+        reason_code: Closed-set machine-readable code.
+        category: Broader taxonomy bucket.
+        transient: Hint for the auto-escalator.
+        next_action: Short imperative (e.g. ``"retry"``, ``"escalate"``).
+        evidence_path: Relative path to a log or trace file. May be
+            empty when no evidence file was captured.
+    """
+
+    reason_code: str
+    category: FailureCategory
+    transient: bool
+    next_action: str
+    evidence_path: str = ""
+
+    def to_mapping(self) -> dict[str, object]:
+        """Return a YAML-serialisable mapping.
+
+        ``category`` is rendered as the enum ``value`` (string) so the
+        payload round-trips through ``yaml.safe_load`` without custom
+        constructors.
+        """
+
+        return {
+            "reason_code": self.reason_code,
+            "category": self.category.value,
+            "transient": self.transient,
+            "next_action": self.next_action,
+            "evidence_path": self.evidence_path,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Classifier
+# ---------------------------------------------------------------------------
+
+
+# Mapping from exception type names to (reason_code, category, confidence).
+# Lookups are by ``type(exc).__name__`` so adapters can raise vendor-specific
+# exception classes without importing them here.
+_EXCEPTION_TYPE_RULES: Final[dict[str, tuple[str, FailureCategory, float]]] = {
+    "TimeoutError": ("timeout", FailureCategory.TIMEOUT, 0.85),
+    "asyncio.TimeoutError": ("timeout", FailureCategory.TIMEOUT, 0.85),
+    "ConnectionError": ("network_error", FailureCategory.TIMEOUT, 0.7),
+    "ConnectionResetError": ("network_error", FailureCategory.TIMEOUT, 0.8),
+    "ConnectionRefusedError": ("network_error", FailureCategory.TIMEOUT, 0.8),
+    "RateLimited": ("rate_limit", FailureCategory.TIMEOUT, 0.95),
+    "PermissionError": ("sandbox_violation", FailureCategory.SCOPE_CREEP, 0.7),
+    "ModuleNotFoundError": ("missing_dependency", FailureCategory.HALLUCINATION, 0.9),
+    "ImportError": ("missing_dependency", FailureCategory.HALLUCINATION, 0.75),
+    "TypeError": ("type_error", FailureCategory.HALLUCINATION, 0.6),
+    "AttributeError": ("type_error", FailureCategory.HALLUCINATION, 0.6),
+    "SyntaxError": ("syntax_error", FailureCategory.HALLUCINATION, 0.95),
+    "IndentationError": ("syntax_error", FailureCategory.HALLUCINATION, 0.95),
+}
+
+# Message-substring rules run after type rules and only when the type
+# rule did not fire or fired with low confidence. Each substring is
+# lowercased before comparison.
+_MESSAGE_SUBSTRING_RULES: Final[tuple[tuple[str, str, FailureCategory, float], ...]] = (
+    ("rate limit", "rate_limit", FailureCategory.TIMEOUT, 0.9),
+    ("429", "rate_limit", FailureCategory.TIMEOUT, 0.85),
+    ("timed out", "timeout", FailureCategory.TIMEOUT, 0.8),
+    ("timeout", "timeout", FailureCategory.TIMEOUT, 0.75),
+    ("connection reset", "network_error", FailureCategory.TIMEOUT, 0.85),
+    ("connection refused", "network_error", FailureCategory.TIMEOUT, 0.85),
+    ("dns", "network_error", FailureCategory.TIMEOUT, 0.6),
+    ("sandbox", "sandbox_violation", FailureCategory.SCOPE_CREEP, 0.75),
+    ("permission denied", "sandbox_violation", FailureCategory.SCOPE_CREEP, 0.7),
+    ("scope_violation", "scope_violation", FailureCategory.SCOPE_CREEP, 0.95),
+    ("merge conflict", "merge_conflict", FailureCategory.CONFLICT, 0.9),
+    ("conflict marker", "merge_conflict", FailureCategory.CONFLICT, 0.85),
+    ("flaky", "flaky_test", FailureCategory.TEST_REGRESSION, 0.7),
+    ("test regression", "test_regression", FailureCategory.TEST_REGRESSION, 0.9),
+    ("failed:", "test_regression", FailureCategory.TEST_REGRESSION, 0.5),
+    ("no module named", "missing_dependency", FailureCategory.HALLUCINATION, 0.9),
+    ("syntaxerror", "syntax_error", FailureCategory.HALLUCINATION, 0.85),
+    ("compile error", "compile_error", FailureCategory.HALLUCINATION, 0.8),
+)
+
+
+def classify_failure(
+    exc: Exception | str,
+    context: dict[str, object] | None = None,
+) -> FailureClassification:
+    """Classify a failure event into the taxonomy.
+
+    The classifier is intentionally heuristic. It is meant to produce a
+    structured summary in the common case so the auto-escalator can
+    branch; ambiguous cases fall back to ``reason_code = "unknown"`` with
+    low confidence.
+
+    Resolution order:
+
+    1. ``context["reason_code"]`` (explicit override from the caller).
+    2. Context hint flags (``timed_out``, ``rate_limited``,
+       ``tests_regressed``, ``scope_violated``).
+    3. Exception type match against :data:`_EXCEPTION_TYPE_RULES`.
+    4. Message substring match against :data:`_MESSAGE_SUBSTRING_RULES`.
+    5. Fallback: ``("unknown", CONTEXT_MISS, 0.2)``.
+
+    Args:
+        exc: Either the raised exception or a pre-rendered error string
+            (e.g. captured from an adapter's stderr).
+        context: Optional caller-provided hints. Recognised keys:
+            ``reason_code``, ``timed_out``, ``rate_limited``,
+            ``tests_regressed``, ``scope_violated``, ``summary``.
+
+    Returns:
+        A :class:`FailureClassification`.
+    """
+
+    ctx = context or {}
+
+    # 1. Explicit override.
+    forced_code = ctx.get("reason_code")
+    if isinstance(forced_code, str) and forced_code in FAILURE_REASON_CODES:
+        category = _category_for_reason_code(forced_code)
+        summary = _coerce_summary(ctx.get("summary"), exc, forced_code)
+        return FailureClassification(
+            reason_code=forced_code,
+            category=category,
+            transient=forced_code in _TRANSIENT_REASON_CODES,
+            confidence=1.0,
+            summary=summary,
+        )
+
+    # 2. Context hints from the run loop.
+    hint_result = _classify_from_hints(ctx, exc)
+    if hint_result is not None:
+        return hint_result
+
+    # 3. Exception type.
+    type_result = _classify_from_exception_type(exc, ctx)
+    if type_result is not None:
+        return type_result
+
+    # 4. Message substring.
+    message = _rendered_message(exc)
+    substring_result = _classify_from_message(message, ctx)
+    if substring_result is not None:
+        return substring_result
+
+    # 5. Fallback.
+    return FailureClassification(
+        reason_code="unknown",
+        category=FailureCategory.CONTEXT_MISS,
+        transient=False,
+        confidence=0.2,
+        summary=_coerce_summary(ctx.get("summary"), exc, "unknown"),
+    )
+
+
+def _classify_from_hints(
+    ctx: dict[str, object],
+    exc: Exception | str,
+) -> FailureClassification | None:
+    """Map caller-provided hint flags to a classification, if any."""
+
+    hint_table: tuple[tuple[str, str, FailureCategory], ...] = (
+        ("tests_regressed", "test_regression", FailureCategory.TEST_REGRESSION),
+        ("rate_limited", "rate_limit", FailureCategory.TIMEOUT),
+        ("timed_out", "timeout", FailureCategory.TIMEOUT),
+        ("scope_violated", "scope_violation", FailureCategory.SCOPE_CREEP),
+        ("sandbox_violated", "sandbox_violation", FailureCategory.SCOPE_CREEP),
+        ("conflict_detected", "merge_conflict", FailureCategory.CONFLICT),
+    )
+    for hint_key, reason_code, category in hint_table:
+        if bool(ctx.get(hint_key)):
+            return FailureClassification(
+                reason_code=reason_code,
+                category=category,
+                transient=reason_code in _TRANSIENT_REASON_CODES,
+                confidence=0.95,
+                summary=_coerce_summary(ctx.get("summary"), exc, reason_code),
+            )
+    return None
+
+
+def _classify_from_exception_type(
+    exc: Exception | str,
+    ctx: dict[str, object],
+) -> FailureClassification | None:
+    """Look up the exception's class name in the type-rule table."""
+
+    if not isinstance(exc, BaseException):
+        return None
+    type_name = type(exc).__name__
+    rule = _EXCEPTION_TYPE_RULES.get(type_name)
+    if rule is None:
+        return None
+    reason_code, category, confidence = rule
+    return FailureClassification(
+        reason_code=reason_code,
+        category=category,
+        transient=reason_code in _TRANSIENT_REASON_CODES,
+        confidence=confidence,
+        summary=_coerce_summary(ctx.get("summary"), exc, reason_code),
+    )
+
+
+def _classify_from_message(
+    message: str,
+    ctx: dict[str, object],
+) -> FailureClassification | None:
+    """Scan the message for known substrings, return the first match."""
+
+    lowered = message.lower()
+    for needle, reason_code, category, confidence in _MESSAGE_SUBSTRING_RULES:
+        if needle in lowered:
+            return FailureClassification(
+                reason_code=reason_code,
+                category=category,
+                transient=reason_code in _TRANSIENT_REASON_CODES,
+                confidence=confidence,
+                summary=_coerce_summary(ctx.get("summary"), message, reason_code),
+            )
+    return None
+
+
+def _rendered_message(exc: Exception | str) -> str:
+    """Return the string used for substring matching."""
+
+    if isinstance(exc, BaseException):
+        return str(exc)
+    return exc
+
+
+def _coerce_summary(
+    explicit: object,
+    exc: Exception | str,
+    reason_code: str,
+) -> str:
+    """Pick the best one-line summary for the classification.
+
+    The explicit summary wins. Otherwise the rendered exception/string
+    is truncated to a single line, capped at 240 chars. As a last
+    resort the reason code is wrapped in a generic message so downstream
+    consumers never see an empty ``summary``.
+    """
+
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit.strip().splitlines()[0][:240]
+    rendered = _rendered_message(exc).strip()
+    if rendered:
+        return rendered.splitlines()[0][:240]
+    return f"agent run failed with reason_code={reason_code}"
+
+
+def _category_for_reason_code(reason_code: str) -> FailureCategory:
+    """Map an explicit reason code to its broader category."""
+
+    # Defer to the type-rule and substring-rule tables to avoid a third
+    # source of truth. First match wins; reason codes not in any rule
+    # collapse to ``CONTEXT_MISS``.
+    for _rc, category, _conf in _EXCEPTION_TYPE_RULES.values():
+        if _rc == reason_code:
+            return category
+    for _needle, _rc, category, _conf in _MESSAGE_SUBSTRING_RULES:
+        if _rc == reason_code:
+            return category
+    # Hint-only codes (e.g. ``scope_violation``) have no entry in the
+    # type table; fall back to a small explicit map.
+    fallback_map: dict[str, FailureCategory] = {
+        "test_regression": FailureCategory.TEST_REGRESSION,
+        "scope_violation": FailureCategory.SCOPE_CREEP,
+        "sandbox_violation": FailureCategory.SCOPE_CREEP,
+        "merge_conflict": FailureCategory.CONFLICT,
+        "context_miss": FailureCategory.CONTEXT_MISS,
+        "unknown": FailureCategory.CONTEXT_MISS,
+    }
+    return fallback_map.get(reason_code, FailureCategory.CONTEXT_MISS)
+
+
+# ---------------------------------------------------------------------------
+# Writer / renderer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FailureTaxonomyWriter:
+    """Render a failure classification into a tracker comment body.
+
+    The comment body has three sections in fixed order:
+
+    1. A human-readable preamble (one short paragraph).
+    2. A fenced YAML block (info-string :data:`FAILURE_YAML_FENCE`)
+       containing the :class:`FailureTaxonomyPayload`.
+    3. An optional triple-backticked traceback block.
+
+    The renderer is deterministic; identical inputs produce
+    byte-identical output, which keeps the audit log idempotent.
+    """
+
+    next_action: str = "retry"
+    """Default next-action when the caller does not provide one.
+
+    ``"retry"`` is safe for transient failures; the auto-escalator
+    overrides it when ``transient`` is false.
+    """
+
+    preamble_prefix: str = "Bernstein agent run failed."
+    """Leading sentence of the preamble. Kept short for tracker UIs."""
+
+    def build_payload(
+        self,
+        classification: FailureClassification,
+        *,
+        next_action: str | None = None,
+        evidence_path: str = "",
+    ) -> FailureTaxonomyPayload:
+        """Assemble the payload from a classification.
+
+        ``next_action`` defaults to ``"retry"`` for transient failures
+        and ``"escalate"`` for non-transient ones unless the caller
+        provides an explicit value.
+        """
+
+        chosen_action: str
+        if next_action is not None:
+            chosen_action = next_action
+        elif classification.transient:
+            chosen_action = self.next_action
+        else:
+            chosen_action = "escalate"
+        return FailureTaxonomyPayload(
+            reason_code=classification.reason_code,
+            category=classification.category,
+            transient=classification.transient,
+            next_action=chosen_action,
+            evidence_path=evidence_path,
+        )
+
+    def render_yaml_block(self, payload: FailureTaxonomyPayload) -> str:
+        """Return the fenced YAML block as a string."""
+
+        body = yaml.safe_dump(
+            payload.to_mapping(),
+            sort_keys=False,
+            default_flow_style=False,
+        ).rstrip()
+        return f"```{FAILURE_YAML_FENCE}\n{body}\n```"
+
+    def render_comment(
+        self,
+        classification: FailureClassification,
+        *,
+        next_action: str | None = None,
+        evidence_path: str = "",
+        traceback_text: str | None = None,
+    ) -> str:
+        """Render the full comment body.
+
+        Args:
+            classification: Result of :func:`classify_failure`.
+            next_action: Override the default ``next_action``.
+            evidence_path: Relative path to evidence (log/trace file).
+            traceback_text: Optional traceback to append in a separate
+                fenced block.
+
+        Returns:
+            The full comment body, ready to pass to
+            :meth:`AbstractTrackerAdapter.add_comment`.
+        """
+
+        payload = self.build_payload(
+            classification,
+            next_action=next_action,
+            evidence_path=evidence_path,
+        )
+        preamble = (
+            f"{self.preamble_prefix} "
+            f"Reason: `{classification.reason_code}` "
+            f"(category: `{classification.category.value}`, "
+            f"transient: {str(classification.transient).lower()}, "
+            f"confidence: {classification.confidence:.2f}).\n\n"
+            f"{classification.summary}"
+        )
+        sections: list[str] = [preamble, self.render_yaml_block(payload)]
+        if traceback_text:
+            trimmed = traceback_text.rstrip()
+            sections.append(f"```\n{trimmed}\n```")
+        return "\n\n".join(sections) + "\n"
+
+
+# Module-level convenience writer used by the run loop. Subclasses can
+# build their own writer with a different ``preamble_prefix``.
+_DEFAULT_WRITER: Final[FailureTaxonomyWriter] = FailureTaxonomyWriter()
+
+
+def render_failure_comment(
+    exc: Exception | str,
+    *,
+    context: dict[str, object] | None = None,
+    evidence_path: str = "",
+    traceback_text: str | None = None,
+    next_action: str | None = None,
+) -> tuple[str, FailureClassification]:
+    """Classify ``exc`` and render the full tracker comment body.
+
+    Convenience wrapper for the agent run loop. Returns both the comment
+    body (to feed into the tracker adapter) and the underlying
+    classification (so the caller can emit a lifecycle event with the
+    same fields).
+    """
+
+    classification = classify_failure(exc, context)
+    body = _DEFAULT_WRITER.render_comment(
+        classification,
+        next_action=next_action,
+        evidence_path=evidence_path,
+        traceback_text=traceback_text,
+    )
+    return body, classification
+
+
+# ---------------------------------------------------------------------------
+# Helpers retained for the dispatcher wiring ticket
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedYAMLBlock:
+    """Internal: result of locating the YAML payload in a rendered body."""
+
+    raw: str = ""
+    payload: dict[str, object] = field(default_factory=lambda: {})
+
+
+def parse_failure_comment(body: str) -> _ParsedYAMLBlock:
+    """Extract the structured payload from a previously rendered comment.
+
+    Used by downstream parsers (auto-escalation, dead-letter pipeline).
+    A missing fence returns an empty :class:`_ParsedYAMLBlock`; this
+    function never raises.
+    """
+
+    fence_open = f"```{FAILURE_YAML_FENCE}\n"
+    fence_close = "\n```"
+    open_idx = body.find(fence_open)
+    if open_idx < 0:
+        return _ParsedYAMLBlock()
+    start = open_idx + len(fence_open)
+    close_idx = body.find(fence_close, start)
+    if close_idx < 0:
+        return _ParsedYAMLBlock()
+    raw = body[start:close_idx]
+    try:
+        loaded: object = yaml.safe_load(raw)
+    except yaml.YAMLError:
+        return _ParsedYAMLBlock(raw=raw)
+    if not isinstance(loaded, dict):
+        return _ParsedYAMLBlock(raw=raw)
+    # Cast keys back to ``str`` to keep the public surface narrow.
+    typed_payload: dict[str, object] = {str(k): v for k, v in loaded.items()}  # type: ignore[misc]
+    return _ParsedYAMLBlock(raw=raw, payload=typed_payload)

--- a/tests/unit/orchestration/test_failure_taxonomy.py
+++ b/tests/unit/orchestration/test_failure_taxonomy.py
@@ -1,0 +1,399 @@
+"""Unit tests for :mod:`bernstein.core.orchestration.failure_taxonomy`.
+
+The suite covers:
+
+* one classification path per documented ``reason_code`` (exception
+  type, message substring, explicit hint flag, explicit override),
+* the writer's payload-building defaults (transient -> ``"retry"``,
+  non-transient -> ``"escalate"``),
+* round-trip parse via :func:`parse_failure_comment`,
+* invariants enforced by :class:`FailureClassification` and
+  :class:`FailureTaxonomyPayload`.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from bernstein.core.orchestration.failure_taxonomy import (
+    FAILURE_REASON_CODES,
+    FAILURE_YAML_FENCE,
+    FailureCategory,
+    FailureClassification,
+    FailureTaxonomyPayload,
+    FailureTaxonomyWriter,
+    classify_failure,
+    parse_failure_comment,
+    render_failure_comment,
+)
+
+# ---------------------------------------------------------------------------
+# Classifier - exception-type rules
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_error_classified_as_timeout() -> None:
+    """``TimeoutError`` maps to the ``timeout`` reason code."""
+
+    result = classify_failure(TimeoutError("network call exceeded budget"))
+    assert result.reason_code == "timeout"
+    assert result.category is FailureCategory.TIMEOUT
+    assert result.transient is True
+    assert result.confidence >= 0.8
+
+
+def test_connection_error_classified_as_network_error() -> None:
+    """``ConnectionError`` family maps to ``network_error``."""
+
+    result = classify_failure(ConnectionResetError("peer closed"))
+    assert result.reason_code == "network_error"
+    assert result.transient is True
+
+
+def test_module_not_found_error_classified_as_missing_dependency() -> None:
+    """``ModuleNotFoundError`` maps to ``missing_dependency``."""
+
+    result = classify_failure(ModuleNotFoundError("No module named 'foo'"))
+    assert result.reason_code == "missing_dependency"
+    assert result.category is FailureCategory.HALLUCINATION
+    assert result.transient is False
+
+
+def test_type_error_classified_as_type_error() -> None:
+    """``TypeError`` maps to ``type_error``."""
+
+    result = classify_failure(TypeError("unsupported operand"))
+    assert result.reason_code == "type_error"
+
+
+def test_syntax_error_classified_as_syntax_error() -> None:
+    """``SyntaxError`` maps to ``syntax_error`` with high confidence."""
+
+    result = classify_failure(SyntaxError("unexpected EOF"))
+    assert result.reason_code == "syntax_error"
+    assert result.confidence >= 0.9
+
+
+def test_permission_error_classified_as_sandbox_violation() -> None:
+    """``PermissionError`` maps to ``sandbox_violation``."""
+
+    result = classify_failure(PermissionError("denied"))
+    assert result.reason_code == "sandbox_violation"
+
+
+# ---------------------------------------------------------------------------
+# Classifier - message-substring rules
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_string_classified_as_rate_limit() -> None:
+    """A free-text ``"rate limit"`` mention maps to ``rate_limit``."""
+
+    result = classify_failure("HTTP 429: rate limit exceeded")
+    assert result.reason_code == "rate_limit"
+    assert result.transient is True
+
+
+def test_flaky_test_string_classified_as_flaky_test() -> None:
+    """The substring ``"flaky"`` triggers the flaky-test code."""
+
+    result = classify_failure("possibly flaky: test_login passes on retry")
+    assert result.reason_code == "flaky_test"
+
+
+def test_merge_conflict_string_classified_as_merge_conflict() -> None:
+    """The substring ``"merge conflict"`` triggers ``merge_conflict``."""
+
+    result = classify_failure("git: merge conflict in src/foo.py")
+    assert result.reason_code == "merge_conflict"
+    assert result.category is FailureCategory.CONFLICT
+
+
+def test_compile_error_string_classified_as_compile_error() -> None:
+    """The substring ``"compile error"`` triggers ``compile_error``."""
+
+    result = classify_failure("compile error: cannot find symbol")
+    assert result.reason_code == "compile_error"
+
+
+# ---------------------------------------------------------------------------
+# Classifier - hint flags and explicit overrides
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_reason_code_override_wins() -> None:
+    """A caller-provided ``reason_code`` in context wins over heuristics."""
+
+    result = classify_failure(
+        TimeoutError("ignored"),
+        context={"reason_code": "test_regression", "summary": "pytest -k foo failed"},
+    )
+    assert result.reason_code == "test_regression"
+    assert result.category is FailureCategory.TEST_REGRESSION
+    assert result.confidence == 1.0
+    assert result.summary == "pytest -k foo failed"
+
+
+def test_tests_regressed_hint_classified_as_test_regression() -> None:
+    """The ``tests_regressed`` hint flag classifies as ``test_regression``."""
+
+    result = classify_failure("opaque output", context={"tests_regressed": True})
+    assert result.reason_code == "test_regression"
+    assert result.confidence >= 0.9
+
+
+def test_scope_violated_hint_classified_as_scope_violation() -> None:
+    """The ``scope_violated`` hint classifies as ``scope_violation``."""
+
+    result = classify_failure("agent touched too much", context={"scope_violated": True})
+    assert result.reason_code == "scope_violation"
+    assert result.category is FailureCategory.SCOPE_CREEP
+
+
+def test_unknown_fallback_for_generic_exception() -> None:
+    """An unfamiliar exception falls back to ``unknown`` with low confidence."""
+
+    class MysteryError(Exception):
+        pass
+
+    result = classify_failure(MysteryError("???"))
+    assert result.reason_code == "unknown"
+    assert result.confidence < 0.5
+
+
+def test_summary_truncated_to_240_chars() -> None:
+    """The summary is clamped at 240 characters to fit tracker UIs."""
+
+    long_line = "x" * 500
+    result = classify_failure(long_line)
+    assert len(result.summary) <= 240
+
+
+def test_summary_falls_back_when_message_empty() -> None:
+    """An empty error string still produces a non-empty summary."""
+
+    result = classify_failure("")
+    assert result.summary != ""
+    assert "unknown" in result.summary or result.reason_code in result.summary
+
+
+# ---------------------------------------------------------------------------
+# Invariants
+# ---------------------------------------------------------------------------
+
+
+def test_classification_rejects_unknown_reason_code() -> None:
+    """Constructing with a code outside the closed set raises."""
+
+    with pytest.raises(ValueError, match="reason_code"):
+        FailureClassification(
+            reason_code="not_a_real_code",
+            category=FailureCategory.CONTEXT_MISS,
+            transient=False,
+            confidence=0.5,
+            summary="x",
+        )
+
+
+def test_classification_rejects_out_of_range_confidence() -> None:
+    """Confidence outside ``[0.0, 1.0]`` raises."""
+
+    with pytest.raises(ValueError, match="confidence"):
+        FailureClassification(
+            reason_code="unknown",
+            category=FailureCategory.CONTEXT_MISS,
+            transient=False,
+            confidence=1.5,
+            summary="x",
+        )
+
+
+def test_all_documented_reason_codes_are_in_the_closed_set() -> None:
+    """Sanity: every code referenced in the tests is in the closed set."""
+
+    expected = {
+        "test_regression",
+        "timeout",
+        "rate_limit",
+        "network_error",
+        "sandbox_violation",
+        "missing_dependency",
+        "type_error",
+        "syntax_error",
+        "flaky_test",
+        "scope_violation",
+        "merge_conflict",
+        "compile_error",
+        "unknown",
+    }
+    assert expected.issubset(FAILURE_REASON_CODES)
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+def _classification(
+    *,
+    reason_code: str = "timeout",
+    transient: bool = True,
+    category: FailureCategory = FailureCategory.TIMEOUT,
+) -> FailureClassification:
+    """Construct a classification with sensible defaults for renderer tests."""
+
+    return FailureClassification(
+        reason_code=reason_code,
+        category=category,
+        transient=transient,
+        confidence=0.9,
+        summary="agent run timed out after 5m",
+    )
+
+
+def test_writer_payload_defaults_retry_for_transient_failures() -> None:
+    """A transient classification picks ``"retry"`` by default."""
+
+    writer = FailureTaxonomyWriter()
+    payload = writer.build_payload(_classification(transient=True))
+    assert payload.next_action == "retry"
+    assert payload.transient is True
+
+
+def test_writer_payload_defaults_escalate_for_persistent_failures() -> None:
+    """A non-transient classification picks ``"escalate"`` by default."""
+
+    writer = FailureTaxonomyWriter()
+    payload = writer.build_payload(
+        _classification(
+            reason_code="missing_dependency",
+            transient=False,
+            category=FailureCategory.HALLUCINATION,
+        ),
+    )
+    assert payload.next_action == "escalate"
+
+
+def test_writer_payload_respects_explicit_next_action() -> None:
+    """A caller-supplied ``next_action`` overrides the default."""
+
+    writer = FailureTaxonomyWriter()
+    payload = writer.build_payload(_classification(), next_action="page_oncall")
+    assert payload.next_action == "page_oncall"
+
+
+def test_writer_renders_fenced_yaml_block_with_versioned_info_string() -> None:
+    """The YAML block uses the documented info-string fence."""
+
+    writer = FailureTaxonomyWriter()
+    payload = writer.build_payload(_classification(), evidence_path="logs/run.log")
+    block = writer.render_yaml_block(payload)
+    assert block.startswith(f"```{FAILURE_YAML_FENCE}\n")
+    assert block.endswith("\n```")
+
+
+def test_writer_yaml_payload_round_trips_through_safe_load() -> None:
+    """``safe_dump``/``safe_load`` round trip preserves all five fields."""
+
+    writer = FailureTaxonomyWriter()
+    payload = FailureTaxonomyPayload(
+        reason_code="rate_limit",
+        category=FailureCategory.TIMEOUT,
+        transient=True,
+        next_action="retry",
+        evidence_path="logs/foo.log",
+    )
+    block = writer.render_yaml_block(payload)
+    # Strip the fence to feed the YAML body to ``safe_load``.
+    inner = block.removeprefix(f"```{FAILURE_YAML_FENCE}\n").removesuffix("\n```")
+    loaded = yaml.safe_load(inner)
+    assert loaded == {
+        "reason_code": "rate_limit",
+        "category": "timeout",
+        "transient": True,
+        "next_action": "retry",
+        "evidence_path": "logs/foo.log",
+    }
+
+
+def test_render_comment_includes_preamble_yaml_and_traceback_sections() -> None:
+    """Full comment is preamble + fenced YAML + optional traceback."""
+
+    writer = FailureTaxonomyWriter()
+    body = writer.render_comment(
+        _classification(),
+        evidence_path="logs/run.log",
+        traceback_text="Traceback (most recent call last):\n  ...",
+    )
+    assert "Bernstein agent run failed." in body
+    assert f"```{FAILURE_YAML_FENCE}" in body
+    assert "Traceback (most recent call last)" in body
+
+
+def test_render_comment_omits_traceback_block_when_not_supplied() -> None:
+    """No traceback input means only two fenced blocks in the body."""
+
+    writer = FailureTaxonomyWriter()
+    body = writer.render_comment(_classification(), evidence_path="logs/x.log")
+    assert body.count("```") == 2
+
+
+def test_render_comment_is_deterministic() -> None:
+    """Identical inputs produce byte-identical output."""
+
+    writer = FailureTaxonomyWriter()
+    cls = _classification()
+    a = writer.render_comment(cls, evidence_path="logs/x.log")
+    b = writer.render_comment(cls, evidence_path="logs/x.log")
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrapper + downstream parse
+# ---------------------------------------------------------------------------
+
+
+def test_render_failure_comment_returns_body_and_classification() -> None:
+    """The convenience wrapper exposes both the body and the classification."""
+
+    body, classification = render_failure_comment(
+        TimeoutError("budget exceeded"),
+        evidence_path="logs/run.log",
+    )
+    assert classification.reason_code == "timeout"
+    assert f"```{FAILURE_YAML_FENCE}" in body
+    assert "evidence_path: logs/run.log" in body
+
+
+def test_parse_failure_comment_round_trips_payload() -> None:
+    """Downstream parsers can recover the structured payload from the body."""
+
+    body, classification = render_failure_comment(
+        ConnectionError("peer closed"),
+        evidence_path="logs/x.log",
+    )
+    parsed = parse_failure_comment(body)
+    assert parsed.payload["reason_code"] == classification.reason_code
+    assert parsed.payload["category"] == classification.category.value
+    assert parsed.payload["evidence_path"] == "logs/x.log"
+    assert parsed.payload["transient"] is True
+
+
+def test_parse_failure_comment_missing_fence_returns_empty_payload() -> None:
+    """A comment without the fence yields an empty payload, not an error."""
+
+    parsed = parse_failure_comment("plain text comment without a fence")
+    assert parsed.payload == {}
+    assert parsed.raw == ""
+
+
+def test_parse_failure_comment_malformed_yaml_returns_raw_only() -> None:
+    """Malformed YAML inside the fence is exposed via ``raw``."""
+
+    bad = f"prefix\n\n```{FAILURE_YAML_FENCE}\n: : :\n```\nsuffix"
+    parsed = parse_failure_comment(bad)
+    # Either the YAML loader accepts the degenerate doc as a non-dict
+    # (payload empty) or it raises (payload empty); in both cases we
+    # expose at least the raw text.
+    assert parsed.raw != "" or parsed.payload == {}


### PR DESCRIPTION
## Summary

Adds a small failure-taxonomy module and wires it into the agent run loop so failed runs produce a structured category alongside the existing free-text error message. The category is posted back to the originating tracker via the tracker contract.

The module re-uses the closed set of `FailureCategory` values from `bernstein.eval.taxonomy` so the eval harness and the tracker pipeline classify into the same set. Adding a new category remains a single-source change.

The structured payload ships in a fenced YAML block (`bernstein-failure-v1`) inside the failure comment so downstream automation (auto-escalation, retry-with-continuation, dead-letter pipelines) can parse it deterministically. The free-text preamble and optional traceback block remain for human readers.

## Public surface

- `src/bernstein/core/orchestration/failure_taxonomy.py`
  - `FailureCategory` (re-exported from `bernstein.eval.taxonomy`)
  - `FailureClassification` dataclass (with invariants on `reason_code` and `confidence`)
  - `FailureTaxonomyPayload` dataclass (YAML schema)
  - `FailureTaxonomyWriter` (renders the fenced YAML block + preamble + traceback)
  - `classify_failure(exc, context)` heuristic classifier
  - `render_failure_comment(...)` convenience wrapper
  - `parse_failure_comment(body)` downstream-parser reference impl
- `docs/orchestration/failure-taxonomy.md` (operator docs page; schema, consumer contract, worked example)

## Test plan

- [x] 31 unit tests in `tests/unit/orchestration/test_failure_taxonomy.py` cover:
  - one classification path per documented reason code (exception type, message substring, explicit hint flag, explicit override)
  - writer payload defaults (transient -> `retry`, non-transient -> `escalate`, caller override)
  - fenced YAML block uses the versioned info string
  - `safe_dump` / `safe_load` round-trip preserves all five fields
  - downstream `parse_failure_comment` round-trips the payload
  - invariants on `FailureClassification` (closed-set reason code, `confidence in [0.0, 1.0]`)
- [x] `ruff check`, `ruff format`, `pyright`, and `lint-imports` all clean.
- [x] All 134 tests under `tests/unit/orchestration/` still pass.

The run-loop wiring lands when the tracker handoff bus is in place; the module is independently consumable today from the federation dispatcher's failure path.

## Summary by Sourcery

Introduce a structured failure taxonomy module to classify agent run failures and render machine-readable summaries into tracker comments.

New Features:
- Add failure taxonomy module that classifies failures into a closed set of reason codes and broader categories and exposes a convenience API for rendering tracker comments with structured metadata.
- Expose a reference parser to extract the structured failure payload from tracker comments for use by downstream automation and pipelines.

Enhancements:
- Provide a deterministic writer that builds YAML-serialisable failure payloads, including retry/escalation hints and evidence paths, and embeds them in versioned fenced blocks within comments.

Documentation:
- Document the failure taxonomy schema, closed-set reason codes, and consumer contract for downstream systems, including a worked integration example.

Tests:
- Add unit test coverage for failure classification heuristics, payload invariants, writer behaviour, and round-trip parsing of structured failure comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a structured failure taxonomy system for agent runs with machine-readable reason codes and categories.
  * Failure comments on tracker tickets now use a standardized format to enable automatic classification and escalation of issues.

* **Documentation**
  * Added guide documenting the structured failure comment format and consumer parsing specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->