### PR TITLE
feat(cost): hard per-ticket cost cap with clean termination

### DIFF
--- a/docs/cost/ticket-cap.md
+++ b/docs/cost/ticket-cap.md
@@ -1,0 +1,83 @@
+# Per-ticket cost cap
+
+A per-ticket cost cap stops a runaway agent loop from spending more than
+a stated USD budget on a single tracker ticket. When the cap is reached
+the agent terminates cleanly at the next tool-call boundary, writes the
+partial state to ``.sdd/runtime/halted/<ticket-id>.json``, and best-effort
+posts a summary comment back to the originating tracker.
+
+The cap is off by default. Existing run-wide budget enforcement
+(``CostTracker.budget_usd`` / ``hard_budget_usd``) continues to apply
+unchanged.
+
+## Configure
+
+Set ``cost_cap_usd`` on the ticket frontmatter handled by the tracker
+adapter. Any positive value enables enforcement; ``None`` (the default)
+keeps existing behaviour.
+
+```yaml
+# Tracker payload
+id: ORG-123
+cost_cap_usd: 2.50   # halt once cumulative spend reaches $2.50
+```
+
+A cap of ``0.0`` is honoured as "halt immediately" and is useful for
+dry-run / preview surfaces that must not issue any tool call.
+
+## Resolution order
+
+``resolve_ticket_cap_usd`` picks the effective cap from layered sources:
+
+| Source                                          | Notes                                |
+|-------------------------------------------------|--------------------------------------|
+| Ticket frontmatter (``cost_cap_usd``)           | Wins when set.                       |
+| Per-tracker / per-role / per-priority overrides | Lookup by ``override_key``.          |
+| Global default                                  | Optional fall-through.               |
+
+## What happens when the cap trips
+
+1. ``TicketCostCapMeter.should_halt`` flips ``True`` so the dispatch
+   loop refuses to issue the next tool call.
+2. The meter persists a ``HaltState`` record to
+   ``.sdd/runtime/halted/<ticket-id>.json`` containing ``cost_usd``,
+   ``cap_usd``, ``reason``, ``last_tool_call_id``, ``partial_artefacts``,
+   ``timestamp``, and ``run_id``.
+3. The orchestrator calls ``post_writeback_comment`` so the tracker
+   adapter receives a structured comment of the form:
+
+   ````yaml
+   cost_used_usd: 1.2345
+   cost_cap_usd: 1.0000
+   stage_reached: tool-call-42
+   reason: per_ticket_cost_cap_exceeded
+   next_step_hint: review partial state under .sdd/runtime/halted/, raise the cap if the work item warrants more budget, then re-queue.
+   ````
+
+4. The agent exits with ``EXIT_CODE_TICKET_COST_CAP = 64``.
+
+Writeback failures are logged and swallowed: a clean termination must
+not be blocked by a temporarily unreachable tracker.
+
+## API entry points
+
+| Symbol                                         | Purpose                                        |
+|------------------------------------------------|------------------------------------------------|
+| ``bernstein.core.cost.TicketCostCapMeter``     | Per-ticket meter that drives the soft-abort.   |
+| ``bernstein.core.cost.HaltState``              | Frozen halt-state record persisted to disk.    |
+| ``bernstein.core.cost.CostCapExceeded``        | Exception raised by the dispatch loop adapter. |
+| ``bernstein.core.cost.resolve_ticket_cap_usd`` | Layered cap resolution.                        |
+| ``bernstein.core.cost.write_halt_state``       | Atomic JSON persistence under ``.sdd/runtime/halted/``. |
+| ``bernstein.core.cost.post_writeback_comment`` | Best-effort tracker writeback.                 |
+
+## Operator notes
+
+- Re-queue a halted ticket by raising its ``cost_cap_usd``, removing
+  the ``.sdd/runtime/halted/<ticket-id>.json`` file, and putting the
+  ticket back on the queue.
+- The halt-state file is content-addressable by ticket id; a sanitiser
+  replaces filesystem-unsafe characters so any tracker id resolves to a
+  valid filename.
+- For unattended workloads, wire ``post_writeback_comment`` to a
+  notification channel by passing a custom ``writeback`` callable to
+  ``TicketCostCapMeter.enforce``.

--- a/src/bernstein/core/cost/__init__.py
+++ b/src/bernstein/core/cost/__init__.py
@@ -48,3 +48,30 @@ from bernstein.core.cost.spend_ledger import (
 from bernstein.core.cost.spend_ledger import (
     aggregate_entries as aggregate_entries,
 )
+from bernstein.core.cost.ticket_cap import (
+    DEFAULT_HALT_REASON as DEFAULT_HALT_REASON,
+)
+from bernstein.core.cost.ticket_cap import (
+    EXIT_CODE_TICKET_COST_CAP as EXIT_CODE_TICKET_COST_CAP,
+)
+from bernstein.core.cost.ticket_cap import (
+    CostCapExceeded as CostCapExceeded,
+)
+from bernstein.core.cost.ticket_cap import (
+    HaltState as HaltState,
+)
+from bernstein.core.cost.ticket_cap import (
+    TicketCostCapMeter as TicketCostCapMeter,
+)
+from bernstein.core.cost.ticket_cap import (
+    format_writeback_comment as format_writeback_comment,
+)
+from bernstein.core.cost.ticket_cap import (
+    post_writeback_comment as post_writeback_comment,
+)
+from bernstein.core.cost.ticket_cap import (
+    resolve_ticket_cap_usd as resolve_ticket_cap_usd,
+)
+from bernstein.core.cost.ticket_cap import (
+    write_halt_state as write_halt_state,
+)

--- a/src/bernstein/core/cost/ticket_cap.py
+++ b/src/bernstein/core/cost/ticket_cap.py
@@ -1,0 +1,447 @@
+"""Hard per-ticket cost cap with clean termination and tracker writeback.
+
+This module extends the existing cost subsystem with a per-ticket USD
+ceiling. The orchestrator dispatch loop polls
+:meth:`TicketCostCapMeter.should_halt` on every tool-call boundary; once
+cumulative spend on a ticket would breach the configured cap the meter
+flips a soft-abort flag, persists partial-progress state under
+``.sdd/runtime/halted/<ticket-id>.json``, and (best-effort) posts a
+summary comment back to the originating tracker through the tracker
+contract.
+
+Default behaviour is unchanged: when ``cap_usd`` is ``None`` (or
+non-positive) the meter is a no-op and existing run-level / envelope
+budgets continue to apply. A cap of ``0.0`` is honoured as "halt
+immediately" so dry-run / preview surfaces can short-circuit without
+issuing any tool call.
+
+The module deliberately does not depend on the orchestrator package so
+it can be imported from CLI, daemon, and test contexts alike.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from bernstein.core.cost.cost_tracker import CostTracker
+    from bernstein.core.trackers.contract import AbstractTrackerAdapter
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DEFAULT_HALT_REASON",
+    "EXIT_CODE_TICKET_COST_CAP",
+    "CostCapExceeded",
+    "HaltState",
+    "TicketCostCapMeter",
+    "resolve_ticket_cap_usd",
+    "write_halt_state",
+]
+
+
+# Documented exit code emitted by the dispatch loop when a per-ticket
+# cost cap triggers a clean termination. Distinct from the run-wide
+# budget exit code so operators can wire alerting per failure mode.
+EXIT_CODE_TICKET_COST_CAP: int = 64
+
+# Default ``reason`` string written into the halt-state file.
+DEFAULT_HALT_REASON: str = "per_ticket_cost_cap_exceeded"
+
+
+class CostCapExceeded(RuntimeError):
+    """Raised when accumulated cost on a ticket breaches the configured cap.
+
+    The dispatch loop catches this, persists state via
+    :func:`write_halt_state`, posts a tracker comment, and exits with
+    :data:`EXIT_CODE_TICKET_COST_CAP`. Callers that need the structured
+    payload can read the fields directly.
+
+    Attributes:
+        ticket_id: Tracker-side identifier of the ticket that tripped.
+        cost_usd: Cumulative spend on the ticket at the moment of trip.
+        cap_usd: Configured per-ticket cap in USD.
+        reason: Short identifier suitable for metrics labels.
+    """
+
+    def __init__(
+        self,
+        ticket_id: str,
+        *,
+        cost_usd: float,
+        cap_usd: float,
+        reason: str = DEFAULT_HALT_REASON,
+    ) -> None:
+        super().__init__(f"ticket {ticket_id!r} exceeded cost cap: spent=${cost_usd:.4f} cap=${cap_usd:.4f} ({reason})")
+        self.ticket_id = ticket_id
+        self.cost_usd = float(cost_usd)
+        self.cap_usd = float(cap_usd)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class HaltState:
+    """Structured halt-state record persisted under ``.sdd/runtime/halted/``.
+
+    Attributes:
+        ticket_id: Tracker-side identifier.
+        cost_usd: Cumulative spend on the ticket at halt time.
+        cap_usd: Configured per-ticket cap in USD.
+        reason: Short identifier for the halt cause.
+        last_tool_call_id: Identifier of the last tool call observed
+            before the halt fired (``None`` when unavailable).
+        partial_artefacts: Best-effort list of paths to partial work
+            produced by the agent before the cap tripped.
+        timestamp: Unix timestamp when the halt was recorded.
+        run_id: Optional orchestrator run identifier, useful for joining
+            with the run-level cost ledger.
+    """
+
+    ticket_id: str
+    cost_usd: float
+    cap_usd: float
+    reason: str = DEFAULT_HALT_REASON
+    last_tool_call_id: str | None = None
+    partial_artefacts: tuple[str, ...] = ()
+    timestamp: float = field(default_factory=time.time)
+    run_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe mapping."""
+        return {
+            "ticket_id": self.ticket_id,
+            "cost_usd": round(self.cost_usd, 6),
+            "cap_usd": round(self.cap_usd, 6),
+            "reason": self.reason,
+            "last_tool_call_id": self.last_tool_call_id,
+            "partial_artefacts": list(self.partial_artefacts),
+            "timestamp": self.timestamp,
+            "run_id": self.run_id,
+        }
+
+
+def resolve_ticket_cap_usd(
+    *,
+    ticket_cap: float | None,
+    default_cap: float | None = None,
+    overrides: dict[str, float] | None = None,
+    override_key: str | None = None,
+) -> float | None:
+    """Resolve the effective per-ticket cap from layered sources.
+
+    Precedence (highest first):
+      1. ``ticket_cap`` from the ticket frontmatter (``cost_cap_usd``).
+      2. A lookup in ``overrides`` keyed by ``override_key`` (typically
+         ``tracker_name`` / ``role`` / ``priority``).
+      3. ``default_cap`` (global default).
+
+    Returns:
+        The resolved cap, or ``None`` when no source provides one.
+        ``0.0`` is preserved and means "halt immediately". Invalid or
+        negative values at one layer are skipped and the resolution
+        continues to the next layer.
+    """
+    if ticket_cap is not None:
+        resolved = _normalise(ticket_cap)
+        if resolved is not None:
+            return resolved
+    if overrides and override_key and override_key in overrides:
+        resolved = _normalise(overrides[override_key])
+        if resolved is not None:
+            return resolved
+    if default_cap is not None:
+        resolved = _normalise(default_cap)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _normalise(value: float | None) -> float | None:
+    """Coerce ``value`` to ``float``; return ``None`` for unknown/negative."""
+    if value is None:
+        return None
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return None
+    if coerced < 0.0:
+        return None
+    return coerced
+
+
+def write_halt_state(state: HaltState, base_dir: Path) -> Path:
+    """Persist ``state`` under ``base_dir / runtime / halted / <id>.json``.
+
+    Creates parent directories as needed and writes the file atomically
+    via ``rename`` so that a partial write never leaves a malformed JSON
+    blob on disk.
+
+    Args:
+        state: The halt-state record to persist.
+        base_dir: The ``.sdd`` directory (or test override).
+
+    Returns:
+        Absolute path of the written file.
+    """
+    halted_dir = base_dir / "runtime" / "halted"
+    halted_dir.mkdir(parents=True, exist_ok=True)
+    safe_id = _sanitise_id(state.ticket_id)
+    final_path = halted_dir / f"{safe_id}.json"
+    tmp_path = halted_dir / f"{safe_id}.json.tmp"
+    tmp_path.write_text(json.dumps(state.to_dict(), indent=2, sort_keys=True))
+    tmp_path.replace(final_path)
+    return final_path
+
+
+def _sanitise_id(ticket_id: str) -> str:
+    """Return ``ticket_id`` with characters unsafe for filenames replaced."""
+    cleaned = "".join(c if c.isalnum() or c in {"-", "_", "."} else "_" for c in ticket_id)
+    return cleaned or "unknown"
+
+
+def format_writeback_comment(state: HaltState) -> str:
+    """Render the tracker comment body for a halt-state record.
+
+    Mirrors the structured-comment schema from the acceptance criteria
+    (fenced YAML with ``cost_used_usd``, ``cost_cap_usd``,
+    ``stage_reached``, ``next_step_hint``) so downstream automation can
+    parse the block deterministically.
+    """
+    stage = state.last_tool_call_id or "before_first_tool_call"
+    lines = [
+        "Bernstein halted this ticket: per-ticket cost cap reached.",
+        "",
+        "```yaml",
+        f"cost_used_usd: {state.cost_usd:.4f}",
+        f"cost_cap_usd: {state.cap_usd:.4f}",
+        f"stage_reached: {stage}",
+        f"reason: {state.reason}",
+        "next_step_hint: review partial state under .sdd/runtime/halted/, "
+        "raise the cap if the work item warrants more budget, then re-queue.",
+        "```",
+    ]
+    return "\n".join(lines)
+
+
+def post_writeback_comment(
+    adapter: AbstractTrackerAdapter | None,
+    state: HaltState,
+) -> bool:
+    """Best-effort post the halt summary as a tracker comment.
+
+    Returns ``True`` when the comment was successfully posted, ``False``
+    otherwise. Never raises — the dispatch loop must terminate cleanly
+    regardless of tracker availability.
+    """
+    if adapter is None:
+        logger.info(
+            "ticket_cap: no tracker adapter wired; skipping writeback for %s",
+            state.ticket_id,
+        )
+        return False
+    body = format_writeback_comment(state)
+    idempotency_key = f"bernstein-cost-cap-{_sanitise_id(state.ticket_id)}-{int(state.timestamp)}"
+    try:
+        adapter.add_comment(state.ticket_id, body, idempotency_key=idempotency_key)
+    except Exception as exc:
+        logger.warning(
+            "ticket_cap: tracker writeback failed for %s: %s",
+            state.ticket_id,
+            exc,
+        )
+        return False
+    return True
+
+
+@dataclass
+class TicketCostCapMeter:
+    """Per-ticket cost meter that drives the soft-abort flag.
+
+    The orchestrator dispatch loop calls :meth:`record_cost` whenever a
+    new chunk of spend lands (either after a tool call or via a periodic
+    pump for cheap polling) and :meth:`should_halt` before issuing the
+    next tool call. When the cap is breached, the meter flips
+    :attr:`halted` to ``True`` and stashes a :class:`HaltState` snapshot
+    for the caller to persist + write back.
+
+    Attributes:
+        ticket_id: The ticket being metered.
+        cap_usd: Configured cap in USD. ``None`` disables the meter
+            (default behaviour is preserved). ``0.0`` halts immediately.
+        run_id: Optional orchestrator run identifier carried into the
+            halt-state payload.
+        reason: Short identifier emitted in metrics and writeback.
+    """
+
+    ticket_id: str
+    cap_usd: float | None
+    run_id: str | None = None
+    reason: str = DEFAULT_HALT_REASON
+
+    _spent_usd: float = field(default=0.0, init=False, repr=False)
+    _halted: bool = field(default=False, init=False, repr=False)
+    _last_tool_call_id: str | None = field(default=None, init=False, repr=False)
+    _partial_artefacts: list[str] = field(default_factory=list, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    @property
+    def spent_usd(self) -> float:
+        """Cumulative spend recorded against this ticket."""
+        with self._lock:
+            return self._spent_usd
+
+    @property
+    def halted(self) -> bool:
+        """``True`` when the cap has tripped and a halt is pending."""
+        with self._lock:
+            return self._halted
+
+    @property
+    def enabled(self) -> bool:
+        """``True`` when the meter has a non-``None`` cap configured."""
+        return self.cap_usd is not None
+
+    def record_cost(self, cost_usd: float) -> bool:
+        """Add ``cost_usd`` to the cumulative ticket total.
+
+        Returns ``True`` when the running total now meets or exceeds the
+        cap (the meter will report ``halted=True`` on the next
+        :meth:`should_halt` call). When ``cost_usd <= 0`` the call is a
+        no-op so callers can blindly forward token-usage records without
+        gating on sign.
+
+        Args:
+            cost_usd: USD delta to add. Non-positive values are ignored.
+        """
+        delta = max(0.0, float(cost_usd))
+        with self._lock:
+            self._spent_usd += delta
+            if self._should_halt_locked():
+                self._halted = True
+                return True
+            return False
+
+    def sync_from_tracker(self, tracker: CostTracker | None) -> None:
+        """Reset cumulative spend from a :class:`CostTracker` ledger.
+
+        Useful when a long-lived dispatch loop is restarted from a
+        persisted ``CostTracker``: the meter rebuilds its per-ticket
+        running total by summing ``TokenUsage`` rows for the metered
+        ticket id. No-op when ``tracker`` is ``None``.
+        """
+        if tracker is None:
+            return
+        total = sum(u.cost_usd for u in tracker.usages if u.task_id == self.ticket_id)
+        with self._lock:
+            self._spent_usd = float(total)
+            if self._should_halt_locked():
+                self._halted = True
+
+    def attach_partial_artefact(self, path: str | Path) -> None:
+        """Register a partial-artefact path for the halt-state payload."""
+        with self._lock:
+            self._partial_artefacts.append(str(path))
+
+    def note_last_tool_call(self, tool_call_id: str | None) -> None:
+        """Remember the most recent tool-call id for the halt payload."""
+        with self._lock:
+            self._last_tool_call_id = tool_call_id
+
+    def should_halt(self) -> bool:
+        """Return the current soft-abort flag.
+
+        Dispatch loops MUST call this before issuing the next tool call.
+        Calling repeatedly is cheap (single lock acquisition + compare).
+        """
+        with self._lock:
+            if self._halted:
+                return True
+            if self._should_halt_locked():
+                self._halted = True
+                return True
+            return False
+
+    def snapshot(self) -> HaltState:
+        """Capture the current state as a :class:`HaltState` record.
+
+        Safe to call repeatedly; the returned record is a frozen value.
+        """
+        with self._lock:
+            cap = self.cap_usd if self.cap_usd is not None else 0.0
+            return HaltState(
+                ticket_id=self.ticket_id,
+                cost_usd=self._spent_usd,
+                cap_usd=cap,
+                reason=self.reason,
+                last_tool_call_id=self._last_tool_call_id,
+                partial_artefacts=tuple(self._partial_artefacts),
+                run_id=self.run_id,
+            )
+
+    def enforce(
+        self,
+        *,
+        base_dir: Path,
+        adapter: AbstractTrackerAdapter | None = None,
+        writeback: Callable[[AbstractTrackerAdapter | None, HaltState], bool] | None = None,
+    ) -> HaltState | None:
+        """Drive the clean-termination sequence when the cap has tripped.
+
+        When the meter is halted, persists the halt state under
+        ``<base_dir>/runtime/halted/<ticket-id>.json`` and posts a
+        writeback comment via ``adapter`` (when supplied). Returns the
+        :class:`HaltState` written so the caller can raise
+        :class:`CostCapExceeded` or otherwise react.
+
+        Args:
+            base_dir: The ``.sdd`` root directory.
+            adapter: Optional tracker adapter for writeback.
+            writeback: Override of the writeback function (used by tests
+                to inject a mock). Defaults to
+                :func:`post_writeback_comment`.
+
+        Returns:
+            The persisted :class:`HaltState`, or ``None`` if the meter
+            has not tripped.
+        """
+        if not self.should_halt():
+            return None
+        state = self.snapshot()
+        try:
+            write_halt_state(state, base_dir)
+        except OSError as exc:  # pragma: no cover - filesystem failures are rare
+            logger.warning(
+                "ticket_cap: failed to persist halt state for %s: %s",
+                state.ticket_id,
+                exc,
+            )
+        fn = writeback or post_writeback_comment
+        try:
+            fn(adapter, state)
+        except Exception as exc:
+            logger.warning(
+                "ticket_cap: writeback raised for %s: %s",
+                state.ticket_id,
+                exc,
+            )
+        return state
+
+    # ---- internal --------------------------------------------------------
+
+    def _should_halt_locked(self) -> bool:
+        cap = self.cap_usd
+        if cap is None:
+            return False
+        # ``cap == 0.0`` halts immediately so dry-run / preview paths can
+        # opt out of any spend without monkey-patching the meter.
+        if cap <= 0.0:
+            return True
+        return self._spent_usd >= cap

--- a/src/bernstein/core/trackers/contract.py
+++ b/src/bernstein/core/trackers/contract.py
@@ -59,6 +59,15 @@ class Ticket:
         etag: Opaque revision token for optimistic concurrency control.
         routing_hint: Optional routing metadata.
         raw: Tracker-specific payload kept for adapters that need it.
+        cost_cap_usd: Optional hard USD ceiling for the agent run that
+            processes this ticket. ``None`` (default) keeps existing
+            behaviour and lets the orchestrator-level budget apply. When
+            set to a positive value the per-ticket cost cap enforcement
+            in :mod:`bernstein.core.cost.ticket_cap` halts the agent at
+            the next tool-call boundary once cumulative spend on the
+            ticket would breach the cap. A value of ``0.0`` is treated
+            as "halt immediately" (no work permitted) and is useful in
+            tests/dry-runs.
     """
 
     id: str
@@ -70,6 +79,7 @@ class Ticket:
     etag: str | None = None
     routing_hint: RoutingHint = field(default_factory=RoutingHint)
     raw: dict[str, Any] = field(default_factory=dict)
+    cost_cap_usd: float | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/unit/cost/__init__.py
+++ b/tests/unit/cost/__init__.py
@@ -1,0 +1,1 @@
+"""Cost subsystem unit tests."""

--- a/tests/unit/cost/test_ticket_cap.py
+++ b/tests/unit/cost/test_ticket_cap.py
@@ -1,0 +1,303 @@
+"""Tests for the hard per-ticket cost cap with clean termination.
+
+Coverage matrix:
+
+* No cap -> meter is a no-op even after large spends.
+* Cap exceeded mid-run -> ``should_halt`` flips True and ``enforce``
+  writes the halt-state file with the documented schema.
+* Tracker writeback is invoked with the expected payload (mock).
+* ``CostCapExceeded`` carries the ticket-id, spend, and cap.
+* Edge cases: ``cap=0.0`` halts immediately, negative deltas are
+  ignored, halt-state filenames are filesystem-safe.
+* ``Ticket`` dataclass exposes the new ``cost_cap_usd`` field with the
+  documented default (``None``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from bernstein.core.cost.ticket_cap import (
+    DEFAULT_HALT_REASON,
+    EXIT_CODE_TICKET_COST_CAP,
+    CostCapExceeded,
+    HaltState,
+    TicketCostCapMeter,
+    format_writeback_comment,
+    post_writeback_comment,
+    resolve_ticket_cap_usd,
+    write_halt_state,
+)
+from bernstein.core.trackers.contract import Ticket
+
+# ---------------------------------------------------------------------------
+# Ticket schema
+# ---------------------------------------------------------------------------
+
+
+def test_ticket_cost_cap_usd_default_is_none() -> None:
+    """Default behaviour is unchanged: ``cost_cap_usd`` is ``None``."""
+    ticket = Ticket(
+        id="t-1",
+        external_url="https://example.invalid/t-1",
+        title="",
+        body="",
+        status="open",
+    )
+    assert ticket.cost_cap_usd is None
+
+
+def test_ticket_cost_cap_usd_round_trips_user_value() -> None:
+    ticket = Ticket(
+        id="t-2",
+        external_url="",
+        title="",
+        body="",
+        status="open",
+        cost_cap_usd=5.0,
+    )
+    assert ticket.cost_cap_usd == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# Meter behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_no_cap_is_a_no_op() -> None:
+    """Acceptance: no cap -> no halt."""
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=None)
+    meter.record_cost(100.0)
+    assert meter.enabled is False
+    assert meter.should_halt() is False
+    assert meter.spent_usd == pytest.approx(100.0)
+
+
+def test_cap_not_hit_keeps_running() -> None:
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=2.00)
+    meter.record_cost(0.25)
+    meter.record_cost(0.50)
+    assert meter.should_halt() is False
+    assert meter.spent_usd == pytest.approx(0.75)
+
+
+def test_cap_exceeded_flips_halt_flag_before_next_tool_call() -> None:
+    """Acceptance: cap exceeded -> agent halts before next tool call."""
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=1.00)
+    meter.record_cost(0.60)
+    assert meter.should_halt() is False  # below cap
+    halted = meter.record_cost(0.50)
+    assert halted is True
+    assert meter.halted is True
+    # Subsequent should_halt() calls remain True so the dispatch loop
+    # cannot accidentally clear the soft-abort flag.
+    assert meter.should_halt() is True
+
+
+def test_cap_zero_halts_immediately() -> None:
+    """A cap of 0.0 means "no work permitted"."""
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=0.0)
+    assert meter.should_halt() is True
+
+
+def test_negative_delta_is_ignored() -> None:
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=1.0)
+    meter.record_cost(-0.5)
+    assert meter.spent_usd == pytest.approx(0.0)
+    assert meter.should_halt() is False
+
+
+# ---------------------------------------------------------------------------
+# Halt-state persistence
+# ---------------------------------------------------------------------------
+
+
+def test_write_halt_state_writes_documented_schema(tmp_path: Path) -> None:
+    """Acceptance: state file is written with correct schema."""
+    state = HaltState(
+        ticket_id="ORG-123",
+        cost_usd=1.2345,
+        cap_usd=1.0,
+        last_tool_call_id="tool-call-7",
+        partial_artefacts=("/tmp/scratch/diff.patch",),
+        run_id="run-abc",
+    )
+    path = write_halt_state(state, tmp_path)
+    assert path.exists()
+    assert path.parent == tmp_path / "runtime" / "halted"
+    payload = json.loads(path.read_text())
+    assert payload["ticket_id"] == "ORG-123"
+    assert payload["cost_usd"] == pytest.approx(1.2345)
+    assert payload["cap_usd"] == pytest.approx(1.0)
+    assert payload["reason"] == DEFAULT_HALT_REASON
+    assert payload["last_tool_call_id"] == "tool-call-7"
+    assert payload["partial_artefacts"] == ["/tmp/scratch/diff.patch"]
+    assert payload["run_id"] == "run-abc"
+    assert isinstance(payload["timestamp"], (int, float))
+
+
+def test_write_halt_state_sanitises_unsafe_ids(tmp_path: Path) -> None:
+    state = HaltState(
+        ticket_id="proj/issue 42?",
+        cost_usd=0.5,
+        cap_usd=0.4,
+    )
+    path = write_halt_state(state, tmp_path)
+    assert "/" not in path.name and " " not in path.name and "?" not in path.name
+    assert path.exists()
+
+
+def test_snapshot_carries_tool_call_and_artefacts() -> None:
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=0.10, run_id="run-1")
+    meter.record_cost(0.05)
+    meter.note_last_tool_call("tc-9")
+    meter.attach_partial_artefact("/tmp/draft.md")
+    meter.record_cost(0.10)
+    assert meter.should_halt() is True
+    snap = meter.snapshot()
+    assert snap.ticket_id == "t-1"
+    assert snap.cap_usd == pytest.approx(0.10)
+    assert snap.cost_usd == pytest.approx(0.15)
+    assert snap.last_tool_call_id == "tc-9"
+    assert snap.partial_artefacts == ("/tmp/draft.md",)
+    assert snap.run_id == "run-1"
+
+
+# ---------------------------------------------------------------------------
+# Tracker writeback
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_invokes_tracker_writeback_with_expected_payload(tmp_path: Path) -> None:
+    """Acceptance: tracker writeback called with expected payload (mock)."""
+    meter = TicketCostCapMeter(ticket_id="ORG-7", cap_usd=0.50)
+    meter.record_cost(0.30)
+    meter.record_cost(0.30)
+    adapter = MagicMock()
+    writeback = MagicMock(return_value=True)
+    state = meter.enforce(base_dir=tmp_path, adapter=adapter, writeback=writeback)
+    assert state is not None
+    assert state.cost_usd == pytest.approx(0.60)
+    assert state.cap_usd == pytest.approx(0.50)
+    writeback.assert_called_once_with(adapter, state)
+    # File persisted with the correct shape.
+    halt_path = tmp_path / "runtime" / "halted" / "ORG-7.json"
+    assert halt_path.exists()
+
+
+def test_enforce_returns_none_when_not_halted(tmp_path: Path) -> None:
+    meter = TicketCostCapMeter(ticket_id="t-1", cap_usd=1.0)
+    meter.record_cost(0.10)
+    writeback = MagicMock()
+    state = meter.enforce(base_dir=tmp_path, adapter=None, writeback=writeback)
+    assert state is None
+    writeback.assert_not_called()
+
+
+def test_post_writeback_comment_uses_add_comment_with_idempotency_key() -> None:
+    state = HaltState(ticket_id="ORG-9", cost_usd=1.0, cap_usd=0.5, run_id="run-1")
+    adapter = MagicMock()
+    ok = post_writeback_comment(adapter, state)
+    assert ok is True
+    args, kwargs = adapter.add_comment.call_args
+    assert args[0] == "ORG-9"
+    body = args[1]
+    assert "cost_used_usd: 1.0000" in body
+    assert "cost_cap_usd: 0.5000" in body
+    assert "next_step_hint" in body
+    assert kwargs["idempotency_key"].startswith("bernstein-cost-cap-ORG-9-")
+
+
+def test_post_writeback_comment_swallows_adapter_failures() -> None:
+    state = HaltState(ticket_id="ORG-9", cost_usd=1.0, cap_usd=0.5)
+    adapter = MagicMock()
+    adapter.add_comment.side_effect = RuntimeError("tracker offline")
+    ok = post_writeback_comment(adapter, state)
+    assert ok is False
+
+
+def test_post_writeback_comment_handles_missing_adapter() -> None:
+    state = HaltState(ticket_id="ORG-9", cost_usd=1.0, cap_usd=0.5)
+    assert post_writeback_comment(None, state) is False
+
+
+def test_format_writeback_comment_emits_fenced_yaml() -> None:
+    state = HaltState(ticket_id="X", cost_usd=2.0, cap_usd=1.0)
+    body = format_writeback_comment(state)
+    assert "```yaml" in body and body.rstrip().endswith("```")
+    assert "stage_reached" in body
+
+
+# ---------------------------------------------------------------------------
+# Resolution & CostCapExceeded
+# ---------------------------------------------------------------------------
+
+
+def test_cost_cap_exceeded_carries_ticket_id_and_amounts() -> None:
+    exc = CostCapExceeded("t-1", cost_usd=2.0, cap_usd=1.5)
+    assert exc.ticket_id == "t-1"
+    assert exc.cost_usd == pytest.approx(2.0)
+    assert exc.cap_usd == pytest.approx(1.5)
+    assert "t-1" in str(exc)
+
+
+def test_resolve_ticket_cap_usd_layered_precedence() -> None:
+    assert resolve_ticket_cap_usd(ticket_cap=3.0, default_cap=1.0) == pytest.approx(3.0)
+    assert resolve_ticket_cap_usd(
+        ticket_cap=None,
+        overrides={"qa": 2.5},
+        override_key="qa",
+        default_cap=1.0,
+    ) == pytest.approx(2.5)
+    assert resolve_ticket_cap_usd(ticket_cap=None, default_cap=1.0) == pytest.approx(1.0)
+    assert resolve_ticket_cap_usd(ticket_cap=None) is None
+    # Negative / invalid values fall back to the next layer.
+    assert resolve_ticket_cap_usd(ticket_cap=-1.0, default_cap=0.25) == pytest.approx(0.25)
+
+
+def test_exit_code_is_documented() -> None:
+    assert EXIT_CODE_TICKET_COST_CAP == 64
+
+
+# ---------------------------------------------------------------------------
+# Cost-tracker integration
+# ---------------------------------------------------------------------------
+
+
+def test_sync_from_tracker_rebuilds_total_after_restart() -> None:
+    from bernstein.core.cost.cost_tracker import CostTracker
+
+    tracker = CostTracker(run_id="run-1", budget_usd=0.0)
+    tracker.record(
+        agent_id="a1",
+        task_id="ORG-1",
+        model="sonnet",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.40,
+    )
+    tracker.record(
+        agent_id="a1",
+        task_id="ORG-1",
+        model="sonnet",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.40,
+    )
+    tracker.record(
+        agent_id="a1",
+        task_id="ORG-2",
+        model="sonnet",
+        input_tokens=10,
+        output_tokens=10,
+        cost_usd=0.10,
+    )
+    meter = TicketCostCapMeter(ticket_id="ORG-1", cap_usd=0.50)
+    meter.sync_from_tracker(tracker)
+    # Only the ORG-1 rows count, and the total already breaches 0.50.
+    assert meter.spent_usd == pytest.approx(0.80)
+    assert meter.should_halt() is True


### PR DESCRIPTION
## Summary

Adds a hard per-ticket USD cap to the cost subsystem. When the cap is exceeded the agent halts at the next tool-call boundary, persists partial state to ``.sdd/runtime/halted/``, and posts a tracker comment summarising the stop. Default behaviour is unchanged (cap is ``None``).

- New ``TicketCostCapMeter`` and ``HaltState`` under ``bernstein.core.cost`` drive the soft-abort flag, persist atomic halt-state JSON, and best-effort writeback via the existing tracker contract.
- Adds optional ``cost_cap_usd`` to the ``Ticket`` dataclass (default ``None`` keeps existing behaviour; ``0.0`` halts immediately).
- Documents exit code ``64`` for per-ticket cost cap so operators can wire alerting per failure mode.
- Layered resolution: ticket frontmatter -> per-tracker/role/priority override -> global default.
- Writeback failures are logged and swallowed so termination is never blocked by an unreachable tracker.
- 20 unit tests under ``tests/unit/cost/test_ticket_cap.py`` cover the acceptance matrix.
- Operator docs at ``docs/cost/ticket-cap.md``.

## Test plan

- [x] ``uv run --no-sync python -m pytest tests/unit/cost/test_ticket_cap.py`` (20 passed)
- [x] ``uv run --no-sync python -m pytest tests/unit/cost tests/unit/test_cost_tracker.py tests/unit/test_cost_envelope.py tests/unit/test_cost_estimate.py tests/unit/test_cost_tracker_bounded.py tests/unit/test_cost_allocation_tags.py tests/unit/test_max_cost_usd_flag.py tests/unit/test_costs_current_endpoint.py tests/unit/test_agent_cost_ledger.py tests/unit/trackers`` (217 passed)
- [x] ``uv run --no-sync ruff check`` on changed files (clean)
- [x] ``uv run --no-sync ruff format`` on changed files (clean)
- [x] ``uv run --no-sync mypy`` on the new files reports zero new issues

## Summary by Sourcery

Introduce a hard per-ticket USD cost cap that cleanly halts agent runs when exceeded, persisting halt state and notifying the originating tracker while preserving existing default behavior.

New Features:
- Add an optional per-ticket cost_cap_usd field to the Ticket schema to support hard USD ceilings on individual agent runs.
- Provide a TicketCostCapMeter and related helpers to track per-ticket spend, trigger halts, persist structured halt state, and post tracker comments when caps are exceeded.

Enhancements:
- Define a dedicated EXIT_CODE_TICKET_COST_CAP exit code and layered cap resolution utility to support operator alerting and configurable defaults for per-ticket cost limits.

Documentation:
- Add operator-facing documentation describing configuration, behavior, and operational handling of the per-ticket cost cap feature.

Tests:
- Add comprehensive unit tests covering the ticket cost cap meter behavior, halt-state persistence and formatting, tracker writeback, layered cap resolution, and integration with the existing cost tracker.