### PR TITLE
feat(trackers): Asana adapter conforming to TrackerContract

### DIFF
--- a/docs/trackers/asana.md
+++ b/docs/trackers/asana.md
@@ -1,0 +1,144 @@
+# Asana tracker adapter
+
+Bernstein can pull work from an Asana project, post progress stories
+back to the task, and move the task between sections when a task
+transitions. The adapter also supports per-step CLI choice: an
+operator-declared custom field can name the CLI adapter (`claude`,
+`codex`, `aider`, ...) Bernstein should pick for each task.
+
+The adapter implements `bernstein.core.trackers.AbstractTrackerAdapter`
+and lives under `bernstein.core.trackers.builtin.asana_adapter`. It is
+disabled by default and must be opted in via `bernstein.yaml`.
+
+## Auth
+
+Authentication uses an Asana Personal Access Token (PAT). Point the
+adapter at the environment variable that holds the token. If `pat_env`
+is omitted the adapter falls back to `ASANA_PERSONAL_ACCESS_TOKEN`.
+
+```yaml
+trackers:
+  asana:
+    workspace_gid: "1199999999999999"
+    project_gid: "1201234567890123"
+    auth:
+      pat_env: ASANA_PERSONAL_ACCESS_TOKEN
+```
+
+A PAT with read+write access on the workspace is sufficient. See the
+Asana developer docs for how to mint one.
+
+## Sections vs. status
+
+Asana does not have a global "status" surface. Sections are per-project
+workflow buckets and act as the status surface for this adapter.
+Section gids are operator-supplied because they cannot be inferred
+without the schema.
+
+```yaml
+trackers:
+  asana:
+    workspace_gid: "1199999999999999"
+    project_gid: "1201234567890123"
+    section_filter_gid: "1207770000000001"  # default section to pull
+    section_map:
+      ready: "1207770000000001"
+      claimed: "1207770000000002"
+      done: "1207770000000003"
+      failed: "1207770000000004"
+```
+
+`transition(ticket_id, status_id)` resolves `status_id` in this order:
+
+1. Treat the value as a section gid (opaque).
+2. Look it up in `section_map`.
+
+If neither resolves, `TrackerUnavailable` is raised.
+
+## Per-step CLI choice
+
+Add a single-select custom field whose enum values name the CLI
+(`claude`, `codex`, `aider`). Point the adapter at the field's gid:
+
+```yaml
+trackers:
+  asana:
+    workspace_gid: "1199999999999999"
+    project_gid: "1201234567890123"
+    cli_choice_custom_field_gid: "1207770099999999"
+```
+
+The adapter exposes the field value on the ticket dataclass:
+
+```python
+from bernstein.core.trackers.builtin import AsanaAdapter, AsanaConfig
+
+config = AsanaConfig(
+    workspace_gid="1199999999999999",
+    project_gid="1201234567890123",
+    section_filter_gid="1207770000000001",
+    cli_choice_custom_field_gid="1207770099999999",
+    pat_env="ASANA_PERSONAL_ACCESS_TOKEN",
+)
+with AsanaAdapter(config) as adapter:
+    for ticket in adapter.pull_open_tickets():
+        cli = ticket.routing_hint.cli  # "claude" / "codex" / "aider" / None
+```
+
+When the orchestrator's routing layer sees a non-empty
+`ticket.routing_hint.cli`, it pins the spawned CLI for that ticket.
+
+## Example workflow
+
+A common ops-team setup keeps four sections in one Asana project:
+
+| Section   | Bernstein status | Meaning                          |
+|-----------|------------------|----------------------------------|
+| Ready     | ready            | Available for an agent to claim. |
+| In flight | claimed          | An agent has picked it up.       |
+| Done      | done             | Acceptance criteria green.       |
+| Failed    | failed           | Hard halt, operator follow-up.   |
+
+A custom field `Agent` (text or enum) lets the requester pin a specific
+CLI per task. Stories (comments) on the task carry the agent's status
+updates back to the requester without leaving the Asana UI.
+
+## Comments and transitions
+
+- `add_comment(ticket_id, body)` posts a story to the task. Pass
+  `ticket.id` (the task gid) as `ticket_id`.
+- `transition(ticket_id, status_id)` moves the task into the target
+  section via `POST /sections/{section_gid}/addTask`.
+
+Both methods accept an `idempotency_key` that is forwarded as an
+`X-Idempotency-Key` request header. The server ignores unknown headers;
+operator-side logging can use the value to correlate retries.
+
+## Custom-field writes
+
+For non-section custom-field writes, call
+`adapter.update_custom_field(ticket_id, custom_field_gid, value)`. The
+accepted shape of `value` depends on the custom-field type (text,
+number, enum option gid, etc.) and matches the body shape documented in
+the Asana API reference.
+
+## Rate limiting
+
+- A cooperative per-adapter token-bucket throttles outbound calls when
+  `rate_limit_min_interval` is set.
+- A `429` response is translated into `RateLimited(retry_after=...)`.
+  The hint is taken from the `Retry-After` header when present.
+
+## Exceptions
+
+| Exception            | When                                            |
+|----------------------|-------------------------------------------------|
+| `TrackerUnavailable` | 4xx (other than 429), 5xx, malformed JSON, payload `errors`, missing token, empty section gid. |
+| `RateLimited`        | 429.                                            |
+
+## Out of scope
+
+- Portfolios and goals (separate adapter shape if needed).
+- Asana Forms (we read tasks, not forms).
+- Auto-discovery of custom-field schemas. Custom-field gids must be
+  declared in `bernstein.yaml` by the operator.

--- a/src/bernstein/core/trackers/builtin/__init__.py
+++ b/src/bernstein/core/trackers/builtin/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from bernstein.core.trackers.builtin.asana_adapter import (
+    AsanaAdapter,
+    AsanaConfig,
+)
 from bernstein.core.trackers.builtin.clickup_adapter import (
     ClickUpAdapter,
     ClickUpConfig,
@@ -12,6 +16,8 @@ from bernstein.core.trackers.builtin.github_projects_adapter import (
 )
 
 __all__ = [
+    "AsanaAdapter",
+    "AsanaConfig",
     "ClickUpAdapter",
     "ClickUpConfig",
     "GitHubProjectsV2Adapter",

--- a/src/bernstein/core/trackers/builtin/asana_adapter.py
+++ b/src/bernstein/core/trackers/builtin/asana_adapter.py
@@ -1,0 +1,492 @@
+"""Asana tracker adapter.
+
+Implements the ``AbstractTrackerAdapter`` contract on top of the public
+Asana REST API (https://app.asana.com/api/1.0).
+
+Auth:
+- Personal Access Token (PAT) read from an environment variable.
+
+Capabilities:
+- ``pull_open_tickets``: paginate the configured project's tasks,
+  optionally filtered by section, and emit normalised ``Ticket``
+  objects.
+- ``add_comment``: post a story (comment) on the task.
+- ``transition``: move the task between sections. Asana sections are
+  per-project workflow buckets and act as the status surface for this
+  adapter. An operator-supplied ``section_map`` maps canonical status
+  names to section gids.
+
+Per-step CLI choice:
+- If ``cli_choice_custom_field_gid`` is configured and a task has an
+  enum value for that custom field, the adapter exposes
+  ``ticket.routing_hint.cli`` so the orchestrator can route the work to
+  a specific CLI adapter.
+
+Rate-limit handling:
+- Token-bucket per-instance (cooperative, advisory).
+- ``RateLimited`` raised with ``retry_after`` derived from the
+  ``Retry-After`` header on a 429 response.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:  # pragma: no cover - optional dep already present in project deps
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    RateLimited,
+    RoutingHint,
+    Ticket,
+    TrackerUnavailable,
+    TransitionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+ASANA_API_BASE = "https://app.asana.com/api/1.0"
+DEFAULT_PAGE_SIZE = 50
+DEFAULT_PAT_ENV = "ASANA_PERSONAL_ACCESS_TOKEN"
+
+# Comma-separated list of task fields requested from the API. Keeps the
+# payload small while exposing everything the adapter needs to populate a
+# ``Ticket``.
+_TASK_OPT_FIELDS = (
+    "gid,name,notes,permalink_url,completed,"
+    "memberships.section.gid,memberships.section.name,"
+    "tags.name,"
+    "custom_fields.gid,custom_fields.name,"
+    "custom_fields.enum_value.name,custom_fields.text_value,"
+    "custom_fields.display_value"
+)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AsanaConfig:
+    """Configuration for an Asana adapter instance.
+
+    Attributes:
+        workspace_gid: Asana workspace gid the project lives in.
+        project_gid: Numeric/string gid of the project to pull tasks from.
+        section_filter_gid: Optional section gid the adapter filters on
+            when ``pull_open_tickets`` is called with no filter override.
+        section_map: Optional mapping from canonical status names to
+            section gids. ``done`` -> ``1201234567890123``, etc.
+        cli_choice_custom_field_gid: Optional custom-field gid whose enum
+            value selects a CLI adapter (``claude``, ``codex``, ...).
+        include_completed: Whether to yield completed tasks. Default
+            ``False`` (matches the ``completed_since=now`` semantics on
+            the upstream API).
+        pat_env: Environment variable name holding the Personal Access
+            Token. Defaults to ``ASANA_PERSONAL_ACCESS_TOKEN``.
+        page_size: REST pagination ``limit``.
+        rate_limit_min_interval: Minimum seconds between API calls per
+            adapter instance (cheap client-side throttle).
+    """
+
+    workspace_gid: str
+    project_gid: str
+    section_filter_gid: str | None = None
+    section_map: dict[str, str] = field(default_factory=dict)
+    cli_choice_custom_field_gid: str | None = None
+    include_completed: bool = False
+    pat_env: str | None = None
+    page_size: int = DEFAULT_PAGE_SIZE
+    rate_limit_min_interval: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token(config: AsanaConfig) -> str:
+    """Resolve the PAT from the configured environment variable.
+
+    Order of precedence:
+        1. ``config.pat_env`` if set.
+        2. ``ASANA_PERSONAL_ACCESS_TOKEN``.
+
+    Raises:
+        TrackerUnavailable: if no token is available.
+    """
+    env_var = config.pat_env or DEFAULT_PAT_ENV
+    token = os.environ.get(env_var, "")
+    if not token:
+        msg = f"Asana adapter: no token available (env var '{env_var}' is empty)"
+        raise TrackerUnavailable(msg)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Token bucket
+# ---------------------------------------------------------------------------
+
+
+class _TokenBucket:
+    """Minimal cooperative token-bucket throttle.
+
+    A single shared lock-protected next-allowed timestamp. Calls block
+    until the timestamp is reached. ``min_interval == 0`` disables the
+    throttle. This is intentionally simple: we lean on server-side rate
+    limits + ``Retry-After`` headers for hard enforcement.
+    """
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = max(0.0, float(min_interval))
+        self._next_allowed = 0.0
+        self._lock = threading.Lock()
+
+    def acquire(self, *, now: float | None = None, sleep: Any = time.sleep) -> None:
+        if self._min_interval <= 0.0:
+            return
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            wait = self._next_allowed - now
+            if wait > 0:
+                sleep(wait)
+                now = now + wait
+            self._next_allowed = now + self._min_interval
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class AsanaAdapter(AbstractTrackerAdapter):
+    """Adapter for Asana.
+
+    The adapter is intentionally thin: every call is a single REST
+    round-trip. Section gids are operator-supplied because Asana
+    sections are per-project (not workspace-global).
+
+    Parameters:
+        config: Adapter configuration.
+        http_client: Optional pre-built ``httpx.Client`` (tests pass a
+            mocked transport via ``respx``).
+        token_provider: Optional callable returning the PAT. The default
+            reads from ``_resolve_token(config)`` on each call.
+    """
+
+    name = "asana"
+
+    def __init__(
+        self,
+        config: AsanaConfig,
+        *,
+        http_client: Any | None = None,
+        token_provider: Any | None = None,
+    ) -> None:
+        if httpx is None:  # pragma: no cover - dep is declared in pyproject
+            msg = "httpx is required for AsanaAdapter"
+            raise RuntimeError(msg)
+        self._config = config
+        self._client: Any = http_client or httpx.Client(timeout=30.0)
+        self._owns_client = http_client is None
+        self._token_provider = token_provider or (lambda: _resolve_token(config))
+        self._bucket = _TokenBucket(config.rate_limit_min_interval)
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying HTTP client if we own it."""
+        if self._owns_client:
+            try:
+                self._client.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("ignoring error while closing httpx client", exc_info=True)
+
+    def __enter__(self) -> AsanaAdapter:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- public API ---------------------------------------------------------
+
+    def pull_open_tickets(
+        self,
+        filter: dict[str, Any] | None = None,
+    ) -> Iterator[Ticket]:
+        """Yield project tasks as ``Ticket`` objects.
+
+        ``filter`` keys:
+            - ``section``: override ``config.section_filter_gid`` for
+              this call. Pass a section gid.
+            - ``include_completed``: bool, default
+              ``config.include_completed``.
+        """
+        filter_dict = filter or {}
+        section_filter = filter_dict.get("section", self._config.section_filter_gid)
+        include_completed = bool(filter_dict.get("include_completed", self._config.include_completed))
+        page_size = max(1, min(100, self._config.page_size))
+
+        # Asana exposes a ``/projects/{gid}/tasks`` endpoint that yields
+        # every task in the project; we filter by section client-side so
+        # operator configs that omit a section still work.
+        params: dict[str, Any] = {
+            "limit": page_size,
+            "opt_fields": _TASK_OPT_FIELDS,
+        }
+        if not include_completed:
+            # ``completed_since=now`` asks Asana for tasks completed
+            # after "now", which effectively returns only open tasks.
+            params["completed_since"] = "now"
+
+        path = f"/projects/{self._config.project_gid}/tasks"
+        next_offset: str | None = None
+        while True:
+            if next_offset:
+                params["offset"] = next_offset
+            data = self._request("GET", path, params=params)
+            for raw_task in data.get("data") or []:
+                ticket = self._task_to_ticket(raw_task)
+                if ticket is None:
+                    continue
+                if section_filter and ticket.raw.get("section_gid") != section_filter:
+                    continue
+                yield ticket
+            next_page = (data.get("next_page") or {}) if isinstance(data, dict) else {}
+            next_offset = next_page.get("offset") if isinstance(next_page, dict) else None
+            if not next_offset:
+                break
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        """Post a story (comment) on ``ticket_id``.
+
+        Asana does not have a native idempotency-key header, so
+        ``idempotency_key`` is forwarded as an ``X-Idempotency-Key``
+        request header. The server ignores unknown headers; the value is
+        kept so that operator-side logging can correlate retries.
+        """
+        path = f"/tasks/{ticket_id}/stories"
+        headers: dict[str, str] = {}
+        if idempotency_key:
+            headers["X-Idempotency-Key"] = idempotency_key
+        payload = {"data": {"text": body}}
+        result = self._request("POST", path, json_body=payload, headers=headers)
+        story = result.get("data") or {}
+        return CommentResult(
+            comment_id=str(story.get("gid", "")),
+            ticket_id=ticket_id,
+        )
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        """Move ``ticket_id`` (task gid) into the section ``status_id``.
+
+        ``status_id`` may be either:
+            - a section gid (preferred, opaque)
+            - a key in ``config.section_map`` that resolves to a gid.
+
+        Asana's REST API ignores ``etag`` on this endpoint; the
+        parameter is accepted for contract conformance and discarded.
+        """
+        del etag
+        section_gid = self._config.section_map.get(status_id, status_id)
+        if not section_gid:
+            msg = f"Asana adapter: empty section gid for status '{status_id}'"
+            raise TrackerUnavailable(msg)
+        path = f"/sections/{section_gid}/addTask"
+        headers: dict[str, str] = {}
+        if idempotency_key:
+            headers["X-Idempotency-Key"] = idempotency_key
+        payload = {"data": {"task": ticket_id}}
+        self._request("POST", path, json_body=payload, headers=headers)
+        return TransitionResult(
+            ticket_id=ticket_id,
+            new_status=status_id,
+            etag=None,
+        )
+
+    def update_custom_field(
+        self,
+        ticket_id: str,
+        custom_field_gid: str,
+        value: Any,
+        *,
+        idempotency_key: str | None = None,
+    ) -> None:
+        """Write ``value`` to ``custom_field_gid`` on ``ticket_id``.
+
+        Asana custom-field writes go through ``PUT /tasks/{gid}`` with a
+        ``custom_fields`` body keyed by gid. The accepted shape of
+        ``value`` depends on the custom-field type (text, number, enum
+        option gid, etc.); the caller is responsible for matching it.
+        """
+        path = f"/tasks/{ticket_id}"
+        headers: dict[str, str] = {}
+        if idempotency_key:
+            headers["X-Idempotency-Key"] = idempotency_key
+        payload = {"data": {"custom_fields": {custom_field_gid: value}}}
+        self._request("PUT", path, json_body=payload, headers=headers)
+
+    # -- internals ----------------------------------------------------------
+
+    def _task_to_ticket(self, raw_task: dict[str, Any]) -> Ticket | None:
+        if not isinstance(raw_task, dict):
+            return None
+
+        section_gid = ""
+        section_name = ""
+        for membership in raw_task.get("memberships") or []:
+            section = membership.get("section") if isinstance(membership, dict) else None
+            if isinstance(section, dict) and section.get("gid"):
+                section_gid = str(section.get("gid") or "")
+                section_name = str(section.get("name") or "")
+                break
+
+        cli_choice: str | None = None
+        if self._config.cli_choice_custom_field_gid:
+            for cf in raw_task.get("custom_fields") or []:
+                if not isinstance(cf, dict):
+                    continue
+                if str(cf.get("gid") or "") != self._config.cli_choice_custom_field_gid:
+                    continue
+                enum_value = cf.get("enum_value")
+                if isinstance(enum_value, dict) and enum_value.get("name"):
+                    cli_choice = str(enum_value["name"])
+                    break
+                text_value = cf.get("text_value")
+                if isinstance(text_value, str) and text_value:
+                    cli_choice = text_value
+                    break
+
+        labels = tuple(
+            str(tag.get("name") or "")
+            for tag in (raw_task.get("tags") or [])
+            if isinstance(tag, dict) and tag.get("name")
+        )
+        return Ticket(
+            id=str(raw_task.get("gid", "")),
+            external_url=str(raw_task.get("permalink_url", "") or ""),
+            title=str(raw_task.get("name", "") or ""),
+            body=str(raw_task.get("notes", "") or ""),
+            status=section_name,
+            labels=labels,
+            etag=None,
+            routing_hint=RoutingHint(cli=cli_choice),
+            raw={
+                "gid": str(raw_task.get("gid", "")),
+                "section_gid": section_gid,
+                "section_name": section_name,
+                "completed": bool(raw_task.get("completed", False)),
+            },
+        )
+
+    # -- HTTP --------------------------------------------------------------
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        self._bucket.acquire()
+        token = self._token_provider()
+        merged_headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+        if headers:
+            merged_headers.update(headers)
+        url = f"{ASANA_API_BASE}{path}"
+        try:
+            response = self._client.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                headers=merged_headers,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            msg = f"Asana transport error: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+        status_code = getattr(response, "status_code", 0)
+        if status_code == 429:
+            retry_after = _parse_retry_after(response)
+            raise RateLimited(
+                f"Asana rate-limited (status={status_code})",
+                retry_after=retry_after,
+            )
+        if status_code >= 500:
+            msg = f"Asana server error (status={status_code})"
+            raise TrackerUnavailable(msg)
+        if status_code >= 400:
+            body = _safe_text(response)
+            msg = f"Asana HTTP {status_code}: {body[:200]}"
+            raise TrackerUnavailable(msg)
+
+        try:
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - malformed JSON
+            msg = f"Asana returned non-JSON: {exc}"
+            raise TrackerUnavailable(msg) from exc
+        if not isinstance(data, dict):
+            msg = f"Asana returned non-object payload: {type(data).__name__}"
+            raise TrackerUnavailable(msg)
+        errors = data.get("errors")
+        if errors:
+            msg = f"Asana errors: {errors}"
+            raise TrackerUnavailable(msg)
+        return data
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(response: Any) -> float | None:
+    """Best-effort ``Retry-After`` parser."""
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if retry_after:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _safe_text(response: Any) -> str:
+    try:
+        return str(getattr(response, "text", ""))
+    except Exception:  # pragma: no cover
+        return ""

--- a/tests/unit/trackers/test_asana_adapter.py
+++ b/tests/unit/trackers/test_asana_adapter.py
@@ -1,0 +1,460 @@
+"""Tests for :mod:`bernstein.core.trackers.builtin.asana_adapter`."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.trackers import (
+    RateLimited,
+    TrackerUnavailable,
+)
+from bernstein.core.trackers.builtin.asana_adapter import (
+    ASANA_API_BASE,
+    AsanaAdapter,
+    AsanaConfig,
+    _resolve_token,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    *,
+    gid: str = "TASK_1",
+    name: str = "Refactor parser",
+    notes: str = "Body 1",
+    section_gid: str = "SEC_PROGRESS",
+    section_name: str = "In Progress",
+    permalink: str = "https://app.asana.com/0/PRJ/TASK_1",
+    tags: list[str] | None = None,
+    custom_fields: list[dict[str, Any]] | None = None,
+    completed: bool = False,
+) -> dict[str, Any]:
+    return {
+        "gid": gid,
+        "name": name,
+        "notes": notes,
+        "permalink_url": permalink,
+        "completed": completed,
+        "memberships": [{"section": {"gid": section_gid, "name": section_name}}],
+        "tags": [{"name": t} for t in (tags or [])],
+        "custom_fields": custom_fields or [],
+    }
+
+
+def _tasks_page(
+    *,
+    tasks: list[dict[str, Any]] | None = None,
+    next_offset: str | None = None,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {
+        "data": tasks
+        if tasks is not None
+        else [
+            _task(
+                gid="TASK_1",
+                name="Refactor parser",
+                section_gid="SEC_PROGRESS",
+                section_name="In Progress",
+                tags=["bug", "P1"],
+                custom_fields=[
+                    {
+                        "gid": "CF_CLI",
+                        "name": "CLI",
+                        "enum_value": {"name": "claude"},
+                    },
+                ],
+            ),
+            _task(
+                gid="TASK_2",
+                name="Add tests",
+                notes="Body 2",
+                section_gid="SEC_TODO",
+                section_name="Todo",
+                permalink="https://app.asana.com/0/PRJ/TASK_2",
+            ),
+        ],
+    }
+    if next_offset:
+        body["next_page"] = {"offset": next_offset}
+    else:
+        body["next_page"] = None
+    return body
+
+
+def _make_adapter(
+    *,
+    section_filter_gid: str | None = None,
+    cli_cf_gid: str | None = "CF_CLI",
+    section_map: dict[str, str] | None = None,
+    include_completed: bool = False,
+) -> AsanaAdapter:
+    config = AsanaConfig(
+        workspace_gid="WS_1",
+        project_gid="PRJ_1",
+        section_filter_gid=section_filter_gid,
+        section_map=section_map or {},
+        cli_choice_custom_field_gid=cli_cf_gid,
+        include_completed=include_completed,
+        pat_env="ASANA_PAT_TEST",
+    )
+    return AsanaAdapter(
+        config=config,
+        token_provider=lambda: "tok-test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_from_configured_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_ASANA_PAT", "abc123")
+    config = AsanaConfig(
+        workspace_gid="WS_1",
+        project_gid="PRJ_1",
+        pat_env="MY_ASANA_PAT",
+    )
+    assert _resolve_token(config) == "abc123"
+
+
+def test_resolve_token_falls_back_to_default_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MY_ASANA_PAT", raising=False)
+    monkeypatch.setenv("ASANA_PERSONAL_ACCESS_TOKEN", "fallback")
+    config = AsanaConfig(workspace_gid="WS_1", project_gid="PRJ_1")
+    assert _resolve_token(config) == "fallback"
+
+
+def test_resolve_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ASANA_PERSONAL_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("MY_ASANA_PAT", raising=False)
+    config = AsanaConfig(
+        workspace_gid="WS_1",
+        project_gid="PRJ_1",
+        pat_env="MY_ASANA_PAT",
+    )
+    with pytest.raises(TrackerUnavailable):
+        _resolve_token(config)
+
+
+# ---------------------------------------------------------------------------
+# pull_open_tickets
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_pull_open_tickets_emits_normalised_tickets() -> None:
+    adapter = _make_adapter()
+    route = respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(200, json=_tasks_page())
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 1
+    assert len(tickets) == 2
+    first, second = tickets
+    assert first.id == "TASK_1"
+    assert first.title == "Refactor parser"
+    assert first.status == "In Progress"
+    assert first.labels == ("bug", "P1")
+    assert first.routing_hint.cli == "claude"
+    assert first.raw["section_gid"] == "SEC_PROGRESS"
+    assert first.external_url == "https://app.asana.com/0/PRJ/TASK_1"
+    assert second.routing_hint.cli is None
+    assert second.raw["section_gid"] == "SEC_TODO"
+
+
+@respx.mock
+def test_pull_open_tickets_filters_by_section() -> None:
+    adapter = _make_adapter(section_filter_gid="SEC_PROGRESS")
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(return_value=httpx.Response(200, json=_tasks_page()))
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["TASK_1"]
+
+
+@respx.mock
+def test_pull_open_tickets_filter_override_via_arg() -> None:
+    adapter = _make_adapter(section_filter_gid="SEC_PROGRESS")
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(return_value=httpx.Response(200, json=_tasks_page()))
+    try:
+        tickets = list(adapter.pull_open_tickets({"section": "SEC_TODO"}))
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["TASK_2"]
+
+
+@respx.mock
+def test_pull_open_tickets_paginates() -> None:
+    adapter = _make_adapter()
+    page_one = _tasks_page(
+        tasks=[_task(gid="TASK_1", name="Page one")],
+        next_offset="OFFSET_2",
+    )
+    page_two = _tasks_page(
+        tasks=[_task(gid="TASK_3", name="Page two", section_gid="SEC_DONE", section_name="Done")],
+    )
+    route = respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        side_effect=[
+            httpx.Response(200, json=page_one),
+            httpx.Response(200, json=page_two),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["TASK_1", "TASK_3"]
+    assert route.call_count == 2
+    second_request = route.calls[1].request
+    assert b"offset=OFFSET_2" in second_request.url.query
+
+
+@respx.mock
+def test_pull_open_tickets_passes_completed_since_when_open_only() -> None:
+    adapter = _make_adapter(include_completed=False)
+    route = respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(200, json=_tasks_page(tasks=[])),
+    )
+    try:
+        list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    request = route.calls[0].request
+    assert b"completed_since=now" in request.url.query
+
+
+@respx.mock
+def test_pull_open_tickets_omits_completed_since_when_include_completed() -> None:
+    adapter = _make_adapter(include_completed=True)
+    route = respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(200, json=_tasks_page(tasks=[])),
+    )
+    try:
+        list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    request = route.calls[0].request
+    assert b"completed_since" not in request.url.query
+
+
+# ---------------------------------------------------------------------------
+# add_comment
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_add_comment_posts_story_with_idempotency_header() -> None:
+    adapter = _make_adapter()
+    route = respx.post(f"{ASANA_API_BASE}/tasks/TASK_1/stories").mock(
+        return_value=httpx.Response(
+            201,
+            json={"data": {"gid": "STORY_1", "text": "hello"}},
+        )
+    )
+    try:
+        result = adapter.add_comment("TASK_1", "hello", idempotency_key="k1")
+    finally:
+        adapter.close()
+
+    assert result.comment_id == "STORY_1"
+    assert result.ticket_id == "TASK_1"
+    sent = route.calls[0].request
+    body = json.loads(sent.content)
+    assert body == {"data": {"text": "hello"}}
+    assert sent.headers["X-Idempotency-Key"] == "k1"
+    assert sent.headers["Authorization"] == "Bearer tok-test"
+
+
+# ---------------------------------------------------------------------------
+# transition
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_transition_moves_task_to_section_by_gid() -> None:
+    adapter = _make_adapter()
+    route = respx.post(f"{ASANA_API_BASE}/sections/SEC_DONE/addTask").mock(
+        return_value=httpx.Response(200, json={"data": {}}),
+    )
+    try:
+        result = adapter.transition("TASK_1", "SEC_DONE", idempotency_key="k2")
+    finally:
+        adapter.close()
+    assert result.new_status == "SEC_DONE"
+    assert result.ticket_id == "TASK_1"
+    sent = route.calls[0].request
+    body = json.loads(sent.content)
+    assert body == {"data": {"task": "TASK_1"}}
+    assert sent.headers["X-Idempotency-Key"] == "k2"
+
+
+@respx.mock
+def test_transition_resolves_section_via_section_map() -> None:
+    adapter = _make_adapter(section_map={"done": "SEC_DONE"})
+    route = respx.post(f"{ASANA_API_BASE}/sections/SEC_DONE/addTask").mock(
+        return_value=httpx.Response(200, json={"data": {}}),
+    )
+    try:
+        result = adapter.transition("TASK_1", "done")
+    finally:
+        adapter.close()
+    assert result.new_status == "done"
+    assert route.call_count == 1
+
+
+@respx.mock
+def test_transition_empty_section_gid_raises() -> None:
+    adapter = _make_adapter(section_map={"done": ""})
+    try:
+        with pytest.raises(TrackerUnavailable):
+            adapter.transition("TASK_1", "done")
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# update_custom_field
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_update_custom_field_puts_task() -> None:
+    adapter = _make_adapter()
+    route = respx.put(f"{ASANA_API_BASE}/tasks/TASK_1").mock(
+        return_value=httpx.Response(200, json={"data": {"gid": "TASK_1"}}),
+    )
+    try:
+        adapter.update_custom_field(
+            "TASK_1",
+            "CF_AGENT",
+            "claude",
+            idempotency_key="k3",
+        )
+    finally:
+        adapter.close()
+    sent = route.calls[0].request
+    body = json.loads(sent.content)
+    assert body == {"data": {"custom_fields": {"CF_AGENT": "claude"}}}
+    assert sent.headers["X-Idempotency-Key"] == "k3"
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit & error handling
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_rate_limit_with_retry_after_header() -> None:
+    adapter = _make_adapter()
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(
+            429,
+            json={"errors": [{"message": "slow down"}]},
+            headers={"Retry-After": "11"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 11.0
+
+
+@respx.mock
+def test_5xx_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(503, json={"errors": [{"message": "down"}]}),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_4xx_other_than_429_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(403, json={"errors": [{"message": "forbidden"}]}),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_payload_errors_field_surfaces_as_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(
+            200,
+            json={"errors": [{"message": "schema error"}]},
+        )
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# CLI choice custom field
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_cli_choice_custom_field_disabled_when_unconfigured() -> None:
+    adapter = _make_adapter(cli_cf_gid=None)
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(200, json=_tasks_page()),
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert all(t.routing_hint.cli is None for t in tickets)
+
+
+@respx.mock
+def test_cli_choice_reads_text_value_when_enum_absent() -> None:
+    adapter = _make_adapter()
+    page = _tasks_page(
+        tasks=[
+            _task(
+                gid="TASK_X",
+                name="Text CF",
+                custom_fields=[
+                    {"gid": "CF_CLI", "name": "CLI", "text_value": "codex"},
+                ],
+            ),
+        ],
+    )
+    respx.get(f"{ASANA_API_BASE}/projects/PRJ_1/tasks").mock(
+        return_value=httpx.Response(200, json=page),
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert len(tickets) == 1
+    assert tickets[0].routing_hint.cli == "codex"


### PR DESCRIPTION
Adds the Asana adapter following the pattern established by the GitHub Projects v2 adapter. Auth via personal access token env var (`ASANA_PERSONAL_ACCESS_TOKEN`, overridable via `pat_env`). Sections are the per-project status surface and are operator-mapped. Mocked unit tests cover list/fetch/comment/transition/custom-field updates plus rate-limit and error paths.

## Summary

- New `AsanaAdapter` and `AsanaConfig` under `bernstein.core.trackers.builtin.asana_adapter`, implementing `AbstractTrackerAdapter`.
- PAT auth with `pat_env` precedence and `ASANA_PERSONAL_ACCESS_TOKEN` fallback.
- `pull_open_tickets` paginates the configured project, filters by section client-side, exposes optional `routing_hint.cli` via a custom field.
- `add_comment` posts a story; `transition` moves the task between sections via `addTask`; `update_custom_field` writes arbitrary custom fields.
- 429 responses surface as `RateLimited` with `Retry-After`; 4xx/5xx surface as `TrackerUnavailable`.
- Registered in `bernstein.core.trackers.builtin.__init__`.
- Docs page at `docs/trackers/asana.md` covering auth, section-vs-status semantics, and an ops-team example workflow.

## Test plan

- [x] `uv run pytest tests/unit/trackers/test_asana_adapter.py` (20 passed)
- [x] `uv run pytest tests/unit/trackers/test_github_projects_adapter.py` (no regression)
- [x] `uv run ruff check` on the new files

## Summary by Sourcery

Add a new built-in Asana tracker adapter implementing the tracker contract and wire it into the trackers package, with accompanying documentation and unit tests.

New Features:
- Introduce an AsanaAdapter and AsanaConfig implementing the AbstractTrackerAdapter over the Asana REST API, supporting ticket listing, commenting, transitions, and custom-field updates.

Enhancements:
- Register the Asana adapter in the builtin trackers module exports for consumption by the rest of the system.

Documentation:
- Add user-facing documentation describing configuration, auth, sections vs. status mapping, CLI routing via custom fields, rate limiting, and failure modes for the Asana adapter.

Tests:
- Add unit tests covering Asana adapter token resolution, pagination and filtering, CLI choice hinting, comment posting, transitions, custom-field updates, and rate-limit/error handling.