### PR TITLE
feat(trackers): Linear adapter

### DIFF
--- a/docs/trackers/linear.md
+++ b/docs/trackers/linear.md
@@ -1,0 +1,118 @@
+# Linear tracker adapter
+
+Bernstein can pull work directly from a Linear team, post progress
+comments back to the underlying issue, and move the issue between
+workflow states when a task transitions. The adapter also supports
+per-ticket CLI choice via Linear labels: a label prefix such as
+`cli/claude` pins the spawned CLI for that ticket.
+
+The adapter implements `bernstein.core.trackers.AbstractTrackerAdapter`
+and lives at `bernstein.core.trackers.linear.LinearTracker`. It is
+disabled by default and must be opted in via `bernstein.yaml`.
+
+## Auth
+
+The adapter authenticates with a Linear Personal API Key (issued in
+Linear under `Settings -> API -> Personal API keys`).
+
+| Environment variable | Purpose |
+|----------------------|---------|
+| `LINEAR_API_KEY`     | Personal API key sent verbatim as the `Authorization` header. |
+
+Override the env var name with `LinearConfig.api_key_env` when running
+multiple Linear adapters against different workspaces:
+
+```yaml
+trackers:
+  linear:
+    team_key: ENG
+    api_key_env: LINEAR_API_KEY_PROD
+```
+
+## State mapping
+
+Linear teams own a list of workflow states (e.g. `Todo`, `In Progress`,
+`Done`, `Canceled`). The adapter discovers them once on first call and
+caches the schema. `state_map` maps canonical Bernstein statuses to the
+team's state names:
+
+```yaml
+trackers:
+  linear:
+    team_key: ENG
+    state_map:
+      todo: Todo
+      in_progress: In Progress
+      done: Done
+```
+
+The adapter resolves a transition target in this order:
+1. Treat the value as a state id (opaque UUID).
+2. Look it up in `state_map`.
+3. Look it up in the team's workflow-state list by display name.
+
+## Per-ticket CLI choice via labels
+
+Linear does not have first-class single-select fields the way GitHub
+Projects v2 does. Instead, the adapter routes by label prefix. Add
+labels named `cli/claude`, `cli/codex`, `cli/aider` to issues that
+need a specific CLI:
+
+```yaml
+trackers:
+  linear:
+    team_key: ENG
+    label_routing_field: "cli/"
+```
+
+The adapter exposes the selected CLI on the ticket dataclass:
+
+```python
+from bernstein.core.trackers.linear import LinearTracker, LinearConfig
+
+config = LinearConfig(
+    team_key="ENG",
+    state_filter="Todo",
+    label_routing_field="cli/",
+)
+with LinearTracker(config) as adapter:
+    for ticket in adapter.pull_open_tickets():
+        cli = ticket.routing_hint.cli  # "claude" / "codex" / "aider" / None
+        # hand cli + ticket.id to the orchestrator's routing layer
+```
+
+## Comments and transitions
+
+- `add_comment(ticket_id, body)` posts to the underlying Linear issue
+  via the `commentCreate` mutation. Pass the issue UUID as
+  `ticket_id` (the `ticket.id` yielded by `pull_open_tickets`).
+- `transition(ticket_id, status_id)` updates the issue's workflow
+  state via the `issueUpdate` mutation.
+
+Linear's GraphQL mutations do not surface a `clientMutationId`
+parameter, so `add_comment` appends `idempotency_key` to the comment
+body as a hidden HTML-comment marker so operators can de-duplicate
+posts client-side.
+
+## Rate limiting
+
+- A cooperative per-adapter token-bucket throttles outbound calls when
+  `rate_limit_min_interval` is set.
+- Server-side `429` is translated into `RateLimited(retry_after=...)`,
+  with the hint taken from the `Retry-After` header.
+- Secondary rate-limit errors that Linear returns inside a 200 (with
+  `extensions.code == "RATELIMITED"`) are surfaced the same way.
+
+## Exceptions
+
+| Exception                       | When                                                          |
+|---------------------------------|---------------------------------------------------------------|
+| `TrackerUnavailable`            | 5xx, missing token, unknown state, malformed JSON, 4xx auth.  |
+| `RateLimited`                   | 429, GraphQL `RATELIMITED` error.                              |
+| `OptimisticConcurrencyError`    | 412 Precondition Failed on a write.                            |
+
+## Out of scope
+
+- Webhook ingestion (separate cross-cutting ticket).
+- Linear Sub-Issues federation (handled by the federation layer).
+- Linear documents and projects -- this adapter handles issues only.

--- a/src/bernstein/core/trackers/__init__.py
+++ b/src/bernstein/core/trackers/__init__.py
@@ -22,6 +22,7 @@ from bernstein.core.trackers.contract import (
     TrackerUnavailable,
     TransitionResult,
 )
+from bernstein.core.trackers.linear import LinearConfig, LinearTracker
 from bernstein.core.trackers.servicenow import ServiceNowConfig, ServiceNowTracker
 
 __all__ = [
@@ -31,6 +32,8 @@ __all__ = [
     "Comment",
     "CommentResult",
     "IdempotencyConflict",
+    "LinearConfig",
+    "LinearTracker",
     "OptimisticConcurrencyError",
     "RateLimited",
     "RoutingHint",
@@ -54,6 +57,8 @@ def get_tracker(name: str, **kwargs: object) -> AbstractTrackerAdapter:
     """
     if name == "servicenow":
         return ServiceNowTracker(**kwargs)  # type: ignore[arg-type]
+    if name == "linear":
+        return LinearTracker(**kwargs)  # type: ignore[arg-type]
     if name == "github_projects" or name == "github_projects_v2":
         from bernstein.core.trackers.builtin import (
             GitHubProjectsV2Adapter,

--- a/src/bernstein/core/trackers/linear.py
+++ b/src/bernstein/core/trackers/linear.py
@@ -1,0 +1,551 @@
+"""Linear tracker adapter.
+
+Implements the ``AbstractTrackerAdapter`` contract on top of Linear's
+public GraphQL API at ``https://api.linear.app/graphql``.
+
+Auth:
+- Personal API key (Linear OAuth Personal API Key) via an environment
+  variable. ``LINEAR_API_KEY`` is read by default; an alternative env
+  variable name can be set via ``LinearConfig.api_key_env``.
+
+Capabilities:
+- ``pull_open_tickets``: paginate the configured team's issues, filter
+  by an optional workflow-state name, and emit normalised ``Ticket``
+  objects.
+- ``add_comment``: write a comment to the underlying issue via the
+  ``commentCreate`` mutation.
+- ``transition``: update the issue's workflow state via the
+  ``issueUpdate`` mutation. The target state can be supplied as an
+  opaque state id, a state name, or a key in ``LinearConfig.state_map``.
+
+Rate-limit handling:
+- Cooperative client-side token-bucket via ``min_interval`` is supported
+  through ``LinearConfig.rate_limit_min_interval``.
+- HTTP 429 is translated into ``RateLimited(retry_after=...)`` using the
+  ``Retry-After`` header.
+- Linear's secondary rate-limit errors are returned inside a 200 with a
+  GraphQL error whose ``extensions.code`` mentions ``RATELIMIT``; those
+  are surfaced as ``RateLimited`` as well.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+try:  # pragma: no cover - optional dep already present in project deps
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+from bernstein.core.trackers.contract import (
+    AbstractTrackerAdapter,
+    CommentResult,
+    OptimisticConcurrencyError,
+    RateLimited,
+    RoutingHint,
+    Ticket,
+    TrackerUnavailable,
+    TransitionResult,
+)
+
+logger = logging.getLogger(__name__)
+
+LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+DEFAULT_API_KEY_ENV = "LINEAR_API_KEY"
+DEFAULT_PAGE_SIZE = 50
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LinearConfig:
+    """Configuration for a Linear adapter instance.
+
+    Attributes:
+        team_key: Linear team key (e.g. ``ENG``) the adapter scopes to.
+            Used to look up the team's workflow states for ``transition``
+            and to filter ``pull_open_tickets``.
+        state_filter: Optional workflow-state name the adapter filters
+            on when calling ``pull_open_tickets`` with no filter
+            override (e.g. ``Todo``, ``In Progress``).
+        state_map: Optional mapping from canonical Bernstein status
+            names to Linear workflow-state names. ``done`` -> ``Done``,
+            ``in_progress`` -> ``In Progress``, etc.
+        label_routing_field: Optional Linear label prefix used to route
+            tickets to a CLI adapter. When set to e.g. ``cli/``, an
+            issue carrying the label ``cli/claude`` exposes
+            ``ticket.routing_hint.cli = "claude"``.
+        api_key_env: Environment variable name holding the Linear
+            Personal API key. Defaults to ``LINEAR_API_KEY``.
+        include_archived: Include archived issues in ``pull_open_tickets``.
+        page_size: GraphQL issues page size. Linear caps this at 250 per
+            page; the adapter clamps the configured value to that.
+        rate_limit_min_interval: Minimum seconds between GraphQL calls
+            per adapter instance.
+    """
+
+    team_key: str
+    state_filter: str | None = None
+    state_map: dict[str, str] = field(default_factory=dict)
+    label_routing_field: str | None = None
+    api_key_env: str = DEFAULT_API_KEY_ENV
+    include_archived: bool = False
+    page_size: int = DEFAULT_PAGE_SIZE
+    rate_limit_min_interval: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_token(config: LinearConfig) -> str:
+    """Resolve the Linear API key from the configured environment variable.
+
+    Raises:
+        TrackerUnavailable: if the environment variable is unset or empty.
+    """
+    env_var = config.api_key_env or DEFAULT_API_KEY_ENV
+    token = os.environ.get(env_var, "")
+    if not token:
+        msg = f"Linear adapter: no API key available (env var '{env_var}' is empty)"
+        raise TrackerUnavailable(msg)
+    return token
+
+
+# ---------------------------------------------------------------------------
+# Token bucket
+# ---------------------------------------------------------------------------
+
+
+class _TokenBucket:
+    """Minimal cooperative token-bucket throttle.
+
+    A single shared lock-protected next-allowed timestamp. Calls block
+    until the timestamp is reached. ``min_interval == 0`` disables the
+    throttle.
+    """
+
+    def __init__(self, min_interval: float) -> None:
+        self._min_interval = max(0.0, float(min_interval))
+        self._next_allowed = 0.0
+        self._lock = threading.Lock()
+
+    def acquire(self, *, now: float | None = None, sleep: Any = time.sleep) -> None:
+        if self._min_interval <= 0.0:
+            return
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            wait = self._next_allowed - now
+            if wait > 0:
+                sleep(wait)
+                now = now + wait
+            self._next_allowed = now + self._min_interval
+
+
+# ---------------------------------------------------------------------------
+# GraphQL queries
+# ---------------------------------------------------------------------------
+
+
+_QUERY_TEAM = """
+query($key: String!) {
+  teams(filter: { key: { eq: $key } }, first: 1) {
+    nodes {
+      id
+      key
+      name
+      states(first: 100) {
+        nodes { id name type }
+      }
+    }
+  }
+}
+""".strip()
+
+
+_QUERY_ISSUES = """
+query($teamId: String!, $first: Int!, $after: String, $includeArchived: Boolean) {
+  issues(
+    filter: { team: { id: { eq: $teamId } } }
+    first: $first
+    after: $after
+    includeArchived: $includeArchived
+    orderBy: updatedAt
+  ) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      identifier
+      title
+      description
+      url
+      updatedAt
+      state { id name }
+      labels(first: 20) { nodes { name } }
+    }
+  }
+}
+""".strip()
+
+
+_MUTATION_ADD_COMMENT = """
+mutation($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment { id }
+  }
+}
+""".strip()
+
+
+_MUTATION_UPDATE_STATE = """
+mutation($issueId: String!, $stateId: String!) {
+  issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+    success
+    issue { id updatedAt }
+  }
+}
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TeamSchema:
+    team_id: str
+    states_by_name: dict[str, dict[str, Any]]
+
+
+class LinearTracker(AbstractTrackerAdapter):
+    """Adapter for Linear.
+
+    The adapter is intentionally thin: every call is a single GraphQL
+    round-trip. The team schema (workflow states) is discovered once and
+    cached.
+
+    Parameters:
+        config: Adapter configuration.
+        http_client: Optional pre-built ``httpx.Client`` (tests pass a
+            mocked transport via ``respx``).
+        token_provider: Optional callable returning the auth token. The
+            default reads from ``_resolve_token(config)`` on each call,
+            which makes credential rotation trivial.
+    """
+
+    name = "linear"
+
+    def __init__(
+        self,
+        config: LinearConfig,
+        *,
+        http_client: Any | None = None,
+        token_provider: Any | None = None,
+    ) -> None:
+        if httpx is None:  # pragma: no cover - dep is declared in pyproject
+            msg = "httpx is required for LinearTracker"
+            raise RuntimeError(msg)
+        self._config = config
+        self._client: Any = http_client or httpx.Client(timeout=30.0)
+        self._owns_client = http_client is None
+        self._token_provider = token_provider or (lambda: _resolve_token(config))
+        self._bucket = _TokenBucket(config.rate_limit_min_interval)
+        self._schema: _TeamSchema | None = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the underlying HTTP client if we own it."""
+        if self._owns_client:
+            try:
+                self._client.close()
+            except Exception:  # pragma: no cover - best effort
+                logger.debug("ignoring error while closing httpx client", exc_info=True)
+
+    def __enter__(self) -> LinearTracker:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- public API ---------------------------------------------------------
+
+    def pull_open_tickets(
+        self,
+        filter: dict[str, Any] | None = None,
+    ) -> Iterator[Ticket]:
+        """Yield Linear issues as ``Ticket`` objects.
+
+        ``filter`` keys:
+            - ``state``: override ``config.state_filter`` for this call.
+            - ``include_archived``: bool, default
+              ``config.include_archived``.
+        """
+        filter_dict = filter or {}
+        state_filter = filter_dict.get("state", self._config.state_filter)
+        include_archived = bool(filter_dict.get("include_archived", self._config.include_archived))
+
+        schema = self._ensure_schema()
+        cursor: str | None = None
+        page_size = max(1, min(250, self._config.page_size))
+
+        while True:
+            data = self._graphql(
+                _QUERY_ISSUES,
+                {
+                    "teamId": schema.team_id,
+                    "first": page_size,
+                    "after": cursor,
+                    "includeArchived": include_archived,
+                },
+            )
+            issues_block = (data.get("data") or {}).get("issues") or {}
+            for raw_issue in issues_block.get("nodes") or []:
+                ticket = self._issue_to_ticket(raw_issue)
+                if ticket is None:
+                    continue
+                if state_filter and ticket.status != state_filter:
+                    continue
+                yield ticket
+            page_info = issues_block.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            cursor = page_info.get("endCursor")
+
+    def add_comment(
+        self,
+        ticket_id: str,
+        body: str,
+        *,
+        idempotency_key: str | None = None,
+    ) -> CommentResult:
+        """Post a comment on a Linear issue.
+
+        ``ticket_id`` is the Linear issue UUID (the ``id`` field on
+        ``Ticket``). Linear's GraphQL mutation does not surface a
+        ``clientMutationId`` parameter, so ``idempotency_key`` is
+        appended to the body as a hidden HTML-comment marker so
+        operators can de-duplicate posts client-side.
+        """
+        payload_body = body
+        if idempotency_key:
+            payload_body = f"{body}\n\n<!-- bernstein-idempotency:{idempotency_key} -->"
+        variables = {"issueId": ticket_id, "body": payload_body}
+        result = self._graphql(_MUTATION_ADD_COMMENT, variables)
+        block = (result.get("data") or {}).get("commentCreate") or {}
+        if not block.get("success"):
+            msg = f"Linear commentCreate did not succeed: {block!r}"
+            raise TrackerUnavailable(msg)
+        comment = block.get("comment") or {}
+        return CommentResult(comment_id=comment.get("id", ""), ticket_id=ticket_id)
+
+    def transition(
+        self,
+        ticket_id: str,
+        status_id: str,
+        *,
+        idempotency_key: str | None = None,
+        etag: str | None = None,
+    ) -> TransitionResult:
+        """Move ``ticket_id`` (Linear issue id) to ``status_id``.
+
+        ``status_id`` can be either:
+            - the workflow state id (preferred, opaque)
+            - the workflow state name (resolved via the cached schema)
+            - a key in ``config.state_map`` (resolved twice: through the
+              map then through the schema)
+        """
+        schema = self._ensure_schema()
+        state_id = self._resolve_state_id(schema, status_id)
+        variables = {"issueId": ticket_id, "stateId": state_id}
+        try:
+            data = self._graphql(_MUTATION_UPDATE_STATE, variables, etag=etag)
+        except OptimisticConcurrencyError:
+            raise
+        block = (data.get("data") or {}).get("issueUpdate") or {}
+        if not block.get("success"):
+            msg = f"Linear issueUpdate did not succeed: {block!r}"
+            raise TrackerUnavailable(msg)
+        new_etag = ((block.get("issue") or {}).get("updatedAt")) or None
+        return TransitionResult(
+            ticket_id=ticket_id,
+            new_status=status_id,
+            etag=new_etag,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    def _ensure_schema(self) -> _TeamSchema:
+        if self._schema is not None:
+            return self._schema
+        data = self._graphql(_QUERY_TEAM, {"key": self._config.team_key})
+        teams = ((data.get("data") or {}).get("teams") or {}).get("nodes") or []
+        if not teams:
+            msg = f"Linear team not found: key='{self._config.team_key}'"
+            raise TrackerUnavailable(msg)
+        team = teams[0]
+        states_by_name: dict[str, dict[str, Any]] = {}
+        for state in (team.get("states") or {}).get("nodes") or []:
+            name = state.get("name")
+            if name:
+                states_by_name[name] = state
+        self._schema = _TeamSchema(
+            team_id=team["id"],
+            states_by_name=states_by_name,
+        )
+        return self._schema
+
+    def _resolve_state_id(self, schema: _TeamSchema, status_id: str) -> str:
+        """Resolve ``status_id`` (id, name, or mapped name) to a state id."""
+        # Direct id match (states_by_name only has names, so fall through).
+        for state in schema.states_by_name.values():
+            if state.get("id") == status_id:
+                return str(state["id"])
+        mapped = self._config.state_map.get(status_id, status_id)
+        mapped_state = schema.states_by_name.get(mapped)
+        if mapped_state:
+            return str(mapped_state["id"])
+        msg = f"Linear state '{status_id}' (mapped='{mapped}') not found for team '{self._config.team_key}'"
+        raise TrackerUnavailable(msg)
+
+    def _issue_to_ticket(self, raw_issue: dict[str, Any]) -> Ticket | None:
+        state = (raw_issue.get("state") or {}).get("name") or ""
+        labels_nodes = (raw_issue.get("labels") or {}).get("nodes") or []
+        labels = tuple((lab.get("name") or "") for lab in labels_nodes if lab.get("name"))
+        cli_choice = self._cli_choice_from_labels(labels)
+        return Ticket(
+            id=raw_issue.get("id", ""),
+            external_url=raw_issue.get("url", ""),
+            title=raw_issue.get("title", "") or "",
+            body=raw_issue.get("description", "") or "",
+            status=state,
+            labels=labels,
+            etag=raw_issue.get("updatedAt"),
+            routing_hint=RoutingHint(cli=cli_choice),
+            raw={
+                "identifier": raw_issue.get("identifier", ""),
+                "team_key": self._config.team_key,
+                "state_id": (raw_issue.get("state") or {}).get("id", ""),
+            },
+        )
+
+    def _cli_choice_from_labels(self, labels: tuple[str, ...]) -> str | None:
+        """Pick a CLI choice from a labelled-prefix routing field."""
+        prefix = self._config.label_routing_field
+        if not prefix:
+            return None
+        for label in labels:
+            if label.startswith(prefix):
+                value = label[len(prefix) :].strip()
+                if value:
+                    return value
+        return None
+
+    # -- HTTP --------------------------------------------------------------
+
+    def _graphql(
+        self,
+        query: str,
+        variables: dict[str, Any],
+        *,
+        etag: str | None = None,
+    ) -> dict[str, Any]:
+        self._bucket.acquire()
+        token = self._token_provider()
+        headers = {
+            "Authorization": token,
+            "Content-Type": "application/json",
+        }
+        if etag:
+            headers["If-Match"] = etag
+        payload = {"query": query, "variables": variables}
+        try:
+            response = self._client.post(
+                LINEAR_GRAPHQL_URL,
+                json=payload,
+                headers=headers,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            msg = f"Linear GraphQL transport error: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+        status_code = getattr(response, "status_code", 0)
+        if status_code == 412:
+            msg = "Precondition Failed (etag mismatch)"
+            raise OptimisticConcurrencyError(msg)
+        if status_code == 429:
+            retry_after = _parse_retry_after(response)
+            msg = f"Linear GraphQL rate-limited (status={status_code})"
+            raise RateLimited(msg, retry_after=retry_after)
+        if status_code in {401, 403}:
+            body = _safe_text(response)
+            msg = f"Linear GraphQL auth error (status={status_code}): {body[:200]}"
+            raise TrackerUnavailable(msg)
+        if status_code >= 500:
+            msg = f"Linear GraphQL server error (status={status_code})"
+            raise TrackerUnavailable(msg)
+        if status_code >= 400:
+            body = _safe_text(response)
+            msg = f"Linear GraphQL HTTP {status_code}: {body[:200]}"
+            raise TrackerUnavailable(msg)
+
+        try:
+            data = response.json()
+        except Exception as exc:  # pragma: no cover - malformed JSON
+            msg = f"Linear GraphQL returned non-JSON: {exc}"
+            raise TrackerUnavailable(msg) from exc
+
+        errors = data.get("errors") if isinstance(data, dict) else None
+        if errors:
+            for err in errors:
+                code = ""
+                extensions = err.get("extensions") if isinstance(err, dict) else None
+                if isinstance(extensions, dict):
+                    code = str(extensions.get("code") or "").upper()
+                err_type = (err.get("type") or "").upper() if isinstance(err, dict) else ""
+                if "RATELIMIT" in code or "RATE_LIMIT" in code or "RATELIMIT" in err_type:
+                    raise RateLimited(
+                        f"Linear GraphQL rate-limit: {err.get('message')}",
+                        retry_after=None,
+                    )
+            msg = f"Linear GraphQL errors: {errors}"
+            raise TrackerUnavailable(msg)
+        return data  # type: ignore[no-any-return]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after(response: Any) -> float | None:
+    """Best-effort ``Retry-After`` parser."""
+    headers = getattr(response, "headers", {}) or {}
+    retry_after = headers.get("Retry-After") if hasattr(headers, "get") else None
+    if retry_after:
+        try:
+            return float(retry_after)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _safe_text(response: Any) -> str:
+    try:
+        return str(getattr(response, "text", ""))
+    except Exception:  # pragma: no cover
+        return ""

--- a/tests/unit/core/trackers/test_linear.py
+++ b/tests/unit/core/trackers/test_linear.py
@@ -1,0 +1,553 @@
+"""Tests for :mod:`bernstein.core.trackers.linear`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from bernstein.core.trackers import (
+    OptimisticConcurrencyError,
+    RateLimited,
+    TrackerUnavailable,
+)
+from bernstein.core.trackers.linear import (
+    LINEAR_GRAPHQL_URL,
+    LinearConfig,
+    LinearTracker,
+    _resolve_token,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _team_response() -> dict[str, Any]:
+    """Return a canned team-and-states GraphQL response."""
+    return {
+        "data": {
+            "teams": {
+                "nodes": [
+                    {
+                        "id": "team-uuid-1",
+                        "key": "ENG",
+                        "name": "Engineering",
+                        "states": {
+                            "nodes": [
+                                {"id": "state-todo", "name": "Todo", "type": "unstarted"},
+                                {"id": "state-progress", "name": "In Progress", "type": "started"},
+                                {"id": "state-done", "name": "Done", "type": "completed"},
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    }
+
+
+def _issues_page(
+    *,
+    cursor: str | None = None,
+    has_next: bool = False,
+    nodes: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    default_nodes = [
+        {
+            "id": "issue-uuid-1",
+            "identifier": "ENG-7",
+            "title": "Refactor parser",
+            "description": "Body 1",
+            "url": "https://linear.app/acme/issue/ENG-7",
+            "updatedAt": "2026-05-19T10:00:00.000Z",
+            "state": {"id": "state-progress", "name": "In Progress"},
+            "labels": {"nodes": [{"name": "bug"}, {"name": "cli/claude"}]},
+        },
+        {
+            "id": "issue-uuid-2",
+            "identifier": "ENG-8",
+            "title": "Add tests",
+            "description": "Body 2",
+            "url": "https://linear.app/acme/issue/ENG-8",
+            "updatedAt": "2026-05-19T11:00:00.000Z",
+            "state": {"id": "state-todo", "name": "Todo"},
+            "labels": {"nodes": []},
+        },
+    ]
+    return {
+        "data": {
+            "issues": {
+                "pageInfo": {"hasNextPage": has_next, "endCursor": cursor},
+                "nodes": nodes if nodes is not None else default_nodes,
+            },
+        },
+    }
+
+
+def _make_adapter(
+    *,
+    state_filter: str | None = None,
+    label_routing_field: str | None = "cli/",
+    state_map: dict[str, str] | None = None,
+) -> LinearTracker:
+    config = LinearConfig(
+        team_key="ENG",
+        state_filter=state_filter,
+        state_map=state_map or {},
+        label_routing_field=label_routing_field,
+        api_key_env="LINEAR_API_KEY_TEST",
+    )
+    return LinearTracker(
+        config=config,
+        token_provider=lambda: "lin_test_token",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_from_default_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LINEAR_API_KEY", "lin_abc123")
+    config = LinearConfig(team_key="ENG")
+    assert _resolve_token(config) == "lin_abc123"
+
+
+def test_resolve_token_from_custom_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_LINEAR_KEY", "lin_custom")
+    config = LinearConfig(team_key="ENG", api_key_env="MY_LINEAR_KEY")
+    assert _resolve_token(config) == "lin_custom"
+
+
+def test_resolve_token_raises_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LINEAR_API_KEY", raising=False)
+    monkeypatch.delenv("MY_LINEAR_KEY", raising=False)
+    config = LinearConfig(team_key="ENG", api_key_env="MY_LINEAR_KEY")
+    with pytest.raises(TrackerUnavailable):
+        _resolve_token(config)
+
+
+# ---------------------------------------------------------------------------
+# pull_open_tickets
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_pull_open_tickets_emits_normalised_tickets() -> None:
+    adapter = _make_adapter()
+    route = respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(200, json=_issues_page()),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+    assert route.call_count == 2
+    assert len(tickets) == 2
+    first, second = tickets
+    assert first.id == "issue-uuid-1"
+    assert first.title == "Refactor parser"
+    assert first.status == "In Progress"
+    assert first.labels == ("bug", "cli/claude")
+    assert first.routing_hint.cli == "claude"
+    assert first.raw["identifier"] == "ENG-7"
+    assert first.raw["team_key"] == "ENG"
+    assert first.etag == "2026-05-19T10:00:00.000Z"
+    assert second.routing_hint.cli is None
+
+
+@respx.mock
+def test_pull_open_tickets_filters_by_state() -> None:
+    adapter = _make_adapter(state_filter="In Progress")
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(200, json=_issues_page()),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["issue-uuid-1"]
+
+
+@respx.mock
+def test_pull_open_tickets_paginates() -> None:
+    adapter = _make_adapter()
+    page_one = _issues_page(cursor="CUR1", has_next=True)
+    page_two = _issues_page(
+        cursor=None,
+        has_next=False,
+        nodes=[
+            {
+                "id": "issue-uuid-3",
+                "identifier": "ENG-9",
+                "title": "Page two",
+                "description": "",
+                "url": "https://linear.app/acme/issue/ENG-9",
+                "updatedAt": "2026-05-19T12:00:00.000Z",
+                "state": {"id": "state-todo", "name": "Todo"},
+                "labels": {"nodes": []},
+            },
+        ],
+    )
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(200, json=page_one),
+            httpx.Response(200, json=page_two),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["issue-uuid-1", "issue-uuid-2", "issue-uuid-3"]
+
+
+@respx.mock
+def test_pull_open_tickets_filter_state_override() -> None:
+    adapter = _make_adapter(state_filter="Todo")
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(200, json=_issues_page()),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets({"state": "In Progress"}))
+    finally:
+        adapter.close()
+    assert [t.id for t in tickets] == ["issue-uuid-1"]
+
+
+# ---------------------------------------------------------------------------
+# add_comment
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_add_comment_posts_mutation() -> None:
+    adapter = _make_adapter()
+    route = respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": {
+                    "commentCreate": {
+                        "success": True,
+                        "comment": {"id": "comment-uuid-1"},
+                    },
+                },
+            },
+        )
+    )
+    try:
+        result = adapter.add_comment("issue-uuid-1", "hello world", idempotency_key="k1")
+    finally:
+        adapter.close()
+
+    assert result.comment_id == "comment-uuid-1"
+    assert result.ticket_id == "issue-uuid-1"
+    sent = route.calls[0].request
+    assert b"commentCreate" in sent.content
+    assert b"issue-uuid-1" in sent.content
+    # Idempotency key is appended as an HTML-comment marker.
+    assert b"bernstein-idempotency:k1" in sent.content
+
+
+@respx.mock
+def test_add_comment_raises_when_success_false() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"commentCreate": {"success": False, "comment": None}}},
+        )
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            adapter.add_comment("issue-uuid-1", "hi")
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# transition
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_transition_resolves_state_by_name() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "issueUpdate": {
+                            "success": True,
+                            "issue": {
+                                "id": "issue-uuid-1",
+                                "updatedAt": "2026-05-19T13:00:00.000Z",
+                            },
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    try:
+        result = adapter.transition("issue-uuid-1", "Done", idempotency_key="k2")
+    finally:
+        adapter.close()
+    assert result.new_status == "Done"
+    assert result.ticket_id == "issue-uuid-1"
+    assert result.etag == "2026-05-19T13:00:00.000Z"
+
+
+@respx.mock
+def test_transition_uses_state_map() -> None:
+    adapter = _make_adapter(state_map={"done": "Done"})
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "issueUpdate": {
+                            "success": True,
+                            "issue": {
+                                "id": "issue-uuid-1",
+                                "updatedAt": "2026-05-19T14:00:00.000Z",
+                            },
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    try:
+        result = adapter.transition("issue-uuid-1", "done")
+    finally:
+        adapter.close()
+    assert result.new_status == "done"
+
+
+@respx.mock
+def test_transition_accepts_state_id_directly() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "issueUpdate": {
+                            "success": True,
+                            "issue": {
+                                "id": "issue-uuid-1",
+                                "updatedAt": "2026-05-19T15:00:00.000Z",
+                            },
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    try:
+        result = adapter.transition("issue-uuid-1", "state-done")
+    finally:
+        adapter.close()
+    assert result.new_status == "state-done"
+
+
+@respx.mock
+def test_transition_unknown_state_raises() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(200, json=_team_response()),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            adapter.transition("issue-uuid-1", "Mystery")
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_transition_raises_when_success_false() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(
+                200,
+                json={"data": {"issueUpdate": {"success": False, "issue": None}}},
+            ),
+        ]
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            adapter.transition("issue-uuid-1", "Done")
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Rate-limit & concurrency
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_rate_limit_with_retry_after_header() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            429,
+            json={"message": "slow down"},
+            headers={"Retry-After": "11"},
+        )
+    )
+    try:
+        with pytest.raises(RateLimited) as exc:
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert exc.value.retry_after == 11.0
+
+
+@respx.mock
+def test_secondary_rate_limit_typed_error() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "errors": [
+                    {
+                        "message": "API rate limit exceeded",
+                        "extensions": {"code": "RATELIMITED"},
+                    },
+                ],
+            },
+        )
+    )
+    try:
+        with pytest.raises(RateLimited):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_etag_mismatch_raises_optimistic_concurrency() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(412, json={"message": "Precondition Failed"}),
+        ]
+    )
+    try:
+        with pytest.raises(OptimisticConcurrencyError):
+            adapter.transition("issue-uuid-1", "Done", etag="2026-05-19T10:00:00.000Z")
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_5xx_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(503, json={"message": "down"}),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_401_raises_tracker_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(401, json={"message": "Unauthorized"}),
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+# ---------------------------------------------------------------------------
+# Label-based CLI routing hint
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_cli_routing_disabled_when_unconfigured() -> None:
+    adapter = _make_adapter(label_routing_field=None)
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=_team_response()),
+            httpx.Response(200, json=_issues_page()),
+        ]
+    )
+    try:
+        tickets = list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+    assert all(t.routing_hint.cli is None for t in tickets)
+
+
+# ---------------------------------------------------------------------------
+# Schema discovery edge cases
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_schema_missing_team_raises() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": {"teams": {"nodes": []}}},
+        )
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()
+
+
+@respx.mock
+def test_graphql_top_level_error_surfaces_as_unavailable() -> None:
+    adapter = _make_adapter()
+    respx.post(LINEAR_GRAPHQL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={"errors": [{"message": "broken", "extensions": {"code": "INTERNAL"}}]},
+        )
+    )
+    try:
+        with pytest.raises(TrackerUnavailable):
+            list(adapter.pull_open_tickets())
+    finally:
+        adapter.close()


### PR DESCRIPTION
Adds the Linear adapter following the GitHub Projects v2 pattern. Uses Linear's GraphQL API; auth via API key.

## Summary by Sourcery

Add a Linear tracker adapter that integrates with Linear’s GraphQL API to fetch and update issues, including comments and state transitions, with rate limiting and error handling.

New Features:
- Introduce LinearTracker and LinearConfig to support Linear as a first-class tracker backend, including ticket retrieval, commenting, and state transitions.
- Expose LinearTracker and LinearConfig from the trackers package for external use.
- Add label-based CLI routing via configurable Linear label prefixes on tickets.

Enhancements:
- Implement cooperative client-side throttling and robust error translation (rate limiting, auth, concurrency) for Linear GraphQL calls.

Documentation:
- Add user-facing documentation describing configuration, authentication, state mapping, label-based routing, rate limiting, and error semantics for the Linear tracker adapter.

Tests:
- Add a comprehensive unit test suite for the Linear adapter covering token resolution, pagination, filtering, comments, transitions, rate limiting, error handling, and label-based CLI routing.