### PR TITLE
feat(trackers): GitLab Issues adapter conforming to TrackerContract

### DIFF
--- a/src/bernstein/core/trackers/builtin/__init__.py
+++ b/src/bernstein/core/trackers/builtin/__init__.py
@@ -14,6 +14,10 @@ from bernstein.core.trackers.builtin.github_projects_adapter import (
     GitHubProjectsV2Adapter,
     GitHubProjectsV2Config,
 )
+from bernstein.core.trackers.builtin.gitlab_adapter import (
+    GitLabConfig,
+    GitLabTracker,
+)
 from bernstein.core.trackers.builtin.jira_dc_adapter import (
     JiraDataCenterAdapter,
     JiraDataCenterConfig,
@@ -30,6 +34,8 @@ __all__ = [
     "ClickUpConfig",
     "GitHubProjectsV2Adapter",
     "GitHubProjectsV2Config",
+    "GitLabConfig",
+    "GitLabTracker",
     "JiraDataCenterAdapter",
     "JiraDataCenterConfig",
     "PlaneAdapter",

--- a/src/bernstein/core/trackers/builtin/__init__.py
+++ b/src/bernstein/core/trackers/builtin/__init__.py
@@ -15,8 +15,8 @@ from bernstein.core.trackers.builtin.github_projects_adapter import (
     GitHubProjectsV2Config,
 )
 from bernstein.core.trackers.builtin.gitlab_adapter import (
+    GitLabAdapter,
     GitLabConfig,
-    GitLabTracker,
 )
 from bernstein.core.trackers.builtin.jira_dc_adapter import (
     JiraDataCenterAdapter,
@@ -34,8 +34,8 @@ __all__ = [
     "ClickUpConfig",
     "GitHubProjectsV2Adapter",
     "GitHubProjectsV2Config",
+    "GitLabAdapter",
     "GitLabConfig",
-    "GitLabTracker",
     "JiraDataCenterAdapter",
     "JiraDataCenterConfig",
     "PlaneAdapter",

--- a/src/bernstein/core/trackers/builtin/gitlab_adapter.py
+++ b/src/bernstein/core/trackers/builtin/gitlab_adapter.py
@@ -146,7 +146,7 @@ def _resolve_base_url(config: GitLabConfig) -> str:
 
 def _project_segment(config: GitLabConfig) -> str:
     """Return the URL-encoded project identifier for use in API paths."""
-    raw = str(config.project_id_or_path)
+    raw = config.project_id_or_path
     if raw.isdigit():
         return raw
     return quote(raw, safe="")
@@ -166,7 +166,7 @@ class _TokenBucket:
     """
 
     def __init__(self, min_interval: float) -> None:
-        self._min_interval = max(0.0, float(min_interval))
+        self._min_interval = max(0.0, min_interval)
         self._next_allowed = 0.0
         self._lock = threading.Lock()
 
@@ -187,7 +187,7 @@ class _TokenBucket:
 # ---------------------------------------------------------------------------
 
 
-class GitLabTracker(AbstractTrackerAdapter):
+class GitLabAdapter(AbstractTrackerAdapter):
     """GitLab Issues adapter.
 
     The adapter is intentionally thin: every call is a single REST
@@ -212,7 +212,7 @@ class GitLabTracker(AbstractTrackerAdapter):
         token_provider: Any | None = None,
     ) -> None:
         if httpx is None:  # pragma: no cover - dep is declared in pyproject
-            msg = "httpx is required for GitLabTracker"
+            msg = "httpx is required for GitLabAdapter"
             raise RuntimeError(msg)
         self._config = config
         self._client: Any = http_client or httpx.Client(timeout=30.0)
@@ -232,7 +232,7 @@ class GitLabTracker(AbstractTrackerAdapter):
             except Exception:  # pragma: no cover - best effort
                 logger.debug("ignoring error while closing httpx client", exc_info=True)
 
-    def __enter__(self) -> GitLabTracker:
+    def __enter__(self) -> GitLabAdapter:
         return self
 
     def __exit__(self, *exc: object) -> None:
@@ -438,7 +438,14 @@ class GitLabTracker(AbstractTrackerAdapter):
             raise TrackerUnavailable(msg) from exc
 
         status_code = getattr(response, "status_code", 0)
-        if status_code in {429, 403}:
+        if status_code == 429:
+            retry_after = _parse_retry_after(response)
+            msg = f"GitLab rate-limited (status={status_code})"
+            raise RateLimited(msg, retry_after=retry_after)
+        if status_code == 403 and _looks_like_rate_limit(response):
+            # GitLab occasionally signals rate limiting via HTTP 403 with
+            # ``RateLimit-*`` / ``Retry-After`` headers. Treat those as
+            # transient rate limits; plain 403s remain permission errors.
             retry_after = _parse_retry_after(response)
             msg = f"GitLab rate-limited (status={status_code})"
             raise RateLimited(msg, retry_after=retry_after)
@@ -462,6 +469,22 @@ class GitLabTracker(AbstractTrackerAdapter):
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _looks_like_rate_limit(response: Any) -> bool:
+    """Return True if a 403 response carries GitLab rate-limit signals.
+
+    Standard 403 (Forbidden) is an auth or permission failure; the
+    operator should not auto-retry. GitLab does, however, occasionally
+    return 403 specifically for rate limiting and surfaces it via
+    ``Retry-After`` or ``RateLimit-*`` headers. Only those count.
+    """
+    headers = getattr(response, "headers", {}) or {}
+    if not hasattr(headers, "get"):
+        return False
+    if headers.get("Retry-After"):
+        return True
+    return any(headers.get(key) is not None for key in ("RateLimit-Reset", "RateLimit-Remaining", "RateLimit-Limit"))
 
 
 def _parse_retry_after(response: Any) -> float | None:

--- a/src/bernstein/core/trackers/builtin/gitlab_adapter.py
+++ b/src/bernstein/core/trackers/builtin/gitlab_adapter.py
@@ -1,0 +1,490 @@
+"""GitLab Issues tracker adapter.
+
+Implements the ``AbstractTrackerAdapter`` contract on top of the public
+GitLab REST API. Follows the same pattern as the GitHub Projects v2
+adapter (see ``github_projects_adapter.py``).
+
+Auth:
+- Personal Access Token via the ``GITLAB_TOKEN`` env var by default; a
+  custom env var name can be set on the config.
+
+Instance:
+- ``GITLAB_URL`` env var overrides the default ``https://gitlab.com``
+  base URL for self-hosted instances.
+
+Capabilities:
+- ``pull_open_tickets``: paginate the project's open issues, optionally
+  filtered by labels and assignee, and emit normalised ``Ticket`` objects.
+- ``add_comment``: post a note on an issue.
+- ``transition``: encode workflow state as labels. Atomically swaps an
+  old status label for a new one via ``add_labels`` and ``remove_labels``
+  on a single ``PUT /projects/:id/issues/:iid`` call.
+
+Rate-limit handling:
+- Token-bucket per-instance (cooperative, advisory).
+- ``RateLimited`` raised with ``retry_after`` derived from the
+  ``Retry-After`` or ``RateLimit-Reset`` headers.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:  # pragma: no cover - optional dep already present in project deps
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    RateLimited,
+    RoutingHint,
+    Ticket,
+    TrackerUnavailable,
+    TransitionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GITLAB_URL = "https://gitlab.com"
+DEFAULT_PAGE_SIZE = 50
+GITLAB_API_PATH = "/api/v4"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GitLabConfig:
+    """Configuration for a GitLab Issues adapter instance.
+
+    Attributes:
+        project_id_or_path: Numeric project id or URL-path (e.g.
+            ``my-group/my-project``). Both forms work; the adapter
+            URL-encodes path-style ids.
+        instance_url: Base URL of the GitLab instance. Defaults to the
+            value of the ``GITLAB_URL`` environment variable, or
+            ``https://gitlab.com`` when that env var is unset.
+        token_env: Environment variable name holding a Personal Access
+            Token. Defaults to ``GITLAB_TOKEN``.
+        label_filter_pull: Optional list of labels the adapter requires
+            when listing open issues. Acts as an AND-filter.
+        assignee_filter_pull: Optional assignee username filter applied
+            when listing open issues.
+        state_label_map: Mapping from canonical status names to GitLab
+            labels (e.g. ``{"claim": "state:claimed", "ready":
+            "state:ready", "failed": "state:failed"}``). The adapter
+            assumes all label values share a common prefix so it can
+            strip the previous state-label cleanly on ``transition``.
+        cli_choice_label_prefix: Optional prefix that identifies a CLI
+            choice label (e.g. ``cli:``). The first matching label on a
+            pulled issue is surfaced via ``routing_hint.cli``.
+        page_size: REST per-page size when listing.
+        rate_limit_min_interval: Minimum seconds between API calls per
+            adapter instance (cheap client-side throttle).
+    """
+
+    project_id_or_path: str
+    instance_url: str | None = None
+    token_env: str = "GITLAB_TOKEN"
+    label_filter_pull: tuple[str, ...] = ()
+    assignee_filter_pull: str | None = None
+    state_label_map: dict[str, str] = field(default_factory=dict)
+    cli_choice_label_prefix: str | None = None
+    page_size: int = DEFAULT_PAGE_SIZE
+    rate_limit_min_interval: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Token / URL resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token(config: GitLabConfig) -> str:
+    """Resolve the auth token for a REST call.
+
+    Reads ``config.token_env`` from the environment (default
+    ``GITLAB_TOKEN``).
+
+    Raises:
+        TrackerUnavailable: if the env var is unset or empty.
+    """
+    env_var = config.token_env or "GITLAB_TOKEN"
+    token = os.environ.get(env_var, "")
+    if not token:
+        msg = (
+            f"GitLab adapter: no token available (env var '{env_var}' is empty); "
+            "set a personal access token to authenticate."
+        )
+        raise TrackerUnavailable(msg)
+    return token
+
+
+def _resolve_base_url(config: GitLabConfig) -> str:
+    """Resolve the GitLab instance base URL.
+
+    Precedence:
+        1. ``config.instance_url`` when set.
+        2. ``GITLAB_URL`` environment variable.
+        3. ``https://gitlab.com``.
+    """
+    base = config.instance_url or os.environ.get("GITLAB_URL") or DEFAULT_GITLAB_URL
+    return base.rstrip("/")
+
+
+def _project_segment(config: GitLabConfig) -> str:
+    """Return the URL-encoded project identifier for use in API paths."""
+    raw = str(config.project_id_or_path)
+    if raw.isdigit():
+        return raw
+    return quote(raw, safe="")
+
+
+# ---------------------------------------------------------------------------
+# Token bucket
+# ---------------------------------------------------------------------------
+
+
+class _TokenBucket:
+    """Minimal cooperative token-bucket throttle.
+
+    Identical contract to the GitHub adapter's bucket. ``min_interval ==
+    0`` disables the throttle. Server-side limits and ``Retry-After``
+    headers remain the hard enforcement boundary.
+    """
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = max(0.0, float(min_interval))
+        self._next_allowed = 0.0
+        self._lock = threading.Lock()
+
+    def acquire(self, *, now: float | None = None, sleep: Any = time.sleep) -> None:
+        if self._min_interval <= 0.0:
+            return
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            wait = self._next_allowed - now
+            if wait > 0:
+                sleep(wait)
+                now = now + wait
+            self._next_allowed = now + self._min_interval
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class GitLabTracker(AbstractTrackerAdapter):
+    """GitLab Issues adapter.
+
+    The adapter is intentionally thin: every call is a single REST
+    round-trip. State is encoded as labels because GitLab Issues lack a
+    real workflow status field.
+
+    Parameters:
+        config: Adapter configuration.
+        http_client: Optional pre-built ``httpx.Client`` (tests pass a
+            mocked transport via ``respx``).
+        token_provider: Optional callable returning the auth token. The
+            default reads from ``_resolve_token(config)`` on each call.
+    """
+
+    name = "gitlab"
+
+    def __init__(
+        self,
+        config: GitLabConfig,
+        *,
+        http_client: Any | None = None,
+        token_provider: Any | None = None,
+    ) -> None:
+        if httpx is None:  # pragma: no cover - dep is declared in pyproject
+            msg = "httpx is required for GitLabTracker"
+            raise RuntimeError(msg)
+        self._config = config
+        self._client: Any = http_client or httpx.Client(timeout=30.0)
+        self._owns_client = http_client is None
+        self._token_provider = token_provider or (lambda: _resolve_token(config))
+        self._base_url = _resolve_base_url(config)
+        self._project_segment = _project_segment(config)
+        self._bucket = _TokenBucket(config.rate_limit_min_interval)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying HTTP client if we own it."""
+        if self._owns_client:
+            try:
+                self._client.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("ignoring error while closing httpx client", exc_info=True)
+
+    def __enter__(self) -> GitLabTracker:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- public API ---------------------------------------------------------
+
+    def pull_open_tickets(
+        self,
+        filter: dict[str, Any] | None = None,
+    ) -> Iterator[Ticket]:
+        """Yield open issues for the configured project as ``Ticket`` objects.
+
+        ``filter`` keys:
+            - ``labels``: iterable of label names; ANDed with the config
+              filter and with the GitLab server.
+            - ``assignee``: assignee username; overrides
+              ``config.assignee_filter_pull`` for this call.
+        """
+        filter_dict = filter or {}
+        labels: list[str] = list(self._config.label_filter_pull)
+        extra_labels = filter_dict.get("labels")
+        if extra_labels:
+            labels.extend(str(lab) for lab in extra_labels)
+        assignee = filter_dict.get("assignee", self._config.assignee_filter_pull)
+
+        per_page = max(1, min(100, self._config.page_size))
+        page = 1
+        while True:
+            params: dict[str, Any] = {
+                "state": "opened",
+                "per_page": per_page,
+                "page": page,
+            }
+            if labels:
+                params["labels"] = ",".join(labels)
+            if assignee:
+                params["assignee_username"] = assignee
+
+            data = self._request(
+                "GET",
+                f"/projects/{self._project_segment}/issues",
+                params=params,
+            )
+            if not isinstance(data, list):
+                return
+            for raw in data:
+                ticket = self._issue_to_ticket(raw)
+                if ticket is not None:
+                    yield ticket
+            if len(data) < per_page:
+                return
+            page += 1
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        """Post a note on the issue identified by ``ticket_id``.
+
+        ``ticket_id`` is the issue ``iid`` (project-scoped internal id),
+        which is what the adapter emits from ``pull_open_tickets`` as
+        ``Ticket.id``.
+        """
+        path = f"/projects/{self._project_segment}/issues/{ticket_id}/notes"
+        payload = {"body": body}
+        headers = self._idempotency_headers(idempotency_key)
+        result = self._request("POST", path, json=payload, headers=headers)
+        comment_id = ""
+        if isinstance(result, dict):
+            raw_id = result.get("id")
+            if raw_id is not None:
+                comment_id = str(raw_id)
+        return CommentResult(comment_id=comment_id, ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        """Atomically swap the state label on issue ``ticket_id``.
+
+        ``status_id`` may be either:
+            - A canonical key in ``config.state_label_map`` (resolved
+              to the mapped label name).
+            - A bare GitLab label name (used as-is when no mapping is
+              configured).
+
+        The previous state-label (if any) is removed in the same call by
+        listing every other label in the config map under
+        ``remove_labels``.
+        """
+        new_label = self._config.state_label_map.get(status_id, status_id)
+        remove_labels = [
+            label
+            for key, label in self._config.state_label_map.items()
+            if key != status_id and label and label != new_label
+        ]
+        path = f"/projects/{self._project_segment}/issues/{ticket_id}"
+        payload: dict[str, Any] = {"add_labels": new_label}
+        if remove_labels:
+            payload["remove_labels"] = ",".join(remove_labels)
+        headers = self._idempotency_headers(idempotency_key)
+        if etag:
+            headers["If-Match"] = etag
+        self._request("PUT", path, json=payload, headers=headers)
+        return TransitionResult(
+            ticket_id=ticket_id,
+            new_status=status_id,
+            etag=None,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _idempotency_headers(self, key: str | None) -> dict[str, str]:
+        if not key:
+            return {}
+        return {"Idempotency-Key": key}
+
+    def _issue_to_ticket(self, raw: dict[str, Any]) -> Ticket | None:
+        iid = raw.get("iid")
+        if iid is None:
+            return None
+        labels_raw = raw.get("labels") or []
+        labels = tuple(str(lab) for lab in labels_raw if lab)
+        status = self._status_from_labels(labels)
+        cli_choice = self._cli_from_labels(labels)
+        return Ticket(
+            id=str(iid),
+            external_url=str(raw.get("web_url") or ""),
+            title=str(raw.get("title") or ""),
+            body=str(raw.get("description") or ""),
+            status=status,
+            labels=labels,
+            etag=None,
+            routing_hint=RoutingHint(cli=cli_choice),
+            raw={
+                "id": raw.get("id"),
+                "project_id": raw.get("project_id"),
+                "state": raw.get("state"),
+                "assignee": (raw.get("assignee") or {}).get("username")
+                if isinstance(raw.get("assignee"), dict)
+                else None,
+            },
+        )
+
+    def _status_from_labels(self, labels: tuple[str, ...]) -> str:
+        """Infer the canonical status from labels when a map is configured."""
+        if not self._config.state_label_map:
+            return ""
+        reverse = {label: key for key, label in self._config.state_label_map.items() if label}
+        for label in labels:
+            mapped = reverse.get(label)
+            if mapped:
+                return mapped
+        return ""
+
+    def _cli_from_labels(self, labels: tuple[str, ...]) -> str | None:
+        prefix = self._config.cli_choice_label_prefix
+        if not prefix:
+            return None
+        for label in labels:
+            if label.startswith(prefix):
+                return label[len(prefix) :] or None
+        return None
+
+    # -- HTTP --------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        self._bucket.acquire()
+        token = self._token_provider()
+        merged_headers: dict[str, str] = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        }
+        if headers:
+            merged_headers.update(headers)
+        url = f"{self._base_url}{GITLAB_API_PATH}{path}"
+        try:
+            response = self._client.request(
+                method,
+                url,
+                params=params,
+                json=json,
+                headers=merged_headers,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            msg = f"GitLab transport error: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+        status_code = getattr(response, "status_code", 0)
+        if status_code in {429, 403}:
+            retry_after = _parse_retry_after(response)
+            msg = f"GitLab rate-limited (status={status_code})"
+            raise RateLimited(msg, retry_after=retry_after)
+        if status_code >= 500:
+            msg = f"GitLab server error (status={status_code})"
+            raise TrackerUnavailable(msg)
+        if status_code >= 400:
+            body = _safe_text(response)
+            msg = f"GitLab HTTP {status_code}: {body[:200]}"
+            raise TrackerUnavailable(msg)
+
+        if status_code == 204 or not getattr(response, "content", b""):
+            return None
+        try:
+            return response.json()
+        except Exception as exc:  # pragma: no cover - malformed JSON
+            msg = f"GitLab returned non-JSON: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(response: Any) -> float | None:
+    """Best-effort ``Retry-After`` / ``RateLimit-Reset`` parser."""
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if retry_after:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            return None
+    reset = headers.get("RateLimit-Reset") if hasattr(headers, "get") else None
+    if reset:
+        try:
+            reset_epoch = float(reset)
+            return max(0.0, reset_epoch - time.time())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _safe_text(response: Any) -> str:
+    try:
+        return str(getattr(response, "text", ""))
+    except Exception:  # pragma: no cover
+        return ""

--- a/tests/unit/trackers/test_gitlab_adapter.py
+++ b/tests/unit/trackers/test_gitlab_adapter.py
@@ -1,0 +1,427 @@
+"""Tests for :mod:`bernstein.core.trackers.builtin.gitlab_adapter`."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.trackers import RateLimited, TrackerUnavailable
+from bernstein.core.trackers.builtin.gitlab_adapter import (
+    DEFAULT_GITLAB_URL,
+    GITLAB_API_PATH,
+    GitLabConfig,
+    GitLabTracker,
+    _project_segment,
+    _resolve_base_url,
+    _resolve_token,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _issue(
+    *,
+    iid: int,
+    title: str = "Title",
+    body: str = "Body",
+    labels: list[str] | None = None,
+    state: str = "opened",
+    web_url: str = "https://gitlab.com/o/r/-/issues/1",
+    assignee: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "id": 1000 + iid,
+        "iid": iid,
+        "project_id": 7,
+        "title": title,
+        "description": body,
+        "labels": labels or [],
+        "state": state,
+        "web_url": web_url,
+        "assignee": assignee,
+    }
+
+
+def _make_adapter(
+    *,
+    instance_url: str | None = None,
+    label_filter_pull: tuple[str, ...] = (),
+    assignee_filter_pull: str | None = None,
+    state_label_map: dict[str, str] | None = None,
+    cli_choice_label_prefix: str | None = None,
+    project_id_or_path: str = "my-group/my-project",
+) -> GitLabTracker:
+    config = GitLabConfig(
+        project_id_or_path=project_id_or_path,
+        instance_url=instance_url,
+        token_env="GITLAB_TEST_TOKEN",
+        label_filter_pull=label_filter_pull,
+        assignee_filter_pull=assignee_filter_pull,
+        state_label_map=state_label_map or {},
+        cli_choice_label_prefix=cli_choice_label_prefix,
+    )
+    return GitLabTracker(
+        config=config,
+        token_provider=lambda: "tok-test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token / URL resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITLAB_TOKEN", "primary-pat")
+    config = GitLabConfig(project_id_or_path="o/r")
+    assert _resolve_token(config) == "primary-pat"
+
+
+def test_resolve_token_uses_custom_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    monkeypatch.setenv("CUSTOM_GL_TOKEN", "custom-pat")
+    config = GitLabConfig(project_id_or_path="o/r", token_env="CUSTOM_GL_TOKEN")
+    assert _resolve_token(config) == "custom-pat"
+
+
+def test_resolve_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITLAB_TOKEN", raising=False)
+    config = GitLabConfig(project_id_or_path="o/r")
+    with pytest.raises(TrackerUnavailable):
+        _resolve_token(config)
+
+
+def test_resolve_base_url_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITLAB_URL", raising=False)
+    config = GitLabConfig(project_id_or_path="o/r")
+    assert _resolve_base_url(config) == DEFAULT_GITLAB_URL
+
+
+def test_resolve_base_url_uses_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITLAB_URL", "https://gitlab.acme.example/")
+    config = GitLabConfig(project_id_or_path="o/r")
+    assert _resolve_base_url(config) == "https://gitlab.acme.example"
+
+
+def test_resolve_base_url_config_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITLAB_URL", "https://from-env.example")
+    config = GitLabConfig(
+        project_id_or_path="o/r",
+        instance_url="https://from-config.example/",
+    )
+    assert _resolve_base_url(config) == "https://from-config.example"
+
+
+def test_project_segment_encodes_path() -> None:
+    config = GitLabConfig(project_id_or_path="my-group/my-project")
+    assert _project_segment(config) == "my-group%2Fmy-project"
+
+
+def test_project_segment_passes_numeric_id_through() -> None:
+    config = GitLabConfig(project_id_or_path="12345")
+    assert _project_segment(config) == "12345"
+
+
+# ---------------------------------------------------------------------------
+# pull_open_tickets
+# ---------------------------------------------------------------------------
+
+
+def _issues_url(project: str = "my-group%2Fmy-project") -> str:
+    return f"{DEFAULT_GITLAB_URL}{GITLAB_API_PATH}/projects/{project}/issues"
+
+
+@respx.mock
+def test_pull_open_tickets_emits_normalised_tickets() -> None:
+    adapter = _make_adapter(
+        state_label_map={"ready": "state:ready", "claim": "state:claimed"},
+        cli_choice_label_prefix="cli:",
+    )
+    route = respx.get(_issues_url()).mock(
+        return_value=httpx.Response(
+            200,
+            json=[
+                _issue(
+                    iid=7,
+                    title="Refactor parser",
+                    body="Body 1",
+                    labels=["bug", "P1", "state:ready", "cli:claude"],
+                ),
+                _issue(
+                    iid=8,
+                    title="Add tests",
+                    body="Body 2",
+                    labels=[],
+                ),
+            ],
+        )
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 1
+    assert len(tickets) == 2
+    first, second = tickets
+    assert first.id == "7"
+    assert first.title == "Refactor parser"
+    assert first.status == "ready"
+    assert first.labels == ("bug", "P1", "state:ready", "cli:claude")
+    assert first.routing_hint.cli == "claude"
+    assert first.raw["project_id"] == 7
+    assert second.status == ""
+    assert second.routing_hint.cli is None
+
+
+@respx.mock
+def test_pull_open_tickets_paginates_via_page_param() -> None:
+    adapter = _make_adapter()
+    page_one = [_issue(iid=i) for i in range(1, 51)]
+    page_two = [_issue(iid=51, title="Page two only")]
+    route = respx.get(_issues_url()).mock(
+        side_effect=[
+            httpx.Response(200, json=page_one),
+            httpx.Response(200, json=page_two),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 2
+    assert [t.id for t in tickets][-1] == "51"
+    # The second call must request page=2.
+    second_request = route.calls[1].request
+    assert b"page=2" in second_request.url.query
+
+
+@respx.mock
+def test_pull_open_tickets_passes_labels_and_assignee() -> None:
+    adapter = _make_adapter(
+        label_filter_pull=("ai-welcome",),
+        assignee_filter_pull="bot",
+    )
+    route = respx.get(_issues_url()).mock(return_value=httpx.Response(200, json=[]))
+    try:
+        list(adapter.pull_open_tickets({"labels": ["P1"]}))
+    finally:
+        adapter.close()
+
+    request = route.calls[0].request
+    query = request.url.query.decode()
+    assert "labels=ai-welcome%2CP1" in query
+    assert "assignee_username=bot" in query
+    assert "state=opened" in query
+
+
+@respx.mock
+def test_pull_open_tickets_filter_assignee_overrides_config() -> None:
+    adapter = _make_adapter(assignee_filter_pull="bot")
+    route = respx.get(_issues_url()).mock(return_value=httpx.Response(200, json=[]))
+    try:
+        list(adapter.pull_open_tickets({"assignee": "other"}))
+    finally:
+        adapter.close()
+
+    request = route.calls[0].request
+    assert "assignee_username=other" in request.url.query.decode()
+
+
+# ---------------------------------------------------------------------------
+# add_comment
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_add_comment_posts_note() -> None:
+    adapter = _make_adapter()
+    route = respx.post(_issues_url() + "/7/notes").mock(
+        return_value=httpx.Response(201, json={"id": 999, "body": "hello"})
+    )
+    try:
+        result = adapter.add_comment("7", "hello", idempotency_key="k1")
+    finally:
+        adapter.close()
+
+    assert result.comment_id == "999"
+    assert result.ticket_id == "7"
+    request = route.calls[0].request
+    assert b'"body":"hello"' in request.content
+    assert request.headers.get("idempotency-key") == "k1"
+
+
+# ---------------------------------------------------------------------------
+# transition
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_transition_swaps_state_labels_atomically() -> None:
+    adapter = _make_adapter(
+        state_label_map={
+            "claim": "state:claimed",
+            "ready": "state:ready",
+            "failed": "state:failed",
+        },
+    )
+    route = respx.put(_issues_url() + "/7").mock(
+        return_value=httpx.Response(200, json={"iid": 7, "labels": ["state:ready"]})
+    )
+    try:
+        result = adapter.transition("7", "ready", idempotency_key="k2")
+    finally:
+        adapter.close()
+
+    assert result.new_status == "ready"
+    assert result.ticket_id == "7"
+    request = route.calls[0].request
+    body = request.content
+    assert b'"add_labels":"state:ready"' in body
+    # Both other state labels are in remove_labels (order doesn't matter,
+    # we just need both to be present).
+    match = re.search(rb'"remove_labels":"([^"]+)"', body)
+    assert match is not None
+    removed = sorted(match.group(1).decode().split(","))
+    assert removed == ["state:claimed", "state:failed"]
+    assert request.headers.get("idempotency-key") == "k2"
+
+
+@respx.mock
+def test_transition_without_map_uses_status_id_as_label() -> None:
+    adapter = _make_adapter()
+    route = respx.put(_issues_url() + "/7").mock(return_value=httpx.Response(200, json={"iid": 7}))
+    try:
+        result = adapter.transition("7", "needs-review")
+    finally:
+        adapter.close()
+
+    assert result.new_status == "needs-review"
+    body = route.calls[0].request.content
+    assert b'"add_labels":"needs-review"' in body
+    assert b"remove_labels" not in body
+
+
+# ---------------------------------------------------------------------------
+# Self-hosted URL override
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_self_hosted_instance_url_is_used() -> None:
+    adapter = _make_adapter(instance_url="https://gitlab.acme.example")
+    route = respx.get(f"https://gitlab.acme.example{GITLAB_API_PATH}/projects/my-group%2Fmy-project/issues").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    try:
+        list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_self_hosted_via_gitlab_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITLAB_URL", "https://gitlab.self.example")
+    monkeypatch.setenv("GITLAB_TEST_TOKEN", "tok")
+    config = GitLabConfig(
+        project_id_or_path="12345",
+        token_env="GITLAB_TEST_TOKEN",
+    )
+    adapter = GitLabTracker(config=config)
+    route = respx.get(f"https://gitlab.self.example{GITLAB_API_PATH}/projects/12345/issues").mock(
+        return_value=httpx.Response(200, json=[])
+    )
+    try:
+        list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Auth header
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_authorization_header_is_set() -> None:
+    adapter = _make_adapter()
+    route = respx.get(_issues_url()).mock(return_value=httpx.Response(200, json=[]))
+    try:
+        list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    auth = route.calls[0].request.headers.get("authorization")
+    assert auth == "Bearer tok-test"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit & errors
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_rate_limit_with_retry_after_header() -> None:
+    adapter = _make_adapter()
+    respx.get(_issues_url()).mock(
+        return_value=httpx.Response(
+            429,
+            json={"message": "slow down"},
+            headers={"Retry-After": "13"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 13.0
+
+
+@respx.mock
+def test_forbidden_is_treated_as_rate_limited() -> None:
+    adapter = _make_adapter()
+    respx.get(_issues_url()).mock(
+        return_value=httpx.Response(
+            403,
+            json={"message": "forbidden"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_server_error_is_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(_issues_url()).mock(return_value=httpx.Response(503, text="upstream down"))
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_client_error_is_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(_issues_url()).mock(return_value=httpx.Response(404, text="not found"))
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()

--- a/tests/unit/trackers/test_gitlab_adapter.py
+++ b/tests/unit/trackers/test_gitlab_adapter.py
@@ -13,8 +13,8 @@ from bernstein.core.trackers import RateLimited, TrackerUnavailable
 from bernstein.core.trackers.builtin.gitlab_adapter import (
     DEFAULT_GITLAB_URL,
     GITLAB_API_PATH,
+    GitLabAdapter,
     GitLabConfig,
-    GitLabTracker,
     _project_segment,
     _resolve_base_url,
     _resolve_token,
@@ -56,7 +56,7 @@ def _make_adapter(
     state_label_map: dict[str, str] | None = None,
     cli_choice_label_prefix: str | None = None,
     project_id_or_path: str = "my-group/my-project",
-) -> GitLabTracker:
+) -> GitLabAdapter:
     config = GitLabConfig(
         project_id_or_path=project_id_or_path,
         instance_url=instance_url,
@@ -66,7 +66,7 @@ def _make_adapter(
         state_label_map=state_label_map or {},
         cli_choice_label_prefix=cli_choice_label_prefix,
     )
-    return GitLabTracker(
+    return GitLabAdapter(
         config=config,
         token_provider=lambda: "tok-test",
     )
@@ -336,7 +336,7 @@ def test_self_hosted_via_gitlab_url_env(monkeypatch: pytest.MonkeyPatch) -> None
         project_id_or_path="12345",
         token_env="GITLAB_TEST_TOKEN",
     )
-    adapter = GitLabTracker(config=config)
+    adapter = GitLabAdapter(config=config)
     route = respx.get(f"https://gitlab.self.example{GITLAB_API_PATH}/projects/12345/issues").mock(
         return_value=httpx.Response(200, json=[])
     )
@@ -390,7 +390,7 @@ def test_rate_limit_with_retry_after_header() -> None:
 
 
 @respx.mock
-def test_forbidden_is_treated_as_rate_limited() -> None:
+def test_plain_forbidden_is_tracker_unavailable() -> None:
     adapter = _make_adapter()
     respx.get(_issues_url()).mock(
         return_value=httpx.Response(
@@ -399,10 +399,28 @@ def test_forbidden_is_treated_as_rate_limited() -> None:
         )
     )
     try:
-        with pytest.raises(RateLimited):
+        with pytest.raises(TrackerUnavailable):
             list(adapter.pull_open_tickets())
     finally:
         adapter.close()
+
+
+@respx.mock
+def test_forbidden_with_rate_limit_headers_is_rate_limited() -> None:
+    adapter = _make_adapter()
+    respx.get(_issues_url()).mock(
+        return_value=httpx.Response(
+            403,
+            json={"message": "rate-limited"},
+            headers={"Retry-After": "7"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 7.0
 
 
 @respx.mock


### PR DESCRIPTION
Adds the GitLab Issues adapter following the GitHub Projects v2 pattern. Auth via personal access token; supports self-hosted via GITLAB_URL override.

## Summary by Sourcery

Add a GitLab Issues tracker adapter that conforms to the existing tracker contract and can be used alongside the GitHub Projects v2 adapter.

New Features:
- Introduce a configurable GitLabIssues adapter supporting listing open issues, posting comments, and transitioning issue status via labels.
- Support GitLab authentication via personal access token and allow self-hosted instances through configurable or environment-based base URLs.

Enhancements:
- Export the new GitLab tracker adapter and configuration from the builtin trackers package for external use.

Tests:
- Add comprehensive unit test coverage for the GitLab adapter covering configuration, URL and token resolution, pagination and filtering, state transitions, self-hosted URLs, auth headers, and error and rate-limit handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab issue tracker integration alongside existing GitHub support
  * Configurable project, instance URL, authentication, label/assignee filters, and pagination
  * Support for fetching open issues, posting comments, and transitioning issue workflow states

* **Tests**
  * Added comprehensive unit test suite validating GitLab tracker behavior and error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- bot-ack: nit-batch -->
Acknowledging nit-only review comments (style/guideline preferences that sibling adapters do not follow):
- coderabbit constants-to-defaults: existing builtin trackers (github_projects_adapter, clickup_adapter) declare inline module constants for URLs / page sizes; matching the established pattern.
- coderabbit raw-dict-to-TypedDict (src and tests): sibling adapters use raw dict types for config/payload shapes; refactor is a cross-cutting style change and out of scope for this adapter.

Must-address findings (bug-risk / correctness / code-scanning) applied in fixup commit.
