### PR TITLE
feat(trackers): ServiceNow adapter conforming to TrackerContract

### DIFF
--- a/docs/trackers/servicenow.md
+++ b/docs/trackers/servicenow.md
@@ -1,0 +1,98 @@
+# ServiceNow tracker adapter
+
+Bernstein can pull work directly from a ServiceNow tenant, post
+progress to the underlying record's `work_notes` field, and move the
+record through its state field when a task transitions. The adapter
+targets the `incident` table by default. `change_request`, `problem`,
+and custom-application tables are supported via the `table_name`
+config field.
+
+The adapter implements `bernstein.core.trackers.AbstractTrackerAdapter`
+and lives at `bernstein.core.trackers.servicenow.ServiceNowTracker`.
+It is disabled by default and must be opted in via `bernstein.yaml`.
+
+## Auth
+
+Basic auth with three environment variables. This is the most common
+path for ServiceNow Table API tenants. OAuth client-credentials is a
+future extension.
+
+| Environment variable        | Purpose                                  |
+|-----------------------------|------------------------------------------|
+| `SERVICENOW_INSTANCE_URL`   | Base URL of the tenant, e.g. `https://dev12345.service-now.com`. |
+| `SERVICENOW_USERNAME`       | Basic-auth username.                     |
+| `SERVICENOW_PASSWORD`       | Basic-auth password.                     |
+
+Override the env var names per tenant via `username_env` and
+`password_env` on `ServiceNowConfig`.
+
+## Configuration
+
+```yaml
+trackers:
+  servicenow:
+    instance_url: https://dev12345.service-now.com
+    table_name: incident
+    state_field: state
+    open_query: "active=true"
+    state_map:
+      todo: "1"
+      in_progress: "2"
+      done: "6"
+```
+
+| Field                      | Default        | Purpose                            |
+|----------------------------|----------------|------------------------------------|
+| `instance_url`             | env var        | Tenant base URL.                   |
+| `table_name`               | `incident`     | Table to operate against.          |
+| `state_field`              | `state`        | Workflow state field.              |
+| `open_query`               | `active=true`  | Default `sysparm_query` clause.    |
+| `state_map`                | `{}`           | Canonical -> tenant state mapping. |
+| `page_size`                | `50`           | `sysparm_limit` page size.         |
+| `rate_limit_min_interval`  | `0.0`          | Min seconds between calls.         |
+
+## Pulling, commenting, transitioning
+
+```python
+from bernstein.core.trackers import ServiceNowConfig, ServiceNowTracker
+
+config = ServiceNowConfig(
+    instance_url="https://dev12345.service-now.com",
+    table_name="incident",
+    state_map={"done": "6"},
+)
+with ServiceNowTracker(config) as tracker:
+    for ticket in tracker.pull_open_tickets():
+        tracker.add_comment(ticket.id, "Bernstein picked this up.")
+        tracker.transition(ticket.id, "done")
+```
+
+- `pull_open_tickets(filter)` accepts `sysparm_query` and `fields`
+  overrides via the filter dict.
+- `add_comment(ticket_id, body)` appends to `work_notes`. The
+  `ticket_id` is the record's `sys_id`.
+- `transition(ticket_id, status_id)` updates the state field. The
+  value is resolved through `state_map` first, then passed to
+  ServiceNow as-is.
+
+## Rate limiting
+
+- 429 responses surface as `RateLimited(retry_after=...)`. The hint is
+  taken from the `Retry-After` header.
+- A cooperative per-adapter min-interval throttle is available via
+  `rate_limit_min_interval`.
+
+## Exceptions
+
+| Exception                     | When                                                  |
+|-------------------------------|-------------------------------------------------------|
+| `TrackerUnavailable`          | 5xx, 401/403, missing config, malformed JSON.         |
+| `RateLimited`                 | 429 with optional `Retry-After`.                      |
+| `OptimisticConcurrencyError`  | 412 Precondition Failed on a write with an `etag`.    |
+
+## Out of scope
+
+- OAuth client-credentials auth (future extension).
+- Custom-application schema discovery (operator declares the table
+  and state field).
+- Multi-instance routing inside a single adapter instance.

--- a/src/bernstein/core/trackers/__init__.py
+++ b/src/bernstein/core/trackers/__init__.py
@@ -22,6 +22,7 @@ from bernstein.core.trackers.contract import (
     TrackerUnavailable,
     TransitionResult,
 )
+from bernstein.core.trackers.servicenow import ServiceNowConfig, ServiceNowTracker
 
 __all__ = [
     "AbstractTrackerAdapter",
@@ -33,8 +34,31 @@ __all__ = [
     "OptimisticConcurrencyError",
     "RateLimited",
     "RoutingHint",
+    "ServiceNowConfig",
+    "ServiceNowTracker",
     "Status",
     "Ticket",
     "TrackerUnavailable",
     "TransitionResult",
 ]
+
+
+def get_tracker(name: str, **kwargs: object) -> AbstractTrackerAdapter:
+    """Construct a tracker adapter by short name.
+
+    Minimal factory used by callers that resolve trackers from
+    configuration. New adapters register here.
+
+    Raises:
+        ValueError: if ``name`` is not a known tracker.
+    """
+    if name == "servicenow":
+        return ServiceNowTracker(**kwargs)  # type: ignore[arg-type]
+    if name == "github_projects" or name == "github_projects_v2":
+        from bernstein.core.trackers.builtin import (
+            GitHubProjectsV2Adapter,
+        )
+
+        return GitHubProjectsV2Adapter(**kwargs)  # type: ignore[arg-type]
+    msg = f"Unknown tracker '{name}'"
+    raise ValueError(msg)

--- a/src/bernstein/core/trackers/servicenow.py
+++ b/src/bernstein/core/trackers/servicenow.py
@@ -1,0 +1,447 @@
+"""ServiceNow tracker adapter.
+
+Implements ``AbstractTrackerAdapter`` on top of the ServiceNow Table API,
+targeting the ``incident`` table by default. ``change_request``,
+``problem``, and custom tables are also supported via the
+``table_name`` config field.
+
+Auth:
+- HTTP Basic auth using ``SERVICENOW_INSTANCE_URL``,
+  ``SERVICENOW_USERNAME``, and ``SERVICENOW_PASSWORD`` environment
+  variables. Basic auth is the most common path for ServiceNow Table
+  API tenants; OAuth client-credentials remains available as a future
+  extension.
+
+Capabilities:
+- ``pull_open_tickets``: ``GET /api/now/table/<table>`` with a
+  ``sysparm_query`` filter, paginated via ``sysparm_offset`` /
+  ``sysparm_limit``.
+- ``add_comment``: appends to the ``work_notes`` field on the record.
+- ``transition``: updates the configured state field on the record.
+
+Rate-limit handling:
+- 429 responses are surfaced as ``RateLimited`` with ``retry_after``
+  parsed from the ``Retry-After`` header.
+- A cooperative per-adapter min-interval throttle is available via
+  ``rate_limit_min_interval``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:  # pragma: no cover - optional dep already present in project deps
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    OptimisticConcurrencyError,
+    RateLimited,
+    RoutingHint,
+    Ticket,
+    TrackerUnavailable,
+    TransitionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TABLE_NAME = "incident"
+DEFAULT_STATE_FIELD = "state"
+DEFAULT_PAGE_SIZE = 50
+DEFAULT_OPEN_QUERY = "active=true"
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ServiceNowConfig:
+    """Configuration for a ServiceNow adapter instance.
+
+    Attributes:
+        instance_url: Base URL of the ServiceNow tenant (e.g.
+            ``https://dev12345.service-now.com``). If empty, the
+            adapter reads ``SERVICENOW_INSTANCE_URL``.
+        username_env: Environment variable name holding the basic-auth
+            username. Defaults to ``SERVICENOW_USERNAME``.
+        password_env: Environment variable name holding the basic-auth
+            password. Defaults to ``SERVICENOW_PASSWORD``.
+        table_name: Table to operate against. Common values:
+            ``incident`` (default), ``change_request``, ``problem``,
+            ``sn_si_incident``, or any custom-application table.
+        state_field: Single-choice field used as the workflow state.
+            Defaults to ``state``.
+        open_query: ``sysparm_query`` clause used by ``pull_open_tickets``
+            when the caller does not override it. Defaults to
+            ``active=true``.
+        state_map: Optional mapping from canonical status names to the
+            tenant's display values. ``done`` -> ``6`` (Resolved), etc.
+        page_size: ``sysparm_limit`` page size.
+        rate_limit_min_interval: Minimum seconds between HTTP calls per
+            adapter instance.
+    """
+
+    instance_url: str = ""
+    username_env: str = "SERVICENOW_USERNAME"
+    password_env: str = "SERVICENOW_PASSWORD"
+    table_name: str = DEFAULT_TABLE_NAME
+    state_field: str = DEFAULT_STATE_FIELD
+    open_query: str = DEFAULT_OPEN_QUERY
+    state_map: dict[str, str] = field(default_factory=dict)
+    page_size: int = DEFAULT_PAGE_SIZE
+    rate_limit_min_interval: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Credential resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_instance_url(config: ServiceNowConfig) -> str:
+    url = config.instance_url or os.environ.get("SERVICENOW_INSTANCE_URL", "")
+    if not url:
+        msg = "ServiceNow adapter: SERVICENOW_INSTANCE_URL is not set"
+        raise TrackerUnavailable(msg)
+    return url.rstrip("/")
+
+
+def _resolve_credentials(config: ServiceNowConfig) -> tuple[str, str]:
+    username = os.environ.get(config.username_env, "")
+    password = os.environ.get(config.password_env, "")
+    if not username or not password:
+        msg = (
+            f"ServiceNow adapter: credentials missing (env vars "
+            f"'{config.username_env}' and '{config.password_env}' must both be set)"
+        )
+        raise TrackerUnavailable(msg)
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# Token bucket
+# ---------------------------------------------------------------------------
+
+
+class _TokenBucket:
+    """Minimal cooperative token-bucket throttle.
+
+    A single shared lock-protected next-allowed timestamp. Calls block
+    until the timestamp is reached. ``min_interval == 0`` disables the
+    throttle.
+    """
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = max(0.0, float(min_interval))
+        self._next_allowed = 0.0
+        self._lock = threading.Lock()
+
+    def acquire(self, *, now: float | None = None, sleep: Any = time.sleep) -> None:
+        if self._min_interval <= 0.0:
+            return
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            wait = self._next_allowed - now
+            if wait > 0:
+                sleep(wait)
+                now = now + wait
+            self._next_allowed = now + self._min_interval
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class ServiceNowTracker(AbstractTrackerAdapter):
+    """Adapter for ServiceNow Table API.
+
+    Parameters:
+        config: Adapter configuration.
+        http_client: Optional pre-built ``httpx.Client``. Tests pass a
+            mocked transport via ``respx``.
+        credential_provider: Optional callable returning the
+            ``(username, password)`` tuple. The default reads from
+            ``_resolve_credentials(config)`` on each call.
+        instance_url_provider: Optional callable returning the instance
+            URL. The default reads ``_resolve_instance_url(config)``
+            once at construction time.
+    """
+
+    name = "servicenow"
+
+    def __init__(
+        self,
+        config: ServiceNowConfig,
+        *,
+        http_client: Any | None = None,
+        credential_provider: Any | None = None,
+        instance_url_provider: Any | None = None,
+    ) -> None:
+        if httpx is None:  # pragma: no cover - dep is declared in pyproject
+            msg = "httpx is required for ServiceNowTracker"
+            raise RuntimeError(msg)
+        self._config = config
+        self._client: Any = http_client or httpx.Client(timeout=30.0)
+        self._owns_client = http_client is None
+        self._credential_provider = credential_provider or (lambda: _resolve_credentials(config))
+        url_provider = instance_url_provider or (lambda: _resolve_instance_url(config))
+        self._instance_url = url_provider()
+        self._bucket = _TokenBucket(config.rate_limit_min_interval)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying HTTP client if we own it."""
+        if self._owns_client:
+            try:
+                self._client.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("ignoring error while closing httpx client", exc_info=True)
+
+    def __enter__(self) -> ServiceNowTracker:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- public API ---------------------------------------------------------
+
+    def pull_open_tickets(
+        self,
+        filter: dict[str, Any] | None = None,
+    ) -> Iterator[Ticket]:
+        """Yield records as ``Ticket`` objects.
+
+        ``filter`` keys:
+            - ``sysparm_query``: override ``config.open_query`` for this
+              call.
+            - ``fields``: comma-separated list passed to
+              ``sysparm_fields``. Optional; if omitted ServiceNow
+              returns every column on the record.
+        """
+        filter_dict = filter or {}
+        sysparm_query = filter_dict.get("sysparm_query", self._config.open_query)
+        sysparm_fields = filter_dict.get("fields")
+        page_size = max(1, min(1000, self._config.page_size))
+        offset = 0
+        while True:
+            params: dict[str, Any] = {
+                "sysparm_query": sysparm_query,
+                "sysparm_limit": page_size,
+                "sysparm_offset": offset,
+                "sysparm_display_value": "all",
+            }
+            if sysparm_fields:
+                params["sysparm_fields"] = sysparm_fields
+            data = self._request(
+                "GET",
+                f"/api/now/table/{self._config.table_name}",
+                params=params,
+            )
+            records = data.get("result") or []
+            if not records:
+                break
+            for raw in records:
+                yield self._record_to_ticket(raw)
+            if len(records) < page_size:
+                break
+            offset += page_size
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        """Append ``body`` to the ``work_notes`` field on ``ticket_id``.
+
+        ``ticket_id`` is the record's ``sys_id``. ServiceNow has no
+        first-class comment id, so we return the record ``sys_id`` as
+        the comment id; callers that need a stable comment id can store
+        the optional ``idempotency_key`` they passed in.
+        """
+        payload: dict[str, Any] = {"work_notes": body}
+        if idempotency_key is not None:
+            # Append a marker so re-runs with the same key can be spotted
+            # by operators scanning the journal. ServiceNow ignores the
+            # marker for ordering / lookup; it is informational only.
+            payload["work_notes"] = f"{body}\n[idempotency:{idempotency_key}]"
+        self._request(
+            "PATCH",
+            f"/api/now/table/{self._config.table_name}/{ticket_id}",
+            json_body=payload,
+        )
+        return CommentResult(comment_id=ticket_id, ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        """Move ``ticket_id`` (record ``sys_id``) to ``status_id``.
+
+        ``status_id`` is resolved through ``config.state_map`` first,
+        then passed through to the state field as-is. ServiceNow state
+        values are commonly small integers (e.g. ``1`` = New,
+        ``6`` = Resolved) but the field can also be a string.
+        """
+        mapped = self._config.state_map.get(status_id, status_id)
+        payload = {self._config.state_field: mapped}
+        if idempotency_key is not None:
+            payload["x_bernstein_idempotency"] = idempotency_key
+        self._request(
+            "PATCH",
+            f"/api/now/table/{self._config.table_name}/{ticket_id}",
+            json_body=payload,
+            etag=etag,
+        )
+        return TransitionResult(
+            ticket_id=ticket_id,
+            new_status=status_id,
+            etag=None,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _record_to_ticket(self, raw: dict[str, Any]) -> Ticket:
+        """Normalise a single Table API record into a ``Ticket``.
+
+        ServiceNow returns each field as either a bare string or an
+        object with ``value`` / ``display_value`` keys when
+        ``sysparm_display_value=all`` is set. We try both shapes.
+        """
+
+        def _get(name: str, *, display: bool = False) -> str:
+            value = raw.get(name)
+            if isinstance(value, dict):
+                key = "display_value" if display else "value"
+                return str(value.get(key) or value.get("value") or "")
+            return "" if value is None else str(value)
+
+        sys_id = _get("sys_id")
+        number = _get("number")
+        short_description = _get("short_description")
+        description = _get("description")
+        state = _get(self._config.state_field, display=True) or _get(self._config.state_field)
+        external_url = f"{self._instance_url}/nav_to.do?uri={self._config.table_name}.do?sys_id={sys_id}"
+        return Ticket(
+            id=sys_id,
+            external_url=external_url,
+            title=short_description or number,
+            body=description,
+            status=state,
+            labels=(),
+            etag=None,
+            routing_hint=RoutingHint(),
+            raw={
+                "number": number,
+                "table": self._config.table_name,
+                "sys_id": sys_id,
+            },
+        )
+
+    # -- HTTP --------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        etag: str | None = None,
+    ) -> dict[str, Any]:
+        self._bucket.acquire()
+        username, password = self._credential_provider()
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if etag:
+            headers["If-Match"] = etag
+        url = f"{self._instance_url}{path}"
+        try:
+            response = self._client.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                headers=headers,
+                auth=(username, password),
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            msg = f"ServiceNow transport error: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+        status_code = getattr(response, "status_code", 0)
+        if status_code == 412:
+            msg = "Precondition Failed (etag mismatch)"
+            raise OptimisticConcurrencyError(msg)
+        if status_code == 429:
+            retry_after = _parse_retry_after(response)
+            msg = f"ServiceNow rate-limited (status={status_code})"
+            raise RateLimited(msg, retry_after=retry_after)
+        if status_code in {401, 403}:
+            body = _safe_text(response)
+            msg = f"ServiceNow auth/permission error (status={status_code}): {body[:200]}"
+            raise TrackerUnavailable(msg)
+        if status_code >= 500:
+            msg = f"ServiceNow server error (status={status_code})"
+            raise TrackerUnavailable(msg)
+        if status_code >= 400:
+            body = _safe_text(response)
+            msg = f"ServiceNow HTTP {status_code}: {body[:200]}"
+            raise TrackerUnavailable(msg)
+
+        if status_code == 204 or not getattr(response, "content", b""):
+            return {}
+        try:
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - malformed JSON
+            msg = f"ServiceNow returned non-JSON: {exc}"
+            raise TrackerUnavailable(msg) from exc
+        if not isinstance(data, dict):
+            msg = "ServiceNow returned a non-object JSON body"
+            raise TrackerUnavailable(msg)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(response: Any) -> float | None:
+    """Best-effort ``Retry-After`` parser."""
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if retry_after:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _safe_text(response: Any) -> str:
+    try:
+        return str(getattr(response, "text", ""))
+    except Exception:  # pragma: no cover
+        return ""

--- a/tests/unit/trackers/test_servicenow.py
+++ b/tests/unit/trackers/test_servicenow.py
@@ -1,0 +1,333 @@
+"""Tests for :mod:`bernstein.core.trackers.servicenow`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.trackers import (
+    OptimisticConcurrencyError,
+    RateLimited,
+    TrackerUnavailable,
+)
+from bernstein.core.trackers.servicenow import (
+    ServiceNowConfig,
+    ServiceNowTracker,
+    _resolve_credentials,
+    _resolve_instance_url,
+)
+
+INSTANCE_URL = "https://dev12345.service-now.com"
+TABLE_URL = f"{INSTANCE_URL}/api/now/table/incident"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _record(
+    *,
+    sys_id: str = "abc123",
+    number: str = "INC0010001",
+    short_description: str = "Disk full on web-01",
+    description: str = "Root volume at 99%.",
+    state_value: str = "1",
+    state_display: str = "New",
+) -> dict[str, Any]:
+    return {
+        "sys_id": {"value": sys_id, "display_value": sys_id},
+        "number": {"value": number, "display_value": number},
+        "short_description": {
+            "value": short_description,
+            "display_value": short_description,
+        },
+        "description": {"value": description, "display_value": description},
+        "state": {"value": state_value, "display_value": state_display},
+    }
+
+
+def _make_adapter(
+    *,
+    state_map: dict[str, str] | None = None,
+    table_name: str = "incident",
+    state_field: str = "state",
+) -> ServiceNowTracker:
+    config = ServiceNowConfig(
+        instance_url=INSTANCE_URL,
+        table_name=table_name,
+        state_field=state_field,
+        state_map=state_map or {},
+    )
+    return ServiceNowTracker(
+        config=config,
+        credential_provider=lambda: ("admin", "secret"),
+        instance_url_provider=lambda: INSTANCE_URL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Credential / instance-URL resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_instance_url_from_config() -> None:
+    config = ServiceNowConfig(instance_url=INSTANCE_URL + "/")
+    assert _resolve_instance_url(config) == INSTANCE_URL
+
+
+def test_resolve_instance_url_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SERVICENOW_INSTANCE_URL", INSTANCE_URL)
+    config = ServiceNowConfig()
+    assert _resolve_instance_url(config) == INSTANCE_URL
+
+
+def test_resolve_instance_url_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SERVICENOW_INSTANCE_URL", raising=False)
+    config = ServiceNowConfig()
+    with pytest.raises(TrackerUnavailable):
+        _resolve_instance_url(config)
+
+
+def test_resolve_credentials_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SERVICENOW_USERNAME", "user")
+    monkeypatch.setenv("SERVICENOW_PASSWORD", "pass")
+    config = ServiceNowConfig()
+    assert _resolve_credentials(config) == ("user", "pass")
+
+
+def test_resolve_credentials_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SERVICENOW_USERNAME", raising=False)
+    monkeypatch.delenv("SERVICENOW_PASSWORD", raising=False)
+    config = ServiceNowConfig()
+    with pytest.raises(TrackerUnavailable):
+        _resolve_credentials(config)
+
+
+# ---------------------------------------------------------------------------
+# pull_open_tickets
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_pull_open_tickets_emits_normalised_tickets() -> None:
+    adapter = _make_adapter()
+    route = respx.get(TABLE_URL).mock(return_value=httpx.Response(200, json={"result": [_record()]}))
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert route.call_count == 1
+    assert len(tickets) == 1
+    ticket = tickets[0]
+    assert ticket.id == "abc123"
+    assert ticket.title == "Disk full on web-01"
+    assert ticket.body == "Root volume at 99%."
+    assert ticket.status == "New"
+    assert ticket.raw["number"] == "INC0010001"
+    assert ticket.raw["table"] == "incident"
+    assert "sys_id=abc123" in ticket.external_url
+    # Default open query is applied.
+    call = route.calls[0].request
+    assert b"sysparm_query=active%3Dtrue" in call.url.query
+
+
+@respx.mock
+def test_pull_open_tickets_respects_filter_override() -> None:
+    adapter = _make_adapter()
+    route = respx.get(TABLE_URL).mock(return_value=httpx.Response(200, json={"result": [_record()]}))
+    try:
+        list(adapter.pull_open_tickets({"sysparm_query": "active=true^priority=1", "fields": "sys_id,number"}))
+    finally:
+        adapter.close()
+    call = route.calls[0].request
+    query_str = call.url.query.decode()
+    assert "sysparm_query=active%3Dtrue%5Epriority%3D1" in query_str
+    assert "sysparm_fields=sys_id%2Cnumber" in query_str
+
+
+@respx.mock
+def test_pull_open_tickets_paginates_until_short_page() -> None:
+    adapter = _make_adapter()
+    config = adapter._config
+    full_page = {"result": [_record(sys_id=f"id{i}") for i in range(config.page_size)]}
+    short_page = {"result": [_record(sys_id="tail")]}
+    route = respx.get(TABLE_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=full_page),
+            httpx.Response(200, json=short_page),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert route.call_count == 2
+    assert len(tickets) == config.page_size + 1
+    assert tickets[-1].id == "tail"
+
+
+@respx.mock
+def test_pull_open_tickets_handles_empty_result() -> None:
+    adapter = _make_adapter()
+    respx.get(TABLE_URL).mock(return_value=httpx.Response(200, json={"result": []}))
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert tickets == []
+
+
+# ---------------------------------------------------------------------------
+# add_comment
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_add_comment_appends_to_work_notes() -> None:
+    adapter = _make_adapter()
+    record_url = f"{TABLE_URL}/abc123"
+    route = respx.patch(record_url).mock(return_value=httpx.Response(200, json={"result": {"sys_id": "abc123"}}))
+    try:
+        result = adapter.add_comment("abc123", "Hello there", idempotency_key="k1")
+    finally:
+        adapter.close()
+    assert result.comment_id == "abc123"
+    assert result.ticket_id == "abc123"
+    sent = route.calls[0].request.content
+    assert b'"work_notes"' in sent
+    assert b"Hello there" in sent
+    assert b"idempotency:k1" in sent
+
+
+# ---------------------------------------------------------------------------
+# transition
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_transition_passes_status_directly() -> None:
+    adapter = _make_adapter()
+    record_url = f"{TABLE_URL}/abc123"
+    route = respx.patch(record_url).mock(return_value=httpx.Response(200, json={"result": {"sys_id": "abc123"}}))
+    try:
+        result = adapter.transition("abc123", "6")
+    finally:
+        adapter.close()
+    assert result.ticket_id == "abc123"
+    assert result.new_status == "6"
+    sent = route.calls[0].request.content
+    assert b'"state":"6"' in sent
+
+
+@respx.mock
+def test_transition_uses_state_map() -> None:
+    adapter = _make_adapter(state_map={"done": "6"})
+    record_url = f"{TABLE_URL}/abc123"
+    route = respx.patch(record_url).mock(return_value=httpx.Response(200, json={"result": {"sys_id": "abc123"}}))
+    try:
+        result = adapter.transition("abc123", "done")
+    finally:
+        adapter.close()
+    assert result.new_status == "done"
+    sent = route.calls[0].request.content
+    assert b'"state":"6"' in sent
+
+
+@respx.mock
+def test_transition_supports_custom_table_and_state_field() -> None:
+    adapter = _make_adapter(table_name="change_request", state_field="approval")
+    record_url = f"{INSTANCE_URL}/api/now/table/change_request/abc123"
+    route = respx.patch(record_url).mock(return_value=httpx.Response(200, json={"result": {"sys_id": "abc123"}}))
+    try:
+        adapter.transition("abc123", "approved")
+    finally:
+        adapter.close()
+    sent = route.calls[0].request.content
+    assert b'"approval":"approved"' in sent
+
+
+# ---------------------------------------------------------------------------
+# Rate limit / concurrency / errors
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_rate_limit_with_retry_after_header() -> None:
+    adapter = _make_adapter()
+    respx.get(TABLE_URL).mock(
+        return_value=httpx.Response(
+            429,
+            json={"error": "slow down"},
+            headers={"Retry-After": "23"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 23.0
+
+
+@respx.mock
+def test_etag_mismatch_raises_optimistic_concurrency() -> None:
+    adapter = _make_adapter()
+    record_url = f"{TABLE_URL}/abc123"
+    respx.patch(record_url).mock(return_value=httpx.Response(412, json={"error": "etag"}))
+    try:
+        with pytest.raises(OptimisticConcurrencyError):
+            adapter.transition("abc123", "6", etag='W/"abc"')
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_5xx_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(TABLE_URL).mock(return_value=httpx.Response(503, json={"error": "down"}))
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_401_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(TABLE_URL).mock(return_value=httpx.Response(401, json={"error": "auth"}))
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_factory_returns_servicenow_tracker(monkeypatch: pytest.MonkeyPatch) -> None:
+    from bernstein.core.trackers import get_tracker
+
+    monkeypatch.setenv("SERVICENOW_INSTANCE_URL", INSTANCE_URL)
+    monkeypatch.setenv("SERVICENOW_USERNAME", "u")
+    monkeypatch.setenv("SERVICENOW_PASSWORD", "p")
+    adapter = get_tracker("servicenow", config=ServiceNowConfig(instance_url=INSTANCE_URL))
+    try:
+        assert isinstance(adapter, ServiceNowTracker)
+        assert adapter.name == "servicenow"
+    finally:
+        adapter.close()
+
+
+def test_factory_unknown_name_raises() -> None:
+    from bernstein.core.trackers import get_tracker
+
+    with pytest.raises(ValueError, match="Unknown tracker"):
+        get_tracker("does_not_exist")


### PR DESCRIPTION
Adds the ServiceNow adapter for operators running compliance-sensitive workflows. Follows the GitHub Projects v2 pattern. Auth via basic auth env vars.

## Summary

- New `ServiceNowTracker` in `src/bernstein/core/trackers/servicenow.py` implementing `AbstractTrackerAdapter`.
- Targets the `incident` table by default; `change_request`, `problem`, and custom tables supported via `table_name`.
- Basic auth via `SERVICENOW_INSTANCE_URL`, `SERVICENOW_USERNAME`, `SERVICENOW_PASSWORD`.
- `pull_open_tickets` paginates with `sysparm_query` / `sysparm_offset`.
- `add_comment` appends to `work_notes` with an idempotency marker.
- `transition` updates the configured state field, resolved through `state_map`.
- 429 returns `RateLimited(retry_after=...)`; 412 returns `OptimisticConcurrencyError`.
- Small `get_tracker(name)` factory in `bernstein.core.trackers` for config-driven construction.

## Test plan

- [x] 19 unit tests under `tests/unit/trackers/test_servicenow.py` covering pagination, filter overrides, payload contents, rate limits, auth failures, etag mismatch, factory.
- [x] All existing tracker tests still pass (`tests/unit/trackers/`).
- [x] `ruff check` clean on touched files.
- [x] Docs page added at `docs/trackers/servicenow.md`.

## Summary by Sourcery

Add a ServiceNow tracker adapter implementing the common tracker contract and wire it into the tracker factory for config-driven usage.

New Features:
- Introduce ServiceNowTracker and ServiceNowConfig to integrate with the ServiceNow Table API for pulling, commenting on, and transitioning tickets.
- Add a get_tracker factory helper to construct tracker adapters by short name, including ServiceNow and GitHub Projects v2 adapters.

Enhancements:
- Implement rate limiting, credential resolution, and error handling abstractions for the ServiceNow adapter, including pagination and optimistic concurrency support.

Documentation:
- Add user-facing documentation for configuring and using the ServiceNow tracker adapter, including auth setup, configuration options, and behavior.

Tests:
- Add comprehensive unit tests for the ServiceNow tracker covering credential resolution, pagination, filtering, state transitions, rate limiting, error handling, and factory registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ServiceNow tracker adapter to pull open tickets, post comments to work notes, and transition ticket states.
  * Supports configurable incident tables, state fields, and environment-based authentication.
  * Includes rate limiting and optimistic concurrency handling via ETags.

* **Documentation**
  * Added complete ServiceNow tracker configuration guide and usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sipyourdrink-ltd/bernstein/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->