### PR TITLE
feat(trackers): ClickUp adapter conforming to TrackerContract

### DIFF
--- a/docs/trackers/clickup.md
+++ b/docs/trackers/clickup.md
@@ -1,0 +1,134 @@
+# ClickUp tracker adapter
+
+Bernstein can pull work directly from a ClickUp list, post progress
+comments back to the underlying task, and move tasks between statuses
+when work transitions. The adapter also supports per-step CLI choice: a
+custom field can name the CLI adapter (`claude`, `codex`, `aider`, ...)
+Bernstein should pick for each ticket.
+
+The adapter implements `bernstein.core.trackers.AbstractTrackerAdapter`
+and lives under `bernstein.core.trackers.builtin.clickup_adapter`. It is
+disabled by default and must be opted in via `bernstein.yaml`.
+
+It talks to the public ClickUp REST API v2 directly rather than the
+ClickUp MCP server, which keeps the call surface predictable and avoids
+paying the MCP metering bill.
+
+## Auth
+
+ClickUp accepts a personal API token in the `Authorization` header. Set
+the environment variable named by `token_env` and reference it from
+`bernstein.yaml`:
+
+| Environment variable    | Purpose                                |
+|-------------------------|----------------------------------------|
+| `CLICKUP_API_TOKEN`     | Personal API token (default env name). |
+
+```yaml
+trackers:
+  clickup:
+    list_id: "9012345"
+    workspace_id: "1234567"
+    space_id: "8901234"
+    auth:
+      token_env: CLICKUP_API_TOKEN
+```
+
+OAuth bearer tokens work too; pass the full token string in the
+environment variable and the adapter forwards it as-is.
+
+## Status mapping
+
+`status_map` maps canonical Bernstein statuses to the list's display
+status names. ClickUp status names are case-sensitive and per-list:
+
+```yaml
+trackers:
+  clickup:
+    status_map:
+      todo: "to do"
+      in_progress: "in progress"
+      done: "complete"
+```
+
+`transition(ticket_id, status_id)` resolves the target name through
+`status_map` first, then sends it on the wire.
+
+## Per-step CLI choice (worked example)
+
+Add a custom field to the list (single-select or short-text) with values
+`claude`, `codex`, `aider`. Capture the field id from the ClickUp UI or
+the `/list/{list_id}/field` endpoint, then point the adapter at it:
+
+```yaml
+trackers:
+  clickup:
+    list_id: "9012345"
+    cli_choice_custom_field_id: "1f0c9c8d-c0ff-ee00-1234-deadbeefcafe"
+    auth:
+      token_env: CLICKUP_API_TOKEN
+```
+
+The adapter exposes the field value on the ticket dataclass:
+
+```python
+from bernstein.core.trackers.builtin import (
+    ClickUpAdapter,
+    ClickUpConfig,
+)
+
+config = ClickUpConfig(
+    list_id="9012345",
+    status_filter="to do",
+    cli_choice_custom_field_id="1f0c9c8d-c0ff-ee00-1234-deadbeefcafe",
+    token_env="CLICKUP_API_TOKEN",
+)
+with ClickUpAdapter(config) as adapter:
+    for ticket in adapter.pull_open_tickets():
+        cli = ticket.routing_hint.cli  # "claude" / "codex" / "aider" / None
+        # hand cli + ticket.id to the orchestrator's routing layer
+```
+
+When the orchestrator's routing layer sees a non-empty
+`ticket.routing_hint.cli`, it pins the spawned CLI for that ticket.
+
+## Comments and transitions
+
+- `add_comment(ticket_id, body)` posts to `/task/{task_id}/comment`.
+  When `idempotency_key` is set, the key is appended as an HTML marker
+  so re-tries stay traceable without duplicating the visible body.
+- `transition(ticket_id, status_id)` issues
+  `PUT /task/{task_id}` with the resolved status name.
+
+## Rate limiting
+
+- A cooperative per-adapter token-bucket throttles outbound calls when
+  `rate_limit_min_interval` is set. Size it per plan tier:
+
+  | Plan        | Suggested `rate_limit_min_interval` |
+  |-------------|--------------------------------------|
+  | Free        | `0.6` s (about 100 rpm)              |
+  | Unlimited   | `0.06` s (about 1000 rpm)            |
+  | Enterprise  | `0.006` s (about 10000 rpm)          |
+
+- Server-side `429` responses are translated into
+  `RateLimited(retry_after=...)`. The hint is taken from `Retry-After`
+  first, then `X-RateLimit-Reset`.
+- ClickUp also returns `{"err": "...", "ECODE": "RATE_..."}` in a `200`
+  body when a soft limit is exceeded. The adapter surfaces those as
+  `RateLimited` too.
+
+## Exceptions
+
+| Exception                        | When                                            |
+|----------------------------------|-------------------------------------------------|
+| `TrackerUnavailable`             | 5xx, missing token, error payload from ClickUp. |
+| `RateLimited`                    | 429 or inline `RATE_...` ECODE.                 |
+| `OptimisticConcurrencyError`     | 412 Precondition Failed on a write.             |
+
+## Out of scope
+
+- ClickUp Docs (this adapter is tasks-only).
+- ClickUp MCP server consumer mode (separate ticket if requested).
+- Webhooks. Pair this adapter with the existing webhook trigger-source
+  subsystem if you need push-style updates instead of polling.

--- a/src/bernstein/core/trackers/builtin/__init__.py
+++ b/src/bernstein/core/trackers/builtin/__init__.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+from bernstein.core.trackers.builtin.clickup_adapter import (
+    ClickUpAdapter,
+    ClickUpConfig,
+)
 from bernstein.core.trackers.builtin.github_projects_adapter import (
     GitHubProjectsV2Adapter,
     GitHubProjectsV2Config,
 )
 
-__all__ = ["GitHubProjectsV2Adapter", "GitHubProjectsV2Config"]
+__all__ = [
+    "ClickUpAdapter",
+    "ClickUpConfig",
+    "GitHubProjectsV2Adapter",
+    "GitHubProjectsV2Config",
+]

--- a/src/bernstein/core/trackers/builtin/clickup_adapter.py
+++ b/src/bernstein/core/trackers/builtin/clickup_adapter.py
@@ -1,0 +1,462 @@
+"""ClickUp tracker adapter.
+
+Implements the ``AbstractTrackerAdapter`` contract on top of the public
+ClickUp REST API v2. Avoids the metered ClickUp MCP server by calling
+the documented REST surface directly.
+
+Auth:
+- API token via an environment variable (default ``CLICKUP_API_TOKEN``).
+  ClickUp accepts both personal-API tokens (raw token in the
+  ``Authorization`` header) and OAuth bearer tokens; the adapter sends
+  the token verbatim and lets the caller choose.
+
+Capabilities:
+- ``pull_open_tickets``: paginate ``/list/{list_id}/task`` and emit
+  normalised ``Ticket`` objects, optionally filtered by status.
+- ``add_comment``: post to ``/task/{task_id}/comment``.
+- ``transition``: ``PUT /task/{task_id}`` with a new status value.
+
+Per-step CLI choice:
+- If ``cli_choice_custom_field_id`` is configured and a task has a value
+  for that custom field, the adapter exposes
+  ``ticket.routing_hint.cli`` so the orchestrator can pin a CLI adapter.
+
+Rate-limit handling:
+- Cooperative client-side token bucket sized per-plan via
+  ``rate_limit_min_interval``.
+- ``RateLimited`` raised with ``retry_after`` derived from the
+  ``Retry-After`` or ``X-RateLimit-Reset`` headers ClickUp emits.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:  # pragma: no cover - optional dep already present in project deps
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    OptimisticConcurrencyError,
+    RateLimited,
+    RoutingHint,
+    Ticket,
+    TrackerUnavailable,
+    TransitionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+CLICKUP_API_BASE = "https://api.clickup.com/api/v2"
+DEFAULT_PAGE_SIZE = 100
+DEFAULT_TOKEN_ENV = "CLICKUP_API_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ClickUpConfig:
+    """Configuration for a ClickUp adapter instance.
+
+    Attributes:
+        list_id: ClickUp list id the adapter pulls tasks from.
+        workspace_id: Optional workspace (team) id. Not needed for the
+            list-scoped REST calls used here, but kept on the config so
+            operators can surface a single ``trackers.clickup`` block.
+        space_id: Optional space id. Same rationale as ``workspace_id``.
+        status_filter: Optional default status the adapter filters on
+            when ``pull_open_tickets`` is called with no override.
+        status_map: Optional mapping from canonical Bernstein statuses to
+            the list's display status names (e.g.
+            ``{"done": "complete"}``).
+        cli_choice_custom_field_id: Optional id of a custom field that
+            names the CLI adapter for each task (``claude``, ``codex``,
+            ``aider``, ...). The value is surfaced as
+            ``ticket.routing_hint.cli``.
+        token_env: Environment variable name that holds the API token.
+            Default ``CLICKUP_API_TOKEN``.
+        api_base: Override the API base URL (useful for tests and
+            self-hosted proxies).
+        page_size: Page size used by ``pull_open_tickets``. ClickUp
+            caps task pages at 100.
+        rate_limit_min_interval: Minimum seconds between API calls per
+            adapter instance. Set per plan tier (free plans bucket at
+            100 rpm shared, enterprise at 10k rpm).
+        include_archived: Whether to include archived tasks. Default
+            ``False``.
+    """
+
+    list_id: str
+    workspace_id: str | None = None
+    space_id: str | None = None
+    status_filter: str | None = None
+    status_map: dict[str, str] = field(default_factory=dict)
+    cli_choice_custom_field_id: str | None = None
+    token_env: str = DEFAULT_TOKEN_ENV
+    api_base: str = CLICKUP_API_BASE
+    page_size: int = DEFAULT_PAGE_SIZE
+    rate_limit_min_interval: float = 0.0
+    include_archived: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token(config: ClickUpConfig) -> str:
+    """Resolve the API token from the configured environment variable.
+
+    Raises:
+        TrackerUnavailable: if the environment variable is empty.
+    """
+    env_var = config.token_env or DEFAULT_TOKEN_ENV
+    token = os.environ.get(env_var, "")
+    if not token:
+        msg = f"ClickUp adapter: no token available (env var '{env_var}' is empty)"
+        raise TrackerUnavailable(msg)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Token bucket
+# ---------------------------------------------------------------------------
+
+
+class _TokenBucket:
+    """Minimal cooperative token-bucket throttle.
+
+    A single shared lock-protected next-allowed timestamp. Calls block
+    until the timestamp is reached. ``min_interval == 0`` disables the
+    throttle. The adapter leans on server-side rate limits and
+    ``Retry-After`` headers for hard enforcement.
+    """
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = max(0.0, float(min_interval))
+        self._next_allowed = 0.0
+        self._lock = threading.Lock()
+
+    def acquire(self, *, now: float | None = None, sleep: Any = time.sleep) -> None:
+        if self._min_interval <= 0.0:
+            return
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            wait = self._next_allowed - now
+            if wait > 0:
+                sleep(wait)
+                now = now + wait
+            self._next_allowed = now + self._min_interval
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class ClickUpAdapter(AbstractTrackerAdapter):
+    """Adapter for ClickUp.
+
+    The adapter is intentionally thin: every call is a single REST
+    round-trip with bearer-style auth. ClickUp returns task ids as
+    opaque strings; the adapter passes them through.
+
+    Parameters:
+        config: Adapter configuration.
+        http_client: Optional pre-built ``httpx.Client``. Tests inject a
+            mocked transport via ``respx``.
+        token_provider: Optional callable returning the auth token. The
+            default reads from ``_resolve_token(config)`` on each call so
+            token rotation is trivial.
+    """
+
+    name = "clickup"
+
+    def __init__(
+        self,
+        config: ClickUpConfig,
+        *,
+        http_client: Any | None = None,
+        token_provider: Any | None = None,
+    ) -> None:
+        if httpx is None:  # pragma: no cover - dep is declared in pyproject
+            msg = "httpx is required for ClickUpAdapter"
+            raise RuntimeError(msg)
+        self._config = config
+        self._client: Any = http_client or httpx.Client(timeout=30.0)
+        self._owns_client = http_client is None
+        self._token_provider = token_provider or (lambda: _resolve_token(config))
+        self._bucket = _TokenBucket(config.rate_limit_min_interval)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying HTTP client if we own it."""
+        if self._owns_client:
+            try:
+                self._client.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("ignoring error while closing httpx client", exc_info=True)
+
+    def __enter__(self) -> ClickUpAdapter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- public API ---------------------------------------------------------
+
+    def pull_open_tickets(
+        self,
+        filter: dict[str, Any] | None = None,
+    ) -> Iterator[Ticket]:
+        """Yield tasks from the configured list as ``Ticket`` objects.
+
+        ``filter`` keys:
+            - ``status``: override ``config.status_filter`` for this call.
+            - ``include_archived``: bool, default ``config.include_archived``.
+        """
+        filter_dict = filter or {}
+        status_filter = filter_dict.get("status", self._config.status_filter)
+        include_archived = bool(filter_dict.get("include_archived", self._config.include_archived))
+
+        page = 0
+        page_size = max(1, min(100, self._config.page_size))
+        path = f"/list/{self._config.list_id}/task"
+        while True:
+            params: dict[str, Any] = {
+                "archived": "true" if include_archived else "false",
+                "page": page,
+                "subtasks": "true",
+                "include_closed": "true",
+            }
+            data = self._request("GET", path, params=params)
+            tasks = data.get("tasks") or []
+            for raw_task in tasks:
+                ticket = self._task_to_ticket(raw_task)
+                if status_filter and ticket.status != status_filter:
+                    continue
+                yield ticket
+            # ClickUp signals "last page" by returning fewer than page_size
+            # tasks; some plans also include ``last_page`` in the response.
+            if data.get("last_page") is True:
+                break
+            if len(tasks) < page_size:
+                break
+            page += 1
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        """Post a comment on ``ticket_id``.
+
+        ``idempotency_key`` is appended to the comment as an HTML marker
+        so re-tries with the same key do not duplicate the visible body
+        but stay traceable in the audit log.
+        """
+        marker = ""
+        if idempotency_key:
+            marker = f"\n\n<!-- bernstein-idempotency: {idempotency_key} -->"
+        payload = {
+            "comment_text": f"{body}{marker}",
+            "notify_all": False,
+        }
+        data = self._request(
+            "POST",
+            f"/task/{ticket_id}/comment",
+            json=payload,
+        )
+        comment_id = str(data.get("id", "") or data.get("hist_id", ""))
+        return CommentResult(comment_id=comment_id, ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        """Move ``ticket_id`` to ``status_id``.
+
+        ``status_id`` is treated as a status name and resolved through
+        ``config.status_map`` first (e.g. ``done`` -> ``complete``).
+        ClickUp does not expose an etag surface; ``etag`` is accepted to
+        keep the contract uniform but is not sent on the wire.
+        """
+        del idempotency_key  # ClickUp PUT does not honour an idempotency key
+        mapped = self._config.status_map.get(status_id, status_id)
+        payload = {"status": mapped}
+        headers: dict[str, str] | None = None
+        if etag:
+            headers = {"If-Match": etag}
+        self._request(
+            "PUT",
+            f"/task/{ticket_id}",
+            json=payload,
+            extra_headers=headers,
+        )
+        return TransitionResult(
+            ticket_id=ticket_id,
+            new_status=status_id,
+            etag=None,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _task_to_ticket(self, raw_task: dict[str, Any]) -> Ticket:
+        status_block = raw_task.get("status") or {}
+        status = status_block.get("status") if isinstance(status_block, dict) else str(status_block or "")
+        cli_choice: str | None = None
+        if self._config.cli_choice_custom_field_id:
+            for cf in raw_task.get("custom_fields") or []:
+                if cf.get("id") == self._config.cli_choice_custom_field_id:
+                    value = cf.get("value")
+                    if isinstance(value, str) and value:
+                        cli_choice = value
+                    elif isinstance(value, dict):
+                        cli_choice = value.get("name") or value.get("value")
+                    break
+        labels = tuple((tag.get("name") or "") for tag in raw_task.get("tags") or [] if tag.get("name"))
+        return Ticket(
+            id=str(raw_task.get("id", "")),
+            external_url=str(raw_task.get("url", "")),
+            title=str(raw_task.get("name", "")),
+            body=str(raw_task.get("description") or raw_task.get("text_content") or ""),
+            status=str(status or ""),
+            labels=labels,
+            etag=None,
+            routing_hint=RoutingHint(cli=cli_choice),
+            raw={
+                "task_id": str(raw_task.get("id", "")),
+                "list_id": str(((raw_task.get("list") or {}).get("id")) or self._config.list_id),
+                "space_id": str(((raw_task.get("space") or {}).get("id")) or (self._config.space_id or "")),
+            },
+        )
+
+    # -- HTTP --------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        self._bucket.acquire()
+        token = self._token_provider()
+        headers = {
+            "Authorization": token,
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if extra_headers:
+            headers.update(extra_headers)
+        url = f"{self._config.api_base.rstrip('/')}{path}"
+        try:
+            response = self._client.request(
+                method,
+                url,
+                params=params,
+                json=json,
+                headers=headers,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            msg = f"ClickUp transport error: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+        status_code = getattr(response, "status_code", 0)
+        if status_code == 412:
+            msg = "Precondition Failed (etag mismatch)"
+            raise OptimisticConcurrencyError(msg)
+        if status_code == 429:
+            retry_after = _parse_retry_after(response)
+            msg = f"ClickUp rate-limited (status={status_code})"
+            raise RateLimited(msg, retry_after=retry_after)
+        if status_code >= 500:
+            msg = f"ClickUp server error (status={status_code})"
+            raise TrackerUnavailable(msg)
+        if status_code >= 400:
+            body = _safe_text(response)
+            msg = f"ClickUp HTTP {status_code}: {body[:200]}"
+            raise TrackerUnavailable(msg)
+
+        if status_code == 204 or method.upper() == "PUT":
+            # ClickUp returns the updated task on PUT; some endpoints
+            # return an empty body. Parse defensively.
+            try:
+                data = response.json()
+            except Exception:
+                return {}
+            return data if isinstance(data, dict) else {}
+
+        try:
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - malformed JSON
+            msg = f"ClickUp returned non-JSON: {exc}"
+            raise TrackerUnavailable(msg) from exc
+        if not isinstance(data, dict):
+            msg = f"ClickUp returned non-object payload: {type(data).__name__}"
+            raise TrackerUnavailable(msg)
+        # ClickUp signals soft errors with ``{"err": "...", "ECODE": "..."}``.
+        if data.get("err") and not data.get("tasks") and not data.get("id"):
+            ecode = data.get("ECODE") or "UNKNOWN"
+            if str(ecode).startswith("RATE"):
+                raise RateLimited(
+                    f"ClickUp rate-limit: {data.get('err')}",
+                    retry_after=None,
+                )
+            msg = f"ClickUp error {ecode}: {data.get('err')}"
+            raise TrackerUnavailable(msg)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(response: Any) -> float | None:
+    """Best-effort ``Retry-After`` / ``X-RateLimit-Reset`` parser."""
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if retry_after:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            return None
+    reset = headers.get("X-RateLimit-Reset") if hasattr(headers, "get") else None
+    if reset:
+        try:
+            reset_epoch = float(reset)
+            return max(0.0, reset_epoch - time.time())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _safe_text(response: Any) -> str:
+    try:
+        return str(getattr(response, "text", ""))
+    except Exception:  # pragma: no cover
+        return ""

--- a/tests/unit/trackers/test_clickup_adapter.py
+++ b/tests/unit/trackers/test_clickup_adapter.py
@@ -1,0 +1,439 @@
+"""Tests for :mod:`bernstein.core.trackers.builtin.clickup_adapter`."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.trackers import (
+    OptimisticConcurrencyError,
+    RateLimited,
+    TrackerUnavailable,
+)
+from bernstein.core.trackers.builtin.clickup_adapter import (
+    CLICKUP_API_BASE,
+    ClickUpAdapter,
+    ClickUpConfig,
+    _resolve_token,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_TASK_LIST_URL = re.compile(re.escape(f"{CLICKUP_API_BASE}/list/") + r".+/task")
+_TASK_DETAIL_URL = re.compile(re.escape(f"{CLICKUP_API_BASE}/task/") + r"[^/]+$")
+_TASK_COMMENT_URL = re.compile(re.escape(f"{CLICKUP_API_BASE}/task/") + r"[^/]+/comment")
+
+
+def _tasks_page(
+    *,
+    tasks: list[dict[str, Any]] | None = None,
+    last_page: bool = True,
+) -> dict[str, Any]:
+    nodes = tasks or [
+        {
+            "id": "abc123",
+            "name": "Refactor parser",
+            "description": "Body 1",
+            "text_content": "Body 1",
+            "url": "https://app.clickup.com/t/abc123",
+            "status": {"status": "in progress", "type": "open"},
+            "tags": [{"name": "bug"}, {"name": "p1"}],
+            "list": {"id": "L1"},
+            "space": {"id": "S1"},
+            "custom_fields": [
+                {
+                    "id": "cf-cli",
+                    "name": "CLI",
+                    "value": "claude",
+                },
+            ],
+        },
+        {
+            "id": "def456",
+            "name": "Add tests",
+            "description": "Body 2",
+            "url": "https://app.clickup.com/t/def456",
+            "status": {"status": "to do", "type": "open"},
+            "tags": [],
+            "list": {"id": "L1"},
+            "space": {"id": "S1"},
+            "custom_fields": [],
+        },
+    ]
+    payload: dict[str, Any] = {"tasks": nodes}
+    if last_page:
+        payload["last_page"] = True
+    return payload
+
+
+def _make_adapter(
+    *,
+    status_filter: str | None = None,
+    cli_field: str | None = "cf-cli",
+    status_map: dict[str, str] | None = None,
+    page_size: int = 100,
+) -> ClickUpAdapter:
+    config = ClickUpConfig(
+        list_id="L1",
+        workspace_id="W1",
+        space_id="S1",
+        status_filter=status_filter,
+        status_map=status_map or {},
+        cli_choice_custom_field_id=cli_field,
+        token_env="CLICKUP_TEST_TOKEN",
+        page_size=page_size,
+    )
+    return ClickUpAdapter(
+        config=config,
+        token_provider=lambda: "tok-test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CLICKUP_API_TOKEN", "pk_abc")
+    config = ClickUpConfig(list_id="L1")
+    assert _resolve_token(config) == "pk_abc"
+
+
+def test_resolve_token_custom_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_CLICKUP", "pk_xyz")
+    config = ClickUpConfig(list_id="L1", token_env="MY_CLICKUP")
+    assert _resolve_token(config) == "pk_xyz"
+
+
+def test_resolve_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CLICKUP_API_TOKEN", raising=False)
+    monkeypatch.delenv("MY_CLICKUP", raising=False)
+    config = ClickUpConfig(list_id="L1", token_env="MY_CLICKUP")
+    with pytest.raises(TrackerUnavailable):
+        _resolve_token(config)
+
+
+# ---------------------------------------------------------------------------
+# pull_open_tickets
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_pull_open_tickets_emits_normalised_tickets() -> None:
+    adapter = _make_adapter()
+    route = respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(200, json=_tasks_page()),
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 1
+    assert len(tickets) == 2
+    issue, other = tickets
+    assert issue.id == "abc123"
+    assert issue.title == "Refactor parser"
+    assert issue.status == "in progress"
+    assert issue.labels == ("bug", "p1")
+    assert issue.routing_hint.cli == "claude"
+    assert issue.raw["task_id"] == "abc123"
+    assert issue.raw["list_id"] == "L1"
+    assert other.routing_hint.cli is None
+    assert other.status == "to do"
+
+
+@respx.mock
+def test_pull_open_tickets_filters_by_status() -> None:
+    adapter = _make_adapter(status_filter="in progress")
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(200, json=_tasks_page()),
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["abc123"]
+
+
+@respx.mock
+def test_pull_open_tickets_paginates() -> None:
+    adapter = _make_adapter(page_size=2)
+    page_one = _tasks_page(last_page=False)
+    page_two = _tasks_page(
+        last_page=True,
+        tasks=[
+            {
+                "id": "ghi789",
+                "name": "Page two",
+                "description": "",
+                "url": "https://app.clickup.com/t/ghi789",
+                "status": {"status": "to do"},
+                "tags": [],
+                "list": {"id": "L1"},
+                "space": {"id": "S1"},
+                "custom_fields": [],
+            },
+        ],
+    )
+    route = respx.get(_TASK_LIST_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=page_one),
+            httpx.Response(200, json=page_two),
+        ],
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert route.call_count == 2
+    assert [t.id for t in tickets] == ["abc123", "def456", "ghi789"]
+
+
+@respx.mock
+def test_pull_open_tickets_passes_archived_flag() -> None:
+    adapter = _make_adapter()
+    route = respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(200, json=_tasks_page()),
+    )
+    try:
+        list(adapter.pull_open_tickets({"include_archived": True}))
+    finally:
+        adapter.close()
+    request = route.calls[0].request
+    assert b"archived=true" in request.url.query
+
+
+# ---------------------------------------------------------------------------
+# add_comment
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_add_comment_posts_to_task_endpoint() -> None:
+    adapter = _make_adapter()
+    route = respx.post(_TASK_COMMENT_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"id": "cmt-1", "hist_id": "hist-9"},
+        ),
+    )
+    try:
+        result = adapter.add_comment("abc123", "hello", idempotency_key="k1")
+    finally:
+        adapter.close()
+
+    assert result.comment_id == "cmt-1"
+    assert result.ticket_id == "abc123"
+    sent = route.calls[0].request
+    assert sent.url.path.endswith("/task/abc123/comment")
+    assert b"hello" in sent.content
+    assert b"bernstein-idempotency: k1" in sent.content
+
+
+@respx.mock
+def test_add_comment_without_idempotency_key_omits_marker() -> None:
+    adapter = _make_adapter()
+    route = respx.post(_TASK_COMMENT_URL).mock(
+        return_value=httpx.Response(200, json={"id": "cmt-2"}),
+    )
+    try:
+        adapter.add_comment("abc123", "hello")
+    finally:
+        adapter.close()
+    assert b"bernstein-idempotency" not in route.calls[0].request.content
+
+
+# ---------------------------------------------------------------------------
+# transition
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_transition_sends_status_name() -> None:
+    adapter = _make_adapter()
+    route = respx.put(_TASK_DETAIL_URL).mock(
+        return_value=httpx.Response(200, json={"id": "abc123", "status": {"status": "complete"}}),
+    )
+    try:
+        result = adapter.transition("abc123", "complete", idempotency_key="k2")
+    finally:
+        adapter.close()
+    assert result.new_status == "complete"
+    assert result.ticket_id == "abc123"
+    sent = route.calls[0].request
+    assert sent.url.path.endswith("/task/abc123")
+    assert b'"status":"complete"' in sent.content
+
+
+@respx.mock
+def test_transition_uses_status_map() -> None:
+    adapter = _make_adapter(status_map={"done": "complete"})
+    route = respx.put(_TASK_DETAIL_URL).mock(
+        return_value=httpx.Response(200, json={"id": "abc123"}),
+    )
+    try:
+        result = adapter.transition("abc123", "done")
+    finally:
+        adapter.close()
+    assert result.new_status == "done"
+    assert b'"status":"complete"' in route.calls[0].request.content
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit & concurrency
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_rate_limit_with_retry_after_header() -> None:
+    adapter = _make_adapter()
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(
+            429,
+            json={"err": "Rate limit reached", "ECODE": "RATE_001"},
+            headers={"Retry-After": "13"},
+        ),
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 13.0
+
+
+@respx.mock
+def test_inline_rate_limit_error_payload() -> None:
+    adapter = _make_adapter()
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"err": "Rate limit reached", "ECODE": "RATE_002"},
+        ),
+    )
+    try:
+        with pytest.raises(RateLimited):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_etag_mismatch_raises_optimistic_concurrency() -> None:
+    adapter = _make_adapter()
+    respx.put(_TASK_DETAIL_URL).mock(
+        return_value=httpx.Response(412, json={"err": "Precondition Failed"}),
+    )
+    try:
+        with pytest.raises(OptimisticConcurrencyError):
+            adapter.transition("abc123", "complete", etag="W/abc")
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_5xx_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(503, json={"err": "down"}),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_4xx_error_payload_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"err": "List not found", "ECODE": "LIST_001"},
+        ),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI choice routing hint
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_cli_choice_field_disabled_when_unconfigured() -> None:
+    adapter = _make_adapter(cli_field=None)
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(200, json=_tasks_page()),
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert all(t.routing_hint.cli is None for t in tickets)
+
+
+@respx.mock
+def test_cli_choice_field_supports_dict_value() -> None:
+    adapter = _make_adapter()
+    payload = _tasks_page(
+        tasks=[
+            {
+                "id": "abc999",
+                "name": "Dict-shaped CLI value",
+                "description": "",
+                "url": "https://app.clickup.com/t/abc999",
+                "status": {"status": "to do"},
+                "tags": [],
+                "list": {"id": "L1"},
+                "space": {"id": "S1"},
+                "custom_fields": [
+                    {
+                        "id": "cf-cli",
+                        "value": {"name": "codex"},
+                    },
+                ],
+            },
+        ],
+    )
+    respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(200, json=payload),
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert len(tickets) == 1
+    assert tickets[0].routing_hint.cli == "codex"
+
+
+# ---------------------------------------------------------------------------
+# Auth header
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_token_is_sent_in_authorization_header() -> None:
+    adapter = _make_adapter()
+    route = respx.get(_TASK_LIST_URL).mock(
+        return_value=httpx.Response(200, json=_tasks_page()),
+    )
+    try:
+        list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert route.calls[0].request.headers.get("Authorization") == "tok-test"


### PR DESCRIPTION
Adds the ClickUp adapter following the pattern established by the GitHub Projects v2 adapter. Auth via API token env var.

## Test plan

- [x] `uv run --no-sync pytest tests/unit/trackers/ -x -q` -> 38 passed (19 new).
- [x] `uv run --no-sync ruff check src/bernstein/core/trackers tests/unit/trackers` -> clean.
- [x] `uv run --no-sync ruff format src/bernstein/core/trackers tests/unit/trackers` -> clean.
- [ ] Manual smoke against a real ClickUp list (operator follow-up).

## Summary by Sourcery

Add a ClickUp tracker adapter implementing the common tracker contract, wired into the builtin trackers package and covered by tests and docs.

New Features:
- Introduce a ClickUpAdapter and ClickUpConfig implementing the tracker contract against the ClickUp REST API, including ticket fetching, commenting, transitions, routing hints, and rate limiting.

Documentation:
- Add user-facing documentation for configuring and using the ClickUp tracker adapter, including auth, status mapping, CLI choice routing, comments, transitions, and rate limiting.

Tests:
- Add comprehensive unit tests for the ClickUp adapter covering token resolution, pagination, filtering, routing hints, rate limiting, error handling, and auth headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClickUp tracker adapter for task synchronization.
  * Supports pulling tasks, posting comments, and updating task statuses.
  * Configurable status mapping and authentication via API token.

* **Documentation**
  * Added ClickUp tracker adapter setup and configuration guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->